### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=227690

### DIFF
--- a/streams/piping/pipe-through.any.js
+++ b/streams/piping/pipe-through.any.js
@@ -266,3 +266,66 @@ test(() => {
     }
   }), 'pipeThrough should throw');
 }, 'pipeThrough() should throw if an option getter grabs a writer');
+
+test(() => {
+  const rs = new ReadableStream();
+  const readable = new ReadableStream();
+  const writable = new WritableStream();
+  rs.pipeThrough({readable, writable}, null);
+}, 'pipeThrough() should not throw if option is null');
+
+test(() => {
+  const rs = new ReadableStream();
+  const readable = new ReadableStream();
+  const writable = new WritableStream();
+  rs.pipeThrough({readable, writable}, {signal:undefined});
+}, 'pipeThrough() should not throw if signal is undefined');
+
+function tryPipeThrough(pair, options)
+{
+  const rs = new ReadableStream();
+  if (!pair)
+    pair = {readable:new ReadableStream(), writable:new WritableStream()};
+  try {
+    rs.pipeThrough(pair, options)
+  } catch (e) {
+    return e;
+  }
+}
+
+test(() => {
+  let result = tryPipeThrough({
+    get readable() {
+      return new ReadableStream();
+    },
+    get writable() {
+      throw "writable threw";
+    }
+  }, { });
+  assert_equals(result, "writable threw");
+
+  result = tryPipeThrough({
+    get readable() {
+      throw "readable threw";
+    },
+    get writable() {
+      throw "writable threw";
+    }
+  }, { });
+  assert_equals(result, "readable threw");
+
+  result = tryPipeThrough({
+    get readable() {
+      throw "readable threw";
+    },
+    get writable() {
+      throw "writable threw";
+    }
+  }, {
+    get preventAbort() {
+      throw "preventAbort threw";
+    }
+  });
+  assert_equals(result, "readable threw");
+
+}, 'pipeThrough() should throw if readable/writable getters throw');


### PR DESCRIPTION
WebKit export from bug: [ReadableStream's pipeTo() and pipeThrough() don't handle options in spec-perfect way](https://bugs.webkit.org/show_bug.cgi?id=227690)