### PR TITLE
[python3] Remove usages of `six` in wptrunner and wptserve

### DIFF
--- a/tools/wptrunner/test/test.py
+++ b/tools/wptrunner/test/test.py
@@ -3,11 +3,11 @@ import argparse
 import os
 import sys
 
+from configparser import ConfigParser
+
 from mozlog import structuredlog
 from mozlog.handlers import BaseHandler, StreamHandler
 from mozlog.formatters import MachFormatter
-from six import iteritems
-from six.moves.configparser import ConfigParser
 from wptrunner import wptcommandline, wptrunner
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -84,7 +84,7 @@ def run_tests(product, kwargs):
 
 def settings_to_argv(settings):
     rv = []
-    for name, value in iteritems(settings):
+    for name, value in settings.items():
         key = "--%s" % name
         if not value:
             rv.append(key)
@@ -110,7 +110,7 @@ def run(config, args):
 
     logger.suite_start(tests=[])
 
-    for product, product_settings in iteritems(config["products"]):
+    for product, product_settings in config["products"].items():
         if args.product and product not in args.product:
             continue
 

--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -3,7 +3,6 @@ import platform
 import socket
 from abc import ABCMeta, abstractmethod
 from copy import deepcopy
-from six import iteritems
 
 from ..wptcommandline import require_arg  # noqa: F401
 
@@ -202,5 +201,5 @@ class ExecutorBrowser(object):
     up the browser from the runner process.
     """
     def __init__(self, **kwargs):
-        for k, v in iteritems(kwargs):
+        for k, v in kwargs.items():
             setattr(self, k, v)

--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -12,7 +12,7 @@ import time
 
 import requests
 
-from six.moves import cStringIO as StringIO
+from io import StringIO
 
 from .base import Browser, ExecutorBrowser, require_arg
 from .base import get_timeout_multiplier   # noqa: F401

--- a/tools/wptrunner/wptrunner/config.py
+++ b/tools/wptrunner/wptrunner/config.py
@@ -1,4 +1,4 @@
-from six.moves.configparser import SafeConfigParser
+from configparser import SafeConfigParser
 import os
 import sys
 from collections import OrderedDict

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -5,7 +5,6 @@ import signal
 import socket
 import sys
 import time
-from six import iteritems
 
 from mozlog import get_default_logger, handlers, proxy
 
@@ -108,7 +107,7 @@ class TestEnvironment(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.process_interrupts()
 
-        for scheme, servers in iteritems(self.servers):
+        for scheme, servers in self.servers.items():
             for port, server in servers:
                 server.kill()
         for cm in self.env_extras_cms:
@@ -215,7 +214,7 @@ class TestEnvironment(object):
         route_builder.add_handler("GET", "/resources/testdriver.js",
                                   StringHandler(data, "text/javascript"))
 
-        for url_base, paths in iteritems(self.test_paths):
+        for url_base, paths in self.test_paths.items():
             if url_base == "/":
                 continue
             route_builder.add_mount_point(url_base, paths["tests_path"])
@@ -247,13 +246,13 @@ class TestEnvironment(object):
         failed = []
         pending = []
         host = self.config["server_host"]
-        for scheme, servers in iteritems(self.servers):
+        for scheme, servers in self.servers.items():
             for port, server in servers:
                 if not server.is_alive():
                     failed.append((scheme, port))
 
         if not failed and self.test_server_port:
-            for scheme, servers in iteritems(self.servers):
+            for scheme, servers in self.servers.items():
                 # TODO(Hexcles): Find a way to test QUIC's UDP port.
                 if scheme == "quic-transport":
                     continue

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -8,9 +8,8 @@ import traceback
 import socket
 import sys
 from abc import ABCMeta, abstractmethod
-from six import text_type
-from six.moves.http_client import HTTPConnection
-from six.moves.urllib.parse import urljoin, urlsplit, urlunsplit
+from http.client import HTTPConnection
+from urllib.parse import urljoin, urlsplit, urlunsplit
 
 from .actions import actions
 from .protocol import Protocol, BaseProtocolPart
@@ -333,7 +332,7 @@ class TestExecutor(object):
             status = e.status
         else:
             status = "INTERNAL-ERROR"
-        message = text_type(getattr(e, "message", ""))
+        message = str(getattr(e, "message", ""))
         if message:
             message += "\n"
         message += exception_string

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -1,7 +1,7 @@
 import os
 import traceback
 
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urljoin
 
 from .base import WdspecProtocol, WdspecExecutor, get_pages
 from .executorwebdriver import WebDriverProtocol, WebDriverRefTestExecutor, WebDriverRun

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -5,8 +5,7 @@ import time
 import traceback
 import uuid
 
-from six import iteritems, iterkeys
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urljoin
 
 errors = None
 marionette = None
@@ -727,14 +726,14 @@ class MarionetteProtocol(Protocol):
 
     def on_environment_change(self, old_environment, new_environment):
         #Unset all the old prefs
-        for name in iterkeys(old_environment.get("prefs", {})):
+        for name in old_environment.get("prefs", {}).keys():
             value = self.executor.original_pref_values[name]
             if value is None:
                 self.prefs.clear(name)
             else:
                 self.prefs.set(name, value)
 
-        for name, value in iteritems(new_environment.get("prefs", {})):
+        for name, value in new_environment.get("prefs", {}).items():
             self.executor.original_pref_values[name] = self.prefs.get(name)
             self.prefs.set(name, value)
 
@@ -1048,8 +1047,7 @@ class InternalRefTestImplementation(RefTestImplementation):
         data = {"screenshot": screenshot, "isPrint": self.executor.is_print}
         if self.executor.group_metadata is not None:
             data["urlCount"] = {urljoin(self.executor.server_url(key[0]), key[1]):value
-                                for key, value in iteritems(
-                                    self.executor.group_metadata.get("url_count", {}))
+                                for key, value in self.executor.group_metadata.get("url_count", {}).items()
                                 if value > 1}
         self.chrome_scope = chrome_scope
         if chrome_scope:

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -6,7 +6,7 @@ import threading
 import time
 import traceback
 import uuid
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urljoin
 
 from .base import (CallbackHandler,
                    RefTestExecutor,

--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -7,7 +7,7 @@ import tempfile
 import threading
 import traceback
 import uuid
-from six import ensure_str, iteritems
+from six import ensure_str
 
 from mozprocess import ProcessHandler
 
@@ -48,7 +48,7 @@ def build_servo_command(test, test_url_func, browser, binary, pause_after_test, 
         args += ["-Z", debug_opts]
     for stylesheet in browser.user_stylesheets:
         args += ["--user-stylesheet", stylesheet]
-    for pref, value in iteritems(test.environment.get('prefs', {})):
+    for pref, value in test.environment.get('prefs', {}).items():
         args += ["--pref", "%s=%s" % (pref, value)]
     if browser.ca_certificate_path:
         args += ["--certificate-path", browser.ca_certificate_path]

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -6,7 +6,7 @@ import threading
 import time
 import traceback
 import uuid
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urljoin
 
 from .base import (CallbackHandler,
                    CrashtestExecutor,

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -531,7 +531,7 @@ class DebugProtocolPart(ProtocolPart):
     def load_reftest_analyzer(self, test, result):
         import io
         import mozlog
-        from six.moves.urllib.parse import quote, urljoin
+        from urllib.parse import quote, urljoin
 
         debug_test_logger = mozlog.structuredlog.StructuredLogger("debug_test")
         output = io.StringIO()

--- a/tools/wptrunner/wptrunner/expectedtree.py
+++ b/tools/wptrunner/wptrunner/expectedtree.py
@@ -1,6 +1,5 @@
 from math import log
 from collections import defaultdict
-from six import iteritems, itervalues
 
 class Node(object):
     def __init__(self, prop, value):
@@ -34,7 +33,7 @@ def entropy(results):
 
     result_counts = defaultdict(int)
     total = float(len(results))
-    for values in itervalues(results):
+    for values in results.values():
         # Not sure this is right, possibly want to treat multiple values as
         # distinct from multiple of the same value?
         for value in values:
@@ -42,7 +41,7 @@ def entropy(results):
 
     entropy_sum = 0
 
-    for count in itervalues(result_counts):
+    for count in result_counts.values():
         prop = float(count) / total
         entropy_sum -= prop * log(prop, 2)
 
@@ -53,7 +52,7 @@ def split_results(prop, results):
     """Split a dictionary of results into a dictionary of dictionaries where
     each sub-dictionary has a specific value of the given property"""
     by_prop = defaultdict(dict)
-    for run_info, value in iteritems(results):
+    for run_info, value in results.items():
         by_prop[run_info[prop]][run_info] = value
 
     return by_prop
@@ -78,13 +77,13 @@ def build_tree(properties, dependent_props, results, tree=None):
     prop_index = {prop: i for i, prop in enumerate(properties)}
 
     all_results = defaultdict(int)
-    for result_values in itervalues(results):
-        for result_value, count in iteritems(result_values):
+    for result_values in results.values():
+        for result_value, count in result_values.items():
             all_results[result_value] += count
 
     # If there is only one result we are done
     if not properties or len(all_results) == 1:
-        for value, count in iteritems(all_results):
+        for value, count in all_results.items():
             tree.result_values[value] += count
         tree.run_info |= set(results.keys())
         return tree
@@ -100,7 +99,7 @@ def build_tree(properties, dependent_props, results, tree=None):
             continue
         new_entropy = 0.
         results_sets_entropy = []
-        for prop_value, result_set in iteritems(result_sets):
+        for prop_value, result_set in result_sets.items():
             results_sets_entropy.append((entropy(result_set), prop_value, result_set))
             new_entropy += (float(len(result_set)) / len(results)) * results_sets_entropy[-1][0]
 
@@ -110,7 +109,7 @@ def build_tree(properties, dependent_props, results, tree=None):
 
     # In the case that no properties partition the space
     if not results_partitions:
-        for value, count in iteritems(all_results):
+        for value, count in all_results.items():
             tree.result_values[value] += count
         tree.run_info |= set(results.keys())
         return tree

--- a/tools/wptrunner/wptrunner/formatters/chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/chromium.py
@@ -1,6 +1,5 @@
 import json
 import time
-import six
 
 from collections import defaultdict
 from mozlog.formatters import base
@@ -88,7 +87,7 @@ class ChromiumFormatter(base.BaseFormatter):
         :param str artifact_name: the name of the artifact
         :param str artifact_value: the value of the artifact
         """
