### PR TITLE
[css-fonts] Font palettes have to be named with a <dashed-ident>

### DIFF
--- a/css/css-fonts/parsing/font-palette-computed.html
+++ b/css/css-fonts/parsing/font-palette-computed.html
@@ -16,7 +16,7 @@ test_computed_value('font-palette', 'none');
 test_computed_value('font-palette', 'normal');
 test_computed_value('font-palette', 'light');
 test_computed_value('font-palette', 'dark');
-test_computed_value('font-palette', 'pitchfork');
+test_computed_value('font-palette', '--pitchfork');
 </script>
 </body>
 </html>

--- a/css/css-fonts/parsing/font-palette-invalid.html
+++ b/css/css-fonts/parsing/font-palette-invalid.html
@@ -13,6 +13,7 @@
 <script>
 test_invalid_value('font-palette', 'normal none');
 test_invalid_value('font-palette', 'none, light');
+test_invalid_value('font-palette', 'A');
 </script>
 </body>
 </html>

--- a/css/css-fonts/parsing/font-palette-valid.html
+++ b/css/css-fonts/parsing/font-palette-valid.html
@@ -15,7 +15,7 @@ test_valid_value('font-palette', 'none');
 test_valid_value('font-palette', 'normal');
 test_valid_value('font-palette', 'light');
 test_valid_value('font-palette', 'dark');
-test_valid_value('font-palette', 'pitchfork');
+test_valid_value('font-palette', '--pitchfork');
 </script>
 </body>
 </html>

--- a/css/css-fonts/parsing/font-palette-valid.html
+++ b/css/css-fonts/parsing/font-palette-valid.html
@@ -16,6 +16,7 @@ test_valid_value('font-palette', 'normal');
 test_valid_value('font-palette', 'light');
 test_valid_value('font-palette', 'dark');
 test_valid_value('font-palette', '--pitchfork');
+test_valid_value('font-palette', '--');
 </script>
 </body>
 </html>

--- a/css/css-fonts/parsing/font-palette-values-invalid.html
+++ b/css/css-fonts/parsing/font-palette-values-invalid.html
@@ -11,71 +11,74 @@
 @font-palette-values {
 }
 
