### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=233153

### DIFF
--- a/css/motion/parsing/offset-path-computed.html
+++ b/css/motion/parsing/offset-path-computed.html
@@ -19,7 +19,7 @@ test_computed_value("offset-path", "ray(0.25turn closest-corner contain)", "ray(
 test_computed_value("offset-path", "ray(200grad farthest-side)", "ray(180deg farthest-side)");
 test_computed_value("offset-path", "ray(270deg farthest-corner contain)");
 test_computed_value("offset-path", "ray(-720deg sides)");
-test_computed_value("offset-path", "ray(calc(180deg - 45deg) farthest-side)", "ray(calc(135deg) farthest-side)");
+test_computed_value("offset-path", "ray(calc(180deg - 45deg) farthest-side)", "ray(135deg farthest-side)");
 
 test_computed_value("offset-path", 'path("m 20 0 h -100")', 'path("M 20 0 H -80")');
 test_computed_value("offset-path", 'path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 300 300 Z")');


### PR DESCRIPTION
WebKit export from bug: [Implement parsing and animation support for ray() shape accepted by offset-path](https://bugs.webkit.org/show_bug.cgi?id=233153).