### PR TITLE
Enable webtransport tests for chrome

### DIFF
--- a/webtransport/close.https.any.js.ini
+++ b/webtransport/close.https.any.js.ini
@@ -1,14 +1,19 @@
 [close.https.any.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [close.https.any.window.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [close.https.any.worker.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [close.https.any.sharedworker.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [close.https.any.serviceworker.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true

--- a/webtransport/connect.https.any.js.ini
+++ b/webtransport/connect.https.any.js.ini
@@ -1,14 +1,19 @@
 [connect.https.any.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [connect.https.any.window.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [connect.https.any.worker.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [connect.https.any.sharedworker.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [connect.https.any.serviceworker.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true

--- a/webtransport/csp-fail.https.window.js.ini
+++ b/webtransport/csp-fail.https.window.js.ini
@@ -1,2 +1,3 @@
 [csp-fail.https.window.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true

--- a/webtransport/csp-pass.https.window.js.ini
+++ b/webtransport/csp-pass.https.window.js.ini
@@ -1,2 +1,3 @@
 [csp-pass.https.window.html]
   disabled: true
+    if product != "chrome"

--- a/webtransport/csp-pass.https.window.js.ini
+++ b/webtransport/csp-pass.https.window.js.ini
@@ -1,3 +1,3 @@
 [csp-pass.https.window.html]
-  disabled: true
-    if product != "chrome"
+  disabled:
+    if product != "chrome": true

--- a/webtransport/datagrams.https.any.js.ini
+++ b/webtransport/datagrams.https.any.js.ini
@@ -1,14 +1,19 @@
 [datagrams.https.any.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [datagrams.https.any.window.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [datagrams.https.any.worker.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [datagrams.https.any.sharedworker.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [datagrams.https.any.serviceworker.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true

--- a/webtransport/streams-close.https.any.js.ini
+++ b/webtransport/streams-close.https.any.js.ini
@@ -1,14 +1,19 @@
 [streams-close.https.any.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [streams-close.https.any.window.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [streams-close.https.any.worker.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [streams-close.https.any.sharedworker.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [streams-close.https.any.serviceworker.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true

--- a/webtransport/streams-echo.https.any.js.ini
+++ b/webtransport/streams-echo.https.any.js.ini
@@ -1,14 +1,19 @@
 [streams-echo.https.any.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [streams-echo.https.any.window.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [streams-echo.https.any.worker.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [streams-echo.https.any.sharedworker.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true
 
 [streams-echo.https.any.serviceworker.html]
-  disabled: true
+  disabled:
+    if product != "chrome": true


### PR DESCRIPTION
Update expectations to run WebTransport tests for Chrome.