### PR TITLE
[wpt] Reject python versions <3.6

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -77,6 +77,9 @@ jobs:
   pool:
     vmImage: 'ubuntu-18.04'
   steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.8.x'
   - template: tools/ci/azure/checkout.yml
   - script: |
       set -euo pipefail

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -10,6 +10,10 @@ jobs:
   build-and-tag:
     runs-on: ubuntu-18.04
     steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
     - name: Checkout
       uses: actions/checkout@v1
       with:

--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -50,10 +50,6 @@ def parse_args(argv, commands=load_commands()):
                         dest="skip_venv_setup",
                         help="Whether to use the virtualenv as-is. Must set --venv as well")
     parser.add_argument("--debug", action="store_true", help="Run the debugger in case of an exception")
-    parser.add_argument("--py3", action="store_true",
-                        help="Run with Python 3 (requires a `python3` binary on the PATH)")
-    parser.add_argument("--py2", action="store_true",
-                        help="Run with Python 2 (requires a `python2` binary on the PATH)")
     subparsers = parser.add_subparsers(dest="command")
     for command, props in iteritems(commands):
         subparsers.add_parser(command, help=props["help"], add_help=False)

--- a/wpt
+++ b/wpt
@@ -1,34 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 if __name__ == "__main__":
     import sys
-    from tools.wpt import wpt
-    args, extra = wpt.parse_args(sys.argv[1:])
-    commands = wpt.load_commands()
-    py3only = commands[args.command]["py3only"]
+    if (sys.version_info.major < 3 or
+            (sys.version_info.major == 3 and sys.version_info.minor < 6)):
+        sys.stderr.write("wpt requires Python 3.6 or higher\n")
+        sys.exit(1)
 
-    if (args.py2) and sys.version_info.major > 2:
-        if py3only:
-            sys.stderr.write("This command only works with Python 3\n")
-            sys.exit(1)
-        from subprocess import call
-        try:
-            sys.exit(call(['python2'] + sys.argv))
-        except OSError as e:
-            if e.errno == 2:
-                sys.stderr.write("python2 is needed to run this command\n")
-                sys.exit(1)
-            else:
-                raise
-    elif (not args.py2) and sys.version_info.major < 3:
-        from subprocess import call
-        try:
-            sys.exit(call(['python3'] + sys.argv))
-        except OSError as e:
-            if e.errno == 2:
-                sys.stderr.write("python3 is needed to run this command\n")
-                sys.exit(1)
-            else:
-                raise
-    else:
-        wpt.main()
+    from tools.wpt import wpt
+    wpt.main()


### PR DESCRIPTION
This commit changes the entrypoint to reject any Python version that is
not 3.6 or higher. It also removes the --py2 and --py3 flags.

We are deliberately doing a rejection rather than a fallback to Python 3
to quickly find any remaining entrypoints using Py2.