### PR TITLE
Adds the --keep-app-data-directory command line argument for running tests on Android browsers

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/android_webview.py
+++ b/tools/wptrunner/wptrunner/browsers/android_webview.py
@@ -55,6 +55,8 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
         kwargs.get("package_name", "org.chromium.webview_shell")
     capabilities["goog:chromeOptions"]["androidActivity"] = \
         "org.chromium.webview_shell.WebPlatformTestsActivity"
+    capabilities["goog:chromeOptions"]["androidKeepAppDataDir"] = \
+        kwargs.get("keep_app_data_directory")
     if kwargs.get("device_serial"):
         capabilities["goog:chromeOptions"]["androidDeviceSerial"] = kwargs["device_serial"]
 

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -191,6 +191,16 @@ scheme host and port.""")
     debugging_group.add_argument("--pdb", action="store_true",
                                  help="Drop into pdb on python exception")
 
+    android_group = parser.add_argument_group("Android specific arguments")
+    android_group.add_argument("--adb-binary", action="store",
+                        help="Path to adb binary to use")
+    android_group.add_argument("--package-name", action="store",
+                        help="Android package name to run tests against")
+    android_group.add_argument("--keep-app-data-directory", action="store_true",
+                        help="Don't delete the app data directory")
+    android_group.add_argument("--device-serial", action="store",
+                              help="Running Android instance to connect to, if not emulator-5554")
+
     config_group = parser.add_argument_group("Configuration")
     config_group.add_argument("--binary", action="store",
                               type=abs_path, help="Desktop binary to run tests against")
@@ -202,12 +212,6 @@ scheme host and port.""")
     config_group.add_argument('--webdriver-arg',
                               default=[], action="append", dest="webdriver_args",
                               help="Extra argument for the WebDriver binary")
-    config_group.add_argument("--adb-binary", action="store",
-                              help="Path to adb binary to use")
-    config_group.add_argument("--package-name", action="store",
-                              help="Android package name to run tests against")
-    config_group.add_argument("--device-serial", action="store",
-                              help="Running Android instance to connect to, if not emulator-5554")
     config_group.add_argument("--metadata", action="store", type=abs_path, dest="metadata_root",
                               help="Path to root directory containing test metadata"),
     config_group.add_argument("--tests", action="store", type=abs_path, dest="tests_root",


### PR DESCRIPTION
This new argument will make ChromeDriver not delete the app data directory when launching an Android browser. This CL also creates an android specific command line argument group and moves several arguments into that group

Bug: crbug.com/1233679, crbug.com/1261285