### PR TITLE
Run mypy for tools/wptrunner/ (but still allow untyped defs)

### DIFF
--- a/tools/mypy.ini
+++ b/tools/mypy.ini
@@ -33,19 +33,55 @@ ignore_missing_imports = True
 [mypy-html5lib.*]
 ignore_missing_imports = True
 
+[mypy-marionette_driver.*]
+ignore_missing_imports = True
+
+[mypy-mozcrash.*]
+ignore_missing_imports = True
+
+[mypy-mozdebug.*]
+ignore_missing_imports = True
+
 [mypy-mozdevice.*]
+ignore_missing_imports = True
+
+[mypy-mozinfo.*]
 ignore_missing_imports = True
 
 [mypy-mozinstall.*]
 ignore_missing_imports = True
 
+[mypy-mozleak.*]
+ignore_missing_imports = True
+
 [mypy-mozlog.*]
+ignore_missing_imports = True
+
+[mypy-moznetwork.*]
+ignore_missing_imports = True
+
+[mypy-mozprocess.*]
+ignore_missing_imports = True
+
+[mypy-mozprofile.*]
 ignore_missing_imports = True
 
 [mypy-mozrunner.*]
 ignore_missing_imports = True
 
+[mypy-mozversion.*]
+ignore_missing_imports = True
+
+[mypy-PIL.*]
+ignore_missing_imports = True
+
+[mypy-psutil.*]
+ignore_missing_imports = True
+
 [mypy-pytest.*]
+ignore_missing_imports = True
+
+[mypy-selenium.*]
 ignore_missing_imports = True
 
 [mypy-taskcluster.*]
@@ -80,6 +116,15 @@ ignore_errors = True
 [mypy-tools.wpt.tests.*]
 ignore_errors = True
 
+[mypy-wptrunner.tests.*]
+ignore_errors = True
+
+[mypy-wptrunner.formatters.tests.*]
+ignore_errors = True
+
+[mypy-wptrunner.wptmanifest.tests.*]
+ignore_errors = True
+
 # Ignore errors in parts of the code which don't have type annotations or where
 # mypy has never been run. TODO: Enable mypy for all of the below.
 
@@ -102,7 +147,7 @@ disallow_untyped_defs = False
 disallow_untyped_defs = False
 
 [mypy-wptrunner.*]
-ignore_errors = True
+disallow_untyped_defs = False
 
 [mypy-wptserve.*]
 ignore_errors = True

--- a/tools/wptrunner/wptrunner/browsers/edge.py
+++ b/tools/wptrunner/wptrunner/browsers/edge.py
@@ -66,7 +66,6 @@ def env_options():
 
 
 class EdgeBrowser(Browser):
