### PR TITLE
Fix accent-color-checkbox-checked-001 reference

### DIFF
--- a/css/css-ui/accent-color-checkbox-checked-001-notref.html
+++ b/css/css-ui/accent-color-checkbox-checked-001-notref.html
@@ -1,2 +1,2 @@
 <!doctype html>
-<input type=checkbox style="accent-color: blue">
+<input type=checkbox checked style="accent-color: blue">


### PR DESCRIPTION
The test was using "checked" but the reference wasn't.