### PR TITLE
Fix setting os.environ["PATH"] to a binary string

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -3,7 +3,6 @@ import os
 import platform
 import signal
 import subprocess
-import sys
 from abc import ABCMeta, abstractmethod
 
 import mozinfo
@@ -676,8 +675,7 @@ class ProfileCreator(object):
 
 
         env[env_var] = (os.path.pathsep.join([certutil_dir, env[env_var]])
-                        if env_var in env else certutil_dir).encode(
-                            sys.getfilesystemencoding() or 'utf-8', 'replace')
+                        if env_var in env else certutil_dir)
 
         def certutil(*args):
             cmd = [self.certutil_binary] + list(args)


### PR DESCRIPTION
This code would raise "TypeError: str expected, not bytes" is run using
Python 3, since setting os.environ keys implictly encodes using
sys.getfilesystemencoding():
https://docs.python.org/3/library/os.html#os.environ

This might be dead code, or simply not exercised in wpt's CI.

Spotted while preparing https://github.com/web-platform-tests/wpt/pull/28848.