### PR TITLE
[META] Update URL of WebCodecs spec

### DIFF
--- a/webcodecs/META.yml
+++ b/webcodecs/META.yml
@@ -1,1 +1,1 @@
-spec: https://wicg.github.io/web-codecs/
+spec: https://w3c.github.io/webcodecs/


### PR DESCRIPTION
Repo migrated from WICG to W3C org, and renamed.