### PR TITLE
Fix the link to my email address in tests

### DIFF
--- a/css/css-multicol/column-balancing-paged-001-print-ref.html
+++ b/css/css-multicol/column-balancing-paged-001-print-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test fragmentation for a nested multi-column container with column-span in paginated context</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/column-balancing-paged-001-print.html
+++ b/css/css-multicol/column-balancing-paged-001-print.html
@@ -3,7 +3,7 @@
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test fragmentation for a nested multi-column container with column-span in paginated context</title>
   <link rel="match" href="column-balancing-paged-001-print-ref.html">
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="help" href="https://drafts.csswg.org/css-break/#breaking-rules">

--- a/css/css-multicol/multicol-breaking-004-ref.html
+++ b/css/css-multicol/multicol-breaking-004-ref.html
@@ -2,7 +2,7 @@
 <title>CSS Test Reference: breaking of a multicolumn</title>
 <meta charset="utf-8">
 <link rel="author" title="L. David Baron" href="https://dbaron.org/">
-<link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+<link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
 <link rel="author" title="Mozilla" href="https://mozilla.org/">
 <style>
 

--- a/css/css-multicol/multicol-breaking-004.html
+++ b/css/css-multicol/multicol-breaking-004.html
@@ -2,7 +2,7 @@
 <title>CSS Test: breaking of a multicolumn</title>
 <meta charset="utf-8">
 <link rel="author" title="L. David Baron" href="https://dbaron.org/">
-<link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+<link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
 <link rel="author" title="Mozilla" href="https://mozilla.org/">
 <link rel="help" href="https://drafts.csswg.org/css-multicol/#column-gaps-and-rules">
 <link rel="help" href="https://drafts.csswg.org/css-multicol/#cf">

--- a/css/css-multicol/multicol-breaking-005-ref.html
+++ b/css/css-multicol/multicol-breaking-005-ref.html
@@ -2,7 +2,7 @@
 <title>CSS Test Reference: breaking of a multicolumn</title>
 <meta charset="utf-8">
 <link rel="author" title="L. David Baron" href="https://dbaron.org/">
-<link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+<link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
 <link rel="author" title="Mozilla" href="https://mozilla.org/">
 <style>
 

--- a/css/css-multicol/multicol-breaking-005.html
+++ b/css/css-multicol/multicol-breaking-005.html
@@ -2,7 +2,7 @@
 <title>CSS Test: breaking of a multicolumn</title>
 <meta charset="utf-8">
 <link rel="author" title="L. David Baron" href="https://dbaron.org/">
-<link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+<link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
 <link rel="author" title="Mozilla" href="https://mozilla.org/">
 <link rel="help" href="https://drafts.csswg.org/css-multicol/#column-gaps-and-rules">
 <link rel="help" href="https://drafts.csswg.org/css-multicol/#cf">

--- a/css/css-multicol/multicol-breaking-nobackground-004-ref.html
+++ b/css/css-multicol/multicol-breaking-nobackground-004-ref.html
@@ -2,7 +2,7 @@
 <title>CSS Test Reference: breaking of a multicolumn</title>
 <meta charset="utf-8">
 <link rel="author" title="L. David Baron" href="https://dbaron.org/">
-<link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+<link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
 <link rel="author" title="Mozilla" href="https://mozilla.org/">
 <style>
 

--- a/css/css-multicol/multicol-breaking-nobackground-004.html
+++ b/css/css-multicol/multicol-breaking-nobackground-004.html
@@ -2,7 +2,7 @@
 <title>CSS Test: breaking of a multicolumn</title>
 <meta charset="utf-8">
 <link rel="author" title="L. David Baron" href="https://dbaron.org/">
-<link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+<link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
 <link rel="author" title="Mozilla" href="https://mozilla.org/">
 <link rel="help" href="https://drafts.csswg.org/css-multicol/#column-gaps-and-rules">
 <link rel="help" href="https://drafts.csswg.org/css-multicol/#cf">

--- a/css/css-multicol/multicol-breaking-nobackground-005-ref.html
+++ b/css/css-multicol/multicol-breaking-nobackground-005-ref.html
@@ -2,7 +2,7 @@
 <title>CSS Test Reference: breaking of a multicolumn</title>
 <meta charset="utf-8">
 <link rel="author" title="L. David Baron" href="https://dbaron.org/">
