### PR TITLE
[css-color-4] Update lab and lch tests to use rectangles

### DIFF
--- a/css/css-color/blacksquare-ref.html
+++ b/css/css-color/blacksquare-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Black square reference</title>
+<style>
+    .test { background-color: #000000; width: 12em; height: 12em; }
+</style>
+<body>
+    <p>Test passes if you see a black square, and no red.</p>
+    <div class="test"></div>
+</body>

--- a/css/css-color/lab-001.html
+++ b/css/css-color/lab-001.html
@@ -3,11 +3,13 @@
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
-<link rel="match" href="greentext-ref.html">
+<link rel="match" href="greensquare-ref.html">
 <meta name="assert" content="lab() with no alpha">
 <style>
-    .test {color: lab(46.277% -47.562 48.583)} /* green (sRGB #008000) converted to Lab */
+    .test { background-color: red; width: 12em; height: 12em; }
+    .test { background-color: lab(46.2775% -47.5621 48.5837); } /* green (sRGB #008000) converted to Lab */
 </style>
 <body>
-    <p class="test">Test passes if this text is green</p>
+    <p>Test passes if you see a green square, and no red.</p>
+    <div class="test"></div>
 </body>

--- a/css/css-color/lab-002.html
+++ b/css/css-color/lab-002.html
@@ -3,12 +3,13 @@
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
-<link rel="match" href="blacktext-ref.html">
+<link rel="match" href="blacksquare-ref.html">
 <meta name="assert" content="lab() with no alpha">
 <style>
-    .test { color: red; }
-    .test { color: lab(0% 0 0)} /* black (sRGB #000000) converted to Lab */
+    .test { background-color: red; width: 12em; height: 12em; }
+    .test { background-color: lab(0% 0 0); } /* black (sRGB #000000) converted to Lab */
 </style>
 <body>
-    <p class="test">Test passes if this text is black</p>
+    <p>Test passes if you see a black square, and no red.</p>
+    <div class="test"></div>
 </body>

--- a/css/css-color/lab-003.html
+++ b/css/css-color/lab-003.html
@@ -3,12 +3,14 @@
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
-<link rel="match" href="whitetext-ref.html">
+<link rel="match" href="whitesquare-ref.html">
 <meta name="assert" content="lab() with no alpha">
 <style>
-    .test { color: red; background-color: #333; padding: 3px;}
-    .test { color: lab(100% 0 0);} /* white (sRGB #FFFFFF) converted to Lab */
+    body { background-color: grey; }
+    .test { background-color: red; width: 12em; height: 12em; }
+    .test { background-color: lab(100% 0 0); } /* white (sRGB #FFFFFF) converted to Lab */
 </style>
 <body>
-    <p class="test">Test passes if this text is white</p>
+    <p>Test passes if you see a white square, and no red.</p>
+    <div class="test"></div>
 </body>

--- a/css/css-color/lab-004-ref.html
+++ b/css/css-color/lab-004-ref.html
@@ -2,10 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <style>
-    .match { color: rgb(75.62% 30.45% 47.56%)} /* lab(50 50 0) converted to sRGB */
+    .test { background-color: rgb(75.6208% 30.4487% 47.5634%); width: 12em; height: 12em; } /* lab(50% 50 0) converted to sRGB */
 </style>
 <body>
-    <p>Test passes if the two lines of filler text are the same color.</p>
-    <p class="match">Filler text. Filler text. Filler text. </p>
-    <p class="match">Filler text. Filler text. Filler text. </p>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="test"></div>
 </body>

--- a/css/css-color/lab-004.html
+++ b/css/css-color/lab-004.html
@@ -6,12 +6,12 @@
 <link rel="match" href="lab-004-ref.html">
 <meta name="assert" content="lab() with no alpha, positive a axis">
 <style>
-    .test { color: red; }
-    .test { color: lab(50% 50 0)}
-    .match { color: rgb(75.62%, 30.45%, 47.56%)} /* lab(50 50 0) converted to sRGB */
+    .test { background-color: red; width: 12em; height: 6em; margin-top: 0; }
+    .ref { background-color: rgb(75.6208% 30.4487% 47.5634%); width: 12em; height: 6em; margin-bottom: 0; }/* lab(50% 50 0) converted to sRGB */
+    .test { background-color: lab(50% 50 0); }
 </style>
 <body>
-    <p>Test passes if the two lines of filler text are the same color.</p>
-    <p class="test">Filler text. Filler text. Filler text. </p>
-    <p class="match">Filler text. Filler text. Filler text. </p>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="ref"></div>
+    <div class="test"></div>
 </body>

--- a/css/css-color/lab-005-ref.html
+++ b/css/css-color/lab-005-ref.html
@@ -2,10 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <style>
-    .match { color: rgb(10.79%, 75.55%, 66.40%)} /* lab(70 -45 0) converted to sRGB */
+    .test { background-color: rgb(10.7906% 75.5567% 66.3982%); width: 12em; height: 12em; } /* lab(70% -45 0) converted to sRGB */
 </style>
 <body>
-    <p>Test passes if the two lines of filler text are the same color.</p>
-    <p class="match">Filler text. Filler text. Filler text. </p>
-    <p class="match">Filler text. Filler text. Filler text. </p>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="test"></div>
 </body>

--- a/css/css-color/lab-005.html
+++ b/css/css-color/lab-005.html
@@ -6,12 +6,12 @@
 <link rel="match" href="lab-005-ref.html">
 <meta name="assert" content="lab() with no alpha, negative a axis">
 <style>
-    .test { color: red; }
-    .test { color: lab(70% -45 0)}
-    .match { color: rgb(10.79%, 75.55%, 66.40%)} /* lab(70 -45 0) converted to sRGB */
+    .test { background-color: red; width: 12em; height: 6em; margin-top: 0; }
+    .ref { background-color: rgb(10.7906% 75.5567% 66.3982%); width: 12em; height: 6em; margin-bottom: 0; } /* lab(70% -45 0) converted to sRGB */
+    .test { background-color: lab(70% -45 0); }
 </style>
 <body>
-    <p>Test passes if the two lines of filler text are the same color.</p>
-    <p class="test">Filler text. Filler text. Filler text. </p>
-    <p class="match">Filler text. Filler text. Filler text. </p>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="ref"></div>
+    <div class="test"></div>
 </body>

--- a/css/css-color/lab-006.html
+++ b/css/css-color/lab-006.html
@@ -6,12 +6,12 @@
 <link rel="match" href="lab-006-ref.html">
 <meta name="assert" content="lab() with no alpha, positive b axis">
 <style>
-    .test { color: red; }
-    .test { color: lab(70% 0 70)}
-    .match { color: rgb(76.62%, 66.36%, 5.58%)} /* lab(70 0 70) converted to sRGB */
+    .test { background-color: red; width: 12em; height: 6em; margin-top: 0; }
+    .ref { background-color: rgb(76.6254% 66.3607% 5.5775%); width: 12em; height: 6em; margin-bottom: 0; } /* lab(70% 0 70) converted to sRGB */
+    .test { background-color: lab(70% 0 70); }
 </style>
 <body>
-    <p>Test passes if the two lines of filler text are the same color.</p>
-    <p class="test">Filler text. Filler text. Filler text. </p>
-    <p class="match">Filler text. Filler text. Filler text. </p>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="ref"></div>
+    <div class="test"></div>
 </body>

--- a/css/css-color/lab-007-ref.html
+++ b/css/css-color/lab-007-ref.html
@@ -2,10 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <style>
-    .match { color: rgb(12.81%, 53.10%, 92.76%)} /* lab(55 0 -60) converted to sRGB */
+    .test { background-color: rgb(12.8128% 53.105% 92.7645%); width: 12em; height: 12em; } /* lab(55% 0 -60) converted to sRGB */
 </style>
 <body>
-    <p>Test passes if the two lines of filler text are the same color.</p>
-    <p class="match">Filler text. Filler text. Filler text. </p>
-    <p class="match">Filler text. Filler text. Filler text. </p>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="test"></div>
 </body>

--- a/css/css-color/lab-007.html
+++ b/css/css-color/lab-007.html
@@ -6,12 +6,12 @@
 <link rel="match" href="lab-007-ref.html">
 <meta name="assert" content="lab() with no alpha, negative b axis">
 <style>
-    .test { color: red; }
-    .test { color: lab(55% 0 -60)}
-    .match { color: rgb(12.81%, 53.10%, 92.76%)} /* lab(55 0 -60) converted to sRGB */
+    .test { background-color: red; width: 12em; height: 6em; margin-top: 0; }
+    .ref { background-color: rgb(12.8128% 53.105% 92.7645%); width: 12em; height: 6em; margin-bottom: 0; } /* lab(55% 0 -60) converted to sRGB */
+    .test { background-color: lab(55% 0 -60); }
 </style>
 <body>
-    <p>Test passes if the two lines of filler text are the same color.</p>
-    <p class="test">Filler text. Filler text. Filler text. </p>
-    <p class="match">Filler text. Filler text. Filler text. </p>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="ref"></div>
+    <div class="test"></div>
 </body>

--- a/css/css-color/lch-001.html
+++ b/css/css-color/lch-001.html
@@ -3,11 +3,13 @@
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
-<link rel="match" href="greentext-ref.html">
+<link rel="match" href="greensquare-ref.html">
 <meta name="assert" content="lch() with no alpha">
 <style>
-    .test {color: lch(46.277% 67.945 134.427)} /* green (sRGB #008000) converted to LCH */
+    .test { background-color: red; width: 12em; height: 12em; }
+    .test { background-color: lch(46.2775% 67.9892 134.3912); } /* green (sRGB #008000) converted to LCH */
 </style>
 <body>
-    <p class="test">Test passes if this text is green</p>
+    <p>Test passes if you see a green square, and no red.</p>
+    <div class="test"></div>
 </body>

--- a/css/css-color/lch-002.html
+++ b/css/css-color/lch-002.html
@@ -3,12 +3,13 @@
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
-<link rel="match" href="blacktext-ref.html">
+<link rel="match" href="blacksquare-ref.html">
 <meta name="assert" content="lch() with no alpha">
 <style>
-    .test { color: red; }
-    .test { color: lch(0% 0 0)} /* black (sRGB #000000) converted to LCH */
+    .test { background-color: red; width: 12em; height: 12em; }
+    .test { background-color: lch(0% 0 0); } /* black (sRGB #000000) converted to LCH */
 </style>
 <body>
-    <p class="test">Test passes if this text is black</p>
+    <p>Test passes if you see a black square, and no red.</p>
+    <div class="test"></div>
 </body>

--- a/css/css-color/lch-003.html
+++ b/css/css-color/lch-003.html
@@ -3,12 +3,14 @@
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
-<link rel="match" href="whitetext-ref.html">
+<link rel="match" href="whitesquare-ref.html">
 <meta name="assert" content="lch() with no alpha">
 <style>
-    .test { color: red; background-color: #333; padding: 3px;}
-    .test { color: lch(100% 0 0);} /* white (sRGB #FFFFFF) converted to LCH */
+    body { background-color: grey; }
+    .test { background-color: red; width: 12em; height: 12em; }
+    .test { background-color: lch(100% 0 0); } /* white (sRGB #FFFFFF) converted to LCH */
 </style>
 <body>
-    <p class="test">Test passes if this text is white</p>
+    <p>Test passes if you see a white square, and no red.</p>
+    <div class="test"></div>
 </body>

--- a/css/css-color/lch-004-ref.html
+++ b/css/css-color/lch-004-ref.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <style>
-    .test { background-color: rgb(76.6254% 66.3607% 5.5775%); width: 12em; height: 12em; } /* lab(70% 0 70) converted to sRGB */
+    .test { background-color: rgb(75.6208% 30.4487% 47.5634%); width: 12em; height: 12em; } /* lch(50% 50 0) converted to sRGB (happens to be the same as lab(50% 50 0)) */
 </style>
 <body>
     <p>Test passes if you see a single square, and not two rectangles of different colors.</p>

--- a/css/css-color/lch-004.html
+++ b/css/css-color/lch-004.html
@@ -3,15 +3,15 @@
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
-<link rel="match" href="lab-004-ref.html">
-<meta name="assert" content="lch() with no alpha, positive a axis">
+<link rel="match" href="lch-004-ref.html">
+<meta name="assert" content="lch() with no alpha, positive a axis (when converted to Lab)">
 <style>
-    .test { color: red; }
-    .test { color: lch(50% 50 0)}
-    .match { color: rgb(75.62%, 30.45%, 47.56%)} /* lch(50 50 0) converted to sRGB (happens to be the same as lab(50 50 0)*/
+    .test { background-color: red; width: 12em; height: 6em; margin-top: 0; }
+    .ref { background-color: rgb(75.6208% 30.4487% 47.5634%); width: 12em; height: 6em; margin-bottom: 0; } /* lch(50% 50 0) converted to sRGB (happens to be the same as lab(50% 50 0)) */
+    .test { background-color: lch(50% 50 0); }
 </style>
 <body>
-    <p>Test passes if the two lines of filler text are the same color.</p>
-    <p class="test">Filler text. Filler text. Filler text. </p>
-    <p class="match">Filler text. Filler text. Filler text. </p>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="ref"></div>
+    <div class="test"></div>
 </body>

--- a/css/css-color/lch-005-ref.html
+++ b/css/css-color/lch-005-ref.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <style>
-    .test { background-color: rgb(76.6254% 66.3607% 5.5775%); width: 12em; height: 12em; } /* lab(70% 0 70) converted to sRGB */
+    .test { background-color: rgb(10.7906% 75.5567% 66.3982%); width: 12em; height: 12em; } /* lch(70% 45 180) converted to sRGB */
 </style>
 <body>
     <p>Test passes if you see a single square, and not two rectangles of different colors.</p>

--- a/css/css-color/lch-005.html
+++ b/css/css-color/lch-005.html
@@ -3,15 +3,15 @@
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
-<link rel="match" href="lab-005-ref.html">
-<meta name="assert" content="lch() with no alpha, negative a axis">
+<link rel="match" href="lch-005-ref.html">
+<meta name="assert" content="lch() with no alpha, negative a axis (when converted to Lab)">
 <style>
-    .test { color: red; }
-    .test { color: lch(70% 45 -180)}
-    .match { color: rgb(10.79%, 75.55%, 66.40%)} /* lch(70 45 180) converted to sRGB */
+    .test { background-color: red; width: 12em; height: 6em; margin-top: 0; }
+    .ref { background-color: rgb(10.7906% 75.5567% 66.3982%); width: 12em; height: 6em; margin-bottom: 0; } /* lch(70% 45 180) converted to sRGB */
+    .test { background-color: lch(70% 45 -180); }
 </style>
 <body>
-    <p>Test passes if the two lines of filler text are the same color.</p>
-    <p class="test">Filler text. Filler text. Filler text. </p>
-    <p class="match">Filler text. Filler text. Filler text. </p>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="ref"></div>
+    <div class="test"></div>
 </body>

--- a/css/css-color/lch-006-ref.html
+++ b/css/css-color/lch-006-ref.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <style>
-    .test { background-color: rgb(76.6254% 66.3607% 5.5775%); width: 12em; height: 12em; } /* lab(70% 0 70) converted to sRGB */
+    .test { background-color: rgb(76.6254% 66.3607% 5.5775%); width: 12em; height: 12em; } /* lch(70% 70 90) converted to sRGB */
 </style>
 <body>
     <p>Test passes if you see a single square, and not two rectangles of different colors.</p>

--- a/css/css-color/lch-006.html
+++ b/css/css-color/lch-006.html
@@ -3,15 +3,15 @@
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
-<link rel="match" href="lab-006-ref.html">
-<meta name="assert" content="lch() with no alpha, positive b axis">
+<link rel="match" href="lch-006-ref.html">
+<meta name="assert" content="lch() with no alpha, positive b axis (when converted to Lab)">
 <style>
-    .test { color: red; }
-    .test { color: lch(70% 70 90)}
-    .match { color: rgb(76.62%, 66.36%, 5.58%)} /* lch(70 70 90) converted to sRGB */
+    .test { background-color: red; width: 12em; height: 6em; margin-top: 0; }
+    .ref { background-color: rgb(76.6254% 66.3607% 5.5775%); width: 12em; height: 6em; margin-bottom: 0; } /* lch(70% 70 90) converted to sRGB */
+    .test { background-color: lch(70% 70 90); }
 </style>
 <body>
-    <p>Test passes if the two lines of filler text are the same color.</p>
-    <p class="test">Filler text. Filler text. Filler text. </p>
-    <p class="match">Filler text. Filler text. Filler text. </p>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="ref"></div>
+    <div class="test"></div>
 </body>

--- a/css/css-color/lch-007-ref.html
+++ b/css/css-color/lch-007-ref.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <style>
-    .test { background-color: rgb(76.6254% 66.3607% 5.5775%); width: 12em; height: 12em; } /* lab(70% 0 70) converted to sRGB */
+    .test { background-color: rgb(12.8128% 53.105% 92.7645%); width: 12em; height: 12em; } /* lch(55% 60 270) converted to sRGB */
 </style>
 <body>
     <p>Test passes if you see a single square, and not two rectangles of different colors.</p>

--- a/css/css-color/lch-007.html
+++ b/css/css-color/lch-007.html
@@ -3,15 +3,15 @@
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
-<link rel="match" href="lab-007-ref.html">
-<meta name="assert" content="lab() with no alpha, negative b axis">
+<link rel="match" href="lch-007-ref.html">
+<meta name="assert" content="lch() with no alpha, negative b axis (when converted to Lab)">
 <style>
-    .test { color: red; }
-    .test { color: lch(56% 58 275)}
-    .match { color: rgb(12.81%, 53.10%, 92.76%)} /* lch(56 58 275) converted to sRGB */
+    .test { background-color: red; width: 12em; height: 6em; margin-top: 0; }
+    .ref { background-color: rgb(12.8128% 53.105% 92.7645%); width: 12em; height: 6em; margin-bottom: 0; } /* lch(55% 60 270) converted to sRGB */
+    .test { background-color: lch(55% 60 270); }
 </style>
 <body>
-    <p>Test passes if the two lines of filler text are the same color.</p>
-    <p class="test">Filler text. Filler text. Filler text. </p>
-    <p class="match">Filler text. Filler text. Filler text. </p>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="ref"></div>
+    <div class="test"></div>
 </body>

--- a/css/css-color/whitesquare-ref.html
+++ b/css/css-color/whitesquare-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>White square reference</title>
+<style>
+    body { background-color: grey; }
+    .test { background-color: #FFFFFF; width: 12em; height: 12em; }
+</style>
+<body>
+    <p>Test passes if you see a white square, and no red.</p>
+    <div class="test"></div>
+</body>


### PR DESCRIPTION
When running the lab and lch test in WebKit, the use of text to try and match colors caused small differences in antialiasing causing the tests to fail. By changing the tests to use rectangles for comparisons, it is much easier to see that they are passing or failing and don't have these antialiasing issues. 