### PR TITLE
Properly catch exception so that test can run to end

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -286,9 +286,9 @@ class TestExecutor(object):
         """Run a particular test.
 
         :param test: The test to run"""
-        if test.environment != self.last_environment:
-            self.on_environment_change(test.environment)
         try:
+            if test.environment != self.last_environment:
+                self.on_environment_change(test.environment)
             result = self.do_test(test)
         except Exception as e:
             exception_string = traceback.format_exc()


### PR DESCRIPTION
Met WebDriverException and it is not properly catched,
and cause an Assertion error in restart_runner, cause
the whole test abort early

Bug: 27751