### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=233833

### DIFF
--- a/dom/events/event-global-is-still-set-when-coercing-beforeunload-result.html
+++ b/dom/events/event-global-is-still-set-when-coercing-beforeunload-result.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>window.event is still set when 'beforeunload' result is coerced to string</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#ref-for-window-current-event%E2%91%A1">
+<link rel="help" href="https://webidl.spec.whatwg.org/#call-a-user-objects-operation">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<iframe id="iframe" src="resources/event-global-is-still-set-when-coercing-beforeunload-result-frame.html"></iframe>
+<body>
+<script>
+window.onload = () => {
+  async_test(t => {
+    iframe.onload = t.step_func_done(() => {
+      assert_equals(typeof window.currentEventInToString, "object");
+      assert_equals(window.currentEventInToString.type, "beforeunload");
+    });
+
+    iframe.contentWindow.location.href = "about:blank";
+  });
+};
+</script>

--- a/dom/events/event-global-set-before-handleEvent-lookup.any.js
+++ b/dom/events/event-global-set-before-handleEvent-lookup.any.js
@@ -1,0 +1,19 @@
+// https://dom.spec.whatwg.org/#concept-event-listener-inner-invoke (steps 8.2 - 12)
+// https://webidl.spec.whatwg.org/#call-a-user-objects-operation (step 10.1)
+
+test(() => {
+  const eventTarget = new EventTarget;
+
+  let currentEvent;
+  eventTarget.addEventListener("foo", {
+    get handleEvent() {
+      currentEvent = self.event;
+      return () => {};
+    }
+  });
+
+  const event = new Event("foo");
+  eventTarget.dispatchEvent(event);
+
+  assert_equals(currentEvent, event);
+}, "self.event is set before 'handleEvent' lookup");

--- a/dom/events/resources/event-global-is-still-set-when-coercing-beforeunload-result-frame.html
+++ b/dom/events/resources/event-global-is-still-set-when-coercing-beforeunload-result-frame.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta charset="utf-8">
+<body>
+<script>
+window.onbeforeunload = () => ({ toString: () => { parent.currentEventInToString = window.event; } });
+</script>


### PR DESCRIPTION
This upstream reviewed change ensures that `window.event` is set before `"handleEvent"` lookup and restored only after `beforeunload` result is coerced to a string.