### PR TITLE
Remove 'font-size: 0' from some css-flexbox scrollbars reference cases.

### DIFF
--- a/css/css-flexbox/scrollbars-auto-ref.html
+++ b/css/css-flexbox/scrollbars-auto-ref.html
@@ -41,7 +41,6 @@
   max-width: 100px;
   max-height: 100px;
   white-space: nowrap;
-  font-size: 0;
 }
 .row > div, .row-reverse > div {
   display: inline-flex;

--- a/css/css-flexbox/scrollbars-ref.html
+++ b/css/css-flexbox/scrollbars-ref.html
@@ -41,7 +41,6 @@
   max-width: 100px;
   max-height: 100px;
   white-space: nowrap;
-  font-size: 0;
 }
 .row > div, .row-reverse > div {
   display: inline-flex;


### PR DESCRIPTION
The zero font-size is essentially non-functional, but it causes a slight
rendering difference in Firefox's scrollbar-thumb-sizing (and results in a test
failure), for what turns out to be good reasons:

Essentially, the scrollbar thumb is a reflection of the pagedown-distance; and
in Firefox, we use a slightly-larger pagedown-distance if the scrollport has a
sufficiently-small font size, because we only aim to have a few lines of
overlap between the old and new scrollport during a pagedown operation.  And "a
few lines of overlap" is based on the scrollport's font-size.  So the
pagedown-distance is dependent on the font-size, and therefore so is the
scrollbar thumb size.

(See https://bugzilla.mozilla.org/show_bug.cgi?id=1743924#c9 for more.)