### PR TITLE
Unpin docutils in docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,3 @@ recommonmark==0.7.1
 # Pin this to the same major version as https://docs.python.org/3/
 Sphinx==2.4.4  # pyup: <3.0
 sphinx-argparse==0.2.5
-docutils==0.16  # https://github.com/sphinx-doc/sphinx/issues/9049


### PR DESCRIPTION
It was pinned in https://github.com/web-platform-tests/wpt/pull/28467,
but with the release of 0.17.1 it seems to be working again:
https://github.com/web-platform-tests/wpt/pull/28561

Closes https://github.com/web-platform-tests/wpt/pull/28561.