### PR TITLE
[css-fonts] Only absolute colors are allowed in override-colors

### DIFF
--- a/css/css-fonts/parsing/font-palette-values-invalid.html
+++ b/css/css-fonts/parsing/font-palette-values-invalid.html
@@ -84,13 +84,18 @@
     base-palette: -1;
     override-color: -1 #123;
 }
+
+/* 14 */
+@font-palette-values A {
+    override-color: 0 canvas;
+}
 </style>
 </head>
 <body>
 <script>
 let rules = document.getElementById("style").sheet.cssRules;
 test(function() {
-    assert_equals(rules.length, 14);
+    assert_equals(rules.length, 15);
 });
 
 test(function() {
@@ -188,6 +193,14 @@ test(function() {
     let text = rules[13].cssText;
     let rule = rules[13];
     assert_equals(text.indexOf("base-palette"), -1);
+    assert_equals(text.indexOf("override-color"), -1);
+    assert_equals(rule.size, 0);
+    assert_equals(rule.basePalette, "");
+});
+
+test(function() {
+    let text = rules[14].cssText;
+    let rule = rules[14];
     assert_equals(text.indexOf("override-color"), -1);
     assert_equals(rule.size, 0);
     assert_equals(rule.basePalette, "");

--- a/css/css-fonts/parsing/font-palette-values-valid.html
+++ b/css/css-fonts/parsing/font-palette-values-valid.html
@@ -89,6 +89,11 @@
 @font-palette-values N {
     override-color: 0 color(display-p3 100% 100% 100%);
 }
+
+/* 14 */
+@font-palette-values O {
+    override-color: 0 transparent;
+}
 </style>
 </head>
 <body>
@@ -305,6 +310,18 @@ test(function() {
     assert_equals(rule.basePalette, "");
     assert_equals(rule.size, 1);
     assert_not_equals(rule.get(0).indexOf("display-p3"), -1);
+});
+
+test(function() {
+    let text = rules[14].cssText;
+    assert_not_equals(text.indexOf("override-color"), -1);
+});
+
+test(function() {
+    let rule = rules[14];
+    assert_equals(rule.fontFamily, "");
+    assert_equals(rule.basePalette, "");
+    assert_equals(rule.size, 1);
 });
 </script>
 </body>


### PR DESCRIPTION
The spec changed in https://github.com/w3c/csswg-drafts/commit/da9c67d6b2f20a0feba11d9e88cc9d9631bcce73.

The relevant WebKit bug is https://bugs.webkit.org/show_bug.cgi?id=231052.