### PR TITLE
Add ability to run servers on different IP addresses.

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -747,8 +747,8 @@ class WebSocketDaemon(object):
         if not ports:
             # TODO: Fix the logging configuration in WebSockets processes
             # see https://github.com/web-platform-tests/wpt/issues/22719
-            print("Failed to start websocket server on port %s, "
-                  "is something already using that port?" % port, file=sys.stderr)
+            print("Failed to start websocket server on %s:%s, "
+                  "is something already using that port?" % (host, port), file=sys.stderr)
             raise OSError()
         assert all(item == ports[0] for item in ports)
         self.port = ports[0]

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -507,7 +507,7 @@ class ServerProc(object):
         self.proc = self.mp_context.Process(target=self.create_daemon,
                                             args=(init_func, host, port, paths, routes, bind_address,
                                                   config),
-                                            name='%s on port %s' % (self.scheme, port),
+                                            name='%s on %s:%s' % (self.scheme, host, port),
                                             kwargs=kwargs)
         self.proc.daemon = True
         self.proc.start()
@@ -588,24 +588,30 @@ def check_subdomains(config, routes, mp_context):
                         "on {}. {}".format(url, EDIT_HOSTS_HELP))
         sys.exit(1)
 
-    for domain in config.domains_set:
-        if domain == host:
+    for host_key, subdomains in config.domains.items():
+        if host_key in config.alternate_ip_addresses:
+            # These domains are served on a different IP than `host`.
             continue
 
-        try:
-            urllib.request.urlopen("http://%s:%d/" % (domain, port))
-        except Exception:
-            logger.critical("Failed probing domain {}. {}".format(domain, EDIT_HOSTS_HELP))
-            sys.exit(1)
+        for subdomain, domain in subdomains.items():
+            if domain == host:
+                # Already tested above.
+                continue
+
+            try:
+                urllib.request.urlopen("http://%s:%d/" % (domain, port))
+            except Exception:
+                logger.critical("Failed probing domain {}. {}".format(domain, EDIT_HOSTS_HELP))
+                sys.exit(1)
 
     wrapper.wait()
 
 
-def make_hosts_file(config, host):
+def make_hosts_file(config, default_ip_address):
     rv = []
 
-    for domain in config.domains_set:
-        rv.append("%s\t%s\n" % (host, domain))
+    for domain, ip_address in config.domains_ip_addresses.items():
+        rv.append("%s\t%s\n" % (ip_address or default_ip_address, domain))
 
     # Windows interpets the IP address 0.0.0.0 as non-existent, making it an
     # appropriate alias for non-existent hosts. However, UNIX-like systems
@@ -621,32 +627,35 @@ def make_hosts_file(config, host):
     return "".join(rv)
 
 
-def start_servers(host, ports, paths, routes, bind_address, config,
-                  mp_context, **kwargs):
+def start(config, routes, mp_context, **kwargs):
     servers = defaultdict(list)
-    for scheme, ports in ports.items():
-        assert len(ports) == {"http": 2, "https": 2}.get(scheme, 1)
 
-        # If trying to start HTTP/2.0 server, check compatibility
-        if scheme == 'h2' and not http2_compatible():
-            logger.error('Cannot start HTTP/2.0 server as the environment is not compatible. ' +
-                         'Requires Python 2.7.10+ or 3.6+ and OpenSSL 1.0.2+')
-            continue
+    logger.debug("Using ports: %r" % config.ports)
 
-        for port in ports:
-            if port is None:
+    for host in config.all_server_hosts:
+        for scheme, ports in config.ports.items():
+            assert len(ports) == {"http": 2, "https": 2}.get(scheme, 1)
+
+            # If trying to start HTTP/2.0 server, check compatibility
+            if scheme == 'h2' and not http2_compatible():
+                logger.error('Cannot start HTTP/2.0 server as the environment is not compatible. ' +
+                             'Requires Python 2.7.10+ or 3.6+ and OpenSSL 1.0.2+')
                 continue
-            init_func = {"http": start_http_server,
-                         "https": start_https_server,
-                         "h2": start_http2_server,
-                         "ws": start_ws_server,
-                         "wss": start_wss_server,
-                         "quic-transport": start_quic_transport_server}[scheme]
 
-            server_proc = ServerProc(mp_context, scheme=scheme)
-            server_proc.start(init_func, host, port, paths, routes, bind_address,
-                              config, **kwargs)
-            servers[scheme].append((port, server_proc))
+            for port in ports:
+                if port is None:
+                    continue
+                init_func = {"http": start_http_server,
+                             "https": start_https_server,
+                             "h2": start_http2_server,
+                             "ws": start_ws_server,
+                             "wss": start_wss_server,
+                             "quic-transport": start_quic_transport_server}[scheme]
+
+                server_proc = ServerProc(mp_context, scheme=scheme)
+                server_proc.start(init_func, host, port, config.paths, routes, config.bind_address,
+                                  config, **kwargs)
+                servers[scheme].append((port, server_proc))
 
     return servers
 
