### PR TITLE
url/failure.html shouldn't expect failure when using valid relative U…

### DIFF
--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -3303,12 +3303,14 @@
   {
     "input": "http:@:www.example.com",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "http:/@:www.example.com",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   {
     "input": "http://@:www.example.com",
@@ -6373,7 +6375,8 @@
   {
     "input": "\\\\\\.\\Y:",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   "# file: drive letter cases from https://crbug.com/1078698 but lowercased",
   {
@@ -6435,7 +6438,8 @@
   {
     "input": "\\\\\\.\\y:",
     "base": "about:blank",
-    "failure": true
+    "failure": true,
+    "inputCanBeRelative": true
   },
   "# Additional file URL tests for (https://github.com/whatwg/url/issues/405)",
   {


### PR DESCRIPTION
url/failure.html shouldn't expect failure when using valid relative URLs as relative URLs

urltestdata.json contains several URLs like "http:/:@/www.example.com"
which, when parsed without a base URL or with a base URL like "about:blank"
result in a parsing failure, but which when parsed with a base URL that can
be a base URL like "http://wpt.live/url/failure.html" then they result in a valid
URL.  The test used to verify that they would throw when given to APIs like
window.open, but this was incorrect because those APIs treat the input string
as a URL relative to the current document's URL.  We were already filtering out
many of the tests from urltestdata.json.  We need another filter.