### PR TITLE
[css-ruby] Creating a reliable ruby text pairing test and reference

### DIFF
--- a/css/css-ruby/reference/ruby-annotation-pairing-001-ref.html
+++ b/css/css-ruby/reference/ruby-annotation-pairing-001-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+
+ <meta charset="UTF-8">
+
+ <title>CSS Reference File</title>
+
+ <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+ <link rel="stylesheet" href="/fonts/ahem.css">
+
+  <style>
+  div
+    {
+      font-family: Ahem;
+      font-size: 60px;
+      line-height: 1;
+    }
+
+  div.annotation
+    {
+      font-size: 30px;
+      margin-top: 60px;
+      text-indent: 15px;
+    }
+  </style>
+
+  <div class="annotation">A</div>
+
+  <div>W Z</div>
+
+  <div class="annotation">A</div>
+
+  <div>W Z</div>
+
+  <div class="annotation">A</div>
+
+  <div>W Z</div>

--- a/css/css-ruby/ruby-annotation-pairing-001.html
+++ b/css/css-ruby/ruby-annotation-pairing-001.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+
+ <meta charset="UTF-8">
+
+ <title>CSS Ruby Test: single ruby annotation pairing</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-ruby-1/#base-annotation-pairing">
+  <link rel="match" href="reference/ruby-annotation-pairing-001-ref.html">
+  <link rel="stylesheet" href="/fonts/ahem.css">
+
+  <meta content="" name="flags">
+  <meta content="This test checks that a single ruby annotation must be paired with the corresponding first ruby base of its segment.">
+
+  <!--
+  Chromium 90.0.4430.212 and Chromium 93.0.4559.0 fail this test.
+  -->
+
+  <style>
+  div, p
+    {
+      font-family: Ahem;
+      font-size: 60px;
+      line-height: 1;
+    }
+
+  div#annotation
+    {
+      font-size: 30px;
+      text-indent: 15px;
+    }
+  </style>
+
+  <p><ruby><rb>W</rb> <rb>Z</rb> <rt>A</rt></ruby></p>
+
+  <div id="annotation" title="reference">A</div>
+
+  <div id="base" title="reference">W Z</div>
+
+  <p><ruby><rb>W</rb> <span>Z</span> <rt>A</rt></ruby></p>


### PR DESCRIPTION
css-ruby/ruby-annotation-pairing-001.html

css-ruby/reference/ruby-annotation-pairing-001-ref.html

Over at my website:

http://www.gtalbot.org/BrowserBugsSection/CSS3Ruby/ruby-annotation-pairing-001.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Ruby/reference/ruby-annotation-pairing-001-ref.html

The test and reference are **more reliable and more trustworthy** regarding expected rendering.

Chrome 90 and 93 fails this test.