### PR TITLE
New tests to distinguish between content-list and content-replacement

### DIFF
--- a/css/css-content/replacement-size-001.html
+++ b/css/css-content/replacement-size-001.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test that a single generated-content image is treated as a content-replacement</title>
+<link rel="author" title="Mike Bremford" href="https://bfo.com/">
+<link rel="help" href="https://www.w3.org/TR/css-content-3/#typedef-content-content-replacement">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="If a node's generated content is a single image it is 'content-replacement'. It becomes the replaced content of the node and, if the node is inline-block, is sized by the width/height properties"/>
+<style>
+div::before {
+    display: inline-block;
+    width: 100px;
+    content: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'><rect width='100%' height='100%' fill='green'/></svg>");
+}
+div {
+    width: 100px;
+    height: 100px;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div></div>
+</body>
+</html>

--- a/css/css-content/replacement-size-002.html
+++ b/css/css-content/replacement-size-002.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test that an image as part of a list of generated content is treated as a content-list</title>
+<link rel="author" title="Mike Bremford" href="https://bfo.com/">
+<link rel="help" href="https://www.w3.org/TR/css-content-3/#content-property">
+<link rel="help" href="https://www.w3.org/TR/css-content-3/#typedef-content-content-list">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="If generated content is not a single image, it is part of a 'content-list' and becomes an anonymous inline child of the node. As an inline child it is not sized by its parent"/>
+<style>
+div::before {
+    display: inline-block;
+    width: 10px;
+    content: "" url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'><rect width='100%' height='100%' fill='green'/></svg>");
+}
+div {
+    width: 100px;
+    height: 100px;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div></div>
+</body>
+</html>

--- a/css/css-pseudo/marker-content-012-ref.html
+++ b/css/css-pseudo/marker-content-012-ref.html
@@ -27,7 +27,7 @@ ul {
   content: "text";
 }
 .image::before {
-  content: var(--green-image);
+  content: "" var(--green-image); /* Make it a content-list */
 }
 </style>
 <ul style="list-style-type: none">


### PR DESCRIPTION
There's a distinction in [css-content](https://www.w3.org/TR/css-content-3/) between `content-replacement` and `content-list`, but this distinction isn't currently implemented in any browser, and as a result there are some incorrect assertions being made in other reftests, eg http://wpt.live/css/css-pseudo/marker-content-012-ref.html.

These new tests demonstrates the distinction (and fixes the above reftest).

This has come up in https://github.com/w3c/csswg-drafts/issues/2657