### PR TITLE
[Import Maps] Add test cases for packages with querystring and fragments

### DIFF
--- a/import-maps/data-driven/resources/packages-via-trailing-slashes.json
+++ b/import-maps/data-driven/resources/packages-via-trailing-slashes.json
@@ -28,6 +28,9 @@
     "package submodules": {
       "expectedResults": {
         "moment/foo": "https://example.com/node_modules/moment/src/foo",
+        "moment/foo?query": "https://example.com/node_modules/moment/src/foo?query",
+        "moment/foo#fragment": "https://example.com/node_modules/moment/src/foo#fragment",
+        "moment/foo?query#fragment": "https://example.com/node_modules/moment/src/foo?query#fragment",
         "lodash-dot/foo": "https://example.com/app/node_modules/lodash-es/foo",
         "lodash-dotdot/foo": "https://example.com/node_modules/lodash-es/foo"
       }


### PR DESCRIPTION
Prompted by a regression we found in Deno (https://github.com/denoland/deno/pull/11976) and making sure our [`import_map`](https://crates.io/crates/import_map) create is spec-compliant and doesn't contain bugs I've added test cases for resolution of "package submodules" that contain `?` and `#` chars (ie. specifiers with querystring and fragments).

CC @lucacasonato @domenic 