### PR TITLE
Fix typo in navigatesuccess tests

### DIFF
--- a/app-history/navigate-event/navigatesuccess-cross-document.html
+++ b/app-history/navigate-event/navigatesuccess-cross-document.html
@@ -10,5 +10,5 @@ async_test(t => {
     i.contentWindow.location.search = "?1";
     i.onload = t.step_func_done(() => assert_equals(i.contentWindow.location.search, "?1"));
   });
-}, "navigatesucess does not fire for a cross-document navigation");
+}, "navigatesuccess does not fire for a cross-document navigation");
 </script>

--- a/app-history/navigate-event/navigatesuccess-same-document.html
+++ b/app-history/navigate-event/navigatesuccess-same-document.html
@@ -6,5 +6,5 @@
 async_test(t => {
   appHistory.onnavigatesuccess = t.step_func_done(() => assert_equals(location.hash, "#1"));
   a.click();
-}, "navigatesucess fires for a same-document navigation");
+}, "navigatesuccess fires for a same-document navigation");
 </script>

--- a/app-history/navigate-event/resources/navigatesuccess-cross-document-helper.html
+++ b/app-history/navigate-event/resources/navigatesuccess-cross-document-helper.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <head>
 <script>
-appHistory.onnavigatesuccess = () => top.postMessage("navigatesucess received");
+appHistory.onnavigatesuccess = () => top.postMessage("navigatesuccess received");
 </script>
 </head>


### PR DESCRIPTION
`navigatesucess` -> `navigatesuccess`