### PR TITLE
Remove vendor prefixes from intrinsic sizes

### DIFF
--- a/css/css-flexbox/flex-basis-intrinsics-001.html
+++ b/css/css-flexbox/flex-basis-intrinsics-001.html
@@ -49,7 +49,7 @@
 </div>
 
 <div class=flexbox>
-  <div class=flex-item style="flex-basis: -moz-fit-content; flex-basis: fit-content;" data-expected-width=75>
+  <div class=flex-item style="flex-basis: fit-content;" data-expected-width=75>
     <div class=inline-block></div><div class=inline-block></div>
   </div>
 </div>
@@ -67,7 +67,7 @@
 </div>
 
 <div class=flexbox style="flex-flow: column;">
-  <div class=flex-item style="flex-basis: -moz-fit-content; flex-basis: fit-content;" data-expected-height=100>
+  <div class=flex-item style="flex-basis: fit-content;" data-expected-height=100>
     <div class=inline-block></div><div class=inline-block></div>
   </div>
 </div>
@@ -85,7 +85,7 @@
 </div>
 
 <div class=flexbox>
-  <div class="flex-item ortho-item" style="flex-basis: -moz-fit-content; flex-basis: fit-content;" data-expected-width=100>
+  <div class="flex-item ortho-item" style="flex-basis: fit-content;" data-expected-width=100>
     <div class=inline-block></div><div class=inline-block></div>
   </div>
 </div>
@@ -103,7 +103,7 @@
 </div>
 
 <div class=flexbox style="flex-flow: column;">
-  <div class="flex-item ortho-item" style="flex-basis: -moz-fit-content; flex-basis: fit-content;" data-expected-height=75>
+  <div class="flex-item ortho-item" style="flex-basis: fit-content;" data-expected-height=75>
     <div class=inline-block></div><div class=inline-block></div>
   </div>
 </div>

