### PR TITLE
Replace all uses of six.move by the Python 3-only equivalent

### DIFF
--- a/common/security-features/subresource/static-import.py
+++ b/common/security-features/subresource/static-import.py
@@ -1,5 +1,5 @@
 import os, sys
-from six.moves.urllib.parse import unquote
+from urllib.parse import unquote
 
 from wptserve.utils import isomorphic_decode
 import importlib

--- a/common/security-features/subresource/subresource.py
+++ b/common/security-features/subresource/subresource.py
@@ -1,5 +1,5 @@
 import os, json
-from six.moves.urllib.parse import parse_qsl, SplitResult, urlencode, urlsplit, urlunsplit
+from urllib.parse import parse_qsl, SplitResult, urlencode, urlsplit, urlunsplit
 
 from wptserve.utils import isomorphic_decode, isomorphic_encode
 

--- a/cookie-store/resources/cookie_helper.py
+++ b/cookie-store/resources/cookie_helper.py
@@ -22,7 +22,7 @@ import encodings, re
 
 from six import PY3
 
-from six.moves.urllib.parse import parse_qs, quote
+from urllib.parse import parse_qs, quote
 
 from wptserve.utils import isomorphic_decode, isomorphic_encode
 

--- a/cookies/resources/helpers.py
+++ b/cookies/resources/helpers.py
@@ -1,6 +1,6 @@
 from six import integer_types
 
-from six.moves.urllib.parse import parse_qs
+from urllib.parse import parse_qs
 
 from wptserve.utils import isomorphic_encode
 

--- a/cookies/resources/set.py
+++ b/cookies/resources/set.py
@@ -1,5 +1,5 @@
 from cookies.resources import helpers
-from six.moves.urllib.parse import unquote
+from urllib.parse import unquote
 
 from wptserve.utils import isomorphic_encode
 

--- a/fetch/api/resources/redirect.py
+++ b/fetch/api/resources/redirect.py
@@ -1,6 +1,6 @@
 import time
 
-from six.moves.urllib.parse import urlencode, urlparse
+from urllib.parse import urlencode, urlparse
 
 from wptserve.utils import isomorphic_decode, isomorphic_encode
 

--- a/fetch/api/resources/trickle.py
+++ b/fetch/api/resources/trickle.py
@@ -1,7 +1,5 @@
 import time
 
-from six.moves import xrange
-
 def main(request, response):
     delay = float(request.GET.first(b"ms", 500)) / 1E3
     count = int(request.GET.first(b"count", 50))
@@ -11,6 +9,6 @@ def main(request, response):
     response.headers.set(b"Content-type", b"text/plain")
     response.write_status_headers()
     time.sleep(delay)
-    for i in xrange(count):
+    for i in range(count):
         response.writer.write_content(b"TEST_TRICKLE\n")
         time.sleep(delay)

--- a/resource-timing/SyntheticResponse.py
+++ b/resource-timing/SyntheticResponse.py
@@ -1,4 +1,4 @@
-from six.moves.urllib.parse import unquote
+from urllib.parse import unquote
 
 from wptserve.utils import isomorphic_decode, isomorphic_encode
 

--- a/resources/test/conftest.py
+++ b/resources/test/conftest.py
@@ -4,12 +4,12 @@ import os
 import ssl
 import sys
 import subprocess
+import urllib
 
 import html5lib
 import py
 import pytest
 from six import text_type
-from six.moves import urllib
 
 from wptserver import WPTServer
 

--- a/resources/test/wptserver.py
+++ b/resources/test/wptserver.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import time
 import sys
-from six.moves import urllib
+import urllib
 
 
 class WPTServer(object):

--- a/service-workers/service-worker/resources/notification_icon.py
+++ b/service-workers/service-worker/resources/notification_icon.py
@@ -1,4 +1,4 @@
-from six.moves.urllib.parse import parse_qs
+from urllib.parse import parse_qs
 
 from wptserve.utils import isomorphic_encode
 

--- a/service-workers/service-worker/resources/update-worker.py
+++ b/service-workers/service-worker/resources/update-worker.py
@@ -1,4 +1,4 @@
-from six.moves.urllib.parse import unquote
+from urllib.parse import unquote
 
 from wptserve.utils import isomorphic_decode, isomorphic_encode
 

