### PR TITLE
Simplify away Kwargs helper class

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -7,7 +7,7 @@ from distutils.spawn import find_executable
 wpt_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
 sys.path.insert(0, os.path.abspath(os.path.join(wpt_root, "tools")))
 
-from . import browser, install, testfiles, utils, virtualenv
+from . import browser, install, testfiles, virtualenv
 from ..serve import serve
 
 logger = None
@@ -67,10 +67,16 @@ def exit(msg=None):
 
 
 def args_general(kwargs):
-    kwargs.set_if_none("tests_root", wpt_root)
-    kwargs.set_if_none("metadata_root", wpt_root)
-    kwargs.set_if_none("manifest_update", True)
-    kwargs.set_if_none("manifest_download", True)
+
+    def set_if_none(name, value):
+        if kwargs.get(name) is None:
+            kwargs[name] = value
+            logger.info("Set %s to %s" % (name, value))
+
+    set_if_none("tests_root", wpt_root)
+    set_if_none("metadata_root", wpt_root)
+    set_if_none("manifest_update", True)
+    set_if_none("manifest_download", True)
 
     if kwargs["ssl_type"] in (None, "pregenerated"):
         cert_root = os.path.join(wpt_root, "tools", "certs")
@@ -757,7 +763,7 @@ def setup_logging(kwargs, default_config=None, formatter_defaults=None):
 def setup_wptrunner(venv, **kwargs):
     from wptrunner import wptcommandline
 
-    kwargs = utils.Kwargs(kwargs.items())
+    kwargs = kwargs.copy()
 
     kwargs["product"] = kwargs["product"].replace("-", "_")
 

--- a/tools/wpt/utils.py
+++ b/tools/wpt/utils.py
@@ -11,38 +11,7 @@ from io import BytesIO
 from socket import error as SocketError  # NOQA: N812
 from urllib.request import urlopen
 
-MYPY = False
-if MYPY:
-    from typing import Any
-    from typing import Callable
-
 logger = logging.getLogger(__name__)
-
-
-class Kwargs(dict):
-    def set_if_none(self,
-                    name,            # type: str
-                    value,           # type: Any
-                    err_fn=None,     # type: Callable[[Kwargs, str], Any]
-                    desc=None,       # type: str
-                    extra_cond=None  # type: Callable[[Kwargs], Any]
-                    ):
-        # type: (...) -> Any
-        if desc is None:
-            desc = name
-
-        if name not in self or self[name] is None:
-            if extra_cond is not None and not extra_cond(self):
-                return
-            if callable(value):
-                value = value()
-            if not value:
-                if err_fn is not None:
-                    return err_fn(self, "Failed to find %s" % desc)
-                else:
-                    return
-            self[name] = value
-            logger.info("Set %s to %s" % (desc, value))
 
 
 def call(*args):


### PR DESCRIPTION
This was only used in a single place and with two arguments, so it could
be collapsed into a much simpler helper, inlined where it's used.