### PR TITLE
Test CSP hash-algorithm case-insensitive matching

### DIFF
--- a/content-security-policy/script-src/scripthash-case-insensitive.sub.html
+++ b/content-security-policy/script-src/scripthash-case-insensitive.sub.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'nonce-abc' 'SHA256-VCOfB9NQbtW8/s+T7yizqn0dz0Ipt5krwH9BPUaXJTA=' 'SHA384-efOmACJwOYjUewZJTpktK4Kxl9spgncVwxok9DaIBIMN2zBzwxDni19L5uHkIX3E' 'SHA512-t9CmeiAGRym+Wsi8F+5TV1QEjcbFppf7ONB9HUTOs5pMLUy3BQCmASwXD/VKl0B5QytTTJawA2IhVvoebs7Gyg==' 'sHa256-BPe1cNQpEQoucXTYM91Ku9xnHT/BZXMOeOFeMZTPWis=' 'shA384-qNmIi2ya4g29IbFyUBBPFJ5BdkW43bygT/MrFSoe7o/ALn+a3iJDkssigmMHQ4J0' 'Sha512-GuQbQFeVHDBySntDnOpbrNCe4xwjLhnnaVRAGz5JAnYK9pj0vOEAkmKgzNJApgufV3r37DE7Derx5DGUmqkukg=='; connect-src 'self';">
+    <title>scripthash-case-insensitive</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/content-security-policy/support/alertAssert.sub.js?alerts=%5B%22PASS%20(1%2F6)%22%2C%22PASS%20(2%2F6)%22%2C%22PASS%20(3%2F6)%22%2C%22PASS%20(4%2F6)%22%2C%22PASS%20(5%2F6)%22%2C%22PASS%20(6%2F6)%22%5D">
+    <script>
+        window.addEventListener('securitypolicyviolation', function(e) {
+            alert_assert("Fail");
+        });
+    </script>
+    
+    <script>
+        alert_assert('PASS (1/6)');
+
+    </script>
+    <script>
+        alert_assert('PASS (2/6)');
+
+    </script>
+    <script>
+        alert_assert('PASS (3/6)');
+
+    </script>
+    <script>
+        alert_assert('PASS (4/6)');
+
+    </script>
+    <script>
+        alert_assert('PASS (5/6)');
+
+    </script>
+    <script>
+        alert_assert('PASS (6/6)');
+
+    </script>
+</head>
+
+<body>
+    <p>
+        This tests whether hash-algorithm parts are matched case-insensitively. It passes if no CSP violation is generated, and the alert_assert() calls are executed.
+    </p>
+    <div id="log"></div>
+</body>
+
+</html>

--- a/content-security-policy/script-src/scripthash-case-insensitive.sub.html
+++ b/content-security-policy/script-src/scripthash-case-insensitive.sub.html
@@ -41,7 +41,9 @@
 
 <body>
     <p>
-        This tests whether hash-algorithm parts are matched case-insensitively. It passes if no CSP violation is generated, and the alert_assert() calls are executed.
+        This tests whether hash-algorithm parts are matched
+        case-insensitively. It passes if no CSP violation is generated, and
+        the alert_assert() calls are executed.
     </p>
     <div id="log"></div>
 </body>

--- a/content-security-policy/script-src/scripthash-case-insensitive.sub.html
+++ b/content-security-policy/script-src/scripthash-case-insensitive.sub.html
@@ -16,7 +16,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/content-security-policy/support/alertAssert.sub.js?alerts=%5B%22PASS%20(1%2F6)%22%2C%22PASS%20(2%2F6)%22%2C%22PASS%20(3%2F6)%22%2C%22PASS%20(4%2F6)%22%2C%22PASS%20(5%2F6)%22%2C%22PASS%20(6%2F6)%22%5D"></script>
-    <script nonce=EDNnf03nceIOfn39fn3e9h3sdfa>
+    <script nonce="EDNnf03nceIOfn39fn3e9h3sdfa">
         window.addEventListener('securitypolicyviolation', function(e) {
             alert_assert("Fail");
         });

