### PR TITLE
Drop read_gzp workaround for a mypy problem in Python 2

### DIFF
--- a/tools/manifest/download.py
+++ b/tools/manifest/download.py
@@ -158,7 +158,7 @@ def download_manifest(
             fileobj = io.BytesIO(resp.read())
             try:
                 with gzip.GzipFile(fileobj=fileobj) as gzf:
-                    data = read_gzf(gzf)  # type: ignore
+                    data = gzf.read()
                     decompressed = data
             except IOError:
                 logger.warning("Failed to decompress downloaded file")
@@ -178,12 +178,6 @@ def download_manifest(
         return False
     logger.info("Manifest downloaded")
     return True
-
-
-def read_gzf(gzf):  # type: ignore
-    # This is working around a mypy problem in Python 2:
-    # "Call to untyped function "read" in typed context"
-    return gzf.read()
 
 
 def create_parser():


### PR DESCRIPTION
There's no issue here with mypy on Python 3.

Part of https://github.com/web-platform-tests/wpt/pull/28895.