### PR TITLE
Enable mypy for tools/quic/

### DIFF
--- a/tools/mypy.ini
+++ b/tools/mypy.ini
@@ -24,6 +24,9 @@ warn_unused_ignores = True
 
 # Ignore missing or untyped libraries.
 
+[mypy-aioquic.*]
+ignore_missing_imports = True
+
 [mypy-html5lib.*]
 ignore_missing_imports = True
 
@@ -67,9 +70,6 @@ ignore_errors = True
 
 [mypy-tools.docker.*]
 disallow_untyped_defs = False
-
-[mypy-tools.quic.*]
-ignore_errors = True
 
 [mypy-tools.serve.*]
 ignore_errors = True

--- a/tools/quic/quic_transport_server.py
+++ b/tools/quic/quic_transport_server.py
@@ -27,7 +27,7 @@ class EventHandler:
 
     def handle_client_indication(
             self,
-            origin: Optional[str],
+            origin: str,
             query: Dict[str, str]) -> None:
         name = 'handle_client_indication'
         if name in self.global_dict:
@@ -117,8 +117,10 @@ class QuicTransportProtocol(QuicConnectionProtocol):  # type: ignore
         logger.info('origin = %s, path = %s', origin_string, path_string)
         if origin is None:
             raise Exception('No origin is given')
+        assert origin_string is not None
         if path is None:
             raise Exception('No path is given')
+        assert path_string is not None
         if origin.scheme != 'https' and origin.scheme != 'http':
             raise Exception('Invalid origin: %s' % origin_string)
         if origin.netloc == '':

--- a/tools/quic/quic_transport_server.py
+++ b/tools/quic/quic_transport_server.py
@@ -6,7 +6,7 @@ import re
 import struct
 import urllib.parse
 import traceback
-from typing import Dict, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from aioquic.asyncio import QuicConnectionProtocol, serve
 from aioquic.quic.configuration import QuicConfiguration
@@ -21,13 +21,13 @@ handlers_path = ''
 
 
 class EventHandler:
-    def __init__(self, connection: QuicConnectionProtocol, global_dict: Dict):
+    def __init__(self, connection: QuicConnectionProtocol, global_dict: Dict[str, Any]):
         self.connection = connection
         self.global_dict = global_dict
 
     def handle_client_indication(
             self,
-            origin: str,
+            origin: Optional[str],
             query: Dict[str, str]) -> None:
         name = 'handle_client_indication'
         if name in self.global_dict:
@@ -39,14 +39,13 @@ class EventHandler:
             self.global_dict[name](self.connection, event)
 
 
-class QuicTransportProtocol(QuicConnectionProtocol):
-    def __init__(self, *args, **kwargs) -> None:
+class QuicTransportProtocol(QuicConnectionProtocol):  # type: ignore
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.streams = dict()
-        self.pending_events = []
+        self.pending_events: List[QuicEvent] = []
         self.client_indication_finished = False
         self.client_indication_data = b''
-        self.handler = None
+        self.handler: Optional[EventHandler] = None
 
     def quic_event_received(self, event: QuicEvent) -> None:
         prefix = '!!'
@@ -62,6 +61,7 @@ class QuicTransportProtocol(QuicConnectionProtocol):
                     raise Exception('too large data for client indication')
                 if event.end_stream:
                     self.process_client_indication()
+                    assert self.handler is not None
                     if self.is_closing_or_closed():
                         return
                     prefix = 'Event handling Error: '
@@ -79,7 +79,7 @@ class QuicTransportProtocol(QuicConnectionProtocol):
             traceback.print_exc()
             self.close()
 
-    def parse_client_indication(self, bs):
+    def parse_client_indication(self, bs: io.BytesIO) -> Iterator[Tuple[int, bytes]]:
         while True:
             key_b = bs.read(2)
             if len(key_b) == 0:
@@ -138,8 +138,8 @@ class QuicTransportProtocol(QuicConnectionProtocol):
         self.client_indication_finished = True
         logger.info('Client indication finished')
 
-    def create_event_handler(self, handler_name: str) -> None:
-        global_dict = {}
+    def create_event_handler(self, handler_name: str) -> EventHandler:
+        global_dict: Dict[str, Any] = {}
         with open(handlers_path + '/' + handler_name) as f:
             exec(f.read(), global_dict)
         return EventHandler(self, global_dict)
@@ -167,7 +167,7 @@ class SessionTicketStore:
         return self.tickets.pop(label, None)
 
 
-def start(kwargs):
+def start(**kwargs: Any) -> None:
     configuration = QuicConfiguration(
         alpn_protocols=['wq-vvv-01'] + ['siduck'],
         is_client=False,

--- a/tools/quic/serve.py
+++ b/tools/quic/serve.py
@@ -4,11 +4,12 @@ import argparse
 import logging
 import os
 import sys
+from typing import Any
 
 _dir = os.path.dirname(__file__)
 
 
-def get_parser():
+def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description='QUIC server')
     parser.add_argument(
         '-c',
@@ -52,7 +53,8 @@ def get_parser():
     return parser
 
 
-def run(venv, **kwargs):
+def run(venv: Any, **kwargs: Any) -> None:
+    # The venv argument is passed with `wpt serve-quic-transport` but is unused.
     assert sys.version_info.major == 3, 'QUIC server only runs in Python 3'
     logging.basicConfig(
         format='%(asctime)s %(levelname)s %(name)s %(message)s',
@@ -61,15 +63,15 @@ def run(venv, **kwargs):
 
     # Delay import after version check to make the error easier to understand.
     from .quic_transport_server import start
-    start(kwargs)
+    start(**kwargs)
 
 
-def main():
+def main() -> None:
     # This is only used when executing the script directly. Users are
     # responsible for managing venv themselves. `wpt serve-quic-transport` does
     # NOT use this code path.
     kwargs = vars(get_parser().parse_args())
-    return run(None, **kwargs)
+    run(None, **kwargs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This code was already mostly annotated, but needs updating to pass our
mypy.ini rules. A few changes are noteworthy:
 - QuicTransportProtocol.streams was removed rather than annotated,
   because it's actually unused.
 - An assert for self.handler is added after process_client_indication()
   to it clear that that it can't be None in the following loop.

Part of https://github.com/web-platform-tests/wpt/issues/28833.