### PR TITLE
Fix many tests to use correct syntax for SVG transform attribute.

### DIFF
--- a/css/css-transforms/document-styles/svg-document-styles-004.html
+++ b/css/css-transforms/document-styles/svg-document-styles-004.html
@@ -15,7 +15,6 @@
         }
         g.testGroup {
             transform: rotate(90deg);
-            transform-origin: 50px 50px;
         }
     </style>
 </head>
@@ -31,7 +30,7 @@
         </defs>
         <rect x="1" y="1" width="98" height="98" fill="red"/>
         <g class="testGroup" transform="scale(0.5)">
-            <rect width="100" height="100" fill="url(#grad)" transform="translateY(-100)"/>
+            <rect width="100" height="100" fill="url(#grad)" transform="translate(0 -100)"/>
         </g>
     </svg>
 </body>

--- a/css/css-transforms/document-styles/svg-document-styles-014.html
+++ b/css/css-transforms/document-styles/svg-document-styles-014.html
@@ -30,7 +30,7 @@
             </linearGradient>
         </defs>
         <rect x="1" y="1" width="98" height="98" fill="red"/>
-        <rect class="testRect" width="100" height="100" fill="url(#grad)" transform="rotate(90deg,invalid,invalid)"/>
+        <rect class="testRect" width="100" height="100" fill="url(#grad)" transform="rotate(90,invalid,invalid)"/>
     </svg>
 </body>
 </html>

--- a/css/css-transforms/external-styles/svg-external-styles-014.html
+++ b/css/css-transforms/external-styles/svg-external-styles-014.html
@@ -28,7 +28,7 @@
             </linearGradient>
         </defs>
         <rect x="1" y="1" width="98" height="98" fill="red"/>
-        <rect class="invalid" width="100" height="100" fill="url(#grad)" transform="rotate(90deg,)"/>
+        <rect class="invalid" width="100" height="100" fill="url(#grad)" transform="rotate(90,)"/>
     </svg>
 </body>
 </html>

--- a/css/css-transforms/group/svg-transform-group-002.html
+++ b/css/css-transforms/group/svg-transform-group-002.html
@@ -19,7 +19,7 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="41" y="41" width="78" height="78" fill="red"/>
-        <g transform="translate(40px 0)">
+        <g transform="translate(40 0)">
             <rect y="40" width="80" height="80" fill="green"/>
         </g>
     </svg>

--- a/css/css-transforms/group/svg-transform-group-005.html
+++ b/css/css-transforms/group/svg-transform-group-005.html
@@ -19,7 +19,7 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="41" y="41" width="78" height="78" fill="red"/>
-        <g transform="scaleX(2)">
+        <g transform="scale(2 1)">
             <rect x="20" y="40" width="40" height="80" fill="green"/>
         </g>
     </svg>

--- a/css/css-transforms/group/svg-transform-group-006.html
+++ b/css/css-transforms/group/svg-transform-group-006.html
@@ -19,7 +19,7 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="41" y="41" width="78" height="78" fill="red"/>
-        <g transform="scaleY(2)">
+        <g transform="scale(1 2)">
             <rect x="40" y="20" width="80" height="40" fill="green"/>
         </g>
     </svg>

--- a/css/css-transforms/group/svg-transform-group-011.html
+++ b/css/css-transforms/group/svg-transform-group-011.html
@@ -20,7 +20,7 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="41" y="41" width="78" height="78" fill="red"/>
-        <g transform="rotate(90deg,20px,20px)">
+        <g transform="rotate(90,20,20)">
             <rect x="40" y="-80" width="80" height="80" fill="green"/>
         </g>
     </svg>

--- a/css/css-transforms/group/svg-transform-nested-005.html
+++ b/css/css-transforms/group/svg-transform-nested-005.html
@@ -19,8 +19,8 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="41" y="41" width="78" height="78" fill="red"/>
-        <g transform="scaleX(2)">
-            <rect x="10" y="40" width="20" height="80" fill="green" transform="scaleX(2)"/>
+        <g transform="scale(2 1)">
+            <rect x="10" y="40" width="20" height="80" fill="green" transform="scale(2 1)"/>
         </g>
     </svg>
 </body>

--- a/css/css-transforms/group/svg-transform-nested-006.html
+++ b/css/css-transforms/group/svg-transform-nested-006.html
@@ -19,8 +19,8 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="41" y="41" width="78" height="78" fill="red"/>
-        <g transform="scaleY(2)">
-            <rect x="40" y="10" width="80" height="20" fill="green" transform="scaleY(2)"/>
+        <g transform="scale(1 2)">
+            <rect x="40" y="10" width="80" height="20" fill="green" transform="scale(1 2)"/>
         </g>
     </svg>
 </body>

