### PR TITLE
Rewrite use of socket.error and socket.timeout errors

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -7,7 +7,6 @@ import multiprocessing
 import os
 import platform
 import signal
-import socket
 import subprocess
 import sys
 import threading
@@ -531,7 +530,7 @@ class ServerProc(object):
                 resource.setrlimit(resource.RLIMIT_NOFILE, (new_soft, hard))
         try:
             self.daemon = init_func(logger, host, port, paths, routes, bind_address, config, **kwargs)
-        except socket.error:
+        except OSError:
             logger.critical("Socket error on port %s" % port, file=sys.stderr)
             raise
         except Exception:

--- a/tools/wave/tests/test_wave.py
+++ b/tools/wave/tests/test_wave.py
@@ -15,7 +15,7 @@ def is_port_8000_in_use():
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
         s.bind(("127.0.0.1", 8000))
-    except socket.error as e:
+    except OSError as e:
         if e.errno == errno.EADDRINUSE:
             return True
         else:

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -20,7 +20,7 @@ def is_port_8000_in_use():
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
         s.bind(("127.0.0.1", 8000))
-    except socket.error as e:
+    except OSError as e:
         if e.errno == errno.EADDRINUSE:
             return True
         else:

--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -45,7 +45,7 @@ def get_free_port():
         s = socket.socket()
         try:
             s.bind(("127.0.0.1", 0))
-        except socket.error:
+        except OSError:
             continue
         else:
             return s.getsockname()[1]

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -275,7 +275,7 @@ class TestEnvironment(object):
                     s.settimeout(0.1)
                     try:
                         s.connect((host, port))
-                    except socket.error:
+                    except OSError:
                         pending.append((host, port))
                     finally:
                         s.close()

--- a/tools/wptrunner/wptrunner/webdriver_server.py
+++ b/tools/wptrunner/wptrunner/webdriver_server.py
@@ -221,7 +221,7 @@ def get_free_port():
         s = socket.socket()
         try:
             s.bind(("127.0.0.1", 0))
-        except socket.error:
+        except OSError:
             continue
         else:
             return s.getsockname()[1]
@@ -232,7 +232,7 @@ def get_free_port():
 def wait_for_service(addr, timeout=60):
     """Waits until network service given as a tuple of (host, port) becomes
     available or the `timeout` duration is reached, at which point
-    ``socket.error`` is raised."""
+    ``socket.timeout`` is raised."""
     end = time.time() + timeout
     while end > time.time():
         so = socket.socket()
@@ -240,7 +240,7 @@ def wait_for_service(addr, timeout=60):
             so.connect(addr)
         except socket.timeout:
             pass
-        except socket.error as e:
+        except OSError as e:
             if e.errno != errno.ECONNREFUSED:
                 raise
         else:
@@ -248,4 +248,4 @@ def wait_for_service(addr, timeout=60):
         finally:
             so.close()
         time.sleep(0.5)
-    raise socket.error("Service is unavailable: %s:%i" % addr)
+    raise socket.timeout("Service is unavailable: %s:%i" % addr)

--- a/tools/wptserve/wptserve/response.py
+++ b/tools/wptserve/wptserve/response.py
@@ -2,7 +2,6 @@ from collections import OrderedDict
 from datetime import datetime, timedelta
 from io import BytesIO
 import json
-import socket
 import uuid
 
 from hpack.struct import HeaderTuple
@@ -782,7 +781,7 @@ class ResponseWriter(object):
         try:
             self._wfile.write(self.encode(data))
             return True
-        except socket.error:
+        except OSError:
             # This can happen if the socket got closed by the remote end
             return False
 
@@ -797,7 +796,7 @@ class ResponseWriter(object):
                 break
             try:
                 self._wfile.write(buf)
-            except socket.error:
+            except OSError:
                 success = False
                 break
         data.close()

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -223,7 +223,7 @@ class WebTestServer(ThreadingMixIn, http.server.HTTPServer):
     def handle_error(self, request, client_address):
         error = sys.exc_info()[1]
 
-        if ((isinstance(error, socket.error) and
+        if ((isinstance(error, OSError) and
              isinstance(error.args, tuple) and
              error.args[0] in self.acceptable_errors) or
             (isinstance(error, IOError) and
@@ -411,7 +411,7 @@ class Http2WebTestRequestHandler(BaseWebTestRequestHandler):
                         if isinstance(frame, StreamEnded) or (hasattr(frame, "stream_ended") and frame.stream_ended):
                             del stream_queues[frame.stream_id]
 
-        except (socket.timeout, socket.error) as e:
+        except OSError as e:
             self.logger.error('(%s) Closing Connection - \n%s' % (self.uid, str(e)))
             if not self.close_connection:
                 self.close_connection = True
@@ -712,7 +712,7 @@ class Http1WebTestRequestHandler(BaseWebTestRequestHandler):
     def get_request_line(self):
         try:
             self.raw_requestline = self.rfile.readline(65537)
-        except socket.error:
+        except OSError:
             self.close_connection = True
             return False
         if len(self.raw_requestline) > 65536:


### PR DESCRIPTION
Part of these changes are made by pyupgrade, but it doesn't simplify use
of socket.timeout.

socket.error is now an alias of OSError:
https://docs.python.org/3/library/socket.html#socket.error

socket.timeout is now a subclass of OSError:
https://docs.python.org/3/library/socket.html#socket.timeout