### PR TITLE
screen wake lock: Stop setting |one_realm| in testdriver.set_permission()

### DIFF
--- a/screen-wake-lock/idlharness.https.window.js
+++ b/screen-wake-lock/idlharness.https.window.js
@@ -20,7 +20,7 @@ idl_test(
     });
 
     await test_driver.set_permission(
-        { name: 'screen-wake-lock' }, 'granted', false);
+        { name: 'screen-wake-lock' }, 'granted');
     self.sentinel = await navigator.wakeLock.request('screen');
     self.sentinel.release();
   }

--- a/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub.html
+++ b/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub.html
@@ -15,7 +15,7 @@
 
   promise_test(async t => {
     await test_driver.set_permission(
-        { name: 'screen-wake-lock' }, 'granted', false);
+        { name: 'screen-wake-lock' }, 'granted');
     await navigator.wakeLock.request('screen').then(lock => lock.release());
   }, 'Feature-Policy header {"screen-wake-lock" : ["*"]} allows the top-level document.');
 

--- a/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub.html
+++ b/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub.html
@@ -16,7 +16,7 @@
 
   promise_test(async t => {
     await test_driver.set_permission(
-        { name: 'screen-wake-lock' }, 'granted', false);
+        { name: 'screen-wake-lock' }, 'granted');
     await navigator.wakeLock.request('screen').then(lock => lock.release());
   }, 'Feature-Policy header screen-wake-lock "self" allows the top-level document.');
 

--- a/screen-wake-lock/wakelock-onrelease.https.html
+++ b/screen-wake-lock/wakelock-onrelease.https.html
@@ -6,7 +6,7 @@
 <script src="/resources/testdriver-vendor.js"></script>
 <script>
 promise_test(async t => {
-  await test_driver.set_permission({name: 'screen-wake-lock'}, 'granted', false);
+  await test_driver.set_permission({name: 'screen-wake-lock'}, 'granted');
 
   const lock = await navigator.wakeLock.request("screen");
   return new Promise(resolve => {
@@ -22,7 +22,7 @@ promise_test(async t => {
 }, "Test onreleased event's basic properties");
 
 promise_test(async t => {
-  await test_driver.set_permission({ name: 'screen-wake-lock' }, 'granted', false);
+  await test_driver.set_permission({ name: 'screen-wake-lock' }, 'granted');
 
   const lock = await navigator.wakeLock.request("screen");
 

--- a/screen-wake-lock/wakelock-released.https.html
+++ b/screen-wake-lock/wakelock-released.https.html
@@ -6,7 +6,7 @@
 <script src="/resources/testdriver-vendor.js"></script>
 <script>
 promise_test(async t => {
-  await test_driver.set_permission({ name: 'screen-wake-lock' }, 'granted', false);
+  await test_driver.set_permission({ name: 'screen-wake-lock' }, 'granted');
 
   const lock = await navigator.wakeLock.request("screen");
   assert_false(lock.released, "lock.released must be false on creation");

--- a/screen-wake-lock/wakelock-request-denied.https.html
+++ b/screen-wake-lock/wakelock-request-denied.https.html
@@ -9,7 +9,7 @@
 'use strict';
 
 promise_test(async t => {
-  await test_driver.set_permission({name: 'screen-wake-lock'}, 'denied', false);
+  await test_driver.set_permission({name: 'screen-wake-lock'}, 'denied');
   return promise_rejects_dom(t, "NotAllowedError", navigator.wakeLock.request('screen'));
 }, 'Denied requests should abort with NotAllowedError');
 </script>

--- a/screen-wake-lock/wakelock-type.https.window.js
+++ b/screen-wake-lock/wakelock-type.https.window.js
@@ -3,7 +3,7 @@
 
 promise_test(async t => {
   await test_driver.set_permission(
-      {name: 'screen-wake-lock'}, 'granted', false);
+      {name: 'screen-wake-lock'}, 'granted');
 
   const lock = await navigator.wakeLock.request();
   t.add_cleanup(() => {

--- a/screen-wake-lock/wakelockpermissiondescriptor.https.html
+++ b/screen-wake-lock/wakelockpermissiondescriptor.https.html
@@ -6,7 +6,7 @@
 <script src="/resources/testdriver-vendor.js"></script>
 <script>
 promise_test(async t => {
-  await test_driver.set_permission({name: 'screen-wake-lock'}, 'denied', false);
+  await test_driver.set_permission({name: 'screen-wake-lock'}, 'denied');
 
   return navigator.permissions.query({name:'screen-wake-lock'}).then(status => {
     assert_class_string(status, "PermissionStatus");


### PR DESCRIPTION
The parameter defaults to false, so there is no need to explicitly set it in
the tests.