### PR TITLE
Add support for rerunning testharness(+testdriver) tests

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -3413,7 +3413,12 @@
                                                 ["span", {"class":status_class(status)},
                                                  status
                                                 ],
-                                               ]
+                                               ],
+                                               ["button",
+                                                {"onclick": "let evt = new Event('__test_restart'); " +
+                                                 "let run_default = window.dispatchEvent(evt);" +
+                                                 "if (run_default) { location.reload() }"},
+                                                "Rerun"]
                                               ]];
 
                                     if (harness_status.status === harness_status.ERROR) {

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -3416,8 +3416,8 @@
                                                ],
                                                ["button",
                                                 {"onclick": "let evt = new Event('__test_restart'); " +
-                                                 "let run_default = window.dispatchEvent(evt);" +
-                                                 "if (run_default) { location.reload() }"},
+                                                 "let canceled = !window.dispatchEvent(evt);" +
+                                                 "if (!canceled) { location.reload() }"},
                                                 "Rerun"]
                                               ]];
 

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -347,7 +347,7 @@ class TestExecutor(object):
         return test.result_cls(status, message), []
 
     def wait(self):
-        self.protocol.base.wait()
+        return self.protocol.base.wait()
 
 
 class TestharnessExecutor(TestExecutor):
@@ -700,7 +700,7 @@ class ConnectionlessBaseProtocolPart(BaseProtocolPart):
         pass
 
     def wait(self):
-        pass
+        return False
 
     def set_window(self, handle):
         pass

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -118,7 +118,8 @@ class MarionetteBaseProtocolPart(BaseProtocolPart):
 
         while True:
             try:
-                self.marionette.execute_async_script("")
+                return self.marionette.execute_async_script("""let callback = arguments[arguments.length - 1];
+addEventListener("__test_restart", e => {e.preventDefault(); callback(true)})""")
             except errors.NoSuchWindowException:
                 # The window closed
                 break
@@ -135,6 +136,7 @@ class MarionetteBaseProtocolPart(BaseProtocolPart):
             except Exception:
                 self.logger.warning(traceback.format_exc())
                 break
+        return False
 
 
 class MarionetteTestharnessProtocolPart(TestharnessProtocolPart):

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -69,7 +69,8 @@ class SeleniumBaseProtocolPart(BaseProtocolPart):
     def wait(self):
         while True:
             try:
-                self.webdriver.execute_async_script("")
+                return self.webdriver.execute_async_script("""let callback = arguments[arguments.length - 1];
+addEventListener("__test_restart", e => {e.preventDefault(); callback(true)})""")
             except exceptions.TimeoutException:
                 pass
             except (socket.timeout, exceptions.NoSuchWindowException,
@@ -78,6 +79,7 @@ class SeleniumBaseProtocolPart(BaseProtocolPart):
             except Exception:
                 self.logger.error(traceback.format_exc())
                 break
+        return False
 
 
 class SeleniumTestharnessProtocolPart(TestharnessProtocolPart):

--- a/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -70,7 +70,7 @@ class ServoBaseProtocolPart(BaseProtocolPart):
         pass
 
     def wait(self):
-        pass
+        return False
 
     def set_window(self, handle):
         pass
@@ -123,7 +123,8 @@ class ServoWebDriverProtocol(Protocol):
     def wait(self):
         while True:
             try:
-                self.session.execute_async_script("")
+                return self.session.execute_async_script("""let callback = arguments[arguments.length - 1];
+addEventListener("__test_restart", e => {e.preventDefault(); callback(true)})""")
             except webdriver.TimeoutException:
                 pass
             except (socket.timeout, IOError):
@@ -131,6 +132,7 @@ class ServoWebDriverProtocol(Protocol):
             except Exception:
                 self.logger.error(traceback.format_exc())
                 break
+        return False
 
 
 class ServoWebDriverRun(TimedRunner):

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -70,6 +70,8 @@ class WebDriverBaseProtocolPart(BaseProtocolPart):
     def wait(self):
         while True:
             try:
+                self.webdriver.execute_async_script("""let callback = arguments[arguments.length - 1];
+addEventListener("__test_restart", e => {e.preventDefault(); callback(true)})""")
                 self.webdriver.execute_async_script("")
             except (error.TimeoutException,
                     error.ScriptTimeoutException,
@@ -86,6 +88,7 @@ class WebDriverBaseProtocolPart(BaseProtocolPart):
             except Exception:
                 self.logger.error(traceback.format_exc())
                 break
+        return False
 
 
 class WebDriverTestharnessProtocolPart(TestharnessProtocolPart):

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -129,7 +129,9 @@ class BaseProtocolPart(ProtocolPart):
 
     @abstractmethod
     def wait(self):
-        """Wait indefinitely for the browser to close"""
+        """Wait indefinitely for the browser to close.
+
+        :returns: True to re-run the test, or False to continue with the next test"""
         pass
 
     @property

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -114,8 +114,8 @@ class TestRunner(object):
             raise
 
     def wait(self):
-        self.executor.wait()
-        self.send_message("wait_finished")
+        rerun = self.executor.wait()
+        self.send_message("wait_finished", rerun)
 
     def send_message(self, command, *args):
         self.result_queue.put((command, args))
@@ -696,17 +696,20 @@ class TestRunnerManager(threading.Thread):
         else:
             return self.after_test_end(test, restart_before_next)
 
-    def wait_finished(self):
+    def wait_finished(self, rerun=False):
         assert isinstance(self.state, RunnerManagerState.running)
         self.logger.debug("Wait finished")
 
         # The browser should be stopped already, but this ensures we do any
         # post-stop processing
-        return self.after_test_end(self.state.test, True)
+        return self.after_test_end(self.state.test, not rerun, force_rerun=rerun)
 
-    def after_test_end(self, test, restart):
+    def after_test_end(self, test, restart, force_rerun=False):
         assert isinstance(self.state, RunnerManagerState.running)
-        if self.run_count == self.rerun:
+        # Mixing manual reruns and automatic reruns is confusing; we currently assume
+        # that as long as we've done at least the automatic run count in total we can
+        # continue with the next test.
+        if not force_rerun and self.run_count >= self.rerun:
             test, test_group, group_metadata = self.get_next_test()
             if test is None:
                 return RunnerManagerState.stop()


### PR DESCRIPTION
When running a test that uses testdriver using reload doesn't work,
because the testdriver parts won't rerun. This is annoying. To make
the development experience better, add a rerun button to testharness
tests. In the case where the test is being run directly from the
server, this just ends up calling window.reload(). In the case we're
running via wptrunner, it causes the test to be rerun from the start.

Implementation wise, this works by dispatching an event (currently
named `__test_restart`) from the rerun button. This can be caught by
the wait() implementation in executors, which now provide a return
value of True to rerun the test and False to continue with the next
test.

There is an edge case where the manual reruns are mixed with automatic
reruns specified on the command line. In practice it's not clear what
the use case is, but the behaviour as written is to ensure the test is
run at least as many times as specified on the command line, counting
manual reruns against that total.