### PR TITLE
Remove deprecated font css flag from css directory files

### DIFF
--- a/css/CSS2/fonts/font-052.xht
+++ b/css/CSS2/fonts/font-052.xht
@@ -12,7 +12,6 @@
   <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-prop" title="3.7 Shorthand font property: the font property" />
   <link rel="bookmark" href="http://lists.w3.org/Archives/Public/www-style/2012May/0878.html" title="Re: [css2.1][css3-fonts] keywords in unquoted font family names" />
 
-  <meta content="font" name="flags" />
   <meta content="This test verifies different valid and invalid font shorthand declarations involving reserved keywords (caption, inherit)." name="assert" />
 
   <style type="text/css"><![CDATA[

--- a/css/CSS2/fonts/font-family-rule-002.xht
+++ b/css/CSS2/fonts/font-family-rule-002.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="Font names containing any white space need to be quoted. It is also recognized if it is not quoted." />
         <style type="text/css">
             #div1

--- a/css/CSS2/fonts/font-family-rule-002a.xht
+++ b/css/CSS2/fonts/font-family-rule-002a.xht
@@ -11,7 +11,6 @@
   <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop" title="3.1 Font family: the font-family property" />
   <link rel="match" href="font-family-rule-002a-ref.xht" />
 
-  <meta content="font" name="flags" />
   <meta content="Any white space characters before or after an unquoted and unescaped font-family name are removed. Any sequence of white space characters between identifiers of an unquoted and unescaped font-family name should be converted to a single white space separating its identifiers." name="assert" />
 
   <style type="text/css"><![CDATA[

--- a/css/CSS2/fonts/font-family-rule-003.xht
+++ b/css/CSS2/fonts/font-family-rule-003.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
-        <meta name="flags" content="font invalid" />
+        <meta name="flags" content="invalid" />
         <meta name="assert" content="Font names containing any special characters can be quoted. Otherwise the special character need to be escaped." />
         <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
         <style type="text/css">

--- a/css/CSS2/fonts/font-family-rule-004.xht
+++ b/css/CSS2/fonts/font-family-rule-004.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="Font family named 'inherit' needs to be quoted to avoid conflict with keyword 'inherit'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/fonts/font-family-rule-004a.xht
+++ b/css/CSS2/fonts/font-family-rule-004a.xht
@@ -12,7 +12,7 @@
   <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop" title="3.1 Font family: the font-family property" />
   <link rel="bookmark" href="http://lists.w3.org/Archives/Public/www-style/2012May/0878.html" title="Re: [css2.1][css3-fonts] keywords in unquoted font family names" />
 
-  <meta content="font invalid" name="flags" />
+  <meta content="invalid" name="flags" />
   <meta content="This test verifies 9 font-family declarations with inherit and 2 font-family declarations with invalid identifiers." name="assert" />
 
   <style type="text/css"><![CDATA[

--- a/css/CSS2/fonts/font-family-rule-007.xht
+++ b/css/CSS2/fonts/font-family-rule-007.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
-        <meta name="flags" content="font invalid" />
+        <meta name="flags" content="invalid" />
         <meta name="assert" content="Font family name having special characters needs to escape special character. Otherwise the font family name need to be quoted." />
         <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
         <style type="text/css">

--- a/css/CSS2/fonts/font-family-rule-009.xht
+++ b/css/CSS2/fonts/font-family-rule-009.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="Multiple white spaces inside quoted font-family name cannot be collapsed to single white space." />
         <style type="text/css">
             div

--- a/css/CSS2/fonts/font-family-rule-010.xht
+++ b/css/CSS2/fonts/font-family-rule-010.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="Font named 'initial' needs to be quoted to avoid conflict with reserved keyword 'initial'." />
         <style type="text/css">
             #test1

--- a/css/CSS2/fonts/font-family-rule-011.xht
+++ b/css/CSS2/fonts/font-family-rule-011.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="Font named 'default' needs to be quoted to avoid conflict with reserved keyword 'default'." />
         <style type="text/css">
             #test1

--- a/css/CSS2/fonts/font-family-rule-012.xht
+++ b/css/CSS2/fonts/font-family-rule-012.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="Font named 'serif' needs to be quoted to avoid conflict with generic 'font-family' 'serif'." />
         <style type="text/css">
             #test1

--- a/css/CSS2/fonts/font-family-rule-013.xht
+++ b/css/CSS2/fonts/font-family-rule-013.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="Font named 'sans-serif' needs to be quoted to avoid conflict with generic 'font-family' 'sans-serif'." />
         <style type="text/css">
             #test1

--- a/css/CSS2/fonts/font-family-rule-014.xht
+++ b/css/CSS2/fonts/font-family-rule-014.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="Font named 'cursive' needs to be quoted to avoid conflict with generic 'font-family' 'cursive'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/fonts/font-family-rule-015.xht
+++ b/css/CSS2/fonts/font-family-rule-015.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="Font named 'fantasy' needs to be quoted to avoid conflict with generic 'font-family' 'fantasy'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/fonts/font-family-rule-016.xht
+++ b/css/CSS2/fonts/font-family-rule-016.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="Font named 'monospace' need to be quoted to avoid conflict with generic 'font-family' 'monospace'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/fonts/font-family-rule-017.xht
+++ b/css/CSS2/fonts/font-family-rule-017.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="Multiple (1 or many) white spaces before and after an unquoted font-family name are ignored. Multiple (more than 1) white spaces inside an unquoted font name get converted to single white space." />
         <style type="text/css">
             div

--- a/css/CSS2/fonts/font-matching-rule-010.xht
+++ b/css/CSS2/fonts/font-matching-rule-010.xht
@@ -6,7 +6,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#algorithm" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-matching-algorithm" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-style-matching" />
-        <meta name="flags" content="font" />
         <meta name="assert" content="If a font property value is not defined, user agent still can use normal value of that property." />
         <style type="text/css">
             div

--- a/css/CSS2/fonts/font-matching-rule-013.xht
+++ b/css/CSS2/fonts/font-matching-rule-013.xht
@@ -4,7 +4,6 @@
         <title>CSS Test: Font Matching Algorithm, font-variant font missing small-caps property</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#algorithm" />
-        <meta name="flags" content="font" />
         <meta name="assert" content="A font that is only available as small-caps can be assigned either a normal or a small-caps to its font-variant property. Both values have the same effect." />
         <style type="text/css">
             span

--- a/css/CSS2/fonts/font-matching-rule-014.xht
+++ b/css/CSS2/fonts/font-matching-rule-014.xht
@@ -6,7 +6,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#algorithm" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-matching-algorithm" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-style-matching" />
-        <meta name="flags" content="font" />
         <meta name="assert" content="If all available fonts are exactly same in all properties, the user agent selects one of them." />
         <style type="text/css">
             div

--- a/css/CSS2/fonts/font-style-rule-001.xht
+++ b/css/CSS2/fonts/font-style-rule-001.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#algorithm" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-matching-algorithm" />
-        <meta name="flags" content="font" />
         <meta name="assert" content="When font-style italic is not available, find value oblique, if it's still not available, either use the alternate font-family that has italic or oblique value or use 'font-style: normal'." />
         <style type="text/css">
             div

--- a/css/WOFF2/support/available-002b.xht
+++ b/css/WOFF2/support/available-002b.xht
@@ -7,7 +7,6 @@
 		<link rel="author" title="Khaled Hosny" href="http://khaledhosny.org" />
 		<link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
 		<link rel="help" href="http://dev.w3.org/webfonts/WOFF2/spec/#conform-mustLoadFontCollection" />
-		<meta name="flags" content="font" />
 		<meta name="assert" content="Fonts must be loaded from font collections." />
 		<style type="text/css"><![CDATA[
 			@import url("test-fonts.css");

--- a/css/css-counter-styles/arabic-indic/css3-counter-styles-101-ref.html
+++ b/css/css-counter-styles/arabic-indic/css3-counter-styles-101-ref.html
@@ -5,7 +5,6 @@
 <title>arabic-indic, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style: arabic-indic produces numbers up to 9 items per the spec.">
 <style type='text/css'>
 ol li { list-style-type: arabic-indic;  }

--- a/css/css-counter-styles/arabic-indic/css3-counter-styles-102-ref.html
+++ b/css/css-counter-styles/arabic-indic/css3-counter-styles-102-ref.html
@@ -5,7 +5,6 @@
 <title>arabic-indic, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: arabic-indic produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: arabic-indic;  }

--- a/css/css-counter-styles/arabic-indic/css3-counter-styles-103-ref.html
+++ b/css/css-counter-styles/arabic-indic/css3-counter-styles-103-ref.html
@@ -5,7 +5,6 @@
 <title>arabic-indic, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type:  arabic-indic produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: arabic-indic;  }

--- a/css/css-counter-styles/armenian/css3-counter-styles-006-ref.html
+++ b/css/css-counter-styles/armenian/css3-counter-styles-006-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: armenian produces numbers up to 9 items per the spec.">
 <style type='text/css'>
 ol li { list-style-type: armenian;  }

--- a/css/css-counter-styles/armenian/css3-counter-styles-007-ref.html
+++ b/css/css-counter-styles/armenian/css3-counter-styles-007-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: armenian produces numbers after 9 items per the spec.">
 <style type='text/css'>
 ol li { list-style-type: armenian;  }

--- a/css/css-counter-styles/armenian/css3-counter-styles-008-ref.html
+++ b/css/css-counter-styles/armenian/css3-counter-styles-008-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: armenian produces counter values outside its ranges using its fallback style.">
 <style type='text/css'>
 ol li { list-style-type: armenian;  }

--- a/css/css-counter-styles/armenian/css3-counter-styles-009-ref.html
+++ b/css/css-counter-styles/armenian/css3-counter-styles-009-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: armenian will produce a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: armenian;  }

--- a/css/css-counter-styles/bengali/css3-counter-styles-116-ref.html
+++ b/css/css-counter-styles/bengali/css3-counter-styles-116-ref.html
@@ -5,7 +5,6 @@
 <title>bengali, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type:bengali produces numbers up to 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: bengali;  }

--- a/css/css-counter-styles/bengali/css3-counter-styles-117-ref.html
+++ b/css/css-counter-styles/bengali/css3-counter-styles-117-ref.html
@@ -5,7 +5,6 @@
 <title>bengali, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: bengali produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: bengali;  }

--- a/css/css-counter-styles/bengali/css3-counter-styles-118-ref.html
+++ b/css/css-counter-styles/bengali/css3-counter-styles-118-ref.html
@@ -5,7 +5,6 @@
 <title>bengali, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: bengali produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: bengali;  }

--- a/css/css-counter-styles/cambodian/css3-counter-styles-158-ref.html
+++ b/css/css-counter-styles/cambodian/css3-counter-styles-158-ref.html
@@ -5,7 +5,6 @@
 <title>cambodian, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: cambodian produces numbers up to 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: cambodian;  }

--- a/css/css-counter-styles/cambodian/css3-counter-styles-159-ref.html
+++ b/css/css-counter-styles/cambodian/css3-counter-styles-159-ref.html
@@ -5,7 +5,6 @@
 <title>cambodian, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: cambodian produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: cambodian;  }

