### PR TITLE
[testharness.js] Check if value is null in _assert_inherits

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1566,7 +1566,8 @@ policies and contribution forms [3].
     function _assert_inherits(name) {
         return function (object, property_name, description)
         {
-            assert(typeof object === "object" || typeof object === "function" ||
+            assert((typeof object === "object" && object !== null) ||
+                   typeof object === "function" ||
                    // Or has [[IsHTMLDDA]] slot
                    String(object) === "[object HTMLAllCollection]",
                    name, description,


### PR DESCRIPTION
Otherwise, the `"hasOwnProperty" in object` check that follows will
throw a TypeError instead of an AssertionError with the right message.

It looks like all other `typeof v === "object"` in testharness.js
already have the null check as well.