### PR TITLE
[wave] Use the correct part of uri for the reporturl api

### DIFF
--- a/tools/wave/network/api/results_api_handler.py
+++ b/tools/wave/network/api/results_api_handler.py
@@ -80,7 +80,7 @@ class ResultsApiHandler(ApiHandler):
     def read_results_api_wpt_multi_report_uri(self, request, response):
         try:
             uri_parts = self.parse_uri(request)
-            api = uri_parts[3]
+            api = uri_parts[2]
             query = self.parse_query_parameters(request)
             tokens = query["tokens"].split(",")
             uri = self._results_manager.read_results_wpt_multi_report_uri(


### PR DESCRIPTION
uri_parts[3] is the function "reporturl" in this case, the
api is the part before that.

This fix targets the comparison view in the wave UI. Without this
fix wave won't even try to make a comparison since it will use
"reporturl" as identifier for the test group. It should be "acid"
for the "acid" test group etc.

However, note that the comparison view depends on a specific
version of wptreport to function properly, namely
https://github.com/fraunhoferfokus/wptreport

The reason is that it uses the --tokenFileName command line
flag which is only available in that version of wptreport at the
time of preparing this patch.