### PR TITLE
testdriver: Explicitly set a default for the one_realm parameter.

### DIFF
--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -159,7 +159,7 @@ For example, to send the tab key you would send "\uE004".
 
 ### set_permission
 
-Usage: `test_driver.set_permission(descriptor, state, one_realm, context=null)`
+Usage: `test_driver.set_permission(descriptor, state, one_realm=false, context=null)`
  * _descriptor_: a
    [PermissionDescriptor](https://w3c.github.io/permissions/#dictdef-permissiondescriptor)
    or derived object

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -277,7 +277,7 @@
          * @returns {Promise} fulfilled after the permission is set, or rejected if setting the
          *                    permission fails
          */
-        set_permission: function(descriptor, state, one_realm, context=null) {
+        set_permission: function(descriptor, state, one_realm=false, context=null) {
             let permission_params = {
               descriptor,
               state,


### PR DESCRIPTION
The parameter was already optional, but since it is supposed to be a boolean
it is more clear to default it to false. Doing so in the documentation also
makes it easier for API users to know that it is not always necessary to set
it.