### PR TITLE
Remove document.createEvent("touchevent")

### DIFF
--- a/dom/nodes/Document-createEvent.https.html
+++ b/dom/nodes/Document-createEvent.https.html
@@ -134,6 +134,7 @@ var someNonCreateableEvents = [
   "SpeechSynthesisEvent",
   "SyncEvent",
   "TimeEvent",
+  "TouchEvent",
   "TrackEvent",
   "TransitionEvent",
   "WebGLContextEvent",

--- a/dom/nodes/Document-createEvent.js
+++ b/dom/nodes/Document-createEvent.js
@@ -17,7 +17,6 @@ var aliases = {
   "StorageEvent": "StorageEvent",
   "SVGEvents": "Event",
   "TextEvent": "CompositionEvent",
-  "TouchEvent": "TouchEvent",
   "UIEvent": "UIEvent",
   "UIEvents": "UIEvent",
 };

--- a/touch-events/historical.html
+++ b/touch-events/historical.html
@@ -32,14 +32,14 @@ test(function() {
                "Should not be supported on the instance");
 }, "TouchList::identifiedTouch");
 
-test(function() {
-  assert_false("initTouchEvent" in TouchEvent.prototype,
-               "Should not be supported on the prototype");
+// test(function() {
+//   assert_false("initTouchEvent" in TouchEvent.prototype,
+//                "Should not be supported on the prototype");
 
-  var touchEvent = document.createEvent("touchevent");
-  assert_false("initTouchEvent" in touchEvent,
-               "Should not be supported on the instance");
-}, "TouchEvent::initTouchEvent");
+//   var touchEvent = document.createEvent("touchevent");
+//   assert_false("initTouchEvent" in touchEvent,
+//                "Should not be supported on the instance");
+// }, "TouchEvent::initTouchEvent");
 
 test(function() {
   assert_false("createTouch" in Document.prototype,

--- a/touch-events/historical.html
+++ b/touch-events/historical.html
@@ -33,6 +33,15 @@ test(function() {
 }, "TouchList::identifiedTouch");
 
 test(function() {
+  assert_false("initTouchEvent" in TouchEvent.prototype,
+               "Should not be supported on the prototype");
+
+  var touchEvent = new TouchEvent("touchstart");
+  assert_false("initTouchEvent" in touchEvent,
+               "Should not be supported on the instance");
+}, "TouchEvent::initTouchEvent");
+
+test(function() {
   assert_false("createTouch" in Document.prototype,
                "Should not be supported on the prototype");
 

--- a/touch-events/historical.html
+++ b/touch-events/historical.html
@@ -32,15 +32,6 @@ test(function() {
                "Should not be supported on the instance");
 }, "TouchList::identifiedTouch");
 
-// test(function() {
-//   assert_false("initTouchEvent" in TouchEvent.prototype,
-//                "Should not be supported on the prototype");
-
-//   var touchEvent = document.createEvent("touchevent");
-//   assert_false("initTouchEvent" in touchEvent,
-//                "Should not be supported on the instance");
-// }, "TouchEvent::initTouchEvent");
-
 test(function() {
   assert_false("createTouch" in Document.prototype,
                "Should not be supported on the prototype");


### PR DESCRIPTION
Since in DOM spec, createEvent(interface) is not recommended and suggests "Event constructors ought to be used instead." Also, Chrome, Edge, Firefox and Safari do not support document.createEvent("touchevent"), we should just delete it.
DOM spec: https://dom.spec.whatwg.org/#dom-document-createevent.