### PR TITLE
Pass server config to WebDriver via a file instead of an env variable.

### DIFF
--- a/tools/serve/test_serve.py
+++ b/tools/serve/test_serve.py
@@ -78,15 +78,9 @@ def test_pickle():
         pickle.dumps(c)
 
 
-def test_config_json_length():
-    # we serialize the config as JSON for pytestrunner and put it in an env
-    # variable, which on Windows must have a length <= 0x7FFF (int16)
-    with ConfigBuilder() as c:
-        data = json.dumps(c.as_dict_for_wd_env_variable())
-    assert len(data) <= 0x7FFF
-
 def test_alternate_host_unspecified():
     ConfigBuilder(browser_host="web-platform.test")
+
 
 @pytest.mark.parametrize("primary, alternate", [
     ("web-platform.test", "web-platform.test"),

--- a/tools/serve/test_serve.py
+++ b/tools/serve/test_serve.py
@@ -1,4 +1,3 @@
-import json
 import os
 import pickle
 import platform

--- a/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
+++ b/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
@@ -43,17 +43,22 @@ def run(path, server_config, session_config, timeout=0, environ=None):
 
     old_environ = os.environ.copy()
     try:
-        os.environ["WD_HOST"] = session_config["host"]
-        os.environ["WD_PORT"] = str(session_config["port"])
-        os.environ["WD_CAPABILITIES"] = json.dumps(session_config["capabilities"])
-        os.environ["WD_SERVER_CONFIG"] = json.dumps(server_config.as_dict_for_wd_env_variable())
-        if environ:
-            os.environ.update(environ)
-
-        harness = HarnessResultRecorder()
-        subtests = SubtestResultRecorder()
-
         with TemporaryDirectory() as cache:
+            os.environ["WD_HOST"] = session_config["host"]
+            os.environ["WD_PORT"] = str(session_config["port"])
+            os.environ["WD_CAPABILITIES"] = json.dumps(session_config["capabilities"])
+
+            config_path = os.path.join(cache, "wd_server_config.json")
+            os.environ["WD_SERVER_CONFIG_FILE"] = config_path
+            with open(config_path, "w") as f:
+                json.dump(server_config.as_dict(), f)
+
+            if environ:
+                os.environ.update(environ)
+
+            harness = HarnessResultRecorder()
+            subtests = SubtestResultRecorder()
+
             try:
                 pytest.main(["--strict",  # turn warnings into errors
                              "-vv",  # show each individual subtest and full failure logs

--- a/tools/wptserve/wptserve/config.py
+++ b/tools/wptserve/wptserve/config.py
@@ -68,31 +68,6 @@ class Config(Mapping):
     def as_dict(self):
         return json_types(self.__dict__)
 
-    # Environment variables are limited in size so we need to prune the most egregious contributors
-    # to size, the origin policy subdomains.
-    def as_dict_for_wd_env_variable(self):
-        result = self.as_dict()
-
-        for key in [
-            ("subdomains",),
-            ("domains", "alt"),
-            ("domains", ""),
-            ("all_domains", "alt"),
-            ("all_domains", ""),
-            ("domains_set",),
-            ("all_domains_set",)
-        ]:
-            target = result
-            for part in key[:-1]:
-                target = target[part]
-            value = target[key[-1]]
-            if isinstance(value, dict):
-                target[key[-1]] = {k:v for (k,v) in value.items() if not k.startswith("op")}
-            else:
-                target[key[-1]] = [x for x in value if not x.startswith("op")]
-
-        return result
-
 
 def json_types(obj):
     if isinstance(obj, dict):

--- a/webdriver/tests/support/fixtures.py
+++ b/webdriver/tests/support/fixtures.py
@@ -107,7 +107,8 @@ def http(configuration):
 
 @pytest.fixture
 def server_config():
-    return json.loads(os.environ.get("WD_SERVER_CONFIG"))
+    with open(os.environ.get("WD_SERVER_CONFIG_FILE"), "r") as f:
+        return json.load(f)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Instead of serializing the whole config in an environment variable, I amended the code to dump the config as JSON in a temporary file (the tests are conveniently executed against a temporary directory) and pass the file path in the environment variable instead.

This should avoid failures due to the 16-bit length limit being exceeded for good. In other words, no more issues like https://github.com/web-platform-tests/wpt/pull/21705#issuecomment-587578635 and #12461 :) This also removes the need to special-case origin-policy subdomains.

This change was extracted from #28768 per @jgraham's suggestion.