### PR TITLE
[idlharness.js] Drop validation test created by idl_test()

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -3243,18 +3243,6 @@ IdlNamespace.prototype.test_member_attribute = function (member)
 
 IdlNamespace.prototype.test_self = function ()
 {
-    /**
-     * TODO(lukebjerring): Assert:
-     * - "Note that unlike interfaces or dictionaries, namespaces do not create types."
-     */
-
-    subsetTestByKey(this.name, test, () => {
-        assert_true(this.extAttrs.every(o => o.name === "Exposed" || o.name === "SecureContext"),
-            "Only the [Exposed] and [SecureContext] extended attributes are applicable to namespaces");
-        assert_true(this.has_extended_attribute("Exposed"),
-            "Namespaces must be annotated with the [Exposed] extended attribute");
-    }, `${this.name} namespace: extended attributes`);
-
     const namespaceObject = self[this.name];
 
     subsetTestByKey(this.name, test, () => {
@@ -3348,25 +3336,12 @@ function idl_test(srcs, deps, idl_setup_func) {
     return promise_test(function (t) {
         var idl_array = new IdlArray();
         var setup_error = null;
-        const validationIgnored = [
-            "constructor-member",
-            "dict-arg-default",
-            "require-exposed"
-        ];
         return Promise.all(
             srcs.concat(deps).map(fetch_spec))
             .then(function(results) {
                 const astArray = results.map(result =>
                     WebIDL2.parse(result.idl, { sourceName: result.spec })
                 );
-                test(() => {
-                    const validations = WebIDL2.validate(astArray)
-                        .filter(v => !validationIgnored.includes(v.ruleName));
-                    if (validations.length) {
-                        const message = validations.map(v => v.message).join("\n\n");
-                        throw new Error(message);
-                    }
-                }, "idl_test validation");
                 for (var i = 0; i < srcs.length; i++) {
                     idl_array.internal_add_idls(astArray[i]);
                 }

--- a/resources/test/tests/functional/idlharness/IdlNamespace/test_attribute.html
+++ b/resources/test/tests/functional/idlharness/IdlNamespace/test_attribute.html
@@ -42,12 +42,6 @@ idlArray.test();
   },
   "summarized_tests": [
     {
-      "name": "foo namespace: extended attributes",
-      "status_string": "PASS",
-      "properties": {},
-      "message": null
-    },
-    {
       "name": "foo namespace: property descriptor",
       "status_string": "PASS",
       "properties": {},

--- a/resources/test/tests/functional/idlharness/IdlNamespace/test_operation.html
+++ b/resources/test/tests/functional/idlharness/IdlNamespace/test_operation.html
@@ -81,12 +81,6 @@ idlArray.test();
   },
   "summarized_tests": [
     {
-      "name": "foo namespace: extended attributes",
-      "status_string": "PASS",
-      "properties": {},
-      "message": null
-    },
-    {
       "name": "foo namespace: property descriptor",
       "status_string": "PASS",
       "properties": {},
@@ -135,12 +129,6 @@ idlArray.test();
       "message": "assert_own_property: namespace object missing operation \"Lies\" expected property \"Lies\" missing"
     },
     {
-      "name": "bar namespace: extended attributes",
-      "status_string": "PASS",
-      "properties": {},
-      "message": null
-    },
-    {
       "name": "bar namespace: property descriptor",
       "status_string": "PASS",
       "properties": {},
@@ -178,13 +166,6 @@ idlArray.test();
     },
     {
       "name": "bar namespace: operation Truth()",
-      "status_string": "PASS",
-      "properties": {},
-      "message": null
-    },
-
-    {
-      "name": "baz namespace: extended attributes",
       "status_string": "PASS",
       "properties": {},
       "message": null


### PR DESCRIPTION
This was testing the spec and not the implementation.

The IDL in interfaces/*.idl (except *.tentative.idl) is already
validated individually and all together by webidl2.js in the webref
tests which run before @webref/idl is published:
https://github.com/w3c/webref/blob/703e161604ffa6f1ed9619a8786e0aec24b55eba/test/idl/validate.js

Also remove the "extended attributes" validation subtest.

Part of https://github.com/web-platform-tests/wpt/issues/28678.