### PR TITLE
Update basic color parsing and serialization tests to cover the CSS Color 4 color grammar

### DIFF
--- a/css/css-color/parsing/color-computed.html
+++ b/css/css-color/parsing/color-computed.html
@@ -34,6 +34,91 @@ test_computed_value("color", "rgb(-2, 3, 4)", "rgb(0, 3, 4)");
 test_computed_value("color", "rgb(100, 200, 300)", "rgb(100, 200, 255)");
 test_computed_value("color", "rgb(20, 10, 0, -10)", "rgba(20, 10, 0, 0)");
 test_computed_value("color", "rgb(100%, 200%, 300%)", "rgb(255, 255, 255)");
+
+for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb" ]) {
+    test_computed_value("color", `color(${colorSpace} 0% 0% 0%)`, `color(${colorSpace} 0 0 0)`);
+    test_computed_value("color", `color(${colorSpace} 10% 10% 10%)`, `color(${colorSpace} 0.1 0.1 0.1)`);
+    test_computed_value("color", `color(${colorSpace} .2 .2 25%)`, `color(${colorSpace} 0.2 0.2 0.25)`);
+    test_computed_value("color", `color(${colorSpace} 0 0 0 / 1)`, `color(${colorSpace} 0 0 0)`);
+    test_computed_value("color", `color(${colorSpace} 0% 0 0 / 0.5)`, `color(${colorSpace} 0 0 0 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} 20% 0 10/0.5)`, `color(${colorSpace} 0.2 0 1 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} 20% 0 10/50%)`, `color(${colorSpace} 0.2 0 1 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} 400% 0 10/50%)`, `color(${colorSpace} 1 0 1 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} 50% -160 160)`, `color(${colorSpace} 0.5 0 1)`);
+    test_computed_value("color", `color(${colorSpace} 50% -200 200)`, `color(${colorSpace} 0.5 0 1)`);
+    test_computed_value("color", `color(${colorSpace} 0 0 0 / -10%)`, `color(${colorSpace} 0 0 0 / 0)`);
+    test_computed_value("color", `color(${colorSpace} 0 0 0 / 110%)`, `color(${colorSpace} 0 0 0)`);
+    test_computed_value("color", `color(${colorSpace} 0 0 0 / 300%)`, `color(${colorSpace} 0 0 0)`);
+    test_computed_value("color", `color(${colorSpace} 50% -200)`, `color(${colorSpace} 0.5 0 0)`);
+    test_computed_value("color", `color(${colorSpace} 50%)`, `color(${colorSpace} 0.5 0 0)`);
+    test_computed_value("color", `color(${colorSpace})`, `color(${colorSpace} 0 0 0)`);
+    test_computed_value("color", `color(${colorSpace} 50% -200 / 0.5)`, `color(${colorSpace} 0.5 0 0 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} 50% / 0.5)`, `color(${colorSpace} 0.5 0 0 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} / 0.5)`, `color(${colorSpace} 0 0 0 / 0.5)`);
+}
+
+for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
+    const resultColorSpace = colorSpace == "xyz" ? "xyz-d65" : colorSpace;
+
+    test_computed_value("color", `color(${colorSpace} 0 0 0)`, `color(${resultColorSpace} 0 0 0)`);
+    test_computed_value("color", `color(${colorSpace} 0 0 0 / 1)`, `color(${resultColorSpace} 0 0 0)`);
+    test_computed_value("color", `color(${colorSpace} 1 1 1)`, `color(${resultColorSpace} 1 1 1)`);
+    test_computed_value("color", `color(${colorSpace} 1 1 1 / 1)`, `color(${resultColorSpace} 1 1 1)`);
+    test_computed_value("color", `color(${colorSpace} -1 -1 -1)`, `color(${resultColorSpace} -1 -1 -1)`);
+    test_computed_value("color", `color(${colorSpace} 0.1 0.1 0.1)`, `color(${resultColorSpace} 0.1 0.1 0.1)`);
+    test_computed_value("color", `color(${colorSpace} 10 10 10)`, `color(${resultColorSpace} 10 10 10)`);
+    test_computed_value("color", `color(${colorSpace} .2 .2 .25)`, `color(${resultColorSpace} 0.2 0.2 0.25)`);
+    test_computed_value("color", `color(${colorSpace} 0 0 0 / 0.5)`, `color(${resultColorSpace} 0 0 0 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} .20 0 10/0.5)`, `color(${resultColorSpace} 0.2 0 10 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} .20 0 10/50%)`, `color(${resultColorSpace} 0.2 0 10 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} 0 0 0 / -10%)`, `color(${resultColorSpace} 0 0 0 / 0)`);
+    test_computed_value("color", `color(${colorSpace} 0 0 0 / 110%)`, `color(${resultColorSpace} 0 0 0)`);
+    test_computed_value("color", `color(${colorSpace} 0 0 0 / 300%)`, `color(${resultColorSpace} 0 0 0)`);
+    test_computed_value("color", `color(${colorSpace} 1 1)`, `color(${resultColorSpace} 1 1 0)`);
+    test_computed_value("color", `color(${colorSpace} 1)`, `color(${resultColorSpace} 1 0 0)`);
+    test_computed_value("color", `color(${colorSpace})`, `color(${resultColorSpace} 0 0 0)`);
+    test_computed_value("color", `color(${colorSpace} 1 1 / .5)`, `color(${resultColorSpace} 1 1 0 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} 1 / 0.5)`, `color(${resultColorSpace} 1 0 0 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} / 50%)`, `color(${resultColorSpace} 0 0 0 / 0.5)`);
+}
+
+for (const colorSpace of [ "lab", "oklab" ]) {
+    test_computed_value("color", `${colorSpace}(0% 0 0)`, `${colorSpace}(0% 0 0)`);
+    test_computed_value("color", `${colorSpace}(0% 0 0 / 1)`, `${colorSpace}(0% 0 0)`);
+    test_computed_value("color", `${colorSpace}(0% 0 0 / 0.5)`, `${colorSpace}(0% 0 0 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(20% 0 10/0.5)`, `${colorSpace}(20% 0 10 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(20% 0 10/50%)`, `${colorSpace}(20% 0 10 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(400% 0 10/50%)`, `${colorSpace}(400% 0 10 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(50% -160 160)`, `${colorSpace}(50% -160 160)`);
+    test_computed_value("color", `${colorSpace}(50% -200 200)`, `${colorSpace}(50% -200 200)`);
+    test_computed_value("color", `${colorSpace}(0% 0 0 / -10%)`, `${colorSpace}(0% 0 0 / 0)`);
+    test_computed_value("color", `${colorSpace}(0% 0 0 / 110%)`, `${colorSpace}(0% 0 0)`);
+    test_computed_value("color", `${colorSpace}(0% 0 0 / 300%)`, `${colorSpace}(0% 0 0)`);
+    test_computed_value("color", `${colorSpace}(-40% 0 0)`, `${colorSpace}(0% 0 0)`);
+    test_computed_value("color", `${colorSpace}(50% -20 0)`, `${colorSpace}(50% -20 0)`);
+    test_computed_value("color", `${colorSpace}(50% 0 -20)`, `${colorSpace}(50% 0 -20)`);
+}
+
+for (const colorSpace of [ "lch", "oklch" ]) {
+    test_computed_value("color", `${colorSpace}(0% 0 0deg)`, `${colorSpace}(0% 0 0)`);
+    test_computed_value("color", `${colorSpace}(0% 0 0deg / 1)`, `${colorSpace}(0% 0 0)`);
+    test_computed_value("color", `${colorSpace}(0% 0 0deg / 0.5)`, `${colorSpace}(0% 0 0 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(100% 230 0deg / 0.5)`, `${colorSpace}(100% 230 0 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(20% 50 20deg/0.5)`, `${colorSpace}(20% 50 20 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(20% 50 20deg/50%)`, `${colorSpace}(20% 50 20 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(10% 20 20deg / -10%)`, `${colorSpace}(10% 20 20 / 0)`);
+    test_computed_value("color", `${colorSpace}(10% 20 20deg / 110%)`, `${colorSpace}(10% 20 20)`);
+    test_computed_value("color", `${colorSpace}(10% 20 1.28rad)`, `${colorSpace}(10% 20 73.3386)`);
+    test_computed_value("color", `${colorSpace}(10% 20 380deg)`, `${colorSpace}(10% 20 20)`);
+    test_computed_value("color", `${colorSpace}(10% 20 -340deg)`, `${colorSpace}(10% 20 20)`);
+    test_computed_value("color", `${colorSpace}(10% 20 740deg)`, `${colorSpace}(10% 20 20)`);
+    test_computed_value("color", `${colorSpace}(10% 20 -700deg)`, `${colorSpace}(10% 20 20)`);
+    test_computed_value("color", `${colorSpace}(-40% 0 0)`, `${colorSpace}(0% 0 0)`);
+    test_computed_value("color", `${colorSpace}(20% -20 0)`, `${colorSpace}(20% 0 0)`);
+    test_computed_value("color", `${colorSpace}(0% 0 0 / 0.5)`, `${colorSpace}(0% 0 0 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(10% 20 20 / 110%)`, `${colorSpace}(10% 20 20)`);
+    test_computed_value("color", `${colorSpace}(10% 20 -700)`, `${colorSpace}(10% 20 20)`);
+}
 </script>
 </body>
 </html>

