### PR TITLE
Close a worker test environment in the completion callback

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -312,6 +312,13 @@
                         status: harness_status.structured_clone(),
                         asserts: asserts.map(assert => assert.structured_clone()),
                     });
+
+                    // Close the worker after completion.
+                    // TODO: Worker tests don't have an implicit timeout, so in
+                    // cases where an async/promise test never resolves, the
+                    // completion callback won't be called and the worker won't
+                    // be closed.
+                    this_obj.close_worker();
                 });
     };
 
@@ -322,6 +329,9 @@
         // worker tests behave as if settings.explicit_timeout is true.
         return null;
     };
+
+    // Closes the worker, if applicable.
+    WorkerTestEnvironment.prototype.close_worker = function() {};
 
     /*
      * Dedicated web workers.
@@ -346,6 +356,10 @@
         tests.wait_for_finish = true;
     };
 
+    DedicatedWorkerTestEnvironment.prototype.close_worker = function() {
+        self.close();
+    };
+
     /*
      * Shared web workers.
      * https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope
@@ -356,11 +370,19 @@
     function SharedWorkerTestEnvironment() {
         WorkerTestEnvironment.call(this);
         var this_obj = this;
+
+        this.connected = false;
+        this.close_on_connect = false;
+
         // Shared workers receive message ports via the 'onconnect' event for
         // each connection.
         self.addEventListener("connect",
                 function(message_event) {
+                    this_obj.connected = true;
                     this_obj._add_message_port(message_event.source);
+                    if (this_obj.close_on_connect) {
+                        self.close();
+                    }
                 }, false);
     }
     SharedWorkerTestEnvironment.prototype = Object.create(WorkerTestEnvironment.prototype);
@@ -370,6 +392,14 @@
         // In the absence of an onload notification, we a require shared
         // workers to explicitly signal when the tests are done.
         tests.wait_for_finish = true;
+    };
+
+    SharedWorkerTestEnvironment.prototype.close_worker = function() {
+        if (this.connected) {
+            self.close();
+        } else {
+            this.close_on_connect = true;
+        }
     };
 
     /*


### PR DESCRIPTION
This fixes a bug where the worker was not being closed or terminated after the tests were run, only being garbage collected when navigating away. This fixes it for the cases of dedicated and shared workers.

Fixes #29778.
