### PR TITLE
Timer tests can be flaky when system is very slow

### DIFF
--- a/html/webappapis/timers/negative-settimeout.any.js
+++ b/html/webappapis/timers/negative-settimeout.any.js
@@ -1,3 +1,4 @@
 setup({ single_test: true });
-setTimeout(done, -100);
-setTimeout(assert_unreached, 10);
+var otherTimeout;
+setTimeout(() => { clearTimeout(otherTimeout); done(); }, -100);
+otherTimeout = setTimeout(assert_unreached, 10);

--- a/html/webappapis/timers/type-long-settimeout.any.js
+++ b/html/webappapis/timers/type-long-settimeout.any.js
@@ -1,3 +1,4 @@
 setup({ single_test: true });
-setTimeout(done, Math.pow(2, 32));
-setTimeout(assert_unreached, 100);
+var otherTimeout;
+setTimeout(() => { clearTimeout(otherTimeout); done(); }, Math.pow(2, 32));
+otherTimeout = setTimeout(assert_unreached, 100);


### PR DESCRIPTION
`negative-settimeout.any.js` and `type-long-settimeout.any.js` (less so) can be somewhat flaky when a system is under pressure or very very slow. As I assume that these tests exist to check the order of the timeouts, I've changed them so that the "early" timeout clears the "later" one. I'd be happy to change it to a boolean, if depending on clearTimeout is an issue. I also think that this was faced here a few months ago [on Chrome](https://github.com/web-platform-tests/wpt/pull/27094#issuecomment-756656479) as well, where there were some complaints in the PR that this test is flaky.

Consider the following test:
```js
setup({ single_test: true });
setTimeout(done, -100);
setTimeout(assert_unreached, 10);
```

Suppose that for some reason our machine is _so_ _slow_ that it takes `10` ms until the browser executes our timers, and would decide to execute both of the timers. So, our timer execution is equivalent to:
```js
setup({ single_test: true });
setTimeout(done, 10);
setTimeout(assert_unreached, 10);
```
IMO the above shouldn't fail, as indeed the first timeout executed before the second one. It can be more easily observed on faster systems if we change the second timeout in the original test to `5` or lower (at least on my machine on Safari).