### PR TITLE
[css-fonts] Add parsing tests for CSSFontPaletteValuesRule.name

### DIFF
--- a/css/css-fonts/parsing/font-palette-values-valid.html
+++ b/css/css-fonts/parsing/font-palette-values-valid.html
@@ -119,6 +119,7 @@ test(function() {
     let rule = rules[0];
     assert_equals(rule.type, CSSRule.FONT_PALETTE_VALUES_RULE);
     assert_equals(rule.constructor.name, "CSSFontPaletteValuesRule");
+    assert_equals(rule.name, "A");
     assert_equals(rule.fontFamily, "");
     assert_equals(rule.basePalette, "");
     assert_equals(rule.size, 0);
@@ -131,6 +132,7 @@ test(function() {
 
 test(function() {
     let rule = rules[1];
+    assert_equals(rule.name, "B");
     assert_equals(rule.fontFamily, "");
     assert_equals(rule.basePalette, "");
     assert_equals(rule.size, 0);
@@ -150,6 +152,7 @@ test(function() {
 
 test(function() {
     let rule = rules[2];
+    assert_equals(rule.name, "C");
     assert_equals(rule.fontFamily, "bar");
     assert_equals(rule.basePalette, "2");
     assert_equals(rule.size, 0);
@@ -167,6 +170,7 @@ test(function() {
 
 test(function() {
     let rule = rules[3];
+    assert_equals(rule.name, "D");
     assert_equals(rule.fontFamily, "");
     assert_equals(rule.basePalette, "bar");
     assert_equals(rule.size, 1);
@@ -182,6 +186,7 @@ test(function() {
 
 test(function() {
     let rule = rules[4];
+    assert_equals(rule.name, "E");
     assert_equals(rule.fontFamily, "");
     assert_equals(rule.basePalette, "");
     assert_equals(rule.size, 1);
@@ -196,6 +201,7 @@ test(function() {
 
 test(function() {
     let rule = rules[5];
+    assert_equals(rule.name, "F");
     assert_equals(rule.fontFamily, "foo");
     assert_equals(rule.basePalette, "");
     assert_equals(rule.size, 0);
@@ -209,6 +215,7 @@ test(function() {
 
 test(function() {
     let rule = rules[6];
+    assert_equals(rule.name, "G");
     assert_equals(rule.fontFamily, "");
     assert_equals(rule.basePalette, "");
     assert_equals(rule.size, 2);
@@ -225,6 +232,7 @@ test(function() {
 
 test(function() {
     let rule = rules[7];
+    assert_equals(rule.name, "H");
     assert_equals(rule.fontFamily, "");
     assert_equals(rule.basePalette, "");
     assert_equals(rule.size, 1);
@@ -240,6 +248,7 @@ test(function() {
 
 test(function() {
     let rule = rules[8];
+    assert_equals(rule.name, "I");
     assert_equals(rule.fontFamily, "");
     assert_equals(rule.basePalette, "-3");
     assert_equals(rule.size, 0);
@@ -252,6 +261,7 @@ test(function() {
 
 test(function() {
     let rule = rules[9];
+    assert_equals(rule.name, "J");
     assert_equals(rule.fontFamily, "");
     assert_equals(rule.basePalette, "");
     assert_equals(rule.size, 1);
@@ -267,6 +277,7 @@ test(function() {
 
 test(function() {
     let rule = rules[10];
+    assert_equals(rule.name, "K");
     assert_equals(rule.fontFamily, "");
     assert_equals(rule.basePalette, "");
     assert_equals(rule.size, 1);
@@ -281,6 +292,7 @@ test(function() {
 
 test(function() {
     let rule = rules[11];
+    assert_equals(rule.name, "L");
     assert_equals(rule.fontFamily, "");
     assert_equals(rule.basePalette, "");
     assert_equals(rule.size, 1);
@@ -295,6 +307,7 @@ test(function() {
 
 test(function() {
     let rule = rules[12];
+    assert_equals(rule.name, "M");
     assert_equals(rule.fontFamily, "");
     assert_equals(rule.basePalette, "");
     assert_equals(rule.size, 1);
@@ -309,6 +322,7 @@ test(function() {
 
 test(function() {
     let rule = rules[13];
+    assert_equals(rule.name, "N");
     assert_equals(rule.fontFamily, "");
     assert_equals(rule.basePalette, "");
     assert_equals(rule.size, 1);
@@ -323,6 +337,7 @@ test(function() {
 
 test(function() {
     let rule = rules[14];
+    assert_equals(rule.name, "O");
     assert_equals(rule.fontFamily, "");
     assert_equals(rule.basePalette, "");
     assert_equals(rule.size, 1);
@@ -337,6 +352,7 @@ test(function() {
 
 test(function() {
     let rule = rules[15];
+    assert_equals(rule.name, "P");
     assert_equals(rule.fontFamily, "");
     assert_equals(rule.basePalette, "");
     assert_equals(rule.size, 1);


### PR DESCRIPTION
It was added in https://github.com/w3c/csswg-drafts/commit/8868476c571d63b7f3f2718e22601a711a2d8683.

The relevant WebKit patch is https://bugs.webkit.org/show_bug.cgi?id=230787.