### PR TITLE
Add test for IntersectionObserver with document as root

### DIFF
--- a/intersection-observer/same-document-with-document-root.html
+++ b/intersection-observer/same-document-with-document-root.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<script src="../resources/testharness.js"></script>
-<script src="../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <script src="./resources/intersection-observer-test-utils.js"></script>
 
 <style>

--- a/intersection-observer/same-document-with-document-root.html
+++ b/intersection-observer/same-document-with-document-root.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./resources/intersection-observer-test-utils.js"></script>
+
+<style>
+    pre,
+    #log {
+        position: absolute;
+        top: 0;
+        left: 200px;
+    }
+
+    .spacer {
+        height: calc(100vh + 100px);
+    }
+
+    #target {
+        width: 100px;
+        height: 100px;
+        background-color: green;
+    }
+</style>
+
+<div class="spacer"></div>
+<div id="target"></div>
+<div class="spacer"></div>
+
+<script>
+    var vw = document.documentElement.clientWidth;
+    var vh = document.documentElement.clientHeight;
+
+    var entries = [];
+    var target;
+
+    runTestCycle(function () {
+        target = document.getElementById("target");
+        assert_true(!!target, "target exists");
+        var observer = new IntersectionObserver(function (changes) {
+            entries = entries.concat(changes)
+        }, {root: document});
+        observer.observe(target);
+        entries = entries.concat(observer.takeRecords());
+        assert_equals(entries.length, 0, "No initial notifications.");
+        runTestCycle(step0, "First rAF.");
+    }, "IntersectionObserver in a single document using document as root.");
+
+    function step0() {
+        document.scrollingElement.scrollTop = 300;
+        runTestCycle(step1, "document.scrollingElement.scrollTop = 300");
+        checkLastEntry(entries, 0, [8, 108, vh + 108, vh + 208, 0, 0, 0, 0, 0, vw, 0, vh, false]);
+    }
+
+    function step1() {
+        document.scrollingElement.scrollTop = 0;
+        checkLastEntry(entries, 1, [8, 108, vh - 192, vh - 92, 8, 108, vh - 192, vh - 92, 0, vw, 0, vh, true]);
+    }
+</script>

--- a/intersection-observer/same-document-with-document-root.html
+++ b/intersection-observer/same-document-with-document-root.html
@@ -57,3 +57,4 @@
         checkLastEntry(entries, 1, [8, 108, vh - 192, vh - 92, 8, 108, vh - 192, vh - 92, 0, vw, 0, vh, true]);
     }
 </script>
+


### PR DESCRIPTION
Hi,
This patch adds test for intersectionObserver with IntersectionObserverInit { root: document }.
To ensure that rootBounds should be the root intersection rectangle which is the document's viewport,
per https://www.w3.org/TR/intersection-observer/#dom-intersectionobserverentry-rootbounds
