### PR TITLE
Remove use of six.integer_types/string_types/text_type

### DIFF
--- a/cookies/resources/helpers.py
+++ b/cookies/resources/helpers.py
@@ -1,5 +1,3 @@
-from six import integer_types
-
 from urllib.parse import parse_qs
 
 from wptserve.utils import isomorphic_encode
@@ -25,7 +23,7 @@ def makeCookieHeader(name, value, otherAttrs):
     def makeAV(a, v):
         if None == v or b"" == v:
             return a
-        if isinstance(v, integer_types):
+        if isinstance(v, int):
             return b"%s=%i" % (a, v)
         else:
             return b"%s=%s" % (a, v)

--- a/resources/test/conftest.py
+++ b/resources/test/conftest.py
@@ -9,7 +9,6 @@ import urllib
 import html5lib
 import py
 import pytest
-from six import text_type
 
 from wptserver import WPTServer
 
@@ -122,7 +121,7 @@ class HTMLItem(pytest.Item, pytest.Collector):
             if element.tag == 'script':
                 if element.attrib.get('id') == 'expected':
                     try:
-                        self.expected = json.loads(text_type(element.text))
+                        self.expected = json.loads(element.text)
                     except ValueError:
                         print("Failed parsing JSON in %s" % filename)
                         raise

--- a/service-workers/cache-storage/resources/vary.py
+++ b/service-workers/cache-storage/resources/vary.py
@@ -1,5 +1,3 @@
-from six import text_type
-
 def main(request, response):
   if b"clear-vary-value-override-cookie" in request.GET:
     response.unset_cookie(b"vary-value-override")
@@ -15,9 +13,9 @@ def main(request, response):
   # for the VARY header no matter what the query string is set to.  This
   # override is necessary to test the case when two URLs are identical
   # (including query), but differ by VARY header.
-  cookie_vary = request.cookies.get(b"vary-value-override");
+  cookie_vary = request.cookies.get(b"vary-value-override")
   if cookie_vary:
-    response.headers.set(b"vary", text_type(cookie_vary))
+    response.headers.set(b"vary", str(cookie_vary))
   else:
     # If there is no cookie, then use the query string value, if present.
     query_vary = request.GET.first(b"vary", default=b"")

