### PR TITLE
Do not call xrFrame.getPose with null values

### DIFF
--- a/webxr/getInputPose_pointer.https.html
+++ b/webxr/getInputPose_pointer.https.html
@@ -29,12 +29,11 @@ let testFunction =
 
       function CheckInvalidGrip(time, xrFrame) {
         let source = session.inputSources[0];
-        let grip_pose = xrFrame.getPose(source.gripSpace, referenceSpace);
 
         t.step( () => {
           // The input pose should be null when no grip matrix is provided.
           assert_equals(source.targetRayMode, "tracked-pointer");
-          assert_equals(grip_pose, null);
+          assert_equals(source.gripSpace, null);
         });
 
         input_source.setGripOrigin(VALID_GRIP_TRANSFORM);


### PR DESCRIPTION
Do not call xrFrame.getPose with null values

According to the spec getPose() arguments are not nullable, so UAs may throw an exception instead of returning a null pose.