### PR TITLE
Don't use a non-local address for relative-to-base.html

### DIFF
--- a/css/css-values/urls/resolve-relative-to-base.html
+++ b/css/css-values/urls/resolve-relative-to-base.html
@@ -3,7 +3,7 @@
 <link rel=help href=https://drafts.csswg.org/css-values/#relative-urls>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<base href="http://www.example.com">
+<base href="http://{{hosts[alt][www]}}">
 <style>
 :root {
     --image-path: url("images/test.png");


### PR DESCRIPTION
We don't allow it on automation and thus the test crashes, see:

https://bugzilla.mozilla.org/show_bug.cgi?id=1730229