### PR TITLE
Fix svg-origin-relative-length-* tests.

### DIFF
--- a/css/css-transforms/transform-origin/svg-origin-relative-length-001.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-001.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-002.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-002.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-003.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-003.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-004.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-004.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-005.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-005.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-006.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-006.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-007.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-007.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-008.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-008.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-009.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-009.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-010.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-010.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-011.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-011.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-012.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-012.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-013.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-013.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-014.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-014.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-015.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-015.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-016.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-016.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-017.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-017.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-018.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-018.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-019.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-019.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-020.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-020.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-021.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-021.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-022.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-022.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-023.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-023.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-024.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-024.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-025.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-025.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-026.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-026.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-027.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-027.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-028.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-028.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-029.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-029.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-030.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-030.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-031.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-031.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-032.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-032.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-033.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-033.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-034.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-034.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-035.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-035.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-036.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-036.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-037.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-037.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-038.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-038.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-039.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-039.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-040.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-040.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-041.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-041.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-042.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-042.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-043.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-043.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-044.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-044.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-045.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-045.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-046.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-046.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-001.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-001.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-002.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-002.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-003.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-003.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-004.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-004.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-005.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-005.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-006.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-006.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-007.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-007.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-008.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-008.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-009.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-009.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-010.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-010.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-011.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-011.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>

--- a/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-012.html
+++ b/css/css-transforms/transform-origin/svg-origin-relative-length-invalid-012.html
@@ -14,6 +14,9 @@
       width: 200px;
       height: 200px;
     }
+    rect {
+      transform-box: fill-box;
+    }
   </style>
  </head>
  <body>


### PR DESCRIPTION
These tests were written under the assumption that transform-origin has
the behavior described by transform-box: fill-box.  Since, as described
in https://drafts.csswg.org/css-transforms-1/#transform-box, this is not
the default, set it explicitly.

Prior to this change, the svg-origin-relative-length-{001 to 046}.html
tests were failing in Chromium, Gecko, and WebKit.  The
svg-origin-relative-length-invalid-{001 to 012}.html tests were passing,
but this change shouldn't change that they're passing.