### PR TITLE
[wdspec] Add tests for xpaths containing unicode characters

### DIFF
--- a/webdriver/tests/find_element/find.py
+++ b/webdriver/tests/find_element/find.py
@@ -46,7 +46,10 @@ def test_invalid_selector_argument(session, value):
                           ("link text", "full link text"),
                           ("partial link text", "link text"),
                           ("tag name", "a"),
-                          ("xpath", "//a")])
+                          ("xpath", "//a"),
+                          # Note the below includes a literal \u200E character.
+                          ("xpath", "//*[translate(text(), '‎', '') ='full link text']"),
+                          ("xpath", "//*[translate(text(), '\\u200E', '') ='full link text']")])
 def test_find_element(session, inline, using, value):
     # Step 8 - 9
     session.url = inline("<a href=# id=linkText>full link text</a>")
@@ -100,7 +103,10 @@ def test_no_element(session, using, value):
                           ("link text", "full link text"),
                           ("partial link text", "link text"),
                           ("tag name", "a"),
-                          ("xpath", "//*[name()='a']")])
+                          ("xpath", "//*[name()='a']"),
+                          # Note the below includes a literal \u200E character.
+                          ("xpath", "//*[translate(text(), '‎', '') ='full link text']"),
+                          ("xpath", "//*[translate(text(), '\\u200E', '') ='full link text']")])
 def test_xhtml_namespace(session, inline, using, value):
     session.url = inline("""<a href="#" id="linkText">full link text</a>""",
                          doctype="xhtml")

--- a/webdriver/tests/find_elements/find.py
+++ b/webdriver/tests/find_elements/find.py
@@ -46,7 +46,10 @@ def test_invalid_selector_argument(session, value):
                           ("link text", "full link text"),
                           ("partial link text", "link text"),
                           ("tag name", "a"),
-                          ("xpath", "//a")])
+                          ("xpath", "//a"),
+                          # Note the below includes a literal \u200E character.
+                          ("xpath", "//*[translate(text(), '‎', '') ='full link text']"),
+                          ("xpath", "//*[translate(text(), '\\u200E', '') ='full link text']")])
 def test_find_elements(session, inline, using, value):
     # Step 8 - 9
     session.url = inline("<a href=# id=linkText>full link text</a>")
@@ -114,7 +117,10 @@ def test_no_element(session, using, value):
                           ("link text", "full link text"),
                           ("partial link text", "link text"),
                           ("tag name", "a"),
-                          ("xpath", "//*[name()='a']")])
+                          ("xpath", "//*[name()='a']"),
+                          # Note the below includes a literal \u200E character.
+                          ("xpath", "//*[translate(text(), '‎', '') ='full link text']"),
+                          ("xpath", "//*[translate(text(), '\\u200E', '') ='full link text']")])
 def test_xhtml_namespace(session, inline, using, value):
     session.url = inline("""<a href="#" id="linkText">full link text</a>""",
                          doctype="xhtml")


### PR DESCRIPTION
The wdspec does not limit the use of any valid xpath queries.

Use of unicode characters in both their text representation and their
unicode literal value are both supported by xpath, but the text
representations do not seem to be supported by mainstream browsers.

This patch adds two new xpath searches to find_element and find_elements
to search for the unicode character for &lrm; (left-to-right marker):
* a literal unicode character; and
* the text representation of that character (\u200E).

These are both valid xpath queries which work in-browser, but not
through webdriver.