### PR TITLE
Add WebTransport abort-server-initiated-stream wpt

### DIFF
--- a/webtransport/abort-server-initiated-stream.https.any.js
+++ b/webtransport/abort-server-initiated-stream.https.any.js
@@ -1,0 +1,22 @@
+// META: global=window,worker
+// META: script=/common/get-host-info.sub.js
+// META: script=resources/webtransport-test-helpers.sub.js
+
+promise_test(async t => {
+  const wt =
+      new WebTransport(webtransport_url('abort-server-initiated-stream.py'));
+  await wt.ready;
+
+  // Need to ensure that the reset has been processed. Unfortunately, there's no
+  // reliable way to do this, we just have to wait a second and hope that's long
+  // enough.
+  await wait(1000);
+
+  const reader = wt.incomingUnidirectionalStreams.getReader();
+
+  // read() should not return, since the stream has been reset. Unfortunately,
+  // in order to be sure it won't return we need another delay.
+  const result = await Promise.any([reader.read(), wait(1000)]);
+
+  assert_equals(result, undefined, 'read() should not have happened');
+}, 'Reset incoming unidirectional stream should not be seen by JavaScript');

--- a/webtransport/abort-server-initiated-stream.https.any.js
+++ b/webtransport/abort-server-initiated-stream.https.any.js
@@ -5,6 +5,7 @@
 promise_test(async t => {
   const wt =
       new WebTransport(webtransport_url('abort-server-initiated-stream.py'));
+  add_completion_callback(() => wt.close());
   await wt.ready;
 
   // Need to ensure that the reset has been processed. Unfortunately, there's no

--- a/webtransport/handlers/abort-server-initiated-stream.py
+++ b/webtransport/handlers/abort-server-initiated-stream.py
@@ -1,4 +1,4 @@
 def session_established(session):
     stream_id = session.create_unidirectional_stream()
     session.send_stream_data(stream_id, b'hello')
-    session.reset_stream(stream_id, 0x52e4a40fa8db)
+    session.reset_stream(stream_id, code=0x52e4a40fa8db)

--- a/webtransport/handlers/abort-server-initiated-stream.py
+++ b/webtransport/handlers/abort-server-initiated-stream.py
@@ -1,0 +1,4 @@
+def session_established(session):
+    stream_id = session.create_unidirectional_stream()
+    session.send_stream_data(stream_id, b'hello')
+    session.reset_stream(stream_id, 0x52e4a40fa8db)


### PR DESCRIPTION
Verify that if the server creates a unidirectional stream, sends a
packet and then resets it immediately, that the stream will not be seen
by JavaScript as long as JavaScript doesn't attempt to look for streams
until after the reset.