### PR TITLE
Fix svg-rotate-3args-invalid-00{1,3,4,5}.html.

### DIFF
--- a/css/css-transforms/rotate/svg-rotate-3args-invalid-001.html
+++ b/css/css-transforms/rotate/svg-rotate-3args-invalid-001.html
@@ -7,7 +7,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#svg-transform-functions">
     <link rel="match" href="reference/svg-rotate-3args-ref.html">
     <meta name="flags" content="svg">
-    <meta name="assert" content="The rotate transform function takes two optional translation values. If one of the translation values is not provided, then both translation-value parameters fall back to zero. The green rect in this test should be rotated by 90 degrees clockwise but the transform origin should not be translated.  The green rect should completely cover the red rect.">
+    <meta name="assert" content="The rotate transform function takes two optional translation values. If one of the translation values is not provided, then the entire argument list is invalid and therefore no transform is applied. The green rect in this test should not be rotated.  The green rect should completely cover the red rect.">
     <style type="text/css">
     svg {
         width: 200px;
@@ -19,7 +19,7 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="1" y="1" width="78" height="78" fill="red"/>
-        <rect x="0" y="-80" width="80" height="80" fill="green" transform="rotate(90 20)"/>
+        <rect x="0" y="0" width="80" height="80" fill="green" transform="rotate(90 20)"/>
     </svg>
 </body>
 </html>

--- a/css/css-transforms/rotate/svg-rotate-3args-invalid-003.html
+++ b/css/css-transforms/rotate/svg-rotate-3args-invalid-003.html
@@ -7,7 +7,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#svg-transform-functions">
     <link rel="match" href="reference/svg-rotate-3args-ref.html">
     <meta name="flags" content="svg">
-    <meta name="assert" content="The rotate transform function takes two optional translation values. If a third absolute translation-value argument is provided, then all translation-value parameters fall back to zero. The green rect in this test should be rotated by 90 degrees clockwise, but the transform origin should not be translated. The green rect should completely cover the red rect.">
+    <meta name="assert" content="The rotate transform function takes two optional translation values. If a third absolute translation-value argument is provided, then the entire argument list is invalid and therefore no transform is applied. The green rect in this test should not be rotated.  The green rect should completely cover the red rect.">
     <style type="text/css">
     svg {
         width: 200px;
@@ -19,7 +19,7 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="1" y="1" width="78" height="78" fill="red"/>
-        <rect x="0" y="-80" width="80" height="80" fill="green" transform="rotate(90,20,20,20)"/>
+        <rect x="0" y="0" width="80" height="80" fill="green" transform="rotate(90,20,20,20)"/>
     </svg>
 </body>
 </html>

--- a/css/css-transforms/rotate/svg-rotate-3args-invalid-004.html
+++ b/css/css-transforms/rotate/svg-rotate-3args-invalid-004.html
@@ -7,7 +7,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#svg-transform-functions">
     <link rel="match" href="reference/svg-rotate-3args-ref.html">
     <meta name="flags" content="svg">
-    <meta name="assert" content="The rotate transform function takes two optional translation values. If one of the translation values is not provided, then both translation-value parameters fall back to zero. The green rect in this test should be rotated by 90 degrees clockwise but the transform origin should not be translated.  The green rect should completely cover the red rect.">
+    <meta name="assert" content="The rotate transform function takes two optional translation values. If one of the translation values is not provided, then the entire argument list is invalid and therefore no transform is applied. The green rect in this test should not be rotated.  The green rect should completely cover the red rect.">
     <style type="text/css">
     svg {
         width: 200px;
@@ -19,7 +19,7 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="1" y="1" width="78" height="78" fill="red"/>
-        <rect x="0" y="-80" width="80" height="80" fill="green" transform="rotate(90 30%)"/>
+        <rect x="0" y="0" width="80" height="80" fill="green" transform="rotate(90 30%)"/>
     </svg>
 </body>
 </html>

--- a/css/css-transforms/rotate/svg-rotate-3args-invalid-005.html
+++ b/css/css-transforms/rotate/svg-rotate-3args-invalid-005.html
@@ -7,7 +7,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#svg-transform-functions">
     <link rel="match" href="reference/svg-rotate-3args-ref.html">
     <meta name="flags" content="svg">
-    <meta name="assert" content="The rotate transform function takes two optional translation values. If a third relative translation-value argument is provided, then all translation-value parameters fall back to zero. The green rect in this test should be rotated by 90 degrees clockwise, but the transform origin should not be translated. The green rect should completely cover the red rect.">
+    <meta name="assert" content="The rotate transform function takes two optional translation values. If a third relative translation-value argument is provided, then the entire argument list is invalid and therefore no transform is applied. The green rect in this test should not be rotated.  The green rect should completely cover the red rect.">
     <style type="text/css">
     svg {
         width: 200px;
@@ -19,7 +19,7 @@
     <p>The test passes if there is a green square and no red.</p>
     <svg>
         <rect x="1" y="1" width="78" height="78" fill="red"/>
-        <rect x="0" y="-80" width="80" height="80" fill="green" transform="rotate(90,30%,20%,40%)"/>
+        <rect x="0" y="0" width="80" height="80" fill="green" transform="rotate(90,30%,20%,40%)"/>
     </svg>
 </body>
 </html>


### PR DESCRIPTION
The assertions in tests 1, 3, 4, and 5, that assert that *part* of the
syntax of these transform functions will be ignored and part will still
be honored, is not supported by the current specification at
https://drafts.csswg.org/css-transforms-1/#svg-syntax (though it was
likely in older versions).  (I mentioned this briefly in #30852.)

Thus, this changes those tests to match test 2 and assume that the
entire invalid value will be ignored.

This causes these tests to change from failing to passing in all of
Chromium, Gecko, and WebKit.