### PR TITLE
Fix use of headers pipe in permissions policy tests

### DIFF
--- a/permissions-policy/permissions-policy-frame-policy-allowed-for-all.https.sub.html
+++ b/permissions-policy/permissions-policy-frame-policy-allowed-for-all.https.sub.html
@@ -20,7 +20,7 @@
     {allow: "'self'", sameOriginTestExpect: true, crossOriginTestExpect: false, dataOriginTestExpect: false},
     {allow: "'none'", sameOriginTestExpect: false, crossOriginTestExpect: false, dataOriginTestExpect: false},
     {allow: "'self' " + cross_origin + " https://www.example.com", sameOriginTestExpect: true, crossOriginTestExpect: true, dataOriginTestExpect: false}];
-  var pipe_front = '?pipe=sub|header(Permissions-Policy, fullscreen=';
+  var pipe_front = '?pipe=sub|header(Permissions-Policy,fullscreen=';
   var pipe_end = ';)';
   var header_policies = ["*", "self", "()"];
 
@@ -88,7 +88,7 @@
       test(function() {
         test_frame_policy(
           'fullscreen',
-          same_origin_src + pipe_front + header_policies[j] + pipe_end,
+          same_origin_src + pipe_front + header_policies[j].replace(")", "\\)") + pipe_end,
           undefined, policies[i].sameOriginTestExpect,
           'fullscreen ' + policies[i].allow + ';');
       }, 'Test frame policy on same origin iframe with allow = "' + policies[i].allow +
@@ -96,7 +96,7 @@
       test(function() {
         test_frame_policy(
           'fullscreen',
-          cross_origin_src + pipe_front + header_policies[j] + pipe_end,
+          cross_origin_src + pipe_front + header_policies[j].replace(")", "\\)") + pipe_end,
           undefined, policies[i].crossOriginTestExpect,
           'fullscreen ' + policies[i].allow + ';');
       }, 'Test frame policy on cross origin iframe with allow = "' + policies[i].allow +


### PR DESCRIPTION
The headers with a close paren require escaping to avoid it being
treated as the end of the function (probably this should be fixed by
improving the parsing in wptserve).

Also the space in the header looks unintentional.