### PR TITLE
WebTransport: call transmit() in close()

### DIFF
--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -152,6 +152,7 @@ class WebTransportSession:
         """
         self._http._quic.close(error_code=error_code,
                                reason_phrase=reason_phrase)
+        self._protocol.transmit()
 
     def create_unidirectional_stream(self) -> int:
         """


### PR DESCRIPTION
To flush pending datagrams. This makes sure the session is actually closed.