### PR TITLE
Remove __future__ imports in tools/

### DIFF
--- a/tools/lint/fnmatch.py
+++ b/tools/lint/fnmatch.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import fnmatch as _stdlib_fnmatch
 import os
 

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, unicode_literals
-
 import abc
 import argparse
 import ast

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import abc
 import inspect
 import os

--- a/tools/lint/tests/base.py
+++ b/tools/lint/tests/base.py
@@ -1,6 +1,3 @@
-from __future__ import unicode_literals
-
-
 def check_errors(errors):
     for e in errors:
         error_type, description, path, line_number = e

--- a/tools/lint/tests/test_path_lints.py
+++ b/tools/lint/tests/test_path_lints.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import mock
 import os
 

--- a/tools/manifest/download.py
+++ b/tools/manifest/download.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import argparse
 import bz2
 import gzip

--- a/tools/runner/report.py
+++ b/tools/runner/report.py
@@ -1,7 +1,5 @@
 # flake8: noqa
 
-from __future__ import print_function
-
 import argparse
 import json
 import sys

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 import abc
 import argparse
 import importlib

--- a/tools/wave/configuration_loader.py
+++ b/tools/wave/configuration_loader.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import json
 import os
 

--- a/tools/wave/data/session.py
+++ b/tools/wave/data/session.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
 from ..testing.test_loader import MANUAL, AUTOMATIC
 
 PAUSED = "paused"

--- a/tools/wave/network/api/results_api_handler.py
+++ b/tools/wave/network/api/results_api_handler.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import json
 
 from .api_handler import ApiHandler

--- a/tools/wave/network/api/sessions_api_handler.py
+++ b/tools/wave/network/api/sessions_api_handler.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import json
 import threading
 

--- a/tools/wave/network/static_handler.py
+++ b/tools/wave/network/static_handler.py
@@ -1,6 +1,3 @@
-from __future__ import with_statement
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import os
 
 

--- a/tools/wave/testing/event_dispatcher.py
+++ b/tools/wave/testing/event_dispatcher.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 STATUS_EVENT = "status"
 RESUME_EVENT = "resume"
 TEST_COMPLETED_EVENT = "test_completed"

--- a/tools/wave/testing/results_manager.py
+++ b/tools/wave/testing/results_manager.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import os
 import shutil
 import re

--- a/tools/wave/testing/sessions_manager.py
+++ b/tools/wave/testing/sessions_manager.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import uuid
 import time
 import os

--- a/tools/wave/testing/test_loader.py
+++ b/tools/wave/testing/test_loader.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import os
 import re
 

--- a/tools/wave/testing/tests_manager.py
+++ b/tools/wave/testing/tests_manager.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import re
 from threading import Timer
 

--- a/tools/wave/testing/wpt_report.py
+++ b/tools/wave/testing/wpt_report.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import subprocess
 import os
 import ntpath

--- a/tools/wave/utils/deserializer.py
+++ b/tools/wave/utils/deserializer.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
 from ..data.session import Session, UNKNOWN
 
 

--- a/tools/wave/utils/serializer.py
+++ b/tools/wave/utils/serializer.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 def serialize_session(session):
     return {
         "token": session.token,

--- a/tools/wave/utils/user_agent_parser.py
+++ b/tools/wave/utils/user_agent_parser.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
 from ua_parser import user_agent_parser
 
 

--- a/tools/wave/wave_server.py
+++ b/tools/wave/wave_server.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import os
 import logging
 

--- a/tools/wptrunner/setup.py
+++ b/tools/wptrunner/setup.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import print_function
-
 import glob
 import os
 import sys

--- a/tools/wptrunner/wptrunner/browsers/edge.py
+++ b/tools/wptrunner/wptrunner/browsers/edge.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import time
 import subprocess
 from .base import Browser, ExecutorBrowser, require_arg

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import json
 import os
 import socket

--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import base64
 import json
 import os

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import json
 import os
 import socket

--- a/tools/wptrunner/wptrunner/manifestupdate.py
+++ b/tools/wptrunner/wptrunner/manifestupdate.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 from urllib.parse import urljoin, urlsplit
 from collections import namedtuple, defaultdict, deque

--- a/tools/wptrunner/wptrunner/metadata.py
+++ b/tools/wptrunner/wptrunner/metadata.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import array
 import os
 from collections import defaultdict, namedtuple

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import threading
 import traceback
 from queue import Empty

--- a/tools/wptrunner/wptrunner/tests/test_testloader.py
+++ b/tools/wptrunner/wptrunner/tests/test_testloader.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import os
 import sys
 import tempfile

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 import argparse
 import os
 import sys

--- a/tools/wptrunner/wptrunner/wptmanifest/parser.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/parser.py
@@ -12,8 +12,6 @@
 
 # TODO: keep comments in the tree
 
-from __future__ import unicode_literals
-
 from io import BytesIO
 
 from .node import (Node, AtomNode, BinaryExpressionNode, BinaryOperatorNode,

--- a/tools/wptrunner/wptrunner/wptmanifest/serializer.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/serializer.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from six import ensure_text
 
 from .node import NodeVisitor, ValueNode, ListNode, BinaryExpressionNode

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, unicode_literals
-
 import json
 import os
 import sys

--- a/tools/wptserve/tests/functional/base.py
+++ b/tools/wptserve/tests/functional/base.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import base64
 import logging
 import os

--- a/tools/wptserve/tests/test_replacement_tokenizer.py
+++ b/tools/wptserve/tests/test_replacement_tokenizer.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 
 from wptserve.pipes import ReplacementTokenizer

--- a/tools/wptserve/wptserve/ws_h2_handshake.py
+++ b/tools/wptserve/wptserve/ws_h2_handshake.py
@@ -5,8 +5,6 @@ Specification:
 https://tools.ietf.org/html/rfc8441
 """
 
-from __future__ import absolute_import
-
 from mod_pywebsocket import common
 
 from mod_pywebsocket.handshake.base import get_mandatory_header


### PR DESCRIPTION
The imports being removed are:
 - absolute_import, mandatory since 3.0
 - division, mandatory since 3.0
 - print_function, mandatory since 3.0
 - unicode_literals, mandatory since 3.0
 - with_statement, mandatory since 2.6

See https://docs.python.org/3/library/__future__.html for details.