### PR TITLE
[idlharness.js] Rename NoInterfaceObject to LegacyNoInterfaceObject

### DIFF
--- a/css/geometry/DOMRectList.html
+++ b/css/geometry/DOMRectList.html
@@ -11,7 +11,7 @@ setup(() => {
 
 test(() => {
   assert_true('DOMRectList' in window);
-}, 'DOMRectList is not [NoInterfaceObject]');
+}, 'DOMRectList is exposed');
 
 test(() => {
   assert_false(domRectList instanceof Array);

--- a/docs/writing-tests/idlharness.md
+++ b/docs/writing-tests/idlharness.md
@@ -61,7 +61,7 @@ _dict_ should be an object whose keys are the names of interfaces or exceptions,
 are arrays of strings.  When an interface or exception is tested, every string registered for it
 with `add_objects()` will be evaluated, and tests will be run on the result to verify that it
 correctly implements that interface or exception.  This is the only way to test anything about
-`[NoInterfaceObject]` interfaces, and there are many tests that can't be run on any interface
+`[LegacyNoInterfaceObject]` interfaces, and there are many tests that can't be run on any interface
 without an object to fiddle with.
 
 The interface has to be the *primary* interface of all the objects provided.  For example, don't

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -1236,11 +1236,11 @@ IdlArray.prototype.assert_type_is = function(value, type)
         // We don't want to run the full
         // IdlInterface.prototype.test_instance_of, because that could result
         // in an infinite loop.  TODO: This means we don't have tests for
-        // NoInterfaceObject interfaces, and we also can't test objects that
-        // come from another self.
+        // LegacyNoInterfaceObject interfaces, and we also can't test objects
+        // that come from another self.
         assert_in_array(typeof value, ["object", "function"], "wrong type: not object or function");
         if (value instanceof Object
-        && !this.members[type].has_extended_attribute("NoInterfaceObject")
+        && !this.members[type].has_extended_attribute("LegacyNoInterfaceObject")
         && type in self)
         {
             assert_true(value instanceof self[type], "instanceof " + type);
@@ -1415,10 +1415,10 @@ IdlInterface.prototype.should_have_interface_object = function()
     // environment and:
     // * is a callback interface that has constants declared on it, or
     // * is a non-callback interface that is not declared with the
-    //   [NoInterfaceObject] extended attribute,
+    //   [LegacyNoInterfaceObject] extended attribute,
     // a corresponding property MUST exist on the ECMAScript global object.
 
-    return this.is_callback() ? this.has_constants() : !this.has_extended_attribute("NoInterfaceObject");
+    return this.is_callback() ? this.has_constants() : !this.has_extended_attribute("LegacyNoInterfaceObject");
 };
 
 IdlInterface.prototype.assert_interface_object_exists = function()
@@ -1429,7 +1429,7 @@ IdlInterface.prototype.assert_interface_object_exists = function()
 
 IdlInterface.prototype.get_interface_object = function() {
     if (!this.should_have_interface_object()) {
-        var reason = this.is_callback() ? "lack of declared constants" : "declared [NoInterfaceObject] attribute";
+        var reason = this.is_callback() ? "lack of declared constants" : "declared [LegacyNoInterfaceObject] attribute";
         throw new IdlHarnessError(this.name + " has no interface object due to " + reason);
     }
 
@@ -1572,7 +1572,7 @@ function _traverse_inherited_and_consequential_interfaces(stack, callback) {
 
 IdlInterface.prototype.test = function()
 {
-    if (this.has_extended_attribute("NoInterfaceObject") || this.is_mixin())
+    if (this.has_extended_attribute("LegacyNoInterfaceObject") || this.is_mixin())
     {
         // No tests to do without an instance.  TODO: We should still be able
         // to run tests on the prototype object, if we obtain one through some
@@ -1681,7 +1681,7 @@ IdlInterface.prototype.test_self = function()
             //    value of [[Prototype]] is the interface object for that other
             //    interface."
             var inherited_interface = this.array.members[this.base];
-            if (!inherited_interface.has_extended_attribute("NoInterfaceObject")) {
+            if (!inherited_interface.has_extended_attribute("LegacyNoInterfaceObject")) {
                 inherited_interface.assert_interface_object_exists();
                 assert_equals(prototype, inherited_interface.get_interface_object(),
                               'prototype of ' + this.name + ' is not ' +
@@ -1773,7 +1773,7 @@ IdlInterface.prototype.test_self = function()
             if (!this.exposureSet.has("Window")) {
                 throw new IdlHarnessError("Invalid IDL: LegacyWindowAlias extended attribute on " + this.name + " which is not exposed in Window");
             }
-            // TODO: when testing of [NoInterfaceObject] interfaces is supported,
+            // TODO: when testing of [LegacyNoInterfaceObject] interfaces is supported,
             // check that it's not specified together with LegacyWindowAlias.
 
             // TODO: maybe check that [LegacyWindowAlias] is not specified on a partial interface.
@@ -1963,7 +1963,7 @@ IdlInterface.prototype.test_self = function()
 
         // Next, test that the [[Prototype]] of the interface prototype object
         // is correct. (This is made somewhat difficult by the existence of
-        // [NoInterfaceObject].)
+        // [LegacyNoInterfaceObject].)
         // TODO: Aryeh thinks there's at least other place in this file where
         //       we try to figure out if an interface prototype object is
         //       correct. Consolidate that code.
@@ -1996,7 +1996,7 @@ IdlInterface.prototype.test_self = function()
             if (this.base) {
                 inherit_interface = this.base;
                 var parent = this.array.members[inherit_interface];
-                if (!parent.has_extended_attribute("NoInterfaceObject")) {
+                if (!parent.has_extended_attribute("LegacyNoInterfaceObject")) {
                     parent.assert_interface_object_exists();
                     inherit_interface_interface_object = parent.get_interface_object();
                 }
@@ -2072,8 +2072,8 @@ IdlInterface.prototype.test_self = function()
         assert_own_property(this.get_interface_object(), "prototype",
                             'interface "' + this.name + '" does not have own property "prototype"');
 
-        // "If the [NoInterfaceObject] extended attribute was not specified on
-        // the interface, then the interface prototype object must also have a
+        // "If the [LegacyNoInterfaceObject] extended attribute was not specified
+        // on the interface, then the interface prototype object must also have a
         // property named “constructor” with attributes { [[Writable]]: true,
         // [[Enumerable]]: false, [[Configurable]]: true } whose value is a
         // reference to the interface object for the interface."

--- a/resources/test/tests/unit/IdlInterface/should_have_interface_object.html
+++ b/resources/test/tests/unit/IdlInterface/should_have_interface_object.html
@@ -19,12 +19,12 @@ test(function() {
 }, "callback interface without a constant");
 
 test(function() {
-    var i = interfaceFrom("[NoInterfaceObject] interface A { };");
+    var i = interfaceFrom("[LegacyNoInterfaceObject] interface A { };");
     assert_false(i.should_have_interface_object());
-}, "non-callback interface with [NoInterfaceObject]");
+}, "non-callback interface with [LegacyNoInterfaceObject]");
 
 test(function() {
     var i = interfaceFrom("interface A { };");
     assert_true(i.should_have_interface_object());
-}, "non-callback interface without [NoInterfaceObject]");
+}, "non-callback interface without [LegacyNoInterfaceObject]");
 </script>

--- a/uievents/resources/eventrecorder.js
+++ b/uievents/resources/eventrecorder.js
@@ -76,12 +76,10 @@
 
 // ----------------------
 
-// [NoInterfaceObject]
-// interface EventRecorderRegistration {
+// partial interface Node {
 //    void addRecordedEventListener(SupportedEventTypes type, EventListener? handler, optional boolean capturePhase = false);
 //    void removeRecordedEventListener(SupportedEventTypes type, EventListener? handler, optional boolean capturePhase = false);
 // };
-// Node implements EventRecorderRegistration;
 //
 // enum SupportedEventTypes = {
 //    "mousemove",


### PR DESCRIPTION
All of interfaces/*.idl already use [LegacyNoInterfaceObject], so the
existing code wouldn't have worked. However, it is also unused
currently, as [LegacyNoInterfaceObject] is only used in WebGL extensions
which aren't being tested by any idlharness.js tests.

In addition to should_have_interface_object.html passing,
[LegacyNoInterfaceObject] was added to an interface locally to ensure
that prevents some subtests from being run.

Also replace [NoInterfaceObject] in a few other places where it remained.