### PR TITLE
Let Dependabot update css/requirements.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 1000
+- package-ecosystem: pip
+  directory: css/
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 1000
 - package-ecosystem: npm
   directory: css/css-writing-modes/tools/generators/
   schedule:


### PR DESCRIPTION
This is used by build-css-testsuites.sh and still uses Python 2.7, but
some updates could still work. In particular, there's a vulnerability in
Mercurial that we could possibly upgrade to get rid of:
https://nvd.nist.gov/vuln/detail/CVE-2018-13347