### PR TITLE
[testharness.js] Fixup assert-tracking UI for worker tests

### DIFF
--- a/resources/test/tests/functional/setup-worker-service.html
+++ b/resources/test/tests/functional/setup-worker-service.html
@@ -80,24 +80,6 @@ promise_test(function() {
         "\"navigator.serviceWorker exists\""
       ],
       "status": 0
-    },
-    {
-      "assert_name": "assert_true",
-      "test": null,
-      "args": [
-        "true",
-        "\"True is true\""
-      ],
-      "status": 0
-    },
-    {
-      "assert_name": "assert_false",
-      "test": "Worker test",
-      "args": [
-        "false",
-        "\"False is false\""
-      ],
-      "status": 0
     }
   ],
   "type": "complete"

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -3570,9 +3570,11 @@ policies and contribution forms [3].
                 escape_html(test.message ? tests[i].message : " ") +
                 (tests[i].stack ? "<pre>" +
                  escape_html(tests[i].stack) +
-                 "</pre>": "") +
-                 "<details><summary>Asserts run</summary>" + get_asserts_output(test) + "</details>"
-                "</td></tr>";
+                 "</pre>": "");
+            if (!(test instanceof RemoteTest)) {
+                 html += "<details><summary>Asserts run</summary>" + get_asserts_output(test) + "</details>"
+            }
+            html += "</td></tr>";
         }
         html += "</tbody></table>";
         try {


### PR DESCRIPTION
Followup to #27351, where we disabled assert-tracking for worker tests
due to performance issues.

The previous change left the UI in a confusing state; we would report
'no asserts run' for tests from workers which isn't true (we just don't record
them). This PR changes that to have worker tests use the old behavior (no
assert-tracking reported at all) whilst non-worker tests will still report asserts.