### PR TITLE
Update Keyboard Lock IDL and test

### DIFF
--- a/interfaces/keyboard-lock.idl
+++ b/interfaces/keyboard-lock.idl
@@ -7,7 +7,8 @@ partial interface Navigator {
   [SecureContext, SameObject] readonly attribute Keyboard keyboard;
 };
 
-[SecureContext, Exposed=Window] interface Keyboard {
+[SecureContext, Exposed=Window]
+interface Keyboard : EventTarget {
   Promise<undefined> lock(optional sequence<DOMString> keyCodes = []);
   undefined unlock();
 };

--- a/keyboard-lock/idlharness.https.window.js
+++ b/keyboard-lock/idlharness.https.window.js
@@ -8,7 +8,7 @@
 
 idl_test(
   ['keyboard-lock'],
-  ['html'],
+  ['html', 'dom'],
   idl_array => {
     idl_array.add_objects({
       Navigator: ['navigator'],

--- a/keyboard-map/idlharness.https.window.js
+++ b/keyboard-map/idlharness.https.window.js
@@ -7,7 +7,7 @@
 
 idl_test(
   ['keyboard-map'],
-  ['html', 'keyboard-lock'],
+  ['keyboard-lock', 'html', 'dom'],
   async idl_array => {
     idl_array.add_objects({
       Navigator: ['navigator'],


### PR DESCRIPTION
This change is extracted from
https://github.com/web-platform-tests/wpt/pull/31151 and done
separately because dom.idl is needed for EventTarget.