### PR TITLE
[python3] Remove a set of `six` uses from `tools/`

### DIFF
--- a/tools/ci/jobs.py
+++ b/tools/ci/jobs.py
@@ -4,7 +4,6 @@ import re
 from ..wpt.testfiles import branch_point, files_changed
 
 from tools import localpaths  # noqa: F401
-from six import iteritems
 
 wpt_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
 
@@ -109,7 +108,7 @@ def get_jobs(paths, **kwargs):
     includes = kwargs.get("includes")
     if includes is not None:
         includes = set(includes)
-    for key, value in iteritems(job_path_map):
+    for key, value in job_path_map.items():
         if includes is None or key in includes:
             rules[key] = Ruleset(value)
 
@@ -124,7 +123,7 @@ def get_jobs(paths, **kwargs):
 
     # Default jobs shuld run even if there were no changes
     if not paths:
-        for job, path_re in iteritems(job_path_map):
+        for job, path_re in job_path_map.items():
             if ".*" in path_re:
                 jobs.add(job)
 

--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Wrapper script for running jobs in Taskcluster
 
@@ -58,6 +58,8 @@ def run(cmd, return_stdout=False, **kwargs):
     print(" ".join(cmd))
     if return_stdout:
         f = subprocess.check_output
+        if "encoding" not in kwargs:
+            kwargs["encoding"] = "utf-8"
     else:
         f = subprocess.check_call
     return f(cmd, **kwargs)
@@ -146,7 +148,7 @@ def install_chrome(channel):
 
     dest = os.path.join("/tmp", deb_archive)
     deb_url = "https://dl.google.com/linux/direct/%s" % deb_archive
-    with open(dest, "w") as f:
+    with open(dest, "wb") as f:
         get_download_to_descriptor(f, deb_url)
 
     run(["sudo", "apt-get", "-qqy", "update"])

--- a/tools/ci/tc/decision.py
+++ b/tools/ci/tc/decision.py
@@ -7,7 +7,6 @@ import subprocess
 from collections import OrderedDict
 
 import taskcluster
-from six import iteritems, itervalues
 
 from . import taskgraph
 
@@ -48,7 +47,7 @@ def fetch_event_data(queue):
 def filter_triggers(event, all_tasks):
     is_pr, branch = get_triggers(event)
     triggered = OrderedDict()
-    for name, task in iteritems(all_tasks):
+    for name, task in all_tasks.items():
         if "trigger" in task:
             if is_pr and "pull-request" in task["trigger"]:
                 triggered[name] = task
@@ -104,7 +103,7 @@ def get_extra_jobs(event):
 def filter_schedule_if(event, tasks):
     scheduled = OrderedDict()
     run_jobs = None
-    for name, task in iteritems(tasks):
+    for name, task in tasks.items():
         if "schedule-if" in task:
             if "run-job" in task["schedule-if"]:
                 if run_jobs is None:
@@ -283,7 +282,7 @@ def build_task_graph(event, all_tasks, tasks):
                                             env_extra=env_extra)
         task_id_map[task_name] = (task_id, task_data)
 
-    for task_name, task in iteritems(tasks):
+    for task_name, task in tasks.items():
         if task_name == "sink-task":
             # sink-task will be created below at the end of the ordered dict,
             # so that it can depend on all other tasks.
@@ -309,7 +308,7 @@ def build_task_graph(event, all_tasks, tasks):
 
 
 def create_tasks(queue, task_id_map):
-    for (task_id, task_data) in itervalues(task_id_map):
+    for (task_id, task_data) in task_id_map.values():
         queue.createTask(task_id, task_data)
 
 

--- a/tools/ci/tc/taskgraph.py
+++ b/tools/ci/tc/taskgraph.py
@@ -4,9 +4,7 @@ import re
 from collections import OrderedDict
 from copy import deepcopy
 
-import six
 import yaml
-from six import iteritems
 
 here = os.path.dirname(__file__)
 
@@ -27,7 +25,7 @@ def load_task_file(path):
 
 
 def update_recursive(data, update_data):
-    for key, value in iteritems(update_data):
+    for key, value in update_data.items():
         if key not in data:
             data[key] = value
         else:
@@ -94,13 +92,13 @@ def replace_vars(input_string, variables):
 
 
 def sub_variables(data, variables):
