### PR TITLE
Remove use of six.range

### DIFF
--- a/service-workers/service-worker/resources/trickle.py
+++ b/service-workers/service-worker/resources/trickle.py
@@ -1,7 +1,5 @@
 import time
 
-from six import range
-
 def main(request, response):
     delay = float(request.GET.first(b"ms", 500)) / 1E3
     count = int(request.GET.first(b"count", 50))


### PR DESCRIPTION
No longer needed on Python 3:
https://docs.python.org/3/library/functions.html#func-range

Part of https://github.com/web-platform-tests/wpt/issues/28776.