### PR TITLE
Remove references to wasm-constants.js.

### DIFF
--- a/wasm/jsapi/table/constructor-reftypes.tentative.any.js
+++ b/wasm/jsapi/table/constructor-reftypes.tentative.any.js
@@ -1,6 +1,5 @@
 // META: global=window,dedicatedworker,jsshell
 // META: script=assertions.js
-// META: script=/wasm/jsapi/wasm-constants.js
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 // Test cases for changes to the WebAssembly.Table constructor API that

--- a/wasm/jsapi/table/grow-reftypes.tentative.any.js
+++ b/wasm/jsapi/table/grow-reftypes.tentative.any.js
@@ -1,6 +1,5 @@
 // META: global=window,dedicatedworker,jsshell
 // META: script=assertions.js
-// META: script=/wasm/jsapi/wasm-constants.js
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 // Test cases for changes to the WebAssembly.Table.prototype.grow() API that

--- a/wasm/jsapi/table/set-reftypes.tentative.any.js
+++ b/wasm/jsapi/table/set-reftypes.tentative.any.js
@@ -1,6 +1,5 @@
 // META: global=window,dedicatedworker,jsshell
 // META: script=assertions.js
-// META: script=/wasm/jsapi/wasm-constants.js
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 // Test cases for changes to the WebAssembly.Table.prototype.set() API that


### PR DESCRIPTION
This was removed in #16326.