### PR TITLE
Fix the remaining instances of mixed-case `WebIDL`

### DIFF
--- a/tools/ci/jobs.py
+++ b/tools/ci/jobs.py
@@ -37,7 +37,7 @@ job_path_map = {
                      "html/",
                      "infrastructure/",
                      "mimesniff/",
-                     "WebIDL"],
+                     "webidl"],
     "wpt_integration": ["tools/"],
     "wptrunner_infrastructure": ["infrastructure/",
                                  "tools/",

--- a/update-built-tests.sh
+++ b/update-built-tests.sh
@@ -8,4 +8,4 @@ infrastructure/assumptions/tools/build.sh
 html/tools/build.sh
 python3 mimesniff/mime-types/resources/generated-mime-types.py
 python3 css/css-ui/tools/appearance-build-webkit-reftests.py
-python3 WebIDL/tools/generate-setlike.py
+python3 webidl/tools/generate-setlike.py


### PR DESCRIPTION
The `WebIDL` directory was renamed to lowercase `webidl` in #30327. This change fixes two remaining instances of mixed-case `WebIDL` in `update-built-tests.sh` and `tools/ci/jobs.py`.
