### PR TITLE
Send alert text

### DIFF
--- a/webdriver/tests/send_alert_text/send.py
+++ b/webdriver/tests/send_alert_text/send.py
@@ -62,7 +62,7 @@ def test_alert_element_not_interactable(session, inline, dialog_type):
 
 
 @pytest.mark.parametrize("text", ["", "Federer", " Fed erer ", "Fed\terer"])
-def test_send_alert_text(session, page, text):
+def test_send_prompt_text(session, page, text):
     send_response = send_alert_text(session, text)
     assert_success(send_response)
 

--- a/webdriver/tests/send_alert_text/send.py
+++ b/webdriver/tests/send_alert_text/send.py
@@ -1,6 +1,6 @@
 import pytest
 
-from webdriver.error import NoSuchAlertException
+from webdriver.error import NoSuchAlertException, InvalidElementStateException
 from webdriver.transport import Response
 
 from tests.support.asserts import assert_error, assert_success
@@ -69,6 +69,21 @@ def test_send_prompt_text(session, page, text):
     session.alert.accept()
 
     assert session.execute_script("return window.result") == text
+
+def test_send_alert_text_should_fail(session, inline):
+    session.url = inline("""
+        <input type=button onClick='doAlert()' id=button value='click me'>
+        <script>function doAlert() {
+            alert('cheese')
+        }
+        </script>
+    """)
+
+    session.find.css('#button', all=False).click()
+    alert = session.alert
+    with pytest.raises(InvalidElementStateException):
+        send_alert_text(session, "sausages")
+    alert.accept()
 
 
 def test_unexpected_alert(session):


### PR DESCRIPTION
When sending text to an alert modal an `InvalidElementStateException` should be thrown. Currently this does not happen in Firefox, haven't tested in Chrome.