### PR TITLE
Improve flexbox-basic-* tests robustness

### DIFF
--- a/css/css-flexbox/flexbox-basic-canvas-vert-001-ref.xhtml
+++ b/css/css-flexbox/flexbox-basic-canvas-vert-001-ref.xhtml
@@ -36,8 +36,8 @@
     </div>
 
     <div class="flexbox">
-      <canvas style="height: 122.5px"
-    /><canvas style="height: 73.5px"/>
+      <canvas style="height: 108.8px"
+    /><canvas style="height: 87.1px"/>
     </div>
 
     <div class="flexbox">

--- a/css/css-flexbox/flexbox-basic-canvas-vert-001.xhtml
+++ b/css/css-flexbox/flexbox-basic-canvas-vert-001.xhtml
@@ -48,12 +48,12 @@
          Space-to-be-distributed = 200px - borders = 200 - (1 + 1) - (1 + 1)
                                  = 196px
 
-         1st element gets 5/8 of space: 5/8 * 196px = 122.5px
-         1st element gets 3/8 of space: 3/8 * 196px = 73.5px
+         1st element gets 5/9 of space: 5/9 * 196px = 108.8px
+         1st element gets 4/9 of space: 4/9 * 196px = 87.1px
       -->
     <div class="flexbox">
       <canvas style="flex: 5"/>
-      <canvas style="flex: 3"/>
+      <canvas style="flex: 4"/>
     </div>
 
     <!-- D) Two canvas elements, getting stretched by different ratios, from

--- a/css/css-flexbox/flexbox-basic-canvas-vert-001v.xhtml
+++ b/css/css-flexbox/flexbox-basic-canvas-vert-001v.xhtml
@@ -52,12 +52,12 @@
          Space-to-be-distributed = 200px - borders = 200 - (1 + 1) - (1 + 1)
                                  = 196px
 
-         1st element gets 5/8 of space: 5/8 * 196px = 122.5px
-         1st element gets 3/8 of space: 3/8 * 196px = 73.5px
+         1st element gets 5/9 of space: 5/9 * 196px = 108.8px
+         1st element gets 4/9 of space: 4/9 * 196px = 87.1px
       -->
     <div class="flexbox">
       <canvas style="flex: 5"/>
-      <canvas style="flex: 3"/>
+      <canvas style="flex: 4"/>
     </div>
 
     <!-- D) Two canvas elements, getting stretched by different ratios, from

--- a/css/css-flexbox/flexbox-basic-iframe-vert-001-ref.xhtml
+++ b/css/css-flexbox/flexbox-basic-iframe-vert-001-ref.xhtml
@@ -36,8 +36,8 @@
     </div>
 
     <div class="flexbox">
-      <iframe style="height: 122.5px"
-    /><iframe style="height: 73.5px"/>
+      <iframe style="height: 108.8px"
+    /><iframe style="height: 87.1px"/>
     </div>
 
     <div class="flexbox">

--- a/css/css-flexbox/flexbox-basic-iframe-vert-001.xhtml
+++ b/css/css-flexbox/flexbox-basic-iframe-vert-001.xhtml
@@ -49,12 +49,12 @@
          Space-to-be-distributed = 200px - borders = 200 - (1 + 1) - (1 + 1)
                                  = 196px
 
-         1st element gets 5/8 of space: 5/8 * 196px = 122.5px
-         1st element gets 3/8 of space: 3/8 * 196px = 73.5px
+         1st element gets 5/9 of space: 5/9 * 196px = 108.8px
+         1st element gets 4/9 of space: 4/9 * 196px = 87.1px
       -->
     <div class="flexbox">
       <iframe style="flex: 5"/>
-      <iframe style="flex: 3"/>
+      <iframe style="flex: 4"/>
     </div>
 
     <!-- D) Two iframe elements, getting stretched by different ratios, from

--- a/css/css-flexbox/flexbox-basic-img-vert-001-ref.xhtml
+++ b/css/css-flexbox/flexbox-basic-img-vert-001-ref.xhtml
@@ -36,8 +36,8 @@
     </div>
 
     <div class="flexbox">
-      <img src="support/solidblue.png" style="height: 122.5px"
-    /><img src="support/solidblue.png" style="height: 73.5px"/>
+      <img src="support/solidblue.png" style="height: 108.8px"
+    /><img src="support/solidblue.png" style="height: 87.1px"/>
     </div>
 
     <div class="flexbox">

