### PR TITLE
[css-fonts] Add tests to test dynamic updates to @font-palette-values

### DIFF
--- a/css/css-fonts/palette-values-rule-add-2-ref.html
+++ b/css/css-fonts/palette-values-rule-add-2-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically adding a @font-palette-values rule causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-values">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+</style>
+</head>
+<body>
+<div style="font: 48px 'COLR-test-font'; font-palette: MyPalette;">A</div>
+</body>
+</html>

--- a/css/css-fonts/palette-values-rule-add-2.html
+++ b/css/css-fonts/palette-values-rule-add-2.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically adding a @font-palette-values rule causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-values">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<link rel="match" href="palette-values-rule-add-2-ref.html">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+</style>
+</head>
+<body>
+<div style="font: 48px 'COLR-test-font'; font-palette: MyPalette;">A</div>
+<script>
+let count = 0;
+function tick() {
+    if (count > 3) {
+        let style = document.createElement("style");
+        document.head.appendChild(style);
+        style.sheet.insertRule(`
+            @font-palette-values MyPalette {
+                font-family: "COLR-test-font";
+                base-palette: 1;
+            }`);
+        document.documentElement.classList.remove("reftest-wait");
+    } else {
+        ++count;
+        requestAnimationFrame(tick);
+    }
+}
+[...document.fonts][0].load().then(tick);
+</script>
+</body>
+</html>

--- a/css/css-fonts/palette-values-rule-add-notref.html
+++ b/css/css-fonts/palette-values-rule-add-notref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically adding a @font-palette-values rule causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-values">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+</style>
+</head>
+<body>
+<div style="font: 48px 'COLR-test-font'; font-palette: MyPalette;">A</div>
+</body>
+</html>

--- a/css/css-fonts/palette-values-rule-add.html
+++ b/css/css-fonts/palette-values-rule-add.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically adding a @font-palette-values rule causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-values">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<link rel="mismatch" href="palette-values-rule-add-notref.html">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+</style>
+</head>
+<body>
+<div style="font: 48px 'COLR-test-font'; font-palette: MyPalette;">A</div>
+<script>
+let count = 0;
+function tick() {
+    if (count > 3) {
+        let style = document.createElement("style");
+        document.head.appendChild(style);
+        style.sheet.insertRule(`
+            @font-palette-values MyPalette {
+                font-family: "COLR-test-font";
+                base-palette: 1;
+            }`);
+        document.documentElement.classList.remove("reftest-wait");
+    } else {
+        ++count;
+        requestAnimationFrame(tick);
+    }
+}
+[...document.fonts][0].load().then(tick);
+</script>
+</body>
+</html>

--- a/css/css-fonts/palette-values-rule-delete-2-ref.html
+++ b/css/css-fonts/palette-values-rule-delete-2-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically deleting a @font-palette-values rule causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-values">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<style id="style">
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+</style>
+</head>
+<body>
+<div style="font: 48px 'COLR-test-font'; font-palette: MyPalette;">A</div>
+</body>
+</html>

--- a/css/css-fonts/palette-values-rule-delete-2.html
+++ b/css/css-fonts/palette-values-rule-delete-2.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically deleting a @font-palette-values rule causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-values">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<link rel="match" href="palette-values-rule-delete-2-ref.html">
+<style id="style">
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+</style>
+</head>
+<body>
+<div style="font: 48px 'COLR-test-font'; font-palette: MyPalette;">A</div>
+<script>
+let count = 0;
+function tick() {
+    if (count > 3) {
+        document.getElementById("style").sheet.deleteRule(1);
+        document.documentElement.classList.remove("reftest-wait");
+    } else {
+        ++count;
+        requestAnimationFrame(tick);
+    }
+}
+[...document.fonts][0].load().then(tick);
+</script>
+</body>
+</html>

--- a/css/css-fonts/palette-values-rule-delete-notref.html
+++ b/css/css-fonts/palette-values-rule-delete-notref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically deleting a @font-palette-values rule causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-values">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<style id="style">
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+</style>
+</head>
+<body>
+<div style="font: 48px 'COLR-test-font'; font-palette: MyPalette;">A</div>
+</body>
+</html>

--- a/css/css-fonts/palette-values-rule-delete.html
+++ b/css/css-fonts/palette-values-rule-delete.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically deleting a @font-palette-values rule causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-values">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<link rel="mismatch" href="palette-values-rule-delete-notref.html">
+<style id="style">
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+</style>
+</head>
+<body>
+<div style="font: 48px 'COLR-test-font'; font-palette: MyPalette;">A</div>
+<script>
+let count = 0;
+function tick() {
+    if (count > 3) {
+        document.getElementById("style").sheet.deleteRule(1);
+        document.documentElement.classList.remove("reftest-wait");
+    } else {
+        ++count;
+        requestAnimationFrame(tick);
+    }
+}
+[...document.fonts][0].load().then(tick);
+</script>
+</body>
+</html>


### PR DESCRIPTION
These tests make sure that adding and removing a `@font-palette-values` rule from script cause the necessary rendering updates.

I didn't test modification of any individual descriptor inside `@font-palette-values`, because https://github.com/w3c/csswg-drafts/issues/6645 isn't resolved yet.

(I also haven't updated the test font yet, like I said I would in https://github.com/web-platform-tests/wpt/pull/30910#discussion_r714487080. However, these tests don't require those updates.)

I'm making these tests pass in WebKit in https://bugs.webkit.org/show_bug.cgi?id=230448.