### PR TITLE
Rewrite test for setting blob on srcObject

### DIFF
--- a/html/semantics/embedded-content/media-elements/src_object_blob.html
+++ b/html/semantics/embedded-content/media-elements/src_object_blob.html
@@ -15,9 +15,8 @@
     } catch (error) {
       assert_unreached(error);
     }
-    const done = new Promise(res => video.addEventListener('ended', res))
+    const done = new Promise(res => video.addEventListener('ended', res));
     video.play();
     return done;
   });
 </script>
-

--- a/html/semantics/embedded-content/media-elements/src_object_blob.html
+++ b/html/semantics/embedded-content/media-elements/src_object_blob.html
@@ -6,26 +6,20 @@
 <script src="/resources/testharnessreport.js"></script>
 <video></video>
 <script>
-  async_test(function(t) {
-    t.step(function() {
-      fetch(getVideoURI('/media/movie_5'))
-        .then(function(response) {
-          return response.blob();
-        })
-        .then(function(blob) {
-          let video = document.querySelector("video");
-          video.srcObject = blob;
-          video.addEventListener('ended', function() {
-            t.done();
-          });
-          video.play().catch(function(error) {
-            assert(false, error);
-          });
-        })
-        .catch(function(error) {
-          assert(false, error);
-        });
+  let video = document.querySelector("video");
+  promise_test(async t => {
+    const blob = await fetch(getVideoURI('/media/movie_5'))
+          .then(r => r.blob());
+    try {
+      video.srcObject = blob;
+    } catch (error) {
+      assert_unreached(error);
+      return t.done();
+    }
+    video.addEventListener('ended', function() {
+      t.done();
     });
+    video.play();
   });
 </script>
 

--- a/html/semantics/embedded-content/media-elements/src_object_blob.html
+++ b/html/semantics/embedded-content/media-elements/src_object_blob.html
@@ -14,12 +14,10 @@
       video.srcObject = blob;
     } catch (error) {
       assert_unreached(error);
-      return t.done();
     }
-    video.addEventListener('ended', function() {
-      t.done();
-    });
+    const done = new Promise(res => video.addEventListener('ended', res))
     video.play();
+    return done;
   });
 </script>
 

--- a/html/semantics/embedded-content/media-elements/src_object_blob.html
+++ b/html/semantics/embedded-content/media-elements/src_object_blob.html
@@ -6,7 +6,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <video></video>
 <script>
-  let video = document.querySelector("video");
+  const video = document.querySelector("video");
   promise_test(async () => {
     const blob = await fetch(getVideoURI('/media/movie_5'))
           .then(r => r.blob());

--- a/html/semantics/embedded-content/media-elements/src_object_blob.html
+++ b/html/semantics/embedded-content/media-elements/src_object_blob.html
@@ -7,7 +7,7 @@
 <video></video>
 <script>
   let video = document.querySelector("video");
-  promise_test(async t => {
+  promise_test(async () => {
     const blob = await fetch(getVideoURI('/media/movie_5'))
           .then(r => r.blob());
     try {


### PR DESCRIPTION
Use assert_unreached instead of buggy assert
Use async/await for readability
Wrap srcObject assignment in try/catch to catch where the error actually happens

Triggered by reviewing https://github.com/mdn/content/issues/1704 and https://github.com/mdn/browser-compat-data/commit/d608b88b138bcec53e816c8c63aa1317466c750b