-@font-palette-values A B {
+@font-palette-values A {
+}
+
+@font-palette-values --A --B {
 }
 
 /* 0 */
-@font-palette-values A {
+@font-palette-values --A {
     font-family: a, b;
 }
 
 /* 1 */
-@font-palette-values A {
+@font-palette-values --A {
     font-family: 1;
 }
 
 /* 2 */
-@font-palette-values A {
+@font-palette-values --A {
     font: 12px a;
 }
 
 /* 3 */
-@font-palette-values A {
+@font-palette-values --A {
     base-palette: 1 2;
 }
 
 /* 4 */
-@font-palette-values A {
+@font-palette-values --A {
     base-palette: ident;
 }
 
 /* 5 */
-@font-palette-values A {
+@font-palette-values --A {
     base-palette: "a" "b";
 }
 
 /* 6 */
-@font-palette-values A {
+@font-palette-values --A {
     base-palette: ;
 }
 
 /* 7 */
-@font-palette-values A {
+@font-palette-values --A {
     override-color: ident #123;
 }
 
 /* 8 */
-@font-palette-values A {
+@font-palette-values --A {
     override-color: 0 "red";
 }
 
 /* 9 */
-@font-palette-values A {
+@font-palette-values --A {
     override-color: 0 #123, 1;
 }
 
 /* 10 */
-@font-palette-values A {
+@font-palette-values --A {
     override-color: ;
 }
 
 /* 11 */
-@font-palette-values A {
+@font-palette-values --A {
     override-color: 0 #123 1;
 }
 
 /* 12 */
-@font-palette-values A {
+@font-palette-values --A {
     override-color: 0;
 }
 

--- a/css/css-fonts/parsing/font-palette-values-valid.html
+++ b/css/css-fonts/parsing/font-palette-values-valid.html
@@ -89,6 +89,10 @@
 @font-palette-values --N {
     override-color: 0 color(display-p3 100% 100% 100%);
 }
+
+/* 14 */
+@font-palette-values -- {
+}
 </style>
 </head>
 <body>
@@ -305,6 +309,17 @@ test(function() {
     assert_equals(rule.basePalette, "");
     assert_equals(rule.size, 1);
     assert_not_equals(rule.get(0).indexOf("display-p3"), -1);
+});
+
+test(function() {
+    let text = rules[14].cssText;
+    assert_not_equals(text.indexOf("--"), -1);
+});
+
+test(function() {
+    let rule = rules[14];
+    assert_equals(rule.fontFamily, "");
+    assert_equals(rule.basePalette, "");
 });
 </script>
 </body>

--- a/css/css-fonts/parsing/font-palette-values-valid.html
+++ b/css/css-fonts/parsing/font-palette-values-valid.html
@@ -9,16 +9,16 @@
 <script src="/resources/testharnessreport.js"></script>
 <style id="style">
 /* 0 */
-@font-palette-values A {
+@font-palette-values --A {
 }
 
 /* 1 */
-@font-palette-values B {
+@font-palette-values --B {
     font-weight: 400;
 }
 
 /* 2 */
-@font-palette-values C {
+@font-palette-values --C {
     font-family: foo;
     font-family: bar;
     base-palette: 1;
@@ -30,7 +30,7 @@
 }
 
 /* 3 */
-@font-palette-values D {
+@font-palette-values --D {
     base-palette: "foo";
     base-palette: 1;
     base-palette: "bar";
@@ -40,53 +40,53 @@
 }
 
 /* 4 */
-@font-palette-values E {
+@font-palette-values --E {
     override-color: 3 rgb(17, 34, 51);
     override-color: 3 rgb(68, 85, 102);
 }
 
 /* 5 */
-@font-palette-values F {
+@font-palette-values --F {
     font-family: "foo";
 }
 
 /* 6 */
-@font-palette-values G {
+@font-palette-values --G {
     override-color: 3 rgb(17, 34, 51), 4 rgb(68, 85, 102);
 }
 
 /* 7 */
-@font-palette-values H {
+@font-palette-values --H {
     override-color: 3 rgb(17, 34, 51), 3 rgb(68, 85, 102);
 }
 
 /* 8 */
-@font-palette-values I {
+@font-palette-values --I {
     override-color: 0 #0000FF;
 }
 
 /* 9 */
-@font-palette-values J {
+@font-palette-values --J {
     override-color: 0 green;
 }
 
 /* 10 */
-@font-palette-values K {
+@font-palette-values --K {
     override-color: 0 transparent;
 }
 
 /* 11 */
-@font-palette-values L {
+@font-palette-values --L {
     override-color: 0 rgba(1 2 3 / 4);
 }
 
 /* 12 */
-@font-palette-values M {
+@font-palette-values --M {
     override-color: 0 lab(29.2345% 39.3825 20.0664);
 }
 
 /* 13 */
-@font-palette-values N {
+@font-palette-values --N {
     override-color: 0 color(display-p3 100% 100% 100%);
 }
 </style>
@@ -97,7 +97,7 @@ let rules = document.getElementById("style").sheet.cssRules;
 test(function() {
     let text = rules[0].cssText;
     assert_not_equals(text.indexOf("@font-palette-values "), -1);
-    assert_not_equals(text.indexOf(" A "), -1);
+    assert_not_equals(text.indexOf(" --A "), -1);
     assert_not_equals(text.indexOf("{"), -1);
     assert_not_equals(text.indexOf("}"), -1);
     assert_equals(text.indexOf("font-family"), -1);


### PR DESCRIPTION
The spec changed in https://github.com/w3c/csswg-drafts/commit/9ddf9388a2fe0ac300c41b7244e10c0a40fe0cae.

The relevant WebKit bug is https://bugs.webkit.org/show_bug.cgi?id=230790.