### PR TITLE
This adds some additional tests for URL issue 619

### DIFF
--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -8173,5 +8173,39 @@
     "input": "http://foo.0x4.",
     "base": "about:blank",
     "failure": true
+  },
+  {
+    "input": "http://foo.09..",
+    "base": "about:blank",
+    "hash": "",
+    "host": "foo.09..",
+    "hostname": "foo.09..",
+    "href":"http://foo.09../",
+    "password": "",
+    "pathname": "/",
+    "port":"",
+    "protocol": "http:",
+    "search": "",
+    "username": ""
+  },
+  {
+    "input": "http://0999999999999999999/",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://foo.0x",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://foo.0XFfFfFfFfFfFfFfFfFfAcE123",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "http://💩.123/",
+    "base": "about:blank",
+    "failure": true
   }
 ]


### PR DESCRIPTION
These are based on my implementation in https://bugs.webkit.org/show_bug.cgi?id=228826
where I found some untested code paths.

The first is to cover my interpretation of strictly splitting by '.' and finding the last non-empty entry.
There were no tests covering the case where a host ends in a number followed by more than one dot,
and this is my interpretation of the spec's change's intent that we should look at the last non-empty entry.

The second covers an untested case in my state machine implementation of the change
where "0x" is considered a valid IPv4 address, which is the behavior of Chrome and Safari and I believe the spec, too.

The third covers the non-ASCII input path.  Our recent addition of tests with xn-- and invalid punycode
leads me to believe that other browsers also have an ASCII path and a non-ASCII path for parsing URL hosts.
This covers the non-ASCII path, which was previously uncovered.