### PR TITLE
Revert "Remove 'speak-as' from CSS.supports() API WPT"

### DIFF
--- a/css/css-conditional/js/CSS-supports-CSSStyleDeclaration.html
+++ b/css/css-conditional/js/CSS-supports-CSSStyleDeclaration.html
@@ -612,6 +612,7 @@ const properties = [
   "shape-rendering",
   "size",
   "speak",
+  "speak-as",
   "src",
   "stop-color",
   "stop-opacity",


### PR DESCRIPTION
This reverts commit 01bda5c03bf8ae4ee00251b8969adf1ef69f443d. (#26479)

Testing descriptors is a specific goal of this test, given per spec both CSS.supports and CSSStyleDeclaration are based on properties and exclude descriptors. The recent CSS WG resolution in https://github.com/w3c/csswg-drafts/issues/5649#issuecomment-755796005 doesn't change this: `document.body.style` should still not contain any descriptors. That Chrome fails this test is a bug in Chrome, and not a bug in the test.

cc/ @xiaochengh 

