### PR TITLE
Updating suggested reviewers from Microsoft for Webdriver tests

### DIFF
--- a/webdriver/META.yml
+++ b/webdriver/META.yml
@@ -1,6 +1,7 @@
 spec: https://w3c.github.io/webdriver/
 suggested_reviewers:
   - AutomatedTester
+  - bwalderman
   - jgraham
   - juliandescottes
   - sadym-chromium


### PR DESCRIPTION
Similar to #31909 where we updated the list of suggested reviewers for Mozilla. It would be good to have at least one person from Microsoft to get notified of newly incoming pull requests.

@bwalderman would you be ok in getting added? If not, or if you have other suggestions please let me know. Thanks!