### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=230131

### DIFF
--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/url-entry-document-incumbent-frame.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/url-entry-document-incumbent-frame.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<script>
+window.callDocumentMethod = methodName => document[methodName]();
+</script>

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url-entry-document-sync-call.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url-entry-document-sync-call.window.js
@@ -1,0 +1,13 @@
+for (const methodName of ["open", "write", "writeln"]) {
+  async_test(t => {
+    const frame = document.body.appendChild(document.createElement("iframe"));
+    t.add_cleanup(() => { frame.remove(); });
+    const frameURL = new URL("resources/url-entry-document-incumbent-frame.html", document.URL).href;
+    frame.onload = t.step_func_done(() => {
+      assert_equals(frame.contentDocument.URL, frameURL);
+      frame.contentWindow.callDocumentMethod(methodName);
+      assert_equals(frame.contentDocument.URL, document.URL);
+    });
+    frame.src = frameURL;
+  }, `document.${methodName}() changes document's URL to the entry global object's associate document's (sync call)`);
+}


### PR DESCRIPTION
This upstream reviewed change tests that `document.open()` and friends use [entry global object](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#opening-the-input-stream:entry-global-object) to set the URL of reseted document from and to perform same-origin security check.