### PR TITLE
Add BigInt objects to structured cloning test

### DIFF
--- a/IndexedDB/structured-clone.any.js
+++ b/IndexedDB/structured-clone.any.js
@@ -120,7 +120,7 @@ const strings = [
   }));
 
 // "Primitive" Objects (Boolean, Number, BigInt, String)
-[].concat(booleans, numbers, strings)
+[].concat(booleans, numbers, bigints, strings)
   .forEach(value => cloneObjectTest(Object(value), (orig, clone) => {
     assert_equals(orig.valueOf(), clone.valueOf());
   }));


### PR DESCRIPTION
BigInts were missing on the structured clone test although it was defined in [the HTML specification](https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal) (Specifically the 9th item of `StructuredSerializeInternal`).