### PR TITLE
[css-backgrounds] Add test for background-clip on multi-line inline elements

### DIFF
--- a/css/css-backgrounds/background-clip/clip-text-multi-line-ref.html
+++ b/css/css-backgrounds/background-clip/clip-text-multi-line-ref.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
 <head>
-<title>CSS Test: background-clip: text paints multi-line text in the wrong place</title>
-<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#valdef-background-clip-text">
+<title>CSS test reference: background-clip: text paints multi-line text in the wrong place</title>
 <link rel="author" href="mailto:mmaxfield@apple.com" title="Myles C. Maxfield">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style>

--- a/css/css-backgrounds/background-clip/clip-text-multi-line-ref.html
+++ b/css/css-backgrounds/background-clip/clip-text-multi-line-ref.html
@@ -3,7 +3,7 @@
 <head>
 <title>CSS test reference: background-clip: text paints multi-line text in the wrong place</title>
 <link rel="author" href="mailto:mmaxfield@apple.com" title="Myles C. Maxfield">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<link rel="stylesheet" href="/fonts/ahem.css">
 <style>
 #container {
     position: relative;

--- a/css/css-backgrounds/background-clip/clip-text-multi-line-ref.html
+++ b/css/css-backgrounds/background-clip/clip-text-multi-line-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>CSS Test: background-clip: text paints multi-line text in the wrong place</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#valdef-background-clip-text">
+<link rel="author" href="mailto:mmaxfield@apple.com" title="Myles C. Maxfield">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+#container {
+    position: relative;
+    padding: 3px;
+}
+
+span {
+    color: green;
+    font: 48px "Ahem";
+}
+
+div.cover {
+    position: absolute;
+    background: green;
+}
+</style>
+</head>
+<body>
+<p>This test makes sure that multi-line elements with <code>background-clip: text</code> are placed correctly. The test passes if the top rectangle is (roughly) half as wide as the bottom rectangle.</p>
+<div id="container">
+<span>AAA<br>AAAAAA</span>
+<div class="cover" style="left: 0px; top: 0px; width: calc(48px * 3 + 3px); height: 3px;"></div>
+<div class="cover" style="left: 0px; top: 48px; width: calc(48px * 6 + 3px); height: 6px;"></div>
+<div class="cover" style="left: 0px; top: calc(48px * 2); width: calc(48px * 6 + 3px); height: 3px;"></div>
+<div class="cover" style="left: 0px; top: 0px; width: 3px; height: calc(48px * 2);"></div>
+<div class="cover" style="left: calc(48px * 3); top: 0px; width: 3px; height: 48px;"></div>
+<div class="cover" style="left: calc(48px * 6); top: 48px; width: 3px; height: 48px;"></div>
+</body>
+</html>

--- a/css/css-backgrounds/background-clip/clip-text-multi-line.html
+++ b/css/css-backgrounds/background-clip/clip-text-multi-line.html
@@ -6,7 +6,7 @@
 <link rel="help" href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-color">
 <link rel="author" href="mailto:mmaxfield@apple.com" title="Myles C. Maxfield">
 <link rel="match" href="clip-text-multi-line-ref.html">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<link rel="stylesheet" href="/fonts/ahem.css">
 <style>
 #container {
     position: relative;

--- a/css/css-backgrounds/background-clip/clip-text-multi-line.html
+++ b/css/css-backgrounds/background-clip/clip-text-multi-line.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
 <head>
 <title>CSS Test: background-clip: text paints multi-line text in the wrong place</title>
 <link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#valdef-background-clip-text">
+<link rel="help" href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-color">
 <link rel="author" href="mailto:mmaxfield@apple.com" title="Myles C. Maxfield">
 <link rel="match" href="clip-text-multi-line-ref.html">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">

--- a/css/css-backgrounds/background-clip/clip-text-multi-line.html
+++ b/css/css-backgrounds/background-clip/clip-text-multi-line.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>CSS Test: background-clip: text paints multi-line text in the wrong place</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#valdef-background-clip-text">
+<link rel="author" href="mailto:mmaxfield@apple.com" title="Myles C. Maxfield">
+<link rel="match" href="clip-text-multi-line-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+#container {
+    position: relative;
+    padding: 3px;
+}
+
+span {
+    font: 48px "Ahem";
+    background-clip: text;
+    fill-color: rgba(0, 0, 0, 0);
+    background-image: linear-gradient(0deg, green 0%, green 100%);
+}
+
+div.cover {
+    position: absolute;
+    background: green;
+}
+</style>
+</head>
+<body>
+<p>This test makes sure that multi-line elements with <code>background-clip: text</code> are placed correctly. The test passes if the top rectangle is (roughly) half as wide as the bottom rectangle.</p>
+<div id="container">
+<span>AAA<br>AAAAAA</span>
+<div class="cover" style="left: 0px; top: 0px; width: calc(48px * 3 + 3px); height: 3px;"></div>
+<div class="cover" style="left: 0px; top: 48px; width: calc(48px * 6 + 3px); height: 6px;"></div>
+<div class="cover" style="left: 0px; top: calc(48px * 2); width: calc(48px * 6 + 3px); height: 3px;"></div>
+<div class="cover" style="left: 0px; top: 0px; width: 3px; height: calc(48px * 2);"></div>
+<div class="cover" style="left: calc(48px * 3); top: 0px; width: 3px; height: 48px;"></div>
+<div class="cover" style="left: calc(48px * 6); top: 48px; width: 3px; height: 48px;"></div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Currently, all browsers fail this test, because none implement both `background-clip: text` and `fill-color`.

If you replace those properties with `-webkit-background-clip` and `-webkit-text-fill-color`, all browsers (and WebKit after https://bugs.webkit.org/show_bug.cgi?id=230335) pass. But since those are both non-standard properties, I don't believe they have any place in WPT.

(I'm not sure why I can't add @LeaVerou as a reviewer to this PR.)