### PR TITLE
Fix: Test errors in workers don't have an associated stack trace

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -2629,7 +2629,7 @@
     RemoteContext.prototype.remote_done = function(data) {
         if (tests.status.status === null &&
             data.status.status !== data.status.OK) {
-            tests.set_status(data.status.status, data.status.message, data.status.sack);
+            tests.set_status(data.status.status, data.status.message, data.status.stack);
         }
 
         for (let assert of data.asserts) {


### PR DESCRIPTION
This typo, introduced in #8748, had `undefined` being passed as the third argument to `Tests.prototype.set_status`, which made test errors in worker tests not have an associated stack trace.