### PR TITLE
Make the Referrer-Policy tests allow further truncated referrers

### DIFF
--- a/referrer-policy/generic/test-case.sub.js
+++ b/referrer-policy/generic/test-case.sub.js
@@ -41,14 +41,20 @@ function invokeScenario(scenario) {
 }
 
 const referrerUrlResolver = {
+  // The spec allows UAs to "enforce arbitrary policy considerations in the
+  // interests of minimizing data leakage"; to start to vaguely approximate
+  // this, we allow stronger policies to be used instead of what's specificed.
   "omitted": function(sourceUrl) {
-    return undefined;
+    return [undefined];
   },
   "origin": function(sourceUrl) {
-    return stripUrlForUseAsReferrer(sourceUrl, true);
+    return [stripUrlForUseAsReferrer(sourceUrl, true),
+            undefined];
   },
   "stripped-referrer": function(sourceUrl) {
-    return stripUrlForUseAsReferrer(sourceUrl, false);
+    return [stripUrlForUseAsReferrer(sourceUrl, false),
+            stripUrlForUseAsReferrer(sourceUrl, true),
+            undefined];
   }
 };
 
@@ -74,14 +80,12 @@ function checkResult(scenario, expectation, result) {
     referrerUrlResolver[expectation](referrerSource);
 
   // Check the reported URL.
-  assert_equals(result.referrer,
-                expectedReferrerUrl,
-                "Reported Referrer URL is '" +
-                expectation + "'.");
-  assert_equals(result.headers.referer,
-                expectedReferrerUrl,
-                "Reported Referrer URL from HTTP header is '" +
-                expectedReferrerUrl + "'");
+  assert_in_array(result.referrer,
+                  expectedReferrerUrl,
+                  "document.referrer");
+  assert_in_array(result.headers.referer,
+                  expectedReferrerUrl,
+                  "HTTP Referer header");
 }
 
 function runLengthTest(scenario, urlLength, expectation, testDescription) {

--- a/referrer-policy/generic/test-case.sub.js
+++ b/referrer-policy/generic/test-case.sub.js
@@ -76,15 +76,15 @@ function checkResult(scenario, expectation, result) {
     // external <iframe>.
     referrerSource = location.toString();
   }
-  const expectedReferrerUrl =
+  const possibleReferrerUrls =
     referrerUrlResolver[expectation](referrerSource);
 
   // Check the reported URL.
   assert_in_array(result.referrer,
-                  expectedReferrerUrl,
+                  possibleReferrerUrls,
                   "document.referrer");
   assert_in_array(result.headers.referer,
-                  expectedReferrerUrl,
+                  possibleReferrerUrls,
                   "HTTP Referer header");
 }
 


### PR DESCRIPTION
This allows UAs to take advantage of the spec's allowance to be more aggressive than otherwise:

> The user agent MAY alter referrerURL or referrerOrigin at this point to enforce arbitrary policy considerations in the interests of minimizing data leakage.

Notably, this increases the number that Safari passes considerably, avoiding the status quo of actual failures being largely hidden behind many more false-fails.

cc @johnwilander @foolip 