### PR TITLE
Integrate Android logcat to wptrunner

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/android_weblayer.py
+++ b/tools/wptrunner/wptrunner/browsers/android_weblayer.py
@@ -1,9 +1,7 @@
-import subprocess
-
-from .base import Browser, ExecutorBrowser, require_arg
+from .base import require_arg
 from .base import get_timeout_multiplier   # noqa: F401
 from .chrome import executor_kwargs as chrome_executor_kwargs
-from .chrome_android import AndroidBrowser
+from .chrome_android import ChromeAndroidBrowserBase
 from ..webdriver_server import ChromeDriverServer
 from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
                                            WebDriverRefTestExecutor)  # noqa: F401
@@ -75,7 +73,7 @@ def env_options():
     return {"server_host": "127.0.0.1"}
 
 
-class WeblayerShell(AndroidBrowser):
+class WeblayerShell(ChromeAndroidBrowserBase):
     """Chrome is backed by chromedriver, which is supplied through
     ``wptrunner.webdriver.ChromeDriverServer``.
     """
@@ -90,12 +88,5 @@ class WeblayerShell(AndroidBrowser):
         super(WeblayerShell, self).__init__(logger,
                 webdriver_binary, remote_queue, device_serial, webdriver_args)
         self.binary = binary
+        self.wptserver_ports = _wptserve_ports
 
-    def setup_adb_reverse(self):
-        self._adb_run(['wait-for-device'])
-        self._adb_run(['forward', '--remove-all'])
-        self._adb_run(['reverse', '--remove-all'])
-        # "adb reverse" basically forwards network connection from device to
-        # host.
-        for port in _wptserve_ports:
-            self._adb_run(['reverse', 'tcp:%d' % port, 'tcp:%d' % port])

--- a/tools/wptrunner/wptrunner/browsers/android_weblayer.py
+++ b/tools/wptrunner/wptrunner/browsers/android_weblayer.py
@@ -88,4 +88,3 @@ class WeblayerShell(ChromeAndroidBrowserBase):
                 webdriver_binary, remote_queue, device_serial, webdriver_args)
         self.binary = binary
         self.wptserver_ports = _wptserve_ports
-

--- a/tools/wptrunner/wptrunner/browsers/android_weblayer.py
+++ b/tools/wptrunner/wptrunner/browsers/android_weblayer.py
@@ -2,7 +2,6 @@ from .base import require_arg
 from .base import get_timeout_multiplier   # noqa: F401
 from .chrome import executor_kwargs as chrome_executor_kwargs
 from .chrome_android import ChromeAndroidBrowserBase
-from ..webdriver_server import ChromeDriverServer
 from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
                                            WebDriverRefTestExecutor)  # noqa: F401
 from ..executors.executorchrome import ChromeDriverWdspecExecutor  # noqa: F401

--- a/tools/wptrunner/wptrunner/browsers/android_weblayer.py
+++ b/tools/wptrunner/wptrunner/browsers/android_weblayer.py
@@ -3,6 +3,7 @@ import subprocess
 from .base import Browser, ExecutorBrowser, require_arg
 from .base import get_timeout_multiplier   # noqa: F401
 from .chrome import executor_kwargs as chrome_executor_kwargs
+from .chrome_android import AndroidBrowser
 from ..webdriver_server import ChromeDriverServer
 from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
                                            WebDriverRefTestExecutor)  # noqa: F401
@@ -74,32 +75,21 @@ def env_options():
     return {"server_host": "127.0.0.1"}
 
 
-#TODO: refactor common elements of WeblayerShell and ChromeAndroidBrowser
-class WeblayerShell(Browser):
+class WeblayerShell(AndroidBrowser):
     """Chrome is backed by chromedriver, which is supplied through
     ``wptrunner.webdriver.ChromeDriverServer``.
     """
 
