### PR TITLE
Fix padding-valid.html to use sorted calc() in expected serialized value according to spec

### DIFF
--- a/css/css-box/parsing/padding-valid.html
+++ b/css/css-box/parsing/padding-valid.html
@@ -23,7 +23,9 @@ test_valid_value("padding-left", "40px");
 test_valid_value("padding", "20%");
 test_valid_value("padding", "10px 20% 30% 40px");
 test_valid_value("padding-right", "20%");
-test_valid_value("padding-right", "calc(2em + 3%)");
+
+// https://drafts.csswg.org/css-values-4/#sort-a-calculations-children
+test_valid_value("padding-right", "calc(2em + 3%)", "calc(3% + 2em)");
 </script>
 </body>
 </html>


### PR DESCRIPTION
https://drafts.csswg.org/css-values-4/#sort-a-calculations-children

> 11.13. Serialization
> [...]
> 6. If root is a Sum node, let s be a string initially containing "(".
>    Sort root’s children.