### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=217916

### DIFF
--- a/WebIDL/ecmascript-binding/interface-object-set-receiver.html
+++ b/WebIDL/ecmascript-binding/interface-object-set-receiver.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>window.Interface is defined on [[Set]] receiver</title>
+<link rel="help" href="https://heycam.github.io/webidl/#define-the-global-property-references">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+"use strict";
+const testValue = Object.freeze(function() {});
+
+test(() => {
+  window.Window = testValue;
+  assert_false(window.propertyIsEnumerable("Window"));
+
+  window.History = testValue;
+  assert_false(window.propertyIsEnumerable("History"));
+
+  window.HTMLDivElement = testValue;
+  assert_false(window.propertyIsEnumerable("HTMLDivElement"))
+}, "Direct [[Set]] preserves [[Enumerable]]: false property attribute");
+
+test(() => {
+  const heir = Object.create(window);
+
+  heir.Location = testValue;
+  assert_equals(heir.Location, testValue);
+  assert_not_equals(window.Location, testValue);
+
+  heir.HTMLDocument = testValue;
+  assert_equals(heir.HTMLDocument, testValue);
+  assert_not_equals(window.HTMLDocument, testValue);
+
+  heir.HTMLPreElement = testValue;
+  assert_equals(heir.HTMLPreElement, testValue);
+  assert_not_equals(window.HTMLPreElement, testValue);
+}, "Prototype chain [[Set]] creates property on receiver");
+</script>

--- a/WebIDL/ecmascript-binding/interface-prototype-constructor-set-receiver.html
+++ b/WebIDL/ecmascript-binding/interface-prototype-constructor-set-receiver.html
@@ -6,42 +6,31 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 "use strict";
+const testValue = Object.freeze(function() {});
 
 test(() => {
-  window.constructor = null;
+  Location.prototype.constructor = testValue;
+  assert_false(Location.prototype.propertyIsEnumerable("constructor"));
+
+  HTMLDocument.prototype.constructor = testValue;
+  assert_false(HTMLDocument.prototype.propertyIsEnumerable("constructor"));
+
+  HTMLDivElement.prototype.constructor = testValue;
+  assert_false(HTMLDivElement.prototype.propertyIsEnumerable("constructor"));
+}, "Direct [[Set]] preserves [[Enumerable]]: false property attribute");
+
+test(() => {
+  window.constructor = testValue;
+  assert_equals(window.constructor, testValue);
   assert_equals(Window.prototype.constructor, Window);
 
-  location.constructor = false;
-  assert_equals(Location.prototype.constructor, Location);
-
-  navigator.constructor = 1;
+  navigator.constructor = testValue;
+  assert_equals(navigator.constructor, testValue);
   assert_equals(Navigator.prototype.constructor, Navigator);
 
-  document.constructor = {};
-  assert_equals(HTMLDocument.prototype.constructor, HTMLDocument);
-
-  document.head.constructor = [];
-  assert_equals(HTMLHeadElement.prototype.constructor, HTMLHeadElement);
-}, "Window, Location, Navigator, HTMLDocument, and HTMLHeadElement");
-
-test(() => {
-  for (let key of Object.getOwnPropertyNames(window)) {
-    if (!/^[A-Z]/.test(key)) continue;
-
-    let desc = Object.getOwnPropertyDescriptor(window, key);
-    if (!desc || desc.enumerable) continue;
-    let {value} = desc;
-    if (typeof value !== "function") continue;
-    let {prototype} = value;
-    if (!prototype) continue;
-
-    let heir = Object.create(prototype);
-    let newConstructor = function() {};
-    heir.constructor = newConstructor;
-
-    assert_not_equals(prototype.constructor, newConstructor, key);
-    assert_own_property(heir, "constructor", key);
-    assert_equals(heir.constructor, newConstructor, key);
-  }
-}, "All window.* constructors");
+  const span = document.createElement("span");
+  span.constructor = testValue;
+  assert_equals(span.constructor, testValue);
+  assert_equals(HTMLSpanElement.prototype.constructor, HTMLSpanElement);
+}, "Prototype chain [[Set]] creates property on receiver");
 </script>


### PR DESCRIPTION
This upstream reviewed change tests `[[Set]]` with `window.%Interface%` and `%Interface%.prototype.constructor`, which are special lazy properties in WebKit that need extra.