### PR TITLE
Test Web Neural Network API by WebNN-polyfill

### DIFF
--- a/webnn/README.md
+++ b/webnn/README.md
@@ -1,0 +1,1 @@
+Currently, we could test Web Neural Network API by [WebNN-polyfill](https://github.com/webmachinelearning/webnn-polyfill) which is a JavaScript implementation of the Web Neural Network API.

--- a/webnn/idlharness.https.any.js
+++ b/webnn/idlharness.https.any.js
@@ -1,6 +1,7 @@
 // META: global=window,dedicatedworker
 // META: script=/resources/WebIDLParser.js
 // META: script=/resources/idlharness.js
+// META: script=https://webmachinelearning.github.io/webnn-polyfill/dist/webnn-polyfill.js
 // META: timeout=long
 
 // https://webmachinelearning.github.io/webnn/


### PR DESCRIPTION
According to [the previous comment](https://github.com/web-platform-tests/wpt/pull/31201#discussion_r752915202) by @dontcallmedom on https://github.com/web-platform-tests/wpt/pull/31201, 

 > We could also have a separate open PR with just the polyfill added which would allow us to use WPT.fyi to collect results once the polyfill is added.

I added this pr of testing Web Neural Network API by WebNN-polyfill.

@dontcallmedom @Honry PTAL, thanks.