-<link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+<link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
 <link rel="author" title="Mozilla" href="https://mozilla.org/">
 <style>
 

--- a/css/css-multicol/multicol-breaking-nobackground-005.html
+++ b/css/css-multicol/multicol-breaking-nobackground-005.html
@@ -2,7 +2,7 @@
 <title>CSS Test: breaking of a multicolumn</title>
 <meta charset="utf-8">
 <link rel="author" title="L. David Baron" href="https://dbaron.org/">
-<link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+<link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
 <link rel="author" title="Mozilla" href="https://mozilla.org/">
 <link rel="help" href="https://drafts.csswg.org/css-multicol/#column-gaps-and-rules">
 <link rel="help" href="https://drafts.csswg.org/css-multicol/#cf">

--- a/css/css-multicol/multicol-dynamic-add-001-ref.html
+++ b/css/css-multicol/multicol-dynamic-add-001-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Append a block to an empty inline element</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-dynamic-add-001.html
+++ b/css/css-multicol/multicol-dynamic-add-001.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Append a block to an empty inline element</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#cf">
   <link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#anonymous-block-level">

--- a/css/css-multicol/multicol-fill-auto-block-children-003-ref.html
+++ b/css/css-multicol/multicol-fill-auto-block-children-003-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: 'column-fill: auto' and height constrained of a multi-column container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-fill-auto-block-children-003.html
+++ b/css/css-multicol/multicol-fill-auto-block-children-003.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: 'column-fill: auto' and height constrained of a multi-column container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol/#cf">
   <link rel="match" href="multicol-fill-auto-block-children-003-ref.html">

--- a/css/css-multicol/multicol-margin-003.html
+++ b/css/css-multicol/multicol-margin-003.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: multi-column and margin bottom of last child</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#the-multi-column-model">
   <link rel="match" href="../reference/ref-filled-green-100px-square-only.html">

--- a/css/css-multicol/multicol-rule-nested-balancing-001-ref.html
+++ b/css/css-multicol/multicol-rule-nested-balancing-001-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test the column rules' block-size with nested balancing multicol container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-rule-nested-balancing-001.html
+++ b/css/css-multicol/multicol-rule-nested-balancing-001.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test the column rules' block-size with nested balancing multicol container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#cf">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-gaps-and-rules">

--- a/css/css-multicol/multicol-rule-nested-balancing-002-ref.html
+++ b/css/css-multicol/multicol-rule-nested-balancing-002-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test the column rules' block-size with nested balancing multicol container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-rule-nested-balancing-002.html
+++ b/css/css-multicol/multicol-rule-nested-balancing-002.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test the column rules' block-size with nested balancing multicol container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#cf">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-gaps-and-rules">

--- a/css/css-multicol/multicol-rule-nested-balancing-003-ref.html
+++ b/css/css-multicol/multicol-rule-nested-balancing-003-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test the column rules' block-size with nested balancing multicol container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-rule-nested-balancing-003.html
+++ b/css/css-multicol/multicol-rule-nested-balancing-003.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test the column rules' block-size with nested balancing multicol container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#cf">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-gaps-and-rules">

--- a/css/css-multicol/multicol-rule-nested-balancing-004-ref.html
+++ b/css/css-multicol/multicol-rule-nested-balancing-004-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test the column rules' block-size with nested balancing multicol container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-rule-nested-balancing-004.html
+++ b/css/css-multicol/multicol-rule-nested-balancing-004.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test the column rules' block-size with nested balancing multicol container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#cf">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-gaps-and-rules">

--- a/css/css-multicol/multicol-span-all-004-ref.html
+++ b/css/css-multicol/multicol-span-all-004-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: column-span:all should act like column-span:none in different block formatting context</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-004.html
+++ b/css/css-multicol/multicol-span-all-004.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: column-span:all should act like column-span:none in different block formatting context</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-004-ref.html">

--- a/css/css-multicol/multicol-span-all-005-ref.html
+++ b/css/css-multicol/multicol-span-all-005-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test column-span:all with various display types</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-005.html
+++ b/css/css-multicol/multicol-span-all-005.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test column-span:all with various display types</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-005-ref.html">

--- a/css/css-multicol/multicol-span-all-006-ref.html
+++ b/css/css-multicol/multicol-span-all-006-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test column-span:all under HTML details tag</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-006.html
+++ b/css/css-multicol/multicol-span-all-006.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test column-span:all under HTML details tag</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-006-ref.html">

