### PR TITLE
Work around FontFaceSet ready promise problems in WebKit

### DIFF
--- a/mathml/presentation-markup/fractions/frac-1.html
+++ b/mathml/presentation-markup/fractions/frac-1.html
@@ -10,6 +10,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   math, mspace {
@@ -38,7 +39,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/fractions/frac-bar-001.html
+++ b/mathml/presentation-markup/fractions/frac-bar-001.html
@@ -24,8 +24,9 @@
       }
     </style>
     <script src="/common/reftest-wait.js"></script>
+    <script src="/mathml/support/fonts.js"></script>
     <script>
-      window.addEventListener("load", () => { document.fonts.ready.then(adjustPositionOfFraction); });
+      window.addEventListener("load", () => { loadAllFonts().then(adjustPositionOfFraction); });
 
       function adjustPositionOfFraction()
       {

--- a/mathml/presentation-markup/fractions/frac-bar-002.html
+++ b/mathml/presentation-markup/fractions/frac-bar-002.html
@@ -30,9 +30,10 @@
           height: 148px;
       }
     </style>
+    <script src="/mathml/support/fonts.js"></script>
     <script src="/common/reftest-wait.js"></script>
     <script>
-      window.addEventListener("load", () => { document.fonts.ready.then(adjustPositionOfFraction); });
+      window.addEventListener("load", () => { loadAllFonts().then(adjustPositionOfFraction); });
 
       function adjustPositionOfFraction()
       {

--- a/mathml/presentation-markup/fractions/frac-linethickness-002.html
+++ b/mathml/presentation-markup/fractions/frac-linethickness-002.html
@@ -9,6 +9,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/mathml/support/feature-detection.js"></script>
+    <script src="/mathml/support/fonts.js"></script>
     <style type="text/css">
       @font-face {
         font-family: TestFont;
@@ -29,7 +30,7 @@
       }
 
       setup({ explicit_done: true });
-      window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+      window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
       function runTests() {
         var defaultRuleThickness = 100;

--- a/mathml/presentation-markup/fractions/frac-parameters-1.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-1.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <style>
   math, mspace {
     font-size: 10px;
@@ -62,7 +63,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/fractions/frac-parameters-2.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-2.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <style>
   math, mspace {
     font-size: 10px;
@@ -46,7 +47,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
 

--- a/mathml/presentation-markup/fractions/frac-parameters-3.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-3.html
@@ -9,6 +9,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <style>
   /* Testing fallback values is tricky as we don't have a lot of flexibility to
      make sure one parameter is not shadowed by another one. We also use the
@@ -43,7 +44,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
       test(function() {

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-001-ref.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-001-ref.html
@@ -21,6 +21,7 @@
     width: 100%;
   }
 </style>
+<script src="/mathml/support/fonts.js"></script>
 <script>
   function runTests() {
     var div = document.getElementById("frame");
@@ -29,7 +30,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-001.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-001.html
@@ -39,6 +39,7 @@
     width: 100%;
   }
 </style>
+<script src="/mathml/support/fonts.js"></script>
 <script>
   function runTests() {
     var div = document.getElementById("frame");
@@ -47,7 +48,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-002-ref.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-002-ref.html
@@ -21,6 +21,7 @@
     width: 100%;
   }
 </style>
+<script src="/mathml/support/fonts.js"></script>
 <script>
   function runTests() {
     var div = document.getElementById("frame");
@@ -29,7 +30,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-002.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-002.html
@@ -39,6 +39,7 @@
     width: 100%;
   }
 </style>
+<script src="/mathml/support/fonts.js"></script>
 <script>
   function runTests() {
     var div = document.getElementById("frame");
@@ -47,7 +48,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-003-ref.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-003-ref.html
@@ -21,6 +21,7 @@
     width: 100%;
   }
 </style>
+<script src="/mathml/support/fonts.js"></script>
 <script>
   function runTests() {
     var div = document.getElementById("frame");
@@ -29,7 +30,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-003.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-003.html
@@ -39,6 +39,7 @@
     width: 100%;
   }
 </style>
+<script src="/mathml/support/fonts.js"></script>
 <script>
   function runTests() {
     var div = document.getElementById("frame");
@@ -47,7 +48,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-004-ref.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-004-ref.html
@@ -21,6 +21,7 @@
     width: 100%;
   }
 </style>
+<script src="/mathml/support/fonts.js"></script>
 <script>
   function runTests() {
     var div = document.getElementById("frame");
@@ -29,7 +30,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-004.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-004.html
@@ -39,6 +39,7 @@
     width: 100%;
   }
 </style>
+<script src="/mathml/support/fonts.js"></script>
 <script>
   function runTests() {
     var div = document.getElementById("frame");
@@ -47,7 +48,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-005-ref.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-005-ref.html
@@ -21,6 +21,7 @@
     width: 100%;
   }
 </style>
+<script src="/mathml/support/fonts.js"></script>
 <script>
   function runTests() {
     var div = document.getElementById("frame");
@@ -29,7 +30,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-005.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-005.html
@@ -39,6 +39,7 @@
     width: 100%;
   }
 </style>
+<script src="/mathml/support/fonts.js"></script>
 <script>
   function runTests() {
     var div = document.getElementById("frame");
@@ -47,7 +48,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-006-ref.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-006-ref.html
@@ -21,6 +21,7 @@
     width: 100%;
   }
 </style>
+<script src="/mathml/support/fonts.js"></script>
 <script>
   function runTests() {
     var div = document.getElementById("frame");
@@ -29,7 +30,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-006.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-006.html
@@ -39,6 +39,7 @@
     width: 100%;
   }
 </style>
+<script src="/mathml/support/fonts.js"></script>
 <script>
   function runTests() {
     var div = document.getElementById("frame");
@@ -47,7 +48,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/mrow/inferred-mrow-stretchy.html
+++ b/mathml/presentation-markup/mrow/inferred-mrow-stretchy.html
@@ -14,6 +14,7 @@
 <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#operator-fence-separator-or-accent-mo">
 <meta name="assert" content="Operators can stretch inside mrow-like elements.">
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>
@@ -28,7 +29,7 @@
 </style>
 <script type="text/javascript">
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   function runTests()
   {
       ["Mrow", "Sqrt", "Style", "Error", "Phantom", "Math", "Menclose", "Mpadded", "Unknown"].forEach((tag) => {

--- a/mathml/presentation-markup/mrow/no-spacing.html
+++ b/mathml/presentation-markup/mrow/no-spacing.html
@@ -13,12 +13,13 @@
 <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#subscripts-and-superscripts-msub-msup-msubsup">
 <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#underscripts-and-overscripts-munder-mover-munderover">
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <script type="text/javascript">
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   function runTests()
   {
       Array.from(document.getElementsByClassName("testedElement")).forEach((e) => {

--- a/mathml/presentation-markup/mrow/spacing.html
+++ b/mathml/presentation-markup/mrow/spacing.html
@@ -14,11 +14,12 @@
 <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#operator-fence-separator-or-accent-mo">
 <meta name="assert" content="Spacing is added around operators inside mrow-like elements.">
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script type="text/javascript">
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   function runTests()
   {
       ["Mrow", "Sqrt", "Style", "Error", "Phantom", "Math", "Menclose", "Mpadded", "Unknown"].forEach((tag) => {

--- a/mathml/presentation-markup/operators/largeop-hit-testing.html
+++ b/mathml/presentation-markup/operators/largeop-hit-testing.html
@@ -7,6 +7,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <style>
   @font-face {
     font-family: TestFont;
@@ -23,7 +24,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
 

--- a/mathml/presentation-markup/operators/mo-axis-height-1.html
+++ b/mathml/presentation-markup/operators/mo-axis-height-1.html
@@ -7,6 +7,7 @@
 <meta name="assert" content="Element mo correctly uses the axis height parameter from the MATH table.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <style>
   math, mspace {
     font-size: 10px;
@@ -25,7 +26,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/operators/mo-font-relative-lengths-001.html
+++ b/mathml/presentation-markup/operators/mo-font-relative-lengths-001.html
@@ -11,6 +11,7 @@
 <meta name="assert" content="Verify font-relative lengths refer to the core operator, not the embellished operator">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <style>
   math {
       font: 100px/1 Ahem;
@@ -25,7 +26,7 @@
 </style>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
       var epsilon = 1;

--- a/mathml/presentation-markup/operators/mo-minsize-maxsize-001.html
+++ b/mathml/presentation-markup/operators/mo-minsize-maxsize-001.html
@@ -8,6 +8,7 @@
 <meta name="assert" content="Verify edge cases for minsize and maxsize .">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <style>
   math {
       font: 25px/1 Ahem;
@@ -22,7 +23,7 @@
 </style>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
       var epsilon = 1;

--- a/mathml/presentation-markup/operators/mo-stretch-properties-dynamic-001.html
+++ b/mathml/presentation-markup/operators/mo-stretch-properties-dynamic-001.html
@@ -8,6 +8,7 @@
 <meta name="assert" content="Verify stretchy, symmetric, largeop, minsize and maxsize are updated dynamically.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <style>
   math {
       font: 25px/1 Ahem;
@@ -22,7 +23,7 @@
 </style>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
 

--- a/mathml/presentation-markup/operators/operator-dictionary-largeop-001.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-largeop-001.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "largeop", 0);

--- a/mathml/presentation-markup/operators/operator-dictionary-largeop-002.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-largeop-002.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "largeop", 1);

--- a/mathml/presentation-markup/operators/operator-dictionary-largeop-003.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-largeop-003.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "largeop", 2);

--- a/mathml/presentation-markup/operators/operator-dictionary-largeop-004.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-largeop-004.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "largeop", 3);

--- a/mathml/presentation-markup/operators/operator-dictionary-largeop-005.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-largeop-005.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "largeop", 4);

--- a/mathml/presentation-markup/operators/operator-dictionary-largeop-006.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-largeop-006.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "largeop", 5);

--- a/mathml/presentation-markup/operators/operator-dictionary-movablelimits-001.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-movablelimits-001.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "movablelimits", 0);

--- a/mathml/presentation-markup/operators/operator-dictionary-movablelimits-002.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-movablelimits-002.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "movablelimits", 1);

--- a/mathml/presentation-markup/operators/operator-dictionary-movablelimits-003.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-movablelimits-003.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "movablelimits", 2);

--- a/mathml/presentation-markup/operators/operator-dictionary-movablelimits-004.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-movablelimits-004.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "movablelimits", 3);

--- a/mathml/presentation-markup/operators/operator-dictionary-movablelimits-005.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-movablelimits-005.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "movablelimits", 4);

--- a/mathml/presentation-markup/operators/operator-dictionary-movablelimits-006.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-movablelimits-006.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "movablelimits", 5);

--- a/mathml/presentation-markup/operators/operator-dictionary-spacing-001.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-spacing-001.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "lspace/rspace", 0);

--- a/mathml/presentation-markup/operators/operator-dictionary-spacing-002.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-spacing-002.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "lspace/rspace", 1);

--- a/mathml/presentation-markup/operators/operator-dictionary-spacing-003.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-spacing-003.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "lspace/rspace", 2);

--- a/mathml/presentation-markup/operators/operator-dictionary-spacing-004.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-spacing-004.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "lspace/rspace", 3);

--- a/mathml/presentation-markup/operators/operator-dictionary-spacing-005.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-spacing-005.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "lspace/rspace", 4);

--- a/mathml/presentation-markup/operators/operator-dictionary-spacing-006.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-spacing-006.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "lspace/rspace", 5);

--- a/mathml/presentation-markup/operators/operator-dictionary-stretchy-001.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-stretchy-001.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "stretchy", 0);

--- a/mathml/presentation-markup/operators/operator-dictionary-stretchy-002.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-stretchy-002.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "stretchy", 1);

--- a/mathml/presentation-markup/operators/operator-dictionary-stretchy-003.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-stretchy-003.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "stretchy", 2);

--- a/mathml/presentation-markup/operators/operator-dictionary-stretchy-004.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-stretchy-004.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "stretchy", 3);

--- a/mathml/presentation-markup/operators/operator-dictionary-stretchy-005.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-stretchy-005.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "stretchy", 4);

--- a/mathml/presentation-markup/operators/operator-dictionary-stretchy-006.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-stretchy-006.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "stretchy", 5);

--- a/mathml/presentation-markup/operators/operator-dictionary-symmetric-001.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-symmetric-001.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "symmetric", 0);

--- a/mathml/presentation-markup/operators/operator-dictionary-symmetric-002.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-symmetric-002.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "symmetric", 1);

--- a/mathml/presentation-markup/operators/operator-dictionary-symmetric-003.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-symmetric-003.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "symmetric", 2);

--- a/mathml/presentation-markup/operators/operator-dictionary-symmetric-004.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-symmetric-004.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "symmetric", 3);

--- a/mathml/presentation-markup/operators/operator-dictionary-symmetric-005.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-symmetric-005.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "symmetric", 4);

--- a/mathml/presentation-markup/operators/operator-dictionary-symmetric-006.html
+++ b/mathml/presentation-markup/operators/operator-dictionary-symmetric-006.html
@@ -13,12 +13,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/feature-detection-operators.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/operator-dictionary.js"></script>
 <script src="./support/operator-dictionary-tests.js"></script>
 <link rel="stylesheet" href="./support/operator-dictionary-tests.css"/>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   async function runTests() {
       let json = await fetchOperatorDictionary();
       await OperatorDictionaryTests.run(json, "symmetric", 5);

--- a/mathml/presentation-markup/radicals/dynamic-radical-paint-invalidation-001.html
+++ b/mathml/presentation-markup/radicals/dynamic-radical-paint-invalidation-001.html
@@ -29,8 +29,9 @@
       margin: 5px;
   }
 </style>
+<script src="/mathml/support/fonts.js"></script>
 <script>
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   function runTests() {
       // force initial layout so we're sure what we're testing against
       document.documentElement.getBoundingClientRect();

--- a/mathml/presentation-markup/radicals/root-parameters-1.html
+++ b/mathml/presentation-markup/radicals/root-parameters-1.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <style>
   math, mspace {
     font-size: 10px;
@@ -50,7 +51,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/radicals/root-parameters-2.html
+++ b/mathml/presentation-markup/radicals/root-parameters-2.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <style>
   @font-face {
       font-family: radical-negativekernbeforedegree1000-rulethickness1000;
@@ -51,7 +52,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
 </script>
 </head>

--- a/mathml/presentation-markup/scripts/cramped-001.html
+++ b/mathml/presentation-markup/scripts/cramped-001.html
@@ -12,6 +12,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/box-navigation.js"></script>
 <style>
   math {
@@ -48,7 +49,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
       test(function() {

--- a/mathml/presentation-markup/scripts/empty-underover.html
+++ b/mathml/presentation-markup/scripts/empty-underover.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script>
   var epsilon = 1;
 
@@ -16,7 +17,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/scripts/subsup-1.html
+++ b/mathml/presentation-markup/scripts/subsup-1.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   math, mspace {
@@ -25,7 +26,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/scripts/subsup-2.html
+++ b/mathml/presentation-markup/scripts/subsup-2.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   math, mspace {
@@ -25,7 +26,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/scripts/subsup-3.html
+++ b/mathml/presentation-markup/scripts/subsup-3.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   math, mspace {
@@ -25,7 +26,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/scripts/subsup-parameters-1.html
+++ b/mathml/presentation-markup/scripts/subsup-parameters-1.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <style>
   math, mspace {
     font-size: 10px;
@@ -62,7 +63,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/scripts/subsup-parameters-2.html
+++ b/mathml/presentation-markup/scripts/subsup-parameters-2.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <style>
   math, mspace {
     font-size: 10px;
@@ -31,7 +32,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   /*
     These two tests verify that:

--- a/mathml/presentation-markup/scripts/underover-1.html
+++ b/mathml/presentation-markup/scripts/underover-1.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   math, mspace, mo {
@@ -28,7 +29,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/scripts/underover-parameters-1.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-1.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <style>
   math, mspace, mo {
     font-size: 10px;
@@ -38,7 +39,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/scripts/underover-parameters-2.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-2.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <style>
   math, mspace, mo {
     font-size: 10px;
@@ -38,7 +39,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/scripts/underover-parameters-3.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-3.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <style>
   math, mspace, mo {
     font-size: 10px;
@@ -41,7 +42,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function getBooleanValue(element, name) {
       return (element.getAttribute(name) || "").toLowerCase() === "true";

--- a/mathml/presentation-markup/scripts/underover-parameters-4.tentative.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-4.tentative.html
@@ -9,6 +9,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <style>
   math, mspace, mo {
     font-size: 10px;
@@ -42,7 +43,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/tables/table-axis-height.html
+++ b/mathml/presentation-markup/tables/table-axis-height.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <style>
   math, mspace {
     font-size: 10px;
@@ -26,7 +27,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/relations/css-styling/color-005.html
+++ b/mathml/relations/css-styling/color-005.html
@@ -75,8 +75,9 @@
       </math>
     </div>
   </div>
+  <script src="/mathml/support/fonts.js"></script>
   <script>
-    window.addEventListener("load", () => document.fonts.ready.then(() => {
+    window.addEventListener("load", () => loadAllFonts().then(() => {
         document.getElementById("dynamic").style.color = "green";
         document.documentElement.classList.remove("reftest-wait");
     }));

--- a/mathml/relations/css-styling/displaystyle-013.html
+++ b/mathml/relations/css-styling/displaystyle-013.html
@@ -10,6 +10,7 @@
     <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#table-or-matrix-mtable">
     <link rel="match" href="displaystyle-013-ref.html"/>
     <meta name="assert" content="Test dynamic change of displaystyle">
+    <script src="/mathml/support/fonts.js"></script>
     <script type="text/javascript">
       function doTest() {
         document.body.offsetTop; // Update layout
@@ -21,7 +22,7 @@
         document.getElementById("m6").removeAttribute("displaystyle");
         document.documentElement.removeAttribute("class");
       }
-      window.addEventListener("load", () => { document.fonts.ready.then(doTest); });
+      window.addEventListener("load", () => { loadAllFonts().then(doTest); });
     </script>
     <link rel="stylesheet" href="/fonts/ahem.css">
     <style>

--- a/mathml/relations/css-styling/displaystyle-014.html
+++ b/mathml/relations/css-styling/displaystyle-014.html
@@ -11,6 +11,7 @@
     <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#fractions-mfrac">
     <link rel="match" href="displaystyle-014-ref.html"/>
     <meta name="assert" content="Test dynamic change of mathbackground on an operator does not interfer with its displaystyle">
+    <script src="/mathml/support/fonts.js"></script>
     <script type="text/javascript">
       function doTest() {
         document.body.offsetTop; // Update layout
@@ -18,7 +19,7 @@
                  setAttribute('mathbackground', 'red');
         document.documentElement.removeAttribute("class");
       }
-      window.addEventListener("load", () => { document.fonts.ready.then(doTest); });
+      window.addEventListener("load", () => { loadAllFonts().then(doTest); });
     </script>
     <link rel="stylesheet" href="/fonts/ahem.css">
     <style>

--- a/mathml/relations/css-styling/displaystyle-1.html
+++ b/mathml/relations/css-styling/displaystyle-1.html
@@ -20,6 +20,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/attribute-values.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script>
   setup({ explicit_done: true });
   var emToPx = 10 / 1000; // font-size: 10px, font.em = 1000
@@ -31,7 +32,7 @@
       assert_approx_equals(elementSize, expectedSize, epsilon, description);
   }
 
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
       for (transform in AttributeValueTransforms) {

--- a/mathml/relations/css-styling/displaystyle-2.html
+++ b/mathml/relations/css-styling/displaystyle-2.html
@@ -20,6 +20,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/attribute-values.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script>
   setup({ explicit_done: true });
   var emToPx = 10 / 1000; // font-size: 10px, font.em = 1000
@@ -31,7 +32,7 @@
       assert_approx_equals(elementSize, expectedSize, epsilon, description);
   }
 
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
       for (transform in AttributeValueTransforms) {

--- a/mathml/relations/css-styling/displaystyle-3.html
+++ b/mathml/relations/css-styling/displaystyle-3.html
@@ -17,9 +17,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <script>
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
   function runTests() {
       ["munder", "mover", "munderover"].forEach((tag) => {
           Array.from(document.getElementsByTagName(tag)).forEach(e => {

--- a/mathml/relations/css-styling/lengths-2.html
+++ b/mathml/relations/css-styling/lengths-2.html
@@ -11,6 +11,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/fonts.js"></script>
 <style>
   @font-face {
     font-family: TestFont;
@@ -29,7 +30,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  window.addEventListener("load", () => { loadAllFonts().then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/relations/css-styling/visibility-005.html
+++ b/mathml/relations/css-styling/visibility-005.html
@@ -75,8 +75,9 @@
       </math>
     </div>
   </div>
+  <script src="/mathml/support/fonts.js"></script>
   <script>
-    window.addEventListener("load", () => document.fonts.ready.then(() => {
+    window.addEventListener("load", () => loadAllFonts().then(() => {
         document.getElementById("dynamic").style.visibility = "hidden";
         document.documentElement.classList.remove("reftest-wait");
     }));

--- a/mathml/support/feature-detection-operators.js
+++ b/mathml/support/feature-detection-operators.js
@@ -22,7 +22,7 @@ Object.assign(MathMLFeatureDetection, {
             let font_face = new FontFace('HasOperatorLargeopTestFont',
                 'url(/fonts/math/largeop-displayoperatorminheight5000.woff)');
             document.fonts.add(font_face);
-            await document.fonts.ready;
+            await font_face.load();
             var math = document.body.lastElementChild;
             var mo = math.getElementsByTagName("mo");
             this._has_operator_largeop =
@@ -47,7 +47,7 @@ Object.assign(MathMLFeatureDetection, {
             let font_face = new FontFace('HasOperatorLargeopTestFont',
                 'url(/fonts/math/largeop-displayoperatorminheight5000.woff)');
             document.fonts.add(font_face);
-            await document.fonts.ready;
+            await font_face.load();
             var math = document.body.lastElementChild;
             var mo = math.getElementsByTagName("mo");
             this._has_operator_stretchy =
@@ -72,7 +72,7 @@ Object.assign(MathMLFeatureDetection, {
             let font_face = new FontFace('HasOperatorLargeopTestFont',
                 'url(/fonts/math/largeop-displayoperatorminheight5000.woff)');
             document.fonts.add(font_face);
-            await document.fonts.ready;
+            await font_face.load();
             var math = document.body.lastElementChild;
             var mo = math.getElementsByTagName("mo");
             this._has_operator_symmetric =

--- a/mathml/support/fonts.js
+++ b/mathml/support/fonts.js
@@ -1,0 +1,9 @@
+function loadAllFonts() {
+  // Use this to wait for all fonts in a testcase to load rather than just using
+  // `document.fonts.ready.then(...)` in the load event, since there are compat
+  // issues between browsers as to whether content initiated font loads are
+  // guaranteed to have been started by this point.
+
+  // FIXME: Use Promise.all() to cause an obvious failure when a font fails to load.
+  return Promise.allSettled([...document.fonts].map(f => f.load()));
+}


### PR DESCRIPTION
These are the WPT changes from https://bugs.webkit.org/show_bug.cgi?id=225728 but updated since the WebKit in-tree copy of WPT is a bit old.  Waiting on document.fonts.ready in the document load event handler will not do the right thing in WebKit for loads initiated by content.  Additionally, document.fonts.ready is never replaced with a fresh unresolved promise whenever font loads are initiated after previous loads have completed. So we replace uses of document.fonts.ready with waiting on promises returned by FontFace.load() calls.

https://bugs.webkit.org/show_bug.cgi?id=225790 tracks fixing WebKit's FontFaceSet behavior.