### PR TITLE
[css-fonts] Remove the "none" value from font-palette

### DIFF
--- a/css/css-fonts/parsing/font-palette-computed.html
+++ b/css/css-fonts/parsing/font-palette-computed.html
@@ -12,7 +12,6 @@
 <body>
 <div id="target"></div>
 <script>
-test_computed_value('font-palette', 'none');
 test_computed_value('font-palette', 'normal');
 test_computed_value('font-palette', 'light');
 test_computed_value('font-palette', 'dark');

--- a/css/css-fonts/parsing/font-palette-invalid.html
+++ b/css/css-fonts/parsing/font-palette-invalid.html
@@ -13,6 +13,7 @@
 <script>
 test_invalid_value('font-palette', 'normal none');
 test_invalid_value('font-palette', 'none, light');
+test_invalid_value('font-palette', 'none');
 </script>
 </body>
 </html>

--- a/css/css-fonts/parsing/font-palette-valid.html
+++ b/css/css-fonts/parsing/font-palette-valid.html
@@ -4,14 +4,13 @@
 <meta charset="utf-8">
 <title>CSS Fonts Module Level 4: parsing font-palette with valid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
-<meta name="assert" content="font-palette supports the full grammar 'none | normal | light | dark | <palette-identifier>'.">
+<meta name="assert" content="font-palette supports the full grammar 'normal | light | dark | <palette-identifier>'.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
 </head>
 <body>
 <script>
-test_valid_value('font-palette', 'none');
 test_valid_value('font-palette', 'normal');
 test_valid_value('font-palette', 'light');
 test_valid_value('font-palette', 'dark');


### PR DESCRIPTION
This value was removed in https://github.com/w3c/csswg-drafts/commit/b7103b0269cde51914af02f5ca1e5582d44e7b70.