### PR TITLE
Fix the transform-fixed-bg-*.html tests.

### DIFF
--- a/css/css-transforms/transform-fixed-bg-001.html
+++ b/css/css-transforms/transform-fixed-bg-001.html
@@ -3,13 +3,15 @@
   <head>
     <title>CSS Test (Transforms): Fixed Background</title>
     <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="author" title="L. David Baron" href="https://dbaron.org/">
+    <link rel="author" title="Google" href="http://www.google.com/">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-rendering">
-    <meta name="assert" content='"Fixed backgrounds are affected by any
-    transform specified for the root element, and not by any other transforms."
-    Thus if we have a div that&apos;s 100px square aligned at the top left of
-    the page, giving it a fixed background and translating it 50px down and
-    right should be the same as giving it a non-fixed background that&apos;s
-    translated 50px down and right.'>
+    <meta name="assert" content='"Fixed backgrounds on the root element are
+    affected by any transform specified for that element. For all other
+    elements that are effected by a transform (i.e. have a transform applied
+    to them, or to any of their ancestor elements), a value of fixed for the
+    background-attachment property is treated as if it had a value of
+    scroll."'>
     <meta name="flags" content="svg">
     <link rel="match" href="transform-fixed-bg-ref.html">
     <style>

--- a/css/css-transforms/transform-fixed-bg-002.html
+++ b/css/css-transforms/transform-fixed-bg-002.html
@@ -3,12 +3,16 @@
   <head>
     <title>CSS Test (Transforms): Fixed Background (with scrolling)</title>
     <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="author" title="L. David Baron" href="https://dbaron.org/">
+    <link rel="author" title="Google" href="http://www.google.com/">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-rendering">
-    <meta name="assert" content='"Fixed backgrounds are affected by any
-    transform specified for the root element, and not by any other transforms."
+    <meta name="assert" content='"Fixed backgrounds on the root element are
+    affected by any transform specified for that element. For all other
+    elements that are effected by a transform (i.e. have a transform applied
+    to them, or to any of their ancestor elements), a value of fixed for the
+    background-attachment property is treated as if it had a value of scroll."
     Here we translate the div 150px down instead of 50px, and also scroll down
-    100px.  This should be the same as the previous test because the background
-    image is 100px square.'>
+    100px.  This should be the same as the previous test.'>
     <meta name="flags" content="svg dom">
     <link rel="match" href="transform-fixed-bg-ref.html">
     <style>

--- a/css/css-transforms/transform-fixed-bg-003.html
+++ b/css/css-transforms/transform-fixed-bg-003.html
@@ -3,6 +3,8 @@
   <head>
     <title>CSS Test (Transforms): Fixed Background (with rotation)</title>
     <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="author" title="L. David Baron" href="https://dbaron.org/">
+    <link rel="author" title="Google" href="http://www.google.com/">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-rendering">
     <meta name="assert" content='This is the same as transform-fixed-bg-001,
     except that we also test that a rotation on a non-root element doesn&apos;t
