### PR TITLE
Avoid `assert not files_list[-1]` errors on TC

### DIFF
--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -154,8 +154,8 @@ def repo_files_changed(revish, include_uncommitted=False, include_new=False):
     if git is None:
         raise Exception("git not found")
 
-    files_list = git("diff", "--name-only", "-z", revish).split(u"\0")
-    assert not files_list[-1]
+    files_list = git("diff", "--no-renames", "--name-only", "-z", revish).split(u"\0")
+    assert not files_list[-1], f"final item should be empty, got: {files_list[-1]!r}"
     files = set(files_list[:-1])
 
     if include_uncommitted:

--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -154,6 +154,15 @@ def repo_files_changed(revish, include_uncommitted=False, include_new=False):
     if git is None:
         raise Exception("git not found")
 
+    if "..." in revish:
+        raise Exception(f"... not supported when finding files changed (revish: {revish!r}")
+
+    if ".." in revish:
+        # ".." isn't treated as a range for git-diff; what we want is
+        # everything reachable from B but not A, and git diff A...B
+        # gives us that (via the merge-base)
+        revish = revish.replace("..", "...")
+
     files_list = git("diff", "--no-renames", "--name-only", "-z", revish).split(u"\0")
     assert not files_list[-1], f"final item should be empty, got: {files_list[-1]!r}"
     files = set(files_list[:-1])


### PR DESCRIPTION
See #31029 and https://github.com/web-platform-tests/wpt/pull/31018 which have both similarly failed recently.

To copy/paste the commit messages here:

---

Disable rename detection when looking for changed tests
At least at times, we could end up with the rename limit warning being
output (i.e., `inexact rename detection was skipped due to too many
files`). This then caused our assert to fail, as it relied on the
output following the -z argument and ending without any trailing out.

This warning is absolutely useless for us, as we're just looking to
find out what files have changed, so we don't care if the file is a
rename or not, so we can avoid it by just outright disabling rename
detection.

This was previously fixed in
#18879 (30c42ec) by
just outright ignoring stderr, but was regressed in
#23733
(6539f1e). Avoiding the warning being output in the first place
seems like a better solution than ignoring any errors git might
produce.

---

Deal with the different semantics of A..B in git-diff in repo_files_changed

At the moment on TaskCluster we pass something like

{PR base}..{PR head} which is sometimes a small range when parsed as a
range (see gitrevisions(7)), as it is everything reachable from PR
head but not from PR base. By comparison, for git-diff, A..B gives all
changes between the two trees A and B, which if the PR is filed with a
merge-base a long way behind master would be a much larger change.

As such, change repo_files_changed to use the merge-base of A..B, as
this gives us the diff of the commits that are new on the PR branch.