### PR TITLE
Remove non-Array support for idl_test arguments srcs and deps

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -3543,8 +3543,6 @@ IdlNamespace.prototype.test = function ()
 function idl_test(srcs, deps, idl_setup_func) {
     return promise_test(function (t) {
         var idl_array = new IdlArray();
-        srcs = (srcs instanceof Array) ? srcs : [srcs] || [];
-        deps = (deps instanceof Array) ? deps : [deps] || [];
         var setup_error = null;
         const validationIgnored = [
             "constructor-member",


### PR DESCRIPTION
This should be fine (`scroll-animations/idlharness.window.js` is also fine) based on `grep -r -A 3 idl_test *`:
```
BackgroundSync/idlharness.https.any.js:idl_test(
BackgroundSync/idlharness.https.any.js-  ['background-sync'],
BackgroundSync/idlharness.https.any.js-  ['service-workers', 'html', 'dom'],
BackgroundSync/idlharness.https.any.js-  idlArray => {
--
FileAPI/idlharness-manual.html:      idl_test(
FileAPI/idlharness-manual.html-        ['FileAPI'],
FileAPI/idlharness-manual.html-        ['dom', 'html', 'url'],
FileAPI/idlharness-manual.html-        async idl_array => {
--
FileAPI/idlharness.html:      idl_test(
FileAPI/idlharness.html-        ['FileAPI'],
FileAPI/idlharness.html-        ['dom', 'html', 'url'],
FileAPI/idlharness.html-        idl_array => {
--
FileAPI/idlharness.worker.js:idl_test(
FileAPI/idlharness.worker.js-  ['FileAPI'],
FileAPI/idlharness.worker.js-  ['dom', 'html', 'url'],
FileAPI/idlharness.worker.js-  idl_array => {
--
IndexedDB/idlharness.any.js:idl_test(
IndexedDB/idlharness.any.js-  ['IndexedDB'],
IndexedDB/idlharness.any.js-  ['html', 'dom'],
IndexedDB/idlharness.any.js-  idl_array => {
--
WebCryptoAPI/idlharness.https.any.js:idl_test(
WebCryptoAPI/idlharness.https.any.js-  ['WebCryptoAPI'],
WebCryptoAPI/idlharness.https.any.js-  ['html', 'dom'],
WebCryptoAPI/idlharness.https.any.js-  idl_array => {
--
WebIDL/idlharness.any.js:idl_test(
WebIDL/idlharness.any.js-  ['WebIDL'],
WebIDL/idlharness.any.js-  [],
WebIDL/idlharness.any.js-  idl_array => {
--
accelerometer/idlharness.https.window.js:idl_test(
accelerometer/idlharness.https.window.js-  ['accelerometer'],
accelerometer/idlharness.https.window.js-  ['generic-sensor', 'dom'],
accelerometer/idlharness.https.window.js-  idl_array => {
--
ambient-light/idlharness.https.window.js:idl_test(
ambient-light/idlharness.https.window.js-  ['ambient-light'],
ambient-light/idlharness.https.window.js-  ['generic-sensor', 'dom'],
ambient-light/idlharness.https.window.js-  idl_array => {
--
animation-worklet/idlharness.any.js:idl_test(
animation-worklet/idlharness.any.js-  ['css-animation-worklet'],
animation-worklet/idlharness.any.js-  ['web-animations', 'html', 'cssom', 'dom'],
animation-worklet/idlharness.any.js-  idl_array => {
--
audio-output/idlharness.https.window.js:idl_test(
audio-output/idlharness.https.window.js-  ['audio-output'],
audio-output/idlharness.https.window.js-  ['mediacapture-streams', 'html', 'dom'],
audio-output/idlharness.https.window.js-  idl_array => {
--
background-fetch/idlharness.https.any.js:idl_test(
background-fetch/idlharness.https.any.js-  ['background-fetch'],
background-fetch/idlharness.https.any.js-  ['service-workers', 'html', 'dom'],
background-fetch/idlharness.https.any.js-  idl_array => {
--
badging/idlharness.https.any.js:idl_test(
badging/idlharness.https.any.js-  ['badging'],
badging/idlharness.https.any.js-  ['html', 'dom'],
badging/idlharness.https.any.js-  idl_array => {
--
battery-status/idlharness.https.window.js:idl_test(
battery-status/idlharness.https.window.js-  ['battery-status'],
battery-status/idlharness.https.window.js-  ['dom', 'html'],
battery-status/idlharness.https.window.js-  async idl_array => {
--
beacon/idlharness.any.js:idl_test(
beacon/idlharness.any.js-  ['beacon'],
beacon/idlharness.any.js-  ['html'],
beacon/idlharness.any.js-  idl_array => {
--
bluetooth/idl/idlharness.tentative.https.window.js:idl_test(
bluetooth/idl/idlharness.tentative.https.window.js-  ['web-bluetooth'],
bluetooth/idl/idlharness.tentative.https.window.js-  ['dom', 'html', 'permissions'],
bluetooth/idl/idlharness.tentative.https.window.js-  idl_array => {
--
compat/idlharness.window.js:idl_test(
compat/idlharness.window.js-  ['compat'],
compat/idlharness.window.js-  ['html', 'dom'],
compat/idlharness.window.js-  idl_array => {
--
compression/idlharness.https.any.js:idl_test(
compression/idlharness.https.any.js-  ['compression'],
compression/idlharness.https.any.js-  ['streams'],
compression/idlharness.https.any.js-  idl_array => {
--
console/idlharness.any.js:idl_test(
console/idlharness.any.js-  ['console'],
console/idlharness.any.js-  [] // no deps
console/idlharness.any.js-);
--
content-index/idlharness.https.any.js:idl_test(
content-index/idlharness.https.any.js-  ['content-index'],
content-index/idlharness.https.any.js-  ['service-workers', 'html', 'dom'],
content-index/idlharness.https.any.js-  async (idl_array, t) => {
--
content-security-policy/embedded-enforcement/idlharness.window.js:idl_test(
content-security-policy/embedded-enforcement/idlharness.window.js-  ['csp-embedded-enforcement'],
content-security-policy/embedded-enforcement/idlharness.window.js-  ['html', 'dom'],
content-security-policy/embedded-enforcement/idlharness.window.js-  idl_array => {
--
content-security-policy/securitypolicyviolation/idlharness.window.js:idl_test(
content-security-policy/securitypolicyviolation/idlharness.window.js-  ['CSP'],
content-security-policy/securitypolicyviolation/idlharness.window.js-  ['dom', 'reporting'],
content-security-policy/securitypolicyviolation/idlharness.window.js-  idl_array => {
--
cookie-store/idlharness.tentative.https.any.js:idl_test(
cookie-store/idlharness.tentative.https.any.js-  ['cookie-store'],
cookie-store/idlharness.tentative.https.any.js-  ['service-workers', 'html', 'dom'],
cookie-store/idlharness.tentative.https.any.js-  async (idl_array, t) => {
--
credential-management/idlharness.https.window.js:idl_test(
credential-management/idlharness.https.window.js-  ['credential-management'],
credential-management/idlharness.https.window.js-  ['html', 'dom'],
credential-management/idlharness.https.window.js-  idl_array => {
--
css/css-parser-api/idlharness.html:  idl_test(
css/css-parser-api/idlharness.html-    ['css-parser-api'],
css/css-parser-api/idlharness.html-    ['cssom'],
css/css-parser-api/idlharness.html-    idl_array => {
--
css/css-conditional/idlharness.html:    idl_test(
css/css-conditional/idlharness.html-      ['css-conditional'],
css/css-conditional/idlharness.html-      ['cssom', 'dom'],
css/css-conditional/idlharness.html-      idl_array => {
--
css/css-shadow-parts/idlharness.html:idl_test(
css/css-shadow-parts/idlharness.html-  ['css-shadow-parts'],
css/css-shadow-parts/idlharness.html-  ['dom'],
css/css-shadow-parts/idlharness.html-  idl_array => {
--
css/css-font-loading/idlharness.https.html:idl_test(
css/css-font-loading/idlharness.https.html-  ['css-font-loading'],
css/css-font-loading/idlharness.https.html-  ['dom', 'html', 'cssom'],
css/css-font-loading/idlharness.https.html-  idl_array => {
--
css/css-paint-api/idlharness.html:  idl_test(
css/css-paint-api/idlharness.html-    ["css-paint-api"],
css/css-paint-api/idlharness.html-    ["cssom", "html"]
css/css-paint-api/idlharness.html-    // No objects in Window global
--
css/css-counter-styles/idlharness.html:  idl_test(
css/css-counter-styles/idlharness.html-    ['css-counter-styles'],
css/css-counter-styles/idlharness.html-    ['cssom'],
css/css-counter-styles/idlharness.html-    idl_array => {
--
css/css-typed-om/idlharness.html:idl_test(
css/css-typed-om/idlharness.html-  ['css-typed-om'],
css/css-typed-om/idlharness.html-  ['cssom', 'SVG', 'geometry', 'html', 'dom'],
css/css-typed-om/idlharness.html-  idl_array => {
--
css/cssom-view/idlharness.html:idl_test(
css/cssom-view/idlharness.html-  ['cssom-view'],
css/cssom-view/idlharness.html-  ['css-pseudo', 'cssom', 'uievents', 'SVG', 'html', 'dom'],
css/cssom-view/idlharness.html-  async idlArray => {
--
css/cssom/idlharness.html:idl_test(
css/cssom/idlharness.html-  ['cssom'],
css/cssom/idlharness.html-  ['SVG', 'uievents', 'html', 'dom'],
css/cssom/idlharness.html-  async idlArray => {
--
css/css-masking/idlharness.html:  idl_test(
css/css-masking/idlharness.html-    ['css-masking'],
css/css-masking/idlharness.html-    ['SVG', 'html', 'dom'],
css/css-masking/idlharness.html-    idl_array => {
--
css/geometry/idlharness.any.js:idl_test(
css/geometry/idlharness.any.js-  ["geometry"],
css/geometry/idlharness.any.js-  [],
css/geometry/idlharness.any.js-  idlArray => {
--
css/css-fonts/idlharness.html:  idl_test(
css/css-fonts/idlharness.html-    ["css-fonts"],
css/css-fonts/idlharness.html-    ["cssom"],
css/css-fonts/idlharness.html-    idl_array => {
--
css/construct-stylesheets/idlharness.html:  idl_test(
css/construct-stylesheets/idlharness.html-    ['construct-stylesheets'],
css/construct-stylesheets/idlharness.html-    ['cssom', 'dom'],
css/construct-stylesheets/idlharness.html-    idl_array => {
--
css/filter-effects/idlharness.any.js:idl_test(
css/filter-effects/idlharness.any.js-  ['filter-effects'],
css/filter-effects/idlharness.any.js-  ['SVG', 'html', 'dom'],
css/filter-effects/idlharness.any.js-  idl_array => {
--
css/css-images/idlharness.html:  idl_test(
css/css-images/idlharness.html-    ['css-images'],
css/css-images/idlharness.html-    ['cssom'],
css/css-images/idlharness.html-    idl_array => {
--
css/css-properties-values-api/idlharness.html:  idl_test(
css/css-properties-values-api/idlharness.html-    ["css-properties-values-api"],
css/css-properties-values-api/idlharness.html-    ["cssom"]
css/css-properties-values-api/idlharness.html-    // No objects
--
css/css-animations/idlharness.html:    idl_test(
css/css-animations/idlharness.html-      ['css-animations'],
css/css-animations/idlharness.html-      ['html', 'dom', 'cssom'],
css/css-animations/idlharness.html-      idl_array => {
--
css/css-pseudo/idlharness.html:idl_test(
css/css-pseudo/idlharness.html-  ['css-pseudo'],
css/css-pseudo/idlharness.html-  ['cssom', 'html', 'dom'],
css/css-pseudo/idlharness.html-  idl_array => {
--
css/css-transitions/idlharness.html:  idl_test(
css/css-transitions/idlharness.html-    ['css-transitions'],
css/css-transitions/idlharness.html-    ['cssom', 'html', 'dom'],
css/css-transitions/idlharness.html-    idl_array => {
--
custom-state-pseudo-class/idlharness.window.js:idl_test(
custom-state-pseudo-class/idlharness.window.js-  ['custom-state-pseudo-class'],
custom-state-pseudo-class/idlharness.window.js-  ['html', 'wai-aria'],
custom-state-pseudo-class/idlharness.window.js-  idl_array => {
--
deprecation-reporting/idlharness.any.js:idl_test(
deprecation-reporting/idlharness.any.js-  ['deprecation-reporting'],
deprecation-reporting/idlharness.any.js-  ['reporting'],
deprecation-reporting/idlharness.any.js-  idl_array => {
--
device-memory/idlharness.https.any.js:idl_test(
device-memory/idlharness.https.any.js-  ['device-memory'],
device-memory/idlharness.https.any.js-  ['html'],
device-memory/idlharness.https.any.js-  async idl_array => {
--
docs/writing-tests/idlharness.md:idl_test(
docs/writing-tests/idlharness.md-  ['fetch'],
docs/writing-tests/idlharness.md-  ['referrer-policy', 'html', 'dom'],
docs/writing-tests/idlharness.md-  idl_array => {
--
docs/writing-tests/idlharness.md:These are needed to make the `idl_test` function work.
docs/writing-tests/idlharness.md-
docs/writing-tests/idlharness.md:The `idl_test` function takes three arguments:
docs/writing-tests/idlharness.md-
docs/writing-tests/idlharness.md-* _srcs_: a list of specifications whose IDL you want to test. The names here need to match the filenames (excluding the extension) in `/interfaces/`.
docs/writing-tests/idlharness.md-* _deps_: a list of specifications the IDL listed in _srcs_ depends upon. Be careful to list them in the order that the dependencies are revealed.
--
docs/writing-tests/idlharness.md:`IdlArray` objects can be obtained through the _setup_func_ argument of `idl_test`. Anything not
docs/writing-tests/idlharness.md-documented in this section should be considered an implementation detail, and outside callers should
docs/writing-tests/idlharness.md-not use it.
docs/writing-tests/idlharness.md-
--
dom/idlharness.any.js:idl_test(
dom/idlharness.any.js-  ['dom'],
dom/idlharness.any.js-  ['html'],
dom/idlharness.any.js-  idl_array => {
--
dom/idlharness.window.js:idl_test(
dom/idlharness.window.js-  ['dom'],
dom/idlharness.window.js-  ['html'],
dom/idlharness.window.js-  idl_array => {
--
domparsing/idlharness.window.js:idl_test(
domparsing/idlharness.window.js-  ['DOM-Parsing'],
domparsing/idlharness.window.js-  ['dom'],
domparsing/idlharness.window.js-  idlArray => {
--
element-timing/idlharness.window.js:idl_test(
element-timing/idlharness.window.js-  ['element-timing'],
element-timing/idlharness.window.js-  ['performance-timeline', 'dom'],
element-timing/idlharness.window.js-  idl_array => {
--
encoding/idlharness.any.js:idl_test(
encoding/idlharness.any.js-  ['encoding'],
encoding/idlharness.any.js-  ['streams'],
encoding/idlharness.any.js-  idl_array => {
--
encrypted-media/idlharness.https.html:      idl_test(
encrypted-media/idlharness.https.html-        ['encrypted-media'],
encrypted-media/idlharness.https.html-        ['html', 'dom'],
encrypted-media/idlharness.https.html-        idl_array => {
--
entries-api/idlharness-manual.window.js:idl_test(
entries-api/idlharness-manual.window.js-  ['entries-api'],
entries-api/idlharness-manual.window.js-  ['FileAPI', 'html', 'dom'],
entries-api/idlharness-manual.window.js-  async idl_array => {
--
entries-api/idlharness.window.js:idl_test(
entries-api/idlharness.window.js-  ['entries-api'],
entries-api/idlharness.window.js-  ['FileAPI', 'html', 'dom'],
entries-api/idlharness.window.js-  idl_array => {
--
event-timing/idlharness.any.js:idl_test(
event-timing/idlharness.any.js-  ['event-timing'],
event-timing/idlharness.any.js-  ['performance-timeline', 'hr-time', 'dom'],
event-timing/idlharness.any.js-  idl_array => {
--
feature-policy/idlharness.window.js:idl_test(
feature-policy/idlharness.window.js-  ['permissions-policy'],
feature-policy/idlharness.window.js-  ['reporting', 'html', 'dom'],
feature-policy/idlharness.window.js-  idl_array => {
--
fetch/cors-rfc1918/idlharness.tentative.any.js:idl_test(
fetch/cors-rfc1918/idlharness.tentative.any.js-  ['cors-rfc1918'],
fetch/cors-rfc1918/idlharness.tentative.any.js-  ['html', 'dom'],
fetch/cors-rfc1918/idlharness.tentative.any.js-  idlArray => {
--
fetch/api/idlharness.any.js:idl_test(
fetch/api/idlharness.any.js-  ['fetch'],
fetch/api/idlharness.any.js-  ['referrer-policy', 'html', 'dom'],
fetch/api/idlharness.any.js-  idl_array => {
--
fullscreen/idlharness.window.js:idl_test(
fullscreen/idlharness.window.js-  ['fullscreen'],
fullscreen/idlharness.window.js-  ['dom', 'html'],
fullscreen/idlharness.window.js-  idl_array => {
--
gamepad/idlharness.https.window.js:idl_test(
gamepad/idlharness.https.window.js-  ['gamepad'],
gamepad/idlharness.https.window.js-  ['dom', 'html'],
gamepad/idlharness.https.window.js-  idl_array => {
--
gamepad/idlharness-extensions.window.js:idl_test(
gamepad/idlharness-extensions.window.js-  ['gamepad-extensions'],
gamepad/idlharness-extensions.window.js-  ['gamepad'],
gamepad/idlharness-extensions.window.js-);
--
gamepad/idlharness-manual.html:idl_test(
gamepad/idlharness-manual.html-  ['gamepad'],
gamepad/idlharness-manual.html-  ['dom', 'html'],
gamepad/idlharness-manual.html-  (idl_array, t) => {
--
generic-sensor/idlharness.https.window.js:idl_test(
generic-sensor/idlharness.https.window.js-  ['generic-sensor'],
generic-sensor/idlharness.https.window.js-  ['dom', 'html', 'WebIDL'],
generic-sensor/idlharness.https.window.js-  idl_array => {
--
geolocation-API/idlharness.https.window.js:idl_test(
geolocation-API/idlharness.https.window.js-  ['geolocation-API'],
geolocation-API/idlharness.https.window.js-  ['html'],
geolocation-API/idlharness.https.window.js-  idl_array => {
--
geolocation-sensor/idlharness.https.window.js:idl_test(
geolocation-sensor/idlharness.https.window.js-  ['geolocation-sensor'],
geolocation-sensor/idlharness.https.window.js-  ['generic-sensor', 'dom'],
geolocation-sensor/idlharness.https.window.js-  idl_array => {
--
gyroscope/idlharness.https.window.js:idl_test(
gyroscope/idlharness.https.window.js-  ['gyroscope'],
gyroscope/idlharness.https.window.js-  ['generic-sensor', 'dom'],
gyroscope/idlharness.https.window.js-  idl_array => {
--
hr-time/idlharness.any.js:idl_test(
hr-time/idlharness.any.js-  ['hr-time'],
hr-time/idlharness.any.js-  ['html', 'dom'],
hr-time/idlharness.any.js-  async idl_array => {
--
html/editing/dnd/the-draggable-attribute/draggable_attribute.html:      function run_idl_test(element, element_name, exp) {
html/editing/dnd/the-draggable-attribute/draggable_attribute.html-        if (exp) {
html/editing/dnd/the-draggable-attribute/draggable_attribute.html-          assert_equals(element.getAttribute('draggable'), 'true', 'Element ' + element_name +' should be draggable');
html/editing/dnd/the-draggable-attribute/draggable_attribute.html-        } else {
--
html/editing/dnd/the-draggable-attribute/draggable_attribute.html:          run_idl_test(eElement, a[0] + '.getAttribute(\'draggable\') is \'false\'', false);
html/editing/dnd/the-draggable-attribute/draggable_attribute.html-
html/editing/dnd/the-draggable-attribute/draggable_attribute.html-          //If the draggable IDL attribute is set to the value true,
html/editing/dnd/the-draggable-attribute/draggable_attribute.html-          //the draggable content attribute must be set to the literal value true.
--
html/editing/dnd/the-draggable-attribute/draggable_attribute.html:          run_idl_test(eElement, a[0] + '.getAttribute(\'draggable\') is \'true\'', true);
html/editing/dnd/the-draggable-attribute/draggable_attribute.html-          }, 'Element ' + a[0] +' draggable attribute test');
html/editing/dnd/the-draggable-attribute/draggable_attribute.html-
html/editing/dnd/the-draggable-attribute/draggable_attribute.html-        });
--
html/dom/idlharness.https.html:idl_test(
html/dom/idlharness.https.html-  ['html'],
html/dom/idlharness.https.html-  ['wai-aria', 'SVG', 'cssom', 'touch-events', 'uievents', 'dom', 'xhr', 'FileAPI', 'mediacapture-streams'],
html/dom/idlharness.https.html-  async idlArray => {
--
html/dom/idlharness.worker.js:idl_test(
html/dom/idlharness.worker.js-  ["html"],
html/dom/idlharness.worker.js-  ["wai-aria", "dom", "cssom", "touch-events", "uievents"],
html/dom/idlharness.worker.js-  idlArray => {
--
html-media-capture/idlharness.window.js:idl_test(
html-media-capture/idlharness.window.js-  ['html-media-capture'],
html-media-capture/idlharness.window.js-  ['html', 'dom'],
html-media-capture/idlharness.window.js-  idl_array => {
--
idle-detection/idlharness.https.window.js:idl_test(
idle-detection/idlharness.https.window.js-    ['idle-detection.tentative'],
idle-detection/idlharness.https.window.js-    ['dom', 'html'],
idle-detection/idlharness.https.window.js-    async (idl_array, t) => {
--
idle-detection/resources/idlharness-worker.js:idl_test(
idle-detection/resources/idlharness-worker.js-    ['idle-detection.tentative'],
idle-detection/resources/idlharness-worker.js-    ['dom', 'html'],
idle-detection/resources/idlharness-worker.js-    async (idl_array, t) => {
--
input-device-capabilities/idlharness.window.js:idl_test(
input-device-capabilities/idlharness.window.js-  ['input-device-capabilities'],
input-device-capabilities/idlharness.window.js-  ['uievents', 'dom'],
input-device-capabilities/idlharness.window.js-  idl_array => {
--
input-events/idlharness.window.js:idl_test(
input-events/idlharness.window.js-  ['input-events'],
input-events/idlharness.window.js-  ['uievents', 'dom'],
input-events/idlharness.window.js-  idl_array => {
--
installedapp/idlharness.https.window.js:idl_test(
installedapp/idlharness.https.window.js-  ['get-installed-related-apps'],
installedapp/idlharness.https.window.js-  ['html'],
installedapp/idlharness.https.window.js-  idl_array => {
--
intersection-observer/idlharness.window.js:idl_test(
intersection-observer/idlharness.window.js-  ['intersection-observer'],
intersection-observer/idlharness.window.js-  ['dom'],
intersection-observer/idlharness.window.js-  idl_array => {
--
intervention-reporting/idlharness.any.js:idl_test(
intervention-reporting/idlharness.any.js-  ['intervention-reporting'],
intervention-reporting/idlharness.any.js-  ['reporting'],
intervention-reporting/idlharness.any.js-  idl_array => {
--
is-input-pending/idlharness.window.js:idl_test(
is-input-pending/idlharness.window.js-  ['is-input-pending'],
is-input-pending/idlharness.window.js-  ['html', 'dom'],
is-input-pending/idlharness.window.js-  async idl_array => {
--
js-self-profiling/idlharness.https.html:    idl_test(
js-self-profiling/idlharness.https.html-          ['js-self-profiling'],
js-self-profiling/idlharness.https.html-          ['hr-time', 'dom'],
js-self-profiling/idlharness.https.html-          async idl_array => {
--
keyboard-lock/idlharness.https.window.js:idl_test(
keyboard-lock/idlharness.https.window.js-  ['keyboard-lock'],
keyboard-lock/idlharness.https.window.js-  ['html'],
keyboard-lock/idlharness.https.window.js-  idl_array => {
--
keyboard-map/idlharness.https.window.js:idl_test(
keyboard-map/idlharness.https.window.js-  ['keyboard-map'],
keyboard-map/idlharness.https.window.js-  ['html'],
keyboard-map/idlharness.https.window.js-  async idl_array => {
--
largest-contentful-paint/idlharness.html:idl_test(
largest-contentful-paint/idlharness.html-  ['largest-contentful-paint'],
largest-contentful-paint/idlharness.html-  ['performance-timeline', 'dom', 'hr-time'],
largest-contentful-paint/idlharness.html-  async (idl_array, t) => {
--
layout-instability/idlharness.html:idl_test(
layout-instability/idlharness.html-  ['layout-instability'],
layout-instability/idlharness.html-  ['performance-timeline', 'geometry', 'dom', 'hr-time'],
layout-instability/idlharness.html-  async (idl_array, t) => {
--
longtask-timing/idlharness.window.js:idl_test(
longtask-timing/idlharness.window.js-  ['longtasks'],
longtask-timing/idlharness.window.js-  ['performance-timeline', 'hr-time'],
longtask-timing/idlharness.window.js-  (idl_array, t) => new Promise((resolve, reject) => {
--
magnetometer/idlharness.https.window.js:idl_test(
magnetometer/idlharness.https.window.js-  ['magnetometer'],
magnetometer/idlharness.https.window.js-  ['generic-sensor', 'dom'],
magnetometer/idlharness.https.window.js-  idl_array => {
--
measure-memory/idlharness.window.js:idl_test(
measure-memory/idlharness.window.js-  ['performance-measure-memory'],
measure-memory/idlharness.window.js-  ['hr-time', 'dom'],
measure-memory/idlharness.window.js-  async idl_array => {
--
media-capabilities/idlharness.any.js:  idl_test(
media-capabilities/idlharness.any.js-    ['media-capabilities'],
media-capabilities/idlharness.any.js-    ['html', 'cssom-view'],
media-capabilities/idlharness.any.js-    idl_array => {
--
media-playback-quality/idlharness.window.js:idl_test(
media-playback-quality/idlharness.window.js-  ['media-playback-quality'],
media-playback-quality/idlharness.window.js-  ['html', 'dom'],
media-playback-quality/idlharness.window.js-  idl_array => {
--
media-source/idlharness.window.js:idl_test(
media-source/idlharness.window.js-  ['media-source'],
media-source/idlharness.window.js-  ['dom', 'html', 'url'],
media-source/idlharness.window.js-  async idl_array => {
--
mediacapture-depth/idlharness.html:    idl_test(
mediacapture-depth/idlharness.html-      ['mediacapture-depth'],
mediacapture-depth/idlharness.html-      ['mediacapture-streams'],
mediacapture-depth/idlharness.html-      idl_array => {
--
mediacapture-fromelement/idlharness.window.js:idl_test(
mediacapture-fromelement/idlharness.window.js-  ['mediacapture-fromelement'],
mediacapture-fromelement/idlharness.window.js-  ['mediacapture-streams', 'html', 'dom'],
mediacapture-fromelement/idlharness.window.js-  idl_array => {
--
mediacapture-image/idlharness.window.js:idl_test(
mediacapture-image/idlharness.window.js-  ['image-capture'],
mediacapture-image/idlharness.window.js-  ['mediacapture-streams', 'html', 'dom'],
mediacapture-image/idlharness.window.js-  idl_array => {
--
mediacapture-record/idlharness.window.js:idl_test(
mediacapture-record/idlharness.window.js-  ['mediastream-recording'],
mediacapture-record/idlharness.window.js-  ['mediacapture-streams', 'FileAPI', 'html', 'dom', 'WebIDL'],
mediacapture-record/idlharness.window.js-  idl_array => {
--
mediacapture-streams/idlharness.https.window.js:idl_test(
mediacapture-streams/idlharness.https.window.js-  ['mediacapture-streams'],
mediacapture-streams/idlharness.https.window.js-  ['WebIDL', 'dom', 'html'],
mediacapture-streams/idlharness.https.window.js-  async idl_array => {
--
mediasession/idlharness.window.js:idl_test(
mediasession/idlharness.window.js-  ['mediasession'],
mediasession/idlharness.window.js-  ['html'],
mediasession/idlharness.window.js-  idl_array => {
--
mst-content-hint/idlharness.window.js:idl_test(
mst-content-hint/idlharness.window.js-  ['mst-content-hint'],
mst-content-hint/idlharness.window.js-  ['mediacapture-streams', 'dom'],
mst-content-hint/idlharness.window.js-  async idl_array => {
--
native-file-system/idlharness.https.any.js:idl_test(
native-file-system/idlharness.https.any.js-  ['native-file-system'],
native-file-system/idlharness.https.any.js-  ['storage', 'permissions', 'streams', 'html', 'dom'],
native-file-system/idlharness.https.any.js-  idl_array => {
--
navigation-timing/idlharness.window.js:idl_test(
navigation-timing/idlharness.window.js-  ['navigation-timing', 'hr-time'],
navigation-timing/idlharness.window.js-  ['resource-timing', 'performance-timeline', 'dom', 'html'],
navigation-timing/idlharness.window.js-  idlArray => {
--
netinfo/idlharness.any.js:idl_test(
netinfo/idlharness.any.js-  ['netinfo'],
netinfo/idlharness.any.js-  ['html', 'dom'],
netinfo/idlharness.any.js-  idl_array => {
--
notifications/idlharness.https.any.js:idl_test(
notifications/idlharness.https.any.js-  ['notifications'],
notifications/idlharness.https.any.js-  ['service-workers', 'html', 'dom'],
notifications/idlharness.https.any.js-  idl_array => {
--
orientation-event/idlharness.https.window.js:idl_test(
orientation-event/idlharness.https.window.js-  ['orientation-event'],
orientation-event/idlharness.https.window.js-  ['html', 'dom'],
orientation-event/idlharness.https.window.js-  idl_array => {
--
orientation-sensor/idlharness.https.window.js:idl_test(
orientation-sensor/idlharness.https.window.js-  ['orientation-sensor'],
orientation-sensor/idlharness.https.window.js-  ['generic-sensor', 'dom'],
orientation-sensor/idlharness.https.window.js-  idl_array => {
--
origin-policy/idlharness.any.js:idl_test(
origin-policy/idlharness.any.js-  ['origin-policy'],
origin-policy/idlharness.any.js-  ['html', 'dom'],
origin-policy/idlharness.any.js-  idl_array => {
--
page-lifecycle/idlharness.html:  idl_test(
page-lifecycle/idlharness.html-    ['page-lifecycle'],
page-lifecycle/idlharness.html-    ['service-workers', 'html', 'dom'],
page-lifecycle/idlharness.html-    idl_array => {
--
page-visibility/idlharness.window.js:idl_test(
page-visibility/idlharness.window.js-  ['page-visibility'],
page-visibility/idlharness.window.js-  ['dom', 'html'],
page-visibility/idlharness.window.js-  idl_array => {
--
paint-timing/idlharness.window.js:idl_test(
paint-timing/idlharness.window.js-  ['paint-timing'],
paint-timing/idlharness.window.js-  ['performance-timeline'],
paint-timing/idlharness.window.js-  (idl_array, t) => {
--
payment-handler/idlharness.https.any.js:idl_test(
payment-handler/idlharness.https.any.js-  ['payment-handler'],
payment-handler/idlharness.https.any.js-  ['service-workers', 'html', 'dom'],
payment-handler/idlharness.https.any.js-  async (idl_array, t) => {
--
payment-method-basic-card/idlharness.window.js:idl_test(
payment-method-basic-card/idlharness.window.js-  ['payment-method-basic-card'],
payment-method-basic-card/idlharness.window.js-  [], // No deps
payment-method-basic-card/idlharness.window.js-  null, // No objects
--
payment-request/idlharness.https.window.js:idl_test(
payment-request/idlharness.https.window.js-  ['payment-request'],
payment-request/idlharness.https.window.js-  ['dom', 'html'],
payment-request/idlharness.https.window.js-  idlArray => {
--
performance-timeline/idlharness.any.js:idl_test(
performance-timeline/idlharness.any.js-  ['performance-timeline'],
performance-timeline/idlharness.any.js-  ['hr-time', 'dom'],
performance-timeline/idlharness.any.js-  async idl_array => {
--
periodic-background-sync/idlharness.https.any.js:idl_test(
periodic-background-sync/idlharness.https.any.js-  ['periodic-background-sync'],
periodic-background-sync/idlharness.https.any.js-  ['service-workers', 'html', 'dom'],
periodic-background-sync/idlharness.https.any.js-  async idl_array => {
--
permissions/idlharness.any.js:idl_test(
permissions/idlharness.any.js-  ['permissions'],
permissions/idlharness.any.js-  ['html', 'dom'],
permissions/idlharness.any.js-  async idl_array => {
--
permissions-policy/idlharness.window.js:idl_test(
permissions-policy/idlharness.window.js-  ['permissions-policy'],
permissions-policy/idlharness.window.js-  ['reporting', 'html', 'dom'],
permissions-policy/idlharness.window.js-  idl_array => {
--
permissions-request/idlharness.any.js:idl_test(
permissions-request/idlharness.any.js-  ['permissions-request'],
permissions-request/idlharness.any.js-  ['permissions', 'html', 'dom'],
permissions-request/idlharness.any.js-  async idl_array => {
--
permissions-revoke/idlharness.any.js:idl_test(
permissions-revoke/idlharness.any.js-  ['permissions-revoke'],
permissions-revoke/idlharness.any.js-  ['permissions', 'html', 'dom'],
permissions-revoke/idlharness.any.js-  async idl_array => {
--
picture-in-picture/idlharness.window.js:idl_test(
picture-in-picture/idlharness.window.js-  ['picture-in-picture'],
picture-in-picture/idlharness.window.js-  ['html', 'dom'],
picture-in-picture/idlharness.window.js-  async idl_array => {
--
pointerevents/idlharness.window.js:idl_test(
pointerevents/idlharness.window.js-  ['pointerevents'],
pointerevents/idlharness.window.js-  ['uievents', 'html', 'dom'],
pointerevents/idlharness.window.js-  idl_array => {
--
pointerlock/idlharness.window.js:idl_test(
pointerlock/idlharness.window.js-  ['pointerlock'],
pointerlock/idlharness.window.js-  ['uievents', 'html', 'dom'],
pointerlock/idlharness.window.js-  idl_array => {
--
proximity/idlharness.https.window.js:idl_test(
proximity/idlharness.https.window.js-  ['proximity'],
proximity/idlharness.https.window.js-  ['generic-sensor','dom'],
proximity/idlharness.https.window.js-  idl_array => {
--
push-api/idlharness.https.any.js:idl_test(
push-api/idlharness.https.any.js-  ['push-api'],
push-api/idlharness.https.any.js-  ['service-workers', 'html', 'dom'],
push-api/idlharness.https.any.js-  async (idl_array, t) => {
--
remote-playback/idlharness.window.js:idl_test(
remote-playback/idlharness.window.js-  ['remote-playback'],
remote-playback/idlharness.window.js-  ['html', 'dom'],
remote-playback/idlharness.window.js-  idl_array => {
--
reporting/idlharness.any.js:idl_test(
reporting/idlharness.any.js-  ['reporting'],
reporting/idlharness.any.js-  [],
reporting/idlharness.any.js-  idl_array => {
--
requestidlecallback/idlharness.window.js:idl_test(
requestidlecallback/idlharness.window.js-  ['requestidlecallback'],
requestidlecallback/idlharness.window.js-  ['html', 'dom'],
requestidlecallback/idlharness.window.js-  async idl_array => {
--
resize-observer/idlharness.window.js:idl_test(
resize-observer/idlharness.window.js-  ['resize-observer'],
resize-observer/idlharness.window.js-  ['dom', 'geometry'],
resize-observer/idlharness.window.js-  async idl_array => {
--
resource-timing/idlharness.any.js:idl_test(
resource-timing/idlharness.any.js-  ['resource-timing'],
resource-timing/idlharness.any.js-  ['performance-timeline', 'hr-time', 'dom', 'html'],
resource-timing/idlharness.any.js-  idl_array => {
--
resources/idlharness.js: * idl_test is a promise_test wrapper that handles the fetching of the IDL,
resources/idlharness.js- * avoiding repetitive boilerplate.
resources/idlharness.js- *
resources/idlharness.js- * @param {String|String[]} srcs Spec name(s) for source idl files (fetched from
--
resources/idlharness.js: *      called by this function (idl_test).
resources/idlharness.js- */
resources/idlharness.js:function idl_test(srcs, deps, idl_setup_func) {
resources/idlharness.js-    return promise_test(function (t) {
resources/idlharness.js-        var idl_array = new IdlArray();
resources/idlharness.js-        srcs = (srcs instanceof Array) ? srcs : [srcs] || [];
--
resources/idlharness.js:                }, "idl_test validation");
resources/idlharness.js-                for (var i = 0; i < srcs.length; i++) {
resources/idlharness.js-                    idl_array.internal_add_idls(astArray[i]);
resources/idlharness.js-                }
--
resources/idlharness.js:    }, 'idl_test setup');
resources/idlharness.js-}
resources/idlharness.js-
resources/idlharness.js-/**
--
sanitizer-api/idlharness.tentative.window.js:idl_test(
sanitizer-api/idlharness.tentative.window.js-  ['sanitizer-api.tentative'],
sanitizer-api/idlharness.tentative.window.js-  ['html'],
sanitizer-api/idlharness.tentative.window.js-  idl_array => {
--
savedata/idlharness.any.js:idl_test(
savedata/idlharness.any.js-  ['savedata'],
savedata/idlharness.any.js-  ['netinfo', 'html', 'dom'],
savedata/idlharness.any.js-  idl_array => {
--
screen-capture/idlharness.https.window.js:idl_test(
screen-capture/idlharness.https.window.js-  ['screen-capture'],
screen-capture/idlharness.https.window.js-  ['mediacapture-streams', 'html', 'dom'],
screen-capture/idlharness.https.window.js-  idl_array => {
--
screen-orientation/idlharness.window.js:idl_test(
screen-orientation/idlharness.window.js-  ['screen-orientation'],
screen-orientation/idlharness.window.js-  ['dom', 'cssom-view', 'html'],
screen-orientation/idlharness.window.js-  idl_array => {
--
screen-wake-lock/idlharness.https.window.js:idl_test(
screen-wake-lock/idlharness.https.window.js-  ['screen-wake-lock'],
screen-wake-lock/idlharness.https.window.js-  ['dom', 'html'],
screen-wake-lock/idlharness.https.window.js-  async idl_array => {
--
scroll-animations/idlharness.window.js:idl_test(
scroll-animations/idlharness.window.js-  ['scroll-animations'],
scroll-animations/idlharness.window.js-  // The css-pseudo dependency shouldn't be necessary, but is:
scroll-animations/idlharness.window.js-  // https://github.com/web-platform-tests/wpt/issues/12574
--
scroll-to-text-fragment/idlharness.window.js:idl_test(
scroll-to-text-fragment/idlharness.window.js-  ['scroll-to-text-fragment'],
scroll-to-text-fragment/idlharness.window.js-  ['dom', 'html'],
scroll-to-text-fragment/idlharness.window.js-  idl_array => {
--
selection/idlharness.window.js:idl_test(
selection/idlharness.window.js-  ['selection-api'],
selection/idlharness.window.js-  ['html', 'dom'],
selection/idlharness.window.js-  idlArray => {
--
serial/idlharness.https.any.js:idl_test(
serial/idlharness.https.any.js-  ['serial'],
serial/idlharness.https.any.js-  ['html', 'dom'],
serial/idlharness.https.any.js-  idl_array => {
--
server-timing/idlharness.https.any.js:idl_test(
server-timing/idlharness.https.any.js-  ['resource-timing', 'server-timing'],
server-timing/idlharness.https.any.js-  ['performance-timeline', 'hr-time', 'dom'],
server-timing/idlharness.https.any.js-  idl_array => new Promise((resolve, reject) => {
--
service-workers/idlharness.https.any.js:idl_test(
service-workers/idlharness.https.any.js-  ['service-workers'],
service-workers/idlharness.https.any.js-  ['dom', 'html'],
service-workers/idlharness.https.any.js-  async (idl_array, t) => {
--
shape-detection/idlharness.https.any.js:idl_test(
shape-detection/idlharness.https.any.js-  ['shape-detection-api', 'text-detection-api'],
shape-detection/idlharness.https.any.js-  ['dom', 'geometry'],
shape-detection/idlharness.https.any.js-  async idl_array => {
--
speech-api/idlharness.window.js:idl_test(
speech-api/idlharness.window.js-  ['speech-api'],
speech-api/idlharness.window.js-  ['dom', 'html'],
speech-api/idlharness.window.js-  (idl_array, t) => {
--
storage/idlharness.https.any.js:idl_test(
storage/idlharness.https.any.js-  ['storage'],
storage/idlharness.https.any.js-  ['html'],
storage/idlharness.https.any.js-  idl_array => {
--
storage-access-api/idlharness.window.js:idl_test(
storage-access-api/idlharness.window.js-  ['storage-access'],
storage-access-api/idlharness.window.js-  ['dom'],
storage-access-api/idlharness.window.js-  idl_array => {
--
streams/idlharness.any.js:idl_test(
streams/idlharness.any.js-  ['streams'],
streams/idlharness.any.js-  ['dom'], // for AbortSignal
streams/idlharness.any.js-  async idl_array => {
--
svg/idlharness.window.js:idl_test(
svg/idlharness.window.js-  ['SVG'],
svg/idlharness.window.js-  ['cssom', 'web-animations', 'html', 'dom'],
svg/idlharness.window.js-  idlArray => {
--
tools/third_party/html5lib/benchmarks/data/wpt/random/idlharness.html:  idl_test(
tools/third_party/html5lib/benchmarks/data/wpt/random/idlharness.html-    ["css-fonts"],
tools/third_party/html5lib/benchmarks/data/wpt/random/idlharness.html-    ["cssom"],
tools/third_party/html5lib/benchmarks/data/wpt/random/idlharness.html-    idl_array => {
--
touch-events/idlharness.window.js:idl_test(
touch-events/idlharness.window.js-  ['touch-events'],
touch-events/idlharness.window.js-  ['uievents', 'html', 'dom'],
touch-events/idlharness.window.js-  idl_array => {
--
trusted-types/idlharness.tentative.window.js:idl_test(
trusted-types/idlharness.tentative.window.js-    ['trusted-types.tentative'],
trusted-types/idlharness.tentative.window.js-    ['dom', 'html'],
trusted-types/idlharness.tentative.window.js-    idl_array => {
--
ua-client-hints/idlharness.https.any.js:idl_test(
ua-client-hints/idlharness.https.any.js-  ['ua-client-hints'],
ua-client-hints/idlharness.https.any.js-  ['html', 'dom'],
ua-client-hints/idlharness.https.any.js-  idl_array => {
--
uievents/idlharness.window.js:idl_test(
uievents/idlharness.window.js-  ['uievents'],
uievents/idlharness.window.js-  ['dom'],
uievents/idlharness.window.js-  idl_array => {
--
url/idlharness.any.js:idl_test(
url/idlharness.any.js-  ['url'],
url/idlharness.any.js-  [], // no deps
url/idlharness.any.js-  idl_array => {
--
user-timing/idlharness.any.js:idl_test(
user-timing/idlharness.any.js-  ['user-timing'],
user-timing/idlharness.any.js-  ['hr-time', 'performance-timeline', 'dom'],
user-timing/idlharness.any.js-  idl_array => {
--
vibration/idlharness.window.js:idl_test(
vibration/idlharness.window.js-  ['vibration'],
vibration/idlharness.window.js-  ['html'],
vibration/idlharness.window.js-  idl_array => {
--
video-rvfc/idlharness.window.js:idl_test(
video-rvfc/idlharness.window.js-  ['video-rvfc'],
video-rvfc/idlharness.window.js-  ['html', 'dom'],
video-rvfc/idlharness.window.js-  idl_array => {
--
visual-viewport/idlharness.window.js:idl_test(
visual-viewport/idlharness.window.js-  ['visual-viewport'],
visual-viewport/idlharness.window.js-  ['html', 'dom'],
visual-viewport/idlharness.window.js-  idl_array => {
--
wai-aria/idlharness.window.js:idl_test(
wai-aria/idlharness.window.js-  ['wai-aria'],
wai-aria/idlharness.window.js-  ['dom'],
wai-aria/idlharness.window.js-  idl_array => {
--
wasm/jsapi/idlharness.any.js:idl_test(
wasm/jsapi/idlharness.any.js-  ['wasm-js-api'],
wasm/jsapi/idlharness.any.js-  [],
wasm/jsapi/idlharness.any.js-  async idl_array => {
--
wasm/webapi/idlharness.any.js:idl_test(
wasm/webapi/idlharness.any.js-  ["wasm-web-api"],
wasm/webapi/idlharness.any.js-  ["wasm-js-api"],
wasm/webapi/idlharness.any.js-  idl_array => {}
--
web-animations/idlharness.window.js:idl_test(
web-animations/idlharness.window.js-  ['web-animations'],
web-animations/idlharness.window.js-  ['dom', 'html'],
web-animations/idlharness.window.js-  idl_array => {
--
web-locks/idlharness.tentative.https.any.js:idl_test(
web-locks/idlharness.tentative.https.any.js-  ['web-locks'],
web-locks/idlharness.tentative.https.any.js-  ['html'],
web-locks/idlharness.tentative.https.any.js-  async idl_array => {
--
web-nfc/idlharness.https.window.js:idl_test(
web-nfc/idlharness.https.window.js-  ['web-nfc'],
web-nfc/idlharness.https.window.js-  ['html', 'dom', 'WebIDL'],
web-nfc/idlharness.https.window.js-  idl_array => {
--
web-otp/idlharness.https.window.js:idl_test(
web-otp/idlharness.https.window.js-  ['web-otp'],
web-otp/idlharness.https.window.js-  ['credential-management'],
web-otp/idlharness.https.window.js-  idlArray => {
--
web-share/idlharness.https.window.js:idl_test(
web-share/idlharness.https.window.js-  ['web-share'],
web-share/idlharness.https.window.js-  ['html'],
web-share/idlharness.https.window.js-  idl_array => {
--
webaudio/idlharness.https.window.js:idl_test(
webaudio/idlharness.https.window.js-  ['webaudio'],
webaudio/idlharness.https.window.js-  ['cssom', 'uievents', 'mediacapture-streams', 'html', 'dom'],
webaudio/idlharness.https.window.js-  async idl_array => {
--
webauthn/idlharness.https.window.js:idl_test(
webauthn/idlharness.https.window.js-  ['webauthn'],
webauthn/idlharness.https.window.js-  ['credential-management'],
webauthn/idlharness.https.window.js-  async idlArray => {
--
webauthn/idlharness-manual.https.window.js:idl_test(
webauthn/idlharness-manual.https.window.js-  ['webauthn'],
webauthn/idlharness-manual.https.window.js-  ['credential-management'],
webauthn/idlharness-manual.https.window.js-  async idlArray => {
--
webdriver/tests/idlharness.window.js:idl_test(
webdriver/tests/idlharness.window.js-  ["webdriver"],
webdriver/tests/idlharness.window.js-  ["html"],
webdriver/tests/idlharness.window.js-  idl_array => {
--
webgl/idlharness.any.js:idl_test(
webgl/idlharness.any.js-  ['webgl1', 'webgl2'],
webgl/idlharness.any.js-  ['dom'],
webgl/idlharness.any.js-  idl_array => {
--
webhid/idlharness.https.window.js:idl_test(
webhid/idlharness.https.window.js-  ['webhid'],
webhid/idlharness.https.window.js-  ['html', 'dom'],
webhid/idlharness.https.window.js-  idl_array => {
--
webmidi/idlharness.https.window.js:idl_test(
webmidi/idlharness.https.window.js-  ['webmidi'],
webmidi/idlharness.https.window.js-  ['html', 'dom'],
webmidi/idlharness.https.window.js-  async idl_array => {
--
webrtc/idlharness.https.window.js:idl_test(
webrtc/idlharness.https.window.js-  ['webrtc'],
webrtc/idlharness.https.window.js-  ['WebIDL', 'mediacapture-streams', 'dom', 'html'],
webrtc/idlharness.https.window.js-  async idlArray => {
--
webrtc-identity/idlharness.https.window.js:idl_test(
webrtc-identity/idlharness.https.window.js-  ['webrtc-identity'],
webrtc-identity/idlharness.https.window.js-  ['webrtc', 'mediacapture-streams', 'html', 'dom', 'WebIDL'],
webrtc-identity/idlharness.https.window.js-  async idlArray => {
--
webrtc-insertable-streams/idlharness.https.window.js:idl_test(
webrtc-insertable-streams/idlharness.https.window.js-  ['webrtc-insertable-streams'],
webrtc-insertable-streams/idlharness.https.window.js-  ['webrtc'],
webrtc-insertable-streams/idlharness.https.window.js-  async idlArray => {
--
webrtc-stats/idlharness.window.js:idl_test(
webrtc-stats/idlharness.window.js-  ['webrtc-stats'],
webrtc-stats/idlharness.window.js-  ['webrtc'],
webrtc-stats/idlharness.window.js-  idl_array => {
--
webusb/idlharness.https.any.js:idl_test(
webusb/idlharness.https.any.js-  ['webusb'],
webusb/idlharness.https.any.js-  ['permissions', 'html', 'dom'],
webusb/idlharness.https.any.js-  async idl_array => {
--
webvtt/api/idlharness.window.js:idl_test(
webvtt/api/idlharness.window.js-  ['webvtt'],
webvtt/api/idlharness.window.js-  ['html', 'dom'],
webvtt/api/idlharness.window.js-  idl_array => {
--
webxr/idlharness.https.window.js:idl_test(
webxr/idlharness.https.window.js-  ['webxr'],
webxr/idlharness.https.window.js-  ['permissions', 'webgl1', 'geometry', 'html', 'dom'],
webxr/idlharness.https.window.js-  async idl_array => {
--
webxr/hand-input/idlharness.https.window.js:idl_test(
webxr/hand-input/idlharness.https.window.js-  ['webxr-hand-input'],
webxr/hand-input/idlharness.https.window.js-  ['webxr', 'dom'],
webxr/hand-input/idlharness.https.window.js-  async idl_array => {
--
webxr/dom-overlay/idlharness.https.window.js:idl_test(
webxr/dom-overlay/idlharness.https.window.js-  ['dom-overlays'],
webxr/dom-overlay/idlharness.https.window.js-  ['webxr', 'html', 'dom', 'SVG'],
webxr/dom-overlay/idlharness.https.window.js-  async idl_array => {
--
webxr/gamepads-module/idlharness.https.window.js:idl_test(
webxr/gamepads-module/idlharness.https.window.js-  ['webxr-gamepads-module'],
webxr/gamepads-module/idlharness.https.window.js-  ['webxr', 'dom'],
webxr/gamepads-module/idlharness.https.window.js-  async idl_array => {
--
webxr/ar-module/idlharness.https.window.js:idl_test(
webxr/ar-module/idlharness.https.window.js-  ['webxr-ar-module'],
webxr/ar-module/idlharness.https.window.js-  ['webxr', 'dom'],
webxr/ar-module/idlharness.https.window.js-  async idl_array => {
--
webxr/anchors/idlharness.https.window.js:idl_test(
webxr/anchors/idlharness.https.window.js-  ['anchors'],
webxr/anchors/idlharness.https.window.js-  ['hit-test', 'webxr', 'dom'],
webxr/anchors/idlharness.https.window.js-  async idl_array => {
--
webxr/hit-test/idlharness.https.html:  idl_test(
webxr/hit-test/idlharness.https.html-    ['hit-test'],
webxr/hit-test/idlharness.https.html-    ['webxr', 'geometry', 'dom'],
webxr/hit-test/idlharness.https.html-    async idl_array => {
--
xhr/idlharness.any.js:idl_test(
xhr/idlharness.any.js-  ['xhr'],
xhr/idlharness.any.js-  ['dom', 'html'],
xhr/idlharness.any.js-  idl_array => {
--
xslt/idlharness.tentative.window.js:idl_test(
xslt/idlharness.tentative.window.js-  ['xslt.tentative'],
xslt/idlharness.tentative.window.js-  ['html'],
xslt/idlharness.tentative.window.js-  async idlArray => {
```