### PR TITLE
Add test for iframe navigation following load

### DIFF
--- a/html/browsers/browsing-the-web/navigating-across-documents/iframe-following-load.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/iframe-following-load.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<script src="/resources/testharness.js"></script>
+		<script src="/resources/testharnessreport.js"></script>
+	</head>
+	<body>
+<script>
+'use strict';
+const whenLoaded = (iframe) => {
+	return new Promise((resolve) => iframe.onload = resolve);
+};
+
+promise_test(async (t) => {
+	const firstSrc = new URL('/common/blank.html?first', location).toString();
+	const secondSrc = new URL('/common/blank.html?second', location).toString();
+	const iframe = document.createElement('iframe');
+	iframe.src = firstSrc;
+	document.body.appendChild(iframe);
+	t.add_cleanup(() => iframe.remove());
+	await whenLoaded(iframe);
+
+	// Because the "load" event has fired, the session history includes the
+	// `firstSrc` URL (as per the "page load processing model for HTML files",
+	// which states, "After creating the Document object, but before any script
+	// execution, certainly before the parser stops, the user agent must update
+	// the session history with the new page given navigationParams and the
+	// newly-created Document."
+	// The following change to the `src` attribute will trigger navigation
+	// *without* history replacement because the framed document is completely
+	// loaded.
+	iframe.src = secondSrc;
+	await whenLoaded(iframe);
+
+	iframe.contentWindow.history.back();
+	await whenLoaded(iframe);
+
+	assert_equals(iframe.contentWindow.location.href, firstSrc);
+}, 'navigates without history replacement following initial load');
+</script>
+	</body>
+</html>


### PR DESCRIPTION
Firefox, Chromium, and Safari all fail this test. That's a pretty good indication that I've misinterpreted something, but I can't find the missing piece. Deferring the navigation to `secondSrc` to the next task causes this test to pass in all three browsers, e.g.

```diff
+await new Promise((resolve) => setTimeout(resolve));
 iframe.src = secondSrc;
```

@zcorpan @domenic @jakearchibald @rakina you folks are all researching navigation these days; do any you have a minute to check my work?