### PR TITLE
Fix "wpt update-expectations" for Chrome

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -24,6 +24,7 @@ __wptrunner__ = {"product": "chrome",
                  "executor_kwargs": "executor_kwargs",
                  "env_extras": "env_extras",
                  "env_options": "env_options",
+                 "update_properties": "update_properties",
                  "timeout_multiplier": "get_timeout_multiplier",}
 
 def check_args(**kwargs):
@@ -129,6 +130,8 @@ def env_extras(**kwargs):
 def env_options():
     return {"server_host": "127.0.0.1"}
 
+def update_properties():
+    return (["debug", "os", "processor"], {"os": ["version"], "processor": ["bits"]})
 
 class ChromeBrowser(Browser):
     """Chrome is backed by chromedriver, which is supplied through


### PR DESCRIPTION
`wpt update-expectations --product chrome` currently doesn't work because it's missing the `update_properties` hook, which is (apparently) required for `update-expectations`. This PR copies [the implementation from `tools/wptrunner/wptrunner/browsers/servo.py`](https://github.com/web-platform-tests/wpt/blob/fe0ce76957bfd2ee58608c28d42b95e9d3e31f4c/tools/wptrunner/wptrunner/browsers/servo.py#L67-L68) over to `chrome.py`.

Example usage:
```
$ ./wpt run chrome "url/url-constructor.any.html" --binary "path/to/chrome" --install-webdriver --yes --no-pause-after-test --log-wptreport url.log.json
...
Ran 1 tests finished in 2.9 seconds.
  • 0 ran as expected. 0 tests skipped.
  • 1 tests had unexpected subtest results

$ ./wpt update-expectations --product chrome url.log.json
Processing log 1/1

$ ./wpt run chrome "url/url-constructor.any.html" --meta "meta/" --binary "path/to/chrome" --install-webdriver --yes --no-pause-after-test --log-wptreport url.log.json
...
Ran 1 tests finished in 2.1 seconds.
  • 1 ran as expected. 0 tests skipped.
```

Thanks to @jgraham for [the suggestion](https://github.com/MattiasBuelens/web-streams-polyfill/issues/78#issuecomment-878099098)! 😄 