### PR TITLE
Automatically detect Chrome browser binary if it exists

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -633,16 +633,7 @@ class Chrome(Browser):
 
     def find_binary(self, venv_path=None, channel=None):
         if channel == "nightly":
-            # If nightly channel is specified, only the virtual env path will be checked for a browser binary.
-            nightly_binary = self.find_nightly_binary(self._get_dest(venv_path, channel))
-            if nightly_binary:
-                return nightly_binary
-            else:
-                raise FileNotFoundError(
-                    "Unable to locate browser binary in virtual environment. "
-                    "Use command \"wpt install chrome browser\" to install the latest browser binary "
-                    "or use --binary to set the binary path."
-                )
+            return self.find_nightly_binary(self._get_dest(venv_path, channel))
 
         if uname[0] == "Linux":
             name = "google-chrome"

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -633,7 +633,9 @@ class Chrome(Browser):
 
     def find_binary(self, venv_path=None, channel=None):
         if channel == "nightly":
-            return self.find_nightly_binary(self._get_dest(venv_path, channel))
+            nightly_binary = self.find_nightly_binary(self._get_dest(venv_path, channel))
+            if nightly_binary is not None:
+                return nightly_binary
 
         if uname[0] == "Linux":
             name = "google-chrome"

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -633,9 +633,16 @@ class Chrome(Browser):
 
     def find_binary(self, venv_path=None, channel=None):
         if channel == "nightly":
+            # If nightly channel is specified, only the virtual env path will be checked for a browser binary.
             nightly_binary = self.find_nightly_binary(self._get_dest(venv_path, channel))
-            if nightly_binary is not None:
+            if nightly_binary:
                 return nightly_binary
+            else:
+                raise FileNotFoundError(
+                    "Unable to locate browser binary in virtual environment. "
+                    "Use command \"wpt install chrome browser\" to install the latest browser binary "
+                    "or use --binary to set the binary path."
+                )
 
         if uname[0] == "Linux":
             name = "google-chrome"

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -325,7 +325,7 @@ class Chrome(BrowserSetup):
     def setup_kwargs(self, kwargs):
         browser_channel = kwargs["browser_channel"]
         if kwargs["binary"] is None:
-            binary = self.browser.find_binary(channel=browser_channel)
+            binary = self.browser.find_binary(venv_path=self.venv.path, channel=browser_channel)
             if binary:
                 kwargs["binary"] = binary
             else:


### PR DESCRIPTION
The current implementation of the Chrome class does not check the specified virtualenv path for an existing Chrome browser binary. Passing in the `venv_path` when trying to find the binary will ensure the binary is found properly if it exists.

~~Also, currently a generic error "Unable to locate Chrome binary" will be thrown when running tests against Chrome via `wpt run chrome` command with no browser binary in the virtualenv directory. Because a browser binary must exist in the virtualenv directory and not just the local machine, a more verbose error message has been added to explain how to fix the issue.~~
**EDIT:** This part is more of a separate issue, and can be fixed at a later time.