### PR TITLE
Cleanup. Remove assignment to undeclared attribute.

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -2105,8 +2105,6 @@ policies and contribution forms [3].
             this.set_status(status, message, stack);
             this.phase = this.phases.HAS_RESULT;
             this.done();
-        } finally {
-            this.current_test = null;
         }
     };
 


### PR DESCRIPTION
In testharness.js:
- The class `Tests` has the `current_test` attribute.
- The class `Test` doesn't.

This patch removes an instruction. This seems to be about assigning
`null` to a `Test.current_test`, and this doesn't really make sense.