@@ -14,7 +16,7 @@
         margin: 0;
       }
       div {
-        background: url(support/transform-triangle-left.svg) fixed;
+        background: url(support/transform-triangle-down.svg) fixed;
         width: 100px;
         height: 100px;
         transform: translate(50px, 50px) rotate(90deg);

--- a/css/css-transforms/transform-fixed-bg-004.html
+++ b/css/css-transforms/transform-fixed-bg-004.html
@@ -3,6 +3,8 @@
   <head>
     <title>CSS Test (Transforms): Fixed Background (with rotation and scrolling)</title>
     <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="author" title="L. David Baron" href="https://dbaron.org/">
+    <link rel="author" title="Google" href="http://www.google.com/">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-rendering">
     <meta name="assert" content='This is the same as transform-fixed-bg-002,
     except that we also test that a rotation on a non-root element doesn&apos;t
@@ -16,7 +18,7 @@
         overflow: hidden;
       }
       div {
-        background: url(support/transform-triangle-left.svg) fixed;
+        background: url(support/transform-triangle-down.svg) fixed;
         width: 100px;
         height: 100px;
         transform: translate(50px, 150px) rotate(90deg);

--- a/css/css-transforms/transform-fixed-bg-005.html
+++ b/css/css-transforms/transform-fixed-bg-005.html
@@ -3,9 +3,16 @@
   <head>
     <title>CSS Test (Transforms): Fixed Background (no-op transform)</title>
     <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="author" title="L. David Baron" href="https://dbaron.org/">
+    <link rel="author" title="Google" href="http://www.google.com/">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-rendering">
-    <meta name="assert" content='This affects that adding a no-op transform to
-    an element with a fixed background doesn&apos;t affect  rendering.'>
+    <meta name="assert" content='"Fixed backgrounds on the root element are
+    affected by any transform specified for that element. For all other
+    elements that are effected by a transform (i.e. have a transform applied
+    to them, or to any of their ancestor elements), a value of fixed for the
+    background-attachment property is treated as if it had a value of scroll."
+    This tests that adding a no-op transform to an element with a fixed
+    background doesn&apos;t change rendering from scroll background.'>
     <meta name="flags" content="svg">
     <link rel="match" href="transform-fixed-bg-ref.html">
     <style>

--- a/css/css-transforms/transform-fixed-bg-006.html
+++ b/css/css-transforms/transform-fixed-bg-006.html
@@ -3,10 +3,17 @@
   <head>
     <title>CSS Test (Transforms): Fixed Background (transform of intermediate)</title>
     <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="author" title="L. David Baron" href="https://dbaron.org/">
+    <link rel="author" title="Google" href="http://www.google.com/">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-rendering">
-    <meta name="assert" content='This tests that adding a rotation to a
-    non-root element doesn&apos;t affect rendering of fixed backgrounds on its
-    descendants.'>
+    <meta name="assert" content='"Fixed backgrounds on the root element are
+    affected by any transform specified for that element. For all other
+    elements that are effected by a transform (i.e. have a transform applied
+    to them, or to any of their ancestor elements), a value of fixed for the
+    background-attachment property is treated as if it had a value of scroll."
+    This tests that adding a rotation to a non-root element doesn&apos;t
+    change rendering of fixed backgrounds on its descendants relative to what
+    they would be if background-attachment: scroll.'>
     <meta name="flags" content="svg">
     <link rel="match" href="transform-fixed-bg-ref.html">
     <style>
@@ -17,7 +24,7 @@
         overflow: hidden;
       }
       div {
-        background: url(support/transform-triangle-left.svg) fixed;
+        background: url(support/transform-triangle-down.svg) fixed;
         width: 100px;
         height: 100px;
         position: relative;

--- a/css/css-transforms/transform-fixed-bg-007.html
+++ b/css/css-transforms/transform-fixed-bg-007.html
@@ -3,10 +3,17 @@
   <head>
     <title>CSS Test (Transforms): Fixed Background (transform on root)</title>
     <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="author" title="L. David Baron" href="https://dbaron.org/">
+    <link rel="author" title="Google" href="http://www.google.com/">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-rendering">
-    <meta name="assert" content='This tests that a transform on the root
-    element *does* affect the rendering of fixed backgrounds on its
-    descendants.'>
+    <meta name="assert" content='"Fixed backgrounds on the root element are
+    affected by any transform specified for that element. For all other
+    elements that are effected by a transform (i.e. have a transform applied
+    to them, or to any of their ancestor elements), a value of fixed for the
+    background-attachment property is treated as if it had a value of scroll."
+    This tests that a transform on the root element still leads fixed
+    backgrounds on descendants to act as though they were scrolled
+    backgrounds.'>
     <meta name="flags" content="svg">
     <link rel="match" href="transform-fixed-bg-ref.html">
     <style>

--- a/css/css-transforms/transform-fixed-bg-ref.html
+++ b/css/css-transforms/transform-fixed-bg-ref.html
@@ -3,12 +3,14 @@
   <head>
     <title>CSS Reftest Reference</title>
     <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="author" title="L. David Baron" href="https://dbaron.org/">
+    <link rel="author" title="Google" href="http://www.google.com/">
     <style>
       body {
         margin: 0;
       }
       div {
-        background: url(support/transform-triangle-left.svg) 50px 50px;
+        background: url(support/transform-triangle-left.svg);
         width: 100px;
         height: 100px;
         position: relative;


### PR DESCRIPTION
These tests were, I believe, testing an old version of the spec, prior
to the wording:
>  Fixed backgrounds on the root element are affected by any transform
> specified for that element. For all other elements that are effected
>  by a transform (i.e. have a transform applied to them, or to any of
>  their ancestor elements), a value of fixed for the
>  background-attachment property is treated as if it had a value of
>  scroll.

This updates the tests to reflect that change.

I intend to write an additional set of tests testing fixed backgrounds
on the root element, which these did not test.

Prior to this change:
 * Chromium and WebKit pass tests 005 and 007 only and fail the other 5
   tests (but fail 002 and 004 differently).
 * Gecko fails all 7 tests

After this change:
 * Chromium and WebKit pass tests 001 and 003 only, and fail the other 5
   tests (but fail 002 and 004 differently).
 * Gecko passes all 7 tests.

I checked in both Chromium and Gecko that all 7 tests match the
reference if I remove the background-attachment: fixed.