### PR TITLE
Update tests verifying TypeError when setting window.location.href to…

### DIFF
--- a/url/failure.html
+++ b/url/failure.html
@@ -42,7 +42,7 @@ function runTests(testData) {
       }, "sendBeacon(): " + name)
 
       self.test(() => {
-        assert_throws_js(self[0].TypeError, () => self[0].location = test.input)
+        assert_throws_js(TypeError, () => self[0].location = test.input)
       }, "Location's href: " + name)
 
       self.test(() => {


### PR DESCRIPTION
Update tests verifying TypeError when setting window.location.href to an invalid URL

Chrome and Safari don't pass the test as written, but I'm investigating fixing it.
Firefox passed the test as written, which verifies that an instance of window.TypeError
is thrown instead of just a normal TypeError, even though the spec does not say that
at https://html.spec.whatwg.org/multipage/history.html#dom-location-href
I believe this aligns the test with the spec, even though now nobody passes it.