### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=222739

### DIFF
--- a/html/browsers/origin/cross-origin-objects/cross-origin-objects-function-caching.html
+++ b/html/browsers/origin/cross-origin-objects/cross-origin-objects-function-caching.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Cross-origin methods and accessors are cached per Realm via[[CrossOriginPropertyDescriptorMap]]</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/browsers.html#crossorigingetownpropertyhelper-(-o,-p-)">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="cross-origin-objects-function-common.js"></script>
+<div id=log></div>
+<script>
+"use strict";
+
+promise_test(async t => {
+    const w = await makeCrossOriginWindow(t);
+    for (const {key} of crossOriginWindowMethods) {
+        assert_equals(w[key], w[key], `w.${key} via [[Get]]`);
+        const desc1 = Object.getOwnPropertyDescriptor(w, key);
+        const desc2 = Object.getOwnPropertyDescriptor(w, key);
+        assert_equals(desc1.value, desc2.value, `w.${key} via [[GetOwnProperty]]`);
+    }
+}, "Cross-origin Window methods are cached");
+
+promise_test(async t => {
+    const w = await makeCrossOriginWindow(t);
+    for (const {key} of crossOriginWindowAccessors) {
+        const desc1 = Object.getOwnPropertyDescriptor(w, key);
+        const desc2 = Object.getOwnPropertyDescriptor(w, key);
+        assert_equals(desc1.get, desc2.get, `w.${key} getter`);
+        if (key === "location") {
+            assert_equals(desc1.set, desc2.set, `w.${key} setter`);
+        }
+    }
+}, "Cross-origin Window accessors are cached");
+
+promise_test(async t => {
+    const w = await makeCrossOriginWindow(t);
+    assert_equals(w.location.replace, w.location.replace, "via [[Get]]");
+    const desc1 = Object.getOwnPropertyDescriptor(w.location, "replace");
+    const desc2 = Object.getOwnPropertyDescriptor(w.location, "replace");
+    assert_equals(desc1.value, desc2.value, "via [[GetOwnProperty]]");
+}, "Cross-origin Location `replace` method is cached");
+
+promise_test(async t => {
+    const w = await makeCrossOriginWindow(t);
+    const desc1 = Object.getOwnPropertyDescriptor(w.location, "href");
+    const desc2 = Object.getOwnPropertyDescriptor(w.location, "href");
+    assert_equals(desc1.set, desc2.set);
+}, "Cross-origin Location `href` setter is cached");
+</script>

--- a/html/browsers/origin/cross-origin-objects/cross-origin-objects-function-common.js
+++ b/html/browsers/origin/cross-origin-objects/cross-origin-objects-function-common.js
@@ -1,0 +1,34 @@
+"use strict";
+
+const crossOriginWindowMethods = [
+    {key: "close", length: 0},
+    {key: "focus", length: 0},
+    {key: "blur", length: 0},
+    {key: "postMessage", length: 1},
+];
+
+const crossOriginWindowAccessors = [
+    "window",
+    "self",
+    "location",
+    "closed",
+    "frames",
+    "length",
+    "top",
+    "opener",
+    "parent",
+].map(key => ({key}));
+
+const makeCrossOriginWindow = t => {
+    const iframe = document.createElement("iframe");
+    const path = location.pathname.slice(0, location.pathname.lastIndexOf("/")) + "/frame.html";
+    iframe.src = get_host_info().HTTP_REMOTE_ORIGIN + path;
+
+    return new Promise((resolve, reject) => {
+        iframe.onload = () => { resolve(iframe.contentWindow); };
+        iframe.onerror = reject;
+
+        document.body.append(iframe);
+        t.add_cleanup(() => { iframe.remove(); });
+    });
+};