@@ -873,19 +882,6 @@ def start_quic_transport_server(host, port, paths, routes, bind_address, config,
         startup_failed(log=False)
 
 
-def start(config, routes, mp_context, **kwargs):
-    host = config["server_host"]
-    ports = config.ports
-    paths = config.paths
-    bind_address = config["bind_address"]
-
-    logger.debug("Using ports: %r" % ports)
-
-    servers = start_servers(host, ports, paths, routes, bind_address, config, mp_context, **kwargs)
-
-    return servers
-
-
 def iter_procs(servers):
     for servers in servers.values():
         for port, server in servers:
@@ -927,7 +923,15 @@ class ConfigBuilder(config.ConfigBuilder):
     _default = {
         "browser_host": "web-platform.test",
         "alternate_hosts": {
-            "alt": "not-web-platform.test"
+            "alt": "not-web-platform.test",
+            "private": "private-web-platform.test",
+            "public": "public-web-platform.test",
+        },
+        "alternate_ip_addresses": {
+            # Missing hosts use the default IP address passed to
+            # `make_hosts_file()`.
+            "private": "127.1.0.1",
+            "public": "127.2.0.1",
         },
         "doc_root": repo_root,
         "ws_doc_root": os.path.join(repo_root, "websockets", "handlers"),

--- a/tools/serve/test_functional.py
+++ b/tools/serve/test_functional.py
@@ -56,7 +56,7 @@ def test_subprocess_exit(server_subprocesses, tempfile_name):
         # which are relevant to this functionality. Disable the check so that
         # the constructor is only used to create relevant processes.
         with open(tempfile_name, 'w') as handle:
-            json.dump({"check_subdomains": False, "bind_address": False}, handle)
+            json.dump({"check_subdomains": False}, handle)
 
         # The `logger` module from the wptserver package uses a singleton
         # pattern which resists testing. In order to avoid conflicting with

--- a/tools/serve/test_serve.py
+++ b/tools/serve/test_serve.py
@@ -80,15 +80,9 @@ def test_pickle():
         pickle.dumps(c)
 
 
-def test_config_json_length():
-    # we serialize the config as JSON for pytestrunner and put it in an env
-    # variable, which on Windows must have a length <= 0x7FFF (int16)
-    with ConfigBuilder() as c:
-        data = json.dumps(c.as_dict_for_wd_env_variable())
-    assert len(data) <= 0x7FFF
-
 def test_alternate_host_unspecified():
     ConfigBuilder(browser_host="web-platform.test")
+
 
 @pytest.mark.parametrize("primary, alternate", [
     ("web-platform.test", "web-platform.test"),

--- a/tools/serve/test_serve.py
+++ b/tools/serve/test_serve.py
@@ -16,17 +16,18 @@ def test_make_hosts_file_nix():
     with ConfigBuilder(ports={"http": [8000]},
                        browser_host="foo.bar",
                        alternate_hosts={"alt": "foo2.bar"},
+                       alternate_ip_addresses={"alt": "192.168.13.37"},
                        subdomains={"a", "b"},
                        not_subdomains={"x, y"}) as c:
         hosts = serve.make_hosts_file(c, "192.168.42.42")
         lines = hosts.split("\n")
         assert set(lines) == {"",
                               "192.168.42.42\tfoo.bar",
-                              "192.168.42.42\tfoo2.bar",
+                              "192.168.13.37\tfoo2.bar",
                               "192.168.42.42\ta.foo.bar",
-                              "192.168.42.42\ta.foo2.bar",
+                              "192.168.13.37\ta.foo2.bar",
                               "192.168.42.42\tb.foo.bar",
-                              "192.168.42.42\tb.foo2.bar"}
+                              "192.168.13.37\tb.foo2.bar"}
         assert lines[-1] == ""
 
 @pytest.mark.skipif(platform.uname()[0] != "Windows",
@@ -35,6 +36,7 @@ def test_make_hosts_file_windows():
     with ConfigBuilder(ports={"http": [8000]},
                        browser_host="foo.bar",
                        alternate_hosts={"alt": "foo2.bar"},
+                       alternate_ip_addresses={"alt": "192.168.13.37"},
                        subdomains={"a", "b"},
                        not_subdomains={"x", "y"}) as c:
         hosts = serve.make_hosts_file(c, "192.168.42.42")
@@ -45,11 +47,11 @@ def test_make_hosts_file_windows():
                               "0.0.0.0\ty.foo.bar",
                               "0.0.0.0\ty.foo2.bar",
                               "192.168.42.42\tfoo.bar",
-                              "192.168.42.42\tfoo2.bar",
+                              "192.168.13.37\tfoo2.bar",
                               "192.168.42.42\ta.foo.bar",
-                              "192.168.42.42\ta.foo2.bar",
+                              "192.168.13.37\ta.foo2.bar",
                               "192.168.42.42\tb.foo.bar",
-                              "192.168.42.42\tb.foo2.bar"}
+                              "192.168.13.37\tb.foo2.bar"}
         assert lines[-1] == ""
 
 
@@ -96,7 +98,8 @@ def test_alternate_host_unspecified():
 ])
 def test_alternate_host_invalid(primary, alternate):
     with pytest.raises(ValueError):
