### PR TITLE
[css-fonts] Make sure CSSFontPaletteValuesRule attributes are readonly

### DIFF
--- a/css/css-fonts/parsing/font-palette-values-invalid.html
+++ b/css/css-fonts/parsing/font-palette-values-invalid.html
@@ -92,6 +92,20 @@ test(function() {
     let rule = rules[0];
     assert_equals(text.indexOf("font-family"), -1);
     assert_equals(rule.fontFamily, "");
+    rule.fontFamily = "SomeFontFamily";
+    assert_equals(rule.fontFamily, "");
+    assert_equals(rule.basePalette, "");
+    rule.basePalette = "7";
+    assert_equals(rule.basePalette, "");
+    assert_throws_js(TypeError, function() {
+        rule.clear();
+    });
+    assert_throws_js(TypeError, function() {
+        rule.delete(4);
+    });
+    assert_throws_js(TypeError, function() {
+        rule.set(4, "0 #123");
+    });
 });
 
 test(function() {


### PR DESCRIPTION
The spec enforces this in https://github.com/w3c/csswg-drafts/commit/9ddf9388a2fe0ac300c41b7244e10c0a40fe0cae.

This test still assumes that the `CSSFontPaletteValuesRule` is `maplike` (it hasn't been updated for
https://github.com/w3c/csswg-drafts/commit/c10855a2c65f51a09697613b977059fae78ff0bc yet). There are a bunch of
places in WPT where the tests still assume that `CSSFontPaletteValuesRule` is `maplike`, so this patch is consistent
with that. I plan to update all the tests together in a single future patch to migrate away from maplike.

The relevant WebKit bug is https://bugs.webkit.org/show_bug.cgi?id=230791.