### PR TITLE
Simplify GitHubChecksOutputter.output() to only accept strings

### DIFF
--- a/tools/ci/tc/github_checks_output.py
+++ b/tools/ci/tc/github_checks_output.py
@@ -1,9 +1,7 @@
-from six import ensure_text
-
 MYPY = False
 if MYPY:
     # MYPY is set to True when run under Mypy.
-    from typing import AnyStr, Optional, Text
+    from typing import Optional, Text
 
 
 class GitHubChecksOutputter(object):
@@ -20,11 +18,10 @@ class GitHubChecksOutputter(object):
         self.path = path
 
     def output(self, line):
-        # type: (AnyStr) -> None
-        text = ensure_text(line)
+        # type: (Text) -> None
         with open(self.path, mode="a") as f:
-            f.write(text)
-            f.write(u"\n")
+            f.write(line)
+            f.write("\n")
 
 
 __outputter = None


### PR DESCRIPTION
All of the call sites are ultimately using string literals:
https://github.com/web-platform-tests/wpt/blob/53b3a8eda25cce01aec86f70d0d1c4354ea7e09f/tools/ci/tc/sink_task.py#L32-L43
https://github.com/web-platform-tests/wpt/blob/53b3a8eda25cce01aec86f70d0d1c4354ea7e09f/tools/ci/tc/sink_task.py#L59-L63
https://github.com/web-platform-tests/wpt/blob/53b3a8eda25cce01aec86f70d0d1c4354ea7e09f/tools/lint/lint.py#L885-L902
https://github.com/web-platform-tests/wpt/blob/53b3a8eda25cce01aec86f70d0d1c4354ea7e09f/tools/lint/lint.py#L850-L856
https://github.com/web-platform-tests/wpt/blob/53b3a8eda25cce01aec86f70d0d1c4354ea7e09f/tools/lint/lint.py#L1105-L1106
https://github.com/web-platform-tests/wpt/blob/53b3a8eda25cce01aec86f70d0d1c4354ea7e09f/tools/wptrunner/wptrunner/stability.py#L181-L202

Part of https://github.com/web-platform-tests/wpt/issues/28776.