--- a/css/css-counter-styles/cambodian/css3-counter-styles-160-ref.html
+++ b/css/css-counter-styles/cambodian/css3-counter-styles-160-ref.html
@@ -5,7 +5,6 @@
 <title>cambodian, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: cambodian produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: cambodian;  }

--- a/css/css-counter-styles/cjk-decimal/css3-counter-styles-001-ref.html
+++ b/css/css-counter-styles/cjk-decimal/css3-counter-styles-001-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: cjk-decimal produces numbers up to 9 items per the spec.">
 <style type='text/css'>
 ol li { list-style-type: cjk-decimal;  }

--- a/css/css-counter-styles/cjk-decimal/css3-counter-styles-004-ref.html
+++ b/css/css-counter-styles/cjk-decimal/css3-counter-styles-004-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: cjk-decimal produces numbers after 9 items per the spec.">
 <style type='text/css'>
 ol li { list-style-type: cjk-decimal;  }

--- a/css/css-counter-styles/cjk-decimal/css3-counter-styles-005-ref.html
+++ b/css/css-counter-styles/cjk-decimal/css3-counter-styles-005-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: cjk-decimal will produce a suffix as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 ol li { list-style-type: cjk-decimal;  }

--- a/css/css-counter-styles/cjk-earthly-branch/css3-counter-styles-201-ref.html
+++ b/css/css-counter-styles/cjk-earthly-branch/css3-counter-styles-201-ref.html
@@ -5,7 +5,6 @@
 <title>cjk-earthly-branch, 0-12</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type:cjk-earthly-branch produces numbers up to 12 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: cjk-earthly-branch;  }

--- a/css/css-counter-styles/cjk-earthly-branch/css3-counter-styles-202-ref.html
+++ b/css/css-counter-styles/cjk-earthly-branch/css3-counter-styles-202-ref.html
@@ -5,7 +5,6 @@
 <title>cjk-earthly-branch, 13+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: cjk-earthly-branch produces numbers after 12 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: cjk-earthly-branch;  }

--- a/css/css-counter-styles/cjk-earthly-branch/css3-counter-styles-203-ref.html
+++ b/css/css-counter-styles/cjk-earthly-branch/css3-counter-styles-203-ref.html
@@ -5,7 +5,6 @@
 <title>cjk-earthly-branch, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: cjk-earthly-branch produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: cjk-earthly-branch;  }

--- a/css/css-counter-styles/cjk-heavenly-stem/css3-counter-styles-204-ref.html
+++ b/css/css-counter-styles/cjk-heavenly-stem/css3-counter-styles-204-ref.html
@@ -5,7 +5,6 @@
 <title>cjk-heavenly-stem, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type:cjk-heavenly-stem produces numbers up to 12 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: cjk-heavenly-stem;  }

--- a/css/css-counter-styles/cjk-heavenly-stem/css3-counter-styles-205-ref.html
+++ b/css/css-counter-styles/cjk-heavenly-stem/css3-counter-styles-205-ref.html
@@ -5,7 +5,6 @@
 <title>cjk-heavenly-stem, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: cjk-heavenly-stem produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: cjk-heavenly-stem;  }

--- a/css/css-counter-styles/cjk-heavenly-stem/css3-counter-styles-206-ref.html
+++ b/css/css-counter-styles/cjk-heavenly-stem/css3-counter-styles-206-ref.html
@@ -5,7 +5,6 @@
 <title>cjk-heavenly-stem, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: cjk-heavenly-stem produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: cjk-heavenly-stem;  }

--- a/css/css-counter-styles/devanagari/css3-counter-styles-119-ref.html
+++ b/css/css-counter-styles/devanagari/css3-counter-styles-119-ref.html
@@ -5,7 +5,6 @@
 <title>devanagari, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type:devanagari produces numbers up to 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: devanagari;  }

--- a/css/css-counter-styles/devanagari/css3-counter-styles-120-ref.html
+++ b/css/css-counter-styles/devanagari/css3-counter-styles-120-ref.html
@@ -5,7 +5,6 @@
 <title>devanagari, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: devanagari produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: devanagari;  }

--- a/css/css-counter-styles/devanagari/css3-counter-styles-121-ref.html
+++ b/css/css-counter-styles/devanagari/css3-counter-styles-121-ref.html
@@ -5,7 +5,6 @@
 <title>devanagari, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: devanagari produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: devanagari;  }

--- a/css/css-counter-styles/ethiopic-numeric/css3-counter-styles-068.html
+++ b/css/css-counter-styles/ethiopic-numeric/css3-counter-styles-068.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#ethiopic-numeric-counter-style'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to ethiopic-numeric will produce numbering for a list of up to 9 items as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/ethiopic-numeric/css3-counter-styles-069.html
+++ b/css/css-counter-styles/ethiopic-numeric/css3-counter-styles-069.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#ethiopic-numeric-counter-style'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to ethiopic-numeric will produce numbering for a list of items over 9 as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/ethiopic-numeric/css3-counter-styles-070.html
+++ b/css/css-counter-styles/ethiopic-numeric/css3-counter-styles-070.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#ethiopic-numeric-counter-style'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to ethiopic-numeric will produce a suffix as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/georgian/css3-counter-styles-010-ref.html
+++ b/css/css-counter-styles/georgian/css3-counter-styles-010-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style: georgian produces numbers up to 9 items per the spec.">
 <style type='text/css'>
 ol li { list-style-type: georgian;  }

--- a/css/css-counter-styles/georgian/css3-counter-styles-011-ref.html
+++ b/css/css-counter-styles/georgian/css3-counter-styles-011-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style: georgian produces numbers after 9 items per the spec.">
 <style type='text/css'>
 ol li { list-style-type: georgian;  }

--- a/css/css-counter-styles/georgian/css3-counter-styles-012-ref.html
+++ b/css/css-counter-styles/georgian/css3-counter-styles-012-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: georgian produces numbers in the fallback counter style above the limit per the spec.">
 <style type='text/css'>
 ol li { list-style-type: georgian;  }

--- a/css/css-counter-styles/georgian/css3-counter-styles-014-ref.html
+++ b/css/css-counter-styles/georgian/css3-counter-styles-014-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: georgian produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: georgian;  }

