### PR TITLE
Test that float values are correctly produced while interpolating box-shadow and text-shadow

### DIFF
--- a/css/css-backgrounds/animations/box-shadow-interpolation.html
+++ b/css/css-backgrounds/animations/box-shadow-interpolation.html
@@ -94,6 +94,19 @@ test_interpolation({
   {at: 1.5, expect: 'rgb(255, 248, 0) -30px -20px 35px -9px'},
 ]);
 
+test_interpolation({
+  property: 'box-shadow',
+  from: '0px 0px 0px 0px black',
+  to: '1px 1px 1px 1px black',
+}, [
+  {at: -0.3, expect: 'rgb(0, 0, 0) -0.3px -0.3px 0px -0.3px'},
+  {at: 0, expect: 'rgb(0, 0, 0) 0px 0px 0px 0px'},
+  {at: 0.3, expect: 'rgb(0, 0, 0) 0.3px 0.3px 0.3px 0.3px'},
+  {at: 0.6, expect: 'rgb(0, 0, 0) 0.6px 0.6px 0.6px 0.6px'},
+  {at: 1, expect: 'rgb(0, 0, 0) 1px 1px 1px 1px'},
+  {at: 1.5, expect: 'rgb(0, 0, 0) 1.5px 1.5px 1.5px 1.5px'},
+]);
+
 // Test with color as first value.
 test_interpolation({
   property: 'box-shadow',

--- a/css/css-transitions/animations/text-shadow-interpolation.html
+++ b/css/css-transitions/animations/text-shadow-interpolation.html
@@ -106,5 +106,18 @@ test_interpolation({
   {at: 1, expect: 'rgb(0, 128, 0) 10px 10px 10px'},
   {at: 1.5, expect: 'rgb(0, 192, 0) 10px 10px 10px'},
 ]);
+
+test_interpolation({
+  property: 'text-shadow',
+  from: 'black 0px 0px 0px',
+  to: 'black 1px 1px 1px',
+}, [
+  {at: -0.3, expect: 'rgb(0, 0, 0) -0.3px -0.3px 0px'},
+  {at: 0, expect: 'rgb(0, 0, 0) 0px 0px 0px'},
+  {at: 0.3, expect: 'rgb(0, 0, 0) 0.3px 0.3px 0.3px'},
+  {at: 0.6, expect: 'rgb(0, 0, 0) 0.6px 0.6px 0.6px'},
+  {at: 1, expect: 'rgb(0, 0, 0) 1px 1px 1px'},
+  {at: 1.5, expect: 'rgb(0, 0, 0) 1.5px 1.5px 1.5px'},
+]);
 </script>
 </body>


### PR DESCRIPTION
Added for [WebKit bug 230347](https://bugs.webkit.org/show_bug.cgi?id=230347). Some of the newly added tests would fail in WebKit prior to that patch while they all already pass in Chrome and Firefox.