### PR TITLE
Use Python 3.3+ method for importing collection abcs

### DIFF
--- a/webdriver/tests/support/helpers.py
+++ b/webdriver/tests/support/helpers.py
@@ -113,7 +113,7 @@ def deep_update(source, overrides):
     Modify ``source`` in place.
     """
     for key, value in overrides.items():
-        if isinstance(value, collections.Mapping) and value:
+        if isinstance(value, collections.abc.Mapping) and value:
             returned = deep_update(source.get(key, {}), value)
             source[key] = returned
         else:

--- a/webdriver/tests/support/sync.py
+++ b/webdriver/tests/support/sync.py
@@ -81,7 +81,7 @@ class Poll(object):
 
         exceptions = []
         if ignored_exceptions is not None:
-            if isinstance(ignored_exceptions, collections.Iterable):
+            if isinstance(ignored_exceptions, collections.abc.Iterable):
                 exceptions.extend(iter(ignored_exceptions))
             else:
                 exceptions.append(ignored_exceptions)


### PR DESCRIPTION
Some classes were moved from `collections` to
`collections.abc` in Python 3.3. The compatibility shims
were removed in Python 3.10, so this patch should fix some
some `webdriver` tests that are likely currently failing when
run on that version.