### PR TITLE
[Resource-Timing] content-length/encodedBodySize

### DIFF
--- a/resource-timing/resource_timing_content_length.html
+++ b/resource-timing/resource_timing_content_length.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>This test validates the value of encodedBodySize in certain situations.</title>
+<link rel="help" href="http://www.w3.org/TR/resource-timing/#performanceresourcetiming"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+    function test_resource_timing_for_content_length({actualContentLength, lengthHeader}, title) {
+        promise_test(async t => {
+            const content = new Array(actualContentLength).fill('x').join('')
+            const url = `resources/resource-timing-content-length.py?content=${content}&length=${lengthHeader}`
+            fetch(url)
+            const entry = await new Promise(resolve => new PerformanceObserver((entryList, observer) => {
+                observer.disconnect()
+                resolve(entryList.getEntries()[0])
+            }).observe({entryTypes: ['resource']}))
+
+            const expectedContentLength = Number.isInteger(lengthHeader) ? Math.min(actualContentLength, lengthHeader) : actualContentLength
+            assert_equals(entry.encodedBodySize, expectedContentLength)
+        }, title);
+    }
+
+    test_resource_timing_for_content_length({actualContentLength: 3, lengthHeader: 'auto'},
+        "encodedBodySize should be equal to the actual byte size of the content")
+    test_resource_timing_for_content_length({actualContentLength: 13, lengthHeader: 'none'},
+        "encodedBodySize should be equal to the actual byte size of the content when no header present")
+    test_resource_timing_for_content_length({actualContentLength: 7, lengthHeader: 3},
+        "encodedBodySize should be equal to the actual byte size of the content when header value is lower than actual content")
+    test_resource_timing_for_content_length({actualContentLength: 8, lengthHeader: 40},
+        "encodedBodySize should be equal to the actual byte size of the content when header value is higher than actual content")
+</script>
+</html>

--- a/resource-timing/resources/resource-timing-content-length.py
+++ b/resource-timing/resources/resource-timing-content-length.py
@@ -1,0 +1,19 @@
+def main(request, response):
+    content = request.GET.first(b"content")
+    length = request.GET.first(b"length").decode("ascii")
+    response.add_required_headers = False
+
+    output =  b"HTTP/1.1 200 OK\r\n"
+    output += b"Content-Type: text/plain;charset=UTF-8\r\n"
+    if length == b"auto" :
+        output += b"Content-Length:"
+        output += "{0}".format(len(content)).encode("ascii")
+        output += b"\r\n"
+    elif length != b"none" :
+        output += b"Content-Length:"
+        output += "{0}".format(length).encode("ascii")
+        output += b"\r\n"
+    output += b"\r\n"
+    output += content
+    response.writer.write(output)
+    response.close_connection = True


### PR DESCRIPTION
Added tests for different scenarios of `Content-Length`
header and how it affects `encodedBodySize`.

Closes https://github.com/web-platform-tests/wpt/issues/27952