### PR TITLE
Don't expect newline normalizations when constructing the entry list

### DIFF
--- a/html/semantics/forms/form-submission-0/newline-normalization.html
+++ b/html/semantics/forms/form-submission-0/newline-normalization.html
@@ -2,7 +2,9 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>Form newline normalization</title>
+    <title>
+      Constructing the entry list shouldn't perform newline normalization
+    </title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
   </head>
@@ -40,71 +42,71 @@
 
       test((testCase) => {
         const formData = new FormData(createForm(testCase, "a", "b\nc"));
-        assert_equals(formData.get("a"), "b\r\nc");
-      }, document.title + ": \\n in the value becomes \\r\\n");
+        assert_equals(formData.get("a"), "b\nc");
+      }, document.title + ": \\n in the value");
 
       test((testCase) => {
         const formData = new FormData(createForm(testCase, "a", "b\rc"));
-        assert_equals(formData.get("a"), "b\r\nc");
-      }, document.title + ": \\r in the value becomes \\r\\n");
+        assert_equals(formData.get("a"), "b\rc");
+      }, document.title + ": \\r in the value");
 
       test((testCase) => {
         const formData = new FormData(createForm(testCase, "a", "b\r\nc"));
         assert_equals(formData.get("a"), "b\r\nc");
-      }, document.title + ": \\r\\n in the value stays unchanged");
+      }, document.title + ": \\r\\n in the value");
 
       test((testCase) => {
         const formData = new FormData(createForm(testCase, "a", "b\n\rc"));
-        assert_equals(formData.get("a"), "b\r\n\r\nc");
-      }, document.title + ": \\n\\r in the value becomes \\r\\n\\r\\n");
+        assert_equals(formData.get("a"), "b\n\rc");
+      }, document.title + ": \\n\\r in the value");
 
       test((testCase) => {
         const formData = new FormData(createForm(testCase, "a\nb", "c"));
-        assert_equals([...formData][0][0], "a\r\nb");
-      }, document.title + ": \\n in the name becomes \\r\\n");
+        assert_equals([...formData][0][0], "a\nb");
+      }, document.title + ": \\n in the name");
 
       test((testCase) => {
         const formData = new FormData(createForm(testCase, "a\rb", "c"));
-        assert_equals([...formData][0][0], "a\r\nb");
-      }, document.title + ": \\r in the name becomes \\r\\n");
+        assert_equals([...formData][0][0], "a\rb");
+      }, document.title + ": \\r in the name");
 
       test((testCase) => {
         const formData = new FormData(createForm(testCase, "a\r\nb", "c"));
         assert_equals([...formData][0][0], "a\r\nb");
-      }, document.title + ": \\r\\n in the name stays unchanged");
+      }, document.title + ": \\r\\n in the name");
 
       test((testCase) => {
         const formData = new FormData(createForm(testCase, "a\n\rb", "c"));
-        assert_equals([...formData][0][0], "a\r\n\r\nb");
-      }, document.title + ": \\n\\r in the name becomes \\r\\n\\r\\n");
+        assert_equals([...formData][0][0], "a\n\rb");
+      }, document.title + ": \\n\\r in the name");
 
       test((testCase) => {
         const formData = new FormData(
           createFormWithFile(testCase, "a", "b\nc")
         );
         assert_equals(formData.get("a").name, "b\nc");
-      }, document.title + ": \\n in the filename stays unchanged");
+      }, document.title + ": \\n in the filename");
 
       test((testCase) => {
         const formData = new FormData(
           createFormWithFile(testCase, "a", "b\rc")
         );
         assert_equals(formData.get("a").name, "b\rc");
-      }, document.title + ": \\r in the filename stays unchanged");
+      }, document.title + ": \\r in the filename");
 
       test((testCase) => {
         const formData = new FormData(
           createFormWithFile(testCase, "a", "b\r\nc")
         );
         assert_equals(formData.get("a").name, "b\r\nc");
-      }, document.title + ": \\r\\n in the filename stays unchanged");
+      }, document.title + ": \\r\\n in the filename");
 
       test((testCase) => {
         const formData = new FormData(
           createFormWithFile(testCase, "a", "b\n\rc")
         );
         assert_equals(formData.get("a").name, "b\n\rc");
-      }, document.title + ": \\n\\r in the filename stays unchanged");
+      }, document.title + ": \\n\\r in the filename");
     </script>
   </body>
 </html>

