### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=229997

### DIFF
--- a/css/css-position/sticky/position-sticky-large-top-2-ref.html
+++ b/css/css-position/sticky/position-sticky-large-top-2-ref.html
@@ -12,7 +12,7 @@
     overflow: auto;
     height: 200px;
     width: 200px;
-    transform: scale(1);
+    position: relative;
   }
 
   .block {

--- a/css/css-position/sticky/position-sticky-large-top-ref.html
+++ b/css/css-position/sticky/position-sticky-large-top-ref.html
@@ -11,7 +11,7 @@
     overflow: auto;
     height: 200px;
     width: 200px;
-    transform: scale(1);
+    position: relative;
   }
 
   .block {


### PR DESCRIPTION
WebKit export from bug: [\[css-position-sticky\] Sticky constraints are calculated incorrectly when scrolling container has padding and borders](https://bugs.webkit.org/show_bug.cgi?id=229997)