### PR TITLE
Add fetch test to complement PR #28870

### DIFF
--- a/infrastructure/assumptions/non-local-ports.sub.window.js
+++ b/infrastructure/assumptions/non-local-ports.sub.window.js
@@ -107,5 +107,5 @@ promise_test(async (t) => {
     resolveUrl("/common/blank-with-cors.html").toString(), "*");
 
   const evt = await futureMessage;
-  assert_equals(evt.data, "TypeError: Failed to fetch");
+  assert_equals(evt.data, "failure: error = TypeError");
 }, "Fetch from http-public to local http fails.");

--- a/infrastructure/assumptions/non-local-ports.sub.window.js
+++ b/infrastructure/assumptions/non-local-ports.sub.window.js
@@ -8,6 +8,13 @@
 //
 // More tests can be found in `fetch/private-network-access/`.
 
+const kPorts = {
+  httpPrivate:  "{{ports[http-private][0]}}",
+  httpsPrivate: "{{ports[https-private][0]}}",
+  httpPublic:   "{{ports[http-public][0]}}",
+  httpsPublic:  "{{ports[https-public][0]}}",
+};
+
 // Resolves a URL relative to the current location, returning an absolute URL.
 //
 // `url` specifies the relative URL, e.g. "foo.html" or "http://foo.example".
@@ -30,38 +37,71 @@ function resolveUrl(url, options) {
   return result;
 }
 