--- a/css/css-flexbox/flexbox-basic-img-vert-001.xhtml
+++ b/css/css-flexbox/flexbox-basic-img-vert-001.xhtml
@@ -48,12 +48,12 @@
          Space-to-be-distributed = 200px - borders = 200 - (1 + 1) - (1 + 1)
                                  = 196px
 
-         1st element gets 5/8 of space: 5/8 * 196px = 122.5px
-         1st element gets 3/8 of space: 3/8 * 196px = 73.5px
+         1st element gets 5/9 of space: 5/9 * 196px = 108.8px
+         1st element gets 4/9 of space: 4/9 * 196px = 87.1px
       -->
     <div class="flexbox">
       <img src="support/solidblue.png" style="flex: 5"/>
-      <img src="support/solidblue.png" style="flex: 3"/>
+      <img src="support/solidblue.png" style="flex: 4"/>
     </div>
 
     <!-- D) Two img elements, getting stretched by different ratios, from

--- a/css/css-flexbox/flexbox-basic-textarea-vert-001-ref.xhtml
+++ b/css/css-flexbox/flexbox-basic-textarea-vert-001-ref.xhtml
@@ -40,8 +40,8 @@
     </div>
 
     <div class="flexbox">
-      <textarea style="height: 122.5px"
-    /><textarea style="height: 73.5px"/>
+      <textarea style="height: 108.8px"
+    /><textarea style="height: 87.1px"/>
     </div>
 
     <div class="flexbox">

--- a/css/css-flexbox/flexbox-basic-textarea-vert-001.xhtml
+++ b/css/css-flexbox/flexbox-basic-textarea-vert-001.xhtml
@@ -54,12 +54,12 @@
          Space-to-be-distributed = 200px - borders = 200 - (1 + 1) - (1 + 1)
                                  = 196px
 
-         1st element gets 5/8 of space: 5/8 * 196px = 122.5px
-         1st element gets 3/8 of space: 3/8 * 196px = 73.5px
+         1st element gets 5/9 of space: 5/9 * 196px = 108.8px
+         1st element gets 4/9 of space: 4/9 * 196px = 87.1px
       -->
     <div class="flexbox">
       <textarea style="flex: 5"/>
-      <textarea style="flex: 3"/>
+      <textarea style="flex: 4"/>
     </div>
 
     <!-- D) Two textarea elements, getting stretched by different ratios, from

--- a/css/css-flexbox/flexbox-basic-video-vert-001-ref.xhtml
+++ b/css/css-flexbox/flexbox-basic-video-vert-001-ref.xhtml
@@ -36,8 +36,8 @@
     </div>
 
     <div class="flexbox">
-      <video style="height: 122.5px"
-    /><video style="height: 73.5px"/>
+      <video style="height: 108.8px"
+    /><video style="height: 87.1px"/>
     </div>
 
     <div class="flexbox">

--- a/css/css-flexbox/flexbox-basic-video-vert-001.xhtml
+++ b/css/css-flexbox/flexbox-basic-video-vert-001.xhtml
@@ -48,12 +48,12 @@
          Space-to-be-distributed = 200px - borders = 200 - (1 + 1) - (1 + 1)
                                  = 196px
 
-         1st element gets 5/8 of space: 5/8 * 196px = 122.5px
-         1st element gets 3/8 of space: 3/8 * 196px = 73.5px
+         1st element gets 5/9 of space: 5/9 * 196px = 108.8px
+         1st element gets 4/9 of space: 4/9 * 196px = 87.1px
       -->
     <div class="flexbox">
       <video style="flex: 5"/>
-      <video style="flex: 3"/>
+      <video style="flex: 4"/>
     </div>
 
     <!-- D) Two video elements, getting stretched by different ratios, from


### PR DESCRIPTION
Six of those tests are failing in WebKit because one of the subtests of each test generates two boxes with decimal values for heights which generates some rounding issues due to https://bugs.webkit.org/show_bug.cgi?id=222603

So although the bug in WebKit is valid, the main point of the flexbox test is not to check that but the flexbox behaviour with different types of elements as flex items. By carefully tunning the flex fractions we can end up with decimal values that are properly rounded in WebKit even if bug 222603 is not fixed.