### PR TITLE
[css-counter-styles] Explicitly test zero values for 'pad' and 'additive-symbols' descriptors

### DIFF
--- a/css/css-counter-styles/counter-style-additive-symbols-syntax.html
+++ b/css/css-counter-styles/counter-style-additive-symbols-syntax.html
@@ -15,6 +15,7 @@ function test_invalid_additive_symbols(value) {
 
 // [ <integer [0,∞]> && <symbol> ]#
 
+test_valid_additive_symbols('0 "X"');
 test_valid_additive_symbols('1 "X"');
 test_valid_additive_symbols('"X" 1', '1 "X"');
 test_valid_additive_symbols('5 "V", 1 "I"');

--- a/css/css-counter-styles/counter-style-pad-syntax.html
+++ b/css/css-counter-styles/counter-style-pad-syntax.html
@@ -17,6 +17,7 @@ function test_invalid_pad(value) {
 
 test_invalid_pad('10');
 test_invalid_pad('"X"');
+test_valid_pad('0 "X"');
 test_valid_pad('10 "X"');
 test_valid_pad('"X" 10', '10 "X"');
 test_invalid_pad('-1 "X"');


### PR DESCRIPTION
Explicitly test zero values for `pad` and `additive-symbols` @counter-style descriptors.  This would've caught a bug I made in WebKit's @counter-style implementation.

https://www.w3.org/TR/css-counter-styles-3/#counter-style-pad

> The \<integer\> must be non-negative. A negative value is a syntax error.

https://www.w3.org/TR/css-counter-styles-3/#counter-style-symbols

> Each entry in the additive-symbols descriptor’s value defines an additive tuple, which consists of a counter symbol and a non-negative integer weight.