### PR TITLE
url/failure.html: skip could-be-relative URLs as appropriate

### DIFF
--- a/url/failure.html
+++ b/url/failure.html
@@ -28,22 +28,27 @@ function runTests(testData) {
       assert_throws_js(TypeError, () => url.href = test.input)
     }, "URL's href: " + name)
 
-    self.test(() => {
-      const client = new XMLHttpRequest()
-      assert_throws_dom("SyntaxError", () => client.open("GET", test.input))
-    }, "XHR: " + name)
+    // The following use cases resolve the URL input relative to the current
+    // document's URL. If this test input could be construed as a valid URL
+    // when resolved against a base URL, skip these cases.
+    if (!test.inputCanBeRelative) {
+      self.test(() => {
+        const client = new XMLHttpRequest()
+        assert_throws_dom("SyntaxError", () => client.open("GET", test.input))
+      }, "XHR: " + name)
 
-    self.test(() => {
-      assert_throws_js(TypeError, () => self.navigator.sendBeacon(test.input))
-    }, "sendBeacon(): " + name)
+      self.test(() => {
+        assert_throws_js(TypeError, () => self.navigator.sendBeacon(test.input))
+      }, "sendBeacon(): " + name)
 
-    self.test(() => {
-      assert_throws_js(self[0].TypeError, () => self[0].location = test.input)
-    }, "Location's href: " + name)
+      self.test(() => {
+        assert_throws_js(self[0].TypeError, () => self[0].location = test.input)
+      }, "Location's href: " + name)
 
-    self.test(() => {
-      assert_throws_dom("SyntaxError", () => self.open(test.input).close())
-    }, "window.open(): " + name)
+      self.test(() => {
+        assert_throws_dom("SyntaxError", () => self.open(test.input).close())
+      }, "window.open(): " + name)
+    }
   }
 }
 </script>

--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -3156,7 +3156,8 @@
   {
     "input": "http:/:@/www.example.com",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "http://user@/www.example.com",
@@ -3166,12 +3167,14 @@
   {
     "input": "http:@/www.example.com",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "http:/@/www.example.com",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "http://@/www.example.com",
@@ -3181,17 +3184,20 @@
   {
     "input": "https:@/www.example.com",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "http:a:b@/www.example.com",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "http:/a:b@/www.example.com",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "http://a:b@/www.example.com",
@@ -3201,7 +3207,8 @@
   {
     "input": "http::@/www.example.com",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "http:a:@www.example.com",
@@ -7320,17 +7327,20 @@
   {
     "input": "a",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "a/",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "a//",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   "Bases that don't fail to parse but fail to be bases",
   {


### PR DESCRIPTION
These skipped tests fail on every browser: https://wpt.fyi/results/url/failure.html