### PR TITLE
Service worker: Fail if fetch event has targetClientId

### DIFF
--- a/service-workers/service-worker/fetch-event.https.html
+++ b/service-workers/service-worker/fetch-event.https.html
@@ -148,17 +148,6 @@ promise_test(t => {
         });
   }, 'Service Worker responds to fetch event with the correct resulting client id');
 
-promise_test(async t => {
-  const page_url = 'resources/simple.html?targetClientId';
-  const frame = await with_iframe(page_url);
-  t.add_cleanup(() => frame.remove());
-  assert_equals(
-    frame.contentDocument.body.textContent,
-    'not-present',
-    `targetClientId should not be on FetchEvent - it's been renamed replacesClientId`
-  );
-}, `targetClientId should not be on FetchEvent`);
-
 promise_test(t => {
     const page_url = 'resources/simple.html?ignore';
     return with_iframe(page_url)

--- a/service-workers/service-worker/fetch-event.https.html
+++ b/service-workers/service-worker/fetch-event.https.html
@@ -17,6 +17,8 @@ promise_test(async t => {
     const registration =
         await service_worker_unregister_and_register(t, worker, scope);
     await wait_for_state(t, registration.installing, 'activated');
+
+    // This will happen after all other tests
     promise_test(t => {
         return registration.unregister();
       }, 'restore global state');
@@ -145,6 +147,17 @@ promise_test(t => {
             'Service Worker should respond with an empty resulting client id for subresource requests');
         });
   }, 'Service Worker responds to fetch event with the correct resulting client id');
+
+promise_test(async t => {
+  const page_url = 'resources/simple.html?targetClientId';
+  const frame = await with_iframe(page_url);
+  t.add_cleanup(() => frame.remove());
+  assert_equals(
+    frame.contentDocument.body.textContent,
+    'not-present',
+    `targetClientId should not be on FetchEvent - it's been renamed replacesClientId`
+  );
+}, `targetClientId should not be on FetchEvent`);
 
 promise_test(t => {
     const page_url = 'resources/simple.html?ignore';

--- a/service-workers/service-worker/historical.https.any.js
+++ b/service-workers/service-worker/historical.https.any.js
@@ -1,0 +1,5 @@
+// META: global=serviceworker
+
+test((t) => {
+  assert_false('targetClientId' in FetchEvent.prototype)
+}, 'targetClientId should not be on FetchEvent');

--- a/service-workers/service-worker/resources/fetch-event-test-worker.js
+++ b/service-workers/service-worker/resources/fetch-event-test-worker.js
@@ -47,12 +47,6 @@ function handleResultingClientId(event) {
   event.respondWith(new Response(body));
 }
 
-function handleTargetClientId(event) {
-  event.respondWith(new Response(
-    ('targetClientId' in event) ? 'present' : 'not-present'
-  ));
-}
-
 function handleNullBody(event) {
   event.respondWith(new Response());
 }
@@ -195,7 +189,6 @@ self.addEventListener('fetch', function(event) {
       { pattern: '?referrer', fn: handleReferrer },
       { pattern: '?clientId', fn: handleClientId },
       { pattern: '?resultingClientId', fn: handleResultingClientId },
-      { pattern: '?targetClientId', fn: handleTargetClientId },
       { pattern: '?ignore', fn: function() {} },
       { pattern: '?null', fn: handleNullBody },
       { pattern: '?fetch', fn: handleFetch },

--- a/service-workers/service-worker/resources/fetch-event-test-worker.js
+++ b/service-workers/service-worker/resources/fetch-event-test-worker.js
@@ -47,6 +47,12 @@ function handleResultingClientId(event) {
   event.respondWith(new Response(body));
 }
 
+function handleTargetClientId(event) {
+  event.respondWith(new Response(
+    ('targetClientId' in event) ? 'present' : 'not-present'
+  ));
+}
+
 function handleNullBody(event) {
   event.respondWith(new Response());
 }
@@ -189,6 +195,7 @@ self.addEventListener('fetch', function(event) {
       { pattern: '?referrer', fn: handleReferrer },
       { pattern: '?clientId', fn: handleClientId },
       { pattern: '?resultingClientId', fn: handleResultingClientId },
+      { pattern: '?targetClientId', fn: handleTargetClientId },
       { pattern: '?ignore', fn: function() {} },
       { pattern: '?null', fn: handleNullBody },
       { pattern: '?fetch', fn: handleFetch },


### PR DESCRIPTION
On `FetchEvent`, `targetClientId` was renamed to `replacesClientId`. Unfortunately Safari shipped `targetClientId` before we made the change, and didn't realise due to some miscommunication.

This test fails in browsers that have `targetClientId`.

Unfortunately there aren't any proper tests for `replacesClientId` (or `targetClientId`), but that's for another day.