### PR TITLE
[webdriver]: element cloned into iframe

### DIFF
--- a/webdriver/tests/switch_to_frame/switch_webelement.py
+++ b/webdriver/tests/switch_to_frame/switch_webelement.py
@@ -82,3 +82,20 @@ def test_frame_id_webelement_no_frame_element(session, inline):
 
     response = switch_to_frame(session, no_frame)
     assert_error(response, "no such frame")
+
+
+def test_frame_id_webelement_cloned_into_iframe(session, inline):
+    session.url = inline("""
+        <iframe></iframe>
+        <script>
+            const div = document.createElement('div');
+            div.innerHTML = 'I am a div created in top window and appended into the iframe';
+            document.getElementById('iframe').contentWindow.document.body.appendChild(div);
+        </script>""")
+    
+    frame = session.find.css("iframe", all=False)
+    response = switch_to_frame(session, frame)
+    assert_success(response)
+
+    element = session.find.css("div", all=False)
+    assert element.text == "I am a div created in top window and appended into the iframe"

--- a/webdriver/tests/switch_to_frame/switch_webelement.py
+++ b/webdriver/tests/switch_to_frame/switch_webelement.py
@@ -85,7 +85,7 @@ def test_frame_id_webelement_no_frame_element(session, inline):
 
 
 def test_frame_id_webelement_cloned_into_iframe(session, inline):
-    iframe_url = inline("<p>foo</p>")
+    iframe_url = inline("<body><p>foo</p></body>")
     session.url = inline("""
         <iframe src="{iframe_url}"></iframe>
         <script>

--- a/webdriver/tests/switch_to_frame/switch_webelement.py
+++ b/webdriver/tests/switch_to_frame/switch_webelement.py
@@ -83,11 +83,9 @@ def test_frame_id_webelement_no_frame_element(session, inline):
     response = switch_to_frame(session, no_frame)
     assert_error(response, "no such frame")
 
-
 def test_frame_id_webelement_cloned_into_iframe(session, inline):
-    iframe_url = inline("<body><p>foo</p></body>")
     session.url = inline("""
-        <iframe src="{iframe_url}"></iframe>
+        <iframe id="iframe"></iframe>
         <script>
             const div = document.createElement('div');
             div.innerHTML = 'I am a div created in top window and appended into the iframe';

--- a/webdriver/tests/switch_to_frame/switch_webelement.py
+++ b/webdriver/tests/switch_to_frame/switch_webelement.py
@@ -85,8 +85,9 @@ def test_frame_id_webelement_no_frame_element(session, inline):
 
 
 def test_frame_id_webelement_cloned_into_iframe(session, inline):
+    iframe_url = inline("<p>foo</p>")
     session.url = inline("""
-        <iframe></iframe>
+        <iframe src="{iframe_url}"></iframe>
         <script>
             const div = document.createElement('div');
             div.innerHTML = 'I am a div created in top window and appended into the iframe';

--- a/webdriver/tests/switch_to_frame/switch_webelement.py
+++ b/webdriver/tests/switch_to_frame/switch_webelement.py
@@ -92,7 +92,7 @@ def test_frame_id_webelement_cloned_into_iframe(session, inline):
             div.innerHTML = 'I am a div created in top window and appended into the iframe';
             document.getElementById('iframe').contentWindow.document.body.appendChild(div);
         </script>""")
-    
+
     frame = session.find.css("iframe", all=False)
     response = switch_to_frame(session, frame)
     assert_success(response)

--- a/webdriver/tests/switch_to_frame/switch_webelement.py
+++ b/webdriver/tests/switch_to_frame/switch_webelement.py
@@ -5,7 +5,6 @@ import webdriver.protocol as protocol
 from tests.support.asserts import assert_error, assert_success
 
 
-
 def switch_to_frame(session, frame):
     return session.transport.send(
         "POST", "session/{session_id}/frame".format(**vars(session)),
@@ -84,14 +83,15 @@ def test_frame_id_webelement_no_frame_element(session, inline):
     response = switch_to_frame(session, no_frame)
     assert_error(response, "no such frame")
 
+
 def test_frame_id_webelement_cloned_into_iframe(session, inline, iframe):
     session.url = inline(iframe("<body><p>hello world</p></body>"))
 
     session.execute_script("""
-            const iframe = document.getElementsByTagName('iframe')[0];
-            const div = document.createElement('div');
-            div.innerHTML = 'I am a div created in top window and appended into the iframe';
-            iframe.contentWindow.document.body.appendChild(div);
+        const iframe = document.getElementsByTagName('iframe')[0];
+        const div = document.createElement('div');
+        div.innerHTML = 'I am a div created in top window and appended into the iframe';
+        iframe.contentWindow.document.body.appendChild(div);
     """)
 
     frame = session.find.css("iframe", all=False)

--- a/webdriver/tests/switch_to_frame/switch_webelement.py
+++ b/webdriver/tests/switch_to_frame/switch_webelement.py
@@ -5,15 +5,6 @@ import webdriver.protocol as protocol
 from tests.support.asserts import assert_error, assert_success
 
 
-def execute_script(session, script, args=None):
-    if args is None:
-        args = []
-    body = {"script": script, "args": args}
-
-    return session.transport.send(
-        "POST", "/session/{session_id}/execute/sync".format(
-            session_id=session.session_id),
-        body)
 
 def switch_to_frame(session, frame):
     return session.transport.send(
@@ -96,7 +87,7 @@ def test_frame_id_webelement_no_frame_element(session, inline):
 def test_frame_id_webelement_cloned_into_iframe(session, inline, iframe):
     session.url = inline(iframe("<body><p>hello world</p></body>"))
 
-    response = execute_script(session, """
+    response = session.execute_script("""
             const iframe = document.getElementsByTagName('iframe')[0];
             const div = document.createElement('div');
             div.innerHTML = 'I am a div created in top window and appended into the iframe';

--- a/webdriver/tests/switch_to_frame/switch_webelement.py
+++ b/webdriver/tests/switch_to_frame/switch_webelement.py
@@ -87,14 +87,12 @@ def test_frame_id_webelement_no_frame_element(session, inline):
 def test_frame_id_webelement_cloned_into_iframe(session, inline, iframe):
     session.url = inline(iframe("<body><p>hello world</p></body>"))
 
-    response = session.execute_script("""
+    session.execute_script("""
             const iframe = document.getElementsByTagName('iframe')[0];
             const div = document.createElement('div');
             div.innerHTML = 'I am a div created in top window and appended into the iframe';
             iframe.contentWindow.document.body.appendChild(div);
-            return 1;
     """)
-    assert_success(response, 1)
 
     frame = session.find.css("iframe", all=False)
     response = switch_to_frame(session, frame)


### PR DESCRIPTION
Added a new test to verify webdriver can access & serialize elements transferred in between iframes
following this [bug](https://bugs.webkit.org/show_bug.cgi?id=228270)