### PR TITLE
realtimeanalyser-fft-scaling.html webaudio test is flaky in WebKit te…

### DIFF
--- a/webaudio/the-audio-api/the-analysernode-interface/realtimeanalyser-fft-scaling.html
+++ b/webaudio/the-audio-api/the-analysernode-interface/realtimeanalyser-fft-scaling.html
@@ -78,13 +78,11 @@
             label: 'FFT scaling tests',
             description: 'Test Scaling of FFT in AnalyserNode'
           },
-          function(task, should) {
+          async function(task, should) {
             let tests = [];
             for (let k = 5; k <= 15; ++k)
-              tests.push(runTest(k, should));
-
-            // The order in which the tests finish is not important.
-            Promise.all(tests).then(task.done.bind(task));
+              await runTest(k, should);
+            task.done();
           });
 
       function runTest(order, should) {


### PR DESCRIPTION
…st suite

The subtests in the tests were running in parallel without any kind of synchronization. There was therefore
no guarantee about the order the PASS lines would be printed in. This led to flakiness in the WebKit test
suite: https://bugs.webkit.org/show_bug.cgi?id=223966.

To address the issue, we now run subtests one after another, in a well-defined order.