### PR TITLE
Fix perspective interpolation test to allow 0 as value

### DIFF
--- a/css/css-transforms/animation/perspective-interpolation.html
+++ b/css/css-transforms/animation/perspective-interpolation.html
@@ -40,8 +40,8 @@ test_interpolation({
   from: neutralKeyframe,
   to: '20px',
 }, [
-  {at: -20, expect: 'none'},
-  {at: -1, expect: 'none'},
+  {at: -20, expect: '0px'},
+  {at: -1, expect: '0px'},
   {at: -0.3, expect: '7px'},
   {at: 0, expect: '10px'},
   {at: 0.3, expect: '13px'},
@@ -82,8 +82,8 @@ test_interpolation({
   from: '50px',
   to: '100px',
 }, [
-  {at: -20, expect: 'none'}, // perspective does not accept 0 or negative values
-  {at: -1, expect: 'none'}, // perspective does not accept 0 or negative values
+  {at: -20, expect: '0px'}, // perspective does not accept negative values
+  {at: -1, expect: '0px'}, // perspective does not accept negative values
   {at: -0.3, expect: '35px'},
   {at: 0, expect: '50px'},
   {at: 0.3, expect: '65px'},


### PR DESCRIPTION
The `perspective` property allows `0` as a value, per [the CSS Transforms spec](https://drafts.csswg.org/css-transforms-2/#perspective-property):

> As very small <length> values can produce bizarre rendering results and stress the numerical accuracy of transform calculations, values less than 1px must be treated as 1px for rendering purposes. (This clamping does not affect the underlying value, so perspective: 0; in a stylesheet will still serialize back as 0.)