### PR TITLE
Move text above tests for `position: sticky` tests

### DIFF
--- a/css/css-position/sticky/position-sticky-flexbox-ref.html
+++ b/css/css-position/sticky/position-sticky-flexbox-ref.html
@@ -35,6 +35,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<p>You should see three green boxes of varying size below. There should be no red or blue.</p>
+
 <div id="scroller1" class="scroller">
   <div class="flex-container">
     <div class="flex-item"></div>
@@ -59,5 +61,3 @@ window.addEventListener('load', function() {
     <div class="green flex-item"></div>
   </div>
 </div>
-
-<p>You should see three green boxes of varying size above. There should be no red or blue.</p>

--- a/css/css-position/sticky/position-sticky-flexbox.html
+++ b/css/css-position/sticky/position-sticky-flexbox.html
@@ -53,6 +53,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<p>You should see three green boxes of varying size below. There should be no red or blue.</p>
+
 <div id="scroller1" class="scroller">
   <div class="flex-container">
     <div class="indicator" style="left: 100px;"></div>
@@ -79,5 +81,3 @@ window.addEventListener('load', function() {
     <div class="green flex-item"></div>
   </div>
 </div>
-
-<p>You should see three green boxes of varying size above. There should be no red or blue.</p>

--- a/css/css-position/sticky/position-sticky-grid-ref.html
+++ b/css/css-position/sticky/position-sticky-grid-ref.html
@@ -44,6 +44,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<p>You should see three green boxes of varying size below. There should be no red or blue.</p>
+
 <div id="scroller1" class="scroller">
   <div class="grid-container">
     <div class="grid-item" style="grid-column: 1;"></div>
@@ -71,6 +73,4 @@ window.addEventListener('load', function() {
   </div>
   <div class="padding"></div>
 </div>
-
-<p>You should see three green boxes of varying size above. There should be no red or blue.</p>
 

--- a/css/css-position/sticky/position-sticky-grid.html
+++ b/css/css-position/sticky/position-sticky-grid.html
@@ -62,6 +62,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<p>You should see three green boxes of varying size below. There should be no red or blue.</p>
+
 <div id="scroller1" class="scroller">
   <div class="grid-container">
     <div class="indicator" style="left: 100px;"></div>
@@ -91,5 +93,3 @@ window.addEventListener('load', function() {
   </div>
   <div class="padding"></div>
 </div>
-
-<p>You should see three green boxes of varying size above. There should be no red or blue.</p>

--- a/css/css-position/sticky/position-sticky-hyperlink-ref.html
+++ b/css/css-position/sticky/position-sticky-hyperlink-ref.html
@@ -28,8 +28,10 @@ window.addEventListener('load', function() {
   document.querySelector('.scroller').scrollTop = 100;
 });
 </script>
+
+<div>You should see a sticky link at the top of the scrollable area.</div>
+
 <div class='scroller'>
   <a href='#' class='positioned'>Link</a>
   <div class='spacer'></div>
 </div>
-<div>You should see a sticky link at the top of the scrollable area.</div>

--- a/css/css-position/sticky/position-sticky-hyperlink.html
+++ b/css/css-position/sticky/position-sticky-hyperlink.html
@@ -32,8 +32,9 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see a sticky link at the top of the scrollable area.</div>
+
 <div class='scroller'>
   <a href='#' class='sticky'>Link</a>
   <div class='spacer'></div>
 </div>
-<div>You should see a sticky link at the top of the scrollable area.</div>

--- a/css/css-position/sticky/position-sticky-inline-ref.html
+++ b/css/css-position/sticky/position-sticky-inline-ref.html
@@ -42,6 +42,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green rectangles below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="contents">
@@ -65,5 +67,3 @@ window.addEventListener('load', function() {
     </div>
   </div>
 </div>
-
-<div>You should see three green rectangles above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-inline.html
+++ b/css/css-position/sticky/position-sticky-inline.html
@@ -67,6 +67,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green rectangles below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="indicator inline" style="top: 150px;">XXX</div>
@@ -105,5 +107,3 @@ window.addEventListener('load', function() {
     </div>
   </div>
 </div>
-
-<div>You should see three green rectangles above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-nested-inline-ref.html
+++ b/css/css-position/sticky/position-sticky-nested-inline-ref.html
@@ -44,6 +44,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green and three yellow rectangles below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="contents">
@@ -70,5 +72,3 @@ window.addEventListener('load', function() {
     </div>
   </div>
 </div>
-
-<div>You should see three green and three yellow rectangles above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-nested-inline.html
+++ b/css/css-position/sticky/position-sticky-nested-inline.html
@@ -77,6 +77,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green and three yellow rectangles below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="outerIndicator" style="top: 150px;">X</div>
@@ -115,5 +117,3 @@ window.addEventListener('load', function() {
     </div>
   </div>
 </div>
-
-<div>You should see three green and three yellow rectangles above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-nested-table-ref.html
+++ b/css/css-position/sticky/position-sticky-nested-table-ref.html
@@ -39,6 +39,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green rectangles below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="contents">
@@ -62,5 +64,3 @@ window.addEventListener('load', function() {
     </div>
   </div>
 </div>
-
-<div>You should see three green rectangles above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-nested-table.html
+++ b/css/css-position/sticky/position-sticky-nested-table.html
@@ -67,6 +67,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green rectangles below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="contents">
@@ -129,5 +131,3 @@ window.addEventListener('load', function() {
     </div>
   </div>
 </div>
-
-<div>You should see three green rectangles above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-nested-thead-th.html
+++ b/css/css-position/sticky/position-sticky-nested-thead-th.html
@@ -67,6 +67,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green rectangles below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="contents">
@@ -129,5 +131,3 @@ window.addEventListener('load', function() {
     </div>
   </div>
 </div>
-
-<div>You should see three green rectangles above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-rendering-ref.html
+++ b/css/css-position/sticky/position-sticky-rendering-ref.html
@@ -66,6 +66,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see four green squares below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="contents">
@@ -100,5 +102,3 @@ window.addEventListener('load', function() {
     </div>
   </div>
 </div>
-
-<div>You should see four green squares above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-rendering.html
+++ b/css/css-position/sticky/position-sticky-rendering.html
@@ -108,6 +108,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see four green squares below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="indicator box" style="top: 175px;"></div>
@@ -155,5 +157,3 @@ window.addEventListener('load', function() {
     </div>
   </div>
 </div>
-
-<div>You should see four green squares above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-stacking-context-ref.html
+++ b/css/css-position/sticky/position-sticky-stacking-context-ref.html
@@ -12,6 +12,6 @@
 }
 </style>
 
-<div class="indicator box"></div>
+<div>You should see a single green box below. No red or blue should be visible.</div>
 
-<div>You should see a single green box above. No red or blue should be visible.</div>
+<div class="indicator box"></div>

--- a/css/css-position/sticky/position-sticky-stacking-context.html
+++ b/css/css-position/sticky/position-sticky-stacking-context.html
@@ -35,11 +35,12 @@ window.addEventListener('load', function() {
    createIndicatorForStickyElements(document.querySelectorAll('.sticky'));
 })
 </script>
+
+<div>You should see a single green box below. No red or blue should be visible.</div>
+
 <div class="indicator box"></div>
 <div class="sticky box">
   <!-- Because sticky forms a stacking context, this child remains on bottom
        even though it has a higher z-index than the indicator box. -->
   <div class="child box"></div>
 </div>
-
-<div>You should see a single green box above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-table-parts-ref.html
+++ b/css/css-position/sticky/position-sticky-table-parts-ref.html
@@ -35,6 +35,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>There should be a green square at the top of the scroll view and no red or blue visible.</div>
+
   <div id="scroller1" class="scroller">
     <div class="contents">
       <div class="prepadding"></div>
@@ -45,4 +47,3 @@ window.addEventListener('load', function() {
       </table>
     </div>
   </div>
-<div>There should be a green square at the top of the scroll view and no red or blue visible.</div>

--- a/css/css-position/sticky/position-sticky-table-parts.html
+++ b/css/css-position/sticky/position-sticky-table-parts.html
@@ -56,6 +56,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>There should be a green square at the top of the scroll view and no red or blue visible.</div>
+
 <div id="scroller1" class="scroller">
   <div class="contents">
     <div class="indicator" style="top: 155px;"></div>
@@ -72,4 +74,3 @@ window.addEventListener('load', function() {
     </table>
   </div>
 </div>
-<div>There should be a green square at the top of the scroll view and no red or blue visible.</div>

--- a/css/css-position/sticky/position-sticky-table-tfoot-bottom-ref.html
+++ b/css/css-position/sticky/position-sticky-table-tfoot-bottom-ref.html
@@ -38,6 +38,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green boxes below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="indicator" style="top: 100px;"></div>
@@ -58,5 +60,3 @@ window.addEventListener('load', function() {
     <div class="contents"></div>
   </div>
 </div>
-
-<div>You should see three green boxes above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-table-tfoot-bottom.html
+++ b/css/css-position/sticky/position-sticky-table-tfoot-bottom.html
@@ -67,6 +67,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green boxes below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="indicator" style="top: 100px;"></div>
@@ -120,5 +122,3 @@ window.addEventListener('load', function() {
     <div class="postpadding"></div>
   </div>
 </div>
-
-<div>You should see three green boxes above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-table-th-bottom-ref.html
+++ b/css/css-position/sticky/position-sticky-table-th-bottom-ref.html
@@ -38,6 +38,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green boxes below. No red should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="indicator" style="top: 100px;"></div>
@@ -58,5 +60,3 @@ window.addEventListener('load', function() {
     <div class="contents"></div>
   </div>
 </div>
-
-<div>You should see three green boxes above. No red should be visible.</div>

--- a/css/css-position/sticky/position-sticky-table-th-bottom.html
+++ b/css/css-position/sticky/position-sticky-table-th-bottom.html
@@ -64,6 +64,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green boxes below. No red should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="indicator" style="top: 100px;"></div>
@@ -123,5 +125,3 @@ window.addEventListener('load', function() {
     <div class="postpadding"></div>
   </div>
 </div>
-
-<div>You should see three green boxes above. No red should be visible.</div>

--- a/css/css-position/sticky/position-sticky-table-th-left-ref.html
+++ b/css/css-position/sticky/position-sticky-table-th-left-ref.html
@@ -38,6 +38,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green boxes below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="indicator" style="left: 100px;"></div>
@@ -58,5 +60,3 @@ window.addEventListener('load', function() {
     <div class="contents"></div>
   </div>
 </div>
-
-<div>You should see three green boxes above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-table-th-left.html
+++ b/css/css-position/sticky/position-sticky-table-th-left.html
@@ -64,6 +64,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green boxes below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="indicator" style="left: 100px;"></div>
@@ -114,5 +116,3 @@ window.addEventListener('load', function() {
     <div class="postpadding"></div>
   </div>
 </div>
-
-<div>You should see three green boxes above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-table-th-right-ref.html
+++ b/css/css-position/sticky/position-sticky-table-th-right-ref.html
@@ -38,6 +38,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green boxes below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="indicator" style="left: 150px;"></div>
@@ -58,5 +60,3 @@ window.addEventListener('load', function() {
     <div class="contents"></div>
   </div>
 </div>
-
-<div>You should see three green boxes above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-table-th-right.html
+++ b/css/css-position/sticky/position-sticky-table-th-right.html
@@ -64,6 +64,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green boxes below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="indicator" style="left: 150px;"></div>
@@ -114,5 +116,3 @@ window.addEventListener('load', function() {
     <div class="postpadding"></div>
   </div>
 </div>
-
-<div>You should see three green boxes above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-table-th-top-ref.html
+++ b/css/css-position/sticky/position-sticky-table-th-top-ref.html
@@ -38,6 +38,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green boxes below. No red should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="indicator" style="top: 100px;"></div>
@@ -58,5 +60,3 @@ window.addEventListener('load', function() {
     <div class="contents"></div>
   </div>
 </div>
-
-<div>You should see three green boxes above. No red should be visible.</div>

--- a/css/css-position/sticky/position-sticky-table-th-top.html
+++ b/css/css-position/sticky/position-sticky-table-th-top.html
@@ -64,6 +64,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green boxes below. No red should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="indicator" style="top: 100px;"></div>
@@ -123,5 +125,3 @@ window.addEventListener('load', function() {
     <div class="postpadding"></div>
   </div>
 </div>
-
-<div>You should see three green boxes above. No red should be visible.</div>

--- a/css/css-position/sticky/position-sticky-table-thead-top-ref.html
+++ b/css/css-position/sticky/position-sticky-table-thead-top-ref.html
@@ -38,6 +38,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green boxes below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="indicator" style="top: 100px;"></div>
@@ -58,5 +60,3 @@ window.addEventListener('load', function() {
     <div class="contents"></div>
   </div>
 </div>
-
-<div>You should see three green boxes above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-table-thead-top.html
+++ b/css/css-position/sticky/position-sticky-table-thead-top.html
@@ -67,6 +67,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green boxes below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="indicator" style="top: 100px;"></div>
@@ -120,5 +122,3 @@ window.addEventListener('load', function() {
     <div class="postpadding"></div>
   </div>
 </div>
-
-<div>You should see three green boxes above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-table-tr-bottom-ref.html
+++ b/css/css-position/sticky/position-sticky-table-tr-bottom-ref.html
@@ -38,6 +38,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green boxes below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="indicator" style="top: 100px;"></div>
@@ -58,5 +60,3 @@ window.addEventListener('load', function() {
     <div class="contents"></div>
   </div>
 </div>
-
-<div>You should see three green boxes above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-table-tr-bottom.html
+++ b/css/css-position/sticky/position-sticky-table-tr-bottom.html
@@ -67,6 +67,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green boxes below. No red or blue should be visible.</div>
+
 <!-- .sticky element pushed as far up as possible to table edge -->
 <div class="group">
   <div id="scroller1" class="scroller">
@@ -117,5 +119,3 @@ window.addEventListener('load', function() {
     <div class="postpadding"></div>
   </div>
 </div>
-
-<div>You should see three green boxes above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-table-tr-top-ref.html
+++ b/css/css-position/sticky/position-sticky-table-tr-top-ref.html
@@ -38,6 +38,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green boxes below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller">
     <div class="indicator" style="top: 100px;"></div>
@@ -58,5 +60,3 @@ window.addEventListener('load', function() {
     <div class="contents"></div>
   </div>
 </div>
-
-<div>You should see three green boxes above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-table-tr-top.html
+++ b/css/css-position/sticky/position-sticky-table-tr-top.html
@@ -67,6 +67,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see three green boxes below. No red or blue should be visible.</div>
+
 <!-- .sticky element not yet stuck -->
 <div class="group">
   <div id="scroller1" class="scroller">
@@ -117,5 +119,3 @@ window.addEventListener('load', function() {
     <div class="postpadding"></div>
   </div>
 </div>
-
-<div>You should see three green boxes above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-writing-modes-ref.html
+++ b/css/css-position/sticky/position-sticky-writing-modes-ref.html
@@ -39,6 +39,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see two green blocks below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller" style="writing-mode: vertical-lr;">
     <div class="contents">
@@ -54,5 +56,3 @@ window.addEventListener('load', function() {
     </div>
   </div>
 </div>
-
-<div>You should see two green blocks above. No red or blue should be visible.</div>

--- a/css/css-position/sticky/position-sticky-writing-modes.html
+++ b/css/css-position/sticky/position-sticky-writing-modes.html
@@ -52,6 +52,8 @@ window.addEventListener('load', function() {
 });
 </script>
 
+<div>You should see two green blocks below. No red or blue should be visible.</div>
+
 <div class="group">
   <div id="scroller1" class="scroller" style="writing-mode: vertical-lr;">
     <div class="indicator" style="left: 40px; top: 100px;">XXX</div>
@@ -69,5 +71,3 @@ window.addEventListener('load', function() {
     </div>
   </div>
 </div>
-
-<div>You should see two green blocks above. No red or blue should be visible.</div>


### PR DESCRIPTION
Some of these tests are failing on Safari, because text positioning
differences. These differences are unrelated to `position:sticky` so
moving the text will improve test coverage of the feature.