### PR TITLE
Move green-dialog-and-backdrop.html out of the resources/ directory

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/green-dialog-and-backdrop.html
+++ b/html/semantics/interactive-elements/the-dialog-element/green-dialog-and-backdrop.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <meta charset="utf-8">
-<link rel="stylesheet" href="dialog.css">
+<link rel="stylesheet" href="resources/dialog.css">
 <style>
 body { background: red; }
 

--- a/html/semantics/interactive-elements/the-dialog-element/top-layer-parent-clip.html
+++ b/html/semantics/interactive-elements/the-dialog-element/top-layer-parent-clip.html
@@ -3,7 +3,7 @@
 <title>Test that parent clip-path does not affect top layer elements</title>
 <meta charset="utf-8">
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
-<link rel="match" href="resources/green-dialog-and-backdrop.html">
+<link rel="match" href="green-dialog-and-backdrop.html">
 <link rel="help" href="https://fullscreen.spec.whatwg.org/#new-stacking-layer">
 <style>
 body { background: red; }

--- a/html/semantics/interactive-elements/the-dialog-element/top-layer-parent-filter.html
+++ b/html/semantics/interactive-elements/the-dialog-element/top-layer-parent-filter.html
@@ -3,7 +3,7 @@
 <title>Test that parent filter does not affect top layer elements</title>
 <meta charset="utf-8">
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
-<link rel="match" href="resources/green-dialog-and-backdrop.html">
+<link rel="match" href="green-dialog-and-backdrop.html">
 <link rel="help" href="https://fullscreen.spec.whatwg.org/#new-stacking-layer">
 <style>
 body { background: red; }

--- a/html/semantics/interactive-elements/the-dialog-element/top-layer-parent-mask.html
+++ b/html/semantics/interactive-elements/the-dialog-element/top-layer-parent-mask.html
@@ -3,7 +3,7 @@
 <title>Test that parent mask does not affect top layer elements</title>
 <meta charset="utf-8">
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
-<link rel="match" href="resources/green-dialog-and-backdrop.html">
+<link rel="match" href="green-dialog-and-backdrop.html">
 <link rel="help" href="https://fullscreen.spec.whatwg.org/#new-stacking-layer">
 <style>
 body { background: red; }

--- a/html/semantics/interactive-elements/the-dialog-element/top-layer-parent-opacity.html
+++ b/html/semantics/interactive-elements/the-dialog-element/top-layer-parent-opacity.html
@@ -3,7 +3,7 @@
 <title>Test that parent opacity does not affect top layer elements</title>
 <meta charset="utf-8">
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
-<link rel="match" href="resources/green-dialog-and-backdrop.html">
+<link rel="match" href="green-dialog-and-backdrop.html">
 <link rel="help" href="https://fullscreen.spec.whatwg.org/#new-stacking-layer">
 <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=229317">
 <style>

--- a/html/semantics/interactive-elements/the-dialog-element/top-layer-parent-overflow-clip.html
+++ b/html/semantics/interactive-elements/the-dialog-element/top-layer-parent-overflow-clip.html
@@ -3,7 +3,7 @@
 <title>Test that parent overflow: clip; does not affect top layer elements</title>
 <meta charset="utf-8">
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
-<link rel="match" href="resources/green-dialog-and-backdrop.html">
+<link rel="match" href="green-dialog-and-backdrop.html">
 <link rel="help" href="https://fullscreen.spec.whatwg.org/#new-stacking-layer">
 <style>
 body { background: red; }

--- a/html/semantics/interactive-elements/the-dialog-element/top-layer-parent-overflow-hidden.html
+++ b/html/semantics/interactive-elements/the-dialog-element/top-layer-parent-overflow-hidden.html
@@ -3,7 +3,7 @@
 <title>Test that parent overflow: hidden; does not affect top layer elements</title>
 <meta charset="utf-8">
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
-<link rel="match" href="resources/green-dialog-and-backdrop.html">
+<link rel="match" href="green-dialog-and-backdrop.html">
 <link rel="help" href="https://fullscreen.spec.whatwg.org/#new-stacking-layer">
 <style>
 body { background: red; }

--- a/html/semantics/interactive-elements/the-dialog-element/top-layer-parent-overflow-scroll.html
+++ b/html/semantics/interactive-elements/the-dialog-element/top-layer-parent-overflow-scroll.html
@@ -3,7 +3,7 @@
 <title>Test that parent overflow: scroll; does not affect top layer elements</title>
 <meta charset="utf-8">
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
-<link rel="match" href="resources/green-dialog-and-backdrop.html">
+<link rel="match" href="green-dialog-and-backdrop.html">
 <link rel="help" href="https://fullscreen.spec.whatwg.org/#new-stacking-layer">
 <style>
 body { background: red; }

--- a/html/semantics/interactive-elements/the-dialog-element/top-layer-parent-transform.html
+++ b/html/semantics/interactive-elements/the-dialog-element/top-layer-parent-transform.html
@@ -3,7 +3,7 @@
 <title>Test that parent transform does not affect top layer elements</title>
 <meta charset="utf-8">
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
-<link rel="match" href="resources/green-dialog-and-backdrop.html">
+<link rel="match" href="green-dialog-and-backdrop.html">
 <link rel="help" href="https://fullscreen.spec.whatwg.org/#new-stacking-layer">
 <style>
 body { background: red; }


### PR DESCRIPTION
Consistent with other references, and makes it easier to import into WebKit