### PR TITLE
Simplify file-submission.py and the tests using it

### DIFF
--- a/html/semantics/forms/form-submission-0/resources/file-submission.py
+++ b/html/semantics/forms/form-submission-0/resources/file-submission.py
@@ -1,9 +1,10 @@
+import json
+
 from wptserve.utils import isomorphic_decode
 
 def main(request, response):
+    headers = [(b"Content-Type", b"text/html")]
     testinput = request.POST.first(b"testinput")
-    # The test asserts the string representation of this FieldStorage
-    # object, but unfortunately the value property has different types in
-    # Python 2 and 3. Unify them to native strings.
-    testinput.value = isomorphic_decode(testinput.value)
-    return ([(b"Content-Type", b"text/html")], u"<script>parent.postMessage(\"" + str(testinput) + u"\", '*');</script>")
+    value = isomorphic_decode(testinput.value)
+    body = u"<script>parent.postMessage(" + json.dumps(value) + u", '*');</script>"
+    return headers, body

--- a/html/semantics/forms/form-submission-0/submit-file.sub.html
+++ b/html/semantics/forms/form-submission-0/submit-file.sub.html
@@ -16,10 +16,10 @@ async_test(t => {
   testinput.files = dataTransfer.files;
   testform.submit();
 
-  onmessage = e => {
+  onmessage = t.step_func(e => {
     if (e.source !== testframe) return;
-    assert_equals("FieldStorage('testinput', 'name', 'foobar')", e.data);
+    assert_equals(e.data, "foobar");
     t.done();
-  };
+  });
 }, 'Posting a File');
 </script>

--- a/service-workers/service-worker/data-transfer-files.https.html
+++ b/service-workers/service-worker/data-transfer-files.https.html
@@ -35,7 +35,7 @@ promise_test(async (t) => {
       resolve(e.data);
     };
   });
-  assert_equals(data, "FieldStorage('testinput', 'name', 'foobar')");
+  assert_equals(data, "foobar");
 }, 'Posting a File in a navigation handled by a service worker');
 </script>
 </body>


### PR DESCRIPTION
This handler was serializing the FieldStorage object in a way that does
not seem useful. It already assumed the "testinput" key of the POST
data, so just properly encode the value and send it back.

Although the tests don't depend on it, this should preserve non-UTF8
input in an escaped form. For example, if testinput were b"\xff", then
the body would end up being:
```html
<script>parent.postMessage("\u00ff", '*');</script>
```

Tests could rely on this if necessary.

Also add missing step_func wrapping.

Follow-up to https://github.com/web-platform-tests/wpt/pull/28747#discussion_r623367603.