### PR TITLE
Add FetchEvent test that should reject none Uint8Array ReadableStream.

### DIFF
--- a/service-workers/service-worker/fetch-event.https.html
+++ b/service-workers/service-worker/fetch-event.https.html
@@ -509,6 +509,32 @@ promise_test(async t => {
         'the network fallback request should include the request body');
   }, 'FetchEvent#body is a ReadableStream and is passed to network fallback');
 
+  // Test that the request body is sent to network upon network fallback,
+// for a ReadableStream body.
+promise_test(async t => {
+    const rs = new ReadableStream({start(c) {
+      c.enqueue('i a');
+      c.enqueue('m the request');
+      t.step_timeout(t.step_func(() => {
+        c.enqueue(' body');
+        c.close();
+      }, 10));
+    }});
+    // Set page_url to "?ignore" so the service worker falls back to network
+    // for the main resource request, and add a suffix to avoid colliding
+    // with other tests.
+    const page_url = 'resources/?ignore-for-request-body-fallback-string';
+    const frame = await with_iframe(page_url);
+    t.add_cleanup(() => { frame.remove(); });
+    // Add "?ignore" so the service worker falls back to echo-content.py.
+    const echo_url = '/fetch/api/resources/echo-content.py?ignore';
+    const w = frame.contentWindow;
+    await promise_rejects_js(t, w.TypeError,  w.fetch(echo_url, {
+        method: 'POST',
+        body: rs
+    }));
+  }, 'FetchEvent#body is a none Uint8Array ReadableStream and is passed to a service worker');
+
 // Test that the request body is sent to network upon network fallback even when
 // the request body is used in the service worker, for a string body.
 promise_test(async t => {


### PR DESCRIPTION
Following whatwg/fetch#267,
passing such ReadableStream to a service worker should be rejected.