### PR TITLE
[WebTransport] Fix tests for client initiated closure

### DIFF
--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -291,10 +291,9 @@ class WebTransportSession:
             buffer.push_bytes(reason)
             capsule =\
                 H3Capsule(CapsuleType.CLOSE_WEBTRANSPORT_SESSION, buffer.data)
-            self.send_stream_data(session_stream_id, capsule.encode())
+            self._http.send_data(session_stream_id, capsule.encode(), end_stream=False)
 
-        self.send_stream_data(session_stream_id, b'', end_stream=True)
-        self._protocol.transmit()
+        self._http.send_data(session_stream_id, b'', end_stream=True)
         # TODO(yutakahirano): Reset all other streams.
         # TODO(yutakahirano): Reject future stream open requests
         # We need to wait for the stream data to arrive at the client, and then

--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -169,7 +169,7 @@ class WebTransportH3Protocol(QuicConnectionProtocol):
                 code = buffer.pull_uint32()
                 # TODO(yutakahirano): Make sure `reason` is a
                 # UTF-8 text.
-                reason = buffer.data
+                reason = buffer.pull_bytes(len(capsule.data) - 4)
                 self._close_info = (code, reason)
                 if fin:
                     self._call_session_closed(self._close_info, abruptly=False)

--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -167,9 +167,9 @@ class WebTransportH3Protocol(QuicConnectionProtocol):
             elif capsule.type == CapsuleType.CLOSE_WEBTRANSPORT_SESSION:
                 buffer = Buffer(data=capsule.data)
                 code = buffer.pull_uint32()
-                # TODO(yutakahirano): Make sure `reason` is a
-                # UTF-8 text.
+                # 4 bytes for the uint32.
                 reason = buffer.pull_bytes(len(capsule.data) - 4)
+                # TODO(yutakahirano): Make sure `reason` is a UTF-8 text.
                 self._close_info = (code, reason)
                 if fin:
                     self._call_session_closed(self._close_info, abruptly=False)

--- a/webtransport/close.https.any.js
+++ b/webtransport/close.https.any.js
@@ -80,6 +80,14 @@ promise_test(async t => {
 }, 'close with code and long reason');
 
 promise_test(async t => {
+  const wt = new WebTransport(webtransport_url('server-close.py'));
+
+  const close_info = await wt.closed;
+  assert_not_own_property(close_info, 'closeCode');
+  assert_not_own_property(close_info, 'reason');
+}, 'server initiated closure');
+
+promise_test(async t => {
   const code = 32;
   const reason = 'abc';
   const wt = new WebTransport(
@@ -87,9 +95,9 @@ promise_test(async t => {
   add_completion_callback(() => wt.close());
 
   const close_info = await wt.closed;
-  assert_equals(close_info.code, code, 'code');
+  assert_equals(close_info.closeCode, code, 'code');
   assert_equals(close_info.reason, reason, 'reason');
-}, 'server initiated closure');
+}, 'server initiated closure with code and reason');
 
 promise_test(async t => {
   const wt = new WebTransport(webtransport_url('server-connection-close.py'));

--- a/webtransport/close.https.any.js
+++ b/webtransport/close.https.any.js
@@ -13,7 +13,7 @@ promise_test(async t => {
 
   const close_info = await wt.closed;
 
-  assert_not_own_property(close_info, 'code');
+  assert_not_own_property(close_info, 'closeCode');
   assert_not_own_property(close_info, 'reason');
 
   await wait(10);
@@ -23,7 +23,8 @@ promise_test(async t => {
   const info = data['session-close-info']
 
   assert_false(info.abruptly, 'abruptly');
-  assert_equals(info.close_info, null, 'close_info');
+  assert_equals(info.close_info.code, 0, 'code');
+  assert_equals(info.close_info.reason, '', 'reason');
 }, 'close');
 
 promise_test(async t => {
@@ -70,11 +71,12 @@ promise_test(async t => {
   assert_own_property(data, 'session-close-info');
   const info = data['session-close-info']
 
-  const expectedReason =
-    new TextDecoder().decode(new TextEncoder().encode(reason).slice(1024))
+  const expected_reason =
+    new TextDecoder().decode(
+      new TextEncoder().encode(reason).slice(0, 1024)).replaceAll('\ufffd', '');
   assert_false(info.abruptly, 'abruptly');
   assert_equals(info.close_info.code, 11, 'code');
-  assert_equals(info.close_info.reason, expectedReason, 'reason');
+  assert_equals(info.close_info.reason, expected_reason, 'reason');
 }, 'close with code and long reason');
 
 promise_test(async t => {

--- a/webtransport/handlers/client-close.py
+++ b/webtransport/handlers/client-close.py
@@ -45,7 +45,7 @@ def session_closed(
     token = session.dict_for_handlers['token']
     data = session.stash.take(key=token) or {}
 
-    decoded_close_info : Optional[Dict[str, Any]]
+    decoded_close_info: Optional[Dict[str, Any]] = None
     if close_info:
         decoded_close_info = {
             'code': close_info[0],

--- a/webtransport/handlers/client-close.py
+++ b/webtransport/handlers/client-close.py
@@ -45,8 +45,15 @@ def session_closed(
     token = session.dict_for_handlers['token']
     data = session.stash.take(key=token) or {}
 
+    decoded_close_info : Optional[Dict[str, Any]]
+    if close_info:
+        decoded_close_info = {
+            'code': close_info[0],
+            'reason': close_info[1].decode()
+        }
+
     data['session-close-info'] = {
         'abruptly': abruptly,
-        'close_info': close_info
+        'close_info': decoded_close_info
     }
     session.stash.put(key=token, value=data)

--- a/webtransport/handlers/server-close.py
+++ b/webtransport/handlers/server-close.py
@@ -9,8 +9,8 @@ def session_established(session):
             path = value
     assert path is not None
     qs = dict(parse_qsl(urlsplit(path).query))
-    code = qs[b'code']
-    reason = qs[b'reason'] or b''
+    code = qs[b'code'] if b'code' in qs else None
+    reason = qs[b'reason'] if b'reason' in qs else b''
     close_info = None if code is None else (int(code), reason)
 
     session.close(close_info)


### PR DESCRIPTION
1. Close() leads to a CLOSE_WEBTRANPORT_SESSION with 0 and "".
2. Store decoded reason so that we can generate JSON data
3. Fix a bug on parsing CLOSE_WEBTRANPORT_SESSION
4. Fix wrong property names on close.https.any.js.
5. Remove replacement characters from the expected reason string.
6. Use _http.send_data instead of send_stream_data for capsules.