### PR TITLE
Change documentation to point at Matrix rather than IRC.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -57,11 +57,12 @@ than others.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-Examples of representing our community include official IRC channels (#testing
-on irc.w3.org); GitHub repositories under the web-platform-tests organization;
-and the public-test-infra@w3.org mailing list.
+This Code of Conduct applies within all community spaces, and also
+applies when an individual is officially representing the community in
+public spaces.  Examples of representing our community include
+official Matrix channel (wpt:matrix.org); GitHub repositories under
+the web-platform-tests organization; and the public-test-infra@w3.org
+mailing list.
 
 There may arise situations where both the WPT code of conduct and that of
 another organization (such as the WHATWG or W3C) may apply.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ than others.
 This Code of Conduct applies within all community spaces, and also
 applies when an individual is officially representing the community in
 public spaces.  Examples of representing our community include
-official Matrix channel (wpt:matrix.org); GitHub repositories under
+the official Matrix channel (wpt:matrix.org); GitHub repositories under
 the web-platform-tests organization; and the public-test-infra@w3.org
 mailing list.
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,9 @@ The most important sources of information and activity are:
   Internet-enabled browser of their choice
 - [wpt.fyi](https://wpt.fyi): an archive of test results collected from an
   array of web browsers on a regular basis
-- [Real-time chat room](http://irc.w3.org/?channels=testing): the
-  [IRC](http://www.irchelp.org/) chat room named `#testing` on
-  [irc.w3.org](https://www.w3.org/wiki/IRC); includes participants located
-  around the world, but busiest during the European working day; [all
-  discussion is archived here](https://w3.logbot.info/testing)
+- [Real-time chat room](https://app.element.io/#/room/#wpt:matrix.org): the
+  `wpt:matrix.org` matrix channel; includes participants located
+  around the world, but busiest during the European working day.
 - [Mailing list](https://lists.w3.org/Archives/Public/public-test-infra/): a
   public and low-traffic discussion list
 - [RFCs](https://github.com/web-platform-tests/rfcs): a repo for requesting

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,11 +24,9 @@ The most important sources of information and activity are:
   Internet-enabled browser of their choice
 - [wpt.fyi](https://wpt.fyi): an archive of test results collected from an
   array of web browsers on a regular basis
-- [Real-time chat room](http://irc.w3.org/?channels=testing): the
-  [IRC](http://www.irchelp.org/) chat room named `#testing` on
-  [irc.w3.org](https://www.w3.org/wiki/IRC); includes participants located
-  around the world, but busiest during the European working day; [all
-  discussion is archived here](https://w3.logbot.info/testing)
+- [Real-time chat room](https://app.element.io/#/room/#wpt:matrix.org): the
+  `wpt:matrix.org` matrix channel; includes participants located
+  around the world, but busiest during the European working day.
 - [Mailing list](https://lists.w3.org/Archives/Public/public-test-infra/): a
   public and low-traffic discussion list
 

--- a/docs/running-tests/custom-runner.md
+++ b/docs/running-tests/custom-runner.md
@@ -11,12 +11,11 @@ ways to define test types), and hence its behavior should be
 considered the canonical definition of how to enumerate tests and find
 their type in the repository.
 
-For test execution, please read the documentation for the various test types
-very carefully and then check your understanding on
-the [mailing list][public-test-infra] or [IRC][] ([webclient][web irc], join
-channel `#testing`). It's possible edge-case behavior isn't properly
-documented!
+For test execution, please read the documentation for the various test
+types very carefully and then check your understanding on the [mailing
+list][public-test-infra] or [matrix][matrix]. It's possible edge-case
+behavior isn't properly documented!
 
 [public-test-infra]: https://lists.w3.org/Archives/Public/public-test-infra/
-[IRC]: irc://irc.w3.org:6667/testing
+[matrix]: https://app.element.io/#/room/#wpt:matrix.org
 [web irc]: http://irc.w3.org

--- a/docs/writing-tests/general-guidelines.md
+++ b/docs/writing-tests/general-guidelines.md
@@ -74,9 +74,9 @@ Some test types support other formats:
   features])
 - [WebDriver specification tests](wdspec) are expressed as Python files
 
-The best way to determine how to format a new test is to look at how similar
-tests have been formatted. You can also ask for advice in [the project's IRC
-room][IRC].
+The best way to determine how to format a new test is to look at how
+similar tests have been formatted. You can also ask for advice in [the
+project's matrix channel][matrix].
 
 
 ### Character Encoding
@@ -216,7 +216,7 @@ for CSS have some additional requirements for:
 [server features]: server-features
 [assumptions]: assumptions
 [ahem]: ahem
-[IRC]: irc://irc.w3.org:6667/testing
+[matrix]: https://app.element.io/#/room/#wpt:matrix.org
 [lint-tool]: lint-tool
 [css-metadata]: css-metadata
 [css-user-styles]: css-user-styles

--- a/docs/writing-tests/submission-process.md
+++ b/docs/writing-tests/submission-process.md
@@ -32,7 +32,7 @@ correctly. But we look at all of them, and take everything that we can.
 
 Hop on to the [mailing list][public-test-infra] or [matrix
 channel][matrix] if you have an issue.  There is no need to announce
-your review request, as soon as you make a Pull Request GitHub will
+your review request; as soon as you make a Pull Request, GitHub will
 inform interested parties.
 
 ## Previews

--- a/docs/writing-tests/submission-process.md
+++ b/docs/writing-tests/submission-process.md
@@ -30,10 +30,10 @@ We can sometimes take a little while to go through pull requests because we
 have to go through all the tests and ensure that they match the specification
 correctly. But we look at all of them, and take everything that we can.
 
-Hop on to the [mailing list][public-test-infra] or [IRC][]
-([webclient][web irc], join channel `#testing`) if you have an issue.  There is
-no need to announce your review request, as soon as you make a Pull Request
-GitHub will inform interested parties.
+Hop on to the [mailing list][public-test-infra] or [matrix
+channel][matrix] if you have an issue.  There is no need to announce
+your review request, as soon as you make a Pull Request GitHub will
+inform interested parties.
 
 ## Previews
 
@@ -60,5 +60,4 @@ trust the authors not to submit malicious code.
 [repo]: https://github.com/web-platform-tests/wpt/
 [github flow]: https://guides.github.com/introduction/flow/
 [public-test-infra]: https://lists.w3.org/Archives/Public/public-test-infra/
-[IRC]: irc://irc.w3.org:6667/testing
-[web irc]: http://irc.w3.org
+[matrix]: https://app.element.io/#/room/#wpt:matrix.org


### PR DESCRIPTION
We are now using the `wpt:matrix.org` matrix channel rather than IRC
for synchrnous communications.

There is still a transcript of a video in the repo that mentions the
old venue; it's unclear what to do about that other than delete the video.