### PR TITLE
Test should assert if bodiesNum is 0

### DIFF
--- a/html/syntax/parsing/template/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-body-context.html
+++ b/html/syntax/parsing/template/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-body-context.html
@@ -13,7 +13,7 @@
 <div id="log"></div>
 <script type="text/javascript">
 
-function doTest(doc, tagToTest, templateInnerHTML, id, tagName, bodiesNum, footerIsNull,
+function doTest(doc, tagToTest, templateInnerHTML, id, tagName, bodiesNum = null, footerIsNull,
         footerId, headerIsNull, headerId) {
 
     doc.body.innerHTML = '' +
@@ -51,7 +51,7 @@ function doTest(doc, tagToTest, templateInnerHTML, id, tagName, bodiesNum, foote
 
     assert_equals(table.caption, null, 'Table should have no caption');
 
-    if (bodiesNum !== null && bodiesNum !== undefined) {
+    if (bodiesNum !== null) {
         assert_equals(table.tBodies.length, bodiesNum, 'Table should have '
                 + bodiesNum + ' body');
     }

--- a/html/syntax/parsing/template/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-body-context.html
+++ b/html/syntax/parsing/template/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-body-context.html
@@ -51,7 +51,7 @@ function doTest(doc, tagToTest, templateInnerHTML, id, tagName, bodiesNum, foote
 
     assert_equals(table.caption, null, 'Table should have no caption');
 
-    if (bodiesNum) {
+    if (bodiesNum !== null && bodiesNum !== undefined) {
         assert_equals(table.tBodies.length, bodiesNum, 'Table should have '
                 + bodiesNum + ' body');
     }

--- a/html/syntax/parsing/template/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-context.html
+++ b/html/syntax/parsing/template/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-context.html
@@ -13,7 +13,7 @@
 <div id="log"></div>
 <script type="text/javascript">
 
-function doTest(doc, templateInnerHTML, id, tagName, bodiesNum, footerIsNull,
+function doTest(doc, templateInnerHTML, id, tagName, bodiesNum = null, footerIsNull,
         headerIsNull) {
 
     doc.body.innerHTML = '' +
@@ -43,7 +43,7 @@ function doTest(doc, templateInnerHTML, id, tagName, bodiesNum, footerIsNull,
     assert_equals(doc.querySelector('#tbl').caption, null, 'Table should have no caption');
     assert_equals(template.content.querySelector('#' + id).tagName, tagName,
                 'Wrong element in the template content');
-    if (bodiesNum !== null && bodiesNum !== undefined) {
+    if (bodiesNum !== null) {
         assert_equals(table.tBodies.length, bodiesNum, 'Table should have '
                 + bodiesNum + ' body');
     }

--- a/html/syntax/parsing/template/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-context.html
+++ b/html/syntax/parsing/template/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-context.html
@@ -43,7 +43,7 @@ function doTest(doc, templateInnerHTML, id, tagName, bodiesNum, footerIsNull,
     assert_equals(doc.querySelector('#tbl').caption, null, 'Table should have no caption');
     assert_equals(template.content.querySelector('#' + id).tagName, tagName,
                 'Wrong element in the template content');
-    if (bodiesNum) {
+    if (bodiesNum !== null && bodiesNum !== undefined) {
         assert_equals(table.tBodies.length, bodiesNum, 'Table should have '
                 + bodiesNum + ' body');
     }


### PR DESCRIPTION
Currently, [clearing-stack-back-to-a-table-body-context.html#L54](https://github.com/web-platform-tests/wpt/blob/master/html/syntax/parsing/template/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-body-context.html#L54) will only assert that `bodiesNum === table.tBodies.length` if `bodiesNum` is truthy, however, [clearing-stack-back-to-a-table-body-context.html#L127](https://github.com/web-platform-tests/wpt/blob/master/html/syntax/parsing/template/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-body-context.html#L127) specifies 0 for `bodiesNum`, which is falsy and we skip the assert. Presumably, we want to assert if an integer is given so we change the condition to explicitly check for `null` and `undefined` instead.

This also proactively fixes the same condition in [clearing-stack-back-to-a-table-context.html#L46](https://github.com/web-platform-tests/wpt/blob/master/html/syntax/parsing/template/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-context.html#L46)