### PR TITLE
[wptserve] Pass BytesIO to GzipFile constructor

### DIFF
--- a/tools/wptserve/tests/functional/test_pipes.py
+++ b/tools/wptserve/tests/functional/test_pipes.py
@@ -224,5 +224,10 @@ class TestPipesWithVariousHandlers(TestUsingServer):
         self.assertTrue(b'Content' in resp.read())
         self.assertGreater(6, t1-t0)
 
+    def test_gzip_handler(self):
+        resp = self.request("/document.txt", query="pipe=gzip")
+        self.assertEqual(resp.getcode(), 200)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -7,7 +7,7 @@ import re
 import time
 import uuid
 
-from io import StringIO
+from io import BytesIO
 
 try:
     from html import escape
@@ -548,7 +548,7 @@ def gzip(request, response):
     content = resolve_content(response)
     response.headers.set("Content-Encoding", "gzip")
 
-    out = StringIO()
+    out = BytesIO()
     with gzip_module.GzipFile(fileobj=out, mode="w") as f:
         f.write(content)
     response.content = out.getvalue()


### PR DESCRIPTION
The GzipFile module expects to operate on bytes, so when passed a
StringIO it would throw. Pass a BytesIO object instead to resolve this.

Fixes https://github.com/web-platform-tests/wpt/issues/27917