### PR TITLE
Fix typo in coop-same-origin-allow-popups-document-write.html

### DIFF
--- a/html/cross-origin-opener-policy/coop-same-origin-allow-popups-document-write.html
+++ b/html/cross-origin-opener-policy/coop-same-origin-allow-popups-document-write.html
@@ -52,7 +52,7 @@ promise_test(async t => {
   // for the openee' document to load and the various fetch() with the
   // dispatcher should be largely enough. However these aren't causal guarantee.
   // So wait a bit to be sure:
-  await new Promise(r => test.step_timeout(r, 1000));
+  await new Promise(r => t.step_timeout(r, 1000));
 
   // Check the opener see the openee as 'closed' after the navigation.
   send(opener_token, `


### PR DESCRIPTION
`test` is undefined, it should be `t`.