### PR TITLE
The rotate property should not specify an axis when the provided axis is parallel to the z axis

### DIFF
--- a/css/css-transforms/animation/rotate-interpolation.html
+++ b/css/css-transforms/animation/rotate-interpolation.html
@@ -56,7 +56,7 @@ test_interpolation({
   to: '-1 1 0 60deg',
 }, [
   {at: -1, expect: '0.447214 -0.447214 0.774597 104.478deg'},
-  {at: 0, expect: 'z 45deg'},
+  {at: 0, expect: '45deg'},
   {at: 0.125, expect: '-0.136456 0.136456 0.981203 40.6037deg'},
   {at: 0.875, expect: '-0.70246 0.70246 0.114452 53.1994deg'},
   {at: 1, expect: '-0.71 0.71 0 60deg'},

--- a/css/css-transforms/parsing/rotate-parsing-valid.html
+++ b/css/css-transforms/parsing/rotate-parsing-valid.html
@@ -24,7 +24,7 @@ test_valid_value("rotate", "100 200 300 400grad");
 test_valid_value("rotate", "400grad 100 200 300", "100 200 300 400grad");
 test_valid_value("rotate", "0 0 0 400grad", "0 0 0 400grad");
 
-// If the axis is parallel with the x, y, or z axis, it must serialize as the appropriate keyword.
+// If the axis is parallel with the x or y axis, it must serialize as the appropriate keyword.
 test_valid_value("rotate", "x 400grad");
 test_valid_value("rotate", "400grad x", "x 400grad");
 test_valid_value("rotate", "0.5 0 0 400grad", "x 400grad");
@@ -35,10 +35,11 @@ test_valid_value("rotate", "400grad y", "y 400grad");
 test_valid_value("rotate", "0 0.5 0 400grad", "y 400grad");
 test_valid_value("rotate", "0 1 0 400grad", "y 400grad");
 
-test_valid_value("rotate", "z 400grad");
-test_valid_value("rotate", "400grad z", "z 400grad");
-test_valid_value("rotate", "0 0 0.5 400grad", "z 400grad");
-test_valid_value("rotate", "0 0 1 400grad", "z 400grad");
+// If the axis is parallel with the z axis the property must serialize as just an <angle>.
+test_valid_value("rotate", "400grad");
+test_valid_value("rotate", "400grad z", "400grad");
+test_valid_value("rotate", "0 0 0.5 400grad", "400grad");
+test_valid_value("rotate", "0 0 1 400grad", "400grad");
 </script>
 </body>
 </html>


### PR DESCRIPTION
Followup to #28691 following changes made in https://github.com/w3c/csswg-drafts/pull/6147.