### PR TITLE
[docs] avoid the use of Docker to build/deploy documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,18 +14,21 @@ on:
       - 'tools/**'
 jobs:
   build-and-publish:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Set up Virtualenv
+      run: pip install virtualenv
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         fetch-depth: 50
     - name: Run website_build.sh
       # Use a conditional step instead of a conditional job to work around #20700.
       if: github.repository == 'web-platform-tests/wpt'
-      uses: ./tools/docker/documentation
+      run: ./tools/ci/website_build.sh
       env:
         DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
-      with:
-        entrypoint: /bin/bash
-        args: tools/ci/website_build.sh

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ recommonmark==0.7.1
 # Pin this to the same major version as https://docs.python.org/3/
 Sphinx==2.4.4  # pyup: <3.0
 sphinx-argparse==0.2.5
+docutils==0.16  # https://github.com/sphinx-doc/sphinx/issues/9049

--- a/tools/docker/documentation/Dockerfile
+++ b/tools/docker/documentation/Dockerfile
@@ -1,3 +1,0 @@
-FROM python:3.8-buster
-
-RUN apt-get update && apt-get install --yes git virtualenv


### PR DESCRIPTION
Since the Docker image was so minimal, we can just use GitHub Actions
agents directly for this.