### PR TITLE
Streams: test whether enqueue() and close() works while both branches are pulling

### DIFF
--- a/streams/readable-byte-streams/tee.any.js
+++ b/streams/readable-byte-streams/tee.any.js
@@ -898,22 +898,22 @@ promise_test(async () => {
   const rs = recordingReadableStream({ type: 'bytes' });
 
   const [reader1, reader2] = rs.tee().map(branch => branch.getReader());
-  const read1 = reader1.read();
-  const read2 = reader2.read();
+  const branch1Reads = [reader1.read(), reader1.read()];
+  const branch2Reads = [reader2.read(), reader2.read()];
 
   await flushAsyncEvents();
   rs.controller.enqueue(new Uint8Array([0x11]));
   rs.controller.close();
 
-  const result1 = await read1;
+  const result1 = await branch1Reads[0];
   assert_equals(result1.done, false, 'first read() from branch1 should be not done');
   assert_typed_array_equals(result1.value, new Uint8Array([0x11]), 'first chunk from branch1 should be correct');
-  const result2 = await read2;
+  const result2 = await branch2Reads[0];
   assert_equals(result2.done, false, 'first read() from branch2 should be not done');
   assert_typed_array_equals(result2.value, new Uint8Array([0x11]), 'first chunk from branch2 should be correct');
 
-  assert_object_equals(await reader1.read(), { value: undefined, done: true }, 'second read() from branch1 should be done');
-  assert_object_equals(await reader2.read(), { value: undefined, done: true }, 'second read() from branch2 should be done');
+  assert_object_equals(await branch1Reads[1], { value: undefined, done: true }, 'second read() from branch1 should be done');
+  assert_object_equals(await branch2Reads[1], { value: undefined, done: true }, 'second read() from branch2 should be done');
 
 }, 'ReadableStream teeing with byte source: enqueue() and close() while both branches are pulling');
 

--- a/streams/readable-byte-streams/tee.any.js
+++ b/streams/readable-byte-streams/tee.any.js
@@ -916,3 +916,32 @@ promise_test(async () => {
   assert_object_equals(await reader2.read(), { value: undefined, done: true }, 'second read() from branch2 should be done');
 
 }, 'ReadableStream teeing with byte source: enqueue() and close() while both branches are pulling');
+
+promise_test(async () => {
+
+  const rs = recordingReadableStream({ type: 'bytes' });
+
+  const [reader1, reader2] = rs.tee().map(branch => branch.getReader({ mode: 'byob' }));
+  const branch1Reads = [reader1.read(new Uint8Array(1)), reader1.read(new Uint8Array(1))];
+  const branch2Reads = [reader2.read(new Uint8Array(1)), reader2.read(new Uint8Array(1))];
+
+  await flushAsyncEvents();
+  rs.controller.byobRequest.view[0] = 0x11;
+  rs.controller.byobRequest.respond(1);
+  rs.controller.close();
+
+  const result1 = await branch1Reads[0];
+  assert_equals(result1.done, false, 'first read() from branch1 should be not done');
+  assert_typed_array_equals(result1.value, new Uint8Array([0x11]), 'first chunk from branch1 should be correct');
+  const result2 = await branch2Reads[0];
+  assert_equals(result2.done, false, 'first read() from branch2 should be not done');
+  assert_typed_array_equals(result2.value, new Uint8Array([0x11]), 'first chunk from branch2 should be correct');
+
+  const result3 = await branch1Reads[1];
+  assert_equals(result3.done, true, 'second read() from branch1 should be done');
+  assert_typed_array_equals(result3.value, new Uint8Array([0]).subarray(0, 0), 'second chunk from branch1 should be correct');
+  const result4 = await branch2Reads[1];
+  assert_equals(result4.done, true, 'second read() from branch2 should be done');
+  assert_typed_array_equals(result4.value, new Uint8Array([0]).subarray(0, 0), 'second chunk from branch2 should be correct');
+
+}, 'ReadableStream teeing with byte source: respond() and close() while both branches are pulling');

--- a/streams/readable-streams/tee.any.js
+++ b/streams/readable-streams/tee.any.js
@@ -463,17 +463,17 @@ promise_test(async () => {
   const rs = recordingReadableStream();
 
   const [reader1, reader2] = rs.tee().map(branch => branch.getReader());
-  const read1 = reader1.read();
-  const read2 = reader2.read();
+  const branch1Reads = [reader1.read(), reader1.read()];
+  const branch2Reads = [reader2.read(), reader2.read()];
 
   await flushAsyncEvents();
   rs.controller.enqueue('a');
   rs.controller.close();
 
-  assert_object_equals(await read1, { value: 'a', done: false }, 'first chunk from branch1 should be correct');
-  assert_object_equals(await read2, { value: 'a', done: false }, 'first chunk from branch2 should be correct');
+  assert_object_equals(await branch1Reads[0], { value: 'a', done: false }, 'first chunk from branch1 should be correct');
+  assert_object_equals(await branch2Reads[0], { value: 'a', done: false }, 'first chunk from branch2 should be correct');
 
-  assert_object_equals(await reader1.read(), { value: undefined, done: true }, 'second read() from branch1 should be done');
-  assert_object_equals(await reader2.read(), { value: undefined, done: true }, 'second read() from branch2 should be done');
+  assert_object_equals(await branch1Reads[1], { value: undefined, done: true }, 'second read() from branch1 should be done');
+  assert_object_equals(await branch2Reads[1], { value: undefined, done: true }, 'second read() from branch2 should be done');
 
 }, 'ReadableStream teeing: enqueue() and close() while both branches are pulling');

--- a/streams/readable-streams/tee.any.js
+++ b/streams/readable-streams/tee.any.js
@@ -457,3 +457,23 @@ promise_test(t => {
   });
 
 }, 'ReadableStreamTee stops pulling when original stream errors while both branches are reading');
+
+promise_test(async () => {
+
+  const rs = recordingReadableStream();
+
+  const [reader1, reader2] = rs.tee().map(branch => branch.getReader());
+  const read1 = reader1.read();
+  const read2 = reader2.read();
+
+  await flushAsyncEvents();
+  rs.controller.enqueue('a');
+  rs.controller.close();
+
+  assert_object_equals(await read1, { value: 'a', done: false }, 'first chunk from branch1 should be correct');
+  assert_object_equals(await read2, { value: 'a', done: false }, 'first chunk from branch2 should be correct');
+
+  assert_object_equals(await reader1.read(), { value: undefined, done: true }, 'second read() from branch1 should be done');
+  assert_object_equals(await reader2.read(), { value: undefined, done: true }, 'second read() from branch2 should be done');
+
+}, 'ReadableStream teeing: enqueue() and close() while both branches are pulling');


### PR DESCRIPTION
See whatwg/streams#1172 for the accompanying spec change.