### PR TITLE
[idlharness.js] Drop support for [Constructor] extended attributes

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -1603,15 +1603,10 @@ IdlInterface.prototype.test = function()
     this.test_members();
 };
 
-// This supports both Constructor extended attributes and constructor
-// operations until all idl fragments have been updated.
 IdlInterface.prototype.constructors = function()
 {
-    var extendedAttributes = this.extAttrs
-        .filter(function(attr) { return attr.name == "Constructor"; });
-    var operations = this.members
+    return this.members
         .filter(function(m) { return m.type == "constructor"; });
-    return extendedAttributes.concat(operations);
 }
 
 IdlInterface.prototype.test_self = function()
@@ -1696,11 +1691,7 @@ IdlInterface.prototype.test_self = function()
         }
 
         if (!this.constructors().length) {
-            // "The internal [[Call]] method of the interface object behaves as
-            // follows . . .
-            //
-            // "If I was not declared with a [Constructor] extended attribute,
-            // then throw a TypeError."
+            // "If I was not declared with a constructor operation, then throw a TypeError."
             var interface_object = this.get_interface_object();
             assert_throws_js(globalOf(interface_object).TypeError, function() {
                 interface_object();

--- a/resources/test/tests/functional/idlharness/IdlInterface/test_immutable_prototype.html
+++ b/resources/test/tests/functional/idlharness/IdlInterface/test_immutable_prototype.html
@@ -33,8 +33,8 @@ idlArray.add_idls(
     "[Global=Window, Exposed=Window]\n" +
     "interface Window : EventTarget {};\n" +
 
-    "[Global=Window, Exposed=Window, Constructor()]\n" +
-    "interface Foo {};"
+    "[Global=Window, Exposed=Window]\n" +
+    "interface Foo { constructor(); };"
   );
 idlArray.add_objects({
   Foo: ["new Foo()"],

--- a/resources/test/tests/functional/idlharness/IdlInterface/test_primary_interface_of.html
+++ b/resources/test/tests/functional/idlharness/IdlInterface/test_primary_interface_of.html
@@ -40,8 +40,7 @@ Foo.prototype[Symbol.toStringTag] = "Foo";
 var idlArray = new IdlArray();
 idlArray.add_untested_idls("interface FooParent {};");
 idlArray.add_idls(
-    "[Constructor()]\n" +
-    "interface Foo : FooParent {};"
+    "interface Foo : FooParent { constructor(); };"
   );
 idlArray.add_objects({
   Foo: ["new Foo()"],

--- a/resources/test/tests/unit/IdlInterface/constructors.html
+++ b/resources/test/tests/unit/IdlInterface/constructors.html
@@ -8,9 +8,10 @@
 <script src="../../../idl-helper.js"></script>
 <script>
 "use strict";
+// [Constructor] extended attribute should not be supported:
 test(function() {
     var i = interfaceFrom('[Constructor] interface A { };');
-    assert_equals(i.constructors().length, 1);
+    assert_equals(i.constructors().length, 0);
 }, 'Interface with Constructor extended attribute.');
 
 test(function() {
@@ -19,7 +20,7 @@ test(function() {
 }, 'Interface with constructor method');
 
 test(function() {
-    var i = interfaceFrom('[Constructor] interface A { constructor(); };');
+    var i = interfaceFrom('interface A { constructor(); constructor(any value); };');
     assert_equals(i.constructors().length, 2);
-}, 'Interface with both');
+}, 'Interface with constructor overloads');
 </script>

--- a/web-animations/interfaces/Animation/constructor.html
+++ b/web-animations/interfaces/Animation/constructor.html
@@ -73,7 +73,7 @@ for (const args of gTestArguments) {
                       'An animation sohuld be created');
     assert_equals(animation.effect, effect,
                   'Animation returns the same effect passed to ' +
-                  'the Constructor');
+                  'the constructor');
     assert_equals(animation.timeline, args.expectedTimeline,
                   'Animation timeline should be ' + args.expectedTimelineDescription);
     assert_equals(animation.playState, 'idle',

--- a/webvr/idlharness.https.html
+++ b/webvr/idlharness.https.html
@@ -144,8 +144,9 @@ interface VRPose {
   readonly attribute Float32Array? angularAcceleration;
 };
 
-[Constructor]
 interface VRFrameData {
+  constructor();
+
   readonly attribute Float32Array leftProjectionMatrix;
   readonly attribute Float32Array leftViewMatrix;
 
@@ -182,8 +183,8 @@ enum VRDisplayEventReason {
   "unmounted"
 };
 
-[Constructor(DOMString type, VRDisplayEventInit eventInitDict)]
 interface VRDisplayEvent : Event {
+  constructor(DOMString type, VRDisplayEventInit eventInitDict);
   readonly attribute VRDisplay display;
   readonly attribute VRDisplayEventReason? reason;
 };


### PR DESCRIPTION
These are complete gone from interfaces/*.idl so this code is unused.