### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=233725

### DIFF
--- a/html/semantics/forms/form-submission-0/constructing-form-data-set.html
+++ b/html/semantics/forms/form-submission-0/constructing-form-data-set.html
@@ -77,6 +77,26 @@ test(() => {
   assert_true(didCallHandler);
 }, '"formdata" event bubbles in an orphan tree.');
 
+for (const enctype of ["application/x-www-form-urlencoded", "multipart/form-data", "text/plain"]) {
+  test((t) => {
+    let form = populateForm('<input name=file type=file><input name=empty type=file>');
+    form.enctype = enctype;
+
+    const file = new File([], "filename");
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(file);
+    form.querySelector('input[name=file]').files = dataTransfer.files;
+
+    form.addEventListener('formdata', t.step_func(e => {
+      assert_true(e.formData.has('file'));
+      assert_equals(e.formData.get('file'), file);
+      assert_true(e.formData.has('empty'));
+      assert_true(e.formData.get('empty') instanceof File);
+    }));
+    form.submit();
+  }, `Files in a ${enctype} form show up as File objects in the "formData" IDL attribute`);
+}
+
 test(() => {
   let listener1ok = false;
   let listeern2ok = false;


### PR DESCRIPTION
WebKit export from bug: [File inputs in non-multipart form submissions show up as string values in the formdata event](https://bugs.webkit.org/show_bug.cgi?id=233725)﻿
