### PR TITLE
Fix reporting-common.js so it stops polling when it finds the expecte…

### DIFF
--- a/html/cross-origin-opener-policy/reporting/resources/reporting-common.js
+++ b/html/cross-origin-opener-policy/reporting/resources/reporting-common.js
@@ -72,6 +72,7 @@ async function checkForExpectedReport(expectedReport) {
             expectedReport.report)){
           expectedReport.endpoint.reports.splice(j,1);
           resolve();
+          return;
         }
       };
       await wait(waitTime);


### PR DESCRIPTION
…d report

We were failing to return after finding the expected report checkForExpectedReport().
As a result, the function would keep looping and making requests to the server.
We found that this was sometimes leading to flakiness in WebKit when running 2 COOP
tests one after another that use the same endpoint.