### PR TITLE
fix: make testharness.js strict mode compatible

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1193,7 +1193,7 @@ policies and contribution forms [3].
                 if (settings.output) {
                     tests.set_assert(name, ...args);
                 }
-                rv = f(...args);
+                const rv = f(...args);
                 status = Test.statuses.PASS;
                 return rv;
             } catch(e) {
@@ -3750,7 +3750,7 @@ policies and contribution forms [3].
 
     AssertionError.prototype = Object.create(Error.prototype);
 
-    get_stack = function() {
+    const get_stack = function() {
         var stack = new Error().stack;
         // IE11 does not initialize 'Error.stack' until the object is thrown.
         if (!stack) {


### PR DESCRIPTION
PR #27224 broke strict mode compatibility in testharness.js. This restores that.
