### PR TITLE
Fix URLManifestItem.https for serviceworker-module

### DIFF
--- a/infrastructure/metadata/infrastructure/server/context.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/context.any.js.ini
@@ -19,4 +19,4 @@
 [context.any.serviceworker-module.html]
   expected:
     if product == "firefox": ERROR
-    if product == "chrome": ERROR # https://crbug.com/1136775
+    if os == "linux" and product == "chrome": ERROR # https://crbug.com/1136775

--- a/infrastructure/metadata/infrastructure/server/context.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/context.any.js.ini
@@ -1,8 +1,22 @@
+[context.any.worker-module.html]
+  expected:
+    if product == "firefox": TIMEOUT # https://bugzilla.mozilla.org/show_bug.cgi?id=1247687
+
 [context.any.sharedworker.html]
   expected:
     if product == "safari" or product == "epiphany" or product == "webkit": ERROR # https://bugs.webkit.org/show_bug.cgi?id=149850
+
+[context.any.sharedworker-module.html]
+  expected:
+    if product == "safari" or product == "epiphany" or product == "webkit": ERROR # https://bugs.webkit.org/show_bug.cgi?id=149850
+    if product == "firefox": TIMEOUT # https://bugzilla.mozilla.org/show_bug.cgi?id=1247687
 
 [context.any.serviceworker.html]
   [context]
     expected:
       if product == "epiphany" or product == "webkit": FAIL # https://bugs.webkit.org/show_bug.cgi?id=200815
+
+[context.any.serviceworker-module.html]
+  expected:
+    if product == "firefox": ERROR
+    if product == "chrome": ERROR # https://crbug.com/1136775

--- a/infrastructure/server/context.any.js
+++ b/infrastructure/server/context.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,sharedworker,serviceworker
+// META: global=window,dedicatedworker,sharedworker,serviceworker,dedicatedworker-module,sharedworker-module,serviceworker-module
 test(t => {
   // Test for object that's only exposed in serviceworker
   if (self.clients) {

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -140,7 +140,7 @@ class URLManifestItem(ManifestItem):
     @property
     def https(self):
         # type: () -> bool
-        return "https" in self._flags or "serviceworker" in self._flags
+        return "https" in self._flags or "serviceworker" in self._flags or "serviceworker-module" in self._flags
 
     @property
     def h2(self):


### PR DESCRIPTION
This PR makes `URLManifestItem.https` handle `serviceworker-module` in the same way as `serviceworker`, and thus makes `serviceworker-module` tests served via HTTPS on wpt runner.

This PR also adds module-related globals to `infrastructure/server/context.any.js` to see whether they are working.
`context.any.serviceworker-module.html` will be still failing on Chromium after this PR though, due to another issue (https://crbug.com/1136775).

Fixes #29130.