### PR TITLE
Fix redirect to not include duplicate URL scheme

### DIFF
--- a/resource-timing/tao-origin-SO-XO-SO-redirect-chain.https.html
+++ b/resource-timing/tao-origin-SO-XO-SO-redirect-chain.https.html
@@ -15,7 +15,7 @@
 const {HTTPS_REMOTE_ORIGIN} = get_host_info();
 const SAME_ORIGIN = location.origin;
 let destUrl = `${HTTPS_REMOTE_ORIGIN}/resource-timing/resources/multi_redirect.py?`;
-destUrl += `page_origin=http://${SAME_ORIGIN}`;
+destUrl += `page_origin=${SAME_ORIGIN}`;
 destUrl += `&cross_origin=${HTTPS_REMOTE_ORIGIN}`;
 destUrl += `&final_resource=/resource-timing/resources/blue-with-tao.png`;
 destUrl += '&tao_steps=3';


### PR DESCRIPTION
I don't know whether this is meant to be HTTP or not, given it currently seems to be using the same origin for everything?