### PR TITLE
New test for percentage paddings

### DIFF
--- a/css/css-flexbox/percentage-padding-002-ref.html
+++ b/css/css-flexbox/percentage-padding-002-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<link rel="author" title="Sergio Villar Senin" href="mailto:svillar@igalia.com">
+<style>
+div {
+    width: 50px;
+    height: 50px;
+}
+span {
+    display: block;
+    padding: 100%;
+    border: 5px solid black;
+}
+</style>
+<p>Test passes if there is an almost centered small white box inside another white box.</p>
+<div>
+    <span style="width: 10px; height: 30px;">
+	    <span></span>
+    </span>
+<div>

--- a/css/css-flexbox/percentage-padding-002-ref.html
+++ b/css/css-flexbox/percentage-padding-002-ref.html
@@ -7,13 +7,12 @@ div {
 }
 span {
     display: block;
-    padding: 100%;
     border: 5px solid black;
 }
 </style>
-<p>Test passes if there is an almost centered small white box inside another white box.</p>
+<p>Test passes if there is a white square inside a 10x30 white box.</p>
 <div>
     <span style="width: 10px; height: 30px;">
-	    <span></span>
+	    <span style="padding: 10px;"></span>
     </span>
 <div>

--- a/css/css-flexbox/percentage-padding-002.html
+++ b/css/css-flexbox/percentage-padding-002.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>This test checks that percentage paddings do not lead to flex items with negative sizes.</title>
+<link rel="author" title="Sergio Villar Senin" href="mailto:svillar@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#padding-physical" title="Percentages line">
+<link rel="match" href="scrollbars-ref.html">
+<style>
+div {
+    width: 50px;
+    height: 50px;
+}
+span {
+    display: inline-flex;
+    padding: 100%; /* A big padding was making the content size negative in WebKit. */
+    border: 5px solid black;
+}
+</style>
+<p>Test passes if there is an almost centered small white box inside another white box.</p>
+<div>
+    <span>
+	    <span></span>
+    </span>
+<div>

--- a/css/css-flexbox/percentage-padding-002.html
+++ b/css/css-flexbox/percentage-padding-002.html
@@ -10,13 +10,12 @@ div {
 }
 span {
     display: inline-flex;
-    padding: 100%; /* A big padding was making the content size negative in WebKit. */
     border: 5px solid black;
 }
 </style>
-<p>Test passes if there is an almost centered small white box inside another white box.</p>
+<p>Test passes if there is a white square inside a 10x30 white box.</p>
 <div>
     <span>
-	    <span></span>
+	    <span style="padding: 100%;"></span>
     </span>
 <div>


### PR DESCRIPTION
WebKit was wrongly computing some content size suggestions as negative in some cases were a percentage padding was specified.  The problem was that the extent of the border and the padding were computed just when computing the intrinsic size but not recomputed later during layout. This caused a mismatch between the content size and the border and padding extents leading to negative values for the content.