### PR TITLE
[workers] Fixing test `setting-port-members.html`

### DIFF
--- a/workers/constructors/SharedWorker/setting-port-members.html
+++ b/workers/constructors/SharedWorker/setting-port-members.html
@@ -28,8 +28,9 @@ test(() => {
   worker.port.onmessage = ';';
   assert_equals(worker.port.onmessage, null, '";"');
   worker.port.onmessage = f;
-  worker.port.onmessage = {handleEvent:() => {}};
-  assert_equals(worker.port.onmessage, null, '{handleEvent:() => {}}');
+  const handler = {handleEvent:() => {}};
+  worker.port.onmessage = handler;
+  assert_equals(worker.port.onmessage, handler, '{handleEvent:() => {}}');
   worker.port.onmessage = f;
   worker.port.onmessage = null;
   assert_equals(worker.port.onmessage, null, 'null');


### PR DESCRIPTION
This fixes https://github.com/web-platform-tests/wpt/issues/31125.
According to the [specification](https://webidl.spec.whatwg.org/#LegacyTreatNonObjectAsNull), callback functions can be objects if they are annotated with the [LegacyTreatNonObjectAsNull] extended attribute.

Hence, the value of `worker.port.onmessage` should be the object itself instead of `null`.