### PR TITLE
Make overflow-padding.html work with overlay scrollbars

### DIFF
--- a/css/css-overflow/overflow-padding.html
+++ b/css/css-overflow/overflow-padding.html
@@ -84,10 +84,10 @@
 </div>
 <script>
   function hasHorizontalScrollbar(el) {
-    return (el.offsetHeight - el.clientHeight) > 0;
+    return (el.scrollWidth - el.offsetWidth) > 0;
   }
   function hasVerticalScrollbar(el) {
-    return (el.offsetWidth - el.clientWidth) > 0;
+    return (el.scrollHeight - el.offsetHeight) > 0;
   }
   // Tests needs to be run after load.
   function runTest() {


### PR DESCRIPTION
The old helpers assume the scrollbars occupied spaces, so they don't
work on platforms having overlay scrollbars like Android.