### PR TITLE
[wave] Include all js tests in a wave run

### DIFF
--- a/tools/wave/testing/test_loader.py
+++ b/tools/wave/testing/test_loader.py
@@ -70,7 +70,7 @@ class TestLoader(object):
                     paths.append(test)
                     continue
                 if test.endswith(".js"):
-                    for element in tests[test][1:]:
+                    for element in tests[test]:
                         paths.append(element[0])
                     continue
             return paths


### PR DESCRIPTION
The wave test loader expects all js tests to include a list of the
html paths for the tests. But some js tests do not, probably the
ones that only have a single test file. This patch make the
test loader pick up those tests as well.