-        assert isinstance(artifact_value, six.string_types), "artifact_value must be a str"
+        assert isinstance(artifact_value, str), "artifact_value must be a str"
         if "artifacts" not in cur_dict.keys():
             cur_dict["artifacts"] = defaultdict(list)
         cur_dict["artifacts"][artifact_name].append(artifact_value)

--- a/tools/wptrunner/wptrunner/formatters/tests/test_chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/tests/test_chromium.py
@@ -1,7 +1,7 @@
 import json
 import sys
 from os.path import dirname, join
-from six.moves import cStringIO as StringIO
+from io import StringIO
 
 from mozlog import handlers, structuredlog
 

--- a/tools/wptrunner/wptrunner/instruments.py
+++ b/tools/wptrunner/wptrunner/instruments.py
@@ -1,6 +1,6 @@
 import time
 import threading
-from six.moves.queue import Queue
+from queue import Queue
 
 """Instrumentation for measuring high-level time spent on various tasks inside the runner.
 

--- a/tools/wptrunner/wptrunner/manifestexpected.py
+++ b/tools/wptrunner/wptrunner/manifestexpected.py
@@ -1,8 +1,6 @@
 import os
 from collections import deque
-from six import string_types, text_type
-from six.moves.urllib.parse import urljoin
-
+from urllib.parse import urljoin
 
 from .wptmanifest.backends import static
 from .wptmanifest.backends.base import ManifestItem
@@ -49,7 +47,7 @@ def list_prop(name, node):
     """List property"""
     try:
         list_prop = node.get(name)
-        if isinstance(list_prop, string_types):
+        if isinstance(list_prop, str):
             return [list_prop]
         return list(list_prop)
     except KeyError:
@@ -59,7 +57,7 @@ def list_prop(name, node):
 def str_prop(name, node):
     try:
         prop = node.get(name)
-        if not isinstance(prop, string_types):
+        if not isinstance(prop, str):
             raise ValueError
         return prop
     except KeyError:
@@ -70,7 +68,7 @@ def tags(node):
     """Set of tags that have been applied to the test"""
     try:
         value = node.get("tags")
-        if isinstance(value, text_type):
+        if isinstance(value, str):
             return {value}
         return set(value)
     except KeyError:
@@ -79,7 +77,7 @@ def tags(node):
 
 def prefs(node):
     def value(ini_value):
-        if isinstance(ini_value, text_type):
+        if isinstance(ini_value, str):
             return tuple(pref_piece.strip() for pref_piece in ini_value.split(':', 1))
         else:
             # this should be things like @Reset, which are apparently type 'object'
@@ -87,7 +85,7 @@ def prefs(node):
 
     try:
         node_prefs = node.get("prefs")
-        if isinstance(node_prefs, text_type):
+        if isinstance(node_prefs, str):
             rv = dict(value(node_prefs))
         else:
             rv = dict(value(item) for item in node_prefs)
@@ -99,7 +97,7 @@ def prefs(node):
 def set_prop(name, node):
     try:
         node_items = node.get(name)
-        if isinstance(node_items, text_type):
+        if isinstance(node_items, str):
             rv = {node_items}
         else:
             rv = set(node_items)
@@ -112,7 +110,7 @@ def leak_threshold(node):
     rv = {}
     try:
         node_items = node.get("leak-threshold")
-        if isinstance(node_items, text_type):
+        if isinstance(node_items, str):
             node_items = [node_items]
         for item in node_items:
             process, value = item.rsplit(":", 1)
@@ -169,7 +167,7 @@ def fuzzy_prop(node):
     if not isinstance(value, list):
         value = [value]
     for item in value:
-        if not isinstance(item, text_type):
+        if not isinstance(item, str):
             rv.append(item)
             continue
         parts = item.rsplit(":", 1)

--- a/tools/wptrunner/wptrunner/manifestinclude.py
+++ b/tools/wptrunner/wptrunner/manifestinclude.py
@@ -6,8 +6,7 @@ be included or excluded.
 """
 import glob
 import os
-from six import iteritems
-from six.moves.urllib.parse import urlparse, urlsplit
+from urllib.parse import urlparse, urlsplit
 
 from .wptmanifest.node import DataNode
 from .wptmanifest.backends import conditional
@@ -95,7 +94,7 @@ class IncludeManifest(ManifestItem):
         if paths:
             urls = []
             for path in paths:
-                for manifest, data in iteritems(test_manifests):
+                for manifest, data in test_manifests.items():
                     found = False
                     rel_path = os.path.relpath(path, data["tests_path"])
                     iterator = manifest.iterpath if os.path.isfile(path) else manifest.iterdir

--- a/tools/wptrunner/wptrunner/manifestupdate.py
+++ b/tools/wptrunner/wptrunner/manifestupdate.py
@@ -1,9 +1,8 @@
 from __future__ import print_function
 import os
-from six.moves.urllib.parse import urljoin, urlsplit
+from urllib.parse import urljoin, urlsplit
 from collections import namedtuple, defaultdict, deque
 from math import ceil
