### PR TITLE
[css-fonts] override-color has been renamed to override-colors

### DIFF
--- a/css/css-fonts/parsing/font-palette-values-invalid.html
+++ b/css/css-fonts/parsing/font-palette-values-invalid.html
@@ -51,32 +51,32 @@
 
 /* 7 */
 @font-palette-values A {
-    override-color: ident #123;
+    override-colors: ident #123;
 }
 
 /* 8 */
 @font-palette-values A {
-    override-color: 0 "red";
+    override-colors: 0 "red";
 }
 
 /* 9 */
 @font-palette-values A {
-    override-color: 0 #123, 1;
+    override-colors: 0 #123, 1;
 }
 
 /* 10 */
 @font-palette-values A {
-    override-color: ;
+    override-colors: ;
 }
 
 /* 11 */
 @font-palette-values A {
-    override-color: 0 #123 1;
+    override-colors: 0 #123 1;
 }
 
 /* 12 */
 @font-palette-values A {
-    override-color: 0;
+    override-colors: 0;
 }
 </style>
 </head>
@@ -139,42 +139,42 @@ test(function() {
 test(function() {
     let text = rules[7].cssText;
     let rule = rules[7];
-    assert_equals(text.indexOf("override-color"), -1);
+    assert_equals(text.indexOf("override-colors"), -1);
     assert_equals(rule.size, 0);
 });
 
 test(function() {
     let text = rules[8].cssText;
     let rule = rules[8];
-    assert_equals(text.indexOf("override-color"), -1);
+    assert_equals(text.indexOf("override-colors"), -1);
     assert_equals(rule.size, 0);
 });
 
 test(function() {
     let text = rules[9].cssText;
     let rule = rules[9];
-    assert_equals(text.indexOf("override-color"), -1);
+    assert_equals(text.indexOf("override-colors"), -1);
     assert_equals(rule.size, 0);
 });
 
 test(function() {
     let text = rules[10].cssText;
     let rule = rules[10];
-    assert_equals(text.indexOf("override-color"), -1);
+    assert_equals(text.indexOf("override-colors"), -1);
     assert_equals(rule.size, 0);
 });
 
 test(function() {
     let text = rules[11].cssText;
     let rule = rules[11];
-    assert_equals(text.indexOf("override-color"), -1);
+    assert_equals(text.indexOf("override-colors"), -1);
     assert_equals(rule.size, 0);
 });
 
 test(function() {
     let text = rules[12].cssText;
     let rule = rules[12];
-    assert_equals(text.indexOf("override-color"), -1);
+    assert_equals(text.indexOf("override-colors"), -1);
     assert_equals(rule.size, 0);
 });
 </script>

--- a/css/css-fonts/parsing/font-palette-values-valid.html
+++ b/css/css-fonts/parsing/font-palette-values-valid.html
@@ -24,9 +24,9 @@
     base-palette: 1;
     base-palette: "baz";
     base-palette: 2;
-    override-color: "a" #123;
-    override-color: 3 #123;
-    override-color: "b" #123;
+    override-colors: "a" #123;
+    override-colors: 3 #123;
+    override-colors: "b" #123;
 }
 
 /* 3 */
@@ -34,15 +34,15 @@
     base-palette: "foo";
     base-palette: 1;
     base-palette: "bar";
-    override-color: 3 #123;
-    override-color: "baz" #123;
-    override-color: 4 #123;
+    override-colors: 3 #123;
+    override-colors: "baz" #123;
+    override-colors: 4 #123;
 }
 
 /* 4 */
 @font-palette-values E {
-    override-color: 3 rgb(17, 34, 51);
-    override-color: 3 rgb(68, 85, 102);
+    override-colors: 3 rgb(17, 34, 51);
+    override-colors: 3 rgb(68, 85, 102);
 }
 
 /* 5 */
@@ -52,12 +52,12 @@
 
 /* 6 */
 @font-palette-values G {
-    override-color: 3 rgb(17, 34, 51), 4 rgb(68, 85, 102);
+    override-colors: 3 rgb(17, 34, 51), 4 rgb(68, 85, 102);
 }
 
 /* 7 */
 @font-palette-values H {
-    override-color: 3 rgb(17, 34, 51), 3 rgb(68, 85, 102);
+    override-colors: 3 rgb(17, 34, 51), 3 rgb(68, 85, 102);
 }
 
 /* 8 */
@@ -67,37 +67,37 @@
 
 /* 9 */
 @font-palette-values J {
-    override-color: -3 rgb(17, 34, 51);
+    override-colors: -3 rgb(17, 34, 51);
 }
 
 /* 10 */
 @font-palette-values K {
-    override-color: 0 #0000FF;
+    override-colors: 0 #0000FF;
 }
 
 /* 11 */
 @font-palette-values L {
-    override-color: 0 green;
+    override-colors: 0 green;
 }
 
 /* 12 */
 @font-palette-values M {
-    override-color: 0 transparent;
+    override-colors: 0 transparent;
 }
 
 /* 13 */
 @font-palette-values N {
-    override-color: 0 rgba(1 2 3 / 4);
+    override-colors: 0 rgba(1 2 3 / 4);
 }
 
 /* 14 */
 @font-palette-values O {
-    override-color: 0 lab(29.2345% 39.3825 20.0664);
+    override-colors: 0 lab(29.2345% 39.3825 20.0664);
 }
 
 /* 15 */
 @font-palette-values P {
-    override-color: 0 color(display-p3 100% 100% 100%);
+    override-colors: 0 color(display-p3 100% 100% 100%);
 }
 </style>
 </head>
