### PR TITLE
Upstream changes made to `rotate` CSS property parsing test in WebKit r276554

### DIFF
--- a/css/css-transforms/parsing/rotate-parsing-valid.html
+++ b/css/css-transforms/parsing/rotate-parsing-valid.html
@@ -22,18 +22,22 @@ test_valid_value("rotate", "0deg");
 // If a 3d rotation is specified, the property must serialize with an axis specified.
 test_valid_value("rotate", "100 200 300 400grad");
 test_valid_value("rotate", "400grad 100 200 300", "100 200 300 400grad");
+test_valid_value("rotate", "0 0 0 400grad", "0 0 0 400grad");
 
 // If the axis is parallel with the x, y, or z axis, it must serialize as the appropriate keyword.
 test_valid_value("rotate", "x 400grad");
 test_valid_value("rotate", "400grad x", "x 400grad");
+test_valid_value("rotate", "0.5 0 0 400grad", "x 400grad");
 test_valid_value("rotate", "1 0 0 400grad", "x 400grad");
 
 test_valid_value("rotate", "y 400grad");
 test_valid_value("rotate", "400grad y", "y 400grad");
+test_valid_value("rotate", "0 0.5 0 400grad", "y 400grad");
 test_valid_value("rotate", "0 1 0 400grad", "y 400grad");
 
 test_valid_value("rotate", "z 400grad");
 test_valid_value("rotate", "400grad z", "z 400grad");
+test_valid_value("rotate", "0 0 0.5 400grad", "z 400grad");
 test_valid_value("rotate", "0 0 1 400grad", "z 400grad");
 </script>
 </body>


### PR DESCRIPTION
WebKit was a bit silly and specifically looked for a `1` value in the rotation vector to determine the axis. The was addressed in [r276554](https://commits.webkit.org/236994@main) with some changes to `css/css-transforms/parsing/rotate-parsing-valid.html`.

Of note, this new test:

```javascript
test_valid_value("rotate", "0 0 0 400grad", "0 0 0 400grad");
```

This passes in Chrome and ToT WebKit but fails in Firefox which returns the value `x 400grad`. I believe the test to be correct and Firefox to be incorrect.