### PR TITLE
COEP reporting: test HTTP SF parsing with multiple headers

### DIFF
--- a/html/cross-origin-embedder-policy/header-parsing.https.html
+++ b/html/cross-origin-embedder-policy/header-parsing.https.html
@@ -70,6 +70,7 @@ function createIframe(t, values) {
   ['require-corp\t '],
   ['require-corp; foo=bar'],
   ['require-corp;require-corp'],
+  ['require-corp; report-to="data:', '"'], // `require-corp; report-to="data:, "`
 
 ].forEach((values) => {
   promise_test((t) => {

--- a/html/cross-origin-embedder-policy/reporting-to-endpoint.https.html
+++ b/html/cross-origin-embedder-policy/reporting-to-endpoint.https.html
@@ -152,4 +152,27 @@ promise_test(async (t) => {
     'report-only-endpoint', targetUrl, iframe.src, 'reporting');
 }, 'COEP violation on nested frame navigation');
 
+promise_test(async (t) => {
+  const iframe = document.createElement('iframe');
+  t.add_cleanup(() => iframe.remove());
+
+  iframe.src = 'resources/reporting-empty-frame-multiple-headers.html.asis';
+  const targetUrl = `/common/blank.html?${token()}`;
+
+  iframe.addEventListener('load', t.step_func(() => {
+    const nested = iframe.contentDocument.createElement('iframe');
+    nested.src = targetUrl;
+    // |nested| doesn't have COEP whereas |iframe| has, so it is blocked.
+    iframe.contentDocument.body.appendChild(nested);
+  }), {once: true});
+
+  document.body.appendChild(iframe);
+
+  await checkNavigationReportExistence(
+      'endpoint', targetUrl, iframe.src, 'enforce');
+  await checkNavigationReportExistence(
+    'report-only-endpoint', targetUrl, iframe.src, 'reporting');
+
+}, 'Two COEP headers, split inside report-to value');
+
 </script>

--- a/html/cross-origin-embedder-policy/resources/reporting-empty-frame-multiple-headers.html.asis
+++ b/html/cross-origin-embedder-policy/resources/reporting-empty-frame-multiple-headers.html.asis
@@ -1,0 +1,9 @@
+HTTP/1.1 200 OK
+Content-Type: text/html
+cross-origin-embedder-policy: require-corp; foo="
+cross-origin-embedder-policy: "; report-to="endpoint"
+cross-origin-embedder-policy-report-only: require-corp; foo="
+cross-origin-embedder-policy-report-only: "; report-to="report-only-endpoint"
+
+<!doctype html>
+<meta charset="utf-8">


### PR DESCRIPTION
See https://fetch.spec.whatwg.org/#concept-header-list-get-structured-header

which calls https://fetch.spec.whatwg.org/#concept-header-list-get

> Return the values of all headers in list whose name is a byte-case-insensitive match for name, separated from each other by 0x2C 0x20, in order.

i.e., this:
```
cross-origin-embedder-policy: require-corp; foo="
cross-origin-embedder-policy: "; report-to="endpoint"
```
is equivalent to
```
cross-origin-embedder-policy: require-corp; foo=", "; report-to="endpoint"
```

Chrome passes the test, so it appears to implement this as the Fetch spec says.