### PR TITLE
Make OffscreenCanvas extraargs test the same as the DOM canvas equivalent

### DIFF
--- a/html/canvas/offscreen/the-offscreen-canvas/2d.getcontext.extraargs.html
+++ b/html/canvas/offscreen/the-offscreen-canvas/2d.getcontext.extraargs.html
@@ -20,13 +20,12 @@ t.step(function() {
 var offscreenCanvas = new OffscreenCanvas(100, 50);
 var ctx = offscreenCanvas.getContext('2d');
 
-var offscreenCanvas2 = new OffscreenCanvas(100, 50);
-_assertDifferent(offscreenCanvas2.getContext('2d', false, {}, [], 1, "2"), null, "offscreenCanvas2.getContext('2d', false, {}, [], 1, \"2\")", "null");
-_assertDifferent(offscreenCanvas2.getContext('2d', 123), null, "offscreenCanvas2.getContext('2d', 123)", "null");
-_assertDifferent(offscreenCanvas2.getContext('2d', "test"), null, "offscreenCanvas2.getContext('2d', \"test\")", "null");
-_assertDifferent(offscreenCanvas2.getContext('2d', undefined), null, "offscreenCanvas2.getContext('2d', undefined)", "null");
-_assertDifferent(offscreenCanvas2.getContext('2d', null), null, "offscreenCanvas2.getContext('2d', null)", "null");
-_assertDifferent(offscreenCanvas2.getContext('2d', Symbol.hasInstance), null, "offscreenCanvas2.getContext('2d', Symbol.hasInstance)", "null");
+_assertDifferent(offscreenCanvas.getContext('2d', false, {}, [], 1, "2"), null, "offscreenCanvas.getContext('2d', false, {}, [], 1, \"2\")", "null");
+_assertDifferent(offscreenCanvas.getContext('2d', 123), null, "offscreenCanvas.getContext('2d', 123)", "null");
+_assertDifferent(offscreenCanvas.getContext('2d', "test"), null, "offscreenCanvas.getContext('2d', \"test\")", "null");
+_assertDifferent(offscreenCanvas.getContext('2d', undefined), null, "offscreenCanvas.getContext('2d', undefined)", "null");
+_assertDifferent(offscreenCanvas.getContext('2d', null), null, "offscreenCanvas.getContext('2d', null)", "null");
+_assertDifferent(offscreenCanvas.getContext('2d', Symbol.hasInstance), null, "offscreenCanvas.getContext('2d', Symbol.hasInstance)", "null");
 t.done();
 
 });

--- a/html/canvas/offscreen/the-offscreen-canvas/2d.getcontext.extraargs.worker.js
+++ b/html/canvas/offscreen/the-offscreen-canvas/2d.getcontext.extraargs.worker.js
@@ -16,13 +16,12 @@ t.step(function() {
 var offscreenCanvas = new OffscreenCanvas(100, 50);
 var ctx = offscreenCanvas.getContext('2d');
 
-var offscreenCanvas2 = new OffscreenCanvas(100, 50);
-_assertDifferent(offscreenCanvas2.getContext('2d', false, {}, [], 1, "2"), null, "offscreenCanvas2.getContext('2d', false, {}, [], 1, \"2\")", "null");
-_assertDifferent(offscreenCanvas2.getContext('2d', 123), null, "offscreenCanvas2.getContext('2d', 123)", "null");
-_assertDifferent(offscreenCanvas2.getContext('2d', "test"), null, "offscreenCanvas2.getContext('2d', \"test\")", "null");
-_assertDifferent(offscreenCanvas2.getContext('2d', undefined), null, "offscreenCanvas2.getContext('2d', undefined)", "null");
-_assertDifferent(offscreenCanvas2.getContext('2d', null), null, "offscreenCanvas2.getContext('2d', null)", "null");
-_assertDifferent(offscreenCanvas2.getContext('2d', Symbol.hasInstance), null, "offscreenCanvas2.getContext('2d', Symbol.hasInstance)", "null");
+_assertDifferent(offscreenCanvas.getContext('2d', false, {}, [], 1, "2"), null, "offscreenCanvas.getContext('2d', false, {}, [], 1, \"2\")", "null");
+_assertDifferent(offscreenCanvas.getContext('2d', 123), null, "offscreenCanvas.getContext('2d', 123)", "null");
+_assertDifferent(offscreenCanvas.getContext('2d', "test"), null, "offscreenCanvas.getContext('2d', \"test\")", "null");
+_assertDifferent(offscreenCanvas.getContext('2d', undefined), null, "offscreenCanvas.getContext('2d', undefined)", "null");
+_assertDifferent(offscreenCanvas.getContext('2d', null), null, "offscreenCanvas.getContext('2d', null)", "null");
+_assertDifferent(offscreenCanvas.getContext('2d', Symbol.hasInstance), null, "offscreenCanvas.getContext('2d', Symbol.hasInstance)", "null");
 t.done();
 
 });

--- a/html/canvas/tools/yaml/offscreen/the-offscreen-canvas.yaml
+++ b/html/canvas/tools/yaml/offscreen/the-offscreen-canvas.yaml
@@ -32,13 +32,12 @@
   testing:
   - context.2d.extraargs
   code: |
-    var offscreenCanvas2 = new OffscreenCanvas(100, 50);
-    @assert offscreenCanvas2.getContext('2d', false, {}, [], 1, "2") !== null;
-    @assert offscreenCanvas2.getContext('2d', 123) !== null;
-    @assert offscreenCanvas2.getContext('2d', "test") !== null;
-    @assert offscreenCanvas2.getContext('2d', undefined) !== null;
-    @assert offscreenCanvas2.getContext('2d', null) !== null;
-    @assert offscreenCanvas2.getContext('2d', Symbol.hasInstance) !== null;
+    @assert offscreenCanvas.getContext('2d', false, {}, [], 1, "2") !== null;
+    @assert offscreenCanvas.getContext('2d', 123) !== null;
+    @assert offscreenCanvas.getContext('2d', "test") !== null;
+    @assert offscreenCanvas.getContext('2d', undefined) !== null;
+    @assert offscreenCanvas.getContext('2d', null) !== null;
+    @assert offscreenCanvas.getContext('2d', Symbol.hasInstance) !== null;
     t.done();
 
 - name: 2d.getcontext.unique


### PR DESCRIPTION
This OffscreenCanvas test current fails as converting arguments to CanvasRenderingContext2DSettings can throw an Exception, as detailed here: https://html.spec.whatwg.org/multipage/canvas.html#offscreen-2d-context-creation-algorithm

Modify this test to test that extra arguments are ignored *in the situation that a same-typed context already exists*, which is the same as the equivalent DOM canvas test.