### PR TITLE
Remove leftover debugging line from dom/historical.html

### DIFF
--- a/dom/historical.html
+++ b/dom/historical.html
@@ -4,8 +4,6 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
 <script>
-// TOUCH
-
 function isInterfaceRemoved(name) {
   test(function() {
     assert_equals(window[name], undefined)


### PR DESCRIPTION
08541eaf5a5c7691f8146bad50a88e28f7dfa05b touched dom/historical.html as
part of testing the main change, and was intended to be reverted before
submitting... but I forgot to do so.