### PR TITLE
`font-stretch` should use keywords for computed style when possible

### DIFF
--- a/css/css-fonts/animations/font-stretch-interpolation.html
+++ b/css/css-fonts/animations/font-stretch-interpolation.html
@@ -155,10 +155,10 @@ test(t => {
   var anim = target.animate({fontStretch: ['normal', 'inherit']}, 1000);
   anim.pause();
   anim.currentTime = 500;
-  assert_equals(getComputedStyle(target).fontStretch, '150%');
+  assert_equals(getComputedStyle(target).fontStretch, 'extra-expanded');
 
   container.setAttribute('class', 'container2');
-  assert_equals(getComputedStyle(target).fontStretch, '75%');
+  assert_equals(getComputedStyle(target).fontStretch, 'condensed');
 }, "An interpolation to inherit updates correctly on a parent style change.");
 
 </script>


### PR DESCRIPTION
According to the [css-fonts-4 definition for `font-stretch`](https://drafts.csswg.org/css-fonts-4/#propdef-font-stretch):

> For compatibility with [CSS-FONTS-3], `getComputedStyle()` serializes values that correspond to one of the `font-stretch` keywords as that keyword (instead of as a `<percentage>`).

Given that `150%` matches [`extra-expanded`](https://drafts.csswg.org/css-fonts-4/#valdef-font-stretch-extra-expanded) and `75%` matches [`condensed`](https://drafts.csswg.org/css-fonts-4/#valdef-font-stretch-condensed), these keywords should be the expected values reported by the computed style in those tests.

Note that this makes this test fail in Firefox and Chrome which both return `<percentage>`, while Safari will only pass the first of the two assertions.