### PR TITLE
[wave] Support calling window.gc() between tests in the wave runner

### DIFF
--- a/tools/wave/resources/testharnessreport.js
+++ b/tools/wave/resources/testharnessreport.js
@@ -147,6 +147,15 @@ if (location.search && location.search.indexOf("token=") != -1) {
 
    function loadNext() {
       logToConsole("Loading next test ...");
+      if (window.gc) {
+         // This is using a chromium/v8 feature, enable it by
+         // --js-flags="expose-gc".
+         // TODO: Replace this with TestUtils.gc() once/if that is available
+         // in browsers:
+         // https://jgraham.github.io/browser-test/#the-testutils-object
+         logToConsole("Forcing garbage collection using window.gc()");
+         window.gc();
+      }
       readNextTest(
          __WAVE__TOKEN,
          function (url) {


### PR DESCRIPTION
This patch make the wave runner call window.gc() if the Chromium
commandline flag --js-flags="--expose-gc" is supplied.

Garbage collecting between test groups provides much more stable
test results when running tests in a single window. Especially on
slow machines where garbage collection might not kick in as
frequently.