### PR TITLE
[idlharness.js] Replace void with undefined where it remains

### DIFF
--- a/requestidlecallback/basic.html
+++ b/requestidlecallback/basic.html
@@ -19,7 +19,7 @@ test(function() {
   assert_equals(typeof window.requestIdleCallback(function() {}), "number");
 }, "window.requestIdleCallback() returns a number");
 
-// The cancelIdleCallback method MUST return void
+// The cancelIdleCallback method MUST return undefined
 test(function() {
   assert_equals(typeof window.cancelIdleCallback(1), "undefined");
 }, "window.cancelIdleCallback() returns undefined");

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -1116,7 +1116,7 @@ IdlArray.prototype.assert_type_is = function(value, type)
 
     switch(type)
     {
-        case "void":
+        case "undefined":
             assert_equals(value, undefined);
             return;
 

--- a/resources/test/tests/functional/idlharness/IdlNamespace/test_operation.html
+++ b/resources/test/tests/functional/idlharness/IdlNamespace/test_operation.html
@@ -58,13 +58,13 @@ var idlArray = new IdlArray();
 idlArray.add_idls(`
 [Exposed=Window]
 namespace foo {
-  void Truth();
-  void Lies();
+  undefined Truth();
+  undefined Lies();
 };
 [Exposed=Window]
 namespace bar {
   [LegacyUnforgeable]
-  void Truth();
+  undefined Truth();
 };
 [Exposed=Window]
 namespace baz {

--- a/resources/test/tests/unit/IdlInterface/should_have_interface_object.html
+++ b/resources/test/tests/unit/IdlInterface/should_have_interface_object.html
@@ -14,7 +14,7 @@ test(function() {
 }, "callback interface with a constant");
 
 test(function() {
-    var i = interfaceFrom("callback interface A { void b(); sequence<any> c(); };");
+    var i = interfaceFrom("callback interface A { undefined b(); sequence<any> c(); };");
     assert_false(i.should_have_interface_object());
 }, "callback interface without a constant");
 

--- a/resources/test/tests/unit/IdlInterfaceMember/is_to_json_regular_operation.html
+++ b/resources/test/tests/unit/IdlInterfaceMember/is_to_json_regular_operation.html
@@ -18,7 +18,7 @@
     }, 'should return false when member is an attribute.');
 
     test(function() {
-        var m = memberFrom("static void foo()");
+        var m = memberFrom("static undefined foo()");
         assert_false(m.is_to_json_regular_operation());
     }, 'should return false when member is a static operation.');
 

--- a/resources/test/tests/unit/IdlInterfaceMember/toString.html
+++ b/resources/test/tests/unit/IdlInterfaceMember/toString.html
@@ -27,7 +27,7 @@ const tests = [
 ];
 for (const [input, output] of tests) {
     test(function() {
-        var m = memberFrom(`void foo(${input})`);
+        var m = memberFrom(`undefined foo(${input})`);
         assert_equals(m.toString(), `foo(${output})`);
     }, `toString for ${input}`);
 }

--- a/webvr/idlharness.https.html
+++ b/webvr/idlharness.https.html
@@ -83,7 +83,7 @@ interface VRDisplay : EventTarget {
    * Passing the value returned by `requestAnimationFrame` to
    * `cancelAnimationFrame` will unregister the callback.
    */
-  void cancelAnimationFrame(long handle);
+  undefined cancelAnimationFrame(long handle);
 
   /**
    * Begin presenting to the VRDisplay. Must be called in response to a user gesture.
@@ -91,12 +91,12 @@ interface VRDisplay : EventTarget {
    * If the number of values in the leftBounds/rightBounds arrays is not 0 or 4 for any of the passed layers the promise is rejected
    * If the source of any of the layers is not present (null), the promise is rejected.
    */
-  Promise<void> requestPresent(sequence<VRLayerInit> layers);
+  Promise<undefined> requestPresent(sequence<VRLayerInit> layers);
 
   /**
    * Stops presenting to the VRDisplay.
    */
-  Promise<void> exitPresent();
+  Promise<undefined> exitPresent();
 
   /**
    * Get the layers currently being presented.
@@ -109,7 +109,7 @@ interface VRDisplay : EventTarget {
    * canvas as any other operation that uses its source image, and canvases
    * created without preserveDrawingBuffer set to true will be cleared.
    */
-  void submitFrame();
+  undefined submitFrame();
 };
 
 typedef (HTMLCanvasElement or


### PR DESCRIPTION
All uses of void have already been replaced in interfaces/*.idl. This
fixes idlharness.js and replaced void in the few places it remains,
except for the tests in WebIDL/ which aren't run as part of WPT.