### PR TITLE
XMLHttpRequest: response stream errors

### DIFF
--- a/service-workers/service-worker/fetch-request-xhr-sync-error.https.window.js
+++ b/service-workers/service-worker/fetch-request-xhr-sync-error.https.window.js
@@ -1,0 +1,19 @@
+// META: script=resources/test-helpers.sub.js
+
+"use strict";
+
+promise_test(async t => {
+  const url = "resources/fetch-request-xhr-sync-error-worker.js";
+  const scope = "resources/fetch-request-xhr-sync-iframe.html";
+
+  const registration = await service_worker_unregister_and_register(t, url, scope);
+  t.add_cleanup(() => registration.unregister());
+
+  await wait_for_state(t, registration.installing, 'activated');
+  const frame = await with_iframe(scope);
+  t.add_cleanup(() => frame.remove());
+
+  assert_throws_dom("NetworkError", frame.contentWindow.DOMException, () => frame.contentWindow.performSyncXHR("non-existent-stream-1.txt"));
+  assert_throws_dom("NetworkError", frame.contentWindow.DOMException, () => frame.contentWindow.performSyncXHR("non-existent-stream-2.txt"));
+  assert_throws_dom("NetworkError", frame.contentWindow.DOMException, () => frame.contentWindow.performSyncXHR("non-existent-stream-3.txt"));
+}, "Verify synchronous XMLHttpRequest always throws a NetworkError for ReadableStream errors");

--- a/service-workers/service-worker/resources/fetch-request-xhr-sync-error-worker.js
+++ b/service-workers/service-worker/resources/fetch-request-xhr-sync-error-worker.js
@@ -1,0 +1,19 @@
+"use strict";
+
+self.onfetch = event => {
+  if (event.request.url.endsWith("non-existent-stream-1.txt")) {
+    const rs1 = new ReadableStream();
+    event.respondWith(new Response(rs1));
+    rs1.cancel(1);
+  } else if (event.request.url.endsWith("non-existent-stream-2.txt")) {
+    const rs2 = new ReadableStream({
+      start(controller) { controller.error(1) }
+    });
+    event.respondWith(new Response(rs2));
+  } else if (event.request.url.endsWith("non-existent-stream-3.txt")) {
+    const rs3 = new ReadableStream({
+      pull(controller) { controller.error(1) }
+    });
+    event.respondWith(new Response(rs3));
+  }
+};

--- a/xhr/response-body-errors.any.js
+++ b/xhr/response-body-errors.any.js
@@ -1,0 +1,23 @@
+// This will transmit two chunks TEST_CHUNK and then garbage, which should result in an error.
+const url = "/fetch/api/resources/bad-chunk-encoding.py?ms=1&count=2";
+
+test(() => {
+  client = new XMLHttpRequest();
+  client.open("GET", url, false);
+  assert_throws_dom("NetworkError", () => client.send());
+}, "Synchronous XMLHttpRequest should throw on bad chunk");
+
+async_test(t => {
+  client = new XMLHttpRequest();
+  client.open("GET", url, true);
+  client.onreadystatechange = t.step_func(() => {
+    if (client.readyState === 3) {
+      assert_true(client.responseText.indexOf("TEST_CHUNK") !== -1);
+    }
+  });
+  client.onerror = t.step_func_done(() => {
+    assert_equals(client.responseText, "");
+  });
+  client.onload = t.unreached_func();
+  client.send();
+}, "Asynchronous XMLHttpRequest should clear response on bad chunk");


### PR DESCRIPTION
For https://github.com/whatwg/xhr/issues/314.

It seems Chrome does not throw exceptions here at all...