### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=221872

### DIFF
--- a/WebIDL/ecmascript-binding/attributes-accessors-unique-function-objects.html
+++ b/WebIDL/ecmascript-binding/attributes-accessors-unique-function-objects.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>All attributes accessors are unique function objects</title>
+<link rel="help" href="https://heycam.github.io/webidl/#idl-interface-mixins">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+"use strict";
+
+test(() => {
+  const seenPrototypes = new WeakSet([Function.prototype]);
+  const seenFunctions = new WeakMap();
+
+  for (const windowKey of Object.getOwnPropertyNames(window)) {
+    const windowValue = window[windowKey];
+    if (typeof windowValue !== "function") continue;
+
+    const {prototype} = windowValue;
+    if (!prototype || seenPrototypes.has(prototype)) continue;
+    seenPrototypes.add(prototype);
+
+    for (const key of Object.getOwnPropertyNames(prototype)) {
+      const assert_not_seen = (fn, field) => {
+        const fnInfo = `${windowKey}.${key}.${field}`;
+        assert_equals(seenFunctions.get(fn), undefined, fnInfo);
+        seenFunctions.set(fn, fnInfo);
+      };
+
+      const desc = Object.getOwnPropertyDescriptor(prototype, key);
+      if (desc.get) assert_not_seen(desc.get, "[[Get]]");
+      if (desc.set) assert_not_seen(desc.set, "[[Set]]");
+    }
+  }
+}, "For attributes, each copy of the accessor property has distinct built-in function objects for its getters and setters.");
+</script>


### PR DESCRIPTION
This upstream reviewed change tests that getters & setters, that are originated from the same mixin but for different interfaces, fails reference equality test (are different objects).