### PR TITLE
Use assert_less_than in nav2_test_redirect_server.html

### DIFF
--- a/navigation-timing/nav2_test_redirect_server.html
+++ b/navigation-timing/nav2_test_redirect_server.html
@@ -13,7 +13,7 @@
 
             function verifyTimingEventOrder(eventOrder, timingEntry) {
                 for (let i = 0; i < eventOrder.length - 1; i++) {
-                    assert_true(timingEntry[eventOrder[i]] < timingEntry[eventOrder[i + 1]],
+                    assert_less_than(timingEntry[eventOrder[i]], timingEntry[eventOrder[i + 1]],
                         "Expected " + eventOrder[i] + " to be no greater than " + eventOrder[i + 1] + ".");
                 }
             }


### PR DESCRIPTION
This is first step to investigate this failure on Firefox. Convert
the test to `assert_less_than` so that we can actually see what
values are failing.