### PR TITLE
Remove SurrogateReplacementUcs2 (conditional on sys.maxunicode)

### DIFF
--- a/tools/wptrunner/wptrunner/formatters/wptreport.py
+++ b/tools/wptrunner/wptrunner/formatters/wptreport.py
@@ -1,6 +1,5 @@
 import json
 import re
-import sys
 
 from mozlog.structured.formatters.base import BaseFormatter
 from ..executors.base import strip_server
@@ -9,42 +8,8 @@ from ..executors.base import strip_server
 LONE_SURROGATE_RE = re.compile(u"[\uD800-\uDFFF]")
 
 
-def surrogate_replacement_ucs4(match):
+def surrogate_replacement(match):
     return "U+" + hex(ord(match.group()))[2:]
-
-
-class SurrogateReplacementUcs2(object):
-    def __init__(self):
-        self.skip = False
-
-    def __call__(self, match):
-        char = match.group()
-
-        if self.skip:
-            self.skip = False
-            return char
-
-        is_low = 0xD800 <= ord(char) <= 0xDBFF
-
-        escape = True
-        if is_low:
-            next_idx = match.end()
-            if next_idx < len(match.string):
-                next_char = match.string[next_idx]
-                if 0xDC00 <= ord(next_char) <= 0xDFFF:
-                    escape = False
-
-        if not escape:
-            self.skip = True
-            return char
-
-        return "U+" + hex(ord(match.group()))[2:]
-
-
-if sys.maxunicode == 0x10FFFF:
-    surrogate_replacement = surrogate_replacement_ucs4
-else:
-    surrogate_replacement = SurrogateReplacementUcs2()
 
 
 def replace_lone_surrogate(data):

--- a/tools/wptrunner/wptrunner/tests/test_formatters.py
+++ b/tools/wptrunner/wptrunner/tests/test_formatters.py
@@ -2,11 +2,8 @@ import json
 import time
 from io import StringIO
 
-import mock
-
 from mozlog import handlers, structuredlog
 
-from ..formatters import wptreport
 from ..formatters.wptscreenshot import WptscreenshotFormatter
 from ..formatters.wptreport import WptreportFormatter
 
@@ -95,45 +92,6 @@ def test_wptreport_lone_surrogate(capfd):
     subtest = test["subtests"][0]
     assert subtest["name"] == u"Name with surrogateU+d800"
     assert subtest["message"] == u"\U0001F601 U+de0aU+d83d"
-
-
-def test_wptreport_lone_surrogate_ucs2(capfd):
-    # Since UCS4 is a superset of UCS2 we can meaningfully test the UCS2 code on a
-    # UCS4 build, but not the reverse. However UCS2 is harder to handle and UCS4 is
-    # the commonest (and sensible) configuration, so that's OK.
-    output = StringIO()
-    logger = structuredlog.StructuredLogger("test_a")
-    logger.add_handler(handlers.StreamHandler(output, WptreportFormatter()))
-
-    with mock.patch.object(wptreport,
-                           'surrogate_replacement',
-                           wptreport.SurrogateReplacementUcs2()):
-        # output a bunch of stuff
-        logger.suite_start(["test-id-1"])  # no run_info arg!
-        logger.test_start("test-id-1")
-        logger.test_status("test-id-1",
-                           subtest=u"Name with surrogate\uD800",
-                           status="FAIL",
-                           message=u"\U0001F601 \uDE0A\uD83D \uD83D\uDE0A")
-        logger.test_end("test-id-1",
-                        status="PASS",
-                        message=u"\uDE0A\uD83D \uD83D\uDE0A \U0001F601")
-        logger.suite_end()
-
-    # check nothing got output to stdout/stderr
-    # (note that mozlog outputs exceptions during handling to stderr!)
-    captured = capfd.readouterr()
-    assert captured.out == ""
-    assert captured.err == ""
-
-    # check the actual output of the formatter
-    output.seek(0)
-    output_obj = json.load(output)
-    test = output_obj["results"][0]
-    assert test["message"] == u"U+de0aU+d83d \U0001f60a \U0001F601"
-    subtest = test["subtests"][0]
-    assert subtest["name"] == u"Name with surrogateU+d800"
-    assert subtest["message"] == u"\U0001F601 U+de0aU+d83d \U0001f60a"
 
 
 def test_wptreport_known_intermittent(capfd):

--- a/tools/wptrunner/wptrunner/wptmanifest/tests/test_serializer.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/tests/test_serializer.py
@@ -1,7 +1,4 @@
-import sys
 import unittest
-
-import pytest
 
 from .. import parser, serializer
 
@@ -192,7 +189,6 @@ class TokenizerTest(unittest.TestCase):
                      r"""key: "#"
 """)
 
-    @pytest.mark.xfail(sys.maxunicode == 0xFFFF, reason="narrow unicode")
     def test_escape_9(self):
         self.compare(br"""key: \U10FFFFabc""",
                      u"""key: \U0010FFFFabc


### PR DESCRIPTION
Since Python 3.3, this is always 0x10FFFF:
https://docs.python.org/3/library/sys.html#sys.maxunicode

This is py2/3 simplification, but actually done because mypy is
otherwise going to want SurrogateReplacementUcs2 to be annotated, which
is pointless when it's unused.

Part of https://github.com/web-platform-tests/wpt/issues/28833.