### PR TITLE
Delete annotation-protocol/requirements.txt

### DIFF
--- a/annotation-protocol/requirements.txt
+++ b/annotation-protocol/requirements.txt
@@ -1,1 +1,0 @@
-wptserve


### PR DESCRIPTION
This lists only wptserve, which is part of this repo. This
requirements.txt file does not seem to be referenced anywhere in the
repo, so there should be nothing more to clean up.

Discovered as part of https://github.com/web-platform-tests/wpt/issues/28809.