### PR TITLE
Added a text-shadow and text-orientation: upright test

### DIFF
--- a/css/css-writing-modes/reference/text-shadow-orientation-upright-001-ref.html
+++ b/css/css-writing-modes/reference/text-shadow-orientation-upright-001-ref.html
@@ -5,35 +5,42 @@
   <title>CSS Reference Test</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 
   <style>
   div
     {
-      color: purple;
-      font-size: 25px;
-      height: 4em;
-      line-height: 1;
-      font-family: Ahem;
-      text-orientation: upright;
-      writing-mode: vertical-rl;
+      height: 100px;
+      margin-left: 100px;
+      width: 100px;
+    }
+
+  div#purple
+    {
+      background-color: purple;
+    }
+
+  img
+    {
+      height: 100px;
+      vertical-align: top;
+      width: 100px;
+    }
+
+  div#orange-blue
+    {
+      background-color: blue;
+      margin-left: 0px;
+      width: 300px;
+    }
+
+  div#fuchsia
+    {
+      background-color: fuchsia;
     }
   </style>
 
-  <p>Test passes if there is a filled purple square.
+  <div id="purple"></div>
 
-  <div>1234 5678 9012 3456</div>
+  <div id="orange-blue"><img src="../support/swatch-orange.png" alt="Image download support must be enabled"><img src="../support/swatch-yellow.png" alt="Image download support must be enabled"></div>
 
-  <!--
-  . . . . . . . . . .
-  .                 .
-  .  3   9   5   1  .
-  .                 .
-  .  4   0   6   2  .
-  .                 .
-  .  5   1   7   3  .
-  .                 .
-  .  6   2   8   4  .
-  ...................
-
-  -->
+  <div id="fuchsia"></div>

--- a/css/css-writing-modes/reference/text-shadow-orientation-upright-001-ref.html
+++ b/css/css-writing-modes/reference/text-shadow-orientation-upright-001-ref.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+  <style>
+  div
+    {
+      color: purple;
+      font-size: 25px;
+      height: 4em;
+      line-height: 1;
+      font-family: Ahem;
+      text-orientation: upright;
+      writing-mode: vertical-rl;
+    }
+  </style>
+
+  <p>Test passes if there is a filled purple square.
+
+  <div>1234 5678 9012 3456</div>
+
+  <!--
+  . . . . . . . . . .
+  .                 .
+  .  3   9   5   1  .
+  .                 .
+  .  4   0   6   2  .
+  .                 .
+  .  5   1   7   3  .
+  .                 .
+  .  6   2   8   4  .
+  ...................
+
+  -->

--- a/css/css-writing-modes/text-shadow-orientation-upright-001.html
+++ b/css/css-writing-modes/text-shadow-orientation-upright-001.html
@@ -24,13 +24,15 @@
   <style>
   div
     {
-      color: purple;
+      color: yellow;
       font-family: Ahem;
-      font-size: 25px;
-      height: 4em;
+      font-size: 100px;
       line-height: 1;
+      margin: calc(1em + 8px) auto auto 1em;
       text-orientation: upright;
       writing-mode: vertical-rl;
+
+      text-shadow: 0em -1em purple, 1em 0em blue, 0em 1em fuchsia, -1em 0em orange;
     }
 
   /*
@@ -38,9 +40,6 @@
   Value: [ <color>? && <length>{2,3} ]#
 
   color: color of text-shadow
-  If the color of the shadow is not specified, it defaults
-  to currentColor, i.e. the shadow’s color is taken from
-  the element’s color property.
 
   1st <length>
     Specifies the horizontal offset
@@ -55,53 +54,24 @@
 
   */
 
-  span#B
-    {
-      text-shadow: -1em 0em;
-      /* text-shadow toward lefthand side */
-    }
-
-  span#F
-    {
-      text-shadow: 1em 0em;
-      /* text-shadow toward righthand side */
-    }
-
-  span#G
-    {
-      text-shadow: 0em 1em;
-      /* text-shadow toward down side */
-    }
-
-  span#K
-    {
-      text-shadow: 0em -1em;
-      /* text-shadow toward up side */
-    }
   </style>
 
