### PR TITLE
Rendering test for `box-shadow` with `calc()`

### DIFF
--- a/css/css-backgrounds/box-shadow-calc-ref.html
+++ b/css/css-backgrounds/box-shadow-calc-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style type="text/css">
+div {
+  width: 100px;
+  height: 100px;
+  background-color: blue;
+  box-shadow: 26px 26px 26px black;
+}
+</style>
+<div>
+</div>

--- a/css/css-backgrounds/box-shadow-calc-ref.html
+++ b/css/css-backgrounds/box-shadow-calc-ref.html
@@ -4,7 +4,7 @@ div {
   width: 100px;
   height: 100px;
   background-color: blue;
-  box-shadow: 26px 26px 26px black;
+  box-shadow: 26px 43px 60px black;
 }
 </style>
 <div>

--- a/css/css-backgrounds/box-shadow-calc.html
+++ b/css/css-backgrounds/box-shadow-calc.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<link rel="author" title="Antoine Quint" href="mailto:graouts@apple.com" />
+<link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#the-box-shadow" />
+<link rel="match" href="box-shadow-calc-ref.html" />
+<meta name="assert" content="Test checks whether box-shadow supports calc() values.">
+<style type="text/css">
+div {
+  width: 100px;
+  height: 100px;
+  background-color: blue;
+  box-shadow: calc(1em + 10px) calc(1em + 10px) calc(1em + 10px) black;
+}
+</style>
+<div>
+</div>

--- a/css/css-backgrounds/box-shadow-calc.html
+++ b/css/css-backgrounds/box-shadow-calc.html
@@ -8,7 +8,7 @@ div {
   width: 100px;
   height: 100px;
   background-color: blue;
-  box-shadow: calc(1em + 10px) calc(1em + 10px) calc(1em + 10px) black;
+  box-shadow: calc(1em + 10px) calc(2em + 11px) calc(3em + 12px) black;
 }
 </style>
 <div>


### PR DESCRIPTION
This was added in [WebKit revision 282768](https://commits.webkit.org/241903@main) for [bug 230347](https://bugs.webkit.org/show_bug.cgi?id=230347).