### PR TITLE
Rely on os.path.* returning strings (not bytes)

### DIFF
--- a/tools/localpaths.py
+++ b/tools/localpaths.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 here = os.path.abspath(os.path.dirname(__file__))
+repo_root = os.path.abspath(os.path.join(here, os.pardir))
 
 sys.path.insert(0, os.path.join(here))
 sys.path.insert(0, os.path.join(here, "wptserve"))
@@ -32,7 +33,3 @@ if sys.version_info < (3, 8):
     sys.path.insert(0, os.path.join(here, "third_party", "importlib_metadata"))
 sys.path.insert(0, os.path.join(here, "webdriver"))
 sys.path.insert(0, os.path.join(here, "wptrunner"))
-
-# We can't import six until we've set the path above.
-from six import ensure_text
-repo_root = ensure_text(os.path.abspath(os.path.join(here, os.pardir)))

--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -6,7 +6,6 @@ import subprocess
 import sys
 
 from collections import OrderedDict
-from six import ensure_text, ensure_str
 
 try:
     from ..manifest import manifest
@@ -38,7 +37,7 @@ if MYPY:
 
 DEFAULT_IGNORE_RULERS = ("resources/testharness*", "resources/testdriver*")
 
-here = ensure_text(os.path.dirname(__file__))
+here = os.path.dirname(__file__)
 wpt_root = os.path.abspath(os.path.join(here, os.pardir, os.pardir))
 
 logger = logging.getLogger()
@@ -136,7 +135,7 @@ def branch_point():
 
 def compile_ignore_rule(rule):
     # type: (Text) -> Pattern[Text]
-    rule = rule.replace(ensure_text(os.path.sep), u"/")
+    rule = rule.replace(os.path.sep, u"/")
     parts = rule.split(u"/")
     re_parts = []
     for part in parts:
@@ -398,7 +397,7 @@ def run_changed_files(**kwargs):
 
     for item in sorted(changed):
         line = os.path.relpath(item, wpt_root) + separator
-        sys.stdout.write(ensure_str(line))
+        sys.stdout.write(line)
 
 
 def run_tests_affected(**kwargs):


### PR DESCRIPTION
Part of https://github.com/web-platform-tests/wpt/issues/28776.