### PR TITLE
Fix test_tests_affected_idlharness

### DIFF
--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -314,7 +314,8 @@ def test_tests_affected_idlharness(capsys, manifest_dir):
         wpt.main(argv=["tests-affected", "--metadata", manifest_dir, "%s~..%s" % (commit, commit)])
     assert excinfo.value.code == 0
     out, err = capsys.readouterr()
-    assert ("webrtc-encoded-transform/idlharness.https.window.js\n" +
+    assert ("mst-content-hint/idlharness.window.js\n" +
+            "webrtc-encoded-transform/idlharness.https.window.js\n" +
             "webrtc-identity/idlharness.https.window.js\n" +
             "webrtc-stats/idlharness.window.js\n" +
             "webrtc-stats/supported-stats.html\n" +


### PR DESCRIPTION
Broken by https://github.com/web-platform-tests/wpt/pull/28544, where
this test didn't run. It's the addition of webrtc as a dependency there
that is the broken, as commit 47cea8c38b88c0ddd3854e4edec0c5b6f2697e62
updates webrtc.idl.

This test is indeed funny, depending both on an old commit and on the
current state of the tree...