--- a/css/css-transforms/group/svg-transform-nested-012.html
+++ b/css/css-transforms/group/svg-transform-nested-012.html
@@ -20,7 +20,7 @@
     <svg>
         <rect x="41" y="41" width="78" height="78" fill="red"/>
         <g transform="translate(40 0)">
-            <rect y="20" width="80" height="40" fill="green" transform="scaleY(2)"/>
+            <rect y="20" width="80" height="40" fill="green" transform="scale(1 2)"/>
         </g>
     </svg>
 </body>

--- a/css/css-transforms/group/svg-transform-nested-015.html
+++ b/css/css-transforms/group/svg-transform-nested-015.html
@@ -19,7 +19,7 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="41" y="41" width="78" height="78" fill="red"/>
-        <g transform="scaleX(2)">
+        <g transform="scale(2 1)">
             <rect x="40" y="-60" width="80" height="40" fill="green" transform="rotate(90)"/>
         </g>
     </svg>

--- a/css/css-transforms/group/svg-transform-nested-016.html
+++ b/css/css-transforms/group/svg-transform-nested-016.html
@@ -19,7 +19,7 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="41" y="41" width="78" height="78" fill="red"/>
-        <g transform="scaleY(2)">
+        <g transform="scale(1 2)">
             <rect y="20" width="80" height="40" fill="green" transform="translate(40 0)"/>
         </g>
     </svg>

--- a/css/css-transforms/group/svg-transform-nested-018.html
+++ b/css/css-transforms/group/svg-transform-nested-018.html
@@ -21,7 +21,8 @@
     <svg>
         <path d="M 2,1 100,1 198,99 100,99 Z" fill="red"/>
         <g transform="skewX(45)">
-            <rect width="200" height="100" fill="green" transform="scaleX(0.5)"/>
+            <!-- FIXME: This test will still pass if the transform= is ignored -->
+            <rect width="200" height="100" fill="green" transform="scale(0.5 1)"/>
         </g>
     </svg>
 </body>

--- a/css/css-transforms/group/svg-transform-nested-020.html
+++ b/css/css-transforms/group/svg-transform-nested-020.html
@@ -20,7 +20,7 @@
   <svg>
       <rect x="41" y="41" width="78" height="78" fill="red"/>
       <g transform="matrix(-1 0 0 -2 120 120)">
-          <rect width="40" height="40" fill="green" transform="scaleX(2)"/>
+          <rect width="40" height="40" fill="green" transform="scale(2 1)"/>
       </g>
   </svg>
 </body>

--- a/css/css-transforms/group/svg-transform-nested-021.html
+++ b/css/css-transforms/group/svg-transform-nested-021.html
@@ -20,7 +20,7 @@
     <svg>
         <rect x="41" y="41" width="78" height="78" fill="red"/> <!-- this rect is outside the group to catch failures of the group transform -->
         <g transform="translate(20 20)">
-            <rect x="21" y="42" width="78" height="156" fill="red" transform="scaleY(0.5)"/> <!-- false positive if scaleY is negative; need to fix -->
+            <rect x="21" y="42" width="78" height="156" fill="red" transform="scale(1 0.5)"/> <!-- false positive if scaleY is negative; need to fix -->
             <rect x="20" y="-100" width="80" height="80" fill="green" transform="rotate(90)"/>
         </g>
     </svg>

--- a/css/css-transforms/group/svg-transform-nested-022.html
+++ b/css/css-transforms/group/svg-transform-nested-022.html
@@ -20,7 +20,7 @@
     <svg>
         <rect x="41" y="41" width="78" height="78" fill="red"/> <!-- this rect is outside the group to catch failures of the group transform -->
         <g transform="translate(20 0)">
-            <rect x="42" y="41" width="156" height="78" fill="red" transform="scaleX(0.5)"/> <!-- false positive if scaleX is negative -->
+            <rect x="42" y="41" width="156" height="78" fill="red" transform="scale(0.5 1)"/> <!-- false positive if scaleX is negative -->
             <rect width="40" height="40" fill="green" transform="matrix(-2 0 0 -2 100 120)"/>
         </g>
     </svg>

--- a/css/css-transforms/group/svg-transform-nested-023.html
+++ b/css/css-transforms/group/svg-transform-nested-023.html
@@ -19,8 +19,8 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="41" y="41" width="78" height="78" fill="red"/> <!-- this rect is outside the group to catch failures of the group transform -->
-        <g transform="translate(0 25px)">
-            <rect x="1" y="1" width="78" height="78" fill="red" transform="translate(40px 15px)"/>
+        <g transform="translate(0 25)">
+            <rect x="1" y="1" width="78" height="78" fill="red" transform="translate(40 15)"/>
             <rect x="80" y="30" width="160" height="160" fill="green" transform="scale(0.5)"/>
         </g>
     </svg>

