### PR TITLE
Test other form of explicit stretching

### DIFF
--- a/css/css-sizing/aspect-ratio/grid-aspect-ratio-018.html
+++ b/css/css-sizing/aspect-ratio/grid-aspect-ratio-018.html
@@ -17,6 +17,9 @@
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 
 <div id="reference-overlapped-red"></div>
-<div style="display: grid; grid-template-columns: 100px; grid-template-rows: 100px;">
-  <div style="height: 100px; aspect-ratio: 1/2; justify-self: stretch; background: green;"></div>
+<div style="display: grid; grid-template-columns: 100px; grid-template-rows: 50px;">
+  <div style="height: 50px; aspect-ratio: 1/2; justify-self: stretch; background: green;"></div>
+</div>
+<div style="display: grid; grid-template-columns: 100px; grid-template-rows: 50px;justify-items: stretch">
+  <div style="height: 50px; aspect-ratio: 1/2; justify-self: auto; background: green;"></div>
 </div>

--- a/css/css-sizing/aspect-ratio/grid-aspect-ratio-019.html
+++ b/css/css-sizing/aspect-ratio/grid-aspect-ratio-019.html
@@ -17,6 +17,9 @@
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 
 <div id="reference-overlapped-red"></div>
-<div style="display: grid; grid-template-columns: 100px; grid-template-rows: 100px;">
+<div style="display: grid; grid-template-columns: 100px; grid-template-rows: 50px;">
   <div style="width: 100px; aspect-ratio: 2/1; align-self: stretch; background: green;"></div>
+</div>
+<div style="display: grid; grid-template-columns: 100px; grid-template-rows: 50px; align-items: stretch">
+  <div style="width: 100px; aspect-ratio: 2/1; align-self: auto; background: green;"></div>
 </div>


### PR DESCRIPTION
Grid item sizing can be done explicitly using align-items:stretch/justify-items: stretch as long as align-self:auto/justify-self:auto are used on the items, so add tests to verify it has the same result as using align-self:stretch/justify-self:stretch.