--- a/content-security-policy/script-src/scripthash-case-insensitive.sub.html
+++ b/content-security-policy/script-src/scripthash-case-insensitive.sub.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'nonce-abc' 'SHA256-VCOfB9NQbtW8/s+T7yizqn0dz0Ipt5krwH9BPUaXJTA=' 'SHA384-efOmACJwOYjUewZJTpktK4Kxl9spgncVwxok9DaIBIMN2zBzwxDni19L5uHkIX3E' 'SHA512-t9CmeiAGRym+Wsi8F+5TV1QEjcbFppf7ONB9HUTOs5pMLUy3BQCmASwXD/VKl0B5QytTTJawA2IhVvoebs7Gyg==' 'sHa256-BPe1cNQpEQoucXTYM91Ku9xnHT/BZXMOeOFeMZTPWis=' 'shA384-qNmIi2ya4g29IbFyUBBPFJ5BdkW43bygT/MrFSoe7o/ALn+a3iJDkssigmMHQ4J0' 'Sha512-GuQbQFeVHDBySntDnOpbrNCe4xwjLhnnaVRAGz5JAnYK9pj0vOEAkmKgzNJApgufV3r37DE7Derx5DGUmqkukg=='; connect-src 'self';">
+    <meta http-equiv="Content-Security-Policy" content="'SHA256-VCOfB9NQbtW8/s+T7yizqn0dz0Ipt5krwH9BPUaXJTA=' 'SHA384-efOmACJwOYjUewZJTpktK4Kxl9spgncVwxok9DaIBIMN2zBzwxDni19L5uHkIX3E' 'SHA512-t9CmeiAGRym+Wsi8F+5TV1QEjcbFppf7ONB9HUTOs5pMLUy3BQCmASwXD/VKl0B5QytTTJawA2IhVvoebs7Gyg==' 'sHa256-BPe1cNQpEQoucXTYM91Ku9xnHT/BZXMOeOFeMZTPWis=' 'shA384-qNmIi2ya4g29IbFyUBBPFJ5BdkW43bygT/MrFSoe7o/ALn+a3iJDkssigmMHQ4J0' 'Sha512-GuQbQFeVHDBySntDnOpbrNCe4xwjLhnnaVRAGz5JAnYK9pj0vOEAkmKgzNJApgufV3r37DE7Derx5DGUmqkukg=='">
     <title>scripthash-case-insensitive</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>

--- a/content-security-policy/script-src/scripthash-case-insensitive.sub.html
+++ b/content-security-policy/script-src/scripthash-case-insensitive.sub.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta http-equiv="Content-Security-Policy"
-    content="
+    content="script-src 'self'
     'SHA256-VCOfB9NQbtW8/s+T7yizqn0dz0Ipt5krwH9BPUaXJTA='
     'SHA384-efOmACJwOYjUewZJTpktK4Kxl9spgncVwxok9DaIBIMN2zBzwxDni19L5uHkIX3E'
     'SHA512-t9CmeiAGRym+Wsi8F+5TV1QEjcbFppf7ONB9HUTOs5pMLUy3BQCmASwXD/VKl0B5QytTTJawA2IhVvoebs7Gyg=='

--- a/content-security-policy/script-src/scripthash-case-insensitive.sub.html
+++ b/content-security-policy/script-src/scripthash-case-insensitive.sub.html
@@ -10,12 +10,13 @@
     'sHa256-BPe1cNQpEQoucXTYM91Ku9xnHT/BZXMOeOFeMZTPWis='
     'shA384-qNmIi2ya4g29IbFyUBBPFJ5BdkW43bygT/MrFSoe7o/ALn+a3iJDkssigmMHQ4J0'
     'Sha512-GuQbQFeVHDBySntDnOpbrNCe4xwjLhnnaVRAGz5JAnYK9pj0vOEAkmKgzNJApgufV3r37DE7Derx5DGUmqkukg=='
