### PR TITLE
Tests for forbidden host code-points and resolution of non-special URLs

### DIFF
--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -7794,5 +7794,204 @@
     "protocol": "wss:",
     "search": "",
     "username": ""
+  },
+  "Forbidden host codepoints",
+  { "input": "foo://ho\u0000st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  { "input": "foo://ho<st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  { "input": "foo://ho>st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  { "input": "foo://ho^st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  { "input": "foo://ho|st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  "Forbidden host codepoints: tabs and newlines are removed during preprocessing",
+  { "input": "foo://ho\u0009st/",
+    "base": "about:blank",
+    "hash": "",
+    "host": "host",
+    "hostname": "host",
+    "href":"foo://host/",
+    "password": "",
+    "pathname": "/",
+    "port":"",
+    "protocol": "foo:",
+    "search": "",
+    "username": ""
+  },
+  { "input": "foo://ho\u000Ast/",
+    "base": "about:blank",
+    "hash": "",
+    "host": "host",
+    "hostname": "host",
+    "href":"foo://host/",
+    "password": "",
+    "pathname": "/",
+    "port":"",
+    "protocol": "foo:",
+    "search": "",
+    "username": ""
+  },
+  { "input": "foo://ho\u000Dst/",
+    "base": "about:blank",
+    "hash": "",
+    "host": "host",
+    "hostname": "host",
+    "href":"foo://host/",
+    "password": "",
+    "pathname": "/",
+    "port":"",
+    "protocol": "foo:",
+    "search": "",
+    "username": ""
+  },
+  "Encoded forbidden host codepoints in special URLs",
+  {
+    "input": "http://ho%00st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%09st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%0Ast/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%0Dst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%20st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%23st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%2Fst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%3Ast/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%3Cst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%3Est/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%3Fst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%40st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%5Bst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%5Cst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%5Dst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%7Cst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  "Ensure that non-special URLs use strict resolution",
+  {
+    "input": "abc:rootless",
+    "base": "abc://host/path",
+    "hash": "",
+    "host": "",
+    "hostname": "",
+    "href":"abc:rootless",
+    "password": "",
+    "pathname": "rootless",
+    "port":"",
+    "protocol": "abc:",
+    "search": "",
+    "username": ""
+  },
+  {
+    "input": "abc:rootless",
+    "base": "abc:/path",
+    "hash": "",
+    "host": "",
+    "hostname": "",
+    "href":"abc:rootless",
+    "password": "",
+    "pathname": "rootless",
+    "port":"",
+    "protocol": "abc:",
+    "search": "",
+    "username": ""
+  },
+  {
+    "input": "abc:rootless",
+    "base": "abc:path",
+    "hash": "",
+    "host": "",
+    "hostname": "",
+    "href":"abc:rootless",
+    "password": "",
+    "pathname": "rootless",
+    "port":"",
+    "protocol": "abc:",
+    "search": "",
+    "username": ""
+  },
+  {
+    "input": "abc:/rooted",
+    "base": "abc://host/path",
+    "hash": "",
+    "host": "",
+    "hostname": "",
+    "href":"abc:/rooted",
+    "password": "",
+    "pathname": "/rooted",
+    "port":"",
+    "protocol": "abc:",
+    "search": "",
+    "username": ""
   }
 ]

--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -4698,6 +4698,140 @@
     "base": "about:blank",
     "failure": true
   },
