### PR TITLE
Add tests for streaming upload feature detects

### DIFF
--- a/fetch/api/basic/request-upload.any.js
+++ b/fetch/api/basic/request-upload.any.js
@@ -143,3 +143,30 @@ promise_test(async (test) => {
   const text = await resp.text();
   assert_equals(text, "ok. Request was sent 1 times. 1 connections were created.");
 }, "Fetch with POST with ReadableStream on 421 response should return the response and not retry.");
+
+promise_test(async (test) => {
+  const request = new Request('', {
+    body: new ReadableStream(),
+    method: 'POST',
+  });
+
+  assert_equals(request.headers.get('Content-Type'), null, `Request should not have a content-type set`);
+
+  const response = await fetch('data:a/a;charset=utf-8,test', {
+    method: 'POST',
+    body: new ReadableStream(),
+  });
+
+  assert_equals(await response.text(), 'test', `Response has correct body`);
+}, "Feature detect for POST with ReadableStream");
+
+promise_test(async (test) => {
+  const request = new Request('data:a/a;charset=utf-8,test', {
+    body: new ReadableStream(),
+    method: 'POST',
+  });
+
+  assert_equals(request.headers.get('Content-Type'), null, `Request should not have a content-type set`);
+  const response = await fetch(request);
+  assert_equals(await response.text(), 'test', `Response has correct body`);
+}, "Feature detect for POST with ReadableStream, using request object");


### PR DESCRIPTION
Safari supports streams in `Request` objects, but not in `fetch`. The feature detect is a bit messy as a result. Hopefully this will ensure that the feature test continues to work.

I deliberately put "feature test" in the test name, so hopefully folks won't make it work without making the rest of the feature work too.

There's two versions of this test, as Chrome fails the latter https://bugs.chromium.org/p/chromium/issues/detail?id=1234368