### PR TITLE
Test that BlinkMacSystemFont behaves as a <family-name>

### DIFF
--- a/css/css-fonts/generic-family-keywords-002.html
+++ b/css/css-fonts/generic-family-keywords-002.html
@@ -20,7 +20,6 @@
   <body>
     <div><span id="ahem">00000</span></div>
     <div><span id="test">00000</span></div>
-  </body>
 <script>
   setup({ explicit_done: true });
   window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
@@ -32,7 +31,7 @@
   function runTests() {
     let ahem = document.getElementById('ahem');
     let ahem_expected_width = ahem.offsetWidth;
-    let families = kGenericFontFamilyKeywords.map(keyword => `-webkit-${keyword}`).concat(kWebKitPrefixKeywords);
+    let families = kGenericFontFamilyKeywords.map(keyword => `-webkit-${keyword}`).concat(kNonGenericFontFamilyKeywords);
     families.forEach(name => {
       test(function() {
       assert_equals(SetFontFamilyAndMeasure(name), ahem_expected_width);
@@ -41,4 +40,5 @@
     done();
   }
 </script>
+  </body>
 </html>

--- a/css/css-fonts/support/font-family-keywords.js
+++ b/css/css-fonts/support/font-family-keywords.js
@@ -1,17 +1,27 @@
-var kGenericFontFamilyKeywords = ["serif",
-                                  "sans-serif",
-                                  "cursive",
-                                  "fantasy",
-                                  "monospace",
-                                  "system-ui",
-                                  "emoji",
-                                  "math",
-                                  "fangsong",
-                                  "ui-serif",
-                                  "ui-sans-serif",
-                                  "ui-monospace",
-                                  "ui-rounded"];
+// <generic-family> keywords, as specified in
+// https://drafts.csswg.org/css-fonts/#generic-family-value
+var kGenericFontFamilyKeywords = [
+    "serif",
+    "sans-serif",
+    "cursive",
+    "fantasy",
+    "monospace",
+    "system-ui",
+    "emoji",
+    "math",
+    "fangsong",
+    "ui-serif",
+    "ui-sans-serif",
+    "ui-monospace",
+    "ui-rounded",
+];
 
-var kWebKitPrefixKeywords = ["-webkit-body",
-                             "-webkit-standard",
-                             "-webkit-pictograph"];
+// <family-name> values that had/have web-exposed behavior in some browsers, but
+// are not defined in the specification.
+var kNonGenericFontFamilyKeywords = [
+    "NonGenericFontFamilyName",
+    "-webkit-body",
+    "-webkit-standard",
+    "-webkit-pictograph",
+    "BlinkMacSystemFont",
+];

--- a/css/cssom/font-family-serialization-001.html
+++ b/css/cssom/font-family-serialization-001.html
@@ -35,10 +35,10 @@
   }, "Serialization of prefixed -webkit-<generic-family>");
 
   test(function() {
-    kWebKitPrefixKeywords.forEach(keyword => {
+    kNonGenericFontFamilyKeywords.forEach(keyword => {
       assert_equals(SetFontFamilyAndSerialize(keyword), keyword);
     });
-  }, `Serialization of ${kWebKitPrefixKeywords}`);
+  }, `Serialization of ${kNonGenericFontFamilyKeywords}`);
 
 </script>
 </html>


### PR DESCRIPTION
Chrome for macOS currently converts it internally to "system-ui" and
so incorrectly serializes it [1] [2].

Also add value "NonGenericFontFamilyName" which should work in all
browsers and tweak a bit the code.

[1] https://bugs.chromium.org/p/chromium/issues/detail?id=554590
[2] https://docs.google.com/document/d/1nYJzL-MWQrTmf9Z-KscTWuM_5n6-IVdJeEllJ3Appro