--- a/css/css-transforms/group/svg-transform-nested-024.html
+++ b/css/css-transforms/group/svg-transform-nested-024.html
@@ -21,7 +21,7 @@
         <rect x="41" y="41" width="78" height="78" fill="red"/> <!-- this rect is outside the group to catch failures of the group transform -->
         <g transform="scale(0.5)">
             <rect x="62" y="82" width="156" height="156" fill="red" transform="translate(20 0)"/>
-            <rect x="160" y="80" width="320" height="160" fill="green" transform="scaleX(0.5)"/>
+            <rect x="160" y="80" width="320" height="160" fill="green" transform="scale(0.5 1)"/>
         </g>
     </svg>
 </body>

--- a/css/css-transforms/group/svg-transform-nested-025.html
+++ b/css/css-transforms/group/svg-transform-nested-025.html
@@ -19,7 +19,7 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="41" y="41" width="78" height="78" fill="red"/> <!-- this rect is outside the group to catch failures of the group transform -->
-        <g transform="scaleX(0.5)">
+        <g transform="scale(0.5 1)">
             <rect x="82" y="21" width="156" height="78" fill="red" transform="translate(0 20)"/>
             <rect x="160" y="80" width="320" height="160" fill="green" transform="scale(0.5)"/>
         </g>

--- a/css/css-transforms/group/svg-transform-nested-026.html
+++ b/css/css-transforms/group/svg-transform-nested-026.html
@@ -19,7 +19,7 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="41" y="41" width="78" height="78" fill="red"/> <!-- this rect is outside the group to catch failures of the group transform -->
-        <g transform="scaleY(0.5)"> <!-- false positive if scaleY is negative; need to fix -->
+        <g transform="scale(1 0.5)"> <!-- false positive if scaleY is negative; need to fix -->
             <rect x="21" y="42" width="78" height="156" fill="red" transform="translate(20 40)"/>
             <rect x="80" y="-120" width="160" height="80" fill="green" transform="rotate(90)"/>
         </g>

--- a/css/css-transforms/group/svg-transform-nested-027.html
+++ b/css/css-transforms/group/svg-transform-nested-027.html
@@ -21,7 +21,7 @@
         <rect x="41" y="41" width="78" height="78" fill="red"/> <!-- this rect is outside the group to catch failures of the group transform -->
         <g transform="rotate(90)">
             <rect x="20" y="-120" width="80" height="80" fill="green" transform="translate(20 0)"/>
-            <rect x="40" y="-240" width="80" height="160" fill="green" transform="scaleY(0.5)"/> <!-- false positive if scaleY is negative; need to fix -->
+            <rect x="40" y="-240" width="80" height="160" fill="green" transform="scale(1 0.5)"/> <!-- false positive if scaleY is negative; need to fix -->
         </g>
     </svg>
 </body>

--- a/css/css-transforms/group/svg-transform-nested-028.html
+++ b/css/css-transforms/group/svg-transform-nested-028.html
@@ -20,7 +20,7 @@
     <svg>
         <rect x="41" y="41" width="78" height="78" fill="red"/> <!-- this rect is outside the group to catch failures of the group transform -->
         <g transform="matrix(-0.5 0 0 -0.5 120 90)">
-            <rect x="2" y="-116" width="156" height="312" fill="red" transform="scaleY(0.5)"/> <!-- false positive if scaleY is between 0.4 and -0.3 -->
+            <rect x="2" y="-116" width="156" height="312" fill="red" transform="scale(1 0.5)"/> <!-- false positive if scaleY is between 0.4 and -0.3 -->
             <rect width="160" height="160" fill="green" transform="translate(0 -60)"/>
         </g>
     </svg>

--- a/css/css-transforms/group/svg-transform-nested-029.html
+++ b/css/css-transforms/group/svg-transform-nested-029.html
@@ -19,8 +19,8 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="41" y="41" width="78" height="78" fill="red"/>
-        <g transform="scaleX(2)">
-          <rect x="40" y="-20" width="80" height="40" fill="green" transform="rotate(90deg,20px,20px)"/>
+        <g transform="scale(2 1)">
+          <rect x="40" y="-20" width="80" height="40" fill="green" transform="rotate(90,20,20)"/>
         </g>
     </svg>
 </body>

--- a/css/css-transforms/inline-styles/svg-inline-styles-014.html
+++ b/css/css-transforms/inline-styles/svg-inline-styles-014.html
@@ -27,7 +27,7 @@
             </linearGradient>
         </defs>
         <rect x="1" y="1" width="98" height="98" fill="red"/>
-        <rect width="100" height="100" fill="url(#grad)" style="transform: scale(invalid)" transform="rotate(90deg,invalid,invalid)"/>
+        <rect width="100" height="100" fill="url(#grad)" style="transform: scale(invalid)" transform="rotate(90,invalid,invalid)"/>
     </svg>
 </body>
 </html>

