### PR TITLE
Allow tests in test group to be a partial list

### DIFF
--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -494,9 +494,8 @@ class GroupFileTestSource(TestSource):
         for test in tests:
             try:
                 group = test_groups.group_by_test[test.id]
+                tests_by_group[group].append(test.id)
             except KeyError:
-                logger.error("%s is missing from test groups file" % test.id)
-                raise
-            tests_by_group[group].append(test.id)
+                logger.warning("%s is missing from test groups file" % test.id)
 
         return tests_by_group


### PR DESCRIPTION
Run with a partial list, now test can run to complete
Bug: 1175457