### PR TITLE
[python3] Remove more `six` usages in tools/

### DIFF
--- a/tools/docker/frontend.py
+++ b/tools/docker/frontend.py
@@ -5,8 +5,6 @@ import re
 import subprocess
 import sys
 
-from six import iteritems
-
 here = os.path.abspath(os.path.dirname(__file__))
 wpt_root = os.path.abspath(os.path.join(here, os.pardir, os.pardir))
 
@@ -37,7 +35,7 @@ def walk_yaml(root, target):
             if isinstance(value, (dict, list)):
                 rv.extend(walk_yaml(value, target))
     elif isinstance(root, dict):
-        for key, value in iteritems(root):
+        for key, value in root.items():
             if isinstance(value, (dict, list)):
                 rv.extend(walk_yaml(value, target))
             elif key == target:

--- a/tools/gitignore/gitignore.py
+++ b/tools/gitignore/gitignore.py
@@ -1,7 +1,7 @@
 import re
 import os
 import itertools
-from six import ensure_binary, itervalues, iteritems
+from six import ensure_binary
 from collections import defaultdict
 
 MYPY = False
@@ -194,13 +194,13 @@ class PathFilter(object):
                 rule = cast(Tuple[bool, Pattern[bytes]], rule)
             if not dir_only:
                 rules_iter = itertools.chain(
-                    itertools.chain(*(iteritems(item) for item in itervalues(self.literals_dir))),
-                    itertools.chain(*(iteritems(item) for item in itervalues(self.literals_file))),
+                    itertools.chain(*(item.items() for item in self.literals_dir.values())),
+                    itertools.chain(*(item.items() for item in self.literals_file.values())),
                     self.patterns_dir,
                     self.patterns_file)  # type: Iterable[Tuple[Any, List[Tuple[bool, Pattern[bytes]]]]]
             else:
                 rules_iter = itertools.chain(
-                    itertools.chain(*(iteritems(item) for item in itervalues(self.literals_dir))),
+                    itertools.chain(*(item.items() for item in self.literals_dir.values())),
                     self.patterns_dir)
 
             for rules in rules_iter:

--- a/tools/manifest/XMLParser.py
+++ b/tools/manifest/XMLParser.py
@@ -6,8 +6,6 @@ from collections import OrderedDict
 from xml.parsers import expat
 import xml.etree.ElementTree as etree  # noqa: N813
 
-from six import text_type
-
 MYPY = False
 if MYPY:
     # MYPY is set to True when run under Mypy.
@@ -83,7 +81,7 @@ class XMLParser(object):
 
     def _start(self, tag, attrib_in):
         # type: (Text, List[str]) -> etree.Element
-        assert isinstance(tag, text_type)
+        assert isinstance(tag, str)
         self._fed_data = None
         tag = _fixname(tag)
         attrib = OrderedDict()  # type: Dict[Union[bytes, Text], Union[bytes, Text]]

--- a/tools/manifest/download.py
+++ b/tools/manifest/download.py
@@ -7,8 +7,7 @@ import json
 import io
 import os
 from datetime import datetime, timedelta
-
-from six.moves.urllib.request import urlopen
+from urllib.request import urlopen
 
 try:
     import zstandard

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -1,7 +1,6 @@
 import os.path
 from inspect import isabstract
-from six import iteritems, with_metaclass
-from six.moves.urllib.parse import urljoin, urlparse, parse_qs
+from urllib.parse import urljoin, urlparse, parse_qs
 from abc import ABCMeta, abstractproperty
 
 from .utils import to_os_path
@@ -42,7 +41,7 @@ class ManifestItemMeta(ABCMeta):
         return rv  # type: ignore
 
 
-class ManifestItem(with_metaclass(ManifestItemMeta)):
+class ManifestItem(metaclass=ManifestItemMeta):
     __slots__ = ("_tests_root", "path")
 
     def __init__(self, tests_root, path):
@@ -289,7 +288,7 @@ class RefTest(URLManifestItem):
         if self.dpi is not None:
             extras["dpi"] = self.dpi
         if self.fuzzy:
-            extras["fuzzy"] = list(iteritems(self.fuzzy))
+            extras["fuzzy"] = list(self.fuzzy.items())
         return rv
 
     @classmethod

--- a/tools/manifest/jsonlib.py
+++ b/tools/manifest/jsonlib.py
@@ -1,8 +1,6 @@
 import re
 import json
 
-from six import PY3
-
 
 MYPY = False
 if MYPY:
@@ -49,10 +47,8 @@ _ujson_dump_local_kwargs = {
     'ensure_ascii': False,
     'escape_forward_slashes': False,
     'indent': 1,
+    'reject_bytes': True,
 }  # type: Dict[str, Any]
