### PR TITLE
Make targetted-form.js's populateForm() deal better with being re-ent…

### DIFF
--- a/html/semantics/forms/form-submission-0/resources/targetted-form.js
+++ b/html/semantics/forms/form-submission-0/resources/targetted-form.js
@@ -3,13 +3,13 @@ let frameCounter = 0;
 function populateForm(optionalContentHtml) {
   if (!optionalContentHtml)
     optionalContentHtml = '';
+  const frameName = "form-test-target-" + frameCounter++;
   document.body.insertAdjacentHTML(
       'afterbegin',
-      `<iframe name="form-test-target-${frameCounter}"></iframe>` +
+      `<iframe name="${frameName}"></iframe>` +
           `<form action="/common/blank.html" target="` +
-          `form-test-target-${frameCounter}">${optionalContentHtml}</form>`);
-  ++frameCounter;
-  return document.body.firstChild.nextSibling;
+          `${frameName}">${optionalContentHtml}</form>`);
+  return document.getElementsByName(frameName)[0].nextSibling;
 }
 
 function submitPromise(form, iframe) {


### PR DESCRIPTION
…ered

In WebKit, calling `document.body.insertAdjacentHTML()` to insert in <iframe> will
load the initial empty document synchronously and finish parsing, which will perform
a microtask checkpoint. Because of this checkpoint, one of the other promise tests in
html/semantics/forms/form-submission-0/form-submission-algorithm.html may run and
call populateForm() again. populateForm() was not safe to re-enter because of its
`frameCounter` variable that was used in insertAdjacentHTML() but only incremented
after. Similarly, `document.body.firstChild.nextSibling` would not return the right
form since a new frame/form may have been prepended to the <body> when re-entering.