### PR TITLE
COEP credentialless: fix video.tentative.https.html

### DIFF
--- a/html/cross-origin-embedder-policy/credentialless/video.tentative.https.html
+++ b/html/cross-origin-embedder-policy/credentialless/video.tentative.https.html
@@ -7,6 +7,11 @@
 
 <script>
 
+// Some web browser require the window to be focused before autoplaying video.
+// This function is similar to window.open, but create a new window instead of a
+// new tab.
+const openPopup = url => window.open(url, undefined, "width=100");
+
 promise_test_parallel(async test => {
   const same_origin = get_host_info().HTTPS_ORIGIN;
   const cross_origin = get_host_info().HTTPS_REMOTE_ORIGIN;
@@ -25,14 +30,14 @@ promise_test_parallel(async test => {
   const w_control_token = token();
   const w_control_url = same_origin + executor_path +
     coep_none + `&uuid=${w_control_token}`
-  const w_control = window.open(w_control_url);
+  const w_control = openPopup(w_control_url);
   add_completion_callback(() => w_control.close());
 
   // One window with COEP:credentialless. (experiment)
   const w_credentialless_token = token();
   const w_credentialless_url = same_origin + executor_path +
     coep_credentialless + `&uuid=${w_credentialless_token}`;
-  const w_credentialless = window.open(w_credentialless_url);
+  const w_credentialless = openPopup(w_credentialless_url);
   add_completion_callback(() => w_credentialless.close());
 
   let videoTest = function(


### PR DESCRIPTION
This test was passing with ContentShell, but not Chrome. The reason was
autplaying a video is not enabled in a background tab.

The fix was to open a new window instead.