### PR TITLE
Simplify try-except imports of things moved between Python 2 and 3

### DIFF
--- a/dom/nodes/encoding.py
+++ b/dom/nodes/encoding.py
@@ -1,7 +1,4 @@
-try:
-    from cgi import escape
-except ImportError:
-    from html import escape
+from html import escape
 
 from wptserve.utils import isomorphic_decode
 

--- a/tools/serve/test_functional.py
+++ b/tools/serve/test_functional.py
@@ -4,11 +4,7 @@ except ImportError:
     pass
 import json
 import os
-try:
-    # import Queue under its Python 3 name
-    import Queue as queue  # noqa: N813
-except ImportError:
-    import queue
+import queue
 import tempfile
 import threading
 

--- a/tools/wave/tests/test_wave.py
+++ b/tools/wave/tests/test_wave.py
@@ -4,11 +4,8 @@ import socket
 import subprocess
 import time
 
-try:
-    from urllib.request import urlopen
-    from urllib.error import URLError
-except ImportError:
-    from urllib2 import urlopen, URLError
+from urllib.request import urlopen
+from urllib.error import URLError
 
 import pytest
 

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -7,11 +7,8 @@ import sys
 import tempfile
 import time
 
-try:
-    from urllib.request import urlopen
-    from urllib.error import URLError
-except ImportError:
-    from urllib2 import urlopen, URLError
+from urllib.request import urlopen
+from urllib.error import URLError
 
 import pytest
 

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -12,10 +12,7 @@ from .request import Authentication
 from .response import MultipartContent
 from .utils import HTTPException
 
-try:
-    from html import escape
-except ImportError:
-    from cgi import escape
+from html import escape
 
 __all__ = ["file_handler", "python_script_handler",
            "FunctionHandler", "handler", "json_handler",

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -7,12 +7,9 @@ import re
 import time
 import uuid
 
+from html import escape
 from io import BytesIO
 
-try:
-    from html import escape
-except ImportError:
-    from cgi import escape
 
 def resolve_content(response):
     return b"".join(item for item in response.iter_content(read_file=True))


### PR DESCRIPTION
It's not clear from the code alone which is which, but these import
statements work on Python 3.8.2:
```py
from html import escape
import queue
from urllib.request import urlopen
```

Part of https://github.com/web-platform-tests/wpt/issues/28776.
Part of https://github.com/web-platform-tests/wpt/issues/28833.