### PR TITLE
HTTP/1 parsing of responses without newlines after headers

### DIFF
--- a/fetch/h1-parsing/incomplete-response.window.js
+++ b/fetch/h1-parsing/incomplete-response.window.js
@@ -1,0 +1,16 @@
+// This only tests headers without a single newline after them for now.
+// See https://github.com/whatwg/fetch/issues/472 for context.
+
+const statusLine = "HTTP/1.1 200 OKAYISH\n";
+
+[
+  "header: value\t",
+  "header: value ",
+  "header: value\f",
+  "header: value\r"
+].forEach(input => {
+  promise_test(t => {
+    const message = encodeURIComponent(statusLine + input)
+    return promise_rejects_js(t, TypeError, fetch(`resources/message.py?message=${message}`));
+  }, `Parsing response without trailing newline (${input})`);
+});

--- a/fetch/h1-parsing/incomplete-response.window.js
+++ b/fetch/h1-parsing/incomplete-response.window.js
@@ -7,7 +7,8 @@ const statusLine = "HTTP/1.1 200 OKAYISH\n";
   "header: value\t",
   "header: value ",
   "header: value\f",
-  "header: value\r"
+  "header: value\r",
+  "header: value\r\r"
 ].forEach(input => {
   promise_test(t => {
     const message = encodeURIComponent(statusLine + input)

--- a/fetch/h1-parsing/resources/message.py
+++ b/fetch/h1-parsing/resources/message.py
@@ -1,0 +1,3 @@
+def main(request, response):
+    response.writer.write(request.GET.first(b"message"))
+    response.close_connection = True


### PR DESCRIPTION
For https://github.com/whatwg/fetch/issues/472.