### PR TITLE
[shadow-dom] shadow-dom/nested-slot-remove-crash.html should use `let` instead of `const` to declare variables

### DIFF
--- a/shadow-dom/nested-slot-remove-crash.html
+++ b/shadow-dom/nested-slot-remove-crash.html
@@ -8,7 +8,7 @@
 <span>This test passes if the renderer does not crash.</span>
 
 <script>
-  const root = host.attachShadow({mode:"open"});
+  let root = host.attachShadow({mode:"open"});
   root.innerHTML = `
     <slot id=outer1 name=outer>
       <slot id=inner1 name=inner>Fallback</slot>
@@ -27,7 +27,7 @@
   // The renderer should not crash here:
   root.querySelector("#outer2").remove();
 
-  const root = host.attachShadow({mode:"open"});
+  root = host.attachShadow({mode:"open"});
   root.innerHTML = `
     <slot id=outer3>
       <slot id=inner3>


### PR DESCRIPTION
I cannot see https://crbug.com/1159328 by the permission problem, so I'm not sure about the original details. However, from the code comment, I doubt the current code does not works as intended.

------

1. If this code runs on Chromium/Firefox/WebKit, [this test](https://github.com/web-platform-tests/wpt/blob/master/shadow-dom/nested-slot-remove-crash.html) does not crash.
2. But by the browser's developer tools console, the execution is stopped at https://github.com/web-platform-tests/wpt/blob/0fa6dc568c006811e1fc0035d3b9c70dd7efadf5/shadow-dom/nested-slot-remove-crash.html#L30 by `SyntaxError`.
    - By the comment, I seem this test is expected to reach https://github.com/web-platform-tests/wpt/blob/0fa6dc568c006811e1fc0035d3b9c70dd7efadf5/shadow-dom/nested-slot-remove-crash.html#L39-L40.
3. By pull requests which imported this tests (https://github.com/web-platform-tests/wpt/pull/26951, https://github.com/web-platform-tests/wpt/pull/27001), I feel their original bug is related to DOM.

So I think this `root` should be declare by `let` instead of `const`.

Is this guess right?