-
-if PY3:
-    _ujson_dump_local_kwargs['reject_bytes'] = True
 
 
 _json_dump_local_kwargs = {
@@ -99,10 +95,9 @@ else:
 _ujson_dump_dist_kwargs = {
     'sort_keys': True,
     'indent': 1,
+    'reject_bytes': True,
 }  # type: Dict[str, Any]
 
-if PY3:
-    _ujson_dump_dist_kwargs['reject_bytes'] = True
 
 _json_dump_dist_kwargs = {
     'sort_keys': True,

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -1,17 +1,10 @@
 import io
-import itertools
 import os
 import sys
 from atomicwrites import atomic_write
 from copy import deepcopy
 from multiprocessing import Pool, cpu_count
-from six import (
-    PY3,
-    ensure_text,
-    iteritems,
-    itervalues,
-    string_types,
-)
+from six import ensure_text
 
 from . import jsonlib
 from . import vcs
@@ -93,7 +86,7 @@ class ManifestData(ManifestDataType):
         """Dictionary subclass containing a TypeData instance for each test type,
         keyed by type name"""
         self.initialized = False  # type: bool
-        for key, value in iteritems(item_classes):
+        for key, value in item_classes.items():
             self[key] = TypeData(manifest, value)
         self.initialized = True
         self.json_obj = None  # type: None
@@ -109,7 +102,7 @@ class ManifestData(ManifestDataType):
         """Get a list of all paths containing test items
         without actually constructing all the items"""
         rv = set()  # type: Set[Text]
-        for item_data in itervalues(self):
+        for item_data in self.values():
             for item in item_data:
                 rv.add(os.path.sep.join(item))
         return rv
@@ -117,7 +110,7 @@ class ManifestData(ManifestDataType):
     def type_by_path(self):
         # type: () -> Dict[Tuple[Text, ...], Text]
         rv = {}
-        for item_type, item_data in iteritems(self):
+        for item_type, item_data in self.items():
             for item in item_data:
                 rv[item] = item_type
         return rv
@@ -159,7 +152,7 @@ class Manifest(object):
         tpath_len = len(tpath)
 
         for type_tests in self._data.values():
-            for path, tests in iteritems(type_tests):
+            for path, tests in type_tests.items():
                 if path[:tpath_len] == tpath:
                     for test in tests:
                         yield test
@@ -253,10 +246,8 @@ class Manifest(object):
                                           to_update,
                                           chunksize=chunksize
                                           )  # type: Iterator[Tuple[Tuple[Text, ...], Text, Set[ManifestItem], Text]]
-        elif PY3:
-            results = map(compute_manifest_items, to_update)
         else:
-            results = itertools.imap(compute_manifest_items, to_update)
+            results = map(compute_manifest_items, to_update)
 
         for result in results:
             rel_path_parts, new_type, manifest_items, file_hash = result
@@ -271,7 +262,7 @@ class Manifest(object):
         if remaining_manifest_paths:
             changed = True
             for rel_path_parts in remaining_manifest_paths:
-                for test_data in itervalues(data):
+                for test_data in data.values():
                     if rel_path_parts in test_data:
                         del test_data[rel_path_parts]
 
@@ -291,7 +282,7 @@ class Manifest(object):
         """
         out_items = {
             test_type: type_paths.to_json()
-            for test_type, type_paths in iteritems(self._data) if type_paths
+            for test_type, type_paths in self._data.items() if type_paths
         }
 
         if caller_owns_obj:
@@ -325,7 +316,7 @@ class Manifest(object):
         if not hasattr(obj, "items"):
             raise ManifestError
 
-        for test_type, type_paths in iteritems(obj["items"]):
+        for test_type, type_paths in obj["items"].items():
             if test_type not in item_classes:
                 raise ManifestError
 
@@ -358,12 +349,12 @@ def _load(logger,  # type: Logger
           allow_cached=True  # type: bool
           ):
     # type: (...) -> Optional[Manifest]
-    manifest_path = (manifest if isinstance(manifest, string_types)
+    manifest_path = (manifest if isinstance(manifest, str)
                      else manifest.name)
     if allow_cached and manifest_path in __load_cache:
         return __load_cache[manifest_path]
 
-    if isinstance(manifest, string_types):
+    if isinstance(manifest, str):
         if os.path.exists(manifest):
             logger.debug("Opening manifest at %s" % manifest)
         else:

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -3,8 +3,7 @@ import re
 import os
 from collections import deque
 from io import BytesIO
-from six import binary_type, iteritems, text_type
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urljoin
 from fnmatch import fnmatch
 
 MYPY = False
@@ -74,7 +73,7 @@ def read_script_metadata(f, regexp):
                value.
     """
     for line in f:
-        assert isinstance(line, binary_type), line
+        assert isinstance(line, bytes), line
         m = regexp.match(line)
         if not m:
             break
@@ -97,7 +96,7 @@ def get_any_variants(item):
     """
     Returns a set of variants (strings) defined by the given keyword.
     """
-    assert isinstance(item, text_type), item
+    assert isinstance(item, str), item
 
     variant = _any_variants.get(item, None)
     if variant is None:
@@ -119,7 +118,7 @@ def parse_variants(value):
     """
     Returns a set of variants (strings) defined by a comma-separated value.
     """
-    assert isinstance(value, text_type), value
+    assert isinstance(value, str), value
 
     if value == "":
         return get_default_any_variants()
@@ -138,7 +137,7 @@ def global_suffixes(value):
     variant is intended to run in a JS shell, for the variants defined by the
     given comma-separated value.
     """
-    assert isinstance(value, text_type), value
+    assert isinstance(value, str), value
 
     rv = set()
 
@@ -243,7 +242,7 @@ class SourceFile(object):
 
         if "__cached_properties__" in rv:
             cached_properties = rv["__cached_properties__"]
-            rv = {key:value for key, value in iteritems(rv) if key not in cached_properties}
+            rv = {key:value for key, value in rv.items() if key not in cached_properties}
             del rv["__cached_properties__"]
         return rv
 
@@ -304,7 +303,7 @@ class SourceFile(object):
                 content = f.read()
 
             data = b"".join((b"blob ", b"%d" % len(content), b"\0", content))
-            self._hash = text_type(hashlib.sha1(data).hexdigest())
+            self._hash = str(hashlib.sha1(data).hexdigest())
 
         return self._hash
 

--- a/tools/manifest/testpaths.py
+++ b/tools/manifest/testpaths.py
@@ -3,8 +3,6 @@ import json
 import os
 from collections import defaultdict
 
-from six import iteritems
-
 from .manifest import load_and_update, Manifest
 from .log import get_logger
 
@@ -102,7 +100,7 @@ def write_output(path_id_map, as_json):
     if as_json:
         print(json.dumps(path_id_map))
     else:
-        for path, test_ids in sorted(iteritems(path_id_map)):
+        for path, test_ids in sorted(path_id_map.items()):
             print(path)
             for test_id in sorted(test_ids):
                 print("  " + test_id)

--- a/tools/manifest/tests/test_manifest.py
+++ b/tools/manifest/tests/test_manifest.py
@@ -6,8 +6,6 @@ import mock
 import hypothesis as h
 import hypothesis.strategies as hs
 
-from six import iteritems
-
 here = os.path.dirname(__file__)
 root = os.path.abspath(os.path.join(here, "..", "..", ".."))
 sys.path.insert(0, root)
@@ -99,11 +97,11 @@ def manifest_tree(draw):
 
     reftest_urls = []
     output = []
-    stack = [((k,), v) for k, v in iteritems(generated_root)]
+    stack = [((k,), v) for k, v in generated_root.items()]
     while stack:
         path, node = stack.pop()
         if isinstance(node, dict):
-            stack.extend((path + (k,), v) for k, v in iteritems(node))
+            stack.extend((path + (k,), v) for k, v in node.items())
         else:
             rel_path = os.path.sep.join(path)
             node.rel_path = rel_path

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from six import BytesIO
+from io import BytesIO
 from ...lint.lint import check_global_metadata
 from ..sourcefile import SourceFile, read_script_metadata, js_meta_re, python_meta_re
 

--- a/tools/manifest/typedata.py
+++ b/tools/manifest/typedata.py
@@ -1,5 +1,4 @@
-from six import itervalues, iteritems
-from six.moves.collections_abc import MutableMapping
+from collections.abc import MutableMapping
 
 
 MYPY = False
@@ -181,7 +180,7 @@ class TypeData(TypeDataType):
             if isinstance(v, set):
                 count += 1
             else:
-                stack.extend(itervalues(v))
+                stack.extend(v.values())
 
         stack = [self._json_data]
         while stack:
@@ -189,7 +188,7 @@ class TypeData(TypeDataType):
             if isinstance(v, list):
                 count += 1
             else:
-                stack.extend(itervalues(v))
+                stack.extend(v.values())
 
         return count
 
@@ -270,7 +269,7 @@ class TypeData(TypeDataType):
         stack = [(self._data, json_rv, tuple())]  # type: List[Tuple[Dict[Text, Any], Dict[Text, Any], Tuple[Text, ...]]]
         while stack:
             data_node, json_node, par_full_key = stack.pop()
-            for k, v in iteritems(data_node):
+            for k, v in data_node.items():
                 full_key = par_full_key + (k,)
                 if isinstance(v, set):
                     assert k not in json_node

--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -2,9 +2,7 @@ import abc
 import os
 import stat
 from collections import deque
-
-from six import with_metaclass, PY2
-from six.moves.collections_abc import MutableMapping
+from collections.abc import MutableMapping
 
 from . import jsonlib
 from .utils import git
@@ -19,10 +17,7 @@ if MYPY:
     # MYPY is set to True when run under Mypy.
     from typing import Dict, Optional, List, Set, Text, Iterable, Any, Tuple, Iterator
     from .manifest import Manifest  # cyclic import under MYPY guard
-    if PY2:
-        stat_result = Any
-    else:
-        stat_result = os.stat_result
+    stat_result = os.stat_result
 
     GitIgnoreCacheType = MutableMapping[bytes, bool]
 else:
@@ -132,7 +127,7 @@ class FileSystem(object):
                 cache.dump()
 
 
-class CacheFile(with_metaclass(abc.ABCMeta)):
+class CacheFile(metaclass=abc.ABCMeta):
     def __init__(self, cache_root, tests_root, rebuild=False):
         # type: (Text, Text, bool) -> None
         self.tests_root = tests_root

--- a/tools/runner/report.py
+++ b/tools/runner/report.py
@@ -9,7 +9,6 @@ import types
 
 from cgi import escape
 from collections import defaultdict
-from six import iteritems
 
 
 def html_escape(item, escape_quote=False):
@@ -45,7 +44,7 @@ class Node(object):
             attrs_unicode = " " + " ".join("%s=\"%s\"" % (html_escape(key),
                                                           html_escape(value,
                                                                       escape_quote=True))
-                                           for key, value in iteritems(self.attrs))
+                                           for key, value in self.attrs.items())
         else:
             attrs_unicode = ""
         return "<%s%s>%s</%s>\n" % (self.name,

--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -2,8 +2,7 @@ from . import error
 from . import protocol
 from . import transport
 
-from six import string_types
-from six.moves.urllib import parse as urlparse
+from urllib import parse as urlparse
 
 
 def command(func):
@@ -435,7 +434,7 @@ class Cookies(object):
         cookie = {"name": name,
                   "value": None}
 
-        if isinstance(name, string_types):
+        if isinstance(name, str):
             cookie["value"] = value
         elif hasattr(value, "value"):
             cookie["value"] = value.value

--- a/tools/webdriver/webdriver/error.py
+++ b/tools/webdriver/webdriver/error.py
@@ -1,8 +1,6 @@
 import collections
 import json
 
-from six import itervalues
-
 
 class WebDriverException(Exception):
     http_status = None
@@ -220,6 +218,6 @@ def get(error_code):
 
 
 _errors = collections.defaultdict()
-for item in list(itervalues(locals())):
+for item in list(locals().values()):
     if type(item) == type and issubclass(item, WebDriverException):
         _errors[item.status_code] = item

--- a/tools/webdriver/webdriver/protocol.py
+++ b/tools/webdriver/webdriver/protocol.py
@@ -2,8 +2,6 @@ import json
 
 import webdriver
 
-from six import iteritems
-
 
 """WebDriver wire protocol codecs."""
 
@@ -45,5 +43,5 @@ class Decoder(json.JSONDecoder):
         elif isinstance(payload, dict) and webdriver.ShadowRoot.identifier in payload:
             return webdriver.ShadowRoot.from_json(payload, self.session)
         elif isinstance(payload, dict):
-            return {k: self.object_hook(v) for k, v in iteritems(payload)}
+            return {k: self.object_hook(v) for k, v in payload.items()}
         return payload

--- a/tools/webdriver/webdriver/transport.py
+++ b/tools/webdriver/webdriver/transport.py
@@ -1,10 +1,9 @@
 import json
 import select
 
-from six import text_type, PY3
-from six.moves.collections_abc import Mapping
-from six.moves.http_client import HTTPConnection
-from six.moves.urllib import parse as urlparse
+from collections.abc import Mapping
+from http.client import HTTPConnection
+from urllib import parse as urlparse
 
 from . import error
 
@@ -157,8 +156,6 @@ class HTTPWireProtocol(object):
         """Gets the current HTTP connection, or lazily creates one."""
         if not self._conn:
             conn_kwargs = {}
-            if not PY3:
-                conn_kwargs["strict"] = True
             # We are not setting an HTTP timeout other than the default when the
             # connection its created. The send method has a timeout value if needed.
             self._conn = HTTPConnection(self.host, self.port, **conn_kwargs)
@@ -240,7 +237,7 @@ class HTTPWireProtocol(object):
         return Response.from_http(response, decoder=decoder, **codec_kwargs)
 
     def _request(self, method, uri, payload, headers=None, timeout=None):
-        if isinstance(payload, text_type):
+        if isinstance(payload, str):
             payload = payload.encode("utf-8")
 
         if headers is None:


### PR DESCRIPTION
This PR removes six usages from `tools/manifest`, `tools/webdriver`,
and a few other misc locations. 

 In each I removed all uses of six except for the `ensure_*` calls,
which are not trivially replaceable.