### PR TITLE
[css-flexbox] Margin collapsing bug in WebKit preventing some flexbox tests from succeeding

### DIFF
--- a/css/css-flexbox/flexbox-writing-mode-013-ref.html
+++ b/css/css-flexbox/flexbox-writing-mode-013-ref.html
@@ -33,6 +33,8 @@
     display: block;
     overflow: hidden;
     height: 0;
+    /* Hack to prevent WebKit from collapsing margins. See https://wkb.ug/224185 */
+    padding-block: 0.05px;
   }
   .small { font: 12px Ahem; }
   .big   { font: 20px Ahem; }

--- a/css/css-flexbox/flexbox-writing-mode-014-ref.html
+++ b/css/css-flexbox/flexbox-writing-mode-014-ref.html
@@ -32,6 +32,8 @@
     display: block;
     overflow: hidden;
     height: 0;
+    /* Hack to prevent WebKit from collapsing margins. See https://wkb.ug/224185 */
+    padding-block: 0.05px;
   }
   .small { font: 12px Ahem; }
   .big   { font: 20px Ahem; }

--- a/css/css-flexbox/flexbox-writing-mode-015-ref.html
+++ b/css/css-flexbox/flexbox-writing-mode-015-ref.html
@@ -32,6 +32,8 @@
     display: block;
     overflow: hidden;
     height: 0;
+    /* Hack to prevent WebKit from collapsing margins. See https://wkb.ug/224185 */
+    padding-block: 0.05px;
   }
   .small { font: 12px Ahem; }
   .big   { font: 20px Ahem; }


### PR DESCRIPTION
There are three flexbox tests `flexbox-writing-modes-{013|014|015}` that are rendered perfectly by WebKit but still fail. The problem is in the reference tests used. They use a special `<nocollapse>` element with `overflow:hidden` that prevents margin collapsing from happening. However due to [this bug](https://wkb.ug/224185) that is not working properly for WebKit.

I'm adding a subpixel layout hack that prevents margin collapsing from happening without affecting the rendered content at least until the WebKit bug is not fixed.