--- a/css/css-color/parsing/color-invalid.html
+++ b/css/css-color/parsing/color-invalid.html
@@ -22,6 +22,45 @@ test_invalid_value("color", "rgb(1,2,3,4,5)");
 test_invalid_value("color", "hsla(1,2,3,4,5)");
 test_invalid_value("color", "rgb(10%, 20, 30%)");
 test_invalid_value("color", "rgba(-2, 300, 400%, -0.5)");
+
+for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb" ]) {
+    test_invalid_value("color", `color(${colorSpace} 0 0 0 0)`);
+    test_invalid_value("color", `color(${colorSpace} 0deg 0% 0)`);
+    test_invalid_value("color", `color(${colorSpace} 0% 0 0 1)`);
+    test_invalid_value("color", `color(${colorSpace} 0% 0 0 10%)`);
+    test_invalid_value("color", `color(${colorSpace} 0% 0 0deg)`);
+    test_invalid_value("color", `color(${colorSpace} 0% 0% 0deg)`);
+    test_invalid_value("color", `color(${colorSpace} 40% 0 0deg)`);
+}
+
+for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
+    test_invalid_value("color", `color(${colorSpace} 0 0 0 0)`);
+    test_invalid_value("color", `color(${colorSpace} 0deg 0% 0)`);
+    test_invalid_value("color", `color(${colorSpace} 0% 0 0)`);
+    test_invalid_value("color", `color(${colorSpace} 0% 0 0 1)`);
+    test_invalid_value("color", `color(${colorSpace} 0% 0 0 10%)`);
+    test_invalid_value("color", `color(${colorSpace} 0% 0 0deg)`);
+    test_invalid_value("color", `color(${colorSpace} 0% 0% 0deg)`);
+    test_invalid_value("color", `color(${colorSpace} 40% 0 0deg)`);
+}
+
+for (const colorSpace of [ "lab", "oklab" ]) {
+    test_invalid_value("color", `${colorSpace}(0 0 0)`);
+    test_invalid_value("color", `${colorSpace}(0% 0% 0)`);
+    test_invalid_value("color", `${colorSpace}(0% 0 0 1)`);
+    test_invalid_value("color", `${colorSpace}(0% 0 0 10%)`);
+    test_invalid_value("color", `${colorSpace}(0% 0 0deg)`);
+    test_invalid_value("color", `${colorSpace}(0% 0% 0deg)`);
+    test_invalid_value("color", `${colorSpace}(40% 0 0deg)`);
+    test_invalid_value("color", `color(${colorSpace} 20% 0 10 / 50%)`);
+}
+
+for (const colorSpace of [ "lch", "oklch" ]) {
+    test_invalid_value("color", `${colorSpace}(0 0 0 / 0.5)`);
+    test_invalid_value("color", `${colorSpace}(20% 10 10deg 10)`);
+    test_invalid_value("color", `${colorSpace}(20% 10 10deg 10 / 0.5)`);
+    test_invalid_value("color", `color(${colorSpace} 20% 0 10 / 50%)`);
+}
 </script>
 </body>
 </html>