--- a/css/css-multicol/multicol-span-all-007-ref.html
+++ b/css/css-multicol/multicol-span-all-007-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test column-span:all when the body tag is the multi-column container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-007.html
+++ b/css/css-multicol/multicol-span-all-007.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test column-span:all when the body tag is the multi-column container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-007-ref.html">

--- a/css/css-multicol/multicol-span-all-008-ref.html
+++ b/css/css-multicol/multicol-span-all-008-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test a bidi-override multi-column container with a dir=rtl column-span:all child</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-008.html
+++ b/css/css-multicol/multicol-span-all-008.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test a bidi-override multi-column container with a dir=rtl column-span:all child</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-008-ref.html">

--- a/css/css-multicol/multicol-span-all-009-ref.html
+++ b/css/css-multicol/multicol-span-all-009-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test the multicol element is the containing block of absolute elements</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-009.html
+++ b/css/css-multicol/multicol-span-all-009.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test the multicol element is the containing block of absolute elements</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#the-multi-column-model">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">

--- a/css/css-multicol/multicol-span-all-010-ref.html
+++ b/css/css-multicol/multicol-span-all-010-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test the position of the out-of-flow block is relative to the fragment divided by column-span:all</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-010.html
+++ b/css/css-multicol/multicol-span-all-010.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test the position of the out-of-flow block is relative to the later fragment divided by the column-span:all</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#the-multi-column-model">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">

--- a/css/css-multicol/multicol-span-all-011-ref.html
+++ b/css/css-multicol/multicol-span-all-011-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test a bidi-override multi-column container with a dir=rtl column-span:all child</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-011.html
+++ b/css/css-multicol/multicol-span-all-011.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test a bidi-override multi-column container with a dir=rtl column-span:all child</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-011-ref.html">

--- a/css/css-multicol/multicol-span-all-button-001-ref.html
+++ b/css/css-multicol/multicol-span-all-button-001-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test a multi-column container on button works with a column-span:all child</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-button-001.html
+++ b/css/css-multicol/multicol-span-all-button-001.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test a multi-column container on button works with a column-span:all child</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-button-001-ref.html">

--- a/css/css-multicol/multicol-span-all-button-002-ref.html
+++ b/css/css-multicol/multicol-span-all-button-002-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test a overflow:hidden and position:absolute multi-column container on button works with a column-span:all child and position:absolute boxes</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-button-002.html
+++ b/css/css-multicol/multicol-span-all-button-002.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test a overflow:hidden and position:absolute multi-column container on button works with a column-span:all child and position:absolute boxes</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-button-002-ref.html">

--- a/css/css-multicol/multicol-span-all-button-003-ref.html
+++ b/css/css-multicol/multicol-span-all-button-003-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test a overflow:hidden and position:absolute multi-column container on button works with a column-span:all child and position:fixed boxes</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-button-003.html
+++ b/css/css-multicol/multicol-span-all-button-003.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test a overflow:hidden and position:absolute multi-column container on button works with a column-span:all child and position:fixed boxes</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-button-003-ref.html">

--- a/css/css-multicol/multicol-span-all-children-height-001-ref.html
+++ b/css/css-multicol/multicol-span-all-children-height-001-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test a multi-column container with percentage height children</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-children-height-001.html
+++ b/css/css-multicol/multicol-span-all-children-height-001.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test a multi-column container with percentage height children</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-children-height-001-ref.html">

--- a/css/css-multicol/multicol-span-all-children-height-002-ref.html
+++ b/css/css-multicol/multicol-span-all-children-height-002-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test a multi-column container with percentage height children</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-children-height-002.html
+++ b/css/css-multicol/multicol-span-all-children-height-002.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test a multi-column container with percentage height children</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-children-height-002-ref.html">

--- a/css/css-multicol/multicol-span-all-children-height-003-ref.html
+++ b/css/css-multicol/multicol-span-all-children-height-003-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test a multi-column container with percentage height children</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-children-height-003.html
+++ b/css/css-multicol/multicol-span-all-children-height-003.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test a multi-column container with percentage height children</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="help" href="https://drafts.csswg.org/css-break/#breaking-rules">

--- a/css/css-multicol/multicol-span-all-children-height-004a-ref.html
+++ b/css/css-multicol/multicol-span-all-children-height-004a-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test the block-size distribution across column-span split in a balancing multicol container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-children-height-004a.html
+++ b/css/css-multicol/multicol-span-all-children-height-004a.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test the block-size distribution across column-span split in a balancing multicol container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-children-height-004a-ref.html">

