### PR TITLE
Test if AbortController and AbortSignal perform brand checks

### DIFF
--- a/dom/abort/event.any.js
+++ b/dom/abort/event.any.js
@@ -70,22 +70,22 @@ test(t => {
 }, "the AbortSignal.abort() static returns an already aborted signal");
 
 test(t => {
-  const acSignalGet = Object.getOwnPropertyDescriptor(AbortController.prototype, 'signal').get;
+  const acSignalGet = Object.getOwnPropertyDescriptor(AbortController.prototype, "signal").get;
   const acAbort = AbortController.prototype.abort;
 
-  const badAbortControllers = [null, undefined, 0, NaN, true, 'AbortController', Object.create(AbortController.prototype)];
+  const badAbortControllers = [null, undefined, 0, NaN, true, "AbortController", Object.create(AbortController.prototype)];
   for (const badController of badAbortControllers) {
-    assert_throws_js(TypeError, acSignalGet.bind(badController), 'controller.signal should throw');
-    assert_throws_js(TypeError, acAbort.bind(badController), 'controller.abort() should throw');
+    assert_throws_js(TypeError, acSignalGet.bind(badController), "controller.signal should throw");
+    assert_throws_js(TypeError, acAbort.bind(badController), "controller.abort() should throw");
   }
 }, "AbortController should perform brand checks");
 
 test(t => {
-  const signalAbortedGet = Object.getOwnPropertyDescriptor(AbortSignal.prototype, 'aborted').get;
+  const signalAbortedGet = Object.getOwnPropertyDescriptor(AbortSignal.prototype, "aborted").get;
 
-  const badAbortSignals = [null, undefined, 0, NaN, true, 'AbortSignal', Object.create(AbortSignal.prototype)];
+  const badAbortSignals = [null, undefined, 0, NaN, true, "AbortSignal", Object.create(AbortSignal.prototype)];
   for (const badSignal of badAbortSignals) {
-    assert_throws_js(TypeError, signalAbortedGet.bind(badSignal), 'signal.aborted should throw');
+    assert_throws_js(TypeError, signalAbortedGet.bind(badSignal), "signal.aborted should throw");
   }
 }, "AbortSignal should perform brand checks");
 

--- a/dom/abort/event.any.js
+++ b/dom/abort/event.any.js
@@ -69,4 +69,24 @@ test(t => {
   assert_true(signal.aborted);
 }, "the AbortSignal.abort() static returns an already aborted signal");
 
+test(t => {
+  const acSignalGet = Object.getOwnPropertyDescriptor(AbortController.prototype, 'signal').get;
+  const acAbort = AbortController.prototype.abort;
+
+  const badAbortControllers = [null, undefined, 0, NaN, true, 'AbortController', Object.create(AbortController.prototype)];
+  for (const badController of badAbortControllers) {
+    assert_throws_js(TypeError, acSignalGet.bind(badController), 'controller.signal should throw');
+    assert_throws_js(TypeError, acAbort.bind(badController), 'controller.abort() should throw');
+  }
+}, "AbortController should perform brand checks");
+
+test(t => {
+  const signalAbortedGet = Object.getOwnPropertyDescriptor(AbortSignal.prototype, 'aborted').get;
+
+  const badAbortSignals = [null, undefined, 0, NaN, true, 'AbortSignal', Object.create(AbortSignal.prototype)];
+  for (const badSignal of badAbortSignals) {
+    assert_throws_js(TypeError, signalAbortedGet.bind(badSignal), 'signal.aborted should throw');
+  }
+}, "AbortSignal should perform brand checks");
+
 done();


### PR DESCRIPTION
The properties and methods on these interfaces should perform a brand check on their receiver (as required by Web IDL). However, this is currently untested, since the IDL harness doesn't know how to *call* an interface method. This makes them easy to miss for implementors, such as in nodejs/node#37720.

This PR adds tests for these brand checks. These are upstreamed from nodejs/node#37720, which in turn are based on [these WPT tests for Streams](https://github.com/web-platform-tests/wpt/blob/887350c2f46def5b01c4dd1f8d2eee35dfb9c5bb/streams/piping/pipe-through.any.js#L99-L105).