### PR TITLE
Fix expectations of a recently committed test

### DIFF
--- a/css/css-flexbox/reference/percentage-descendant-of-anonymous-flex-item-ref.html
+++ b/css/css-flexbox/reference/percentage-descendant-of-anonymous-flex-item-ref.html
@@ -4,5 +4,5 @@
 <link rel="author" title="Sergio Villar Senin" href="mailto:svillar@igalia.com">
 <p>The test PASS if you see a 200x100 green rectangle inside a button.</p>
 <button style="width: 200px; height: 100px;">
-    <div style="width: 200px; height: 100px; background-color: green;"></div>
+    <div style="width: 200px; height: 100%; background-color: green;"></div>
 </button>


### PR DESCRIPTION
In PR #27520 we landed a new test for buttons with children with percentage heights called `percentage-descendant-of-anonymous-flex-item.html`

In the review process the `height: 100%` was replaced by `height: 100px`. However that was a bad decision because every UA styles buttons in a different way (even the same UA in different platforms) meaning that due to margins and paddings that height could be smaller than 100px. Switching back to the percentage height in the expectations.