### PR TITLE
Make img-aspect-ratio-lazy.tentative.html non-tentative

### DIFF
--- a/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-aspect-ratio-lazy.html
+++ b/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-aspect-ratio-lazy.html
@@ -22,9 +22,14 @@ function assert_ratio(img, expected) {
 
 t.step(function() {
   let img = document.querySelector("img");
+  // The initial aspect ratio is given by the width/height attributes:
+  // https://html.spec.whatwg.org/#map-to-the-aspect-ratio-property-(using-dimension-rules)
   assert_ratio(img, 1.0);
   img.addEventListener("load", t.step_func_done(function() {
-    assert_ratio(img, 2.0); // 2.0 is the original aspect ratio of green.png
+    // Now the element "represents an image":
+    // https://html.spec.whatwg.org/multipage/rendering.html#images-3
+    // 2.0 is the original aspect ratio of green.png
+    assert_ratio(img, 2.0);
   }));
   window.scrollTo(0, img.getBoundingClientRect().top);
 });


### PR DESCRIPTION
Both the initial and final aspect ratio seem to be explained by the HTML spec.