### PR TITLE
[idlharness.js] Remove legacycaller support

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -2626,9 +2626,6 @@ IdlInterface.prototype.test_object = function(desc)
     {
         // Result of [[IsHTMLDDA]] slot
         expected_typeof = "undefined";
-    } else if (this.members.some(function(member) { return member.legacycaller; }))
-    {
-        expected_typeof = "function";
     }
     else
     {


### PR DESCRIPTION
It no longer appears in any IDL under test, and importantly isn't
supported by webidl2.js since https://github.com/w3c/webidl2.js/issues/78.

Fixes https://github.com/web-platform-tests/wpt/issues/7258.