### PR TITLE
Test for inline blocks with children with orthogonal writing modes and margins

### DIFF
--- a/css/css-writing-modes/inline-box-orthogonal-child-with-margins-ref.html
+++ b/css/css-writing-modes/inline-box-orthogonal-child-with-margins-ref.html
@@ -1,7 +1,4 @@
 <!DOCTYPE html>
-<link rel="author" title="Sergio Villar Senin" href="mailto:svillar@igalia.com"/>
-<link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#block-flow"
-  title="3.1 Block Flow Direction: the writing-mode property">
 <style>
 .container {
   border: 1px dashed blue;
@@ -24,5 +21,5 @@
 
 <div class="container">
   <div></div>
-  <div style="writing-mode: vertical-lr;"></div>
+  <div></div>
 </div>

--- a/css/css-writing-modes/inline-box-orthogonal-child-with-margins-ref.html
+++ b/css/css-writing-modes/inline-box-orthogonal-child-with-margins-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<link rel="author" title="Sergio Villar Senin" href="mailto:svillar@igalia.com"/>
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#block-flow"
+  title="3.1 Block Flow Direction: the writing-mode property">
+<style>
+.container {
+  border: 1px dashed blue;
+  height: 200px;
+  width: 560px;
+  box-sizing: content-box;
+}
+.container > div {
+  float: left;
+  width: 40px;
+  margin:       10px 20px 30px 40px;
+  border-width: 20px 30px 40px 50px;
+  padding:      30px 40px 50px 60px;
+  border-style: dotted;
+}
+.container > div:nth-child(1) { background: yellow; }
+.container > div:nth-child(2) { background: purple; }
+
+</style>
+
+<div class="container">
+  <div></div>
+  <div style="writing-mode: vertical-lr;"></div>
+</div>

--- a/css/css-writing-modes/inline-box-orthogonal-child-with-margins.html
+++ b/css/css-writing-modes/inline-box-orthogonal-child-with-margins.html
@@ -2,7 +2,7 @@
 <link rel="author" title="Sergio Villar Senin" href="mailto:svillar@igalia.com"/>
 <link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#block-flow"
   title="3.1 Block Flow Direction: the writing-mode property">
-<link rel="match" href="inline-box-orthogonal-child-width-margins-ref.html">
+<link rel="match" href="inline-box-orthogonal-child-with-margins-ref.html">
  <style>
 .container {
   border: 1px dashed blue;

--- a/css/css-writing-modes/inline-box-orthogonal-child-with-margins.html
+++ b/css/css-writing-modes/inline-box-orthogonal-child-with-margins.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<link rel="author" title="Sergio Villar Senin" href="mailto:svillar@igalia.com"/>
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#block-flow"
+  title="3.1 Block Flow Direction: the writing-mode property">
+<link rel="match" href="inline-box-orthogonal-child-width-margins-ref.html">
+ <style>
+.container {
+  border: 1px dashed blue;
+  height: 200px;
+  display: inline-block;
+}
+.container > div {
+  float: left;
+  width: 40px;
+  margin:       10px 20px 30px 40px;
+  border-width: 20px 30px 40px 50px;
+  padding:      30px 40px 50px 60px;
+  border-style: dotted;
+}
+.container > div:nth-child(1) { background: yellow; }
+.container > div:nth-child(2) { background: purple; }
+
+</style>
+
+<div class="container">
+  <div></div>
+  <div style="writing-mode: vertical-lr;"></div>
+</div>

--- a/css/css-writing-modes/inline-box-orthogonal-child-with-margins.html
+++ b/css/css-writing-modes/inline-box-orthogonal-child-with-margins.html
@@ -3,6 +3,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#block-flow"
   title="3.1 Block Flow Direction: the writing-mode property">
 <link rel="match" href="inline-box-orthogonal-child-with-margins-ref.html">
+<meta content="This test checks that the correct margins of orthogonal children are used to compute the container's shrink to fit size. The test PASS if both children are rendered inside the container's blue border." name="assert" />
  <style>
 .container {
   border: 1px dashed blue;


### PR DESCRIPTION
This was created after [this WebKit bug](https://bugs.webkit.org/show_bug.cgi?id=233562).

In order to compute the shrink to fit inline size of an inline block we must compute first the inline sizes of our children. This includes margins as well. The bug in WebKit was that it was always using the inline (from the child POV) margins of its children. That works if the children are parallel to the parent, but if any of them is orthogonal then we should use the margins in the block direction of the child (which correspond to the inline direction of the parent).