### PR TITLE
Streams: Add/update WPTs with AbortSignal's abort reason

### DIFF
--- a/streams/piping/abort.any.js
+++ b/streams/piping/abort.any.js
@@ -64,6 +64,12 @@ for (const reason of [null, undefined, error1]) {
     return rs.pipeTo(ws, { signal })
         .catch(e => {
           error = e;
+          if (reason === error1) {
+            assert_equals(error, error1, 'error is not undefined');
+          } else {
+            assert_true(error instanceof DOMException, 'error is a DOMException');
+            assert_equals(error.name, 'AbortError', 'error is an AbortError');
+          }
         })
         .then(() => Promise.all([
           rs.getReader().closed,
@@ -77,7 +83,7 @@ for (const reason of [null, undefined, error1]) {
       assert_equals(rs.events[0], 'cancel', 'first event should be cancel');
       assert_equals(rs.events[1], error, 'the readable should be canceled with the same object');
     });
-  }, 'all the error objects should be the same object');
+  }, '(reason: '${reason}') all the error objects should be the same object');
 }
 
 promise_test(t => {
@@ -136,14 +142,22 @@ for (const reason of [null, undefined, error1]) {
       }
     });
     return rs.pipeTo(ws, { signal })
-        .catch(e => { error = e; })
+        .catch(e => {
+          error = e;
+          if (reason === error1) {
+            assert_equals(error, error1, 'error is not undefined');
+          } else {
+            assert_true(error instanceof DOMException, 'error is a DOMException');
+            assert_equals(error.name, 'AbortError', 'error is an AbortError');
+          }
+        })
         .then(() => {
           assert_equals(signal.reason, error, 'signal.reason should be error');
           assert_equals(ws.events.length, 4, 'only chunk "a" should have been written');
           assert_array_equals(ws.events.slice(0, 3), ['write', 'a', 'abort'], 'events should match');
           assert_equals(ws.events[3], error, 'abort reason should be error');
         });
-  }, 'abort should prevent further reads');
+  }, '(reason: '${reason}') abort should prevent further reads');
 }
 
 for (const reason of [null, undefined, error1]) {
@@ -173,14 +187,22 @@ for (const reason of [null, undefined, error1]) {
       abortController.abort(reason);
       readController.close(); // Make sure the test terminates when signal is not implemented.
       resolveWrite();
-      return pipeToPromise.catch(e => { error = e; })
+      return pipeToPromise.catch(e => {
+        error = e;
+        if (reason === error1) {
+          assert_equals(error, error1, 'error is not undefined');
+        } else {
+          assert_true(error instanceof DOMException, 'error is a DOMException');
+          assert_equals(error.name, 'AbortError', 'error is an AbortError');
+        }
+      })
     }).then(() => {
       assert_equals(signal.reason, error, 'signal.reason should be error');
       assert_equals(ws.events.length, 6, 'chunks "a" and "b" should have been written');
       assert_array_equals(ws.events.slice(0, 5), ['write', 'a', 'write', 'b', 'abort'], 'events should match');
       assert_equals(ws.events[5], error, 'abort reason should be error');
     });
-  }, 'all pending writes should complete on abort');
+  }, '(reason: '${reason}') all pending writes should complete on abort');
 }
 
 promise_test(t => {

--- a/streams/writable-streams/aborting.any.js
+++ b/streams/writable-streams/aborting.any.js
@@ -1384,7 +1384,7 @@ test(t => {
 
   assert_true(ctrl.signal instanceof AbortSignal);
   assert_false(ctrl.signal.aborted);
-  assert_equals(ctrl.signal.reason, undefined);
+  assert_equals(ctrl.signal.reason, undefined, 'signal.reason before abort');
   ws.abort(e);
   assert_true(ctrl.signal.aborted);
   assert_equals(ctrl.signal.reason, e);
@@ -1405,10 +1405,11 @@ promise_test(async t => {
   await called;
 
   assert_false(ctrl.signal.aborted);
-  assert_equals(ctrl.signal.reason, undefined);
+  assert_equals(ctrl.signal.reason, undefined, 'signal.reason before abort');
   writer.abort();
   assert_true(ctrl.signal.aborted);
-  assert_equals(ctrl.signal.reason, undefined);
+  assert_true(ctrl.signal.reason instanceof DOMException, 'signal.reason is a DOMException');
+  assert_equals(ctrl.signal.reason.name, 'AbortError', 'signal.reason is an AbortError');
 }, 'the abort signal is signalled synchronously - write');
 
 promise_test(async t => {

--- a/streams/writable-streams/aborting.any.js
+++ b/streams/writable-streams/aborting.any.js
@@ -1384,8 +1384,10 @@ test(t => {
 
   assert_true(ctrl.signal instanceof AbortSignal);
   assert_false(ctrl.signal.aborted);
+  assert_equals(ctrl.signal.reason, undefined);
   ws.abort(e);
   assert_true(ctrl.signal.aborted);
+  assert_equals(ctrl.signal.reason, e);
 }, 'WritableStreamDefaultController.signal');
 
 promise_test(async t => {
@@ -1403,8 +1405,10 @@ promise_test(async t => {
   await called;
 
   assert_false(ctrl.signal.aborted);
+  assert_equals(ctrl.signal.reason, undefined);
   writer.abort();
   assert_true(ctrl.signal.aborted);
+  assert_equals(ctrl.signal.reason, undefined);
 }, 'the abort signal is signalled synchronously - write');
 
 promise_test(async t => {


### PR DESCRIPTION
This PR updates the existing aborting test cases to check the `ctrl.signal.reason` again, which was initially removed in https://github.com/web-platform-tests/wpt/pull/31293 when `abortReason` was removed from the spec.

I've also parameterized a few test cases to check the AbortSignal's abort reason is properly used in `rs.pipeTo()` calls.

See https://github.com/whatwg/streams/pull/1182 for the accompanying spec change.

/cc @yutakahirano, @MattiasBuelens 