+    'nonce-EDNnf03nceIOfn39fn3e9h3sdfa'
     ">
     <title>Test whether hash-algorithm parts are matched case-insensitively</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <script src="/content-security-policy/support/alertAssert.sub.js?alerts=%5B%22PASS%20(1%2F6)%22%2C%22PASS%20(2%2F6)%22%2C%22PASS%20(3%2F6)%22%2C%22PASS%20(4%2F6)%22%2C%22PASS%20(5%2F6)%22%2C%22PASS%20(6%2F6)%22%5D">
-    <script>
+    <script src="/content-security-policy/support/alertAssert.sub.js?alerts=%5B%22PASS%20(1%2F6)%22%2C%22PASS%20(2%2F6)%22%2C%22PASS%20(3%2F6)%22%2C%22PASS%20(4%2F6)%22%2C%22PASS%20(5%2F6)%22%2C%22PASS%20(6%2F6)%22%5D"></script>
+    <script nonce=EDNnf03nceIOfn39fn3e9h3sdfa>
         window.addEventListener('securitypolicyviolation', function(e) {
             alert_assert("Fail");
         });

--- a/content-security-policy/script-src/scripthash-case-insensitive.sub.html
+++ b/content-security-policy/script-src/scripthash-case-insensitive.sub.html
@@ -2,7 +2,15 @@
 <html>
 
 <head>
-    <meta http-equiv="Content-Security-Policy" content="'SHA256-VCOfB9NQbtW8/s+T7yizqn0dz0Ipt5krwH9BPUaXJTA=' 'SHA384-efOmACJwOYjUewZJTpktK4Kxl9spgncVwxok9DaIBIMN2zBzwxDni19L5uHkIX3E' 'SHA512-t9CmeiAGRym+Wsi8F+5TV1QEjcbFppf7ONB9HUTOs5pMLUy3BQCmASwXD/VKl0B5QytTTJawA2IhVvoebs7Gyg==' 'sHa256-BPe1cNQpEQoucXTYM91Ku9xnHT/BZXMOeOFeMZTPWis=' 'shA384-qNmIi2ya4g29IbFyUBBPFJ5BdkW43bygT/MrFSoe7o/ALn+a3iJDkssigmMHQ4J0' 'Sha512-GuQbQFeVHDBySntDnOpbrNCe4xwjLhnnaVRAGz5JAnYK9pj0vOEAkmKgzNJApgufV3r37DE7Derx5DGUmqkukg=='">
+    <meta http-equiv="Content-Security-Policy"
+    content="
+    'SHA256-VCOfB9NQbtW8/s+T7yizqn0dz0Ipt5krwH9BPUaXJTA='
+    'SHA384-efOmACJwOYjUewZJTpktK4Kxl9spgncVwxok9DaIBIMN2zBzwxDni19L5uHkIX3E'
+    'SHA512-t9CmeiAGRym+Wsi8F+5TV1QEjcbFppf7ONB9HUTOs5pMLUy3BQCmASwXD/VKl0B5QytTTJawA2IhVvoebs7Gyg=='
+    'sHa256-BPe1cNQpEQoucXTYM91Ku9xnHT/BZXMOeOFeMZTPWis='
+    'shA384-qNmIi2ya4g29IbFyUBBPFJ5BdkW43bygT/MrFSoe7o/ALn+a3iJDkssigmMHQ4J0'
+    'Sha512-GuQbQFeVHDBySntDnOpbrNCe4xwjLhnnaVRAGz5JAnYK9pj0vOEAkmKgzNJApgufV3r37DE7Derx5DGUmqkukg=='
+    ">
     <title>scripthash-case-insensitive</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>

--- a/content-security-policy/script-src/scripthash-case-insensitive.sub.html
+++ b/content-security-policy/script-src/scripthash-case-insensitive.sub.html
@@ -11,7 +11,7 @@
     'shA384-qNmIi2ya4g29IbFyUBBPFJ5BdkW43bygT/MrFSoe7o/ALn+a3iJDkssigmMHQ4J0'
     'Sha512-GuQbQFeVHDBySntDnOpbrNCe4xwjLhnnaVRAGz5JAnYK9pj0vOEAkmKgzNJApgufV3r37DE7Derx5DGUmqkukg=='
     ">