-    def __init__(self, logger, binary, webdriver_binary="chromedriver",
+    def __init__(self, logger, binary,
+                 webdriver_binary="chromedriver",
+                 remote_queue=None,
                  device_serial=None,
                  webdriver_args=None):
         """Creates a new representation of Chrome.  The `binary` argument gives
         the browser binary to use for testing."""
-        Browser.__init__(self, logger)
+        super(WeblayerShell, self).__init__(logger,
+                webdriver_binary, remote_queue, device_serial, webdriver_args)
         self.binary = binary
-        self.device_serial = device_serial
-        self.server = ChromeDriverServer(self.logger,
-                                         binary=webdriver_binary,
-                                         args=webdriver_args)
-        self.setup_adb_reverse()
-
-    def _adb_run(self, args):
-        cmd = ['adb']
-        if self.device_serial:
-            cmd.extend(['-s', self.device_serial])
-        cmd.extend(args)
-        self.logger.info(' '.join(cmd))
-        subprocess.check_call(cmd)
 
     def setup_adb_reverse(self):
         self._adb_run(['wait-for-device'])
@@ -109,26 +99,3 @@ class WeblayerShell(Browser):
         # host.
         for port in _wptserve_ports:
             self._adb_run(['reverse', 'tcp:%d' % port, 'tcp:%d' % port])
-
-    def start(self, **kwargs):
-        self.server.start(block=False)
-
-    def stop(self, force=False):
-        self.server.stop(force=force)
-
-    def pid(self):
-        return self.server.pid
-
-    def is_alive(self):
-        # TODO(ato): This only indicates the driver is alive,
-        # and doesn't say anything about whether a browser session
-        # is active.
-        return self.server.is_alive()
-
-    def cleanup(self):
-        self.stop()
-        self._adb_run(['forward', '--remove-all'])
-        self._adb_run(['reverse', '--remove-all'])
-
-    def executor_browser(self):
-        return ExecutorBrowser, {"webdriver_url": self.server.url}

--- a/tools/wptrunner/wptrunner/browsers/android_webview.py
+++ b/tools/wptrunner/wptrunner/browsers/android_webview.py
@@ -2,7 +2,6 @@ from .base import require_arg
 from .base import get_timeout_multiplier   # noqa: F401
 from .chrome import executor_kwargs as chrome_executor_kwargs
 from .chrome_android import ChromeAndroidBrowserBase
-from ..webdriver_server import ChromeDriverServer
 from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
                                            WebDriverRefTestExecutor)  # noqa: F401
 from ..executors.executorchrome import ChromeDriverWdspecExecutor  # noqa: F401

--- a/tools/wptrunner/wptrunner/browsers/android_webview.py
+++ b/tools/wptrunner/wptrunner/browsers/android_webview.py
@@ -3,6 +3,7 @@ import subprocess
 from .base import Browser, ExecutorBrowser, require_arg
 from .base import get_timeout_multiplier   # noqa: F401
 from .chrome import executor_kwargs as chrome_executor_kwargs
+from .chrome_android import AndroidBrowser
 from ..webdriver_server import ChromeDriverServer
 from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
                                            WebDriverRefTestExecutor)  # noqa: F401
@@ -73,32 +74,20 @@ def env_options():
     return {"server_host": "127.0.0.1"}
 
 
-#TODO: refactor common elements of SystemWebViewShell and ChromeAndroidBrowser
 class SystemWebViewShell(Browser):
     """Chrome is backed by chromedriver, which is supplied through
     ``wptrunner.webdriver.ChromeDriverServer``.
     """
 
     def __init__(self, logger, binary, webdriver_binary="chromedriver",
+                 remote_queue=None,
                  device_serial=None,
                  webdriver_args=None):
         """Creates a new representation of Chrome.  The `binary` argument gives
         the browser binary to use for testing."""
-        Browser.__init__(self, logger)
+        super(SystemWebViewShell, self).__init__(logger,
+                webdriver_binary, remote_queue, device_serial, webdriver_args)
         self.binary = binary
