### PR TITLE
HTML: Test ordering of COEP reporting vs CSP and X-Frame-Options

### DIFF
--- a/html/cross-origin-embedder-policy/reporting-navigation.https.html
+++ b/html/cross-origin-embedder-policy/reporting-navigation.https.html
@@ -12,6 +12,10 @@ const COEP_RO =
   '|header(cross-origin-embedder-policy-report-only,require-corp)';
 const CORP_CROSS_ORIGIN =
   '|header(cross-origin-resource-policy,cross-origin)';
+const CSP_FRAME_ANCESTORS_NONE =
+  '|header(content-security-policy,frame-ancestors \'none\')';
+const XFRAMEOPTIONS_DENY =
+  '|header(x-frame-options,deny)';
 const FRAME_URL = `${ORIGIN}/common/blank.html?pipe=`;
 const REMOTE_FRAME_URL = `${REMOTE_ORIGIN}/common/blank.html?pipe=`;
 
@@ -103,6 +107,10 @@ const CASES = [
   { parent: COEP_RO, target: COEP + CORP_CROSS_ORIGIN, reports: [] },
 
   { parent: COEP, target: COEP_RO + CORP_CROSS_ORIGIN, reports: ['NAV'] },
+
+  // Test ordering of CSP frame-ancestors, COEP, and X-Frame-Options
+  { parent: COEP, target: CORP_CROSS_ORIGIN + CSP_FRAME_ANCESTORS_NONE, reports: [] },
+  { parent: COEP, target: CORP_CROSS_ORIGIN + XFRAMEOPTIONS_DENY, reports: ['NAV'] },
 ];
 
 for (const testcase of CASES) {


### PR DESCRIPTION
See https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response step 4

Chromium seems to issue the COEP report even when CSP blocks the response. Is that right? Should the spec have a different order of these checks, such that COEP is checked first? or checked unconditionally?