@@ -112,7 +112,7 @@ test(function() {
     assert_not_equals(text.indexOf("}"), -1);
     assert_equals(text.indexOf("font-family"), -1);
     assert_equals(text.indexOf("base-palette"), -1);
-    assert_equals(text.indexOf("override-color"), -1);
+    assert_equals(text.indexOf("override-colors"), -1);
 });
 
 test(function() {
@@ -143,9 +143,9 @@ test(function() {
     assert_equals(text.indexOf("base-palette: 1;"), -1);
     assert_equals(text.indexOf("base-palette: \"baz\""), -1);
     assert_not_equals(text.indexOf("base-palette: 2;"), -1);
-    assert_equals(text.indexOf("override-color: \"a\""), -1);
-    assert_equals(text.indexOf("override-color: 3"), -1);
-    assert_not_equals(text.indexOf("override-color: \"b\""), -1);
+    assert_equals(text.indexOf("override-colors: \"a\""), -1);
+    assert_equals(text.indexOf("override-colors: 3"), -1);
+    assert_not_equals(text.indexOf("override-colors: \"b\""), -1);
 });
 
 test(function() {
@@ -160,9 +160,9 @@ test(function() {
     assert_equals(text.indexOf("base-palette: \"foo\";"), -1);
     assert_equals(text.indexOf("base-palette: 1"), -1);
     assert_not_equals(text.indexOf("base-palette: \"bar\";"), -1);
-    assert_equals(text.indexOf("override-color: 3"), -1);
-    assert_equals(text.indexOf("override-color: \"baz\""), -1);
-    assert_not_equals(text.indexOf("override-color: 4"), -1);
+    assert_equals(text.indexOf("override-colors: 3"), -1);
+    assert_equals(text.indexOf("override-colors: \"baz\""), -1);
+    assert_not_equals(text.indexOf("override-colors: 4"), -1);
 });
 
 test(function() {
@@ -247,7 +247,7 @@ test(function() {
 
 test(function() {
     let text = rules[9].cssText;
-    assert_not_equals(text.indexOf("override-color"), -1);
+    assert_not_equals(text.indexOf("override-colors"), -1);
 });
 
 test(function() {
@@ -261,7 +261,7 @@ test(function() {
 
 test(function() {
     let text = rules[10].cssText;
-    assert_not_equals(text.indexOf("override-color"), -1);
+    assert_not_equals(text.indexOf("override-colors"), -1);
     assert_not_equals(text.indexOf("rgb(0, 0, 255)"), -1);
 });
 
@@ -275,7 +275,7 @@ test(function() {
 
 test(function() {
     let text = rules[11].cssText;
-    assert_not_equals(text.indexOf("override-color"), -1);
+    assert_not_equals(text.indexOf("override-colors"), -1);
     assert_not_equals(text.indexOf("rgb(0, 128, 0)"), -1);
 });
 
@@ -289,7 +289,7 @@ test(function() {
 
 test(function() {
     let text = rules[12].cssText;
-    assert_not_equals(text.indexOf("override-color"), -1);
+    assert_not_equals(text.indexOf("override-colors"), -1);
     assert_not_equals(text.indexOf("rgba(0, 0, 0, 0)"), -1);
 });
 
@@ -303,7 +303,7 @@ test(function() {
 
 test(function() {
     let text = rules[13].cssText;
-    assert_not_equals(text.indexOf("override-color"), -1);
+    assert_not_equals(text.indexOf("override-colors"), -1);
     assert_not_equals(text.indexOf("2"), -1);
 });
 
@@ -317,7 +317,7 @@ test(function() {
 
 test(function() {
     let text = rules[14].cssText;
-    assert_not_equals(text.indexOf("override-color"), -1);
+    assert_not_equals(text.indexOf("override-colors"), -1);
     assert_not_equals(text.indexOf("29"), -1);
 });
 
@@ -331,7 +331,7 @@ test(function() {
 
 test(function() {
     let text = rules[15].cssText;
-    assert_not_equals(text.indexOf("override-color"), -1);
+    assert_not_equals(text.indexOf("override-colors"), -1);
     assert_not_equals(text.indexOf("display-p3"), -1);
 });
 


### PR DESCRIPTION
In https://github.com/w3c/csswg-drafts/commit/9de250d6692d07ddb8af3e3face37b909e5aad7b.

The relevant WebKit bug is https://bugs.webkit.org/show_bug.cgi?id=230789.