### PR TITLE
[testharness.js] Do not wrap assert_any in expose_assert

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1929,7 +1929,10 @@ policies and contribution forms [3].
             throw new AssertionError(errors.join("\n\n"));
         }
     }
-    expose_assert(assert_any, "assert_any");
+    // FIXME: assert_any cannot use expose_assert, because assert_wrapper does
+    // not support nested assert calls (e.g. to assert_func). We need to
+    // support bypassing assert_wrapper for the inner asserts here.
+    expose(assert_any, "assert_any");
 
     /**
      * Assert that a feature is implemented, based on a 'truthy' condition.


### PR DESCRIPTION
The assert tracking code cannot handle nested asserts. It ends up both
recording all the inner-asserts for assert_any (which is arguably
correct but also looks confusing since some fail), as well as not
properly recording the result for the `assert_any` itself (it overrides
the last inner-assert results instead - even more confusing!)

To workaround this quickly, do not wrap assert_any in the wrapper
script. This means it will not show up in the asserts run, though its
children will (but the last child will no longer have the wrong status).
This isn't perfect, but it's a quick fix.

Fixes https://github.com/web-platform-tests/wpt/pull/27824