### PR TITLE
Fix missing assert_equals

### DIFF
--- a/dom/nodes/Node-contains-xml.xml
+++ b/dom/nodes/Node-contains-xml.xml
@@ -55,7 +55,7 @@ test(function() {
   assert_equals(pi.contains(document), false, "Processing instruction shouldn't contain document");
   assert_equals(document.contains(pi), false, "Document shouldn't contain newly created processing instruction");
   document.documentElement.appendChild(pi);
-  document.contains(pi, true, "Document should contain processing instruction");
+  assert_equals(document.contains(pi), true, "Document should contain processing instruction");
 }, "contains with a processing instruction");
 
 test(function() {


### PR DESCRIPTION
[Node-contains-xml.xml#L58](https://github.com/web-platform-tests/wpt/blob/master/dom/nodes/Node-contains-xml.xml#L58) calls `document.contains()` with 3 args, which isn't correct. Presumably, the author intended to call `assert_equals()`.