-  <p>Test passes if there is a filled purple square.
-
-  <div>A<span id="B">B</span>C&nbsp;
-  D E<span id="F">F</span>
-  <span id="G">G</span> HI
-  J <span id="K">K</span>L</div>
+  <div>A</div>
 
   <!--
 
-  . . . . . . . . . .
-  .                 .
-  .  J   G   D   A  .
-  .      |          .
-  .  ^   v     <-B  .
-  .  |              .
-  .  K   H   E   C  .
-  .                 .
-  .  L   I   F ->   .
-  ...................
-
-  Arrows indicate where
-  the 4 shadow offsets
-  must be painted
+                  .........
+                  .       .
+                  .       . <-purple
+                  .       .
+           .......................
+           .      .       .      .
+  orange-> .      .  yel  .      . <-blue
+           .      .  low  .      .
+           .......................
+                  .       .
+                  .       . <-fuchsia
+                  .       .
+                  .........
 
   -->

--- a/css/css-writing-modes/text-shadow-orientation-upright-001.html
+++ b/css/css-writing-modes/text-shadow-orientation-upright-001.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'text-shadow' and upright text orientation</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#physical-only">
+  <link rel="help" href="https://www.w3.org/TR/css-text-decor-3/#text-shadow-property">
+  <link rel="match" href="reference/text-shadow-orientation-upright-001-ref.html">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+  <!--
+
+  Issue 229211: text-shadow is drawn at the invalid position in vertical writing mode
+  on Chromium for Mac
+  https://bugs.chromium.org/p/chromium/issues/detail?id=229211#c8
+
+  -->
+
+  <meta content="" name="flags">
+  <meta content="This test checks that text-shadow offsets are purely physical and do not change with vertical writing mode.">
+
+  <style>
+  div
+    {
+      color: purple;
+      font-family: Ahem;
+      font-size: 25px;
+      height: 4em;
+      line-height: 1;
+      text-orientation: upright;
+      writing-mode: vertical-rl;
+    }
+
+  /*
+
+  Value: [ <color>? && <length>{2,3} ]#
+
+  color: color of text-shadow
+  If the color of the shadow is not specified, it defaults
+  to currentColor, i.e. the shadow’s color is taken from
+  the element’s color property.
+
+  1st <length>
+    Specifies the horizontal offset
+    of the shadow. A positive value draws a shadow that is
+    offset to the right of the box, a negative length to the
+    left.
+
+  2nd <length>
+    Specifies the vertical offset
+    of the shadow. A positive value offsets the shadow down,
+    a negative one up.
+
+  */
+
+  span#B
+    {
+      text-shadow: -1em 0em;
+      /* text-shadow toward lefthand side */
+    }
+
+  span#F
+    {
+      text-shadow: 1em 0em;
+      /* text-shadow toward righthand side */
+    }
+
+  span#G
+    {
+      text-shadow: 0em 1em;
+      /* text-shadow toward down side */
+    }
+
+  span#K
+    {
+      text-shadow: 0em -1em;
+      /* text-shadow toward up side */
+    }
+  </style>
+
+  <p>Test passes if there is a filled purple square.
+
+  <div>A<span id="B">B</span>C&nbsp;
+  D E<span id="F">F</span>
+  <span id="G">G</span> HI
+  J <span id="K">K</span>L</div>
+
+  <!--
+
+  . . . . . . . . . .
+  .                 .
+  .  J   G   D   A  .
+  .      |          .
+  .  ^   v     <-B  .
+  .  |              .
+  .  K   H   E   C  .
+  .                 .
+  .  L   I   F ->   .
+  ...................
+
+  Arrows indicate where
+  the 4 shadow offsets
+  must be painted
+
+  -->


### PR DESCRIPTION
text-shadow-orientation-upright-001.html
reference/text-shadow-orientation-upright-001-ref.html

This test spun from
[Issue 229211: text-shadow is drawn at the invalid position in vertical writing mode
on Chromium for Mac](https://bugs.chromium.org/p/chromium/issues/detail?id=229211#c8)

The test and reference are coded in a way to elegantly work around subpixel positioning issue with Ahem font.

On my website:

http://www.gtalbot.org/BrowserBugsSection/CSS3WritingModes/s76-text-shadow-orientation-upright-001.html

http://www.gtalbot.org/BrowserBugsSection/CSS3WritingModes/reference/text-shadow-orientation-upright-001-ref.html