### PR TITLE
chore(webmessaging/broadcastchannel): html -> js

### DIFF
--- a/webmessaging/broadcastchannel/basics.any.js
+++ b/webmessaging/broadcastchannel/basics.any.js
@@ -1,9 +1,3 @@
-<!DOCTYPE html>
-<meta charset=utf-8>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script>
-
 async_test(t => {
     let c1 = new BroadcastChannel('eventType');
     let c2 = new BroadcastChannel('eventType');
@@ -124,5 +118,3 @@ async_test(t => {
     c1.postMessage('first');
     c1.postMessage('done');
   }, 'Closing a channel in onmessage prevents already queued tasks from firing onmessage events');
-
-</script>

--- a/webmessaging/broadcastchannel/interface.any.js
+++ b/webmessaging/broadcastchannel/interface.any.js
@@ -1,9 +1,3 @@
-<!DOCTYPE html>
-<meta charset=utf-8>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script>
-
 test(() => assert_throws_js(TypeError, () => new BroadcastChannel()),
   'Should throw if no name is provided');
 
@@ -69,5 +63,3 @@ test(() => {
     c.close();
     assert_throws_dom('InvalidStateError', () => c.postMessage(Symbol()));
   }, 'postMessage should throw InvalidStateError after close, even with uncloneable data');
-
-</script>


### PR DESCRIPTION
Change two BroadcastChannel tests from .html to .any.js in order to
make them runnable under Deno.

Refs: https://github.com/denoland/deno/issues/10354