### PR TITLE
Return if rangeEndpoints is a string

### DIFF
--- a/dom/ranges/Range-collapse.html
+++ b/dom/ranges/Range-collapse.html
@@ -10,20 +10,11 @@
 "use strict";
 
 function testCollapse(rangeEndpoints, toStart) {
-  var range;
-  if (rangeEndpoints == "detached") {
-    range = document.createRange();
-    range.detach(); // should be a no-op and therefore the following should not throw
-    range.collapse(toStart);
-    assert_equals(true, range.collapsed);
-    return;
-  }
-
   // Have to account for Ranges involving Documents!
   var ownerDoc = rangeEndpoints[0].nodeType == Node.DOCUMENT_NODE
     ? rangeEndpoints[0]
     : rangeEndpoints[0].ownerDocument;
-  range = ownerDoc.createRange();
+  var range = ownerDoc.createRange();
   range.setStart(rangeEndpoints[0], rangeEndpoints[1]);
   range.setEnd(rangeEndpoints[2], rangeEndpoints[3]);
 

--- a/dom/ranges/Range-collapse.html
+++ b/dom/ranges/Range-collapse.html
@@ -16,6 +16,7 @@ function testCollapse(rangeEndpoints, toStart) {
     range.detach(); // should be a no-op and therefore the following should not throw
     range.collapse(toStart);
     assert_equals(true, range.collapsed);
+    return;
   }
 
   // Have to account for Ranges involving Documents!


### PR DESCRIPTION
If `rangeEndpoints == "detached"`, then we know it's not an array. This adds a `return` since the rest of the test expects `rangeEndpoints` to be an array.