--- a/css/css-transforms/matrix/svg-matrix-064.html
+++ b/css/css-transforms/matrix/svg-matrix-064.html
@@ -5,7 +5,7 @@
     <link rel="author" title="Rebecca Hauck" href="mailto:rhauck@adobe.com">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#svg-transform">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
-		<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#funcdef-transform-matrix">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#funcdef-transform-matrix">
     <link rel="match" href="reference/svg-matrix-four-color-ref.html">
     <meta name="flags" content="svg">
     <meta name="assert" content="The matrix function does not support percentage values. If one argument is invalid in one function, none of the transforms in the function list should happen. The rect in this test should remain the same.">
@@ -28,7 +28,7 @@
             </pattern>
         </defs>
         <rect x="1" y="1" width="98" height="98" fill="red"/>
-        <rect width="100" height="100" fill="url(#coloredBoxes)" transform="matrix(50% 0 0 -0.5 100 100) translateX(100)"/>
+        <rect width="100" height="100" fill="url(#coloredBoxes)" transform="matrix(50% 0 0 -0.5 100 100) translate(100 0)"/>
     </svg>
 </body>
 </html>

--- a/css/css-transforms/matrix/svg-matrix-065.html
+++ b/css/css-transforms/matrix/svg-matrix-065.html
@@ -5,7 +5,7 @@
     <link rel="author" title="Rebecca Hauck" href="mailto:rhauck@adobe.com">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#svg-transform">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
-		<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#funcdef-transform-matrix">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#funcdef-transform-matrix">
     <link rel="match" href="reference/svg-matrix-four-color-ref.html">
     <meta name="flags" content="svg">
     <meta name="assert" content="The matrix function does not support radian units. If one argument is invalid in one function, none of the transforms in the function list should happen. The rect in this test should remain the same.">
@@ -28,7 +28,7 @@
             </pattern>
         </defs>
         <rect x="1" y="1" width="98" height="98" fill="red"/>
-        <rect width="100" height="100" fill="url(#coloredBoxes)" transform="matrix(0.5 45rad 0 -0.5 100 100) translateY(100)"/>
+        <rect width="100" height="100" fill="url(#coloredBoxes)" transform="matrix(0.5 45rad 0 -0.5 100 100) translate(0 100)"/>
     </svg>
 </body>
 </html>

--- a/css/css-transforms/matrix/svg-matrix-068.html
+++ b/css/css-transforms/matrix/svg-matrix-068.html
@@ -5,7 +5,7 @@
     <link rel="author" title="Rebecca Hauck" href="mailto:rhauck@adobe.com">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#svg-transform">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
-		<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#funcdef-transform-matrix">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#funcdef-transform-matrix">
     <link rel="match" href="reference/svg-matrix-four-color-ref.html">
     <meta name="flags" content="svg">
     <meta name="assert" content="The matrix function does not support pc units. If one argument is invalid in one function, none of the transforms in the function list should happen. The rect in this test should remain the same.">
@@ -28,7 +28,7 @@
             </pattern>
         </defs>
         <rect x="1" y="1" width="98" height="98" fill="red"/>
-        <rect width="100" height="100" fill="url(#coloredBoxes)" transform="matrix(0.5 0 0.5 0.5 100pc 100) scaleX(0.5)"/>
+        <rect width="100" height="100" fill="url(#coloredBoxes)" transform="matrix(0.5 0 0.5 0.5 100pc 100) scale(0.5 1)"/>
     </svg>
 </body>
 </html>

--- a/css/css-transforms/matrix/svg-matrix-069.html
+++ b/css/css-transforms/matrix/svg-matrix-069.html
@@ -5,7 +5,7 @@
     <link rel="author" title="Rebecca Hauck" href="mailto:rhauck@adobe.com">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#svg-transform">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
-		<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#funcdef-transform-matrix">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#funcdef-transform-matrix">
     <link rel="match" href="reference/svg-matrix-four-color-ref.html">
     <meta name="flags" content="svg">
     <meta name="assert" content="The matrix function does not support mm units. If one argument is invalid in one function, none of the transforms in the function list should happen. The rect in this test should remain the same.">
@@ -28,7 +28,7 @@
             </pattern>
         </defs>
         <rect x="1" y="1" width="98" height="98" fill="red"/>
-        <rect width="100" height="100" fill="url(#coloredBoxes)" transform="matrix(0.5 0 0.5 0.5 100 100mm) scaleY(0.5)"/>
+        <rect width="100" height="100" fill="url(#coloredBoxes)" transform="matrix(0.5 0 0.5 0.5 100 100mm) scale(1 0.5)"/>
     </svg>
 </body>
 </html>

