### PR TITLE
Add a debug mode to testharness

### DIFF
--- a/lint.ignore
+++ b/lint.ignore
@@ -107,6 +107,7 @@ CONSOLE: console/*
 CONSOLE: js/builtins/weakrefs/resources/maybe-garbage-collect.js
 CONSOLE: resources/check-layout-th.js
 CONSOLE: resources/chromium/*
+CONSOLE: resources/testharness.js
 CONSOLE: streams/resources/test-utils.js
 CONSOLE: service-workers/service-worker/resources/navigation-redirect-other-origin.html
 CONSOLE: service-workers/service-worker/navigation-redirect.https.html

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -15,7 +15,6 @@ policies and contribution forms [3].
 
 (function (global_scope)
 {
-    var debug = false;
     // default timeout is 10 seconds, test can override if needed
     var settings = {
         output:true,
@@ -24,7 +23,8 @@ policies and contribution forms [3].
             "long":60000
         },
         test_timeout:null,
-        message_events: ["start", "test_state", "result", "completion"]
+        message_events: ["start", "test_state", "result", "completion"],
+        debug: false,
     };
 
     var xhtml_ns = "http://www.w3.org/1999/xhtml";
@@ -132,11 +132,7 @@ policies and contribution forms [3].
                         if (has_selector) {
                             try {
                                 w[selector].apply(undefined, callback_args);
-                            } catch (e) {
-                                if (debug) {
-                                    throw e;
-                                }
-                            }
+                            } catch (e) {}
                         }
                     }
                     if (supports_post_message(w) && w !== self) {
@@ -1190,6 +1186,9 @@ policies and contribution forms [3].
             let status = Test.statuses.TIMEOUT;
             let stack = null;
             try {
+                if (settings.debug) {
+                    console.debug("ASSERT", name, tests.current_test.name, args);
+                }
                 if (settings.output) {
                     tests.set_assert(name, ...args);
                 }
@@ -2064,6 +2063,9 @@ policies and contribution forms [3].
             return;
         }
 
+        if (settings.debug && this.phase !== this.phases.STARTED) {
+            console.log("TEST START", this.name);
+        }
         this.phase = this.phases.STARTED;
         //If we don't get a result before the harness times out that will be a test timeout
         this.set_status(this.TIMEOUT, "Test timed out");
@@ -2080,6 +2082,10 @@ policies and contribution forms [3].
 
         if (arguments.length === 1) {
             this_obj = this;
+        }
+
+        if (settings.debug) {
+            console.debug("TEST STEP", this.name);
         }
 
         try {
@@ -2312,6 +2318,12 @@ policies and contribution forms [3].
 
         if (global_scope.clearTimeout) {
             clearTimeout(this.timeout_id);
+        }
+
+        if (settings.debug) {
+            console.log("TEST DONE",
+                        this.status,
+                        this.name,)
         }
 
         this.cleanup();

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -248,7 +248,7 @@ Consider installing certutil via your OS package manager or directly.""")
                                                     channel=kwargs["browser_channel"])
             kwargs["prefs_root"] = prefs_root
 
-        if kwargs["headless"] is None:
+        if kwargs["headless"] is None and not kwargs["debug_test"]:
             kwargs["headless"] = True
             logger.info("Running in headless mode, pass --no-headless to disable")
 

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -55,7 +55,7 @@ class TestEnvironment(object):
     """Context manager that owns the test environment i.e. the http and
     websockets servers"""
     def __init__(self, test_paths, testharness_timeout_multipler,
-                 pause_after_test, debug_info, options, ssl_config, env_extras,
+                 pause_after_test, debug_test, debug_info, options, ssl_config, env_extras,
                  enable_quic=False, mojojs_path=None):
         self.test_paths = test_paths
         self.server = None
@@ -63,6 +63,7 @@ class TestEnvironment(object):
         self.config = None
         self.testharness_timeout_multipler = testharness_timeout_multipler
         self.pause_after_test = pause_after_test
+        self.debug_test = debug_test
         self.test_server_port = options.pop("test_server_port", True)
         self.debug_info = debug_info
         self.options = options if options is not None else {}
@@ -195,7 +196,8 @@ class TestEnvironment(object):
                 (self.options.get("testharnessreport", "testharnessreport.js"),
                  {"output": self.pause_after_test,
                   "timeout_multiplier": self.testharness_timeout_multipler,
-                  "explicit_timeout": "true" if self.debug_info is not None else "false"},
+                  "explicit_timeout": "true" if self.debug_info is not None else "false",
+                  "debug": "true" if self.debug_test else "false"},
                  "text/javascript;charset=utf8",
                  "/resources/testharnessreport.js")]:
             path = os.path.normpath(os.path.join(here, path))

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -42,7 +42,7 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
     # want to view the results, however, the executor has to skip that cleanup.
     if kwargs["pause_after_test"] or kwargs["pause_on_unexpected"]:
         executor_kwargs["cleanup_after_test"] = False
-
+    executor_kwargs["debug_test"] = kwargs["debug_test"]
     return executor_kwargs
 
 

--- a/tools/wptrunner/wptrunner/testharnessreport-servo.js
+++ b/tools/wptrunner/wptrunner/testharnessreport-servo.js
@@ -1,4 +1,4 @@
-var props = {output:%(output)d};
+var props = {output:%(output)d, debug: %(debug)s};
 var start_loc = document.createElement('a');
 start_loc.href = location.href;
 setup(props);

--- a/tools/wptrunner/wptrunner/testharnessreport-servodriver.js
+++ b/tools/wptrunner/wptrunner/testharnessreport-servodriver.js
@@ -1,4 +1,4 @@
-setup({output:%(output)d});
+setup({output:%(output)d, debug: %(debug)s});
 
 add_completion_callback(function() {
     add_completion_callback(function (tests, status) {

--- a/tools/wptrunner/wptrunner/testharnessreport.js
+++ b/tools/wptrunner/wptrunner/testharnessreport.js
@@ -73,6 +73,7 @@ window.__wptrunner_process_next_event = function() {
   var props = {output: %(output)d,
                timeout_multiplier: %(timeout_multiplier)s,
                explicit_timeout: %(explicit_timeout)s,
+               debug: %(debug)s,
                message_events: ["completion"]};
 
   add_completion_callback(function(tests, harness_status) {

--- a/tools/wptrunner/wptrunner/tests/browsers/test_webkitgtk.py
+++ b/tools/wptrunner/wptrunner/tests/browsers/test_webkitgtk.py
@@ -41,6 +41,7 @@ def test_webkitgtk_certificate_domain_list(product):
     kwargs["webdriver_binary"] = None
     kwargs["pause_after_test"] = False
     kwargs["pause_on_unexpected"] = False
+    kwargs["debug_test"] = False
     with ConfigBuilder(browser_host="example.net",
                        alternate_hosts={"alt": "example.org"},
                        subdomains={"a", "b"},

--- a/tools/wptrunner/wptrunner/tests/test_products.py
+++ b/tools/wptrunner/wptrunner/tests/test_products.py
@@ -42,6 +42,7 @@ def test_server_start_config(product):
         with environment.TestEnvironment(test_paths,
                                          1,
                                          False,
+                                         False,
                                          None,
                                          env_options,
                                          {"type": "none"},

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -170,6 +170,8 @@ scheme host and port.""")
                                  help="Halt the test runner after each test (this happens by default if only a single test is run)")
     debugging_group.add_argument('--no-pause-after-test', dest="pause_after_test", action="store_false",
                                  help="Don't halt the test runner irrespective of the number of tests run")
+    debugging_group.add_argument('--debug-test', dest="debug_test", action="store_true",
+                                 help="Run tests with additional debugging features enabled")
 
     debugging_group.add_argument('--pause-on-unexpected', action="store_true",
                                  help="Halt the test runner when an unexpected result is encountered")

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -141,6 +141,8 @@ def get_pause_after_test(test_loader, **kwargs):
             return False
         if kwargs["headless"]:
             return False
+        if kwargs["debug_test"]:
+            return True
         tests = test_loader.tests
         is_single_testharness = (sum(len(item) for item in itervalues(tests)) == 1 and
                                  len(tests.get("testharness", [])) == 1)

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -224,6 +224,7 @@ def run_tests(config, test_paths, product, **kwargs):
         with env.TestEnvironment(test_paths,
                                  testharness_timeout_multipler,
                                  kwargs["pause_after_test"],
+                                 kwargs["debug_test"],
                                  kwargs["debug_info"],
                                  product.env_options,
                                  ssl_config,


### PR DESCRIPTION
This adds console logging of various things that happen e.g. tests starting and stopping, asserts. It's currently enabled by a settings switch.

It also adds a `--debug-test` option to wptrunner, which enables the debug mode (but is intended to eventually cover various useful debugging features for different test types).