### PR TITLE
Test for revokation of blob URLs in `import()` and `importScripts()`

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/blob-url.any.js
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/blob-url.any.js
@@ -1,0 +1,66 @@
+// META: global=window,dedicatedworker,sharedworker
+
+function objectUrlFromModule(module) {
+  const blob = new Blob([module], { type: "text/javascript" });
+  return URL.createObjectURL(blob);
+}
+
+const moduleText = `export const foo = "bar";`;
+
+promise_test(async (t) => {
+  const moduleBlobUrl = objectUrlFromModule(moduleText);
+  t.add_cleanup(() => URL.revokeObjectURL(moduleBlobUrl));
+
+  const module = await import(moduleBlobUrl);
+  assert_equals(module.foo, "bar");
+}, "Blob URLs are supported in dynamic imports");
+
+promise_test(async (t) => {
+  const moduleBlobUrl = objectUrlFromModule(moduleText);
+  t.add_cleanup(() => URL.revokeObjectURL(moduleBlobUrl));
+
+  const module1 = await import(moduleBlobUrl);
+  const module2 = await import(moduleBlobUrl);
+  assert_equals(module1, module2);
+}, "Identical blob URLs resolve to the same module");
+
+promise_test(async (t) => {
+  const moduleBlob = new Blob([moduleText], { type: "text/javascript" });
+  const moduleBlobUrl1 = URL.createObjectURL(moduleBlob);
+  const moduleBlobUrl2 = URL.createObjectURL(moduleBlob);
+  t.add_cleanup(() => {
+    URL.revokeObjectURL(moduleBlobUrl1);
+    URL.revokeObjectURL(moduleBlobUrl2);
+  });
+
+  const module1 = await import(moduleBlobUrl1);
+  const module2 = await import(moduleBlobUrl2);
+  assert_not_equals(module1, module2);
+}, "Different blob URLs pointing to the same blob resolve to different modules");
+
+promise_test(async (t) => {
+  const moduleBlobUrl = objectUrlFromModule(moduleText);
+  URL.revokeObjectURL(moduleBlobUrl);
+
+  await promise_rejects_js(t, TypeError, import(moduleBlobUrl));
+}, "A revoked blob URL will not resolve");
+
+promise_test(async () => {
+  const moduleBlobUrl = objectUrlFromModule(moduleText);
+  const module1 = await import(moduleBlobUrl);
+
+  URL.revokeObjectURL(moduleBlobUrl);
+
+  const module2 = await import(moduleBlobUrl);
+  assert_equals(module1, module2);
+}, "A revoked blob URL will resolve if it's already in the module graph");
+
+promise_test(async () => {
+  const moduleBlobUrl = objectUrlFromModule(moduleText);
+
+  const importPromise = import(moduleBlobUrl);
+  URL.revokeObjectURL(moduleBlobUrl);
+
+  const module = await importPromise;
+  assert_equals(module.foo, "bar");
+}, "Revoking a blob URL immediately after calling import will not fail");

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/blob-url.any.js
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/blob-url.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,sharedworker
+// META: global=window,dedicatedworker,sharedworker,dedicatedworker-module,sharedworker-module
 
 function objectUrlFromModule(module) {
   const blob = new Blob([module], { type: "text/javascript" });

--- a/workers/interfaces/WorkerUtils/importScripts/blob-url.worker.js
+++ b/workers/interfaces/WorkerUtils/importScripts/blob-url.worker.js
@@ -1,0 +1,40 @@
+importScripts("/resources/testharness.js");
+
+function objectUrlFromScript(script) {
+  const blob = new Blob([script], { type: "text/javascript" });
+  return URL.createObjectURL(blob);
+}
+
+test((t) => {
+  self.run = false;
+  const blobScriptUrl = objectUrlFromScript(`self.run = true;`);
+  t.add_cleanup(() => URL.revokeObjectURL(blobScriptUrl));
+
+  importScripts(blobScriptUrl);
+  assert_true(self.run);
+}, "Blob URLs work on importScripts");
+
+test(() => {
+  self.run = false;
+  const blobScriptUrl = objectUrlFromScript(`self.run = true;`);
+
+  URL.revokeObjectURL(blobScriptUrl);
+
+  assert_throws_dom("NetworkError", () => {
+    importScripts(blobScriptUrl);
+  });
+  assert_false(self.run);
+}, "A revoked blob URL will fail");
+
+test(() => {
+  self.run = false;
+  const runScriptUrl = objectUrlFromScript(`self.run = true;`);
+  const revokeScriptUrl = objectUrlFromScript(
+    `URL.revokeObjectURL(${JSON.stringify(runScriptUrl)});`
+  );
+
+  importScripts(revokeScriptUrl, runScriptUrl);
+  assert_true(self.run);
+}, "Revoking a blob URL in an earlier script will not fail");
+
+done();


### PR DESCRIPTION
These tests are analogous to the ones in:

- `FileAPI/url/url-in-tags-revoke.window.js`
- `FileAPI/url/url-reload.window.js`
- `FileAPI/url/url-with-fetch.any.js`
- `FileAPI/url/url-with-xhr.any.js`
- `workers/dedicated-worker-from-blob-url.window.js`
- `workers/shared-worker-from-blob-url.window.js`