--- a/css/css-multicol/multicol-span-all-children-height-004b-ref.html
+++ b/css/css-multicol/multicol-span-all-children-height-004b-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test the block-size distribution across column-span split in a balancing multicol container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-children-height-004b.html
+++ b/css/css-multicol/multicol-span-all-children-height-004b.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test the block-size distribution across column-span split in a balancing multicol container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-children-height-004b-ref.html">

--- a/css/css-multicol/multicol-span-all-children-height-005-ref.html
+++ b/css/css-multicol/multicol-span-all-children-height-005-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test the block-size distribution across column-span split in a column-fill:auto multicol container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-children-height-005.html
+++ b/css/css-multicol/multicol-span-all-children-height-005.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test the block-size distribution across column-span split in a column-fill:auto multicol container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-children-height-005-ref.html">

--- a/css/css-multicol/multicol-span-all-children-height-006-ref.html
+++ b/css/css-multicol/multicol-span-all-children-height-006-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test the borders drawing for a block split by column-span</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-children-height-006.html
+++ b/css/css-multicol/multicol-span-all-children-height-006.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test the borders drawing for a block split by column-span</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-children-height-006-ref.html">

--- a/css/css-multicol/multicol-span-all-children-height-007-ref.html
+++ b/css/css-multicol/multicol-span-all-children-height-007-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test fragmentation for a nested multi-column container with column-span</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-children-height-007.html
+++ b/css/css-multicol/multicol-span-all-children-height-007.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test fragmentation for a nested multi-column container with column-span</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="help" href="https://drafts.csswg.org/css-break/#breaking-rules">

--- a/css/css-multicol/multicol-span-all-children-height-008-ref.html
+++ b/css/css-multicol/multicol-span-all-children-height-008-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Test the borders drawing for a block split by column-span</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-children-height-008.html
+++ b/css/css-multicol/multicol-span-all-children-height-008.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test the borders drawing for a block split by column-span</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-children-height-008-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-add-001-ref.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-001-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Add the spanner as the first child of the columns</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-dynamic-add-001.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-001.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Add the spanner as the first child of the columns</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-add-001-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-add-002-ref.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-002-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Add the spanner as the second child of the columns</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-dynamic-add-002.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-002.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Add the spanner as the second child of the columns</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-add-002-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-add-003-ref.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-003-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Add the spanner in block1. It should correctly span across all columns</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-dynamic-add-003.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-003.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Add the spanner in block1. It should correctly span across all columns</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-add-003-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-add-004-ref.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-004-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Add the spanner to the inner column</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-dynamic-add-004.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-004.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Add the spanner to the inner column</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-add-004-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-add-005.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-005.html
@@ -3,7 +3,7 @@
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Add block1 before block2. It should join the column content box with
     block2, not with the spanner</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-add-001-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-add-006.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-006.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Append a text in column-span</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-add-002-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-add-007-ref.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-007-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Append the block to the inline element which contains "column-span"</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-dynamic-add-007.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-007.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Append the block to the inline element which contains "column-span"</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-add-007-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-add-008-ref.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-008-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Add a nested multi-column spanner to the outer column</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-dynamic-add-008.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-008.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Add a nested multi-column spanner to the outer column</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-add-008-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-add-009.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-009.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Add a simple block to columns which already contains a column-span</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-add-002-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-add-010-ref.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-010-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Append a block containing a spanner kid. The spanner kid should correctly span across all columns.</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-dynamic-add-010.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-010.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Append a block containing a spanner kid. The spanner kid should correctly span across all columns.</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-add-010-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-add-011.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-011.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Insert a block containing a spanner kid. The spanner kid should correctly span across all columns</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-add-003-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-add-012-ref.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-012-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Append a block containing a spanner kid. The spanner kid should correctly span across all columns</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-dynamic-add-012.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-012.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Append a block containing a spanner kid. The spanner kid should correctly span across all columns</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-add-012-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-add-013-ref.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-013-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Insert a block into a multicol details containing column-span:all</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-dynamic-add-013.html
