### PR TITLE
[css-fonts] Add test for @font-palette-values with an empty font family

### DIFF
--- a/css/css-fonts/font-palette-empty-font-family-notref.html
+++ b/css/css-fonts/font-palette-empty-font-family-notref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests that an empty font family name is handled correctly</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-family-2-desc">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+</style>
+</head>
+<body>
+<div style="font: 48px 'COLR-test-font'; color-palette: MyPalette;">A</div>
+</body>
+</html>

--- a/css/css-fonts/font-palette-empty-font-family.html
+++ b/css/css-fonts/font-palette-empty-font-family.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests that an empty font family name is handled correctly</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-family-2-desc">
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<link rel="mismatch" href="font-palette-empty-font-family-notref.html">
+<style>
+@font-face {
+    font-family: "";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values MyPalette {
+    font-family: "";
+    base-palette: 1;
+}
+</style>
+</head>
+<body>
+<div style="font: 48px ''; color-palette: MyPalette;">A</div>
+</body>
+</html>

--- a/css/css-fonts/parsing/font-palette-values-invalid.html
+++ b/css/css-fonts/parsing/font-palette-values-invalid.html
@@ -87,17 +87,22 @@
 
 /* 14 */
 @font-palette-values A {
+    font-family: "";
+}
+
+/* 15 */
+@font-palette-values A {
     base-palette: initial;
     override-color: initial;
 }
 
-/* 15 */
+/* 16 */
 @font-palette-values A {
     base-palette: inherit;
     override-color: inherit;
 }
 
-/* 16 */
+/* 17 */
 @font-palette-values A {
     base-palette: unset;
     override-color: unset;
@@ -108,7 +113,7 @@
 <script>
 let rules = document.getElementById("style").sheet.cssRules;
 test(function() {
-    assert_equals(rules.length, 17);
+    assert_equals(rules.length, 18);
 });
 
 test(function() {
@@ -214,10 +219,8 @@ test(function() {
 test(function() {
     let text = rules[14].cssText;
     let rule = rules[14];
-    assert_equals(text.indexOf("base-palette"), -1);
-    assert_equals(text.indexOf("override-color"), -1);
-    assert_equals(rule.size, 0);
-    assert_equals(rule.basePalette, "");
+    // I see nothing in the spec that indicates an empty string is a parse error.
+    assert_not_equals(text.indexOf("font-family"), -1);
 });
 
 test(function() {
@@ -232,6 +235,15 @@ test(function() {
 test(function() {
     let text = rules[16].cssText;
     let rule = rules[16];
+    assert_equals(text.indexOf("base-palette"), -1);
+    assert_equals(text.indexOf("override-color"), -1);
+    assert_equals(rule.size, 0);
+    assert_equals(rule.basePalette, "");
+});
+
+test(function() {
+    let text = rules[17].cssText;
+    let rule = rules[17];
     assert_equals(text.indexOf("base-palette"), -1);
     assert_equals(text.indexOf("override-color"), -1);
     assert_equals(rule.size, 0);


### PR DESCRIPTION
The relevant WebKit bug is https://bugs.webkit.org/show_bug.cgi?id=230598.