### PR TITLE
chore: move FileAPI/reading-data-section to any.js

### DIFF
--- a/FileAPI/reading-data-section/Determining-Encoding.any.js
+++ b/FileAPI/reading-data-section/Determining-Encoding.any.js
@@ -1,13 +1,5 @@
-<!DOCTYPE html>
-<meta charset=utf-8>
-<title>FileAPI Test: Blob Determining Encoding</title>
-<link ref="author" title="march1993" href="mailto:march511@gmail.com">
-<link rel=help href="http://dev.w3.org/2006/webapi/FileAPI/#enctype">
-<link rel=help href="http://encoding.spec.whatwg.org/#decode">
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<div id="log"></div>
-<script>
+// META: title=FileAPI Test: Blob Determining Encoding
+
 var t = async_test("Blob Determing Encoding with encoding argument");
 t.step(function() {
     // string 'hello'
@@ -87,5 +79,3 @@ t.step(function() {
 
     reader.readAsText(blob);
 });
-
-</script>

--- a/FileAPI/reading-data-section/FileReader-event-handler-attributes.any.js
+++ b/FileAPI/reading-data-section/FileReader-event-handler-attributes.any.js
@@ -1,10 +1,5 @@
-<!doctype html>
-<meta charset="utf-8">
-<title>FileReader event handler attributes</title>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<div id=log></div>
-<script>
+// META: title=FileReader event handler attributes
+
 var attributes = [
   "onloadstart",
   "onprogress",
@@ -20,4 +15,3 @@ attributes.forEach(function(a) {
                   "event handler attribute should initially be null");
   }, "FileReader." + a + ": initial value");
 });
-</script>

--- a/FileAPI/reading-data-section/FileReader-multiple-reads.any.js
+++ b/FileAPI/reading-data-section/FileReader-multiple-reads.any.js
@@ -1,11 +1,5 @@
-﻿<!DOCTYPE html>
-<title>FileReader: starting new reads while one is in progress</title>
-<link rel="author" title="Yinkan Li" href="mailto:liyinkan.biz@gmail.com">
-<link rel="help" href="http://dev.w3.org/2006/webapi/FileAPI/#MultipleReads">
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<div id="log"></div>
-<script>
+// META: title=FileReader: starting new reads while one is in progress
+
 test(function() {
   var blob_1 = new Blob(['TEST000000001'])
   var blob_2 = new Blob(['TEST000000002'])
@@ -85,5 +79,3 @@ async_test(function() {
   });
   reader.readAsText(blob_1);
 }, 'test abort and restart in onloadstart event for readAsText');
-
-</script>

--- a/FileAPI/reading-data-section/filereader_abort.any.js
+++ b/FileAPI/reading-data-section/filereader_abort.any.js
@@ -1,17 +1,5 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>FileAPI Test: filereader_abort</title>
-    <link rel="author" title="Intel" href="http://www.intel.com">
-    <link rel="help" href="http://dev.w3.org/2006/webapi/FileAPI/#abort">
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-  </head>
-  <body>
-    <div id="log"></div>
+// META: title=FileAPI Test: filereader_abort
 
-    <script>
     test(function() {
       var readerNoRead = new FileReader();
       readerNoRead.abort();
@@ -48,6 +36,3 @@
               assert_equals(readerAbort.readyState, readerAbort.DONE);
             });
       }, "Aborting after read");
-    </script>
-  </body>
-</html>

--- a/FileAPI/reading-data-section/filereader_error.any.js
+++ b/FileAPI/reading-data-section/filereader_error.any.js
@@ -1,18 +1,5 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>FileAPI Test: filereader_error</title>
-    <link rel="author" title="Intel" href="http://www.intel.com">
-    <link rel="help" href="http://dev.w3.org/2006/webapi/FileAPI/#dfn-domerror">
-    <link rel="help" href="http://dev.w3.org/2006/webapi/FileAPI/#abort">
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-  </head>
-  <body>
-    <div id="log"></div>
+// META: title=FileAPI Test: filereader_error
 
-    <script>
     async_test(function() {
       var blob = new Blob(["TEST THE ERROR ATTRIBUTE AND ERROR EVENT"]);
       var reader = new FileReader();
@@ -30,6 +17,3 @@
       reader.readAsText(blob);
       reader.abort();
     });
-    </script>
-  </body>
-</html>

--- a/FileAPI/reading-data-section/filereader_readAsArrayBuffer.any.js
+++ b/FileAPI/reading-data-section/filereader_readAsArrayBuffer.any.js
@@ -1,17 +1,5 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>FileAPI Test: filereader_readAsArrayBuffer</title>
-    <link rel="author" title="Intel" href="http://www.intel.com">
-    <link rel="help" href="http://dev.w3.org/2006/webapi/FileAPI/#readAsArrayBuffer">
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-  </head>
-  <body>
-    <div id="log"></div>
+// META: title=FileAPI Test: filereader_readAsArrayBuffer
 
