### PR TITLE
Revert "Bump pycodestyle from 2.7.0 to 2.8.0 in /tools"

### DIFF
--- a/tools/requirements_flake8.txt
+++ b/tools/requirements_flake8.txt
@@ -1,4 +1,4 @@
 flake8==3.9.2
-pycodestyle==2.8.0
+pycodestyle==2.7.0
 pyflakes==2.4.0
 pep8-naming==0.11.1


### PR DESCRIPTION
Reverts web-platform-tests/wpt#31195

This apparently broke the flake8 jobs, but apparently we didn't run them in CI for the original PR so we didn't notice.