### PR TITLE
RFC75: async_promise_test

### DIFF
--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -248,6 +248,18 @@ promise_test(function(t) {
 }, "Another example");
 ```
 
+## Asynchronous Promise Tests ##
+
+`promise_test` are running sequentially. This might causes timeout when too many
+have to run. `async_promise_test` is a variant, running in parallel.
+
+|              | in sequence | in parallel       |
+| -------------| ----------: | ----------------: |
+| **Function** | test        | async_test        |
+| **Promise**  | promise_test| async_promise_test|
+
+`async_promise_test()` signature is the same as `promise_test()`:
+
 ## `EventWatcher` ##
 
 `EventWatcher` is a constructor function that allows DOM events to be handled
@@ -536,6 +548,12 @@ additional subtests defined with the `promise_test` function. If the value is
 rejected, the harness will report an error and cancel the remaining tests.
 `properties` may optionally be provided as an object which specifies global
 properties of the test harness (enumerated in the following section).
+
+`async_test()`, `promise_test()`, and `async_promise_test()` are guaranteed to
+execute after every `promise_setup()` defined earlier.
+
+Authors are encouraged to define add `setup()` and `promise_setup()` before
+tests. It is a bad practice to interleave setup and tests.
 
 ### Setup properties ##
 

--- a/html/browsers/sandboxing/sandbox-inherited-from-required-csp.html
+++ b/html/browsers/sandboxing/sandbox-inherited-from-required-csp.html
@@ -38,18 +38,7 @@ const check_sandbox_script = `
 
 const sandbox_policy = "sandbox allow-scripts allow-same-origin";
 
