### PR TITLE
Update Safari Technology Preview to 124

### DIFF
--- a/tools/ci/azure/safari-technology-preview.rb
+++ b/tools/ci/azure/safari-technology-preview.rb
@@ -1,10 +1,10 @@
 cask "safari-technology-preview" do
   if MacOS.version <= :catalina
-    version "123,071-23564-20210330-f6b89a7f-4800-4af7-93cb-0dbb005db0e8"
-    sha256 "16e7ed118cd3e839d48c7c68827c59fd2f9d2d3341514d7b301fb5d8c30d55fb"
+    version "124,071-27612-20210507-96cb5150-2454-422d-b3be-d9253bbf746c"
+    sha256 "3c7958aa9a61d1af323ef9c004301b37e27241ace465d98ccd53b34ea282d422"
   else
-    version "123,071-23628-20210330-8224de12-9cd5-4c33-b944-149b5f4cd543"
-    sha256 "9d1319f78bc27cf6163691f61b70f9457a59a125b9adfb44253ac7a597a87767"
+    version "124,071-40182-20210507-d07bb1e1-ffd5-4fc9-ab00-64fc3ca17bcd"
+    sha256 "d69043deee786a304aea2dfaffcce5f9a5f0dd3e77ba427deba47db306241616"
   end
 
   url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"


### PR DESCRIPTION
Version as reported by safaridriver --version:
Included with Safari Technology Preview (Release 124, 15612.1.11.10)

Source: https://developer.apple.com/safari/download/
Build: https://dev.azure.com/foolip/safari-technology-preview-updater/_build/results?buildId=3074&view=logs