-    <script>
     async_test(function() {
       var blob = new Blob(["TEST"]);
       var reader = new FileReader();
@@ -33,6 +21,3 @@
 
       reader.readAsArrayBuffer(blob);
     });
-    </script>
-  </body>
-</html>

--- a/FileAPI/reading-data-section/filereader_readAsBinaryString.any.js
+++ b/FileAPI/reading-data-section/filereader_readAsBinaryString.any.js
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>FileAPI Test: filereader_readAsBinaryString</title>
-<link rel="author" title="Intel" href="http://www.intel.com">
-<link rel="help" href="https://w3c.github.io/FileAPI/#readAsBinaryString">
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script>
+// META: title=FileAPI Test: filereader_readAsBinaryString
 
 async_test(t => {
   const blob = new Blob(["σ"]);
@@ -28,5 +21,3 @@ async_test(t => {
 
   reader.readAsBinaryString(blob);
 });
-
-</script>

--- a/FileAPI/reading-data-section/filereader_readAsDataURL.any.js
+++ b/FileAPI/reading-data-section/filereader_readAsDataURL.any.js
@@ -1,12 +1,5 @@
-<!doctype html>
-<meta charset="utf-8">
-<title>FileAPI Test: FileReader.readAsDataURL</title>
-<link rel="author" title="Intel" href="http://www.intel.com">
-<link rel="help" href="https://w3c.github.io/FileAPI/#readAsDataURL">
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
+// META: title=FileAPI Test: FileReader.readAsDataURL
 
-<script>
 async_test(function(testCase) {
   var blob = new Blob(["TEST"]);
   var reader = new FileReader();
@@ -47,5 +40,3 @@ async_test(function(testCase) {
   });
   reader.readAsDataURL(blob);
 }, 'readAsDataURL result for Blob with unspecified MIME type');
-
-</script>

--- a/FileAPI/reading-data-section/filereader_readAsText.any.js
+++ b/FileAPI/reading-data-section/filereader_readAsText.any.js
@@ -1,17 +1,5 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>FileAPI Test: filereader_readAsText</title>
-    <link rel="author" title="Intel" href="http://www.intel.com">
-    <link rel="help" href="http://dev.w3.org/2006/webapi/FileAPI/#readAsDataText">
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-  </head>
-  <body>
-    <div id="log"></div>
+// META: title=FileAPI Test: filereader_readAsText
 
-    <script>
     async_test(function() {
       var blob = new Blob(["TEST"]);
       var reader = new FileReader();
@@ -46,6 +34,3 @@
       });
       reader_UTF16.readAsText(blob, "UTF-16");
     }, "readAsText should correctly read UTF-16.");
-    </script>
-  </body>
-</html>

--- a/FileAPI/reading-data-section/filereader_readystate.any.js
+++ b/FileAPI/reading-data-section/filereader_readystate.any.js
@@ -1,17 +1,5 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>FileAPI Test: filereader_readystate</title>
-    <link rel="author" title="Intel" href="http://www.intel.com">
-    <link rel="help" href="http://dev.w3.org/2006/webapi/FileAPI/#blobreader-state">
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-  </head>
-  <body>
-    <div id="log"></div>
+// META: title=FileAPI Test: filereader_readystate
 
-    <script>
     async_test(function() {
       var blob = new Blob(["THIS TEST THE READYSTATE WHEN READ BLOB"]);
       var reader = new FileReader();
@@ -29,6 +17,3 @@
 
       reader.readAsDataURL(blob);
     });
-    </script>
-  </body>
-</html>

--- a/FileAPI/reading-data-section/filereader_result.any.js
+++ b/FileAPI/reading-data-section/filereader_result.any.js
@@ -1,17 +1,5 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>FileAPI Test: filereader_result</title>
-    <link rel="author" title="Intel" href="http://www.intel.com">
-    <link rel="help" href="http://dev.w3.org/2006/webapi/FileAPI/#filedata-attr">
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-  </head>
-  <body>
-    <div id="log"></div>
+// META: title=FileAPI Test: filereader_result
 
-    <script>
     var blob, blob2;
     setup(function() {
       blob = new Blob(["This test the result attribute"]);
@@ -92,6 +80,3 @@
         }, 'result is null during "' + event + '" event for ' + method);
       }
     }
-    </script>
-  </body>
-</html>


### PR DESCRIPTION
This PR intentionally does not touch indentation in the JS files to make the review diff less painful. Indentation can be changed in a follow-up PR.﻿
