### PR TITLE
Use proper cleanup in dialog-focusing-steps-inert.html

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/dialog-focusing-steps-inert.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-focusing-steps-inert.html
@@ -11,7 +11,7 @@
   <input autofocus>
 </dialog>
 <script>
-function test_focusing_steps_with_inert_dialog(isModal) {
+function test_focusing_steps_with_inert_dialog(test, isModal) {
   const outerInput = document.querySelector("#outer-input");
   outerInput.focus();
   assert_equals(document.activeElement, outerInput,
@@ -21,28 +21,27 @@ function test_focusing_steps_with_inert_dialog(isModal) {
   assert_false(dialog.open, "Dialog should initially be closed");
 
   dialog.inert = true;
+  test.add_cleanup(() => { dialog.inert = false; });
 
   if (isModal) {
     dialog.showModal();
+    test.add_cleanup(() => { dialog.close(); });
     assert_equals(document.activeElement, document.body,
       "dialog.showModal(): focusing steps should apply focus fixup rule when dialog is inert");
   } else {
     dialog.show();
+    test.add_cleanup(() => { dialog.close(); });
     assert_equals(document.activeElement, outerInput,
       "dialog.show(): focusing steps should not change focus when dialog is inert");
   }
-
-  // Clean up
-  dialog.close();
-  dialog.inert = false;
 }
 
-test(() => {
-  test_focusing_steps_with_inert_dialog(false);
+test(function() {
+  test_focusing_steps_with_inert_dialog(this, false);
 }, "dialog.show(): focusing steps should not change focus when dialog is inert");
 
-test(() => {
-  test_focusing_steps_with_inert_dialog(true);
+test(function() {
+  test_focusing_steps_with_inert_dialog(this, true);
 }, "dialog.showModal(): focusing steps should apply focus fixup rule when dialog is inert");
 </script>
 </body>


### PR DESCRIPTION
The test was just cleaning up at the end of the test(), but the code was
not reached if some assert failed, making the following test() fail too.
The proper way to clean up is with add_cleanup().
This change makes the 2nd test pass in Firefox and Chromium.