### PR TITLE
Fix incorrect svg-document-styles tests.

### DIFF
--- a/css/css-transforms/document-styles/svg-document-styles-004.html
+++ b/css/css-transforms/document-styles/svg-document-styles-004.html
@@ -15,6 +15,7 @@
         }
         g.testGroup {
             transform: rotate(90deg);
+            transform-origin: 50px 50px;
         }
     </style>
 </head>

--- a/css/css-transforms/document-styles/svg-document-styles-012.html
+++ b/css/css-transforms/document-styles/svg-document-styles-012.html
@@ -15,7 +15,8 @@
             width: 300px;
         }
         rect.testRect {
-            transform: rotate(90deg,20px,20px);
+            transform: rotate(90deg);
+            transform-origin: 20px 20px;
         }
     </style>
 </head>

--- a/css/css-transforms/document-styles/svg-document-styles-013.html
+++ b/css/css-transforms/document-styles/svg-document-styles-013.html
@@ -30,7 +30,7 @@
             </linearGradient>
         </defs>
         <rect x="1" y="1" width="98" height="98" fill="red"/>
-        <rect class="testRect" y="-60" width="100" height="100" fill="url(#grad)" transform="rotate(90,20px,20px)"/>
+        <rect class="testRect" y="-60" width="100" height="100" fill="url(#grad)" transform="rotate(90,20,20)"/>
     </svg>
 </body>
 </html>


### PR DESCRIPTION
This fixes three tests that were failing identically across Chromium,
Gecko, and WebKit.

svg-document-styles-004 is fixed by adding a transform-origin so the
transform ends up in the right place.

svg-document-styles-012 is fixed by avoiding the SVG transform attribute
syntax in CSS.

svg-document-styles-013 is fixed by conforming to the SVG transform
attribute syntax as specified in
https://drafts.csswg.org/css-transforms-1/#svg-rotate