--- a/css/css-color/parsing/color-valid.html
+++ b/css/css-color/parsing/color-valid.html
@@ -20,14 +20,99 @@ test_valid_value("color", "#234", "rgb(34, 51, 68)");
 test_valid_value("color", "#FEDCBA", "rgb(254, 220, 186)");
 test_valid_value("color", "rgb(2, 3, 4)");
 test_valid_value("color", "rgb(100%, 0%, 0%)", "rgb(255, 0, 0)");
-test_valid_value("color", "rgba(2, 3, 4, 0.5)"); // Safari serializes alpha-value 0.498039
-test_valid_value("color", "rgba(2, 3, 4, 50%)", "rgba(2, 3, 4, 0.5)"); // Safari serializes alpha-value 0.498039
-test_valid_value("color", "hsl(120, 100%, 50%)", ["rgb(0, 255, 0)", "hsl(120, 100%, 50%)"]);
-test_valid_value("color", "hsla(120, 100%, 50%, 0.25)", ["rgba(0, 255, 0, 0.25)", "hsla(120, 100%, 50%, 0.25)"]); // Safari serializes alpha-value 0.247059
+test_valid_value("color", "rgba(2, 3, 4, 0.5)");
+test_valid_value("color", "rgba(2, 3, 4, 50%)", "rgba(2, 3, 4, 0.5)");
+test_valid_value("color", "hsl(120, 100%, 50%)", "rgb(0, 255, 0)");
+test_valid_value("color", "hsla(120, 100%, 50%, 0.25)", "rgba(0, 255, 0, 0.25)");
 test_valid_value("color", "rgb(-2, 3, 4)", "rgb(0, 3, 4)");
 test_valid_value("color", "rgb(100, 200, 300)", "rgb(100, 200, 255)");
