### PR TITLE
Update Safari Technology Preview to 119

### DIFF
--- a/tools/ci/azure/safari-technology-preview.rb
+++ b/tools/ci/azure/safari-technology-preview.rb
@@ -1,10 +1,10 @@
 cask "safari-technology-preview" do
   if MacOS.version <= :catalina
-    version "118,001-92142-20210105-a1c7713a-1f38-411e-85e3-c650a62d5c06"
-    sha256 "8ffd7f83166106992cfc65a9760efe61578b55e1d8a1c960d56867f2048bd953"
+    version "119,001-97793-20210126-7aa49ced-c2f2-415d-a564-6fab25fcb8e6"
+    sha256 "f5ca6acc23d65e23aaf0df5ff35fb3e28c9ae7a40e46331122d29a3e788ca2c1"
   else
-    version "118,001-92171-20210105-8d3c22a7-e518-4758-8df4-fe87c4fa078a"
-    sha256 "98c60037f4dace62ca78d5bc3ab6974c9ca078f60fe2a82062bbc8e3cbcfc55a"
+    version "119,001-98875-20210126-7699f76e-e3a5-4f45-80f9-8975c236d337"
+    sha256 "048e5ac1e761df757075134fa3d1f80ae7da56d5eef2511970aeac34f5ed0027"
   end
 
   url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"


### PR DESCRIPTION
Version as reported by safaridriver --version:
Included with Safari Technology Preview (Release 119, 15611.1.10.1)

Source: https://developer.apple.com/safari/download/
Build: https://dev.azure.com/foolip/safari-technology-preview-updater/_build/results?buildId=2659&view=logs