### PR TITLE
[docs] fix broken links in testharness.md

### DIFF
--- a/docs/writing-tests/testharness.md
+++ b/docs/writing-tests/testharness.md
@@ -38,7 +38,7 @@ test(() => {
 }, "Ensure HTML boilerplate uses UTF-8"); // This is the title of the test
 ```
 
-If you only need to test a [single thing](testharness-api.md#single-page-tests), you could also use:
+If you only need to test a [single thing](testharness-api.html#single-page-tests), you could also use:
 ```js
 // META: title=Ensure HTML boilerplate uses UTF-8
 setup({ single_test: true });
@@ -46,8 +46,8 @@ assert_equals(document.characterSet, "UTF-8");
 done();
 ```
 
-See [asynchronous (`async_test()`)](testharness-api.md#asynchronous-tests) and
-[promise tests (`promise_test()`)](testharness-api.md#promise-tests) for more involved setups.
+See [asynchronous (`async_test()`)](testharness-api.html#asynchronous-tests) and
+[promise tests (`promise_test()`)](testharness-api.html#promise-tests) for more involved setups.
 
 ### With HTML boilerplate
 


### PR DESCRIPTION
This will fix the links on web-platform-tests.org, but will
unfortunately break them if browsing the docs/ folder on GitHub.

A search for ".html#" shows this is the prevailing style.