### PR TITLE
Run mypy for tools/wpt/ (but still allow untyped defs)

### DIFF
--- a/tools/mypy.ini
+++ b/tools/mypy.ini
@@ -27,6 +27,18 @@ warn_unused_ignores = True
 [mypy-html5lib.*]
 ignore_missing_imports = True
 
+[mypy-mozdevice.*]
+ignore_missing_imports = True
+
+[mypy-mozinstall.*]
+ignore_missing_imports = True
+
+[mypy-mozlog.*]
+ignore_missing_imports = True
+
+[mypy-mozrunner.*]
+ignore_missing_imports = True
+
 [mypy-websockets.*]
 ignore_missing_imports = True
 
@@ -42,6 +54,9 @@ ignore_errors = True
 ignore_errors = True
 
 [mypy-tools.manifest.tests.*]
+ignore_errors = True
+
+[mypy-tools.wpt.tests.*]
 ignore_errors = True
 
 # Ignore errors in parts of the code which don't have type annotations or where
@@ -63,7 +78,7 @@ ignore_errors = True
 ignore_errors = True
 
 [mypy-tools.wpt.*]
-ignore_errors = True
+disallow_untyped_defs = False
 
 [mypy-webdriver.*]
 disallow_untyped_defs = False

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -3,6 +3,7 @@ import os
 import platform
 import sys
 from distutils.spawn import find_executable
+from typing import ClassVar, Type
 
 wpt_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
 sys.path.insert(0, os.path.abspath(os.path.join(wpt_root, "tools")))
@@ -152,8 +153,8 @@ in PowerShell with Administrator privileges.""" % (wpt_path, hosts_path)
 
 
 class BrowserSetup(object):
-    name = None
-    browser_cls = None
+    name = None  # type: ClassVar[str]
+    browser_cls = None  # type: ClassVar[Type[browser.Browser]]
 
     def __init__(self, venv, prompt=True):
         self.browser = self.browser_cls(logger)
@@ -873,6 +874,6 @@ if __name__ == "__main__":
     import pdb
     from tools import localpaths  # noqa: F401
     try:
-        main()
+        main()  # type: ignore
     except Exception:
         pdb.post_mortem()

--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -179,4 +179,4 @@ def main(prog=None, argv=None):
 
 
 if __name__ == "__main__":
-    main()
+    main()  # type: ignore


### PR DESCRIPTION
This is (intended to be) the smallest set of changes required to pass
mypy with our settings. revlist.py already had annotations which weren't
being checked and had become wrong over time, so those are fixed. Also
remove the very minimal logging that only showed the 1st and 3rd
argument, since it would not be enough to actually debug this script.

Part of https://github.com/web-platform-tests/wpt/issues/28833.