### PR TITLE
[WebTransport] Send the draft version header as a part of server reply

### DIFF
--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -203,6 +203,7 @@ class WebTransportH3Protocol(QuicConnectionProtocol):
 
         response_headers = [
             (b"server", SERVER_NAME.encode()),
+            (b"sec-webtransport-http3-draft", b"draft02"),
         ]
         self._handler.connect_received(response_headers=response_headers)
 


### PR DESCRIPTION
The header is defined in <https://github.com/ietf-wg-webtrans/draft-ietf-webtrans-http3/pull/64> and is required for draft02 support.