### PR TITLE
Remove dead code guarded by sys.version_info checks

### DIFF
--- a/tools/localpaths.py
+++ b/tools/localpaths.py
@@ -33,9 +33,6 @@ if sys.version_info < (3, 8):
 sys.path.insert(0, os.path.join(here, "webdriver"))
 sys.path.insert(0, os.path.join(here, "wptrunner"))
 
-if sys.version_info[0] == 2:
-    sys.path.insert(0, os.path.join(here, "third_party", "enum"))
-
 # We can't import six until we've set the path above.
 from six import ensure_text
 repo_root = ensure_text(os.path.abspath(os.path.join(here, os.pardir)))

--- a/tools/manifest/XMLParser.py
+++ b/tools/manifest/XMLParser.py
@@ -1,4 +1,3 @@
-import sys
 from os.path import dirname, join
 
 from collections import OrderedDict
@@ -37,11 +36,7 @@ def _fixname(key):
     return name
 
 
-if sys.version_info[0:2] >= (3, 2):
-    _undefined_entity_code = expat.errors.codes[expat.errors.XML_ERROR_UNDEFINED_ENTITY]  # type: int
-else:
-    _codes = {expat.ErrorString(i): i for i in range(0x100)}  # type: Dict[str, int]
-    _undefined_entity_code = _codes[expat.errors.XML_ERROR_UNDEFINED_ENTITY]
+_undefined_entity_code = expat.errors.codes[expat.errors.XML_ERROR_UNDEFINED_ENTITY]  # type: int
 
 
 class XMLParser(object):

--- a/tools/wptrunner/wptrunner/metadata.py
+++ b/tools/wptrunner/wptrunner/metadata.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import array
 import os
-import sys
 from collections import defaultdict, namedtuple
 
 from mozlog import structuredlog
@@ -327,10 +326,7 @@ def write_new_expected(metadata_path, expected):
         try:
             with open(tmp_path, "wb") as f:
                 f.write(manifest_str.encode("utf8"))
-            if sys.version_info >= (3, 3):
-                os.replace(tmp_path, path)
-            else:
-                os.rename(tmp_path, path)
+            os.replace(tmp_path, path)
         except (Exception, KeyboardInterrupt):
             try:
                 os.unlink(tmp_path)


### PR DESCRIPTION
We can assume Python 3.6 or later.

Part of https://github.com/web-platform-tests/wpt/issues/28776.