### PR TITLE
Remove use of six.ensure_str/ensure_text in wptrunner

### DIFF
--- a/tools/wptrunner/wptrunner/metadata.py
+++ b/tools/wptrunner/wptrunner/metadata.py
@@ -1,10 +1,10 @@
 import array
 import os
+import sys
 from collections import defaultdict, namedtuple
 from typing import Dict, List, Tuple
 
 from mozlog import structuredlog
-from six import ensure_str, ensure_text
 from sys import intern
 
 from . import manifestupdate
@@ -336,6 +336,17 @@ def write_new_expected(metadata_path, expected):
             os.unlink(path)
         except OSError:
             pass
+
+
+def ensure_str(s):
+    if type(s) is str:
+        return s
+    print(f'ensure_str in metadata.py was called with type {type(s)}')
+    sys.exit(1)
+
+
+def ensure_text(s):
+    return ensure_str(s)
 
 
 class ExpectedUpdater:

--- a/tools/wptrunner/wptrunner/wptmanifest/serializer.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/serializer.py
@@ -1,4 +1,4 @@
-from six import ensure_text
+import sys
 
 from .node import NodeVisitor, ValueNode, ListNode, BinaryExpressionNode
 from .parser import atoms, precedence
@@ -6,6 +6,18 @@ from .parser import atoms, precedence
 atom_names = {v: "@%s" % k for (k,v) in atoms.items()}
 
 named_escapes = {"\a", "\b", "\f", "\n", "\r", "\t", "\v"}
+
+
+def ensure_str(s):
+    if type(s) is str:
+        return s
+    print(f'ensure_str in serializer.py was called with type {type(s)}')
+    sys.exit(1)
+
+
+def ensure_text(s):
+    return ensure_str(s)
+
 
 def escape(string, extras=""):
     # Assumes input bytes are either UTF8 bytes or unicode.


### PR DESCRIPTION
Part of https://github.com/web-platform-tests/wpt/issues/28776.