### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=231647

### DIFF
--- a/css/selectors/focus-visible-009.html
+++ b/css/selectors/focus-visible-009.html
@@ -7,6 +7,7 @@
   <link rel="help" href="https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo" />
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
+  <script src="/html/interaction/focus/the-autofocus-attribute/resources/utils.js"></script>
   <style>
     @supports not selector(:focus-visible) {
       #button:focus {
@@ -33,20 +34,11 @@
   <br />
   <button id="button" autofocus tabindex="-1">I will be focused automatically.</button>
   <script>
-    async_test(function(t) {
-      button.addEventListener("focus", t.step_func(function() {
-        assert_equals(getComputedStyle(button).outlineColor, "rgb(0, 128, 0)", `outlineColor for ${button.tagName}#${button.id} should be green`);
-        assert_not_equals(getComputedStyle(button).backgroundColor, "rgb(255, 0, 0)", `backgroundColor for ${button.tagName}#${button.id} should NOT be red`);
-        t.done();
-      }));
-
-      // Handle the case where the button is focused before the test runs.
-     if (document.activeElement === button) {
-        assert_equals(getComputedStyle(button).outlineColor, "rgb(0, 128, 0)", `outlineColor for ${button.tagName}#${button.id} should be green`);
-        assert_not_equals(getComputedStyle(button).backgroundColor, "rgb(255, 0, 0)", `backgroundColor for ${button.tagName}#${button.id} should NOT be red`);
-        t.done();
-     }
-
+    promise_test(async function() {
+      await waitUntilStableAutofocusState();
+      assert_equals(document.activeElement, button, "Should have correct focused element");
+      assert_equals(getComputedStyle(button).outlineColor, "rgb(0, 128, 0)", `outlineColor for ${button.tagName}#${button.id} should be green`);
+      assert_not_equals(getComputedStyle(button).backgroundColor, "rgb(255, 0, 0)", `backgroundColor for ${button.tagName}#${button.id} should NOT be red`);
     }, "Autofocus should match :focus-visible");
   </script>
 </body>


### PR DESCRIPTION
WebKit export from bug: [REGRESSION (r283935): \[ macOS wk1 \] imported/w3c/web-platform-tests/css/selectors/focus-visible-009.html is a flaky failure](https://bugs.webkit.org/show_bug.cgi?id=231647)