### PR TITLE
[chrome] Enable WebTransport over HTTP/3 server for `wpt run`

### DIFF
--- a/infrastructure/metadata/infrastructure/server/webtransport-h3.sub.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/webtransport-h3.sub.any.js.ini
@@ -1,16 +1,19 @@
 [webtransport-h3.sub.any.html]
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
-      FAIL # TODO(bashi): Enable the WebTransport test server once aioquic dependency is resolved. Ditto below.
+      if product == "chrome": PASS
+      FAIL
 
 [webtransport-h3.sub.any.window.html]
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
+      if product == "chrome": PASS
       FAIL
 
 [webtransport-h3.sub.any.worker.html]
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
+      if product == "chrome": PASS
       FAIL
 
 [webtransport-h3.sub.any.sharedworker.html]
@@ -18,9 +21,11 @@
     if product == "safari" or product == "epiphany" or product == "webkit": ERROR # https://bugs.webkit.org/show_bug.cgi?id=149850
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
+      if product == "chrome": PASS
       FAIL
 
 [webtransport-h3.sub.any.serviceworker.html]
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
+      if product == "chrome": PASS
       FAIL

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -375,6 +375,8 @@ class Chrome(BrowserSetup):
             kwargs["binary_args"].append("--enable-experimental-web-platform-features")
             # HACK(Hexcles): work around https://github.com/web-platform-tests/wpt/issues/16448
             kwargs["webdriver_args"].append("--disable-build-check")
+            # To start the WebTransport over HTTP/3 test server.
+            kwargs["enable_webtransport_h3"] = True
         if os.getenv("TASKCLUSTER_ROOT_URL"):
             # We are on Taskcluster, where our Docker container does not have
             # enough capabilities to run Chrome with sandboxing. (gh-20133)

--- a/tools/wptrunner/requirements_chrome.txt
+++ b/tools/wptrunner/requirements_chrome.txt
@@ -1,1 +1,2 @@
+aioquic==0.9.15
 mozprocess==1.3.0


### PR DESCRIPTION
* Add aioquic dependency to requirements_chrome.txt
* Start the WebTranport over HTTP/3 server