--- a/html/semantics/forms/form-submission-0/textarea.window.js
+++ b/html/semantics/forms/form-submission-0/textarea.window.js
@@ -13,7 +13,6 @@ test((t) => {
   assert_equals(textarea.value, "a\nb\nc\nd\n\ne");
 
   const formData = new FormData(form);
-  console.log(formData);
   assert_equals(
     formData.get("linebreakTest"),
     "a\nb\nc\nd\n\ne",

--- a/html/semantics/forms/form-submission-0/textarea.window.js
+++ b/html/semantics/forms/form-submission-0/textarea.window.js
@@ -1,0 +1,59 @@
+test((t) => {
+  const form = document.createElement("form");
+  const textarea = document.createElement("textarea");
+  textarea.name = "linebreakTest";
+  textarea.textContent = "a\nb\rc\r\nd\n\re";
+  form.appendChild(textarea);
+  document.body.appendChild(form);
+  t.add_cleanup(() => {
+    document.body.removeChild(form);
+  });
+
+  assert_equals(textarea.textContent, "a\nb\rc\r\nd\n\re");
+  assert_equals(textarea.value, "a\nb\nc\nd\n\ne");
+
+  const formData = new FormData(form);
+  console.log(formData);
+  assert_equals(
+    formData.get("linebreakTest"),
+    "a\nb\nc\nd\n\ne",
+  );
+}, "Newlines in textarea elements should be normalized to LF.");
+
+test((t) => {
+  const form = document.createElement("form");
+  const textarea = document.createElement("textarea");
+  textarea.name = "wrapTest";
+  textarea.cols = 10;
+  textarea.wrap = "hard";
+  textarea.textContent =
+    "Some text that is too long for the specified character width.";
+  form.appendChild(textarea);
+  document.body.appendChild(form);
+  t.add_cleanup(() => {
+    document.body.removeChild(form);
+  });
+
+  assert_true(
+    !textarea.textContent.includes("\n") &&
+      !textarea.textContent.includes("\r"),
+    "textContent shouldn't contain any newlines",
+  );
+  assert_true(
+    !textarea.textContent.includes("\n") &&
+      !textarea.textContent.includes("\r"),
+    "The API value shouldn't be line wrapped.",
+  );
+
+  const formData = new FormData(form);
+  const formDataValue = formData.get("wrapTest");
+
+  assert_true(
+    !formDataValue.includes("\r"),
+    "The wrapping done on the value must be LF, not CRLF.",
+  );
+  assert_true(
+    formDataValue.includes("\n"),
+    "The value must be wrapped.",
+  );
+}, "Testing the textarea wrapping transformation.");

--- a/html/semantics/forms/the-textarea-element/wrapping-transformation.window.js
+++ b/html/semantics/forms/the-textarea-element/wrapping-transformation.window.js
@@ -17,7 +17,7 @@ test((t) => {
     formData.get("linebreakTest"),
     "a\nb\nc\nd\n\ne",
   );
-}, "Newlines in textarea elements should be normalized to LF.");
+}, "Textarea wrapping transformation: Newlines should be normalized to LF.");
 
 test((t) => {
   const form = document.createElement("form");
@@ -55,4 +55,4 @@ test((t) => {
     formDataValue.includes("\n"),
     "The value must be wrapped.",
   );
-}, "Testing the textarea wrapping transformation.");
+}, "Textarea wrapping transformation: Wrapping happens with LF newlines.");

--- a/xhr/formdata/constructor-formelement.html
+++ b/xhr/formdata/constructor-formelement.html
@@ -77,7 +77,7 @@
   <input type="color" name="submit-me-15" value="#123456">
 
   <textarea name="submit-me-16">textarea value
-with linebreaks set to CRLF</textarea>
+with linebreaks set to LF</textarea>
 
   <!-- this generates two form data entries! -->
   <input type="text" name="dirname-is-special" dirname="submit-me-17" value="dirname-value">
@@ -123,11 +123,11 @@ test(() => {
     ["submit-me-13", "11"],
     ["submit-me-14", "11"],
     ["submit-me-15", "#123456"],
-    ["submit-me-16", "textarea value\r\nwith linebreaks set to CRLF"],
+    ["submit-me-16", "textarea value\nwith linebreaks set to LF"],
     ["dirname-is-special", "dirname-value"],
     ["submit-me-17", "ltr"],
     ["submit-me-18-\uFFFD", "value-\uFFFD"],
-    ["submit-me-\r\n19\r\n", "value"],
+    ["submit-me-\r19\n", "value"],
     ["submit-me-21", ""]
   ];
 


### PR DESCRIPTION
This tests the spec changes in whatwg/html#6624, as well as the `<textarea>` cases to be covered in a follow-up spec PR (#6697).