### PR TITLE
Find and install EdgeDriver using installed Edge channel

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1047,6 +1047,8 @@ class EdgeChromium(Browser):
         raise NotImplementedError
 
     def find_binary(self, venv_path=None, channel=None):
+        self.logger.info('Finding Edge binary for channel %s' % channel)
+
         if self.platform == "linux":
             name = "microsoft-edge"
             if channel == "stable":
@@ -1153,8 +1155,13 @@ class EdgeChromium(Browser):
         return find_executable(self.edgedriver_name, dest)
 
     def install_webdriver(self, dest=None, channel=None, browser_binary=None):
+        self.logger.info("Installing MSEdgeDriver for channel %s" % channel)
+
         if browser_binary is None:
-            browser_binary = self.find_binary(channel)
+            browser_binary = self.find_binary(channel=channel)
+        else:
+            self.logger.info("Installing matching MSEdgeDriver for Edge binary at %s" % browser_binary)
+
         return self.install_webdriver_by_version(
             self.version(browser_binary), dest)
 

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1115,13 +1115,14 @@ class EdgeChromium(Browser):
         if dest is None:
             dest = os.pwd
 
-        if self.platform == "linux":
-            version_url = "https://msedgedriver.azureedge.net/LATEST_DEV_LINUX"
-        elif self.platform == "macos":
-            version_url = "https://msedgedriver.azureedge.net/LATEST_DEV_MACOS"
-        else:
-            version_url = "https://msedgedriver.azureedge.net/LATEST_DEV_WINDOWS"
-        version = get(version_url).text.strip()
+        if version is None:
+            if self.platform == "linux":
+                version_url = "https://msedgedriver.azureedge.net/LATEST_DEV_LINUX"
+            elif self.platform == "macos":
+                version_url = "https://msedgedriver.azureedge.net/LATEST_DEV_MACOS"
+            else:
+                version_url = "https://msedgedriver.azureedge.net/LATEST_DEV_WINDOWS"
+            version = get(version_url).text.strip()
 
         if self.platform == "linux":
             bits = "linux64"

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1132,7 +1132,7 @@ class EdgeChromium(Browser):
             edgedriver_path = os.path.join(dest, self.edgedriver_name)
         else:
             bits = "win64" if uname[4] == "x86_64" else "win32"
-            edgedriver_path = os.path.join(dest, f"self.edgedriver_name.exe")
+            edgedriver_path = os.path.join(dest, f"{self.edgedriver_name}.exe")
         url = f"https://msedgedriver.azureedge.net/{version}/edgedriver_{bits}.zip"
 
         # cleanup existing Edge driver files to avoid access_denied errors when unzipping

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1047,7 +1047,7 @@ class EdgeChromium(Browser):
         raise NotImplementedError
 
     def find_binary(self, venv_path=None, channel=None):
-        self.logger.info('Finding Edge binary for channel %s' % channel)
+        self.logger.info(f'Finding Edge binary for channel {channel}')
 
         if self.platform == "linux":
             name = "microsoft-edge"
@@ -1063,7 +1063,7 @@ class EdgeChromium(Browser):
             suffix = ""
             if channel in ("beta", "dev", "canary"):
                 suffix = " " + channel.capitalize()
-            return "/Applications/Microsoft Edge%s.app/Contents/MacOS/Microsoft Edge%s" % (suffix, suffix)
+            return f"/Applications/Microsoft Edge{suffix}.app/Contents/MacOS/Microsoft Edge{suffix}"
         if self.platform == "win":
             binaryname = "msedge"
             if channel == "beta":
@@ -1093,8 +1093,7 @@ class EdgeChromium(Browser):
         edgedriver_version = self.webdriver_version(webdriver_binary)
         if not edgedriver_version:
             self.logger.warning(
-                "Unable to get version for EdgeDriver %s, rejecting it" %
-                webdriver_binary)
+                f"Unable to get version for EdgeDriver {webdriver_binary}, rejecting it")
             return False
 
         browser_version = self.version(browser_binary)
@@ -1108,8 +1107,7 @@ class EdgeChromium(Browser):
         browser_major = int(browser_version.split('.')[0])
         if edgedriver_major != browser_major:
             self.logger.warning(
-                "EdgeDriver %s does not match Edge %s" %
-                (edgedriver_version, browser_version))
+                f"EdgeDriver {edgedriver_version} does not match Edge {browser_version}")
             return False
         return True
 
@@ -1134,33 +1132,33 @@ class EdgeChromium(Browser):
             edgedriver_path = os.path.join(dest, self.edgedriver_name)
         else:
             bits = "win64" if uname[4] == "x86_64" else "win32"
