### PR TITLE
Test disturbed Response streams coming from different body sources.

### DIFF
--- a/fetch/api/response/response-stream-disturbed-1.any.js
+++ b/fetch/api/response/response-stream-disturbed-1.any.js
@@ -1,42 +1,44 @@
 // META: global=window,worker
 // META: title=Consuming Response body after getting a ReadableStream
+// META: script=./response-stream-disturbed-util.js
 
-function createResponseWithReadableStream(callback) {
-    return fetch("../resources/data.json").then(function(response) {
-        var reader = response.body.getReader();
-        reader.releaseLock();
-        return callback(response);
-    });
+async function createResponseWithReadableStream(bodySource, callback) {
+    const response = await responseFromBodySource(bodySource);
+    const reader = response.body.getReader();
+    reader.releaseLock();
+    return callback(response);
 }
 
-promise_test(function() {
-    return createResponseWithReadableStream(function(response) {
-        return response.blob().then(function(blob) {
-            assert_true(blob instanceof Blob);
+for (const bodySource of ["fetch", "stream", "string"]) {
+    promise_test(function() {
+        return createResponseWithReadableStream(bodySource, function(response) {
+            return response.blob().then(function(blob) {
+                assert_true(blob instanceof Blob);
+            });
         });
-    });
-}, "Getting blob after getting the Response body - not disturbed, not locked");
+    }, `Getting blob after getting the Response body - not disturbed, not locked (body source: ${bodySource})`);
 
-promise_test(function() {
-    return createResponseWithReadableStream(function(response) {
-        return response.text().then(function(text) {
-            assert_true(text.length > 0);
+    promise_test(function() {
+        return createResponseWithReadableStream(bodySource, function(response) {
+            return response.text().then(function(text) {
+                assert_true(text.length > 0);
+            });
         });
-    });
-}, "Getting text after getting the Response body - not disturbed, not locked");
+    }, `Getting text after getting the Response body - not disturbed, not locked (body source: ${bodySource})`);
 
-promise_test(function() {
-    return createResponseWithReadableStream(function(response) {
-        return response.json().then(function(json) {
-            assert_equals(typeof json, "object");
+    promise_test(function() {
+        return createResponseWithReadableStream(bodySource, function(response) {
+            return response.json().then(function(json) {
+                assert_equals(typeof json, "object");
+            });
         });
-    });
-}, "Getting json after getting the Response body - not disturbed, not locked");
+    }, `Getting json after getting the Response body - not disturbed, not locked (body source: ${bodySource})`);
 
-promise_test(function() {
-    return createResponseWithReadableStream(function(response) {
-        return response.arrayBuffer().then(function(arrayBuffer) {
-            assert_true(arrayBuffer.byteLength > 0);
+    promise_test(function() {
+        return createResponseWithReadableStream(bodySource, function(response) {
+            return response.arrayBuffer().then(function(arrayBuffer) {
+                assert_true(arrayBuffer.byteLength > 0);
+            });
         });
-    });
-}, "Getting arrayBuffer after getting the Response body - not disturbed, not locked");
+    }, `Getting arrayBuffer after getting the Response body - not disturbed, not locked (body source: ${bodySource})`);
+}

--- a/fetch/api/response/response-stream-disturbed-2.any.js
+++ b/fetch/api/response/response-stream-disturbed-2.any.js
@@ -1,33 +1,35 @@
 // META: global=window,worker
 // META: title=Consuming Response body after getting a ReadableStream
+// META: script=./response-stream-disturbed-util.js
 
-function createResponseWithLockedReadableStream(callback) {
-    return fetch("../resources/data.json").then(function(response) {
-        var reader = response.body.getReader();
-        return callback(response);
-    });
+async function createResponseWithLockedReadableStream(bodySource, callback) {
+  const response = await responseFromBodySource(bodySource);
+    response.body.getReader();
+    return callback(response);
 }
 
-promise_test(function(test) {
-    return createResponseWithLockedReadableStream(function(response) {
-        return promise_rejects_js(test, TypeError, response.blob());
-    });
-}, "Getting blob after getting a locked Response body");
+for (const bodySource of ["fetch", "stream", "string"]) {
+    promise_test(function(test) {
+        return createResponseWithLockedReadableStream(bodySource, function(response) {
+            return promise_rejects_js(test, TypeError, response.blob());
+        });
+    }, `Getting blob after getting a locked Response body (body source: ${bodySource})`);
 
-promise_test(function(test) {
-    return createResponseWithLockedReadableStream(function(response) {
-        return promise_rejects_js(test, TypeError, response.text());
-    });
-}, "Getting text after getting a locked Response body");
+    promise_test(function(test) {
+        return createResponseWithLockedReadableStream(bodySource, function(response) {
+            return promise_rejects_js(test, TypeError, response.text());
+        });
+    }, `Getting text after getting a locked Response body (body source: ${bodySource})`);
 
-promise_test(function(test) {
-    return createResponseWithLockedReadableStream(function(response) {
-        return promise_rejects_js(test, TypeError, response.json());
-    });
-}, "Getting json after getting a locked Response body");
+    promise_test(function(test) {
+        return createResponseWithLockedReadableStream(bodySource, function(response) {
+            return promise_rejects_js(test, TypeError, response.json());
+        });
+    }, `Getting json after getting a locked Response body (body source: ${bodySource})`);
 
-promise_test(function(test) {
-    return createResponseWithLockedReadableStream(function(response) {
-        return promise_rejects_js(test, TypeError, response.arrayBuffer());
-    });
-}, "Getting arrayBuffer after getting a locked Response body");
+    promise_test(function(test) {
+        return createResponseWithLockedReadableStream(bodySource, function(response) {
+            return promise_rejects_js(test, TypeError, response.arrayBuffer());
+        });
+    }, `Getting arrayBuffer after getting a locked Response body (body source: ${bodySource})`);
+}

--- a/fetch/api/response/response-stream-disturbed-3.any.js
+++ b/fetch/api/response/response-stream-disturbed-3.any.js
@@ -1,34 +1,36 @@
 // META: global=window,worker
 // META: title=Consuming Response body after getting a ReadableStream
+// META: script=./response-stream-disturbed-util.js
 
-function createResponseWithDisturbedReadableStream(callback) {
-    return fetch("../resources/data.json").then(function(response) {
-        var reader = response.body.getReader();
-        reader.read();
-        return callback(response);
-    });
+async function createResponseWithDisturbedReadableStream(bodySource, callback) {
+  const response = await responseFromBodySource(bodySource);
+    const reader = response.body.getReader();
+    reader.read();
+    return callback(response);
 }
 
-promise_test(function(test) {
-    return createResponseWithDisturbedReadableStream(function(response) {
-        return promise_rejects_js(test, TypeError, response.blob());
-    });
-}, "Getting blob after reading the Response body");
+for (const bodySource of ["fetch", "stream", "string"]) {
+    promise_test(function(test) {
+        return createResponseWithDisturbedReadableStream(bodySource, function(response) {
+            return promise_rejects_js(test, TypeError, response.blob());
+        });
+    }, `Getting blob after reading the Response body (body source: ${bodySource})`);
 
-promise_test(function(test) {
-    return createResponseWithDisturbedReadableStream(function(response) {
-        return promise_rejects_js(test, TypeError, response.text());
-    });
-}, "Getting text after reading the Response body");
+    promise_test(function(test) {
+        return createResponseWithDisturbedReadableStream(bodySource, function(response) {
+            return promise_rejects_js(test, TypeError, response.text());
+        });
+    }, `Getting text after reading the Response body (body source: ${bodySource})`);
 
-promise_test(function(test) {
-    return createResponseWithDisturbedReadableStream(function(response) {
-        return promise_rejects_js(test, TypeError, response.json());
-    });
-}, "Getting json after reading the Response body");
+    promise_test(function(test) {
+        return createResponseWithDisturbedReadableStream(bodySource, function(response) {
+            return promise_rejects_js(test, TypeError, response.json());
+        });
+    }, `Getting json after reading the Response body (body source: ${bodySource})`);
 
-promise_test(function(test) {
-    return createResponseWithDisturbedReadableStream(function(response) {
-        return promise_rejects_js(test, TypeError, response.arrayBuffer());
-    });
-}, "Getting arrayBuffer after reading the Response body");
+    promise_test(function(test) {
+        return createResponseWithDisturbedReadableStream(bodySource, function(response) {
+            return promise_rejects_js(test, TypeError, response.arrayBuffer());
+        });
+    }, `Getting arrayBuffer after reading the Response body (body source: ${bodySource})`);
+}

--- a/fetch/api/response/response-stream-disturbed-4.any.js
+++ b/fetch/api/response/response-stream-disturbed-4.any.js
@@ -1,33 +1,35 @@
 // META: global=window,worker
 // META: title=Consuming Response body after getting a ReadableStream
+// META: script=./response-stream-disturbed-util.js
 
-function createResponseWithCancelledReadableStream(callback) {
-    return fetch("../resources/data.json").then(function(response) {
-        response.body.cancel();
-        return callback(response);
-    });
+async function createResponseWithCancelledReadableStream(bodySource, callback) {
+  const response = await responseFromBodySource(bodySource);
+    response.body.cancel();
+    return callback(response);
 }
 
-promise_test(function(test) {
-    return createResponseWithCancelledReadableStream(function(response) {
-        return promise_rejects_js(test, TypeError, response.blob());
-    });
-}, "Getting blob after cancelling the Response body");
+for (const bodySource of ["fetch", "stream", "string"]) {
+    promise_test(function(test) {
+        return createResponseWithCancelledReadableStream(bodySource, function(response) {
+            return promise_rejects_js(test, TypeError, response.blob());
+        });
+    }, `Getting blob after cancelling the Response body (body source: ${bodySource})`);
 
-promise_test(function(test) {
-    return createResponseWithCancelledReadableStream(function(response) {
-        return promise_rejects_js(test, TypeError, response.text());
-    });
-}, "Getting text after cancelling the Response body");
+    promise_test(function(test) {
+        return createResponseWithCancelledReadableStream(bodySource, function(response) {
+            return promise_rejects_js(test, TypeError, response.text());
+        });
+    }, `Getting text after cancelling the Response body (body source: ${bodySource})`);
 
-promise_test(function(test) {
-    return createResponseWithCancelledReadableStream(function(response) {
-        return promise_rejects_js(test, TypeError, response.json());
-    });
-}, "Getting json after cancelling the Response body");
+    promise_test(function(test) {
+        return createResponseWithCancelledReadableStream(bodySource, function(response) {
+            return promise_rejects_js(test, TypeError, response.json());
+        });
+    }, `Getting json after cancelling the Response body (body source: ${bodySource})`);
 
-promise_test(function(test) {
-    return createResponseWithCancelledReadableStream(function(response) {
-        return promise_rejects_js(test, TypeError, response.arrayBuffer());
-    });
-}, "Getting arrayBuffer after cancelling the Response body");
+    promise_test(function(test) {
+        return createResponseWithCancelledReadableStream(bodySource, function(response) {
+            return promise_rejects_js(test, TypeError, response.arrayBuffer());
+        });
+    }, `Getting arrayBuffer after cancelling the Response body (body source: ${bodySource})`);
+}

--- a/fetch/api/response/response-stream-disturbed-5.any.js
+++ b/fetch/api/response/response-stream-disturbed-5.any.js
@@ -1,34 +1,19 @@
 // META: global=window,worker
 // META: title=Consuming Response body after getting a ReadableStream
+// META: script=./response-stream-disturbed-util.js
 
-promise_test(function() {
-    return fetch("../resources/data.json").then(function(response) {
-        response.blob();
+for (const bodySource of ["fetch", "stream", "string"]) {
+  for (const consumeAs of ["blob", "text", "json", "arrayBuffer"]) {
+    promise_test(
+      async () => {
+        const response = await responseFromBodySource(bodySource);
+        response[consumeAs]();
         assert_not_equals(response.body, null);
-        assert_throws_js(TypeError, function() { response.body.getReader(); });
-    });
-}, "Getting a body reader after consuming as blob");
-
-promise_test(function() {
-    return fetch("../resources/data.json").then(function(response) {
-        response.text();
-        assert_not_equals(response.body, null);
-        assert_throws_js(TypeError, function() { response.body.getReader(); });
-    });
-}, "Getting a body reader after consuming as text");
-
-promise_test(function() {
-    return fetch("../resources/data.json").then(function(response) {
-        response.json();
-        assert_not_equals(response.body, null);
-        assert_throws_js(TypeError, function() { response.body.getReader(); });
-    });
-}, "Getting a body reader after consuming as json");
-
-promise_test(function() {
-    return fetch("../resources/data.json").then(function(response) {
-        response.arrayBuffer();
-        assert_not_equals(response.body, null);
-        assert_throws_js(TypeError, function() { response.body.getReader(); });
-    });
-}, "Getting a body reader after consuming as arrayBuffer");
+        assert_throws_js(TypeError, function () {
+          response.body.getReader();
+        });
+      },
+      `Getting a body reader after consuming as ${consumeAs} (body source: ${bodySource})`,
+    );
+  }
+}

--- a/fetch/api/response/response-stream-disturbed-util.js
+++ b/fetch/api/response/response-stream-disturbed-util.js
@@ -1,0 +1,17 @@
+const BODY = '{"key": "value"}';
+
+function responseFromBodySource(bodySource) {
+  if (bodySource === "fetch") {
+    return fetch("../resources/data.json");
+  } else if (bodySource === "stream") {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(BODY));
+        controller.close();
+      },
+    });
+    return new Response(stream);
+  } else {
+    return new Response(BODY);
+  }
+}


### PR DESCRIPTION
Deno's internal implementation of `Request` and `Response` bodies depends on their source – whether they were created from a stream or from a string or byte sequence. Deno passes the current tests that use `Response`s returned from the `fetch` API, but it would fail with `Response`s created from a string (denoland/deno#11211).