### PR TITLE
Update URLs to Web IDL

### DIFF
--- a/IndexedDB/idb-binary-key-detached.htm
+++ b/IndexedDB/idb-binary-key-detached.htm
@@ -2,7 +2,7 @@
 <meta charset=utf-8>
 <title>IndexedDB: Detached buffers supplied as binary keys</title>
 <meta name="help" href="http://w3c.github.io/IndexedDB/#convert-a-value-to-a-key">
-<meta name="help" href="https://heycam.github.io/webidl/#dfn-get-buffer-source-copy">
+<meta name="help" href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support.js"></script>

--- a/common/stringifiers.js
+++ b/common/stringifiers.js
@@ -1,5 +1,5 @@
 /**
- * Runs tests for <http://heycam.github.io/webidl/#es-stringifier>.
+ * Runs tests for <https://webidl.spec.whatwg.org/#es-stringifier>.
  * @param {Object} aObject - object to test
  * @param {string} aAttribute - IDL attribute name that is annotated with `stringifier`
  * @param {boolean} aIsUnforgeable - whether the IDL attribute is `[LegacyUnforgeable]`

--- a/console/console-is-a-namespace.any.js
+++ b/console/console-is-a-namespace.any.js
@@ -1,5 +1,5 @@
 "use strict";
-// https://heycam.github.io/webidl/#es-namespaces
+// https://webidl.spec.whatwg.org/#es-namespaces
 // https://console.spec.whatwg.org/#console-namespace
 
 test(() => {

--- a/console/console-namespace-object-class-string.any.js
+++ b/console/console-namespace-object-class-string.any.js
@@ -1,5 +1,5 @@
 "use strict";
-// https://heycam.github.io/webidl/#es-namespaces
+// https://webidl.spec.whatwg.org/#es-namespaces
 // https://console.spec.whatwg.org/#console-namespace
 
 test(() => {

--- a/css/cssom-view/scrollintoview.html
+++ b/css/cssom-view/scrollintoview.html
@@ -4,8 +4,8 @@
 <meta name="viewport" content="initial-scale=1">
 <link rel="author" title="Chris Wu" href="mailto:pwx.frontend@gmail.com">
 <link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview">
-<link rel="help" href="https://heycam.github.io/webidl/#es-operations">
-<link rel="help" href="https://heycam.github.io/webidl/#es-overloads">
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-operations">
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-overloads">
 <meta name="flags" content="dom">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/css/cssom/CSS-namespace-object-class-string.html
+++ b/css/cssom/CSS-namespace-object-class-string.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <title>CSSOM - Symbol.toStringTag value of CSS namespace object</title>
-<link rel="help" href="https://heycam.github.io/webidl/#es-namespaces">
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-namespaces">
 <link rel="help" href="https://drafts.csswg.org/cssom/#namespacedef-css">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/docs/writing-tests/making-a-testing-plan.md
+++ b/docs/writing-tests/making-a-testing-plan.md
@@ -76,7 +76,7 @@ Notifications standard](https://notifications.spec.whatwg.org/#constructors):
 >    object](https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object)
 >    is a
 >    [ServiceWorkerGlobalScope](https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope)
->    object, then [throw](https://heycam.github.io/webidl/#dfn-throw) a
+>    object, then [throw](https://webidl.spec.whatwg.org/#dfn-throw) a
 >    `TypeError` exception.
 > 2. Let *notification* be the result of [creating a
 >    notification](https://notifications.spec.whatwg.org/#create-a-notification)
@@ -263,9 +263,9 @@ standard](https://dom.spec.whatwg.org/) powers
 >    selector](https://drafts.csswg.org/selectors-4/#parse-a-selector)
 >    *selectors*.
 > 2. If *s* is failure, then
->    [throw](https://heycam.github.io/webidl/#dfn-throw) a
->    "[`SyntaxError`](https://heycam.github.io/webidl/#syntaxerror)"
->    [DOMException](https://heycam.github.io/webidl/#idl-DOMException).
+>    [throw](https://webidl.spec.whatwg.org/#dfn-throw) a
+>    "[`SyntaxError`](https://webidl.spec.whatwg.org/#syntaxerror)"
+>    [DOMException](https://webidl.spec.whatwg.org/#idl-DOMException).
 > 3. Return the result of [match a selector against a
 >    tree](https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree)
 >    with *s* and *node*'s
@@ -312,7 +312,7 @@ standard](https://fetch.spec.whatwg.org/)
 > steps:
 >
 > 1. If *init*["`status`"] is not in the range `200` to `599`, inclusive, then
->    [throw](https://heycam.github.io/webidl/#dfn-throw) a `RangeError`.
+>    [throw](https://webidl.spec.whatwg.org/#dfn-throw) a `RangeError`.
 >
 > [...]
 

--- a/dom/collections/HTMLCollection-iterator.html
+++ b/dom/collections/HTMLCollection-iterator.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <link rel="help" href="https://dom.spec.whatwg.org/#interface-htmlcollection">
-<link rel="help" href="https://heycam.github.io/webidl/#es-iterator">
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-iterator">
 <title>HTMLCollection @@iterator Test</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/domxpath/resolver-callback-interface.html
+++ b/domxpath/resolver-callback-interface.html
@@ -2,7 +2,7 @@
 <meta charset=utf-8>
 <title>XPathNSResolver implements callback interface</title>
 <link rel="help" href="https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathEvaluator">
-<link rel="help" href="https://heycam.github.io/webidl/#call-a-user-objects-operation">
+<link rel="help" href="https://webidl.spec.whatwg.org/#call-a-user-objects-operation">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/invalid_namespace_test.js"></script>

--- a/fetch/api/headers/headers-record.any.js
+++ b/fetch/api/headers/headers-record.any.js
@@ -49,7 +49,7 @@ test(function() {
   // we're a sequence, during overload resolution.
   assert_array_equals(log[0], ["get", record, Symbol.iterator, proxy]);
   // Then we have the [[OwnPropertyKeys]] from
-  // https://heycam.github.io/webidl/#es-to-record step 4.
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
   assert_array_equals(log[1], ["ownKeys", record]);
   // Then the [[GetOwnProperty]] from step 5.1.
   assert_array_equals(log[2], ["getOwnPropertyDescriptor", record, "a"]);
@@ -75,7 +75,7 @@ test(function() {
   // we're a sequence, during overload resolution.
   assert_array_equals(log[0], ["get", record, Symbol.iterator, proxy]);
   // Then we have the [[OwnPropertyKeys]] from
-  // https://heycam.github.io/webidl/#es-to-record step 4.
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
   assert_array_equals(log[1], ["ownKeys", record]);
   // Then the [[GetOwnProperty]] from step 5.1.
   assert_array_equals(log[2], ["getOwnPropertyDescriptor", record, "a"]);
@@ -100,7 +100,7 @@ test(function() {
   // we're a sequence, during overload resolution.
   assert_array_equals(log[0], ["get", record, Symbol.iterator, proxy]);
   // Then we have the [[OwnPropertyKeys]] from
-  // https://heycam.github.io/webidl/#es-to-record step 4.
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
   assert_array_equals(log[1], ["ownKeys", record]);
   // Then the [[GetOwnProperty]] from step 5.1.
   assert_array_equals(log[2], ["getOwnPropertyDescriptor", record, "a"]);
@@ -133,7 +133,7 @@ test(function() {
   // we're a sequence, during overload resolution.
   assert_array_equals(log[0], ["get", record, Symbol.iterator, proxy]);
   // Then we have the [[OwnPropertyKeys]] from
-  // https://heycam.github.io/webidl/#es-to-record step 4.
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
   assert_array_equals(log[1], ["ownKeys", record]);
   // Then the [[GetOwnProperty]] from step 5.1.
   assert_array_equals(log[2], ["getOwnPropertyDescriptor", record, "a"]);
@@ -158,7 +158,7 @@ test(function() {
   // we're a sequence, during overload resolution.
   assert_array_equals(log[0], ["get", record, Symbol.iterator, proxy]);
   // Then we have the [[OwnPropertyKeys]] from
-  // https://heycam.github.io/webidl/#es-to-record step 4.
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
   assert_array_equals(log[1], ["ownKeys", record]);
   // Then the [[GetOwnProperty]] from step 5.1.
   assert_array_equals(log[2], ["getOwnPropertyDescriptor", record, "a"]);
@@ -182,7 +182,7 @@ test(function() {
   // we're a sequence, during overload resolution.
   assert_array_equals(log[0], ["get", record, Symbol.iterator, proxy]);
   // Then we have the [[OwnPropertyKeys]] from
-  // https://heycam.github.io/webidl/#es-to-record step 4.
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
   assert_array_equals(log[1], ["ownKeys", record]);
   // Then the [[GetOwnProperty]] from step 5.1.
   assert_array_equals(log[2], ["getOwnPropertyDescriptor", record, "a"]);
@@ -222,7 +222,7 @@ test(function() {
   // we're a sequence, during overload resolution.
   assert_array_equals(log[0], ["get", lyingProxy, Symbol.iterator, proxy]);
   // Then we have the [[OwnPropertyKeys]] from
-  // https://heycam.github.io/webidl/#es-to-record step 4.
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
   assert_array_equals(log[1], ["ownKeys", lyingProxy]);
   // Then the [[GetOwnProperty]] from step 5.1.
   assert_array_equals(log[2], ["getOwnPropertyDescriptor", lyingProxy, "a"]);
@@ -262,7 +262,7 @@ test(function() {
   // we're a sequence, during overload resolution.
   assert_array_equals(log[0], ["get", lyingProxy, Symbol.iterator, proxy]);
   // Then we have the [[OwnPropertyKeys]] from
-  // https://heycam.github.io/webidl/#es-to-record step 4.
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
   assert_array_equals(log[1], ["ownKeys", lyingProxy]);
 }, "Correct operation ordering with repeated keys");
 
@@ -285,7 +285,7 @@ test(function() {
   // we're a sequence, during overload resolution.
   assert_array_equals(log[0], ["get", record, Symbol.iterator, proxy]);
   // Then we have the [[OwnPropertyKeys]] from
-  // https://heycam.github.io/webidl/#es-to-record step 4.
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
   assert_array_equals(log[1], ["ownKeys", record]);
   // Then the [[GetOwnProperty]] from step 5.1.
   assert_array_equals(log[2], ["getOwnPropertyDescriptor", record, "a"]);
@@ -328,7 +328,7 @@ test(function() {
   // we're a sequence, during overload resolution.
   assert_array_equals(log[0], ["get", record, Symbol.iterator, proxy]);
   // Then we have the [[OwnPropertyKeys]] from
-  // https://heycam.github.io/webidl/#es-to-record step 4.
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
   assert_array_equals(log[1], ["ownKeys", record]);
   // Then the [[GetOwnProperty]] from step 5.1.
   assert_array_equals(log[2], ["getOwnPropertyDescriptor", record, "a"]);

--- a/html/browsers/history/the-location-interface/location-stringifier.html
+++ b/html/browsers/history/the-location-interface/location-stringifier.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>Location stringifier</title>
 <link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
-<link rel="help" href="https://heycam.github.io/webidl/#es-stringifier">
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-stringifier">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script src=/common/stringifiers.js></script>

--- a/html/browsers/origin/cross-origin-objects/window-location-and-location-href-cross-realm-set.html
+++ b/html/browsers/origin/cross-origin-objects/window-location-and-location-href-cross-realm-set.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>Cross-realm [[Set]] to window.location and location.href throws an error of correct realm</title>
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#window">
-<link rel="help" href="https://heycam.github.io/webidl/#Unforgeable">
+<link rel="help" href="https://webidl.spec.whatwg.org/#Unforgeable">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/common/get-host-info.sub.js"></script>

--- a/html/browsers/the-window-object/named-access-on-the-window-object/window-named-properties.html
+++ b/html/browsers/the-window-object/named-access-on-the-window-object/window-named-properties.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Boris Zbarsky" href="bzbarsky@mit.edu">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#window">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-window-nameditem">
-<link rel="help" href="https://heycam.github.io/webidl/#named-properties-object">
+<link rel="help" href="https://webidl.spec.whatwg.org/#named-properties-object">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>

--- a/html/browsers/the-window-object/named-access-on-the-window-object/window-null-names.html
+++ b/html/browsers/the-window-object/named-access-on-the-window-object/window-null-names.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Ms2ger" href="ms2ger@gmail.com">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#window">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-window-nameditem">
-<link rel="help" href="https://heycam.github.io/webidl/#named-properties-object">
+<link rel="help" href="https://webidl.spec.whatwg.org/#named-properties-object">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>

--- a/html/browsers/the-window-object/proxy-getOwnPropertyDescriptor.html
+++ b/html/browsers/the-window-object/proxy-getOwnPropertyDescriptor.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>getOwnPropertyDescriptor() is correct for Proxy with host object target</title>
   <link rel="help" href="https://html.spec.whatwg.org/multipage/#window">
-  <link rel="help" href="https://heycam.github.io/webidl/#Unforgeable">
+  <link rel="help" href="https://webidl.spec.whatwg.org/#Unforgeable">
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/html/browsers/the-window-object/window-indexed-properties-strict.html
+++ b/html/browsers/the-window-object/window-indexed-properties-strict.html
@@ -4,8 +4,8 @@
 <link rel="author" title="Ms2ger" href="ms2ger@gmail.com">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#window">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-window-item">
-<link rel="help" href="https://heycam.github.io/webidl/#getownproperty">
-<link rel="help" href="https://heycam.github.io/webidl/#defineownproperty">
+<link rel="help" href="https://webidl.spec.whatwg.org/#getownproperty">
+<link rel="help" href="https://webidl.spec.whatwg.org/#defineownproperty">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>

--- a/html/browsers/the-window-object/window-indexed-properties.html
+++ b/html/browsers/the-window-object/window-indexed-properties.html
@@ -4,8 +4,8 @@
 <link rel="author" title="Ms2ger" href="ms2ger@gmail.com">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#window">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-window-item">
-<link rel="help" href="https://heycam.github.io/webidl/#getownproperty">
-<link rel="help" href="https://heycam.github.io/webidl/#defineownproperty">
+<link rel="help" href="https://webidl.spec.whatwg.org/#getownproperty">
+<link rel="help" href="https://webidl.spec.whatwg.org/#defineownproperty">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>

--- a/html/browsers/the-window-object/window-properties.https.html
+++ b/html/browsers/the-window-object/window-properties.https.html
@@ -3,9 +3,9 @@
 <title>Properties of the window object</title>
 <link rel="author" title="Ms2ger" href="mailto:Ms2ger@gmail.com">
 <link rel="help" href="http://ecma-international.org/ecma-262/5.1/#sec-15.1">
-<link rel="help" href="https://heycam.github.io/webidl/#interface-prototype-object">
-<link rel="help" href="https://heycam.github.io/webidl/#es-attributes">
-<link rel="help" href="https://heycam.github.io/webidl/#es-operations">
+<link rel="help" href="https://webidl.spec.whatwg.org/#interface-prototype-object">
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-attributes">
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-operations">
 <link rel="help" href="https://dom.spec.whatwg.org/#eventtarget">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#window">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#windowtimers">

--- a/html/browsers/the-window-object/window-prototype-chain.html
+++ b/html/browsers/the-window-object/window-prototype-chain.html
@@ -4,8 +4,8 @@
 <link rel="author" title="Ms2ger" href="ms2ger@gmail.com">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#window">
 <link rel="help" href="https://dom.spec.whatwg.org/#eventtarget">
-<link rel="help" href="https://heycam.github.io/webidl/#interface-prototype-object">
-<link rel="help" href="https://heycam.github.io/webidl/#named-properties-object">
+<link rel="help" href="https://webidl.spec.whatwg.org/#interface-prototype-object">
+<link rel="help" href="https://webidl.spec.whatwg.org/#named-properties-object">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>

--- a/html/dom/documents/dom-tree-accessors/document.forms.html
+++ b/html/dom/documents/dom-tree-accessors/document.forms.html
@@ -53,7 +53,7 @@ test(function() {
   for (var p in document.forms) {
     result.push(p);
   }
-  // http://heycam.github.io/webidl/#property-enumeration
+  // https://webidl.spec.whatwg.org/#property-enumeration
   // If the object supports indexed properties, then the object’s supported
   // property indices are enumerated first, in numerical order.
   assert_array_equals(result.splice(0, 3), ["0", "1", "2"]);

--- a/html/dom/documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-null-undef-xhtml.xhtml
+++ b/html/dom/documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-null-undef-xhtml.xhtml
@@ -3,7 +3,7 @@
 <title>Calling getElementsByName with null and undefined</title>
 <link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com"/>
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-document-getelementsbyname"/>
-<link rel="help" href="https://heycam.github.io/webidl/#es-DOMString"/>
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-DOMString"/>
 <link rel="help" href="http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-262.pdf#page=57"/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/html/dom/documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-null-undef.html
+++ b/html/dom/documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-null-undef.html
@@ -2,7 +2,7 @@
 <title>Calling getElementsByName with null and undefined</title>
 <link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-document-getelementsbyname">
-<link rel="help" href="https://heycam.github.io/webidl/#es-DOMString">
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-DOMString">
 <link rel="help" href="http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-262.pdf#page=57">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/html/dom/elements/global-attributes/classlist-nonstring.html
+++ b/html/dom/elements/global-attributes/classlist-nonstring.html
@@ -3,7 +3,7 @@
 <link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#classes">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#domtokenlist">
-<link rel="help" href="https://heycam.github.io/webidl/#es-DOMString">
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-DOMString">
 <link rel="help" href="http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-262.pdf#page=57">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/heading-obsolete-attributes-01.html
+++ b/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/heading-obsolete-attributes-01.html
@@ -2,7 +2,7 @@
 <title>HTMLHeadingElement: obsolete attribute reflecting</title>
 <link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-hx-align">
-<link rel="help" href="https://heycam.github.io/webidl/#es-DOMString">
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-DOMString">
 <link rel="help" href="http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-262.pdf#page=57">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/html/semantics/document-metadata/the-link-element/link-rellist.html
+++ b/html/semantics/document-metadata/the-link-element/link-rellist.html
@@ -3,7 +3,7 @@
 <link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-link-element">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#domtokenlist">
-<link rel="help" href="https://heycam.github.io/webidl/#ecmascript-binding">
+<link rel="help" href="https://webidl.spec.whatwg.org/#ecmascript-binding">
 <link rel="help" href="http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-262.pdf#page=57">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/html/semantics/embedded-content/the-area-element/area-stringifier.html
+++ b/html/semantics/embedded-content/the-area-element/area-stringifier.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>HTMLAreaElement stringifier</title>
 <link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
-<link rel="help" href="https://heycam.github.io/webidl/#es-stringifier">
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-stringifier">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script src=/common/stringifiers.js></script>

--- a/html/semantics/interfaces.html
+++ b/html/semantics/interfaces.html
@@ -3,7 +3,7 @@
 <title>Test of interfaces</title>
 <link rel="author" title="Ms2ger" href="mailto:Ms2ger@gmail.com">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/">
-<link rel="help" href="https://heycam.github.io/webidl/#host-objects">
+<link rel="help" href="https://webidl.spec.whatwg.org/#host-objects">
 <link rel="help" href="http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-262.pdf#page=96">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/html/semantics/scripting-1/the-script-element/microtasks/resources/checkpoint-after-error-event.js
+++ b/html/semantics/scripting-1/the-script-element/microtasks/resources/checkpoint-after-error-event.js
@@ -14,7 +14,7 @@ self.setup({allow_uncaught_exception: true});
 // handlers are evaluated, not after each error event handler.
 
 // Just after each event handler is invoked,
-// https://heycam.github.io/webidl/#call-a-user-objects-operation
+// https://webidl.spec.whatwg.org/#call-a-user-objects-operation
 // calls #clean-up-after-running-script, but this doesn't execute new
 // microtasks immediately, because:
 // - Before https://github.com/whatwg/html/pull/4352:
@@ -57,7 +57,7 @@ async_test(t => {
 // around event events other than the `self` error event cases above.
 // In this case, microtasks are executed just after each event handler is
 // invoked via #clean-up-after-running-script called from
-// https://heycam.github.io/webidl/#call-a-user-objects-operation,
+// https://webidl.spec.whatwg.org/#call-a-user-objects-operation,
 // because the event handlers are executed outside the
 // #prepare-to-run-script/#clean-up-after-running-script scopes in
 // #run-a-classic-script/#run-a-module-script.

--- a/html/semantics/text-level-semantics/the-a-element/a-stringifier.html
+++ b/html/semantics/text-level-semantics/the-a-element/a-stringifier.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>HTMLAnchorElement stringifier</title>
 <link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
-<link rel="help" href="https://heycam.github.io/webidl/#es-stringifier">
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-stringifier">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script src=/common/stringifiers.js></script>

--- a/html/webappapis/timers/evil-spec-example.html
+++ b/html/webappapis/timers/evil-spec-example.html
@@ -3,7 +3,7 @@
 <link rel="author" title="Ian Hickson" href="mailto:ian@hixie.ch">
 <link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-windowtimers-settimeout">
-<link rel="help" href="https://heycam.github.io/webidl/#es-operations">
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-operations">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>

--- a/interfaces/README.md
+++ b/interfaces/README.md
@@ -1,3 +1,3 @@
-This directory contains [Web IDL](https://heycam.github.io/webidl/) interface definitions for use in idlharness.js tests.
+This directory contains [Web IDL](https://webidl.spec.whatwg.org/) interface definitions for use in idlharness.js tests.
 
 The `.idl` files (except `*.tentative.idl`) are copied from [@webref/idl](https://www.npmjs.com/package/@webref/idl) by a [workflow](https://github.com/web-platform-tests/wpt/blob/master/.github/workflows/interfaces.yml) that tries to sync the files daily. The resulting pull requests require manual review but can be approved/merged by anyone with write access.

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -508,7 +508,7 @@ IdlArray.prototype.is_json_type = function(type)
 {
     /**
      * Checks whether type is a JSON type as per
-     * https://heycam.github.io/webidl/#dfn-json-types
+     * https://webidl.spec.whatwg.org/#dfn-json-types
      */
 
     var idlType = type.idlType;
