### PR TITLE
Replace int2byte from six with string literals or bytes(...)

### DIFF
--- a/encoding/resources/single-byte-raw.py
+++ b/encoding/resources/single-byte-raw.py
@@ -1,5 +1,3 @@
-from six import int2byte
-
 def main(request, response):
   response.headers.set(b"Content-Type", b"text/plain;charset=" + request.GET.first(b"label"))
-  response.content = b"".join(int2byte(byte) for byte in range(255))
+  response.content = bytes(range(255))

--- a/xhr/resources/invalid-utf8-html.py
+++ b/xhr/resources/invalid-utf8-html.py
@@ -1,7 +1,5 @@
-from six import int2byte
-
 def main(request, response):
     headers = [(b"Content-type", b"text/html;charset=utf-8")]
-    content = int2byte(0xff)
+    content = b"\xff"
 
     return headers, content

--- a/xhr/resources/shift-jis-html.py
+++ b/xhr/resources/shift-jis-html.py
@@ -1,8 +1,6 @@
-from six import int2byte
-
 def main(request, response):
     headers = [(b"Content-type", b"text/html;charset=shift-jis")]
     # Shift-JIS bytes for katakana TE SU TO ('test')
-    content = int2byte(0x83) + int2byte(0x65) + int2byte(0x83) + int2byte(0x58) + int2byte(0x83) + int2byte(0x67)
+    content = bytes([0x83, 0x65, 0x83, 0x58, 0x83, 0x67])
 
     return headers, content

--- a/xhr/resources/win-1252-xml.py
+++ b/xhr/resources/win-1252-xml.py
@@ -1,7 +1,5 @@
-from six import int2byte
-
 def main(request, response):
     headers = [(b"Content-type", b"application/xml;charset=windows-1252")]
-    content = b'<' + int2byte(0xff) + b'/>'
+    content = b'<\xff/>'
 
     return headers, content


### PR DESCRIPTION
The following expressions were evaluated as True in a Python 3.8.2 shell
to gain confidence:
```py
from six import int2byte
b"".join(int2byte(byte) for byte in range(255)) == bytes(range(255))
int2byte(0xff) == b"\xff"
int2byte(0x83) + int2byte(0x65) + int2byte(0x83) + int2byte(0x58) + int2byte(0x83) + int2byte(0x67) == bytes([0x83, 0x65, 0x83, 0x58, 0x83, 0x67])
b'<' + int2byte(0xff) + b'/>' == b'<\xff/>'
```