### PR TITLE
[css-color-4] Expand CSS Color tests to include tests for hwb() and color(xyz).

### DIFF
--- a/css/css-color/color-resolving-hwb.html
+++ b/css/css-color/color-resolving-hwb.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: Resolving HWB color values</title>
+<link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#hwb-to-rgb">
+<meta name="assert" content="Tests if HWB color values are resolved properly">
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="parent" style="color: rgb(45, 23, 27)">
+    <div id="inner"></div>
+</div>
+
+<script>
+    function color_test(color, expected, reason) {
+        test(function() {
+            var element = document.getElementById('inner');
+            // Random value not in our test data.
+            fail_value = "rgb(12, 34, 223)"
+            element.style.color = "black";
+            element.style.cssText = "color: " + fail_value + "; color: " + color;
+
+            if (expected === null)
+                assert_equals(getComputedStyle(element).color, fail_value);
+            else
+                assert_equals(getComputedStyle(element).color, expected);
+        }, `${reason}: ${color}`);
+    }
+
+    function expected_value(rgb_channels) {
+        if (rgb_channels === null)
+            return null;
+        else if (rgb_channels.length === 3 || rgb_channels[3] == 1 || rgb_channels[3] === undefined)
+            return "rgb(" + rgb_channels.slice(0, 3).join(", ") + ")";
+        else
+            return "rgba(" + rgb_channels.join(", ") + ")";
+    }
+
+    function hslToRgb(hue, sat, light) {
+      if (light <= .5) {
+        var t2 = light * (sat + 1);
+      } else {
+        var t2 = light + sat - (light * sat);
+      }
+      var t1 = light * 2 - t2;
+      var r = hueToRgb(t1, t2, hue + 2);
+      var g = hueToRgb(t1, t2, hue);
+      var b = hueToRgb(t1, t2, hue - 2);
+      return [r,g,b];
+    }
+
+    function hueToRgb(t1, t2, hue) {
+      if (hue < 0) hue += 6;
+      if (hue >= 6) hue -= 6;
+
+      if (hue < 1) return (t2 - t1) * hue + t1;
+      else if (hue < 3) return t2;
+      else if (hue < 4) return (t2 - t1) * (4 - hue) + t1;
+      else return t1;
+    }
+
+    function hwbToRgb(hue, white, black) {
+      if (white + black >= 1) {
+        let gray = Math.min(Math.max(Math.round(white / (white + black) * 255), 0), 255);
+        return [gray, gray, gray];
+      }
+
+      var rgb = hslToRgb(hue, 1, .5);
+      for (var i = 0; i < 3; i++) {
+        rgb[i] *= (1 - white - black);
+        rgb[i] += white;
+        rgb[i] = Math.min(Math.max(Math.round(rgb[i] * 255), 0), 255);
+      }
+      return rgb;
+    }
+
+    // Test HWB parsing.
+    for (var hue of [0, 30, 60, 90, 120, 180, 210, 240, 270, 300, 330, 360]) {
+        for (var white of [0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1]) {
+            for (var black of [0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1]) {
+                rgb_channels = hwbToRgb(hue / 60, white, black);
+                for (var alpha of [undefined, 0, 0.2, 1]) {
+                    rgb_channels[3] = alpha;
+
+                    // Test hue using angle notation.
+                    let hwb_color_using_degrees = `hwb(${hue}deg ${white * 100}% ${black * 100}%)`;
+                    if (alpha !== undefined) {
+                        hwb_color_using_degrees = `hwb(${hue}deg ${white * 100}% ${black * 100}% / ${alpha})`;
+                    }
+                    color_test(hwb_color_using_degrees, expected_value(rgb_channels), "HWB value should parse and round correctly");
+
+                    // Test hue using number notation.
+                    let hwb_color_using_number = `hwb(${hue} ${white * 100}% ${black * 100}%)`;
+                    if (alpha !== undefined) {
+                        hwb_color_using_number = `hwb(${hue} ${white * 100}% ${black * 100}% / ${alpha})`;
+                    }
+                    color_test(hwb_color_using_number, expected_value(rgb_channels), "HWB value should parse and round correctly");
+                }
+            }
+        }
+    }
+</script>