@@ -1255,7 +1255,7 @@ IdlInterface.prototype.is_global = function()
 /**
  * Value of the LegacyNamespace extended attribute, if any.
  *
- * https://heycam.github.io/webidl/#LegacyNamespace
+ * https://webidl.spec.whatwg.org/#LegacyNamespace
  */
 IdlInterface.prototype.get_legacy_namespace = function()
 {
@@ -1299,7 +1299,7 @@ IdlInterface.prototype.get_interface_object = function() {
 };
 
 IdlInterface.prototype.get_qualified_name = function() {
-    // https://heycam.github.io/webidl/#qualified-name
+    // https://webidl.spec.whatwg.org/#qualified-name
     var legacyNamespace = this.get_legacy_namespace();
     if (legacyNamespace) {
         return legacyNamespace + "." + this.name;
@@ -1320,7 +1320,7 @@ IdlInterface.prototype.has_default_to_json_regular_operation = function() {
 };
 
 /**
- * Implementation of https://heycam.github.io/webidl/#create-an-inheritance-stack
+ * Implementation of https://webidl.spec.whatwg.org/#create-an-inheritance-stack
  * with the order reversed.
  *
  * The order is reversed so that the base class comes first in the list, because
@@ -1358,7 +1358,7 @@ IdlInterface.prototype.get_reverse_inheritance_stack = function() {
 
 /**
  * Implementation of
- * https://heycam.github.io/webidl/#default-tojson-operation
+ * https://webidl.spec.whatwg.org/#default-tojson-operation
  * for testing purposes.
  *
  * Collects the IDL types of the attributes that meet the criteria
@@ -1524,7 +1524,7 @@ IdlInterface.prototype.test_self = function()
     if (this.should_have_interface_object() && !this.is_callback()) {
         subsetTestByKey(this.name, test, function() {
             // This function tests WebIDL as of 2014-10-25.
-            // https://heycam.github.io/webidl/#es-interface-call
+            // https://webidl.spec.whatwg.org/#es-interface-call
 
             this.assert_interface_object_exists();
 
@@ -1549,7 +1549,7 @@ IdlInterface.prototype.test_self = function()
     if (this.should_have_interface_object()) {
         subsetTestByKey(this.name, test, function() {
             // This function tests WebIDL as of 2015-11-17.
-            // https://heycam.github.io/webidl/#interface-object
+            // https://webidl.spec.whatwg.org/#interface-object
 
             this.assert_interface_object_exists();
 
@@ -1741,7 +1741,7 @@ IdlInterface.prototype.test_self = function()
     subsetTestByKey(this.name, test, function()
     {
         // This function tests WebIDL as of 2015-01-21.
-        // https://heycam.github.io/webidl/#interface-object
+        // https://webidl.spec.whatwg.org/#interface-object
 
         if (!this.should_have_interface_object()) {
             return;
@@ -1860,7 +1860,7 @@ IdlInterface.prototype.test_self = function()
     // interfaces for any other interface that is declared with one of these
     // attributes, then the interface prototype object must be an immutable
     // prototype exotic object."
-    // https://heycam.github.io/webidl/#interface-prototype-object
+    // https://webidl.spec.whatwg.org/#interface-prototype-object
     if (this.is_global()) {
         this.test_immutable_prototype("interface prototype object", this.get_interface_object().prototype);
     }
@@ -2237,7 +2237,7 @@ IdlInterface.prototype.test_member_operation = function(member)
     a_test.step(function()
     {
         // This function tests WebIDL as of 2015-12-29.
-        // https://heycam.github.io/webidl/#es-operations
+        // https://webidl.spec.whatwg.org/#es-operations
 
         if (!this.should_have_interface_object()) {
             a_test.done();
@@ -2666,7 +2666,7 @@ IdlInterface.prototype.test_primary_interface_of = function(desc, obj, exception
     // attribute must execute the same algorithm as is defined for the
     // [[SetPrototypeOf]] internal method of an immutable prototype exotic
     // object."
-    // https://heycam.github.io/webidl/#platform-object-setprototypeof
+    // https://webidl.spec.whatwg.org/#platform-object-setprototypeof
     if (this.is_global())
     {
         this.test_immutable_prototype("global platform object", obj);

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1674,7 +1674,7 @@
      *
      * @param {number|string} type The expected exception name or code.  See the
      *        table of names and codes at
-     *        https://heycam.github.io/webidl/#dfn-error-names-table
+     *        https://webidl.spec.whatwg.org/#dfn-error-names-table
      *        If a number is passed it should be one of the numeric code values
      *        in that table (e.g. 3, 4, etc).  If a string is passed it can
      *        either be an exception name (e.g. "HierarchyRequestError",

--- a/wasm/jsapi/constructor/toStringTag.any.js
+++ b/wasm/jsapi/constructor/toStringTag.any.js
@@ -1,7 +1,7 @@
 // META: global=window,dedicatedworker,jsshell
 
 "use strict";
-// https://heycam.github.io/webidl/#es-namespaces
+// https://webidl.spec.whatwg.org/#es-namespaces
 // https://webassembly.github.io/spec/js-api/#namespacedef-webassembly
 
 test(() => {

--- a/wasm/jsapi/proto-from-ctor-realm.html
+++ b/wasm/jsapi/proto-from-ctor-realm.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>WebAssembly JS API: Default [[Prototype]] value is from NewTarget's Realm</title>
-<link rel="help" href="https://heycam.github.io/webidl/#internally-create-a-new-object-implementing-the-interface">
+<link rel="help" href="https://webidl.spec.whatwg.org/#internally-create-a-new-object-implementing-the-interface">
 <link rel="help" href="https://tc39.es/ecma262/#sec-nativeerror">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/webidl/META.yml
+++ b/webidl/META.yml
@@ -1,4 +1,4 @@
-spec: https://heycam.github.io/webidl/
+spec: https://webidl.spec.whatwg.org/
 suggested_reviewers:
   - domenic
   - yuki3

--- a/webidl/ecmascript-binding/attributes-accessors-unique-function-objects.html
+++ b/webidl/ecmascript-binding/attributes-accessors-unique-function-objects.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>All attributes accessors are unique function objects</title>
-<link rel="help" href="https://heycam.github.io/webidl/#idl-interface-mixins">
+<link rel="help" href="https://webidl.spec.whatwg.org/#idl-interface-mixins">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/webidl/ecmascript-binding/global-object-implicit-this-value-cross-realm.html
+++ b/webidl/ecmascript-binding/global-object-implicit-this-value-cross-realm.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Cross-realm getter / setter / operation doesn't use lexical global object if |this| value is incompatible object / null / undefined</title>
-<link rel="help" href="https://heycam.github.io/webidl/#dfn-attribute-getter">
-<link rel="help" href="https://heycam.github.io/webidl/#dfn-attribute-setter">
-<link rel="help" href="https://heycam.github.io/webidl/#dfn-create-operation-function">
+<link rel="help" href="https://webidl.spec.whatwg.org/#dfn-attribute-getter">
+<link rel="help" href="https://webidl.spec.whatwg.org/#dfn-attribute-setter">
+<link rel="help" href="https://webidl.spec.whatwg.org/#dfn-create-operation-function">
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/webidl/ecmascript-binding/global-object-implicit-this-value.any.js
+++ b/webidl/ecmascript-binding/global-object-implicit-this-value.any.js
@@ -1,8 +1,8 @@
 // META: global=window,worker
 
-// https://heycam.github.io/webidl/#dfn-attribute-getter (step 1.1.2.1)
-// https://heycam.github.io/webidl/#dfn-attribute-setter (step 4.5.1)
-// https://heycam.github.io/webidl/#dfn-create-operation-function (step 2.1.2.1)
+// https://webidl.spec.whatwg.org/#dfn-attribute-getter (step 1.1.2.1)
+// https://webidl.spec.whatwg.org/#dfn-attribute-setter (step 4.5.1)
+// https://webidl.spec.whatwg.org/#dfn-create-operation-function (step 2.1.2.1)
 
 const notGlobalObject = Object.create(Object.getPrototypeOf(globalThis));
 

--- a/webidl/ecmascript-binding/interface-object-set-receiver.html
+++ b/webidl/ecmascript-binding/interface-object-set-receiver.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>window.Interface is defined on [[Set]] receiver</title>
-<link rel="help" href="https://heycam.github.io/webidl/#define-the-global-property-references">
+<link rel="help" href="https://webidl.spec.whatwg.org/#define-the-global-property-references">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/webidl/ecmascript-binding/interface-prototype-constructor-set-receiver.html
+++ b/webidl/ecmascript-binding/interface-prototype-constructor-set-receiver.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Interface.prototype.constructor is defined on [[Set]] receiver</title>
-<link rel="help" href="https://heycam.github.io/webidl/#interface-prototype-object">
+<link rel="help" href="https://webidl.spec.whatwg.org/#interface-prototype-object">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/webidl/ecmascript-binding/interface-prototype-object.html
+++ b/webidl/ecmascript-binding/interface-prototype-object.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Interface prototype objects</title>
-<link rel="help" href="https://heycam.github.io/webidl/#interface-prototype-object">
+<link rel="help" href="https://webidl.spec.whatwg.org/#interface-prototype-object">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
 test(function() {
-  // https://heycam.github.io/webidl/#create-an-interface-prototype-object
+  // https://webidl.spec.whatwg.org/#create-an-interface-prototype-object
   assert_own_property(Element.prototype, Symbol.unscopables, "Element.prototype has @@unscopables.");
   let unscopables = Element.prototype[Symbol.unscopables];
   assert_equals(typeof unscopables, "object", "@@unscopables is an Object.");

--- a/webidl/ecmascript-binding/invalid-this-value-cross-realm.html
+++ b/webidl/ecmascript-binding/invalid-this-value-cross-realm.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Cross-realm getter / setter / operation doesn't use lexical global object to throw an error for incompatible |this| value</title>
-<link rel="help" href="https://heycam.github.io/webidl/#dfn-attribute-getter">
-<link rel="help" href="https://heycam.github.io/webidl/#dfn-attribute-setter">
-<link rel="help" href="https://heycam.github.io/webidl/#dfn-create-operation-function">
+<link rel="help" href="https://webidl.spec.whatwg.org/#dfn-attribute-getter">
+<link rel="help" href="https://webidl.spec.whatwg.org/#dfn-attribute-setter">
+<link rel="help" href="https://webidl.spec.whatwg.org/#dfn-create-operation-function">
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/webidl/ecmascript-binding/iterator-invalidation-foreach.html
+++ b/webidl/ecmascript-binding/iterator-invalidation-foreach.html
@@ -3,7 +3,7 @@
 <title>Behavior of iterators when modified within foreach</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<link rel="help" href="https://heycam.github.io/webidl/#es-forEach">
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-forEach">
 <link rel="author" title="Manish Goregaokar" href="mailto:manishsmail@gmail.com">
 <script>
 test(function() {

--- a/webidl/ecmascript-binding/legacy-callback-interface-object.html
+++ b/webidl/ecmascript-binding/legacy-callback-interface-object.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
-<link rel="help" href="https://heycam.github.io/webidl/#legacy-callback-interface-object">
+<link rel="help" href="https://webidl.spec.whatwg.org/#legacy-callback-interface-object">
 
 <script>
 test(() => {

--- a/webidl/ecmascript-binding/legacy-platform-object/DefineOwnProperty.html
+++ b/webidl/ecmascript-binding/legacy-platform-object/DefineOwnProperty.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Legacy platform objects [[DefineOwnProperty]] method</title>
-<link rel="help" href="https://heycam.github.io/webidl/#legacy-platform-object-defineownproperty">
+<link rel="help" href="https://webidl.spec.whatwg.org/#legacy-platform-object-defineownproperty">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="./helper.js"></script>

--- a/webidl/ecmascript-binding/legacy-platform-object/GetOwnProperty.html
+++ b/webidl/ecmascript-binding/legacy-platform-object/GetOwnProperty.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Legacy platform objects [[GetOwnProperty]] method</title>
-<link rel="help" href="https://heycam.github.io/webidl/#legacy-platform-object-getownproperty">
+<link rel="help" href="https://webidl.spec.whatwg.org/#legacy-platform-object-getownproperty">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="./helper.js"></script>

--- a/webidl/ecmascript-binding/legacy-platform-object/OwnPropertyKeys.html
+++ b/webidl/ecmascript-binding/legacy-platform-object/OwnPropertyKeys.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Legacy platform objects [[OwnPropertyKeys]] method</title>
-<link rel="help" href="https://heycam.github.io/webidl/#legacy-platform-object-ownpropertykeys">
+<link rel="help" href="https://webidl.spec.whatwg.org/#legacy-platform-object-ownpropertykeys">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/webidl/ecmascript-binding/legacy-platform-object/Set.html
+++ b/webidl/ecmascript-binding/legacy-platform-object/Set.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Legacy platform objects [[Set]] method</title>
-<link rel="help" href="https://heycam.github.io/webidl/#legacy-platform-object-set">
+<link rel="help" href="https://webidl.spec.whatwg.org/#legacy-platform-object-set">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/webidl/ecmascript-binding/put-forwards.html
+++ b/webidl/ecmascript-binding/put-forwards.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <link rel="author" title="Jens Widell" href="mailto:jl@opera.com">
-<link rel="help" href="https://heycam.github.io/webidl/#PutForwards">
+<link rel="help" href="https://webidl.spec.whatwg.org/#PutForwards">
 
 <script>
 test(() => {

--- a/webidl/ecmascript-binding/sequence-conversion.html
+++ b/webidl/ecmascript-binding/sequence-conversion.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Sequence conversion</title>
-<link rel="help" href="https://heycam.github.io/webidl/#es-sequence">
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-sequence">
 <link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
 
 <script src="/resources/testharness.js"></script>

--- a/webidl/ecmascript-binding/window-named-properties-object.html
+++ b/webidl/ecmascript-binding/window-named-properties-object.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <title>Internal methods of Window's named properties object</title>
-<link rel="help" href="https://heycam.github.io/webidl/#named-properties-object">
+<link rel="help" href="https://webidl.spec.whatwg.org/#named-properties-object">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
@@ -62,7 +62,7 @@ test(t => {
     w.Object.prototype.a = {};
     w.EventTarget.prototype[0] = {};
 
-    // These are shadowed by properties higher in [[Prototype]] chain. See https://heycam.github.io/webidl/#dfn-named-property-visibility
+    // These are shadowed by properties higher in [[Prototype]] chain. See https://webidl.spec.whatwg.org/#dfn-named-property-visibility
     assert_equals(Object.getOwnPropertyDescriptor(wp, "hasOwnProperty"), undefined, supportedNonIndex);
     assert_equals(Reflect.getOwnPropertyDescriptor(wp, "addEventListener"), undefined, supportedNonIndex);
     assert_equals(Object.getOwnPropertyDescriptor(wp, "a"), undefined, supportedNonIndex);
@@ -123,7 +123,7 @@ test(t => {
     w.EventTarget.prototype.a = 10;
     w.Object.prototype[0] = 20;
 
-    // These are shadowed by properties higher in [[Prototype]] chain. See https://heycam.github.io/webidl/#dfn-named-property-visibility
+    // These are shadowed by properties higher in [[Prototype]] chain. See https://webidl.spec.whatwg.org/#dfn-named-property-visibility
     assert_equals(wp.isPrototypeOf, w.Object.prototype.isPrototypeOf, supportedNonIndex);
     assert_equals(wp.dispatchEvent, w.EventTarget.prototype.dispatchEvent, supportedNonIndex);
     assert_equals(wp.a, 10, supportedNonIndex);

--- a/webvtt/api/VTTRegion/lines.html
+++ b/webvtt/api/VTTRegion/lines.html
@@ -14,7 +14,7 @@ test(function() {
         assert_equals(region.lines, i);
     }
 
-    // https://heycam.github.io/webidl/#abstract-opdef-converttoint
+    // https://webidl.spec.whatwg.org/#abstract-opdef-converttoint
     [[0, 0],
      [-0, 0],
      [-1, 4294967295],

--- a/workers/semantics/interface-objects/001.worker.js
+++ b/workers/semantics/interface-objects/001.worker.js
@@ -54,7 +54,7 @@ var expected = [
   "ErrorEvent",
   "Event",
   "CustomEvent",
-  // http://heycam.github.io/webidl/
+  // https://webidl.spec.whatwg.org/
   "DOMException",
   // https://streams.spec.whatwg.org/
   "ReadableStream",

--- a/workers/semantics/interface-objects/003.any.js
+++ b/workers/semantics/interface-objects/003.any.js
@@ -55,7 +55,7 @@ var expected = [
   "ErrorEvent",
   "Event",
   "CustomEvent",
-  // http://heycam.github.io/webidl/
+  // https://webidl.spec.whatwg.org/
   "DOMException",
   // https://streams.spec.whatwg.org/
   "ReadableStream",

--- a/xhr/send-data-unexpected-tostring.htm
+++ b/xhr/send-data-unexpected-tostring.htm
@@ -4,7 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <link rel="help" href="https://xhr.spec.whatwg.org/#the-send()-method" data-tested-assertations="following::ol/li[4]" />
-<link rel="help" href="https://heycam.github.io/webidl/#es-union" data-tested-assertations="following::ol/li[16]" />
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-union" data-tested-assertations="following::ol/li[16]" />
 
 
 <div id="log"></div>


### PR DESCRIPTION
Only two instances of "heycam.github.io" remain now.

interfaces/WebIDL.idl will be updated when webref is updated next time,
as it has already been fixed there:
https://github.com/w3c/webref/commit/7c04f47557121d2f7ad5203bc3254c62a44e182f

resources/webidl2/lib/webidl2.js is third-party code and will be updated
at some point in the future.