### PR TITLE
Change `Tests.prototype.all_done` to require either tests or pending remotes

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -2942,7 +2942,8 @@
     };
 
     Tests.prototype.all_done = function() {
-        return this.tests.length > 0 && test_environment.all_loaded &&
+        return (this.tests.length > 0 || this.pending_remotes.length > 0) &&
+                test_environment.all_loaded &&
                 (this.num_pending === 0 || this.is_aborted) && !this.wait_for_finish &&
                 !this.processing_callbacks &&
                 !this.pending_remotes.some(function(w) { return w.running; });


### PR DESCRIPTION
`Tests.prototype.all_done` used to treat the presence of at least one test as a necessary condition for all tests to be done. This would be false in cases where an exception is thrown inside the `setup` function, but the code path that runs in that case doesn't use the `all_done()` function.

However, if an exception is thrown inside the `setup` function in a worker test, `tests.all_done()` is called in that code path, which results in the completion message from the worker being ignored. This change fixes this by changing the condition to require the presence of either tests or remote contexts.

~For service worker tests, however, that is not enough, since service worker registration is asynchronous and `tests.all_done()` will be called before the SW remote context is set up. This change lets the `fetch_tests_from_worker` function take a promise or an async function that returns the worker, and it guarantees that the test won't be considered complete until the promise is resolved. The HTML boilerplate for service worker tests is also changed in turn.~

Closes #29777.

--------------------

For historical context, this PR was initially a draft fix for #29777 that removed the condition that `this.tests.length > 0`. This turned out to break many tests (https://github.com/web-platform-tests/wpt/issues/29777#issuecomment-896439309), and this PR was repurposed to solve this in a different way.