-// Test using the modern async/await primitives are easier to read/write.
-// However they run sequentially, contrary to async_test. This is the parallel
-// version, to avoid timing out.
-let promise_test_parallel = (promise, description) => {
-  async_test(test => {
-    promise(test)
-    .then(() => {test.done();})
-    .catch(test.step_func(error => { throw error; }));
-  }, description);
-};
-
-promise_test_parallel(async test => {
+async_promise_test(async test => {
   const iframe = document.createElement("iframe");
   iframe.csp = sandbox_policy;
 
@@ -67,7 +56,7 @@ promise_test_parallel(async test => {
   assert_equals(result.data, "document-domain-is-disallowed");
 }, "initial empty document");
 
-promise_test_parallel(async test => {
+async_promise_test(async test => {
   const iframe = document.createElement("iframe");
   iframe.src = "data:text/html,dummy";
 
@@ -87,7 +76,7 @@ promise_test_parallel(async test => {
   assert_equals(result.data, "document-domain-is-disallowed");
 }, "about:blank");
 
-promise_test_parallel(async test => {
+async_promise_test(async test => {
   const iframe = document.createElement("iframe");
   iframe.csp = sandbox_policy;
   iframe.src =
@@ -100,7 +89,7 @@ promise_test_parallel(async test => {
   assert_equals(result.data, "document-domain-is-disallowed");
 }, "data-url");
 
-promise_test_parallel(async test => {
+async_promise_test(async test => {
   const iframe = document.createElement("iframe");
   iframe.csp = sandbox_policy;
   iframe.srcdoc = check_sandbox_script;
@@ -112,7 +101,7 @@ promise_test_parallel(async test => {
   assert_equals(result.data, "document-domain-is-disallowed");
 }, "srcdoc");
 
-promise_test_parallel(async test => {
+async_promise_test(async test => {
   const iframe = document.createElement("iframe");
   iframe.csp = sandbox_policy;
 
@@ -127,7 +116,7 @@ promise_test_parallel(async test => {
   assert_equals(result.data, "document-domain-is-disallowed");
 }, "blob URL");
 
-promise_test_parallel(async test => {
+async_promise_test(async test => {
   const iframe = document.createElement("iframe");
   iframe.csp = sandbox_policy;
   iframe.src = same_origin + check_sandbox_url + allow_csp_from_star;
@@ -139,7 +128,7 @@ promise_test_parallel(async test => {
   assert_equals(result.data, "document-domain-is-disallowed");
 }, "same-origin");
 
-promise_test_parallel(async test => {
+async_promise_test(async test => {
   const iframe = document.createElement("iframe");
   iframe.csp = sandbox_policy;
   iframe.src = cross_origin + check_sandbox_url + allow_csp_from_star;

--- a/html/cross-origin-embedder-policy/credentialless/cors-or-credentialless/fetch.tentative.https.html
+++ b/html/cross-origin-embedder-policy/credentialless/cors-or-credentialless/fetch.tentative.https.html
@@ -6,125 +6,129 @@
 <script src="../resources/dispatcher.js"></script>
 <script>
 
-promise_test(async test => {
-  const same_origin = get_host_info().HTTPS_ORIGIN;
-  const cross_origin = get_host_info().HTTPS_REMOTE_ORIGIN;
-  const cookie_key = "coep_credentialless_fetch";
-  const cookie_same_origin = "same_origin";
-  const cookie_cross_origin = "cross_origin";
+const same_origin = get_host_info().HTTPS_ORIGIN;
+const cross_origin = get_host_info().HTTPS_REMOTE_ORIGIN;
+const cookie_key = "coep_credentialless_fetch";
+const cookie_same_origin = "same_origin";
+const cookie_cross_origin = "cross_origin";
 
+const w_control_token = token();
+const w_credentialless_token = token();
+
+promise_setup(async () => {
   await Promise.all([
     setCookie(same_origin, cookie_key, cookie_same_origin),
     setCookie(cross_origin, cookie_key, cookie_cross_origin),
   ]);
+}, "Set cookies");
 
+promise_setup(async () => {
   // One window with COEP:none. (control)
-  const w_control_token = token();
   const w_control_url = same_origin + executor_path +
     coep_none + `&uuid=${w_control_token}`
   const w_control = window.open(w_control_url);
   add_completion_callback(() => w_control.close());
 
   // One window with COEP:credentialless. (experiment)
-  const w_credentialless_token = token();
   const w_credentialless_url = same_origin + executor_path +
     coep_credentialless + `&uuid=${w_credentialless_token}`;
   const w_credentialless = window.open(w_credentialless_url);
   add_completion_callback(() => w_credentialless.close());
+}, "Create test windows");
 
-  const fetchTest = function(
-    description, origin, mode, credentials,
-    expected_cookies_control,
-    expected_cookies_credentialless)
-  {
-    promise_test_parallel(async test => {
-      const token_1 = token();
-      const token_2 = token();
+const fetchTest = function(
+  description, origin, mode, credentials,
+  expected_cookies_control,
+  expected_cookies_credentialless)
+{
+  async_promise_test(async test => {
+    this.current_test = test;
+    const token_1 = token();
+    const token_2 = token();
 
-      send(w_control_token, `
-        fetch("${showRequestHeaders(origin, token_1)}", {
-          mode:"${mode}",
-          credentials: "${credentials}",
-        });
-      `);
-      send(w_credentialless_token, `
-        fetch("${showRequestHeaders(origin, token_2)}", {
-          mode:"${mode}",
-          credentials: "${credentials}",
-        });
-      `);
+    send(w_control_token, `
+      fetch("${showRequestHeaders(origin, token_1)}", {
+        mode:"${mode}",
+        credentials: "${credentials}",
+      });
+    `);
+    send(w_credentialless_token, `
+      fetch("${showRequestHeaders(origin, token_2)}", {
+        mode:"${mode}",
+        credentials: "${credentials}",
+      });
+    `);
 
-      const headers_control = JSON.parse(await receive(token_1));
-      const headers_credentialless = JSON.parse(await receive(token_2));
+    const headers_control = JSON.parse(await receive(token_1));
+    const headers_credentialless = JSON.parse(await receive(token_2));
 
-      assert_equals(parseCookies(headers_control)[cookie_key],
-        expected_cookies_control,
-        "coep:none => ");
-      assert_equals(parseCookies(headers_credentialless)[cookie_key],
-        expected_cookies_credentialless,
-        "coep:credentialless => ");
-    }, `fetch ${description}`)
-  };
+    assert_equals(parseCookies(headers_control)[cookie_key],
+      expected_cookies_control,
+      "coep:none => ");
+    assert_equals(parseCookies(headers_credentialless)[cookie_key],
+      expected_cookies_credentialless,
+      "coep:credentialless => ");
+  }, `fetch ${description}`)
+};
 
-  // Cookies are never sent with credentials='omit'
-  fetchTest("same-origin + no-cors + credentials:omit",
-    same_origin, 'no-cors', 'omit',
-    undefined,
-    undefined);
-  fetchTest("same-origin + cors + credentials:omit",
-    same_origin, 'cors', 'omit',
-    undefined,
-    undefined);
-  fetchTest("cross-origin + no-cors + credentials:omit",
-    cross_origin, 'no-cors', 'omit',
-    undefined,
-    undefined);
-  fetchTest("cross-origin + cors + credentials:omit",
-    cross_origin, 'cors', 'omit',
-    undefined,
-    undefined);
+// Cookies are never sent with credentials='omit'
+fetchTest("same-origin + no-cors + credentials:omit",
+  same_origin, 'no-cors', 'omit',
+  undefined,
+  undefined);
+fetchTest("same-origin + cors + credentials:omit",
+  same_origin, 'cors', 'omit',
+  undefined,
+  undefined);
+fetchTest("cross-origin + no-cors + credentials:omit",
+  cross_origin, 'no-cors', 'omit',
+  undefined,
+  undefined);
+fetchTest("cross-origin + cors + credentials:omit",
+  cross_origin, 'cors', 'omit',
+  undefined,
+  undefined);
 
-  // Same-origin request contains Cookies.
-  fetchTest("same-origin + no-cors + credentials:include",
-    same_origin, 'no-cors', 'include',
-    cookie_same_origin,
-    cookie_same_origin);
-  fetchTest("same-origin + cors + credentials:include",
-    same_origin, 'cors', 'include',
-    cookie_same_origin,
-    cookie_same_origin);
-  fetchTest("same-origin + no-cors + credentials:same-origin",
-    same_origin, 'no-cors', 'same-origin',
-    cookie_same_origin,
-    cookie_same_origin);
-  fetchTest("same-origin + cors + credentials:same-origin",
-    same_origin, 'cors', 'same-origin',
-    cookie_same_origin,
-    cookie_same_origin);
+// Same-origin request contains Cookies.
+fetchTest("same-origin + no-cors + credentials:include",
+  same_origin, 'no-cors', 'include',
+  cookie_same_origin,
+  cookie_same_origin);
+fetchTest("same-origin + cors + credentials:include",
+  same_origin, 'cors', 'include',
+  cookie_same_origin,
+  cookie_same_origin);
+fetchTest("same-origin + no-cors + credentials:same-origin",
+  same_origin, 'no-cors', 'same-origin',
+  cookie_same_origin,
+  cookie_same_origin);
+fetchTest("same-origin + cors + credentials:same-origin",
+  same_origin, 'cors', 'same-origin',
+  cookie_same_origin,
+  cookie_same_origin);
 
-  // Cross-origin CORS requests contains Cookies, if credentials mode is set to
-  // 'include'. This does not depends on COEP.
-  fetchTest("cross-origin + cors + credentials:include",
-    cross_origin, 'cors', 'include',
-    cookie_cross_origin,
-    cookie_cross_origin);
-  fetchTest("cross-origin + cors + same-origin-credentials",
-    cross_origin, 'cors', 'same-origin',
-    undefined,
-    undefined);
+// Cross-origin CORS requests contains Cookies, if credentials mode is set to
+// 'include'. This does not depends on COEP.
+fetchTest("cross-origin + cors + credentials:include",
+  cross_origin, 'cors', 'include',
+  cookie_cross_origin,
+  cookie_cross_origin);
+fetchTest("cross-origin + cors + same-origin-credentials",
+  cross_origin, 'cors', 'same-origin',
+  undefined,
+  undefined);
 
-  // Cross-origin no-CORS requests includes Cookies when:
-  // 1. credentials mode is 'include'
-  // 2. COEP: is not credentialless.
-  fetchTest("cross-origin + no-cors + credentials:include",
-    cross_origin, 'no-cors', 'include',
-    cookie_cross_origin,
-    undefined);
+// Cross-origin no-CORS requests includes Cookies when:
+// 1. credentials mode is 'include'
+// 2. COEP: is not credentialless.
+fetchTest("cross-origin + no-cors + credentials:include",
+  cross_origin, 'no-cors', 'include',
+  cookie_cross_origin,
+  undefined);
 
-  fetchTest("cross-origin + no-cors + credentials:same-origin",
-    cross_origin, 'no-cors', 'same-origin',
-    undefined,
-    undefined);
-}, "");
+fetchTest("cross-origin + no-cors + credentials:same-origin",
+  cross_origin, 'no-cors', 'same-origin',
+  undefined,
+  undefined);
 
 </script>

--- a/html/cross-origin-embedder-policy/credentialless/cors-or-credentialless/resources/iframeTest.js
+++ b/html/cross-origin-embedder-policy/credentialless/cors-or-credentialless/resources/iframeTest.js
@@ -41,7 +41,7 @@ const iframeTest = function(
   child_headers,
   expectation
 ) {
-  promise_test_parallel(async test => {
+  async_promise_test(async test => {
     const test_token = token();
 
     const child_token = token();

--- a/lint.ignore
+++ b/lint.ignore
@@ -329,6 +329,7 @@ SET TIMEOUT: resources/test/tests/functional/step_wait.html
 SET TIMEOUT: resources/test/tests/functional/step_wait_func.html
 SET TIMEOUT: resources/test/tests/functional/worker.js
 SET TIMEOUT: resources/test/tests/functional/worker-uncaught-allow.js
+SET TIMEOUT: resources/test/tests/unit/async_promise_test.html
 SET TIMEOUT: resources/test/tests/unit/exceptional-cases.html
 SET TIMEOUT: resources/test/tests/unit/exceptional-cases-timeouts.html
 SET TIMEOUT: resources/test/tests/unit/promise_setup.html

--- a/resources/test/tests/unit/async_promise_test.html
+++ b/resources/test/tests/unit/async_promise_test.html
@@ -1,0 +1,166 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="/resources/testharness.js"></script>
+  <script src="../../nested-testharness.js"></script>
+  <title>async_promise_test</title>
+</head>
+<body>
+<script>
+'use strict';
+
+async_promise_test(async test => {
+  var expected_sequence = ['a','b','c','d'];
+  var actual_sequence = window.actual_sequence_1 = [];
+
+  const {harness, tests} = await makeTest(() => {
+    var unlock_1;
+    var lock_1 = new Promise(resolve => unlock_1 = resolve);
+
+    var unlock_2;
+    var lock_2 = new Promise(resolve => unlock_2 = resolve);
+
+    async_promise_test(async test => {
+      parent.actual_sequence_1.push('a');
+      await lock_1;
+      parent.actual_sequence_1.push('c');
+      unlock_2();
+    }, 'track1');
+
+    async_promise_test(async test => {
+      parent.actual_sequence_1.push('b');
+      unlock_1();
+      await lock_2;
+      parent.actual_sequence_1.push('d');
+    }, 'track2');
+  });
+
+  assert_equals(harness, 'OK');
+  assert_equals(tests.track1, 'PASS');
+  assert_equals(tests.track2, 'PASS');
+  assert_array_equals(actual_sequence, expected_sequence);
+}, 'async_promise_test are run in parallel');
+
+async_promise_test(async test => {
+  const {harness, tests} = await makeTest(() => {
+    async_promise_test(async test => {
+      throw new Error('this error is expected');
+    }, 'track1');
+
+    async_promise_test(async test => {
+    }, 'track2');
+  });
+
+  assert_equals(harness, 'OK');
+  assert_equals(tests.track1, 'FAIL');
+  assert_equals(tests.track2, 'PASS');
+}, 'async_promise_test [FAIL, PASS]');
+
+async_promise_test(async test => {
+  const {harness, tests} = await makeTest(() => {
+    async_promise_test(async test => {
+    }, 'track1');
+
+    async_promise_test(async test => {
+      throw new Error('this error is expected');
+    }, 'track2');
+  })
+
+  assert_equals(harness, 'OK');
+  assert_equals(tests.track1, 'PASS');
+  assert_equals(tests.track2, 'FAIL');
+}, 'async_promise_test [PASS, FAIL]');
+
+async_promise_test(async test => {
+  var expected_sequence = [
+    'setup start',
+    'setup end',
+    'async_promise_test',
+  ];
+  var actual_sequence = window.actual_sequence_2 = [];
+
+  const {harness, tests} = await makeTest(() => {
+    promise_setup(async () => {
+      parent.actual_sequence_2.push('setup start');
+      await new Promise(resolve => step_timeout(resolve, 100));
+      parent.actual_sequence_2.push('setup end');
+    }, "setup_1");
+
+    async_promise_test(async test => {
+      parent.actual_sequence_2.push('async_promise_test');
+    }, 'async_promise_test_1');
+  });
+
+  assert_equals(harness, 'OK');
+  assert_array_equals(actual_sequence, expected_sequence);
+}, 'async_promise_test waits for previously defined promise_setup');
+
+// async_promise_test() are guaranteed to execute after any previously defined
+// promise_setup().
+// Note: the opposite isn't guaranteed. A promise_setup is not guaranteed to
+// execute after previously defined async_promise_test. Test authors are
+// encouraged not to interleave promise_setup() and async_promise_test()
+async_promise_test(async test => {
+  var expected_sequence = [
+    'setup_1 start',
+    'setup_1 end',
+    'async_promise_test_1',
+    'setup_2 start',
+    'setup_2 end',
+    'async_promise_test_2',
+  ];
+  var actual_sequence = window.actual_sequence_3 = [];
+
+  const {harness, tests} = await makeTest(() => {
+    promise_setup(async () => {
+      parent.actual_sequence_3.push('setup_1 start');
+      await new Promise(resolve => step_timeout(resolve, 100));
+      parent.actual_sequence_3.push('setup_1 end');
+    }, "setup_1");
+
+    async_promise_test(async test => {
+      parent.actual_sequence_3.push('async_promise_test_1');
+    }, 'async_promise_test_1');
+
+    promise_setup(async () => {
+      parent.actual_sequence_3.push('setup_2 start');
+      await new Promise(resolve => step_timeout(resolve, 100));
+      parent.actual_sequence_3.push('setup_2 end');
+    }, "setup_2");
+
+    async_promise_test(async test => {
+      parent.actual_sequence_3.push('async_promise_test_2');
+    }, 'async_promise_test_2');
+  });
+
+  assert_equals(harness, 'OK');
+  assert_array_equals(actual_sequence, expected_sequence);
+}, 'Interleaving several promise_setup and async_promise_test');
+
+
+async_promise_test(async test => {
+  const {harness, tests} = await makeTest(() => {
+    async_promise_test(async () => {
+      setTimeout(t.step_func_done(), 1000);
+      return new Promise(() => {}); // never resolves
+    })
+  });
+
+  assert_equals(harness, 'OK');
+}, "Resolution outside of the promise for async_promise_test");
+
+async_promise_test(async test => {
+  const {harness, tests} = await makeTest(() => {
+    promise_test(async () => {
+      setTimeout(t.step_func_done(), 1000);
+      return new Promise(() => {}); // never resolves
+    })
+  });
+
+  assert_equals(harness, 'OK');
+}, "Resolution outside of the promise for promise_test");
+
+</script>
+</body>
+</html>

--- a/resources/test/tests/unit/async_test.html
+++ b/resources/test/tests/unit/async_test.html
@@ -1,0 +1,152 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="/resources/testharness.js"></script>
+  <script src="../../nested-testharness.js"></script>
+  <title>async_test</title>
+</head>
+<body>
+<script>
+'use strict';
+
+async_test(test => {
+  var expected_sequence = ['a','b','c','d'];
+  var actual_sequence = window.actual_sequence_1 = [];
+
+  makeTest(() => {
+    var unlock_1;
+    var lock_1 = new Promise(resolve => unlock_1 = resolve);
+
+    var unlock_2;
+    var lock_2 = new Promise(resolve => unlock_2 = resolve);
+
+    async_test(test => {
+      parent.actual_sequence_1.push('a');
+      lock_1.then(test.step_func_done(() => {
+        parent.actual_sequence_1.push('c');
+        unlock_2();
+      }));
+    }, 'track1');
+
+    async_test(test => {
+      parent.actual_sequence_1.push('b');
+      unlock_1()
+      lock_2.then(test.step_func_done(() => {
+        parent.actual_sequence_1.push('d');
+      }));
+    }, 'track2');
+  }).then(test.step_func_done(({harness, tests}) => {
+    assert_equals(harness, 'OK');
+    assert_equals(tests.track1, 'PASS');
+    assert_equals(tests.track2, 'PASS');
+    assert_array_equals(actual_sequence, expected_sequence);
+  }));
+}, 'async_test are run in parallel');
+
+async_test(test => {
+  makeTest(() => {
+    async_test(test => {
+      throw new Error('this error is expected');
+      test.done();
+    }, 'track1');
+
+    async_test(test => {
+      test.done();
+    }, 'track2');
+  }).then(test.step_func_done(({harness, tests}) => {
+    assert_equals(harness, 'OK');
+    assert_equals(tests.track1, 'FAIL');
+    assert_equals(tests.track2, 'PASS');
+  }));
+}, 'async_test [FAIL, PASS]');
+
+async_test(test => {
+  makeTest(() => {
+    async_test(test => {
+      test.done();
+    }, 'track1');
+
+    async_test(test => {
+      throw new Error('this error is expected');
+      test.done();
+    }, 'track2');
+  }).then(test.step_func_done(({harness, tests}) => {
+    assert_equals(harness, 'OK');
+    assert_equals(tests.track1, 'PASS');
+    assert_equals(tests.track2, 'FAIL');
+  }));
+}, 'async_test [PASS, FAIL]');
+
+async_test(test => {
+  var expected_sequence = [
+    'setup start',
+    'setup end',
+    'async_test',
+  ];
+  var actual_sequence = window.actual_sequence_2 = [];
+
+  makeTest(() => {
+    promise_setup(async () => {
+      parent.actual_sequence_2.push('setup start');
+      await new Promise(resolve => step_timeout(resolve, 100));
+      parent.actual_sequence_2.push('setup end');
+    }, "setup_1");
+
+    async_test(test => {
+      parent.actual_sequence_2.push('async_test');
+      test.done();
+    }, 'async_test_1');
+  }).then(test.step_func_done(({harness, tests}) => {
+    assert_equals(harness, 'OK');
+    assert_array_equals(actual_sequence, expected_sequence);
+  }));
+}, 'async_test waits for previously defined promise_setup');
+
+// async_test() are guaranteed to execute after any previously defined
+// promise_setup().
+// Note: the opposite isn't guaranteed. A promise_setup is not guaranteed to
+// execute after previously defined async_test. Test authors are
+// encouraged not to interleave promise_setup() and async_test()
+async_test(test => {
+  var expected_sequence = [
+    'setup_1 start',
+    'setup_1 end',
+    'async_test_1',
+    'setup_2 start',
+    'setup_2 end',
+    'async_test_2',
+  ];
+  var actual_sequence = window.actual_sequence_3 = [];
+
+  makeTest(() => {
+    promise_setup(async () => {
+      parent.actual_sequence_3.push('setup_1 start');
+      await new Promise(resolve => step_timeout(resolve, 100));
+      parent.actual_sequence_3.push('setup_1 end');
+    }, "setup_1");
+
+    async_test(test => {
+      parent.actual_sequence_3.push('async_test_1');
+      test.done();
+    }, 'async_test_1');
+
+    promise_setup(async () => {
+      parent.actual_sequence_3.push('setup_2 start');
+      await new Promise(resolve => step_timeout(resolve, 100));
+      parent.actual_sequence_3.push('setup_2 end');
+    }, "setup_2");
+
+    async_test(test => {
+      parent.actual_sequence_3.push('async_test_2');
+      test.done();
+    }, 'async_test_2');
+  }).then(test.step_func_done(({harness, tests}) => {
+    assert_equals(harness, 'OK');
+    assert_array_equals(actual_sequence, expected_sequence);
+  }));
+}, 'Interleaving several promise_setup and async_test');
+
+</script>
+</body>
+</html>

--- a/resources/test/tests/unit/promise_setup.html
+++ b/resources/test/tests/unit/promise_setup.html
@@ -214,11 +214,11 @@ promise_test(() => {
         async_test((t) => t.done(), 'after');
       }
     ).then(({harness, tests}) => {
-      assert_equals(harness, 'ERROR');
+      assert_equals(harness, 'OK');
       assert_equals(tests.before, 'PASS');
-      assert_equals(tests.after, undefined);
+      assert_equals(tests.after, 'PASS');
     });
-}, 'Error for subsequent invocation of `async_test`');
+}, 'No errors for subsequent invocation of `async_test`');
 
 promise_test(() => {
   return makeTest(
@@ -328,6 +328,106 @@ promise_test(() => {
       assert_equals(tests.before, 'PASS');
     });
 }, 'Defers application of setup properties');
+
+promise_test(() => {
+  var expected_sequence = [
+    'test body',
+    'promise_setup begin',
+    'promise_setup end',
+    'async_promise_test body'
+  ];
+  var actual_sequence = window.actual_sequence = [];
+
+  return makeTest(
+      () => {
+        test(() => { parent.actual_sequence.push('test body'); }, 'before');
+        promise_setup(() => {
+          parent.actual_sequence.push('promise_setup begin');
+
+          return Promise.resolve()
+            .then(() => new Promise((resolve) => setTimeout(resolve, 300)))
+            .then(() => parent.actual_sequence.push('promise_setup end'));
+        });
+        async_promise_test(() => {
+          parent.actual_sequence.push('async_promise_test body');
+          return Promise.resolve();
+        }, 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'OK');
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.after, 'PASS');
+      assert_array_equals(actual_sequence, expected_sequence);
+    });
+}, 'async_promise_test waits for promise_setup to settle');
+
+promise_test(() => {
+  var expected_sequence = ['a','b','c','d'];
+  var actual_sequence = window.actual_sequence = [];
+
+  return makeTest(
+      () => {
+        var unlock_1;
+        var lock_1 = new Promise(resolve => unlock_1= resolve);
+
+        var unlock_2;
+        var lock_2 = new Promise(resolve => unlock_2 = resolve);
+
+        async_promise_test(async test => {
+          parent.actual_sequence.push('a');
+          await lock_1;
+          parent.actual_sequence.push('c');
+          unlock_2();
+        }, 'track1');
+
+        async_promise_test(async test => {
+          parent.actual_sequence.push('b');
+          unlock_1();
+          await lock_2;
+          parent.actual_sequence.push('d');
+        }, 'track2');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'OK');
+      assert_equals(tests.track1, 'PASS');
+      assert_equals(tests.track2, 'PASS');
+      assert_array_equals(actual_sequence, expected_sequence);
+    });
+}, 'async_promise_test are run in parallel');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        async_promise_test(async test => {
+          throw new Error('this error is expected');
+        }, 'track1');
+
+        async_promise_test(async test => {
+        }, 'track2');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'OK');
+      assert_equals(tests.track1, 'FAIL');
+      assert_equals(tests.track2, 'PASS');
+    });
+}, 'async_promise_test [FAIL, PASS]');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        async_promise_test(async test => {
+        }, 'track1');
+
+        async_promise_test(async test => {
+          throw new Error('this error is expected');
+        }, 'track2');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'OK');
+      assert_equals(tests.track1, 'PASS');
+      assert_equals(tests.track2, 'FAIL');
+    });
+}, 'async_promise_test [PASS, FAIL]');
 </script>
 </body>
 </html>


### PR DESCRIPTION
See:
https://github.com/web-platform-tests/rfcs/pull/75

1. Add a short documentation.
2. Add `async_promise_test()`, based on `async_test()`.
   It can be seen as:
   - A variant of `async_test()`, taking a promise.
   - A variant of `promise_test()`, running in parallel.
3. Defer `async_test()`/`async_promise_test()` when it exists a
   `promise_setup()` running.
4. Modify a few existing WPT tests to use/test `async_promise_test()`.