-    if isinstance(data, six.string_types):
+    if isinstance(data, str):
         return replace_vars(data, variables)
     if isinstance(data, list):
         return [sub_variables(item, variables) for item in data]
     if isinstance(data, dict):
         return {key: sub_variables(value, variables)
-                for key, value in iteritems(data)}
+                for key, value in data.items()}
     return data
 
 
@@ -154,7 +152,7 @@ def load_tasks(tasks_data):
                 raise ValueError("Got duplicate task name %s" % new_name)
             map_resolved_tasks[new_name] = substitute_variables(data)
 
-    for task_default_name, data in iteritems(map_resolved_tasks):
+    for task_default_name, data in map_resolved_tasks.items():
         task = resolve_use(data, tasks_data["components"])
         task = resolve_name(task, task_default_name)
         tasks.extend(resolve_chunks(task))

--- a/tools/ci/tc/tests/test_decision.py
+++ b/tools/ci/tc/tests/test_decision.py
@@ -3,8 +3,6 @@ import pytest
 import os
 import sys
 
-from six import iteritems
-
 here = os.path.dirname(__file__)
 root = os.path.abspath(os.path.join(here, "..", "..", "..", ".."))
 sys.path.insert(0, root)
@@ -49,7 +47,7 @@ def test_extra_jobs_pr(msg, expected, event):
         """Copy obj, except if it's a string with the value <message>
         replace it with the value of the msg argument"""
         if isinstance(obj, dict):
-            return {key: sub(value) for (key, value) in iteritems(obj)}
+            return {key: sub(value) for (key, value) in obj.items()}
         elif isinstance(obj, list):
             return [sub(value) for value in obj]
         elif obj == "<message>":

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -14,6 +14,7 @@ import sys
 import tempfile
 
 from collections import defaultdict
+from urllib.parse import urlsplit, urljoin
 
 from . import fnmatch
 from . import rules
@@ -24,9 +25,7 @@ from ..wpt import testfiles
 from ..manifest.vcs import walk
 
 from ..manifest.sourcefile import SourceFile, js_meta_re, python_meta_re, space_chars, get_any_variants
-from six import binary_type, ensure_binary, ensure_text, iteritems, itervalues, with_metaclass
-from six.moves import range
-from six.moves.urllib.parse import urlsplit, urljoin
+from six import ensure_binary, ensure_text
 
 MYPY = False
 if MYPY:
@@ -325,7 +324,7 @@ def check_css_globally_unique(repo_root, paths):
 
     errors = []
 
-    for name, colliding in iteritems(test_files):
+    for name, colliding in test_files.items():
         if len(colliding) > 1:
             if not _all_files_equal([os.path.join(repo_root, x) for x in colliding]):
                 # Only compute by_spec if there are prima-facie collisions because of cost
@@ -342,7 +341,7 @@ def check_css_globally_unique(repo_root, paths):
                             continue
                         by_spec[spec].add(path)
 
-                for spec, spec_paths in iteritems(by_spec):
+                for spec, spec_paths in by_spec.items():
                     if not _all_files_equal([os.path.join(repo_root, x) for x in spec_paths]):
                         for x in spec_paths:
                             context1 = (name, spec, ", ".join(sorted(spec_paths)))
@@ -351,7 +350,7 @@ def check_css_globally_unique(repo_root, paths):
 
     for rule_class, d in [(rules.CSSCollidingRefName, ref_files),
                           (rules.CSSCollidingSupportName, support_files)]:
-        for name, colliding in iteritems(d):
+        for name, colliding in d.items():
             if len(colliding) > 1:
                 if not _all_files_equal([os.path.join(repo_root, x) for x in colliding]):
                     context2 = (name, ", ".join(sorted(colliding)))
@@ -451,7 +450,7 @@ def filter_ignorelist_errors(data, errors):
         # which explains how to fix it correctly and shouldn't be skipped.
         if error_type in data and error_type != "IGNORED PATH":
             wl_files = data[error_type]
-            for file_match, allowed_lines in iteritems(wl_files):
+            for file_match, allowed_lines in wl_files.items():
                 if None in allowed_lines or line in allowed_lines:
                     if fnmatch.fnmatchcase(normpath, file_match):
                         skipped[i] = True
