### PR TITLE
Add a note about counterintuitive send_keys() code points

### DIFF
--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -156,7 +156,7 @@ between the function being called and the promise settling.
 To send special keys, one must send the respective key's codepoint. Since this uses the WebDriver protocol, you can find a [list for code points to special keys in the spec](https://w3c.github.io/webdriver/#keyboard-actions).
 For example, to send the tab key you would send "\uE004".
 
-_Note: these special key codepoints are not necessarily what you would expect. For example, <kbd>Esc</kbd> is the invalid Unicode character `\uE00C`, not the `\u001B` Escape character from ASCII._
+_Note: these special-key codepoints are not necessarily what you would expect. For example, <kbd>Esc</kbd> is the invalid Unicode character `\uE00C`, not the `\u001B` Escape character from ASCII._
 
 [activation]: https://html.spec.whatwg.org/multipage/interaction.html#activation
 

--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -156,6 +156,8 @@ between the function being called and the promise settling.
 To send special keys, one must send the respective key's codepoint. Since this uses the WebDriver protocol, you can find a [list for code points to special keys in the spec](https://w3c.github.io/webdriver/#keyboard-actions).
 For example, to send the tab key you would send "\uE004".
 
+_Note: these special key codepoints are not necessarily what you would expect. For example, <kbd>Esc</kbd> is the invalid Unicode character `\uE00C`, not the `\u001B` Escape character from ASCII._
+
 [activation]: https://html.spec.whatwg.org/multipage/interaction.html#activation
 
 ### set_permission


### PR DESCRIPTION
This caused us a good deal of confusion on https://bugs.chromium.org/p/chromium/issues/detail?id=1252038 and related CLs.