### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=221916

### DIFF
--- a/mediacapture-record/MediaRecorder-pause-resume.html
+++ b/mediacapture-record/MediaRecorder-pause-resume.html
@@ -56,6 +56,34 @@
         assert_array_equals(events, ["start", "pause", "resume", "dataavailable", "stop"],
             "Should have gotten expected events");
     }, "MediaRecorder handles pause() and resume() calls appropriately in state and events");
+
+    promise_test(async () => {
+        let video = createVideoStream();
+        let recorder = new MediaRecorder(video);
+        let events = recordEvents(recorder,
+            ["start", "stop", "dataavailable", "pause", "resume", "error"]);
+
+        recorder.start();
+        assert_equals(recorder.state, "recording", "MediaRecorder has been started successfully");
+        await new Promise(r => recorder.onstart = r);
+
+        recorder.pause();
+        assert_equals(recorder.state, "paused", "MediaRecorder should be paused immediately following pause()");
+        let event = await new Promise(r => recorder.onpause = r);
+        assert_equals(event.type, "pause", "the event type should be pause");
+        assert_true(event.isTrusted, "isTrusted should be true when the event is created by C++");
+
+        recorder.stop();
+        assert_equals(recorder.state, "inactive", "MediaRecorder should be inactive after being stopped");
+        await new Promise(r => recorder.onstop = r);
+
+        recorder.start();
+        assert_equals(recorder.state, "recording", "MediaRecorder has been started successfully");
+        await new Promise(r => recorder.onstart = r);
+
+        assert_array_equals(events, ["start", "pause", "dataavailable", "stop", "start"],
+            "Should have gotten expected events");
+    }, "MediaRecorder handles stop() in paused state appropriately");
 </script>
 </body>
 </html>


### PR DESCRIPTION
WebKit export from bug: [MediaRecorder.stop() does not work correctly when recording has been paused.](https://bugs.webkit.org/show_bug.cgi?id=221916)