### PR TITLE
[do not merge] Demo: exposing cross-origin info with navigation timing

### DIFF
--- a/navigation-timing/navigation-timing-xo-demo.html
+++ b/navigation-timing/navigation-timing-xo-demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Navigation Timing 2 WPT</title>
+        <link rel="author" title="Google" href="http://www.google.com/" />
+        <link rel="help" href="http://www.w3.org/TR/navigation-timing-2/#sec-PerformanceNavigationTiming"/>
+        <script src="/common/get-host-info.sub.js"></script>
+<script>
+    const {ORIGIN, REMOTE_ORIGIN} = get_host_info();
+</script>
+    </head>
+    <body>
+        <h1>Description</h1>
+
+        <p>This example shows how navigation timing exposes cross-origin information.</p>
+        <form method="post" action="resources/redirect_delay.py">
+            <input type="hidden" name="location" /> 
+            <label><input type="checkbox" name="delay" value="2" /> Subscribe to our
+            newsletter.</label>
+            <input type="submit" value="OK" />
+        </form>
+        <script>
+            document.forms[0].elements.location.value = `${REMOTE_ORIGIN}/navigation-timing/resources/xo-result.html`
+        </script>
+    </body>
+</html>

--- a/navigation-timing/resources/redirect_delay.py
+++ b/navigation-timing/resources/redirect_delay.py
@@ -1,0 +1,12 @@
+import time
+
+def main(request, response):
+    status = 302
+    delay = 0
+    if b"delay" in request.POST:
+        delay = float(request.POST.first(b"delay"))
+        
+    time.sleep(delay)
+    response.status = status
+    location = request.POST.first(b"location")
+    response.headers.set(b"Location", location)

--- a/navigation-timing/resources/xo-result.html
+++ b/navigation-timing/resources/xo-result.html
@@ -1,0 +1,7 @@
+<p>
+You probably <span id="result">did not subscribe</span> to the newsletter.
+</p>
+<script>
+    if (performance.now() > 1000)
+        document.getElementById("result").innerHTML = "subscribed"
+</script>


### PR DESCRIPTION
The demo does the following:
- A form with a "subscribe" option posts to a same-origin URL
- The server at that domain takes a second, only if "subscribe" is selected
- After processing, the server redirects to a page at a different origin
- The other origin can roughly detect how long it took the first server to perform the post, because the `timeOrigin` for performance calls is the start of navigation regardless of cross-origin redirects.