-        self.device_serial = device_serial
-        self.server = ChromeDriverServer(self.logger,
-                                         binary=webdriver_binary,
-                                         args=webdriver_args)
-        self.setup_adb_reverse()
-
-    def _adb_run(self, args):
-        cmd = ['adb']
-        if self.device_serial:
-            cmd.extend(['-s', self.device_serial])
-        cmd.extend(args)
-        self.logger.info(' '.join(cmd))
-        subprocess.check_call(cmd)
 
     def setup_adb_reverse(self):
         self._adb_run(['wait-for-device'])
@@ -108,26 +97,3 @@ class SystemWebViewShell(Browser):
         # host.
         for port in _wptserve_ports:
             self._adb_run(['reverse', 'tcp:%d' % port, 'tcp:%d' % port])
-
-    def start(self, **kwargs):
-        self.server.start(block=False)
-
-    def stop(self, force=False):
-        self.server.stop(force=force)
-
-    def pid(self):
-        return self.server.pid
-
-    def is_alive(self):
-        # TODO(ato): This only indicates the driver is alive,
-        # and doesn't say anything about whether a browser session
-        # is active.
-        return self.server.is_alive()
-
-    def cleanup(self):
-        self.stop()
-        self._adb_run(['forward', '--remove-all'])
-        self._adb_run(['reverse', '--remove-all'])
-
-    def executor_browser(self):
-        return ExecutorBrowser, {"webdriver_url": self.server.url}

--- a/tools/wptrunner/wptrunner/browsers/android_webview.py
+++ b/tools/wptrunner/wptrunner/browsers/android_webview.py
@@ -1,9 +1,7 @@
-import subprocess
-
-from .base import Browser, ExecutorBrowser, require_arg
+from .base import require_arg
 from .base import get_timeout_multiplier   # noqa: F401
 from .chrome import executor_kwargs as chrome_executor_kwargs
-from .chrome_android import AndroidBrowser
+from .chrome_android import ChromeAndroidBrowserBase
 from ..webdriver_server import ChromeDriverServer
 from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
                                            WebDriverRefTestExecutor)  # noqa: F401
@@ -74,7 +72,7 @@ def env_options():
     return {"server_host": "127.0.0.1"}
 
 
-class SystemWebViewShell(Browser):
+class SystemWebViewShell(ChromeAndroidBrowserBase):
     """Chrome is backed by chromedriver, which is supplied through
     ``wptrunner.webdriver.ChromeDriverServer``.
     """
@@ -88,12 +86,5 @@ class SystemWebViewShell(Browser):
         super(SystemWebViewShell, self).__init__(logger,
                 webdriver_binary, remote_queue, device_serial, webdriver_args)
         self.binary = binary
+        self.wptserver_ports = _wptserve_ports
 
-    def setup_adb_reverse(self):
-        self._adb_run(['wait-for-device'])
-        self._adb_run(['forward', '--remove-all'])
-        self._adb_run(['reverse', '--remove-all'])
-        # "adb reverse" basically forwards network connection from device to
-        # host.
-        for port in _wptserve_ports:
-            self._adb_run(['reverse', 'tcp:%d' % port, 'tcp:%d' % port])

--- a/tools/wptrunner/wptrunner/browsers/android_webview.py
+++ b/tools/wptrunner/wptrunner/browsers/android_webview.py
@@ -86,4 +86,3 @@ class SystemWebViewShell(ChromeAndroidBrowserBase):
                 webdriver_binary, remote_queue, device_serial, webdriver_args)
         self.binary = binary
         self.wptserver_ports = _wptserve_ports
