### PR TITLE
[navigation-timing] Add test that queries PerformanceNavigationTiming inside about:blank

### DIFF
--- a/navigation-timing/nav2_test_about_blank.html
+++ b/navigation-timing/nav2_test_about_blank.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+promise_test(async() => {
+    await new Promise((resolve) => {
+        let iframe = document.createElement('iframe');
+        iframe.src = 'about:blank';
+        document.body.appendChild(iframe);
+        assert_equals(iframe.contentWindow.performance.getEntriesByType('navigation').length, 0);
+        resolve();
+    })
+}, 'navigation entries should not exist in about:blank')
+</script>
+</body>
+</html>


### PR DESCRIPTION
I found a behavior difference between Chrome and Firefox.  While the spec isn't clear about who is right,
Safari behaves the same as Chrome and I though it worth adding a test that highlights this behavior difference.