### PR TITLE
Avoid putting device-dependent string in test names.

### DIFF
--- a/css/mediaqueries/test_media_queries.html
+++ b/css/mediaqueries/test_media_queries.html
@@ -32,14 +32,14 @@ function run() {
 
     function should_apply(q) {
       test(function() {
-        assert_true(query_applies(q));
-      }, "subtest_" + ++testNum + ": " + q + " should apply");
+        assert_true(query_applies(q), q + " should apply");
+      }, "subtest_" + ++testNum);
     }
 
     function should_not_apply(q) {
       test(function() {
-        assert_false(query_applies(q));
-      }, "subtest_" + ++testNum + ": " + q + " should not apply");
+        assert_false(query_applies(q), q + " should not apply");
+      }, "subtest_" + ++testNum);
     }
 
     /*


### PR DESCRIPTION
Fixes #28879