### PR TITLE
[css-fonts] Add tests for CSS-wide keywords in @font-palette-values

### DIFF
--- a/css/css-fonts/parsing/font-palette-values-invalid.html
+++ b/css/css-fonts/parsing/font-palette-values-invalid.html
@@ -84,13 +84,31 @@
     base-palette: -1;
     override-color: -1 #123;
 }
+
+/* 14 */
+@font-palette-values A {
+    base-palette: initial;
+    override-color: initial;
+}
+
+/* 15 */
+@font-palette-values A {
+    base-palette: inherit;
+    override-color: inherit;
+}
+
+/* 16 */
+@font-palette-values A {
+    base-palette: unset;
+    override-color: unset;
+}
 </style>
 </head>
 <body>
 <script>
 let rules = document.getElementById("style").sheet.cssRules;
 test(function() {
-    assert_equals(rules.length, 14);
+    assert_equals(rules.length, 17);
 });
 
 test(function() {
@@ -187,6 +205,33 @@ test(function() {
 test(function() {
     let text = rules[13].cssText;
     let rule = rules[13];
+    assert_equals(text.indexOf("base-palette"), -1);
+    assert_equals(text.indexOf("override-color"), -1);
+    assert_equals(rule.size, 0);
+    assert_equals(rule.basePalette, "");
+});
+
+test(function() {
+    let text = rules[14].cssText;
+    let rule = rules[14];
+    assert_equals(text.indexOf("base-palette"), -1);
+    assert_equals(text.indexOf("override-color"), -1);
+    assert_equals(rule.size, 0);
+    assert_equals(rule.basePalette, "");
+});
+
+test(function() {
+    let text = rules[15].cssText;
+    let rule = rules[15];
+    assert_equals(text.indexOf("base-palette"), -1);
+    assert_equals(text.indexOf("override-color"), -1);
+    assert_equals(rule.size, 0);
+    assert_equals(rule.basePalette, "");
+});
+
+test(function() {
+    let text = rules[16].cssText;
+    let rule = rules[16];
     assert_equals(text.indexOf("base-palette"), -1);
     assert_equals(text.indexOf("override-color"), -1);
     assert_equals(rule.size, 0);


### PR DESCRIPTION
The relevant WebKit bug is https://bugs.webkit.org/show_bug.cgi?id=230737.