### PR TITLE
Streams: tests for WritableStreamDefaultController.releaseBackpressure()

### DIFF
--- a/streams/piping/transform-streams.any.js
+++ b/streams/piping/transform-streams.any.js
@@ -1,7 +1,7 @@
 // META: global=window,worker,jsshell
 'use strict';
 
-promise_test(() => {
+promise_test(async () => {
   const rs = new ReadableStream({
     start(c) {
       c.enqueue('a');
@@ -15,8 +15,8 @@ promise_test(() => {
 
   const ws = new WritableStream();
 
-  return rs.pipeThrough(ts).pipeTo(ws).then(() => {
-    const writer = ws.getWriter();
-    return writer.closed;
-  });
+  await rs.pipeThrough(ts).pipeTo(ws);
+
+  const writer = ws.getWriter();
+  await writer.closed;
 }, 'Piping through an identity transform stream should close the destination when the source closes');

--- a/streams/piping/transform-streams.any.js
+++ b/streams/piping/transform-streams.any.js
@@ -1,4 +1,5 @@
 // META: global=window,worker,jsshell
+// META: script=../resources/recording-streams.js
 'use strict';
 
 promise_test(async () => {
@@ -13,10 +14,32 @@ promise_test(async () => {
 
   const ts = new TransformStream();
 
-  const ws = new WritableStream();
+  const ws = recordingWritableStream();
 
   await rs.pipeThrough(ts).pipeTo(ws);
+  assert_array_equals(ws.events, ['write', 'a', 'write', 'b', 'write', 'c', 'close']);
 
   const writer = ws.getWriter();
   await writer.closed;
 }, 'Piping through an identity transform stream should close the destination when the source closes');
+
+promise_test(async () => {
+  const rs = new ReadableStream({
+    start(c) {
+      c.enqueue('a');
+      c.enqueue('b');
+      c.enqueue('c');
+      c.close();
+    }
+  });
+
+  const ts = new TransformStream({}, { highWaterMark: 0 });
+
+  const ws = recordingWritableStream();
+
+  await rs.pipeThrough(ts).pipeTo(ws);
+  assert_array_equals(ws.events, ['write', 'a', 'write', 'b', 'write', 'c', 'close']);
+
+  const writer = ws.getWriter();
+  await writer.closed;
+}, 'Piping through an identity transform stream with writable HWM = 0 should work');

--- a/streams/writable-streams/backpressure.any.js
+++ b/streams/writable-streams/backpressure.any.js
@@ -1,0 +1,39 @@
+// META: global=window,worker,jsshell
+// META: script=../resources/test-utils.js
+'use strict';
+
+promise_test(async () => {
+  let controller;
+  const ws = new WritableStream({
+    start(c) {
+      controller = c;
+    }
+  }, { highWaterMark: 0 });
+  const writer = ws.getWriter();
+  assert_equals(writer.desiredSize, 0, 'desiredSize should be 0');
+
+  let ready1Resolved = false;
+  const ready1 = writer.ready;
+  ready1.then(() => { ready1Resolved = true });
+  await flushAsyncEvents();
+  assert_false(ready1Resolved, 'writer.ready should be pending');
+
+  controller.releaseBackpressure();
+  await ready1;
+  assert_true(ready1Resolved, 'writer.ready should be resolved after releaseBackpressure()');
+  assert_equals(writer.desiredSize, 0, 'desiredSize should be 0');
+
+  writer.write('a');
+  let ready2Resolved = false;
+  const ready2 = writer.ready;
+  ready2.then(() => { ready2Resolved = true });
+  assert_not_equals(ready1, ready2, 'writer.ready should be a new promise after write()');
+  await flushAsyncEvents();
+  assert_false(ready2Resolved, 'writer.ready should be pending');
+  assert_equals(writer.desiredSize, 0, 'desiredSize should be 0');
+
+  controller.releaseBackpressure();
+  await ready2;
+  assert_true(ready2Resolved, 'writer.ready should be resolved after releaseBackpressure()');
+  assert_equals(writer.desiredSize, 0, 'desiredSize should be 0');
+}, 'releaseBackpressure() resolves ready promise on a stream with HWM 0');

--- a/streams/writable-streams/backpressure.any.js
+++ b/streams/writable-streams/backpressure.any.js
@@ -58,9 +58,14 @@ promise_test(async () => {
   resolveWrite();
   await flushAsyncEvents();
   assert_equals(writer.desiredSize, -1, 'desiredSize should be -1');
-  assert_false(ready1Resolved, 'writer.ready should still be pending');
+  assert_false(ready1Resolved, 'writer.ready should be pending');
 
   resolveWrite();
+  await flushAsyncEvents();
+  assert_equals(writer.desiredSize, 0, 'desiredSize should be 0');
+  assert_false(ready1Resolved, 'writer.ready should be pending');
+
+  ws.controller.releaseBackpressure();
   await ready1;
   assert_equals(writer.desiredSize, 0, 'desiredSize should be 0');
   assert_true(ready1Resolved, 'writer.ready should be resolved');

--- a/streams/writable-streams/backpressure.any.js
+++ b/streams/writable-streams/backpressure.any.js
@@ -1,14 +1,10 @@
 // META: global=window,worker,jsshell
 // META: script=../resources/test-utils.js
+// META: script=../resources/recording-streams.js
 'use strict';
 
 promise_test(async () => {
-  let controller;
-  const ws = new WritableStream({
-    start(c) {
-      controller = c;
-    }
-  }, { highWaterMark: 0 });
+  const ws = recordingWritableStream({}, { highWaterMark: 0 });
   const writer = ws.getWriter();
   assert_equals(writer.desiredSize, 0, 'desiredSize should be 0');
 
@@ -18,7 +14,7 @@ promise_test(async () => {
   await flushAsyncEvents();
   assert_false(ready1Resolved, 'writer.ready should be pending');
 
-  controller.releaseBackpressure();
+  ws.controller.releaseBackpressure();
   await ready1;
   assert_true(ready1Resolved, 'writer.ready should be resolved after releaseBackpressure()');
   assert_equals(writer.desiredSize, 0, 'desiredSize should be 0');
@@ -32,7 +28,7 @@ promise_test(async () => {
   assert_false(ready2Resolved, 'writer.ready should be pending');
   assert_equals(writer.desiredSize, 0, 'desiredSize should be 0');
 
-  controller.releaseBackpressure();
+  ws.controller.releaseBackpressure();
   await ready2;
   assert_true(ready2Resolved, 'writer.ready should be resolved after releaseBackpressure()');
   assert_equals(writer.desiredSize, 0, 'desiredSize should be 0');


### PR DESCRIPTION
See https://github.com/whatwg/streams/pull/1190 for the accompanying spec change.