### PR TITLE
New test for buttons with percentage children

### DIFF
--- a/css/css-flexbox/percentage-descendant-of-anonymous-flex-item.html
+++ b/css/css-flexbox/percentage-descendant-of-anonymous-flex-item.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Flexbox Test: percentage heights in descendants of anonymous flex items</title>
+<link href="resources/flexbox.css" rel="stylesheet">
+<link rel="author" title="Sergio Villar Senin" href="mailto:svillar@igalia.com">
+<link rel="match" href="reference/percentage-descendant-of-anonymous-flex-item-ref.html">
+<style>
+.flexbox {
+    width: 200px;
+    height: 200px;
+}
+</style>
+<!--
+    Both Blink and WebKit implement buttons as flexboxes, which in this case, wrap the child in an anonymous box.
+    Anonymous boxes are skipped when computing percentage heights but we need to ensure that their children with
+    percentage heights are properly sized.
+-->
+<div class="flexbox column">
+    <div style="height: 50%;">
+        <button style="width: 200px; height: 100%;">
+            <div style="width: 200px; height: 100%; background-color: green;"></div>
+        </button>
+    </div>
+</div>

--- a/css/css-flexbox/percentage-descendant-of-anonymous-flex-item.html
+++ b/css/css-flexbox/percentage-descendant-of-anonymous-flex-item.html
@@ -15,6 +15,7 @@
     Anonymous boxes are skipped when computing percentage heights but we need to ensure that their children with
     percentage heights are properly sized.
 -->
+<p>The test PASS is you see a 200x100 green rectangle inside a button.</p>
 <div class="flexbox column">
     <div style="height: 50%;">
         <button style="width: 200px; height: 100%;">

--- a/css/css-flexbox/percentage-descendant-of-anonymous-flex-item.html
+++ b/css/css-flexbox/percentage-descendant-of-anonymous-flex-item.html
@@ -15,7 +15,7 @@
     Anonymous boxes are skipped when computing percentage heights but we need to ensure that their children with
     percentage heights are properly sized.
 -->
-<p>The test PASS is you see a 200x100 green rectangle inside a button.</p>
+<p>The test PASS if you see a 200x100 green rectangle inside a button.</p>
 <div class="flexbox column">
     <div style="height: 50%;">
         <button style="width: 200px; height: 100%;">

--- a/css/css-flexbox/percentage-descendant-of-anonymous-flex-item.html
+++ b/css/css-flexbox/percentage-descendant-of-anonymous-flex-item.html
@@ -4,6 +4,7 @@
 <link href="resources/flexbox.css" rel="stylesheet">
 <link rel="author" title="Sergio Villar Senin" href="mailto:svillar@igalia.com">
 <link rel="match" href="reference/percentage-descendant-of-anonymous-flex-item-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#flex-items">
 <style>
 .flexbox {
     width: 200px;

--- a/css/css-flexbox/reference/percentage-descendant-of-anonymous-flex-item-ref.html
+++ b/css/css-flexbox/reference/percentage-descendant-of-anonymous-flex-item-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Flexbox Test: percentage heights in descendants of anonymous flex items</title>
+<link href="resources/flexbox.css" rel="stylesheet">
+<link rel="author" title="Sergio Villar Senin" href="mailto:svillar@igalia.com">
+<button style="width: 200px; height: 100px;">
+    <div style="width: 200px; height: 100%; background-color: green;"></div>
+</button>

--- a/css/css-flexbox/reference/percentage-descendant-of-anonymous-flex-item-ref.html
+++ b/css/css-flexbox/reference/percentage-descendant-of-anonymous-flex-item-ref.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Flexbox Test: percentage heights in descendants of anonymous flex items</title>
-<link href="resources/flexbox.css" rel="stylesheet">
 <link rel="author" title="Sergio Villar Senin" href="mailto:svillar@igalia.com">
+<p>The test PASS is you see a 200x100 green rectangle inside a button.</p>
 <button style="width: 200px; height: 100px;">
-    <div style="width: 200px; height: 100%; background-color: green;"></div>
+    <div style="width: 200px; height: 100px; background-color: green;"></div>
 </button>

--- a/css/css-flexbox/reference/percentage-descendant-of-anonymous-flex-item-ref.html
+++ b/css/css-flexbox/reference/percentage-descendant-of-anonymous-flex-item-ref.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Flexbox Test: percentage heights in descendants of anonymous flex items</title>
 <link rel="author" title="Sergio Villar Senin" href="mailto:svillar@igalia.com">
-<p>The test PASS is you see a 200x100 green rectangle inside a button.</p>
+<p>The test PASS if you see a 200x100 green rectangle inside a button.</p>
 <button style="width: 200px; height: 100px;">
     <div style="width: 200px; height: 100px; background-color: green;"></div>
 </button>


### PR DESCRIPTION
Both Blink and WebKit implement buttons as flexboxes, which in this case, wrap the child in an anonymous box. Anonymous boxes are skipped when computing percentage heights but we need to ensure that their children with percentage heights are properly sized.