### PR TITLE
Streams: read with fixed endianness

### DIFF
--- a/streams/readable-byte-streams/general.any.js
+++ b/streams/readable-byte-streams/general.any.js
@@ -957,8 +957,8 @@ promise_test(() => {
     assert_equals(view.byteOffset, 0, 'byteOffset');
     assert_equals(view.byteLength, 2, 'byteLength');
 
-    const data_view = new DataView(view.buffer, view.byteOffset, view.byteLength);
-    assert_equals(data_view.getUint16(0), 0x0102);
+    const dataView = new DataView(view.buffer, view.byteOffset, view.byteLength);
+    assert_equals(dataView.getUint16(0), 0x0102);
 
     return reader.read(new Uint8Array(1));
   }).then(result => {
@@ -1328,8 +1328,8 @@ promise_test(() => {
     assert_equals(view.byteOffset, 0);
     assert_equals(view.byteLength, 2);
 
-    const data_view = new DataView(view.buffer, view.byteOffset, view.byteLength);
-    assert_equals(data_view.getUint16(0), 0xffaa);
+    const dataView = new DataView(view.buffer, view.byteOffset, view.byteLength);
+    assert_equals(dataView.getUint16(0), 0xffaa);
 
     assert_equals(viewInfo.constructor, Uint8Array, 'view.constructor should be Uint8Array');
     assert_equals(viewInfo.bufferByteLength, 2, 'view.buffer.byteLength should be 2');
@@ -1385,8 +1385,8 @@ promise_test(() => {
       assert_equals(view.byteOffset, 0, 'byteOffset');
       assert_equals(view.byteLength, 2, 'byteLength');
 
-      const data_view = new DataView(view.buffer, view.byteOffset, view.byteLength);
-      assert_equals(data_view.getUint16(0), 0x0100, 'contents are set');
+      const dataView = new DataView(view.buffer, view.byteOffset, view.byteLength);
+      assert_equals(dataView.getUint16(0), 0x0100, 'contents are set');
 
       const p = reader.read(new Uint16Array(1));
 
@@ -1401,8 +1401,8 @@ promise_test(() => {
       assert_equals(view.byteOffset, 0, 'byteOffset');
       assert_equals(view.byteLength, 2, 'byteLength');
 
-      const data_view = new DataView(view.buffer, view.byteOffset, view.byteLength);
-      assert_equals(data_view.getUint16(0), 0x0203, 'contents are set');
+      const dataView = new DataView(view.buffer, view.byteOffset, view.byteLength);
+      assert_equals(dataView.getUint16(0), 0x0203, 'contents are set');
 
       assert_not_equals(byobRequest, null, 'byobRequest must not be null');
       assert_equals(viewInfo.constructor, Uint8Array, 'view.constructor should be Uint8Array');

--- a/streams/readable-byte-streams/general.any.js
+++ b/streams/readable-byte-streams/general.any.js
@@ -1138,7 +1138,7 @@ promise_test(() => {
 
     assert_equals(pullCount, 1, '1 pull() should have been made in response to partial fill by enqueue()');
     assert_not_equals(byobRequest, null, 'byobRequest should not be null');
-    assert_equals(viewInfos[0].byteLength, 2, 'byteLength before enqueue() shouild be 2');
+    assert_equals(viewInfos[0].byteLength, 2, 'byteLength before enqueue() should be 2');
     assert_equals(viewInfos[1].byteLength, 1, 'byteLength after enqueue() should be 1');
 
     reader.cancel();

--- a/streams/readable-byte-streams/general.any.js
+++ b/streams/readable-byte-streams/general.any.js
@@ -957,7 +957,8 @@ promise_test(() => {
     assert_equals(view.byteOffset, 0, 'byteOffset');
     assert_equals(view.byteLength, 2, 'byteLength');
 
-    assert_equals(view[0], 0x0201);
+    const data_view = new DataView(view.buffer, view.byteOffset, view.byteLength);
+    assert_equals(data_view.getUint16(0), 0x0102);
 
     return reader.read(new Uint8Array(1));
   }).then(result => {
@@ -1326,7 +1327,9 @@ promise_test(() => {
     const view = result.value;
     assert_equals(view.byteOffset, 0);
     assert_equals(view.byteLength, 2);
-    assert_equals(view[0], 0xaaff);
+
+    const data_view = new DataView(view.buffer, view.byteOffset, view.byteLength);
+    assert_equals(data_view.getUint16(0), 0xffaa);
 
     assert_equals(viewInfo.constructor, Uint8Array, 'view.constructor should be Uint8Array');
     assert_equals(viewInfo.bufferByteLength, 2, 'view.buffer.byteLength should be 2');
@@ -1381,7 +1384,9 @@ promise_test(() => {
       assert_equals(view.buffer.byteLength, 4, 'buffer.byteLength');
       assert_equals(view.byteOffset, 0, 'byteOffset');
       assert_equals(view.byteLength, 2, 'byteLength');
-      assert_equals(view[0], 0x0001, 'Contents are set');
+
+      const data_view = new DataView(view.buffer, view.byteOffset, view.byteLength);
+      assert_equals(data_view.getUint16(0), 0x0100, 'contents are set');
 
       const p = reader.read(new Uint16Array(1));
 
@@ -1395,7 +1400,9 @@ promise_test(() => {
       assert_equals(view.buffer.byteLength, 2, 'buffer.byteLength');
       assert_equals(view.byteOffset, 0, 'byteOffset');
       assert_equals(view.byteLength, 2, 'byteLength');
-      assert_equals(view[0], 0x0302, 'Contents are set');
+
+      const data_view = new DataView(view.buffer, view.byteOffset, view.byteLength);
+      assert_equals(data_view.getUint16(0), 0x0203, 'contents are set');
 
       assert_not_equals(byobRequest, null, 'byobRequest must not be null');
       assert_equals(viewInfo.constructor, Uint8Array, 'view.constructor should be Uint8Array');


### PR DESCRIPTION
In some tests for readable byte streams, we pass a `Uint16Array` to `reader.read(view)`, then write into it as a `Uint8Array` and finally read the results back as a `Uint16Array`. However, `Uint16Array` uses the *platform byte order*, whereas these tests assume that it's always in *little-endian order*.

Node.js has also started implementing the Streams API (nodejs/node#39062), and they also run on big-endian platforms. To support this, the tests must be independent of the platform byte order. The simplest way to achieve this is by using a `DataView` instead, which is what I did in this PR.