### PR TITLE
screen-wake-lock: Adapt to https://github.com/w3c/screen-wake-lock/pull/299

### DIFF
--- a/screen-wake-lock/wakelock-onrelease.https.html
+++ b/screen-wake-lock/wakelock-onrelease.https.html
@@ -20,4 +20,20 @@ promise_test(async t => {
     assert_false(ev.cancelable);
   });
 }, "Test onreleased event's basic properties");
+
+promise_test(async t => {
+  await test_driver.set_permission({ name: 'screen-wake-lock' }, 'granted', false);
+
+  const lock = await navigator.wakeLock.request("screen");
+
+  let releaseFired = false;
+  lock.onrelease = t.step_func(() => {
+    releaseFired = true;
+  });
+
+  const releasePromise = lock.release();
+  assert_true(releaseFired, "The 'release' event fires immediately after release() is called");
+
+  return releasePromise;
+}, "Ensure onreleased is called before WakeLockSentinel.release() resolves");
 </script>

--- a/screen-wake-lock/wakelock-released.https.html
+++ b/screen-wake-lock/wakelock-released.https.html
@@ -6,33 +6,15 @@
 <script src="/resources/testdriver-vendor.js"></script>
 <script>
 promise_test(async t => {
-  await test_driver.set_permission({name: 'screen-wake-lock'}, 'granted', false);
-
-  const lock = await navigator.wakeLock.request("screen");
-  assert_false(lock.released, "lock.release must be false on creation");
-
-  const watcher = new EventWatcher(t, lock, "release");
-
-  lock.release();
-  assert_false(lock.released, "WakeLockSentinel.release does not become true immediately");
-
-  await watcher.wait_for("release");
-  assert_true(lock.released, "lock.release must be true after calling release()");
-}, "Basic WakeLockSentinel.released functionality");
-
-promise_test(async t => {
   await test_driver.set_permission({ name: 'screen-wake-lock' }, 'granted', false);
 
   const lock = await navigator.wakeLock.request("screen");
-  assert_false(lock.released, "lock.release must be false on creation");
+  assert_false(lock.released, "lock.released must be false on creation");
 
-  return new Promise(resolve => {
-    lock.onrelease = t.step_func(ev => {
-      assert_true(lock.released, "WakeLockSentinel.release is true in an onrelease event handler");
-      resolve();
-    });
-    lock.release();
-    assert_false(lock.released, "WakeLockSentinel.release does not become true immediately")
-  })
-}, "The release attribute inside an event handler");
+  lock.onrelease = t.step_func(() => {
+    assert_true(lock.released, "WakeLockSentinel.released is true in an onrelease event handler");
+  });
+  await lock.release();
+  assert_true(lock.released, "WakeLockSentinel.released remains true outside the event handler");
+}, "The released attribute inside an event handler");
 </script>


### PR DESCRIPTION
Besides tidying up uses of "in parallel" in algorithms, that spec change
also makes the "release wake lock" algorithm fire the "release" event and
change the `[[Released]]` slot immediately rather than in a queued task.

Adjust some tests to make sure the new behavior is properly verified here.