### PR TITLE
Remove cache_manager argument from edgechromium executor_kwargs

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/edgechromium.py
+++ b/tools/wptrunner/wptrunner/browsers/edgechromium.py
@@ -32,11 +32,11 @@ def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
             "webdriver_args": kwargs.get("webdriver_args")}
 
 
-def executor_kwargs(logger, test_type,test_environment, cache_manager, run_info_data,
+def executor_kwargs(logger, test_type, test_environment, run_info_data,
                     **kwargs):
     executor_kwargs = base_executor_kwargs(test_type,
                                            test_environment,
-                                           cache_manager, run_info_data,
+                                           run_info_data,
                                            **kwargs)
     executor_kwargs["close_after_done"] = True
     executor_kwargs["supports_eager_pageload"] = False


### PR DESCRIPTION
This was removed previously but this case was missed