### PR TITLE
conformance-checkers: Use Python 3 in Makefile; don't override envars

### DIFF
--- a/conformance-checkers/Makefile
+++ b/conformance-checkers/Makefile
@@ -1,20 +1,20 @@
-HTML2MARKDOWN=html2text
-PERL=perl
-PERLFLAGS=
-FMT=fmt
-FMTFLAGS=-80
-EXPAND=expand
-EXPANDFLAGS=
-GIT=git
-GITFLAGS=
-PYTHON=python
-PYTHONFLAGS=
-CURL=curl
-CURLFLAGS=
-JAVA=java
-JAVAFLAGS=
-VNU_TEST_REPO=git@github.com:validator/tests.git
-ITS_REPO=git@github.com:w3c/its-2.0-testsuite-inputdata.git
+HTML2MARKDOWN ?= html2text
+PERL ?= perl
+PERLFLAGS ?=
+FMT ?= fmt
+FMTFLAGS ?= -80
+EXPAND ?= expand
+EXPANDFLAGS ?=
+GIT? = git
+GITFLAGS ?=
+PYTHON ?= python3
+PYTHONFLAGS ?=
+CURL ?= curl
+CURLFLAGS ?=
+JAVA ?= java
+JAVAFLAGS ?=
+VNU_TEST_REPO ?= git@github.com:validator/tests.git
+ITS_REPO ?= git@github.com:w3c/its-2.0-testsuite-inputdata.git
 .PHONY: .FORCE
 
 all: README.md messages.json


### PR DESCRIPTION
Makefile uses the --sort-keys command line option which was introduced
in Python 3.5. Setting PYTHON to "python" means make will fail in
environments where Python 2 is the default. Furthermore, setting it
unconditionally means that users cannot work around this in their own
environment.

Set PYTHON to "python3" and also replace the = operator with ?= so that
variables are only set by Makefile when not already set locally. (Thanks
gsnedders for the operator tip!)

Fixes #29196.