### PR TITLE
[testharness.js] Disable assert tracking on workers

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -2780,7 +2780,15 @@ policies and contribution forms [3].
 
         this.current_test = null;
         this.asserts_run = [];
-        this.output = settings.output;
+
+        // Track whether output is enabled, and thus whether or not we should
+        // track asserts.
+        //
+        // On workers we don't get properties set from testharnessreport.js, so
+        // we don't know whether or not to track asserts. To avoid the
+        // resulting performance hit, we assume we are not meant to. This means
+        // that assert tracking does not function on workers.
+        this.output = settings.output && 'document' in global_scope;
 
         this.status = new TestsStatus();
 


### PR DESCRIPTION
We are continuing to see a performance regression from assert tracking
in Chromium. After investigation, it appears that the root problem is
that there is no way currently for a testharness.js script loaded in a
worker to know that it shouldn't be tracking asserts (since
testharnessreport.js isn't loaded).

To fix the performance hit, this commit disables assert tracking
entirely in workers. This is a behavior regression for the feature, but
is necessary to avoid an unacceptable performance regression.

Associated Chromium bug: https://crbug.com/1170588