-    used_ports = set()
     init_timeout = 60
 
     def __init__(self, logger, webdriver_binary,

--- a/tools/wptrunner/wptrunner/config.py
+++ b/tools/wptrunner/wptrunner/config.py
@@ -1,11 +1,12 @@
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 import os
 import sys
 from collections import OrderedDict
+from typing import Any, Dict
 
 here = os.path.dirname(__file__)
 
-class ConfigDict(dict):
+class ConfigDict(Dict[str, Any]):
     def __init__(self, base_path, *args, **kwargs):
         self.base_path = base_path
         dict.__init__(self, *args, **kwargs)
@@ -20,7 +21,7 @@ class ConfigDict(dict):
 def read(config_path):
     config_path = os.path.abspath(config_path)
     config_root = os.path.dirname(config_path)
-    parser = SafeConfigParser()
+    parser = ConfigParser()
     success = parser.read(config_path)
     assert config_path in success, success
 

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -1,6 +1,7 @@
 import traceback
 
 from abc import ABCMeta, abstractmethod
+from typing import ClassVar, List, Type
 
 
 class Protocol(object):
@@ -16,7 +17,7 @@ class Protocol(object):
     :param Browser browser: The Browser using this protocol"""
     __metaclass__ = ABCMeta
 
-    implements = []
+    implements = []  # type: ClassVar[List[Type[ProtocolPart]]]
 
     def __init__(self, executor, browser):
         self.executor = executor
@@ -82,7 +83,7 @@ class ProtocolPart(object):
     :param Protocol parent: The parent protocol"""
     __metaclass__ = ABCMeta
 
-    name = None
+    name = None  # type: ClassVar[str]
 
     def __init__(self, parent):
         self.parent = parent

--- a/tools/wptrunner/wptrunner/formatters/chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/chromium.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from mozlog.formatters import base
 
 
-class ChromiumFormatter(base.BaseFormatter):
+class ChromiumFormatter(base.BaseFormatter):  # type: ignore
     """Formatter to produce results matching the Chromium JSON Test Results format.
     https://chromium.googlesource.com/chromium/src/+/master/docs/testing/json_test_results_format.md
 

--- a/tools/wptrunner/wptrunner/formatters/wptreport.py
+++ b/tools/wptrunner/wptrunner/formatters/wptreport.py
@@ -16,7 +16,7 @@ def replace_lone_surrogate(data):
     return LONE_SURROGATE_RE.subn(surrogate_replacement, data)[0]
 
 
-class WptreportFormatter(BaseFormatter):
+class WptreportFormatter(BaseFormatter):  # type: ignore
     """Formatter that produces results in the format that wptreport expects."""
 
     def __init__(self):

--- a/tools/wptrunner/wptrunner/formatters/wptscreenshot.py
+++ b/tools/wptrunner/wptrunner/formatters/wptscreenshot.py
@@ -4,7 +4,7 @@ from mozlog.structured.formatters.base import BaseFormatter
 DEFAULT_API = "https://wpt.fyi/api/screenshots/hashes"
 
 
-class WptscreenshotFormatter(BaseFormatter):
+class WptscreenshotFormatter(BaseFormatter):  # type: ignore
     """Formatter that outputs screenshots in the format expected by wpt.fyi."""
 
     def __init__(self, api=None):

--- a/tools/wptrunner/wptrunner/manifestupdate.py
+++ b/tools/wptrunner/wptrunner/manifestupdate.py
@@ -3,6 +3,7 @@ import os
 from urllib.parse import urljoin, urlsplit
 from collections import namedtuple, defaultdict, deque
 from math import ceil
+from typing import Any, Callable, ClassVar, Dict, List
 
 from .wptmanifest import serialize
 from .wptmanifest.node import (DataNode, ConditionalNode, BinaryExpressionNode,
@@ -320,10 +321,13 @@ def build_unconditional_tree(_, run_info_properties, results):
 
 
 class PropertyUpdate(object):
-    property_name = None
-    cls_default_value = None
-    value_type = None
-    property_builder = None
+    property_name = None  # type: ClassVar[str]
+    cls_default_value = None  # type: ClassVar[Any]
+    value_type = None  # type: ClassVar[type]
+    # property_builder is a class variable set to either build_conditional_tree
+    # or build_unconditional_tree. TODO: Make this type stricter when those
+    # methods are annotated.
+    property_builder = None  # type: ClassVar[Callable[..., Any]]
 
     def __init__(self, node):
         self.node = node
@@ -764,7 +768,7 @@ class MinAssertsUpdate(PropertyUpdate):
 
 
 class AppendOnlyListUpdate(PropertyUpdate):
-    cls_default_value = []
+    cls_default_value = []  # type: ClassVar[List[str]]
     property_builder = build_unconditional_tree
 
     def updated_value(self, current, new):
@@ -817,7 +821,7 @@ class LeakObjectUpdate(AppendOnlyListUpdate):
 
 class LeakThresholdUpdate(PropertyUpdate):
     property_name = "leak-threshold"
-    cls_default_value = {}
+    cls_default_value = {}  # type: ClassVar[Dict[str, int]]
     property_builder = build_unconditional_tree
 
     def from_result_value(self, result):

--- a/tools/wptrunner/wptrunner/metadata.py
+++ b/tools/wptrunner/wptrunner/metadata.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import array
 import os
 from collections import defaultdict, namedtuple
+from typing import Dict, List, Tuple
 
 from mozlog import structuredlog
 from six import ensure_str, ensure_text
@@ -21,7 +22,7 @@ logger = structuredlog.StructuredLogger("web-platform-tests")
 try:
     import ujson as json
 except ImportError:
-    import json
+    import json  # type: ignore
 
 
 class RunInfo(object):
@@ -92,7 +93,7 @@ def update_expected(test_paths, serve_root, log_file_names,
 
 def do_delayed_imports(serve_root=None):
     global manifest, manifestitem
-    from manifest import manifest, item as manifestitem
+    from manifest import manifest, item as manifestitem  # type: ignore
 
 
 def files_in_repo(repo_root):
@@ -169,9 +170,10 @@ class InternedData(object):
     type_conv = None
     rev_type_conv = None
 
-    def __init__(self, max_bits=8):
+    def __init__(self, max_bits: int = 8):
         self.max_idx = 2**max_bits - 2
         # Reserve 0 as a sentinal
+        self._data: Tuple[List[object], Dict[int, object]]
         self._data = [None], {}
 
     def clear(self):

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -12,8 +12,8 @@ from mozlog.handlers import BaseHandler, StreamHandler, LogLevelFilter
 
 here = os.path.dirname(__file__)
 localpaths = imp.load_source("localpaths", os.path.abspath(os.path.join(here, os.pardir, os.pardir, "localpaths.py")))
-from ci.tc.github_checks_output import get_gh_checks_outputter
-from wpt.markdown import markdown_adjust, table
+from ci.tc.github_checks_output import get_gh_checks_outputter  # type: ignore
+from wpt.markdown import markdown_adjust, table  # type: ignore
 
 
 # If a test takes more than (FLAKY_THRESHOLD*timeout) and does not consistently
@@ -21,7 +21,7 @@ from wpt.markdown import markdown_adjust, table
 FLAKY_THRESHOLD = 0.8
 
 
-class LogActionFilter(BaseHandler):
+class LogActionFilter(BaseHandler):  # type: ignore
 
     """Handler that filters out messages not of a given set of actions.
 
@@ -43,7 +43,7 @@ class LogActionFilter(BaseHandler):
             return self.inner(item)
 
 
-class LogHandler(reader.LogHandler):
+class LogHandler(reader.LogHandler):  # type: ignore
 
     """Handle updating test and subtest status in log.
 

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -20,9 +20,9 @@ download_from_github = None
 def do_delayed_imports():
     # This relies on an already loaded module having set the sys.path correctly :(
     global manifest, manifest_update, download_from_github
-    from manifest import manifest
+    from manifest import manifest  # type: ignore
     from manifest import update as manifest_update
-    from manifest.download import download_from_github
+    from manifest.download import download_from_github  # type: ignore
 
 
 class TestGroupsFile(object):

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -254,7 +254,7 @@ class BrowserManager(object):
 
 class _RunnerManagerState(object):
     before_init = namedtuple("before_init", [])
-    initializing = namedtuple("initializing_browser",
+    initializing = namedtuple("initializing",
                               ["test", "test_group", "group_metadata", "failure_count"])
     running = namedtuple("running", ["test", "test_group", "group_metadata"])
     restarting = namedtuple("restarting", ["test", "test_group", "group_metadata"])

--- a/tools/wptrunner/wptrunner/update/base.py
+++ b/tools/wptrunner/wptrunner/update/base.py
@@ -1,9 +1,11 @@
+from typing import ClassVar, List, Type
+
 exit_unclean = object()
 exit_clean = object()
 
 
 class Step(object):
-    provides = []
+    provides = []  # type: ClassVar[List[str]]
 
     def __init__(self, logger):
         self.logger = logger
@@ -45,7 +47,7 @@ class Step(object):
 
 
 class StepRunner(object):
-    steps = []
+    steps = []  # type: ClassVar[List[Type[Step]]]
 
     def __init__(self, logger, state):
         """Class that runs a specified series of Steps with a common State"""

--- a/tools/wptrunner/wptrunner/update/sync.py
+++ b/tools/wptrunner/wptrunner/update/sync.py
@@ -98,7 +98,7 @@ class UpdateManifest(Step):
     provides = ["manifest_path", "test_manifest"]
 
     def create(self, state):
-        from manifest import manifest
+        from manifest import manifest  # type: ignore
         state.manifest_path = os.path.join(state.metadata_path, "MANIFEST.json")
         state.test_manifest = manifest.load_and_update(state.sync["path"],
                                                        state.manifest_path,

--- a/tools/wptrunner/wptrunner/vcs.py
+++ b/tools/wptrunner/wptrunner/vcs.py
@@ -1,5 +1,6 @@
 import subprocess
 from functools import partial
+from typing import Callable
 
 from mozlog import get_default_logger
 
@@ -7,7 +8,7 @@ from wptserve.utils import isomorphic_decode
 
 logger = None
 
-def vcs(bin_name):
+def vcs(bin_name: str) -> Callable[..., None]:
     def inner(command, *args, **kwargs):
         global logger
 

--- a/tools/wptrunner/wptrunner/webdriver_server.py
+++ b/tools/wptrunner/wptrunner/webdriver_server.py
@@ -5,6 +5,7 @@ import platform
 import socket
 import time
 import traceback
+from typing import ClassVar, Type
 
 import mozprocess
 
@@ -21,7 +22,7 @@ class WebDriverServer(object):
     __metaclass__ = abc.ABCMeta
 
     default_base_path = "/"
-    output_handler_cls = OutputHandler
+    output_handler_cls = OutputHandler  # type: ClassVar[Type[OutputHandler]]
 
     def __init__(self, logger, binary, host="127.0.0.1", port=None,
                  base_path="", env=None, args=None):

--- a/tools/wptrunner/wptrunner/wptmanifest/parser.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/parser.py
@@ -58,7 +58,7 @@ def precedence(operator_node):
 
 
 class TokenTypes(object):
-    def __init__(self):
+    def __init__(self) -> None:
         for type in ["group_start", "group_end", "paren", "list_start", "list_end", "separator", "ident", "string", "number", "atom", "eof"]:
             setattr(self, type, type)
 

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 from collections import defaultdict
+from typing import Any, ClassVar, Dict, Type
 from urllib.parse import urljoin
 
 from .wptmanifest.parser import atoms
@@ -82,7 +83,7 @@ def get_run_info(metadata_root, product, **kwargs):
     return RunInfo(metadata_root, product, **kwargs)
 
 
-class RunInfo(dict):
+class RunInfo(Dict[str, Any]):
     def __init__(self, metadata_root, product, debug,
                  browser_version=None,
                  browser_channel=None,
@@ -149,9 +150,9 @@ def server_protocol(manifest_item):
 
 class Test(object):
 
-    result_cls = None
-    subtest_result_cls = None
-    test_type = None
+    result_cls = None  # type: ClassVar[Type[Result]]
+    subtest_result_cls = None  # type: ClassVar[Type[SubtestResult]]
+    test_type = None  # type: ClassVar[str]
 
     default_timeout = 10  # seconds
     long_timeout = 60  # seconds


### PR DESCRIPTION
Make ConfigDict a Dict[str, Any] since the keys come from
parser.options() which are strings in typeshed:
https://github.com/python/typeshed/blob/7a9b4f93baa03fff3ef7f319988cea2cbb6e2135/stdlib/configparser.pyi#L105

Also s/SafeConfigParser/ConfigParser/ since SafeConfigParser is now a
legacy alias not mentioned in Python 3 documentation.

Part of https://github.com/web-platform-tests/wpt/issues/28833.