--- a/css/css-transforms/rotate/svg-rotate-3args-invalid-001.html
+++ b/css/css-transforms/rotate/svg-rotate-3args-invalid-001.html
@@ -19,7 +19,7 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="1" y="1" width="78" height="78" fill="red"/>
-        <rect x="0" y="-80" width="80" height="80" fill="green" transform="rotate(90deg 20px)"/>
+        <rect x="0" y="-80" width="80" height="80" fill="green" transform="rotate(90 20)"/>
     </svg>
 </body>
 </html>

--- a/css/css-transforms/rotate/svg-rotate-3args-invalid-002.html
+++ b/css/css-transforms/rotate/svg-rotate-3args-invalid-002.html
@@ -19,7 +19,7 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="1" y="1" width="78" height="78" fill="red"/>
-        <rect x="0" y="0" width="80" height="80" fill="green" transform="rotate(90deg,)"/>
+        <rect x="0" y="0" width="80" height="80" fill="green" transform="rotate(90,)"/>
     </svg>
 </body>
 </html>

--- a/css/css-transforms/rotate/svg-rotate-3args-invalid-003.html
+++ b/css/css-transforms/rotate/svg-rotate-3args-invalid-003.html
@@ -19,7 +19,7 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="1" y="1" width="78" height="78" fill="red"/>
-        <rect x="0" y="-80" width="80" height="80" fill="green" transform="rotate(90deg,20px,20px,20px)"/>
+        <rect x="0" y="-80" width="80" height="80" fill="green" transform="rotate(90,20,20,20)"/>
     </svg>
 </body>
 </html>

--- a/css/css-transforms/rotate/svg-rotate-3args-invalid-004.html
+++ b/css/css-transforms/rotate/svg-rotate-3args-invalid-004.html
@@ -19,7 +19,7 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="1" y="1" width="78" height="78" fill="red"/>
-        <rect x="0" y="-80" width="80" height="80" fill="green" transform="rotate(90deg 30%)"/>
+        <rect x="0" y="-80" width="80" height="80" fill="green" transform="rotate(90 30%)"/>
     </svg>
 </body>
 </html>

--- a/css/css-transforms/rotate/svg-rotate-3args-invalid-005.html
+++ b/css/css-transforms/rotate/svg-rotate-3args-invalid-005.html
@@ -19,7 +19,7 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="1" y="1" width="78" height="78" fill="red"/>
-        <rect x="0" y="-80" width="80" height="80" fill="green" transform="rotate(90deg,30%,20%,40%)"/>
+        <rect x="0" y="-80" width="80" height="80" fill="green" transform="rotate(90,30%,20%,40%)"/>
     </svg>
 </body>
 </html>

--- a/css/css-transforms/transform-list-separation/svg-transform-list-separations-007.html
+++ b/css/css-transforms/transform-list-separation/svg-transform-list-separations-007.html
@@ -27,7 +27,7 @@
                 <stop offset="50%" stop-color="orange"/>
             </linearGradient>
         </defs>
-        <rect width="100" height="100" fill="url(#grad)" transform="      translateX(200),translateY(100)  rotate(45)rotate(45)      "/>
+        <rect width="100" height="100" fill="url(#grad)" transform="      translate(200 0),translate(0 100)  rotate(45)rotate(45)      "/>
     </svg>
 </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-001.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-001.html
@@ -26,7 +26,7 @@
      </defs>
      <rect x="1" y="1" width="98" height="98" fill="red"/>
      <rect x="1" y="1" width="98" height="98" fill="red"/>
