### PR TITLE
[css-ui] Added "checked" to accent-color test

### DIFF
--- a/css/css-ui/accent-color-visited-ref.html
+++ b/css/css-ui/accent-color-visited-ref.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <a href="">
-  <input type=checkbox>
+  <input type=checkbox checked>
 </a>

--- a/css/css-ui/accent-color-visited.tentative.html
+++ b/css/css-ui/accent-color-visited.tentative.html
@@ -11,5 +11,5 @@
 }
 </style>
 <a href="">
-  <input type=checkbox>
+  <input type=checkbox checked>
 </a>


### PR DESCRIPTION
This test was comparing an unchecked checkbox
but you usually don't see the accent-color in that case.
This patch just marks it as "checked" so if accent-color applies
we'll see some difference.