### PR TITLE
Add IDL tests for Web Neural Network API

### DIFF
--- a/webnn/META.yml
+++ b/webnn/META.yml
@@ -1,0 +1,1 @@
+spec: https://webmachinelearning.github.io/webnn/

--- a/webnn/META.yml
+++ b/webnn/META.yml
@@ -1,1 +1,4 @@
 spec: https://webmachinelearning.github.io/webnn/
+suggested_reviewers:
+  - dontcallmedom
+  - Honry

--- a/webnn/idlharness.https.any.js
+++ b/webnn/idlharness.https.any.js
@@ -1,0 +1,40 @@
+// META: global=window,worker
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+// META: script=https://webmachinelearning.github.io/webnn-polyfill/dist/webnn-polyfill.js
+// META: timeout=long
+
+// https://webmachinelearning.github.io/webnn/
+
+'use strict';
+
+idl_test(
+  ['webnn'],
+  ['html', 'WebIDL', 'webgl1', 'webgpu'],
+  idl_array => {
+    if (self.GLOBAL.isWindow()) {
+      idl_array.add_objects({ Navigator: ['navigator'] });
+    } else if (self.GLOBAL.isWorker()) {
+      idl_array.add_objects({ WorkerNavigator: ['navigator'] });
+    }
+
+    idl_array.add_objects({
+      NavigatorML: [],
+      ML: ['navigator.ml'],
+      MLContext: ['context'],
+      MLOperand: ['input', 'filter'],
+      MLOperator: ['relu'],
+      MLGraphBuilder: ['builder'],
+      MLGraph: ['graph']
+    });
+
+    const operandType = {type: 'float32', dimensions: [1, 1, 5, 5]};
+    self.context = navigator.ml.createContext();
+    self.builder = new MLGraphBuilder(context);
+    self.input = builder.input('input', operandType);
+    self.filter = builder.constant({type: 'float32', dimensions: [1, 1, 3, 3]}, new Float32Array(9).fill(1));
+    self.relu = builder.relu();
+    self.output = builder.conv2d(input, filter, {activation: relu});
+    self.graph = builder.build({output});
+  }
+);

--- a/webnn/idlharness.https.any.js
+++ b/webnn/idlharness.https.any.js
@@ -1,7 +1,6 @@
-// META: global=window,worker
+// META: global=window,dedicatedworker
 // META: script=/resources/WebIDLParser.js
 // META: script=/resources/idlharness.js
-// META: script=https://webmachinelearning.github.io/webnn-polyfill/dist/webnn-polyfill.js
 // META: timeout=long
 
 // https://webmachinelearning.github.io/webnn/
@@ -19,7 +18,7 @@ idl_test(
     }
 
     idl_array.add_objects({
-      NavigatorML: [],
+      NavigatorML: ['navigator'],
       ML: ['navigator.ml'],
       MLContext: ['context'],
       MLOperand: ['input', 'filter'],


### PR DESCRIPTION
This PR is trying to add IDL tests for [Web Neural Network API (WebNN API)](https://www.w3.org/TR/webnn/).

Current we could run these tests using [WebNN-Polyfill](https://github.com/webmachinelearning/webnn-polyfill/) which is a JavaScript implementation of the WebNN API. There're totally 353 IDL tests including 213 PASS tests and 140 Fail tests now, some FAIL tests are due to unimplemented WebNN API ops in the WebNN-Polyfill.

@dontcallmedom @anssiko @Honry, PTAL, thanks.