### PR TITLE
[resources] Fix conftest.py for pytest>6

### DIFF
--- a/resources/test/conftest.py
+++ b/resources/test/conftest.py
@@ -39,7 +39,11 @@ def pytest_collect_file(path, parent):
         return
     test_type = test_type.split(os.path.sep)[1]
 
-    return HTMLItem(str(path), test_type, parent)
+    # Handle the deprecation of Node construction in pytest6
+    # https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent
+    if hasattr(HTMLItem, "from_parent"):
+        return HTMLItem.from_parent(parent, filename=str(path), test_type=test_type)
+    return HTMLItem(parent, str(path), test_type)
 
 
 def pytest_configure(config):
@@ -83,7 +87,7 @@ def resolve_uri(context, uri):
 
 
 class HTMLItem(pytest.Item, pytest.Collector):
-    def __init__(self, filename, test_type, parent):
+    def __init__(self, parent, filename, test_type):
         self.url = parent.session.config.server.url(filename)
         self.type = test_type
         self.variants = []

--- a/resources/test/tox.ini
+++ b/resources/test/tox.ini
@@ -5,9 +5,10 @@ skipsdist=True
 [testenv]
 passenv=DISPLAY # Necessary for the spawned GeckoDriver process to connect to
                 # the appropriate display.
+
 deps =
   html5lib
-  pytest>=2.9,<6 # pinned to <6 due to https://github.com/web-platform-tests/wpt/issues/26132
+  pytest>=2.9
   pyvirtualdisplay
   six
   requests


### PR DESCRIPTION
Handle the shift away from Node constructors to from_parent, whilst
keeping a backwards-compatible path for earlier versions of pytest.

See https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent

Fixes https://github.com/web-platform-tests/wpt/issues/26132