### PR TITLE
Allow multiple equivalent representations for flex-{grow|shrink} computed values

### DIFF
--- a/css/css-flexbox/parsing/flex-grow-computed.html
+++ b/css/css-flexbox/parsing/flex-grow-computed.html
@@ -13,8 +13,8 @@
 <div id="target"></div>
 <script>
 test_computed_value("flex-grow", "1");
-test_computed_value("flex-grow", "2.34e+06");
-test_computed_value("flex-grow", "6.78e+08");
+test_computed_value("flex-grow", "2.34e+06", ["2.34e+06", "2340000"]);
+test_computed_value("flex-grow", "6.78e+08", ["6.78e+08", "678000000"]);
 test_computed_value("flex-grow", "0");
 </script>
 </body>

--- a/css/css-flexbox/parsing/flex-shrink-computed.html
+++ b/css/css-flexbox/parsing/flex-shrink-computed.html
@@ -13,8 +13,8 @@
 <div id="target"></div>
 <script>
 test_computed_value("flex-shrink", "1");
-test_computed_value("flex-shrink", "2.34e+06");
-test_computed_value("flex-shrink", "6.78e+08");
+test_computed_value("flex-shrink", "2.34e+06", ["2.34e+06", "2340000"]);
+test_computed_value("flex-shrink", "6.78e+08", ["6.78e+08", "678000000"]);
 test_computed_value("flex-shrink", "0");
 </script>
 </body>


### PR DESCRIPTION
Both Firefox and WebKit-based browsers report failures in `flex-{grow|shrink}-computed.html` tests because the way these engines serialize large float numbers is not exactly the same as the specified values. For example if authors use the 1e+06 notation they'll get 1000000 in return which is basically the same number but with a different notation.

The reason why it's like that is because (at least in the case of WebKit) once the value is parsed, the engine forgets about the original representation (the specified one) and when `getComputedStyle()` is called the engine just serializes an internal representation.