### PR TITLE
Streams: remove WritableStreamDefaultController.abortReason asserts in tests

### DIFF
--- a/streams/writable-streams/aborting.any.js
+++ b/streams/writable-streams/aborting.any.js
@@ -1384,10 +1384,8 @@ test(t => {
 
   assert_true(ctrl.signal instanceof AbortSignal);
   assert_false(ctrl.signal.aborted);
-  assert_equals(ctrl.abortReason, undefined);
   ws.abort(e);
   assert_true(ctrl.signal.aborted);
-  assert_equals(ctrl.abortReason, e);
 }, 'WritableStreamDefaultController.signal');
 
 promise_test(async t => {
@@ -1405,10 +1403,8 @@ promise_test(async t => {
   await called;
 
   assert_false(ctrl.signal.aborted);
-  assert_equals(ctrl.abortReason, undefined);
   writer.abort();
   assert_true(ctrl.signal.aborted);
-  assert_equals(ctrl.abortReason, undefined);
 }, 'the abort signal is signalled synchronously - write');
 
 promise_test(async t => {


### PR DESCRIPTION
Based on https://github.com/whatwg/streams/pull/1177, since we are removing abortReason from the WritableStream spec, this change removes the `controller.abortReason` assertions from the WPTs as well.

@yutakahirano Can you take a look at this for me?
/cc @MattiasBuelens 