### PR TITLE
Make dialog cancel event tests use test_driver.send_keys instead of test_driver.Actions()

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-events.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-events.html
@@ -6,7 +6,7 @@
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/testdriver.js"></script>
   <script src="/resources/testdriver-vendor.js"></script>
-  <script src="/resources/testdriver-actions.js"></script>
+  <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=227534">
   <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1322947">
 </head>
 <body>
@@ -39,12 +39,7 @@
   });
 
   dialog.showModal();
-
-  const escKey = "\uE00C";
-  new test_driver.Actions()
-    .keyDown(escKey)
-    .keyUp(escKey)
-    .send();
+  test_driver.send_keys(document.documentElement, "\uE00C"); // ESC key
 </script>
 </body>
 </html>

--- a/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-preventDefault.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-preventDefault.html
@@ -6,7 +6,7 @@
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/testdriver.js"></script>
   <script src="/resources/testdriver-vendor.js"></script>
-  <script src="/resources/testdriver-actions.js"></script>
+  <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=227534">
   <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1322947">
 </head>
 <body>
@@ -39,11 +39,7 @@
   });
 
   dialog.showModal();
-  const escKey = "\uE00C";
-  new test_driver.Actions()
-    .keyDown(escKey)
-    .keyUp(escKey)
-    .send();
+  test_driver.send_keys(document.documentElement, "\uE00C"); // ESC key
 </script>
 </body>
 </html>

--- a/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-with-input.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-with-input.html
@@ -6,7 +6,7 @@
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/testdriver.js"></script>
   <script src="/resources/testdriver-vendor.js"></script>
-  <script src="/resources/testdriver-actions.js"></script>
+  <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=227534">
   <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1322947">
 </head>
 <body>
@@ -23,11 +23,7 @@
   setup({ single_test: true });
 
   const triggerEscKey = () => {
-    const escKey = "\uE00C";
-    new test_driver.Actions()
-      .keyDown(escKey)
-      .keyUp(escKey)
-      .send();
+    test_driver.send_keys(document.documentElement, "\uE00C"); // ESC key
   };
 
   /* Make sure we still cancel the dialog even if the input element is focused */
@@ -49,7 +45,7 @@
 
   dialog.addEventListener("close", function() {
     assert_false(dialog.open, "dialog closed");
-    step_timeout(function(){
+    step_timeout(function() {
       runTestCancelWhenInputFocused();
     }, 0);
   });
@@ -60,4 +56,3 @@
 </pre>
 </body>
 </html>
-

--- a/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-with-select.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-with-select.html
@@ -6,7 +6,7 @@
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/testdriver.js"></script>
   <script src="/resources/testdriver-vendor.js"></script>
-  <script src="/resources/testdriver-actions.js"></script>
+  <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=227534">
   <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1322947">
 </head>
 <body>
@@ -31,12 +31,7 @@
   dialog.showModal();
   assert_true(select == document.activeElement, "select element should be focused");
 
-  const escKey = "\uE00C";
-  new test_driver.Actions()
-    .keyDown(escKey)
-    .keyUp(escKey)
-    .send();
+  test_driver.send_keys(document.documentElement, "\uE00C"); // ESC key
 </script>
 </body>
 </html>
-

--- a/html/semantics/interactive-elements/the-dialog-element/dialog-keydown-preventDefault.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-keydown-preventDefault.html
@@ -6,7 +6,7 @@
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/testdriver.js"></script>
   <script src="/resources/testdriver-vendor.js"></script>
-  <script src="/resources/testdriver-actions.js"></script>
+  <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=227534">
   <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1322947">
 </head>
 <body>
@@ -39,11 +39,7 @@
     }, 0);
   });
   dialog.showModal();
-  const escKey = "\uE00C";
-  new test_driver.Actions()
-    .keyDown(escKey)
-    .keyUp(escKey)
-    .send();
+  test_driver.send_keys(document.documentElement, "\uE00C"); // ESC key
 </script>
 </body>
 </html>


### PR DESCRIPTION
Because WebKit test runner does not support the latter.