### PR TITLE
[css-contain] Fix broken spec URLs in vendor-imports

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-formatting-context-float-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-formatting-context-float-001.html
@@ -5,7 +5,7 @@
   <title>CSS Test: 'contain: layout' should contain floats as a formatting context.</title>
   <link rel="author" title="Kyle Zentner" href="mailto:zentner.kyle@gmail.com">
   <link rel="author" title="Morgan Rae Reschenberg" href="mailto:mreschenberg@berkeley.edu">
-  <link rel="help" href="http://www.w3.org/TR/css-containment-1/#containment-layout">
+  <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-layout">
   <link rel="match" href="contain-paint-formatting-context-float-001-ref.html">
   <style>
   #left {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-formatting-context-margin-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-formatting-context-margin-001.html
@@ -5,7 +5,7 @@
   <title>CSS Test: 'contain: layout' with a vertical margin child. Margin collapse should not occur, and neither should overflow clipping.</title>
   <link rel="author" title="Kyle Zentner" href="mailto:zentner.kyle@gmail.com">
   <link rel="author" title="Morgan Rae Reschenberg" href="mailto:mreschenberg@berkeley.edu">
-  <link rel="help" href="http://www.w3.org/TR/css-containment-1/#containment-layout">
+  <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-layout">
   <link rel="match" href="contain-layout-formatting-context-margin-001-ref.html">
   <style>
   #a {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-clip-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-clip-001.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>CSS Test: 'contain: paint' with various overflowing block descendants.</title>
   <link rel="author" title="Kyle Zentner" href="mailto:zentner.kyle@gmail.com">
