### PR TITLE
[css-text-decor] Verify wavy decorations cover the whole line length

### DIFF
--- a/css/css-text-decor/reference/text-decoration-wavy-covers-whole-line-length-001-notref.html
+++ b/css/css-text-decor/reference/text-decoration-wavy-covers-whole-line-length-001-notref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Decoration Test: Wavy decorations covers the whole line length mismatch reference file</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<p>The test passes if you see some green below (the end of a wavy green text decoration).</p>

--- a/css/css-text-decor/text-decoration-line-through-wavy-covers-whole-line-length-001.html
+++ b/css/css-text-decor/text-decoration-line-through-wavy-covers-whole-line-length-001.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Decoration Test: Wavy line-through covers the whole line length</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#text-decoration-line-property">
+<meta name="assert" content="Checks that a wavy line-through covers the whole line length.">
+<link rel="mismatch" href="reference/text-decoration-wavy-covers-whole-line-length-001-notref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body {
+    overflow: hidden;
+  }
+  #wrapper {
+    position: absolute;
+    margin: 100px;
+  }
+  #decoration {
+    font: 400px/1 Ahem;
+    color: transparent;
+    text-decoration-line: line-through;
+    text-decoration-color: green;
+    text-decoration-style: wavy;
+    text-decoration-skip-ink: none;
+  }
+  #abspos {
+    position: absolute;
+    left: -100px;
+    top: -100px;
+    width: 480px;
+    height: 1000px;
+    background: white;
+  }
+</style>
+<p>The test passes if you see some green below (the end of a wavy green text decoration).</p>
+<div id="wrapper">
+  <div id="decoration">X</div>
+  <div id="abspos"></div>
+</div>

--- a/css/css-text-decor/text-decoration-overline-wavy-covers-whole-line-length-001.html
+++ b/css/css-text-decor/text-decoration-overline-wavy-covers-whole-line-length-001.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Decoration Test: Wavy overline covers the whole line length</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#text-decoration-line-property">
+<meta name="assert" content="Checks that a wavy overline covers the whole line length.">
+<link rel="mismatch" href="reference/text-decoration-wavy-covers-whole-line-length-001-notref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body {
+    overflow: hidden;
+  }
+  #wrapper {
+    position: absolute;
+    margin: 100px;
+    padding-top: 200px;
+  }
+  #decoration {
+    font: 400px/1 Ahem;
+    color: transparent;
+    text-decoration-line: overline;
+    text-decoration-color: green;
+    text-decoration-style: wavy;
+    text-decoration-skip-ink: none;
+  }
+  #abspos {
+    position: absolute;
+    left: -100px;
+    top: -100px;
+    width: 480px;
+    height: 1000px;
+    background: white;
+  }
+</style>
+<p>The test passes if you see some green below (the end of a wavy green text decoration).</p>
+<div id="wrapper">
+  <div id="decoration">X</div>
+  <div id="abspos"></div>
+</div>

--- a/css/css-text-decor/text-decoration-underline-wavy-covers-whole-line-length-001.html
+++ b/css/css-text-decor/text-decoration-underline-wavy-covers-whole-line-length-001.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Decoration Test: Wavy underline covers the whole line length</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#text-decoration-line-property">
+<meta name="assert" content="Checks that a wavy underline covers the whole line length.">
+<link rel="mismatch" href="reference/text-decoration-wavy-covers-whole-line-length-001-notref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body {
+    overflow: hidden;
+  }
+  #wrapper {
+    position: absolute;
+    margin: 100px;
+  }
+  #decoration {
+    font: 400px/1 Ahem;
+    color: transparent;
+    text-decoration-line: underline;
+    text-decoration-color: green;
+    text-decoration-style: wavy;
+    text-decoration-skip-ink: none;
+  }
+  #abspos {
+    position: absolute;
+    left: -100px;
+    top: -100px;
+    width: 480px;
+    height: 1000px;
+    background: white;
+  }
+</style>
+<p>The test passes if you see some green below (the end of a wavy green text decoration).</p>
+<div id="wrapper">
+  <div id="decoration">X</div>
+  <div id="abspos"></div>
+</div>


### PR DESCRIPTION
These are some reference mismatch tests to verify that
wavy text decorations cover the whole line length.

They paint a wavy underline|overline|line-through and then put
an absolute positioned white element on top,
hiding most of the decoration except the last part.