### PR TITLE
[docs] Link to wpt.live alongside w3c-test.org in a few more places

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The most important sources of information and activity are:
 - [web-platform-tests.org](https://web-platform-tests.org): the documentation
   website; details how to set up the project, how to write tests, how to give
   and receive peer review, how to serve as an administrator, and more
-- [wpt.live](http://wpt.live): a public deployment of the test suite,
+- [wpt.live](https://wpt.live): a public deployment of the test suite,
   allowing anyone to run the tests by visiting from an
   Internet-enabled browser of their choice
 - [wpt.fyi](https://wpt.fyi): an archive of test results collected from an
@@ -94,10 +94,11 @@ line endings, as it will cause lint errors. For git, please set
 Publication
 ===========
 
-The master branch is automatically synced to http://w3c-test.org/.
+The master branch is automatically synced to [wpt.live](https://wpt.live/) and
+[w3c-test.org](https://w3c-test.org/).
 
 Pull requests are
-[automatically mirrored](http://w3c-test.org/submissions/) except those
+[automatically mirrored](https://w3c-test.org/submissions/) except those
 that modify sensitive resources (such as `.py`). The latter require
 someone with merge access to comment with "LGTM" or "w3c-test:mirror" to
 indicate the pull request has been checked.

--- a/docs/admin/index.md
+++ b/docs/admin/index.md
@@ -46,7 +46,7 @@ explicitly-managed secret.
 - [Google Domains](https://domains.google/): https://wpt.fyi
   - smcgruer@google.com
   - foolip@google.com
-- (Google internal): https://wpt.live https://wptpr.live
+- (Google internal): https://wpt.live
   - smcgruer@google.com
   - foolip@google.com
 - [GitHub](https://github.com/): web-platform-tests
@@ -76,9 +76,6 @@ explicitly-managed secret.
   - boaz@bocoup.com
   - mike@bocoup.com
   - simon@bocoup.com
-
-[web-platform-tests]: https://github.com/e3c/web-platform-tests
-[wpt.fyi]: https://github.com/web-platform-tests/wpt.fyi
 
 ## Emergency playbook
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ The most important sources of information and activity are:
 - [web-platform-tests.org](https://web-platform-tests.org): the documentation
   website; details how to set up the project, how to write tests, how to give
   and receive peer review, how to serve as an administrator, and more
-- [wpt.live](http://wpt.live): a public deployment of the test suite,
+- [wpt.live](https://wpt.live): a public deployment of the test suite,
   allowing anyone to run the tests by visiting from an
   Internet-enabled browser of their choice
 - [wpt.fyi](https://wpt.fyi): an archive of test results collected from an

--- a/docs/running-tests/from-web.md
+++ b/docs/running-tests/from-web.md
@@ -1,6 +1,7 @@
 # Running Tests from the Web
 
-Tests that have been merged on GitHub are mirrored at [http://w3c-test.org/][w3c-test].
+Tests that have been merged on GitHub are mirrored at
+[wpt.live](https://wpt.live) and [w3c-test.org](https://w3c-test.org).
 [On properly-configured systems](from-local-system), local files may also be
 served from the URL [http://web-platform.test](http://web-platform.test).
 
@@ -24,5 +25,3 @@ more than one reference involved.
 
 Because it runs entirely in-browser, this runner cannot deal with
 edge-cases like tests that cause the browser to crash or hang.
-
-[w3c-test]: http://w3c-test.org


### PR DESCRIPTION
wpt.live has been up since early 2020. wptpr.live for PR mirroring was
never made reliable enough, so this doesn't fully replace w3c-test.org.

Drive-by: fix broken and unused links in admin/index.md.