### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=231062

### DIFF
--- a/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage.https.html
+++ b/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage.https.html
@@ -6,7 +6,7 @@
 // Test that drawing images with different bit depths and color profiles into
 // sRGB and Display P3 canvases works, by reading pixels with getImageData()
 // as sRGB and Display P3 values.
-for (let [filename, expectedPixels] of Object.entries(imageTests)) {
+for (let [filename, expectedPixels] of Object.entries({...imageTests, ...svgImageTests})) {
     for (let contextColorSpace of ["srgb", "display-p3"]) {
         for (let imageDataColorSpace of ["srgb", "display-p3"]) {
             for (let scaleImage of [false, true]) {

--- a/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3.js
+++ b/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3.js
@@ -1,4 +1,4 @@
-// Each image:
+// Each PNG:
 //  * is 2x2 and has a single color
 //  * has a filename that indicates its contents:
 //      <embedded-profile>-<8-or-16-bit-color-value>.png
@@ -174,6 +174,36 @@ const imageTests = {
         "srgb display-p3": [201, 42, 29, 204],
         "display-p3 srgb": [219, 0, 1, 204],
         "display-p3 display-p3": [201, 42, 29, 204],
+    },
+};
+
+const svgImageTests = {
+    // SVG source images
+
+    "sRGB-FF0000.svg": {
+        "srgb srgb": [255, 0, 0, 255],
+        "srgb display-p3": [234, 51, 35, 255],
+        "display-p3 srgb": [255, 0, 0, 255],
+        "display-p3 display-p3": [234, 51, 35, 255],
+    },
+    "sRGB-BB0000.svg": {
+        "srgb srgb": [187, 0, 0, 255],
+        "srgb display-p3": [171, 35, 23, 255],
+        "display-p3 srgb": [187, 1, 0, 255],
+        "display-p3 display-p3": [171, 35, 23, 255],
+    },
+
+    "Display-P3-1-0-0.svg": {
+        "srgb srgb": [255, 0, 0, 255],
+        "srgb display-p3": [234, 51, 35, 255],
+        "display-p3 srgb": [255, 0, 0, 255],
+        "display-p3 display-p3": [255, 0, 0, 255],
+    },
+    "Display-P3-0.7333-0-0.svg": {
+        "srgb srgb": [205, 0, 0, 255],
+        "srgb display-p3": [188, 39, 26, 255],
+        "display-p3 srgb": [205, 0, 0, 255],
+        "display-p3 display-p3": [187, 0, 0, 255],
     },
 };
 

--- a/html/canvas/element/manual/wide-gamut-canvas/resources/Display-P3-0.7333-0-0.svg
+++ b/html/canvas/element/manual/wide-gamut-canvas/resources/Display-P3-0.7333-0-0.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2" height="2">
+  <rect width="2" height="2" style="fill: color(display-p3 0.7333 0 0);"/>
+</svg>

--- a/html/canvas/element/manual/wide-gamut-canvas/resources/Display-P3-1-0-0.svg
+++ b/html/canvas/element/manual/wide-gamut-canvas/resources/Display-P3-1-0-0.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2" height="2">
+  <rect width="2" height="2" style="fill: color(display-p3 1 0 0);"/>
+</svg>

--- a/html/canvas/element/manual/wide-gamut-canvas/resources/sRGB-BB0000.svg
+++ b/html/canvas/element/manual/wide-gamut-canvas/resources/sRGB-BB0000.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2" height="2">
+  <rect width="2" height="2" style="fill: #BB0000;"/>
+</svg>

--- a/html/canvas/element/manual/wide-gamut-canvas/resources/sRGB-FF0000.svg
+++ b/html/canvas/element/manual/wide-gamut-canvas/resources/sRGB-FF0000.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2" height="2">
+  <rect width="2" height="2" style="fill: #FF0000;"/>
+</svg>


### PR DESCRIPTION
WebKit export from bug: [SVG images drawn onto display-p3 canvas are flattened to sRGB](https://bugs.webkit.org/show_bug.cgi?id=231062)