### PR TITLE
Add a set of tests for transforms and backgrounds on the root element.

### DIFF
--- a/css/css-transforms/transform-fixed-bg-root-001.html
+++ b/css/css-transforms/transform-fixed-bg-root-001.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset=UTF-8>
+<title>CSS Test (Transforms): Fixed backgrounds on transformed root element</title>
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Google" href="http://www.google.com/">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-rendering">
+<meta name="assert" content='"Fixed backgrounds on the root element are
+affected by any transform specified for that element."'>
+<meta name="flags" content="svg">
+<link rel="match" href="transform-fixed-bg-root-ref.html">
+
+<style>
+
+html {
+  background-attachment: fixed;
+  background-image: url(support/transform-triangle-left.svg);
+  background-size: 50px 50px;
+  transform: translate(25px, -25px);
+}
+
+</style>

--- a/css/css-transforms/transform-fixed-bg-root-002.html
+++ b/css/css-transforms/transform-fixed-bg-root-002.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset=UTF-8>
+<title>CSS Test (Transforms): Fixed backgrounds on transformed root element</title>
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Google" href="http://www.google.com/">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-rendering">
+<meta name="assert" content='"Fixed backgrounds on the root element are
+affected by any transform specified for that element."'>
+<meta name="flags" content="svg">
+<link rel="match" href="transform-fixed-bg-root-ref.html">
+
+<style>
+
+html {
+  background-attachment: fixed;
+  background-image: url(support/transform-triangle-left.svg);
+  background-size: 200px 200px;
+  /* scale, and bring the top left of the image to 25px 25px */
+  transform: scale(0.5) translate(50px, 50px) scale(0.5);
+  transform-origin: 0 0;
+}
+
+</style>

--- a/css/css-transforms/transform-fixed-bg-root-003.html
+++ b/css/css-transforms/transform-fixed-bg-root-003.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset=UTF-8>
+<title>CSS Test (Transforms): Fixed backgrounds on transformed root element</title>
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Google" href="http://www.google.com/">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-rendering">
+<meta name="assert" content='"Fixed backgrounds on the root element are
+affected by any transform specified for that element."'>
+<meta name="flags" content="svg">
+<link rel="match" href="transform-fixed-bg-root-ref.html">
+
+<style>
+
+html {
+  background-attachment: fixed;
+  background-image: url(support/transform-triangle-up.svg);
+  background-size: 50px 50px;
+  transform: rotate(270deg) translate(25px, -25px);
+  transform-origin: 50px 200px;
+}
+
+</style>

--- a/css/css-transforms/transform-fixed-bg-root-004.html
+++ b/css/css-transforms/transform-fixed-bg-root-004.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset=UTF-8>
+<title>CSS Test (Transforms): Fixed backgrounds on transformed root element</title>
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Google" href="http://www.google.com/">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-rendering">
+<meta name="assert" content='"Fixed backgrounds on the root element are
+affected by any transform specified for that element."'>
+<meta name="flags" content="svg">
+<link rel="match" href="transform-fixed-bg-root-ref.html">
+
+<style>
+
+html {
+  background-attachment: fixed;
+  background-image: url(support/transform-triangle-down.svg);
+  background-size: 100px 100px;
+  transform-origin: 100px 100px;
+  transform: scale(0.5) rotate(90deg) translate(150px, 50px);
+}
+
+</style>

--- a/css/css-transforms/transform-fixed-bg-root-ref.html
+++ b/css/css-transforms/transform-fixed-bg-root-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset=UTF-8>
+<title>CSS Reftest Reference: Fixed backgrounds on transformed root element</title>
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Google" href="http://www.google.com/">
+
+<style>
+
+html {
+  background-image: url(support/transform-triangle-left.svg);
+  background-size: 50px 50px;
+  background-position: 25px 25px;
+}
+
+</style>

--- a/css/css-transforms/transform-scroll-bg-root-001.html
+++ b/css/css-transforms/transform-scroll-bg-root-001.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset=UTF-8>
+<title>CSS Test (Transforms): Fixed backgrounds on transformed root element</title>
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Google" href="http://www.google.com/">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-rendering">
+<meta name="assert" content="background-attachment scroll backgrounds on the root element should be propagated to the canvas (as usual) and not affected by the root's transform">
+<meta name="flags" content="svg">
+<link rel="match" href="transform-fixed-bg-root-ref.html">
+
+<style>
+
+html {
+  background-image: url(support/transform-triangle-left.svg);
+  background-size: 50px 50px;
+  background-position: 25px 25px;
+  /* a transform that is noticeably different from the identity (and which should have no visible effects) */
+  transform: translate(11px, 3px) scale(0.732) rotate(17deg);
+}
+
+</style>


### PR DESCRIPTION
As a followup to #30937, which updated the transform-fixed-bg-00*.html
tests to the current spec and thus made them less interesting, this adds
tests for the more interesting part of the current spec:  the behavior
of backgrounds on the root element when the root element has a
transform.

The current spec, as I understand it, requires that
background-attachment: fixed backgrounds on the root element honor the
root element's transform (which it explicitly states), and requires that
background-attachment: scoll backgrounds on the root element do not
(thanks to its silence on the topic combined with the general rules for
root element background propagation to the canvas).

Chromium has the exact opposite behavior:  it ignores the root's
transform when background-attachment is fixed, and honors the transform
when background-attachment is scroll (and thus fails all the new tests).

Gecko ignores the root's transform regardless of background-attachment
(and thus fails the transform-fixed-bg-root-* tests but passes
transform-scroll-bg-root-001).

WebKit honors the root's transform regardless of background-attachment,
but also has some clipping bugs in the fixed background cases.  Were it
not for the clipping bugs, it would pass the transform-fixed-bg-root-*
tests.  It fails transform-scroll-bg-root-001.

I intend to file a csswg-drafts issue on whether the spec is what it
should be.