--- a/css/css-counter-styles/gujarati/css3-counter-styles-122-ref.html
+++ b/css/css-counter-styles/gujarati/css3-counter-styles-122-ref.html
@@ -5,7 +5,6 @@
 <title>gujarati, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type:gujarati produces numbers up to 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: gujarati;  }

--- a/css/css-counter-styles/gujarati/css3-counter-styles-123-ref.html
+++ b/css/css-counter-styles/gujarati/css3-counter-styles-123-ref.html
@@ -5,7 +5,6 @@
 <title>gujarati, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: gujarati produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: gujarati;  }

--- a/css/css-counter-styles/gujarati/css3-counter-styles-124-ref.html
+++ b/css/css-counter-styles/gujarati/css3-counter-styles-124-ref.html
@@ -5,7 +5,6 @@
 <title>gujarati, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: gujarati produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: gujarati;  }

--- a/css/css-counter-styles/gurmukhi/css3-counter-styles-125-ref.html
+++ b/css/css-counter-styles/gurmukhi/css3-counter-styles-125-ref.html
@@ -5,7 +5,6 @@
 <title>gurmukhi, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type:gurmukhi produces numbers up to 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: gurmukhi;  }

--- a/css/css-counter-styles/gurmukhi/css3-counter-styles-126-ref.html
+++ b/css/css-counter-styles/gurmukhi/css3-counter-styles-126-ref.html
@@ -5,7 +5,6 @@
 <title>gurmukhi, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: gurmukhi produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: gurmukhi;  }

--- a/css/css-counter-styles/gurmukhi/css3-counter-styles-127-ref.html
+++ b/css/css-counter-styles/gurmukhi/css3-counter-styles-127-ref.html
@@ -5,7 +5,6 @@
 <title>gurmukhi, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: gurmukhi produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: gurmukhi;  }

--- a/css/css-counter-styles/hebrew/css3-counter-styles-015-ref.html
+++ b/css/css-counter-styles/hebrew/css3-counter-styles-015-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style: hebrew produces numbers up to 9 items per the spec.">
 <style type='text/css'>
 ol li { list-style-type: hebrew;  }

--- a/css/css-counter-styles/hebrew/css3-counter-styles-016-ref.html
+++ b/css/css-counter-styles/hebrew/css3-counter-styles-016-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style: hebrew produces numbers after 9 items per the spec.">
 <style type='text/css'>
 ol li { list-style-type: hebrew;  }

--- a/css/css-counter-styles/hebrew/css3-counter-styles-016a-alt-ref.html
+++ b/css/css-counter-styles/hebrew/css3-counter-styles-016a-alt-ref.html
@@ -6,7 +6,6 @@
 <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel='help' href='https://bugzilla.mozilla.org/show_bug.cgi?id=1738356'>
-<meta name='flags' content='font'>
 <style>
 ol li { list-style-type: hebrew;  }
 /* the following CSS is not part of the test */

--- a/css/css-counter-styles/hebrew/css3-counter-styles-016a-ref.html
+++ b/css/css-counter-styles/hebrew/css3-counter-styles-016a-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: hebrew produces numbers in the fallback counter style above the limit per the spec.">
 <style type='text/css'>
 ol li { list-style-type: hebrew;  }

--- a/css/css-counter-styles/hebrew/css3-counter-styles-017-ref.html
+++ b/css/css-counter-styles/hebrew/css3-counter-styles-017-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style: hebrew produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: hebrew;  }

--- a/css/css-counter-styles/hiragana-iroha/css3-counter-styles-033-ref.html
+++ b/css/css-counter-styles/hiragana-iroha/css3-counter-styles-033-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to hiragana-iroha will produce list numbering for the basic alphabet as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/hiragana-iroha/css3-counter-styles-034-ref.html
+++ b/css/css-counter-styles/hiragana-iroha/css3-counter-styles-034-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to hiragana-iroha will produce list numbering after the basic alphabet as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/hiragana-iroha/css3-counter-styles-035-ref.html
+++ b/css/css-counter-styles/hiragana-iroha/css3-counter-styles-035-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to hiragana-iroha will produce a suffix as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/hiragana/css3-counter-styles-030-ref.html
+++ b/css/css-counter-styles/hiragana/css3-counter-styles-030-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to hiragana will produce list numbering for the basic alphabet as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/hiragana/css3-counter-styles-031-ref.html
+++ b/css/css-counter-styles/hiragana/css3-counter-styles-031-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to hiragana will produce list numbering after the basic alphabet as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/hiragana/css3-counter-styles-032-ref.html
+++ b/css/css-counter-styles/hiragana/css3-counter-styles-032-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to hiragana will produce a suffix as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/japanese-formal/css3-counter-styles-047-ref.html
+++ b/css/css-counter-styles/japanese-formal/css3-counter-styles-047-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to japanese-formal will produce list of up to 9 items numbering as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/japanese-formal/css3-counter-styles-048-ref.html
+++ b/css/css-counter-styles/japanese-formal/css3-counter-styles-048-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to japanese-formal will produce list numbering after 9 as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/japanese-formal/css3-counter-styles-049-alt-ref.html
+++ b/css/css-counter-styles/japanese-formal/css3-counter-styles-049-alt-ref.html
@@ -6,7 +6,6 @@
 <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel='help' href='https://bugzilla.mozilla.org/show_bug.cgi?id=1738356'>
-<meta name='flags' content='font'>
 <style type='text/css'>
 .test { font-size: 25px; }
 ol { margin: 0; padding-left: 8em; }

--- a/css/css-counter-styles/japanese-formal/css3-counter-styles-049-ref.html
+++ b/css/css-counter-styles/japanese-formal/css3-counter-styles-049-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="[Exploratory] list-style-type: japanese-formal produces counter values outside its range without using the prescribed fallback style.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/japanese-formal/css3-counter-styles-050-ref.html
+++ b/css/css-counter-styles/japanese-formal/css3-counter-styles-050-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="With list-style-type set to japanese-formal, negative list markers will be rendered according to the rules described.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/japanese-formal/css3-counter-styles-051-ref.html
+++ b/css/css-counter-styles/japanese-formal/css3-counter-styles-051-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to japanese-formal will produce a suffix as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/japanese-informal/css3-counter-styles-042-ref.html
+++ b/css/css-counter-styles/japanese-informal/css3-counter-styles-042-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to japanese-informal will produce list of up to 9 items numbering as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/japanese-informal/css3-counter-styles-043-ref.html
+++ b/css/css-counter-styles/japanese-informal/css3-counter-styles-043-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to japanese-informal will produce list numbering after 9 as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/japanese-informal/css3-counter-styles-044-alt-ref.html
+++ b/css/css-counter-styles/japanese-informal/css3-counter-styles-044-alt-ref.html
@@ -6,7 +6,6 @@
 <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel='help' href='https://bugzilla.mozilla.org/show_bug.cgi?id=1738356'>
-<meta name='flags' content='font'>
 <style>
 ol li { list-style-type: japanese-informal;  }
 /* the following CSS is not part of the test */

--- a/css/css-counter-styles/japanese-informal/css3-counter-styles-044-ref.html
+++ b/css/css-counter-styles/japanese-informal/css3-counter-styles-044-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="[Exploratory] list-style-type: japanese-informal produces counter values outside its range without using the prescribed fallback style.">
 <style type='text/css'>
 ol li { list-style-type: japanese-informal;  }

--- a/css/css-counter-styles/japanese-informal/css3-counter-styles-045-ref.html
+++ b/css/css-counter-styles/japanese-informal/css3-counter-styles-045-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="With list-style-type set to japanese-informal, negative list markers will be rendered according to the rules described.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/japanese-informal/css3-counter-styles-046-ref.html
+++ b/css/css-counter-styles/japanese-informal/css3-counter-styles-046-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to japanese-informal will produce a suffix as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/kannada/css3-counter-styles-128-ref.html
+++ b/css/css-counter-styles/kannada/css3-counter-styles-128-ref.html
@@ -5,7 +5,6 @@
 <title>kannada, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type:kannada produces numbers up to 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: kannada;  }

--- a/css/css-counter-styles/kannada/css3-counter-styles-129-ref.html
+++ b/css/css-counter-styles/kannada/css3-counter-styles-129-ref.html
@@ -5,7 +5,6 @@
 <title>kannada, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: kannada produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: kannada;  }

--- a/css/css-counter-styles/kannada/css3-counter-styles-130-ref.html
+++ b/css/css-counter-styles/kannada/css3-counter-styles-130-ref.html
@@ -5,7 +5,6 @@
 <title>kannada, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: kannada produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: kannada;  }

