### PR TITLE
[AspectRatio] Fix select-element-001.html

### DIFF
--- a/css/css-sizing/aspect-ratio/select-element-001-ref.html
+++ b/css/css-sizing/aspect-ratio/select-element-001-ref.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
 <title>CSS aspect-ratio reference: select elements</title>
+<!-- WebKit uses quirky em in user agent sheet for margins of select, avoid it -->
+<style>
+  select {
+    margin: 0px;
+  }
+</style>
 <select style="height: 50px; width: 50px; background: green;">
   <option value=""></option>
 </select>

--- a/css/css-sizing/aspect-ratio/select-element-001.html
+++ b/css/css-sizing/aspect-ratio/select-element-001.html
@@ -3,6 +3,12 @@
 <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
 <link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">
 <link rel="match" href="select-element-001-ref.html">
+<!-- WebKit uses quirky em in user agent sheet for margins of select, avoid it -->
+<style>
+  select {
+    margin: 0px;
+  }
+</style>
 
 <!-- Sanity Check - aspect-ratio should be applied on the select element -->
 <select style="height: 50px; aspect-ratio: 1/1; background: green;">


### PR DESCRIPTION
WebKit has the concept of quirky em's which apply to
select elements among other things. In the user agent
stylesheet they are set to apply margin's based on
width/height values but does not take aspect ratio into
account. To avoid the resulting mismatch make sure
margins are set to 0px.