### PR TITLE
Remove empty meta flags tags in the CSS2 directory (6/8)

### DIFF
--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-001.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-001.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=1' />
-<meta name='flags' content='' />
 <meta name="assert" content="In the default context, if direction:rtl and unicode-bidi:embed are applied to an inline element containing mixed direction text, the text in that element will be displayed correctly." />
 <style type='text/css'>
 .test span { direction: rtl; unicode-bidi: embed; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-002.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-002.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=2' />
-<meta name='flags' content='' />
 <meta name="assert" content="In the default context, if direction:rtl alone is applied to an inline element containing mixed direction text, the different directional runs in that element will not be in the correct order." />
 <style type='text/css'>
 .test span { direction: rtl; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-003.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-003.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=3' />
-<meta name='flags' content='' />
 <meta name="assert" content="In a LTR context, if direction:rtl and unicode-bidi:embed are applied to an inline element containing mixed direction text, the text in that element will be displayed correctly." />
 <style type='text/css'>
 .test { direction: ltr; } .test span { direction: rtl; unicode-bidi: embed; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-004.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-004.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=4' />
-<meta name='flags' content='' />
 <meta name="assert" content="In a LTR context, if direction:rtl alone is applied to an inline element containing mixed direction text, the different directional runs in that element will not be in the correct order." />
 <style type='text/css'>
 .test { direction: ltr; } .test span { direction: rtl; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-005.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-005.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=5' />
-<meta name='flags' content='' />
 <meta name="assert" content="In a RTL context, if direction:ltr and unicode-bidi:embed are applied to a LTR inline element containing mixed direction text, the text in that element will be displayed correctly." />
 <style type='text/css'>
 .test { direction: rtl; } .test span { direction: ltr; unicode-bidi: embed; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-006.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-006.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=6' />
-<meta name='flags' content='' />
 <meta name="assert" content="In a RTL context, if direction:ltr alone is applied to a LTR inline element containing mixed direction text, the different directional runs in that element will not be in the correct order." />
 <style type='text/css'>
 .test { direction: rtl; } .test span { direction: ltr; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-007.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-007.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=7' />
-<meta name='flags' content='' />
 <meta name="assert" content="In a RTL context, if direction:ltr and unicode-bidi:embed are applied to an inline element containing mixed direction text, the the inline element will interact with surrounding ltr text as a LTR directional run." />
 <style type='text/css'>
 .test { direction: rtl; } .test span { direction: ltr; unicode-bidi: embed; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-008.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-008.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=8' />
-<meta name='flags' content='' />
 <meta name="assert" content="In a LTR context, if direction:rtl and unicode-bidi:embed are applied to an inline element containing mixed direction text, the the inline element will interact with surrounding rtl text as a RTL directional run." />
 <style type='text/css'>
 .test { direction: ltr; } .test span { direction: rtl; unicode-bidi: embed; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-009.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-009.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=9' />
-<meta name='flags' content='' />
 <meta name="assert" content="direction:ltr alone on a block element will cause the text to be left-aligned, directional runs to be arranged LTR (but the words should look correct within each run), and punctuation should be treated as LTR." />
 <style type='text/css'>
 .test { direction: ltr; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-010.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-010.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=10' />
-<meta name='flags' content='' />
 <meta name="assert" content="direction:rtl alone on a block element will cause the text to be right-aligned, directional runs to be arranged RTL (but the words should look correct within each run), and punctuation should be treated as RTL." />
 <style type='text/css'>
 .test { direction: rtl; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-011.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-011.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=11' />
-<meta name='flags' content='' />
 <meta name="assert" content="direction:ltr on a container element will be inherited by an embedded block element." />
 <style type='text/css'>
 .test { direction: ltr; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-012.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-012.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=12' />
-<meta name='flags' content='' />
 <meta name="assert" content="direction:rtl on a container element will be inherited by an embedded block element." />
 <style type='text/css'>
 .test { direction: rtl; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-013.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-013.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=13' />
-<meta name='flags' content='' />
 <meta name="assert" content="In the default context, if unicode-bidi:bidi-override and no direction are applied to an inline element containing mixed direction text, the characters in that element will be displayed in backing-store order from left to right." />
 <style type='text/css'>
 .test span { unicode-bidi: bidi-override; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-014.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-014.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=14' />
-<meta name='flags' content='' />
 <meta name="assert" content="In the default context, if direction:ltr and unicode-bidi:bidi-override are applied to an inline element containing mixed direction text, the characters in that element will be displayed in backing-store order from left to right." />
 <style type='text/css'>
 .test span { direction: ltr; unicode-bidi: bidi-override; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-015.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-015.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=15' />
-<meta name='flags' content='' />
 <meta name="assert" content="In the default context, if unicode-bidi:bidi-override and direction:rtl are applied to an inline element containing mixed direction text, the characters in that element will be displayed in reverse backing-store order from left to right." />
 <style type='text/css'>
 .test span { direction: rtl; unicode-bidi: bidi-override; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-016.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-016.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=16' />
-<meta name='flags' content='' />
 <meta name="assert" content="In a LTR context, if unicode-bidi:bidi-override and no direction are applied to an inline element containing mixed direction text, the characters in that element will be displayed in backing-store order from left to right." />
 <style type='text/css'>
 .test { direction: ltr; }  .test span { unicode-bidi: bidi-override; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-017.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-017.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=17' />
-<meta name='flags' content='' />
 <meta name="assert" content="In a LTR context, if direction:ltr and unicode-bidi:bidi-override are applied to an inline element containing mixed direction text, the characters in that element will be displayed in backing-store order from left to right." />
 <style type='text/css'>
 .test { direction: ltr; }  .test span { direction: ltr; unicode-bidi: bidi-override; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-018.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-018.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=18' />
-<meta name='flags' content='' />
 <meta name="assert" content="In a LTR context, if unicode-bidi:bidi-override and direction:rtl are applied to an inline element containing mixed direction text, the characters in that element will be displayed in reverse backing-store order from left to right." />
 <style type='text/css'>
 .test { direction: ltr; }  .test span { direction: rtl; unicode-bidi: bidi-override; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-019.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-019.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=19' />
-<meta name='flags' content='' />
 <meta name="assert" content="In a RTL context, if unicode-bidi:bidi-override and no direction are applied to a LTR inline element containing mixed direction text, the characters in that element will be displayed in backing-store order from right to left." />
 <style type='text/css'>
 .test { direction: rtl; }  .test span { unicode-bidi: bidi-override; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-020.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-020.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=20' />
-<meta name='flags' content='' />
 <meta name="assert" content="In a RTL context, if direction:ltr and unicode-bidi:bidi-override are applied to a LTR inline element containing mixed direction text, the characters in that element will be displayed in reverse backing-store order from right to left." />
 <style type='text/css'>
 .test { direction: rtl; }  .test span { direction: ltr; unicode-bidi: bidi-override; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-021.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-021.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=21' />
-<meta name='flags' content='' />
 <meta name="assert" content="In a RTL context, if unicode-bidi:bidi-override and direction:rtl are applied to a LTR inline element containing mixed direction text, the characters in that element will be displayed in backing-store order from right to left." />
 <style type='text/css'>
 .test { direction: rtl; }  .test span { direction: rtl; unicode-bidi: bidi-override; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-022.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-022.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=22' />
-<meta name='flags' content='' />
 <meta name="assert" content="direction:ltr and unicode-bidi:bidi-override on a block element will cause the text to be left-aligned, and all text to be displayed in backing-store order from left to right." />
 <style type='text/css'>
 .test { direction: ltr; unicode-bidi: bidi-override; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-023.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-023.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=23' />
-<meta name='flags' content='' />
 <meta name="assert" content="direction:rtl and unicode-bidi:bidi-override on a block element will cause the text to be right-aligned, and all text to be displayed in backing-store order from right to left." />
 <style type='text/css'>
 .test { direction: rtl; unicode-bidi: bidi-override; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-024.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-024.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=24' />
-<meta name='flags' content='' />
 <meta name="assert" content="When direction:ltr and unicode-bidi:bidi-override is set on a block element, the override will not be inherited by a child block element, but the direction will." />
 <style type='text/css'>
 .test { direction: ltr; unicode-bidi: bidi-override; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-025.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-025.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=25' />
-<meta name='flags' content='' />
 <meta name="assert" content="When direction:rtl and unicode-bidi:bidi-override is set on a block element, the override will not be inherited by a child block element, but the direction will." />
 <style type='text/css'>
 .test { direction: rtl; unicode-bidi: bidi-override; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-026.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-026.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=26' />
-<meta name='flags' content='' />
 <meta name="assert" content="When direction:ltr and unicode-bidi:bidi-override is set on a block element containing block and inline elements, only the direction of the inline text will be overridden." />
 <style type='text/css'>
 .test { direction: ltr; unicode-bidi: bidi-override; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-027.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-027.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=27' />
-<meta name='flags' content='' />
 <meta name="assert" content="When direction:rtl and unicode-bidi:bidi-override is set on a block element containing block and inline elements, only the direction of the inline text will be overridden." />
 <style type='text/css'>
 .test { direction: rtl; unicode-bidi: bidi-override; }

--- a/css/CSS2/i18n/visuren/direction-unicode-bidi-028.xht
+++ b/css/CSS2/i18n/visuren/direction-unicode-bidi-028.xht
@@ -6,7 +6,6 @@
 <link rel='author' title='Richard Ishida' href='http://rishida.net' />
 <link rel='help' href='http://www.w3.org/TR/CSS21/visuren.html#direction' />
 <link rel='alternate' href='http://www.w3.org/International/tests/tests-html-css/tests-direction-unicode-bidi/generate?test=28' />
-<meta name='flags' content='' />
 <meta name="assert" content="When direction:rtl and unicode-bidi:bidi-override is set on a block element containing block and inline elements, and CSS is used to change the block element to an inline element, the direction of all the text will be overridden." />
 <style type='text/css'>
 .test { direction: rtl; unicode-bidi: bidi-override; }

--- a/css/CSS2/linebox/empty-inline-001.xht
+++ b/css/CSS2/linebox/empty-inline-001.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#inline-formatting" />
         <link rel="match" href="../reference/ref-if-there-is-no-red.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="Empty inline elements create a zero-height line box." />
         <style type="text/css">
             div

--- a/css/CSS2/linebox/empty-inline-003.xht
+++ b/css/CSS2/linebox/empty-inline-003.xht
@@ -12,7 +12,6 @@
   <link rel="match" href="empty-inline-003-ref.xht" />
 
   <meta content="The line-height of an empty inline element influences the height of a line containing it with some other content" name="assert" />
-  <meta content="" name="flags" />
 
   <style type="text/css"><![CDATA[
   div#rel-pos-wrapper {position: relative;}

--- a/css/CSS2/linebox/inline-box-001.xht
+++ b/css/CSS2/linebox/inline-box-001.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level" />
         <link rel="match" href="inline-box-001-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="Inline boxes that contain block boxes will break up the inline content around the block box." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/inline-box-002.xht
+++ b/css/CSS2/linebox/inline-box-002.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level" />
         <link rel="match" href="inline-box-002-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="Block boxes within inline boxes are also affected by relative positioning on the inline box." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/inline-formatting-context-001.xht
+++ b/css/CSS2/linebox/inline-formatting-context-001.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#inline-formatting" />
         <link rel="match" href="inline-formatting-context-001-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="Inline boxes are laid out horizontally or one after the other starting at the top of the containing block." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/inline-formatting-context-002.xht
+++ b/css/CSS2/linebox/inline-formatting-context-002.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#inline-formatting" />
         <link rel="match" href="inline-formatting-context-002-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="Horizontal left margins are respected between inline boxes." />
         <style type="text/css">
             div

--- a/css/CSS2/linebox/inline-formatting-context-003.xht
+++ b/css/CSS2/linebox/inline-formatting-context-003.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#inline-formatting" />
         <link rel="match" href="inline-formatting-context-003-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="Horizontal right margins are respected between inline boxes." />
         <style type="text/css">
             div

--- a/css/CSS2/linebox/inline-formatting-context-004.xht
+++ b/css/CSS2/linebox/inline-formatting-context-004.xht
@@ -6,7 +6,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#inline-formatting" />
         <link rel="match" href="inline-formatting-context-002-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="Left borders are respected between inline boxes." />
         <style type="text/css">
             div

--- a/css/CSS2/linebox/inline-formatting-context-005.xht
+++ b/css/CSS2/linebox/inline-formatting-context-005.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#inline-formatting" />
         <link rel="match" href="inline-formatting-context-003-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="Right borders are respected between inline boxes." />
         <style type="text/css">
             div

--- a/css/CSS2/linebox/inline-formatting-context-006.xht
+++ b/css/CSS2/linebox/inline-formatting-context-006.xht
@@ -6,7 +6,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#inline-formatting" />
         <link rel="match" href="inline-formatting-context-002-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="Left padding are respected between inline boxes." />
         <style type="text/css">
             div

--- a/css/CSS2/linebox/inline-formatting-context-007.xht
+++ b/css/CSS2/linebox/inline-formatting-context-007.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#inline-formatting" />
         <link rel="match" href="inline-formatting-context-003-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="Right padding are respected between inline boxes." />
         <style type="text/css">
             div

--- a/css/CSS2/linebox/inline-formatting-context-012.xht
+++ b/css/CSS2/linebox/inline-formatting-context-012.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#inline-formatting" />
         <link rel="match" href="../generated-content/after-content-display-002-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="Inline boxes stack vertically when they do not fit within an element horizontally." />
         <style type="text/css">
             div

--- a/css/CSS2/linebox/inline-formatting-context-015.xht
+++ b/css/CSS2/linebox/inline-formatting-context-015.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#inline-formatting" />
         <link rel="match" href="inline-formatting-context-015-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="Line boxes adjust for floated elements." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/inline-formatting-context-016.xht
+++ b/css/CSS2/linebox/inline-formatting-context-016.xht
@@ -4,7 +4,6 @@
         <title>CSS Test: Line box distribution with the 'text-align' property</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#inline-formatting" />
-        <meta name="flags" content="" />
         <meta name="assert" content="When the inline box is wider than the line boxes the 'text-align' property is used to align the line boxes." />
         <style type="text/css">
             div

--- a/css/CSS2/linebox/inline-formatting-context-018.xht
+++ b/css/CSS2/linebox/inline-formatting-context-018.xht
@@ -4,7 +4,6 @@
         <title>CSS Test: Text-align 'justify' and 'inline-table' elements</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#inline-formatting" />
-        <meta name="flags" content="" />
         <meta name="assert" content="If 'text-align' is set to 'justify' the user agent does not stretch spaces and/or words when the 'display' property is set to 'inline-table'." />
         <style type="text/css">
             div

--- a/css/CSS2/linebox/inline-formatting-context-019.xht
+++ b/css/CSS2/linebox/inline-formatting-context-019.xht
@@ -4,7 +4,6 @@
         <title>CSS Test: Text-align 'justify' and 'inline-block' elements</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#inline-formatting" />
-        <meta name="flags" content="" />
         <meta name="assert" content="If 'text-align' is set to 'justify' the user agent does not stretch spaces and/or words when the 'display' property is set to 'inline-block'." />
         <style type="text/css">
             div

--- a/css/CSS2/linebox/inline-formatting-context-020.xht
+++ b/css/CSS2/linebox/inline-formatting-context-020.xht
@@ -4,7 +4,6 @@
         <title>CSS Test: Inline boxes exceeding the line box</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#inline-formatting" />
-        <meta name="flags" content="" />
         <meta name="assert" content="Inline boxes are split onto additional lines if the line box does not fit within the width." />
         <style type="text/css">
             div

--- a/css/CSS2/linebox/inline-formatting-context-021.xht
+++ b/css/CSS2/linebox/inline-formatting-context-021.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-04-04 -->
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#inline-formatting" />
-        <meta name="flags" content="" />
         <meta name="assert" content="If inline boxes cannot be split (i.e.: white-space: nowrap) then the inline box overflows the line box." />
         <style type="text/css">
             div

--- a/css/CSS2/linebox/inline-formatting-context-023.xht
+++ b/css/CSS2/linebox/inline-formatting-context-023.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#inline-formatting" />
         <link rel="match" href="inline-formatting-context-023-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="Additional inline boxes can be created for the bidirectional text." />
         <style type="text/css">
             #span1

--- a/css/CSS2/linebox/line-height-applies-to-001.xht
+++ b/css/CSS2/linebox/line-height-applies-to-001.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
         <link rel="match" href="line-height-applies-to-001-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'line-height' property applies to elements with 'display' set to 'table-row-group'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/line-height-applies-to-002.xht
+++ b/css/CSS2/linebox/line-height-applies-to-002.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
         <link rel="match" href="line-height-applies-to-001-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'line-height' property applies to elements with 'display' set to 'table-header-group'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/line-height-applies-to-003.xht
+++ b/css/CSS2/linebox/line-height-applies-to-003.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
         <link rel="match" href="line-height-applies-to-001-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'line-height' property applies to elements with 'display' set to 'table-footer-group'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/line-height-applies-to-004.xht
+++ b/css/CSS2/linebox/line-height-applies-to-004.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
         <link rel="match" href="line-height-applies-to-001-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'line-height' property applies to elements with 'display' set to 'table-row'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/line-height-applies-to-005.xht
+++ b/css/CSS2/linebox/line-height-applies-to-005.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
         <link rel="match" href="line-height-applies-to-005-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'line-height' property applies to elements with 'display' set to 'table-column-group'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/line-height-applies-to-006.xht
+++ b/css/CSS2/linebox/line-height-applies-to-006.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
         <link rel="match" href="line-height-applies-to-005-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'line-height' property applies to elements with 'display' set to 'table-column'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/line-height-applies-to-007.xht
+++ b/css/CSS2/linebox/line-height-applies-to-007.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
         <link rel="match" href="line-height-applies-to-001-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'line-height' property applies to elements with 'display' set to 'table-cell'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/line-height-applies-to-008.xht
+++ b/css/CSS2/linebox/line-height-applies-to-008.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
         <link rel="match" href="line-height-applies-to-001-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'line-height' property applies to elements with 'display' set to 'inline'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/line-height-applies-to-009.xht
+++ b/css/CSS2/linebox/line-height-applies-to-009.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
         <link rel="match" href="line-height-applies-to-001-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'line-height' property applies to elements with 'display' set to 'block'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/line-height-applies-to-010.xht
+++ b/css/CSS2/linebox/line-height-applies-to-010.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#propdef-line-height" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'line-height' property applies to elements with 'display' set to 'list-item'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/line-height-applies-to-012.xht
+++ b/css/CSS2/linebox/line-height-applies-to-012.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
         <link rel="match" href="line-height-applies-to-001-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'line-height' property applies to elements with 'display' set to 'inline-block'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/line-height-applies-to-013.xht
+++ b/css/CSS2/linebox/line-height-applies-to-013.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
         <link rel="match" href="line-height-applies-to-001-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'line-height' property applies to elements with 'display' set to 'table'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/line-height-applies-to-014.xht
+++ b/css/CSS2/linebox/line-height-applies-to-014.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
         <link rel="match" href="line-height-applies-to-001-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'line-height' property applies to elements with 'display' set to 'inline-table'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/line-height-applies-to-015.xht
+++ b/css/CSS2/linebox/line-height-applies-to-015.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
         <link rel="match" href="line-height-applies-to-001-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'line-height' property applies to elements with 'display' set to 'table-caption'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/line-height-applies-to-016.xht
+++ b/css/CSS2/linebox/line-height-applies-to-016.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
         <link rel="match" href="line-height-applies-to-016-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'line-height' property applies to elements with 'display' set to 'none'." />
         <style type="text/css">
             div

--- a/css/CSS2/linebox/line-height-bleed-001.xht
+++ b/css/CSS2/linebox/line-height-bleed-001.xht
@@ -7,7 +7,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
         <link rel="match" href="line-height-bleed-001-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="Glyphs bleed out of the box when 'line-height' is less than the content height and the height of the box is not increased." />
         <style type="text/css">
             #div1

--- a/css/CSS2/linebox/line-height-bleed-003.xht
+++ b/css/CSS2/linebox/line-height-bleed-003.xht
@@ -4,7 +4,6 @@
         <title>CSS Test: Leading and half leading line heights leads to space above and below</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
-        <meta name="flags" content="" />
         <meta name="assert" content="Line-height can be different from the content area so there is space above and below." />
         <style type="text/css">
             div

--- a/css/CSS2/linebox/vertical-align-baseline-003.xht
+++ b/css/CSS2/linebox/vertical-align-baseline-003.xht
@@ -8,7 +8,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
         <link rel="match" href="vertical-align-baseline-003-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'vertical-align' property aligns the last line box of 'inline-block' elements with the baseline." />
         <style type="text/css">
             #span1

--- a/css/CSS2/linebox/vertical-align-baseline-006a.xht
+++ b/css/CSS2/linebox/vertical-align-baseline-006a.xht
@@ -9,7 +9,6 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" title="10.8.1 Leading and half-leading" />
 
-  <meta content="" name="flags" />
   <meta name="assert" content="The baseline of an (anonymous) inline element is aligned with the baseline of the last line box of an 'inline-block' in the normal flow as 'vertical-align: baseline' is by default applied. In such case, the vertical padding and vertical margin have no influence on the position of the baseline line of an 'inline-block'." />
 
   <style type="text/css"><![CDATA[

--- a/css/CSS2/linebox/vertical-align-sub-001.xht
+++ b/css/CSS2/linebox/vertical-align-sub-001.xht
@@ -8,7 +8,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
         <link rel="match" href="vertical-align-sub-001-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'vertical-align' property value 'sub' has no effect on the font-size of an element's text." />
         <style type="text/css">
             div

--- a/css/CSS2/linebox/vertical-align-super-001.xht
+++ b/css/CSS2/linebox/vertical-align-super-001.xht
@@ -8,7 +8,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#leading" />
         <link rel="match" href="vertical-align-sub-001-ref.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'vertical-align' property value 'super' has no effect on the font-size of an element's text." />
         <style type="text/css">
             div

--- a/css/CSS2/media/media-dependency-001.xht
+++ b/css/CSS2/media/media-dependency-001.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/media.html" />
         <link rel="match" href="../reference/filler-text-below-green.xht"/>
-        <meta name="flags" content="" />
         <meta name="assert" content="@media with a target medium applies styles on that target medium (screen)." />
         <style type="text/css">
             @media screen

--- a/css/CSS2/media/media-dependency-002.xht
+++ b/css/CSS2/media/media-dependency-002.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/media.html" />
         <link rel="match" href="../reference/filler-text-below-green.xht"/>
-        <meta name="flags" content="" />
         <meta name="assert" content="@media with a target medium applies styles on that target medium (screen)." />
         <style type="text/css">
             @import url("support/media-dependency-green.css") screen;

--- a/css/CSS2/media/media-dependency-003.xht
+++ b/css/CSS2/media/media-dependency-003.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/media.html" />
         <link rel="match" href="../reference/filler-text-below-green.xht"/>
-        <meta name="flags" content="" />
         <meta name="assert" content="Link with a target medium applies styles on that target medium (screen)." />
         <link rel="stylesheet" type="text/css" media="screen" href="support/media-dependency-green.css" />
         <style type="text/css"></style>

--- a/css/CSS2/media/media-dependency-004.xht
+++ b/css/CSS2/media/media-dependency-004.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/media.html" />
         <link rel="match" href="../reference/filler-text-below-green.xht"/>
-        <meta name="flags" content="" />
         <meta name="assert" content="Media types are case-insensitive." />
         <style type="text/css">
             @import url("support/media-dependency-green.css") ScReEn;

--- a/css/CSS2/media/media-dependency-007.xht
+++ b/css/CSS2/media/media-dependency-007.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/media.html" />
         <link rel="match" href="../reference/no-red-filler-text-ref.xht"/>
-        <meta name="flags" content="" />
         <meta name="assert" content="The @media block does not apply because it does not match the target medium." />
         <style type="text/css">
             @media print

--- a/css/CSS2/media/media-dependency-008.xht
+++ b/css/CSS2/media/media-dependency-008.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/media.html" />
         <link rel="match" href="../reference/no-red-filler-text-ref.xht"/>
-        <meta name="flags" content="" />
         <meta name="assert" content="The @import command does not apply because it does not match the target medium." />
         <style type="text/css">
             @import url("support/media-dependency-red.css") print;

--- a/css/CSS2/media/media-dependency-009.xht
+++ b/css/CSS2/media/media-dependency-009.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/media.html" />
         <link rel="match" href="../reference/filler-text-below-green.xht"/>
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'all' media type applies to the screen medium." />
         <style type="text/css">
             @media all

--- a/css/CSS2/media/media-dependency-010.xht
+++ b/css/CSS2/media/media-dependency-010.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/media.html" />
         <link rel="match" href="../reference/no-red-filler-text-ref.xht"/>
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'braille' media type does not apply to the screen medium." />
         <style type="text/css">
             @media braille

--- a/css/CSS2/media/media-dependency-011.xht
+++ b/css/CSS2/media/media-dependency-011.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/media.html" />
         <link rel="match" href="../reference/no-red-filler-text-ref.xht"/>
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'embossed' media type does not apply to the screen medium." />
         <style type="text/css">
             @media embossed

--- a/css/CSS2/media/media-dependency-012.xht
+++ b/css/CSS2/media/media-dependency-012.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/media.html" />
         <link rel="match" href="../reference/no-red-filler-text-ref.xht"/>
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'handheld' media type does not apply to the screen medium." />
         <style type="text/css">
             @media handheld

--- a/css/CSS2/media/media-dependency-013.xht
+++ b/css/CSS2/media/media-dependency-013.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/media.html" />
         <link rel="match" href="../reference/no-red-filler-text-ref.xht"/>
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'projection' media type does not apply to the screen medium." />
         <style type="text/css">
             @media projection

--- a/css/CSS2/media/media-dependency-014.xht
+++ b/css/CSS2/media/media-dependency-014.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/media.html" />
         <link rel="match" href="../reference/no-red-filler-text-ref.xht"/>
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'speech' media type does not apply to the screen medium." />
         <style type="text/css">
             @media speech

--- a/css/CSS2/media/media-dependency-015.xht
+++ b/css/CSS2/media/media-dependency-015.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/media.html" />
         <link rel="match" href="../reference/no-red-filler-text-ref.xht"/>
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'tty' media type does not apply to the screen medium." />
         <style type="text/css">
             @media tty

--- a/css/CSS2/media/media-dependency-016.xht
+++ b/css/CSS2/media/media-dependency-016.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/media.html" />
         <link rel="match" href="../reference/no-red-filler-text-ref.xht"/>
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'tv' media type does not apply to the screen medium." />
         <style type="text/css">
             @media tv

--- a/css/CSS2/media/media-dependency-017.xht
+++ b/css/CSS2/media/media-dependency-017.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/media.html" />
         <link rel="match" href="../reference/filler-text-below-green.xht"/>
-        <meta name="flags" content="" />
         <meta name="assert" content="An '@media' rule specifies the target media types separated by commas." />
         <style type="text/css">
             @media screen, print

--- a/css/CSS2/sec5/adjacent-000.xht
+++ b/css/CSS2/sec5/adjacent-000.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#adjacent-selectors" />
   <link rel="match" href="adjacent-000-ref.xht"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the adjacent element"/>
 <style type="text/css">
 body > p {color: gray}

--- a/css/CSS2/sec5/adjacent-001.xht
+++ b/css/CSS2/sec5/adjacent-001.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#adjacent-selectors" />
   <link rel="match" href="adjacent-000-ref.xht"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the adjacent element also without the space separator"/>
 <style type="text/css">
 body > p {color: gray}

--- a/css/CSS2/sec5/adjacent-002.xht
+++ b/css/CSS2/sec5/adjacent-002.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#adjacent-selectors" />
   <link rel="match" href="adjacent-000-ref.xht"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the adjacent element when combined with the universal selector"/>
 <style type="text/css">
 body > p {color: gray}

--- a/css/CSS2/sec5/attribute-000.xht
+++ b/css/CSS2/sec5/attribute-000.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#attribute-selectors" />
   <link rel="match" href="attribute-ref.xht"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the elements with the specified attribute, disregarding its value"/>
 <style type="text/css">
 p[id] {color: purple}

--- a/css/CSS2/sec5/attribute-001.xht
+++ b/css/CSS2/sec5/attribute-001.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#attribute-selectors" />
   <link rel="match" href="attribute-ref.xht"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the elements with the specified attribute, disregarding its value"/>
 <style type="text/css">
 [id] {color: purple}

--- a/css/CSS2/sec5/attribute-002.xht
+++ b/css/CSS2/sec5/attribute-002.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#attribute-selectors" />
   <link rel="match" href="attribute-ref.xht"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the elements with the specified attribute and the specified value"/>
 <style type="text/css">
 p[id="foo"] {color: purple}

--- a/css/CSS2/sec5/attribute-003.xht
+++ b/css/CSS2/sec5/attribute-003.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#attribute-selectors" />
   <link rel="match" href="attribute-ref.xht"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the elements with the specified attribute and the specified value"/>
 <style type="text/css">
 [id="foo"] {color: purple}

--- a/css/CSS2/sec5/attribute-004.xht
+++ b/css/CSS2/sec5/attribute-004.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#attribute-selectors" />
   <link rel="match" href="attribute-ref.xht"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the elements with one of the values separated by a space"/>
 <style type="text/css">
 p[id~="moo"] {color: purple}

--- a/css/CSS2/sec5/attribute-005.xht
+++ b/css/CSS2/sec5/attribute-005.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#attribute-selectors" />
   <link rel="match" href="attribute-ref.xht"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the elements with one of the values separated by a space"/>
 <style type="text/css">
 [id~="moo"] {color: purple}

--- a/css/CSS2/sec5/attribute-006.xht
+++ b/css/CSS2/sec5/attribute-006.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#attribute-selectors" />
   <link rel="match" href="attribute-ref.xht"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the elements which have an hyphen-separated list of attribute values"/>
 <style type="text/css">
 p[id|="foo"] {color: purple}

--- a/css/CSS2/sec5/attribute-007.xht
+++ b/css/CSS2/sec5/attribute-007.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#attribute-selectors" />
   <link rel="match" href="attribute-ref.xht"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the elements which have an hyphen-separated list of attribute values"/>
 <style type="text/css">
 [id|="foo"] {color: purple}

--- a/css/CSS2/sec5/class-000.xht
+++ b/css/CSS2/sec5/class-000.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#class-html" />
   <link rel="match" href="class-000-ref.html"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the elements which have the specified class"/>
 <style type="text/css">
 p.foo {color: fuchsia}

--- a/css/CSS2/sec5/class-001.xht
+++ b/css/CSS2/sec5/class-001.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#class-html" />
   <link rel="match" href="class-000-ref.html"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the elements which have the specified class"/>
 <style type="text/css">
 .foo {color: fuchsia}

--- a/css/CSS2/sec5/class-002.xht
+++ b/css/CSS2/sec5/class-002.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#class-html" />
   <link rel="match" href="class-002-ref.html"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the elements which have the specified class or classes"/>
 <style type="text/css">
 .foo {color: fuchsia}

--- a/css/CSS2/sec5/descendant-selector-000.xht
+++ b/css/CSS2/sec5/descendant-selector-000.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#descendant-selectors" />
   <link rel="match" href="descendant-selector-000-ref.xht"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the descendant elements"/>
 <style type="text/css">
 body p {border: thin solid orange}

--- a/css/CSS2/sec5/descendant-selector-001.xht
+++ b/css/CSS2/sec5/descendant-selector-001.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#descendant-selectors" />
   <link rel="match" href="descendant-selector-000-ref.xht"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the descendant elements"/>
 <style type="text/css">
 body * {border: thin solid orange}

--- a/css/CSS2/sec5/first-child-000.xht
+++ b/css/CSS2/sec5/first-child-000.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-child" />
   <link rel="match" href="first-child-000-ref.html"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the element which is the first child of its parent"/>
 <style type="text/css">
 * {color: silver}

--- a/css/CSS2/sec5/first-child-001.xht
+++ b/css/CSS2/sec5/first-child-001.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-child" />
   <link rel="match" href="first-child-000-ref.html"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the element which is the first child of its parent"/>
 <style type="text/css">
 * {color: silver}

--- a/css/CSS2/sec5/first-letter-000.xht
+++ b/css/CSS2/sec5/first-letter-000.xht
@@ -5,7 +5,6 @@
   <title>CSS Test: Selectors: The :first-letter pseudo-element</title>
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-letter" />
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply the rule only to the first letter of a block-level element"/>
 <style type="text/css">
 p:first-letter, div span {color: fuchsia; font-weight: bold; font-size: 1.8em;}

--- a/css/CSS2/sec5/first-line-000.xht
+++ b/css/CSS2/sec5/first-line-000.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-line-pseudo" />
   <link rel="match" href="first-line-000-ref.html"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply the rule only to the first line of a block-level element"/>
 <style type="text/css">
 p, div {color: silver}

--- a/css/CSS2/sec5/grouping-000.xht
+++ b/css/CSS2/sec5/grouping-000.xht
@@ -7,7 +7,6 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#grouping" />
   <link rel="match" href="grouping-000-ref.xht"/>
   <link rel="mismatch" href="grouping-000-notref.xht"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply the rule to all elements grouped"/>
 <style type="text/css">
 p, div, h4 {color: green; font-weight: bold}

--- a/css/CSS2/sec5/id-000.xht
+++ b/css/CSS2/sec5/id-000.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#id-selectors" />
   <link rel="match" href="class-000-ref.html"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the elements which have the specified ID"/>
 <style type="text/css">
 p#foo {color: fuchsia}

--- a/css/CSS2/sec5/id-001.xht
+++ b/css/CSS2/sec5/id-001.xht
@@ -6,7 +6,6 @@
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#id-selectors" />
   <link rel="match" href="class-000-ref.html"/>
-  <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the elements which have the specified ID"/>
 <style type="text/css">
 #foo {color: fuchsia}

--- a/css/CSS2/values/numbers-units-002.xht
+++ b/css/CSS2/values/numbers-units-002.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#numbers" />
         <link rel="help" href="https://www.w3.org/TR/css-values-3/#numbers" />
-        <meta name="flags" content="" />
         <meta name="assert" content="A number can be zero or more digits followed by a dot (.) followed by multiple digits." />
         <style type="text/css">
             div

--- a/css/CSS2/values/numbers-units-004.xht
+++ b/css/CSS2/values/numbers-units-004.xht
@@ -6,7 +6,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#numbers" />
         <link rel="help" href="https://www.w3.org/TR/css-values-3/#integers" />
         <link rel="match" href="../reference/ref-filled-black-96px-square.xht" />
-        <meta name="flags" content="" />
         <meta name="assert" content="Integers can be preceded by '+'." />
         <style type="text/css">
             div

--- a/css/CSS2/values/numbers-units-005.xht
+++ b/css/CSS2/values/numbers-units-005.xht
@@ -6,7 +6,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#length-units" />
         <link rel="help" href="https://www.w3.org/TR/css-values-3/#lengths" />
         <link rel="match" href="../reference/no-red-on-blank-page-ref.xht"/>
-        <meta name="flags" content="" />
         <meta name="assert" content="After a zero length, the unit identifier is not necessary." />
         <style type="text/css">
             div

--- a/css/CSS2/values/numbers-units-017.xht
+++ b/css/CSS2/values/numbers-units-017.xht
@@ -6,7 +6,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#percentage-units" />
         <link rel="help" href="https://www.w3.org/TR/css-values-3/#percentages" />
         <link rel="match" href="../reference/no-red-on-blank-page-ref.xht"/>
-        <meta name="flags" content="" />
         <meta name="assert" content="Percentage of 0% is valid and calculates to 0." />
         <style type="text/css">
             div

--- a/css/CSS2/visudet/content-height-001.html
+++ b/css/CSS2/visudet/content-height-001.html
@@ -4,7 +4,6 @@
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
 <link rel="help" href="https://drafts.csswg.org/css2/visudet.html#line-height">
 <link rel="match" href="reference/content-height-001-ref.html">
-<meta name="flags" content="">
 <meta name="assert" content="The height of the content area of an inline-level box does not depend on the value of the line-height property">
 <style>
 

--- a/css/CSS2/visudet/content-height-002.html
+++ b/css/CSS2/visudet/content-height-002.html
@@ -4,7 +4,6 @@
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
 <link rel="help" href="https://drafts.csswg.org/css2/visudet.html#line-height">
 <link rel="match" href="reference/content-height-002-ref.html">
-<meta name="flags" content="">
 <meta name="assert" content="The height of the content area of an inline-level box does not depend on the value of the line-height property,
                              even when fallback fonts are used">
 <style>

--- a/css/CSS2/visudet/content-height-003.html
+++ b/css/CSS2/visudet/content-height-003.html
@@ -4,7 +4,6 @@
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
 <link rel="help" href="https://drafts.csswg.org/css2/visudet.html#line-height">
 <link rel="match" href="reference/content-height-003-ref.html">
-<meta name="flags" content="">
 <meta name="assert" content="The height of the content area of an inline-level box does not depend on the value of the line-height property,
                              even when fallback fonts are used at the exclusion of the first available font">
 <style>

--- a/css/CSS2/visudet/content-height-004.html
+++ b/css/CSS2/visudet/content-height-004.html
@@ -4,7 +4,6 @@
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
 <link rel="help" href="https://drafts.csswg.org/css2/visudet.html#line-height">
 <link rel="match" href="reference/content-height-004-ref.html">
-<meta name="flags" content="">
 <meta name="assert" content="The height of the content area of an inline-level does not depend on fallback fonts
                              regardless of whether they are used on not.">
 <style>

--- a/css/CSS2/visudet/content-height-005.html
+++ b/css/CSS2/visudet/content-height-005.html
@@ -4,7 +4,6 @@
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
 <link rel="help" href="https://drafts.csswg.org/css2/visudet.html#line-height">
 <link rel="mismatch" href="reference/content-height-005-ref.html">
-<meta name="flags" content="">
 <meta name="assert" content="The height of the content area of an inline-level depends on the primary font">
 <style>
 @font-face {

--- a/css/CSS2/visudet/height-applies-to-010a.xht
+++ b/css/CSS2/visudet/height-applies-to-010a.xht
@@ -12,7 +12,6 @@
   <link rel="help" title="11.1.1 Overflow: the 'overflow' property" href="http://www.w3.org/TR/CSS21/visufx.html#overflow" />
   <link rel="match" href="height-applies-to-010a-ref.xht" />
 
-  <meta content="" name="flags" />
   <meta content="If height of content exceeds the set height of a block-level non-replaced element in normal flow (like a list-item element such as in this test), then the content should overflow according to the 'overflow' property." name="assert" />
 
   <style type="text/css"><![CDATA[

--- a/css/CSS2/visudet/height-computed-001.xht
+++ b/css/CSS2/visudet/height-computed-001.xht
@@ -11,7 +11,6 @@
   <link rel="match" href="height-computed-001-ref.xht" />
   <link rel="author" title="Bert Bos" href="mailto:bert@w3.org" />
 
-  <meta name="flags" content="" />
 
   <style type="text/css"><![CDATA[
   body {background: white; color: black; font-size: 14px}

--- a/css/CSS2/visudet/height-computed-002.xht
+++ b/css/CSS2/visudet/height-computed-002.xht
@@ -11,7 +11,6 @@
     <link rel="match" href="height-computed-002-ref.xht" />
     <link rel="author" title="Bert Bos" href="mailto:bert@w3.org" />
 
-    <meta name="flags" content="" />
 
     <style type="text/css"><![CDATA[
     body {background: white; color: black; font-size: 14px}

--- a/css/CSS2/visudet/height-percentage-003a.xht
+++ b/css/CSS2/visudet/height-percentage-003a.xht
@@ -11,7 +11,6 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#the-height-property" title="10.5 Content height: the 'height' property" />
   <link rel="match" href="height-percentage-003a-ref.xht" />
 
-  <meta name="flags" content="" />
   <meta name="assert" content="The initial containing block has the dimensions of the viewport. A percentage height on the root element is relative to the initial containing block. A 'height: 100%' of the document root element should use all of the document root element's height." />
 
   <style type="text/css"><![CDATA[

--- a/css/CSS2/visudet/height-percentage-004-ref.xht
+++ b/css/CSS2/visudet/height-percentage-004-ref.xht
@@ -6,7 +6,6 @@
 
     <link rel="author" title="Bert Bos" href="mailto:bert@w3.org" />
 
-    <meta name="flags" content="" />
 
     <style type="text/css">
       p {margin-right: 7em}

--- a/css/CSS2/visudet/height-percentage-004.xht
+++ b/css/CSS2/visudet/height-percentage-004.xht
@@ -10,7 +10,6 @@
     <link rel="match" href="height-percentage-004-ref.xht" />
     <link rel="author" title="Bert Bos" href="mailto:bert@w3.org" />
 
-    <meta name="flags" content="" />
 
     <style type="text/css">
       p {margin-right: 7em}

--- a/css/CSS2/visudet/inline-block-baseline-001-ref.xht
+++ b/css/CSS2/visudet/inline-block-baseline-001-ref.xht
@@ -7,7 +7,6 @@
 
   <link rel="author" title="Bert Bos" href="mailto:bert@w3.org" />
 
-  <meta name="flags" content="" />
 
   <style type="text/css"><![CDATA[
   body {background: white; color: black; font-size: 15px}

--- a/css/CSS2/visudet/inline-block-baseline-001.xht
+++ b/css/CSS2/visudet/inline-block-baseline-001.xht
@@ -11,7 +11,6 @@
   <link rel="match" href="inline-block-baseline-001-ref.xht" />
   <link rel="author" title="Bert Bos" href="mailto:bert@w3.org" />
 
-  <meta name="flags" content="" />
 
   <style type="text/css"><![CDATA[
   body {background: white; color: black; font-size: 15px}

--- a/css/CSS2/visudet/inline-block-baseline-002.xht
+++ b/css/CSS2/visudet/inline-block-baseline-002.xht
@@ -11,7 +11,6 @@
   <link rel="match" href="inline-block-baseline-001-ref.xht" />
   <link rel="author" title="Bert Bos" href="mailto:bert@w3.org" />
 
-  <meta name="flags" content="" />
 
   <style type="text/css"><![CDATA[
   body {background: white; color: black; font-size: 15px}

--- a/css/CSS2/visudet/inline-block-baseline-003.xht
+++ b/css/CSS2/visudet/inline-block-baseline-003.xht
@@ -11,7 +11,6 @@
   <link rel="match" href="inline-block-baseline-001-ref.xht" />
   <link rel="author" title="Bert Bos" href="mailto:bert@w3.org" />
 
-  <meta name="flags" content="" />
 
   <style type="text/css"><![CDATA[
   body {background: white; color: black; font-size: 15px}

--- a/css/CSS2/visudet/inline-block-baseline-004.xht
+++ b/css/CSS2/visudet/inline-block-baseline-004.xht
@@ -11,7 +11,6 @@
   <link rel="match" href="inline-block-baseline-001-ref.xht" />
   <link rel="author" title="Bert Bos" href="mailto:bert@w3.org" />
 
-  <meta name="flags" content="" />
 
   <style type="text/css"><![CDATA[
   body {background: white; color: black; font-size: 15px}

--- a/css/CSS2/visudet/inline-block-baseline-005.xht
+++ b/css/CSS2/visudet/inline-block-baseline-005.xht
@@ -11,7 +11,6 @@
   <link rel="match" href="inline-block-baseline-001-ref.xht" />
   <link rel="author" title="Bert Bos" href="mailto:bert@w3.org" />
 
-  <meta name="flags" content="" />
 
   <style type="text/css"><![CDATA[
   body {background: white; color: black; font-size: 15px}

--- a/css/CSS2/visudet/inline-block-baseline-006.xht
+++ b/css/CSS2/visudet/inline-block-baseline-006.xht
@@ -11,7 +11,6 @@
   <link rel="match" href="inline-block-baseline-001-ref.xht" />
   <link rel="author" title="Bert Bos" href="mailto:bert@w3.org" />
 
-  <meta name="flags" content="" />
 
   <style type="text/css"><![CDATA[
   body {background: white; color: black; font-size: 15px}

--- a/css/CSS2/visudet/inline-block-baseline-010-ref.xht
+++ b/css/CSS2/visudet/inline-block-baseline-010-ref.xht
@@ -7,7 +7,6 @@
 
   <link rel="author" title="Bert Bos" href="mailto:bert@w3.org" />
 
-  <meta name="flags" content="" />
 
   <style type="text/css"><![CDATA[
   body {background: white; color: black; font-size: 15px}

--- a/css/CSS2/visudet/inline-block-baseline-010.xht
+++ b/css/CSS2/visudet/inline-block-baseline-010.xht
@@ -11,7 +11,6 @@
   <link rel="match" href="inline-block-baseline-010-ref.xht" />
   <link rel="author" title="Bert Bos" href="mailto:bert@w3.org" />
 
-  <meta name="flags" content="" />
 
   <style type="text/css"><![CDATA[
   body {background: white; color: black; font-size: 15px}

--- a/css/CSS2/visudet/inline-block-baseline-011.xht
+++ b/css/CSS2/visudet/inline-block-baseline-011.xht
@@ -11,7 +11,6 @@
   <link rel="match" href="inline-block-baseline-010-ref.xht" />
   <link rel="author" title="Bert Bos" href="mailto:bert@w3.org" />
 
-  <meta name="flags" content="" />
 
   <style type="text/css"><![CDATA[
   body {background: white; color: black; font-size: 15px}

--- a/css/CSS2/visudet/inline-block-baseline-012.xht
+++ b/css/CSS2/visudet/inline-block-baseline-012.xht
@@ -11,7 +11,6 @@
   <link rel="match" href="inline-block-baseline-010-ref.xht" />
   <link rel="author" title="Bert Bos" href="mailto:bert@w3.org" />
 
-  <meta name="flags" content="" />
 
   <style type="text/css"><![CDATA[
   body {background: white; color: black; font-size: 15px}

--- a/css/CSS2/visudet/inline-block-baseline-013.xht
+++ b/css/CSS2/visudet/inline-block-baseline-013.xht
@@ -11,7 +11,6 @@
   <link rel="match" href="inline-block-baseline-010-ref.xht" />
   <link rel="author" title="Bert Bos" href="mailto:bert@w3.org" />
 
-  <meta name="flags" content="" />
 
   <style type="text/css"><![CDATA[
   body {background: white; color: black; font-size: 15px}

--- a/css/CSS2/visudet/inline-block-baseline-014.xht
+++ b/css/CSS2/visudet/inline-block-baseline-014.xht
@@ -11,7 +11,6 @@
   <link rel="match" href="inline-block-baseline-010-ref.xht" />
   <link rel="author" title="Bert Bos" href="mailto:bert@w3.org" />
 
-  <meta name="flags" content="" />
 
   <style type="text/css"><![CDATA[
   body {background: white; color: black; font-size: 15px}

--- a/css/CSS2/visudet/line-height-201.html
+++ b/css/CSS2/visudet/line-height-201.html
@@ -4,7 +4,6 @@
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
 <link rel="help" href="https://drafts.csswg.org/css2/visudet.html#line-height">
 <link rel="match" href="reference/line-height-201-ref.html">
-<meta name="flags" content="">
 <meta name="assert" content="non-normal values of line-height result in the height of the inline-level box to be exactly the specified dimention,
                              even when fallback fonts with metrics different from the first available font one are used.">
 <style>

--- a/css/CSS2/visudet/line-height-202.html
+++ b/css/CSS2/visudet/line-height-202.html
@@ -4,7 +4,6 @@
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
 <link rel="help" href="https://drafts.csswg.org/css2/visudet.html#line-height">
 <link rel="match" href="reference/line-height-202-ref.html">
-<meta name="flags" content="">
 <meta name="assert" content="The position of the baseline in an inline-level box whose height is determined by a non-normal value of line-height
                              does not depend on fonts other than the first available font">
 <style>

--- a/css/CSS2/visudet/line-height-203.html
+++ b/css/CSS2/visudet/line-height-203.html
@@ -4,7 +4,6 @@
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
 <link rel="help" href="https://drafts.csswg.org/css2/visudet.html#line-height">
 <link rel="mismatch" href="reference/line-height-203-ref.html">
-<meta name="flags" content="">
 <meta name="assert" content="The position of the baseline in an inline-level box whose height is determined by a non-normal value of line-height
                              does depend on the first available font.">
 <style>

--- a/css/CSS2/visudet/line-height-204.html
+++ b/css/CSS2/visudet/line-height-204.html
@@ -5,7 +5,6 @@
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
 <link rel="help" href="https://drafts.csswg.org/css2/visudet.html#line-height">
 <link rel="match" href="reference/line-height-202-ref.html">
-<meta name="flags" content="">
 <meta name="assert" content="The position of the baseline in an inline-level box whose line-height is normal
                              and the position of the baseline in an inline-level box whose line-height is set to a non normal value resulting in the same height
                              are the same,

--- a/css/CSS2/visudet/line-height-205.html
+++ b/css/CSS2/visudet/line-height-205.html
@@ -4,7 +4,6 @@
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
 <link rel="help" href="https://drafts.csswg.org/css2/visudet.html#line-height">
 <link rel="match" href="reference/line-height-202-ref.html">
-<meta name="flags" content="">
 <meta name="assert" content="The height of an inline-level box whose line-height is normal and uses both the first available font and fallback fonts
                              is the same as the union of
                              baseline-aligned adjacent inline-level boxes, each using the various fonts as their primary one.">

--- a/css/CSS2/visudet/line-height-206.html
+++ b/css/CSS2/visudet/line-height-206.html
@@ -4,7 +4,6 @@
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
 <link rel="help" href="https://drafts.csswg.org/css2/visudet.html#line-height">
 <link rel="mismatch" href="reference/line-height-206-ref.html">
-<meta name="flags" content="">
 <meta name="assert" content="The height of an inline-level box whose line-height is normal and which only uses glyphs from the fallback font
                              must still take the strut from the first available font into account.">
 <style>

--- a/css/CSS2/visuren/bidi-direction-001.xht
+++ b/css/CSS2/visuren/bidi-direction-001.xht
@@ -5,7 +5,6 @@
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#propdef-direction"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
-    <meta name="flags" content=""/>
     <meta name="assert" content="direction:rtl on body should inherit to paragraphs"/>
     <style type="text/css"><![CDATA[
       body {direction: rtl;}

--- a/css/CSS2/visuren/bidi-direction-002.xht
+++ b/css/CSS2/visuren/bidi-direction-002.xht
@@ -5,7 +5,6 @@
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#propdef-direction"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
-    <meta name="flags" content=""/>
     <meta name="assert" content="Direction on paragraph should override direction on body"/>
     <style type="text/css"><![CDATA[
       body {

--- a/css/CSS2/visuren/bidi-list-001.xht
+++ b/css/CSS2/visuren/bidi-list-001.xht
@@ -6,7 +6,6 @@
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#alignment-prop" />
-    <meta name="flags" content=""/>
     <meta name="assert" content="direction:rtl should apply to unordered lists, putting bullets on the right"/>
     <style type="text/css"><![CDATA[
       ul {direction: rtl;}

--- a/css/CSS2/visuren/bidi-list-002.xht
+++ b/css/CSS2/visuren/bidi-list-002.xht
@@ -6,7 +6,6 @@
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#alignment-prop" />
-    <meta name="flags" content=""/>
     <meta name="assert" content="direction:rtl should apply to nested unordered lists, putting bullets on the right and offset leftwards"/>
     <style type="text/css"><![CDATA[
       ul {direction: rtl;}

--- a/css/CSS2/visuren/bidi-list-003.xht
+++ b/css/CSS2/visuren/bidi-list-003.xht
@@ -6,7 +6,6 @@
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#alignment-prop" />
-    <meta name="flags" content=""/>
     <meta name="assert" content="direction:rtl should apply to nested ordered lists, putting bullets  on the right and offset leftwards"/>
     <style type="text/css"><![CDATA[
       ol {direction: rtl;}

--- a/css/CSS2/visuren/bidi-list-004.xht
+++ b/css/CSS2/visuren/bidi-list-004.xht
@@ -6,7 +6,6 @@
     <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#alignment-prop" />
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style"/>
-    <meta name="flags" content=""/>
     <meta name="assert" content="text-align: justify should apply to unordered lists in rtl context without affecting their rtlness"/>
     <style type="text/css"><![CDATA[
       html {direction:rtl;}

--- a/css/CSS2/visuren/bidi-list-005.xht
+++ b/css/CSS2/visuren/bidi-list-005.xht
@@ -6,7 +6,6 @@
     <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#alignment-prop" />
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style"/>
-    <meta name="flags" content=""/>
     <meta name="assert" content="text-align:left should be applied to unordered list in rtl context without affecting its rtlness"/>
     <style type="text/css"><![CDATA[
       html {direction: rtl;}

--- a/css/CSS2/visuren/bidi-list-006.xht
+++ b/css/CSS2/visuren/bidi-list-006.xht
@@ -6,7 +6,6 @@
     <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#alignment-prop" />
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style"/>
-    <meta name="flags" content=""/>
     <meta name="assert" content="text-align:right should be applied to unordered list in rtl context without affecting its rtlness"/>
     <style type="text/css"><![CDATA[
       html {direction: rtl;}

--- a/css/CSS2/visuren/bidi-list-007.xht
+++ b/css/CSS2/visuren/bidi-list-007.xht
@@ -6,7 +6,6 @@
     <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#alignment-prop" />
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style"/>
-    <meta name="flags" content=""/>
     <meta name="assert" content="text-align: center should apply to unordered lists in rtl context without affecting their rtlness"/>
     <style type="text/css"><![CDATA[
       html {direction:rtl;}

--- a/css/CSS2/visuren/bidi-override-001.xht
+++ b/css/CSS2/visuren/bidi-override-001.xht
@@ -5,7 +5,6 @@
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#propdef-unicode-bidi"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
-    <meta name="flags" content=""/>
     <meta name="assert" content="bidi-override should not be applied to table cell content when specified on table"/>
     <style type="text/css"><![CDATA[
       .override {

--- a/css/CSS2/visuren/bidi-override-002.xht
+++ b/css/CSS2/visuren/bidi-override-002.xht
@@ -5,7 +5,6 @@
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#propdef-unicode-bidi"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
-    <meta name="flags" content=""/>
     <meta name="assert" content="bidi-override should be applied to table-cell content when specified on the cell"/>
     <style type="text/css"><![CDATA[
       .override {

--- a/css/CSS2/visuren/bidi-override-003.xht
+++ b/css/CSS2/visuren/bidi-override-003.xht
@@ -5,7 +5,6 @@
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#propdef-unicode-bidi"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
-    <meta name="flags" content=""/>
     <meta name="assert" content="bidi-override should not be applied to list item when specified on ul"/>
     <style type="text/css"><![CDATA[
       ul, li { margin: 1em 2em; padding: 0; }

--- a/css/CSS2/visuren/bidi-override-004.xht
+++ b/css/CSS2/visuren/bidi-override-004.xht
@@ -5,7 +5,6 @@
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#propdef-unicode-bidi"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
-    <meta name="flags" content=""/>
     <meta name="assert" content="bidi-override should be applied when specified on list item"/>
     <style type="text/css"><![CDATA[
       ul, li { margin: 1em 2em; padding: 0; }

--- a/css/CSS2/visuren/bidi-override-005.xht
+++ b/css/CSS2/visuren/bidi-override-005.xht
@@ -5,7 +5,6 @@
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#propdef-unicode-bidi"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
-    <meta name="flags" content=""/>
     <meta name="assert" content="bidi-override should be applied to inline-level descendants but not block-level descendants"/>
     <style type="text/css"><![CDATA[
       .override {

--- a/css/CSS2/visuren/bidi-position-fixed-001.xht
+++ b/css/CSS2/visuren/bidi-position-fixed-001.xht
@@ -6,7 +6,6 @@
     <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#abs-non-replaced-width"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#alignment-prop"/>
-    <meta name="flags" content=""/>
     <meta name="assert" content="Default horizontal position of position:fixed block should be right in rtl context, and ancestor direction should still be applied inside the block taken out of normal flow"/>
     <style type="text/css"><![CDATA[
     body {direction:rtl;}

--- a/css/CSS2/visuren/bidi-table-001.xht
+++ b/css/CSS2/visuren/bidi-table-001.xht
@@ -5,7 +5,6 @@
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#table-layout"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
-    <meta name="flags" content=""/>
     <meta name="assert" content="direction:rtl on table should reverse order of table cells"/>
     <style type="text/css"><![CDATA[
       table {border-spacing: 0; margin-bottom: 1em;}

--- a/css/CSS2/visuren/bidi-table-002.xht
+++ b/css/CSS2/visuren/bidi-table-002.xht
@@ -5,7 +5,6 @@
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#table-layout"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
-    <meta name="flags" content=""/>
     <meta name="assert" content="direction: should affect order of table cells"/>
     <style type="text/css"><![CDATA[
       table {direction: rtl;border-spacing: 0;}

--- a/css/CSS2/visuren/bidi-unicode-bidi-001.xht
+++ b/css/CSS2/visuren/bidi-unicode-bidi-001.xht
@@ -5,7 +5,6 @@
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#propdef-unicode-bidi"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
-    <meta name="flags" content=""/>
     <meta name="assert" content="unicode-bidi: bidi-override should order characters strictly according to value of direction property"/>
     <style type="text/css"><![CDATA[
       .override {

--- a/css/CSS2/visuren/bidi-unicode-bidi-003.xht
+++ b/css/CSS2/visuren/bidi-unicode-bidi-003.xht
@@ -5,7 +5,6 @@
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#propdef-unicode-bidi"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
-    <meta name="flags" content=""/>
     <meta name="assert" content="unicode-bidi: embed should open a new bidi embedding level for inline-level element"/>
     <style type="text/css"><![CDATA[
       .firstembed {direction: ltr; unicode-bidi: embed}

--- a/css/CSS2/visuren/bidi-unicode-bidi-004.xht
+++ b/css/CSS2/visuren/bidi-unicode-bidi-004.xht
@@ -4,7 +4,6 @@
     <title>CSS Test: direction and borders - normal</title>
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
-    <meta name="flags" content=""/>
     <meta name="assert" content="Borders should be unaffected by directionality"/>
     <style type="text/css"><![CDATA[
       span {

--- a/css/CSS2/visuren/clear-applies-to-016.xht
+++ b/css/CSS2/visuren/clear-applies-to-016.xht
@@ -20,7 +20,6 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#flow-control" />
   <link rel="match" href="../floats-clear/clear-applies-to-009-ref.xht" />
 
-  <meta name="flags" content="" />
   <meta name="assert" content="The 'clear' property apply to elements with a display of 'table' and is applied to the table wrapper box and not on the table box. In this test, the table wrapper box has a table caption placed before the table box." />
 
   <style type="text/css"><![CDATA[

--- a/css/CSS2/visuren/clear-applies-to-017.xht
+++ b/css/CSS2/visuren/clear-applies-to-017.xht
@@ -22,7 +22,6 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#flow-control" />
   <link rel="match" href="../floats-clear/clear-applies-to-009-ref.xht" />
 
-  <meta name="flags" content="" />
   <meta name="assert" content="The 'clear' property apply to elements with a display of 'table' and is applied to the table wrapper box and not on the table box. In this test, the table wrapper box has a table caption placed after the table box." />
 
   <style type="text/css"><![CDATA[

--- a/css/CSS2/visuren/fixed-pos-stacking-001.xht
+++ b/css/CSS2/visuren/fixed-pos-stacking-001.xht
@@ -10,7 +10,6 @@
     <link rel="match" href="fixed-pos-stacking-001-ref.xht" />
     <link rel="author" title="Bert Bos" href="mailto:bert@w3.org" />
 
-    <meta name="flags" content="" />
 
     <style type="text/css">
       div {width: 5em; height: 2em}

--- a/css/CSS2/visuren/left-offset-position-fixed-001.xht
+++ b/css/CSS2/visuren/left-offset-position-fixed-001.xht
@@ -9,7 +9,6 @@
     <link rel="help" href="https://drafts.csswg.org/css2/visuren.html#position-props" />
     <link rel="help" href="https://drafts.csswg.org/css2/visudet.html#abs-non-replaced-width" />
     <link rel="match" href="left-offset-position-fixed-001-ref.xht" />
-    <meta name="flags" content="" />
     <meta name="assert" content="The 'left' box offset property, for fixed positioning, when set to 'auto' specifies the offset of the box from its 'static-position containing block'. Here, in this test, the 'static-position containing block' is #shifted-column and the containing block for #red is established by the viewport." />
     <style type="text/css">
 #shifted-column {

--- a/css/CSS2/visuren/position-absolute-008a.xht
+++ b/css/CSS2/visuren/position-absolute-008a.xht
@@ -10,7 +10,6 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#dis-pos-flo" title="9.7 Relationships between 'display', 'position', and 'float'" />
   <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
 
-  <meta name="flags" content="" />
   <meta name="assert" content="Float is computed to 'none' when 'position: absolute' is specified." />
 
   <style type="text/css"><![CDATA[

--- a/css/CSS2/visuren/position-absolute-percentage-inherit-001.xht
+++ b/css/CSS2/visuren/position-absolute-percentage-inherit-001.xht
@@ -14,7 +14,6 @@
   <link rel="help" title="4.3.2 Length" href="http://www.w3.org/TR/CSS21/syndata.html#length-units" />
   <link rel="match" href="position-absolute-percentage-inherit-001-ref.xht" />
 
-  <meta content="" name="flags" />
   <meta content="Absolutely positioned boxes can be dimensioned and positioned solely by setting offset 'top', 'right', 'bottom' and 'left' property values with percentage unit and then with inherit keyword. 'inherit' on a offset property makes such offset property take the same computed value as the offset property of the nearest positioned ancestor; in the case of a percentage value - like in this testcase - , the computed value is the specified percentage value of such nearest positioned ancestor." name="assert" />
 
   <style type="text/css"><![CDATA[

--- a/css/CSS2/visuren/right-offset-position-fixed-001.xht
+++ b/css/CSS2/visuren/right-offset-position-fixed-001.xht
@@ -9,7 +9,6 @@
     <link rel="help" href="https://drafts.csswg.org/css2/visuren.html#position-props" />
     <link rel="help" href="https://drafts.csswg.org/css2/visudet.html#abs-non-replaced-width" />
     <link rel="match" href="right-offset-position-fixed-001-ref.xht" />
-    <meta name="flags" content="" />
     <meta name="assert" content="The 'right' box offset property, for fixed positioning, when set to 'auto' specifies the offset of the box from its 'static-position containing block'. Here, in this test, the 'static-position containing block' is #shifted-column and the containing block for #red is established by the viewport." />
     <style type="text/css">
 html {

--- a/css/CSS2/visuren/top-114.xht
+++ b/css/CSS2/visuren/top-114.xht
@@ -13,7 +13,6 @@
   <link rel="help" href="http://www.w3.org/TR/css-cascade-4/#inherit" />
   <link rel="match" href="top-114-ref.xht" />
 
-  <meta content="" name="flags" />
   <meta content="'top: inherit' makes the top property take the same computed value as the top property for the element's parent; in the case of a percentage value, the computed value is the specified percentage value. 'top: [percentage]' refers to height of containing block." name="assert" />
 
   <style type="text/css"><![CDATA[

--- a/css/CSS2/visuren/top-115.xht
+++ b/css/CSS2/visuren/top-115.xht
@@ -11,7 +11,6 @@
   <link rel="help" title="10.5 Content height: the 'height' property" href="http://www.w3.org/TR/CSS21/visudet.html#the-height-property" />
   <link rel="match" href="top-115-ref.xht" />
 
-  <meta content="" name="flags" />
   <meta content="'top: [percentage]' for a relatively positioned box refers to height of its containing block. If the height of the containing block is not specified explicitly (i.e., it depends on content height), and this element is not absolutely positioned, then the percentage height value computes to 'auto'." name="assert" />
 
   <style type="text/css"><![CDATA[

--- a/css/CSS2/zindex/z-index-004.xht
+++ b/css/CSS2/zindex/z-index-004.xht
@@ -8,7 +8,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#z-index" />
 		<link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The property z-index set to '0' prefixed with a minus sign is read as value '0'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/zindex/z-index-005.xht
+++ b/css/CSS2/zindex/z-index-005.xht
@@ -8,7 +8,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#z-index" />
 		<link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The property z-index with a zero value is read and applied as the value '0'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/zindex/z-index-006.xht
+++ b/css/CSS2/zindex/z-index-006.xht
@@ -8,7 +8,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#z-index" />
 		<link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The property z-index set to '0' prefixed with a plus sign is read as value '0'." />
         <style type="text/css">
             #div1

--- a/css/CSS2/zindex/z-index-007.xht
+++ b/css/CSS2/zindex/z-index-007.xht
@@ -8,7 +8,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#z-index" />
 		<link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The property z-index set to a nominal value is correctly read and applied." />
         <style type="text/css">
             #div1

--- a/css/CSS2/zindex/z-index-008.xht
+++ b/css/CSS2/zindex/z-index-008.xht
@@ -8,7 +8,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#z-index" />
 		<link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The property z-index set to nominal value and prefixed with a plus sign is read the same as the value without the plus sign." />
         <style type="text/css">
             #div1

--- a/css/CSS2/zindex/z-index-013.xht
+++ b/css/CSS2/zindex/z-index-013.xht
@@ -8,7 +8,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#z-index" />
 		<link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The property z-index set to 'auto' results in the same stacking level as its parent element." />
         <style type="text/css">
             #div1

--- a/css/CSS2/zindex/z-index-014.xht
+++ b/css/CSS2/zindex/z-index-014.xht
@@ -8,7 +8,6 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#z-index" />
 		<link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
 
-        <meta name="flags" content="" />
         <meta name="assert" content="The property z-index set to 'inherit' sets a value the same as parent element's computed value." />
         <style type="text/css">
             #div1

--- a/css/CSS2/zindex/z-index-applies-to-009.xht
+++ b/css/CSS2/zindex/z-index-applies-to-009.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#propdef-z-index" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#z-index" />
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'z-index' property applies to elements with a display of block." />
         <style type="text/css">
             span

--- a/css/CSS2/zindex/z-index-applies-to-010.xht
+++ b/css/CSS2/zindex/z-index-applies-to-010.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#propdef-z-index" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#z-index" />
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'z-index' property applies to elements with a display of list-item." />
         <style type="text/css">
             body

--- a/css/CSS2/zindex/z-index-applies-to-012.xht
+++ b/css/CSS2/zindex/z-index-applies-to-012.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#propdef-z-index" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#z-index" />
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'z-index' property applies to elements with a display of inline-block." />
         <style type="text/css">
             div

--- a/css/CSS2/zindex/z-index-applies-to-013.xht
+++ b/css/CSS2/zindex/z-index-applies-to-013.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#propdef-z-index" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#z-index" />
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'z-index' property applies to elements with a display of 'table'." />
         <style type="text/css">
             #table

--- a/css/CSS2/zindex/z-index-applies-to-014.xht
+++ b/css/CSS2/zindex/z-index-applies-to-014.xht
@@ -5,7 +5,6 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#propdef-z-index" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#z-index" />
-        <meta name="flags" content="" />
         <meta name="assert" content="The 'z-index' property applies to elements with a display of 'inline-table'." />
         <style type="text/css">
             div

--- a/css/CSS2/zindex/z-index-stack-001.xht
+++ b/css/CSS2/zindex/z-index-stack-001.xht
@@ -4,7 +4,6 @@
         <title>CSS Test: Z-index and stacking levels</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#layers" />
-        <meta name="flags" content="" />
         <meta name="assert" content="Boxes with greater stack levels are always formatted in front of boxes with lower stack levels." />
         <style type="text/css">
             #div1

--- a/css/CSS2/zindex/z-index-stack-002.xht
+++ b/css/CSS2/zindex/z-index-stack-002.xht
@@ -4,7 +4,6 @@
         <title>CSS Test: Z-index and similar stacking levels</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#layers" />
-        <meta name="flags" content="" />
         <meta name="assert" content="Boxes with the same stack level in a stacking context are stacked back-to-front according to document tree order." />
         <style type="text/css">
             #div1

--- a/css/CSS2/zindex/z-index-stack-003.xht
+++ b/css/CSS2/zindex/z-index-stack-003.xht
@@ -8,7 +8,6 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
   <link rel="help" title="Section 9.9.1 Specifying the stack level: the 'z-index' property" href="http://www.w3.org/TR/CSS21/visuren.html#z-index" />
-  <meta content="" name="flags" />
   <meta content="Positioned elements should be painted over floated elements. A positioned descendant with 'z-index: auto' has a greater stacking level than non-positioned floated elements." name="assert" />
 
   <style type="text/css"><![CDATA[

--- a/css/CSS2/zorder/z-index-020-ref.xht
+++ b/css/CSS2/zorder/z-index-020-ref.xht
@@ -4,7 +4,6 @@
     <title>CSS Reference: z-index (option A)</title>
     <link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact"/>
     <link rel="author" title="Mozilla Corporation" href="http://mozilla.com/" />
-    <meta name="flags" content="" />
 <style type="text/css">
 .container {
   z-index:0;

--- a/css/CSS2/zorder/z-index-020-ref2.xht
+++ b/css/CSS2/zorder/z-index-020-ref2.xht
@@ -4,7 +4,6 @@
     <title>CSS Reference: z-index (option B)</title>
     <link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact"/>
     <link rel="author" title="Mozilla Corporation" href="http://mozilla.com/" />
-    <meta name="flags" content="" />
 <style type="text/css">
 .container {
   z-index:0;

--- a/css/CSS2/zorder/z-index-020.xht
+++ b/css/CSS2/zorder/z-index-020.xht
@@ -8,7 +8,6 @@
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#z-index" />
     <link rel="match" href="z-index-020-ref.xht"/>
     <link rel="match" href="z-index-020-ref2.xht"/>
-    <meta name="flags" content="" />
 <style type="text/css">
 .container {
   z-index:0;


### PR DESCRIPTION
Part of #31946 

This is one of 8 Pull Requests opened to remove all empty CSS requirements flag tags from the `css/` directory.
[See here for all PRs](https://github.com/web-platform-tests/wpt/pull/31993#issuecomment-998534105)

Removed from these directories in `css/CSS2/`:
`linebox`
`visudet`
`visuren`
`i18n`
`sec5`
`zindex`
`zorder`
`media`
`values`