--- a/css/css-flexbox/flex-minimum-width-flex-items-014.html
+++ b/css/css-flexbox/flex-minimum-width-flex-items-014.html
@@ -6,10 +6,6 @@
 <style>
 .min-content {
     width: 10px;
-    min-width: -webkit-min-content;
-    min-width: -moz-min-content;
-    min-width: -ie-min-content;
-    min-width: -o-min-content;
     min-width: min-content;
     outline: 2px solid;
     display: flex;
@@ -17,10 +13,6 @@
 }
 .max-content {
     width: 10px;
-    min-width: -webkit-max-content;
-    min-width: -moz-max-content;
-    min-width: -ie-max-content;
-    min-width: -o-max-content;
     min-width: max-content;
     outline: 2px solid;
     display: flex;
@@ -28,10 +20,6 @@
 }
 .fit-content {
     width: 10px;
-    min-width: -webkit-fit-content;
-    min-width: -moz-fit-content;
-    min-width: -ie-fit-content;
-    min-width: -o-fit-content;
     min-width: fit-content;
     outline: 2px solid;
     display: flex;

--- a/css/css-grid/reference/grid-container-auto-margins-scrollbars-001-ref.html
+++ b/css/css-grid/reference/grid-container-auto-margins-scrollbars-001-ref.html
@@ -6,7 +6,6 @@ body {
 }
 .item1 {
    width: fit-content;
-   width: -moz-fit-content;
    margin: 0px auto;
 }
 .item2 {

--- a/css/css-grid/reference/grid-container-scrollbars-sizing-002-ref.html
+++ b/css/css-grid/reference/grid-container-scrollbars-sizing-002-ref.html
@@ -17,7 +17,6 @@
   background: green;
 }
 .fit-content {
-  width: -moz-fit-content;
   width: fit-content;
 }
 </style>

--- a/css/css-sizing/aspect-ratio/intrinsic-size-011.html
+++ b/css/css-sizing/aspect-ratio/intrinsic-size-011.html
@@ -14,6 +14,6 @@ div {
 
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 
-<div style="height: 50px; width: -moz-fit-content; width: fit-content;"></div>
+<div style="height: 50px; width: fit-content;"></div>
 <!-- fit-content in the block axis is treated as auto -->
-<div style="height: -moz-fit-content; height: fit-content; width: 100px;"></div>
+<div style="height: fit-content; width: 100px;"></div>

--- a/css/css-sizing/clone-intrinsic-size-ref.html
+++ b/css/css-sizing/clone-intrinsic-size-ref.html
@@ -12,13 +12,9 @@ div {
   white-space: pre;
 }
 .max > div {
-  width: -moz-max-content;
-  width: -webkit-max-content;
   width: max-content;
 }
 .min > div {
-  width: -moz-min-content;
-  width: -webkit-min-content;
   width: min-content;
 }
 

--- a/css/css-sizing/clone-intrinsic-size.html
+++ b/css/css-sizing/clone-intrinsic-size.html
@@ -15,13 +15,9 @@ div {
   border: 5px solid blue;
 }
 .max > div {
-  width: -moz-max-content;
-  width: -webkit-max-content;
   width: max-content;
 }
 .min > div {
-  width: -moz-min-content;
-  width: -webkit-min-content;
   width: min-content;
 }
 

--- a/css/css-sizing/clone-nowrap-intrinsic-size-bidi-ref.html
+++ b/css/css-sizing/clone-nowrap-intrinsic-size-bidi-ref.html
@@ -12,8 +12,6 @@ div {
   white-space: pre;
 }
 .max > div {
-  width: -moz-max-content;
-  width: -webkit-max-content;
   width: max-content;
 }
 

--- a/css/css-sizing/clone-nowrap-intrinsic-size-bidi.html
+++ b/css/css-sizing/clone-nowrap-intrinsic-size-bidi.html
@@ -16,13 +16,9 @@ div {
   white-space: nowrap;
 }
 .max > div {
-  width: -moz-max-content;
-  width: -webkit-max-content;
   width: max-content;
 }
 .min > div {
-  width: -moz-min-content;
-  width: -webkit-min-content;
   width: min-content;
 }
 

--- a/css/css-sizing/clone-nowrap-intrinsic-size-ref.html
+++ b/css/css-sizing/clone-nowrap-intrinsic-size-ref.html
@@ -12,8 +12,6 @@ div {
   white-space: pre;
 }
 .max > div {
-  width: -moz-max-content;
-  width: -webkit-max-content;
   width: max-content;
 }
 

--- a/css/css-sizing/clone-nowrap-intrinsic-size.html
+++ b/css/css-sizing/clone-nowrap-intrinsic-size.html
@@ -16,13 +16,9 @@ div {
   white-space: nowrap;
 }
 .max > div {
-  width: -moz-max-content;
-  width: -webkit-max-content;
   width: max-content;
 }
 .min > div {
-  width: -moz-min-content;
-  width: -webkit-min-content;
   width: min-content;
 }
 

--- a/css/css-sizing/div-fit-content-auto-margin-bottom.tentative.html
+++ b/css/css-sizing/div-fit-content-auto-margin-bottom.tentative.html
@@ -9,7 +9,6 @@
     margin: auto;
     bottom: 10px;
     position: absolute;
-    block-size: -moz-fit-content;
     block-size: fit-content;
     inline-size: 100px;
     border: 5px solid red;

--- a/css/css-sizing/div-fit-content-auto-margin-top.tentative.html
+++ b/css/css-sizing/div-fit-content-auto-margin-top.tentative.html
@@ -9,7 +9,6 @@
     margin: auto;
     top: 10px;
     position: absolute;
-    block-size: -moz-fit-content;
     block-size: fit-content;
     inline-size: 100px;
     border: 5px solid red;

--- a/css/css-sizing/div-fit-content-auto-margin.tentative.html
+++ b/css/css-sizing/div-fit-content-auto-margin.tentative.html
@@ -8,7 +8,6 @@
     background-color: black;
     margin: auto;
     position: absolute;
-    block-size: -moz-fit-content;
     block-size: fit-content;
     inline-size: 100px;
     border: 5px solid red;

--- a/css/css-sizing/div-fit-content-block-size.tentative.html
+++ b/css/css-sizing/div-fit-content-block-size.tentative.html
@@ -7,7 +7,6 @@
     inset: 0;
     background-color: black;
     position: absolute;
-    block-size: -moz-fit-content;
     block-size: fit-content;
     inline-size: 100px;
     border: 5px solid red;

--- a/css/css-sizing/div-fit-content-orthogonal-auto-margin-left.tentative.html
+++ b/css/css-sizing/div-fit-content-orthogonal-auto-margin-left.tentative.html
@@ -10,7 +10,6 @@
     margin: auto;
     left: 10px;
     position: absolute;
-    block-size: -moz-fit-content;
     block-size: fit-content;
     inline-size: 100px;
     border: 5px solid red;

--- a/css/css-sizing/div-fit-content-orthogonal-auto-margin-right.tentative.html
+++ b/css/css-sizing/div-fit-content-orthogonal-auto-margin-right.tentative.html
@@ -10,7 +10,6 @@
     margin: auto;
     right: 10px;
     position: absolute;
-    block-size: -moz-fit-content;
     block-size: fit-content;
     inline-size: 100px;
     border: 5px solid red;

--- a/css/css-sizing/div-fit-content-orthogonal-auto-margin.tentative.html
+++ b/css/css-sizing/div-fit-content-orthogonal-auto-margin.tentative.html
@@ -9,7 +9,6 @@
     writing-mode: vertical-rl;
     margin: auto;
     position: absolute;
-    block-size: -moz-fit-content;
     block-size: fit-content;
     inline-size: 100px;
     border: 5px solid red;

--- a/css/css-sizing/div-fit-content-orthogonal-block-size.tentative.html
+++ b/css/css-sizing/div-fit-content-orthogonal-block-size.tentative.html
@@ -7,7 +7,6 @@
     inset: 0;
     background-color: black;
     position: absolute;
-    block-size: -moz-fit-content;
     block-size: fit-content;
     inline-size: 100px;
     writing-mode: vertical-rl;

--- a/css/css-sizing/range-percent-intrinsic-size-1-ref.html
+++ b/css/css-sizing/range-percent-intrinsic-size-1-ref.html
@@ -22,7 +22,6 @@ input.i {
 input.mi {
   min-width: 0;
   max-width: 100%;
-  width: -moz-max-content;
   width: max-content;
   background: lime;
 }
@@ -120,7 +119,7 @@ div {
   <input type="range" class="mi n">
 </div></div>
 
-<div style="width:30px"><div style="width:-moz-max-content;width:max-content">
+<div style="width:30px"><div style="width:max-content">
   <input type="range" class="mi n" style="width:50%">
 </div></div>
 

--- a/css/css-sizing/range-percent-intrinsic-size-1.html
+++ b/css/css-sizing/range-percent-intrinsic-size-1.html
@@ -19,14 +19,12 @@ input { margin: 2px; }
 
 input.i {
   width: 50%;
-  min-width: -moz-min-content;
   min-width: min-content;
   background: lime;
 }
 
 input.mi {
   max-width: 50%;
-  min-width: -moz-min-content;
   min-width: min-content;
   background: lime;
 }

--- a/css/css-sizing/range-percent-intrinsic-size-2.html
+++ b/css/css-sizing/range-percent-intrinsic-size-2.html
@@ -19,19 +19,17 @@ input { margin: 2px; }
 
 input.b {
   height: 50%;
-  min-height: -moz-min-content;
   min-height: min-content;
   background: lime;
 }
 
 input.mb {
   max-height: 50%;
-  min-height: -moz-min-content;
   min-height: min-content;
   background: lime;
 }
 
-input.b.min-auto, input.mb.min-auto, {
+input.b.min-auto, input.mb.min-auto {
   min-height: auto;
 }
 

--- a/css/css-sizing/range-percent-intrinsic-size-2a.html
+++ b/css/css-sizing/range-percent-intrinsic-size-2a.html
@@ -19,19 +19,17 @@ input { margin: 2px; }
 
 input.b {
   height: 50%;
-  min-height: -moz-min-content;
   min-height: min-content;
   background: lime;
 }
 
 input.mb {
   max-height: 50%;
-  min-height: -moz-min-content;
   min-height: min-content;
   background: lime;
 }
 
-input.b.min-auto, input.mb.min-auto, {
+input.b.min-auto, input.mb.min-auto {
   min-height: auto;
 }
 

--- a/css/css-sizing/slice-intrinsic-size-ref.html
+++ b/css/css-sizing/slice-intrinsic-size-ref.html
@@ -12,13 +12,9 @@ div {
   white-space: pre;
 }
 .max > div {
-  width: -moz-max-content;
-  width: -webkit-max-content;
   width: max-content;
 }
 .min > div {
-  width: -moz-min-content;
-  width: -webkit-min-content;
   width: min-content;
 }
 

--- a/css/css-sizing/slice-intrinsic-size.html
+++ b/css/css-sizing/slice-intrinsic-size.html
@@ -15,13 +15,9 @@ div {
   border: 5px solid blue;
 }
 .max > div {
-  width: -moz-max-content;
-  width: -webkit-max-content;
   width: max-content;
 }
 .min > div {
-  width: -moz-min-content;
-  width: -webkit-min-content;
   width: min-content;
 }
 

--- a/css/css-sizing/slice-nowrap-intrinsic-size-bidi-ref.html
+++ b/css/css-sizing/slice-nowrap-intrinsic-size-bidi-ref.html
@@ -12,8 +12,6 @@ div {
   white-space: pre;
 }
 .max > div {
-  width: -moz-max-content;
-  width: -webkit-max-content;
   width: max-content;
 }
 

--- a/css/css-sizing/slice-nowrap-intrinsic-size-bidi.html
+++ b/css/css-sizing/slice-nowrap-intrinsic-size-bidi.html
@@ -16,13 +16,9 @@ div {
   white-space: nowrap;
 }
 .max > div {
-  width: -moz-max-content;
-  width: -webkit-max-content;
   width: max-content;
 }
 .min > div {
-  width: -moz-min-content;
-  width: -webkit-min-content;
   width: min-content;
 }
 

--- a/css/css-sizing/slice-nowrap-intrinsic-size-ref.html
+++ b/css/css-sizing/slice-nowrap-intrinsic-size-ref.html
@@ -12,8 +12,6 @@ div {
   white-space: pre;
 }
 .max > div {
-  width: -moz-max-content;
-  width: -webkit-max-content;
   width: max-content;
 }
 

--- a/css/css-sizing/slice-nowrap-intrinsic-size.html
+++ b/css/css-sizing/slice-nowrap-intrinsic-size.html
@@ -16,13 +16,9 @@ div {
   white-space: nowrap;
 }
 .max > div {
-  width: -moz-max-content;
-  width: -webkit-max-content;
   width: max-content;
 }
 .min > div {
-  width: -moz-min-content;
-  width: -webkit-min-content;
   width: min-content;
 }
 

--- a/css/support/height-keyword-classes.css
+++ b/css/support/height-keyword-classes.css
@@ -11,7 +11,6 @@
 }
 
 .fit-content {
-    height: -moz-fit-content;
     height: fit-content;
 }
 
@@ -24,7 +23,6 @@
 }
 
 .max-height-fit-content {
-    max-height: -moz-fit-content;
     max-height: fit-content;
 }
 
@@ -37,6 +35,5 @@
 }
 
 .min-height-fit-content {
-    min-height: -moz-fit-content;
     min-height: fit-content;
 }

--- a/css/support/width-keyword-classes.css
+++ b/css/support/width-keyword-classes.css
@@ -15,7 +15,6 @@
    max(min-content, min(max-content, fill-available))
 */
 .fit-content {
-    width: -moz-fit-content;
     width: fit-content;
 }
 
@@ -28,7 +27,6 @@
 }
 
 .max-width-fit-content {
-    max-width: -moz-fit-content;
     max-width: fit-content;
 }
 
@@ -41,6 +39,5 @@
 }
 
 .min-width-fit-content {
-    min-width: -moz-fit-content;
     min-width: fit-content;
 }

--- a/html/semantics/forms/the-input-element/range-intrinsic-size-ref.html
+++ b/html/semantics/forms/the-input-element/range-intrinsic-size-ref.html
@@ -42,12 +42,10 @@ html,body {
 }
 
 input {
-   width: -moz-max-content;
    width: max-content;
    min-width: 0;
 }
 input.min {
-   min-width: -moz-min-content;
    min-width: min-content;
 }
 input.mbp0 {

--- a/html/semantics/forms/the-input-element/range-intrinsic-size.html
+++ b/html/semantics/forms/the-input-element/range-intrinsic-size.html
@@ -78,8 +78,8 @@ input.mbp0 {
 <div class="ib"><input type="range"></div><br>
 <div class="ib"><input type="range" style="min-width:0"></div><br>
 
-<input type="range" style="width:-moz-min-content; width:min-content;">
-<input type="range" style="width:-moz-max-content; width:max-content;">
+<input type="range" style="width:min-content;">
+<input type="range" style="width:max-content;">
 
 </body>
 </html>

--- a/html/semantics/interactive-elements/the-dialog-element/resources/dialog.css
+++ b/html/semantics/interactive-elements/the-dialog-element/resources/dialog.css
@@ -4,9 +4,7 @@
     right: 0;
     bottom: 0;
     left: 0;
-    width: -moz-fit-content;
     width: fit-content;
-    height: -moz-fit-content;
     height: fit-content;
     margin: auto;
     border: solid;


### PR DESCRIPTION
Fixes #32014 

As discussed in the issue linked above 👆, this PR removes unnecessary vendor prefixes for CSS intrinsic sizes.

While removing the `-moz` prefix for `fit-content` I noticed some leftover prefixes for `min-content` and `max-content` (`-moz` but also `-webkit`, `-o`, and `-ie`). I think they can all be removed since these intrinsic sizes are now supported unprefixed.

I also ran some tests locally and it looked to me like there were no new failures, but I didn't know how to check the results against the expected test data 🙈 

Let me know if there's anything else I'm missing in this PR!