### PR TITLE
Revert "[css-flexbox] Margin collapsing bug in WebKit preventing some flexbox tests from succeeding (#28368)"

### DIFF
--- a/css/css-flexbox/flexbox-writing-mode-013-ref.html
+++ b/css/css-flexbox/flexbox-writing-mode-013-ref.html
@@ -33,8 +33,6 @@
     display: block;
     overflow: hidden;
     height: 0;
-    /* Hack to prevent WebKit from collapsing margins. See https://wkb.ug/224185 */
-    padding-block: 0.05px;
   }
   .small { font: 12px Ahem; }
   .big   { font: 20px Ahem; }

--- a/css/css-flexbox/flexbox-writing-mode-014-ref.html
+++ b/css/css-flexbox/flexbox-writing-mode-014-ref.html
@@ -32,8 +32,6 @@
     display: block;
     overflow: hidden;
     height: 0;
-    /* Hack to prevent WebKit from collapsing margins. See https://wkb.ug/224185 */
-    padding-block: 0.05px;
   }
   .small { font: 12px Ahem; }
   .big   { font: 20px Ahem; }

--- a/css/css-flexbox/flexbox-writing-mode-015-ref.html
+++ b/css/css-flexbox/flexbox-writing-mode-015-ref.html
@@ -32,8 +32,6 @@
     display: block;
     overflow: hidden;
     height: 0;
-    /* Hack to prevent WebKit from collapsing margins. See https://wkb.ug/224185 */
-    padding-block: 0.05px;
   }
   .small { font: 12px Ahem; }
   .big   { font: 20px Ahem; }


### PR DESCRIPTION
This reverts commit 33f6a9c72d11a1629d4afa561a83bdf07bf57e89.

All the other engines started to fail after adding the WebKit hack. What's more the hack was working fine for WebKitGtk+ but not for Safari for example. So I'll just revert it and focus on fixing the WebKit bug.