### PR TITLE
Remove use of six.iteritems

### DIFF
--- a/docs/wpt_lint_rules.py
+++ b/docs/wpt_lint_rules.py
@@ -3,7 +3,6 @@ from docutils.utils import new_document
 from recommonmark.parser import CommonMarkParser
 import importlib
 import textwrap
-from six import iteritems
 
 class WPTLintRules(Directive):
     """A docutils directive to generate documentation for the
@@ -32,7 +31,7 @@ class WPTLintRules(Directive):
                 """wpt-lint-rules: unable to resolve the module at "{}".""".format(self.module_specifier)
             )
 
-        for binding_name, value in iteritems(module.__dict__):
+        for binding_name, value in module.__dict__.items():
             if hasattr(value, "__abstractmethods__") and len(value.__abstractmethods__):
                 continue
 

--- a/webdriver/tests/support/helpers.py
+++ b/webdriver/tests/support/helpers.py
@@ -4,8 +4,6 @@ import collections
 import math
 import sys
 
-from six import iteritems
-
 import webdriver
 
 from tests.support import defaults
@@ -114,7 +112,7 @@ def deep_update(source, overrides):
     Update a nested dictionary or similar mapping.
     Modify ``source`` in place.
     """
-    for key, value in iteritems(overrides):
+    for key, value in overrides.items():
         if isinstance(value, collections.Mapping) and value:
             returned = deep_update(source.get(key, {}), value)
             source[key] = returned

--- a/webdriver/tests/support/merge_dictionaries.py
+++ b/webdriver/tests/support/merge_dictionaries.py
@@ -1,5 +1,3 @@
-from six import iteritems
-
 def merge_dictionaries(first, second):
     """Given two dictionaries, create a third that defines all specified
     key/value pairs. This merge_dictionaries is performed "deeply" on any nested
@@ -7,7 +5,7 @@ def merge_dictionaries(first, second):
     an exception will be raised."""
     result = dict(first)
 
-    for key, value in iteritems(second):
+    for key, value in second.items():
         if key in result and result[key] != value:
             if isinstance(result[key], dict) and isinstance(value, dict):
                 result[key] = merge_dictionaries(result[key], value)


### PR DESCRIPTION
The implementation of this in Python 3 is:
https://github.com/web-platform-tests/wpt/blob/aa9b753e75bb0c7de5a05277c91cef3a7a7348e4/tools/third_party/six/six.py#L588-L589

Replacing itemitems(value) with iter(value.items()) should thus be the
100% safe option, but when used in for loops, just value.items() will
suffice.

Part of https://github.com/web-platform-tests/wpt/issues/28776.