### PR TITLE
[css-fonts] Add parsing tests for font-palette

### DIFF
--- a/css/css-fonts/parsing/font-palette-computed.html
+++ b/css/css-fonts/parsing/font-palette-computed.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Fonts Module Level 4: getComputedStyle().fontPalette</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<meta name="assert" content="font-palette computed value is as specified.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value('font-palette', 'none');
+test_computed_value('font-palette', 'normal');
+test_computed_value('font-palette', 'light');
+test_computed_value('font-palette', 'dark');
+test_computed_value('font-palette', 'pitchfork');
+</script>
+</body>
+</html>

--- a/css/css-fonts/parsing/font-palette-invalid.html
+++ b/css/css-fonts/parsing/font-palette-invalid.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Fonts Module Level 4: parsing font-palette with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<meta name="assert" content="font-palette supports only the grammar 'none | normal | light | dark | <palette-identifier>'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value('font-palette', 'normal none');
+test_invalid_value('font-palette', 'none, light');
+</script>
+</body>
+</html>

--- a/css/css-fonts/parsing/font-palette-valid.html
+++ b/css/css-fonts/parsing/font-palette-valid.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Fonts Module Level 4: parsing font-palette with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<meta name="assert" content="font-palette supports the full grammar 'none | normal | light | dark | <palette-identifier>'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value('font-palette', 'none');
+test_valid_value('font-palette', 'normal');
+test_valid_value('font-palette', 'light');
+test_valid_value('font-palette', 'dark');
+test_valid_value('font-palette', 'pitchfork');
+</script>
+</body>
+</html>


### PR DESCRIPTION
We're starting to implement this in WebKit.