### PR TITLE
Fix false-positive test in firefox

### DIFF
--- a/density-size-correction/density-corrected-size-pseudo-elements-ref.html
+++ b/density-size-correction/density-corrected-size-pseudo-elements-ref.html
@@ -5,6 +5,6 @@
 </head>
 <body>
     <div><img src="resources/exif-resolution-valid-lores.jpg" width="200" height="100"></div>
-    <div><img src="resources/resources/exif-resolution-none.jpg"></div>
+    <div><img src="resources/exif-resolution-none.jpg"></div>
 </body>
 </html>

--- a/density-size-correction/density-corrected-size-pseudo-elements-ref.html
+++ b/density-size-correction/density-corrected-size-pseudo-elements-ref.html
@@ -4,15 +4,7 @@
     <link rel="author" title="Noam Rosenthal" href="noam@webkit.org">
 </head>
 <body>
-    <style>
-        body {
-            --lores: url(resources/exif-resolution-valid-lores.jpg);
-            --default: url(resources/exif-resolution-none.jpg);
-        }
-        .lores-after::after {content: var(--lores); width: 200px; height: 100px; }
-        .default-after::after {content: var(--default); }
-    </style>
-    <div class="lores-after box"></div>
-    <div class="default-after box"></div>
+    <div><img src="resources/exif-resolution-valid-lores.jpg" width="200" height="100"></div>
+    <div><img src="resources/resources/exif-resolution-none.jpg"></div>
 </body>
 </html>


### PR DESCRIPTION
The https://wpt.fyi/results/density-size-correction/density-corrected-size-pseudo-elements.html test currently passes in Firefox, even though the feature is not supported.

This is because `width: 200px; height: 100px;` from the reference file has no effect.

I think using `<img>` elements for the reference file should be more robust.