-            edgedriver_path = os.path.join(dest, "%s.exe" % self.edgedriver_name)
-        url = "https://msedgedriver.azureedge.net/%s/edgedriver_%s.zip" % (version, bits)
+            edgedriver_path = os.path.join(dest, f"self.edgedriver_name.exe")
+        url = f"https://msedgedriver.azureedge.net/{version}/edgedriver_{bits}.zip"
 
         # cleanup existing Edge driver files to avoid access_denied errors when unzipping
         if os.path.isfile(edgedriver_path):
             # remove read-only attribute
             os.chmod(edgedriver_path, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)  # 0777
-            print("Delete %s file" % edgedriver_path)
+            print(f"Delete {edgedriver_path} file")
             os.remove(edgedriver_path)
         driver_notes_path = os.path.join(dest, "Driver_notes")
         if os.path.isdir(driver_notes_path):
-            print("Delete %s folder" % driver_notes_path)
+            print(f"Delete {driver_notes_path} folder")
             rmtree(driver_notes_path)
 
-        self.logger.info("Downloading MSEdgeDriver from %s" % url)
+        self.logger.info(f"Downloading MSEdgeDriver from {url}")
         unzip(get(url).raw, dest)
         if os.path.isfile(edgedriver_path):
-            self.logger.info("Successfully downloaded MSEdgeDriver to %s" % edgedriver_path)
+            self.logger.info(f"Successfully downloaded MSEdgeDriver to {edgedriver_path}")
         return find_executable(self.edgedriver_name, dest)
 
     def install_webdriver(self, dest=None, channel=None, browser_binary=None):
-        self.logger.info("Installing MSEdgeDriver for channel %s" % channel)
+        self.logger.info(f"Installing MSEdgeDriver for channel {channel}")
 
         if browser_binary is None:
             browser_binary = self.find_binary(channel=channel)
         else:
-            self.logger.info("Installing matching MSEdgeDriver for Edge binary at %s" % browser_binary)
+            self.logger.info(f"Installing matching MSEdgeDriver for Edge binary at {browser_binary}")
 
         return self.install_webdriver_by_version(
             self.version(browser_binary), dest)
@@ -1176,11 +1174,11 @@ class EdgeChromium(Browser):
         try:
             version_string = call(binary, "--version").strip()
         except (subprocess.CalledProcessError, OSError) as e:
-            self.logger.warning("Failed to call %s: %s" % (binary, e))
+            self.logger.warning(f"Failed to call {binary}: {e}")
             return None
         m = re.match(r"Microsoft Edge (.*) ", version_string)
         if not m:
-            self.logger.warning("Failed to extract version from: %s" % version_string)
+            self.logger.warning(f"Failed to extract version from: {version_string}")
             return None
         return m.group(1)
 
@@ -1191,11 +1189,11 @@ class EdgeChromium(Browser):
         try:
             version_string = call(webdriver_binary, "--version").strip()
         except (subprocess.CalledProcessError, OSError) as e:
-            self.logger.warning("Failed to call %s: %s" % (webdriver_binary, e))
+            self.logger.warning(f"Failed to call {webdriver_binary}: {e}")
             return None
         m = re.match(r"MSEdgeDriver ([0-9][0-9.]*)", version_string)
         if not m:
-            self.logger.warning("Failed to extract version from: %s" % version_string)
+            self.logger.warning(f"Failed to extract version from: {version_string}")
             return None
         return m.group(1)
 

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -529,6 +529,7 @@ class EdgeChromium(BrowserSetup):
         if kwargs["binary"] is None:
             binary = self.browser.find_binary(channel=browser_channel)
             if binary:
+                logger.info("Using Edge binary %s" % binary)
                 kwargs["binary"] = binary
             else:
                 raise WptrunError("Unable to locate Edge binary")


### PR DESCRIPTION
This change updates the EdgeChromium implementation in tools/wpt/browser.py to search for an installed Edge browser binary for a specified channel, and then download the EdgeDriver that matches that binary's version.

The previous script was querying the LATEST_DEV endpoint. This can fail sometimes if the browser installed on the machine doesn't match the major version number of LATEST_DEV, or if LATEST_DEV points to a release that doesn't include drivers for the current platform. 

As a fallback, if the new script cannot find an Edge binary on the machine to extract a version number, it will query the the new endpoints LATEST_DEV_LINUX, LATEST_DEV_MAC, or LATEST_DEV_WINDOWS which will always return a recent DEV version number that actually has a driver binary for the indicated platform.

Also minor style changes to align with the current Chrome implementation in the same file.