### PR TITLE
Remove use of six.BytesIO

### DIFF
--- a/common/security-features/subresource/image.py
+++ b/common/security-features/subresource/image.py
@@ -1,6 +1,6 @@
 import os, sys, array, math
 
-from six import BytesIO
+from io import BytesIO
 
 from wptserve.utils import isomorphic_decode
 

--- a/resource-timing/resources/gzip_xml.py
+++ b/resource-timing/resources/gzip_xml.py
@@ -1,7 +1,7 @@
 import gzip as gzip_module
 import os
 
-from six import BytesIO
+from io import BytesIO
 
 from wptserve.utils import isomorphic_decode
 

--- a/xhr/resources/gzip.py
+++ b/xhr/resources/gzip.py
@@ -1,6 +1,6 @@
 import gzip as gzip_module
 
-from six import BytesIO
+from io import BytesIO
 
 def main(request, response):
     if b"content" in request.GET:


### PR DESCRIPTION
In Python 3, it's an alias for io.BytesIO:
https://six.readthedocs.io/#six.BytesIO

Part of https://github.com/web-platform-tests/wpt/issues/28776.