--- a/css/css-counter-styles/katakana-iroha/css3-counter-styles-039-ref.html
+++ b/css/css-counter-styles/katakana-iroha/css3-counter-styles-039-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to katakana-iroha will produce list numbering for the basic alphabet as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/katakana-iroha/css3-counter-styles-040-ref.html
+++ b/css/css-counter-styles/katakana-iroha/css3-counter-styles-040-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to katakana-iroha will produce list numbering after the basic alphabet as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/katakana-iroha/css3-counter-styles-041-ref.html
+++ b/css/css-counter-styles/katakana-iroha/css3-counter-styles-041-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to katakana-iroha will produce a suffix as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/katakana/css3-counter-styles-036-ref.html
+++ b/css/css-counter-styles/katakana/css3-counter-styles-036-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to katakana will produce list numbering for the basic alphabet as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/katakana/css3-counter-styles-037-ref.html
+++ b/css/css-counter-styles/katakana/css3-counter-styles-037-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to katakana will produce list numbering after the basic alphabet as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/katakana/css3-counter-styles-038-ref.html
+++ b/css/css-counter-styles/katakana/css3-counter-styles-038-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to katakana will produce a suffix as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/khmer/css3-counter-styles-161-ref.html
+++ b/css/css-counter-styles/khmer/css3-counter-styles-161-ref.html
@@ -5,7 +5,6 @@
 <title>khmer, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: khmer produces numbers up to 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: khmer;  }

--- a/css/css-counter-styles/khmer/css3-counter-styles-162-ref.html
+++ b/css/css-counter-styles/khmer/css3-counter-styles-162-ref.html
@@ -5,7 +5,6 @@
 <title>khmer, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: khmer produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: khmer;  }

--- a/css/css-counter-styles/khmer/css3-counter-styles-163-ref.html
+++ b/css/css-counter-styles/khmer/css3-counter-styles-163-ref.html
@@ -5,7 +5,6 @@
 <title>khmer, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: khmer produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: khmer;  }

--- a/css/css-counter-styles/korean-hangul-formal/css3-counter-styles-052-ref.html
+++ b/css/css-counter-styles/korean-hangul-formal/css3-counter-styles-052-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to korean-hangul-formal will produce list of up to 9 items numbering as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/korean-hangul-formal/css3-counter-styles-053-ref.html
+++ b/css/css-counter-styles/korean-hangul-formal/css3-counter-styles-053-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to korean-hangul-formal will produce list numbering after 9 as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/korean-hangul-formal/css3-counter-styles-054-alt-ref.html
+++ b/css/css-counter-styles/korean-hangul-formal/css3-counter-styles-054-alt-ref.html
@@ -6,7 +6,6 @@
 <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel='help' href='https://bugzilla.mozilla.org/show_bug.cgi?id=1738356'>
-<meta name='flags' content='font'>
 <style>
 .test { font-size: 25px; }
 ol { margin: 0; padding-left: 8em; }

--- a/css/css-counter-styles/korean-hangul-formal/css3-counter-styles-054-ref.html
+++ b/css/css-counter-styles/korean-hangul-formal/css3-counter-styles-054-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="[Exploratory] list-style-type: korean-hangul-formal produces counter values outside its range without using the prescribed fallback style.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/korean-hangul-formal/css3-counter-styles-055-ref.html
+++ b/css/css-counter-styles/korean-hangul-formal/css3-counter-styles-055-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="With list-style-type set to korean-hangul-formal, negative list markers will be rendered according to the rules described.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/korean-hangul-formal/css3-counter-styles-056-ref.html
+++ b/css/css-counter-styles/korean-hangul-formal/css3-counter-styles-056-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to korean-hangul-formal will produce a suffix as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/korean-hanja-formal/css3-counter-styles-062-ref.html
+++ b/css/css-counter-styles/korean-hanja-formal/css3-counter-styles-062-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to korean-hanja-formal will produce list of up to 9 items numbering as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/korean-hanja-formal/css3-counter-styles-063-ref.html
+++ b/css/css-counter-styles/korean-hanja-formal/css3-counter-styles-063-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to korean-hanja-formal will produce list numbering after 9 as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/korean-hanja-formal/css3-counter-styles-064-alt-ref.html
+++ b/css/css-counter-styles/korean-hanja-formal/css3-counter-styles-064-alt-ref.html
@@ -6,7 +6,6 @@
 <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel='help' href='https://bugzilla.mozilla.org/show_bug.cgi?id=1738356'>
-<meta name='flags' content='font'>
 <style>
 .test { font-size: 25px; }
 ol { margin: 0; padding-left: 8em; }

--- a/css/css-counter-styles/korean-hanja-formal/css3-counter-styles-064-ref.html
+++ b/css/css-counter-styles/korean-hanja-formal/css3-counter-styles-064-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="[Exploratory] list-style-type: korean-hanja-formal produces counter values outside its range without using the prescribed fallback style.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/korean-hanja-formal/css3-counter-styles-065-ref.html
+++ b/css/css-counter-styles/korean-hanja-formal/css3-counter-styles-065-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="With list-style-type set to korean-hanja-formal, negative list markers will be rendered according to the rules described.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/korean-hanja-formal/css3-counter-styles-066-ref.html
+++ b/css/css-counter-styles/korean-hanja-formal/css3-counter-styles-066-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to korean-hanja-formal will produce a suffix as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/korean-hanja-informal/css3-counter-styles-057-ref.html
+++ b/css/css-counter-styles/korean-hanja-informal/css3-counter-styles-057-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to korean-hanja-informal will produce list of up to 9 items numbering as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/korean-hanja-informal/css3-counter-styles-058-ref.html
+++ b/css/css-counter-styles/korean-hanja-informal/css3-counter-styles-058-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to korean-hanja-informal will produce list numbering after 9 as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/korean-hanja-informal/css3-counter-styles-059-alt-ref.html
+++ b/css/css-counter-styles/korean-hanja-informal/css3-counter-styles-059-alt-ref.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>korean-hanja-informal, outside range</title>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
-<meta name='flags' content='font'>
 <style>
 .test { font-size: 25px; }
 ol { margin: 0; padding-left: 8em; }

--- a/css/css-counter-styles/korean-hanja-informal/css3-counter-styles-059-ref.html
+++ b/css/css-counter-styles/korean-hanja-informal/css3-counter-styles-059-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="[Exploratory] list-style-type: korean-hanja-informal produces counter values outside its range without using the prescribed fallback style.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/korean-hanja-informal/css3-counter-styles-060-ref.html
+++ b/css/css-counter-styles/korean-hanja-informal/css3-counter-styles-060-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="With list-style-type set to korean-hanja-informal, negative list markers will be rendered according to the rules described.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/korean-hanja-informal/css3-counter-styles-061-ref.html
+++ b/css/css-counter-styles/korean-hanja-informal/css3-counter-styles-061-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to korean-hanja-informal will produce a suffix as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/lao/css3-counter-styles-131-ref.html
+++ b/css/css-counter-styles/lao/css3-counter-styles-131-ref.html
@@ -5,7 +5,6 @@
 <title>lao, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type:lao produces numbers up to 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: lao;  }

--- a/css/css-counter-styles/lao/css3-counter-styles-132-ref.html
+++ b/css/css-counter-styles/lao/css3-counter-styles-132-ref.html
@@ -5,7 +5,6 @@
 <title>lao, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: lao produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: lao;  }

--- a/css/css-counter-styles/lao/css3-counter-styles-133-ref.html
+++ b/css/css-counter-styles/lao/css3-counter-styles-133-ref.html
@@ -5,7 +5,6 @@
 <title>lao, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: lao produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: lao;  }

--- a/css/css-counter-styles/lower-armenian/css3-counter-styles-111-ref.html
+++ b/css/css-counter-styles/lower-armenian/css3-counter-styles-111-ref.html
@@ -5,7 +5,6 @@
 <title>lower-armenian, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: lower-armenian produces numbers up to 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: lower-armenian;  }

--- a/css/css-counter-styles/lower-armenian/css3-counter-styles-112-ref.html
+++ b/css/css-counter-styles/lower-armenian/css3-counter-styles-112-ref.html
@@ -5,7 +5,6 @@
 <title>lower-armenian, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: lower-armenian produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: lower-armenian;  }

--- a/css/css-counter-styles/lower-armenian/css3-counter-styles-114-ref.html
+++ b/css/css-counter-styles/lower-armenian/css3-counter-styles-114-ref.html
@@ -5,7 +5,6 @@
 <title>lower-armenian, outside range</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: lower-armenian produces numbers in the fallback counter style above the limit per the spec.">
 <style type='text/css'>
 ol li { list-style-type: lower-armenian;  }

--- a/css/css-counter-styles/lower-armenian/css3-counter-styles-115-ref.html
+++ b/css/css-counter-styles/lower-armenian/css3-counter-styles-115-ref.html
@@ -5,7 +5,6 @@
 <title>lower-armenian, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: lower-armenian produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: lower-armenian;  }

