### PR TITLE
[css-transition] Add an explicit style flush before changing a style.

### DIFF
--- a/css/css-backgrounds/animations/one-element-transition-with-delay.html
+++ b/css/css-backgrounds/animations/one-element-transition-with-delay.html
@@ -25,7 +25,10 @@
 // should be in its mid-point, that's the time we should take screenshot.
 let start_time;
 function startTransition(timestamp) {
-  document.getElementById('target').style.backgroundColor = "rgb(200, 0, 0)";
+  const target = document.getElementById('target');
+  getComputedStyle(target).backgroundColor;
+
+  target.style.backgroundColor = "rgb(200, 0, 0)";
   requestAnimationFrame(startTimer);
 }
 
@@ -42,7 +45,7 @@ function wait(timestamp) {
   takeScreenshot();
 }
 
-requestAnimationFrame(startTransition);
+startTransition();
 </script>
 </body>
 </html>


### PR DESCRIPTION
If the target transition element hasn't been styled, the new style change
will never be an after-change style, which mean the transition will
never be triggered.

Without this change, this test is very flaky on Firefox. See
https://bugzilla.mozilla.org/show_bug.cgi?id=1698486.