### PR TITLE
Fix `position:sticky` tests to not depend on scrollbar size

### DIFF
--- a/css/css-position/resources/sticky-util.js
+++ b/css/css-position/resources/sticky-util.js
@@ -25,7 +25,10 @@ function setupStickyTest(stickyDirection, stickyOffset) {
   elements.scroller.style.position = 'relative';
   elements.scroller.style.width = (inline ? '200px' : '100px');
   elements.scroller.style.height = (inline ? '100px' : '200px');
-  elements.scroller.style.overflow = 'scroll';
+
+  // 'hidden' is used here instead of 'scroll' because this prevents
+  // scrollbars from affecting the size and offset of sticky items.
+  elements.scroller.style.overflow = 'hidden';
 
   elements.contents = document.createElement('div');
   elements.contents.style.height = (inline ? '100%' : '500px');

--- a/css/css-position/sticky/position-sticky-nested-bottom.html
+++ b/css/css-position/sticky/position-sticky-nested-bottom.html
@@ -30,7 +30,7 @@ test(() => {
   const nonStickyTopY = elements.container.offsetTop +
       elements.filler.clientHeight;
   assert_equals(elements.sticky.offsetTop, nonStickyTopY);
-  assert_equals(elements.innerSticky.offsetTop, 35);
+  assert_equals(elements.innerSticky.offsetTop, 50);
 }, 'the inner sticky can stick before the outer one if necessary');
 
 test(() => {
@@ -52,14 +52,14 @@ test(() => {
 }, 'both sticky boxes can be stuck at the same time');
 
 test(() => {
-  const elements = setupNestedStickyTest('bottom', 25, 35);
+  const elements = setupNestedStickyTest('bottom', 25, 75);
   elements.scroller.scrollTop = 0;
   assert_equals(elements.sticky.offsetTop, elements.container.offsetTop);
   assert_equals(elements.innerSticky.offsetTop, 0);
 }, 'neither sticky can escape their containing block');
 
 test(() => {
-  const elements = setupNestedStickyTest('bottom', 25, 500);
+  const elements = setupNestedStickyTest('bottom', 25, 300);
   elements.scroller.scrollTop = 200;
   // It doesn't matter how big the inner sticky offset is, it cannot escape its
   // containing block (the outer sticky).

--- a/css/css-position/sticky/position-sticky-nested-right.html
+++ b/css/css-position/sticky/position-sticky-nested-right.html
@@ -30,7 +30,7 @@ test(() => {
   const nonStickyLeftX = elements.container.offsetLeft +
       elements.filler.clientWidth;
   assert_equals(elements.sticky.offsetLeft, nonStickyLeftX);
-  assert_equals(elements.innerSticky.offsetLeft, 35);
+  assert_equals(elements.innerSticky.offsetLeft, 50);
 }, 'the inner sticky can stick before the outer one if necessary');
 
 test(() => {
@@ -52,7 +52,7 @@ test(() => {
 }, 'both sticky boxes can be stuck at the same time');
 
 test(() => {
-  const elements = setupNestedStickyTest('right', 25, 35);
+  const elements = setupNestedStickyTest('right', 25, 100);
   elements.scroller.scrollLeft = 0;
   assert_equals(elements.sticky.offsetLeft, elements.container.offsetLeft);
   assert_equals(elements.innerSticky.offsetLeft, 0);


### PR DESCRIPTION
Some sticky tests have a dependency on the size of the vertical and
horizontal scrollbars. Some browser engines do not make room for a
scrollbar or have scrollbars of different sizes, so rewrite the tests to
no longer have this dependency. Also, disable scrollbars (using
`overflow: hidden` instead of `overflow:scroll`) in order to avoid
introducing this kind of dependency when writing new tests.

This fixes two tests in some WebKit ports as well as in Gecko.