### PR TITLE
Correct initial value of transform-style property.

### DIFF
--- a/css/css-transforms/inheritance.html
+++ b/css/css-transforms/inheritance.html
@@ -34,7 +34,7 @@ assert_not_inherited('scale', 'none', '10 11 12');
 assert_not_inherited('transform', 'none', 'matrix(2, 0, 0, 3, 1, 4)');
 assert_not_inherited('transform-box', 'view-box', 'fill-box');
 assert_not_inherited('transform-origin', '30px 20px', '5px 6px'); // '50% 50%' is '30px 20px'
-assert_not_inherited('transform-style', 'auto', 'preserve-3d');
+assert_not_inherited('transform-style', 'flat', 'preserve-3d');
 assert_not_inherited('translate', 'none', '13px 14px 15px');
 </script>
 </body>


### PR DESCRIPTION
This error causes a single (identical) failure across Chromium, Gecko, and
WebKit.  In the current spec at
https://drafts.csswg.org/css-transforms-2/#transform-style-property , the
initial value is 'flat'.