### PR TITLE
HTTP/2fy request-upload test around streaming

### DIFF
--- a/fetch/api/basic/request-upload.any.js
+++ b/fetch/api/basic/request-upload.any.js
@@ -18,17 +18,6 @@ function testUpload(desc, url, method, createBody, expectedBody) {
   }, desc);
 }
 
-function testUploadFailure(desc, url, method, createBody) {
-  const requestInit = {"method": method};
-  promise_test(t => {
-    const body = createBody();
-    if (body) {
-      requestInit["body"] = body;
-    }
-    return promise_rejects_js(t, TypeError, fetch(url, requestInit));
-  }, desc);
-}
-
 const url = RESOURCES_DIR + "echo-content.py"
 
 testUpload("Fetch with PUT with body", url,
@@ -75,56 +64,6 @@ testUpload("Fetch with POST with Blob body with mime type", url,
   "POST",
   () => new Blob(["Test"], { type: "text/maybe" }),
   "Test");
-testUpload("Fetch with POST with ReadableStream", url,
-  "POST",
-  () => {
-    return new ReadableStream({start: controller => {
-      const encoder = new TextEncoder();
-      controller.enqueue(encoder.encode("Test"));
-      controller.close();
-    }})
-  },
-  "Test");
-testUploadFailure("Fetch with POST with ReadableStream containing String", url,
-  "POST",
-  () => {
-    return new ReadableStream({start: controller => {
-      controller.enqueue("Test");
-      controller.close();
-    }})
-  });
-testUploadFailure("Fetch with POST with ReadableStream containing null", url,
-  "POST",
-  () => {
-    return new ReadableStream({start: controller => {
-      controller.enqueue(null);
-      controller.close();
-    }})
-  });
-testUploadFailure("Fetch with POST with ReadableStream containing number", url,
-  "POST",
-  () => {
-    return new ReadableStream({start: controller => {
-      controller.enqueue(99);
-      controller.close();
-    }})
-  });
-testUploadFailure("Fetch with POST with ReadableStream containing ArrayBuffer", url,
-  "POST",
-  () => {
-    return new ReadableStream({start: controller => {
-      controller.enqueue(new ArrayBuffer());
-      controller.close();
-    }})
-  });
-testUploadFailure("Fetch with POST with ReadableStream containing Blob", url,
-  "POST",
-  () => {
-    return new ReadableStream({start: controller => {
-      controller.enqueue(new Blob());
-      controller.close();
-    }})
-  });
 
 promise_test(async (test) => {
   const resp = await fetch(

--- a/fetch/api/basic/request-upload.h2.any.js
+++ b/fetch/api/basic/request-upload.h2.any.js
@@ -1,0 +1,83 @@
+// META: global=window,worker
+// META: script=../resources/utils.js
+// META: script=/common/utils.js
+// META: script=/common/get-host-info.sub.js
+
+function testUpload(desc, url, method, createBody, expectedBody) {
+  const requestInit = {"method": method}
+  promise_test(function(test){
+    const body = createBody();
+    if (body) {
+      requestInit["body"] = body;
+    }
+    return fetch(url, requestInit).then(function(resp) {
+      return resp.text().then((text)=> {
+        assert_equals(text, expectedBody);
+      });
+    });
+  }, desc);
+}
+
+function testUploadFailure(desc, url, method, createBody) {
+  const requestInit = {"method": method};
+  promise_test(t => {
+    const body = createBody();
+    if (body) {
+      requestInit["body"] = body;
+    }
+    return promise_rejects_js(t, TypeError, fetch(url, requestInit));
+  }, desc);
+}
+
+const url = RESOURCES_DIR + "echo-content.h2.py"
+
+testUpload("Fetch with POST with ReadableStream", url,
+  "POST",
+  () => {
+    return new ReadableStream({start: controller => {
+      const encoder = new TextEncoder();
+      controller.enqueue(encoder.encode("Test"));
+      controller.close();
+    }})
+  },
+  "Test");
+testUploadFailure("Fetch with POST with ReadableStream containing String", url,
+  "POST",
+  () => {
+    return new ReadableStream({start: controller => {
+      controller.enqueue("Test");
+      controller.close();
+    }})
+  });
+testUploadFailure("Fetch with POST with ReadableStream containing null", url,
+  "POST",
+  () => {
+    return new ReadableStream({start: controller => {
+      controller.enqueue(null);
+      controller.close();
+    }})
+  });
+testUploadFailure("Fetch with POST with ReadableStream containing number", url,
+  "POST",
+  () => {
+    return new ReadableStream({start: controller => {
+      controller.enqueue(99);
+      controller.close();
+    }})
+  });
+testUploadFailure("Fetch with POST with ReadableStream containing ArrayBuffer", url,
+  "POST",
+  () => {
+    return new ReadableStream({start: controller => {
+      controller.enqueue(new ArrayBuffer());
+      controller.close();
+    }})
+  });
+testUploadFailure("Fetch with POST with ReadableStream containing Blob", url,
+  "POST",
+  () => {
+    return new ReadableStream({start: controller => {
+      controller.enqueue(new Blob());
+      controller.close();
+    }})
+  });

--- a/fetch/api/basic/request-upload.h2.any.js
+++ b/fetch/api/basic/request-upload.h2.any.js
@@ -4,32 +4,28 @@
 // META: script=/common/get-host-info.sub.js
 
 function testUpload(desc, url, method, createBody, expectedBody) {
-  const requestInit = {"method": method}
-  promise_test(function(test){
+  const requestInit = {method};
+  promise_test(async function(){
     const body = createBody();
     if (body) {
       requestInit["body"] = body;
     }
-    return fetch(url, requestInit).then(function(resp) {
-      return resp.text().then((text)=> {
-        assert_equals(text, expectedBody);
-      });
-    });
-  }, desc);
-}
-
-function testUploadFailure(desc, url, method, createBody) {
-  const requestInit = {"method": method};
-  promise_test(t => {
-    const body = createBody();
-    if (body) {
-      requestInit["body"] = body;
-    }
-    return promise_rejects_js(t, TypeError, fetch(url, requestInit));
+    const resp = await fetch(url, requestInit);
+    const text = await resp.text();
+    assert_equals(text, expectedBody);
   }, desc);
 }
 
 const url = RESOURCES_DIR + "echo-content.h2.py"
+
+testUpload("Fetch with POST with empty ReadableStream", url,
+  "POST",
+  () => {
+    return new ReadableStream({start: controller => {
+      controller.close();
+    }})
+  },
+  "");
 
 testUpload("Fetch with POST with ReadableStream", url,
   "POST",
@@ -41,43 +37,3 @@ testUpload("Fetch with POST with ReadableStream", url,
     }})
   },
   "Test");
-testUploadFailure("Fetch with POST with ReadableStream containing String", url,
-  "POST",
-  () => {
-    return new ReadableStream({start: controller => {
-      controller.enqueue("Test");
-      controller.close();
-    }})
-  });
-testUploadFailure("Fetch with POST with ReadableStream containing null", url,
-  "POST",
-  () => {
-    return new ReadableStream({start: controller => {
-      controller.enqueue(null);
-      controller.close();
-    }})
-  });
-testUploadFailure("Fetch with POST with ReadableStream containing number", url,
-  "POST",
-  () => {
-    return new ReadableStream({start: controller => {
-      controller.enqueue(99);
-      controller.close();
-    }})
-  });
-testUploadFailure("Fetch with POST with ReadableStream containing ArrayBuffer", url,
-  "POST",
-  () => {
-    return new ReadableStream({start: controller => {
-      controller.enqueue(new ArrayBuffer());
-      controller.close();
-    }})
-  });
-testUploadFailure("Fetch with POST with ReadableStream containing Blob", url,
-  "POST",
-  () => {
-    return new ReadableStream({start: controller => {
-      controller.enqueue(new Blob());
-      controller.close();
-    }})
-  });

--- a/fetch/api/resources/echo-content.h2.py
+++ b/fetch/api/resources/echo-content.h2.py
@@ -1,0 +1,9 @@
+from wptserve.utils import isomorphic_encode
+
+def handle_headers(frame, request, response):
+    response.status = 200
+    response.headers.update([('Content-Type', 'text/plain')])
+    response.write_status_headers()
+
+def handle_data(frame, request, response):
+    response.writer.write_data(frame.data)


### PR DESCRIPTION
That's because wpt h1 server doesn't support chunked encoding but h2 supports it natively.
Related thread: https://github.com/whatwg/fetch/issues/966