### PR TITLE
Slightly increase max allowed error in a couple of StereoPannerNode t…

### DIFF
--- a/webaudio/resources/stereopanner-testing.js
+++ b/webaudio/resources/stereopanner-testing.js
@@ -79,7 +79,7 @@ let StereoPannerTest = (function() {
     // The max error we allow between the rendered impulse and the
     // expected value.  This value is experimentally determined.  Set
     // to 0 to make the test fail to see what the actual error is.
-    this.maxAllowedError = 9.8015e-8;
+    this.maxAllowedError = 1.284318e-7;
 
     // Max (absolute) error and the index of the maxima for the left
     // and right channels.

--- a/webaudio/the-audio-api/the-stereopanner-interface/no-dezippering.html
+++ b/webaudio/the-audio-api/the-stereopanner-interface/no-dezippering.html
@@ -244,7 +244,7 @@
                 should(
                     actual[k],
                     options.prefix + ' ' + label[k] + ' .value setter output')
-                    .beEqualToArray(expected[k]);
+                    .beCloseToArray(expected[k], {absoluteThreshold: 1.192094e-7});
             should(
                 match,
                 options.prefix + ' ' + label[k] +


### PR DESCRIPTION
…ests

WebKit's implementation of StereoPannerNode's K-Rate processing was vectorized and thus
can no longer achieve the same precision as the previous code that was doing operations
on double variables and only casting to float at the end.