### PR TITLE
Test control characters in Set-Cookie header values

### DIFF
--- a/cookies/bytes.window.js
+++ b/cookies/bytes.window.js
@@ -4,15 +4,42 @@ promise_test(async t => {
   assert_equals(await response.text(), "set");
   response = await fetch("resources/bytes.py?get");
   const get = await response.text();
-  const expected = "cookiesarebananas%3D%FFtest%FF"
+  const expected = "cookiesarebananas%3D%FFtest_utf8%FF"
   assert_equals(get.search(expected), 0, `Needs to contain ${expected} but did not. Full value: ${get}`);
 }, "Cookie containing non-UTF-8 bytes");
 promise_test(async t => {
   t.add_cleanup(async () => { await fetch("resources/bytes.py?delete") });
-  let response = await fetch("resources/bytes.py?set_ctl");
-  assert_equals(await response.text(), "set_ctl");
-  response = await fetch("resources/bytes.py?get_ctl");
+  let response = await fetch("resources/bytes.py?set_CR");
+  assert_equals(await response.text(), "set_CR");
+  response = await fetch("resources/bytes.py?get");
   const get = await response.text();
   const expected = "cookiesarebananas%3D"
   assert_equals(get.search(expected), 0, `Needs to contain ${expected} but did not. Full value: ${get}`);
-}, "Cookie containing control characters");
+}, "Cookie containing CR should be truncated");
+promise_test(async t => {
+  t.add_cleanup(async () => { await fetch("resources/bytes.py?delete") });
+  let response = await fetch("resources/bytes.py?set_LF");
+  assert_equals(await response.text(), "set_LF");
+  response = await fetch("resources/bytes.py?get");
+  const get = await response.text();
+  const expected = "cookiesarebananas%3D"
+  assert_equals(get.search(expected), 0, `Needs to contain ${expected} but did not. Full value: ${get}`);
+}, "Cookie containing LF should be truncated");
+promise_test(async t => {
+  t.add_cleanup(async () => { await fetch("resources/bytes.py?delete") });
+  let response = await fetch("resources/bytes.py?set_NUL");
+  assert_equals(await response.text(), "set_NUL");
+  response = await fetch("resources/bytes.py?get");
+  const get = await response.text();
+  const expected = "cookiesarebananas%3D"
+  assert_equals(get.search(expected), 0, `Needs to contain ${expected} but did not. Full value: ${get}`);
+}, "Cookie containing NUL should be truncated");
+promise_test(async t => {
+  t.add_cleanup(async () => { await fetch("resources/bytes.py?delete") });
+  let response = await fetch("resources/bytes.py?set_CTL");
+  assert_equals(await response.text(), "set_CTL");
+  response = await fetch("resources/bytes.py?get");
+  const get = await response.text();
+  const expected = "EMPTY";
+  assert_equals(get.search(expected), 0, `Needs to contain ${expected} but did not. Full value: ${get}`);
+}, "Cookie containing CTL char other than CR, LF, or NUL should be rejected");

--- a/cookies/bytes.window.js
+++ b/cookies/bytes.window.js
@@ -7,3 +7,12 @@ promise_test(async t => {
   const expected = "cookiesarebananas%3D%FFtest%FF"
   assert_equals(get.search(expected), 0, `Needs to contain ${expected} but did not. Full value: ${get}`);
 }, "Cookie containing non-UTF-8 bytes");
+promise_test(async t => {
+  t.add_cleanup(async () => { await fetch("resources/bytes.py?delete") });
+  let response = await fetch("resources/bytes.py?set_ctl");
+  assert_equals(await response.text(), "set_ctl");
+  response = await fetch("resources/bytes.py?get_ctl");
+  const get = await response.text();
+  const expected = "cookiesarebananas%3D"
+  assert_equals(get.search(expected), 0, `Needs to contain ${expected} but did not. Full value: ${get}`);
+}, "Cookie containing control characters");

--- a/cookies/resources/bytes.py
+++ b/cookies/resources/bytes.py
@@ -6,6 +6,11 @@ def main(request, response):
         response.content = "set"
     elif b"get" in request.GET:
         response.content = quote(request.headers[b"Cookie"])
+    elif b"set_ctl" in request.GET:
+        response.headers.append(b"Set-Cookie", b"cookiesarebananas=\x0Dtest\x0C")
+        response.content = "set_ctl"
+    elif b"get_ctl" in request.GET:
+        response.content = quote(request.headers[b"Cookie"])
     elif b"delete" in request.GET:
         response.headers.append(b"Set-Cookie", b"cookiesarebananas=meh;Max-Age=0")
         response.content = "delete"

--- a/cookies/resources/bytes.py
+++ b/cookies/resources/bytes.py
@@ -1,18 +1,32 @@
 from six.moves.urllib.parse import quote
 
+
 def main(request, response):
     if b"set" in request.GET:
-        response.headers.append(b"Set-Cookie", b"cookiesarebananas=\xFFtest\xFF")
+        response.headers.append(
+            b"Set-Cookie", b"cookiesarebananas=\xFFtest_utf8\xFF")
         response.content = "set"
+    elif b"set_CR" in request.GET:
+        response.headers.append(
+            b"Set-Cookie", b"cookiesarebananas=\x0Dtest_cr")
+        response.content = "set_CR"
+    elif b"set_LF" in request.GET:
+        response.headers.append(
+            b"Set-Cookie", b"cookiesarebananas=\x0Atest_lf")
+        response.content = "set_LF"
+    elif b"set_NUL" in request.GET:
+        response.headers.append(
+            b"Set-Cookie", b"cookiesarebananas=\x00test_ nul")
+        response.content = "set_NUL"
+    elif b"set_CTL" in request.GET:
+        response.headers.append(
+            b"Set-Cookie", b"cookiesarebananas=\x0Ctest_ctl")
+        response.content = "set_CTL"
     elif b"get" in request.GET:
-        response.content = quote(request.headers[b"Cookie"])
-    elif b"set_ctl" in request.GET:
-        response.headers.append(b"Set-Cookie", b"cookiesarebananas=\x0Dtest\x0C")
-        response.content = "set_ctl"
-    elif b"get_ctl" in request.GET:
-        response.content = quote(request.headers[b"Cookie"])
+        response.content = quote(request.headers.get(b"Cookie", "EMPTY"))
     elif b"delete" in request.GET:
-        response.headers.append(b"Set-Cookie", b"cookiesarebananas=meh;Max-Age=0")
+        response.headers.append(
+            b"Set-Cookie", b"cookiesarebananas=meh;Max-Age=0")
         response.content = "delete"
 
     response.headers.append(b"Content-Type", b"text/plain")


### PR DESCRIPTION
Adding to #26170. I didn't see any tests for control characters in set-cookie headers, but would like some to verify changes we're making in https://github.com/httpwg/http-extensions/pull/1420. This can be merged into Anne's PR.

@annevk PTAL