### PR TITLE
[idlharness.js] avoid overtesting the non-exposure of interfaces

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -1580,10 +1580,16 @@ IdlInterface.prototype.test = function()
         return;
     }
 
-    if (!this.exposed) {
-        subsetTestByKey(this.name, test, function() {
-            assert_false(this.name in self);
-        }.bind(this), this.name + " interface: existence and properties of interface object");
+    // If the interface object is not exposed, only test that. Members can't be
+    // tested either, but objects could still be tested in |test_object|.
+    if (!this.exposed)
+    {
+        if (!this.untested)
+        {
+            subsetTestByKey(this.name, test, function() {
+                assert_false(this.name in self);
+            }.bind(this), this.name + " interface: existence and properties of interface object");
+        }
         return;
     }
 


### PR DESCRIPTION
These tests are being generated for dependencies that shouldn't be
tested because |this.untested| wasn't checked in this case.