### PR TITLE
[css-flexbox] Improve robustness of select-element-zero-height-* tests

### DIFF
--- a/css/css-flexbox/select-element-zero-height-001-ref.html
+++ b/css/css-flexbox/select-element-zero-height-001-ref.html
@@ -6,6 +6,13 @@
     height: 0px;
     border: 1px dotted black;
   }
+  select {
+    /*
+      WebKit applies intrinsic (default) margins to control elements in some circumstances,
+      let's disable them to avoid mismatch errors caused by those margins.
+    */
+    margin: 0;
+  }
 </style>
 <body>
   <div class="container">

--- a/css/css-flexbox/select-element-zero-height-001.html
+++ b/css/css-flexbox/select-element-zero-height-001.html
@@ -11,6 +11,13 @@
     height: 0px;
     border: 1px dotted black;
   }
+  select {
+    /*
+      WebKit applies intrinsic (default) margins to control elements in some circumstances,
+      let's disable them to avoid mismatch errors caused by those margins.
+    */
+    margin: 0;
+  }
 </style>
 <body>
   <div class="container">

--- a/css/css-flexbox/select-element-zero-height-002-ref.html
+++ b/css/css-flexbox/select-element-zero-height-002-ref.html
@@ -10,6 +10,13 @@
     width: 100%;
     background: lime;
   }
+  select {
+    /*
+      WebKit applies intrinsic (default) margins to control elements in some circumstances,
+      let's disable them to avoid mismatch errors caused by those margins.
+    */
+    margin: 0;
+  }
 </style>
 <body>
   <div class="container">

--- a/css/css-flexbox/select-element-zero-height-002.html
+++ b/css/css-flexbox/select-element-zero-height-002.html
@@ -14,6 +14,13 @@
   .with-background {
     background: lime;
   }
+  select {
+    /*
+      WebKit applies intrinsic (default) margins to control elements in some circumstances,
+      let's disable them to avoid mismatch errors caused by those margins.
+    */
+    margin: 0;
+  }
 </style>
 <body>
   <div class="container">


### PR DESCRIPTION
WebKit has been applying (since 2003) what it calls intrinsic margins to control elements (like menu lists) for several reasons, mainly to leave space for focus rings and to keep them from butting up against one another. Those intrinsic margins are applied only if the control element (like `<select>`) has auto or intrinsic size.

This is a problem in `select-element-zero-height-*` tests in which the control has `auto` size in the gold standard and a specified size (`100%`) in the reference. From the WebKit POV the former needs "intrinsic margins" while the latter don't, creating 2px differences in the results that has nothing to do with flexbox.