### PR TITLE
[css-pseudo] add link@rel=author to past highlight tests

### DIFF
--- a/css/css-pseudo/highlight-painting-001-ref.html
+++ b/css/css-pseudo/highlight-painting-001-ref.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta charset="utf-8">
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="stylesheet" href="support/highlights.css">
 <style>
     p {

--- a/css/css-pseudo/highlight-painting-001.html
+++ b/css/css-pseudo/highlight-painting-001.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <title>CSS Pseudo-Elements Test: highlight painting</title>
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#highlight-painting">
 <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#painting">
 <link rel="help" href="https://www.w3.org/TR/CSS22/zindex.html#painting-order">

--- a/css/css-pseudo/highlight-painting-002-ref.html
+++ b/css/css-pseudo/highlight-painting-002-ref.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta charset="utf-8">
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="stylesheet" href="support/highlights.css">
 <style>
     :root {

--- a/css/css-pseudo/highlight-painting-002.html
+++ b/css/css-pseudo/highlight-painting-002.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <title>CSS Pseudo-Elements Test: highlight painting</title>
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#highlight-painting">
 <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#painting">
 <link rel="help" href="https://www.w3.org/TR/CSS22/zindex.html#painting-order">

--- a/css/css-pseudo/highlight-painting-003-ref.html
+++ b/css/css-pseudo/highlight-painting-003-ref.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta charset="utf-8">
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="stylesheet" href="support/highlights.css">
 <style>
     * {

--- a/css/css-pseudo/highlight-painting-003.html
+++ b/css/css-pseudo/highlight-painting-003.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <title>CSS Pseudo-Elements Test: highlight painting</title>
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#highlight-painting">
 <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#painting">
 <link rel="help" href="https://www.w3.org/TR/CSS22/zindex.html#painting-order">

--- a/css/css-pseudo/highlight-painting-004-ref1.html
+++ b/css/css-pseudo/highlight-painting-004-ref1.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta charset="utf-8">
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="stylesheet" href="support/highlights.css">
 <style>
     * {

--- a/css/css-pseudo/highlight-painting-004-ref2.html
+++ b/css/css-pseudo/highlight-painting-004-ref2.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta charset="utf-8">
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="stylesheet" href="support/highlights.css">
 <style>
     * {

--- a/css/css-pseudo/highlight-painting-004-ref3.html
+++ b/css/css-pseudo/highlight-painting-004-ref3.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta charset="utf-8">
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="stylesheet" href="support/highlights.css">
 <style>
     * {

--- a/css/css-pseudo/highlight-painting-004.html
+++ b/css/css-pseudo/highlight-painting-004.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <title>CSS Pseudo-Elements Test: highlight painting</title>
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#highlight-painting">
 <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#painting">
 <link rel="help" href="https://www.w3.org/TR/CSS22/zindex.html#painting-order">

--- a/css/css-pseudo/selection-background-painting-order-ref1.html
+++ b/css/css-pseudo/selection-background-painting-order-ref1.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta charset="utf-8">
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="stylesheet" href="support/highlights.css">
 <style>
     @font-face {

--- a/css/css-pseudo/selection-background-painting-order-ref2.html
+++ b/css/css-pseudo/selection-background-painting-order-ref2.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta charset="utf-8">
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="stylesheet" href="support/highlights.css">
 <style>
     @font-face {

--- a/css/css-pseudo/selection-background-painting-order.html
+++ b/css/css-pseudo/selection-background-painting-order.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <!-- see “Selection regression tests” in README.md -->
 <title>CSS Pseudo-Elements Test: ::selection background always paints over unselected parts when selecting text</title>
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#highlight-painting">
 <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#painting">
 <link rel="help" href="https://www.w3.org/TR/CSS22/zindex.html#painting-order">

--- a/css/css-pseudo/selection-originating-decoration-color-ref.html
+++ b/css/css-pseudo/selection-originating-decoration-color-ref.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta charset="utf-8">
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="stylesheet" href="support/highlights.css">
 <link rel="stylesheet" href="/fonts/ahem.css">
 <style>

--- a/css/css-pseudo/selection-originating-decoration-color.html
+++ b/css/css-pseudo/selection-originating-decoration-color.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <!-- see “Selection regression tests” in README.md -->
 <title>CSS Pseudo-Elements Test: originating decorations on unselected parts remain in originating text-decoration-color when selecting text</title>
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#highlight-painting">
 <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#painting">
 <link rel="help" href="https://www.w3.org/TR/CSS22/zindex.html#painting-order">

--- a/css/css-pseudo/selection-originating-strikethrough-order-ref.html
+++ b/css/css-pseudo/selection-originating-strikethrough-order-ref.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta charset="utf-8">
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="stylesheet" href="support/highlights.css">
 <link rel="stylesheet" href="/fonts/ahem.css">
 <style>

--- a/css/css-pseudo/selection-originating-strikethrough-order.html
+++ b/css/css-pseudo/selection-originating-strikethrough-order.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <!-- see “Selection regression tests” in README.md -->
 <title>CSS Pseudo-Elements Test: originating line-through decorations paint over ::selection backgrounds on selected text</title>
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#highlight-painting">
 <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#painting">
 <link rel="help" href="https://www.w3.org/TR/CSS22/zindex.html#painting-order">

--- a/css/css-pseudo/selection-originating-underline-order-ref.html
+++ b/css/css-pseudo/selection-originating-underline-order-ref.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta charset="utf-8">
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="stylesheet" href="support/highlights.css">
 <link rel="stylesheet" href="/fonts/ahem.css">
 <style>

--- a/css/css-pseudo/selection-originating-underline-order.html
+++ b/css/css-pseudo/selection-originating-underline-order.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <!-- see “Selection regression tests” in README.md -->
 <title>CSS Pseudo-Elements Test: originating underlines remain under unselected parts when selecting text</title>
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#highlight-painting">
 <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#painting">
 <link rel="help" href="https://www.w3.org/TR/CSS22/zindex.html#painting-order">


### PR DESCRIPTION
This patch adds an author tag to highlight tests that I previously wrote from scratch. There are no functional changes.