### PR TITLE
Remove serve.ConfigBuilder's ws_doc_root property

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -987,11 +987,6 @@ class ConfigBuilder(config.ConfigBuilder):
         else:
             return os.path.join(data["doc_root"], "websockets", "handlers")
 
-    def ws_doc_root(self, v):
-        self._ws_doc_root = v
-
-    ws_doc_root = property(None, ws_doc_root)
-
     def _get_paths(self, data):
         rv = super(ConfigBuilder, self)._get_paths(data)
         rv["ws_doc_root"] = data["ws_doc_root"]

--- a/tools/serve/test_serve.py
+++ b/tools/serve/test_serve.py
@@ -54,13 +54,16 @@ def test_make_hosts_file_windows():
 
 def test_ws_doc_root_default():
     with ConfigBuilder() as c:
+        assert c.doc_root == localpaths.repo_root
         assert c.ws_doc_root == os.path.join(localpaths.repo_root, "websockets", "handlers")
+        assert c.paths["ws_doc_root"] == c.ws_doc_root
 
 
 def test_init_ws_doc_root():
     with ConfigBuilder(ws_doc_root="/") as c:
         assert c.doc_root == localpaths.repo_root  # check this hasn't changed
         assert c.ws_doc_root == "/"
+        assert c.paths["ws_doc_root"] == c.ws_doc_root
 
 
 def test_set_ws_doc_root():
@@ -69,6 +72,7 @@ def test_set_ws_doc_root():
     with cb as c:
         assert c.doc_root == localpaths.repo_root  # check this hasn't changed
         assert c.ws_doc_root == "/"
+        assert c.paths["ws_doc_root"] == c.ws_doc_root
 
 
 def test_pickle():

--- a/tools/wptserve/wptserve/config.py
+++ b/tools/wptserve/wptserve/config.py
@@ -84,7 +84,7 @@ def json_types(obj):
 
 
 class ConfigBuilder(object):
-    """Builder object for setting the wptsync config.
+    """Builder object for setting the wptserve config.
 
     Configuration can be passed in as a dictionary to the constructor, or
     set via attributes after construction. Configuration options must match


### PR DESCRIPTION
The ConfigBuilder.ws_doc_root setter is apparently unused, and the 
_ws_doc_root property that it sets is never read.

Update the tests to make it clearer how this data ends up in the
config.paths dict, which is what is used in start_http2_server, 
start_ws_server, and start_wss_server.