### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=232387

### DIFF
--- a/dom/traversal/TreeWalker-acceptNode-filter-cross-realm-null-browsing-context.html
+++ b/dom/traversal/TreeWalker-acceptNode-filter-cross-realm-null-browsing-context.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>TreeWalker: NodeFilter from detached iframe works as expected</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#ref-for-call-a-user-objects-operation%E2%91%A0">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+const t = async_test();
+
+const iframe = document.createElement("iframe");
+iframe.src = "support/TreeWalker-acceptNode-filter-cross-realm-null-browsing-context-subframe.html";
+iframe.onload = t.step_func_done(() => {
+    const nodeIterator = iframe.contentWindow.createNodeIterator();
+    iframe.remove();
+
+    assert_equals(iframe.contentWindow, null);
+    assert_equals(nodeIterator.nextNode(), document.body);
+    assert_true(nodeIterator.dummyFilterCalled);
+});
+
+document.body.append(iframe);
+</script>

--- a/dom/traversal/TreeWalker-acceptNode-filter-cross-realm.html
+++ b/dom/traversal/TreeWalker-acceptNode-filter-cross-realm.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>TreeWalker: cross-realm NodeFilter throws TypeError of current realm</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://webidl.spec.whatwg.org/#call-a-user-objects-operation">
+
+<body id="treeWalkerRoot">
+<div></div>
+
+<script>
+const iframe = document.createElement("iframe");
+iframe.src = "support/TreeWalker-acceptNode-filter-cross-realm-subframe.html";
+iframe.onload = () => {
+    for (const testCase of iframe.contentWindow.testCases) {
+        test(t => {
+            assert_equals(testCase.actual.constructor, testCase.expected);
+        }, testCase.description);
+    }
+};
+document.body.append(iframe);
+</script>

--- a/dom/traversal/support/TreeWalker-acceptNode-filter-cross-realm-null-browsing-context-subframe.html
+++ b/dom/traversal/support/TreeWalker-acceptNode-filter-cross-realm-null-browsing-context-subframe.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+
+<script>
+function createNodeIterator() {
+    function filter() {
+        nodeIterator.dummyFilterCalled = true;
+        return true;
+    }
+    const nodeIterator = parent.document.createNodeIterator(parent.document.body, NodeFilter.SHOW_ELEMENT, filter);
+    nodeIterator.dummyFilterCalled = false;
+    return nodeIterator;
+}
+</script>

--- a/dom/traversal/support/TreeWalker-acceptNode-filter-cross-realm-subframe.html
+++ b/dom/traversal/support/TreeWalker-acceptNode-filter-cross-realm-subframe.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+
+<body id="treeWalkerRoot">
+<div></div>
+
+<script>
+window.testCases = [];
+
+(function() {
+    let walker = parent.document.createTreeWalker(parent.treeWalkerRoot, NodeFilter.SHOW_ELEMENT, new parent.Object);
+    try { walker.firstChild(); } catch (err) { testCases.push({ actual: err, expected: parent.TypeError, description: "parent's |this|, parent's method, parent's filter, parent's root" }); }
+
+    walker = parent.document.createTreeWalker(treeWalkerRoot, NodeFilter.SHOW_ELEMENT, new parent.Object);
+    try { walker.firstChild(); } catch (err) { testCases.push({ actual: err, expected: parent.TypeError, description: "parent's |this|, parent's method, parent's filter, iframe's root" }); }
+
+    walker = parent.document.createTreeWalker(treeWalkerRoot, NodeFilter.SHOW_ELEMENT, {});
+    try { walker.firstChild(); } catch (err) { testCases.push({ actual: err, expected: parent.TypeError, description: "parent's |this|, parent's method, iframe's filter, iframe's root" }); }
+
+    walker = document.createTreeWalker.call(parent.document, treeWalkerRoot, NodeFilter.SHOW_ELEMENT, {});
+    try { walker.firstChild(); } catch (err) { testCases.push({ actual: err, expected: TypeError, description: "parent's |this|, iframes's method, iframe's filter, iframe's root" }); }
+})();
+</script>


### PR DESCRIPTION
This upstream reviewed change tests ensure that cross-realm NodeFilter a) uses *current* (at the time of its creation) global object and b) works if it's *incumbent* frame was detached.