### PR TITLE
Remove now-empty cors-rfc1918/ directory.

### DIFF
--- a/cors-rfc1918/META.yml
+++ b/cors-rfc1918/META.yml
@@ -1,5 +1,0 @@
-spec: https://wicg.github.io/cors-rfc1918/
-suggested_reviewers:
-  - letitz
-  - camillelamy
-  - mikewest

--- a/cors-rfc1918/README.md
+++ b/cors-rfc1918/README.md
@@ -1,1 +1,0 @@
-This directory is being deleted. See ../fetch/cors-rfc1918/ instead.


### PR DESCRIPTION
It only contained tests for `window.addressSpace`, which have been deleted since that part of the spec is going away: https://github.com/WICG/private-network-access/issues/21

The rest of the spec will be tested in a subdirectory of `fetch/`: currently `fetch/cors-rfc1918/`, soon to be renamed `fetch/private-network-access/`.