### PR TITLE
Popup window is closing before the end of the test in html/semantics/…

### DIFF
--- a/html/semantics/links/links-created-by-a-and-area-elements/support/noopener-target-2.html
+++ b/html/semantics/links/links-created-by-a-and-area-elements/support/noopener-target-2.html
@@ -4,5 +4,4 @@
   channel.postMessage({ hasOpener: opener !== null ,
                         hasParent: parent != this,
                         name: window.name });
-  window.close();
 </script>


### PR DESCRIPTION
…links/links-created-by-a-and-area-elements/htmlanchorelement_noopener.html

In html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_noopener.html, the "Check that targeting of rel=noopener with
a given name reuses an existing window with that name" test (t1) opens a popup window via window.open() and then navigates this window to
"support/noopener-target-2.html" via link targetting. The issue is that the JS inside noopener-target-2.html sends a BroadcastChannel message
and then calls `window.close()` right away. Then htmlanchorelement_noopener.html receives the BroadcastChannel messages, it does the following
check: `assert_equals(w.opener, window);`. This check is failing in WebKit because the popup window |w| has already been closed by the time
the message is received. The test already takes care of calling `w.close()` as a clean up step so there is actually no need for
noopener-target-2.html to call `window.close()` itself.