-promise_test(async () => {
-  const url = resolveUrl("/common/blank-with-cors.html", {
+const kOptions = {
+  httpPrivate: {
+    protocol: "http:",
+    port: kPorts.httpPrivate,
+  },
+  httpsPrivate: {
     protocol: "https:",
-    port: "{{ports[https-private][0]}}"
-  });
+    port: kPorts.httpsPrivate,
+  },
+  httpPublic: {
+    protocol: "http:",
+    port: kPorts.httpPublic,
+  },
+  httpsPublic: {
+    protocol: "https:",
+    port: kPorts.httpsPublic,
+  },
+};
+
+promise_test(async () => {
+  const url = resolveUrl("/common/blank-with-cors.html", kOptions.httpsPrivate);
   const response = await fetch(url);
   assert_true(response.ok);
 }, "Fetch from https-private port works.");
 
 promise_test(async () => {
-  const url = resolveUrl("/common/blank-with-cors.html", {
-    protocol: "http:",
-    port: "{{ports[http-private][0]}}"
-  });
+  const url = resolveUrl("/common/blank-with-cors.html", kOptions.httpPrivate);
   const response = await fetch(url);
   assert_true(response.ok);
 }, "Fetch from http-private port works.");
 
 promise_test(async () => {
-  const url = resolveUrl("/common/blank-with-cors.html", {
-    protocol: "https:",
-    port: "{{ports[https-public][0]}}"
-  });
+  const url = resolveUrl("/common/blank-with-cors.html", kOptions.httpsPublic);
   const response = await fetch(url);
   assert_true(response.ok);
 }, "Fetch from https-public port works.");
 
 promise_test(async () => {
-  const url = resolveUrl("/common/blank-with-cors.html", {
-    protocol: "http:",
-    port: "{{ports[http-public][0]}}"
-  });
+  const url = resolveUrl("/common/blank-with-cors.html", kOptions.httpPublic);
   const response = await fetch(url);
   assert_true(response.ok);
 }, "Fetch from http-public port works.");
+
+promise_test(async (t) => {
+  const futureMessage = new Promise((resolve) => {
+    window.addEventListener("message", resolve);
+  });
+
+  const iframe = await new Promise((resolve, reject) => {
+    const iframe = document.createElement("iframe");
+    iframe.src =
+      resolveUrl("resources/fetch-and-post-result.html", kOptions.httpPublic);
+
+    iframe.onload = () => { resolve(iframe); };
+    iframe.onerror = reject;
+
+    document.body.appendChild(iframe);
+    t.add_cleanup(() => {
+      document.body.removeChild(iframe);
+    });
+  });
+
+  iframe.contentWindow.postMessage(
+    resolveUrl("/common/blank-with-cors.html").toString(), "*");
+
+  const evt = await futureMessage;
+  assert_equals(evt.data, "TypeError: Failed to fetch");
+}, "Fetch from http-public to local http fails.");

--- a/infrastructure/assumptions/non-local-ports.sub.window.js
+++ b/infrastructure/assumptions/non-local-ports.sub.window.js
@@ -8,7 +8,7 @@
 //
 // More tests can be found in `fetch/private-network-access/`.
 
-const kPorts = {
+const alternatePorts = {
   httpPrivate:  "{{ports[http-private][0]}}",
   httpsPrivate: "{{ports[https-private][0]}}",
   httpPublic:   "{{ports[http-public][0]}}",
@@ -37,45 +37,49 @@ function resolveUrl(url, options) {
   return result;
 }
 
-const kOptions = {
+const alternateOrigins = {
   httpPrivate: {
     protocol: "http:",
-    port: kPorts.httpPrivate,
+    port: alternatePorts.httpPrivate,
   },
   httpsPrivate: {
     protocol: "https:",
-    port: kPorts.httpsPrivate,
+    port: alternatePorts.httpsPrivate,
   },
   httpPublic: {
     protocol: "http:",
-    port: kPorts.httpPublic,
+    port: alternatePorts.httpPublic,
   },
   httpsPublic: {
     protocol: "https:",
-    port: kPorts.httpsPublic,
+    port: alternatePorts.httpsPublic,
   },
 };
 
 promise_test(async () => {
-  const url = resolveUrl("/common/blank-with-cors.html", kOptions.httpsPrivate);
+  const url =
+    resolveUrl("/common/blank-with-cors.html", alternateOrigins.httpsPrivate);
   const response = await fetch(url);
   assert_true(response.ok);
 }, "Fetch from https-private port works.");
 
 promise_test(async () => {
-  const url = resolveUrl("/common/blank-with-cors.html", kOptions.httpPrivate);
+  const url =
+    resolveUrl("/common/blank-with-cors.html", alternateOrigins.httpPrivate);
   const response = await fetch(url);
   assert_true(response.ok);
 }, "Fetch from http-private port works.");
 
 promise_test(async () => {
-  const url = resolveUrl("/common/blank-with-cors.html", kOptions.httpsPublic);
+  const url =
+    resolveUrl("/common/blank-with-cors.html", alternateOrigins.httpsPublic);
   const response = await fetch(url);
   assert_true(response.ok);
 }, "Fetch from https-public port works.");
 
 promise_test(async () => {
-  const url = resolveUrl("/common/blank-with-cors.html", kOptions.httpPublic);
+  const url =
+    resolveUrl("/common/blank-with-cors.html", alternateOrigins.httpPublic);
   const response = await fetch(url);
   assert_true(response.ok);
 }, "Fetch from http-public port works.");
@@ -87,8 +91,8 @@ promise_test(async (t) => {
 
   const iframe = await new Promise((resolve, reject) => {
     const iframe = document.createElement("iframe");
-    iframe.src =
-      resolveUrl("resources/fetch-and-post-result.html", kOptions.httpPublic);
+    iframe.src = resolveUrl("resources/fetch-and-post-result.html",
+                            alternateOrigins.httpPublic);
 
     iframe.onload = () => { resolve(iframe); };
     iframe.onerror = reject;

--- a/infrastructure/assumptions/resources/fetch-and-post-result.html
+++ b/infrastructure/assumptions/resources/fetch-and-post-result.html
@@ -1,8 +1,12 @@
 <script>
   window.addEventListener("message", function (event) {
     fetch(event.data)
-        .then(response => {parent.postMessage(response.ok, "*")})
-        .catch(error => {parent.postMessage(error.toString(), "*")});
+      .then(response => {
+        parent.postMessage(`success: status = ${response.status}`, "*");
+      })
+      .catch(error => {
+        parent.postMessage(`failure: error = ${error.name}`, "*")
+      });
   });
 </script>
 

--- a/infrastructure/assumptions/resources/fetch-and-post-result.html
+++ b/infrastructure/assumptions/resources/fetch-and-post-result.html
@@ -1,0 +1,8 @@
+<script>
+  window.addEventListener("message", function (event) {
+    fetch(event.data)
+        .then(response => {parent.postMessage(response.ok, "*")})
+        .catch(error => {parent.postMessage(error.toString(), "*")});
+  });
+</script>
+

--- a/infrastructure/metadata/infrastructure/assumptions/non-local-ports.sub.window.js.ini
+++ b/infrastructure/metadata/infrastructure/assumptions/non-local-ports.sub.window.js.ini
@@ -1,0 +1,4 @@
+[non-local-ports.sub.window.html]
+  [Fetch from http-public to local http fails.]
+    expected:
+      if product != "chrome": FAIL


### PR DESCRIPTION
This test requires running against Chrome 92. CI is still using Chrome 91, hence it does not yet pass. Splitting this off to its own PR to unblock #28870.