### PR TITLE
Replace most `.__proto__` with `Object.getPrototypeOf()`

### DIFF
--- a/IndexedDB/structured-clone.any.js
+++ b/IndexedDB/structured-clone.any.js
@@ -15,7 +15,7 @@
 function describe(value) {
   let type, str;
   if (typeof value === 'object' && value) {
-    type = value.__proto__.constructor.name;
+    type = Object.getPrototypeOf(value).constructor.name;
     // Handle Number(-0), etc.
     str = Object.is(value.valueOf(), -0) ? '-0' : String(value);
   } else {
@@ -54,7 +54,7 @@ function cloneObjectTest(value, verifyFunc) {
   cloneTest(value, async (orig, clone) => {
     assert_not_equals(orig, clone);
     assert_equals(typeof clone, 'object');
-    assert_equals(orig.__proto__, clone.__proto__);
+    assert_equals(Object.getPrototypeOf(orig), Object.getPrototypeOf(clone));
     await verifyFunc(orig, clone);
   });
 }
@@ -141,7 +141,7 @@ const strings = [
 ].forEach(value => cloneTest(value, (orig, clone) => {
     assert_not_equals(orig, clone);
     assert_equals(typeof clone, 'object');
-    assert_equals(orig.__proto__, clone.__proto__);
+    assert_equals(Object.getPrototypeOf(orig), Object.getPrototypeOf(clone));
     assert_equals(orig.valueOf(), clone.valueOf());
   }));
 
@@ -261,7 +261,7 @@ cloneObjectTest({foo: true, bar: false}, (orig, clone) => {
   new DOMRect,
   new DOMRectReadOnly(),
 ].forEach(value => cloneObjectTest(value, (orig, clone) => {
-  Object.keys(orig.__proto__).forEach(key => {
+  Object.keys(Object.getPrototypeOf(orig)).forEach(key => {
     assert_equals(orig[key], clone[key], `Property ${key}`);
   });
 }));

--- a/custom-elements/upgrading.html
+++ b/custom-elements/upgrading.html
@@ -41,20 +41,20 @@ document_types().filter(function (entry) { return !entry.isOwner && !entry.hasBr
         var name = generateNextCustomElementName();
         var unresolvedElement = document.createElement(name);
 
-        assert_equals(unresolvedElement.__proto__, HTMLElement.prototype,
+        assert_equals(Object.getPrototypeOf(unresolvedElement), HTMLElement.prototype,
             '[[Prototype]] internal slot of the unresolved custom element must be the HTMLElement prototype');
 
         return getDocument().then(function (doc) {
             var unresolvedElementInDoc = doc.createElement(name);
             var prototype = (unresolvedElementInDoc.namespaceURI == 'http://www.w3.org/1999/xhtml' ? HTMLElement : Element).prototype;
 
-            assert_equals(unresolvedElementInDoc.__proto__, prototype,
+            assert_equals(Object.getPrototypeOf(unresolvedElementInDoc), prototype,
                 '[[Prototype]] internal slot of the unresolved custom element must be the ' + prototype.toString() + ' prototype');
             var someCustomElement = class extends HTMLElement {};
             customElements.define(name, someCustomElement);
-            assert_equals(unresolvedElementInDoc.__proto__, prototype, '"define" must not upgrade a disconnected unresolved custom elements');
+            assert_equals(Object.getPrototypeOf(unresolvedElementInDoc), prototype, '"define" must not upgrade a disconnected unresolved custom elements');
             doc.documentElement.appendChild(unresolvedElementInDoc);
-            assert_equals(unresolvedElementInDoc.__proto__, prototype,
+            assert_equals(Object.getPrototypeOf(unresolvedElementInDoc), prototype,
                 'Inserting an element into a document without a browsing context must not enqueue a custom element upgrade reaction');
         });
     }, 'Creating an element in ' + documentName + ' and inserting into the document must not enqueue a custom element upgrade reaction');
@@ -63,25 +63,25 @@ document_types().filter(function (entry) { return !entry.isOwner && !entry.hasBr
         var name = generateNextCustomElementName();
         var unresolvedElement = document.createElement(name);
 
-        assert_equals(unresolvedElement.__proto__, HTMLElement.prototype,
+        assert_equals(Object.getPrototypeOf(unresolvedElement), HTMLElement.prototype,
             '[[Prototype]] internal slot of the unresolved custom element must be the HTMLElement prototype');
 
         return getDocument().then(function (doc) {
             var unresolvedElementInDoc = doc.createElement(name);
             var prototype = (unresolvedElementInDoc.namespaceURI == 'http://www.w3.org/1999/xhtml' ? HTMLElement : Element).prototype;
 
-            assert_equals(unresolvedElementInDoc.__proto__, prototype,
+            assert_equals(Object.getPrototypeOf(unresolvedElementInDoc), prototype,
                 '[[Prototype]] internal slot of the unresolved custom element must be the ' + prototype.toString() + ' prototype');
             var someCustomElement = class extends HTMLElement {};
             customElements.define(name, someCustomElement);
-            assert_equals(unresolvedElementInDoc.__proto__, prototype, '"define" must not upgrade a disconnected unresolved custom elements');
+            assert_equals(Object.getPrototypeOf(unresolvedElementInDoc), prototype, '"define" must not upgrade a disconnected unresolved custom elements');
             document.body.appendChild(unresolvedElementInDoc);
 
             if (unresolvedElementInDoc.namespaceURI == 'http://www.w3.org/1999/xhtml') {
-                assert_equals(unresolvedElementInDoc.__proto__, someCustomElement.prototype,
+                assert_equals(Object.getPrototypeOf(unresolvedElementInDoc), someCustomElement.prototype,
                     'Inserting an element into a document with a browsing context must enqueue a custom element upgrade reaction');
             } else {
-                assert_equals(unresolvedElementInDoc.__proto__, prototype,
+                assert_equals(Object.getPrototypeOf(unresolvedElementInDoc), prototype,
                     'Looking up a custom element definition must return null if the element is not in the HTML namespace');
             }
         });
@@ -116,13 +116,13 @@ document_types().filter(function (entry) { return !entry.isOwner && entry.hasBro
             class UnresolvedElement extends docWindow.HTMLElement { };
             var unresolvedElementInDoc = doc.createElement('unresolved-element');
 
-            assert_equals(unresolvedElement.__proto__, HTMLElement.prototype);
-            assert_equals(unresolvedElementInDoc.__proto__, docWindow.HTMLElement.prototype);
+            assert_equals(Object.getPrototypeOf(unresolvedElement), HTMLElement.prototype);
+            assert_equals(Object.getPrototypeOf(unresolvedElementInDoc), docWindow.HTMLElement.prototype);
 
             docWindow.customElements.define('unresolved-element', UnresolvedElement);
 
-            assert_equals(unresolvedElement.__proto__, HTMLElement.prototype);
-            assert_equals(unresolvedElementInDoc.__proto__, docWindow.HTMLElement.prototype);
+            assert_equals(Object.getPrototypeOf(unresolvedElement), HTMLElement.prototype);
+            assert_equals(Object.getPrototypeOf(unresolvedElementInDoc), docWindow.HTMLElement.prototype);
 
         });
     }, '"define" in ' + documentName + ' must not enqueue a custom element upgrade reaction on a disconnected unresolved custom element');
@@ -134,14 +134,14 @@ document_types().filter(function (entry) { return !entry.isOwner && entry.hasBro
             class UnresolvedElement extends docWindow.HTMLElement { };
             var unresolvedElementInDoc = doc.createElement('unresolved-element');
 
-            assert_equals(unresolvedElement.__proto__, HTMLElement.prototype);
-            assert_equals(unresolvedElementInDoc.__proto__, docWindow.HTMLElement.prototype);
+            assert_equals(Object.getPrototypeOf(unresolvedElement), HTMLElement.prototype);
+            assert_equals(Object.getPrototypeOf(unresolvedElementInDoc), docWindow.HTMLElement.prototype);
 
             docWindow.customElements.define('unresolved-element', UnresolvedElement);
             doc.documentElement.appendChild(unresolvedElementInDoc);
 
-            assert_equals(unresolvedElement.__proto__, HTMLElement.prototype);
-            assert_equals(unresolvedElementInDoc.__proto__, UnresolvedElement.prototype);
+            assert_equals(Object.getPrototypeOf(unresolvedElement), HTMLElement.prototype);
+            assert_equals(Object.getPrototypeOf(unresolvedElementInDoc), UnresolvedElement.prototype);
         });
     }, 'Inserting an unresolved custom element into ' + documentName + ' must enqueue a custom element upgrade reaction');
 
@@ -153,13 +153,13 @@ document_types().filter(function (entry) { return !entry.isOwner && entry.hasBro
             var unresolvedElementInDoc = doc.createElement('unresolved-element');
             doc.documentElement.appendChild(unresolvedElementInDoc);
 
-            assert_equals(unresolvedElement.__proto__, HTMLElement.prototype);
-            assert_equals(unresolvedElementInDoc.__proto__, docWindow.HTMLElement.prototype);
+            assert_equals(Object.getPrototypeOf(unresolvedElement), HTMLElement.prototype);
+            assert_equals(Object.getPrototypeOf(unresolvedElementInDoc), docWindow.HTMLElement.prototype);
 
             docWindow.customElements.define('unresolved-element', UnresolvedElement);
 
-            assert_equals(unresolvedElement.__proto__, HTMLElement.prototype);
-            assert_equals(unresolvedElementInDoc.__proto__, UnresolvedElement.prototype);
+            assert_equals(Object.getPrototypeOf(unresolvedElement), HTMLElement.prototype);
+            assert_equals(Object.getPrototypeOf(unresolvedElementInDoc), UnresolvedElement.prototype);
         });
     }, '"define" in ' + documentName + ' must enqueue a custom element upgrade reaction on a connected unresolved custom element');
 

--- a/html/browsers/sandboxing/sandbox-new-execution-context-iframe.html
+++ b/html/browsers/sandboxing/sandbox-new-execution-context-iframe.html
@@ -1,5 +1,5 @@
 <body>
   <script>
-    document.__proto__.changeFromSandboxedIframe = "change from sandboxed iframe";
+    Object.getPrototypeOf(document).changeFromSandboxedIframe = "change from sandboxed iframe";
   </script>
 </body>

--- a/html/browsers/sandboxing/sandbox-new-execution-context.html
+++ b/html/browsers/sandboxing/sandbox-new-execution-context.html
@@ -25,7 +25,7 @@
           assert_equals(iframe.contentDocument, null,
             "New document in sandboxed iframe should have opaque origin");
 
-          assert_equals(iframeAboutBlankDocument.__proto__.changeFromSandboxedIframe, undefined,
+          assert_equals(Object.getPrototypeOf(iframeAboutBlankDocument).changeFromSandboxedIframe, undefined,
             "Sandboxed iframe contents should not have been able to mess with type system of about:blank document");
 
           let iframeAboutBlankContents = iframeAboutBlankDocument.querySelectorAll('body');

--- a/html/canvas/tools/yaml/element/the-canvas-element.yaml
+++ b/html/canvas/tools/yaml/element/the-canvas-element.yaml
@@ -151,7 +151,7 @@
   testing:
   - 2d.path.contexttypexxx.basic
   code: |
-    @assert CanvasRenderingContext2D.prototype.__proto__ === Object.prototype;
-    @assert ctx.__proto__ === CanvasRenderingContext2D.prototype;
+    @assert Object.getPrototypeOf(CanvasRenderingContext2D.prototype) === Object.prototype;
+    @assert Object.getPrototypeOf(ctx) === CanvasRenderingContext2D.prototype;
     t.done();
 

--- a/html/semantics/embedded-content/the-canvas-element/2d.canvas.context.html
+++ b/html/semantics/embedded-content/the-canvas-element/2d.canvas.context.html
@@ -19,8 +19,8 @@
 var t = async_test("checks CanvasRenderingContext2D prototype");
 _addTest(function(canvas, ctx) {
 
-_assertSame(CanvasRenderingContext2D.prototype.__proto__, Object.prototype, "CanvasRenderingContext2D.prototype.__proto__", "Object.prototype");
-_assertSame(ctx.__proto__, CanvasRenderingContext2D.prototype, "ctx.__proto__", "CanvasRenderingContext2D.prototype");
+_assertSame(Object.getPrototypeOf(CanvasRenderingContext2D.prototype), Object.prototype, "Object.getPrototypeOf(CanvasRenderingContext2D.prototype)", "Object.prototype");
+_assertSame(Object.getPrototypeOf(ctx), CanvasRenderingContext2D.prototype, "Object.getPrototypeOf(ctx)", "CanvasRenderingContext2D.prototype");
 t.done();
 
 

--- a/html/semantics/embedded-content/the-img-element/Image-constructor.html
+++ b/html/semantics/embedded-content/the-img-element/Image-constructor.html
@@ -30,8 +30,8 @@
       assert_equals(Image.name, "Image", "Image name should be Image (not HTMLImageElement)");
       assert_equals(Object.getPrototypeOf(Image), Function.prototype, "Image's prototype is Function.prototype");
       assert_equals(Image.prototype, HTMLImageElement.prototype, "Image.prototype is same as HTMLImageElement.prototype");
-      assert_equals(Object.getPrototypeOf(new Image()), HTMLImageElement.prototype, "Object.getPrototypeOf(new Image()) is HTMLImageElement prototype ");
-      assert_equals(Object.getPrototypeOf(Image.prototype), HTMLElement.prototype, "Object.getPrototypeOf(Image.prototype) is HTMLElement prototype");
+      assert_equals(Object.getPrototypeOf(new Image()), HTMLImageElement.prototype, "new Image()'s prototype is HTMLImageElement.prototype ");
+      assert_equals(Object.getPrototypeOf(Image.prototype), HTMLElement.prototype, "Image.prototype's prototype is HTMLElement.prototype");
 
       const desc = Object.getOwnPropertyDescriptor(Image, "prototype");
       assert_false(desc.configurable, "Image.prototype is not configurable");

--- a/html/semantics/embedded-content/the-img-element/Image-constructor.html
+++ b/html/semantics/embedded-content/the-img-element/Image-constructor.html
@@ -28,7 +28,7 @@
 
   test(function() {
       assert_equals(Image.name, "Image", "Image name should be Image (not HTMLImageElement)");
-      assert_equals(Object.getPrototypeOf(Image), Function.prototype, "Object.getPrototypeOf(Image) is Function prototype");
+      assert_equals(Object.getPrototypeOf(Image), Function.prototype, "Image's prototype is Function.prototype");
       assert_equals(Image.prototype, HTMLImageElement.prototype, "Image.prototype is same as HTMLImageElement.prototype");
       assert_equals(Object.getPrototypeOf(new Image()), HTMLImageElement.prototype, "Object.getPrototypeOf(new Image()) is HTMLImageElement prototype ");
       assert_equals(Object.getPrototypeOf(Image.prototype), HTMLElement.prototype, "Object.getPrototypeOf(Image.prototype) is HTMLElement prototype");

--- a/html/semantics/embedded-content/the-img-element/Image-constructor.html
+++ b/html/semantics/embedded-content/the-img-element/Image-constructor.html
@@ -28,10 +28,10 @@
 
   test(function() {
       assert_equals(Image.name, "Image", "Image name should be Image (not HTMLImageElement)");
-      assert_equals(Image.__proto__, Function.prototype, "Image __proto__ is Function prototype");
+      assert_equals(Object.getPrototypeOf(Image), Function.prototype, "Object.getPrototypeOf(Image) is Function prototype");
       assert_equals(Image.prototype, HTMLImageElement.prototype, "Image.prototype is same as HTMLImageElement.prototype");
-      assert_equals(new Image().__proto__, HTMLImageElement.prototype, "Image __proto__ is HTMLImageElement prototype ");
-      assert_equals(Image.prototype.__proto__, HTMLElement.prototype, "Image.prototype __proto__ is HTMLElement prototype");
+      assert_equals(Object.getPrototypeOf(new Image()), HTMLImageElement.prototype, "Object.getPrototypeOf(new Image()) is HTMLImageElement prototype ");
+      assert_equals(Object.getPrototypeOf(Image.prototype), HTMLElement.prototype, "Object.getPrototypeOf(Image.prototype) is HTMLElement prototype");
 
       const desc = Object.getOwnPropertyDescriptor(Image, "prototype");
       assert_false(desc.configurable, "Image.prototype is not configurable");

--- a/html/webappapis/user-prompts/print-manual.html
+++ b/html/webappapis/user-prompts/print-manual.html
@@ -50,7 +50,7 @@ function testBtn(btn) {
     // t.step_func() does not preserve `this`, which we test below.
     t.step(() => {
       out("beforeprint");
-      assert_equals(ev.__proto__, Event.prototype);
+      assert_equals(Object.getPrototypeOf(ev), Event.prototype);
       assert_equals(this, window);
       assert_equals(ev.target, window);
       assert_equals(ev.type, "beforeprint");
@@ -60,7 +60,7 @@ function testBtn(btn) {
     // t.step_func() does not preserve `this`, which we test below.
     t.step(() => {
       out("afterprint");
-      assert_equals(ev.__proto__, Event.prototype);
+      assert_equals(Object.getPrototypeOf(ev), Event.prototype);
       assert_equals(this, window);
       assert_equals(ev.target, window);
       assert_equals(ev.type, "afterprint");

--- a/orientation-event/motion/create-event.https.html
+++ b/orientation-event/motion/create-event.https.html
@@ -15,7 +15,7 @@ test(test => {
   });
 
   assert_equals(typeof event, 'object');
-  assert_equals(event.__proto__, DeviceMotionEvent.prototype);
+  assert_equals(Object.getPrototypeOf(event), DeviceMotionEvent.prototype);
 
   assert_true('type' in event);
   assert_true('bubbles' in event);

--- a/orientation-event/orientation/create-event.https.html
+++ b/orientation-event/orientation/create-event.https.html
@@ -15,7 +15,7 @@ test(test => {
   });
 
   assert_equals(typeof event, 'object');
-  assert_equals(event.__proto__, DeviceOrientationEvent.prototype);
+  assert_equals(Object.getPrototypeOf(event), DeviceOrientationEvent.prototype);
 
   assert_true('type' in event);
   assert_true('bubbles' in event);

--- a/quirks/blocks-ignore-line-height.html
+++ b/quirks/blocks-ignore-line-height.html
@@ -31,7 +31,7 @@
         s.document.close();
         [q, a, s].forEach(function(win) {
             ['style', 'test', 'ref', 's_ref'].forEach(function(id) {
-                win.__proto__.__defineGetter__(id, function() { return win.document.getElementById(id); });
+                Object.getPrototypeOf(win).__defineGetter__(id, function() { return win.document.getElementById(id); });
             });
         });
 

--- a/quirks/line-height-calculation.html
+++ b/quirks/line-height-calculation.html
@@ -36,7 +36,7 @@
         s.document.close();
         [q, a, s].forEach(function(win) {
             ['style', 'test', 'ref', 's_ref'].forEach(function(id) {
-                win.__proto__.__defineGetter__(id, function() { return win.document.getElementById(id); });
+                Object.getPrototypeOf(win).__defineGetter__(id, function() { return win.document.getElementById(id); });
             });
         });
 

--- a/quirks/percentage-height-calculation.html
+++ b/quirks/percentage-height-calculation.html
@@ -42,7 +42,7 @@
         s.document.close();
         [q, a, s].forEach(function(win) {
             ['style', 'test'].forEach(function(id) {
-                win.__proto__.__defineGetter__(id, function() { return win.document.getElementById(id); });
+                Object.getPrototypeOf(win).__defineGetter__(id, function() { return win.document.getElementById(id); });
             });
         });
 

--- a/quirks/table-cell-nowrap-minimum-width-calculation.html
+++ b/quirks/table-cell-nowrap-minimum-width-calculation.html
@@ -36,7 +36,7 @@
         s.document.close();
         [q, a, s].forEach(function(win) {
             ['style', 'test', 'ref', 's_ref'].forEach(function(id) {
-                win.__proto__.__defineGetter__(id, function() { return win.document.getElementById(id); });
+                Object.getPrototypeOf(win).__defineGetter__(id, function() { return win.document.getElementById(id); });
             });
         });
         q.title = 'quirks mode';

--- a/quirks/table-cell-width-calculation.html
+++ b/quirks/table-cell-width-calculation.html
@@ -36,7 +36,7 @@
         s.document.close();
         [q, a, s].forEach(function(win) {
             ['style', 'test', 'ref', 's_ref'].forEach(function(id) {
-                win.__proto__.__defineGetter__(id, function() { return win.document.getElementById(id); });
+                Object.getPrototypeOf(win).__defineGetter__(id, function() { return win.document.getElementById(id); });
             });
         });
         q.title = 'quirks mode';

--- a/resources/test/tests/functional/idlharness/IdlInterface/test_primary_interface_of.html
+++ b/resources/test/tests/functional/idlharness/IdlInterface/test_primary_interface_of.html
@@ -34,7 +34,7 @@ Object.defineProperty(window.Foo.prototype, "constructor", {
     configurable: true,
     value: window.Foo
   });
-Foo.__proto__ = FooParent;
+Object.setPrototypeOf(Foo, FooParent);
 Foo.prototype[Symbol.toStringTag] = "Foo";
 
 var idlArray = new IdlArray();

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/fetch-on-the-right-interface.https.any.js
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/fetch-on-the-right-interface.https.any.js
@@ -6,9 +6,9 @@ test(function() {
         'instance should not have "fetch" method as its property.');
     assert_inherits(self, 'fetch', 'ServiceWorkerGlobalScope should ' +
         'inherit "fetch" method.');
-    assert_own_property(self.__proto__.__proto__, 'fetch',
+    assert_own_property(Object.getPrototypeOf(Object.getPrototypeOf(self)), 'fetch',
         'WorkerGlobalScope should have "fetch" propery in its prototype.');
-    assert_equals(self.fetch, self.__proto__.__proto__.fetch,
+    assert_equals(self.fetch, Object.getPrototypeOf(Object.getPrototypeOf(self)).fetch,
         'ServiceWorkerGlobalScope.fetch should be the same as ' +
         'WorkerGlobalScope.fetch.');
 }, 'Fetch method on the right interface');

--- a/service-workers/service-worker/resources/immutable-prototype-serviceworker.js
+++ b/service-workers/service-worker/resources/immutable-prototype-serviceworker.js
@@ -2,9 +2,9 @@ function prototypeChain(global) {
   let result = [];
   while (global !== null) {
     let thrown = false;
-    let next = global.__proto__;
+    let next = Object.getPrototypeOf(global);
     try {
-      global.__proto__ = {};
+      Object.setPrototypeOf(global, {});
       result.push('mutable');
     } catch (e) {
       result.push('immutable');

--- a/shadow-dom/HTMLSlotElement-interface.html
+++ b/shadow-dom/HTMLSlotElement-interface.html
@@ -14,7 +14,7 @@
 
 test(function () {
     assert_true('HTMLSlotElement' in window, 'HTMLSlotElement must be defined on window');
-    assert_equals(HTMLSlotElement.prototype.__proto__, HTMLElement.prototype, 'HTMLSlotElement should inherit from HTMLElement');
+    assert_equals(Object.getPrototypeOf(HTMLSlotElement.prototype), HTMLElement.prototype, 'HTMLSlotElement should inherit from HTMLElement');
     assert_true(document.createElement('slot') instanceof HTMLSlotElement, 'slot element should be an instance of HTMLSlotElement');
     assert_true(document.createElement('slot') instanceof HTMLElement, 'slot element should be an instance of HTMLElement');
 }, 'HTMLSlotElement must be defined on window');

--- a/shadow-dom/ShadowRoot-interface.html
+++ b/shadow-dom/ShadowRoot-interface.html
@@ -17,7 +17,7 @@ test(function () {
 }, 'Check the existence of ShadowRoot interface');
 
 test(function () {
-    assert_equals(ShadowRoot.prototype.__proto__, DocumentFragment.prototype, 'ShadowRoot must inherit from DocumentFragment');
+    assert_equals(Object.getPrototypeOf(ShadowRoot.prototype), DocumentFragment.prototype, 'ShadowRoot must inherit from DocumentFragment');
 }, 'ShadowRoot must inherit from DocumentFragment');
 
 test(function () {

--- a/svg/extensibility/interfaces/foreignObject-graphics.svg
+++ b/svg/extensibility/interfaces/foreignObject-graphics.svg
@@ -12,7 +12,7 @@
   <h:script><![CDATA[
   test(function() {
     var target = document.getElementById('target');
-    assert_equals(target.__proto__.__proto__, SVGGraphicsElement.prototype);
+    assert_equals(Object.getPrototypeOf(Object.getPrototypeOf(target)), SVGGraphicsElement.prototype);
   });
   ]]></h:script>
 </svg>

--- a/svg/path/interfaces/SVGAnimatedPathData-removed.svg
+++ b/svg/path/interfaces/SVGAnimatedPathData-removed.svg
@@ -14,7 +14,7 @@
     assert_equals(window.SVGAnimatedPathData, undefined);
 
     var track = document.getElementById('track');
-    assert_equals(track.__proto__, SVGPathElement.prototype);
+    assert_equals(Object.getPrototypeOf(track), SVGPathElement.prototype);
     assert_equals(track.pathSegList, undefined);
     assert_equals(track.normalizedPathSegList, undefined);
     assert_equals(track.animatedPathSegList, undefined);

--- a/svg/struct/UnknownElement/interface.svg
+++ b/svg/struct/UnknownElement/interface.svg
@@ -13,7 +13,7 @@
 <h:script><![CDATA[
 test(function() {
     var e = document.getElementById("target");
-    assert_equals(e.__proto__, SVGUnknownElement.prototype);
+    assert_equals(Object.getPrototypeOf(e), SVGUnknownElement.prototype);
 });
 ]]></h:script>
 </svg>

--- a/trusted-types/Node-multiple-arguments.tentative.html
+++ b/trusted-types/Node-multiple-arguments.tentative.html
@@ -14,7 +14,7 @@
     createScript: t => t,
   });
   function stringify(arg) {
-    return "textContent" in arg.__proto__ ? arg.textContent : arg.toString()
+    return "textContent" in Object.getPrototypeOf(arg) ? arg.textContent : arg.toString()
   }
 
   // This test case mirrors the block-Node-multiple-arguments case except

--- a/trusted-types/block-Node-multiple-arguments.tentative.html
+++ b/trusted-types/block-Node-multiple-arguments.tentative.html
@@ -15,7 +15,7 @@
     createScript: t => t,
   });
   function stringify(arg) {
-    return "textContent" in arg.__proto__ ? arg.textContent : arg.toString()
+    return "textContent" in Object.getPrototypeOf(arg) ? arg.textContent : arg.toString()
   }
 
   // Test all combinations of:

--- a/url/urlsearchparams-constructor.any.js
+++ b/url/urlsearchparams-constructor.any.js
@@ -29,7 +29,7 @@ test(() => {
 test(() => {
     var params = new URLSearchParams('');
     assert_true(params != null, 'constructor returned non-null value.');
-    assert_equals(params.__proto__, URLSearchParams.prototype, 'expected URLSearchParams.prototype as prototype.');
+    assert_equals(Object.getPrototypeOf(params), URLSearchParams.prototype, 'expected URLSearchParams.prototype as prototype.');
 }, "URLSearchParams constructor, empty string as argument")
 
 test(() => {

--- a/workers/SharedWorker-MessageEvent-source.any.js
+++ b/workers/SharedWorker-MessageEvent-source.any.js
@@ -1,6 +1,6 @@
 // META: global=sharedworker
 const t = async_test("Make sure that MessageEvent.source is properly set in connect event.");
 onconnect = t.step_func_done((event) => {
-  assert_equals(event.__proto__, MessageEvent.prototype);
+  assert_equals(Object.getPrototypeOf(event), MessageEvent.prototype);
   assert_equals(event.source, event.ports[0]);
 });

--- a/workers/Worker-constructor-proto.any.js
+++ b/workers/Worker-constructor-proto.any.js
@@ -2,6 +2,6 @@
 test(() => {
   const proto = {};
   assert_equals(String(Object.getPrototypeOf(WorkerLocation)).replace(/\n/g, " ").replace(/\s\s+/g, " "), "function () { [native code] }");
-  WorkerLocation.__proto__ = proto;
+  Object.setPrototypeOf(WorkerLocation, proto);
   assert_equals(Object.getPrototypeOf(WorkerLocation), proto);
 }, 'Tests that setting the proto of a built in constructor is not reset.');

--- a/xhr/responsexml-document-properties.htm
+++ b/xhr/responsexml-document-properties.htm
@@ -39,7 +39,7 @@
       function runTest(name, value){
         test(function(){
           if (name == "all") {
-            assert_equals(client.responseXML[name].__proto__, value.prototype)
+            assert_equals(Object.getPrototypeOf(client.responseXML[name]), value.prototype)
           } else {
             assert_equals(client.responseXML[name], value)
           }


### PR DESCRIPTION
I left out the ones where `.__proto__` appeared to be the subject of the test.

Ref: https://github.com/denoland/deno/issues/4324. We hit this usage in Deno: https://github.com/web-platform-tests/wpt/blob/1f6bc471fb537e733703cce3283fbb4d7f47547b/url/urlsearchparams-constructor.any.js#L32