-     <rect width="100" height="100" fill="url(#grad)" transform="translate(100px, 0) rotate(90deg)" transform-origin=""/>
+     <rect width="100" height="100" fill="url(#grad)" transform="translate(100, 0) rotate(90)" transform-origin=""/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-002.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-002.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="98" height="98" fill="red"/>
-     <rect width="100" height="100" fill="url(#grad)" transform="translate(100px, 0) rotate(90deg)" transform-origin="0 0"/>
+     <rect width="100" height="100" fill="url(#grad)" transform="translate(100, 0) rotate(90)" transform-origin="0 0"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-003.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-003.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="98" height="98" fill="red"/>
-     <rect x="100" width="100" height="100" fill="url(#grad)" transform="rotate(90deg)" transform-origin="100px 0"/>
+     <rect x="100" width="100" height="100" fill="url(#grad)" transform="rotate(90)" transform-origin="100px 0"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-004.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-004.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="98" height="98" fill="red"/>
-     <rect width="100" height="100" fill="url(#grad)" transform="rotate(90deg) translateX(-100px)" transform-origin="0 100px"/>
+     <rect width="100" height="100" fill="url(#grad)" transform="rotate(90) translate(-100 0)" transform-origin="0 100px"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-005.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-005.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="98" height="98" fill="red"/>
-     <rect width="100" height="100" fill="url(#grad)" transform="rotate(90deg)" transform-origin="50px 50px"/>
+     <rect width="100" height="100" fill="url(#grad)" transform="rotate(90)" transform-origin="50px 50px"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-006.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-006.html
@@ -26,7 +26,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="98" height="98" fill="red"/>
-     <rect x="100" width="100" height="100" fill="url(#grad)" transform="rotate(90deg)" transform-origin="100 0"/>
+     <rect x="100" width="100" height="100" fill="url(#grad)" transform="rotate(90)" transform-origin="100 0"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-007.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-007.html
@@ -26,7 +26,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="98" height="98" fill="red"/>
-     <rect width="100" height="100" fill="url(#grad)" transform="rotate(90deg) translateX(-100px)" transform-origin="0 100"/>
+     <rect width="100" height="100" fill="url(#grad)" transform="rotate(90) translate(-100 0)" transform-origin="0 100"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-008.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-008.html
@@ -26,7 +26,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="98" height="98" fill="red"/>
-     <rect width="100" height="100" fill="url(#grad)" transform="rotate(90deg)" transform-origin="50 50"/>
+     <rect width="100" height="100" fill="url(#grad)" transform="rotate(90)" transform-origin="50 50"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-cm-001.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-cm-001.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="73.590551181" height="73.590551181" fill="red"/>
-     <rect width="2cm" height="2cm" fill="url(#grad)" transform="translate(2cm, 0) rotate(90deg)" transform-origin=""/>
+     <rect width="2cm" height="2cm" fill="url(#grad)" transform="translate(75.5905512, 0) rotate(90)" transform-origin=""/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-cm-002.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-cm-002.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="73.590551181" height="73.590551181" fill="red"/>
-     <rect width="2cm" height="2cm" fill="url(#grad)" transform="translate(2cm, 0) rotate(90deg)" transform-origin="0 0"/>
+     <rect width="2cm" height="2cm" fill="url(#grad)" transform="translate(75.5905512, 0) rotate(90)" transform-origin="0 0"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-cm-003.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-cm-003.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="73.590551181" height="73.590551181" fill="red"/>
-     <rect x="2cm" width="2cm" height="2cm" fill="url(#grad)" transform="rotate(90deg)" transform-origin="2cm 0"/>
+     <rect x="2cm" width="2cm" height="2cm" fill="url(#grad)" transform="rotate(90)" transform-origin="2cm 0"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-cm-004.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-cm-004.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="73.590551181" height="73.590551181" fill="red"/>
-     <rect width="2cm" height="2cm" fill="url(#grad)" transform="rotate(90deg) translateX(-2cm)" transform-origin="0 2cm"/>
+     <rect width="2cm" height="2cm" fill="url(#grad)" transform="rotate(90) translateX(-75.5905512)" transform-origin="0 2cm"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-cm-005.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-cm-005.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="73.590551181" height="73.590551181" fill="red"/>
-     <rect width="2cm" height="2cm" fill="url(#grad)" transform="rotate(90deg)" transform-origin="1cm 1cm"/>
+     <rect width="2cm" height="2cm" fill="url(#grad)" transform="rotate(90)" transform-origin="1cm 1cm"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-in-001.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-in-001.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="142" height="142" fill="red"/>
-     <rect width="1.5in" height="1.5in" fill="url(#grad)" transform="translate(1.5in, 0) rotate(90deg)" transform-origin=""/>
+     <rect width="1.5in" height="1.5in" fill="url(#grad)" transform="translate(144, 0) rotate(90)" transform-origin=""/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-in-002.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-in-002.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="142" height="142" fill="red"/>
-     <rect width="1.5in" height="1.5in" fill="url(#grad)" transform="translate(1.5in, 0) rotate(90deg)" transform-origin="0 0"/>
+     <rect width="1.5in" height="1.5in" fill="url(#grad)" transform="translate(144, 0) rotate(90)" transform-origin="0 0"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-in-003.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-in-003.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="142" height="142" fill="red"/>
-     <rect x="1.5in" width="1.5in" height="1.5in" fill="url(#grad)" transform="rotate(90deg)" transform-origin="1.5in 0"/>
+     <rect x="1.5in" width="1.5in" height="1.5in" fill="url(#grad)" transform="rotate(90)" transform-origin="1.5in 0"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-in-004.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-in-004.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="142" height="142" fill="red"/>
-     <rect width="1.5in" height="1.5in" fill="url(#grad)" transform="rotate(90deg) translateX(-1.5in)" transform-origin="0 1.5in"/>
+     <rect width="1.5in" height="1.5in" fill="url(#grad)" transform="rotate(90) translateX(-144)" transform-origin="0 1.5in"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-in-005.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-in-005.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="142" height="142" fill="red"/>
-     <rect width="1.5in" height="1.5in" fill="url(#grad)" transform="rotate(90deg)" transform-origin="0.75in 0.75in"/>
+     <rect width="1.5in" height="1.5in" fill="url(#grad)" transform="rotate(90)" transform-origin="0.75in 0.75in"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-pt-001.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-pt-001.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="104.666666667" height="104.666666667" fill="red"/>
-     <rect width="80pt" height="80pt" fill="url(#grad)" transform="translate(80pt, 0) rotate(90deg)" transform-origin=""/>
+     <rect width="80pt" height="80pt" fill="url(#grad)" transform="translate(106.666667, 0) rotate(90)" transform-origin=""/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-pt-002.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-pt-002.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="104.666666667" height="104.666666667" fill="red"/>
-     <rect width="80pt" height="80pt" fill="url(#grad)" transform="translate(80pt, 0) rotate(90deg)" transform-origin="0 0"/>
+     <rect width="80pt" height="80pt" fill="url(#grad)" transform="translate(106.6666667, 0) rotate(90)" transform-origin="0 0"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-pt-003.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-pt-003.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="104.666666667" height="104.666666667" fill="red"/>
-     <rect x="80pt" width="80pt" height="80pt" fill="url(#grad)" transform="rotate(90deg)" transform-origin="80pt 0"/>
+     <rect x="80pt" width="80pt" height="80pt" fill="url(#grad)" transform="rotate(90)" transform-origin="80pt 0"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-pt-004.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-pt-004.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="104.666666667" height="104.666666667" fill="red"/>
-     <rect width="80pt" height="80pt" fill="url(#grad)" transform="rotate(90deg) translateX(-80pt)" transform-origin="0 80pt"/>
+     <rect width="80pt" height="80pt" fill="url(#grad)" transform="rotate(90) translateX(-106.6666667)" transform-origin="0 80pt"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-length-pt-005.html
+++ b/css/css-transforms/transform-origin/svg-origin-length-pt-005.html
@@ -25,7 +25,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="104.666666667" height="104.666666667" fill="red"/>
-     <rect width="80pt" height="80pt" fill="url(#grad)" transform="rotate(90deg)" transform-origin="40pt 40pt"/>
+     <rect width="80pt" height="80pt" fill="url(#grad)" transform="rotate(90)" transform-origin="40pt 40pt"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-001.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-001.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg)" transform-origin="75"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90)" transform-origin="75"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-002.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-002.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg)" transform-origin="center"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90)" transform-origin="center"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-003.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-003.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg)" transform-origin="50%"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90)" transform-origin="50%"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-004.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-004.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg)" transform-origin="50% 50%"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90)" transform-origin="50% 50%"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-005.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-005.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg)" transform-origin="50% center"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90)" transform-origin="50% center"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-006.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-006.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg)" transform-origin="center 50%"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90)" transform-origin="center 50%"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-007.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-007.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg)" transform-origin="center center"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90)" transform-origin="center center"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-008.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-008.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg)" transform-origin="75 center"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90)" transform-origin="75 center"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-009.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-009.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg)" transform-origin="75 50%"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90)" transform-origin="75 50%"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-010.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-010.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg)" transform-origin="center 75"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90)" transform-origin="center 75"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-011.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-011.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg)" transform-origin="50% 75"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90)" transform-origin="50% 75"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-012.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-012.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-75,-75)" transform-origin="0"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-75,-75)" transform-origin="0"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-013.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-013.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(75,75)" transform-origin="150"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(75,75)" transform-origin="150"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-014.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-014.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(75,75)" transform-origin="100%"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(75,75)" transform-origin="100%"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-015.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-015.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(75,75)" transform-origin="right"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(75,75)" transform-origin="right"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-016.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-016.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-75)" transform-origin="left"/>
+     <rect x="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-75)" transform-origin="left"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-017.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-017.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-37.5,-37.5)" transform-origin="25%"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-37.5,-37.5)" transform-origin="25%"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-018.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-018.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(75,-75)" transform-origin="top"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(75,-75)" transform-origin="top"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-019.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-019.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-75,75)" transform-origin="bottom"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-75,75)" transform-origin="bottom"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-020.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-020.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-75,-75)" transform-origin="0% 0%"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-75,-75)" transform-origin="0% 0%"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-021.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-021.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(75,75)" transform-origin="top right"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(75,75)" transform-origin="top right"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-022.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-022.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-75,-75)" transform-origin="top left"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-75,-75)" transform-origin="top left"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-023.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-023.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg)" transform-origin="top center"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90)" transform-origin="top center"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-024.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-024.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-225,75)" transform-origin="bottom left"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-225,75)" transform-origin="bottom left"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-025.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-025.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-150,150)" transform-origin="bottom center"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-150,150)" transform-origin="bottom center"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-026.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-026.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-75,225)" transform-origin="bottom right"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-75,225)" transform-origin="bottom right"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-027.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-027.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(75,75)" transform-origin="right top"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(75,75)" transform-origin="right top"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-028.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-028.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translateY(150)" transform-origin="right center"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(0 150)" transform-origin="right center"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-029.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-029.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-75,225)" transform-origin="right bottom"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-75,225)" transform-origin="right bottom"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-030.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-030.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(75,75)" transform-origin="right 75"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(75,75)" transform-origin="right 75"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-031.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-031.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(75,75)" transform-origin="right 0%"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(75,75)" transform-origin="right 0%"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-032.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-032.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-75,225)" transform-origin="right 100%"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-75,225)" transform-origin="right 100%"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-033.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-033.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-75,-75)" transform-origin="left top"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-75,-75)" transform-origin="left top"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-034.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-034.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translateX(-150)" transform-origin="left center"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-150 0)" transform-origin="left center"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-035.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-035.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-225,75)" transform-origin="left bottom"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-225,75)" transform-origin="left bottom"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-036.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-036.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-75,-75)" transform-origin="left 75"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-75,-75)" transform-origin="left 75"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-037.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-037.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-75,-75)" transform-origin="left 0%"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-75,-75)" transform-origin="left 0%"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-038.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-038.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-225,75)" transform-origin="left 100%"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-225,75)" transform-origin="left 100%"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-039.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-039.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg)" transform-origin="center top"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90)" transform-origin="center top"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-040.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-040.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-150,150)" transform-origin="center bottom"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-150,150)" transform-origin="center bottom"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-041.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-041.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translateX(-150)" transform-origin="center left"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-150 0)" transform-origin="center left"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-042.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-042.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translateY(150)" transform-origin="center right"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(0 150)" transform-origin="center right"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-043.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-043.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-150,150)" transform-origin="center 100%"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-150,150)" transform-origin="center 100%"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-044.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-044.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(-225,-75)" transform-origin="0 center"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(-225,-75)" transform-origin="0 center"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-045.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-045.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg)" transform-origin="center 0%"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90)" transform-origin="center 0%"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-046.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-046.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translate(75,-75)" transform-origin="center 0"/>
+     <rect x="75" y="75" width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(75,-75)" transform-origin="center 0"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-001.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-001.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translateY(-150)" transform-origin="top 100%"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(0 -150)" transform-origin="top 100%"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-002.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-002.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translateY(-150)" transform-origin="bottom 100%"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(0 -150)" transform-origin="bottom 100%"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-003.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-003.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translateY(-150)" transform-origin="top 150"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(0 -150)" transform-origin="top 150"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-004.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-004.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translateY(-150)" transform-origin="bottom 150"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(0 -150)" transform-origin="bottom 150"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-005.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-005.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translateY(-150)" transform-origin="top top"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(0 -150)" transform-origin="top top"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-006.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-006.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translateY(-150)" transform-origin="bottom bottom"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(0 -150)" transform-origin="bottom bottom"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-007.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-007.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translateY(-150)" transform-origin="top bottom"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(0 -150)" transform-origin="top bottom"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-008.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-008.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translateY(-150)" transform-origin="bottom top"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(0 -150)" transform-origin="bottom top"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-009.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-009.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translateY(-150)" transform-origin="left left"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(0 -150)" transform-origin="left left"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-010.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-010.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translateY(-150)" transform-origin="left right"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(0 -150)" transform-origin="left right"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-011.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-011.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translateY(-150)" transform-origin="right right"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(0 -150)" transform-origin="right right"/>
    </svg>
  </body>
 </html>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-012.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-012.html
