### PR TITLE
[css-ruby] Created 2 containing block related tests and 1 reference file

### DIFF
--- a/css/css-ruby/reference/ruby-abs-pos-002-ref.html
+++ b/css/css-ruby/reference/ruby-abs-pos-002-ref.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference File</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <link rel="stylesheet" href="/fonts/ahem.css">
+
+  <style>
+  body
+    {
+      font-family: Ahem;
+      font-size: 60px;
+      line-height: 1;
+    }
+
+  div
+    {
+      text-align: left;
+    }
+
+  span.add-space-on-the-left
+    {
+      padding-left: calc(4em - 1em - 0.5em);
+    }
+
+  div#first, div#second
+    {
+      padding-left: 2em; /* computes to 120px */
+    }
+
+  div.fontsize30px
+    {
+      font-size: 0.5em;
+    }
+  </style>
+
+  <div class="fontsize30px" style="padding-left: calc(120px + 60px); padding-top: 30px;">C</div>
+
+  <div id="first" style="margin-bottom: 2em;"><span style="padding-right: 0.5em;">A</span>D<span class="add-space-on-the-left">B</span></div>
+
+  <div class="fontsize30px" style="padding-left: calc(120px + 60px + 240px); padding-bottom: 30px;">G</div>
+
+  <div id="second">EFH</div>

--- a/css/css-ruby/reference/ruby-abs-pos-003-ref.html
+++ b/css/css-ruby/reference/ruby-abs-pos-003-ref.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference File</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <link rel="stylesheet" href="/fonts/ahem.css">
+
+  <style>
+  body
+    {
+      font-family: Ahem;
+      font-size: 60px;
+      line-height: 1;
+    }
+
+  div
+    {
+      text-align: right;
+    }
+
+  span.add-space-on-the-left
+    {
+      padding-left: calc(4em - 1em - 0.5em);
+    }
+
+  div#third, div#fourth
+    {
+      padding-right: 2em; /* computes to 120px */
+    }
+
+  div.fontsize30px
+    {
+      font-size: 0.5em;
+    }
+  </style>
+
+  <div class="fontsize30px" style="padding-right: calc(120px + 60px); padding-top: 30px;">K</div>
+
+  <div id="third" style="margin-bottom: 2em;">J<span class="add-space-on-the-left">I</span><span style="padding-left: 0.5em;">L</span></div>
+
+  <div class="fontsize30px" style="padding-right: calc(120px + 60px + 240px); padding-bottom: 30px;">O</div>
+
+  <div id="fourth">MNP</div>

--- a/css/css-ruby/reference/ruby-floats-001-ref.html
+++ b/css/css-ruby/reference/ruby-floats-001-ref.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference File</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      font-size: 32px;
+      line-height: 3;
+    }
+
+  div.floated-right
+    {
+      float: right;
+    }
+
+  div.fontsize16px
+    {
+      font-size: 16px;
+      line-height: 1;
+    }
+  </style>
+
+  <div>a<ruby><rb>&nbsp;</rb><rt>b</ruby>c
+    <div class="floated-right">Far Right</div>
+  </div>
+
+  <div class="floated-right fontsize16px">Far Right</div>
+
+  <div>def</div>
+
+  <div class="floated-right">g<ruby><rb>&nbsp;</rb><rt>h</ruby>i</div>
+
+  <div>Far Left</div>
+
+  <div class="floated-right">jkm</div>
+
+  <div class="fontsize16px">Far Left</div>

