### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=230138

### DIFF
--- a/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-getoutputtimestamp-cross-realm.html
+++ b/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-getoutputtimestamp-cross-realm.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>
+      Testing AudioContext.getOutputTimestamp() method (cross-realm)
+    </title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/webaudio/resources/audit.js"></script>
+  </head>
+  <body>
+    <script id="layout-test-code">
+      const audit = Audit.createTaskRunner();
+
+      audit.define("getoutputtimestamp-cross-realm", function(task, should) {
+        const mainContext = new AudioContext();
+        return task.timeout(() => {
+          const iframe = document.createElement("iframe");
+          document.body.append(iframe);
+          const iframeContext = new iframe.contentWindow.AudioContext();
+
+          should(mainContext.getOutputTimestamp().performanceTime, "mainContext's performanceTime")
+            .beGreaterThan(iframeContext.getOutputTimestamp().performanceTime, "iframeContext's performanceTime");
+          should(iframeContext.getOutputTimestamp.call(mainContext).performanceTime, "mainContext's performanceTime (via iframeContext's method)")
+            .beCloseTo(mainContext.getOutputTimestamp().performanceTime, "mainContext's performanceTime", { threshold: 0.01 });
+        }, 1000);
+      });
+
+      audit.run();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This upstream reviewed change tests that cross-realm [`AudioContext::getOutputTimestamp()`](https://webaudio.github.io/web-audio-api/#dom-audiocontext-getoutputtimestamp) method uses `relevant` global object to compute `performanceTime` per [recommendation for web spec authors](https://html.spec.whatwg.org/multipage/webappapis.html#concept-current-everything).

With WebKit fixed, all 3 major engines now use `relevant`.