### PR TITLE
Test the opposite behavior in css-transforms-transformlist.html.

### DIFF
--- a/css/css-transforms/css-transforms-transformlist.html
+++ b/css/css-transforms/css-transforms-transformlist.html
@@ -6,7 +6,7 @@
     <link rel="author" title="Rik Cabanier" href="mailto:cabanier@adobe.com">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-attribute-dom">
     <link rel="match" href="reference/css-transforms-transformlist-ref.html">
-    <meta name="assert" content="This test verifies that the CSS transform ends up in the list of SVG transforms">
+    <meta name="assert" content="This test verifies that the CSS transform does not end up in the list of SVG transforms">
     <style type="text/css">
 
        #rect {
@@ -25,7 +25,7 @@
 	window.addEventListener('load', function(){
 		var r = document.getElementById("rect");
 		var result = document.getElementById("result");
-		if(r.transform.baseVal.length>0)
+		if (r.transform.baseVal.length == 0)
 			result.style.backgroundColor = "rgb(0, 255, 0)";
 
 		document.getElementById("svgelement").style.display="none";
@@ -35,7 +35,7 @@
 <body>
     <p>The test passes if there is a green square and no red.</p>
     <svg id="svgelement">
-		<rect id="rect" width="100" height="100"></rect>
+		<rect id="rect" style="transform: translate(20px, 20px)" width="100" height="100"></rect>
 	</svg>
     <div id="result"></div>
 </body>


### PR DESCRIPTION
This changes the test to test the opposite behavior of what it was
testing, since I could not find any justification for what it was
testing in:
https://www.w3.org/TR/SVG11/coords.html#InterfaceSVGAnimatedTransformList
https://www.w3.org/TR/SVG11/animate.html
https://www.w3.org/TR/smil-animation/#AnimationSandwichModel

Prior to this change, it failed in all of Chromium, Gecko, and WebKit.