### PR TITLE
Unset __PYVENV_LAUNCHER__ on macOS to avoid virtualenv weirdness

### DIFF
--- a/tools/wpt/virtualenv.py
+++ b/tools/wpt/virtualenv.py
@@ -91,6 +91,13 @@ class Virtualenv(object):
         return self._working_set
 
     def activate(self):
+        if sys.platform == 'darwin':
+            # The default Python on macOS sets a __PYVENV_LAUNCHER__ environment
+            # variable which affects invocation of python (e.g. via pip) in a
+            # virtualenv. Unset it if present to avoid this. More background:
+            # https://github.com/web-platform-tests/wpt/issues/27377
+            # https://github.com/python/cpython/pull/9516
+            os.environ.pop('__PYVENV_LAUNCHER__', None)
         path = os.path.join(self.bin_path, "activate_this.py")
         with open(path) as f:
             exec(f.read(), {"__file__": path})


### PR DESCRIPTION
Exactly how this all works isn't clear, but since the fix in
https://github.com/python/cpython/pull/9516 was to simply hide the
environment variable from the interpreter it seems reasonably safe.

Fixes https://github.com/web-platform-tests/wpt/issues/27377.