### PR TITLE
Correctly pass --py2 or --py3 to some Azure Pipeline tasks

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -233,7 +233,11 @@ jobs:
   - template: tools/ci/azure/install_chrome.yml
   - template: tools/ci/azure/install_firefox.yml
   - template: tools/ci/azure/update_hosts.yml
+    parameters:
+      pyflag: --py2
   - template: tools/ci/azure/update_manifest.yml
+    parameters:
+      pyflag: --py2
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
       directory: tools/wpt/
@@ -403,7 +407,11 @@ jobs:
   # - template: tools/ci/azure/install_chrome.yml
   # - template: tools/ci/azure/install_firefox.yml
   - template: tools/ci/azure/update_hosts.yml
+    parameters:
+      pyflag: --py2
   - template: tools/ci/azure/update_manifest.yml
+    parameters:
+      pyflag: --py2
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
       directory: tools/wpt/

--- a/tools/ci/azure/update_hosts.yml
+++ b/tools/ci/azure/update_hosts.yml
@@ -1,3 +1,6 @@
+parameters:
+  pyflag: --py3
+
 steps:
 - script: ./wpt make-hosts-file | sudo tee -a /etc/hosts
   displayName: 'Update hosts (macOS)'
@@ -5,6 +8,6 @@ steps:
 - powershell: |
     $hostFile = "$env:systemroot\System32\drivers\etc\hosts"
     Copy-Item -Path $hostFile -Destination "$hostFile.back" -Force
-    python wpt --py2 make-hosts-file | Out-File $env:systemroot\System32\drivers\etc\hosts -Encoding ascii -Append
+    python wpt ${{ parameters.pyflag }} make-hosts-file | Out-File $env:systemroot\System32\drivers\etc\hosts -Encoding ascii -Append
   displayName: 'Update hosts (Windows)'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/tools/ci/azure/update_manifest.yml
+++ b/tools/ci/azure/update_manifest.yml
@@ -1,4 +1,7 @@
+parameters:
+  pyflag: --py3
+
 steps:
 # `python wpt` instead of `./wpt` is to make this work on Windows:
-- script: python wpt --py2 manifest
+- script: python wpt ${{ parameters.pyflag }} manifest
   displayName: 'Update manifest'


### PR DESCRIPTION
We had incorrectly assumed that all Azure Pipeline VMs had access to
Python 2, but that isn't true (the Edge run VMs only have Py3 nowadays).
As such, update_hosts.yml and update_manifest.yml broke on those VMs.

Instead, make the pyflag a variable for those yml files and set it
appropriately.