-from six import integer_types, iterkeys, itervalues, iteritems, string_types, text_type
 
 from .wptmanifest import serialize
 from .wptmanifest.node import (DataNode, ConditionalNode, BinaryExpressionNode,
@@ -76,7 +75,7 @@ class UpdateProperties(object):
         return name in self._classes
 
     def __iter__(self):
-        for name in iterkeys(self._classes):
+        for name in self._classes.keys():
             yield getattr(self, name)
 
 
@@ -313,8 +312,8 @@ def build_conditional_tree(_, run_info_properties, results):
 
 def build_unconditional_tree(_, run_info_properties, results):
     root = expectedtree.Node(None, None)
-    for run_info, values in iteritems(results):
-        for value, count in iteritems(values):
+    for run_info, values in results.items():
+        for value, count in values.items():
             root.result_values[value] += count
         root.run_info.add(run_info)
     return root
@@ -411,7 +410,7 @@ class PropertyUpdate(object):
         for e in errors:
             if disable_intermittent:
                 condition = e.cond.children[0] if e.cond else None
-                msg = disable_intermittent if isinstance(disable_intermittent, string_types+(text_type,)) else "unstable"
+                msg = disable_intermittent if isinstance(disable_intermittent, str) else "unstable"
                 self.node.set("disabled", msg, condition)
                 self.node.new_disabled = True
             else:
@@ -499,7 +498,7 @@ class PropertyUpdate(object):
                           for run_info in node.run_info}
 
         node_by_run_info = {run_info: node
-                            for (run_info, node) in iteritems(run_info_index)
+                            for (run_info, node) in run_info_index.items()
                             if node.result_values}
 
         run_info_by_condition = self.run_info_by_condition(run_info_index,
@@ -512,7 +511,7 @@ class PropertyUpdate(object):
             # using the properties we've specified and not matching any run_info
             top_level_props, dependent_props = self.node.root.run_info_properties
             update_properties = set(top_level_props)
-            for item in itervalues(dependent_props):
+            for item in dependent_props.values():
                 update_properties |= set(item)
             for condition in current_conditions:
                 if ((not condition.variables.issubset(update_properties) and
@@ -695,7 +694,7 @@ class ExpectedUpdate(PropertyUpdate):
             raise ConditionError
 
         counts = {}
-        for status, count in iteritems(new):
+        for status, count in new.items():
             if isinstance(status, tuple):
                 counts[status[0]] = count
                 counts.update({intermittent: 0 for intermittent in status[1:] if intermittent not in counts})
@@ -709,9 +708,9 @@ class ExpectedUpdate(PropertyUpdate):
         # Counts with 0 are considered intermittent.
         statuses = ["OK", "PASS", "FAIL", "ERROR", "TIMEOUT", "CRASH"]
         status_priority = {value: i for i, value in enumerate(statuses)}
-        sorted_new = sorted(iteritems(counts), key=lambda x:(-1 * x[1],
-                                                           status_priority.get(x[0],
-                                                           len(status_priority))))
+        sorted_new = sorted(counts.items(), key=lambda x:(-1 * x[1],
+                                                        status_priority.get(x[0],
+                                                        len(status_priority))))
         expected = []
         for status, count in sorted_new:
             # If we are not removing existing recorded intermittents, with a count of 0,
@@ -777,7 +776,7 @@ class AppendOnlyListUpdate(PropertyUpdate):
         for item in new:
             if item is None:
                 continue
-            elif isinstance(item, text_type):
+            elif isinstance(item, str):
                 rv.add(item)
             else:
                 rv |= item
@@ -825,7 +824,7 @@ class LeakThresholdUpdate(PropertyUpdate):
         return result
 
     def to_ini_value(self, data):
-        return ["%s:%s" % item for item in sorted(iteritems(data))]
+        return ["%s:%s" % item for item in sorted(data.items())]
 
     def from_ini_value(self, data):
         rv = {}
@@ -900,10 +899,10 @@ def make_expr(prop_set, rhs):
 
 
 def make_node(value):
-    if isinstance(value, integer_types+(float,)):
+    if isinstance(value, (int, float,)):
         node = NumberNode(value)
-    elif isinstance(value, text_type):
-        node = StringNode(text_type(value))
+    elif isinstance(value, str):
+        node = StringNode(str(value))
     elif hasattr(value, "__iter__"):
         node = ListNode()
         for item in value:
@@ -912,10 +911,10 @@ def make_node(value):
 
 
 def make_value_node(value):
-    if isinstance(value, integer_types+(float,)):
+    if isinstance(value, (int, float,)):
         node = ValueNode(value)
-    elif isinstance(value, text_type):
-        node = ValueNode(text_type(value))
+    elif isinstance(value, str):
+        node = ValueNode(str(value))
     elif hasattr(value, "__iter__"):
         node = ListNode()
         for item in value:

--- a/tools/wptrunner/wptrunner/metadata.py
+++ b/tools/wptrunner/wptrunner/metadata.py
@@ -5,8 +5,8 @@ import sys
 from collections import defaultdict, namedtuple
 
 from mozlog import structuredlog
-from six import ensure_str, ensure_text, iteritems, iterkeys, itervalues, text_type
-from six.moves import intern, range
+from six import ensure_str, ensure_text
+from sys import intern
 
 from . import manifestupdate
 from . import testloader
@@ -45,11 +45,11 @@ class RunInfo(object):
         return self.canonical_repr == other.canonical_repr
 
     def iteritems(self):
-        for key, value in iteritems(self.data):
+        for key, value in self.data.items():
             yield key, value
 
     def items(self):
-        return list(iteritems(self))
+        return list(self.items())
 
 
 def update_expected(test_paths, serve_root, log_file_names,
@@ -129,7 +129,7 @@ def unexpected_changes(manifests, change_data, files_changed):
     files_changed = set(files_changed)
 
     root_manifest = None
-    for manifest, paths in iteritems(manifests):
+    for manifest, paths in manifests.items():
         if paths["url_base"] == "/":
             root_manifest = manifest
             break
@@ -240,7 +240,7 @@ def pack_result(data):
 def unpack_result(data):
     if isinstance(data, int):
         return (status_intern.get(data), None)
-    if isinstance(data, text_type):
+    if isinstance(data, str):
         return (data, None)
     # Unpack multiple statuses into a tuple to be used in the Results named tuple below,
     # separating `status` and `known_intermittent`.
@@ -259,7 +259,7 @@ def load_test_data(test_paths):
     manifests = manifest_loader.load()
 
     id_test_map = {}
-    for test_manifest, paths in iteritems(manifests):
+    for test_manifest, paths in manifests.items():
         id_test_map.update(create_test_tree(paths["metadata_path"],
                                             test_manifest))
     return id_test_map
@@ -287,10 +287,10 @@ def update_results(id_test_map,
                    disable_intermittent,
                    update_intermittent,
                    remove_intermittent):
-    test_file_items = set(itervalues(id_test_map))
+    test_file_items = set(id_test_map.values())
 
     default_expected_by_type = {}
-    for test_type, test_cls in iteritems(wpttest.manifest_test_cls):
+    for test_type, test_cls in wpttest.manifest_test_cls.items():
         if test_cls.result_cls:
             default_expected_by_type[(test_type, False)] = test_cls.result_cls.default_expected
         if test_cls.subtest_result_cls:
@@ -431,7 +431,7 @@ class ExpectedUpdater(object):
             action_map["lsan_leak"](item)
 
         mozleak_data = data.get("mozleak", {})
-        for scope, scope_data in iteritems(mozleak_data):
+        for scope, scope_data in mozleak_data.items():
             for key, action in [("objects", "mozleak_object"),
                                 ("total", "mozleak_total")]:
                 for item in scope_data.get(key, []):
@@ -668,11 +668,11 @@ class TestFileData(object):
         # Return subtest nodes present in the expected file, but missing from the data
         rv = []
 
-        for test_id, subtests in iteritems(self.data):
+        for test_id, subtests in self.data.items():
             test = expected.get_test(ensure_text(test_id))
             if not test:
                 continue
-            seen_subtests = set(ensure_text(item) for item in iterkeys(subtests) if item is not None)
+            seen_subtests = set(ensure_text(item) for item in subtests.keys() if item is not None)
             missing_subtests = set(test.subtests.keys()) - seen_subtests
             for item in missing_subtests:
                 expected_subtest = test.get_subtest(item)
@@ -691,7 +691,7 @@ class TestFileData(object):
         # since removing these may be inappropriate
         top_level_props, dependent_props = update_properties
         all_properties = set(top_level_props)
-        for item in itervalues(dependent_props):
+        for item in dependent_props.values():
             all_properties |= set(item)
 
         filtered = []
@@ -741,9 +741,9 @@ class TestFileData(object):
             test_expected = expected.get_test(test_id)
             expected_by_test[test_id] = test_expected
 
-        for test_id, test_data in iteritems(self.data):
+        for test_id, test_data in self.data.items():
             test_id = ensure_str(test_id)
-            for subtest_id, results_list in iteritems(test_data):
+            for subtest_id, results_list in test_data.items():
                 for prop, run_info, value in results_list:
                     # Special case directory metadata
                     if subtest_id is None and test_id.endswith("__dir__"):

--- a/tools/wptrunner/wptrunner/mpcontext.py
+++ b/tools/wptrunner/wptrunner/mpcontext.py
@@ -1,21 +1,11 @@
 import multiprocessing
 
-import six
-
 _context = None
-
-
-class MpContext(object):
-    def __getattr__(self, name):
-        return getattr(multiprocessing, name)
 
 
 def get_context():
     global _context
 
     if _context is None:
-        if six.PY2:
-            _context = MpContext()
-        else:
-            _context = multiprocessing.get_context("spawn")
+        _context = multiprocessing.get_context("spawn")
     return _context

--- a/tools/wptrunner/wptrunner/process.py
+++ b/tools/wptrunner/wptrunner/process.py
@@ -1,11 +1,8 @@
-import sys
-
 import six
 
 
 def cast_env(env):
-    """Encode all the environment values as the appropriate type for each Python version
+    """Encode all the environment values as the appropriate type.
     This assumes that all the data is or can be represented as UTF8"""
 
-    env_type = six.ensure_binary if sys.version_info[0] < 3 else six.ensure_str
-    return {env_type(key): env_type(value) for key, value in six.iteritems(env)}
+    return {six.ensure_str(key): six.ensure_str(value) for key, value in env.items()}

--- a/tools/wptrunner/wptrunner/products.py
+++ b/tools/wptrunner/wptrunner/products.py
@@ -1,6 +1,5 @@
 import importlib
 import imp
-from six import iteritems
 
 from .browsers import product_list
 
@@ -45,7 +44,7 @@ class Product(object):
         self.get_timeout_multiplier = getattr(module, data["timeout_multiplier"])
 
         self.executor_classes = {}
-        for test_type, cls_name in iteritems(data["executor"]):
+        for test_type, cls_name in data["executor"].items():
             cls = getattr(module, cls_name)
             self.executor_classes[test_type] = cls
 

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -5,7 +5,6 @@ import io
 import os
 from collections import OrderedDict, defaultdict
 from datetime import datetime
-from six import iteritems
 
 from mozlog import reader
 from mozlog.formatters import JSONFormatter
@@ -142,10 +141,10 @@ def process_results(log, iterations):
     handler = LogHandler()
     reader.handle_log(reader.read(log), handler)
     results = handler.results
-    for test_name, test in iteritems(results):
+    for test_name, test in results.items():
         if is_inconsistent(test["status"], iterations):
             inconsistent.append((test_name, None, test["status"], []))
-        for subtest_name, subtest in iteritems(test["subtests"]):
+        for subtest_name, subtest in test["subtests"].items():
             if is_inconsistent(subtest["status"], iterations):
                 inconsistent.append((test_name, subtest_name, subtest["status"], subtest["messages"]))
 
@@ -235,7 +234,7 @@ def write_results(log, results, iterations, pr_number=None, use_details=False):
                                                   "tests" if len(results) > 1
                                                   else "test"))
 
-    for test_name, test in iteritems(results):
+    for test_name, test in results.items():
         baseurl = "http://w3c-test.org/submissions"
         if "https" in os.path.splitext(test_name)[0].split(".")[1:]:
             baseurl = "https://w3c-test.org/submissions"
@@ -305,7 +304,7 @@ def get_steps(logger, repeat_loop, repeat_restart, kwargs_extras):
     for kwargs_extra in kwargs_extras:
         if kwargs_extra:
             flags_string = " with flags %s" % " ".join(
-                "%s=%s" % item for item in iteritems(kwargs_extra))
+                "%s=%s" % item for item in kwargs_extra.items())
         else:
             flags_string = ""
 

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -1,12 +1,11 @@
 import hashlib
 import json
 import os
-from six.moves.urllib.parse import urlsplit
+from urllib.parse import urlsplit
 from abc import ABCMeta, abstractmethod
-from six.moves.queue import Empty
+from queue import Empty
 from collections import defaultdict, deque
-from six import ensure_binary, iteritems
-from six.moves import range
+from six import ensure_binary
 
 from . import manifestinclude
 from . import manifestexpected
@@ -41,7 +40,7 @@ class TestGroupsFile(object):
             raise
 
         self.group_by_test = {}
-        for group, test_ids in iteritems(self._data):
+        for group, test_ids in self._data.items():
             for test_id in test_ids:
                 self.group_by_test[test_id] = group
 
@@ -173,7 +172,7 @@ class ManifestLoader(object):
 
     def load(self):
         rv = {}
-        for url_base, paths in iteritems(self.test_paths):
+        for url_base, paths in self.test_paths.items():
             manifest_file = self.load_manifest(url_base=url_base,
                                                **paths)
             path_data = {"url_base": url_base}
@@ -472,7 +471,7 @@ class GroupFileTestSource(TestSource):
         mp = mpcontext.get_context()
         test_queue = mp.Queue()
 
-        for group_name, test_ids in iteritems(tests_by_group):
+        for group_name, test_ids in tests_by_group.items():
             group_metadata = {"scope": group_name}
             group = deque()
 

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import threading
 import traceback
-from six.moves.queue import Empty
+from queue import Empty
 from collections import namedtuple
 
 from mozlog import structuredlog, capture

--- a/tools/wptrunner/wptrunner/tests/test_formatters.py
+++ b/tools/wptrunner/wptrunner/tests/test_formatters.py
@@ -1,6 +1,6 @@
 import json
 import time
-from six.moves import cStringIO as StringIO
+from io import StringIO
 
 import mock
 

--- a/tools/wptrunner/wptrunner/update/state.py
+++ b/tools/wptrunner/wptrunner/update/state.py
@@ -1,5 +1,5 @@
 import os
-from six.moves import cPickle as pickle  # noqa: N813
+import pickle
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/tools/wptrunner/wptrunner/update/tree.py
+++ b/tools/wptrunner/wptrunner/update/tree.py
@@ -3,8 +3,6 @@ import re
 import subprocess
 import tempfile
 
-from six.moves import range
-
 from .. import vcs
 from ..vcs import git, hg
 

--- a/tools/wptrunner/wptrunner/update/update.py
+++ b/tools/wptrunner/wptrunner/update/update.py
@@ -1,8 +1,6 @@
 import os
 import sys
 
-from six import itervalues
-
 from .metadata import MetadataUpdateRunner
 from .sync import SyncFromUpstreamRunner
 from .tree import GitTree, HgTree, NoVCSTree
@@ -111,7 +109,7 @@ class RemoveObsolete(Step):
         state.tests_path = state.paths["/"]["tests_path"]
         state.metadata_path = state.paths["/"]["metadata_path"]
 
-        for url_paths in itervalues(paths):
+        for url_paths in paths.values():
             tests_path = url_paths["tests_path"]
             metadata_path = url_paths["metadata_path"]
             for dirpath, dirnames, filenames in os.walk(metadata_path):

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -5,7 +5,7 @@ import sys
 from collections import OrderedDict
 from distutils.spawn import find_executable
 from datetime import timedelta
-from six import ensure_text, iterkeys, itervalues, iteritems
+from six import ensure_text
 
 from . import config
 from . import wpttest
@@ -16,7 +16,7 @@ def abs_path(path):
 
 
 def url_or_path(path):
-    from six.moves.urllib.parse import urlparse
+    from urllib.parse import urlparse
 
     parsed = urlparse(path)
     if len(parsed.scheme) > 2:
@@ -408,7 +408,7 @@ def set_from_config(kwargs):
                     ("host_cert_path", "host_cert_path", True),
                     ("host_key_path", "host_key_path", True)]}
 
-    for section, values in iteritems(keys):
+    for section, values in keys.items():
         for config_value, kw_value, is_path in values:
             if kw_value in kwargs and kwargs[kw_value] is None:
                 if not is_path:
@@ -444,7 +444,7 @@ def get_test_paths(config):
     # Set up test_paths
     test_paths = OrderedDict()
 
-    for section in iterkeys(config):
+    for section in config.keys():
         if section.startswith("manifest:"):
             manifest_opts = config.get(section)
             url_base = manifest_opts.get("url_base", "/")
@@ -470,7 +470,7 @@ def exe_path(name):
 
 
 def check_paths(kwargs):
-    for test_paths in itervalues(kwargs["test_paths"]):
+    for test_paths in kwargs["test_paths"].values():
         if not ("tests_path" in test_paths and
                 "metadata_path" in test_paths):
             print("Fatal: must specify both a test path and metadata path")
@@ -478,7 +478,7 @@ def check_paths(kwargs):
         if "manifest_path" not in test_paths:
             test_paths["manifest_path"] = os.path.join(test_paths["metadata_path"],
                                                        "MANIFEST.json")
-        for key, path in iteritems(test_paths):
+        for key, path in test_paths.items():
             name = key.split("_", 1)[0]
 
             if name == "manifest":

--- a/tools/wptrunner/wptrunner/wptmanifest/backends/base.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/backends/base.py
@@ -1,5 +1,4 @@
 import abc
-from six import iteritems, iterkeys, itervalues
 
 from ..node import NodeVisitor
 from ..parser import parse
@@ -187,21 +186,21 @@ class ManifestItem(object):
     def _flatten(self):
         rv = {}
         for node in [self, self.root]:
-            for name, value in iteritems(node._data):
+            for name, value in node._data.items():
                 if name not in rv:
                     rv[name] = value
         return rv
 
     def iteritems(self):
-        for item in iteritems(self._flatten()):
+        for item in self._flatten().items():
             yield item
 
     def iterkeys(self):
-        for item in iterkeys(self._flatten()):
+        for item in self._flatten().keys():
             yield item
 
     def itervalues(self):
-        for item in itervalues(self._flatten()):
+        for item in self._flatten().values():
             yield item
 
     def append(self, child):

--- a/tools/wptrunner/wptrunner/wptmanifest/backends/conditional.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/backends/conditional.py
@@ -1,5 +1,5 @@
 import operator
-from six import ensure_text, iteritems, iterkeys, text_type
+from six import ensure_text
 
 from ..node import NodeVisitor, DataNode, ConditionalNode, KeyValueNode, ListNode, ValueNode, BinaryExpressionNode, VariableNode
 from ..parser import parse
@@ -300,9 +300,9 @@ class ManifestItem(object):
         if isinstance(value, list):
             value_node = ListNode()
             for item in value:
-                value_node.append(ValueNode(text_type(item)))
+                value_node.append(ValueNode(str(item)))
         else:
-            value_node = ValueNode(text_type(value))
+            value_node = ValueNode(str(value))
         if condition is not None:
             if not isinstance(condition, ConditionalNode):
                 conditional_node = ConditionalNode()
@@ -368,17 +368,17 @@ class ManifestItem(object):
     def _flatten(self):
         rv = {}
         for node in [self, self.root]:
-            for name, value in iteritems(node._data):
+            for name, value in node._data.items():
                 if name not in rv:
                     rv[name] = value
         return rv
 
     def iteritems(self):
-        for item in iteritems(self._flatten()):
+        for item in self._flatten().items():
             yield item
 
     def iterkeys(self):
-        for item in iterkeys(self._flatten()):
+        for item in self._flatten().keys():
             yield item
 
     def iter_properties(self):

--- a/tools/wptrunner/wptrunner/wptmanifest/node.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/node.py
@@ -1,5 +1,3 @@
-from six.moves import range
-
 class NodeVisitor(object):
     def visit(self, node):
         # This is ugly as hell, but we don't have multimethods and

--- a/tools/wptrunner/wptrunner/wptmanifest/parser.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/parser.py
@@ -14,8 +14,7 @@
 
 from __future__ import unicode_literals
 
-from six import binary_type, text_type, BytesIO, unichr
-from six.moves import range
+from io import BytesIO
 
 from .node import (Node, AtomNode, BinaryExpressionNode, BinaryOperatorNode,
                    ConditionalNode, DataNode, IndexNode, KeyValueNode, ListNode,
@@ -50,7 +49,7 @@ atoms = {"True": True,
          "Reset": object()}
 
 def decode(s):
-    assert isinstance(s, text_type)
+    assert isinstance(s, str)
     return s
 
 
@@ -79,7 +78,7 @@ class Tokenizer(object):
 
     def tokenize(self, stream):
         self.reset()
-        assert not isinstance(stream, text_type)
+        assert not isinstance(stream, str)
         if isinstance(stream, bytes):
             stream = BytesIO(stream)
         if not hasattr(stream, "name"):
@@ -89,7 +88,7 @@ class Tokenizer(object):
 
         self.next_line_state = self.line_start_state
         for i, line in enumerate(stream):
-            assert isinstance(line, binary_type)
+            assert isinstance(line, bytes)
             self.state = self.next_line_state
             assert self.state is not None
             states = []
@@ -97,7 +96,7 @@ class Tokenizer(object):
             self.line_number = i + 1
             self.index = 0
             self.line = line.decode('utf-8').rstrip()
-            assert isinstance(self.line, text_type)
+            assert isinstance(self.line, str)
             while self.state != self.eol_state:
                 states.append(self.state)
                 tokens = self.state()
@@ -505,7 +504,7 @@ class Tokenizer(object):
             value += self.escape_value(c)
             self.consume()
 
-        return unichr(value)
+        return chr(value)
 
     def escape_value(self, c):
         if '0' <= c <= '9':

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -4,8 +4,6 @@ import json
 import os
 import sys
 
-from six import iteritems, itervalues
-
 import wptserve
 from wptserve import sslutils
 
@@ -117,7 +115,7 @@ def list_disabled(test_paths, product, **kwargs):
     run_info, test_loader = get_loader(test_paths, product,
                                        run_info_extras=run_info_extras, **kwargs)
 
-    for test_type, tests in iteritems(test_loader.disabled_tests):
+    for test_type, tests in test_loader.disabled_tests.items():
         for test in tests:
             rv.append({"test": test.id, "reason": test.disabled()})
     print(json.dumps(rv, indent=2))
@@ -144,7 +142,7 @@ def get_pause_after_test(test_loader, **kwargs):
         if kwargs["debug_test"]:
             return True
         tests = test_loader.tests
-        is_single_testharness = (sum(len(item) for item in itervalues(tests)) == 1 and
+        is_single_testharness = (sum(len(item) for item in tests.values()) == 1 and
                                  len(tests.get("testharness", [])) == 1)
         if kwargs["repeat"] == 1 and kwargs["rerun"] == 1 and is_single_testharness:
             return True

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -1,9 +1,8 @@
 import os
 import subprocess
 import sys
-from six.moves.urllib.parse import urljoin
 from collections import defaultdict
-from six import iteritems, string_types
+from urllib.parse import urljoin
 
 from .wptmanifest.parser import atoms
 
@@ -307,7 +306,7 @@ class Test(object):
         rv = {}
         for meta in self.itermeta(None):
             threshold = meta.leak_threshold
-            for key, value in iteritems(threshold):
+            for key, value in threshold.items():
                 if key not in rv:
                     rv[key] = value
         return rv
@@ -349,7 +348,7 @@ class Test(object):
 
         try:
             expected = metadata.get("expected")
-            if isinstance(expected, string_types):
+            if isinstance(expected, str):
                 return expected
             elif isinstance(expected, list):
                 return expected[0]

--- a/tools/wptserve/tests/functional/base.py
+++ b/tools/wptserve/tests/functional/base.py
@@ -6,10 +6,9 @@ import os
 import pytest
 import unittest
 
-from six.moves.urllib.parse import urlencode, urlunsplit
-from six.moves.urllib.request import Request as BaseRequest
-from six.moves.urllib.request import urlopen
-from six import binary_type, iteritems, PY3
+from urllib.parse import urlencode, urlunsplit
+from urllib.request import Request as BaseRequest
+from urllib.request import urlopen
 
 from hyper import HTTP20Connection, tls
 import ssl
@@ -37,7 +36,7 @@ class Request(BaseRequest):
         if hasattr(data, "items"):
             data = urlencode(data).encode("ascii")
 
-        assert isinstance(data, binary_type)
+        assert isinstance(data, bytes)
 
         if hasattr(BaseRequest, "add_data"):
             BaseRequest.add_data(self, data)
@@ -68,7 +67,7 @@ class TestUsingServer(unittest.TestCase):
         if headers is None:
             headers = {}
 
-        for name, value in iteritems(headers):
+        for name, value in headers.items():
             req.add_header(name, value)
 
         if body is not None:
@@ -80,10 +79,7 @@ class TestUsingServer(unittest.TestCase):
         return urlopen(req)
 
     def assert_multiple_headers(self, resp, name, values):
-        if PY3:
-            assert resp.info().get_all(name) == values
-        else:
-            assert resp.info()[name] == ", ".join(values)
+        assert resp.info().get_all(name) == values
 
 
 @pytest.mark.skipif(not wptserve.utils.http2_compatible(), reason="h2 server only works in python 2.7.10+ and Python 3.6+")

--- a/tools/wptserve/tests/functional/test_handlers.py
+++ b/tools/wptserve/tests/functional/test_handlers.py
@@ -5,7 +5,7 @@ import unittest
 import uuid
 
 import pytest
-from six.moves.urllib.error import HTTPError
+from urllib.error import HTTPError
 
 wptserve = pytest.importorskip("wptserve")
 from .base import TestUsingServer, TestUsingH2Server, doc_root

--- a/tools/wptserve/tests/functional/test_input_file.py
+++ b/tools/wptserve/tests/functional/test_input_file.py
@@ -1,8 +1,6 @@
-import sys
 from io import BytesIO
 
 import pytest
-from six import PY2
 
 from wptserve.request import InputFile
 
@@ -121,8 +119,6 @@ def test_readlines():
     assert input_file.readlines() == test_file.readlines()
 
 
-@pytest.mark.xfail(sys.platform == "win32" and PY2,
-                   reason="https://github.com/web-platform-tests/wpt/issues/12949")
 def test_readlines_file_bigger_than_buffer():
     old_max_buf = InputFile.max_buffer_size
     InputFile.max_buffer_size = 10
@@ -140,8 +136,6 @@ def test_iter():
         assert a == b
 
 
-@pytest.mark.xfail(sys.platform == "win32" and PY2,
-                   reason="https://github.com/web-platform-tests/wpt/issues/12949")
 def test_iter_file_bigger_than_buffer():
     old_max_buf = InputFile.max_buffer_size
     InputFile.max_buffer_size = 10

--- a/tools/wptserve/tests/functional/test_pipes.py
+++ b/tools/wptserve/tests/functional/test_pipes.py
@@ -2,9 +2,7 @@ import os
 import unittest
 import time
 import json
-
-from six import assertRegex
-from six.moves import urllib
+import urllib
 
 import pytest
 
@@ -121,7 +119,7 @@ server: http://localhost:{0}""".format(self.server.port).encode("ascii")
 
     def test_sub_uuid(self):
         resp = self.request("/sub_uuid.sub.txt")
-        assertRegex(self, resp.read().rstrip(), b"Before [a-f0-9-]+ After")
+        self.assertRegex(resp.read().rstrip(), b"Before [a-f0-9-]+ After")
 
     def test_sub_var(self):
         resp = self.request("/sub_var.sub.txt")

--- a/tools/wptserve/tests/functional/test_request.py
+++ b/tools/wptserve/tests/functional/test_request.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
-from six import PY3
+
+from urllib.parse import quote_from_bytes
 
 wptserve = pytest.importorskip("wptserve")
 from .base import TestUsingServer
@@ -144,12 +145,7 @@ class TestRequest(TestUsingServer):
 
         # We intentionally choose an encoding that's not the default UTF-8.
         encoded_text = u"どうも".encode("shift-jis")
-        if PY3:
-            from urllib.parse import quote_from_bytes
-            quoted = quote_from_bytes(encoded_text)
-        else:
-            from urllib import quote
-            quoted = quote(encoded_text)
+        quoted = quote_from_bytes(encoded_text)
         resp = self.request(route[1], query="foo="+quoted)
         self.assertEqual(encoded_text, resp.read())
 
@@ -163,13 +159,8 @@ class TestRequest(TestUsingServer):
 
         # We intentionally choose an encoding that's not the default UTF-8.
         encoded_text = u"どうも".encode("shift-jis")
-        if PY3:
-            from urllib.parse import quote_from_bytes
-            # After urlencoding, the string should only contain ASCII.
-            quoted = quote_from_bytes(encoded_text).encode("ascii")
-        else:
-            from urllib import quote
-            quoted = quote(encoded_text)
+        # After urlencoding, the string should only contain ASCII.
+        quoted = quote_from_bytes(encoded_text).encode("ascii")
         resp = self.request(route[1], method="POST", body=b"foo="+quoted)
         self.assertEqual(encoded_text, resp.read())
 

--- a/tools/wptserve/tests/functional/test_response.py
+++ b/tools/wptserve/tests/functional/test_response.py
@@ -1,11 +1,12 @@
 import os
 import unittest
 import json
+import types
+
+from http.client import BadStatusLine
 from io import BytesIO
 
 import pytest
-from six import create_bound_method, PY3
-from six.moves.http_client import BadStatusLine
 
 wptserve = pytest.importorskip("wptserve")
 from .base import TestUsingServer, TestUsingH2Server, doc_root
@@ -22,8 +23,8 @@ class TestResponse(TestUsingServer):
     def test_head_without_body(self):
         @wptserve.handlers.handler
         def handler(request, response):
-            response.writer.end_headers = create_bound_method(send_body_as_header,
-                                                              response.writer)
+            response.writer.end_headers = types.MethodType(send_body_as_header,
+                                                           response.writer)
             return [("X-Test", "TEST")], "body\r\n"
 
         route = ("GET", "/test/test_head_without_body", handler)
@@ -37,8 +38,8 @@ class TestResponse(TestUsingServer):
         @wptserve.handlers.handler
         def handler(request, response):
             response.send_body_for_head_request = True
-            response.writer.end_headers = create_bound_method(send_body_as_header,
-                                                              response.writer)
+            response.writer.end_headers = types.MethodType(send_body_as_header,
+                                                           response.writer)
             return [("X-Test", "TEST")], "body\r\n"
 
         route = ("GET", "/test/test_head_with_body", handler)
@@ -177,13 +178,9 @@ class TestResponse(TestUsingServer):
         route = ("GET", "/test/test_write_raw_content", handler)
         self.server.router.register(*route)
 
-        try:
-            resp = self.request(route[1])
-            assert resp.read() == resp_content
-        except BadStatusLine as e:
-            # In Python3, an invalid HTTP request should throw BadStatusLine.
-            assert PY3
-            assert str(e) == resp_content.decode('utf-8')
+        with pytest.raises(BadStatusLine) as e:
+            self.request(route[1])
+        assert str(e.value) == resp_content.decode('utf-8')
 
 class TestH2Response(TestUsingH2Server):
     def test_write_without_ending_stream(self):

--- a/tools/wptserve/tests/functional/test_server.py
+++ b/tools/wptserve/tests/functional/test_server.py
@@ -1,7 +1,7 @@
 import unittest
 
 import pytest
-from six.moves.urllib.error import HTTPError
+from urllib.error import HTTPError
 
 wptserve = pytest.importorskip("wptserve")
 from .base import TestUsingServer, TestUsingH2Server

--- a/tools/wptserve/tests/test_request.py
+++ b/tools/wptserve/tests/test_request.py
@@ -1,5 +1,4 @@
 import mock
-from six import binary_type
 
 from wptserve.request import Request, RequestHeaders, MultiDict
 
@@ -49,9 +48,9 @@ def test_request_headers_encoding():
         'x-bar': ['bar1', 'bar2'],
     })
     headers = RequestHeaders(raw_headers)
-    assert isinstance(headers['x-foo'], binary_type)
-    assert isinstance(headers['x-bar'], binary_type)
-    assert isinstance(headers.get_list('x-bar')[0], binary_type)
+    assert isinstance(headers['x-foo'], bytes)
+    assert isinstance(headers['x-bar'], bytes)
+    assert isinstance(headers.get_list('x-bar')[0], bytes)
 
 
 def test_request_url_from_server_address():

--- a/tools/wptserve/tests/test_response.py
+++ b/tools/wptserve/tests/test_response.py
@@ -1,5 +1,5 @@
 import mock
-from six import BytesIO
+from io import BytesIO
 
 from wptserve.response import Response
 

--- a/tools/wptserve/tests/test_stash.py
+++ b/tools/wptserve/tests/test_stash.py
@@ -5,7 +5,6 @@ import sys
 from multiprocessing.managers import BaseManager
 
 import pytest
-from six import PY3
 
 Stash = pytest.importorskip("wptserve.stash").Stash
 
@@ -67,7 +66,7 @@ class SlowLock(BaseManager):
 
 
 @pytest.mark.xfail(sys.platform == "win32" or
-                   PY3 and multiprocessing.get_start_method() == "spawn",
+                   multiprocessing.get_start_method() == "spawn",
                    reason="https://github.com/web-platform-tests/wpt/issues/16938")
 def test_delayed_lock(add_cleanup):
     """Ensure that delays in proxied Lock retrieval do not interfere with
@@ -110,7 +109,7 @@ class SlowDict(BaseManager):
 
 
 @pytest.mark.xfail(sys.platform == "win32" or
-                   PY3 and multiprocessing.get_start_method() == "spawn",
+                   multiprocessing.get_start_method() == "spawn",
                    reason="https://github.com/web-platform-tests/wpt/issues/16938")
 def test_delayed_dict(add_cleanup):
     """Ensure that delays in proxied `dict` retrieval do not interfere with

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -3,8 +3,7 @@ import os
 import traceback
 from collections import defaultdict
 
-from six.moves.urllib.parse import quote, unquote, urljoin
-from six import iteritems
+from urllib.parse import quote, unquote, urljoin
 
 from .constants import content_types
 from .pipes import Pipeline, template
@@ -482,7 +481,7 @@ class StringHandler(object):
         self.data = data
 
         self.resp_headers = [("Content-Type", content_type)]
-        for k, v in iteritems(headers):
+        for k, v in headers.items():
             self.resp_headers.append((k.replace("_", "-"), v))
 
         self.handler = handler(self.handle_request)

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -7,8 +7,7 @@ import re
 import time
 import uuid
 
-from six.moves import StringIO
-from six import text_type, binary_type
+from io import StringIO
 
 try:
     from html import escape
@@ -305,7 +304,7 @@ class ReplacementTokenizer(object):
         return ("var", token)
 
     def tokenize(self, string):
-        assert isinstance(string, binary_type)
+        assert isinstance(string, bytes)
         return self.scanner.scan(string)[0]
 
     scanner = re.Scanner([(br"\$\w+:", var),
@@ -320,7 +319,7 @@ class FirstWrapper(object):
 
     def __getitem__(self, key):
         try:
-            if isinstance(key, text_type):
+            if isinstance(key, str):
                 key = key.encode('iso-8859-1')
             return self.params.first(key)
         except KeyError:
@@ -408,7 +407,7 @@ class SubFunctions(object):
 
     @staticmethod
     def file_hash(request, algorithm, path):
-        assert isinstance(algorithm, text_type)
+        assert isinstance(algorithm, str)
         if algorithm not in SubFunctions.supported_algorithms:
             raise ValueError("Unsupported encryption algorithm: '%s'" % algorithm)
 
@@ -460,12 +459,12 @@ def template(request, content, escape_type="html"):
         tokens = deque(tokens)
 
         token_type, field = tokens.popleft()
-        assert isinstance(field, text_type)
+        assert isinstance(field, str)
 
         if token_type == "var":
             variable = field
             token_type, field = tokens.popleft()
-            assert isinstance(field, text_type)
+            assert isinstance(field, str)
         else:
             variable = None
 
@@ -516,7 +515,7 @@ def template(request, content, escape_type="html"):
                     "unexpected token type %s (token '%r'), expected ident or arguments" % (ttype, field)
                 )
 
-        assert isinstance(value, (int, (binary_type, text_type))), tokens
+        assert isinstance(value, (int, (bytes, str))), tokens
 
         if variable is not None:
             variables[variable] = value
@@ -527,10 +526,10 @@ def template(request, content, escape_type="html"):
         # Should possibly support escaping for other contexts e.g. script
         # TODO: read the encoding of the response
         # cgi.escape() only takes text strings in Python 3.
-        if isinstance(value, binary_type):
+        if isinstance(value, bytes):
             value = value.decode("utf-8")
         elif isinstance(value, int):
-            value = text_type(value)
+            value = str(value)
         return escape_func(value).encode("utf-8")
 
     template_regexp = re.compile(br"{{([^}]*)}}")

--- a/tools/wptserve/wptserve/request.py
+++ b/tools/wptserve/wptserve/request.py
@@ -2,9 +2,9 @@ import base64
 import cgi
 import tempfile
 
-from six import BytesIO, binary_type, iteritems, PY3
-from six.moves.http_cookies import BaseCookie
-from six.moves.urllib.parse import parse_qsl, urlsplit
+from http.cookies import BaseCookie
+from io import BytesIO
+from urllib.parse import parse_qsl, urlsplit
 
 from . import stash
 from .utils import HTTPException, isomorphic_encode, isomorphic_decode
@@ -301,9 +301,8 @@ class Request(object):
         if self._GET is None:
             kwargs = {
                 "keep_blank_values": True,
+                "encoding": "iso-8859-1",
             }
-            if PY3:
-                kwargs["encoding"] = "iso-8859-1"
             params = parse_qsl(self.url_parts.query, **kwargs)
             self._GET = MultiDict()
             for key, value in params:
@@ -321,9 +320,8 @@ class Request(object):
                 "environ": {"REQUEST_METHOD": self.method},
                 "headers": self.raw_headers,
                 "keep_blank_values": True,
+                "encoding": "iso-8859-1",
             }
-            if PY3:
-                kwargs["encoding"] = "iso-8859-1"
             fs = cgi.FieldStorage(**kwargs)
             self._POST = MultiDict.from_field_storage(fs)
             self.raw_input.seek(pos)
@@ -336,7 +334,7 @@ class Request(object):
             cookie_headers = self.headers.get("cookie", b"")
             parser.load(cookie_headers)
             cookies = Cookies()
-            for key, value in iteritems(parser):
+            for key, value in parser.items():
                 cookies[isomorphic_encode(key)] = CookieValue(value)
             self._cookies = cookies
         return self._cookies
@@ -630,11 +628,9 @@ class BinaryCookieParser(BaseCookie):
         This overrides and calls BaseCookie.load. Unlike BaseCookie.load, it
         does not accept dictionaries.
         """
-        assert isinstance(rawdata, binary_type)
-        if PY3:
-            # BaseCookie.load expects a native string, which in Python 3 is text.
-            rawdata = isomorphic_decode(rawdata)
-        super(BinaryCookieParser, self).load(rawdata)
+        assert isinstance(rawdata, bytes)
+        # BaseCookie.load expects a native string
+        super(BinaryCookieParser, self).load(isomorphic_decode(rawdata))
 
 
 class Cookies(MultiDict):
@@ -675,7 +671,7 @@ class Authentication(object):
 
         if "authorization" in headers:
             header = headers.get("authorization")
-            assert isinstance(header, binary_type)
+            assert isinstance(header, bytes)
             auth_type, data = header.split(b" ", 1)
             if auth_type in auth_schemes:
                 self.username, self.password = auth_schemes[auth_type](data)
@@ -683,6 +679,6 @@ class Authentication(object):
                 raise HTTPException(400, "Unsupported authentication scheme %s" % auth_type)
 
     def decode_basic(self, data):
-        assert isinstance(data, binary_type)
+        assert isinstance(data, bytes)
         decoded_data = base64.b64decode(data)
         return decoded_data.split(b":", 1)

--- a/tools/wptserve/wptserve/response.py
+++ b/tools/wptserve/wptserve/response.py
@@ -6,9 +6,8 @@ import socket
 import uuid
 
 from hpack.struct import HeaderTuple
+from http.cookies import BaseCookie, Morsel
 from hyperframe.frame import HeadersFrame, DataFrame, ContinuationFrame
-from six import binary_type, text_type, integer_types, itervalues, PY3
-from six.moves.http_cookies import BaseCookie, Morsel
 
 from .constants import response_codes, h2_headers
 from .logger import get_logger
@@ -91,7 +90,7 @@ class Response(object):
                 message = value[1]
                 # Only call str() if message is not a string type, so that we
                 # don't get `str(b"foo") == "b'foo'"` in Python 3.
-                if not isinstance(message, (binary_type, text_type)):
+                if not isinstance(message, (bytes, str)):
                     message = str(message)
                 self._status = (code, message)
         else:
@@ -122,9 +121,8 @@ class Response(object):
             max_age = 0
             expires = timedelta(days=-1)
 
-        if PY3:
-            name = isomorphic_decode(name)
-            value = isomorphic_decode(value)
+        name = isomorphic_decode(name)
+        value = isomorphic_decode(value)
 
         days = {i+1: name for i, name in enumerate(["jan", "feb", "mar",
                                                     "apr", "may", "jun",
@@ -163,15 +161,11 @@ class Response(object):
 
     def unset_cookie(self, name):
         """Remove a cookie from those that are being sent with the response"""
-        if PY3:
-            name = isomorphic_decode(name)
+        name = isomorphic_decode(name)
         cookies = self.headers.get("Set-Cookie")
         parser = BaseCookie()
         for cookie in cookies:
-            if PY3:
-                # BaseCookie.load expects a text string.
-                cookie = isomorphic_decode(cookie)
-            parser.load(cookie)
+            parser.load(isomorphic_decode(cookie))
 
         if name in parser.keys():
             del self.headers["Set-Cookie"]
@@ -199,9 +193,9 @@ class Response(object):
                           string facilitating non-streaming operations like
                           template substitution.
         """
-        if isinstance(self.content, binary_type):
+        if isinstance(self.content, bytes):
             yield self.content
-        elif isinstance(self.content, text_type):
+        elif isinstance(self.content, str):
             yield self.content.encode(self.encoding)
         elif hasattr(self.content, "read"):
             if read_file:
@@ -256,7 +250,7 @@ class MultipartContent(object):
     def __init__(self, boundary=None, default_content_type=None):
         self.items = []
         if boundary is None:
-            boundary = text_type(uuid.uuid4())
+            boundary = str(uuid.uuid4())
         self.boundary = boundary
         self.default_content_type = default_content_type
 
@@ -284,7 +278,7 @@ class MultipartContent(object):
 
 class MultipartPart(object):
     def __init__(self, data, content_type=None, headers=None):
-        assert isinstance(data, binary_type), data
+        assert isinstance(data, bytes), data
         self.headers = ResponseHeaders()
 
         if content_type is not None:
@@ -303,8 +297,8 @@ class MultipartPart(object):
     def to_bytes(self):
         rv = []
         for key, value in self.headers:
-            assert isinstance(key, binary_type)
-            assert isinstance(value, binary_type)
+            assert isinstance(key, bytes)
+            assert isinstance(value, bytes)
             rv.append(b"%s: %s" % (key, value))
         rv.append(b"")
         rv.append(self.data)
@@ -313,7 +307,7 @@ class MultipartPart(object):
 
 def _maybe_encode(s):
     """Encode a string or an int into binary data using isomorphic_encode()."""
-    if isinstance(s, integer_types):
+    if isinstance(s, int):
         return b"%i" % (s,)
     return isomorphic_encode(s)
 
@@ -377,7 +371,7 @@ class ResponseHeaders(object):
         self.set(key, value)
 
     def __iter__(self):
-        for key, values in itervalues(self.data):
+        for key, values in self.data.values():
             for value in values:
                 yield key, value
 
@@ -447,10 +441,10 @@ class H2ResponseWriter(object):
         for header, value in headers:
             # h2_headers are native strings
             # header field names are strings of ASCII
-            if isinstance(header, binary_type):
+            if isinstance(header, bytes):
                 header = header.decode('ascii')
             # value in headers can be either string or integer
-            if isinstance(value, binary_type):
+            if isinstance(value, bytes):
                 value = self.decode(value)
             if header in h2_headers:
                 header = ':' + header
@@ -482,7 +476,7 @@ class H2ResponseWriter(object):
         :param last: Flag to signal if this is the last frame in stream.
         :param stream_id: Id of stream to send frame on. Will use the request stream ID if None
         """
-        if isinstance(item, (text_type, binary_type)):
+        if isinstance(item, (str, bytes)):
             data = BytesIO(self.encode(item))
         else:
             data = item
@@ -638,18 +632,18 @@ class H2ResponseWriter(object):
 
     def decode(self, data):
         """Convert bytes to unicode according to response.encoding."""
-        if isinstance(data, binary_type):
+        if isinstance(data, bytes):
             return data.decode(self._response.encoding)
-        elif isinstance(data, text_type):
+        elif isinstance(data, str):
             return data
         else:
             raise ValueError(type(data))
 
     def encode(self, data):
         """Convert unicode to bytes according to response.encoding."""
-        if isinstance(data, binary_type):
+        if isinstance(data, bytes):
             return data
-        elif isinstance(data, text_type):
+        elif isinstance(data, str):
             return data.encode(self._response.encoding)
         else:
             raise ValueError
@@ -707,7 +701,7 @@ class ResponseWriter(object):
         if not self.write(b": "):
             return False
         if isinstance(value, int):
-            if not self.write(text_type(value)):
+            if not self.write(str(value)):
                 return False
         elif not self.write(value):
             return False
@@ -720,7 +714,7 @@ class ResponseWriter(object):
                 if not self.write_header(name, f()):
                     return False
 
-        if (isinstance(self._response.content, (binary_type, text_type)) and
+        if (isinstance(self._response.content, (bytes, str)) and
             not self._seen_header("content-length")):
             #Would be nice to avoid double-encoding here
             if not self.write_header("Content-Length", len(self.encode(self._response.content))):
@@ -767,7 +761,7 @@ class ResponseWriter(object):
         """Writes the data 'as is'"""
         if data is None:
             raise ValueError('data cannot be None')
-        if isinstance(data, (text_type, binary_type)):
+        if isinstance(data, (str, bytes)):
             # Deliberately allows both text and binary types. See `self.encode`.
             return self.write(data)
         else:
@@ -805,9 +799,9 @@ class ResponseWriter(object):
 
     def encode(self, data):
         """Convert unicode to bytes according to response.encoding."""
-        if isinstance(data, binary_type):
+        if isinstance(data, bytes):
             return data
-        elif isinstance(data, text_type):
+        elif isinstance(data, str):
             return data.encode(self._response.encoding)
         else:
             raise ValueError("data %r should be text or binary, but is %s" % (data, type(data)))

--- a/tools/wptserve/wptserve/router.py
+++ b/tools/wptserve/wptserve/router.py
@@ -3,7 +3,6 @@ import re
 import sys
 
 from .logger import get_logger
-from six import binary_type, text_type
 
 any_method = object()
 
@@ -146,7 +145,7 @@ class Router(object):
                         object and the response object.
 
         """
-        if isinstance(methods, (binary_type, text_type)) or methods is any_method:
+        if isinstance(methods, (bytes, str)) or methods is any_method:
             methods = [methods]
         for method in methods:
             self.routes.append((method, compile_path_match(path), handler))

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -1,18 +1,16 @@
-from six.moves import BaseHTTPServer
 import errno
+import http.server
 import os
 import socket
-from six.moves.socketserver import ThreadingMixIn
+from socketserver import ThreadingMixIn
 import ssl
 import sys
 import threading
 import time
 import traceback
-from six import binary_type, text_type
 import uuid
 from collections import OrderedDict
-
-from six.moves.queue import Queue
+from queue import Queue
 
 from h2.config import H2Configuration
 from h2.connection import H2Connection
@@ -21,7 +19,7 @@ from h2.exceptions import StreamClosedError, ProtocolError
 from h2.settings import SettingCodes
 from h2.utilities import extract_method_header
 
-from six.moves.urllib.parse import urlsplit, urlunsplit
+from urllib.parse import urlsplit, urlunsplit
 
 from mod_pywebsocket import dispatch
 from mod_pywebsocket.handshake import HandshakeException
@@ -38,13 +36,12 @@ from .ws_h2_handshake import WsH2Handshaker
 
 # We need to stress test that browsers can send/receive many headers (there is
 # no specified limit), but the Python stdlib has an arbitrary limit of 100
-# headers. Hitting the limit would produce an exception that is silently caught
-# in Python 2 but leads to HTTP 431 in Python 3, so we monkey patch it higher.
+# headers. Hitting the limit leads to HTTP 431, so we monkey patch it higher.
 # https://bugs.python.org/issue26586
 # https://github.com/web-platform-tests/wpt/pull/24451
-from six.moves import http_client
-assert isinstance(getattr(http_client, '_MAXHEADERS'), int)
-setattr(http_client, '_MAXHEADERS', 512)
+import http.client
+assert isinstance(getattr(http.client, '_MAXHEADERS'), int)
+setattr(http.client, '_MAXHEADERS', 512)
 
 """
 HTTP server designed for testing purposes.
@@ -106,7 +103,7 @@ class RequestRewriter(object):
         :param output_path: Path to replace the input path with in
                             the request.
         """
-        if isinstance(methods, (binary_type, text_type)):
+        if isinstance(methods, (bytes, str)):
             methods = [methods]
         self.rules[input_path] = (methods, output_path)
 
@@ -129,7 +126,7 @@ class RequestRewriter(object):
                 request_handler.path = new_url
 
 
-class WebTestServer(ThreadingMixIn, BaseHTTPServer.HTTPServer):
+class WebTestServer(ThreadingMixIn, http.server.HTTPServer):
     allow_reuse_address = True
     acceptable_errors = (errno.EPIPE, errno.ECONNABORTED)
     request_queue_size = 2000
@@ -190,8 +187,7 @@ class WebTestServer(ThreadingMixIn, BaseHTTPServer.HTTPServer):
         else:
             hostname_port = ("",server_address[1])
 
-        #super doesn't work here because BaseHTTPServer.HTTPServer is old-style
-        BaseHTTPServer.HTTPServer.__init__(self, hostname_port, request_handler_cls, **kwargs)
+        http.server.HTTPServer.__init__(self, hostname_port, request_handler_cls, **kwargs)
 
         if config is not None:
             Server.config = config
@@ -236,12 +232,12 @@ class WebTestServer(ThreadingMixIn, BaseHTTPServer.HTTPServer):
             self.logger.error(traceback.format_exc())
 
 
-class BaseWebTestRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+class BaseWebTestRequestHandler(http.server.BaseHTTPRequestHandler):
     """RequestHandler for WebTestHttpd"""
 
     def __init__(self, *args, **kwargs):
         self.logger = get_logger()
-        BaseHTTPServer.BaseHTTPRequestHandler.__init__(self, *args, **kwargs)
+        http.server.BaseHTTPRequestHandler.__init__(self, *args, **kwargs)
 
     def finish_handling_h1(self, request_line_is_valid):
 

--- a/tools/wptserve/wptserve/sslutils/openssl.py
+++ b/tools/wptserve/wptserve/sslutils/openssl.py
@@ -6,8 +6,6 @@ import subprocess
 import tempfile
 from datetime import datetime, timedelta
 
-from six import iteritems, PY2
-
 # Amount of time beyond the present to consider certificates "expired." This
 # allows certificates to be proactively re-generated in the "buffer" period
 # prior to their exact expiration time.
@@ -18,11 +16,7 @@ def _ensure_str(s, encoding):
     """makes sure s is an instance of str, converting with encoding if needed"""
     if isinstance(s, str):
         return s
-
-    if PY2:
-        return s.encode(encoding)
-    else:
-        return s.decode(encoding)
+    return s.decode(encoding)
 
 
 class OpenSSL(object):
@@ -79,7 +73,7 @@ class OpenSSL(object):
         # Copy the environment, converting to plain strings. Win32 StartProcess
         # is picky about all the keys/values being str (on both Py2/3).
         env = {}
-        for k, v in iteritems(os.environ):
+        for k, v in os.environ.items():
             env[_ensure_str(k, "utf8")] = _ensure_str(v, "utf8")
 
         if self.base_conf_path is not None:

--- a/tools/wptserve/wptserve/stash.py
+++ b/tools/wptserve/wptserve/stash.py
@@ -1,12 +1,10 @@
 import base64
 import json
 import os
-import six
 import threading
 import uuid
 
 from multiprocessing.managers import AcquirerProxy, BaseManager, DictProxy
-from six import text_type, binary_type
 
 from .utils import isomorphic_encode
 
@@ -67,10 +65,10 @@ def store_env_config(address, authkey):
 
 
 def start_server(address=None, authkey=None, mp_context=None):
-    if isinstance(authkey, text_type):
+    if isinstance(authkey, str):
         authkey = authkey.encode("ascii")
     kwargs = {}
-    if six.PY3 and mp_context is not None:
+    if mp_context is not None:
         kwargs["ctx"] = mp_context
     manager = ServerDictManager(address, authkey, **kwargs)
     manager.start()
@@ -160,7 +158,7 @@ class Stash(object):
         # This key format is required to support using the path. Since the data
         # passed into the stash can be a DictProxy which wouldn't detect
         # changes when writing to a subdict.
-        if isinstance(key, binary_type):
+        if isinstance(key, bytes):
             # UUIDs are within the ASCII charset.
             key = key.decode('ascii')
         return (isomorphic_encode(path), uuid.UUID(key).bytes)

--- a/tools/wptserve/wptserve/utils.py
+++ b/tools/wptserve/wptserve/utils.py
@@ -1,24 +1,22 @@
 import socket
 import sys
 
-from six import binary_type, text_type
-
 
 def isomorphic_decode(s):
     """Decodes a binary string into a text string using iso-8859-1.
 
-    Returns `unicode` in Python 2 and `str` in Python 3. The function is a
-    no-op if the argument already has a text type. iso-8859-1 is chosen because
-    it is an 8-bit encoding whose code points range from 0x0 to 0xFF and the
-    values are the same as the binary representations, so any binary string can
-    be decoded into and encoded from iso-8859-1 without any errors or data
-    loss. Python 3 also uses iso-8859-1 (or latin-1) extensively in http:
+    Returns `str`. The function is a no-op if the argument already has a text
+    type. iso-8859-1 is chosen because it is an 8-bit encoding whose code
+    points range from 0x0 to 0xFF and the values are the same as the binary
+    representations, so any binary string can be decoded into and encoded from
+    iso-8859-1 without any errors or data loss. Python 3 also uses iso-8859-1
+    (or latin-1) extensively in http:
     https://github.com/python/cpython/blob/273fc220b25933e443c82af6888eb1871d032fb8/Lib/http/client.py#L213
     """
-    if isinstance(s, text_type):
+    if isinstance(s, str):
         return s
 
-    if isinstance(s, binary_type):
+    if isinstance(s, bytes):
         return s.decode("iso-8859-1")
 
     raise TypeError("Unexpected value (expecting string-like): %r" % s)
@@ -27,14 +25,13 @@ def isomorphic_decode(s):
 def isomorphic_encode(s):
     """Encodes a text-type string into binary data using iso-8859-1.
 
-    Returns `str` in Python 2 and `bytes` in Python 3. The function is a no-op
-    if the argument already has a binary type. This is the counterpart of
-    isomorphic_decode.
+    Returns `bytes`. The function is a no-op if the argument already has a
+    binary type. This is the counterpart of isomorphic_decode.
     """
-    if isinstance(s, binary_type):
+    if isinstance(s, bytes):
         return s
 
-    if isinstance(s, text_type):
+    if isinstance(s, str):
         return s.encode("iso-8859-1")
 
     raise TypeError("Unexpected value (expecting string-like): %r" % s)

--- a/tools/wptserve/wptserve/ws_h2_handshake.py
+++ b/tools/wptserve/wptserve/ws_h2_handshake.py
@@ -11,8 +11,6 @@ from mod_pywebsocket import common
 from mod_pywebsocket.stream import Stream
 from mod_pywebsocket.stream import StreamOptions
 from mod_pywebsocket import util
-from six.moves import map
-from six.moves import range
 
 # TODO: We are using "private" methods of pywebsocket. We might want to
 # refactor pywebsocket to expose those methods publicly. Also, _get_origin


### PR DESCRIPTION
This PR removes six usages from `tools/wptrunner` and `tools/wptserve`.

In each I removed all uses of six except for the `ensure_*` calls, which
are not trivially replaceable.