### PR TITLE
[WebTransport] Check event type before using its properties

### DIFF
--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -109,8 +109,8 @@ class WebTransportH3Protocol(QuicConnectionProtocol):
                 self._send_error_response(event.stream_id, 400)
             self._session_stream_id = event.stream_id
 
-        if self._session_stream_id == event.stream_id and\
-           isinstance(event, WebTransportStreamDataReceived):
+        if isinstance(event, WebTransportStreamDataReceived) and\
+           self._session_stream_id == event.stream_id:
             self._session_stream_data += event.data
             if event.stream_ended:
                 close_info = None


### PR DESCRIPTION
The below code is problematic

  if self._session_stream_id == event.stream_id and\
    isinstance(event, WebTransportStreamDataReceived):

because it uses event's property before checking its type. This
leads to errors when event without stream_id comes here. This
change fixes that.