### PR TITLE
Change the chunk type used when running tests on TaskCluster to hash

### DIFF
--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -62,6 +62,7 @@ components:
       --log-wptreport=../artifacts/wpt_report.json
       --log-wptscreenshot=../artifacts/wpt_screenshot.txt
       --no-fail-on-unexpected
+      --chunk-type=hash
       --this-chunk=${chunks.id}
       --total-chunks=${chunks.total}
       --test-type=${vars.suite}


### PR DESCRIPTION
webkitgtk has latterly been timing out; this is in part due to us
using dir_hash on TC, which means we run the risk of globally timing
out when a lot of tests within a single directory all timeout, as
they'll all end up in a single job.

See https://github.com/web-platform-tests/wpt/issues/30834.