### PR TITLE
Do not try to format null assert statuses

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -3404,7 +3404,7 @@ policies and contribution forms [3].
 
         function status_class(status)
         {
-            return status.replace(/\s/g, '').toLowerCase();
+            return (status || "").replace(/\s/g, '').toLowerCase();
         }
 
         var summary_template = ["section", {"id":"summary"},


### PR DESCRIPTION
This was causing the completion callback that the harness added,

```js
function (tests, harness_status, asserts_run) {
   this_obj.output_handler.show_results(tests, harness_status, asserts_run);
}
```

to throw an exception, which would prevent all other completion callbacks from running, which would prevent jsdom from ever collecting any results.