### PR TITLE
[Taskcluster] pin Chrome Dev to 94.0.4603

### DIFF
--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -139,9 +139,9 @@ def install_certificates():
 def install_chrome(channel):
     deb_prefix = "https://dl.google.com/linux/direct"
     if channel in ("experimental", "dev"):
-        # Pinned Chrome to 94.0.4603. TODO(kyle).
+        # Pinned Chrome to 93.0.4577.18 TODO(kyle).
         # See https://github.com/web-platform-tests/wpt/issues/30090.
-        deb_archive = "google-chrome-unstable_94.0.4603.0-1_amd64.deb"
+        deb_archive = "google-chrome-unstable_93.0.4577.18-1_amd64.deb"
         deb_prefix = "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/"
     elif channel == "beta":
         deb_archive = "google-chrome-beta_current_amd64.deb"

--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -137,8 +137,12 @@ def install_certificates():
 
 
 def install_chrome(channel):
+    deb_prefix = "https://dl.google.com/linux/direct"
     if channel in ("experimental", "dev"):
-        deb_archive = "google-chrome-unstable_current_amd64.deb"
+        # Pinned Chrome to 94.0.4603. TODO(kyle).
+        # See https://github.com/web-platform-tests/wpt/issues/30090.
+        deb_archive = "google-chrome-unstable_94.0.4603.0-1_amd64.deb"
+        deb_prefix = "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/"
     elif channel == "beta":
         deb_archive = "google-chrome-beta_current_amd64.deb"
     elif channel == "stable":
@@ -147,7 +151,7 @@ def install_chrome(channel):
         raise ValueError("Unrecognized release channel: %s" % channel)
 
     dest = os.path.join("/tmp", deb_archive)
-    deb_url = "https://dl.google.com/linux/direct/%s" % deb_archive
+    deb_url = deb_prefix + deb_archive
     with open(dest, "wb") as f:
         get_download_to_descriptor(f, deb_url)
 

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -745,6 +745,10 @@ class Chrome(Browser):
             os.chmod(existing_binary_path, stat.S_IWUSR)
             os.remove(existing_binary_path)
 
+        # Pinned Chrome to 93.0.4577.18 TODO(kyle).
+        # See https://github.com/web-platform-tests/wpt/issues/30090.
+        version = "93.0.4577.18"
+
         url = self._latest_chromedriver_url(version) if version \
             else self._chromium_chromedriver_url(None)
         self.logger.info("Downloading ChromeDriver from %s" % url)


### PR DESCRIPTION
Per #30090, the latest ChromeDriver downloading URL is failing. Pinned it to the previous working Chrome dev version df1b98507ac8a99daac77bcf78fa68835c1e6b73. Similar to #28661

Mitigation (not fix) for #30090.