### PR TITLE
Reporting API: test webidl conversion of 'types' member

### DIFF
--- a/reporting/ReportingObserverOptions-types.html
+++ b/reporting/ReportingObserverOptions-types.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<meta charset=utf-8>
+<title>ReportingObserverOptions: types member</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  test(() => {
+    const expectedException = {}
+    assert_throws_exactly(expectedException, () => {
+      new ReportingObserver(() => {}, { types: { *[Symbol.iterator]() { throw expectedException; } } });
+    });
+  }, "iterator that throws in `types`");
+
+  test(() => {
+    const expectedException = {}
+    assert_throws_exactly(expectedException, () => {
+      new ReportingObserver(() => {}, { types: [ { valueOf: () => { throw expectedException; } } ] });
+    });
+  }, "object that throws when getting `valueOf` in `types` array");
+</script>
+</body>
+</html>

--- a/reporting/idlharness.any.js
+++ b/reporting/idlharness.any.js
@@ -8,7 +8,9 @@ idl_test(
   [],
   idl_array => {
     idl_array.add_objects({
-      // TODO: objects
+      ReportBody: [],
+      Report: [],
+      ReportingObserver: ['new ReportingObserver((reports, observer) => {})'],
     });
   }
 );


### PR DESCRIPTION
Also add objects to test in idlharness.any.js