### PR TITLE
Fetch: test Body mixin's MIME type

### DIFF
--- a/fetch/api/body/mime-type.any.js
+++ b/fetch/api/body/mime-type.any.js
@@ -1,0 +1,12 @@
+[
+ () => new Request("about:blank", { headers: { "Content-Type": "text/plain" } }),
+ () => new Response("", { headers: { "Content-Type": "text/plain" } })
+].forEach(bodyContainerCreator => {
+  promise_test(async t => {
+    const bodyContainer = bodyContainerCreator();
+    const newMIMEType = "test/test";
+    bodyContainer.headers.set("Content-Type", newMIMEType);
+    const blob = await bodyContainer.blob();
+    assert_equals(blob.type, newMIMEType);
+  });
+});

--- a/fetch/api/body/mime-type.any.js
+++ b/fetch/api/body/mime-type.any.js
@@ -2,11 +2,39 @@
  () => new Request("about:blank", { headers: { "Content-Type": "text/plain" } }),
  () => new Response("", { headers: { "Content-Type": "text/plain" } })
 ].forEach(bodyContainerCreator => {
+  const bodyContainer = bodyContainerCreator();
   promise_test(async t => {
-    const bodyContainer = bodyContainerCreator();
+    assert_equals(bodyContainer.headers.get("Content-Type"), "text/plain");
     const newMIMEType = "test/test";
     bodyContainer.headers.set("Content-Type", newMIMEType);
     const blob = await bodyContainer.blob();
     assert_equals(blob.type, newMIMEType);
-  });
+  }, `${bodyContainer.constructor.name}: overriding explicit Content-Type`);
+});
+
+[
+  () => new Request("about:blank", { body: new URLSearchParams(), method: "POST" }),
+  () => new Response(new URLSearchParams()),
+].forEach(bodyContainerCreator => {
+  const bodyContainer = bodyContainerCreator();
+  promise_test(async t => {
+    assert_equals(bodyContainer.headers.get("Content-Type"), "application/x-www-form-urlencoded;charset=UTF-8");
+    bodyContainer.headers.delete("Content-Type");
+    const blob = await bodyContainer.blob();
+    assert_equals(blob.type, "");
+  }, `${bodyContainer.constructor.name}: removing implicit Content-Type`);
+});
+
+[
+  () => new Request("about:blank", { body: new ArrayBuffer(), method: "POST" }),
+  () => new Response(new ArrayBuffer()),
+].forEach(bodyContainerCreator => {
+  const bodyContainer = bodyContainerCreator();
+  promise_test(async t => {
+    assert_equals(bodyContainer.headers.get("Content-Type"), null);
+    const newMIMEType = "test/test";
+    bodyContainer.headers.set("Content-Type", newMIMEType);
+    const blob = await bodyContainer.blob();
+    assert_equals(blob.type, newMIMEType);
+  }, `${bodyContainer.constructor.name}: setting missing Content-Type`);
 });