--- a/css/css-counter-styles/lower-greek/css3-counter-styles-027-ref.html
+++ b/css/css-counter-styles/lower-greek/css3-counter-styles-027-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to lower-greek will produce list numbering for the basic alphabet as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/lower-greek/css3-counter-styles-028-ref.html
+++ b/css/css-counter-styles/lower-greek/css3-counter-styles-028-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to lower-greek will produce list numbering after the basic alphabet as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/lower-greek/css3-counter-styles-029-ref.html
+++ b/css/css-counter-styles/lower-greek/css3-counter-styles-029-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-alphabetic'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to lower-greek will produce a suffix as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/lower-roman/css3-counter-styles-019-ref.html
+++ b/css/css-counter-styles/lower-roman/css3-counter-styles-019-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style: lower-roman produces numbers up to 9 items per the spec.">
 <style type='text/css'>
 ol li { list-style-type: lower-roman;  }

--- a/css/css-counter-styles/lower-roman/css3-counter-styles-020-ref.html
+++ b/css/css-counter-styles/lower-roman/css3-counter-styles-020-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style: lower-roman produces numbers after 9 items per the spec.">
 <style type='text/css'>
 ol li { list-style-type: lower-roman;  }

--- a/css/css-counter-styles/lower-roman/css3-counter-styles-020a-ref.html
+++ b/css/css-counter-styles/lower-roman/css3-counter-styles-020a-ref.html
@@ -7,7 +7,6 @@
 <link rel='author' title='Chris Lilley' href='mailto:chris@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to lower-roman will produce list of up to 9 items in the range range: 1 to 3999.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/lower-roman/css3-counter-styles-020b-ref.html
+++ b/css/css-counter-styles/lower-roman/css3-counter-styles-020b-ref.html
@@ -7,7 +7,6 @@
 <link rel='author' title='Chris Lilley' href='mailto:chris@w3.org'>
 <link rel="reviewer" title="Tab Atkins" href="mailto:jackalmage@gmail.com" />
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#descdef-counter-style-range'>
-<meta name='flags' content='font'>
 <meta name="assert" content="	If a counter style is used to represent a counter value outside of its ranges, the counter style instead drops down to its fallback counter style.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/lower-roman/css3-counter-styles-021-ref.html
+++ b/css/css-counter-styles/lower-roman/css3-counter-styles-021-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: lower-roman produces numbers in the fallback counter style above the limit per the spec">
 <style type='text/css'>
 ol li { list-style-type: lower-roman;  }

--- a/css/css-counter-styles/lower-roman/css3-counter-styles-022-ref.html
+++ b/css/css-counter-styles/lower-roman/css3-counter-styles-022-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: lower-roman produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: lower-roman;  }

--- a/css/css-counter-styles/malayalam/css3-counter-styles-134-ref.html
+++ b/css/css-counter-styles/malayalam/css3-counter-styles-134-ref.html
@@ -5,7 +5,6 @@
 <title>malayalam, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type:malayalam produces numbers up to 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: malayalam;  }

--- a/css/css-counter-styles/malayalam/css3-counter-styles-135-ref.html
+++ b/css/css-counter-styles/malayalam/css3-counter-styles-135-ref.html
@@ -5,7 +5,6 @@
 <title>malayalam, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: malayalam produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: malayalam;  }

--- a/css/css-counter-styles/malayalam/css3-counter-styles-136-ref.html
+++ b/css/css-counter-styles/malayalam/css3-counter-styles-136-ref.html
@@ -5,7 +5,6 @@
 <title>malayalam, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: malayalam produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: malayalam;  }

--- a/css/css-counter-styles/mongolian/css3-counter-styles-137-ref.html
+++ b/css/css-counter-styles/mongolian/css3-counter-styles-137-ref.html
@@ -5,7 +5,6 @@
 <title>mongolian, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type:mongolian produces numbers up to 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: mongolian;  }

--- a/css/css-counter-styles/mongolian/css3-counter-styles-138-ref.html
+++ b/css/css-counter-styles/mongolian/css3-counter-styles-138-ref.html
@@ -5,7 +5,6 @@
 <title>mongolian, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: mongolian produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: mongolian;  }

--- a/css/css-counter-styles/mongolian/css3-counter-styles-139-ref.html
+++ b/css/css-counter-styles/mongolian/css3-counter-styles-139-ref.html
@@ -5,7 +5,6 @@
 <title>mongolian, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: mongolian produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: mongolian;  }

--- a/css/css-counter-styles/myanmar/css3-counter-styles-140-ref.html
+++ b/css/css-counter-styles/myanmar/css3-counter-styles-140-ref.html
@@ -5,7 +5,6 @@
 <title>myanmar, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type:myanmar produces numbers up to 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: myanmar;  }

--- a/css/css-counter-styles/myanmar/css3-counter-styles-141-ref.html
+++ b/css/css-counter-styles/myanmar/css3-counter-styles-141-ref.html
@@ -5,7 +5,6 @@
 <title>myanmar, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: myanmar produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: myanmar;  }

--- a/css/css-counter-styles/myanmar/css3-counter-styles-142-ref.html
+++ b/css/css-counter-styles/myanmar/css3-counter-styles-142-ref.html
@@ -5,7 +5,6 @@
 <title>myanmar, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: myanmar produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: myanmar;  }

--- a/css/css-counter-styles/oriya/css3-counter-styles-143-ref.html
+++ b/css/css-counter-styles/oriya/css3-counter-styles-143-ref.html
@@ -5,7 +5,6 @@
 <title>oriya, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type:oriya produces numbers up to 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: oriya;  }

--- a/css/css-counter-styles/oriya/css3-counter-styles-144-ref.html
+++ b/css/css-counter-styles/oriya/css3-counter-styles-144-ref.html
@@ -5,7 +5,6 @@
 <title>oriya, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: oriya produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: oriya;  }

--- a/css/css-counter-styles/oriya/css3-counter-styles-145-ref.html
+++ b/css/css-counter-styles/oriya/css3-counter-styles-145-ref.html
@@ -5,7 +5,6 @@
 <title>oriya, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: oriya produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: oriya;  }

--- a/css/css-counter-styles/persian/css3-counter-styles-104-ref.html
+++ b/css/css-counter-styles/persian/css3-counter-styles-104-ref.html
@@ -5,7 +5,6 @@
 <title>persian, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style: persian produces numbers up to 9 items per the spec.">
 <style type='text/css'>
 ol li { list-style-type: persian;  }

--- a/css/css-counter-styles/persian/css3-counter-styles-105-ref.html
+++ b/css/css-counter-styles/persian/css3-counter-styles-105-ref.html
@@ -5,7 +5,6 @@
 <title>persian, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: persian produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: persian;  }

--- a/css/css-counter-styles/persian/css3-counter-styles-106-ref.html
+++ b/css/css-counter-styles/persian/css3-counter-styles-106-ref.html
@@ -5,7 +5,6 @@
 <title>persian, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type:  persian produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: persian;  }

--- a/css/css-counter-styles/simp-chinese-formal/css3-counter-styles-076-ref.html
+++ b/css/css-counter-styles/simp-chinese-formal/css3-counter-styles-076-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to simp-chinese-formal will produce list of up to 9 items numbering as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/simp-chinese-formal/css3-counter-styles-077-ref.html
+++ b/css/css-counter-styles/simp-chinese-formal/css3-counter-styles-077-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to simp-chinese-formal will produce list numbering after 9 as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/simp-chinese-formal/css3-counter-styles-078-alt-ref.html
+++ b/css/css-counter-styles/simp-chinese-formal/css3-counter-styles-078-alt-ref.html
@@ -6,7 +6,6 @@
 <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel='help' href='https://bugzilla.mozilla.org/show_bug.cgi?id=1738356'>
-<meta name='flags' content='font'>
 <style>
 .test { font-size: 25px; }
 ol { margin: 0; padding-left: 8em; }

--- a/css/css-counter-styles/simp-chinese-formal/css3-counter-styles-078-ref.html
+++ b/css/css-counter-styles/simp-chinese-formal/css3-counter-styles-078-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="[Exploratory] list-style-type: simp-chinese-formal produces counter values outside its range without using the prescribed fallback style.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/simp-chinese-formal/css3-counter-styles-079-ref.html
+++ b/css/css-counter-styles/simp-chinese-formal/css3-counter-styles-079-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="With list-style-type set to simp-chinese-formal, negative list markers will be rendered according to the rules described.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/simp-chinese-formal/css3-counter-styles-080-ref.html
+++ b/css/css-counter-styles/simp-chinese-formal/css3-counter-styles-080-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to simp-chinese-formal will produce a suffix as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/simp-chinese-informal/css3-counter-styles-071-ref.html
+++ b/css/css-counter-styles/simp-chinese-informal/css3-counter-styles-071-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to simp-chinese-informal will produce list of up to 9 items numbering as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/simp-chinese-informal/css3-counter-styles-072-ref.html
+++ b/css/css-counter-styles/simp-chinese-informal/css3-counter-styles-072-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to simp-chinese-informal will produce list numbering after 9 as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/simp-chinese-informal/css3-counter-styles-073-alt-ref.html
+++ b/css/css-counter-styles/simp-chinese-informal/css3-counter-styles-073-alt-ref.html
@@ -6,7 +6,6 @@
 <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel='help' href='https://bugzilla.mozilla.org/show_bug.cgi?id=1738356'>
