### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=230941

### DIFF
--- a/dom/events/Event-timestamp-cross-realm-getter.html
+++ b/dom/events/Event-timestamp-cross-realm-getter.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>event.timeStamp is initialized using event's relevant global object</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#ref-for-dom-event-timestamp%E2%91%A1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+const t = async_test();
+t.step_timeout(() => {
+  const iframeDelayed = document.createElement("iframe");
+  iframeDelayed.onload = t.step_func_done(() => {
+    // Use eval() to eliminate false-positive test result for WebKit builds before r280256,
+    // which invoked WebIDL accessors in context of lexical (caller) global object.
+    const timeStampExpected = iframeDelayed.contentWindow.eval(`new Event("foo").timeStamp`);
+    const eventDelayed = new iframeDelayed.contentWindow.Event("foo");
+
+    const {get} = Object.getOwnPropertyDescriptor(Event.prototype, "timeStamp");
+    assert_approx_equals(get.call(eventDelayed), timeStampExpected, 5, "via Object.getOwnPropertyDescriptor");
+
+    Object.setPrototypeOf(eventDelayed, Event.prototype);
+    assert_approx_equals(eventDelayed.timeStamp, timeStampExpected, 5, "via Object.setPrototypeOf");
+  });
+  document.body.append(iframeDelayed);
+}, 1000);
+</script>

--- a/html/browsers/history/the-history-interface/history_back_cross_realm_method.html
+++ b/html/browsers/history/the-history-interface/history_back_cross_realm_method.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>history.back() uses this's associated document's browsing context to determine if navigation is allowed</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/history.html#dom-history-back">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<iframe id="sandboxedIframe" srcdoc="hello" sandbox="allow-scripts allow-same-origin"></iframe>
+<script>
+const t = async_test();
+
+t.step(() => {
+  history.pushState({}, null, "?prev");
+  history.pushState({}, null, "?current");
+
+  sandboxedIframe.contentWindow.history.back.call(history);
+});
+
+window.onpopstate = t.step_func_done(() => {
+  assert_equals(location.search, "?prev");
+});
+</script>

--- a/html/browsers/history/the-history-interface/history_forward_cross_realm_method.html
+++ b/html/browsers/history/the-history-interface/history_forward_cross_realm_method.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>history.forward() uses this's associated document's browsing context to determine if navigation is allowed</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/history.html#dom-history-forward">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<iframe id="sandboxedIframe" srcdoc="hello" sandbox="allow-scripts allow-same-origin"></iframe>
+<script>
+const t = async_test();
+
+t.step(() => {
+  history.pushState({}, null, "?prev");
+  history.pushState({}, null, "?current");
+  history.back();
+});
+
+let isCrossRealmForward = false;
+window.onpopstate = t.step_func(() => {
+  if (isCrossRealmForward) {
+    assert_equals(location.search, "?current");
+    t.done();
+  } else {
+    sandboxedIframe.contentWindow.history.forward.call(history);
+    isCrossRealmForward = true;
+  }
+});
+</script>

--- a/html/browsers/history/the-history-interface/history_go_cross_realm_method.html
+++ b/html/browsers/history/the-history-interface/history_go_cross_realm_method.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>history.go() uses this's associated document's browsing context to determine if navigation is allowed</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/history.html#dom-history-go">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<iframe id="sandboxedIframe" srcdoc="hello" sandbox="allow-scripts allow-same-origin"></iframe>
+<script>
+const t = async_test();
+
+t.step(() => {
+  history.pushState({}, null, "?prev=2");
+  history.pushState({}, null, "?prev=1");
+  history.pushState({}, null, "?current");
+
+  sandboxedIframe.contentWindow.history.go.call(history, -2);
+});
+
+window.onpopstate = t.step_func_done(() => {
+  assert_equals(location.search, "?prev=2");
+});
+</script>

--- a/html/webappapis/scripting/reporterror-cross-realm-method.html
+++ b/html/webappapis/scripting/reporterror-cross-realm-method.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>self.reportError() dispatches an "error" event for this's relevant global object</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-reporterror">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+setup({ allow_uncaught_exception: true });
+
+async_test(t => {
+  window.addEventListener("error", t.unreached_func("'error' event should not be dispatched for top window!"));
+
+  const iframe = document.createElement("iframe");
+  iframe.onload = t.step_func_done(() => {
+    let eventFired = false;
+    const error = new TypeError("foo");
+    const otherWindow = iframe.contentWindow;
+    otherWindow.addEventListener("error", t.step_func(event => {
+      assert_equals(event.error, error);
+      eventFired = true;
+    }));
+
+    window.reportError.call(otherWindow, error);
+    assert_true(eventFired);
+  });
+  document.body.append(iframe);
+});
+</script>

--- a/html/webappapis/structured-clone/structured-clone-cross-realm-method.html
+++ b/html/webappapis/structured-clone/structured-clone-cross-realm-method.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>self.structuredClone() uses this's relevant Realm for deserialization</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/structured-data.html#structured-cloning">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+const iframe = document.createElement("iframe");
+iframe.onload = () => {
+  const otherWindow = iframe.contentWindow;
+  for (const key of ["Object", "Array", "Date", "RegExp"]) {
+    test(() => {
+      const cloned = otherWindow.structuredClone.call(window, new otherWindow[key]);
+      assert_true(cloned instanceof window[key]);
+    }, `${key} instance`);
+  }
+};
+document.body.append(iframe);
+</script>

--- a/requestidlecallback/callback-timeRemaining-cross-realm-method.html
+++ b/requestidlecallback/callback-timeRemaining-cross-realm-method.html
@@ -1,0 +1,25 @@
+<!doctype html><!-- webkit-test-runner [ RequestIdleCallbackEnabled=true ] -->
+<meta charset="utf-8">
+<meta name="timeout" content="long">
+<title>IdleDeadline::timeRemaining() uses relevant global object as a high-res timestamp origin</title>
+<link rel="help" href="https://w3c.github.io/requestidlecallback/#dom-idledeadline-timeremaining">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+const t = async_test();
+t.step_timeout(() => {
+  const iframeDelayed = document.createElement("iframe");
+  iframeDelayed.onload = t.step_func(() => {
+    requestIdleCallback(t.step_func_done(deadline => {
+      assert_approx_equals(
+        iframeDelayed.contentWindow.IdleDeadline.prototype.timeRemaining.call(deadline),
+        deadline.timeRemaining(),
+        5,
+      );
+    }));
+  });
+  document.body.append(iframeDelayed);
+}, 1000);
+</script>


### PR DESCRIPTION
This upstream reviewed change tests that selected WebIDL attributes and operations use *relevant* global object instead of *current* as per their specs or general guideline to [prefer relevant](https://html.spec.whatwg.org/#concept-relevant-everything).