-test_valid_value("color", "rgb(20, 10, 0, -10)", "rgba(20, 10, 0, 0)"); // Not supported by Edge/Safari.
+test_valid_value("color", "rgb(20, 10, 0, -10)", "rgba(20, 10, 0, 0)");
 test_valid_value("color", "rgb(100%, 200%, 300%)", "rgb(255, 255, 255)");
+
+for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb" ]) {
+    test_valid_value("color", `color(${colorSpace} 0% 0% 0%)`, `color(${colorSpace} 0 0 0)`);
+    test_valid_value("color", `color(${colorSpace} 10% 10% 10%)`, `color(${colorSpace} 0.1 0.1 0.1)`);
+    test_valid_value("color", `color(${colorSpace} .2 .2 25%)`, `color(${colorSpace} 0.2 0.2 0.25)`);
+    test_valid_value("color", `color(${colorSpace} 0 0 0 / 1)`, `color(${colorSpace} 0 0 0)`);
+    test_valid_value("color", `color(${colorSpace} 0% 0 0 / 0.5)`, `color(${colorSpace} 0 0 0 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} 20% 0 10/0.5)`, `color(${colorSpace} 0.2 0 1 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} 20% 0 10/50%)`, `color(${colorSpace} 0.2 0 1 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} 400% 0 10/50%)`, `color(${colorSpace} 1 0 1 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} 50% -160 160)`, `color(${colorSpace} 0.5 0 1)`);
+    test_valid_value("color", `color(${colorSpace} 50% -200 200)`, `color(${colorSpace} 0.5 0 1)`);
+    test_valid_value("color", `color(${colorSpace} 0 0 0 / -10%)`, `color(${colorSpace} 0 0 0 / 0)`);
+    test_valid_value("color", `color(${colorSpace} 0 0 0 / 110%)`, `color(${colorSpace} 0 0 0)`);
+    test_valid_value("color", `color(${colorSpace} 0 0 0 / 300%)`, `color(${colorSpace} 0 0 0)`);
+    test_valid_value("color", `color(${colorSpace} 50% -200)`, `color(${colorSpace} 0.5 0 0)`);
+    test_valid_value("color", `color(${colorSpace} 50%)`, `color(${colorSpace} 0.5 0 0)`);
+    test_valid_value("color", `color(${colorSpace})`, `color(${colorSpace} 0 0 0)`);
+    test_valid_value("color", `color(${colorSpace} 50% -200 / 0.5)`, `color(${colorSpace} 0.5 0 0 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} 50% / 0.5)`, `color(${colorSpace} 0.5 0 0 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} / 0.5)`, `color(${colorSpace} 0 0 0 / 0.5)`);
+}
+
+for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
+    const resultColorSpace = colorSpace == "xyz" ? "xyz-d65" : colorSpace;
+
+    test_valid_value("color", `color(${colorSpace} 0 0 0)`, `color(${resultColorSpace} 0 0 0)`);
+    test_valid_value("color", `color(${colorSpace} 0 0 0 / 1)`, `color(${resultColorSpace} 0 0 0)`);
+    test_valid_value("color", `color(${colorSpace} 1 1 1)`, `color(${resultColorSpace} 1 1 1)`);
+    test_valid_value("color", `color(${colorSpace} 1 1 1 / 1)`, `color(${resultColorSpace} 1 1 1)`);
+    test_valid_value("color", `color(${colorSpace} -1 -1 -1)`, `color(${resultColorSpace} -1 -1 -1)`);
+    test_valid_value("color", `color(${colorSpace} 0.1 0.1 0.1)`, `color(${resultColorSpace} 0.1 0.1 0.1)`);
+    test_valid_value("color", `color(${colorSpace} 10 10 10)`, `color(${resultColorSpace} 10 10 10)`);
+    test_valid_value("color", `color(${colorSpace} .2 .2 .25)`, `color(${resultColorSpace} 0.2 0.2 0.25)`);
+    test_valid_value("color", `color(${colorSpace} 0 0 0 / 0.5)`, `color(${resultColorSpace} 0 0 0 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} .20 0 10/0.5)`, `color(${resultColorSpace} 0.2 0 10 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} .20 0 10/50%)`, `color(${resultColorSpace} 0.2 0 10 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} 0 0 0 / -10%)`, `color(${resultColorSpace} 0 0 0 / 0)`);
+    test_valid_value("color", `color(${colorSpace} 0 0 0 / 110%)`, `color(${resultColorSpace} 0 0 0)`);
+    test_valid_value("color", `color(${colorSpace} 0 0 0 / 300%)`, `color(${resultColorSpace} 0 0 0)`);
+    test_valid_value("color", `color(${colorSpace} 1 1)`, `color(${resultColorSpace} 1 1 0)`);
+    test_valid_value("color", `color(${colorSpace} 1)`, `color(${resultColorSpace} 1 0 0)`);
+    test_valid_value("color", `color(${colorSpace})`, `color(${resultColorSpace} 0 0 0)`);
+    test_valid_value("color", `color(${colorSpace} 1 1 / .5)`, `color(${resultColorSpace} 1 1 0 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} 1 / 0.5)`, `color(${resultColorSpace} 1 0 0 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} / 50%)`, `color(${resultColorSpace} 0 0 0 / 0.5)`);
+}
+
+for (const colorSpace of [ "lab", "oklab" ]) {
+    test_valid_value("color", `${colorSpace}(0% 0 0)`, `${colorSpace}(0% 0 0)`);
+    test_valid_value("color", `${colorSpace}(0% 0 0 / 1)`, `${colorSpace}(0% 0 0)`);
+    test_valid_value("color", `${colorSpace}(0% 0 0 / 0.5)`, `${colorSpace}(0% 0 0 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(20% 0 10/0.5)`, `${colorSpace}(20% 0 10 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(20% 0 10/50%)`, `${colorSpace}(20% 0 10 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(400% 0 10/50%)`, `${colorSpace}(400% 0 10 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(50% -160 160)`, `${colorSpace}(50% -160 160)`);
+    test_valid_value("color", `${colorSpace}(50% -200 200)`, `${colorSpace}(50% -200 200)`);
+    test_valid_value("color", `${colorSpace}(0% 0 0 / -10%)`, `${colorSpace}(0% 0 0 / 0)`);
+    test_valid_value("color", `${colorSpace}(0% 0 0 / 110%)`, `${colorSpace}(0% 0 0)`);
+    test_valid_value("color", `${colorSpace}(0% 0 0 / 300%)`, `${colorSpace}(0% 0 0)`);
+    test_valid_value("color", `${colorSpace}(-40% 0 0)`, `${colorSpace}(0% 0 0)`);
+    test_valid_value("color", `${colorSpace}(50% -20 0)`, `${colorSpace}(50% -20 0)`);
+    test_valid_value("color", `${colorSpace}(50% 0 -20)`, `${colorSpace}(50% 0 -20)`);
+}
+
+for (const colorSpace of [ "lch", "oklch" ]) {
+    test_valid_value("color", `${colorSpace}(0% 0 0deg)`, `${colorSpace}(0% 0 0)`);
+    test_valid_value("color", `${colorSpace}(0% 0 0deg / 1)`, `${colorSpace}(0% 0 0)`);
+    test_valid_value("color", `${colorSpace}(0% 0 0deg / 0.5)`, `${colorSpace}(0% 0 0 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(100% 230 0deg / 0.5)`, `${colorSpace}(100% 230 0 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(20% 50 20deg/0.5)`, `${colorSpace}(20% 50 20 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(20% 50 20deg/50%)`, `${colorSpace}(20% 50 20 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(10% 20 20deg / -10%)`, `${colorSpace}(10% 20 20 / 0)`);
+    test_valid_value("color", `${colorSpace}(10% 20 20deg / 110%)`, `${colorSpace}(10% 20 20)`);
+    test_valid_value("color", `${colorSpace}(10% 20 1.28rad)`, `${colorSpace}(10% 20 73.3386)`);
+    test_valid_value("color", `${colorSpace}(10% 20 380deg)`, `${colorSpace}(10% 20 20)`);
+    test_valid_value("color", `${colorSpace}(10% 20 -340deg)`, `${colorSpace}(10% 20 20)`);
+    test_valid_value("color", `${colorSpace}(10% 20 740deg)`, `${colorSpace}(10% 20 20)`);
+    test_valid_value("color", `${colorSpace}(10% 20 -700deg)`, `${colorSpace}(10% 20 20)`);
+    test_valid_value("color", `${colorSpace}(-40% 0 0)`, `${colorSpace}(0% 0 0)`);
+    test_valid_value("color", `${colorSpace}(20% -20 0)`, `${colorSpace}(20% 0 0)`);
+    test_valid_value("color", `${colorSpace}(0% 0 0 / 0.5)`, `${colorSpace}(0% 0 0 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(10% 20 20 / 110%)`, `${colorSpace}(10% 20 20)`);
+    test_valid_value("color", `${colorSpace}(10% 20 -700)`, `${colorSpace}(10% 20 20)`);
+}
 </script>
 </body>
 </html>


### PR DESCRIPTION
This updates basic color tests to include the `color()` function, `lch()`, `lab()`, `oklch()` and `oklab()`. Also removes some invalid alternative serializations and comments that are no longer accurate from color-valid.html.


I'm not sure if it is the right decision to utilize these existing tests initially meant to cover CSS Color 3, so I would be happy to break them out if that makes more sense to folks.

These are based on tests in WebKit's layout tests that I wrote:
- https://github.com/WebKit/WebKit/blob/main/LayoutTests/fast/css/parsing-color-function.html
- https://github.com/WebKit/WebKit/blob/main/LayoutTests/fast/css/parsing-lab-colors.html