--- a/html/browsers/origin/cross-origin-objects/cross-origin-objects-function-length.html
+++ b/html/browsers/origin/cross-origin-objects/cross-origin-objects-function-length.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Cross-origin methods and accessors are created with correct 'length' property</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/browsers.html#crossorigingetownpropertyhelper-(-o,-p-)">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="cross-origin-objects-function-common.js"></script>
+<div id=log></div>
+<script>
+"use strict";
+
+promise_test(async t => {
+    const w = await makeCrossOriginWindow(t);
+    for (const {key, length} of crossOriginWindowMethods) {
+        assert_equals(w[key].length, length, `w.${key} via [[Get]]`);
+        const desc = Object.getOwnPropertyDescriptor(w, key);
+        assert_equals(desc.value.length, length, `w.${key} via [[GetOwnProperty]]`);
+    }
+}, "Cross-origin Window methods have correct 'length'");
+
+promise_test(async t => {
+    const w = await makeCrossOriginWindow(t);
+    for (const {key} of crossOriginWindowAccessors) {
+        const desc = Object.getOwnPropertyDescriptor(w, key);
+        assert_equals(desc.get.length, 0, `w.${key}`);
+        if (key === "location") {
+            assert_equals(desc.set.length, 1, `w.${key}`);
+        }
+    }
+}, "Cross-origin Window accessors have correct 'length'");
+
+promise_test(async t => {
+    const w = await makeCrossOriginWindow(t);
+    assert_equals(w.location.replace.length, 1);
+    const desc = Object.getOwnPropertyDescriptor(w.location, "replace");
+    assert_equals(desc.value.length, 1);
+}, "Cross-origin Location `replace` method has correct 'length'");
+
+promise_test(async t => {
+    const w = await makeCrossOriginWindow(t);
+    const desc = Object.getOwnPropertyDescriptor(w.location, "href");
+    assert_equals(desc.set.length, 1);
+}, "Cross-origin Location `href` setter has correct 'length'");
+</script>

--- a/html/browsers/origin/cross-origin-objects/cross-origin-objects-function-name.html
+++ b/html/browsers/origin/cross-origin-objects/cross-origin-objects-function-name.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Cross-origin methods and accessors are created with correct 'name' property</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/browsers.html#crossorigingetownpropertyhelper-(-o,-p-)">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="cross-origin-objects-function-common.js"></script>
+<div id=log></div>
+<script>
+"use strict";
+
+promise_test(async t => {
+    const w = await makeCrossOriginWindow(t);
+    for (const {key} of crossOriginWindowMethods) {
+        assert_equals(w[key].name, key, `w.${key} via [[Get]]`);
+        const desc = Object.getOwnPropertyDescriptor(w, key);
+        assert_equals(desc.value.name, key, `w.${key} via [[GetOwnProperty]]`);
+    }
+}, "Cross-origin Window methods have correct 'name'");
+
+promise_test(async t => {
+    const w = await makeCrossOriginWindow(t);
+    for (const {key} of crossOriginWindowAccessors) {
+        const desc = Object.getOwnPropertyDescriptor(w, key);
+        assert_equals(desc.get.name, `get ${key}`);
+        if (key === "location") {
+            assert_equals(desc.set.name, `set ${key}`);
+        }
+    }
+}, "Cross-origin Window accessors have correct 'name'");
+
+promise_test(async t => {
+    const w = await makeCrossOriginWindow(t);
+    assert_equals(w.location.replace.name, "replace");
+    const desc = Object.getOwnPropertyDescriptor(w.location, "replace");
+    assert_equals(desc.value.name, "replace");
+}, "Cross-origin Location `replace` method has correct 'name'");
+
+promise_test(async t => {
+    const w = await makeCrossOriginWindow(t);
+    const desc = Object.getOwnPropertyDescriptor(w.location, "href");
+    assert_equals(desc.set.name, "set href");
+}, "Cross-origin Location `href` setter has correct 'name'");
+</script>


### PR DESCRIPTION
This upstream reviewed change adds coverage for `[[CrossOriginPropertyDescriptorMap]]` bit of [`CrossOriginGetOwnPropertyHelper`](https://html.spec.whatwg.org/multipage/browsers.html#crossorigingetownpropertyhelper-(-o,-p-)) for `Window` and `Location`, and ensures that cross-origin function objects are created with correct `"length"` and `"name"` values.