--- a/css/css-color/hwb-001.html
+++ b/css/css-color/hwb-001.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: hwb</title>
+<link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hwb-notation">
+<link rel="match" href="greensquare-ref.html">
+<meta name="assert" content="hwb() with no alpha">
+<style>
+    .test { background-color: red; width: 12em; height: 12em; }
+    .test { background-color: hwb(120 0% 49.8039%); } /* green (sRGB #008000) converted to hwb */
+</style>
+<body>
+    <p>Test passes if you see a green square, and no red.</p>
+    <div class="test"></div>
+</body>

--- a/css/css-color/hwb-002.html
+++ b/css/css-color/hwb-002.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: hwb</title>
+<link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hwb-notation">
+<link rel="match" href="blacksquare-ref.html">
+<meta name="assert" content="hwb() with no alpha">
+<style>
+    .test { background-color: red; width: 12em; height: 12em; }
+    .test { background-color: hwb(0 0% 100%); } /* black (sRGB #000000) converted to hwb */
+</style>
+<body>
+    <p>Test passes if you see a black square, and no red.</p>
+    <div class="test"></div>
+</body>

--- a/css/css-color/hwb-003-ref.html
+++ b/css/css-color/hwb-003-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: CSS Color 4: hwb</title>
+<style>
+    .test { background-color: rgb(50% 50% 50%); width: 12em; height: 12em; } /* hwb(0 100% 100%) converted to sRGB */
+</style>
+<body>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="test"></div>
+</body>

--- a/css/css-color/hwb-003.html
+++ b/css/css-color/hwb-003.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: hwb</title>
+<link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hwb-notation">
+<link rel="match" href="hwb-003-ref.html">
+<meta name="assert" content="hwb with no alpha">
+<style>
+    .test { background-color: red; width: 12em; height: 6em; margin-top: 0; }
+    .ref { background-color: rgb(50% 50% 50%); width: 12em; height: 6em; margin-bottom: 0; } /* hwb(0 100% 100%) converted to sRGB */
+    .test { background-color: hwb(0 100% 100%); }
+</style>
+<body>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="ref"></div>
+    <div class="test"></div>
+</body>

--- a/css/css-color/hwb-004-ref.html
+++ b/css/css-color/hwb-004-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: CSS Color 4: hwb</title>
+<style>
+    .test { background-color: rgb(20% 70% 20%); width: 12em; height: 12em; } /* hwb(120 20% 30%) converted to sRGB */
+</style>
+<body>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="test"></div>
+</body>

--- a/css/css-color/hwb-004.html
+++ b/css/css-color/hwb-004.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: hwb</title>
+<link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hwb-notation">
+<link rel="match" href="hwb-004-ref.html">
+<meta name="assert" content="hwb with no alpha">
+<style>
+    .test { background-color: red; width: 12em; height: 6em; margin-top: 0; }
+    .ref { background-color: rgb(20% 70% 20%); width: 12em; height: 6em; margin-bottom: 0; } /* hwb(120 20% 30%) converted to sRGB */
+    .test { background-color: hwb(120 20% 30%); }
+</style>
+<body>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="ref"></div>
+    <div class="test"></div>
+</body>

--- a/css/css-color/hwb-005-ref.html
+++ b/css/css-color/hwb-005-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: CSS Color 4: hwb</title>
+<style>
+    .test { background-color: rgb(53.8462% 53.8462% 53.8462%); width: 12em; height: 12em; } /* hwb(120 70% 60%) converted to sRGB */
+</style>
+<body>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="test"></div>
+</body>

--- a/css/css-color/hwb-005.html
+++ b/css/css-color/hwb-005.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: hwb</title>
+<link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hwb-notation">
+<link rel="match" href="hwb-005-ref.html">
+<meta name="assert" content="hwb with no alpha">
+<style>
+    .test { background-color: red; width: 12em; height: 6em; margin-top: 0; }
+    .ref { background-color: rgb(53.8462% 53.8462% 53.8462%); width: 12em; height: 6em; margin-bottom: 0; } /* hwb(120 70% 60%) converted to sRGB */
+    .test { background-color: hwb(120 70% 60%); }
+</style>
+<body>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="ref"></div>
+    <div class="test"></div>
+</body>