-<meta name='flags' content='font'>
 <style>
 .test { font-size: 25px; }
 ol { margin: 0; padding-left: 8em; }

--- a/css/css-counter-styles/simp-chinese-informal/css3-counter-styles-073-ref.html
+++ b/css/css-counter-styles/simp-chinese-informal/css3-counter-styles-073-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="[Exploratory] list-style-type: simp-chinese-informal produces counter values outside its range without using the prescribed fallback style.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/simp-chinese-informal/css3-counter-styles-074-ref.html
+++ b/css/css-counter-styles/simp-chinese-informal/css3-counter-styles-074-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="With list-style-type set to simp-chinese-informal, negative list markers will be rendered according to the rules described.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/simp-chinese-informal/css3-counter-styles-075-ref.html
+++ b/css/css-counter-styles/simp-chinese-informal/css3-counter-styles-075-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to simp-chinese-informal will produce a suffix as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/tamil/css3-counter-styles-146-ref.html
+++ b/css/css-counter-styles/tamil/css3-counter-styles-146-ref.html
@@ -5,7 +5,6 @@
 <title>tamil, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type:tamil produces numbers up to 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: tamil;  }

--- a/css/css-counter-styles/tamil/css3-counter-styles-147-ref.html
+++ b/css/css-counter-styles/tamil/css3-counter-styles-147-ref.html
@@ -5,7 +5,6 @@
 <title>tamil, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: tamil produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: tamil;  }

--- a/css/css-counter-styles/tamil/css3-counter-styles-148-ref.html
+++ b/css/css-counter-styles/tamil/css3-counter-styles-148-ref.html
@@ -5,7 +5,6 @@
 <title>tamil, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: tamil produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: tamil;  }

--- a/css/css-counter-styles/telugu/css3-counter-styles-149-ref.html
+++ b/css/css-counter-styles/telugu/css3-counter-styles-149-ref.html
@@ -5,7 +5,6 @@
 <title>telugu, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type:telugu produces numbers up to 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: telugu;  }

--- a/css/css-counter-styles/telugu/css3-counter-styles-150-ref.html
+++ b/css/css-counter-styles/telugu/css3-counter-styles-150-ref.html
@@ -5,7 +5,6 @@
 <title>telugu, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: telugu produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: telugu;  }

--- a/css/css-counter-styles/telugu/css3-counter-styles-151-ref.html
+++ b/css/css-counter-styles/telugu/css3-counter-styles-151-ref.html
@@ -5,7 +5,6 @@
 <title>telugu, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: telugu produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: telugu;  }

--- a/css/css-counter-styles/thai/css3-counter-styles-152-ref.html
+++ b/css/css-counter-styles/thai/css3-counter-styles-152-ref.html
@@ -5,7 +5,6 @@
 <title>thai, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type:thai produces numbers up to 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: thai;  }

--- a/css/css-counter-styles/thai/css3-counter-styles-153-ref.html
+++ b/css/css-counter-styles/thai/css3-counter-styles-153-ref.html
@@ -5,7 +5,6 @@
 <title>thai, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: thai produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: thai;  }

--- a/css/css-counter-styles/thai/css3-counter-styles-154-ref.html
+++ b/css/css-counter-styles/thai/css3-counter-styles-154-ref.html
@@ -5,7 +5,6 @@
 <title>thai, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: thai produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: thai;  }

--- a/css/css-counter-styles/tibetan/css3-counter-styles-155-ref.html
+++ b/css/css-counter-styles/tibetan/css3-counter-styles-155-ref.html
@@ -5,7 +5,6 @@
 <title>tibetan, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type:tibetan produces numbers up to 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: tibetan;  }

--- a/css/css-counter-styles/tibetan/css3-counter-styles-156-ref.html
+++ b/css/css-counter-styles/tibetan/css3-counter-styles-156-ref.html
@@ -5,7 +5,6 @@
 <title>tibetan, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: tibetan produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: tibetan;  }

--- a/css/css-counter-styles/tibetan/css3-counter-styles-157-ref.html
+++ b/css/css-counter-styles/tibetan/css3-counter-styles-157-ref.html
@@ -5,7 +5,6 @@
 <title>tibetan, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: tibetan produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: tibetan;  }

--- a/css/css-counter-styles/trad-chinese-formal/css3-counter-styles-086-ref.html
+++ b/css/css-counter-styles/trad-chinese-formal/css3-counter-styles-086-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to trad-chinese-formal will produce list of up to 9 items numbering as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/trad-chinese-formal/css3-counter-styles-087-ref.html
+++ b/css/css-counter-styles/trad-chinese-formal/css3-counter-styles-087-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to trad-chinese-formal will produce list numbering after 9 as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/trad-chinese-formal/css3-counter-styles-088-alt-ref.html
+++ b/css/css-counter-styles/trad-chinese-formal/css3-counter-styles-088-alt-ref.html
@@ -6,7 +6,6 @@
 <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel='help' href='https://bugzilla.mozilla.org/show_bug.cgi?id=1738356'>
-<meta name='flags' content='font'>
 <style>
 .test { font-size: 25px; }
 ol { margin: 0; padding-left: 8em; }

--- a/css/css-counter-styles/trad-chinese-formal/css3-counter-styles-088-ref.html
+++ b/css/css-counter-styles/trad-chinese-formal/css3-counter-styles-088-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="[Exploratory] list-style-type: trad-chinese-formal produces counter values outside its range without using the prescribed fallback style.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/trad-chinese-formal/css3-counter-styles-089-ref.html
+++ b/css/css-counter-styles/trad-chinese-formal/css3-counter-styles-089-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="With list-style-type set to trad-chinese-formal, negative list markers will be rendered according to the rules described.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/trad-chinese-formal/css3-counter-styles-090-ref.html
+++ b/css/css-counter-styles/trad-chinese-formal/css3-counter-styles-090-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to trad-chinese-formal will produce a suffix as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/trad-chinese-informal/css3-counter-styles-081-ref.html
+++ b/css/css-counter-styles/trad-chinese-informal/css3-counter-styles-081-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to trad-chinese-informal will produce list of up to 9 items numbering as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/trad-chinese-informal/css3-counter-styles-082-ref.html
+++ b/css/css-counter-styles/trad-chinese-informal/css3-counter-styles-082-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to trad-chinese-informal will produce list numbering after 9 as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/trad-chinese-informal/css3-counter-styles-083-alt-ref.html
+++ b/css/css-counter-styles/trad-chinese-informal/css3-counter-styles-083-alt-ref.html
@@ -6,7 +6,6 @@
 <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel='help' href='https://bugzilla.mozilla.org/show_bug.cgi?id=1738356'>
-<meta name='flags' content='font'>
 <style>
 .test { font-size: 25px; }
 ol { margin: 0; padding-left: 8em; }

--- a/css/css-counter-styles/trad-chinese-informal/css3-counter-styles-083-ref.html
+++ b/css/css-counter-styles/trad-chinese-informal/css3-counter-styles-083-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="[Exploratory] list-style-type: trad-chinese-informal produces counter values outside its range without using the prescribed fallback style.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/trad-chinese-informal/css3-counter-styles-084-ref.html
+++ b/css/css-counter-styles/trad-chinese-informal/css3-counter-styles-084-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="With list-style-type set to trad-chinese-informal, negative list markers will be rendered according to the rules described.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/trad-chinese-informal/css3-counter-styles-085-ref.html
+++ b/css/css-counter-styles/trad-chinese-informal/css3-counter-styles-085-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#complex-cjk'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to trad-chinese-informal will produce a suffix as described in the CSS3 Counter Styles module.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/upper-armenian/css3-counter-styles-107-ref.html
+++ b/css/css-counter-styles/upper-armenian/css3-counter-styles-107-ref.html
@@ -5,7 +5,6 @@
 <title>upper-armenian, 0-9</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: upper-armenian produces numbers up to 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: upper-armenian;  }

--- a/css/css-counter-styles/upper-armenian/css3-counter-styles-108-ref.html
+++ b/css/css-counter-styles/upper-armenian/css3-counter-styles-108-ref.html
@@ -5,7 +5,6 @@
 <title>upper-armenian, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: upper-armenian produces numbers after 9 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: upper-armenian;  }

