### PR TITLE
Add WebDriver tests for clicking on elements at viewport boundaries

### DIFF
--- a/webdriver/tests/element_click/viewport_boundaries.py
+++ b/webdriver/tests/element_click/viewport_boundaries.py
@@ -1,0 +1,124 @@
+import pytest
+
+from webdriver.transport import Response
+from tests.support.asserts import assert_error, assert_success
+from tests.support.helpers import (element_position, get_element_property,
+    scroll_to, viewport_size)
+
+def element_click(session, element):
+    return session.transport.send(
+        "POST", "session/{session_id}/element/{element_id}/click".format(
+            session_id=session.session_id,
+            element_id=element.id))
+
+@pytest.mark.parametrize("boundary", range(-4, 4))
+def test_element_at_bottom_edge_of_viewport(session, inline, boundary):
+    session.url = inline("""
+        <style>
+        body {
+          padding: 0.25px;
+        }
+
+        body > div {
+          height: 1000px;
+        }
+        </style>
+
+        <div></div>
+        <label for="checkmeout">Check me out</label>
+        <input type="checkbox" id="checkmeout">
+        """)
+    element = session.find.css("input", all=False)
+    position = element_position(session, element)
+    clientHeight = viewport_size(session)[1]
+    elementBottom = position['y'] - clientHeight
+
+    targetScroll = elementBottom - (boundary * 0.25)
+    scroll_to(session, 0, targetScroll)
+
+    assert_success(element_click(session, element))
+    assert get_element_property(session, element, 'checked') is True
+
+@pytest.mark.parametrize("boundary", range(-4, 4))
+def test_element_at_top_edge_of_viewport(session, inline, boundary):
+    session.url = inline("""
+        <style>
+        body {
+          padding: 0.25px;
+        }
+
+        body > div {
+          height: 1000px;
+        }
+        </style>
+
+        <label for="checkmeout">Check me out</label>
+        <input type="checkbox" id="checkmeout">
+        <div></div>
+        """)
+    element = session.find.css("input", all=False)
+    position = element_position(session, element)
+    elementTop = position['y'] + position['height'];
+
+    targetScroll = elementTop - (boundary * 0.25)
+    scroll_to(session, 0, targetScroll)
+
+    assert_success(element_click(session, element))
+    assert get_element_property(session, element, 'checked') is True
+
+@pytest.mark.parametrize("boundary", range(-4, 4))
+def test_element_at_left_edge_of_viewport(session, inline, boundary):
+    session.url = inline("""
+        <style>
+        body {
+          padding: 0.25px;
+        }
+
+        body > div {
+          padding-right: 1000px;
+        }
+        </style>
+
+        <div>
+            <label for="checkmeout">Check me out</label>
+            <input type="checkbox" id="checkmeout">
+        <div>
+        """)
+    element = session.find.css("input", all=False)
+    position = element_position(session, element)
+    elementLeft = position['x'] + position['width'];
+
+    targetScroll = elementLeft - (boundary * 0.25)
+    scroll_to(session, targetScroll, 0)
+
+    assert_success(element_click(session, element))
+    assert get_element_property(session, element, 'checked') is True
+
+@pytest.mark.parametrize("boundary", range(-4, 4))
+def test_element_at_right_edge_of_viewport(session, inline, boundary):
+    session.url = inline("""
+        <style>
+        body {
+          padding: 0.25px;
+        }
+
+        body > div {
+          padding-left: 1000px;
+        }
+        </style>
+
+        <div>
+            <label for="checkmeout">Check me out</label>
+            <input type="checkbox" id="checkmeout">
+        <div>
+        """)
+    element = session.find.css("input", all=False)
+    position = element_position(session, element)
+    clientWidth = viewport_size(session)[0]
+    elementRight = position['x'] - clientWidth
+
+    targetScroll = elementRight - (boundary * 0.25)
+    scroll_to(session, targetScroll, 0)
+
+    assert_success(element_click(session, element))
+    assert get_element_property(session, element, 'checked') is True

--- a/webdriver/tests/support/helpers.py
+++ b/webdriver/tests/support/helpers.py
@@ -238,6 +238,17 @@ def available_screen_size(session):
         ];
         """))
 
+
+def viewport_size(session):
+    """Returns the available width/height size of the viewport."""
+    return tuple(session.execute_script("""
+        return [
+            window.innerWidth,
+            window.innerHeight,
+        ];
+        """))
+
+
 def filter_dict(source, d):
     """Filter `source` dict to only contain same keys as `d` dict.
 
@@ -261,3 +272,26 @@ def wait_for_new_handle(session, handles_before):
 
     return wait.until(find_new_handle)
 
+
+def element_position(session, element):
+    """Returns the dimensions and location of the specified element."""
+    return dict(session.execute_script("""
+        return {
+            x: arguments[0].offsetLeft,
+            y: arguments[0].offsetTop,
+            width: arguments[0].clientWidth,
+            height: arguments[0].clientHeight,
+        };
+        """, args=(element,)))
+
+
+def scroll_to(session, x, y):
+    """Scroll to the specified location within the docuemnt."""
+    return session.execute_script("window.scrollTo({0}, {1});".format(x, y))
+
+
+def get_element_property(session, element, prop):
+    """Get the named property of the element."""
+    return session.execute_script("""
+        return arguments[0].{0}
+        """.format(prop), args=(element,))


### PR DESCRIPTION
Ensure than when an element is on the bounds of the viewport, element
clicks are still possible as the element should be scrolled into view.

This test relates to a current problem with Chrome, but it's something that all browsers should be testing properly.

See https://chromium-review.googlesource.com/c/chromium/src/+/3089219/1 and https://bugs.chromium.org/p/chromedriver/issues/detail?id=3878&sort=-id for details of the issue we're experiencing.