### PR TITLE
[navigation-timing] test PerformanceNavigationTiming's duration and responseEnd properties before, during, and after the load event

### DIFF
--- a/navigation-timing/nav2_test_response_end_and_duration_before_during_and_after_load_event.html
+++ b/navigation-timing/nav2_test_response_end_and_duration_before_during_and_after_load_event.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe src="resources/respond_slowly.py"></iframe>
+<body>
+<script>
+async_test(function(t) {
+  window.addEventListener('message', t.step_func_done(function(event) {
+    let originalResponseEnd = event.data[0];
+    let originalDuration = event.data[1];
+    let responseEndDuringLoadEvent = event.data[2];
+    let durationDuringLoadEvent = event.data[3];
+    let responseEndAfterLoadEvent = event.data[4];
+    let durationAfterLoadEvent = event.data[5];
+    assert_equals(originalResponseEnd, 0, "PerformanceNavigationTiming.responseEnd == 0 before load event");
+    assert_equals(originalDuration, 0, "PerformanceNavigationTiming.duration is 0 before load event");
+    assert_greater_than(responseEndDuringLoadEvent, 500, "PerformanceNavigationTiming.responseEnd is reasonable during load event");
+    assert_equals(durationDuringLoadEvent, 0, "PerformanceNavigationTiming.duration is 0 during load event");
+    assert_greater_than(responseEndAfterLoadEvent, 500, "PerformanceNavigationTiming.responseEnd is reasonable after load event");
+    assert_greater_than(durationAfterLoadEvent, 500, "PerformanceNavigationTiming.duration is reasonable after load event");
+  }));
+}, "Check that performance.getEntriesByType('navigation')[0].responseEnd has reasonable values before and after the load has finished");
+</script>
+</body>
+</html>

--- a/navigation-timing/resources/respond_slowly.py
+++ b/navigation-timing/resources/respond_slowly.py
@@ -1,0 +1,29 @@
+import time
+
+
+def main(request, response):
+    head = b"""<script>
+    let navigationTiming = performance.getEntriesByType('navigation')[0];
+    let originalResponseEnd = navigationTiming.responseEnd;
+    let originalDuration = navigationTiming.duration;
+    function checkResponseEnd() {
+        let responseEndDuringLoadEvent = navigationTiming.responseEnd;
+        let durationDuringLoadEvent = navigationTiming.duration;
+        setTimeout(function() {
+            parent.postMessage([
+                originalResponseEnd,
+                originalDuration,
+                responseEndDuringLoadEvent,
+                durationDuringLoadEvent,
+                navigationTiming.responseEnd,
+                navigationTiming.duration], '*');
+        }, 0);
+    }
+    </script><body onload='checkResponseEnd()'>"""
+    response.headers.set(b"Content-Length", str(len(head) + 10000))
+    response.headers.set(b"Content-Type", b"text/html")
+    response.write_status_headers()
+    response.writer.write_content(head)
+    for i in range(1000):
+        response.writer.write_content(b"1234567890")
+        time.sleep(0.001)


### PR DESCRIPTION
This comes from https://bugs.webkit.org/show_bug.cgi?id=229751
Chrome and now WebKit agree that responseEnd and duration should be 0 before the load event
and they should be filled in as the information becomes available.