### PR TITLE
Perform xrReferenceSpace_originOffsetBounded.html validations with an active XRFrame.

### DIFF
--- a/webxr/xrReferenceSpace_originOffsetBounded.https.html
+++ b/webxr/xrReferenceSpace_originOffsetBounded.https.html
@@ -66,10 +66,9 @@ function testFunction(session, fakeDeviceController, t) {
   });
 
   return new Promise((resolve, reject) => {
-    requestSkipAnimationFrame(session, (time, frame) => {
-      let input_source = session.inputSources[0];
-
-      session.requestReferenceSpace('bounded-floor').then((referenceSpace) => {
+    session.requestReferenceSpace('bounded-floor').then((referenceSpace) => {
+      requestSkipAnimationFrame(session, (time, frame) => {
+        let input_source = session.inputSources[0];
 
         function CheckState(
           reference_space,


### PR DESCRIPTION
Perform xrReferenceSpace_originOffsetBounded.html validations with an active XRFrame.

Right now validations are run inside the requestReferenceSpace promise callback which may not have an active XRFrame state.