### PR TITLE
[css-fonts] Add some more override-color tests for different color formulations

### DIFF
--- a/css/css-fonts/parsing/font-palette-values-valid.html
+++ b/css/css-fonts/parsing/font-palette-values-valid.html
@@ -69,6 +69,36 @@
 @font-palette-values J {
     override-color: -3 rgb(17, 34, 51);
 }
+
+/* 10 */
+@font-palette-values K {
+    override-color: 0 #0000FF;
+}
+
+/* 11 */
+@font-palette-values L {
+    override-color: 0 green;
+}
+
+/* 12 */
+@font-palette-values M {
+    override-color: 0 transparent;
+}
+
+/* 13 */
+@font-palette-values N {
+    override-color: 0 rgba(1 2 3 / 4);
+}
+
+/* 14 */
+@font-palette-values O {
+    override-color: 0 lab(29.2345% 39.3825 20.0664);
+}
+
+/* 15 */
+@font-palette-values P {
+    override-color: 0 color(display-p3 100% 100% 100%);
+}
 </style>
 </head>
 <body>
@@ -227,6 +257,90 @@ test(function() {
     assert_equals(rule.size, 1);
     assert_equals(rule.get(7), undefined);
     assert_equals(rule.get(-3), undefined);
+});
+
+test(function() {
+    let text = rules[10].cssText;
+    assert_not_equals(text.indexOf("override-color"), -1);
+    assert_not_equals(text.indexOf("rgb(0, 0, 255)"), -1);
+});
+
+test(function() {
+    let rule = rules[10];
+    assert_equals(rule.fontFamily, "");
+    assert_equals(rule.basePalette, "");
+    assert_equals(rule.size, 1);
+    assert_equals(rule.get(0), "rgb(0, 0, 255)");
+});
+
+test(function() {
+    let text = rules[11].cssText;
+    assert_not_equals(text.indexOf("override-color"), -1);
+    assert_not_equals(text.indexOf("rgb(0, 128, 0)"), -1);
+});
+
+test(function() {
+    let rule = rules[11];
+    assert_equals(rule.fontFamily, "");
+    assert_equals(rule.basePalette, "");
+    assert_equals(rule.size, 1);
+    assert_equals(rule.get(0), "rgb(0, 128, 0)");
+});
+
+test(function() {
+    let text = rules[12].cssText;
+    assert_not_equals(text.indexOf("override-color"), -1);
+    assert_not_equals(text.indexOf("rgba(0, 0, 0, 0)"), -1);
+});
+
+test(function() {
+    let rule = rules[12];
+    assert_equals(rule.fontFamily, "");
+    assert_equals(rule.basePalette, "");
+    assert_equals(rule.size, 1);
+    assert_equals(rule.get(0), "rgba(0, 0, 0, 0)");
+});
+
+test(function() {
+    let text = rules[13].cssText;
+    assert_not_equals(text.indexOf("override-color"), -1);
+    assert_not_equals(text.indexOf("2"), -1);
+});
+
+test(function() {
+    let rule = rules[13];
+    assert_equals(rule.fontFamily, "");
+    assert_equals(rule.basePalette, "");
+    assert_equals(rule.size, 1);
+    assert_not_equals(rule.get(0).indexOf("2"), -1);
+});
+
+test(function() {
+    let text = rules[14].cssText;
+    assert_not_equals(text.indexOf("override-color"), -1);
+    assert_not_equals(text.indexOf("29"), -1);
+});
+
+test(function() {
+    let rule = rules[14];
+    assert_equals(rule.fontFamily, "");
+    assert_equals(rule.basePalette, "");
+    assert_equals(rule.size, 1);
+    assert_not_equals(rule.get(0).indexOf("lab"), -1);
+});
+
+test(function() {
+    let text = rules[15].cssText;
+    assert_not_equals(text.indexOf("override-color"), -1);
+    assert_not_equals(text.indexOf("display-p3"), -1);
+});
+
+test(function() {
+    let rule = rules[15];
+    assert_equals(rule.fontFamily, "");
+    assert_equals(rule.basePalette, "");
+    assert_equals(rule.size, 1);
+    assert_not_equals(rule.get(0).indexOf("display-p3"), -1);
 });
 </script>
 </body>


### PR DESCRIPTION
I didn't include the context-sensitive colors because
https://github.com/w3c/csswg-drafts/issues/6680 isn't resolved yet.