+++ b/css/css-multicol/multicol-span-all-dynamic-add-013.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Insert a block into a multicol details containing column-span:all</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-add-013-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-remove-001-ref.html
+++ b/css/css-multicol/multicol-span-all-dynamic-remove-001-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Remove the spanner as the first child</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-dynamic-remove-001.html
+++ b/css/css-multicol/multicol-span-all-dynamic-remove-001.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Remove the spanner as the first child</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-remove-001-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-remove-002-ref.html
+++ b/css/css-multicol/multicol-span-all-dynamic-remove-002-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Remove the spanner in nested blocks</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-dynamic-remove-002.html
+++ b/css/css-multicol/multicol-span-all-dynamic-remove-002.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Remove the spanner in nested blocks</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-remove-002-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-remove-003.html
+++ b/css/css-multicol/multicol-span-all-dynamic-remove-003.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Remove the spanner in a block</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-remove-001-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-remove-004-ref.html
+++ b/css/css-multicol/multicol-span-all-dynamic-remove-004-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Remove the spanner with block siblings in an inline element</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-dynamic-remove-004.html
+++ b/css/css-multicol/multicol-span-all-dynamic-remove-004.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Remove the spanner with a block sibling in an inline element</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-remove-004-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-remove-005-ref.html
+++ b/css/css-multicol/multicol-span-all-dynamic-remove-005-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Remove a block with spanner siblings</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-dynamic-remove-005.html
+++ b/css/css-multicol/multicol-span-all-dynamic-remove-005.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Remove a tall block (spliting across the three columns) with spanner siblings</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-remove-005-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-remove-006.html
+++ b/css/css-multicol/multicol-span-all-dynamic-remove-006.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Remove the parent of a column-spanner</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-remove-001-ref.html">

--- a/css/css-multicol/multicol-span-all-dynamic-remove-007.html
+++ b/css/css-multicol/multicol-span-all-dynamic-remove-007.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Remove the position:fixed spanner as the first child</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-dynamic-remove-001-ref.html">

--- a/css/css-multicol/multicol-span-all-fieldset-001-ref.html
+++ b/css/css-multicol/multicol-span-all-fieldset-001-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test a multi-column container on fieldset works with a column-span:all child</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-fieldset-001.html
+++ b/css/css-multicol/multicol-span-all-fieldset-001.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test a multi-column container on fieldset works with a column-span:all child</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-fieldset-001-ref.html">

--- a/css/css-multicol/multicol-span-all-fieldset-002-ref.html
+++ b/css/css-multicol/multicol-span-all-fieldset-002-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test a overflow:hidden and position:absolute multi-column container on fieldset works with a column-span:all child and position:absolute boxes</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-fieldset-002.html
+++ b/css/css-multicol/multicol-span-all-fieldset-002.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test a overflow:hidden and position:absolute multi-column container on fieldset works with a column-span:all child and position:absolute boxes</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-fieldset-002-ref.html">

--- a/css/css-multicol/multicol-span-all-fieldset-003-ref.html
+++ b/css/css-multicol/multicol-span-all-fieldset-003-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test a overflow:hidden and position:absolute multi-column container on fieldset works with a column-span:all child and position:fixed boxes</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-fieldset-003.html
+++ b/css/css-multicol/multicol-span-all-fieldset-003.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test a overflow:hidden and position:absolute multi-column container on fieldset works with a column-span:all child and position:fixed boxes</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-fieldset-003-ref.html">

--- a/css/css-multicol/multicol-span-all-list-item-001-ref.html
+++ b/css/css-multicol/multicol-span-all-list-item-001-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: columns with list-item and column-span</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-list-item-001.html
+++ b/css/css-multicol/multicol-span-all-list-item-001.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: columns with list-item and column-span</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-list-item-001-ref.html">

--- a/css/css-multicol/multicol-span-all-list-item-002-ref.html
+++ b/css/css-multicol/multicol-span-all-list-item-002-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: columns with list-item, column-span, and overflow</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-list-item-002.html
+++ b/css/css-multicol/multicol-span-all-list-item-002.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: columns with list-item, column-span, and overflow</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="match" href="multicol-span-all-list-item-002-ref.html">

--- a/css/css-multicol/multicol-span-all-restyle-001-ref.html
+++ b/css/css-multicol/multicol-span-all-restyle-001-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Restyle column-span's parent that is a block</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-restyle-001.html
+++ b/css/css-multicol/multicol-span-all-restyle-001.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Restyle column-span's parent that is a block</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/1072">

