### PR TITLE
Change the structured clone runner to always return a promise

### DIFF
--- a/html/webappapis/structured-clone/structured-clone-battery-of-tests-harness.js
+++ b/html/webappapis/structured-clone/structured-clone-battery-of-tests-harness.js
@@ -9,6 +9,7 @@
  * - `postTest()`: An optional, async function run after a test is done
  * - `structuredClone(obj, transferList)`: Required function that somehow
  *                                         structurally clones an object.
+ *                                         Must return a promise.
  * - `hasDocument`: When true, disables tests that require a document. True by default.
  */
 

--- a/html/webappapis/structured-clone/structured-clone.any.js
+++ b/html/webappapis/structured-clone/structured-clone.any.js
@@ -5,9 +5,9 @@
 
 runStructuredCloneBatteryOfTests({
   structuredClone: (obj, transfer) => {
-    return new Promise(resolve => {
-      resolve(self.structuredClone(obj, { transfer }));
-    });
+    return Promise.resolve().then(
+      () => self.structuredClone(obj, { transfer })
+    );
   },
   hasDocument: typeof document !== "undefined",
 });

--- a/html/webappapis/structured-clone/structured-clone.any.js
+++ b/html/webappapis/structured-clone/structured-clone.any.js
@@ -5,9 +5,9 @@
 
 runStructuredCloneBatteryOfTests({
   structuredClone: (obj, transfer) => {
-    return Promise.resolve().then(
-      () => self.structuredClone(obj, { transfer })
-    );
+    return new Promise(resolve => {
+      resolve(self.structuredClone(obj, { transfer }));
+    });
   },
   hasDocument: typeof document !== "undefined",
 });

--- a/html/webappapis/structured-clone/structured-clone.any.js
+++ b/html/webappapis/structured-clone/structured-clone.any.js
@@ -4,6 +4,10 @@
 // META: script=/html/webappapis/structured-clone/structured-clone-battery-of-tests-harness.js
 
 runStructuredCloneBatteryOfTests({
-  structuredClone: (obj, transfer) => self.structuredClone(obj, { transfer }),
+  structuredClone: (obj, transfer) => { 
+    return Promise.resolve().then(
+      () => self.structuredClone(obj, { transfer })
+    );
+  },
   hasDocument: typeof document !== "undefined",
 });

--- a/html/webappapis/structured-clone/structured-clone.any.js
+++ b/html/webappapis/structured-clone/structured-clone.any.js
@@ -4,7 +4,7 @@
 // META: script=/html/webappapis/structured-clone/structured-clone-battery-of-tests-harness.js
 
 runStructuredCloneBatteryOfTests({
-  structuredClone: (obj, transfer) => { 
+  structuredClone: (obj, transfer) => {
     return Promise.resolve().then(
       () => self.structuredClone(obj, { transfer })
     );


### PR DESCRIPTION
The structured clone battery of tests, until #30824, only relied on the result of `runner.structuredClone()` being awaitable. This allowed the runner for `WindowOrGlobalScope.structuredClone` to just return the result of `self.structuredClone()` without wrapping it in a promise.

PR #30824, however, added tests that checked that the structured clone failed in certain cases, using `promise_rejects_dom`. In those cases, the `WindowOrGlobalScope.structuredClone` runner would throw an exception, rather than return a rejected promise, causing those tests to fail.

This change adds the requirement that `runner.structuredClone()` return a promise, and changes the `WindowOrGlobalScope.structuredClone` runner in turn.
