### PR TITLE
Introduce a --no-fail-on-unexpected-pass flag.

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -947,4 +947,3 @@ class ManagerGroup(object):
 
     def unexpected_pass_count(self):
         return sum(manager.unexpected_pass_count for manager in self.pool)
-

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -339,6 +339,7 @@ class TestRunnerManager(threading.Thread):
 
         self.test_count = 0
         self.unexpected_count = 0
+        self.unexpected_pass_count = 0
 
         # This may not really be what we want
         self.daemon = True
@@ -638,6 +639,11 @@ class TestRunnerManager(threading.Thread):
                 self.unexpected_count += 1
                 self.logger.debug("Unexpected count in this thread %i" % self.unexpected_count)
                 subtest_unexpected = True
+
+            is_unexpected_pass = is_unexpected and result.status == "PASS"
+            if is_unexpected_pass:
+                self.unexpected_pass_count += 1
+
             self.logger.test_status(test.id,
                                     result.name,
                                     result.status,
@@ -670,6 +676,10 @@ class TestRunnerManager(threading.Thread):
         if is_unexpected:
             self.unexpected_count += 1
             self.logger.debug("Unexpected count in this thread %i" % self.unexpected_count)
+
+        is_unexpected_pass = is_unexpected and status == "OK"
+        if is_unexpected_pass:
+            self.unexpected_pass_count += 1
 
         if "assertion_count" in file_result.extra:
             assertion_count = file_result.extra["assertion_count"]
@@ -934,3 +944,7 @@ class ManagerGroup(object):
 
     def unexpected_count(self):
         return sum(manager.unexpected_count for manager in self.pool)
+
+    def unexpected_pass_count(self):
+        return sum(manager.unexpected_pass_count for manager in self.pool)
+

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -72,6 +72,10 @@ scheme host and port.""")
                         default=True,
                         dest="fail_on_unexpected",
                         help="Exit with status code 0 when test expectations are violated")
+    parser.add_argument("--no-fail-on-unexpected-pass", action="store_false",
+                        default=True,
+                        dest="fail_on_unexpected_pass",
+                        help="Exit with status code 0 when all unexpected results are PASS")
 
     mode_group = parser.add_argument_group("Mode")
     mode_group.add_argument("--list-test-groups", action="store_true",

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -375,7 +375,8 @@ def run_tests(config, test_paths, product, **kwargs):
         logger.info("Tolerating %s unexpected results" % unexpected_total)
         return True
 
-    all_unexpected_passed = (unexpected_total == unexpected_pass_total)
+    all_unexpected_passed = (unexpected_total and
+                             unexpected_total == unexpected_pass_total)
     if all_unexpected_passed and not kwargs["fail_on_unexpected_pass"]:
         logger.info("Tolerating %i unexpected results because they all PASS" %
                     unexpected_pass_total)

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -201,6 +201,7 @@ def run_tests(config, test_paths, product, **kwargs):
         skipped_tests = 0
         test_total = 0
         unexpected_total = 0
+        unexpected_pass_total = 0
 
         if len(test_loader.test_ids) == 0 and kwargs["test_list"]:
             logger.critical("Unable to find any tests at the path(s):")
@@ -255,6 +256,7 @@ def run_tests(config, test_paths, product, **kwargs):
 
                 test_count = 0
                 unexpected_count = 0
+                unexpected_pass_count = 0
 
                 tests = []
                 for test_type in test_loader.test_types:
@@ -345,10 +347,13 @@ def run_tests(config, test_paths, product, **kwargs):
                             raise
                         test_count += manager_group.test_count()
                         unexpected_count += manager_group.unexpected_count()
+                        unexpected_pass_count += manager_group.unexpected_pass_count()
                 recording.set(["after-end"])
                 test_total += test_count
                 unexpected_total += unexpected_count
-                logger.info("Got %i unexpected results" % unexpected_count)
+                unexpected_pass_total += unexpected_pass_count
+                logger.info("Got %i unexpected results, with %i unexpected passes" %
+                            (unexpected_count, unexpected_pass_count))
                 logger.suite_end()
                 if repeat_until_unexpected and unexpected_total > 0:
                     break
@@ -368,6 +373,12 @@ def run_tests(config, test_paths, product, **kwargs):
 
     if unexpected_total and not kwargs["fail_on_unexpected"]:
         logger.info("Tolerating %s unexpected results" % unexpected_total)
+        return True
+
+    all_unexpected_passed = (unexpected_total == unexpected_pass_total)
+    if all_unexpected_passed and not kwargs["fail_on_unexpected_pass"]:
+        logger.info("Tolerating %i unexpected results because they all PASS" %
+                    unexpected_pass_total)
         return True
 
     return unexpected_total == 0


### PR DESCRIPTION
Very similar to --no-fail-on-unexpected but this will only tolerate
unexpected PASS/OK results.

This addresses a Chromium issue ([crbug.com/1167292](http://crbug.com/1167292))