--- a/css/css-counter-styles/upper-armenian/css3-counter-styles-109-ref.html
+++ b/css/css-counter-styles/upper-armenian/css3-counter-styles-109-ref.html
@@ -5,7 +5,6 @@
 <title>upper-armenian, outside range</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: upper-armenian produces numbers in the fallback counter style above the limit per the spec.">
 <style type='text/css'>
 ol li { list-style-type: upper-armenian;  }

--- a/css/css-counter-styles/upper-armenian/css3-counter-styles-110-ref.html
+++ b/css/css-counter-styles/upper-armenian/css3-counter-styles-110-ref.html
@@ -5,7 +5,6 @@
 <title>upper-armenian, suffix</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: upper-armenian produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: upper-armenian;  }

--- a/css/css-counter-styles/upper-roman/css3-counter-styles-023-ref.html
+++ b/css/css-counter-styles/upper-roman/css3-counter-styles-023-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style: upper-roman produces numbers up to 9 items per the spec.">
 <style type='text/css'>
 ol li { list-style-type: upper-roman;  }

--- a/css/css-counter-styles/upper-roman/css3-counter-styles-024-ref.html
+++ b/css/css-counter-styles/upper-roman/css3-counter-styles-024-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style: upper-roman produces numbers after 9 items per the spec.">
 <style type='text/css'>
 ol li { list-style-type: upper-roman;  }

--- a/css/css-counter-styles/upper-roman/css3-counter-styles-024a-ref.html
+++ b/css/css-counter-styles/upper-roman/css3-counter-styles-024a-ref.html
@@ -7,7 +7,6 @@
 <link rel='author' title='Chris Lilley' href='mailto:chris@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="Setting list-style-type to upper-roman will produce list of up to 9 items in the range range: 1 to 3999.">
 <style type='text/css'>
 .test { font-size: 25px; }

--- a/css/css-counter-styles/upper-roman/css3-counter-styles-025-ref.html
+++ b/css/css-counter-styles/upper-roman/css3-counter-styles-025-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: upper-roman produces numbers in the fallback counter style above the limit per the spec">
 <style type='text/css'>
 ol li { list-style-type: upper-roman;  }

--- a/css/css-counter-styles/upper-roman/css3-counter-styles-026-ref.html
+++ b/css/css-counter-styles/upper-roman/css3-counter-styles-026-ref.html
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel="reviewer" title="Chris Lilley" href="mailto:chris@w3.org" />
-<meta name='flags' content='font'>
 <meta name="assert" content="list-style-type: upper-roman produces a suffix per the spec.">
 <style type='text/css'>
 ol li { list-style-type: upper-roman;  }

--- a/css/css-fonts/font-family-name-000.xht
+++ b/css/css-fonts/font-family-name-000.xht
@@ -6,7 +6,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font-family" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="Test will fail if CSSTest fonts are not installed" />
         <style type="text/css">
             div#test1 {

--- a/css/css-fonts/font-family-name-001.xht
+++ b/css/css-fonts/font-family-name-001.xht
@@ -8,7 +8,6 @@
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-ref.xht"/>
         <link rel="reviewer" href="mailto:chris@w3.org" title="Chris Lilley"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Family name with no quotes." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-002.xht
+++ b/css/css-fonts/font-family-name-002.xht
@@ -8,7 +8,6 @@
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="reviewer" href="mailto:chris@w3.org" title="Chris Lilley"/>
         <link rel="match" href="font-family-name-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Family name with no quotes, lowercase." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-003.xht
+++ b/css/css-fonts/font-family-name-003.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Family name with no quotes, mixed case." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-004.xht
+++ b/css/css-fonts/font-family-name-004.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Family name with double quotes." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-005.xht
+++ b/css/css-fonts/font-family-name-005.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Family name with single quotes." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-006.xht
+++ b/css/css-fonts/font-family-name-006.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Family name with extra whitespace should be condensed to a single space." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-007.xht
+++ b/css/css-fonts/font-family-name-007.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Family name with spaces in double quotes should not match, spaces are not reduced." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-008.xht
+++ b/css/css-fonts/font-family-name-008.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Family name with spaces in single quotes should not match, spaces are not reduced." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-009.xht
+++ b/css/css-fonts/font-family-name-009.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Family name with escaped character." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-010.xht
+++ b/css/css-fonts/font-family-name-010.xht
@@ -8,7 +8,6 @@
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-ref.xht"/>
         <meta http-equiv="Content-Type" content="text/xhtml; charset=utf-8" />
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Localized family names should match." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-011.xht
+++ b/css/css-fonts/font-family-name-011.xht
@@ -8,7 +8,6 @@
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-ref.xht"/>
         <meta http-equiv="Content-Type" content="text/xhtml; charset=utf-8" />
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Quoted localized family names should match." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-012.xht
+++ b/css/css-fonts/font-family-name-012.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Family name with escaped characters." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-013.xht
+++ b/css/css-fonts/font-family-name-013.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Fullname name should not match, only family names." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-014.xht
+++ b/css/css-fonts/font-family-name-014.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Postscript name should not match, only family names." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-015.xht
+++ b/css/css-fonts/font-family-name-015.xht
@@ -8,7 +8,6 @@
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-ref.xht"/>
         <meta http-equiv="Content-Type" content="text/xhtml; charset=utf-8" />
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Localized fullname should not match." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-016-ref.xht
+++ b/css/css-fonts/font-family-name-016-ref.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Mozilla" href="http://www.mozilla.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font-family" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
-        <meta name="flags" content="font" />
         <meta name="assert" content="Unquoted font family names with numbers should not be matched (reference)" />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-016.xht
+++ b/css/css-fonts/font-family-name-016.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-016-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="Unquoted font family names with numbers should not be matched" />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-017.xht
+++ b/css/css-fonts/font-family-name-017.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-mixcase-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="When an unquoted font family name is not found font fallback occurs, the rule is not treated as invalid, the font-family setting of the enclosed body should not be used." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-018.xht
+++ b/css/css-fonts/font-family-name-018.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-mixcase-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="When a quoted font family name is not found font fallback occurs, the rule is not treated as invalid, the font-family setting of the enclosed body should not be used." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-019.xht
+++ b/css/css-fonts/font-family-name-019.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-mixcase-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="When an unquoted font family name is not found font fallback occurs, the rule is not treated as invalid, the font-family setting of the enclosed div should not be used." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-020.xht
+++ b/css/css-fonts/font-family-name-020.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-mixcase-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="When a quoted font family name is not found font fallback occurs, the rule is not treated as invalid, the font-family setting of the enclosed div should not be used." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-021.xht
+++ b/css/css-fonts/font-family-name-021.xht
@@ -7,7 +7,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-ref.xht"/>
-        <meta name="flags" content="font invalid" />
+        <meta name="flags" content="invalid" />
         <meta name="assert" content="Mixing quoted name with unquoted portion is invalid syntax, rule is dropped." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-022-ref.xht
+++ b/css/css-fonts/font-family-name-022-ref.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Mozilla" href="http://www.mozilla.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font-family" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
-        <meta name="flags" content="font" />
         <meta name="assert" content="Font shorthand parsing should not cause incorrect matching of font-family values (ref)" />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-022.xht
+++ b/css/css-fonts/font-family-name-022.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-022-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="Font shorthand parsing should not cause incorrect matching of font-family values" />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-023-ref.xht
+++ b/css/css-fonts/font-family-name-023-ref.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Mozilla" href="http://www.mozilla.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font-family" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Family name with escaped characters." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-023.xht
+++ b/css/css-fonts/font-family-name-023.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-023-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="Font family names that appear similar to font shorthand should match to fonts with those names" />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-024-ref.xht
+++ b/css/css-fonts/font-family-name-024-ref.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Mozilla" href="http://www.mozilla.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font-family" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Family name with escaped characters." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-024.xht
+++ b/css/css-fonts/font-family-name-024.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop"/>
         <link rel="match" href="font-family-name-024-ref.xht"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="System font names are only allowed with the font shorthand, not in font-family rules" />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-mixcase-ref.xht
+++ b/css/css-fonts/font-family-name-mixcase-ref.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Mozilla" href="http://www.mozilla.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font-family" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-family-name-ref.xht
+++ b/css/css-fonts/font-family-name-ref.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Mozilla" href="http://www.mozilla.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font-family" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
-        <meta name="flags" content="font" />
         <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font." />
         <style type="text/css">
             body { font-size: 36px; }

--- a/css/css-fonts/font-size-adjust-003.xht
+++ b/css/css-fonts/font-size-adjust-003.xht
@@ -33,7 +33,6 @@
   It's "Oxygen-Sans" (with a hyphen!) and not "Oxygen Sans"
   -->
 
