### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=230302

### DIFF
--- a/webrtc/RTCPeerConnection-setLocalDescription-answer.html
+++ b/webrtc/RTCPeerConnection-setLocalDescription-answer.html
@@ -131,9 +131,9 @@
     .then(offer =>
       pc.setRemoteDescription(offer)
       .then(() => generateAnswer(offer))
-      .then(answer =>
-        promise_rejects_dom(t, 'InvalidModificationError',
-          pc.setLocalDescription(answer))));
+      .then(answer => pc.setLocalDescription(answer))
+      .then(() => t.unreached_func("setLocalDescription should have rejected"),
+            (error) => assert_equals(error.name, 'InvalidModificationError')));
   }, 'setLocalDescription() with answer not created by own createAnswer() should reject with InvalidModificationError');
 
   /*

--- a/webrtc/RTCPeerConnection-setLocalDescription-offer.html
+++ b/webrtc/RTCPeerConnection-setLocalDescription-offer.html
@@ -110,9 +110,9 @@
     t.add_cleanup(() => pc2.close());
 
     return generateDataChannelOffer(pc)
-    .then(offer =>
-      promise_rejects_dom(t, 'InvalidModificationError',
-        pc2.setLocalDescription(offer)));
+    .then(offer => pc2.setLocalDescription(offer))
+    .then(() => t.unreached_func("setLocalDescription should have rejected"),
+          (error) => assert_equals(error.name, 'InvalidModificationError'));
   }, 'setLocalDescription() with offer not created by own createOffer() should reject with InvalidModificationError');
 
   promise_test(t => {


### PR DESCRIPTION
WebKit export from bug: [WPT webrtc RTCPeerConnection-setLocalDescription-offer.html and RTCPeerConnection-setLocalDescription-answer.html are flaky due to always changing failing assertion](https://bugs.webkit.org/show_bug.cgi?id=230302)