### PR TITLE
Remove use of six.reraise

### DIFF
--- a/webdriver/tests/support/sync.py
+++ b/webdriver/tests/support/sync.py
@@ -2,8 +2,6 @@ import collections
 import sys
 import time
 
-import six
-
 from webdriver import error
 
 
@@ -140,6 +138,6 @@ class Poll(object):
             message = "Timed out after {} seconds".format(elapsed)
             if self.exc_msg is not None:
                 message = "{} with message: {}".format(message, self.exc_msg)
-            six.reraise(self.exc_cls, self.exc_cls(message=message), tb)
+            raise self.exc_cls(message=message).with_traceback(tb)
         else:
             return rv


### PR DESCRIPTION
Implementation of this for Python 3:
https://github.com/web-platform-tests/wpt/blob/aa9b753e75bb0c7de5a05277c91cef3a7a7348e4/tools/third_party/six/six.py#L697-L706

Simplifying that step by step leads to the new code.

Part of https://github.com/web-platform-tests/wpt/issues/28776.