### PR TITLE
Seperate out bidi_session from session in fixtures.py

### DIFF
--- a/webdriver/tests/bidi/new_session/connect.py
+++ b/webdriver/tests/bidi/new_session/connect.py
@@ -4,6 +4,7 @@ import websockets
 import webdriver
 
 # classic session to enable bidi capability manually
+# Intended to be the first test in this file
 @pytest.mark.asyncio
 @pytest.mark.capabilities({"webSocketUrl": True})
 async def test_websocket_url_connect(session):
@@ -11,22 +12,12 @@ async def test_websocket_url_connect(session):
     websocket_url = session.capabilities["webSocketUrl"]
     async with websockets.connect(websocket_url) as websocket:
         await websocket.send("Hello world!")
-        await websocket.close()
 
-# bidi session following classic session to test session
-# recreation in session fixture
-# also test send message via websocket and
-# close websocket at the end.
+# test bidi_session send
+# using bidi_session is the recommended way to test bidi
 @pytest.mark.asyncio
-async def test_bidi_session_send_and_close(bidi_session):
-    assert isinstance(bidi_session, webdriver.BidiSession)
-    await bidi_session.websocket_transport.send("test_bidi_session: send and close")
-    await bidi_session.websocket_transport.close()
-
-# test send after close
-@pytest.mark.asyncio
-async def test_bidi_session_send_after_close(bidi_session):
-    await bidi_session.websocket_transport.send("test_bidi_session: send after close")
+async def test_bidi_session_send(bidi_session):
+    await bidi_session.websocket_transport.send("test_bidi_session: send")
 
 # bidi session following a bidi session with a different capabilities
 # to test session recreation
@@ -37,6 +28,8 @@ async def test_bidi_session_with_different_capability(bidi_session):
 
 # classic session following a bidi session to test session
 # recreation
+# Intended to be the last test in this file to make sure
+# classic session is not impacted by bidi tests
 @pytest.mark.asyncio
 def test_classic_after_bidi_session(session):
     assert not isinstance(session, webdriver.BidiSession)

--- a/webdriver/tests/bidi/new_session/connect.py
+++ b/webdriver/tests/bidi/new_session/connect.py
@@ -1,43 +1,42 @@
 import pytest
 import asyncio
 import websockets
+import webdriver
 
 # classic session to enable bidi capability manually
 @pytest.mark.asyncio
 @pytest.mark.capabilities({"webSocketUrl": True})
 async def test_websocket_url_connect(session):
+    assert not isinstance(session, webdriver.BidiSession)
     websocket_url = session.capabilities["webSocketUrl"]
     async with websockets.connect(websocket_url) as websocket:
         await websocket.send("Hello world!")
         await websocket.close()
 
 # bidi session following classic session to test session
-# recreation with bidi true in session fixture.
-# Close websocket at the end.
+# recreation in session fixture
+# also test send message via websocket and
+# close websocket at the end.
 @pytest.mark.asyncio
-@pytest.mark.bidi(True)
-async def test_bidi_session_1(session):
-    await session.websocket_transport.send("test_bidi_session_1")
-    await session.websocket_transport.close()
+async def test_bidi_session_send_and_close(bidi_session):
+    assert isinstance(bidi_session, webdriver.BidiSession)
+    await bidi_session.websocket_transport.send("test_bidi_session: send and close")
+    await bidi_session.websocket_transport.close()
 
-# bidi session following a bidi session with the same capabilities
-# but closed websocket to test restart of websocket connection.
+# test send after close
 @pytest.mark.asyncio
-@pytest.mark.bidi(True)
-async def test_bidi_session_2(session):
-    await session.websocket_transport.send("test_bidi_session_2")
-    await session.websocket_transport.close()
+async def test_bidi_session_send_after_close(bidi_session):
+    await bidi_session.websocket_transport.send("test_bidi_session: send after close")
 
 # bidi session following a bidi session with a different capabilities
 # to test session recreation
 @pytest.mark.asyncio
-@pytest.mark.bidi(True)
 @pytest.mark.capabilities({"acceptInsecureCerts": True})
-async def test_bidi_session_3(session):
-    await session.websocket_transport.send("test_bidi_session_3")
+async def test_bidi_session_with_different_capability(bidi_session):
+    await bidi_session.websocket_transport.send("test_bidi_session: different capability")
 
 # classic session following a bidi session to test session
 # recreation
 @pytest.mark.asyncio
-async def test_classic(session):
-    pass
+def test_classic_after_bidi_session(session):
+    assert not isinstance(session, webdriver.BidiSession)


### PR DESCRIPTION
PR for https://github.com/web-platform-tests/wpt/issues/27687

Seperated out bidi_session from session in fixtures.py
Removed bidi markers and created bidi_session fixtures

Added handling in bidi_session and session start function
to disguish bidi_session and session so that async functions
can be awaited.

Modified tests to have better names.