### PR TITLE
Increase timeout in webmessaging/MessagePort_onmessage_start.any.work…

### DIFF
--- a/webmessaging/MessagePort_onmessage_start.any.js
+++ b/webmessaging/MessagePort_onmessage_start.any.js
@@ -6,5 +6,5 @@ async_test(function(t) {
   var channel = new MessageChannel();
   channel.port2.onmessage = t.step_func_done();
   channel.port1.postMessage("ping");
-  setTimeout(t.unreached_func(), 100);
+  t.step_timeout(t.unreached_func(), 1000);
 });


### PR DESCRIPTION
…er.html

This test was flaky on slower iOS debug similator configurations because of its
short 100ms timeout. Bump the timeout to 1 second.