### PR TITLE
[idlharness.js] Remove unnecessary Math.fround fallback

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -131,17 +131,6 @@ function awaitNCallbacks(n, cb, ctx)
     };
 }
 
-var fround =
-(function(){
-    if (Math.fround) return Math.fround;
-
-    var arr = new Float32Array(1);
-    return function fround(n) {
-        arr[0] = n;
-        return arr[0];
-    };
-})();
-
 /// IdlHarnessError ///
 // Entry point
 self.IdlHarnessError = function(message)
@@ -1172,7 +1161,7 @@ IdlArray.prototype.assert_type_is = function(value, type)
 
         case "float":
             assert_equals(typeof value, "number");
-            assert_equals(value, fround(value), "float rounded to 32-bit float should be itself");
+            assert_equals(value, Math.fround(value), "float rounded to 32-bit float should be itself");
             assert_not_equals(value, Infinity);
             assert_not_equals(value, -Infinity);
             assert_not_equals(value, NaN);
@@ -1188,7 +1177,7 @@ IdlArray.prototype.assert_type_is = function(value, type)
 
         case "unrestricted float":
             assert_equals(typeof value, "number");
-            assert_equals(value, fround(value), "unrestricted float rounded to 32-bit float should be itself");
+            assert_equals(value, Math.fround(value), "unrestricted float rounded to 32-bit float should be itself");
             return;
 
         case "unrestricted double":


### PR DESCRIPTION
It is supported everywhere since a long time:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/fround#browser_compatibility