### PR TITLE
[python3] Fix regen_certs.yml for the python3 migration

### DIFF
--- a/.github/workflows/regen_certs.yml
+++ b/.github/workflows/regen_certs.yml
@@ -8,6 +8,10 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
     - name: Checkout
       uses: actions/checkout@v2
     - name: Regenerate certs


### PR DESCRIPTION
This was trying to call 'wpt' with python 2, which is now rejected.