### PR TITLE
Remove ES6 ...spread from assert_wrapper() and AssertRecord()

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1190,9 +1190,9 @@ policies and contribution forms [3].
                     console.debug("ASSERT", name, tests.current_test && tests.current_test.name, args);
                 }
                 if (tests.output) {
-                    tests.set_assert(name, ...args);
+                    tests.set_assert(name, args);
                 }
-                const rv = f(...args);
+                const rv = f.apply(undefined, args);
                 status = Test.statuses.PASS;
                 return rv;
             } catch(e) {
@@ -2725,7 +2725,7 @@ policies and contribution forms [3].
         return this.formats[this.status];
     }
 
-    function AssertRecord(test, assert_name, ...args) {
+    function AssertRecord(test, assert_name, args = []) {
         this.assert_name = assert_name;
         this.test = test;
         // Avoid keeping complex objects alive
@@ -3032,8 +3032,8 @@ policies and contribution forms [3].
                   all_complete);
     };
 
-    Tests.prototype.set_assert = function(assert_name, ...args) {
-        this.asserts_run.push(new AssertRecord(this.current_test, assert_name, ...args))
+    Tests.prototype.set_assert = function(assert_name, args) {
+        this.asserts_run.push(new AssertRecord(this.current_test, assert_name, args))
     }
 
     Tests.prototype.set_assert_status = function(status, stack) {


### PR DESCRIPTION
Please note test results for [`WebIDL/ecmascript-binding/sequence-conversion.html` on wpt.fyi](https://wpt.fyi/results/WebIDL/ecmascript-binding/sequence-conversion.html): Firefox and Safari fail 2 cases that modify `Array.prototype[Symbol.iterator]` and `%ArrayIterator%.prototype.next`.

However, if you run these tests in browsers' DevTools using `console.assert`, they are passing. Also, they [pass for WebKit](https://github.com/WebKit/WebKit/blob/b98ba0d8bb727b5345ee4a8d07111109f9ffd30d/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/sequence-conversion-expected.txt#L6-L7) that uses [a few month old `testharness.js`](https://github.com/WebKit/WebKit/blob/f7f6133118319a8574d96b05e3e7f6c14ac63392/LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js).

I can confirm the regression is due to ES6 `...spread` being used in `assert_wrapper` and `AssertRecord`. This PR is minimally necessary change to fix the tests.