### PR TITLE
WritableStreamDefaultController should now be exposed

### DIFF
--- a/workers/semantics/interface-objects/002.worker.js
+++ b/workers/semantics/interface-objects/002.worker.js
@@ -19,8 +19,6 @@ var unexpected = [
   "PageTransitionEvent",
   // https://dom.spec.whatwg.org/
   "DOMImplementation",
-  // https://streams.spec.whatwg.org/
-  "WritableStreamDefaultController",
   // http://w3c.github.io/IndexedDB/
   "IDBEnvironment",
   // https://www.w3.org/TR/2010/NOTE-webdatabase-20101118/


### PR DESCRIPTION
See https://github.com/whatwg/streams/pull/1035. No new test added for its exposure as this is covered by streams/idlharness.any.js.