### PR TITLE
[css-values-3] Improve attr-px-invalid-cast.html and attr-px-invalid-fallback.html tests

### DIFF
--- a/css/css-values/attr-px-invalid-cast.html
+++ b/css/css-values/attr-px-invalid-cast.html
@@ -30,7 +30,7 @@
       html { background: white; overflow: hidden; }
       #outer { position: relative; background: green; }
 
-      #outer { width: attr(data-test px, 200); height: 200px; }
+      #outer { width: attr(data-test px, 200px); height: 200px; }
 
   </style>
 

--- a/css/css-values/attr-px-invalid-cast.html
+++ b/css/css-values/attr-px-invalid-cast.html
@@ -1,43 +1,43 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta charset="utf-8">
-	<title>
-		CSS Values and Units Test:
-		Attributes references (pixels)
-	</title>
-	<meta name="assert" content="
-		When the value of the referenced attribute is not a pixel value, the fallback value is used instead.
-	" />
+  <meta charset="utf-8">
+  <title>
+    CSS Values and Units Test:
+    Attributes references (pixels)
+  </title>
+  <meta name="assert" content="
+    When the value of the referenced attribute is not a pixel value, the fallback value is used instead.
+  " />
 
-	<link
-		rel="author"
-		title="François REMY"
-		href="mailto:fremycompany.developer@yahoo.fr"
-	/ >
+  <link
+    rel="author"
+    title="François REMY"
+    href="mailto:fremycompany.developer@yahoo.fr"
+  / >
 
-	<link rel="help" href="http://www.w3.org/TR/css3-values/#attr-notation"/>
+  <link rel="help" href="http://www.w3.org/TR/css3-values/#attr-notation"/>
 
-	<link
-		rel="match"
-		href="reference/200-200-green.html"
-	/>
+  <link
+    rel="match"
+    href="reference/200-200-green.html"
+  />
 
-	<style type="text/css">
+  <style type="text/css">
 
-			html, body { margin: 0px; padding: 0px; }
+      html, body { margin: 0px; padding: 0px; }
 
-			html { background: white; overflow: hidden; }
-			#outer { position: relative; background: green; }
+      html { background: white; overflow: hidden; }
+      #outer { position: relative; background: green; }
 
-			#outer { width: attr(data-test px, 200); height: 200px; }
+      #outer { width: attr(data-test px, 200); height: 200px; }
 
-	</style>
+  </style>
 
 </head>
 <body>
 
-	<div id="outer" data-test="300px"></div>
+  <div id="outer" data-test="300px"></div>
 
 </body>
 </html>

--- a/css/css-values/attr-px-invalid-fallback.html
+++ b/css/css-values/attr-px-invalid-fallback.html
@@ -1,43 +1,43 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta charset="utf-8">
-	<title>
-		CSS Values and Units Test:
-		Attribute references (pixels)
-	</title>
-	<meta name="assert" content="
-		When the fallback of a pixel attribute reference is invalid, the declaration is ignored.
-	" />
-	<meta name="flags" content="invalid">
-	<link
-		rel="author"
-		title="François REMY"
-		href="mailto:fremycompany.developer@yahoo.fr"
-	/ >
+  <meta charset="utf-8">
+  <title>
+    CSS Values and Units Test:
+    Attribute references (pixels)
+  </title>
+  <meta name="assert" content="
+    When the fallback of a pixel attribute reference is invalid, the declaration is ignored.
+  " />
+  <meta name="flags" content="invalid">
+  <link
+    rel="author"
+    title="François REMY"
+    href="mailto:fremycompany.developer@yahoo.fr"
+  / >
 
-	<link rel="help" href="http://www.w3.org/TR/css3-values/#attr-notation"/>
+  <link rel="help" href="http://www.w3.org/TR/css3-values/#attr-notation"/>
 
-	<link
-		rel="match"
-		href="reference/200-200-green.html"
-	/>
+  <link
+    rel="match"
+    href="reference/200-200-green.html"
+  />
 
-	<style type="text/css">
+  <style type="text/css">
 
-			html, body { margin: 0px; padding: 0px; }
+      html, body { margin: 0px; padding: 0px; }
 
-			html { background: white; overflow: hidden; }
-			#outer { position: relative; background: green; }
+      html { background: white; overflow: hidden; }
+      #outer { position: relative; background: green; }
 
-			#outer { width: 200px; width: attr(data-test px, 300px); height: 200px; }
+      #outer { width: 200px; width: attr(data-test px, 300px); height: 200px; }
 
-	</style>
+  </style>
 
 </head>
 <body>
 
-	<div id="outer" data-test="300"></div>
+  <div id="outer" data-test="300"></div>
 
 </body>
 </html>

--- a/css/css-values/attr-px-invalid-fallback.html
+++ b/css/css-values/attr-px-invalid-fallback.html
@@ -30,7 +30,7 @@
       html { background: white; overflow: hidden; }
       #outer { position: relative; background: green; }
 
-      #outer { width: 200px; width: attr(data-test px, 300px); height: 200px; }
+      #outer { width: 200px; width: attr(data-test px, 300); height: 200px; }
 
   </style>
 


### PR DESCRIPTION
attr-px-invalid-cast.html 
attr-px-invalid-fallback.html

I must first convert the line-starting tabs with 2 blank spaces so that the lint tool does not report this and so that the review of the tests can be easier.

The corrections have been explained in [Issue 28765](https://github.com/web-platform-tests/wpt/issues/28765) and in [Issue 28794](https://github.com/web-platform-tests/wpt/issues/28794) .