### PR TITLE
[css-text] Fix ID and PR rules.

### DIFF
--- a/css/css-text/i18n/other-lang/css-text-line-break-de-pr-loose.html
+++ b/css/css-text/i18n/other-lang/css-text-line-break-de-pr-loose.html
@@ -7,7 +7,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="When the language is neither Japanese nor Chinese, and line-break:loose, a browser wll NOT allow a break before a PR character with East Asian Width of A, F, or W.">
+<meta name="assert" content="When the language is neither Japanese nor Chinese, and line-break:loose, a browser wll allow a break before a PR character with East Asian Width of A, F, or W.">
 <style type="text/css">
 @font-face {
     font-family: 'mplus-1p-regular';
@@ -40,10 +40,10 @@ for (var i=0;i<lines.length;i++) {
 	var firstSpace = lines[i].indexOf(' ')
 	var hex = lines[i].substr(0,firstSpace)
 	var name = lines[i].substr(firstSpace)
-	// make a test
+	// make a test (ID ÷ PR × ID)
 	out +=  '<div class="wrapper"><div>'+hex+'</div>' +
 	'<div class="test" id="test'+i+'" lang="de">文文文文文文&#x'+hex+';字<span id="testSpan'+i+'">字</span></div>' +
-	 '<div class="ref" id="ref'+i+'" lang="de">文文文文文<br/>文&#x'+hex+';字<span id="refSpan'+i+'">字</span></div>' +
+	 '<div class="ref" id="ref'+i+'" lang="de">文文文文文文<br/>&#x'+hex+';字<span id="refSpan'+i+'">字</span></div>' +
 	 '</div>'
 	}
 function spansNearEnough(counter) {
@@ -60,7 +60,7 @@ function validate() {
   for (i=0;i<lines.length;i++) {
     test(function() {
       assert_true(spansNearEnough(i));
-    }, lines[i]+' may NOT appear at line start if de and loose');
+    }, lines[i]+' may appear at line start if de and loose');
     // Hide successful tests.
     if (spansNearEnough(i)) document.getElementById('test'+i).parentNode.style.display = 'none'
   }

--- a/css/css-text/i18n/other-lang/css-text-line-break-de-pr-normal.html
+++ b/css/css-text/i18n/other-lang/css-text-line-break-de-pr-normal.html
@@ -7,7 +7,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="When the language is neither Japanese nor Chinese, and line-break:normal, a browser will NOT allow a break before a PR character with East Asian Width of A, F, or W.">
+<meta name="assert" content="When the language is neither Japanese nor Chinese, and line-break:normal, a browser will allow a break before a PR character with East Asian Width of A, F, or W.">
 <style type="text/css">
 @font-face {
     font-family: 'mplus-1p-regular';
@@ -40,10 +40,10 @@ for (var i=0;i<lines.length;i++) {
 	var firstSpace = lines[i].indexOf(' ')
 	var hex = lines[i].substr(0,firstSpace)
 	var name = lines[i].substr(firstSpace)
-	// make a test
+	// make a test (ID ÷ PR × ID)
 	out +=  '<div class="wrapper"><div>'+hex+'</div>' +
 	'<div class="test" id="test'+i+'" lang="de">文文文文文文&#x'+hex+';字<span id="testSpan'+i+'">字</span></div>' +
-	 '<div class="ref" id="ref'+i+'" lang="de">文文文文文<br/>文&#x'+hex+';字<span id="refSpan'+i+'">字</span></div>' +
+	 '<div class="ref" id="ref'+i+'" lang="de">文文文文文文<br/>&#x'+hex+';字<span id="refSpan'+i+'">字</span></div>' +
 	 '</div>'
 	}
 function spansNearEnough(counter) {
@@ -60,7 +60,7 @@ function validate() {
   for (i=0;i<lines.length;i++) {
     test(function() {
       assert_true(spansNearEnough(i));
-    }, lines[i]+' may NOT appear at line start if de and normal');
+    }, lines[i]+' may appear at line start if de and normal');
     // Hide successful tests.
     if (spansNearEnough(i)) document.getElementById('test'+i).parentNode.style.display = 'none'
   }

--- a/css/css-text/i18n/other-lang/css-text-line-break-de-pr-strict.html
+++ b/css/css-text/i18n/other-lang/css-text-line-break-de-pr-strict.html
@@ -7,7 +7,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="When the language is neither Japanese nor Chinese, and line-break:strict, a browser will NOT allow a break before a PR character with East Asian Width of A, F, or W.">
+<meta name="assert" content="When the language is neither Japanese nor Chinese, and line-break:strict, a browser will allow a break before a PR character with East Asian Width of A, F, or W.">
 <style type="text/css">
 @font-face {
     font-family: 'mplus-1p-regular';
@@ -40,10 +40,10 @@ for (var i=0;i<lines.length;i++) {
 	var firstSpace = lines[i].indexOf(' ')
 	var hex = lines[i].substr(0,firstSpace)
 	var name = lines[i].substr(firstSpace)
-	// make a test
+	// make a test (ID ÷ PR × ID)
 	out +=  '<div class="wrapper"><div>'+hex+'</div>' +
 	'<div class="test" id="test'+i+'" lang="de">文文文文文文&#x'+hex+';字<span id="testSpan'+i+'">字</span></div>' +
-	 '<div class="ref" id="ref'+i+'" lang="de">文文文文文<br/>文&#x'+hex+';字<span id="refSpan'+i+'">字</span></div>' +
+	 '<div class="ref" id="ref'+i+'" lang="de">文文文文文文<br/>&#x'+hex+';字<span id="refSpan'+i+'">字</span></div>' +
 	 '</div>'
 	}
 function spansNearEnough(counter) {
@@ -60,7 +60,7 @@ function validate() {
   for (i=0;i<lines.length;i++) {
     test(function() {
       assert_true(spansNearEnough(i));
-    }, lines[i]+' may NOT appear at line start if de and strict');
+    }, lines[i]+' may appear at line start if de and strict');
     // Hide successful tests.
     if (spansNearEnough(i)) document.getElementById('test'+i).parentNode.style.display = 'none'
   }

--- a/css/css-text/i18n/unknown-lang/css-text-line-break-pr-loose.html
+++ b/css/css-text/i18n/unknown-lang/css-text-line-break-pr-loose.html
@@ -7,7 +7,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="When the language is unknown, and line-break:loose, a browser will NOT allow a break before a PR character with East Asian Width of A, F, or W.">
+<meta name="assert" content="When the language is unknown, and line-break:loose, a browser will allow a break before a PR character with East Asian Width of A, F, or W.">
 <style type="text/css">
 @font-face {
     font-family: 'mplus-1p-regular';
@@ -40,10 +40,10 @@ for (var i=0;i<lines.length;i++) {
 	var firstSpace = lines[i].indexOf(' ')
 	var hex = lines[i].substr(0,firstSpace)
 	var name = lines[i].substr(firstSpace)
-	// make a test
+	// make a test (ID ÷ PR × ID)
 	out +=  '<div class="wrapper"><div>'+hex+'</div>' +
 	'<div class="test" id="test'+i+'" lang="">文文文文文文&#x'+hex+';字<span id="testSpan'+i+'">字</span></div>' +
-	 '<div class="ref" id="ref'+i+'" lang="">文文文文文<br/>文&#x'+hex+';字<span id="refSpan'+i+'">字</span></div>' +
+	 '<div class="ref" id="ref'+i+'" lang="">文文文文文文<br/>&#x'+hex+';字<span id="refSpan'+i+'">字</span></div>' +
 	 '</div>'
 	}
 function spansNearEnough(counter) {
@@ -60,7 +60,7 @@ function validate() {
   for (i=0;i<lines.length;i++) {
     test(function() {
       assert_true(spansNearEnough(i));
-    }, lines[i]+' may NOT appear at line start if loose');
+    }, lines[i]+' may appear at line start if loose');
     // Hide successful tests.
     if (spansNearEnough(i)) document.getElementById('test'+i).parentNode.style.display = 'none'
   }

--- a/css/css-text/i18n/unknown-lang/css-text-line-break-pr-normal.html
+++ b/css/css-text/i18n/unknown-lang/css-text-line-break-pr-normal.html
@@ -7,7 +7,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="When the language is unkonwn, and line-break:normal, a browser will NOT allow a break before a PR character with East Asian Width of A, F, or W.">
+<meta name="assert" content="When the language is unkonwn, and line-break:normal, a browser will allow a break before a PR character with East Asian Width of A, F, or W.">
 <style type="text/css">
 @font-face {
     font-family: 'mplus-1p-regular';
@@ -40,10 +40,10 @@ for (var i=0;i<lines.length;i++) {
 	var firstSpace = lines[i].indexOf(' ')
 	var hex = lines[i].substr(0,firstSpace)
 	var name = lines[i].substr(firstSpace)
-	// make a test
+	// make a test (ID ÷ PR × ID)
 	out +=  '<div class="wrapper"><div>'+hex+'</div>' +
 	'<div class="test" id="test'+i+'" lang="">文文文文文文&#x'+hex+';字<span id="testSpan'+i+'">字</span></div>' +
-	 '<div class="ref" id="ref'+i+'" lang="">文文文文文<br/>文&#x'+hex+';字<span id="refSpan'+i+'">字</span></div>' +
+	 '<div class="ref" id="ref'+i+'" lang="">文文文文文文<br/>&#x'+hex+';字<span id="refSpan'+i+'">字</span></div>' +
 	 '</div>'
 	}
 function spansNearEnough(counter) {
@@ -60,7 +60,7 @@ function validate() {
   for (i=0;i<lines.length;i++) {
     test(function() {
       assert_true(spansNearEnough(i));
-    }, lines[i]+' may NOT appear at line start if normal');
+    }, lines[i]+' may appear at line start if normal');
     // Hide successful tests.
     if (spansNearEnough(i)) document.getElementById('test'+i).parentNode.style.display = 'none'
   }

--- a/css/css-text/i18n/unknown-lang/css-text-line-break-pr-strict.html
+++ b/css/css-text/i18n/unknown-lang/css-text-line-break-pr-strict.html
@@ -7,7 +7,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="When the language is unknown, and line-break:strict, a browser will NOT allow a break before a PR character with East Asian Width of A, F, or W.">
+<meta name="assert" content="When the language is unknown, and line-break:strict, a browser will allow a break before a PR character with East Asian Width of A, F, or W.">
 <style type="text/css">
 @font-face {
     font-family: 'mplus-1p-regular';
@@ -40,10 +40,10 @@ for (var i=0;i<lines.length;i++) {
 	var firstSpace = lines[i].indexOf(' ')
 	var hex = lines[i].substr(0,firstSpace)
 	var name = lines[i].substr(firstSpace)
-	// make a test
+	// make a test (ID ÷ PR × ID)
 	out +=  '<div class="wrapper"><div>'+hex+'</div>' +
 	'<div class="test" id="test'+i+'" lang="">文文文文文文&#x'+hex+';字<span id="testSpan'+i+'">字</span></div>' +
-	 '<div class="ref" id="ref'+i+'" lang="">文文文文文<br/>文&#x'+hex+';字<span id="refSpan'+i+'">字</span></div>' +
+	 '<div class="ref" id="ref'+i+'" lang="">文文文文文文<br/>&#x'+hex+';字<span id="refSpan'+i+'">字</span></div>' +
 	 '</div>'
 	}
 function spansNearEnough(counter) {
@@ -60,7 +60,7 @@ function validate() {
   for (i=0;i<lines.length;i++) {
     test(function() {
       assert_true(spansNearEnough(i));
-    }, lines[i]+' may NOT appear at line start if strict');
+    }, lines[i]+' may appear at line start if strict');
     // Hide successful tests.
     if (spansNearEnough(i)) document.getElementById('test'+i).parentNode.style.display = 'none'
   }


### PR DESCRIPTION
css-text-line-break-*-pr-*.html tests seems to be break opportunity tests for
PR and ID. But according to UAX #14, This rules are `ID ÷ PR × ID`. So these
are incorrect.