### PR TITLE
The `left` and `top` keywords should not appear in the computed style for `background-position`

### DIFF
--- a/css/css-pseudo/first-letter-allowed-properties.html
+++ b/css/css-pseudo/first-letter-allowed-properties.html
@@ -28,7 +28,7 @@ var validProperties = {
   backgroundColor: 'rgb(10, 20, 30)',
   backgroundImage: 'linear-gradient(rgb(0, 0, 0), rgb(255, 255, 255))',
   backgroundOrigin: 'border-box',
-  backgroundPosition: 'left 10px top 20px',
+  backgroundPosition: '10px 20px',
   backgroundRepeat: 'no-repeat',
   backgroundSize: '10px 20px',
   border: '40px dotted rgb(10, 20, 30)',


### PR DESCRIPTION
This test uses the same string to set a given property to a given value and read back from computed style for that value to be returned as-is. However, in the case of `background-position`, the `top` and `left` keywords will be dropped in the computed style since it is not the shortest notation.

Per the [current WPT.fyi results](https://wpt.fyi/results/css/css-pseudo/first-letter-allowed-properties.html?label=experimental&label=master&aligned) Firefox agrees with this but Chrome and Safari do not. However, Safari will get the same behavior as Firefox once the fix for [bug 223878](https://bugs.webkit.org/show_bug.cgi?id=223878) lands. But with this change, all three browsers will agree.