### PR TITLE
Fix input activation behavior tests to test connected inputs

### DIFF
--- a/dom/events/Event-dispatch-click.html
+++ b/dom/events/Event-dispatch-click.html
@@ -301,6 +301,7 @@ for (const type of ["checkbox", "radio"]) {
         assert_equals(input.checked, true);
         t.done();
       });
+      dump.append(input);
       input.click();
     }, `disabling ${type} in onclick listener shouldn't suppress ${handler}`);
   }


### PR DESCRIPTION
HTML requires the inputs be connected to fire input and change events. (That is already tested in [this test](https://wpt.fyi/results/dom/events/Event-dispatch-detached-input-and-change.html?label=master&label=experimental&product=chrome&product=firefox&product=safari&aligned&q=Event-dispatch-detached-input-and-change.html).)