-

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -113,7 +113,7 @@ class ChromeBrowser(Browser):
     """
 
     def __init__(self, logger, binary, webdriver_binary="chromedriver",
-                 webdriver_args=None):
+                 webdriver_args=None, **kwargs):
         """Creates a new representation of Chrome.  The `binary` argument gives
         the browser binary to use for testing."""
         Browser.__init__(self, logger)

--- a/tools/wptrunner/wptrunner/browsers/chrome_android.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_android.py
@@ -203,4 +203,3 @@ class ChromeAndroidBrowser(ChromeAndroidBrowserBase):
                 webdriver_binary, remote_queue, device_serial, webdriver_args)
         self.package_name = package_name
         self.wptserver_ports = _wptserve_ports
-

--- a/tools/wptrunner/wptrunner/browsers/chrome_ios.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_ios.py
@@ -51,7 +51,7 @@ class ChromeiOSBrowser(Browser):
 
     init_timeout = 120
 
-    def __init__(self, logger, webdriver_binary, webdriver_args=None):
+    def __init__(self, logger, webdriver_binary, webdriver_args=None, **kwargs):
         """Creates a new representation of Chrome."""
         Browser.__init__(self, logger)
         self.server = CWTChromeDriverServer(self.logger,

--- a/tools/wptrunner/wptrunner/browsers/edge.py
+++ b/tools/wptrunner/wptrunner/browsers/edge.py
@@ -68,7 +68,8 @@ class EdgeBrowser(Browser):
     used_ports = set()
     init_timeout = 60
 
-    def __init__(self, logger, webdriver_binary, timeout_multiplier=None, webdriver_args=None):
+    def __init__(self, logger, webdriver_binary,
+            timeout_multiplier=None, webdriver_args=None, **kwargs):
         Browser.__init__(self, logger)
         self.server = EdgeDriverServer(self.logger,
                                        binary=webdriver_binary,

--- a/tools/wptrunner/wptrunner/browsers/edgechromium.py
+++ b/tools/wptrunner/wptrunner/browsers/edgechromium.py
@@ -85,7 +85,7 @@ class EdgeChromiumBrowser(Browser):
     """
 
     def __init__(self, logger, binary, webdriver_binary="msedgedriver",
-                 webdriver_args=None):
+                 webdriver_args=None, **kwargs):
         """Creates a new representation of MicrosoftEdge.  The `binary` argument gives
         the browser binary to use for testing."""
         Browser.__init__(self, logger)

--- a/tools/wptrunner/wptrunner/browsers/epiphany.py
+++ b/tools/wptrunner/wptrunner/browsers/epiphany.py
@@ -72,6 +72,6 @@ def run_info_extras(**kwargs):
 
 class EpiphanyBrowser(WebKitBrowser):
     def __init__(self, logger, binary=None, webdriver_binary=None,
-                 webdriver_args=None):
+                 webdriver_args=None, **kwargs):
         WebKitBrowser.__init__(self, logger, binary, webdriver_binary,
                                webdriver_args)

--- a/tools/wptrunner/wptrunner/browsers/ie.py
+++ b/tools/wptrunner/wptrunner/browsers/ie.py
@@ -43,7 +43,7 @@ def env_options():
 class InternetExplorerBrowser(Browser):
     used_ports = set()
 
