### PR TITLE
Update quic transport server

### DIFF
--- a/tools/quic/requirements.txt
+++ b/tools/quic/requirements.txt
@@ -1,1 +1,1 @@
-aioquic==0.8.8
+aioquic==0.9.11

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -1007,6 +1007,9 @@ def build_config(override_path=None, config_cls=ConfigBuilder, **kwargs):
     if enable_http2:
         rv._default["ports"]["h2"] = [9000]
 
+    if kwargs.get("quic_transport"):
+        rv._default["ports"]["quic-transport"] = [10000]
+
     if override_path and os.path.exists(override_path):
         with open(override_path) as f:
             override_obj = json.load(f)


### PR DESCRIPTION
* Update aioquic to 0.9.11 which supports IETF QUIC version draft29.
  The QUIC version is widely supported by servers and clients.
* [serve.py] Set a port for quic-transport when `--quic-transport`
  is specified. Otherwise `./wpt serve --quic-transport` wouldn't
  work.