+  {
+    "input": "foo://ho\u0000st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "foo://ho|st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  "Forbidden host codepoints: tabs and newlines are removed during preprocessing",
+  {
+    "input": "foo://ho\u0009st/",
+    "base": "about:blank",
+    "hash": "",
+    "host": "host",
+    "hostname": "host",
+    "href":"foo://host/",
+    "password": "",
+    "pathname": "/",
+    "port":"",
+    "protocol": "foo:",
+    "search": "",
+    "username": ""
+  },
+  {
+    "input": "foo://ho\u000Ast/",
+    "base": "about:blank",
+    "hash": "",
+    "host": "host",
+    "hostname": "host",
+    "href":"foo://host/",
+    "password": "",
+    "pathname": "/",
+    "port":"",
+    "protocol": "foo:",
+    "search": "",
+    "username": ""
+  },
+  {
+    "input": "foo://ho\u000Dst/",
+    "base": "about:blank",
+    "hash": "",
+    "host": "host",
+    "hostname": "host",
+    "href":"foo://host/",
+    "password": "",
+    "pathname": "/",
+    "port":"",
+    "protocol": "foo:",
+    "search": "",
+    "username": ""
+  },
+  "Encoded forbidden host codepoints in special URLs",
+  {
+    "input": "http://ho%00st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%09st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%0Ast/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%0Dst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%20st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%23st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%2Fst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%3Ast/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%3Cst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%3Est/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%3Fst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%40st/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%5Bst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%5Cst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%5Dst/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://ho%7Cst/",
+    "base": "about:blank",
+    "failure": true
+  },
   "Allowed host code points",
   {
     "input": "http://\u001F!\"$&'()*+,-.;=_`{}~/",
@@ -7676,7 +7810,8 @@
     "search": "",
     "username": "joe"
   },
-  { "input": "foo://!\"$%&'()*+,-.;=_`{}~/",
+  {
+    "input": "foo://!\"$%&'()*+,-.;=_`{}~/",
     "base": "about:blank",
     "hash": "",
     "host": "!\"$%&'()*+,-.;=_`{}~",
@@ -7795,149 +7930,7 @@
     "search": "",
     "username": ""
   },
-  "Forbidden host codepoints",
-  { "input": "foo://ho\u0000st/",
-    "base": "about:blank",
-    "failure": true
-  },
-  { "input": "foo://ho<st/",
-    "base": "about:blank",
-    "failure": true
-  },
-  { "input": "foo://ho>st/",
-    "base": "about:blank",
-    "failure": true
-  },
-  { "input": "foo://ho^st/",
-    "base": "about:blank",
-    "failure": true
-  },
-  { "input": "foo://ho|st/",
-    "base": "about:blank",
-    "failure": true
-  },
-  "Forbidden host codepoints: tabs and newlines are removed during preprocessing",
-  { "input": "foo://ho\u0009st/",
-    "base": "about:blank",
-    "hash": "",
-    "host": "host",
-    "hostname": "host",
-    "href":"foo://host/",
-    "password": "",
-    "pathname": "/",
-    "port":"",
-    "protocol": "foo:",
-    "search": "",
-    "username": ""
-  },
-  { "input": "foo://ho\u000Ast/",
-    "base": "about:blank",
-    "hash": "",
-    "host": "host",
-    "hostname": "host",
-    "href":"foo://host/",
-    "password": "",
-    "pathname": "/",
-    "port":"",
-    "protocol": "foo:",
-    "search": "",
-    "username": ""
-  },
-  { "input": "foo://ho\u000Dst/",
-    "base": "about:blank",
-    "hash": "",
-    "host": "host",
-    "hostname": "host",
-    "href":"foo://host/",
-    "password": "",
-    "pathname": "/",
-    "port":"",
-    "protocol": "foo:",
-    "search": "",
-    "username": ""
-  },
-  "Encoded forbidden host codepoints in special URLs",
-  {
-    "input": "http://ho%00st/",
-    "base": "about:blank",
-    "failure": true
-  },
-  {
-    "input": "http://ho%09st/",
-    "base": "about:blank",
-    "failure": true
-  },
-  {
-    "input": "http://ho%0Ast/",
-    "base": "about:blank",
-    "failure": true
-  },
-  {
-    "input": "http://ho%0Dst/",
-    "base": "about:blank",
-    "failure": true
-  },
-  {
-    "input": "http://ho%20st/",
-    "base": "about:blank",
-    "failure": true
-  },
-  {
-    "input": "http://ho%23st/",
-    "base": "about:blank",
-    "failure": true
-  },
-  {
-    "input": "http://ho%2Fst/",
-    "base": "about:blank",
-    "failure": true
-  },
-  {
-    "input": "http://ho%3Ast/",
-    "base": "about:blank",
-    "failure": true
-  },
-  {
-    "input": "http://ho%3Cst/",
-    "base": "about:blank",
-    "failure": true
-  },
-  {
-    "input": "http://ho%3Est/",
-    "base": "about:blank",
-    "failure": true
-  },
-  {
-    "input": "http://ho%3Fst/",
-    "base": "about:blank",
-    "failure": true
-  },
-  {
-    "input": "http://ho%40st/",
-    "base": "about:blank",
-    "failure": true
-  },
-  {
-    "input": "http://ho%5Bst/",
-    "base": "about:blank",
-    "failure": true
-  },
-  {
-    "input": "http://ho%5Cst/",
-    "base": "about:blank",
-    "failure": true
-  },
-  {
-    "input": "http://ho%5Dst/",
-    "base": "about:blank",
-    "failure": true
-  },
-  {
-    "input": "http://ho%7Cst/",
-    "base": "about:blank",
-    "failure": true
-  },
-  "Ensure that non-special URLs use strict resolution",
+  "Ensure that input schemes are not ignored when resolving non-special URLs",
   {
     "input": "abc:rootless",
     "base": "abc://host/path",


### PR DESCRIPTION
This adds additional tests for:

1. The forbidden host codepoints.
2. Resolution of non-special URLs, 
e.g. `abc:rootless` against `abc://host/path` should result in `abc:rootless`.

Related issues:

- https://github.com/whatwg/url/issues/458
- https://github.com/whatwg/url/pull/589
- https://github.com/alwinb/spec-url/issues/6

/cc @TimothyGu 

**Edit** It seems some of the forbidden host code points were already tested in https://github.com/web-platform-tests/wpt/pull/23572.
Let me know if I should remove the (few) duplicates. 