### PR TITLE
[hr‑time] Use subtests for `performance‑tojson.html`

### DIFF
--- a/hr-time/performance-tojson.html
+++ b/hr-time/performance-tojson.html
@@ -16,60 +16,64 @@ test(() => {
     'performance.toJSON().timeOrigin should match performance.timeOrigin');
 
   // Check PerformanceTiming toJSON.
-  const jsonTiming = json.timing;
-  const timing = performance.timing;
-  assert_equals(typeof(timing.toJSON), 'function');
-  const timingJSON = timing.toJSON();
-  assert_equals(typeof(timingJSON), 'object');
-  // Check PerformanceTiming attributes, from both:
-  // 1) |jsonTiming| from  Performance.
-  // 2) |timingJSON| from PerformanceTiming.
-  const performanceTimingKeys = [
-    'navigationStart',
-    'unloadEventStart',
-    'unloadEventEnd',
-    'redirectStart',
-    'redirectEnd',
-    'fetchStart',
-    'domainLookupStart',
-    'domainLookupEnd',
-    'connectStart',
-    'connectEnd',
-    'secureConnectionStart',
-    'requestStart',
-    'responseStart',
-    'responseEnd',
-    'domLoading',
-    'domInteractive',
-    'domContentLoadedEventStart',
-    'domContentLoadedEventEnd',
-    'domComplete',
-    'loadEventStart',
-    'loadEventEnd'
-  ];
-  for (const key of performanceTimingKeys) {
-    assert_equals(jsonTiming[key], timing[key],
-      `performance.toJSON().timing.${key} should match performance.timing.${key}`);
-    assert_equals(timingJSON[key], timing[key],
-      `performance.timing.toJSON().${key} should match performance.timing.${key}`);
-  }
+  test(() => {
+    const jsonTiming = json.timing;
+    const timing = performance.timing;
+    assert_equals(typeof(timing.toJSON), 'function');
+    const timingJSON = timing.toJSON();
+    assert_equals(typeof(timingJSON), 'object');
+    // Check PerformanceTiming attributes, from both:
+    // 1) |jsonTiming| from Performance.
+    // 2) |timingJSON| from PerformanceTiming.
+    const performanceTimingKeys = [
+      'navigationStart',
+      'unloadEventStart',
+      'unloadEventEnd',
+      'redirectStart',
+      'redirectEnd',
+      'fetchStart',
+      'domainLookupStart',
+      'domainLookupEnd',
+      'connectStart',
+      'connectEnd',
+      'secureConnectionStart',
+      'requestStart',
+      'responseStart',
+      'responseEnd',
+      'domLoading',
+      'domInteractive',
+      'domContentLoadedEventStart',
+      'domContentLoadedEventEnd',
+      'domComplete',
+      'loadEventStart',
+      'loadEventEnd'
+    ];
+    for (const key of performanceTimingKeys) {
+      assert_equals(jsonTiming[key], timing[key],
+        `performance.toJSON().timing.${key} should match performance.timing.${key}`);
+      assert_equals(timingJSON[key], timing[key],
+        `performance.timing.toJSON().${key} should match performance.timing.${key}`);
+    }
+  }, 'Test performance.timing.toJSON()');
 
   // Check PerformanceNavigation toJSON.
-  const jsonNavigation = json.navigation;
-  const navigation = performance.navigation;
-  assert_equals(typeof(navigation.toJSON), 'function');
-  const navigationJSON = navigation.toJSON();
-  assert_equals(typeof(navigationJSON), 'object');
-  // Check PerformanceNavigation attributes, from both:
-  // 1) |jsonNavigation| from  Performance.
-  // 2) |navigationJSON| from PerformanceNavigation.
-  let performanceNavigationKeys = ['type', 'redirectCount'];
-  for (const key of performanceNavigationKeys) {
-    assert_equals(jsonNavigation[key], navigation[key],
-      `performance.toJSON().navigation.${key} should match performance.navigation.${key}`);
-    assert_equals(navigationJSON[key], navigation[key],
-      `performance.navigation.toJSON().${key} should match performance.navigation.${key}`);
-  }
+  test(() => {
+    const jsonNavigation = json.navigation;
+    const navigation = performance.navigation;
+    assert_equals(typeof(navigation.toJSON), 'function');
+    const navigationJSON = navigation.toJSON();
+    assert_equals(typeof(navigationJSON), 'object');
+    // Check PerformanceNavigation attributes, from both:
+    // 1) |jsonNavigation| from Performance.
+    // 2) |navigationJSON| from PerformanceNavigation.
+    let performanceNavigationKeys = ['type', 'redirectCount'];
+    for (const key of performanceNavigationKeys) {
+      assert_equals(jsonNavigation[key], navigation[key],
+        `performance.toJSON().navigation.${key} should match performance.navigation.${key}`);
+      assert_equals(navigationJSON[key], navigation[key],
+        `performance.navigation.toJSON().${key} should match performance.navigation.${key}`);
+    }
+  }, 'Test performance.navigation.toJSON()');
 }, 'Test performance.toJSON()');
 </script>
 </body>


### PR DESCRIPTION
This is needed by **JSDOM** so that <code>[performance‑tojson‑dont‑upstream.html](https://github.com/jsdom/jsdom/blob/03c3dd72536110b525a6616f117dee33b2e4673e/test/web-platform-tests/to-upstream/hr-time/performance-tojson-dont-upstream.html)</code> can be migrated to the subtest‑based failure tracking format: <https://github.com/jsdom/jsdom/pull/3139> and included in <https://github.com/jsdom/jsdom/pull/3156>.

---

/cc @domenic