### PR TITLE
[ci] Remove obsolete PY2_FLAG from ci_wptrunner_infrastructure.sh

### DIFF
--- a/tools/ci/ci_wptrunner_infrastructure.sh
+++ b/tools/ci/ci_wptrunner_infrastructure.sh
@@ -6,8 +6,7 @@ WPT_ROOT=$SCRIPT_DIR/../..
 cd $WPT_ROOT
 
 test_infrastructure() {
-    PY2_FLAG="$2"
-    TERM=dumb ./wpt $PY2_FLAG run --log-mach - --yes --manifest ~/meta/MANIFEST.json --metadata infrastructure/metadata/ --install-fonts --install-webdriver $1 $PRODUCT infrastructure/
+    TERM=dumb ./wpt run --log-mach - --yes --manifest ~/meta/MANIFEST.json --metadata infrastructure/metadata/ --install-fonts --install-webdriver $1 $PRODUCT infrastructure/
 }
 
 main() {


### PR DESCRIPTION
Part of https://github.com/web-platform-tests/wpt/issues/28776.