### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=233647

### DIFF
--- a/html/semantics/scripting-1/the-template-element/innerhtml-on-templates/innerhtml.html
+++ b/html/semantics/scripting-1/the-template-element/innerhtml-on-templates/innerhtml.html
@@ -35,6 +35,25 @@ test(function () {
 }, 'innerHTML of template element replaces all referenced by the content attribute');
 
 
+test(function () {
+    var doc = newHTMLDocument();
+    var template = doc.createElement('template');
+
+    var div1 = doc.createElement('div');
+    div1.setAttribute('id', 'div1');
+    template.content.appendChild(div1);
+
+    assert_not_equals(template.content.querySelector('#div1'), null,
+            'Element should present in template content');
+
+    template.innerHTML = '';
+
+    assert_false(template.content.hasChildNodes(),
+            'Template content should be removed by innerHTML');
+
+}, 'innerHTML of template element replaces all referenced by the content attribute. '
+    + 'Test empty HTML string');
+
 
 test(function () {
     var doc = newHTMLDocument();


### PR DESCRIPTION
I was adding a fast path for `el.innerHTML = ""` and initially missed a case of `el` being a `<template>`. This upstream reviewed change adds coverage for empty string clearing `<template>` contents rather than its children.