### PR TITLE
Use SwiftShader for Chrome and unpin the version used on Taskcluster

### DIFF
--- a/infrastructure/metadata/infrastructure/server/context.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/context.any.js.ini
@@ -19,4 +19,3 @@
 [context.any.serviceworker-module.html]
   expected:
     if product == "firefox": ERROR
-    if os == "linux" and product == "chrome": ERROR # https://crbug.com/1136775

--- a/tools/ci/ci_wptrunner_infrastructure.sh
+++ b/tools/ci/ci_wptrunner_infrastructure.sh
@@ -14,7 +14,8 @@ main() {
     ./wpt manifest --rebuild -p ~/meta/MANIFEST.json
     for PRODUCT in "${PRODUCTS[@]}"; do
         if [[ "$PRODUCT" == "chrome" ]]; then
-            test_infrastructure "--binary=$(which google-chrome-unstable) --channel dev" "$1"
+            # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
+            test_infrastructure "--binary=$(which google-chrome-unstable) --enable-swiftshader --channel dev" "$1"
         else
             test_infrastructure "--binary=~/build/firefox/firefox" "$1"
         fi

--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -137,12 +137,8 @@ def install_certificates():
 
 
 def install_chrome(channel):
-    deb_prefix = "https://dl.google.com/linux/direct/"
     if channel in ("experimental", "dev"):
-        # Pinned since 92.0.4484.7 began crashing on startup.
-        # See https://github.com/web-platform-tests/wpt/issues/28209.
-        deb_archive = "google-chrome-unstable_91.0.4472.19-1_amd64.deb"
-        deb_prefix = "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/"
+        deb_archive = "google-chrome-unstable_current_amd64.deb"
     elif channel == "beta":
         deb_archive = "google-chrome-beta_current_amd64.deb"
     elif channel == "stable":
@@ -151,7 +147,7 @@ def install_chrome(channel):
         raise ValueError("Unrecognized release channel: %s" % channel)
 
     dest = os.path.join("/tmp", deb_archive)
-    deb_url = deb_prefix + deb_archive
+    deb_url = "https://dl.google.com/linux/direct/%s" % deb_archive
     with open(dest, "wb") as f:
         get_download_to_descriptor(f, deb_url)
 

--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -19,9 +19,8 @@ def get_browser_args(product, channel):
     if product == "servo":
         return ["--install-browser", "--processes=12"]
     if product == "chrome":
-        # Taskcluster machines do not have proper GPUs, so we need to use
-        # software rendering for webgl: https://crbug.com/1130585
-        args = ["--binary-arg=--use-gl=swiftshader-webgl"]
+        # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
+        args = ["--enable-swiftshader"]
         if channel == "nightly":
             args.extend(["--install-browser", "--install-webdriver"])
         return args

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -102,8 +102,10 @@ def test_list_tests(manifest_dir):
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--metadata", manifest_dir, "--list-tests",
-                       "--channel", "dev", "--yes", "chrome",
-                       "/dom/nodes/Element-tagName.html"])
+                       "--channel", "dev", "--yes",
+                       # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
+                       "--enable-swiftshader",
+                       "chrome", "/dom/nodes/Element-tagName.html"])
     assert excinfo.value.code == 0
 
 
@@ -170,13 +172,17 @@ def test_run_zero_tests():
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--no-pause", "--channel", "dev",
+                       # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
+                       "--enable-swiftshader",
                        "chrome", "/non-existent-dir/non-existent-file.html"])
     assert excinfo.value.code != 0
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--no-pause", "--no-fail-on-unexpected",
-                       "--channel", "dev", "chrome",
-                       "/non-existent-dir/non-existent-file.html"])
+                       "--channel", "dev",
+                       # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
+                       "--enable-swiftshader",
+                       "chrome", "/non-existent-dir/non-existent-file.html"])
     assert excinfo.value.code != 0
 
 
@@ -195,12 +201,17 @@ def test_run_failing_test():
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--no-pause", "--channel", "dev",
+                       # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
+                       "--enable-swiftshader",
                        "chrome", failing_test])
     assert excinfo.value.code != 0
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--no-pause", "--no-fail-on-unexpected",
-                       "--channel", "dev", "chrome", failing_test])
+                       "--channel", "dev",
+                       # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
+                       "--enable-swiftshader",
+                       "chrome", failing_test])
     assert excinfo.value.code == 0
 
 
@@ -225,6 +236,8 @@ def test_run_verify_unstable(temp_test):
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--verify", "--channel", "dev",
+                       # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
+                       "--enable-swiftshader",
                        "chrome", unstable_test])
     assert excinfo.value.code != 0
 
@@ -232,6 +245,8 @@ def test_run_verify_unstable(temp_test):
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--verify", "--channel", "dev",
+                       # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
+                       "--enable-swiftshader",
                        "chrome", stable_test])
     assert excinfo.value.code == 0
 

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -85,6 +85,10 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     if kwargs["enable_mojojs"]:
         chrome_options["args"].append("--enable-blink-features=MojoJS,MojoJSTest")
 
+    if kwargs["enable_swiftshader"]:
+        # https://chromium.googlesource.com/chromium/src/+/HEAD/docs/gpu/swiftshader.md
+        chrome_options["args"].extend(["--use-gl=angle", "--use-angle=swiftshader"])
+
     # Copy over any other flags that were passed in via --binary_args
     if kwargs["binary_args"] is not None:
         chrome_options["args"].extend(kwargs["binary_args"])

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -322,14 +322,17 @@ scheme host and port.""")
                              default=[], action="append", dest="user_stylesheets",
                              help="Inject a user CSS stylesheet into every test.")
 
-    servo_group = parser.add_argument_group("Chrome-specific")
-    servo_group.add_argument("--enable-mojojs", action="store_true", default=False,
+    chrome_group = parser.add_argument_group("Chrome-specific")
+    chrome_group.add_argument("--enable-mojojs", action="store_true", default=False,
                              help="Enable MojoJS for testing. Note that this flag is usally "
                              "enabled automatically by `wpt run`, if it succeeds in downloading "
                              "the right version of mojojs.zip or if --mojojs-path is specified.")
-    servo_group.add_argument("--mojojs-path",
+    chrome_group.add_argument("--mojojs-path",
                              help="Path to mojojs gen/ directory. If it is not specified, `wpt run` "
                              "will download and extract mojojs.zip into _venv2/mojojs/gen.")
+    chrome_group.add_argument("--enable-swiftshader", action="store_true", default=False,
+                             help="Enable SwiftShader for CPU-based 3D graphics. This can be used "
+                             "in environments with no hardware GPU available.")
 
     sauce_group = parser.add_argument_group("Sauce Labs-specific")
     sauce_group.add_argument("--sauce-browser", dest="sauce_browser",


### PR DESCRIPTION
With --use-gl=angle --use-angle=swiftshader Chrome doesn't crash on startup,
allowing us to unpin the version used.

The original problem hasn't been resolved, but it's tracked by a Chromium bug:
https://bugs.chromium.org/p/chromium/issues/detail?id=1208904

Fixes https://github.com/web-platform-tests/wpt/issues/28209.