### PR TITLE
Added test cases for aspect-ratio from width and height attributes

### DIFF
--- a/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-aspect-ratio.html
+++ b/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-aspect-ratio.html
@@ -31,10 +31,6 @@ function test_computed_style(width, height, expected) {
   test_computed_style_aspect_ratio("input", {type: "submit", width: width, height: height}, "auto");
 }
 
-function assert_cs(img, val) {
-  assert_equals(getComputedStyle(img).aspectRatio, val);
-}
-
 // Create and append a new image and immediately check the ratio.
 // This is not racy because the spec requires the user agent to queue a task:
 // https://html.spec.whatwg.org/multipage/images.html#updating-the-image-data
@@ -109,7 +105,7 @@ onload = function() {
   test(function () {
     assert_not_equals(images[5].offsetHeight, 500, "Images with alt text should be inline and ignore the aspect ratio");
     // Though aspect-ratio is ignored, its value does not change.
-    assert_cs(images[5], "auto 100 / 500");
+    assert_equals(getComputedStyle(images[5]).aspectRatio, "auto 100 / 500");
   }, "Loaded images test: Error image with width, height and alt attributes");
 
   test(function () {

--- a/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-aspect-ratio.html
+++ b/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-aspect-ratio.html
@@ -31,6 +31,10 @@ function test_computed_style(width, height, expected) {
   test_computed_style_aspect_ratio("input", {type: "submit", width: width, height: height}, "auto");
 }
 
+function assert_cs(img, val) {
+  assert_equals(getComputedStyle(img).aspectRatio, val);
+}
+
 // Create and append a new image and immediately check the ratio.
 // This is not racy because the spec requires the user agent to queue a task:
 // https://html.spec.whatwg.org/multipage/images.html#updating-the-image-data
@@ -62,6 +66,15 @@ test(function () {
   // Percentages should be  ignored.
   assert_equals(getComputedStyle(img).height, "0px");
 }, "Create, append and test immediately: <img> with attributes width=50% height=25%");
+
+test(function () {
+  img = new Image();
+  img.setAttribute("width", "50pp");
+  img.setAttribute("height", "25xx");
+  img.src = "/images/blue.png";
+  document.body.appendChild(img);
+  assert_ratio(img, 2);
+}, "Create, append and test immediately: <img> with invalid trailing attributes width=50pp height=25xx");
 
 test_computed_style("10", "20", "auto 10 / 20");
 test_computed_style("0", "1", "auto 0 / 1");
@@ -95,6 +108,8 @@ onload = function() {
 
   test(function () {
     assert_not_equals(images[5].offsetHeight, 500, "Images with alt text should be inline and ignore the aspect ratio");
+    // Though aspect-ratio is ignored, its value does not change.
+    assert_cs(images[5], "auto 100 / 500");
   }, "Loaded images test: Error image with width, height and alt attributes");
 
   test(function () {


### PR DESCRIPTION
Hi,
This patch added two cases.
* `<img>` with invalid trailing width and height attributes.
* The aspect-ratio value of `<img>` showing alt text should be changed.