### PR TITLE
cross-origin-opener-policy/resource-popup.https.html makes incorrect …

### DIFF
--- a/html/cross-origin-opener-policy/resources/resource-popup.html
+++ b/html/cross-origin-opener-policy/resources/resource-popup.html
@@ -13,7 +13,7 @@ bc.onmessage = () => {
   close();
 };
 const id = setInterval(() => {
-  if (win.location.href !== 'about:blank') {
+  if (win.closed || win.location.href !== 'about:blank') {
     clearInterval(id);
     bc.postMessage({name: win.name || null, closed: win.closed});
   }


### PR DESCRIPTION
…assumption about win.location.href

The test expects that win.location.href starts returning something else than "about:blank" after closing.
While this is true in Firefox and Blink, none of the browser engines actually agree on this (Firefox
returns the empty string, Chrome returns undefined and Safari returns "about:blank").

Per the specification, it seems returning "about:blank" after a window is closed is the expected behavior,
see https://github.com/whatwg/html/issues/6899. I am fixing thus fixing the test so that it can run in
all browsers by checking if "the window is closed" OR "href is no longer about:blank because it was
navigated".