### PR TITLE
[ci] Send the full release info when updating a manifest release

### DIFF
--- a/tools/ci/manifest_build.py
+++ b/tools/ci/manifest_build.py
@@ -139,7 +139,8 @@ def create_release(manifest_path, owner, repo, sha, tag, body):
 
     release_id = create_resp["id"]
     edit_url = "https://api.github.com/repos/%s/%s/releases/%s" % (owner, repo, release_id)
-    edit_data = {"draft": False}
+    edit_data = create_data.copy()
+    edit_data["draft"] = False
     edit_resp = request(edit_url, "Release publishing", method=requests.patch, json_data=edit_data)
     if not edit_resp:
         return False


### PR DESCRIPTION
Since 8268c05420f4edfa64bff4ee2e49044ffe96f3f2 the manifest job has
begun creating untagged-* tags instead of merge_pr_* tags. Example:
https://github.com/web-platform-tests/wpt/runs/2468713699?check_suite_focus=true

The script is still determining the correct tag name and nothing has
changed in WPT, so perhaps the GitHub API has changed. Just send all the
information again to be sure, it's not much harder.