-    <title>scripthash-case-insensitive</title>
+    <title>Test whether hash-algorithm parts are matched case-insensitively</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/content-security-policy/support/alertAssert.sub.js?alerts=%5B%22PASS%20(1%2F6)%22%2C%22PASS%20(2%2F6)%22%2C%22PASS%20(3%2F6)%22%2C%22PASS%20(4%2F6)%22%2C%22PASS%20(5%2F6)%22%2C%22PASS%20(6%2F6)%22%5D">

--- a/content-security-policy/style-src/style-src-hash-case-insensitive.html
+++ b/content-security-policy/style-src/style-src-hash-case-insensitive.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html>
+<head>
+    <meta http-equiv="Content-Security-Policy" content="style-src
+                'SHA256-7kQ1KhZCpEzWtsa0RSpbIL7FU3kPNhE3IJMaNeTclMU='
+                'SHA384-OliBBQtittDq3qDaEttMlHG1viNf50PLjSlvXirHZHpeKApMClrTJz+7VB5RTWdN'
+                'SHA512-4/SpqCV0WGbb2QZXBViFlnms4M0I+aUGg9/tIhr10twU89nlMSBLOhi3cVli39kyBZbUAlzk9xcVTMy+JDY+VA=='
+                'sHa256-7+4S4EQgq4w2e2BwX1xnE3sW12GIuGqtQRYDLLhOyaE='
+                'shA384-YmZjKJCd/pjU8gq/sFCON/NHfkHLAZqI0a4JxyX67Ark36qJAvPnEWACZrZlhR62'
+                'Sha512-/fwXanQOq033J+QFjepcRHT0DDD6fsQJGvoeBjpEM2PBV9ETzYYGXdkwH+TMqfiRnYsHAa/sPqQd2W4FoYYlOw=='
+                ">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+
+    <script>
+      var t = async_test("All style elements should load because they have proper hashes with hash-algorithm parts matched case-insensitively");
+      document.addEventListener("securitypolicyviolation", t.unreached_func("Should not trigger a security policy violation"));
+    </script>
+
+    <style>#content1 { margin-left: 2px; }</style>
+    <style>#content2 { margin-left: 2px; }</style>
+    <style>#content3 { margin-left: 2px; }</style>
+    <style>#content4 { margin-left: 2px; }</style>
+    <style>#content5 { margin-left: 2px; }</style>
+    <style>#content6 { margin-left: 2px; }</style>
+</head>
+<body>
+    <div id='log'></div>
+
+    <div id="content1">Lorem ipsum</div>
+    <div id="content2">Lorem ipsum</div>
+    <div id="content3">Lorem ipsum</div>
+    <div id="content4">Lorem ipsum</div>
+    <div id="content5">Lorem ipsum</div>
+    <div id="content6">Lorem ipsum</div>
+
+    <script>
+      function make_assert(contentId) {
+        var contentEl = document.getElementById(contentId);
+        var marginLeftVal = getComputedStyle(contentEl).getPropertyValue('margin-left');
+        assert_equals(marginLeftVal, "2px")
+      }
+      t.step(function() {
+        make_assert("content1");
+        make_assert("content2");
+        make_assert("content3");
+        make_assert("content4");
+        make_assert("content5");
+        make_assert("content6");
+        t.done();
+      });
+    </script>
+
+</body>
+</html>

--- a/content-security-policy/style-src/style-src-hash-case-insensitive.html
+++ b/content-security-policy/style-src/style-src-hash-case-insensitive.html
@@ -13,7 +13,7 @@
     <script src="/resources/testharnessreport.js"></script>
 
     <script>
-      var t = async_test("All style elements should load because they have proper hashes with hash-algorithm parts matched case-insensitively");
+      var t = async_test("All style elements should load because they have proper hashes");
       document.addEventListener("securitypolicyviolation", t.unreached_func("Should not trigger a security policy violation"));
     </script>
 


### PR DESCRIPTION
This tests that the hash-algorithm parts of CSP hash sources are matched case-insensitively. See https://github.com/w3c/webappsec-csp/pull/464