--- a/css/css-color/xyz-001.html
+++ b/css/css-color/xyz-001.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: xyz</title>
+<link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#valdef-color-xyz">
+<link rel="match" href="greensquare-ref.html">
+<meta name="assert" content="xyz with no alpha">
+<style>
+    .test { background-color: red; width: 12em; height: 12em; }
+    .test { background-color: color(xyz 0.08312 0.154746 0.020961); } /* green (sRGB #008000) converted to xyz */
+</style>
+<body>
+    <p>Test passes if you see a green square, and no red.</p>
+    <div class="test"></div>
+</body>

--- a/css/css-color/xyz-002.html
+++ b/css/css-color/xyz-002.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: xyz</title>
+<link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#valdef-color-xyz">
+<link rel="match" href="blacksquare-ref.html">
+<meta name="assert" content="xyz with no alpha">
+<style>
+    .test { background-color: red; width: 12em; height: 12em; }
+    .test { background-color: color(xyz 0 0 0); } /* black (sRGB #000000) converted to xyz */
+</style>
+<body>
+    <p>Test passes if you see a black square, and no red.</p>
+    <div class="test"></div>
+</body>

--- a/css/css-color/xyz-003-ref.html
+++ b/css/css-color/xyz-003-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: CSS Color 4: xyz</title>
+<style>
+    body { background-color: grey; }
+    .test { background-color: lab(100% 6.1097 -13.2268); width: 12em; height: 12em; } /* color(xyz 1 1 1) converted to Lab */
+</style>
+<body>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="test"></div>
+</body>

--- a/css/css-color/xyz-003.html
+++ b/css/css-color/xyz-003.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: xyz</title>
+<link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#valdef-color-xyz">
+<link rel="match" href="xyz-003-ref.html">
+<meta name="assert" content="xyz with no alpha">
+<style>
+    body { background-color: grey; }
+    .test { background-color: red; width: 12em; height: 6em; margin-top: 0; }
+    .ref { background-color: lab(100% 6.1097 -13.2268); width: 12em; height: 6em; margin-bottom: 0; } /* color(xyz 1 1 1) converted to Lab */
+    .test { background-color: color(xyz 1 1 1); }
+</style>
+<body>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="ref"></div>
+    <div class="test"></div>
+</body>

--- a/css/css-color/xyz-004-ref.html
+++ b/css/css-color/xyz-004-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: CSS Color 4: xyz</title>
+<style>
+    .test { background-color: lab(100% -431.0345 172.4138); width: 12em; height: 12em; } /* color(xyz 0 1 0) converted to Lab */
+</style>
+<body>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="test"></div>
+</body>

--- a/css/css-color/xyz-004.html
+++ b/css/css-color/xyz-004.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: xyz</title>
+<link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#valdef-color-xyz">
+<link rel="match" href="xyz-004-ref.html">
+<meta name="assert" content="xyz with no alpha">
+<style>
+    .test { background-color: red; width: 12em; height: 6em; margin-top: 0; }
+    .ref { background-color: lab(100% -431.0345 172.4138); width: 12em; height: 6em; margin-bottom: 0; } /* color(xyz 0 1 0) converted to Lab */
+    .test { background-color: color(xyz 0 1 0); }
+</style>
+<body>
+    <p>Test passes if you see a single square, and not two rectangles of different colors.</p>
+    <div class="ref"></div>
+    <div class="test"></div>
+</body>

--- a/css/css-color/xyz-005.html
+++ b/css/css-color/xyz-005.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: xyz</title>
+<link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#valdef-color-xyz">
+<link rel="match" href="greensquare-display-p3-ref.html">
+<meta name="assert" content="xyz outside the sRGB gamut">
+<style>
+    .test { background-color: red; width: 12em; height: 12em; }
+    .test { background-color: color(xyz 0.29194 0.692236 0.041884); } /* green color(display-p3 0 1 0) converted to xyz */
+</style>
+<body>
+    <p>Test passes if you see a green square, and no red.</p>
+    <div class="test"></div>
+</body>


### PR DESCRIPTION
Adds tests for hwb():

- css/css-color/color-resolving-hwb.html (based on color-resolving-hsl.html)
- css/css-color/hwb-001.html
- css/css-color/hwb-002.html
- css/css-color/hwb-003.html
- css/css-color/hwb-004.html
- css/css-color/hwb-005.html

and color(xyz):

- css/css-color/xyz-001.html
- css/css-color/xyz-002.html
- css/css-color/xyz-003.html
- css/css-color/xyz-004.html
- css/css-color/xyz-005.html

Values pulled from https://colorjs.io/apps/convert/?precision=6