### PR TITLE
chore: make exposed_in matcher work in Deno

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -650,7 +650,7 @@ function exposure_set(object, default_set) {
 }
 
 function exposed_in(globals) {
-    if ('document' in self) {
+    if ('Window' in self) {
         return globals.has("Window");
     }
     if ('DedicatedWorkerGlobalScope' in self &&


### PR DESCRIPTION
Previously exposed_in checked if `"document" in self` to determine if
we are on the main thread. Deno does not have a `document` so this doe
not work there. Instead we now check for `'Window' in self`.
