### PR TITLE
Update URL for MathML Core

### DIFF
--- a/mathml/META.yml
+++ b/mathml/META.yml
@@ -1,3 +1,3 @@
-spec: https://mathml-refresh.github.io/mathml-core/
+spec: https://w3c.github.io/mathml-core/
 suggested_reviewers:
   - fred-wang


### PR DESCRIPTION
Spec now developed by Math Working Group. Repository moved to W3C organization accordingly.