### PR TITLE
Fix duplicate IDL in interfaces/custom-state-pseudo-class.idl

### DIFF
--- a/interfaces/custom-state-pseudo-class.idl
+++ b/interfaces/custom-state-pseudo-class.idl
@@ -13,8 +13,3 @@ interface CustomStateSet {
   undefined add(DOMString value);
 };
 
-[Exposed=Window]
-interface CustomStateSet {
-  setlike<DOMString>;
-  undefined add(DOMString value);
-};


### PR DESCRIPTION
Due to a merge error,
https://github.com/web-platform-tests/wpt/pull/27231 accidentally added
a second copy of an interface. Remove that copy.