### PR TITLE
Fix transform-scale-{001,002}.html and transform-scaley-001.html .

### DIFF
--- a/css/css-transforms/transform-scale-001.html
+++ b/css/css-transforms/transform-scale-001.html
@@ -10,6 +10,10 @@
     box by a factor of one-half.'>
     <link rel="match" href="transform-scale-ref.html">
     <style>
+      body {
+        margin: 0;
+      }
+
       div {
         background: green;
         width: 100px;

--- a/css/css-transforms/transform-scale-002.html
+++ b/css/css-transforms/transform-scale-002.html
@@ -10,6 +10,10 @@
     by a factor of one-half.'>
     <link rel="match" href="transform-scale-ref.html">
     <style>
+      body {
+        margin: 0;
+      }
+
       div {
         background: green;
         width: 100px;

--- a/css/css-transforms/transform-scale-ref.html
+++ b/css/css-transforms/transform-scale-ref.html
@@ -5,6 +5,10 @@
     <link rel="author" title="Clint Talbert" href="mailto:ctalbert@mozilla.com">
     <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
     <style>
+      body {
+        margin: 0;
+      }
+
       div {
         background: green;
         width: 50px;

--- a/css/css-transforms/transform-scaley-001.html
+++ b/css/css-transforms/transform-scaley-001.html
@@ -10,6 +10,10 @@
     box's width by a factor of one-half.">
     <link rel="match" href="transform-scaley-ref.html">
     <style>
+      body {
+        margin: 0;
+      }
+
       div {
         background: green;
         width: 100px;

--- a/css/css-transforms/transform-scaley-ref.html
+++ b/css/css-transforms/transform-scaley-ref.html
@@ -5,6 +5,10 @@
     <link rel="author" title="Clint Talbert" href="mailto:ctalbert@mozilla.com">
     <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
     <style>
+      body {
+        margin: 0;
+      }
+
       div {
         background: green;
         width: 100px;


### PR DESCRIPTION
This fixes this set of tests to account for margin collapsing in the
reference, by removing the default margin on body in both test and
reference.

Prior to this change, the tests failed identically in Chromium, Gecko,
and WebKit.