@@ -27,7 +27,7 @@
        </linearGradient>
      </defs>
      <rect x="1" y="1" width="148" height="148" fill="red"/>
-     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90deg) translateY(-150)" transform-origin="right left"/>
+     <rect width="150" height="150" fill="url(#grad)" transform="rotate(90) translate(0 -150)" transform-origin="right left"/>
    </svg>
  </body>
 </html>


### PR DESCRIPTION
Many tests were using syntax in the SVG transform attribute that is allowed in the CSS transform property but not the SVG transform attribute, according to https://drafts.csswg.org/css-transforms-1/#svg-syntax .

In particular, they were:

 * using units when no units are allowed, or

 * using functions that are not accepted (translateX, translateY,
   scaleX, scaleY, skew).

The modified tests were failing in all of Chromium, Gecko, and WebKit,
with the exceptions of:

 * document-styles/svg-document-styles-004.html, which I fixed
   incorrectly in #30847, and for which this is the correct fix (and
   revert of the prior fix),

 * document-styles/svg-document-styles-014.html,
   external-styles/svg-external-styles-014.html,
   inline-styles/svg-inline-styles-014.html,
   matrix/svg-matrix-{064,065,068,069}.html, and
   rotate/svg-rotate-3args-invalid-002.html, which were testing other
   aspects of invalidity,

 * group/svg-transform-nested-018.html, for which I added a FIXME,

Note that the rotate/svg-rotate-3args-invalid-* tests are mostly wrong,
and I hope to deal with them in a later PR.