### PR TITLE
Streams: add missing asserts in tee test

### DIFF
--- a/streams/readable-streams/tee.any.js
+++ b/streams/readable-streams/tee.any.js
@@ -232,16 +232,19 @@ promise_test(t => {
 
 }, 'ReadableStream teeing: failing to cancel the original stream should cause cancel() to reject on branches');
 
-test(() => {
+test(t => {
 
+  const theError = { name: 'You just watch yourself!' };
   let controller;
   const stream = new ReadableStream({ start(c) { controller = c; } });
   const [branch1, branch2] = stream.tee();
 
-  controller.error("error");
+  controller.error(theError);
 
-  branch1.cancel().catch(_=>_);
-  branch2.cancel().catch(_=>_);
+  return Promise.all([
+    promise_rejects_exactly(t, theError, branch1.cancel()),
+    promise_rejects_exactly(t, theError, branch2.cancel())
+  ]);
 
 }, 'ReadableStream teeing: erroring a teed stream should properly handle canceled branches');
 

--- a/streams/readable-streams/tee.any.js
+++ b/streams/readable-streams/tee.any.js
@@ -232,7 +232,7 @@ promise_test(t => {
 
 }, 'ReadableStream teeing: failing to cancel the original stream should cause cancel() to reject on branches');
 
-test(t => {
+promise_test(t => {
 
   const theError = { name: 'You just watch yourself!' };
   let controller;

--- a/streams/transform-streams/patched-global.any.js
+++ b/streams/transform-streams/patched-global.any.js
@@ -7,12 +7,14 @@
 test(t => {
   // eslint-disable-next-line no-extend-native, accessor-pairs
   Object.defineProperty(Object.prototype, 'highWaterMark', {
-    set() { throw new Error('highWaterMark setter called'); }
+    set() { throw new Error('highWaterMark setter called'); },
+    configurable: true
   });
 
   // eslint-disable-next-line no-extend-native, accessor-pairs
   Object.defineProperty(Object.prototype, 'size', {
-    set() { throw new Error('size setter called'); }
+    set() { throw new Error('size setter called'); },
+    configurable: true
   });
 
   t.add_cleanup(() => {


### PR DESCRIPTION
In [_"ReadableStream teeing: failing to cancel the original stream should cause cancel() to reject on branches"_](https://github.com/web-platform-tests/wpt/blob/e5e5e7a10cbb968b31c51ad87ce8a3da62bb1b34/streams/readable-streams/tee.any.js#L235-L246), we error the stream and then cancel both branches. However, we don't check that those `cancel()` promises are actually rejected with the stream's error.

This PR adds those missing asserts. This also ensures that implementations don't accidentally reject these promises with an unexpected reason.

Accompanies whatwg/streams#1112.