### PR TITLE
Convert Presentation API idlharness.js tests to use idl_test()

### DIFF
--- a/presentation-api/controlling-ua/idlharness.https.html
+++ b/presentation-api/controlling-ua/idlharness.https.html
@@ -1,51 +1,41 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Presentation API IDL tests for Controlling User Agent</title>
+<meta name="variant" content="?exclude=(PresentationReceiver|PresentationConnectionList)">
 <meta name="timeout" content="long">
 <link rel="author" title="Louay Bassbouss" href="http://www.fokus.fraunhofer.de">
 <link rel="help" href="http://w3c.github.io/presentation-api/#dfn-controlling-user-agent">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/subset-tests-by-key.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 
 <script>
   "use strict";
+  idl_test(
+    ['presentation-api'],
+    ['dom', 'html'],
+    idl_array => {
+      try {
+        window.presentation_request = new PresentationRequest("/common/blank.html");
+        window.presentation_request_urls = new PresentationRequest([
+          "/common/blank.html?1",
+          "/common/blank.html?2"
+        ]);
+        navigator.presentation.defaultRequest = window.presentation_request;
+      } catch (e) {
+        // Will be surfaced in idlharness.js's test_object below.
+      }
 
-  promise_test(async () => {
-    const srcs = ['presentation-api', 'dom', 'html'];
-    const [idl, dom, html] = await Promise.all(
-      srcs.map(i => fetch(`/interfaces/${i}.idl`).then(r => r.text())));
-
-    const idl_array = new IdlArray();
-    idl_array.add_idls(idl, {
-      except: [
-        'PresentationReceiver',
-        'PresentationConnectionList'
-      ]
-    });
-    idl_array.add_dependency_idls(dom);
-    idl_array.add_dependency_idls(html);
-
-    try {
-      window.presentation_request = new PresentationRequest("/presentation-api/receiving-ua/idlharness.html");
-      window.presentation_request_urls = new PresentationRequest([
-        "/presentation-api/receiving-ua/idlharness.html",
-        "https://www.example.com/presentation.html"
-      ]);
-      navigator.presentation.defaultRequest = window.presentation_request;
-    } catch (e) {
-      // Will be surfaced in idlharness.js's test_object below.
+      idl_array.add_objects({
+        Presentation: ['navigator.presentation'],
+        PresentationRequest: [
+          'navigator.presentation.defaultRequest',
+          'presentation_request',
+          'presentation_request_urls'
+        ],
+      });
     }
-
-    idl_array.add_objects({
-      Presentation: ['navigator.presentation'],
-      PresentationRequest: [
-        'navigator.presentation.defaultRequest',
-        'presentation_request',
-        'presentation_request_urls'
-      ],
-    });
-    idl_array.test();
-  }, "Test IDL implementation of Presentation API");
+  );
 </script>

--- a/presentation-api/receiving-ua/idlharness-manual.https.html
+++ b/presentation-api/receiving-ua/idlharness-manual.https.html
@@ -15,7 +15,7 @@
     presentBtn.onclick = () => {
         presentBtn.disabled = true;
         const stash = new Stash(stashIds.toController, stashIds.toReceiver);
-        const request = new PresentationRequest('support/idlharness_receiving-ua.html');
+        const request = new PresentationRequest('support/idlharness_receiving-ua.html?exclude=(PresentationRequest|PresentationAvailability)');
 
         return request.start().then(c => {
             connection = c;

--- a/presentation-api/receiving-ua/support/idlharness_receiving-ua.html
+++ b/presentation-api/receiving-ua/support/idlharness_receiving-ua.html
@@ -6,36 +6,28 @@
 <link rel="help" href="http://w3c.github.io/presentation-api/#dfn-receiving-user-agent">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/subset-tests-by-key.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <script src="../common.js"></script>
 <script src="stash.js"></script>
-
 <script>
-    'use strict';
-    (async () => {
-        const srcs = ['presentation-api', 'dom', 'html'];
-        const [idl, dom, html] = await Promise.all(
-            srcs.map(i => fetch(`/interfaces/${i}.idl`).then(r => r.text())));
+  'use strict';
 
-        const idl_array = new IdlArray();
-        idl_array.add_idls(idl, {
-            except: [
-                'PresentationRequest',
-                'PresentationAvailability',
-            ]
-        });
-        idl_array.add_dependency_idls(dom);
-        idl_array.add_dependency_idls(html);
-        idl_array.add_objects({
-            Presentation: ['navigator.presentation'],
-            PresentationReceiver: ['navigator.presentation.receiver']
-        });
-        add_completion_callback((tests, status) => {
-            const stash = new Stash(stashIds.toReceiver, stashIds.toController);
-            const log = document.getElementById('log');
-            stash.send(JSON.stringify({ tests: tests, status: status, log: log.innerHTML }));
-        });
-        idl_array.test();
-    })();
+  idl_test(
+    ['presentation-api'],
+    ['dom', 'html'],
+    idl_array => {
+      idl_array.add_objects({
+        Presentation: ['navigator.presentation'],
+        PresentationReceiver: ['navigator.presentation.receiver']
+      });
+    }
+  );
+
+  add_completion_callback((tests, status) => {
+    const stash = new Stash(stashIds.toReceiver, stashIds.toController);
+    const log = document.getElementById('log');
+    stash.send(JSON.stringify({ tests: tests, status: status, log: log.innerHTML }));
+  });
 </script>


### PR DESCRIPTION
The `idl_array.add_idls(..., { except: ... })` mechanism for filtering
tests was replaced by subset-tests-by-key.js more commonly used with
idlharness.js tests.

idlharness-manual.https.html was tested manually to confirm it's still
working on Chrome 90 on macOS.