### PR TITLE
Add WebIDL.idl as a dependency for webtransport idlharness test

### DIFF
--- a/webtransport/idlharness.any.js
+++ b/webtransport/idlharness.any.js
@@ -6,7 +6,7 @@
 
 idl_test(
   ['webtransport'],
-  ['streams'],
+  ['WebIDL', 'streams'],
   idl_array => {
     idl_array.add_objects({
       WebTransport: ['webTransport'],


### PR DESCRIPTION
In https://github.com/web-platform-tests/wpt/pull/29414 a new interface
WebTransportError which inherits from DOMException will be added, and
this will cause the test to fail. Add the required dependency first to
avoid this.