### PR TITLE
Avoid relying on vertical scrollbar placement in a couple of tests.

### DIFF
--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-013-ref.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-013-ref.xht
@@ -18,6 +18,8 @@
     {
       height: 100%;
       writing-mode: vertical-rl;
+      overflow: hidden; /* since test and reference might place scrollbars on
+                           different sides */
     }
 
   body

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-013.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-013.xht
@@ -60,6 +60,12 @@
   -->
 
   <style type="text/css"><![CDATA[
+  html
+    {
+      overflow: hidden; /* since test and reference might place scrollbars on
+                           different sides */
+    }
+
   body
     {
       font-size: 16px;

--- a/css/cssom-view/cssom-getBoundingClientRect-vertical-rl-ref.html
+++ b/css/cssom-view/cssom-getBoundingClientRect-vertical-rl-ref.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
-<body style="overflow: scroll">
+<body style="overflow: hidden">
   <div style="position: absolute; top: 50px; left: 50px; width: 200px; height: 200px; background: green"></div>
 </body>

--- a/css/cssom-view/cssom-getBoundingClientRect-vertical-rl.html
+++ b/css/cssom-view/cssom-getBoundingClientRect-vertical-rl.html
@@ -3,7 +3,7 @@
 <link rel="help" href="http://www.w3.org/TR/cssom-view/#dom-element-getboundingclientrect">
 <link rel=match href="cssom-getBoundingClientRect-vertical-rl-ref.html">
 <meta name="flags" content="dom">
-<body style="writing-mode: vertical-rl; overflow: scroll">
+<body style="writing-mode: vertical-rl; overflow: hidden">
   <div id="target" style="position: absolute; top: 50px; left: 50px; width: 200px; height: 200px; background: red"></div>
   <div id="overlay" style="position: absolute; background: green"></div>
   <script>


### PR DESCRIPTION
These two tests can end up placing their root vertical scrollbars on different sides of the window, due to the use of different writing modes.  They aren't specifically testing anything to do with scrollbars, so we turn them off.