-    def __init__(self, logger, webdriver_binary, webdriver_args=None):
+    def __init__(self, logger, webdriver_binary, webdriver_args=None, **kwargs):
         Browser.__init__(self, logger)
         self.server = InternetExplorerDriverServer(self.logger,
                                                    binary=webdriver_binary,

--- a/tools/wptrunner/wptrunner/browsers/opera.py
+++ b/tools/wptrunner/wptrunner/browsers/opera.py
@@ -71,7 +71,7 @@ class OperaBrowser(Browser):
     """
 
     def __init__(self, logger, binary, webdriver_binary="operadriver",
-                 webdriver_args=None):
+                 webdriver_args=None, **kwargs):
         """Creates a new representation of Opera.  The `binary` argument gives
         the browser binary to use for testing."""
         Browser.__init__(self, logger)

--- a/tools/wptrunner/wptrunner/browsers/safari.py
+++ b/tools/wptrunner/wptrunner/browsers/safari.py
@@ -58,7 +58,7 @@ class SafariBrowser(Browser):
     ``wptrunner.webdriver.SafariDriverServer``.
     """
 
-    def __init__(self, logger, webdriver_binary, webdriver_args=None):
+    def __init__(self, logger, webdriver_binary, webdriver_args=None, **kwargs):
         """Creates a new representation of Safari.  The `webdriver_binary`
         argument gives the WebDriver binary to use for testing. (The browser
         binary location cannot be specified, as Safari and SafariDriver are

--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -228,7 +228,7 @@ class SauceException(Exception):
 class SauceBrowser(Browser):
     init_timeout = 300
 
-    def __init__(self, logger, sauce_config):
+    def __init__(self, logger, sauce_config, **kwargs):
         Browser.__init__(self, logger)
         self.sauce_config = sauce_config
 

--- a/tools/wptrunner/wptrunner/browsers/servo.py
+++ b/tools/wptrunner/wptrunner/browsers/servo.py
@@ -71,7 +71,7 @@ def update_properties():
 
 class ServoBrowser(NullBrowser):
     def __init__(self, logger, binary, debug_info=None, binary_args=None,
-                 user_stylesheets=None, ca_certificate_path=None):
+                 user_stylesheets=None, ca_certificate_path=None, **kwargs):
         NullBrowser.__init__(self, logger)
         self.binary = binary
         self.debug_info = debug_info

--- a/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -77,7 +77,8 @@ class ServoWebDriverBrowser(Browser):
     init_timeout = 300  # Large timeout for cases where we're booting an Android emulator
 
     def __init__(self, logger, binary, debug_info=None, webdriver_host="127.0.0.1",
-                 server_config=None, binary_args=None, user_stylesheets=None, headless=None):
+                 server_config=None, binary_args=None,
+                 user_stylesheets=None, headless=None, **kwargs):
         Browser.__init__(self, logger)
         self.binary = binary
         self.binary_args = binary_args or []

--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -82,7 +82,7 @@ class WebKitBrowser(Browser):
     """
 
     def __init__(self, logger, binary, webdriver_binary=None,
-                 webdriver_args=None):
+                 webdriver_args=None, **kwargs):
         Browser.__init__(self, logger)
         self.binary = binary
         self.server = WebKitDriverServer(self.logger, binary=webdriver_binary,

--- a/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
+++ b/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
@@ -76,6 +76,6 @@ def run_info_extras(**kwargs):
 
 class WebKitGTKMiniBrowser(WebKitBrowser):
     def __init__(self, logger, binary=None, webdriver_binary=None,
-                 webdriver_args=None):
+                 webdriver_args=None, **kwargs):
         WebKitBrowser.__init__(self, logger, binary, webdriver_binary,
                                webdriver_args)

--- a/tools/wptrunner/wptrunner/formatters/chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/chromium.py
@@ -272,6 +272,6 @@ class ChromiumFormatter(base.BaseFormatter):
         return json.dumps(final_result)
 
     def process_output(self, data):
-        cmd = data.get('command', "")
+        cmd = data.get("command", "")
         if any(c in cmd for c in ["chromedriver", "logcat"]):
             self.browser_log.append(data['data'])

--- a/tools/wptrunner/wptrunner/formatters/chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/chromium.py
@@ -272,5 +272,6 @@ class ChromiumFormatter(base.BaseFormatter):
         return json.dumps(final_result)
 
     def process_output(self, data):
-        if 'command' in data and 'chromedriver' in data['command']:
+        cmd = data.get('command', "")
+        if any(c in cmd for c in ["chromedriver", "logcat"]):
             self.browser_log.append(data['data'])

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -361,7 +361,8 @@ class TestRunnerManager(threading.Thread):
         spins."""
         self.recording.set(["testrunner", "startup"])
         self.logger = structuredlog.StructuredLogger(self.suite_name)
-        with self.browser_cls(self.logger, **self.browser_kwargs) as browser:
+        with self.browser_cls(self.logger, remote_queue=self.command_queue,
+                              **self.browser_kwargs) as browser:
             self.browser = BrowserManager(self.logger,
                                           browser,
                                           self.command_queue,


### PR DESCRIPTION
When running test against android targets(clank, webview, weblayer),
pull logcat with command "adb logcat *:D" on the fly, and save
that to result viewer. Logs are only saved for CRASH case for now.

Test: Use geolocation-API/PositionOptions.https.html as an example,
the waterfall run shows the crashlog missing, but it's present in this CL

Bug: 1071136