### PR TITLE
Remove abortReason from WritableStreamDefaultController interface

### DIFF
--- a/interfaces/streams.idl
+++ b/interfaces/streams.idl
@@ -159,7 +159,6 @@ interface WritableStreamDefaultWriter {
 
 [Exposed=(Window,Worker,Worklet)]
 interface WritableStreamDefaultController {
-  readonly attribute any abortReason;
   readonly attribute AbortSignal signal;
   undefined error(optional any e);
 };


### PR DESCRIPTION
Based on https://github.com/whatwg/streams/pull/1177#issuecomment-947081331, this PR updates the streams IDL so that we can roll the WPTs and proceed with removing the `abortReason` property from the WritableStream spec.

/cc @domenic 