### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=184510

### DIFF
--- a/css/css-ui/input-security-auto-sensitive-text-input-ref.html
+++ b/css/css-ui/input-security-auto-sensitive-text-input-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<title>Test that input-security: auto obscures text in sensitive text inputs</title>
+<style>
+  input { input-security: auto; }
+</style>
+<input type="password" value="abcdefg">

--- a/css/css-ui/input-security-auto-sensitive-text-input.html
+++ b/css/css-ui/input-security-auto-sensitive-text-input.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>Test that input-security: auto obscures text in sensitive text inputs</title>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#input-security">
+<link rel="author" title="Apple Inc">
+<link rel="match" href="input-security-auto-sensitive-text-input-ref.html">
+<style>
+  input { input-security: auto; }
+</style>
+<input type="password" value="hunter2">

--- a/css/css-ui/input-security-computed.html
+++ b/css/css-ui/input-security-computed.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>Test computed values for input-security</title>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#input-security">
+<link rel="author" title="Apple Inc">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<style>
+  #outer { input-security: none; }
+</style>
+<div id="outer">
+  <div id="target"></div>
+</div>
+<div id="noInputSecurity"></div>
+<script>
+test_computed_value('input-security', 'initial', 'auto');
+test_computed_value('input-security', 'inherit', 'none');
+test_computed_value('input-security', 'auto', 'auto');
+test_computed_value('input-security', 'none', 'none');
+
+// When input-security isn't specified, it should return 'auto'
+assert_equals(getComputedStyle(noInputSecurity).inputSecurity, 'auto');
+</script>

--- a/css/css-ui/input-security-non-sensitive-elements-ref.html
+++ b/css/css-ui/input-security-non-sensitive-elements-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>Test that input-security: auto does not obscure text in elements that do not accept sensitive text input</title>
+<style>
+  * { input-security: none; }
+</style>
+<input type="email" value="webkit@webkit.org">
+<input type="number" value="2021">
+<input type="search" value="test">
+<input type="tel" value="555-5555">
+<input type="text" value="test">
+<input type="url" value="webkit.org">
+<div>Test</div>

--- a/css/css-ui/input-security-non-sensitive-elements.html
+++ b/css/css-ui/input-security-non-sensitive-elements.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>Test that input-security: auto does not obscure text in elements that do not accept sensitive text input</title>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#input-security">
+<link rel="author" title="Apple Inc">
+<link rel="match" href="input-security-non-sensitive-elements-ref.html">
+<style>
+  * { input-security: auto; }
+</style>
+<input type="email" value="webkit@webkit.org">
+<input type="number" value="2021">
+<input type="search" value="test">
+<input type="tel" value="555-5555">
+<input type="text" value="test">
+<input type="url" value="webkit.org">
+<div>Test</div>

--- a/css/css-ui/input-security-none-sensitive-text-input-ref.html
+++ b/css/css-ui/input-security-none-sensitive-text-input-ref.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<title>Test that input-security: none does not obscure text in sensitive text inputs</title>
+<input type="text" value="hunter2">

--- a/css/css-ui/input-security-none-sensitive-text-input.html
+++ b/css/css-ui/input-security-none-sensitive-text-input.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>Test that input-security: none does not obscure text in sensitive text inputs</title>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#input-security">
+<link rel="author" title="Apple Inc">
+<link rel="match" href="input-security-none-sensitive-text-input-ref.html">
+<style>
+  input { input-security: none; }
+</style>
+<input type="password" value="hunter2">

--- a/css/css-ui/input-security-parsing.html
+++ b/css/css-ui/input-security-parsing.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Test parsing for input-security</title>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#input-security">
+<link rel="author" title="Apple Inc">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<div id="target"></div>
+<script>
+test_valid_value('input-security', 'initial');
+test_valid_value('input-security', 'inherit');
+test_valid_value('input-security', 'unset');
+test_valid_value('input-security', 'revert');
+test_valid_value('input-security', 'auto');
+test_valid_value('input-security', 'none');
+
+test_invalid_value('input-security', 'auto auto');
+test_invalid_value('input-security', 'disc');
+test_invalid_value('input-security', 'circle');
+test_invalid_value('input-security', 'square');
+</script>


### PR DESCRIPTION
WebKit export from bug: [Implement input-security property (a standardized replacement for -webkit-text-security)](https://bugs.webkit.org/show_bug.cgi?id=184510)