### PR TITLE
Make --py3 the default for 'wpt'

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -97,7 +97,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '2.7.x'
+      versionSpec: '3.8.x'
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/pip_install.yml
     parameters:

--- a/tools/ci/azure/update_hosts.yml
+++ b/tools/ci/azure/update_hosts.yml
@@ -5,6 +5,6 @@ steps:
 - powershell: |
     $hostFile = "$env:systemroot\System32\drivers\etc\hosts"
     Copy-Item -Path $hostFile -Destination "$hostFile.back" -Force
-    python wpt make-hosts-file | Out-File $env:systemroot\System32\drivers\etc\hosts -Encoding ascii -Append
+    python wpt --py2 make-hosts-file | Out-File $env:systemroot\System32\drivers\etc\hosts -Encoding ascii -Append
   displayName: 'Update hosts (Windows)'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/tools/ci/azure/update_manifest.yml
+++ b/tools/ci/azure/update_manifest.yml
@@ -1,4 +1,4 @@
 steps:
 # `python wpt` instead of `./wpt` is to make this work on Windows:
-- script: python wpt manifest
+- script: python wpt --py2 manifest
   displayName: 'Update manifest'

--- a/tools/ci/ci_wptrunner_infrastructure.sh
+++ b/tools/ci/ci_wptrunner_infrastructure.sh
@@ -6,22 +6,18 @@ WPT_ROOT=$SCRIPT_DIR/../..
 cd $WPT_ROOT
 
 test_infrastructure() {
-    PY3_FLAG="$2"
-    TERM=dumb ./wpt $PY3_FLAG run --log-mach - --yes --manifest ~/meta/MANIFEST.json --metadata infrastructure/metadata/ --install-fonts --install-webdriver $1 $PRODUCT infrastructure/
+    PY2_FLAG="$2"
+    TERM=dumb ./wpt $PY2_FLAG run --log-mach - --yes --manifest ~/meta/MANIFEST.json --metadata infrastructure/metadata/ --install-fonts --install-webdriver $1 $PRODUCT infrastructure/
 }
 
 main() {
-    if [[ $# -eq 1 && "$1" = "--py3" ]]; then
-        PRODUCTS=( "chrome" )
-    else
-        PRODUCTS=( "firefox" "chrome" )
-    fi
+    PRODUCTS=( "firefox" "chrome" )
     ./wpt manifest --rebuild -p ~/meta/MANIFEST.json
     for PRODUCT in "${PRODUCTS[@]}"; do
         if [[ "$PRODUCT" == "chrome" ]]; then
             test_infrastructure "--binary=$(which google-chrome-unstable) --channel dev" "$1"
         else
-            test_infrastructure "--binary=~/build/firefox/firefox"
+            test_infrastructure "--binary=~/build/firefox/firefox" "$1"
         fi
     done
 }

--- a/tools/ci/tc/decision.py
+++ b/tools/ci/tc/decision.py
@@ -138,7 +138,7 @@ def get_fetch_rev(event):
                 if not output:
                     logger.error("Failed to get commit for %s" % ref)
                 else:
-                    sha = output.split()[0]
+                    sha = output.decode("utf-8").split()[0]
             rv.append(sha)
         rv = tuple(rv)
     else:

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -581,7 +581,7 @@ tasks:
         - wpt-base
         - trigger-pr
         - browser-firefox
-      command: ./tools/ci/ci_wptrunner_infrastructure.sh
+      command: ./tools/ci/ci_wptrunner_infrastructure.sh --py2
       install:
         - libnss3-tools
         - libappindicator1
@@ -606,7 +606,8 @@ tasks:
       use:
         - wpt-base
         - trigger-pr
-      command: ./tools/ci/ci_wptrunner_infrastructure.sh --py3
+        - browser-firefox
+      command: ./tools/ci/ci_wptrunner_infrastructure.sh
       install:
         - python3-pip
         - libnss3-tools
@@ -615,6 +616,7 @@ tasks:
       options:
         oom-killer: true
         browser:
+          - firefox
           - chrome
         channel: experimental
         xvfb: true

--- a/wpt
+++ b/wpt
@@ -20,7 +20,7 @@ if __name__ == "__main__":
                 sys.exit(1)
             else:
                 raise
-    elif (args.py3 or py3only) and sys.version_info.major < 3:
+    elif (not args.py2) and sys.version_info.major < 3:
         from subprocess import call
         try:
             sys.exit(call(['python3'] + sys.argv))


### PR DESCRIPTION
As per
https://github.com/web-platform-tests/rfcs/blob/master/rfcs/py_3.md,
step #2 of the transition to Python 3-only is to make 'wpt ...' commands
run in Python 3 by default.

Passing --py2 will now be necessary to run under Python 2. (Until ~Feb
2021, when we will remove py2 support entirely).

This does affect some CI runs. Cases where they already specified py3
will remain py3. Cases which are designed to run under py2 had `--py2`
added. Cases that didn't currently specify and aren't version specific
are upgraded from py2 to py3 (one example is Azure Pipelines Mac
infrastructure tests.)

Some Azure Pipelines helper scripts are used for both py2 and py3 tasks.
As a simple way to keep them working, `--py2` is used for them as it is
always available.