--- a/webdriver/tests/support/authentication.py
+++ b/webdriver/tests/support/authentication.py
@@ -1,4 +1,4 @@
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 
 def basic_authentication(url, username=None, password=None, protocol="http"):

--- a/webdriver/tests/support/fixtures.py
+++ b/webdriver/tests/support/fixtures.py
@@ -8,7 +8,7 @@ import webdriver
 
 from six import string_types
 
-from six.moves.urllib.parse import urlunsplit
+from urllib.parse import urlunsplit
 
 from tests.support import defaults
 from tests.support.helpers import cleanup_session, deep_update

--- a/webdriver/tests/support/http_request.py
+++ b/webdriver/tests/support/http_request.py
@@ -3,7 +3,7 @@ import json
 
 from six import text_type
 
-from six.moves.http_client import HTTPConnection
+from http.client import HTTPConnection
 
 
 class HTTPRequest(object):

--- a/webdriver/tests/support/inline.py
+++ b/webdriver/tests/support/inline.py
@@ -1,6 +1,6 @@
 """Helpers for inlining extracts of documents in tests."""
 
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 
 BOILERPLATES = {

--- a/webdriver/tests/switch_to_frame/cross_origin.py
+++ b/webdriver/tests/switch_to_frame/cross_origin.py
@@ -1,4 +1,4 @@
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 import webdriver.protocol as protocol
 

--- a/websockets/cookies/support/set-cookie.py
+++ b/websockets/cookies/support/set-cookie.py
@@ -1,7 +1,7 @@
-from six.moves.urllib import parse
+from urllib.parse import unquote
 
 from wptserve.utils import isomorphic_encode
 
 def main(request, response):
-    response.headers.set(b'Set-Cookie', isomorphic_encode(parse.unquote(request.url_parts.query)))
+    response.headers.set(b'Set-Cookie', isomorphic_encode(unquote(request.url_parts.query)))
     return [(b"Content-Type", b"text/plain")], b""

--- a/websockets/handlers/set-cookie-secure_wsh.py
+++ b/websockets/handlers/set-cookie-secure_wsh.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from six.moves import urllib
+import urllib
 
 
 def web_socket_do_extra_handshake(request):

--- a/websockets/handlers/set-cookie_http_wsh.py
+++ b/websockets/handlers/set-cookie_http_wsh.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-from six.moves import urllib
+import urllib
 
 def web_socket_do_extra_handshake(request):
     url_parts = urllib.parse.urlsplit(request.uri)

--- a/websockets/handlers/set-cookie_wsh.py
+++ b/websockets/handlers/set-cookie_wsh.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from six.moves import urllib
+import urllib
 
 
 def web_socket_do_extra_handshake(request):

--- a/websockets/handlers/set-cookies-samesite_wsh.py
+++ b/websockets/handlers/set-cookies-samesite_wsh.py
@@ -1,4 +1,4 @@
-from six.moves import urllib
+import urllib
 
 
 def web_socket_do_extra_handshake(request):

--- a/websockets/handlers/stash_responder_wsh.py
+++ b/websockets/handlers/stash_responder_wsh.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
-from six.moves import urllib
 import json
+import urllib
 from mod_pywebsocket import common, msgutil, util
 from mod_pywebsocket.handshake import hybi
 from wptserve import stash

--- a/xhr/resources/trickle.py
+++ b/xhr/resources/trickle.py
@@ -1,7 +1,5 @@
 import time
 
-from six.moves import range
-
 def main(request, response):
     chunk = b"TEST_TRICKLE\n"
     delay = float(request.GET.first(b"ms", 500)) / 1E3


### PR DESCRIPTION
To improve confidence that this will work in Python 3.6, all of the
unique import statements were tested in Python 3.5.5 and 3.6.8:
```py
from http.client import HTTPConnection
from urllib.parse import parse_qs
from urllib.parse import parse_qs, quote
from urllib.parse import parse_qsl, SplitResult, urlencode, urlsplit, urlunsplit
from urllib.parse import unquote
from urllib.parse import urlencode
from urllib.parse import urlencode, urlparse
from urllib.parse import urlparse
from urllib.parse import urlunsplit
import urllib
```