### PR TITLE
Enable mypy incremental mode (drop --no-incremental flag)

### DIFF
--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -34,23 +34,19 @@ commands = flake8 --append-config={toxinidir}/flake8.ini {posargs}
 [testenv:py36-mypy]
 deps = -rrequirements_mypy.txt
 changedir = {toxinidir}/..
-commands =
-  mypy --config-file={toxinidir}/mypy.ini --no-incremental tools/
+commands = mypy --config-file={toxinidir}/mypy.ini tools/
 
 [testenv:py37-mypy]
 deps = -rrequirements_mypy.txt
 changedir = {toxinidir}/..
-commands =
-  mypy --config-file={toxinidir}/mypy.ini --no-incremental tools/
+commands = mypy --config-file={toxinidir}/mypy.ini tools/
 
 [testenv:py38-mypy]
 deps = -rrequirements_mypy.txt
 changedir = {toxinidir}/..
-commands =
-  mypy --config-file={toxinidir}/mypy.ini --no-incremental tools/
+commands = mypy --config-file={toxinidir}/mypy.ini tools/
 
 [testenv:py39-mypy]
 deps = -rrequirements_mypy.txt
 changedir = {toxinidir}/..
-commands =
-  mypy --config-file={toxinidir}/mypy.ini --no-incremental tools/
+commands = mypy --config-file={toxinidir}/mypy.ini tools/


### PR DESCRIPTION
This is faster locally when running mypy over and over, and shouldn't
matter in CI where there is no cache. The flag has been around ever
since mypy was introduced:
https://github.com/web-platform-tests/wpt/pull/16346

Mypy documentation of this flag:
https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-incremental