### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=225339

### DIFF
--- a/css/css-flexbox/table-as-item-specified-width-vertical.html
+++ b/css/css-flexbox/table-as-item-specified-width-vertical.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>Table with vertical writing mode inside a row flexbox container</title>
+<link rel="author" title="Felipe Erias Morandeira" href="mailto:felipeerias@igalia.com" />
+<link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#layout-algorithm" title="9. Flex Layout Algorithm">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="The logical heights of table and flexbox container are orthogonal to each other.">
+
+<p>Test passes if there is a filled green square.</p>
+
+<div style="display: flex; flex-direction: row; height: 100px;">
+    <div style="display: table; writing-mode: vertical-lr; width: 500px; background: green; flex: 0 0 100px;"></div>
+</div>

--- a/css/css-flexbox/table-as-item-specified-width-vertical.html
+++ b/css/css-flexbox/table-as-item-specified-width-vertical.html
@@ -3,7 +3,7 @@
 <link rel="author" title="Felipe Erias Morandeira" href="mailto:felipeerias@igalia.com" />
 <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#layout-algorithm" title="9. Flex Layout Algorithm">
 <link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
-<meta name="assert" content="The logical heights of table and flexbox container are orthogonal to each other.">
+<meta name="assert" content="The width of an empty table (vertical direction) inside a flexbox container (row direction) is computed correctly.">
 
 <p>Test passes if there is a filled green square.</p>
 


### PR DESCRIPTION
Add a test for an empty table inside a flexbox container, where the logical heights of both elements are orthogonal to each other (the table has vertical writing mode and the flexbox uses row direction). This is a flipped version of table-as-item-specified-height.html.

Related WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=225339