### PR TITLE
Remove unused dependencies in resources/test/tox.ini

### DIFF
--- a/resources/test/tox.ini
+++ b/resources/test/tox.ini
@@ -9,8 +9,5 @@ passenv=DISPLAY # Necessary for the spawned GeckoDriver process to connect to
 deps =
   -r{toxinidir}/../../tools/requirements_pytest.txt
   html5lib
-  pyvirtualdisplay
-  six
-  requests
 
 commands = pytest -vv {posargs}


### PR DESCRIPTION
pyvirtualdisplay would perhaps have been nice, but the tests just run on
the real display currently.

Part of https://github.com/web-platform-tests/wpt/issues/28776.