### PR TITLE
Ensure test names are constant for input-valueasdate.html

### DIFF
--- a/html/semantics/forms/the-input-element/input-valueasdate.html
+++ b/html/semantics/forms/the-input-element/input-valueasdate.html
@@ -40,18 +40,17 @@
              assert_equals(actualValueAsDate, expectedValueAsDate);
            }
          },
-         `valueAsDate getter on type ${type} (actual value: ${actualValue}, ` +
-         `expected valueAsDate: ${expectedValueAsDate})`
+         `valueAsDate getter on type ${type} (with value: ${JSON.stringify(actualValue)})`
        );
      }
    }
 
    function testValueAsDateSetter(type, element, cases) {
-     for (const [valueAsDate, expectedValue] of cases) {
+     for (const [valueDateStr, expectedValue] of cases) {
        test(() => {
-         element.valueAsDate = valueAsDate;
+         element.valueAsDate = new Date(valueDateStr);
          assert_equals(element.value, expectedValue);
-       }, `valueAsDate setter on type ${type} (actual valueAsDate: ${valueAsDate}, expected value: ${expectedValue})`);
+       }, `valueAsDate setter on type ${type} (new Date(${JSON.stringify(valueDateStr)}))`);
      }
    }
 
@@ -67,8 +66,8 @@
      ["2016-02-29", new Date("2016-02-29T00:00:00.000Z")] // Leap year
    ]);
    testValueAsDateSetter("date", dateInput, [
-     [new Date("2019-12-10T00:00:00.000Z"), "2019-12-10"],
-     [new Date("2016-02-29T00:00:00.000Z"), "2016-02-29"] // Leap year
+     ["2019-12-10T00:00:00.000Z", "2019-12-10"],
+     ["2016-02-29T00:00:00.000Z", "2016-02-29"] // Leap year
    ]);
 
    const monthInput = document.getElementById("input_month");
@@ -78,7 +77,7 @@
      ["2019-00", null],
      ["2019-12", new Date("2019-12-01T00:00:00.000Z")]
    ]);
-   testValueAsDateSetter("month", monthInput, [[new Date("2019-12-01T00:00:00.000Z"), "2019-12"]]);
+   testValueAsDateSetter("month", monthInput, [["2019-12-01T00:00:00.000Z", "2019-12"]]);
 
    const weekInput = document.getElementById("input_week");
    testValueAsDateGetter("week", weekInput, [
@@ -88,7 +87,7 @@
      ["2019-W60", null],
      ["2019-W50", new Date("2019-12-09T00:00:00.000Z")]
    ]);
-   testValueAsDateSetter("week", weekInput, [[new Date("2019-12-09T00:00:00.000Z"), "2019-W50"]]);
+   testValueAsDateSetter("week", weekInput, [["2019-12-09T00:00:00.000Z", "2019-W50"]]);
 
    const timeInput = document.getElementById("input_time");
    testValueAsDateGetter("time", timeInput, [
@@ -100,9 +99,9 @@
      ["23:59", new Date("1970-01-01T23:59:00.000Z")]
    ]);
    testValueAsDateSetter("time", timeInput, [
-     [new Date("1970-01-01T00:00:00.000Z"), "00:00"],
-     [new Date("1970-01-01T12:00:00.000Z"), "12:00"],
-     [new Date("1970-01-01T23:59:00.000Z"), "23:59"]
+     ["1970-01-01T00:00:00.000Z", "00:00"],
+     ["1970-01-01T12:00:00.000Z", "12:00"],
+     ["1970-01-01T23:59:00.000Z", "23:59"]
    ]);
   </script>
  </body>


### PR DESCRIPTION
By putting actual/expected data in the test name, we don't get constant subtest names that can be used to compare cross-browser.