### PR TITLE
[fetch] Replace metadata tests for CORS preflight

### DIFF
--- a/fetch/metadata/generated/cors-preflight.https.sub.html
+++ b/fetch/metadata/generated/cors-preflight.https.sub.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<!--
+This test was procedurally generated. Please do not modify it directly.
+Sources:
+- fetch/metadata/tools/fetch-metadata.conf.yml
+- fetch/metadata/tools/templates/cors-preflight.sub.html
+-->
+<html lang="en">
+  <meta charset="utf-8">
+  <title>HTTP headers on CORS preflight request</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/fetch/metadata/resources/helper.sub.js"></script>
+  <body>
+  <script>
+  'use strict';
+
+  promise_test(() => {
+    const key = '{{uuid()}}';
+    const url = makeRequestURL(key, ['httpsCrossSite'], { requireOPTIONS: true });
+
+    // `DELETE` is not a CORS-safelisted method, so it is expected to induce a
+    // CORS preflight request.
+    // https://fetch.spec.whatwg.org/#ref-for-cors-safelisted-method%E2%91%A0
+    return fetch(url, { method: 'DELETE' })
+      // This request is expected to fail
+      .catch(() => {})
+      .then(() => retrieve(key))
+      .then((headers) => {
+          assert_own_property(headers, 'sec-fetch-site');
+          assert_equals(headers['sec-fetch-site'], 'cross-site');
+        });
+  }, 'sec-fetch-site - Cross-site');
+
+  promise_test(() => {
+    const key = '{{uuid()}}';
+    const url = makeRequestURL(key, ['httpsSameSite'], { requireOPTIONS: true });
+
+    // `DELETE` is not a CORS-safelisted method, so it is expected to induce a
+    // CORS preflight request.
+    // https://fetch.spec.whatwg.org/#ref-for-cors-safelisted-method%E2%91%A0
+    return fetch(url, { method: 'DELETE' })
+      // This request is expected to fail
+      .catch(() => {})
+      .then(() => retrieve(key))
+      .then((headers) => {
+          assert_own_property(headers, 'sec-fetch-site');
+          assert_equals(headers['sec-fetch-site'], 'same-site');
+        });
+  }, 'sec-fetch-site - Same site');
+
+  promise_test(() => {
+    const key = '{{uuid()}}';
+    const url = makeRequestURL(key, ['httpsCrossSite'], { requireOPTIONS: true });
+
+    // `DELETE` is not a CORS-safelisted method, so it is expected to induce a
+    // CORS preflight request.
+    // https://fetch.spec.whatwg.org/#ref-for-cors-safelisted-method%E2%91%A0
+    return fetch(url, { method: 'DELETE' })
+      // This request is expected to fail
+      .catch(() => {})
+      .then(() => retrieve(key))
+      .then((headers) => {
+          assert_own_property(headers, 'sec-fetch-mode');
+          assert_equals(headers['sec-fetch-mode'], 'cors');
+        });
+  }, 'sec-fetch-mode');
+
+  promise_test(() => {
+    const key = '{{uuid()}}';
+    const url = makeRequestURL(key, ['httpsCrossSite'], { requireOPTIONS: true });
+
+    // `DELETE` is not a CORS-safelisted method, so it is expected to induce a
+    // CORS preflight request.
+    // https://fetch.spec.whatwg.org/#ref-for-cors-safelisted-method%E2%91%A0
+    return fetch(url, { method: 'DELETE' })
+      // This request is expected to fail
+      .catch(() => {})
+      .then(() => retrieve(key))
+      .then((headers) => {
+          assert_own_property(headers, 'sec-fetch-dest');
+          assert_equals(headers['sec-fetch-dest'], 'empty');
+        });
+  }, 'sec-fetch-dest');
+
+  promise_test(() => {
+    const key = '{{uuid()}}';
+    const url = makeRequestURL(key, ['httpsCrossSite'], { requireOPTIONS: true });
+
+    // `DELETE` is not a CORS-safelisted method, so it is expected to induce a
+    // CORS preflight request.
+    // https://fetch.spec.whatwg.org/#ref-for-cors-safelisted-method%E2%91%A0
+    return fetch(url, { method: 'DELETE' })
+      // This request is expected to fail
+      .catch(() => {})
+      .then(() => retrieve(key))
+      .then((headers) => {
+          assert_not_own_property(headers, 'sec-fetch-user');
+        });
+  }, 'sec-fetch-user');
+  </script>
+  </body>
+</html>

--- a/fetch/metadata/tools/templates/cors-preflight.sub.html
+++ b/fetch/metadata/tools/templates/cors-preflight.sub.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<!--
+[%provenance%]
+-->
+<html lang="en">
+  <meta charset="utf-8">
+  <title>HTTP headers on CORS preflight request</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/fetch/metadata/resources/helper.sub.js"></script>
+  <body>
+  <script>
+  'use strict';
+
+  {#- This feature can only be observed for cross-domain requests, so subtests
+      which target the current origin are ignored. #}
+  {%- for subtest in subtests %}
+  {%- set origin = subtest.origins[0]|default('httpsCrossSite') %}
+  {%- if origin != 'httpsOrigin' %}
+
+  promise_test(() => {
+    const key = '{{uuid()}}';
+    const url = makeRequestURL(key, ['[% origin %]'], { requireOPTIONS: true });
+
+    // `DELETE` is not a CORS-safelisted method, so it is expected to induce a
+    // CORS preflight request.
+    // https://fetch.spec.whatwg.org/#ref-for-cors-safelisted-method%E2%91%A0
+    return fetch(url, { method: 'DELETE' })
+      // This request is expected to fail
+      .catch(() => {})
+      .then(() => retrieve(key))
+      .then((headers) => {
+        {%- if subtest.expected == none %}
+          assert_not_own_property(headers, '[%subtest.headerName%]');
+        {%- else %}
+          assert_own_property(headers, '[%subtest.headerName%]');
+          assert_equals(headers['[%subtest.headerName%]'], '[%subtest.expected%]');
+        {%- endif %}
+        });
+  }, '[%subtest.headerName%][%subtest.description | pad("start", " - ")%]');
+  {%- endif %}
+  {%- endfor %}
+  </script>
+  </body>
+</html>


### PR DESCRIPTION
Split out from https://github.com/web-platform-tests/wpt/pull/25247 (and will need to be rebased on master after 25247 is landed).

This test appears to be broken. It looks like it's intended to replace `fetch/metadata/fetch-preflight.https.sub.any.html` but it's not covering the serviceworker, sharedworker, or worker tests, and it's failing all subtests. `record-headers.py` doesn't return the same headers in the preflight as `echo-as-json.py` does, which may be the issue. In particular:
```
  # This condition avoids false positives from CORS preflight checks, where the
  # request under test may be followed immediately by a request to the same URL
  # using a different HTTP method.
  if b'requireOPTIONS' in request.GET and request.method != b'OPTIONS':
      return
```
vs `echo-as-json.py`:
```
    # If we're in a preflight, verify that `Sec-Fetch-Mode` is `cors`.
    if request.method == u'OPTIONS':
        if request.headers.get(b"sec-fetch-mode") != b"cors":
            return (403, b"Failed"), [], body

        headers.append((b"Access-Control-Allow-Methods", b"*"))
        headers.append((b"Access-Control-Allow-Headers", b"*"))
```

cc @jugglinmike 