### PR TITLE
Remove copyright year

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # The 3-Clause BSD License
 
-Copyright web-platform-tests contributors
+Copyright © web-platform-tests contributors
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # The 3-Clause BSD License
 
-Copyright 2019 web-platform-tests contributors
+Copyright web-platform-tests contributors
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 


### PR DESCRIPTION
This would align with the WHATWG where we made a similar change recently.

If we do this I'm willing to PR https://github.com/html5lib/html5lib-python/blob/master/benchmarks/data/wpt/LICENSE.md as well.

cc @web-platform-tests/wpt-core-team