### PR TITLE
Fix #31685: ensures run_info gets the actual macOS version

### DIFF
--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -90,9 +90,19 @@ class RunInfo(Dict[str, Any]):
                  verify=None,
                  extras=None,
                  enable_webrender=False):
-        import mozinfo
-        self._update_mozinfo(metadata_root)
-        self.update(mozinfo.info)
+        version_compat = os.environ.pop("SYSTEM_VERSION_COMPAT", None)
+        if version_compat and version_compat.strip() == "1":
+            import mozinfo
+            import importlib
+            mozinfo = importlib.reload(mozinfo)
+            self._update_mozinfo(metadata_root)
+            self.update(mozinfo.info)
+            os.environ["SYSTEM_VERSION_COMPAT"] = version_compat
+            mozinfo = importlib.reload(mozinfo)
+        else:
+            import mozinfo
+            self._update_mozinfo(metadata_root)
+            self.update(mozinfo.info)
 
         from .update.tree import GitTree
         try:


### PR DESCRIPTION
If the environment variable SYSTEM_VERSION_COMPAT is set to 1, macOS 11 and later pretends to be macOS 10.16; if this is set, we need to rerun mozinfo without it set.

Fixes #31685.