### PR TITLE
Add tests for QueuingStrategy size function prototype, constructibility

### DIFF
--- a/streams/queuing-strategies.any.js
+++ b/streams/queuing-strategies.any.js
@@ -80,12 +80,17 @@ for (const QueuingStrategy of [CountQueuingStrategy, ByteLengthQueuingStrategy])
     const size = new QueuingStrategy({ highWaterMark: 5 }).size;
     assert_false('prototype' in size);
   }, `${QueuingStrategy.name}: size should not have a prototype property`);
-
-  test(() => {
-    const size = new QueuingStrategy({ highWaterMark: 5 }).size;
-    assert_throws_js(TypeError, () => new size());
-  }, `${QueuingStrategy.name}: size should not be a constructor`);
 }
+
+test(() => {
+  const size = new CountQueuingStrategy({ highWaterMark: 5 }).size;
+  assert_throws_js(TypeError, () => new size());
+}, `CountQueuingStrategy: size should not be a constructor`);
+
+test(() => {
+  const size = new ByteLengthQueuingStrategy({ highWaterMark: 5 }).size;
+  assert_throws_js(TypeError, () => new size({ byteLength: 1024 }));
+}, `ByteLengthQueuingStrategy: size should not be a constructor`);
 
 test(() => {
   const size = (new CountQueuingStrategy({ highWaterMark: 5 })).size;

--- a/streams/queuing-strategies.any.js
+++ b/streams/queuing-strategies.any.js
@@ -75,6 +75,16 @@ for (const QueuingStrategy of [CountQueuingStrategy, ByteLengthQueuingStrategy])
     assert_equals(sc.size(), 2, 'size() on the subclass should override the parent');
     assert_true(sc.subClassMethod(), 'subClassMethod() should work');
   }, `${QueuingStrategy.name}: subclassing should work correctly`);
+
+  test(() => {
+    const size = new QueuingStrategy({ highWaterMark: 5 }).size;
+    assert_false('prototype' in size);
+  }, `${QueuingStrategy.name}: size should not have a prototype property`);
+
+  test(() => {
+    const size = new QueuingStrategy({ highWaterMark: 5 }).size;
+    assert_throws_js(TypeError, () => new size());
+  }, `${QueuingStrategy.name}: size should not be a constructor`);
 }
 
 test(() => {


### PR DESCRIPTION
Adds four test cases asserting that the `size` functions associated with `streams`' `ByteLengthQueuingStrategy` and `CountQueuingStrategy` functions do not have `prototype` properties and cannot be constructed.

PR requested by @ricea in https://github.com/whatwg/streams/pull/1142#issuecomment-872005574.

I believe this to be spec-required and major-implementation-compliant:

> ```js
> new ByteLengthQueuingStrategy({ highWaterMark: 100 }).size.prototype
> ```
>
> gives undefined in Chrome and Firefox. The Streams spec calls CreateBuiltinFunction without calling MakeConstructor, which is the abstract op that adds the `prototype` property. So it would appear that we should in fact use arrow functions after all
>
> _Originally posted by @TimothyGu in https://github.com/jsdom/jsdom/pull/3200#discussion_r661008480_