### PR TITLE
Use mercurial version 4.6.1

### DIFF
--- a/css/requirements.txt
+++ b/css/requirements.txt
@@ -1,6 +1,6 @@
 Template-Python==0.1.post1
 html5lib==1.1
 lxml==4.6.3
-mercurial==4.5
+mercurial==4.6.1
 six==1.15.0
 webencodings==0.5.1


### PR DESCRIPTION
CVE-2018-13347 reports there is security risk to use version under
4.6.1. Upgrade to 4.6.1 per the suggestion.

Details: Affected versions of this package are vulnerable to Integer
Overflow or Wraparound. mpatch.c in Mercurial mishandles integer
addition and subtraction.

"pip install -r requirements.txt" is successful after the change.