### PR TITLE
Don't preload firefox in some cases

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -101,7 +101,7 @@ def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
             "config": config,
             "browser_channel": kwargs["browser_channel"],
             "headless": kwargs["headless"],
-            "preload_browser": kwargs["preload_browser"],
+            "preload_browser": kwargs["preload_browser"] and not kwargs["pause_after_test"] and not kwargs["num_test_groups"] == 1,
             "specialpowers_path": kwargs["specialpowers_path"]}
 
 

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -287,6 +287,7 @@ def run_tests(config, test_paths, product, **kwargs):
                                                                 test_type,
                                                                 run_info,
                                                                 config=test_environment.config,
+                                                                num_test_groups=len(test_groups),
                                                                 **kwargs)
 
                     executor_cls = product.executor_classes.get(test_type)


### PR DESCRIPTION
When we have a single test group it doesn't make sense. When we are using
--pause-after-test it implies we're in an interactive session so isn't
likely to be helpful.