### PR TITLE
SharedWorker: interface constructors exposed

### DIFF
--- a/workers/constructors/SharedWorker/interface-objects.html
+++ b/workers/constructors/SharedWorker/interface-objects.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 async_test(t => {
-  const expected = 'XMLHttpRequest WebSocket EventSource MessageChannel Worker SharedWorker ApplicationCache'.split(' ');
+  const expected = 'XMLHttpRequest WebSocket EventSource MessageChannel Worker'.split(' ');
   const supported = [];
   for (let i = 0; i < expected.length; ++i) {
   if (expected[i] in window)
@@ -14,7 +14,7 @@ async_test(t => {
   worker.port.start();
   worker.port.postMessage(supported);
   worker.port.onmessage = t.step_func_done(e => {
-    assert_equals(e.data, '');
+    assert_equals(e.data, 'These were missing: ');
   });
 }, 'Test if interface objects exist in a shared worker');
 </script>


### PR DESCRIPTION
This fixes https://github.com/web-platform-tests/wpt/issues/29928?fbclid=IwAR0XslEf-oWotY6ZKbGs1uqrW6KFVcT0LVa_rf_XZtS-OwLV2dFUT_xNNwk.
According to the [specification](https://html.spec.whatwg.org/#shared-workers-and-the-sharedworker-interface), the SharedWorker constructor should not be exposed. The other constructors, however, should not be missing.