### PR TITLE
HTML: <object usemap> is removed

### DIFF
--- a/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference.html
+++ b/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference.html
@@ -31,7 +31,7 @@ onload = function() {
       [img, object].forEach(function(elm) {
         test(function(t) {
           var expected = div.getAttribute('data-expect');
-          var expected_elm = expected === 'no match' ? elm : div.querySelector('area[href="#' + expected + '"]');
+          var expected_elm = (expected === 'no match' || elm === object) ? elm : div.querySelector('area[href="#' + expected + '"]');
           var got_elm = doc.elementFromPoint(elm.offsetLeft, elm.offsetTop);
           assert_not_equals(expected_elm, null, 'sanity check (data-expect value wrong?)');
           assert_not_equals(got_elm, null, 'sanity check (too many tests to fit in viewport?)');

--- a/html/semantics/embedded-content/the-object-element/usemap-casing.html
+++ b/html/semantics/embedded-content/the-object-element/usemap-casing.html
@@ -61,18 +61,7 @@
 setup({ explicit_done: true });
 
 onload = () => {
-  test(() => {
-    const object = document.querySelector(`object[usemap="#sanityCheck"]`);
-    const objectRect = object.getBoundingClientRect();
-    const x = objectRect.left + objectRect.width / 2;
-    const y = objectRect.top + objectRect.height / 2;
-    const element = document.elementFromPoint(x, y);
-    const area = document.querySelector(`map[name="sanityCheck"] > area`);
-
-    assert_equals(element, area);
-  }, `Object with usemap of #sanityCheck should match the area with map named sanityCheck`);
-
-  const objects = Array.from(document.querySelectorAll(`object:not([usemap="#sanityCheck"])`));
+  const objects = Array.from(document.querySelectorAll(`object`));
 
   for (let object of objects) {
     test(() => {
@@ -85,7 +74,7 @@ onload = () => {
       const messageSuffix = name ? `; used <map> with name "${name}"` : "";
 
       assert_equals(element, object, "The element retrieved must be the object, not an area" + messageSuffix);
-    }, `Object with usemap of ${object.useMap} should not match any of the areas`);
+    }, `Object with usemap of ${object.useMap} should not match any of the areas (it does not support usemap)`);
   }
 
   done();

--- a/html/semantics/forms/the-label-element/clicking-interactive-content.html
+++ b/html/semantics/forms/the-label-element/clicking-interactive-content.html
@@ -16,6 +16,7 @@
   <input>
   <label>label</label>
   <object usemap=""></object>
+  <object></object>
   <select></select>
   <textarea></textarea>
   <video controls></video>


### PR DESCRIPTION
Tests for https://github.com/whatwg/html/pull/6283.

So the curious case here is `html/semantics/forms/the-label-element/clicking-interactive-content.html` where browsers fail for `<object>` but not `<object usemap>`. If I add `<span>` or `<div>` I get the same results (only the last of the three tests fails) so I suspect that all browsers do have some logic to consider `<object usemap>` interactive? Despite Chrome and Safari not supporting `<object usemap>` otherwise.