### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=225894

### DIFF
--- a/html/browsers/the-window-object/window-indexed-properties-delete-no-cache.html
+++ b/html/browsers/the-window-object/window-indexed-properties-delete-no-cache.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Deletion of WindowProxy's indexed properties is not cached</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-delete">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+const iframe = document.createElement("iframe");
+iframe.srcdoc = "";
+
+test(() => {
+  assert_equals(window.length, 0);
+  for (let i = 0; i < 1e5; i++) {
+    assert_true(delete window[0]);
+  }
+
+  document.body.append(iframe);
+  assert_false(delete window[0]);
+}, "Absence of index '0' is not cached");
+
+test(() => {
+  assert_equals(window.length, 1);
+  for (let i = 0; i < 1e5; i++) {
+    assert_false(delete window[0]);
+  }
+
+  iframe.remove();
+  assert_true(delete window[0]);
+}, "Presence of index '0' is not cached");
+</script>

--- a/html/browsers/the-window-object/window-indexed-properties-strict.html
+++ b/html/browsers/the-window-object/window-indexed-properties-strict.html
@@ -44,6 +44,29 @@ test(function() {
 });
 test(function() {
   "use strict";
+  assert_throws_js(TypeError, () => { window[4294967294] = 1; });
+  assert_false(Reflect.set(window, 4294967294, 2));
+  assert_false(Reflect.defineProperty(window, 4294967294, { value: 3 }));
+  assert_throws_js(TypeError, () => Object.defineProperty(window, 4294967294, { get: () => 4 }));
+  assert_equals(window[4294967294], undefined);
+  assert_false(4294967294 in window);
+  assert_true(delete window[4294967294]);
+}, "Borderline numeric key: 2 ** 32 - 2 is an index (strict mode)");
+test(function() {
+  "use strict";
+  window[4294967295] = 1;
+  assert_equals(window[4294967295], 1);
+  assert_true(Reflect.set(window, 4294967295, 2));
+  assert_equals(window[4294967295], 2);
+  assert_true(Reflect.defineProperty(window, 4294967295, { value: 3 }));
+  assert_equals(window[4294967295], 3);
+  Object.defineProperty(window, 4294967295, { get: () => 4 });
+  assert_equals(window[4294967295], 4);
+  assert_true(delete window[4294967295]);
+  assert_false(4294967295 in window);
+}, "Borderline numeric key: 2 ** 32 - 1 is not an index (strict mode)");
+test(function() {
+  "use strict";
   var proto = Window.prototype;
   [-1, 0, 1].forEach(function(idx) {
     assert_false(idx in proto, idx + " in proto");

--- a/html/browsers/the-window-object/window-indexed-properties.html
+++ b/html/browsers/the-window-object/window-indexed-properties.html
@@ -42,6 +42,27 @@ test(function() {
   assert_equals(delete window[1], true);
 });
 test(function() {
+  window[4294967294] = 1;
+  assert_false(Reflect.set(window, 4294967294, 2));
+  assert_false(Reflect.defineProperty(window, 4294967294, { value: 3 }));
+  assert_throws_js(TypeError, () => Object.defineProperty(window, 4294967294, { get: () => 4 }));
+  assert_equals(window[4294967294], undefined);
+  assert_false(4294967294 in window);
+  assert_true(delete window[4294967294]);
+}, "Borderline numeric key: 2 ** 32 - 2 is an index");
+test(function() {
+  window[4294967295] = 1;
+  assert_equals(window[4294967295], 1);
+  assert_true(Reflect.set(window, 4294967295, 2));
+  assert_equals(window[4294967295], 2);
+  assert_true(Reflect.defineProperty(window, 4294967295, { value: 3 }));
+  assert_equals(window[4294967295], 3);
+  Object.defineProperty(window, 4294967295, { get: () => 4 });
+  assert_equals(window[4294967295], 4);
+  assert_true(delete window[4294967295]);
+  assert_false(4294967295 in window);
+}, "Borderline numeric key: 2 ** 32 - 1 is not an index");
+test(function() {
   var proto = Window.prototype;
   [-1, 0, 1].forEach(function(idx) {
     assert_false(idx in proto, idx + " in proto");


### PR DESCRIPTION
This change tests [`WindowProxy` internal methods](https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-set) with borderline [array index](https://tc39.es/ecma262/#array-index) values and ensures [`[[Delete]]`](https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-delete) isn't cached for supported indices.