### PR TITLE
Update the rel=help to point to actually tested section of spec

### DIFF
--- a/css/css-color/oklab-001.html
+++ b/css/css-color/oklab-001.html
@@ -2,7 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Color 4: OKLab and OKLCH</title>
 <link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
-<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-oklab-oklch">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#predefined-to-lab-oklab">
 <link rel="match" href="greensquare-ref.html">
 <meta name="assert" content="oklab() with no alpha">
 <style>

--- a/css/css-color/oklab-002.html
+++ b/css/css-color/oklab-002.html
@@ -2,7 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Color 4: OKLab and OKLCH</title>
 <link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
-<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-oklab-oklch">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#predefined-to-lab-oklab">
 <link rel="match" href="blacksquare-ref.html">
 <meta name="assert" content="oklab() with no alpha">
 <style>

--- a/css/css-color/oklab-003.html
+++ b/css/css-color/oklab-003.html
@@ -2,7 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Color 4: OKLab and OKLCH</title>
 <link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
-<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-oklab-oklch">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#predefined-to-lab-oklab">
 <link rel="match" href="whitesquare-ref.html">
 <meta name="assert" content="oklab() with no alpha">
 <style>

--- a/css/css-color/oklab-004.html
+++ b/css/css-color/oklab-004.html
@@ -2,7 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Color 4: OKLab and OKLCH</title>
 <link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
-<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-oklab-oklch">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#oklab-lab-to-predefined">
 <link rel="match" href="oklab-004-ref.html">
 <meta name="assert" content="oklab() with no alpha">
 <style>

--- a/css/css-color/oklab-005.html
+++ b/css/css-color/oklab-005.html
@@ -2,7 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Color 4: OKLab and OKLCH</title>
 <link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
-<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-oklab-oklch">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#oklab-lab-to-predefined">
 <link rel="match" href="oklab-005-ref.html">
 <meta name="assert" content="oklab() with no alpha, negative a axis">
 <style>

--- a/css/css-color/oklab-006.html
+++ b/css/css-color/oklab-006.html
@@ -2,7 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Color 4: OKLab and OKLCH</title>
 <link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
-<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-oklab-oklch">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#oklab-lab-to-predefined">
 <link rel="match" href="oklab-006-ref.html">
 <meta name="assert" content="oklab() with no alpha, positive b axis">
 <style>

--- a/css/css-color/oklab-007.html
+++ b/css/css-color/oklab-007.html
@@ -2,7 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Color 4: OKLab and OKLCH</title>
 <link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
-<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-oklab-oklch">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#oklab-lab-to-predefined">
 <link rel="match" href="oklab-007-ref.html">
 <meta name="assert" content="oklab() with no alpha, negative b axis">
 <style>

--- a/css/css-color/oklab-008.html
+++ b/css/css-color/oklab-008.html
@@ -2,7 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Color 4: OKLab and OKLCH</title>
 <link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
-<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-oklab-oklch">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#predefined-to-lab-oklab">
 <link rel="match" href="greensquare-display-p3-ref.html">
 <meta name="assert" content="oklab() outside the sRGB gamut">
 <style>

--- a/css/css-color/oklch-001.html
+++ b/css/css-color/oklch-001.html
@@ -2,7 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Color 4: OKLab and OKLCH</title>
 <link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
-<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="help" href="https://drafts.csswg.org/css-color/#specifying-oklab-oklch">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#predefined-to-lab-oklab">
 <link rel="match" href="greensquare-ref.html">
 <meta name="assert" content="oklch() with no alpha">
 <style>

--- a/css/css-color/oklch-002.html
+++ b/css/css-color/oklch-002.html
@@ -2,7 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Color 4: OKLab and OKLCH</title>
 <link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
-<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="help" href="https://drafts.csswg.org/css-color/#specifying-oklab-oklch">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#predefined-to-lab-oklab">
 <link rel="match" href="blacksquare-ref.html">
 <meta name="assert" content="oklch() with no alpha">
 <style>

--- a/css/css-color/oklch-003.html
+++ b/css/css-color/oklch-003.html
@@ -2,7 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Color 4: OKLab and OKLCH</title>
 <link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
