### PR TITLE
Update tools/third_party/pywebsocket3 to HEAD

### DIFF
--- a/example/cgi-bin/hi.py
+++ b/example/cgi-bin/hi.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+print('Content-Type: text/plain')
+print('')
+print('Hi from hi.py')

--- a/example/echo_client.py
+++ b/example/echo_client.py
@@ -599,8 +599,14 @@ class EchoClient(object):
 
 
 def main():
+    # Force Python 2 to use the locale encoding, even when the output is not a
+    # tty. This makes the behaviour the same as Python 3. The encoding won't
+    # necessarily support all unicode characters. This problem is particularly
+    # prevalent on Windows.
     if six.PY2:
-        sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
+        import locale
+        encoding = locale.getpreferredencoding()
+        sys.stdout = codecs.getwriter(encoding)(sys.stdout)
 
     parser = argparse.ArgumentParser()
     # We accept --command_line_flag style flags which is the same as Google
@@ -636,7 +642,7 @@ def main():
         '--message',
         dest='message',
         type=six.text_type,
-        default=u'Hello,\u65e5\u672c',
+        default=u'Hello,<>',
         help=('comma-separated messages to send. '
               '%s will force close the connection from server.' %
               _GOODBYE_MESSAGE))

--- a/mod_pywebsocket/standalone.py
+++ b/mod_pywebsocket/standalone.py
@@ -403,8 +403,7 @@ def _parse_args_and_config(args):
 def _main(args=None):
     """You can call this function from your own program, but please note that
     this function has some side-effects that might affect your program. For
-    example, util.wrap_popen3_for_win use in this method replaces implementation
-    of os.popen3.
+    example, it changes the current directory.
     """
 
     options, args = _parse_args_and_config(args=args)
@@ -427,7 +426,6 @@ def _main(args=None):
             # full path of third_party/cygwin/bin.
             if 'CYGWIN_PATH' in os.environ:
                 cygwin_path = os.environ['CYGWIN_PATH']
-            util.wrap_popen3_for_win(cygwin_path)
 
             def __check_script(scriptpath):
                 return util.get_script_interp(scriptpath, cygwin_path)

--- a/mod_pywebsocket/util.py
+++ b/mod_pywebsocket/util.py
@@ -97,25 +97,6 @@ def get_script_interp(script_path, cygwin_path=None):
     return None
 
 
-def wrap_popen3_for_win(cygwin_path):
-    """Wrap popen3 to support #!-script on Windows.
-
-    Args:
-      cygwin_path:  path for cygwin binary if command path is needed to be
-                    translated.  None if no translation required.
-    """
-    __orig_popen3 = os.popen3
-
-    def __wrap_popen3(cmd, mode='t', bufsize=-1):
-        cmdline = cmd.split(' ')
-        interp = get_script_interp(cmdline[0], cygwin_path)
-        if interp:
-            cmd = interp + ' ' + cmd
-        return __orig_popen3(cmd, mode, bufsize)
-
-    os.popen3 = __wrap_popen3
-
-
 def hexify(s):
     return ' '.join(['%02x' % x for x in six.iterbytes(s)])
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ _USE_FAST_MASKING = False
 
 # This is used since python_requires field is not recognized with
 # pip version 9.0.0 and earlier
-if sys.version < '2.7':
+if sys.hexversion < 0x020700f0:
     print('%s requires Python 2.7 or later.' % _PACKAGE_NAME, file=sys.stderr)
     sys.exit(1)
 
@@ -66,9 +66,8 @@ setup(
     packages=[_PACKAGE_NAME, _PACKAGE_NAME + '.handshake'],
     python_requires='>=2.7',
     install_requires=['six'],
-    #TODO(suzukikeita): Update this to new Github URL
-    url='http://code.google.com/p/pywebsocket/',
-    version='3.0.0',
+    url='https://github.com/GoogleChromeLabs/pywebsocket3',
+    version='3.0.1',
 )
 
 # vi:sts=4 sw=4 et

--- a/test/client_for_testing.py
+++ b/test/client_for_testing.py
@@ -303,7 +303,7 @@ class WebSocketHandshake(object):
                                 self._options.server_port,
                                 self._options.use_tls))
 
-        if self._options.version is 8:
+        if self._options.version == 8:
             fields.append(_sec_origin_header(self._options.origin))
         else:
             fields.append(_origin_header(self._options.origin))

--- a/test/test_http_header_util.py
+++ b/test/test_http_header_util.py
@@ -79,7 +79,7 @@ class UnitTest(unittest.TestCase):
 
         host, port, resource = http_header_util.parse_uri(
             'ws://localhost:-1/ws')
-        if sys.version >= '3.6':
+        if sys.hexversion >= 0x030600f0:
             self.assertEqual(None, resource)
         else:
             self.assertEqual('localhost', host)


### PR DESCRIPTION
By request of dolmstead, to pull in a fix for Windows + Py3

Created via: `git subtree pull --prefix tools/third_party/pywebsocket3 https://github.com/GoogleChromeLabs/pywebsocket3 master --squash`