### PR TITLE
Make scrollbars-auto-ref.html more precise about which elements/axes need to be scrolled to nondefault positions.

### DIFF
--- a/css/css-flexbox/scrollbars-auto-ref.html
+++ b/css/css-flexbox/scrollbars-auto-ref.html
@@ -114,25 +114,56 @@ flexDirections.forEach((flexDirection) => {
   document.body.appendChild(containerRow);
 });
 
-// Scroll all flex containers to the emulated beginning of flow.
-var nodes = document.querySelectorAll(".ltr > .row-reverse");
+// Scroll all {row,column}-reverse flex containers to the emulated beginning
+// of flow.
+// * "row-reverse" changes the initial scroll position of a flex container to
+// correspond to its *inline-end* edge. So in our emulation, we need to
+// scroll to the extreme inline-end position. For 'direction:ltr', this is a
+// positive scroll offset; for 'direction:rtl', it's a zero or negative offset.
+var nodes = document.querySelectorAll(".ltr.horizontal > .row-reverse");
 for (var i = 0; i < nodes.length; i++) {
   nodes[i].scrollLeft = 10000;
+}
+nodes = document.querySelectorAll(".ltr.flipped-blocks > .row-reverse");
+for (var i = 0; i < nodes.length; i++) {
   nodes[i].scrollTop = 10000;
 }
-nodes = document.querySelectorAll(".rtl > .row-reverse");
+nodes = document.querySelectorAll(".ltr.flipped-lines > .row-reverse");
+for (var i = 0; i < nodes.length; i++) {
+  nodes[i].scrollTop = 10000;
+}
+var nodes = document.querySelectorAll(".rtl.horizontal > .row-reverse");
 for (var i = 0; i < nodes.length; i++) {
   nodes[i].scrollLeft = -10000;
+}
+nodes = document.querySelectorAll(".rtl.flipped-blocks > .row-reverse");
+for (var i = 0; i < nodes.length; i++) {
   nodes[i].scrollTop = -10000;
 }
-nodes = document.querySelectorAll(".column-reverse");
+nodes = document.querySelectorAll(".rtl.flipped-lines > .row-reverse");
 for (var i = 0; i < nodes.length; i++) {
-  nodes[i].scrollLeft = 10000;
+  nodes[i].scrollTop = -10000;
+}
+// * "column-reverse" changes the initial scroll position of a flex container
+// to correspond to its *block-end* edge. So in our emulation, we need to
+// scroll to the extreme block-end position. For horizontal-tb and
+// vertical-lr, this is a positive scroll offset (since "tb" and "lr" indicate
+// progression in a positive direction along the underlying physical axis).
+// For vertical-rl, this is a zero or negative scroll offset (since "rl"
+// indicates progression in a negative direction (right-to-left) along the
+// underlying physical axis). Note that the 'direction:rtl/ltr' doesn't need to
+// be considered at all in this section, since that only impacts the inline
+// axis, which isn't the axis that we're emulating a reversal for here.
+nodes = document.querySelectorAll(".horizontal > .column-reverse");
+for (var i = 0; i < nodes.length; i++) {
   nodes[i].scrollTop = 10000;
 }
 nodes = document.querySelectorAll(".flipped-blocks > .column-reverse");
 for (var i = 0; i < nodes.length; i++) {
   nodes[i].scrollLeft = -10000;
-  nodes[i].scrollTop = 0;
+}
+nodes = document.querySelectorAll(".flipped-lines > .column-reverse");
+for (var i = 0; i < nodes.length; i++) {
+  nodes[i].scrollLeft = 10000;
 }
 </script>


### PR DESCRIPTION
Make scrollbars-auto-ref.html more precise about which elements/axes need to be scrolled to nondefault positions.

Before this commit, scrollbars-auto-ref.html scrolled the "column-reverse" and
the "row-reverse" mockups to extreme positions **in both axes**, like this for
example:
   nodes[i].scrollLeft = 10000;
   nodes[i].scrollTop = 10000;

But in fact, only one of those two statements is needed for each node, because
only one axis is actually reversed.  I think the test is implicitly assuming
that the other axis will simply have zero leeway to scroll (which is mostly but
not entirely true, see below...), and hence the unnecessary statement is just
non-functional and harmless.

This assumption doesn't hold up in Firefox; there are parts of this testcase
where we've got some room to scroll in *both* axes (which the test does not
expect), due to our choices around some undefined-in-CSS behavior regarding
intrinsic sizing of overflow:auto elements[1].

This commit addresses this problem by removing the unnecessary statements, and
making the reference case strictly scroll in the axis that it needs to. See
code comments in the patch for more detail.

[1] see e.g. https://bugzilla.mozilla.org/show_bug.cgi?id=764076#c7