### PR TITLE
Parse tombstones on android devices

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/android_weblayer.py
+++ b/tools/wptrunner/wptrunner/browsers/android_weblayer.py
@@ -30,7 +30,9 @@ def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
     return {"binary": kwargs["binary"],
             "device_serial": kwargs["device_serial"],
             "webdriver_binary": kwargs["webdriver_binary"],
-            "webdriver_args": kwargs.get("webdriver_args")}
+            "webdriver_args": kwargs.get("webdriver_args"),
+            "stackparser_script": kwargs.get("stackparser_script"),
+            "output_directory": kwargs.get("output_directory")}
 
 
 def executor_kwargs(logger, test_type, server_config, cache_manager, run_info_data,
@@ -81,10 +83,13 @@ class WeblayerShell(ChromeAndroidBrowserBase):
                  webdriver_binary="chromedriver",
                  remote_queue=None,
                  device_serial=None,
-                 webdriver_args=None):
+                 webdriver_args=None,
+                 stackparser_script=None,
+                 output_directory=None):
         """Creates a new representation of Chrome.  The `binary` argument gives
         the browser binary to use for testing."""
         super(WeblayerShell, self).__init__(logger,
-                webdriver_binary, remote_queue, device_serial, webdriver_args)
+                webdriver_binary, remote_queue, device_serial,
+                webdriver_args, stackparser_script, output_directory)
         self.binary = binary
         self.wptserver_ports = _wptserve_ports

--- a/tools/wptrunner/wptrunner/browsers/android_webview.py
+++ b/tools/wptrunner/wptrunner/browsers/android_webview.py
@@ -30,7 +30,9 @@ def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
     return {"binary": kwargs["binary"],
             "device_serial": kwargs["device_serial"],
             "webdriver_binary": kwargs["webdriver_binary"],
-            "webdriver_args": kwargs.get("webdriver_args")}
+            "webdriver_args": kwargs.get("webdriver_args"),
+            "stackparser_script": kwargs.get("stackparser_script"),
+            "output_directory": kwargs.get("output_directory")}
 
 
 def executor_kwargs(logger, test_type, server_config, cache_manager, run_info_data,
@@ -80,10 +82,13 @@ class SystemWebViewShell(ChromeAndroidBrowserBase):
     def __init__(self, logger, binary, webdriver_binary="chromedriver",
                  remote_queue=None,
                  device_serial=None,
-                 webdriver_args=None):
+                 webdriver_args=None,
+                 stackparser_script=None,
+                 output_directory=None):
         """Creates a new representation of Chrome.  The `binary` argument gives
         the browser binary to use for testing."""
         super(SystemWebViewShell, self).__init__(logger,
-                webdriver_binary, remote_queue, device_serial, webdriver_args)
+                webdriver_binary, remote_queue, device_serial,
+                webdriver_args, stackparser_script, output_directory)
         self.binary = binary
         self.wptserver_ports = _wptserve_ports

--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -162,6 +162,10 @@ class Browser(object):
         with which it should be instantiated"""
         return ExecutorBrowser, {}
 
+    def possible_parse_tombstone(self):
+        """Possibly parse tombstones on Android device for Android target"""
+        pass
+
     def check_crash(self, process, test):
         """Check if a crash occured and output any useful information to the
         log. Returns a boolean indicating whether a crash occured."""

--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -162,7 +162,7 @@ class Browser(object):
         with which it should be instantiated"""
         return ExecutorBrowser, {}
 
-    def possible_parse_tombstone(self):
+    def maybe_parse_tombstone(self):
         """Possibly parse tombstones on Android device for Android target"""
         pass
 

--- a/tools/wptrunner/wptrunner/browsers/chrome_android.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_android.py
@@ -189,7 +189,7 @@ class ChromeAndroidBrowserBase(Browser):
         cmd.extend(['logcat', '*:D'])
         return cmd
 
-    def possible_parse_tomestone(self, logger):
+    def possible_parse_tombstone(self, logger):
         if self.stackparser_script:
             cmd = [self.stackparser_script, "-a", "-w"]
             if self.device_serial:

--- a/tools/wptrunner/wptrunner/browsers/chrome_android.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_android.py
@@ -189,7 +189,7 @@ class ChromeAndroidBrowserBase(Browser):
         cmd.extend(['logcat', '*:D'])
         return cmd
 
-    def possible_parse_tombstone(self, logger):
+    def maybe_parse_tombstone(self, logger):
         if self.stackparser_script:
             cmd = [self.stackparser_script, "-a", "-w"]
             if self.device_serial:

--- a/tools/wptrunner/wptrunner/browsers/chrome_android.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_android.py
@@ -34,7 +34,9 @@ def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
     return {"package_name": kwargs["package_name"],
             "device_serial": kwargs["device_serial"],
             "webdriver_binary": kwargs["webdriver_binary"],
-            "webdriver_args": kwargs.get("webdriver_args")}
+            "webdriver_args": kwargs.get("webdriver_args"),
+            "stackparser_script": kwargs.get("stackparser_script"),
+            "output_directory": kwargs.get("output_directory")}
 
 
 def executor_kwargs(logger, test_type, server_config, cache_manager, run_info_data,
@@ -123,9 +125,14 @@ class ChromeAndroidBrowserBase(Browser):
     def __init__(self, logger,
                  webdriver_binary="chromedriver",
                  remote_queue = None,
-                 device_serial=None, webdriver_args=None):
+                 device_serial=None,
+                 webdriver_args=None,
+                 stackparser_script=None,
+                 output_directory=None):
         super(ChromeAndroidBrowserBase, self).__init__(logger)
         self.device_serial = device_serial
+        self.stackparser_script = stackparser_script
+        self.output_directory = output_directory
         self.remote_queue = remote_queue
         self.server = ChromeDriverServer(self.logger,
                                          binary=webdriver_binary,
@@ -182,6 +189,16 @@ class ChromeAndroidBrowserBase(Browser):
         cmd.extend(['logcat', '*:D'])
         return cmd
 
+    def possible_parse_tomestone(self, logger):
+        if self.stackparser_script:
+            cmd = [self.stackparser_script, "-a", "-w"]
+            if self.device_serial:
+                cmd.extend(["--device", self.device_serial])
+            cmd.extend(["--output-directory", self.output_directory])
+            raw_output = subprocess.check_output(cmd)
+            for line in raw_output.splitlines():
+                logger.process_output("TRACE", line, "logcat")
+
     def setup_adb_reverse(self):
         self._adb_run(['wait-for-device'])
         self._adb_run(['forward', '--remove-all'])
@@ -198,8 +215,12 @@ class ChromeAndroidBrowser(ChromeAndroidBrowserBase):
     def __init__(self, logger, package_name,
                  webdriver_binary="chromedriver",
                  remote_queue = None,
-                 device_serial=None, webdriver_args=None):
+                 device_serial=None,
+                 webdriver_args=None,
+                 stackparser_script=None,
+                 output_directory=None):
         super(ChromeAndroidBrowser, self).__init__(logger,
-                webdriver_binary, remote_queue, device_serial, webdriver_args)
+                webdriver_binary, remote_queue, device_serial,
+                webdriver_args, stackparser_script, output_directory)
         self.package_name = package_name
         self.wptserver_ports = _wptserve_ports

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -616,7 +616,7 @@ class TestRunnerManager(threading.Thread):
         if self.timer is not None:
             self.timer.cancel()
 
-        self.browser.browser.possible_parse_tomestone(self.logger)
+        self.browser.browser.possible_parse_tombstone()
 
         # Write the result of each subtest
         file_result, test_results = results

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -615,6 +615,9 @@ class TestRunnerManager(threading.Thread):
             return
         if self.timer is not None:
             self.timer.cancel()
+
+        self.browser.browser.possible_parse_tomestone(self.logger)
+
         # Write the result of each subtest
         file_result, test_results = results
         subtest_unexpected = False

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -616,7 +616,7 @@ class TestRunnerManager(threading.Thread):
         if self.timer is not None:
             self.timer.cancel()
 
-        self.browser.browser.possible_parse_tombstone()
+        self.browser.browser.maybe_parse_tombstone()
 
         # Write the result of each subtest
         file_result, test_results = results

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -185,7 +185,10 @@ scheme host and port.""")
                                  help="Path or url to symbols file used to analyse crash minidumps.")
     debugging_group.add_argument("--stackwalk-binary", action="store", type=abs_path,
                                  help="Path to stackwalker program used to analyse minidumps.")
-
+    debugging_group.add_argument("--output-directory", action="store",
+                                 help="Path to chromium output directory.")
+    debugging_group.add_argument("--stackparser-script", action="store", type=abs_path,
+                                 help="Path to stack parser script used to analyse tombstones.")
     debugging_group.add_argument("--pdb", action="store_true",
                                  help="Drop into pdb on python exception")
 


### PR DESCRIPTION
Added parameter to allow wrapper to pass in a tombstone
parser script, and parse any tombstones at end of each test,
and save result to result viewer

Tested with /font-access, tombstone is passed and saved