### PR TITLE
Use "in" operator to check if a property exists in dom historical tests

### DIFF
--- a/dom/historical.html
+++ b/dom/historical.html
@@ -213,7 +213,7 @@ EventPrototypeRemoved.forEach(name => {
     assert_false(name in Event.prototype)
     assert_equals(Event.prototype[name], undefined)
     assert_false(name in new Event("test"))
-    assert_equals(new Event("test")[name], undefined)
+    assert_equals((new Event("test"))[name], undefined)
   }, "Event.prototype should not have this property: " + name)
 })
 </script>

--- a/dom/historical.html
+++ b/dom/historical.html
@@ -6,7 +6,7 @@
 <script>
 function isInterfaceRemoved(name) {
   test(function() {
-    assert_equals(name in window, false)
+    assert_false(name in window)
   }, "Historical DOM features must be removed: " + name)
 }
 var removedInterfaces = [
@@ -35,8 +35,8 @@ removedInterfaces.forEach(isInterfaceRemoved)
 function isRemovedFromDocument(name) {
   test(function() {
     var doc = document.implementation.createDocument(null,null,null)
-    assert_equals(name in document, false)
-    assert_equals(name in doc, false)
+    assert_false(name in document)
+    assert_false(name in doc)
   }, "Historical DOM features must be removed: " + name)
 }
 var documentRemoved = [
@@ -74,14 +74,14 @@ test(function() {
 }, "XMLDocument.load");
 
 test(function() {
-  assert_equals("getFeature" in document.implementation, false)
+  assert_false("getFeature" in document.implementation)
 }, "DOMImplementation.getFeature() must be removed.")
 
 function isRemovedFromElement(name) {
   test(function() {
     var ele = document.createElementNS("test", "test")
-    assert_equals(name in document.body, false)
-    assert_equals(name in ele, false)
+    assert_false(name in document.body)
+    assert_false(name in ele)
   }, "Historical DOM features must be removed: " + name)
 }
 var elementRemoved = [
@@ -95,7 +95,7 @@ elementRemoved.forEach(isRemovedFromElement)
 function isRemovedFromAttr(name) {
   test(function() {
     var attr = document.createAttribute("test")
-    assert_equals(name in attr, false)
+    assert_false(name in attr)
   }, "Attr member must be removed: " + name)
 }
 var attrRemoved = [
@@ -107,7 +107,7 @@ attrRemoved.forEach(isRemovedFromAttr)
 function isRemovedFromDoctype(name) {
   test(function() {
     var doctype = document.implementation.createDocumentType("test", "", "")
-    assert_equals(name in doctype, false)
+    assert_false(name in doctype)
   }, "DocumentType member must be removed: " + name)
 }
 var doctypeRemoved = [
@@ -120,7 +120,7 @@ doctypeRemoved.forEach(isRemovedFromDoctype)
 function isRemovedFromText(name) {
   test(function() {
     var text = document.createTextNode("test")
-    assert_equals(name in text, false)
+    assert_false(name in text)
   }, "Text member must be removed: " + name)
 }
 var textRemoved = [
@@ -134,9 +134,9 @@ function isRemovedFromNode(name) {
     var doc = document.implementation.createDocument(null,null,null)
     var doctype = document.implementation.createDocumentType("test", "", "")
     var text = document.createTextNode("test")
-    assert_equals(name in doc, false)
-    assert_equals(name in doctype, false)
-    assert_equals(name in text, false)
+    assert_false(name in doc)
+    assert_false(name in doctype)
+    assert_false(name in text)
   }, "Node member must be removed: " + name)
 }
 var nodeRemoved = [
@@ -155,7 +155,7 @@ nodeRemoved.forEach(isRemovedFromNode)
 
 function isRemovedFromWindow(name) {
   test(function() {
-    assert_equals(name in window, false)
+    assert_false(name in window)
   }, "Window member must be removed: " + name)
 }
 var windowRemoved = [
@@ -165,7 +165,7 @@ windowRemoved.forEach(isRemovedFromWindow)
 
 function isRemovedFromEvent(name) {
   test(() => {
-    assert_equals(name in Event, false)
+    assert_false(name in Event)
   }, "Event should not have this constant: " + name)
 }
 var EventRemoved = [
@@ -194,8 +194,8 @@ var EventPrototypeRemoved = [
 ]
 EventPrototypeRemoved.forEach(name => {
   test(() => {
-    assert_equals(name in Event.prototype, false)
-    assert_equals(name in new Event("test"), false)
+    assert_false(name in Event.prototype)
+    assert_false(name in new Event("test"))
   }, "Event.prototype should not have this property: " + name)
 })
 </script>

--- a/dom/historical.html
+++ b/dom/historical.html
@@ -6,7 +6,7 @@
 <script>
 function isInterfaceRemoved(name) {
   test(function() {
-    assert_equals(window[name], undefined)
+    assert_equals(name in window, false)
   }, "Historical DOM features must be removed: " + name)
 }
 var removedInterfaces = [
@@ -35,8 +35,8 @@ removedInterfaces.forEach(isInterfaceRemoved)
 function isRemovedFromDocument(name) {
   test(function() {
     var doc = document.implementation.createDocument(null,null,null)
-    assert_equals(document[name], undefined)
-    assert_equals(doc[name], undefined)
+    assert_equals(name in document, false)
+    assert_equals(name in doc, false)
   }, "Historical DOM features must be removed: " + name)
 }
 var documentRemoved = [
@@ -74,14 +74,14 @@ test(function() {
 }, "XMLDocument.load");
 
 test(function() {
-  assert_equals(document.implementation["getFeature"], undefined)
+  assert_equals("getFeature" in document.implementation, false)
 }, "DOMImplementation.getFeature() must be removed.")
 
 function isRemovedFromElement(name) {
   test(function() {
     var ele = document.createElementNS("test", "test")
-    assert_equals(document.body[name], undefined)
-    assert_equals(ele[name], undefined)
+    assert_equals(name in document.body, false)
+    assert_equals(name in ele, false)
   }, "Historical DOM features must be removed: " + name)
 }
 var elementRemoved = [
@@ -95,7 +95,7 @@ elementRemoved.forEach(isRemovedFromElement)
 function isRemovedFromAttr(name) {
   test(function() {
     var attr = document.createAttribute("test")
-    assert_equals(attr[name], undefined)
+    assert_equals(name in attr, false)
   }, "Attr member must be removed: " + name)
 }
 var attrRemoved = [
@@ -107,7 +107,7 @@ attrRemoved.forEach(isRemovedFromAttr)
 function isRemovedFromDoctype(name) {
   test(function() {
     var doctype = document.implementation.createDocumentType("test", "", "")
-    assert_equals(doctype[name], undefined)
+    assert_equals(name in doctype, false)
   }, "DocumentType member must be removed: " + name)
 }
 var doctypeRemoved = [
@@ -120,7 +120,7 @@ doctypeRemoved.forEach(isRemovedFromDoctype)
 function isRemovedFromText(name) {
   test(function() {
     var text = document.createTextNode("test")
-    assert_equals(text[name], undefined)
+    assert_equals(name in text, false)
   }, "Text member must be removed: " + name)
 }
 var textRemoved = [
@@ -134,9 +134,9 @@ function isRemovedFromNode(name) {
     var doc = document.implementation.createDocument(null,null,null)
     var doctype = document.implementation.createDocumentType("test", "", "")
     var text = document.createTextNode("test")
-    assert_equals(doc[name], undefined)
-    assert_equals(doctype[name], undefined)
-    assert_equals(text[name], undefined)
+    assert_equals(name in doc, false)
+    assert_equals(name in doctype, false)
+    assert_equals(name in text, false)
   }, "Node member must be removed: " + name)
 }
 var nodeRemoved = [
@@ -155,7 +155,7 @@ nodeRemoved.forEach(isRemovedFromNode)
 
 function isRemovedFromWindow(name) {
   test(function() {
-    assert_equals(window[name], undefined)
+    assert_equals(name in window, false)
   }, "Window member must be removed: " + name)
 }
 var windowRemoved = [
@@ -165,7 +165,7 @@ windowRemoved.forEach(isRemovedFromWindow)
 
 function isRemovedFromEvent(name) {
   test(() => {
-    assert_equals(Event[name], undefined)
+    assert_equals(name in Event, false)
   }, "Event should not have this constant: " + name)
 }
 var EventRemoved = [
@@ -194,8 +194,8 @@ var EventPrototypeRemoved = [
 ]
 EventPrototypeRemoved.forEach(name => {
   test(() => {
-    assert_equals(Event.prototype[name], undefined)
-    assert_equals((new Event("test"))[name], undefined)
+    assert_equals(name in Event.prototype, false)
+    assert_equals(name in new Event("test"), false)
   }, "Event.prototype should not have this property: " + name)
 })
 </script>

--- a/dom/historical.html
+++ b/dom/historical.html
@@ -7,6 +7,7 @@
 function isInterfaceRemoved(name) {
   test(function() {
     assert_false(name in window)
+    assert_equals(window[name], undefined)
   }, "Historical DOM features must be removed: " + name)
 }
 var removedInterfaces = [
@@ -36,7 +37,9 @@ function isRemovedFromDocument(name) {
   test(function() {
     var doc = document.implementation.createDocument(null,null,null)
     assert_false(name in document)
+    assert_equals(document[name], undefined)
     assert_false(name in doc)
+    assert_equals(doc[name], undefined)
   }, "Historical DOM features must be removed: " + name)
 }
 var documentRemoved = [
@@ -65,23 +68,28 @@ documentRemoved.forEach(isRemovedFromDocument)
 test(function() {
   // https://github.com/whatwg/html/commit/e236f46820b93d6fe2e2caae0363331075c6c4fb
   assert_false("load" in document);
+  assert_equals(document["load"], undefined)
 }, "document.load");
 
 test(function() {
   // https://github.com/whatwg/html/commit/523f7a8773d2ab8a1eb0da6510651e8c5d2a7531
   var doc = document.implementation.createDocument(null, null, null);
   assert_false("load" in doc);
+  assert_equals(doc["load"], undefined)
 }, "XMLDocument.load");
 
 test(function() {
   assert_false("getFeature" in document.implementation)
+  assert_equals(document.implementation["getFeature"], undefined)
 }, "DOMImplementation.getFeature() must be removed.")
 
 function isRemovedFromElement(name) {
   test(function() {
     var ele = document.createElementNS("test", "test")
     assert_false(name in document.body)
+    assert_equals(document.body[name], undefined)
     assert_false(name in ele)
+    assert_equals(ele[name], undefined)
   }, "Historical DOM features must be removed: " + name)
 }
 var elementRemoved = [
@@ -96,6 +104,7 @@ function isRemovedFromAttr(name) {
   test(function() {
     var attr = document.createAttribute("test")
     assert_false(name in attr)
+    assert_equals(attr[name], undefined)
   }, "Attr member must be removed: " + name)
 }
 var attrRemoved = [
@@ -108,6 +117,7 @@ function isRemovedFromDoctype(name) {
   test(function() {
     var doctype = document.implementation.createDocumentType("test", "", "")
     assert_false(name in doctype)
+    assert_equals(doctype[name], undefined)
   }, "DocumentType member must be removed: " + name)
 }
 var doctypeRemoved = [
@@ -121,6 +131,7 @@ function isRemovedFromText(name) {
   test(function() {
     var text = document.createTextNode("test")
     assert_false(name in text)
+    assert_equals(text[name], undefined)
   }, "Text member must be removed: " + name)
 }
 var textRemoved = [
@@ -135,8 +146,11 @@ function isRemovedFromNode(name) {
     var doctype = document.implementation.createDocumentType("test", "", "")
     var text = document.createTextNode("test")
     assert_false(name in doc)
+    assert_equals(doc[name], undefined)
     assert_false(name in doctype)
+    assert_equals(doctype[name], undefined)
     assert_false(name in text)
+    assert_equals(text[name], undefined)
   }, "Node member must be removed: " + name)
 }
 var nodeRemoved = [
@@ -156,6 +170,7 @@ nodeRemoved.forEach(isRemovedFromNode)
 function isRemovedFromWindow(name) {
   test(function() {
     assert_false(name in window)
+    assert_equals(window[name], undefined)
   }, "Window member must be removed: " + name)
 }
 var windowRemoved = [
@@ -166,6 +181,7 @@ windowRemoved.forEach(isRemovedFromWindow)
 function isRemovedFromEvent(name) {
   test(() => {
     assert_false(name in Event)
+    assert_equals(Event[name], undefined)
   }, "Event should not have this constant: " + name)
 }
 var EventRemoved = [
@@ -195,7 +211,9 @@ var EventPrototypeRemoved = [
 EventPrototypeRemoved.forEach(name => {
   test(() => {
     assert_false(name in Event.prototype)
+    assert_equals(Event.prototype[name], undefined)
     assert_false(name in new Event("test"))
+    assert_equals(new Event("test")[name], undefined)
   }, "Event.prototype should not have this property: " + name)
 })
 </script>


### PR DESCRIPTION
The way the object properties were being checked to see if they were removed caused possible issues in some DOM historical tests. Occasionally, these properties did exist as [getters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) and referencing the property would raise a "TypeError: Illegal Invocation" as the getters where being invoked in an invalid context. Using the "in" operator circumvents this issue.

This change will NOT change the output on whether these tests pass or fail, as the TypeError was being raised only at times when the property existed, which should fail the tests anyway. The change will simply make the tests handle their assertion statements more gracefully rather than failing due to a TypeError.