### PR TITLE
Fix CSP tests for script elements encoding

### DIFF
--- a/content-security-policy/script-src/hash-always-converted-to-utf-8/iso-8859-1.html
+++ b/content-security-policy/script-src/hash-always-converted-to-utf-8/iso-8859-1.html
@@ -10,9 +10,9 @@
       window.addEventListener("securitypolicyviolation", t1.unreached_func("Should not have fired a spv"));
     </script>
 
-    <!-- ï¿½ (micro sign) has the value of 0xB5 in latin-1 and of 0xC2B5 in utf-8 but the hash value should be the same as the utf-8 computed one -->
+    <!-- µ (micro sign) has the value of 0xB5 in latin-1 and of 0xC2B5 in utf-8 but the hash value should be the same as the utf-8 computed one -->
     <script>
-      // ï¿½ - latin micro sign
+      // µ - latin micro sign
       t1.done();
     </script>
 </body>

--- a/content-security-policy/script-src/hash-always-converted-to-utf-8/iso-8859-3.html
+++ b/content-security-policy/script-src/hash-always-converted-to-utf-8/iso-8859-3.html
@@ -10,9 +10,9 @@
       window.addEventListener("securitypolicyviolation", t3.unreached_func("Should not have fired a spv"));
     </script>
 
-    <!-- ï¿½ (latin capital letter g with breve) has the value of 0xAB in latin-3 and of 0xC49E in utf-8 but the hash value should be the same as the utf-8 computed one -->
+    <!-- « (latin capital letter g with breve) has the value of 0xAB in latin-3 and of 0xC49E in utf-8 but the hash value should be the same as the utf-8 computed one -->
     <script>
-      // ï¿½ - latin capital letter g with breve
+      // « - latin capital letter g with breve
       t3.done();
     </script>
 </body>

--- a/content-security-policy/script-src/hash-always-converted-to-utf-8/iso-8859-7.html
+++ b/content-security-policy/script-src/hash-always-converted-to-utf-8/iso-8859-7.html
@@ -10,9 +10,9 @@
       window.addEventListener("securitypolicyviolation", t2.unreached_func("Should not have fired a spv"));
     </script>
 
-    <!-- ï¿½ (greek small letter mu) has the value of 0xEC in latin-7 and of 0xCEBC in utf-8 but the hash value should be the same as the utf-8 computed one -->
+    <!-- ì (greek small letter mu) has the value of 0xEC in latin-7 and of 0xCEBC in utf-8 but the hash value should be the same as the utf-8 computed one -->
     <script>
-      // ï¿½ - greek small letter mu
+      // ì - greek small letter mu
       t2.done();
     </script>
 </body>

--- a/content-security-policy/script-src/hash-always-converted-to-utf-8/iso-8859-9.html
+++ b/content-security-policy/script-src/hash-always-converted-to-utf-8/iso-8859-9.html
@@ -10,9 +10,9 @@
       window.addEventListener("securitypolicyviolation", t3.unreached_func("Should not have fired a spv"));
     </script>
 
-    <!-- ï¿½ (latin capital letter g with breve) has the value of 0xD0 in latin-9 and of 0xC49E in utf-8 but the hash value should be the same as the utf-8 computed one -->
+    <!-- Ð (latin capital letter g with breve) has the value of 0xD0 in latin-9 and of 0xC49E in utf-8 but the hash value should be the same as the utf-8 computed one -->
     <script>
-      // ï¿½ - latin capital letter g with breve
+      // Ð - latin capital letter g with breve
       t3.done();
     </script>
 </body>


### PR DESCRIPTION
The test files are not valid utf8 (since they test other encodings), and it looks like the chrome wpt exporter cannot handle them correctly (https://bugs.chromium.org/p/chromium/issues/detail?id=1252712). Fixing them on WPT directly should solve the issue.