### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=233960

### DIFF
--- a/css/css-backgrounds/border-radius-css-text.html
+++ b/css/css-backgrounds/border-radius-css-text.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 3: border-radius in cssText</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-radius">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="test"></div>
+<script>
+test(() => {
+    const element = document.getElementById("test");
+    assert_equals(element.style.cssText, "", "cssText is initially empty");
+
+    element.style.borderRadius = "10px";
+    assert_equals(element.style.cssText, "border-radius: 10px;");
+
+    element.style.borderTopLeftRadius = "20px";
+    assert_equals(element.style.cssText, "border-radius: 20px 10px 10px;");
+
+    element.style.borderBottomLeftRadius = "30px";
+    assert_equals(element.style.cssText, "border-radius: 20px 10px 10px 30px;");
+}, "Setting border-radius does not expand to longhand properties in cssText.");
+</script>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: ['border-radius shorthand is getting expanded in WebKit](https://bugs.webkit.org/show_bug.cgi?id=233960)