### PR TITLE
Add tests for empty URLs, fragment URLs and url resolution parts of css-values-4

### DIFF
--- a/css/css-values/urls/fragment-only.html
+++ b/css/css-values/urls/fragment-only.html
@@ -1,36 +1,37 @@
 <!doctype html>
-<title>Empty URLs behaviour</title>
-<link rel=help href=https://drafts.csswg.org/css-values/#url-empty>
-<link rel=help href=https://github.com/w3c/csswg-drafts/issues/2211#issuecomment-365677844>
+<title>Fragment-on URLs behaviour</title>
+<link rel=help href=https://drafts.csswg.org/css-values/#local-urls>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <style>
 #inline-unquoted {
-    background-image: url();
+    background-image: url(#foo);
 }
 
 #inline-quoted {
-    background-image: url("");
+    background-image: url("#foo");
 }
 </style>
-<link rel=stylesheet href=support/empty-urls.css>
+<link rel=stylesheet href=support/fragment-only-urls.css>
 <div id="inline-unquoted"></div>
 <div id="inline-quoted"></div>
 <div id="external-unquoted"></div>
 <div id="external-quoted"></div>
+<div id="external-variable"></div>
 <script>
 const ids = [
   "inline-unquoted",
   "inline-quoted",
   "external-unquoted",
-  "external-quoted"
+  "external-quoted",
+  "external-variable",
 ];
 
 for (let id of ids) {
     test(function() {
         const el = document.getElementById(id);
         const style = window.getComputedStyle(el);
-        assert_equals(style["background-image"], 'url("")');
+        assert_equals(style["background-image"], 'url("#foo")');
     }, "empty URL: " + id);
 }
 </script>

--- a/css/css-values/urls/resolve-relative-to-base.html
+++ b/css/css-values/urls/resolve-relative-to-base.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<title>URLs in embedded style sheets resolve relative to the document base URI</title>
+<link rel=help href=https://drafts.csswg.org/css-values/#relative-urls>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<base href="http://www.example.com">
+<style>
+:root {
+    --image-path: url("images/test.png");
+}
+#relative-image-url {
+    background-image: url(images/test.png);
+}
+
+#relative-image-variable-url {
+    background-image: var(--image-path);
+}
+</style>
+<div id="relative-image-url"></div>
+<div id="relative-image-variable-url"></div>
+<script>
+const ids = [
+  "relative-image-url",
+  "relative-image-variable-url"
+];
+
+for (let id of ids) {
+    test(() => {
+        const el = document.getElementById(id);
+        const backgroundImageStyle = window.getComputedStyle(el)["background-image"];
+        const baseRelativeImageURL = new URL("images/test.png", document.baseURI);
+        assert_equals(backgroundImageStyle, `url("${baseRelativeImageURL.href}")`);
+    }, "base-relative URL: " + id);
+}
+</script>

--- a/css/css-values/urls/resolve-relative-to-stylesheet.html
+++ b/css/css-values/urls/resolve-relative-to-stylesheet.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<title>URLs in a stylesheet resolve relative to the stylesheet</title>
+<link rel=help href=https://drafts.csswg.org/css-values/#relative-urls>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<link id="stylesheet" rel=stylesheet href=support/relative-urls.css>
+<div id="stylesheet-relative-image"></div>
+<div id="stylesheet-relative-variable-image"></div>
+<div id="stylesheet-relative-document-variable-image"></div>
+<style>
+    :root {
+        --image-path-document: url("images/test.png");
+    }
+</style>
+<script>
+const ids = [
+  "stylesheet-relative-image",
+  "stylesheet-relative-variable-image",
+  "stylesheet-relative-document-variable-image",
+];
+
+for (let id of ids) {
+    test(() => {
+        const el = document.getElementById(id);
+        const backgroundImageStyle = window.getComputedStyle(el)["background-image"];
+
+        const stylesheet = document.getElementById("stylesheet");
+        const sheetRelativeImageURL = new URL("images/test.png", stylesheet.href);
+
+        assert_equals(backgroundImageStyle, `url("${sheetRelativeImageURL.href}")`);
+    }, "stylesheet-relative URL: " + id);
+}
+</script>

--- a/css/css-values/urls/support/fragment-only-urls.css
+++ b/css/css-values/urls/support/fragment-only-urls.css
@@ -1,0 +1,15 @@
+:root {
+    --fragment-image-url: url("#foo");
+}
+
+#external-unquoted {
+    background-image: url(#foo);
+}
+
+#external-quoted {
+    background-image: url("#foo");
+}
+
+#external-variable {
+    background-image: var(--fragment-image-url);
+}

--- a/css/css-values/urls/support/relative-urls.css
+++ b/css/css-values/urls/support/relative-urls.css
@@ -1,0 +1,15 @@
+:root {
+    --image-path-stylesheet: url("images/test.png");
+}
+
+#stylesheet-relative-image {
+    background-image: url(images/test.png);
+}
+
+#stylesheet-relative-variable-image {
+    background-image: var(--image-path-stylesheet);
+}
+
+#stylesheet-relative-document-variable-image {
+    background-image: var(--image-path-document);
+}


### PR DESCRIPTION
Add tests that empty urls serialize to `url("")` https://github.com/w3c/csswg-drafts/issues/6447, fragment URLs serialize as a fragment, and that urls are resolved relative to the stylesheet and the document base URI as appropriate, including when specified through variables.