### PR TITLE
MathML tools : upgrade scripts to Python 3

### DIFF
--- a/mathml/tools/.gitignore
+++ b/mathml/tools/.gitignore
@@ -1,2 +1,0 @@
-unicode.xml?raw=true
-inline-axis-operators.txt

--- a/mathml/tools/.gitignore
+++ b/mathml/tools/.gitignore
@@ -1,0 +1,2 @@
+unicode.xml?raw=true
+inline-axis-operators.txt

--- a/mathml/tools/axisheight.py
+++ b/mathml/tools/axisheight.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from utils import mathfont
 import fontforge

--- a/mathml/tools/fractions.py
+++ b/mathml/tools/fractions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from utils import mathfont
 import fontforge

--- a/mathml/tools/largeop.py
+++ b/mathml/tools/largeop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from utils import mathfont
 import fontforge
@@ -56,9 +56,9 @@ mathfont.drawRectangleGlyph(g,
 f[nAryWhiteVerticalBarCodePoint].verticalVariants = "uni2AFF"
 # Part: (glyphName, isExtender, startConnector, endConnector, fullAdvance)
 f[nAryWhiteVerticalBarCodePoint].verticalComponents = \
-  (("uni2AFF.bot", False, 0, mathfont.em / 2, mathfont.em),
-   ("uni2AFF.ext", True, mathfont.em / 2, mathfont.em / 2, 2 * mathfont.em),
-   ("uni2AFF.top", False, mathfont.em / 2, 0, mathfont.em)
+  (("uni2AFF.bot", False, 0, mathfont.em // 2, mathfont.em),
+   ("uni2AFF.ext", True, mathfont.em // 2, mathfont.em // 2, 2 * mathfont.em),
+   ("uni2AFF.top", False, mathfont.em // 2, 0, mathfont.em)
   );
 f[nAryWhiteVerticalBarCodePoint].verticalComponentItalicCorrection = v2
 mathfont.save(f)

--- a/mathml/tools/limits.py
+++ b/mathml/tools/limits.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from utils import mathfont
 import fontforge

--- a/mathml/tools/math-text.py
+++ b/mathml/tools/math-text.py
@@ -1,6 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
-from __future__ import print_function
 import fontforge
 
 font = fontforge.font()
@@ -39,18 +38,18 @@ pen.lineTo(1000, -1000)
 pen.closePath();
 
 font.os2_typoascent_add = False
-font.os2_typoascent = lineHeight / 2
+font.os2_typoascent = lineHeight // 2
 font.os2_typodescent_add = False
-font.os2_typodescent = -lineHeight / 2
+font.os2_typodescent = -lineHeight // 2
 font.os2_typolinegap = 0
-font.hhea_ascent = lineHeight / 2
+font.hhea_ascent = lineHeight // 2
 font.hhea_ascent_add = False
-font.hhea_descent = -lineHeight / 2
+font.hhea_descent = -lineHeight // 2
 font.hhea_descent_add = False
 font.hhea_linegap = 0
-font.os2_winascent = lineHeight / 2
+font.os2_winascent = lineHeight // 2
 font.os2_winascent_add = False
-font.os2_windescent = lineHeight / 2
+font.os2_windescent = lineHeight // 2
 font.os2_windescent_add = False
 
 font.os2_use_typo_metrics = True

--- a/mathml/tools/mathvariant-transforms.py
+++ b/mathml/tools/mathvariant-transforms.py
@@ -1,6 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
-from __future__ import print_function
 from lxml import etree
 from utils.misc import downloadWithProgressBar, UnicodeXMLURL
 from utils import mathfont

--- a/mathml/tools/operator-dictionary.py
+++ b/mathml/tools/operator-dictionary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from lxml import etree
 from utils.misc import downloadWithProgressBar, UnicodeXMLURL, InlineAxisOperatorsURL
@@ -30,7 +30,7 @@ def buildKeyAndValueFrom(characters, form):
     # Concatenate characters and form to build the key.
     key = ""
     for c in characters:
-        key += unichr(c)
+        key += chr(c)
     key += " " + form
     # But save characters as an individual property for easier manipulation in
     # this Python script.
@@ -82,7 +82,7 @@ font = mathfont.create("operators", "Copyright (c) 2019 Igalia S.L.")
 
 # Set parameters for largeop and stretchy tests.
 font.math.DisplayOperatorMinHeight = 2 * mathfont.em
-font.math.MinConnectorOverlap = mathfont.em / 2
+font.math.MinConnectorOverlap = mathfont.em // 2
 
 # Set parameters for accent tests so that we only have large gap when
 # overscript is an accent.
@@ -98,10 +98,10 @@ for key in operatorDictionary:
         if c in font:
             continue
         if c == NonBreakingSpace:
-            g = font.createChar(c)
-            mathfont.drawRectangleGlyph(g, mathfont.em, mathfont.em / 3, 0)
+             g = font.createChar(c)
+             mathfont.drawRectangleGlyph(g, mathfont.em, mathfont.em // 3, 0)
         else:
-            mathfont.createSquareGlyph(font, c)
+             mathfont.createSquareGlyph(font, c)
         mathfont.createStretchy(font, c, c in inlineAxisOperators)
 mathfont.save(font)
 

--- a/mathml/tools/operator-dictionary.py
+++ b/mathml/tools/operator-dictionary.py
@@ -98,10 +98,10 @@ for key in operatorDictionary:
         if c in font:
             continue
         if c == NonBreakingSpace:
-             g = font.createChar(c)
-             mathfont.drawRectangleGlyph(g, mathfont.em, mathfont.em // 3, 0)
+            g = font.createChar(c)
+            mathfont.drawRectangleGlyph(g, mathfont.em, mathfont.em // 3, 0)
         else:
-             mathfont.createSquareGlyph(font, c)
+            mathfont.createSquareGlyph(font, c)
         mathfont.createStretchy(font, c, c in inlineAxisOperators)
 mathfont.save(font)
 

--- a/mathml/tools/percentscaledown.py
+++ b/mathml/tools/percentscaledown.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from utils import mathfont
 import fontforge

--- a/mathml/tools/radicals.py
+++ b/mathml/tools/radicals.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from utils import mathfont
 import fontforge

--- a/mathml/tools/scripts.py
+++ b/mathml/tools/scripts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from utils import mathfont
 import fontforge

--- a/mathml/tools/stacks.py
+++ b/mathml/tools/stacks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from utils import mathfont
 import fontforge

--- a/mathml/tools/stretchstacks.py
+++ b/mathml/tools/stretchstacks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from utils import mathfont
 import fontforge

--- a/mathml/tools/stretchy.py
+++ b/mathml/tools/stretchy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from utils import mathfont
 import fontforge
@@ -7,7 +7,7 @@ import fontforge
 font = mathfont.create("stretchy", "Copyright (c) 2021 Igalia S.L.")
 
 # Set parameters for stretchy tests.
-font.math.MinConnectorOverlap = mathfont.em / 2
+font.math.MinConnectorOverlap = mathfont.em // 2
 
 # Make sure that underover parameters don't add extra spacing.
 font.math.LowerLimitBaselineDropMin = 0

--- a/mathml/tools/underover.py
+++ b/mathml/tools/underover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from utils import mathfont
 import fontforge

--- a/mathml/tools/use-typo-lineheight.py
+++ b/mathml/tools/use-typo-lineheight.py
@@ -1,6 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
-from __future__ import print_function
 import fontforge
 
 font = fontforge.font()
@@ -30,15 +29,15 @@ font.os2_typodescent = -200
 font.os2_typolinegap = typoLineHeight - \
                        (font.os2_typoascent - font.os2_typodescent)
 
-font.hhea_ascent = winHeight / 2
+font.hhea_ascent = winHeight // 2
 font.hhea_ascent_add = False
-font.hhea_descent = -winHeight / 2
+font.hhea_descent = -winHeight // 2
 font.hhea_descent_add = False
 font.hhea_linegap = 0
 
-font.os2_winascent = winHeight / 2
+font.os2_winascent = winHeight // 2
 font.os2_winascent_add = False
-font.os2_windescent = winHeight / 2
+font.os2_windescent = winHeight // 2
 font.os2_windescent_add = False
 
 font.os2_use_typo_metrics = True

--- a/mathml/tools/utils/mathfont.py
+++ b/mathml/tools/utils/mathfont.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import fontforge
 
 em = 1000

--- a/mathml/tools/utils/misc.py
+++ b/mathml/tools/utils/misc.py
@@ -1,12 +1,8 @@
-from __future__ import print_function
 import os
 import progressbar
-try:
-    from urllib.request import urlopen
-except ImportError:
-    from urllib2 import urlopen
+from urllib.request import urlopen
 
-UnicodeXMLURL = "https://w3c.github.io/xml-entities/unicode.xml"
+UnicodeXMLURL = "https://github.com/w3c/xml-entities/blob/u14/unicode.xml?raw=true"
 InlineAxisOperatorsURL = "https://w3c.github.io/mathml-core/tables/inline-axis-operators.txt"
 
 def downloadWithProgressBar(url, outputDirectory="./", forceDownload=False):
@@ -18,7 +14,7 @@ def downloadWithProgressBar(url, outputDirectory="./", forceDownload=False):
         return fileName
 
     request = urlopen(url)
-    totalSize = int(request.info().getheader('Content-Length').strip())
+    totalSize = int(request.info().get('Content-Length').strip())
     bar = progressbar.ProgressBar(maxval=totalSize).start()
 
     chunkSize = 16 * 1024

--- a/mathml/tools/xHeight.py
+++ b/mathml/tools/xHeight.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from utils import mathfont
 import fontforge


### PR DESCRIPTION
With this commit, the scripts in mathml/tools/ are upgraded to use
Python 3. A few more tweaks have been made.

- Use '#!/usr/bin/env python3' as header and make files executable.
- Use // for integer division.
- Don't import future print_function anymore.
- Use the latest Python3 API for urlopen.
- Fix url ofXML Entities's unicode.xml.
- Just use chr instead of unichr.