### PR TITLE
doc: improve terminology

### DIFF
--- a/common/security-features/README.md
+++ b/common/security-features/README.md
@@ -278,9 +278,9 @@ The ```excluded_tests``` section have objects with the same format as [Test Expa
 
 Taking the spec JSON, the generator follows this algorithm:
 
-* Expand all ```excluded_tests``` to create a blacklist of selections
+* Expand all ```excluded_tests``` to create a denylist of selections
 
-* For each `specification` entries: Expand the ```test_expansion``` pattern into selections and check each against the blacklist, if not marked as suppresed, generate the test resources for the selection
+* For each `specification` entries: Expand the ```test_expansion``` pattern into selections and check each against the denylist, if not marked as suppresed, generate the test resources for the selection
 
 ###  SourceContext Resolution
 


### PR DESCRIPTION
Related to the effort in the Node.js project to rename
the primary branch to main we are also looking to
remove other references to related terminology.

One instance is through the copy of this file that
we have from wpt as part of the Node.js tests:
https://github.com/nodejs/node/blob/master/test/fixtures/wpt/common/security-features/README.md

Generally we want changes in dependencies landed
upstream first before updating in the Node.js repo
which is why I'm submitting the PR to change it
here first, to be followed by updating wpt in
Node.js core to pull in the change.

Signed-off-by: Michael Dawson <mdawson@devrus.com>