### PR TITLE
Run softwareupdate before running Safari stable

### DIFF
--- a/tools/ci/azure/install_safari.yml
+++ b/tools/ci/azure/install_safari.yml
@@ -20,6 +20,7 @@ steps:
 - ${{ if eq(parameters.channel, 'stable') }}:
   - script: |
       set -eux
+      sudo softwareupdate --install $( softwareupdate -l | grep -o '\* Label: \(Safari.*\)' | sed -e 's/* Label: //' )
       sudo safaridriver --enable
       defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically 1
     displayName: 'Configure Safari'


### PR DESCRIPTION
See https://github.com/web-platform-tests/wpt/runs/3999390840 for an ongoing manually triggered run of Safari stable

This will get us Safari 15 running on Azure Pipelines.