### PR TITLE
Add tests for visibility event sequence in case of back/forward navigation

### DIFF
--- a/page-visibility/iframe-session-history.html
+++ b/page-visibility/iframe-session-history.html
@@ -72,5 +72,5 @@ promise_test(async t => {
     await waitForLoad(iframe)
     assert_sequence(sequence)
 }, "visibilityState & hidden should be affected by window being minimized/restored");
-</script> 
+</script>
 </body>

--- a/page-visibility/iframe-session-history.html
+++ b/page-visibility/iframe-session-history.html
@@ -37,40 +37,29 @@ function assert_sequence(sequence) {
 }
 promise_test(async t => {
     const iframe = document.createElement('iframe');
-    const expected_order = [{
-      type: 'pagehide',
-      target: '#document',
-      visibilityState: 'visible',
-      cancelable: true
-    }, {
-      type: 'visibilitychange',
-      target: '#document',
-      visibilityState: 'hidden',
-      cancelable: false
-    }]
     iframe.src = iframePath1;
     document.body.appendChild(iframe);
-    let sequence = []
+    let sequence = [];
     t.add_cleanup(() => iframe.remove());
-    iframe.src = iframePath1
-    await waitForLoad(iframe)
+    iframe.src = iframePath1;
+    await waitForLoad(iframe);
     const handler = t.step_func(event => sequence.push({
       type: event.type,
       target: event.target.nodeName,
       cancelable: event.cancelable,
       visibilityState: iframe.contentWindow.document.visibilityState
-    }))
-    iframe.contentWindow.document.addEventListener('visibilitychange', handler)
-    iframe.contentWindow.addEventListener('pagehide', handler)
-    iframe.contentWindow.location.href = iframePath2
-    await waitForLoad(iframe)
-    assert_sequence(sequence)
-    sequence = []
-    iframe.contentWindow.addEventListener('pagehide', handler)
-    iframe.contentWindow.document.addEventListener('visibilitychange', handler)
-    iframe.contentWindow.history.back()
-    await waitForLoad(iframe)
-    assert_sequence(sequence)
-}, "visibilityState & hidden should be affected by window being minimized/restored");
+    }));
+    iframe.contentWindow.document.addEventListener('visibilitychange', handler);
+    iframe.contentWindow.addEventListener('pagehide', handler);
+    iframe.contentWindow.location.href = iframePath2;
+    await waitForLoad(iframe);
+    assert_sequence(sequence);
+    sequence = [];
+    iframe.contentWindow.addEventListener('pagehide', handler);
+    iframe.contentWindow.document.addEventListener('visibilitychange', handler);
+    iframe.contentWindow.history.back();
+    await waitForLoad(iframe);
+    assert_sequence(sequence);
+}, "pagehide should be called before visibilitychange, and visibilityState should be set to hidden at the right time");
 </script>
 </body>

--- a/page-visibility/iframe-session-history.html
+++ b/page-visibility/iframe-session-history.html
@@ -1,0 +1,76 @@
+<!DOCTYPE HTML>
+<title>Test the correct sequence of pagevisibility-related events in conjunction with history navigation</title>
+<link rel="author" title="Noam Rosenthal"  href="mailto:noam@webkit.org">
+<link rel="help" href="https://www.w3.org/TR/page-visibility-2/">
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+
+const iframePath1 = 'resources/iframe-post-load.html?v=1'
+const iframePath2 = 'resources/iframe-post-load.html?v=2'
+
+function waitForLoad(iframe) {
+  return new Promise(resolve => {
+    const callback = e => {
+      if (e.data === 'load') {
+        window.removeEventListener('message', callback)
+        resolve()
+      }
+    }
+
+    window.addEventListener('message', callback)
+  })
+}
+
+function assert_sequence(sequence) {
+  assert_equals(sequence.length, 2)
+  assert_equals(sequence[0].type, 'pagehide')
+  assert_equals(sequence[0].target, '#document')
+  assert_equals(sequence[0].visibilityState, 'visible')
+  assert_equals(sequence[0].cancelable, true)
+  assert_equals(sequence[1].type, 'visibilitychange')
+  assert_equals(sequence[1].target, '#document')
+  assert_equals(sequence[1].visibilityState, 'hidden')
+  assert_equals(sequence[1].cancelable, false)
+}
+promise_test(async t => {
+    const iframe = document.createElement('iframe');
+    const expected_order = [{
+      type: 'pagehide',
+      target: '#document',
+      visibilityState: 'visible',
+      cancelable: true
+    }, {
+      type: 'visibilitychange',
+      target: '#document',
+      visibilityState: 'hidden',
+      cancelable: false
+    }]
+    iframe.src = iframePath1;
+    document.body.appendChild(iframe);
+    let sequence = []
+    t.add_cleanup(() => iframe.remove());
+    iframe.src = iframePath1
+    await waitForLoad(iframe)
+    const handler = t.step_func(event => sequence.push({
+      type: event.type,
+      target: event.target.nodeName,
+      cancelable: event.cancelable,
+      visibilityState: iframe.contentWindow.document.visibilityState
+    }))
+    iframe.contentWindow.document.addEventListener('visibilitychange', handler)
+    iframe.contentWindow.addEventListener('pagehide', handler)
+    iframe.contentWindow.location.href = iframePath2
+    await waitForLoad(iframe)
+    assert_sequence(sequence)
+    sequence = []
+    iframe.contentWindow.addEventListener('pagehide', handler)
+    iframe.contentWindow.document.addEventListener('visibilitychange', handler)
+    iframe.contentWindow.history.back()
+    await waitForLoad(iframe)
+    assert_sequence(sequence)
+}, "visibilityState & hidden should be affected by window being minimized/restored");
+</script> 
+</body>

--- a/page-visibility/resources/iframe-post-load.html
+++ b/page-visibility/resources/iframe-post-load.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+<head>
+<script>
+window.addEventListener('load', () => parent.postMessage('load', '*'))
+</script>
+</body>
+</html>


### PR DESCRIPTION
Note that `unload` events are not tested here, are they're not guaranteed to be fired.