### PR TITLE
Stop testing Python 2.7 in resources/ tests

### DIFF
--- a/resources/test/tox.ini
+++ b/resources/test/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py38
+envlist = py36,py38
 skipsdist=True
 
 [testenv]


### PR DESCRIPTION
This isn't run in CI, but it does get run locally if one just runs tox
with no arguments, and won't work.