### PR TITLE
New tests for use of currentColor in @font-palette-values

### DIFF
--- a/css/css-fonts/font-palette-35-ref.html
+++ b/css/css-fonts/font-palette-35-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests use of currentColor in @font-palette-values</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-palette-values">
+<link rel="author" title="Mike Bremford" href="https://bfo.com">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+@font-palette-values --MyPalette {
+    font-family: "COLR-test-font";
+    override-colors: 7 #00FF00;
+}
+
+div {
+    font: 48px 'COLR-test-font';
+    font-palette: --MyPalette;
+}
+</style>
+</head>
+<body>
+<div>A</div>
+</body>
+</html>

--- a/css/css-fonts/font-palette-35.html
+++ b/css/css-fonts/font-palette-35.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests use of currentColor in @font-palette-values</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-palette-values">
+<link rel="author" title="Mike Bremford" href="https://bfo.com">
+<link rel="match" href="font-palette-35-ref.html">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+@font-palette-values --MyPalette {
+    font-family: "COLR-test-font";
+    override-colors: 7 currentColor;
+}
+
+div {
+    color: #00FF00;
+    font: 48px 'COLR-test-font';
+    font-palette: --MyPalette;
+}
+</style>
+</head>
+<body>
+<div>A</div>
+</body>
+</html>

--- a/css/css-fonts/font-palette-36.html
+++ b/css/css-fonts/font-palette-36.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests currentColor in @font-palette-values is inherited as currentColor</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-palette-values">
+<link rel="author" title="Mike Bremford" href="mailto:mike@bfo.com">
+<link rel="match" href="font-palette-35-ref.html">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+@font-palette-values --MyPalette {
+    font-family: "COLR-test-font";
+    override-colors: 7 currentColor;
+}
+div {
+    color: red;
+    font: 48px 'COLR-test-font';
+    font-palette: --MyPalette;
+}
+span {
+    color: #00FF00;
+}
+
+</style>
+</head>
+<body>
+<div><span>A</span></div>
+</body>
+</html>


### PR DESCRIPTION
New tests to verify use of currentColor in @font-palette-values `override-colors` property.

font-palette-36.html makes the assumption that currentColor is inherited in the same way here as everywhere else, but this isn't explicit in the spec.

ping @litherum 