### PR TITLE
[WebTransport] Introduce "stream_reset" to the server

### DIFF
--- a/tools/webtransport/README.md
+++ b/tools/webtransport/README.md
@@ -65,3 +65,14 @@ Called whenever a datagram is received on a WebTransport session.
 
   - <b>session</b>: A WebTransport session object.
   - <b>data</b>: The received data.
+
+---
+
+#### `stream_reset(session, stream_id, error_code)`
+Called whenever a datagram is reset with RESET_STREAM.
+
+- <b>Parameters</b>
+
+  - <b>session</b>: A WebTransport session object.
+  - <b>stream_id</b>: The ID of the stream.
+  - <b>error_code</b>: The reason of the reset.

--- a/tools/webtransport/h3/handler.py
+++ b/tools/webtransport/h3/handler.py
@@ -62,8 +62,9 @@ def session_closed(session: WebTransportSession,
     """
     pass
 
+
 def stream_reset(session: WebTransportSession,
-                 stream_id: int
+                 stream_id: int,
                  error_code: int) -> None:
     """
     Called when a stream is reset with RESET_STREAM.

--- a/tools/webtransport/h3/handler.py
+++ b/tools/webtransport/h3/handler.py
@@ -66,7 +66,7 @@ def stream_reset(session: WebTransportSession,
                  stream_id: int
                  error_code: int) -> None:
     """
-    Called when a stream is Reset with RESET_STREAM.
+    Called when a stream is reset with RESET_STREAM.
 
     :param session: A WebTransport session.
     :param stream_id: The ID of the stream.

--- a/tools/webtransport/h3/handler.py
+++ b/tools/webtransport/h3/handler.py
@@ -61,3 +61,15 @@ def session_closed(session: WebTransportSession,
                      (by a CLOSE_CONNECTION QUIC frame for example).
     """
     pass
+
+def stream_reset(session: WebTransportSession,
+                 stream_id: int
+                 error_code: int) -> None:
+    """
+    Called when a stream is Reset with RESET_STREAM.
+
+    :param session: A WebTransport session.
+    :param stream_id: The ID of the stream.
+    :param error_code: The reason of the reset.
+    """
+    pass


### PR DESCRIPTION
It is called when a stream is reset with a RESET_STREAM frame.
I want to introduce a similar callback for STOP_SENDING, but it
would be much more difficult, given there is no aioquic event
for STOP_SENDING.