### PR TITLE
Introduce conditional_requirements field in commands.json

### DIFF
--- a/tools/wpt/commands.json
+++ b/tools/wpt/commands.json
@@ -10,7 +10,12 @@
     ],
     "requirements": [
       "../wptrunner/requirements.txt"
-    ]
+    ],
+    "optional_requirements": {
+      "enable_webtransport_h3": [
+        "../webtransport/requirements.txt"
+      ]
+    }
   },
   "create": {
     "path": "create.py",

--- a/tools/wpt/commands.json
+++ b/tools/wpt/commands.json
@@ -11,10 +11,12 @@
     "requirements": [
       "../wptrunner/requirements.txt"
     ],
-    "optional_requirements": {
-      "enable_webtransport_h3": [
-        "../webtransport/requirements.txt"
-      ]
+    "conditional_requirements": {
+      "commandline_flag": {
+        "enable_webtransport_h3": [
+          "../webtransport/requirements.txt"
+        ]
+      }
     }
   },
   "create": {

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -93,6 +93,12 @@ def test_help():
     assert excinfo.value.code == 0
 
 
+def test_load_commands():
+    commands = wpt.load_commands()
+    # The `wpt run` command has conditional requirements.
+    assert "conditional_requirements" in commands["run"]
+
+
 @pytest.mark.slow
 @pytest.mark.skipif(sys.platform == "win32",
                     reason="https://github.com/web-platform-tests/wpt/issues/28745")

--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -17,12 +17,12 @@ wpt_root = os.path.abspath(os.path.join(here, os.pardir, os.pardir))
 def load_conditional_requirements(props, base_dir):
     """Load conditional requirements from commands.json."""
 
-    conditional_requirements = props.get("conditional_requirements", {})
+    conditional_requirements = props.get("conditional_requirements")
     if not conditional_requirements:
         return {}
 
     commandline_flag_requirements = {}
-    for key, value in props.get("conditional_requirements", {}).items():
+    for key, value in conditional_requirements.items():
         if key == "commandline_flag":
             for flag_name, requirements_paths in value.items():
                 commandline_flag_requirements[flag_name] = [

--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -203,8 +203,9 @@ def main(prog=None, argv=None):
         kwargs = {}
 
     if venv is not None:
-        requirements = props["conditional_requirements"]["commandline_flag"]
-        install_command_flag_requirements(venv, kwargs, requirements)
+        requirements = props["conditional_requirements"].get("commandline_flag")
+        if requirements is not None:
+            install_command_flag_requirements(venv, kwargs, requirements)
         args = (venv,) + extras
     else:
         args = extras

--- a/tools/wptrunner/README.rst
+++ b/tools/wptrunner/README.rst
@@ -7,6 +7,7 @@ wptrunner is a harness for running the W3C `web-platform-tests testsuite`_.
    :maxdepth: 2
 
    docs/expectation
+   docs/commands
    docs/design
    docs/internals
 

--- a/tools/wptrunner/docs/commands.rst
+++ b/tools/wptrunner/docs/commands.rst
@@ -49,14 +49,14 @@ additional fields. All paths are relative to the commands.json.
   to True.
 
 :code:`install`
-  A list of strings of each string represents a
+  A list of strings where each string represents a
   `requirement object <https://setuptools.readthedocs.io/en/latest/pkg_resources.html#requirement-objects>`_.
   These requirements are installed into the virtualenv environment before
   running the subcommand. :code:`virtualenv` must be true when this field is
   set.
 
 :code:`requirements`
-  A list of paths of each path specifies a requirements.txt. All requirements
+  A list of paths where each path specifies a requirements.txt. All requirements
   listed in these files are installed into the virtualenv environment before
   running the subcommand. :code:`virtualenv` must be true when this field is
   set.
@@ -72,7 +72,7 @@ additional fields. All paths are relative to the commands.json.
     "baz": {
       "path": "baz.py",
       "script": "run",
-      "vritualenv": true,
+      "virtualenv": true,
       "conditional_requirements": {
         "commandline_flag": {
           "enable_feature1": [

--- a/tools/wptrunner/docs/commands.rst
+++ b/tools/wptrunner/docs/commands.rst
@@ -62,12 +62,12 @@ additional fields. All paths are relative to the commands.json.
   set.
 
 :code:`conditional_requirements`
-  A key-value object. Values in this object are lists of paths similar to
-  :code:`requirements`, but requirements specified in these lists are
-  installed only when a certain condition is met. Currently "commandline_flag"
-  is the only supported key. "commandline_flag" is used to specify requirements
-  needed for a certain command line flag of the subcommand. For example, given
-  the following commands.json::
+  A key-value object. Each key represents a condition, and value represents
+  additional requirements when the condition is met. The requirements have the
+  same format as :code:`requirements`. Currently "commandline_flag" is the only
+  supported key. "commandline_flag" is used to specify requirements needed for a
+  certain command line flag of the subcommand. For example, given the following
+  commands.json::
 
     "baz": {
       "path": "baz.py",

--- a/tools/wptrunner/docs/commands.rst
+++ b/tools/wptrunner/docs/commands.rst
@@ -1,0 +1,81 @@
+commands.json
+=============
+
+:code:`commands.json` files define how subcommands are executed by the
+:code:`./wpt` command. :code:`wpt` searches all command.json files under the top
+directory and sets up subcommands from these JSON files. A typical commands.json
+would look like the following::
+
+  {
+    "foo": {
+      "path": "foo.py",
+      "script": "run",
+      "parser": "get_parser",
+      "help": "Run foo"
+    },
+    "bar": {
+      "path": "bar.py",
+      "script": "run",
+      "vritualenv": true,
+      "requirements": [
+        "requirements.txt"
+      ]
+    }
+  }
+
+Each key of the top level object defines a name of a subcommand, and its value
+(a properties object) specifies how the subcommand is executed. Each properties
+object must contain :code:`path` and :code:`script` fields and may contain
+additional fields. All paths are relative to the commands.json.
+
+:code:`path`
+  The path to a Python script that implements the subcommand.
+
+:code:`script`
+  The name of a function that is used as the entry point of the subcommand.
+
+:code:`parser`
+  The name of a function that creates an argparse parser for the subcommand.
+
+:code:`parse_known`
+  When True, `parse_known_args() <https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.parse_known_args>`_
+  is used instead of parse_args() for the subcommand. Default to False.
+
+:code:`help`
+  Brief description of the subcommand.
+
+:code:`virtualenv`
+  When True, the subcommand is executed with a virtualenv environment. Default
+  to True.
+
+:code:`install`
+  A list of strings of each string represents a
+  `requirement object <https://setuptools.readthedocs.io/en/latest/pkg_resources.html#requirement-objects>`_.
+  These requirements are installed into the virtualenv environment before
+  running the subcommand. :code:`virtualenv` must be true when this field is
+  set.
+
+:code:`requirements`
+  A list of paths of each path specifies a requirements.txt. All requirements
+  listed in these files are installed into the virtualenv environment before
+  running the subcommand. :code:`virtualenv` must be true when this field is
+  set.
+
+:code:`optional_requirements`
+  Similar to :code:`requirements`, but requirements specified in this list are
+  installed only when the corresponding command line flag is specified for the
+  subcommand. For example, given the following commands.json::
+
+    "baz": {
+      "path": "baz.py",
+      "script": "run",
+      "vritualenv": true,
+      "optional_requirements": {
+        "enable_feature1": [
+          "requirements_feature1.txt"
+        ]
+      }
+    }
+
+  Requirements in :code:`requirements_features1.txt` are installed only when
+  :code:`--enable-feature1` is specified to :code:`./wpt baz`.

--- a/tools/wptrunner/docs/commands.rst
+++ b/tools/wptrunner/docs/commands.rst
@@ -16,7 +16,7 @@ would look like the following::
     "bar": {
       "path": "bar.py",
       "script": "run",
-      "vritualenv": true,
+      "virtualenv": true,
       "requirements": [
         "requirements.txt"
       ]

--- a/tools/wptrunner/docs/commands.rst
+++ b/tools/wptrunner/docs/commands.rst
@@ -61,19 +61,24 @@ additional fields. All paths are relative to the commands.json.
   running the subcommand. :code:`virtualenv` must be true when this field is
   set.
 
-:code:`optional_requirements`
-  Similar to :code:`requirements`, but requirements specified in this list are
-  installed only when the corresponding command line flag is specified for the
-  subcommand. For example, given the following commands.json::
+:code:`conditional_requirements`
+  A key-value object. Values in this object are lists of paths similar to
+  :code:`requirements`, but requirements specified in these lists are
+  installed only when a certain condition is met. Currently "commandline_flag"
+  is the only supported key. "commandline_flag" is used to specify requirements
+  needed for a certain command line flag of the subcommand. For example, given
+  the following commands.json::
 
     "baz": {
       "path": "baz.py",
       "script": "run",
       "vritualenv": true,
-      "optional_requirements": {
-        "enable_feature1": [
-          "requirements_feature1.txt"
-        ]
+      "conditional_requirements": {
+        "commandline_flag": {
+          "enable_feature1": [
+            "requirements_feature1.txt"
+          ]
+        }
       }
     }
 


### PR DESCRIPTION
Context: https://github.com/web-platform-tests/wpt/pull/29727#discussion_r695287300

I'd like to introduce aioquic dependency to `wpt run` (and `wpt serve` later) using virtualenv for WebTransport tests. This PR introduces a new field `optional_requirements` in commands.json so that it can specify additional requirements when a command line flag is provided.

Alternatively, we may just add "../webtransport/requirements.txt" into `requirements` field of tools/wpt/commands.json. This unconditionally installs aioquic when we run `wpt run`, but per https://github.com/web-platform-tests/rfcs/pull/85 it may be acceptable.
