### PR TITLE
Added 2 writing-modes tests (manual and SHOULD type)

### DIFF
--- a/css/css-writing-modes/alt-display-vertical-001-manual.html
+++ b/css/css-writing-modes/alt-display-vertical-001-manual.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: alternate text should display in the writing mode of associated element</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#block-flow">
+
+  <meta content="should" name="flags">
+
+  <style>
+  .vrl
+    {
+      float: right;
+      writing-mode: vertical-rl;
+    }
+
+  .vlr
+    {
+      float: left;
+      writing-mode: vertical-lr;
+    }
+  </style>
+
+  <h3><img class="vrl" src="support/does-not-exist.png" alt="Test passes if this text is rotated 90°"></h3>
+
+  <h3><img class="vlr" src="support/does-not-exist.png" alt="Test passes if this text is rotated 90°"></h3>
+
+  <h3 class="vrl"><img src="support/does-not-exist.png" alt="Test passes if this text is rotated 90°"></h3>
+
+  <h3 class="vlr"><img src="support/does-not-exist.png" alt="Test passes if this text is rotated 90°"></h3>

--- a/css/css-writing-modes/tooltip-display-vertical-001-manual.html
+++ b/css/css-writing-modes/tooltip-display-vertical-001-manual.html
@@ -17,7 +17,7 @@
 
   -->
 
-  <meta content="should interact" name="flags">
+  <meta content="may interact" name="flags">
 
   <style>
   h3#vrl

--- a/css/css-writing-modes/tooltip-display-vertical-001-manual.html
+++ b/css/css-writing-modes/tooltip-display-vertical-001-manual.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: tooltip should display in the writing mode of associated element</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#block-flow">
+
+  <!--
+
+  Bug 1183691: Tooltips should display in the writing mode of the associated element
+  https://bugzilla.mozilla.org/show_bug.cgi?id=1183691
+
+  Issue 703011: Tooltip should be displayed according to the writing mode of associated element
+  https://bugs.chromium.org/p/chromium/issues/detail?id=703011
+
+  -->
+
+  <meta content="should interact" name="flags">
+
+  <style>
+  h3#vrl
+    {
+      float: right;
+      writing-mode: vertical-rl;
+    }
+
+  h3#vlr
+    {
+      float: left;
+      writing-mode: vertical-lr;
+    }
+  </style>
+
+  <h3 title="Test passes if tooltip is vertical and if tooltip text is rotated 90°" id="vrl">Hover pointing device over this text</h3>
+
+  <h3 title="Test passes if tooltip is vertical and if tooltip text is rotated 90°" id="vlr">Hover pointing device over this text</h3>


### PR DESCRIPTION
alt-display-vertical-001-manual.html

tooltip-display-vertical-001-manual.html

On my website:

http://www.gtalbot.org/BrowserBugsSection/CSS3WritingModes/alt-display-vertical-001-manual.html

http://www.gtalbot.org/BrowserBugsSection/CSS3WritingModes/tooltip-display-vertical-001-manual.html

These 2 tests are somewhat related to [Issue 6031](https://github.com/w3c/csswg-drafts/issues/6031)