-  <link rel="help" href="http://www.w3.org/TR/css-containment-1/#containment-paint">
+  <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-paint">
   <link rel="match" href="contain-paint-clip-001-ref.html">
   <style>
   .root {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-clip-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-clip-002.html
@@ -5,7 +5,7 @@
   <title>CSS Test: 'contain: paint' with overflowing text contents inside a rounded rectangle box.</title>
   <link rel="author" title="Yusuf Sermet" href="mailto:ysermet@mozilla.com">
   <link rel="author" title="Kyle Zentner" href="mailto:zentner.kyle@gmail.com">
-  <link rel="help" href="http://www.w3.org/TR/css-containment-1/#containment-paint">
+  <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-paint">
   <link rel="match" href="contain-paint-clip-002-ref.html">
   <style>
   .root {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-clip-003.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-clip-003.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>CSS Test: 'contain: paint' with overflowing text contents, and 'overflow-y: scroll'.</title>
   <link rel="author" title="Kyle Zentner" href="mailto:zentner.kyle@gmail.com">
-  <link rel="help" href="http://www.w3.org/TR/css-containment-1/#containment-paint">
+  <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-paint">
   <link rel="match" href="contain-paint-clip-003-ref.html">
   <style>
   .root {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-clip-004.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-clip-004.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>CSS Test: 'contain: paint' with overflowing text contents, and 'overflow-x: scroll'.</title>
   <link rel="author" title="Kyle Zentner" href="mailto:zentner.kyle@gmail.com">
-  <link rel="help" href="http://www.w3.org/TR/css-containment-1/#containment-paint">
+  <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-paint">
   <link rel="match" href="contain-paint-clip-004-ref.html">
   <style>
   .root {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-clip-005.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-clip-005.html
@@ -5,7 +5,7 @@
   <title>CSS Test: 'contain: paint' on li with overflowing text contents and
     bullet, and 'overflow-y: scroll'.</title>
   <link rel="author" title="Kyle Zentner" href="mailto:zentner.kyle@gmail.com">
-  <link rel="help" href="http://www.w3.org/TR/css-containment-1/#containment-paint">
+  <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-paint">
   <link rel="match" href="contain-paint-clip-003-ref.html">
   <style>
   ul {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-clip-006.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-clip-006.html
@@ -5,7 +5,7 @@
   <title>CSS Test: 'contain: paint' with overflowing text contents while "overflow-clip-box: content-box" enabled.</title>
   <link rel="author" title="Yusuf Sermet" href="mailto:ysermet@mozilla.com">
   <link rel="author" title="Kyle Zentner" href="mailto:zentner.kyle@gmail.com">
-  <link rel="help" href="http://www.w3.org/TR/css-containment-1/#containment-paint">
+  <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-paint">
   <link rel="match" href="contain-paint-clip-006-ref.html">
   <style>
   .root {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-containing-block-absolute-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-containing-block-absolute-001.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>CSS Test: 'contain: paint' element should contain absolute position elements.</title>
   <link rel="author" title="Kyle Zentner" href="mailto:zentner.kyle@gmail.com">
-  <link rel="help" href="http://www.w3.org/TR/css-containment-1/#containment-paint">
+  <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-paint">
   <link rel="match" href="contain-paint-containing-block-absolute-001-ref.html">
   <style>
   #a {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-containing-block-fixed-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-containing-block-fixed-001.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>CSS Test: 'contain: paint' element should contain fixed position elements.</title>
   <link rel="author" title="Kyle Zentner" href="mailto:zentner.kyle@gmail.com">
-  <link rel="help" href="http://www.w3.org/TR/css-containment-1/#containment-paint">
+  <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-paint">
   <link rel="match" href="contain-paint-containing-block-fixed-001-ref.html">
   <style>
   #a {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-formatting-context-float-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-formatting-context-float-001.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>CSS Test: 'contain: paint' should contain floats as a formatting context.</title>
   <link rel="author" title="Kyle Zentner" href="mailto:zentner.kyle@gmail.com">
-  <link rel="help" href="http://www.w3.org/TR/css-containment-1/#containment-paint">
+  <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-paint">
   <link rel="match" href="contain-paint-formatting-context-float-001-ref.html">
   <style>
   #left {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-formatting-context-margin-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-formatting-context-margin-001.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>CSS Test: 'contain: paint' with a vertical margin child. Margin collapse should not occur.</title>
   <link rel="author" title="Kyle Zentner" href="mailto:zentner.kyle@gmail.com">
-  <link rel="help" href="http://www.w3.org/TR/css-containment-1/#containment-paint">
+  <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-paint">
   <link rel="match" href="contain-paint-formatting-context-margin-001-ref.html">
   <style>
   #a {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-ignored-cases-internal-table-001a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-ignored-cases-internal-table-001a.html
@@ -4,7 +4,7 @@
     <meta charset=utf-8>
     <title>CSS-contain test: paint containment on internal table elements except table-cell.</title>
     <link rel="author" title="Yusuf Sermet" href="mailto:ysermet@mozilla.com">
-    <link rel="help" href="http://www.w3.org/TR/css-containment-1/#containment-paint">
+    <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-paint">
     <link rel="match" href="contain-paint-ignored-cases-internal-table-001-ref.html">
     <meta name="assert" content="Paint containment should not apply to internal table elements except table-cell. This test testes only the tr element, and confirms contain:paint does not create a stacking context.">
     <style>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-ignored-cases-internal-table-001b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-ignored-cases-internal-table-001b.html
@@ -4,7 +4,7 @@
     <meta charset=utf-8>
     <title>CSS-contain test: paint containment on internal table elements except table-cell.</title>
     <link rel="author" title="Yusuf Sermet" href="mailto:ysermet@mozilla.com">
-    <link rel="help" href="http://www.w3.org/TR/css-containment-1/#containment-paint">
+    <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-paint">
     <link rel="match" href="contain-paint-ignored-cases-internal-table-001-ref.html">
     <meta name="assert" content="Paint containment should not apply to internal table elements except table-cell. This test testes only the tbody element, and confirms contain:paint does not create a stacking context.">
     <style>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-ignored-cases-ruby-containing-block-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-ignored-cases-ruby-containing-block-001.html
@@ -4,7 +4,7 @@
     <meta charset=utf-8>
     <title>CSS-contain test: paint containment on internal ruby elements.</title>
     <link rel="author" title="Yusuf Sermet" href="mailto:ysermet@mozilla.com">
-    <link rel="help" href="http://www.w3.org/TR/css-containment-1/#containment-paint">
+    <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-paint">
     <link rel="match" href="contain-paint-ignored-cases-ruby-containing-block-001-ref.html">
     <meta name="assert" content="Paint containment should not apply to ruby base, ruby base container, ruby text, and ruby text container. This test confirms contain:paint does not act as a containing block for fixed positioned descendants.">
     <style>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-ignored-cases-ruby-stacking-and-clipping-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-paint-ignored-cases-ruby-stacking-and-clipping-001.html
@@ -4,7 +4,7 @@
     <meta charset=utf-8>
     <title>CSS-contain test: paint containment on internal ruby elements.</title>
     <link rel="author" title="Yusuf Sermet" href="mailto:ysermet@mozilla.com">
-    <link rel="help" href="http://www.w3.org/TR/css-containment-1/#containment-paint">
+    <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-paint">
     <link rel="match" href="contain-paint-ignored-cases-ruby-stacking-and-clipping-001-ref.html">
     <meta name="assert" content="Paint containment should not apply to ruby base, ruby base container, ruby text, and ruby text container. This test confirms that contain:paint does not create a stacking context and does not apply overflow clipping.">
     <style>


### PR DESCRIPTION
These were 404. The new URLs (including the anchors) all exist.