### PR TITLE
Add test for cross-origin redirect timing

### DIFF
--- a/common/slow-redirect.py
+++ b/common/slow-redirect.py
@@ -1,0 +1,29 @@
+import time
+
+def main(request, response):
+    """Simple handler that causes redirection.
+
+    The request should typically have two query parameters:
+    status - The status to use for the redirection. Defaults to 302.
+    location - The resource to redirect to.
+    """
+    status = 302
+    delay = 2
+    if b"status" in request.GET:
+        try:
+            status = int(request.GET.first(b"status"))
+        except ValueError:
+            pass
+
+    if b"delay" in request.GET:
+        try:
+            delay = int(request.GET.first(b"delay"))
+        except ValueError:
+            pass
+
+    response.status = status
+    time.sleep(delay)
+
+    location = request.GET.first(b"location")
+
+    response.headers.set(b"Location", location)

--- a/resource-timing/cross-origin-start-end-time-with-redirects.html
+++ b/resource-timing/cross-origin-start-end-time-with-redirects.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <title>This test validates the values in resource timing for cross-origin
 redirects.</title>
-<link rel="author" title="Intel" href="http://www.intel.com/" />
+<link rel="author" title="Noam Rosenthal" href="noam@webkit.org">
 <link rel="help" href="https://www.w3.org/TR/resource-timing-2/#sec-performanceresourcetiming"/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/resource-timing/cross-origin-start-end-time-with-redirects.html
+++ b/resource-timing/cross-origin-start-end-time-with-redirects.html
@@ -1,0 +1,32 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>This test validates the values in resource timing for cross-origin
+redirects.</title>
+<link rel="author" title="Intel" href="http://www.intel.com/" />
+<link rel="help" href="https://www.w3.org/TR/resource-timing-2/#sec-performanceresourcetiming"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/resource-loaders.js"></script>
+<script src="resources/entry-invariants.js"></script>
+</head>
+<body>
+<script>
+const {REMOTE_ORIGIN} = get_host_info();
+const delay = 2
+const blank_page = `/resource-timing/resources/blank_page_green.htm`;
+const destUrl = `/common/slow-redirect.py?delay=${delay}&location=${REMOTE_ORIGIN}/${blank_page}`;
+
+const timeBefore = performance.now()
+attribute_test(load.iframe, destUrl, entry => {
+    assert_equals(entry.startTime, entry.fetchStart, 'startTime and fetchStart should be equal');
+    assert_greater_than(entry.startTime, timeBefore, 'startTime and fetchStart should be greater than the time before fetching');
+    // See https://github.com/w3c/resource-timing/issues/264
+    assert_less_than(Math.round(entry.startTime - timeBefore), delay * 1000, 'startTime should not expose redirect delays');
+}, "Verify that cross-origin resources don't implicitly expose their redirect timings")
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
TAO-protected resources (cross-origin) should not expose that some of the delay was caused by redirects.
This test currently fails on Chrome, as it's a behavior change.
Closes https://github.com/w3c/resource-timing/issues/264
