### PR TITLE
CSP: fix typo in checkReport.sub.js

### DIFF
--- a/content-security-policy/support/checkReport.sub.js
+++ b/content-security-policy/support/checkReport.sub.js
@@ -81,7 +81,7 @@
                       "No CSP report sent, but expecting one.");
           // Firefox expands 'self' or origins in a policy to the actual origin value
           // so "www.example.com" becomes "http://www.example.com:80".
-          // Accomodate this by just testing that the correct directive name
+          // Accommodate this by just testing that the correct directive name
           // is reported, not the details...
 
           if (reportBody[reportField] !== undefined) {


### PR DESCRIPTION
Accomodate -> Accommodate