### PR TITLE
chore: move url-constructor and url-origin to .js

### DIFF
--- a/url/url-constructor.any.js
+++ b/url/url-constructor.any.js
@@ -1,9 +1,3 @@
-<!doctype html>
-<meta charset=utf-8>
-<script src=/resources/testharness.js></script>
-<script src=/resources/testharnessreport.js></script>
-<div id=log></div>
-<script>
 function bURL(url, base) {
   return new URL(url, base || "about:blank")
 }
@@ -41,4 +35,3 @@ function runURLTests(urltests) {
 }
 
 promise_test(() => fetch("resources/urltestdata.json").then(res => res.json()).then(runURLTests), "Loading data…");
-</script>

--- a/url/url-origin.any.js
+++ b/url/url-origin.any.js
@@ -1,9 +1,3 @@
-<!doctype html>
-<meta charset=utf-8>
-<script src=/resources/testharness.js></script>
-<script src=/resources/testharnessreport.js></script>
-<div id=log></div>
-<script>
 promise_test(() => fetch("resources/urltestdata.json").then(res => res.json()).then(runURLTests), "Loading data…");
 
 function bURL(url, base) {
@@ -21,4 +15,3 @@ function runURLTests(urltests) {
     }, "Origin parsing: <" + expected.input + "> against <" + expected.base + ">")
   }
 }
-</script>


### PR DESCRIPTION
Background: we want to run these tests in Deno, but we can not run .html tests.﻿

I wonder why these were .html in the first place. Maybe the `charset=utf-8` directive? If this is the reason, would it make sense to add a `//META` directive for this instead?

```
//META: charset=utf-8
```