### PR TITLE
Update pytest and mock to the latest versions

### DIFF
--- a/tools/requirements_pytest.txt
+++ b/tools/requirements_pytest.txt
@@ -1,4 +1,4 @@
-pytest==4.6.11 # the last version that supports Python 2
+pytest==6.2.4
 pytest-cov==2.11.1
-mock==3.0.5 # mock no longer supports Python 2 since v4
+mock==4.0.3
 hypothesis==6.10.1


### PR DESCRIPTION
Note that these are for internal testing only, independent of the
versions in tools/third_party/.

pyest-cov and hypothesis are already up-to-date.

Closes https://github.com/web-platform-tests/wpt/pull/28817.
Closes https://github.com/web-platform-tests/wpt/pull/28788.