### PR TITLE
[css-ruby] Tweaked block-ruby-005 test and reference

### DIFF
--- a/css/css-ruby/block-ruby-005-ref.html
+++ b/css/css-ruby/block-ruby-005-ref.html
@@ -5,14 +5,14 @@
   -->
 <html lang="ja">
 <meta charset="utf-8">
-<title>Reference: DIV append in 'display:ruby/block ruby'.</title>
+<title>CSS Reference File</title>
 <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <style>
 html,body {
-  color:black; background-color:white; font:10px/1 monospace; padding:0; margin:0;
+  font:10px/1 monospace;
 }
 
-rbb, ruby { background:lightblue; text-overflow:ellipses; }
+rbb, ruby { background:lightblue; text-overflow:ellipsis; overflow:hidden; }
 ruby { display: ruby; }
 rbb { display: block ruby; }
 grid { display: grid; }

--- a/css/css-ruby/block-ruby-005-ref.html
+++ b/css/css-ruby/block-ruby-005-ref.html
@@ -3,16 +3,16 @@
      Any copyright is dedicated to the Public Domain.
      http://creativecommons.org/publicdomain/zero/1.0/
   -->
-<html lang="ja">
+<html>
 <meta charset="utf-8">
 <title>CSS Reference File</title>
 <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <style>
-html,body {
+body {
   font:10px/1 monospace;
 }
 
-rbb, ruby { background:lightblue; text-overflow:ellipsis; overflow:hidden; }
+rbb, ruby { background:lightblue; }
 ruby { display: ruby; }
 rbb { display: block ruby; }
 grid { display: grid; }

--- a/css/css-ruby/block-ruby-005.html
+++ b/css/css-ruby/block-ruby-005.html
@@ -13,10 +13,10 @@
 <link rel="match" href="block-ruby-005-ref.html">
 <style>
 html,body {
-  color:black; background-color:white; font:10px/1 monospace; padding:0; margin:0;
+  font:10px/1 monospace;
 }
 
-rbb, ruby { background:lightblue; text-overflow:ellipses; overflow:hidden; width:3em; }
+rbb, ruby { background:lightblue; text-overflow:ellipsis; overflow:hidden; width:3em; }
 ruby { display: ruby; }
 rbb { display: block ruby; }
 grid { display: grid; }

--- a/css/css-ruby/block-ruby-005.html
+++ b/css/css-ruby/block-ruby-005.html
@@ -3,7 +3,7 @@
      Any copyright is dedicated to the Public Domain.
      http://creativecommons.org/publicdomain/zero/1.0/
   -->
-<html lang="ja">
+<html>
 <meta charset="utf-8">
 <title>CSS Ruby Test: DIV append in 'display:ruby/block ruby'.</title>
 <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
@@ -12,11 +12,11 @@
 <link rel="help" href="https://drafts.csswg.org/css-display-3/#inlinify">
 <link rel="match" href="block-ruby-005-ref.html">
 <style>
-html,body {
+body {
   font:10px/1 monospace;
 }
 
-rbb, ruby { background:lightblue; text-overflow:ellipsis; overflow:hidden; width:3em; }
+rbb, ruby { background:lightblue; overflow:hidden; width:3em; }
 ruby { display: ruby; }
 rbb { display: block ruby; }
 grid { display: grid; }


### PR DESCRIPTION
This is a followup to [Issue 29514](https://github.com/web-platform-tests/wpt/issues/29514)

I do not think that `overflow:hidden` at 
line 35: `x { display:block; width:3em; overflow:hidden; background:lightblue; }`
of block-ruby-005-ref.html is needed but I was not sure.