### PR TITLE
[wave] Python 3 fixes for tools/wave/

### DIFF
--- a/tools/wave/network/http_handler.py
+++ b/tools/wave/network/http_handler.py
@@ -79,12 +79,17 @@ class HttpHandler(object):
         port = str(self._http_port)
         uri = request.url_parts.path
         uri = uri + "?" + request.url_parts.query
-        data = request.raw_input.read(request.headers.get('Content-Length'))
+        data = request.raw_input.read(int(request.headers.get('Content-Length', -1)))
         method = request.method
+        # HTTPConnection expects values to be a comma separated string instead
+        # of a list of values.
+        headers = {}
+        for k, v in request.headers.items():
+            headers[k] = b",".join(list(v))
 
         try:
             proxy_connection = httplib.HTTPConnection(host, port)
-            proxy_connection.request(method, uri, data, request.headers)
+            proxy_connection.request(method, uri, data, headers)
             proxy_response = proxy_connection.getresponse()
             response.content = proxy_response.read()
             response.headers = proxy_response.getheaders()

--- a/tools/wave/testing/results_manager.py
+++ b/tools/wave/testing/results_manager.py
@@ -444,9 +444,9 @@ class ResultsManager(object):
         hash = hashlib.sha1()
         ref_tokens.sort()
         for token in ref_tokens:
-            hash.update(token)
+            hash.update(token.encode("utf-8"))
         for token in tokens:
-            hash.update(token)
+            hash.update(token.encode("utf-8"))
         hash = hash.hexdigest()
         comparison_directory += hash[0:8]
         return comparison_directory
@@ -486,7 +486,7 @@ class ResultsManager(object):
 
         zip_file_name = str(time.time()) + ".zip"
         zip = zipfile.ZipFile(zip_file_name, "w")
-        for api, result in results.iteritems():
+        for api, result in results.items():
             zip.writestr(
                 api + ".json",
                 json.dumps({"results": result}, indent=4),
@@ -507,7 +507,7 @@ class ResultsManager(object):
 
         zip.close()
 
-        with open(zip_file_name, "r") as file:
+        with open(zip_file_name, "rb") as file:
             blob = file.read()
             os.remove(zip_file_name)
 
@@ -534,7 +534,7 @@ class ResultsManager(object):
                 zip.write(file_path, file_name, zipfile.ZIP_DEFLATED)
         zip.close()
 
-        with open(zip_file_name, "r") as file:
+        with open(zip_file_name, "rb") as file:
             blob = file.read()
             os.remove(zip_file_name)
 
@@ -568,7 +568,7 @@ class ResultsManager(object):
 
         zip.close()
 
-        with open(tmp_file_name, "r") as file:
+        with open(tmp_file_name, "rb") as file:
             blob = file.read()
 
             self.remove_tmp_files()

--- a/tools/wave/testing/tests_manager.py
+++ b/tools/wave/testing/tests_manager.py
@@ -6,6 +6,32 @@ from .event_dispatcher import TEST_COMPLETED_EVENT
 from ..data.exceptions.not_found_exception import NotFoundException
 from ..data.session import COMPLETED, ABORTED
 
+# Helper class used to adapt a specific compare function to a Python 3
+# key function.
+class CmpWrapper:
+    def __init__(self, test_manager, compare_function, obj):
+        self.obj = obj
+        self.test_manager = test_manager
+        self.compare_function = compare_function
+
+    def __lt__(self, other):
+        return self.compare_function(self.test_manager, self.obj, other.obj) < 0
+
+    def __gt__(self, other):
+        return self.compare_function(self.test_manager, self.obj, other.obj) > 0
+
+    def __eq__(self, other):
+        return self.compare_function(self.test_manager, self.obj, other.obj) == 0
+
+    def __le__(self, other):
+        return self.compare_function(self.test_manager, self.obj, other.obj) <= 0
+
+    def __ge__(self, other):
+        return self.compare_function(self.test_manager, self.obj, other.obj) >= 0
+
+    def __ne__(self, other):
+        return self.compare_function(self.test_manager, self.obj, other.obj) != 0
+
 
 class TestsManager(object):
     def initialize(
@@ -140,9 +166,7 @@ class TestsManager(object):
                 return -1
             return 1
 
-        sorted_tests.sort(cmp=lambda test_a,
-                          test_b: compare(self, test_a, test_b))
-        return sorted_tests
+        return sorted(sorted_tests, key=lambda x:CmpWrapper(self, compare, x))
 
     def _get_next_test_from_list(self, tests):
         test = None


### PR DESCRIPTION
A bunch of minor changes to make the wave test runner work with
Python 3:

* Sort() no longer accepts a cmp function argument, use sorted()
  instead with a key function.

* headers.get('Content-Length') returns byte value now, explicitly cast
  to int. Also return -1 if the header does not exist (instead of None)
  so that it is accepted as int value and to get the same behavior in
  InputFile.read() as with Python 2.

* Pass header values as comma separated byte strings to
  HTTPConnection.request() instead of lists. HTTPConnection.putheader()
  does not like getting lists.

* hashlib.update() accepts a "bytes-like" object so encode the token
  string before passing it in.

* dict.iteritems() was renamed to dict.items().

* Explicitly open zipfiles as binary files. If not, file.read() will
  try to read them as utf-8 which fails.