### PR TITLE
[css-fonts] Add tests for dynamic changes of font-palette property

### DIFF
--- a/css/css-fonts/font-palette-add-2-ref.html
+++ b/css/css-fonts/font-palette-add-2-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically adding font-palette causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+</style>
+</head>
+<body>
+<div id="target" style="font: 48px 'COLR-test-font'; font-palette: MyPalette;">A</div>
+</body>
+</html>

--- a/css/css-fonts/font-palette-add-2.html
+++ b/css/css-fonts/font-palette-add-2.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically adding font-palette causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<link rel="match" href="font-palette-add-2-ref.html">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+</style>
+</head>
+<body>
+<div id="target" style="font: 48px 'COLR-test-font';">A</div>
+<script>
+let count = 0;
+function tick() {
+    if (count > 3) {
+        document.getElementById("target").style.setProperty("font-palette", "MyPalette");
+        document.documentElement.classList.remove("reftest-wait");
+    } else {
+        ++count;
+        requestAnimationFrame(tick);
+    }
+}
+[...document.fonts][0].load().then(tick);
+</script>
+</body>
+</html>

--- a/css/css-fonts/font-palette-add-notref.html
+++ b/css/css-fonts/font-palette-add-notref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically adding font-palette causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+</style>
+</head>
+<body>
+<div id="target" style="font: 48px 'COLR-test-font';">A</div>
+</body>
+</html>

--- a/css/css-fonts/font-palette-add.html
+++ b/css/css-fonts/font-palette-add.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically adding font-palette causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<link rel="mismatch" href="font-palette-add-notref.html">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+</style>
+</head>
+<body>
+<div id="target" style="font: 48px 'COLR-test-font';">A</div>
+<script>
+let count = 0;
+function tick() {
+    if (count > 3) {
+        document.getElementById("target").style.setProperty("font-palette", "MyPalette");
+        document.documentElement.classList.remove("reftest-wait");
+    } else {
+        ++count;
+        requestAnimationFrame(tick);
+    }
+}
+[...document.fonts][0].load().then(tick);
+</script>
+</body>
+</html>

--- a/css/css-fonts/font-palette-modify-2-ref.html
+++ b/css/css-fonts/font-palette-modify-2-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically modifying font-palette causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+
+@font-palette-values MyPalette2 {
+    font-family: "COLR-test-font";
+    base-palette: 0;
+    override-color: 1 #00FF00;
+}
+</style>
+</head>
+<body>
+<div id="target" style="font: 48px 'COLR-test-font'; font-palette: MyPalette2;">A</div>
+</body>
+</html>

--- a/css/css-fonts/font-palette-modify-2.html
+++ b/css/css-fonts/font-palette-modify-2.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically modifying font-palette causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<link rel="match" href="font-palette-modify-2-ref.html">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+
+@font-palette-values MyPalette2 {
+    font-family: "COLR-test-font";
+    base-palette: 0;
+    override-color: 1 #00FF00;
+}
+</style>
+</head>
+<body>
+<div id="target" style="font: 48px 'COLR-test-font'; font-palette: MyPalette;">A</div>
+<script>
+let count = 0;
+function tick() {
+    if (count > 3) {
+        document.getElementById("target").style.setProperty("font-palette", "MyPalette2");
+        document.documentElement.classList.remove("reftest-wait");
+    } else {
+        ++count;
+        requestAnimationFrame(tick);
+    }
+}
+[...document.fonts][0].load().then(tick);
+</script>
+</body>
+</html>

--- a/css/css-fonts/font-palette-modify-notref.html
+++ b/css/css-fonts/font-palette-modify-notref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically modifying font-palette causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+
+@font-palette-values MyPalette2 {
+    font-family: "COLR-test-font";
+    base-palette: 0;
+    override-color: 1 #00FF00;
+}
+</style>
+</head>
+<body>
+<div id="target" style="font: 48px 'COLR-test-font'; font-palette: MyPalette;">A</div>
+</body>
+</html>

--- a/css/css-fonts/font-palette-modify.html
+++ b/css/css-fonts/font-palette-modify.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically modifying font-palette causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<link rel="mismatch" href="font-palette-modify-notref.html">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+
+@font-palette-values MyPalette2 {
+    font-family: "COLR-test-font";
+    base-palette: 0;
+    override-color: 1 #00FF00;
+}
+</style>
+</head>
+<body>
+<div id="target" style="font: 48px 'COLR-test-font'; font-palette: MyPalette;">A</div>
+<script>
+let count = 0;
+function tick() {
+    if (count > 3) {
+        document.getElementById("target").style.setProperty("font-palette", "MyPalette2");
+        document.documentElement.classList.remove("reftest-wait");
+    } else {
+        ++count;
+        requestAnimationFrame(tick);
+    }
+}
+[...document.fonts][0].load().then(tick);
+</script>
+</body>
+</html>

--- a/css/css-fonts/font-palette-remove-2-ref.html
+++ b/css/css-fonts/font-palette-remove-2-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically removing font-palette causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+</style>
+</head>
+<body>
+<div id="target" style="font: 48px 'COLR-test-font';">A</div>
+</body>
+</html>

--- a/css/css-fonts/font-palette-remove-2.html
+++ b/css/css-fonts/font-palette-remove-2.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically removing font-palette causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<link rel="match" href="font-palette-remove-2-ref.html">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+</style>
+</head>
+<body>
+<div id="target" style="font: 48px 'COLR-test-font'; font-palette: MyPalette;">A</div>
+<script>
+let count = 0;
+function tick() {
+    if (count > 3) {
+        document.getElementById("target").style.removeProperty("font-palette");
+        document.documentElement.classList.remove("reftest-wait");
+    } else {
+        ++count;
+        requestAnimationFrame(tick);
+    }
+}
+[...document.fonts][0].load().then(tick);
+</script>
+</body>
+</html>

--- a/css/css-fonts/font-palette-remove-notref.html
+++ b/css/css-fonts/font-palette-remove-notref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically removing font-palette causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+</style>
+</head>
+<body>
+<div id="target" style="font: 48px 'COLR-test-font'; font-palette: MyPalette;">A</div>
+</body>
+</html>

--- a/css/css-fonts/font-palette-remove.html
+++ b/css/css-fonts/font-palette-remove.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>Tests that dynamically removing font-palette causes the necessary rendering update</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<link rel="mismatch" href="font-palette-remove-notref.html">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+</style>
+</head>
+<body>
+<div id="target" style="font: 48px 'COLR-test-font'; font-palette: MyPalette;">A</div>
+<script>
+let count = 0;
+function tick() {
+    if (count > 3) {
+        document.getElementById("target").style.removeProperty("font-palette");
+        document.documentElement.classList.remove("reftest-wait");
+    } else {
+        ++count;
+        requestAnimationFrame(tick);
+    }
+}
+[...document.fonts][0].load().then(tick);
+</script>
+</body>
+</html>


### PR DESCRIPTION
(I haven't updated the test font yet, like I said I would in https://github.com/web-platform-tests/wpt/pull/30910#discussion_r714487080. However, these tests don't require those updates.)

The relevant WebKit bug is https://bugs.webkit.org/show_bug.cgi?id=230673.