-  <meta content="font" name="flags" />
   <meta content="In this test, span.test's first 3 fallback fonts are unavailable and the next fallback fonts have a relatively big aspect value with regards to each fonts listed, declared in span.reference rule (0.450). This test checks that 'font-size-adjust' property adjusts the relative height of lowercase letters of available, installed fallback fonts listed, declared in span.test rule (0.530-0.545) to match the relative height of lowercase letters of fonts listed, declared in span.reference rule (0.450)." name="assert" />
 
   <meta name="DC.date.created" content="2015-01-01T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-fonts/font-weight-bolder-001-ref.xht
+++ b/css/css-fonts/font-weight-bolder-001-ref.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Mozilla" href="http://www.mozilla.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-boldness" />
-        <meta name="flags" content="font" />
         <meta name="assert" content="Font weights should map to corresponding font faces in a family with all weights" />
         <style type="text/css">
             span#verify { font-family: CSSTest Verify; font-weight: normal; }

--- a/css/css-fonts/font-weight-bolder-001.xht
+++ b/css/css-fonts/font-weight-bolder-001.xht
@@ -6,7 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-boldness" />
         <link rel="match" href="font-weight-bolder-001-ref.xht"/>
-        <meta name="flags" content="font should" />
+        <meta name="flags" content="should" />
         <meta name="assert" content="Font weights should map to corresponding font faces in a family with all weights" />
         <style type="text/css">
             span#verify { font-family: CSSTest Verify; font-weight: normal; }

--- a/css/css-fonts/font-weight-lighter-001-ref.xht
+++ b/css/css-fonts/font-weight-lighter-001-ref.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Mozilla" href="http://www.mozilla.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-boldness" />
-        <meta name="flags" content="font" />
         <meta name="assert" content="Font weights should map to corresponding font faces in a family with all weights" />
         <style type="text/css">
             span#verify { font-family: CSSTest Verify; font-weight: normal; }

--- a/css/css-fonts/font-weight-lighter-001.xht
+++ b/css/css-fonts/font-weight-lighter-001.xht
@@ -6,7 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-boldness" />
         <link rel="match" href="font-weight-lighter-001-ref.xht"/>
-        <meta name="flags" content="font should" />
+        <meta name="flags" content="should" />
         <meta name="assert" content="Font weights should map to corresponding font faces in a family with all weights" />
         <style type="text/css">
             span#verify { font-family: CSSTest Verify; font-weight: normal; }

--- a/css/css-fonts/font-weight-normal-001-ref.xht
+++ b/css/css-fonts/font-weight-normal-001-ref.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Mozilla" href="http://www.mozilla.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-boldness" />
-        <meta name="flags" content="font" />
         <meta name="assert" content="Font weights should map to corresponding font faces in a family with all weights" />
         <style type="text/css">
             span#verify { font-family: CSSTest Verify; font-weight: normal; }

--- a/css/css-fonts/font-weight-normal-001.xht
+++ b/css/css-fonts/font-weight-normal-001.xht
@@ -6,7 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-boldness" />
         <link rel="match" href="font-weight-normal-001-ref.xht"/>
-        <meta name="flags" content="font should" />
+        <meta name="flags" content="should" />
         <meta name="assert" content="Font weights should map to corresponding font faces in a family with all weights" />
         <style type="text/css">
             span#verify { font-family: CSSTest Verify; font-weight: normal; }

--- a/css/css-fonts/test-synthetic-bold.xht
+++ b/css/css-fonts/test-synthetic-bold.xht
@@ -6,7 +6,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-boldness" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-weight-prop" />
-        <meta name="flags" content="font" />
         <meta name="assert" content="Synthetic bold text should render differently than normal text" />
         <style type="text/css">
             div { font-size: 36px; }

--- a/css/css-fonts/test-synthetic-italic.xht
+++ b/css/css-fonts/test-synthetic-italic.xht
@@ -6,7 +6,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font-style" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-styling" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-style-prop"/>
-        <meta name="flags" content="font" />
         <meta name="assert" content="Synthetic italic text should render differently than normal text" />
         <style type="text/css">
             div { font-size: 36px; }

--- a/css/css-fonts/variations/font-weight-matching-installed-fonts.html
+++ b/css/css-fonts/variations/font-weight-matching-installed-fonts.html
@@ -6,7 +6,6 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <!-- THIS TEST REQUIRES THAT YOU INSTALL THE [csstest-*.ttf] FONTS OF THE [resources] FOLDER -->
-    <meta name="flags" content="font" />
     <style>
 
         .testcase {

--- a/css/css-text/hanging-punctuation/hanging-punctuation-allow-end-001.xht
+++ b/css/css-text/hanging-punctuation/hanging-punctuation-allow-end-001.xht
@@ -6,7 +6,6 @@
 		<link rel="author" title="Satoshi Umehara" href="mailto:umehara@est.co.jp" />
 		<link rel="help" title="CSS Text Level 3: 10.2. Hanging Punctuation: the ‘hanging-punctuation’ property" href="http://www.w3.org/TR/css-text-3/#hanging-punctuation" />
 		<link rel="match" href="reference/hanging-punctuation-allow-end-001-ref.xht"/>
-		<meta name="flags" content="font" />
 		<meta name="assert" content="This property determines whether a punctuation mark, if one is present, may be placed outside the line box (or in the indent) at the start or at the end of a full line of text." />
 		<style type="text/css">
 			<![CDATA[

--- a/css/css-text/hanging-punctuation/hanging-punctuation-first-001.xht
+++ b/css/css-text/hanging-punctuation/hanging-punctuation-first-001.xht
@@ -6,7 +6,6 @@
 		<link rel="author" title="Satoshi Umehara" href="mailto:umehara@est.co.jp" />
 		<link rel="help" title="CSS Text Level 3: 10.2. Hanging Punctuation: the ‘hanging-punctuation’ property" href="http://www.w3.org/TR/css-text-3/#hanging-punctuation" />
 		<link rel="match" href="reference/hanging-punctuation-first-001-ref.xht"/>
-		<meta name="flags" content="font" />
 		<meta name="assert" content="This property determines whether a punctuation mark, if one is present, may be placed outside the line box (or in the indent) at the start or at the end of a full line of text." />
 		<style type="text/css">
 			<![CDATA[

--- a/css/css-text/hanging-punctuation/hanging-punctuation-force-end-001.xht
+++ b/css/css-text/hanging-punctuation/hanging-punctuation-force-end-001.xht
@@ -6,7 +6,6 @@
 		<link rel="author" title="Satoshi Umehara" href="mailto:umehara@est.co.jp" />
 		<link rel="help" title="CSS Text Level 3: 10.2. Hanging Punctuation: the ‘hanging-punctuation’ property" href="http://www.w3.org/TR/css-text-3/#hanging-punctuation" />
 		<link rel="match" href="reference/hanging-punctuation-force-end-001-ref.xht"/>
-		<meta name="flags" content="font" />
 		<meta name="assert" content="This property determines whether a punctuation mark, if one is present, may be placed outside the line box (or in the indent) at the start or at the end of a full line of text." />
 		<style type="text/css">
 			<![CDATA[

--- a/css/css-text/hanging-punctuation/hanging-punctuation-last-001.xht
+++ b/css/css-text/hanging-punctuation/hanging-punctuation-last-001.xht
@@ -6,7 +6,6 @@
 		<link rel="author" title="Satoshi Umehara" href="mailto:umehara@est.co.jp" />
 		<link rel="help" title="CSS Text Level 3: 10.2. Hanging Punctuation: the ‘hanging-punctuation’ property" href="http://www.w3.org/TR/css-text-3/#hanging-punctuation" />
 		<link rel="match" href="reference/hanging-punctuation-last-001-ref.xht"/>
-		<meta name="flags" content="font" />
 		<meta name="assert" content="This property determines whether a punctuation mark, if one is present, may be placed outside the line box (or in the indent) at the start or at the end of a full line of text." />
 		<style type="text/css">
 			<![CDATA[

--- a/css/css-ui/text-overflow.html
+++ b/css/css-ui/text-overflow.html
@@ -6,7 +6,7 @@
     <link rel="reviewer" title="Leif Arne Storset" href="mailto:lstorset@opera.com">
     <link rel="help" href="http://www.w3.org/TR/css3-ui/#text-overflow" title="8.2. the 'text-overflow' property">
     <link rel="match" href="text-overflow-ref.html">
-    <meta name="flags" content="font ahem">
+    <meta name="flags" content="ahem">
     <meta name="assert" content="'text-overflow:ellipsis' renders U+2026 when text is overflowing.">
 	<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 	<style>


### PR DESCRIPTION
Part of #23253

removes all instances of the `font` css flag that appears in any file in the `css` directory of this repo, as it is no longer a valid requirements flag. [Valid flags can be found here](https://web-platform-tests.org/writing-tests/css-metadata.html#requirement-flags).