--- a/service-workers/cache-storage/script-tests/cache-match.js
+++ b/service-workers/cache-storage/script-tests/cache-match.js
@@ -381,6 +381,7 @@ cache_test(async (cache) => {
 cache_test(async (cache) => {
     const url = '/dummy';
     const original_type = 'text/html';
+    const override_type = 'text/plain';
     const init_with_headers = {
       headers: {
         'content-type': original_type
@@ -396,19 +397,19 @@ cache_test(async (cache) => {
 
     // Verify overwriting the content-type header changes the mime type.
     const overwritten_response = new Response('hello world', init_with_headers);
-    overwritten_response.headers.set('content-type', 'text/plain');
+    overwritten_response.headers.set('content-type', override_type);
     const overwritten_response_type = (await overwritten_response.blob()).type;
-    assert_equals(overwritten_response_type, 'text/plain',
+    assert_equals(overwritten_response_type, override_type,
                   'mime type can be overridden');
 
     // Verify the Response read from Cache uses the original mime type
     // computed when it was first constructed.
     const tmp = new Response('hello world', init_with_headers);
-    tmp.headers.set('content-type', 'text/plain');
+    tmp.headers.set('content-type', override_type);
     await cache.put(url, tmp);
     const cache_response = await cache.match(url);
     const cache_mime_type = (await cache_response.blob()).type;
-    assert_equals(cache_mime_type, 'text/plain',
+    assert_equals(cache_mime_type, override_type,
                   'overwritten and cached response mime types should match');
   }, 'MIME type should reflect Content-Type headers of response.');
 

--- a/service-workers/cache-storage/script-tests/cache-match.js
+++ b/service-workers/cache-storage/script-tests/cache-match.js
@@ -394,13 +394,12 @@ cache_test(async (cache) => {
     assert_true(original_response_type.includes(original_type),
                 'original response should include the expected mime type');
 
-    // Verify overwriting the content-type header does not change the mime
-    // type.  It should be fixed at Response construction time.
+    // Verify overwriting the content-type header changes the mime type.
     const overwritten_response = new Response('hello world', init_with_headers);
     overwritten_response.headers.set('content-type', 'text/plain');
     const overwritten_response_type = (await overwritten_response.blob()).type;
-    assert_equals(overwritten_response_type, original_response_type,
-                  'original and overwritten response mime types should match');
+    assert_equals(overwritten_response_type, 'text/plain',
+                  'mime type can be overridden');
 
     // Verify the Response read from Cache uses the original mime type
     // computed when it was first constructed.
@@ -409,9 +408,8 @@ cache_test(async (cache) => {
     await cache.put(url, tmp);
     const cache_response = await cache.match(url);
     const cache_mime_type = (await cache_response.blob()).type;
-    assert_equals(cache_mime_type, original_response_type,
-                  'original and cached overwritten response mime types ' +
-                  'should match');
-  }, 'MIME type should be frozen at response construction.');
+    assert_equals(cache_mime_type, 'text/plain',
+                  'overwritten and cached response mime types should match');
+  }, 'MIME type should reflect Content-Type headers of response.');
 
 done();

--- a/wasm/webapi/modified-contenttype.any.js
+++ b/wasm/webapi/modified-contenttype.any.js
@@ -1,0 +1,13 @@
+// META: global=window,worker
+// META: script=/wasm/jsapi/wasm-module-builder.js
+
+["compileStreaming", "instantiateStreaming"].forEach(method => {
+  promise_test(async t => {
+    const buffer = new WasmModuleBuilder().toBuffer();
+    const argument = new Response(buffer, { headers: { "Content-Type": "test/test" } });
+    argument.headers.set("Content-Type", "application/wasm");
+    const wasm = await WebAssembly[method](argument);
+    // Ensure body can only be read once
+    return promise_rejects_js(t, TypeError, argument.blob());
+  }, `${method} with Content-Type set late`);
+});

--- a/wasm/webapi/modified-contenttype.any.js
+++ b/wasm/webapi/modified-contenttype.any.js
@@ -6,8 +6,19 @@
     const buffer = new WasmModuleBuilder().toBuffer();
     const argument = new Response(buffer, { headers: { "Content-Type": "test/test" } });
     argument.headers.set("Content-Type", "application/wasm");
-    const wasm = await WebAssembly[method](argument);
+    // This should resolve successfully
+    await WebAssembly[method](argument);
     // Ensure body can only be read once
     return promise_rejects_js(t, TypeError, argument.blob());
   }, `${method} with Content-Type set late`);
+
+  promise_test(async t => {
+    const buffer = new WasmModuleBuilder().toBuffer();
+    const argument = new Response(buffer, { headers: { "Content-Type": "application/wasm" } });
+    argument.headers.delete("Content-Type");
+    // Ensure Wasm cannot be created
+    await promise_rejects_js(t, TypeError, WebAssembly[method](argument));
+    // This should resolve successfully
+    await argument.arrayBuffer();
+  }, `${method} with Content-Type removed late`);
 });


### PR DESCRIPTION
When you can modify the headers of a Request or Response, it does not make a whole lot of sense to only look at the headers when the object was created for the purposes of the MIME type. We should consider changing this.