### PR TITLE
Rename and trim py3-flake8.ini

### DIFF
--- a/tools/flake8.ini
+++ b/tools/flake8.ini
@@ -13,14 +13,12 @@ select = E,W,F,N
 # E731: do not assign a lambda expression, use a def
 # W504: line break after binary operator
 # W601: .has_key() is deprecated, use ‘in’
-# W605: invalid escape sequence
 # N801: class names should use CapWords convention
 # N802: function name should be lowercase
 # N806: variable in function should be lowercase
-ignore = E128,E129,E226,E231,E251,E265,E302,E303,E305,E402,E731,W504,W601,W605,N801,N802,N806
+ignore = E128,E129,E226,E231,E251,E265,E302,E303,E305,E402,E731,W504,W601,N801,N802,N806
 exclude =
     .tox,
-    pywebsocket,
     third_party,
     wptserve/docs/conf.py,
     wptserve/tests/functional/docroot/invalid.py

--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -21,19 +21,19 @@ passenv =
 
 [testenv:py36-flake8]
 deps = -rrequirements_flake8.txt
-commands = flake8 --append-config={toxinidir}/py3-flake8.ini {posargs}
+commands = flake8 --append-config={toxinidir}/flake8.ini {posargs}
 
 [testenv:py37-flake8]
 deps = -rrequirements_flake8.txt
-commands = flake8 --append-config={toxinidir}/py3-flake8.ini {posargs}
+commands = flake8 --append-config={toxinidir}/flake8.ini {posargs}
 
 [testenv:py38-flake8]
 deps = -rrequirements_flake8.txt
-commands = flake8 --append-config={toxinidir}/py3-flake8.ini {posargs}
+commands = flake8 --append-config={toxinidir}/flake8.ini {posargs}
 
 [testenv:py39-flake8]
 deps = -rrequirements_flake8.txt
-commands = flake8 --append-config={toxinidir}/py3-flake8.ini {posargs}
+commands = flake8 --append-config={toxinidir}/flake8.ini {posargs}
 
 [testenv:py36-mypy]
 deps = -rrequirements_mypy.txt


### PR DESCRIPTION
There is no more py27-flake8.ini to distinguish this from.

W605: invalid escape sequence no longer occurs, and the
tools/pywebsocket directory no longer exists.