--- a/css/css-multicol/multicol-span-all-restyle-002-ref.html
+++ b/css/css-multicol/multicol-span-all-restyle-002-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Restyle column-span's parent that is an inline</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-restyle-002.html
+++ b/css/css-multicol/multicol-span-all-restyle-002.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Restyle column-span's parent that is an inline</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/1072">

--- a/css/css-multicol/multicol-span-all-restyle-003-ref.html
+++ b/css/css-multicol/multicol-span-all-restyle-003-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Restyle column-span's multi-column container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-restyle-003.html
+++ b/css/css-multicol/multicol-span-all-restyle-003.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Restyle column-span's multi-column container</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/1072">

--- a/css/css-multicol/multicol-span-all-restyle-004-ref.html
+++ b/css/css-multicol/multicol-span-all-restyle-004-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Reference: Restyle the column-span itself</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-restyle-004.html
+++ b/css/css-multicol/multicol-span-all-restyle-004.html
@@ -2,7 +2,7 @@
 <html class="reftest-wait">
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Restyle the column-span itself</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/1072">

--- a/css/css-multicol/multicol-span-all-rule-001-ref.html
+++ b/css/css-multicol/multicol-span-all-rule-001-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test the column-rule's block-size</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-span-all-rule-001.html
+++ b/css/css-multicol/multicol-span-all-rule-001.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test the column rule's block-size</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-gaps-and-rules">

--- a/css/css-multicol/multicol-width-004-ref.html
+++ b/css/css-multicol/multicol-width-004-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Ref: Test width:min-content for a multi-column container with column-span:all children</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-width-004.html
+++ b/css/css-multicol/multicol-width-004.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test width:min-content for a multi-column container with column-span:all children</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="help" href="https://drafts.csswg.org/css-sizing-3/#sizing-properties">

--- a/css/css-multicol/multicol-width-005-ref.html
+++ b/css/css-multicol/multicol-width-005-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test Ref: Test width:max-content for a multi-column container with column-span:all children</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-multicol/multicol-width-005.html
+++ b/css/css-multicol/multicol-width-005.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS Multi-column Layout Test: Test width:max-content for a multi-column container with column-span:all children</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-multicol-1/#column-span">
   <link rel="help" href="https://drafts.csswg.org/css-sizing-3/#sizing-properties">

--- a/css/css-writing-modes/slr-alongside-vlr-floats-ref.html
+++ b/css/css-writing-modes/slr-alongside-vlr-floats-ref.html
@@ -2,7 +2,7 @@
 <html>
   <title>CSS Writing Modes Test Reference: positioning of a sideways-lr block alongside vertical-lr floats</title>
 
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
   <meta content="image" name="flags">
 

--- a/css/css-writing-modes/slr-alongside-vlr-floats.html
+++ b/css/css-writing-modes/slr-alongside-vlr-floats.html
@@ -2,7 +2,7 @@
 <html>
   <title>CSS Writing Modes Test: positioning of a sideways-lr block alongside vertical-lr floats</title>
 
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-writing-modes/#block-flow" title="3.2. Block Flow Direction: the writing-mode property">
   <link rel="match" href="slr-alongside-vlr-floats-ref.html">

--- a/css/css-writing-modes/srl-alongside-vrl-floats-ref.html
+++ b/css/css-writing-modes/srl-alongside-vrl-floats-ref.html
@@ -2,7 +2,7 @@
 <html>
   <title>CSS Writing Modes Test Reference: positioning of a sideways-rl block alongside vertical-rl floats</title>
 
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
   <meta content="image" name="flags">
 

--- a/css/css-writing-modes/srl-alongside-vrl-floats.html
+++ b/css/css-writing-modes/srl-alongside-vrl-floats.html
@@ -2,7 +2,7 @@
 <html>
   <title>CSS Writing Modes Test: positioning of a sideways-rl block alongside vertical-rl floats</title>
 
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-writing-modes/#block-flow" title="3.2. Block Flow Direction: the writing-mode property">
   <link rel="match" href="srl-alongside-vrl-floats-ref.html">

--- a/css/css-writing-modes/vlr-text-orientation-sideways-alongside-vlr-floats-ref.html
+++ b/css/css-writing-modes/vlr-text-orientation-sideways-alongside-vlr-floats-ref.html
@@ -2,7 +2,7 @@
 <html>
   <title>CSS Writing Modes Test Reference: positioning of a text-orientation:sideways block alongside vertical-lr floats</title>
 
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
 
   <style>