--- a/css/css-ruby/ruby-abs-pos-001.html
+++ b/css/css-ruby/ruby-abs-pos-001.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Ruby Annotation Layout Test: absolutely positioned ruby base unit boxes and absolutely positioned ruby text unit boxes</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-ruby-1/#formatting-context">
+  <link rel="match" href="reference/ruby-floats-001-ref.html">
+
+  <meta content="" name="flags">
+  <meta content="This test checks that the containing block for internal ruby boxes (ruby base units and ruby text units) is the containing block of its own ruby container. This is true for absolutely positioned ruby base unit boxes and absolutely positioned for ruby text unit boxes.">
+
+  <style>
+  div
+    {
+      font-size: 32px;
+      line-height: 3;
+    }
+
+  rb#first-subtest, rt#second-subtest
+    {
+      position: absolute;
+      right: 8px;
+    }
+
+  rb#third-subtest, rt#fourth-subtest
+    {
+      position: absolute;
+      left: 8px;
+    }
+
+  div#third, div#fourth
+    {
+      text-align: right;
+    }
+  </style>
+
+  <div>a<ruby><rb id="first-subtest">Far Right<rt>b</ruby>c</div>
+
+  <div>d<ruby><rb>e<rt id="second-subtest">Far Right</ruby>f</div>
+
+  <div id="third">g<ruby><rb id="third-subtest">Far Left<rt>h</ruby>i</div>
+
+  <div id="fourth">j<ruby><rb>k<rt id="fourth-subtest">Far Left</ruby>m</div>

--- a/css/css-ruby/ruby-abs-pos-001.html
+++ b/css/css-ruby/ruby-abs-pos-001.html
@@ -2,7 +2,7 @@
 
   <meta charset="UTF-8">
 
-  <title>CSS Ruby Annotation Layout Test: absolutely positioned ruby base unit boxes and absolutely positioned ruby text unit boxes</title>
+  <title>CSS Ruby Test: absolutely positioned ruby base unit boxes and absolutely positioned ruby text unit boxes</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-ruby-1/#formatting-context">

--- a/css/css-ruby/ruby-abs-pos-002.html
+++ b/css/css-ruby/ruby-abs-pos-002.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Ruby Test: absolutely positioned ruby base unit boxes and absolutely positioned ruby text unit boxes inside a relatively positioned ruby container element</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-ruby-1/#formatting-context">
+  <link rel="match" href="reference/ruby-abs-pos-002-ref.html">
+
+  <link rel="stylesheet" href="/fonts/ahem.css">
+
+  <meta content="" name="flags">
+  <meta content="This test checks that the containing block for internal ruby boxes (ruby base units and ruby text units) when the ruby container element is relatively positioned is the ruby container element itself.">
+
+  <style>
+  body
+    {
+      font-family: Ahem;
+      overflow-x: hidden;
+      /*
+      With 'overflow-x: hidden', we want to
+      avoid generating unneedlessly
+      an horizontal scrollbar.
+      */
+    }
+
+  div , ruby
+    {
+      position: relative;
+    }
+
+  div
+    {
+      font-size: 60px;
+      line-height: 3;
+      margin-bottom: 1em;
+    }
+
+  div#first, div#second
+    {
+      left: 2em; /* computes to 120px */
+      text-align: left;
+    }
+
+  rb#first-subtest, rt#second-subtest
+    {
+      left: 240px;
+      position: absolute;
+    }
+  </style>
+
+  <div id="first">A<ruby><rb id="first-subtest">B<rt>C</ruby>D</div>
+
+  <div id="second">E<ruby><rb>F<rt id="second-subtest">G</ruby>H</div>

--- a/css/css-ruby/ruby-abs-pos-002.html
+++ b/css/css-ruby/ruby-abs-pos-002.html
@@ -45,7 +45,8 @@
 
   rb#first-subtest, rt#second-subtest
     {
-      left: 240px;
+      left: 50%;
+      color: orange;
       position: absolute;
     }
   </style>