@@ -667,7 +666,7 @@ def check_parsed(repo_root, path, f):
 
     return errors
 
-class ASTCheck(with_metaclass(abc.ABCMeta)):
+class ASTCheck(metaclass=abc.ABCMeta):
     @abc.abstractproperty
     def rule(self):
         # type: () -> Type[rules.Rule]
@@ -740,7 +739,7 @@ def check_script_metadata(repo_root, path, f):
     done = False
     errors = []
     for idx, line in enumerate(f):
-        assert isinstance(line, binary_type), line
+        assert isinstance(line, bytes), line
 
         m = meta_re.match(line)
         if m:
@@ -974,7 +973,7 @@ def create_parser():
 
 def main(**kwargs_str):
     # type: (**Any) -> int
-    kwargs = {ensure_text(key): value for key, value in iteritems(kwargs_str)}
+    kwargs = {ensure_text(key): value for key, value in kwargs_str.items()}
 
     assert logger is not None
     if kwargs.get("json") and kwargs.get("markdown"):
@@ -1102,7 +1101,7 @@ def lint(repo_root, paths, output_format, ignore_glob=None, github_checks_output
     if error_count and github_checks_outputter:
         github_checks_outputter.output("```")
 
-    return sum(itervalues(error_count))
+    return sum(error_count.values())
 
 
 path_lints = [check_file_type, check_path_length, check_worker_collision, check_ahem_copy,

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -5,8 +5,6 @@ import inspect
 import os
 import re
 
-import six
-
 MYPY = False
 if MYPY:
     # MYPY is set to True when run under Mypy.
@@ -19,7 +17,7 @@ def collapse(text):
     return inspect.cleandoc(str(text)).replace("\n", " ")
 
 
-class Rule(six.with_metaclass(abc.ABCMeta)):
+class Rule(metaclass=abc.ABCMeta):
     @abc.abstractproperty
     def name(self):
         # type: () -> Text
@@ -367,7 +365,7 @@ class TentativeDirectoryName(Rule):
     to_fix = "rename directory to be called 'tentative'"
 
 
-class Regexp(six.with_metaclass(abc.ABCMeta)):
+class Regexp(metaclass=abc.ABCMeta):
     @abc.abstractproperty
     def pattern(self):
         # type: () -> bytes

--- a/tools/lint/tests/base.py
+++ b/tools/lint/tests/base.py
@@ -1,11 +1,10 @@
 from __future__ import unicode_literals
 
-from six import integer_types, text_type
 
 def check_errors(errors):
     for e in errors:
         error_type, description, path, line_number = e
-        assert isinstance(error_type, text_type)
-        assert isinstance(description, text_type)
-        assert isinstance(path, text_type)
-        assert line_number is None or isinstance(line_number, integer_types)
+        assert isinstance(error_type, str)
+        assert isinstance(description, str)
+        assert isinstance(path, str)
+        assert line_number is None or isinstance(line_number, int)

--- a/tools/lint/tests/test_lint.py
+++ b/tools/lint/tests/test_lint.py
@@ -1,10 +1,8 @@
-from __future__ import unicode_literals
-
+import io
 import os
 import sys
 
 import mock
-import six
 
 here = os.path.dirname(__file__)
 root = os.path.abspath(os.path.join(here, "..", "..", ".."))
@@ -58,7 +56,7 @@ def test_filter_ignorelist_errors():
 
 
 def test_parse_ignorelist():
-    input_buffer = six.StringIO("""
+    input_buffer = io.StringIO("""
 # Comment
 CR AT EOL: svg/import/*
 CR AT EOL: streams/resources/test-utils.js

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import abc
 import argparse
+import importlib
 import json
 import logging
 import multiprocessing
@@ -16,13 +17,12 @@ import sys
 import threading
 import time
 import traceback
-from six.moves import urllib
+import urllib
 import uuid
 from collections import defaultdict, OrderedDict
 from itertools import chain, product
 
 from localpaths import repo_root
-from six.moves import reload_module
 
 from manifest.sourcefile import read_script_metadata, js_meta_re, parse_variants
 from wptserve import server as wptserve, handlers
@@ -697,7 +697,7 @@ def release_mozlog_lock():
 def start_ws_server(host, port, paths, routes, bind_address, config, **kwargs):
     # Ensure that when we start this in a new process we have the global lock
     # in the logging module unlocked
-    reload_module(logging)
+    importlib.reload(logging)
     release_mozlog_lock()
     try:
         return WebSocketDaemon(host,
@@ -713,7 +713,7 @@ def start_ws_server(host, port, paths, routes, bind_address, config, **kwargs):
 def start_wss_server(host, port, paths, routes, bind_address, config, **kwargs):
     # Ensure that when we start this in a new process we have the global lock
     # in the logging module unlocked
-    reload_module(logging)
+    importlib.reload(logging)
     release_mozlog_lock()
     try:
         return WebSocketDaemon(host,
@@ -771,7 +771,7 @@ class QuicTransportDaemon(object):
 def start_quic_transport_server(host, port, paths, routes, bind_address, config, **kwargs):
     # Ensure that when we start this in a new process we have the global lock
     # in the logging module unlocked
-    reload_module(logging)
+    importlib.reload(logging)
     release_mozlog_lock()
     try:
         return QuicTransportDaemon(host,

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -9,7 +9,7 @@ from abc import ABCMeta, abstractmethod
 from datetime import datetime, timedelta
 from distutils.spawn import find_executable
 
-from six.moves.urllib.parse import urlsplit
+from urllib.parse import urlsplit
 import requests
 
 from .utils import call, get, rmtree, untar, unzip, get_download_to_descriptor, sha256sum

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -3,7 +3,6 @@ import os
 import platform
 import sys
 from distutils.spawn import find_executable
-from six.moves import input
 
 wpt_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
 sys.path.insert(0, os.path.abspath(os.path.join(wpt_root, "tools")))
@@ -757,9 +756,8 @@ def setup_logging(kwargs, default_config=None, formatter_defaults=None):
 
 def setup_wptrunner(venv, **kwargs):
     from wptrunner import wptcommandline
-    from six import iteritems
 
-    kwargs = utils.Kwargs(iteritems(kwargs))
+    kwargs = utils.Kwargs(kwargs.items())
 
     kwargs["product"] = kwargs["product"].replace("-", "_")
 

--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 
 from collections import OrderedDict
-from six import ensure_text, ensure_str, iteritems
+from six import ensure_text, ensure_str
 
 try:
     from ..manifest import manifest
@@ -98,7 +98,7 @@ def branch_point():
         branch_point = None
 
         # if there are any commits, take the first parent that is not in commits
-        for commit, parents in iteritems(commit_parents):
+        for commit, parents in commit_parents.items():
             for parent in parents:
                 if parent not in commit_parents:
                     branch_point = parent

--- a/tools/wpt/utils.py
+++ b/tools/wpt/utils.py
@@ -9,7 +9,7 @@ import time
 import zipfile
 from io import BytesIO
 from socket import error as SocketError  # NOQA: N812
-from six.moves.urllib.request import urlopen
+from urllib.request import urlopen
 
 MYPY = False
 if MYPY:

--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -6,7 +6,6 @@ import sys
 
 from tools import localpaths  # noqa: F401
 
-from six import iteritems
 from . import virtualenv
 
 
@@ -23,7 +22,7 @@ def load_commands():
         base_dir = os.path.dirname(abs_path)
         with open(abs_path, "r") as f:
             data = json.load(f)
-            for command, props in iteritems(data):
+            for command, props in data.items():
                 assert "path" in props
                 assert "script" in props
                 rv[command] = {
@@ -51,7 +50,7 @@ def parse_args(argv, commands=load_commands()):
                         help="Whether to use the virtualenv as-is. Must set --venv as well")
     parser.add_argument("--debug", action="store_true", help="Run the debugger in case of an exception")
     subparsers = parser.add_subparsers(dest="command")
-    for command, props in iteritems(commands):
+    for command, props in commands.items():
         subparsers.add_parser(command, help=props["help"], add_help=False)
 
     args, extra = parser.parse_known_args(argv)


### PR DESCRIPTION
Now that we are Python3-only, this starts to tear out our usage of `six`.

Commits are organized by subdirectory, and this covers four of them: `lint/`, `wpt/`,
`serve/` and `ci/`.  In each I removed all uses of `six` except for the `ensure_*` calls,
which are not trivially replaceable.