--- a/css/css-writing-modes/vlr-text-orientation-sideways-alongside-vlr-floats.html
+++ b/css/css-writing-modes/vlr-text-orientation-sideways-alongside-vlr-floats.html
@@ -2,7 +2,7 @@
 <html>
   <title>CSS Writing Modes Test: positioning of a text-orientation:sideways block alongside vertical-lr floats</title>
 
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-writing-modes/#block-flow" title="3.2. Block Flow Direction: the writing-mode property">
   <link rel="match" href="vlr-text-orientation-sideways-alongside-vlr-floats-ref.html">

--- a/css/css-writing-modes/vrl-text-orientation-sideways-alongside-vrl-floats-ref.html
+++ b/css/css-writing-modes/vrl-text-orientation-sideways-alongside-vrl-floats-ref.html
@@ -2,7 +2,7 @@
 <html>
   <title>CSS Writing Modes Test Reference: positioning of a text-orientation:sideways block alongside vertical-rl floats</title>
 
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
 
   <style>

--- a/css/css-writing-modes/vrl-text-orientation-sideways-alongside-vrl-floats.html
+++ b/css/css-writing-modes/vrl-text-orientation-sideways-alongside-vrl-floats.html
@@ -2,7 +2,7 @@
 <html>
   <title>CSS Writing Modes Test: positioning of a text-orientation:sideways block alongside vertical-rl floats</title>
 
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="https://www.mozilla.org/">
   <link rel="help" href="https://drafts.csswg.org/css-writing-modes/#block-flow" title="3.2. Block Flow Direction: the writing-mode property">
   <link rel="match" href="vrl-text-orientation-sideways-alongside-vrl-floats-ref.html">

--- a/css/css-writing-modes/wm-propagation-body-dynamic-change-001.html
+++ b/css/css-writing-modes/wm-propagation-body-dynamic-change-001.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS-Writing Modes Test: propagation of the writing-mode property from body to root</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel=help href="https://drafts.csswg.org/css-writing-modes-3/#principal-flow">
   <link rel="match" href="block-flow-direction-025-ref.xht">

--- a/css/css-writing-modes/wm-propagation-body-dynamic-change-002-ref.html
+++ b/css/css-writing-modes/wm-propagation-body-dynamic-change-002-ref.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS-Writing Modes Test: propagation of the writing-mode property from body to root</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
   <style>

--- a/css/css-writing-modes/wm-propagation-body-dynamic-change-002.html
+++ b/css/css-writing-modes/wm-propagation-body-dynamic-change-002.html
@@ -2,7 +2,7 @@
 <html>
   <meta charset="utf-8">
   <title>CSS-Writing Modes Test: propagation of the writing-mode property from body to root</title>
-  <link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+  <link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
   <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
   <link rel=help href="https://drafts.csswg.org/css-writing-modes-3/#principal-flow">
   <link rel="match" href="wm-propagation-body-dynamic-change-002-ref.html">

--- a/css/css-writing-modes/wm-propagation-svg-root-scrollbar.svg
+++ b/css/css-writing-modes/wm-propagation-svg-root-scrollbar.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml" width="2000px" height="100px" style="direction: rtl;">
   <g id="testmeta">
     <title>CSS-Writing Modes Test: Principal Writing Mode</title>
-    <html:link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com"/>
+    <html:link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com"/>
     <html:link rel="author" title="Mozilla" href="https://mozilla.org/"/>
     <html:link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#principal-flow"/>
     <html:link rel="mismatch" href="../reference/blank.html"/>

--- a/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-list-item-numbering-ref.html
+++ b/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-list-item-numbering-ref.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Reference for legend and display: list-item numbering</title>
-<link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+<link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
 <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 
 <style>

--- a/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-list-item-numbering.html
+++ b/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-list-item-numbering.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Legend and display: list-item numbering</title>
-<link rel="author" title="Ting-Yu Lin" href="tlin@mozilla.com">
+<link rel="author" title="Ting-Yu Lin" href="mailto:tlin@mozilla.com">
 <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 <link rel=match href="legend-list-item-numbering-ref.html">
 


### PR DESCRIPTION
This patch is generated via the following command in wpt root folder.

```
rg -l tlin@mozilla.com | xargs sed -i 's/href="tlin@mozilla.com"/href="mailto:tlin@mozilla.com"/g'
```