### PR TITLE
Do not run XR WebGL2 tests on platforms not supporting WebGL2

### DIFF
--- a/webxr/resources/webxr_util.js
+++ b/webxr/resources/webxr_util.js
@@ -15,6 +15,10 @@ var xr_debug = function(name, msg) {};
 
 function xr_promise_test(name, func, properties, glContextType, glContextProperties) {
   promise_test(async (t) => {
+    if (glContextType === 'webgl2') {
+      // Fast fail on platforms not supporting WebGL2.
+      assert_implements('WebGL2RenderingContext' in window, 'webgl2 not supported.');
+    }
     // Perform any required test setup:
     xr_debug(name, 'setup');
 


### PR DESCRIPTION
I want to fetch the latest WebXR WPT tests into WebKit but I'm blocked on enabling them because some platforms don't have  webgl2 enabled yet (e.g. WPE).

I changed xr_promise_test to skip webgl2 related tests if webgl2 is not available.