--- a/tools/wptserve/setup.py
+++ b/tools/wptserve/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 PACKAGE_VERSION = '3.0'
-deps = ["six>=1.13.0", "h2>=3.0.1"]
+deps = ["h2>=3.0.1"]
 
 setup(name='wptserve',
       version=PACKAGE_VERSION,

--- a/tools/wptserve/wptserve/request.py
+++ b/tools/wptserve/wptserve/request.py
@@ -636,7 +636,7 @@ class BinaryCookieParser(BaseCookie):
 class Cookies(MultiDict):
     """MultiDict specialised for Cookie values
 
-    Keys and values are binary strings.
+    Keys are binary strings and values are CookieValue objects.
     """
     def __init__(self):
         pass

--- a/webdriver/tests/add_cookie/add.py
+++ b/webdriver/tests/add_cookie/add.py
@@ -1,7 +1,6 @@
 import pytest
 
 from datetime import datetime, timedelta
-from six import text_type
 
 from webdriver.transport import Response
 
@@ -72,11 +71,11 @@ def test_add_domain_cookie(session, url, server_config):
 
     cookie = session.cookies("hello")
     assert "domain" in cookie
-    assert isinstance(cookie["domain"], text_type)
+    assert isinstance(cookie["domain"], str)
     assert "name" in cookie
-    assert isinstance(cookie["name"], text_type)
+    assert isinstance(cookie["name"], str)
     assert "value" in cookie
-    assert isinstance(cookie["value"], text_type)
+    assert isinstance(cookie["value"], str)
 
     assert cookie["name"] == "hello"
     assert cookie["value"] == "world"
@@ -102,11 +101,11 @@ def test_add_cookie_for_ip(session, url, server_config, configuration):
 
     cookie = session.cookies("hello")
     assert "name" in cookie
-    assert isinstance(cookie["name"], text_type)
+    assert isinstance(cookie["name"], str)
     assert "value" in cookie
-    assert isinstance(cookie["value"], text_type)
+    assert isinstance(cookie["value"], str)
     assert "domain" in cookie
-    assert isinstance(cookie["domain"], text_type)
+    assert isinstance(cookie["domain"], str)
 
     assert cookie["name"] == "hello"
     assert cookie["value"] == "world"
@@ -131,9 +130,9 @@ def test_add_non_session_cookie(session, url):
 
     cookie = session.cookies("hello")
     assert "name" in cookie
-    assert isinstance(cookie["name"], text_type)
+    assert isinstance(cookie["name"], str)
     assert "value" in cookie
-    assert isinstance(cookie["value"], text_type)
+    assert isinstance(cookie["value"], str)
     assert "expiry" in cookie
     assert isinstance(cookie["expiry"], int)
 
@@ -156,9 +155,9 @@ def test_add_session_cookie(session, url):
 
     cookie = session.cookies("hello")
     assert "name" in cookie
-    assert isinstance(cookie["name"], text_type)
+    assert isinstance(cookie["name"], str)
     assert "value" in cookie
-    assert isinstance(cookie["value"], text_type)
+    assert isinstance(cookie["value"], str)
     if "expiry" in cookie:
         assert cookie.get("expiry") is None
 
@@ -181,11 +180,11 @@ def test_add_session_cookie_with_leading_dot_character_in_domain(session, url, s
 
     cookie = session.cookies("hello")
     assert "name" in cookie
-    assert isinstance(cookie["name"], text_type)
+    assert isinstance(cookie["name"], str)
     assert "value" in cookie
-    assert isinstance(cookie["value"], text_type)
+    assert isinstance(cookie["value"], str)
     assert "domain" in cookie
-    assert isinstance(cookie["domain"], text_type)
+    assert isinstance(cookie["domain"], str)
 
     assert cookie["name"] == "hello"
     assert cookie["value"] == "world"
@@ -209,11 +208,11 @@ def test_add_cookie_with_valid_samesite_flag(session, url, same_site):
 
     cookie = session.cookies("hello")
     assert "name" in cookie
-    assert isinstance(cookie["name"], text_type)
+    assert isinstance(cookie["name"], str)
     assert "value" in cookie
-    assert isinstance(cookie["value"], text_type)
+    assert isinstance(cookie["value"], str)
     assert "sameSite" in cookie
-    assert isinstance(cookie["sameSite"], text_type)
+    assert isinstance(cookie["sameSite"], str)
 
     assert cookie["name"] == "hello"
     assert cookie["value"] == "world"

--- a/webdriver/tests/execute_async_script/collections.py
+++ b/webdriver/tests/execute_async_script/collections.py
@@ -1,7 +1,5 @@
 import os
 
-from six import text_type
-
 from tests.support.asserts import assert_same_element, assert_success
 
 
@@ -53,7 +51,7 @@ def test_file_list(session, tmpdir, inline):
     for expected, actual in zip(files, value):
         assert isinstance(actual, dict)
         assert "name" in actual
-        assert isinstance(actual["name"], text_type)
+        assert isinstance(actual["name"], str)
         assert os.path.basename(str(expected)) == actual["name"]
 
 

--- a/webdriver/tests/execute_script/collections.py
+++ b/webdriver/tests/execute_script/collections.py
@@ -1,7 +1,5 @@
 import os
 
-from six import text_type
-
 from tests.support.asserts import assert_same_element, assert_success
 
 
@@ -46,7 +44,7 @@ def test_file_list(session, tmpdir, inline):
     for expected, actual in zip(files, value):
         assert isinstance(actual, dict)
         assert "name" in actual
-        assert isinstance(actual["name"], text_type)
+        assert isinstance(actual["name"], str)
         assert os.path.basename(str(expected)) == actual["name"]
 
 

--- a/webdriver/tests/get_alert_text/get.py
+++ b/webdriver/tests/get_alert_text/get.py
@@ -1,5 +1,3 @@
-from six import text_type
-
 from webdriver.error import NoSuchAlertException
 
 from tests.support.asserts import assert_error, assert_success
@@ -33,7 +31,7 @@ def test_get_alert_text(session, inline):
     assert isinstance(response.body, dict)
     assert "value" in response.body
     alert_text = response.body["value"]
-    assert isinstance(alert_text, text_type)
+    assert isinstance(alert_text, str)
     assert alert_text == "Hello"
 
 
@@ -44,7 +42,7 @@ def test_get_confirm_text(session, inline):
     assert isinstance(response.body, dict)
     assert "value" in response.body
     confirm_text = response.body["value"]
-    assert isinstance(confirm_text, text_type)
+    assert isinstance(confirm_text, str)
     assert confirm_text == "Hello"
 
 
@@ -55,7 +53,7 @@ def test_get_prompt_text(session, inline):
     assert isinstance(response.body, dict)
     assert "value" in response.body
     prompt_text = response.body["value"]
-    assert isinstance(prompt_text, text_type)
+    assert isinstance(prompt_text, str)
     assert prompt_text == "Enter Your Name: "
 
 

--- a/webdriver/tests/get_computed_label/get.py
+++ b/webdriver/tests/get_computed_label/get.py
@@ -1,5 +1,4 @@
 import pytest
-from six import text_type
 
 from webdriver.error import NoSuchAlertException
 

--- a/webdriver/tests/get_computed_role/get.py
+++ b/webdriver/tests/get_computed_role/get.py
@@ -1,5 +1,4 @@
 import pytest
-from six import text_type
 
 from webdriver.error import NoSuchAlertException
 

--- a/webdriver/tests/get_current_url/get.py
+++ b/webdriver/tests/get_current_url/get.py
@@ -1,5 +1,4 @@
 import pytest
-from six import text_type
 
 from tests.support import platform_name
 from tests.support.asserts import assert_error, assert_success
@@ -39,7 +38,7 @@ def test_get_current_url_payload(session):
 
     response = get_current_url(session)
     value = assert_success(response)
-    assert isinstance(value, text_type)
+    assert isinstance(value, str)
 
 
 def test_get_current_url_special_pages(session):

--- a/webdriver/tests/get_named_cookie/get.py
+++ b/webdriver/tests/get_named_cookie/get.py
@@ -1,7 +1,6 @@
 import pytest
 
 from datetime import datetime, timedelta
-from six import integer_types, text_type
 
 
 from tests.support.asserts import assert_error, assert_success
@@ -37,13 +36,13 @@ def test_get_named_session_cookie(session, url):
     # table for cookie conversion
     # https://w3c.github.io/webdriver/#dfn-table-for-cookie-conversion
     assert "name" in cookie
-    assert isinstance(cookie["name"], text_type)
+    assert isinstance(cookie["name"], str)
     assert "value" in cookie
-    assert isinstance(cookie["value"], text_type)
+    assert isinstance(cookie["value"], str)
     assert "path" in cookie
-    assert isinstance(cookie["path"], text_type)
+    assert isinstance(cookie["path"], str)
     assert "domain" in cookie
-    assert isinstance(cookie["domain"], text_type)
+    assert isinstance(cookie["domain"], str)
     assert "secure" in cookie
     assert isinstance(cookie["secure"], bool)
     assert "httpOnly" in cookie
@@ -51,7 +50,7 @@ def test_get_named_session_cookie(session, url):
     if "expiry" in cookie:
         assert cookie.get("expiry") is None
     assert "sameSite" in cookie
-    assert isinstance(cookie["sameSite"], text_type)
+    assert isinstance(cookie["sameSite"], str)
 
     assert cookie["name"] == "foo"
     assert cookie["value"] == "bar"
@@ -71,13 +70,13 @@ def test_get_named_cookie(session, url):
     assert isinstance(cookie, dict)
 
     assert "name" in cookie
-    assert isinstance(cookie["name"], text_type)
+    assert isinstance(cookie["name"], str)
     assert "value" in cookie
-    assert isinstance(cookie["value"], text_type)
+    assert isinstance(cookie["value"], str)
     assert "expiry" in cookie
-    assert isinstance(cookie["expiry"], integer_types)
+    assert isinstance(cookie["expiry"], int)
     assert "sameSite" in cookie
-    assert isinstance(cookie["sameSite"], text_type)
+    assert isinstance(cookie["sameSite"], str)
 
     assert cookie["name"] == "foo"
     assert cookie["value"] == "bar"
@@ -112,11 +111,11 @@ def test_duplicated_cookie(session, url, server_config, inline):
     assert isinstance(cookie, dict)
 
     assert "name" in cookie
-    assert isinstance(cookie["name"], text_type)
+    assert isinstance(cookie["name"], str)
     assert "value" in cookie
-    assert isinstance(cookie["value"], text_type)
+    assert isinstance(cookie["value"], str)
     assert "sameSite" in cookie
-    assert isinstance(cookie["sameSite"], text_type)
+    assert isinstance(cookie["sameSite"], str)
 
     assert cookie["name"] == new_cookie["name"]
     assert cookie["value"] == "newworld"
@@ -135,11 +134,11 @@ def test_get_cookie_with_same_site_flag(session, url, same_site):
     assert isinstance(cookie, dict)
 
     assert "name" in cookie
-    assert isinstance(cookie["name"], text_type)
+    assert isinstance(cookie["name"], str)
     assert "value" in cookie
-    assert isinstance(cookie["value"], text_type)
+    assert isinstance(cookie["value"], str)
     assert "sameSite" in cookie
-    assert isinstance(cookie["sameSite"], text_type)
+    assert isinstance(cookie["sameSite"], str)
 
     assert cookie["name"] == "foo"
     assert cookie["value"] == "bar"

--- a/webdriver/tests/get_title/get.py
+++ b/webdriver/tests/get_title/get.py
@@ -1,5 +1,3 @@
-from six import text_type
-
 from tests.support.asserts import assert_error, assert_success
 
 
@@ -13,7 +11,7 @@ def test_payload(session):
 
     response = get_title(session)
     value = assert_success(response)
-    assert isinstance(value, text_type)
+    assert isinstance(value, str)
 
 
 def test_no_top_browsing_context(session, closed_window):

--- a/webdriver/tests/new_session/response.py
+++ b/webdriver/tests/new_session/response.py
@@ -1,29 +1,27 @@
 import uuid
 import pytest
 
-from six import string_types
-
 from tests.support.asserts import assert_success
 
 
 def test_sessionid(new_session, add_browser_capabilities):
     response, _ = new_session({"capabilities": {"alwaysMatch": add_browser_capabilities({})}})
     value = assert_success(response)
-    assert isinstance(value["sessionId"], string_types)
+    assert isinstance(value["sessionId"], str)
     uuid.UUID(hex=value["sessionId"])
 
 
 @pytest.mark.parametrize("capability, type", [
-    ("browserName", string_types),
-    ("browserVersion", string_types),
-    ("platformName", string_types),
+    ("browserName", str),
+    ("browserVersion", str),
+    ("platformName", str),
     ("acceptInsecureCerts", bool),
-    ("pageLoadStrategy", string_types),
+    ("pageLoadStrategy", str),
     ("proxy", dict),
     ("setWindowRect", bool),
     ("timeouts", dict),
     ("strictFileInteractability", bool),
-    ("unhandledPromptBehavior", string_types),
+    ("unhandledPromptBehavior", str),
 ])
 def test_capability_type(session, capability, type):
     assert isinstance(session.capabilities, dict)

--- a/webdriver/tests/perform_actions/support/keys.py
+++ b/webdriver/tests/perform_actions/support/keys.py
@@ -21,7 +21,6 @@ import sys
 
 from collections import OrderedDict
 from inspect import getmembers
-from six import text_type
 
 class Keys(object):
     """
@@ -107,7 +106,7 @@ class Keys(object):
     R_DELETE = u"\uE05D"
 
 
-ALL_KEYS = getmembers(Keys, lambda x: type(x) == text_type)
+ALL_KEYS = getmembers(Keys, lambda x: type(x) == str)
 
 ALL_EVENTS = OrderedDict(
     [

--- a/webdriver/tests/status/status.py
+++ b/webdriver/tests/status/status.py
@@ -1,7 +1,5 @@
 import json
 
-from six import text_type
-
 from tests.support.asserts import assert_success
 
 
@@ -18,7 +16,7 @@ def test_get_status_no_session(http):
         value = parsed_obj["value"]
 
         assert value["ready"] in [True, False]
-        assert isinstance(value["message"], text_type)
+        assert isinstance(value["message"], str)
 
 
 def test_status_with_session_running_on_endpoint_node(session):

--- a/webdriver/tests/support/asserts.py
+++ b/webdriver/tests/support/asserts.py
@@ -2,8 +2,6 @@ import imghdr
 import struct
 from base64 import decodebytes
 
-import six
-
 from webdriver import Element, NoSuchAlertException, WebDriverException
 
 
@@ -52,8 +50,8 @@ def assert_error(response, error_code):
     assert response.status == errors[error_code]
     assert "value" in response.body
     assert response.body["value"]["error"] == error_code
-    assert isinstance(response.body["value"]["message"], six.text_type)
-    assert isinstance(response.body["value"]["stacktrace"], six.text_type)
+    assert isinstance(response.body["value"]["message"], str)
+    assert isinstance(response.body["value"]["stacktrace"], str)
     assert_response_headers(response.headers)
 
 

--- a/webdriver/tests/support/fixtures.py
+++ b/webdriver/tests/support/fixtures.py
@@ -6,8 +6,6 @@ import asyncio
 import pytest
 import webdriver
 
-from six import string_types
-
 from urllib.parse import urlunsplit
 
 from tests.support import defaults
@@ -245,7 +243,7 @@ def create_dialog(session):
         if text is None:
             text = ""
 
-        assert isinstance(text, string_types), "`text` parameter must be a string"
+        assert isinstance(text, str), "`text` parameter must be a string"
 
         # Script completes itself when the user prompt has been opened.
         # For prompt() dialogs, add a value for the 'default' argument,

--- a/webdriver/tests/support/http_request.py
+++ b/webdriver/tests/support/http_request.py
@@ -1,8 +1,6 @@
 import contextlib
 import json
 
-from six import text_type
-
 from http.client import HTTPConnection
 
 
@@ -31,7 +29,7 @@ class HTTPRequest(object):
                 raise ValueError("Failed to encode request body as JSON: {}".format(
                     json.dumps(body, indent=2)))
 
-            if isinstance(payload, text_type):
+            if isinstance(payload, str):
                 payload = body.encode("utf-8")
 
         conn = HTTPConnection(self.host, self.port)

--- a/websockets/handlers/echo_close_data_wsh.py
+++ b/websockets/handlers/echo_close_data_wsh.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-import six
 from mod_pywebsocket import msgutil
 
 _GOODBYE_MESSAGE = u'Goodbye'
@@ -16,7 +15,7 @@ def web_socket_transfer_data(request):
         line = request.ws_stream.receive_message()
         if line is None:
             return
-        if isinstance(line, six.text_type):
+        if isinstance(line, str):
             if line == _GOODBYE_MESSAGE:
                 return
                 request.ws_stream.send_message(line, binary=False)

--- a/websockets/handlers/echo_exit_wsh.py
+++ b/websockets/handlers/echo_exit_wsh.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-import six
 from mod_pywebsocket import msgutil
 
 _GOODBYE_MESSAGE = u'Goodbye'
@@ -16,6 +15,6 @@ def web_socket_transfer_data(request):
         line = request.ws_stream.receive_message()
         if line is None:
             return
-        if isinstance(line, six.text_type):
+        if isinstance(line, str):
             if line == _GOODBYE_MESSAGE:
                 return

--- a/websockets/handlers/echo_wsh.py
+++ b/websockets/handlers/echo_wsh.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-import six
 from mod_pywebsocket import msgutil
 from mod_pywebsocket import common
 
@@ -18,7 +17,7 @@ def web_socket_transfer_data(request):
         line = request.ws_stream.receive_message()
         if line is None:
             return
-        if isinstance(line, six.text_type):
+        if isinstance(line, str):
             request.ws_stream.send_message(line, binary=False)
             if line == _GOODBYE_MESSAGE:
                 return

--- a/websockets/handlers/send-backpressure_wsh.py
+++ b/websockets/handlers/send-backpressure_wsh.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-import six
 import time
 
 # The amount of internal buffering a WebSocket connection has is not
@@ -36,5 +35,5 @@ def web_socket_transfer_data(request):
         request.ws_stream.send_message(b' ' * MESSAGE_SIZE, binary=True)
 
     # Report the time taken to send the large message.
-    request.ws_stream.send_message(six.text_type(time.time() - start_time),
+    request.ws_stream.send_message(str(time.time() - start_time),
                                    binary=False)


### PR DESCRIPTION
These are constants corresponding to just int/str/str in Python 3:
https://six.readthedocs.io/#constants

This is simple search-replace with the exception of
resources/test/conftest.py, where element.text is already a string. If
it were None or bytes, then JSON parsing would fail anyway.

In service-workers/cache-storage/resources/vary.py, the reason why
str(cookie_vary) works was non-obvious. Correct the documentation in
tools/wptserve/wptserve/request.py to show that the cookie_vary value
would be a CookieValue, not a binary string.

Since no use of six remains in tools/wptserve/, it's removed as a 
dependency in wptserve's setup.py.

Part of https://github.com/web-platform-tests/wpt/issues/28776.