-<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="help" href="https://drafts.csswg.org/css-color/#specifying-oklab-oklch">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#predefined-to-lab-oklab">
 <link rel="match" href="whitesquare-ref.html">
 <meta name="assert" content="oklch() with no alpha">
 <style>

--- a/css/css-color/oklch-004.html
+++ b/css/css-color/oklch-004.html
@@ -2,7 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Color 4: OKLab and OKLCH</title>
 <link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
-<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="help" href="https://drafts.csswg.org/css-color/#specifying-oklab-oklch">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#oklab-lab-to-predefined">
 <link rel="match" href="oklch-004-ref.html">
 <meta name="assert" content="oklch() with no alpha">
 <style>

--- a/css/css-color/oklch-005.html
+++ b/css/css-color/oklch-005.html
@@ -2,7 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Color 4: OKLab and OKLCH</title>
 <link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
-<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="help" href="https://drafts.csswg.org/css-color/#specifying-oklab-oklch">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#oklab-lab-to-predefined">
 <link rel="match" href="oklch-005-ref.html">
 <meta name="assert" content="oklch() with no alpha">
 <style>

--- a/css/css-color/oklch-006.html
+++ b/css/css-color/oklch-006.html
@@ -2,7 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Color 4: OKLab and OKLCH</title>
 <link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
-<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="help" href="https://drafts.csswg.org/css-color/#specifying-oklab-oklch">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#oklab-lab-to-predefined">
 <link rel="match" href="oklch-006-ref.html">
 <meta name="assert" content="oklch() with no alpha, positive b axis (when converted to Lab)">
 <style>

--- a/css/css-color/oklch-007.html
+++ b/css/css-color/oklch-007.html
@@ -2,7 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Color 4: OKLab and OKLCH</title>
 <link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
-<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="help" href="https://drafts.csswg.org/css-color/#specifying-oklab-oklch">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#oklab-lab-to-predefined">
 <link rel="match" href="oklch-007-ref.html">
 <meta name="assert" content="oklch() with no alpha">
 <style>

--- a/css/css-color/oklch-008.html
+++ b/css/css-color/oklch-008.html
@@ -2,7 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Color 4: OKLab and OKLCH</title>
 <link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
-<link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
+<link rel="help" href="https://drafts.csswg.org/css-color/#specifying-oklab-oklch">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#predefined-to-lab-oklab">
 <link rel="match" href="greensquare-display-p3-ref.html">
 <meta name="assert" content="oklch() outside the sRGB gamut">
 <style>

--- a/css/css-color/predefined-001.html
+++ b/css/css-color/predefined-001.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Color 4: predefined colorspaces, srgb, decimal values</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-color-4/#predefined">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#valdef-color-srgb">
 <link rel="match" href="greensquare-090-ref.html">
 <meta name="assert" content="Color function with explicit srgb value as decimal matches sRGB #009900">
 <style>

--- a/css/css-color/predefined-002.html
+++ b/css/css-color/predefined-002.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Color 4: predefined colorspaces, srgb, percent values</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-color-4/#predefined">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#valdef-color-srgb">
 <link rel="match" href="greensquare-090-ref.html">
 <meta name="assert" content="Color function with explicit srgb value as percent matches sRGB #009900">
 <style>

--- a/css/css-color/predefined-005.html
+++ b/css/css-color/predefined-005.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Color 4: predefined colorspaces, display-p3, decimal values</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-color-4/#predefined">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#valdef-color-display-p3">
 <link rel="match" href="greensquare-090-ref.html">
 <meta name="assert" content="Color function with explicit display-p3 value as decimal matches sRGB #009900">
 <style>

--- a/css/css-color/predefined-006.html
+++ b/css/css-color/predefined-006.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Color 4: predefined colorspaces, display-p3, percent values</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-color-4/#predefined">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#valdef-color-display-p3">
 <link rel="match" href="greensquare-090-ref.html">
 <meta name="assert" content="Color function with explicit display-p3 value as percent matches sRGB #009900">
 <style>


### PR DESCRIPTION
Some tests were pointing to the introductory sections rather than the testable syntax section which comes next.
Also some tests were testing the oklab to predefined, or predefined to oklab sections, so I added those rel=help as well