### PR TITLE
New test for percentage flex basis in nested column flexboxes

### DIFF
--- a/css/css-flexbox/flex-basis-011-ref.html
+++ b/css/css-flexbox/flex-basis-011-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<link rel="author" title="Sergio Villar Senin" href="mailto:svillar@igalia.com">
+<style>
+.item {
+    border: 1px solid blue;
+}
+</style>
+
+<p>Test PASS if there are two boxes with blue borders stretched to fit their contents.</p>
+<div style="width: min-content">
+    <div>
+        <div class="item">
+            <div>AAA</div>
+        </div>
+        <div class="item">
+            <div>BBB</div>
+        </div>
+    </div>
+</div>

--- a/css/css-flexbox/flex-basis-011-ref.html
+++ b/css/css-flexbox/flex-basis-011-ref.html
@@ -6,7 +6,7 @@
 }
 </style>
 
-<p>Test PASS if there are two boxes with blue borders stretched to fit their contents.</p>
+<p>Test PASS if there are two boxes with blue borders vertically stretched to fit their contents.</p>
 <div style="width: min-content">
     <div>
         <div class="item">

--- a/css/css-flexbox/flex-basis-011.html
+++ b/css/css-flexbox/flex-basis-011.html
@@ -12,7 +12,7 @@
 }
 </style>
 
-<p>Test PASS if there are two boxes with blue borders stretched to fit their contents.</p>
+<p>Test PASS if there are two boxes with blue borders vertically stretched to fit their contents.</p>
 <div class="flexbox">
     <div class="flexbox column">
         <div class="flex-item">

--- a/css/css-flexbox/flex-basis-011.html
+++ b/css/css-flexbox/flex-basis-011.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Flexbox Test: % flex-basis should not cause engines to treat items as percentage sized</title>
+<link rel="author" title="Sergio Villar Senin" href="mailto:svillar@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-basis-property">
+<link href="support/flexbox.css" rel="stylesheet">
+<link rel="match" href="flex-basis-011-ref.html">
+<style>
+.flex-item {
+    flex: 1 0 100%;
+    border: 1px solid blue;
+}
+</style>
+
+<p>Test PASS if there are two boxes with blue borders stretched to fit their contents.</p>
+<div class="flexbox">
+    <div class="flexbox column">
+        <div class="flex-item">
+            <div>AAA</div>
+        </div>
+        <div class="flex-item">
+            <div>BBB</div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
WebKit is not rendering this example correctly because the outer flexbox relays out the nested flexbox because it incorrectly thinks it has a percentage height descendant. Chromium fixed exactly the same issue some time ago. 