### PR TITLE
[Taskcluster] pin Chrome Dev to 91.0.4449.6

### DIFF
--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -137,8 +137,12 @@ def install_certificates():
 
 
 def install_chrome(channel):
+    deb_prefix = "https://dl.google.com/linux/direct/"
     if channel in ("experimental", "dev"):
-        deb_archive = "google-chrome-unstable_current_amd64.deb"
+        # Pinned since 91.0.4455.2-1 began crashing on startup.
+        # See https://github.com/web-platform-tests/wpt/issues/28209.
+        deb_archive = "google-chrome-unstable_91.0.4449.6-1_amd64.deb"
+        deb_prefix = "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/"
     elif channel == "beta":
         deb_archive = "google-chrome-beta_current_amd64.deb"
     elif channel == "stable":
@@ -147,7 +151,7 @@ def install_chrome(channel):
         raise ValueError("Unrecognized release channel: %s" % channel)
 
     dest = os.path.join("/tmp", deb_archive)
-    deb_url = "https://dl.google.com/linux/direct/%s" % deb_archive
+    deb_url = deb_prefix + deb_archive
     with open(dest, "wb") as f:
         get_download_to_descriptor(f, deb_url)
 


### PR DESCRIPTION
This is a temporary measure while the cause of the crash is being
investigated. This follows a similar approach taken before:
https://github.com/web-platform-tests/wpt/pull/19360

Mitigation (not fix) for https://github.com/web-platform-tests/wpt/issues/28209.