### PR TITLE
Avoid use of window.fullScreen and test for its absence

### DIFF
--- a/fullscreen/api/historical.html
+++ b/fullscreen/api/historical.html
@@ -35,4 +35,8 @@
     // it is convenient to just test all names on both <video> and document.
   });
 });
+
+test(function() {
+  assert_false('fullScreen' in window);
+}, 'window.fullScreen must not be supported');
 </script>

--- a/webdriver/tests/support/helpers.py
+++ b/webdriver/tests/support/helpers.py
@@ -199,13 +199,12 @@ def is_element_in_viewport(session, element):
 
 
 def is_fullscreen(session):
-    # At the time of writing, WebKit does not conform to the
-    # Fullscreen API specification.
+    # WebKit does not support the unprefixed Fullscreen API.
     #
-    # Remove the prefixed fallback when
+    # TODO: Remove the prefixed fallback when
     # https://bugs.webkit.org/show_bug.cgi?id=158125 is fixed.
     return session.execute_script("""
-        return !!(window.fullScreen || document.webkitIsFullScreen)
+        return !!(document.fullscreen || document.webkitIsFullScreen)
         """)
 
 


### PR DESCRIPTION
The is_fullscreen helper accidentally depended on both the Gecko-only
window.fullScreen and the WebKit-only document.webkitIsFullScreen, and
wouldn't have worked in a browser supporting only the standard
Fullscreen API.

Use document.fullscreen instead, and add a negative test for
window.fullScreen.