### PR TITLE
Streams: fix tests for abort reason

### DIFF
--- a/dom/abort/event.any.js
+++ b/dom/abort/event.any.js
@@ -111,6 +111,19 @@ test(t => {
 }, "AbortController abort(undefined) creates an \"AbortError\" DOMException");
 
 test(t => {
+  const controller = new AbortController();
+  const signal = controller.signal;
+
+  assert_true("reason" in signal, "signal has reason property");
+  assert_equals(signal.reason, undefined, "signal.reason is initially undefined");
+
+  controller.abort(null);
+
+  assert_true(signal.aborted, "signal.aborted");
+  assert_equals(signal.reason, null, "signal.reason");
+}, "AbortController abort(null) should set signal.reason");
+
+test(t => {
   const signal = AbortSignal.abort();
 
   assert_true(signal.aborted, "signal.aborted");

--- a/streams/piping/abort.any.js
+++ b/streams/piping/abort.any.js
@@ -61,8 +61,8 @@ for (const reason of [null, undefined, error1]) {
     const signal = abortController.signal;
     abortController.abort(reason);
     const pipeToPromise = rs.pipeTo(ws, { signal });
-    if (reason === error1) {
-      await promise_rejects_exactly(t, error1, pipeToPromise, 'pipeTo rejects with abort reason');
+    if (reason !== undefined) {
+      await promise_rejects_exactly(t, reason, pipeToPromise, 'pipeTo rejects with abort reason');
     } else {
       await promise_rejects_dom(t, 'AbortError', pipeToPromise, 'pipeTo rejects with AbortError');
     }
@@ -131,8 +131,8 @@ for (const reason of [null, undefined, error1]) {
       }
     });
     const pipeToPromise = rs.pipeTo(ws, { signal });
-    if (reason === error1) {
-      await promise_rejects_exactly(t, error1, pipeToPromise, 'pipeTo rejects with abort reason');
+    if (reason !== undefined) {
+      await promise_rejects_exactly(t, reason, pipeToPromise, 'pipeTo rejects with abort reason');
     } else {
       await promise_rejects_dom(t, 'AbortError', pipeToPromise, 'pipeTo rejects with AbortError');
     }
@@ -170,8 +170,8 @@ for (const reason of [null, undefined, error1]) {
     await abortController.abort(reason);
     await readController.close(); // Make sure the test terminates when signal is not implemented.
     await resolveWrite();
-    if (reason === error1) {
-      await promise_rejects_exactly(t, error1, pipeToPromise, 'pipeTo rejects with abort reason');
+    if (reason !== undefined) {
+      await promise_rejects_exactly(t, reason, pipeToPromise, 'pipeTo rejects with abort reason');
     } else {
       await promise_rejects_dom(t, 'AbortError', pipeToPromise, 'pipeTo rejects with AbortError');
     }


### PR DESCRIPTION
The tests assume that `controller.abort(null)` behaves like `controller.abort(undefined)` and that `signal.reason` should become an `AbortError`. However, that's not what the spec text says: `signal.reason` should become `null` instead.

See whatwg/streams#1189 for context.