### PR TITLE
Cleaned up tests, fixed mistake

### DIFF
--- a/css/css-flexbox/flexbox_justifycontent-left-001-ref.html
+++ b/css/css-flexbox/flexbox_justifycontent-left-001-ref.html
@@ -9,11 +9,9 @@ div {
   width: 40em;
   display: flex;
   flex-direction: row;
-  justify-content: left;
 }
 span {
   background: white;
-  margin: 1px;
   padding: 0 2em;
   width: 4em;
   height: 2em;
@@ -24,8 +22,6 @@ span:nth-child(3) {background: lightblue;}
 #row-reverse span:nth-child(3) {background: yellow;}
 #row-reverse span:nth-child(1) {background: lightblue;}
 </style>
-
-<p>Test passes if the numbered boxes are placed in the top left corner of both flex containers, and left-to-right order is 1, 2, 3 in the first case and 3, 2, 1 in the second case.</p>
 
 <div id="row">
   <span>one</span>

--- a/css/css-flexbox/flexbox_justifycontent-left-001-ref.html
+++ b/css/css-flexbox/flexbox_justifycontent-left-001-ref.html
@@ -7,10 +7,9 @@ div {
   margin: 1em 0;
   height: 4em;
   width: 40em;
-  display: flex;
-  flex-direction: row;
 }
 span {
+  display: inline-block;
   background: white;
   padding: 0 2em;
   width: 4em;
@@ -23,14 +22,12 @@ span:nth-child(3) {background: lightblue;}
 #row-reverse span:nth-child(1) {background: lightblue;}
 </style>
 
+<p>Test passes if the numbered boxes are placed in the top left corner of the first flex container and left-to-right order is 1, 2, 3, and placed in the top left corner of the second flexbox container and left-to-right order is 3, 2, 1.</p>
+
 <div id="row">
-  <span>one</span>
-  <span>two</span>
-  <span>three</span>
+  <span>one</span><span>two</span><span>three</span>
 </div>
 
 <div id="row-reverse">
-  <span>three</span>
-  <span>two</span>
-  <span>one</span>
+  <span>three</span><span>two</span><span>one</span>
 </div>

--- a/css/css-flexbox/flexbox_justifycontent-left-001.html
+++ b/css/css-flexbox/flexbox_justifycontent-left-001.html
@@ -19,7 +19,6 @@ div#row-reverse {
 
 span {
   background: white;
-  margin: 1px;
   padding: 0 2em;
   width: 4em;
   height: 2em;
@@ -28,8 +27,6 @@ span:nth-child(1) {background: yellow;}
 span:nth-child(2) {background: pink;}
 span:nth-child(3) {background: lightblue;}
 </style>
-
-<p>Test passes if the numbered boxes are placed in the top left corner of both flex containers, and left-to-right order is 1, 2, 3 in the first case and 3, 2, 1 in the second case.</p>
 
 <div id="row">
   <span>one</span>

--- a/css/css-flexbox/flexbox_justifycontent-left-001.html
+++ b/css/css-flexbox/flexbox_justifycontent-left-001.html
@@ -28,6 +28,8 @@ span:nth-child(2) {background: pink;}
 span:nth-child(3) {background: lightblue;}
 </style>
 
+<p>Test passes if the numbered boxes are placed in the top left corner of the first flex container and left-to-right order is 1, 2, 3, and placed in the top left corner of the second flexbox container and left-to-right order is 3, 2, 1.</p>
+
 <div id="row">
   <span>one</span>
   <span>two</span>

--- a/css/css-flexbox/flexbox_justifycontent-left-002-ref.html
+++ b/css/css-flexbox/flexbox_justifycontent-left-002-ref.html
@@ -5,16 +5,12 @@
 div {
   background: blue;
   margin: 1em 0;
-  display: flex;
   width: 12em;
   height: 10em;
-  justify-content: left;
-  flex-direction: column;
 }
-
 span {
+  display: block;
   background: white;
-  margin: 1px;
   padding: 0 2em;
   width: 4em;
   height: 2em;
@@ -24,9 +20,8 @@ span:nth-child(2) {background: pink;}
 span:nth-child(3) {background: lightblue;}
 #column-reverse span:nth-child(3) {background: yellow;}
 #column-reverse span:nth-child(1) {background: lightblue;}
+#column-reverse {padding-top: 4em; height: 6em;}
 </style>
-
-<p>Test passes if the numbered boxes are placed in the top left corner of both flex containers, and top-to-bottom order is 1, 2, 3 in the first case and 3, 2, 1 in the second case.</p>
 
 <div id="column">
   <span>one</span>

--- a/css/css-flexbox/flexbox_justifycontent-left-002-ref.html
+++ b/css/css-flexbox/flexbox_justifycontent-left-002-ref.html
@@ -23,6 +23,8 @@ span:nth-child(3) {background: lightblue;}
 #column-reverse {padding-top: 4em; height: 6em;}
 </style>
 
+<p>Test passes if the numbered boxes are placed in the top left corner of the first flex container and top-to-bottom order is 1, 2, 3, and placed in the bottom left corner of the second flexbox container and top-to-bottom order is 3, 2, 1.</p>
+
 <div id="column">
   <span>one</span>
   <span>two</span>

--- a/css/css-flexbox/flexbox_justifycontent-left-002.html
+++ b/css/css-flexbox/flexbox_justifycontent-left-002.html
@@ -21,7 +21,6 @@ div#column-reverse {
 
 span {
   background: white;
-  margin: 1px;
   padding: 0 2em;
   width: 4em;
   height: 2em;
@@ -30,8 +29,6 @@ span:nth-child(1) {background: yellow;}
 span:nth-child(2) {background: pink;}
 span:nth-child(3) {background: lightblue;}
 </style>
-
-<p>Test passes if the numbered boxes are placed in the top left corner of both flex containers, and top-to-bottom order is 1, 2, 3 in the first case and 3, 2, 1 in the second case.</p>
 
 <div id="column">
   <span>one</span>

--- a/css/css-flexbox/flexbox_justifycontent-left-002.html
+++ b/css/css-flexbox/flexbox_justifycontent-left-002.html
@@ -30,6 +30,8 @@ span:nth-child(2) {background: pink;}
 span:nth-child(3) {background: lightblue;}
 </style>
 
+<p>Test passes if the numbered boxes are placed in the top left corner of the first flex container and top-to-bottom order is 1, 2, 3, and placed in the bottom left corner of the second flexbox container and top-to-bottom order is 3, 2, 1.</p>
+
 <div id="column">
   <span>one</span>
   <span>two</span>

--- a/css/css-flexbox/flexbox_justifycontent-right-001-ref.html
+++ b/css/css-flexbox/flexbox_justifycontent-right-001-ref.html
@@ -9,11 +9,9 @@ div {
   width: 40em;
   display: flex;
   flex-direction: row;
-  justify-content: right;
 }
 span {
   background: white;
-  margin: 1px;
   padding: 0 2em;
   width: 4em;
   height: 2em;
@@ -24,8 +22,6 @@ span:nth-child(3) {background: lightblue;}
 #row-reverse span:nth-child(3) {background: yellow;}
 #row-reverse span:nth-child(1) {background: lightblue;}
 </style>
-
-<p>Test passes if the numbered boxes are placed in the top left corner of both flex containers, and left-to-right order is 1, 2, 3 in the first case and 3, 2, 1 in the second case.</p>
 
 <div id="row">
   <span>one</span>

--- a/css/css-flexbox/flexbox_justifycontent-right-001-ref.html
+++ b/css/css-flexbox/flexbox_justifycontent-right-001-ref.html
@@ -7,30 +7,27 @@ div {
   margin: 1em 0;
   height: 4em;
   width: 40em;
-  display: flex;
-  flex-direction: row;
 }
 span {
+  display: inline-block;
   background: white;
   padding: 0 2em;
   width: 4em;
   height: 2em;
 }
-span:nth-child(1) {background: yellow;}
+span:nth-child(1) {background: yellow; margin-left: 16em;}
 span:nth-child(2) {background: pink;}
 span:nth-child(3) {background: lightblue;}
 #row-reverse span:nth-child(3) {background: yellow;}
 #row-reverse span:nth-child(1) {background: lightblue;}
 </style>
 
+<p>Test passes if the numbered boxes are placed in the top right corner of the first flex container and left-to-right order is 1, 2, 3, and placed in the top right corner of the second flexbox container and left-to-right order is 3, 2, 1.</p>
+
 <div id="row">
-  <span>one</span>
-  <span>two</span>
-  <span>three</span>
+  <span>one</span><span>two</span><span>three</span>
 </div>
 
 <div id="row-reverse">
-  <span>three</span>
-  <span>two</span>
-  <span>one</span>
+  <span>three</span><span>two</span><span>one</span>
 </div>

--- a/css/css-flexbox/flexbox_justifycontent-right-001.html
+++ b/css/css-flexbox/flexbox_justifycontent-right-001.html
@@ -27,6 +27,8 @@ span:nth-child(2) {background: pink;}
 span:nth-child(3) {background: lightblue;}
 </style>
 
+<p>Test passes if the numbered boxes are placed in the top right corner of the first flex container and left-to-right order is 1, 2, 3, and placed in the top right corner of the second flexbox container and left-to-right order is 3, 2, 1.</p>
+
 <div id="row">
   <span>one</span>
   <span>two</span>

--- a/css/css-flexbox/flexbox_justifycontent-right-001.html
+++ b/css/css-flexbox/flexbox_justifycontent-right-001.html
@@ -18,7 +18,6 @@ div + div {
 }
 span {
   background: white;
-  margin: 1px;
   padding: 0 2em;
   width: 4em;
   height: 2em;
@@ -27,8 +26,6 @@ span:nth-child(1) {background: yellow;}
 span:nth-child(2) {background: pink;}
 span:nth-child(3) {background: lightblue;}
 </style>
-
-<p>Test passes if the numbered boxes are placed in the top left corner of both flex containers, and left-to-right order is 1, 2, 3 in the first case and 3, 2, 1 in the second case.</p>
 
 <div id="row">
   <span>one</span>

--- a/css/css-flexbox/flexbox_justifycontent-right-002-ref.html
+++ b/css/css-flexbox/flexbox_justifycontent-right-002-ref.html
@@ -23,6 +23,8 @@ span:nth-child(3) {background: lightblue;}
 #column-reverse {padding-top: 4em; height: 6em;}
 </style>
 
+<p>Test passes if the numbered boxes are placed in the top left corner of the first flex container and top-to-bottom order is 1, 2, 3, and placed in the bottom left corner of the second flexbox container and top-to-bottom order is 3, 2, 1.</p>
+
 <div id="column">
   <span>one</span>
   <span>two</span>

--- a/css/css-flexbox/flexbox_justifycontent-right-002-ref.html
+++ b/css/css-flexbox/flexbox_justifycontent-right-002-ref.html
@@ -7,14 +7,10 @@ div {
   margin: 1em 0;
   width: 12em;
   height: 10em;
-  display: flex;
-  flex-direction: column;
-  justify-content: right;
 }
-
 span {
+  display: block;
   background: white;
-  margin: 1px;
   padding: 0 2em;
   width: 4em;
   height: 2em;
@@ -24,9 +20,8 @@ span:nth-child(2) {background: pink;}
 span:nth-child(3) {background: lightblue;}
 #column-reverse span:nth-child(3) {background: yellow;}
 #column-reverse span:nth-child(1) {background: lightblue;}
+#column-reverse {padding-top: 4em; height: 6em;}
 </style>
-
-<p>Test passes if the numbered boxes are placed in the top left corner of both flex containers, and top-to-bottom order is 1, 2, 3 in the first case and 3, 2, 1 in the second case.</p>
 
 <div id="column">
   <span>one</span>

--- a/css/css-flexbox/flexbox_justifycontent-right-002.html
+++ b/css/css-flexbox/flexbox_justifycontent-right-002.html
@@ -29,6 +29,8 @@ span:nth-child(2) {background: pink;}
 span:nth-child(3) {background: lightblue;}
 </style>
 
+<p>Test passes if the numbered boxes are placed in the top left corner of the first flex container and top-to-bottom order is 1, 2, 3, and placed in the bottom left corner of the second flexbox container and top-to-bottom order is 3, 2, 1.</p>
+
 <div id="column">
   <span>one</span>
   <span>two</span>

--- a/css/css-flexbox/flexbox_justifycontent-right-002.html
+++ b/css/css-flexbox/flexbox_justifycontent-right-002.html
@@ -20,7 +20,6 @@ div#column-reverse {
 }
 span {
   background: white;
-  margin: 1px;
   padding: 0 2em;
   width: 4em;
   height: 2em;
@@ -29,8 +28,6 @@ span:nth-child(1) {background: yellow;}
 span:nth-child(2) {background: pink;}
 span:nth-child(3) {background: lightblue;}
 </style>
-
-<p>Test passes if the numbered boxes are placed in the top left corner of both flex containers, and top-to-bottom order is 1, 2, 3 in the first case and 3, 2, 1 in the second case.</p>
 
 <div id="column">
   <span>one</span>


### PR DESCRIPTION
Two things needed to be fixed.  First, I realized that reftests don’t need descriptive text explaining what they should be, the reftest does that.  Second, I realized I had mistakenly pushed an earlier, incorrect version of the tests, leading to incorrect reftest results.  I’ve changed my processes to prevent such mistakes in the future.  My apologies.  Still learning!