-        ConfigBuilder(browser_host=primary, alternate_hosts={"alt": alternate})
+        ConfigBuilder(browser_host=primary, alternate_hosts={"alt": alternate}, alternate_ip_addresses={})
+
 
 @pytest.mark.parametrize("primary, alternate", [
     ("web-platform.test", "not-web-platform.test"),
@@ -104,4 +107,4 @@ def test_alternate_host_invalid(primary, alternate):
     ("web-platform-tests.dev", "web-platform-tests.live"),
 ])
 def test_alternate_host_valid(primary, alternate):
-    ConfigBuilder(browser_host=primary, alternate_hosts={"alt": alternate})
+    ConfigBuilder(browser_host=primary, alternate_hosts={"alt": alternate}, alternate_ip_addresses={})

--- a/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
+++ b/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
@@ -43,17 +43,22 @@ def run(path, server_config, session_config, timeout=0, environ=None):
 
     old_environ = os.environ.copy()
     try:
-        os.environ["WD_HOST"] = session_config["host"]
-        os.environ["WD_PORT"] = str(session_config["port"])
-        os.environ["WD_CAPABILITIES"] = json.dumps(session_config["capabilities"])
-        os.environ["WD_SERVER_CONFIG"] = json.dumps(server_config.as_dict_for_wd_env_variable())
-        if environ:
-            os.environ.update(environ)
-
-        harness = HarnessResultRecorder()
-        subtests = SubtestResultRecorder()
-
         with TemporaryDirectory() as cache:
+            os.environ["WD_HOST"] = session_config["host"]
+            os.environ["WD_PORT"] = str(session_config["port"])
+            os.environ["WD_CAPABILITIES"] = json.dumps(session_config["capabilities"])
+
+            config_path = os.path.join(cache, "wd_server_config.json")
+            os.environ["WD_SERVER_CONFIG_FILE"] = config_path
+            with open(config_path, "w") as f:
+                json.dump(server_config.as_dict(), f)
+
+            if environ:
+                os.environ.update(environ)
+
+            harness = HarnessResultRecorder()
+            subtests = SubtestResultRecorder()
+
             try:
                 pytest.main(["--strict",  # turn warnings into errors
                              "-vv",  # show each individual subtest and full failure logs

--- a/tools/wptserve/wptserve/config.py
+++ b/tools/wptserve/wptserve/config.py
@@ -68,31 +68,6 @@ class Config(Mapping):
     def as_dict(self):
         return json_types(self.__dict__)
 
-    # Environment variables are limited in size so we need to prune the most egregious contributors
-    # to size, the origin policy subdomains.
-    def as_dict_for_wd_env_variable(self):
-        result = self.as_dict()
-
-        for key in [
-            ("subdomains",),
-            ("domains", "alt"),
-            ("domains", ""),
-            ("all_domains", "alt"),
-            ("all_domains", ""),
-            ("domains_set",),
-            ("all_domains_set",)
-        ]:
-            target = result
-            for part in key[:-1]:
-                target = target[part]
-            value = target[key[-1]]
-            if isinstance(value, dict):
-                target[key[-1]] = {k:v for (k,v) in value.items() if not k.startswith("op")}
-            else:
-                target[key[-1]] = [x for x in value if not x.startswith("op")]
-
-        return result
-
 
 def json_types(obj):
     if isinstance(obj, dict):

--- a/tools/wptserve/wptserve/config.py
+++ b/tools/wptserve/wptserve/config.py
@@ -139,6 +139,7 @@ class ConfigBuilder(object):
     _default = {
         "browser_host": "localhost",
         "alternate_hosts": {},
+        "alternate_ip_addresses": {},
         "doc_root": os.path.dirname("__file__"),
         "server_host": None,
         "ports": {"http": [8000]},
@@ -172,10 +173,12 @@ class ConfigBuilder(object):
     computed_properties = ["log_level",
                            "paths",
                            "server_host",
+                           "all_server_hosts",
                            "ports",
                            "domains",
                            "not_domains",
                            "all_domains",
+                           "domains_ip_addresses",
                            "domains_set",
                            "not_domains_set",
                            "all_domains_set",
@@ -280,8 +283,21 @@ class ConfigBuilder(object):
     def _get_paths(self, data):
         return {"doc_root": data["doc_root"]}
 
+    # Returns the main hostname servers should bind to.
     def _get_server_host(self, data):
         return data["server_host"] if data.get("server_host") is not None else data["browser_host"]
+
+    # Returns the list of different hostnames servers should bind to.
+    def _get_all_server_hosts(self, data):
+        if data["alternate_ip_addresses"]:
+            assert data["bind_address"], (
+                "`bind_address` must be set to `true` in the configuration " +
+                "when using alternate IP addresses.", data["alternate_ip_addresses"])
+
+        rv = [data["server_host"]]
+        for name in data["alternate_ip_addresses"].keys():
+            rv.append(data["alternate_hosts"][name])
+        return rv
 
     def _get_ports(self, data):
         new_ports = defaultdict(list)
@@ -293,6 +309,36 @@ class ConfigBuilder(object):
                 new_ports[scheme].append(real_port)
         return new_ports
 
+    # Returns a two-level dict: host_key -> subdomain -> full_domain_name
+    #
+    # Where:
+    #
+    #  - `host_key` is either "" for `server_host` or one of the keys in
+    #    `alternate_hosts`
+    #  - `subdomain_key` is one of the values in `subdomains`, or "".
+    #
+    # For example, given:
+    #
+    #   server_host = "foo.example"
+    #   alternate_hosts = {"bar": "bar.example"}
+    #   subdomains = ["hello", "你好"]
+    #
+    # This returns:
+    #
+    #   {
+    #     "": {
+    #       ""     : "foo.example",
+    #       "hello": "hello.foo.example",
+    #       "你好" : "xn--6qq79v.foo.example",
+    #     },
+    #     "bar": {
+    #       ""     : "bar.example",
+    #       "hello": "hello.bar.example",
+    #       "你好" : "xn--6qq79v.bar.example",
+    #     },
+    #   }
+    #
+    # Note: the leaves of this tree are all the subdomains in `domains_set`.
     def _get_domains(self, data):
         hosts = data["alternate_hosts"].copy()
         assert "" not in hosts
@@ -323,10 +369,19 @@ class ConfigBuilder(object):
             rv[host].update(nd[host])
         return rv
 
+    # Returns a dict mapping each domain to the IP address it should be served
+    # on. Domains that should use the default IP address map to `None`.
+    def _get_domains_ip_addresses(self, data):
+        rv = {}
+        for host, subdomains in data["domains"].items():
+            ip_address = data["alternate_ip_addresses"].get(host, None)
+            for subdomain in subdomains.values():
+                rv[subdomain] = ip_address
+        return rv
+
+    # The set of all domains / leaves of the `domains` tree.
     def _get_domains_set(self, data):
-        return {domain
-                for per_host_domains in data["domains"].values()
-                for domain in per_host_domains.values()}
+        return {domain for domain in data["domains_ip_addresses"].keys()}
 
     def _get_not_domains_set(self, data):
         return {domain

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -822,8 +822,8 @@ class WebTestHttpd(object):
 
             _host, self.port = self.httpd.socket.getsockname()
         except Exception:
-            self.logger.critical("Failed to start HTTP server on port %s; "
-                                 "is something already using that port?" % port)
+            self.logger.critical("Failed to start HTTP server on %s:%s; "
+                                 "is something already using that port?" % (host, port))
             raise
 
     def start(self, block=False):

--- a/webdriver/tests/support/fixtures.py
+++ b/webdriver/tests/support/fixtures.py
@@ -107,7 +107,8 @@ def http(configuration):
 
 @pytest.fixture
 def server_config():
-    return json.loads(os.environ.get("WD_SERVER_CONFIG"))
+    with open(os.environ.get("WD_SERVER_CONFIG_FILE"), "r") as f:
+        return json.load(f)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This PR adds two new `alternate_hosts` to the default test configuration:

 - `private`: `private-web-platform.test`
 - `public`: `public-web-platform.test`

These are hosted by a collection of new servers bound to different IP addresses (`127.1.0.1` and `127.2.0.1` respectively). All protocols and subdomains are supported. This results in a ~3x increase in the size of `./wpt make-hosts-file`'s output.

These new IP addresses are configurable using a new config property: `alternate_ip_addresses`, which maps host names to IP addresses.

Sending this for review now, but there is one last thing I need to fix: this probably does not work macOS, as noted in https://github.com/web-platform-tests/rfcs/issues/79.