### PR TITLE
Fix skew-test1.html.

### DIFF
--- a/css/css-transforms/reference/skew-test1-ref.html
+++ b/css/css-transforms/reference/skew-test1-ref.html
@@ -26,8 +26,8 @@
     <h4>
       There should be a green block on the page.
     </h4>
-    <svg xmlns="http://www.w3.org/2000/svg" version="1.1">
-      <polygon points="0,0 150,55 235,205 88,150" style="fill:lime"/>
+    <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="300" height="300">
+      <polygon points="0,0 150,54.595535 236.602540,204.595535 86.602540,150" style="fill:lime"/>
     </svg>
 
 </body>

--- a/css/css-transforms/skew-test1.html
+++ b/css/css-transforms/skew-test1.html
@@ -40,10 +40,10 @@
     Test 1 - Tests with degrees on block elements.
     </h3>
     <h4>
-      There should be a green block on the page
+      There should be a green block on the page.
     </h4>
-    <svg xmlns="http://www.w3.org/2000/svg" version="1.1">
-      <polygon points="0,0 150,55 235,205 88,150" style="fill:red"/>
+    <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="300" height="300">
+      <polygon points="1,1 149,56 235,203 88,149" style="fill:red"/>
     </svg>
 
   <div class="skew_div">


### PR DESCRIPTION
This fixes skew-test1.html in four ways:
 * Fixes the mismatch of a "." between test and reference
 * Fixes the SVG elements to have sufficient height.
 * Fixes the polygon in the reference to calculate positions accurately.
 * Modifies the polygon in the test to be slightly smaller than what covers it.

It will likely still require fuzz, which I'll deal with later (for which
I'm waiting on web-platform-tests/wpt.fyi#2595).

Prior to this change, it fails similarly across Chromium, Gecko, and
WebKit.