### PR TITLE
[css-ruby] Added rt-dynamically-appended-001 test

### DIFF
--- a/css/css-ruby/reference/rt-dynamically-appended-001-ref.html
+++ b/css/css-ruby/reference/rt-dynamically-appended-001-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference File</title>
+
+  <style>
+  body
+    {
+      font-size: 60px;
+    }
+
+  ruby
+    {
+      background-color: lightblue;
+    }
+  </style>
+
+  <ruby>bas<rt>T</rt>&nbsp;<rt>X</rt></ruby>

--- a/css/css-ruby/rt-dynamically-appended-001.html
+++ b/css/css-ruby/rt-dynamically-appended-001.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Ruby Test: rt element dynamically appended into a ruby container (basic)</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-ruby-1/#ruby-display">
+  <link rel="help" href="https://www.w3.org/TR/css-ruby-1/#box-fixup">
+  <link rel="match" href="reference/rt-dynamically-appended-001-ref.html">
+
+  <meta content="" name="flags">
+
+  <!--
+
+  This test was triggered by examination of
+  http://wpt.live/css/css-ruby/block-ruby-004.html
+
+  -->
+
+  <style>
+  body
+    {
+      font-size: 60px;
+    }
+
+  ruby
+    {
+      background-color: lightblue;
+      margin: 200px 0px;
+    }
+
+  /*
+  vertical margins should have *_no_* effect,
+  none whatsoever on a non-replaced inline element.
+  */
+  </style>
+
+  <rt id="to-append">X</rt>
+
+  <ruby id="receiver">bas<rt>T</rt></ruby>
+
+  <script>
+  /* We first create an initial reflow */
+  document.body.getClientRects();
+
+  document.getElementById("receiver").appendChild(document.getElementById("to-append"));
+
+  /* We now force a final reflow */
+  document.getElementById("receiver").offsetHeight;
+  </script>


### PR DESCRIPTION
On my website:

http://www.gtalbot.org/BrowserBugsSection/CSS3Ruby/rt-dynamically-appended-001.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Ruby/reference/rt-dynamically-appended-001-ref.html

The reference is more reliable, trustworthy to highlight incomplete or partial implementation of ruby spec. as the test fails in Chromium 94.