### PR TITLE
Fix usage of `brew cask` on Azure Pipelines

### DIFF
--- a/dom/historical.html
+++ b/dom/historical.html
@@ -4,6 +4,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
 <script>
+// TOUCH
+
 function isInterfaceRemoved(name) {
   test(function() {
     assert_equals(window[name], undefined)

--- a/tools/ci/azure/install_chrome.yml
+++ b/tools/ci/azure/install_chrome.yml
@@ -2,8 +2,9 @@ steps:
 # The conflicting google-chrome and chromedriver casks are first uninstalled.
 # The raw google-chrome-dev cask URL is used to bypass caching.
 - script: |
-    HOMEBREW_NO_AUTO_UPDATE=1 brew cask uninstall google-chrome || true
-    HOMEBREW_NO_AUTO_UPDATE=1 brew cask uninstall chromedriver || true
-    HOMEBREW_NO_AUTO_UPDATE=1 brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/master/Casks/google-chrome-dev.rb
+    HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall --cask google-chrome || true
+    HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall --cask chromedriver || true
+    curl https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/master/Casks/google-chrome-dev.rb > google-chrome-dev.rb
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask google-chrome-dev.rb
   displayName: 'Install Chrome Dev'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))

--- a/tools/ci/azure/install_firefox.yml
+++ b/tools/ci/azure/install_firefox.yml
@@ -1,6 +1,8 @@
 steps:
 # This is equivalent to `Homebrew/homebrew-cask-versions/firefox-nightly`,
 # but the raw URL is used to bypass caching.
-- script: HOMEBREW_NO_AUTO_UPDATE=1 brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/master/Casks/firefox-nightly.rb
+- script: |
+    curl https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/master/Casks/firefox-nightly.rb > firefox-nightly.rb
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask firefox-nightly.rb
   displayName: 'Install Firefox Nightly'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))

--- a/tools/ci/azure/install_safari.yml
+++ b/tools/ci/azure/install_safari.yml
@@ -8,7 +8,7 @@ steps:
   condition: eq(variables['safaridriver_diagnose'], true)
 - ${{ if eq(parameters.channel, 'preview') }}:
   - script: |
-      HOMEBREW_NO_AUTO_UPDATE=1 brew cask install tools/ci/azure/safari-technology-preview.rb
+      HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask tools/ci/azure/safari-technology-preview.rb
       # Workaround for `sudo safardriver --enable` not working on Catalina:
       # https://github.com/web-platform-tests/wpt/issues/21751
       mkdir -p ~/Library/WebDriver/


### PR DESCRIPTION
The `brew cask` command was deprecated and has been removed in favour of
`brew install --cask`. Switch to using the latter.

Fixes https://github.com/web-platform-tests/wpt/issues/27249