### PR TITLE
Simplify code converting os.environ to strings (avoiding six)

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -27,7 +27,6 @@ from ..executors.executormarionette import (MarionetteTestharnessExecutor,  # no
                                             MarionettePrintRefTestExecutor,  # noqa: F401
                                             MarionetteWdspecExecutor,  # noqa: F401
                                             MarionetteCrashtestExecutor)  # noqa: F401
-from ..process import cast_env
 
 
 here = os.path.dirname(__file__)
@@ -328,7 +327,7 @@ class FirefoxInstanceManager(object):
         runner = FirefoxRunner(profile=profile,
                                binary=cmd[0],
                                cmdargs=cmd[1:],
-                               env=cast_env(env),
+                               env=env,
                                process_class=ProcessHandler,
                                process_args={"processOutputLine": [output_handler]})
         instance = BrowserInstance(self.logger, runner, marionette_port,
@@ -683,7 +682,7 @@ class ProfileCreator(object):
             cmd = [self.certutil_binary] + list(args)
             self.logger.process_output("certutil",
                                        subprocess.check_output(cmd,
-                                                               env=cast_env(env),
+                                                               env=env,
                                                                stderr=subprocess.STDOUT),
                                        " ".join(cmd))
 

--- a/tools/wptrunner/wptrunner/browsers/firefox_android.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox_android.py
@@ -9,7 +9,6 @@ from .base import (get_free_port,
 from ..executors.executormarionette import (MarionetteTestharnessExecutor,  # noqa: F401
                                             MarionetteRefTestExecutor,  # noqa: F401
                                             MarionetteCrashtestExecutor)  # noqa: F401
-from ..process import cast_env
 from .base import (Browser,
                    ExecutorBrowser)
 from .firefox import (get_timeout_multiplier,  # noqa: F401
@@ -221,7 +220,7 @@ class FirefoxAndroidBrowser(Browser):
         self.runner = FennecEmulatorRunner(app=self.package_name,
                                            profile=self.profile,
                                            cmdargs=cmd[1:],
-                                           env=cast_env(env),
+                                           env=env,
                                            symbols_path=self.symbols_path,
                                            serial=self.device_serial,
                                            # TODO - choose appropriate log dir

--- a/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -11,7 +11,6 @@ from .base import get_timeout_multiplier   # noqa: F401
 from ..executors import executor_kwargs as base_executor_kwargs
 from ..executors.executorservodriver import (ServoWebDriverTestharnessExecutor,  # noqa: F401
                                              ServoWebDriverRefTestExecutor)  # noqa: F401
-from ..process import cast_env
 
 here = os.path.dirname(__file__)
 
@@ -132,11 +131,11 @@ class ServoWebDriverBrowser(Browser):
         if not self.debug_info or not self.debug_info.interactive:
             self.proc = ProcessHandler(self.command,
                                        processOutputLine=[self.on_output],
-                                       env=cast_env(env),
+                                       env=env,
                                        storeOutput=False)
             self.proc.run()
         else:
-            self.proc = subprocess.Popen(self.command, env=cast_env(env))
+            self.proc = subprocess.Popen(self.command, env=env)
 
         self.logger.debug("Servo Started")
 

--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -23,7 +23,6 @@ from .base import (ConnectionlessProtocol,
                    WdspecProtocol)
 from .process import ProcessTestExecutor
 from ..browsers.base import browser_command
-from ..process import cast_env
 from ..webdriver_server import ServoDriverServer
 
 
@@ -103,11 +102,11 @@ class ServoTestharnessExecutor(ProcessTestExecutor):
             self.proc = ProcessHandler(self.command,
                                        processOutputLine=[self.on_output],
                                        onFinish=self.on_finish,
-                                       env=cast_env(env),
+                                       env=env,
                                        storeOutput=False)
             self.proc.run()
         else:
-            self.proc = subprocess.Popen(self.command, env=cast_env(env))
+            self.proc = subprocess.Popen(self.command, env=env)
 
         try:
             timeout = test.timeout * self.timeout_multiplier
@@ -235,7 +234,7 @@ class ServoRefTestExecutor(ProcessTestExecutor):
             if not self.interactive:
                 self.proc = ProcessHandler(self.command,
                                            processOutputLine=[self.on_output],
-                                           env=cast_env(env))
+                                           env=env)
 
 
                 try:
@@ -247,7 +246,7 @@ class ServoRefTestExecutor(ProcessTestExecutor):
                     raise
             else:
                 self.proc = subprocess.Popen(self.command,
-                                             env=cast_env(env))
+                                             env=env)
                 try:
                     rv = self.proc.wait()
                 except KeyboardInterrupt:
@@ -357,11 +356,11 @@ class ServoCrashtestExecutor(ProcessTestExecutor):
 
         if not self.interactive:
             self.proc = ProcessHandler(command,
-                                       env=cast_env(env),
+                                       env=env,
                                        storeOutput=False)
             self.proc.run()
         else:
-            self.proc = subprocess.Popen(command, env=cast_env(env))
+            self.proc = subprocess.Popen(command, env=env)
 
         self.proc.wait()
 

--- a/tools/wptrunner/wptrunner/process.py
+++ b/tools/wptrunner/wptrunner/process.py
@@ -1,8 +1,0 @@
-import six
-
-
-def cast_env(env):
-    """Encode all the environment values as the appropriate type.
-    This assumes that all the data is or can be represented as UTF8"""
-
-    return {six.ensure_str(key): six.ensure_str(value) for key, value in env.items()}

--- a/tools/wptrunner/wptrunner/webdriver_server.py
+++ b/tools/wptrunner/wptrunner/webdriver_server.py
@@ -8,8 +8,6 @@ import traceback
 
 import mozprocess
 
-from .process import cast_env
-
 
 __all__ = ["SeleniumServer", "ChromeDriverServer", "CWTChromeDriverServer",
            "EdgeChromiumDriverServer", "OperaDriverServer", "GeckoDriverServer",
@@ -57,7 +55,7 @@ class WebDriverServer(object):
         self._proc = mozprocess.ProcessHandler(
             self._cmd,
             processOutputLine=self.on_output,
-            env=cast_env(self.env),
+            env=self.env,
             storeOutput=False)
 
         self.logger.debug("Starting WebDriver: %s" % ' '.join(self._cmd))
@@ -189,7 +187,7 @@ class GeckoDriverServer(WebDriverServer):
         WebDriverServer.__init__(self, logger, binary,
                                  host=host,
                                  port=port,
-                                 env=cast_env(env),
+                                 env=env,
                                  args=args)
         self.marionette_port = marionette_port
 
@@ -218,7 +216,7 @@ class ServoDriverServer(WebDriverServer):
         WebDriverServer.__init__(self, logger, binary,
                                  host=host,
                                  port=port,
-                                 env=cast_env(env),
+                                 env=env,
                                  args=args)
         self.binary_args = binary_args
 

--- a/tools/wptserve/wptserve/sslutils/openssl.py
+++ b/tools/wptserve/wptserve/sslutils/openssl.py
@@ -12,13 +12,6 @@ from datetime import datetime, timedelta
 CERT_EXPIRY_BUFFER = dict(hours=6)
 
 
-def _ensure_str(s, encoding):
-    """makes sure s is an instance of str, converting with encoding if needed"""
-    if isinstance(s, str):
-        return s
-    return s.decode(encoding)
-
-
 class OpenSSL(object):
     def __init__(self, logger, binary, base_path, conf_path, hosts, duration,
                  base_conf_path=None):
@@ -70,14 +63,10 @@ class OpenSSL(object):
             self.cmd += ["-config", self.conf_path]
         self.cmd += list(args)
 
-        # Copy the environment, converting to plain strings. Win32 StartProcess
-        # is picky about all the keys/values being str.
-        env = {}
-        for k, v in os.environ.items():
-            env[_ensure_str(k, "utf8")] = _ensure_str(v, "utf8")
-
+        # Copy the environment and add OPENSSL_CONF if available.
+        env = os.environ.copy()
         if self.base_conf_path is not None:
-            env["OPENSSL_CONF"] = _ensure_str(self.base_conf_path, "utf-8")
+            env["OPENSSL_CONF"] = self.base_conf_path
 
         self.proc = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                                      env=env)


### PR DESCRIPTION
os.environ always uses str on Python 3, there's a new os.environb for a
bytes version, which isn't supported on Windows:
https://docs.python.org/3/library/os.html#os.environ
https://docs.python.org/3/library/os.html#os.environb

Simply trust os.environ to be a dict[str, str], and simplify the
openssl.py code to something more like in GeckoDriverServer and
elsewhere:
https://github.com/web-platform-tests/wpt/blob/302039ac7c43c71bc5389104c81871b81d6cc9e0/tools/wptrunner/wptrunner/webdriver_server.py#L187-L193

Part of https://github.com/web-platform-tests/wpt/issues/28776.