--- a/css/css-ruby/ruby-abs-pos-003.html
+++ b/css/css-ruby/ruby-abs-pos-003.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Ruby Test: absolutely positioned ruby base unit boxes and absolutely positioned ruby text unit boxes inside a relatively positioned ruby container element</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-ruby-1/#formatting-context">
+  <link rel="match" href="reference/ruby-abs-pos-003-ref.html">
+
+  <link rel="stylesheet" href="/fonts/ahem.css">
+
+  <meta content="" name="flags">
+  <meta content="This test checks that the containing block for internal ruby boxes (ruby base units and ruby text units) when the ruby container element is relatively positioned is the ruby container element itself.">
+
+  <style>
+  body
+    {
+      font-family: Ahem;
+    }
+
+  div , ruby
+    {
+      position: relative;
+    }
+
+  div
+    {
+      font-size: 60px;
+      line-height: 3;
+      margin-bottom: 1em;
+    }
+
+  div#third, div#fourth
+    {
+      right: 2em; /* computes to 120px */
+      text-align: right;
+    }
+
+  rb#third-subtest, rt#fourth-subtest
+    {
+      position: absolute;
+      right: 240px;
+    }
+  </style>
+
+  <div id="third">I<ruby><rb id="third-subtest">J<rt>K</ruby>L</div>
+
+  <div id="fourth">M<ruby><rb>N<rt id="fourth-subtest">O</ruby>P</div>

--- a/css/css-ruby/ruby-abs-pos-003.html
+++ b/css/css-ruby/ruby-abs-pos-003.html
@@ -40,7 +40,8 @@
   rb#third-subtest, rt#fourth-subtest
     {
       position: absolute;
-      right: 240px;
+      right: 50%;
+      color: orange;
     }
   </style>
 

--- a/css/css-ruby/ruby-floats-001.html
+++ b/css/css-ruby/ruby-floats-001.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Ruby Annotation Layout Test: floating ruby base unit boxes and floating ruby text unit boxes</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-ruby-1/#formatting-context">
+  <link rel="match" href="reference/ruby-floats-001-ref.html">
+
+  <meta content="" name="flags">
+  <meta content="This test checks that the containing block for internal ruby boxes (ruby base units and ruby text units) is the containing block of its own ruby container. This is true for floating ruby base unit boxes and for ruby text unit boxes.">
+
+  <style>
+  div
+    {
+      font-size: 32px;
+      line-height: 3;
+    }
+
+  rb#first-subtest, rt#second-subtest
+    {
+      float: right;
+    }
+
+  rb#third-subtest, rt#fourth-subtest
+    {
+      float: left;
+    }
+
+  div#third, div#fourth
+    {
+      text-align: right;
+    }
+  </style>
+
+  <div>a<ruby><rb id="first-subtest">Far Right<rt>b</ruby>c</div>
+
+  <div>d<ruby><rb>e<rt id="second-subtest">Far Right</ruby>f</div>
+
+  <div id="third">g<ruby><rb id="third-subtest">Far Left<rt>h</ruby>i</div>
+
+  <div id="fourth">j<ruby><rb>k<rt id="fourth-subtest">Far Left</ruby>m</div>

--- a/css/css-ruby/ruby-floats-001.html
+++ b/css/css-ruby/ruby-floats-001.html
@@ -2,7 +2,7 @@
 
   <meta charset="UTF-8">
 
-  <title>CSS Ruby Annotation Layout Test: floating ruby base unit boxes and floating ruby text unit boxes</title>
+  <title>CSS Ruby Test: floating ruby base unit boxes and floating ruby text unit boxes</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-ruby-1/#formatting-context">


### PR DESCRIPTION
ruby-abs-pos-001.html
ruby-floats-001.html
reference/ruby-floats-001-ref.html

At my website, the files are:

http://www.gtalbot.org/BrowserBugsSection/CSS3Ruby/ruby-abs-pos-001.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Ruby/ruby-floats-001.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Ruby/reference/ruby-floats-001-ref.html

These 2 tests are checking that the containing block for internal ruby boxes (ruby base units and ruby text units) is the containing block of its own ruby container. This is true for absolutely positioned or floating ruby base unit boxes and for absolutely positioned or floating ruby text unit boxes.