### PR TITLE
Update Safari Technology Preview to 137

### DIFF
--- a/tools/ci/azure/safari-technology-preview.rb
+++ b/tools/ci/azure/safari-technology-preview.rb
@@ -1,12 +1,12 @@
 cask "safari-technology-preview" do
   if MacOS.version == :monterey
-    version "136,002-41283-20211208-8C6426E9-436F-4CBF-858C-D2486B620976"
+    version "137,002-44127-12172021-A832FFB2-625F-4E4E-9BF9-DAFB114FA03E"
     url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
-    sha256 "3368c2fa034ae81705f9e2fd75333f6a3c68a71eea5097acc591da24b773f257"
+    sha256 "5f41e5293ac71c5ffe33392edb371ef4a1f4a5d8fe3e151b357bcf9a011c53ab"
   elsif MacOS.version == :big_sur
-    version "136,002-40417-20211208-C267452B-9B20-410C-83B9-D5740E745638"
+    version "137,002-44115-12172021-8673CE5E-6E26-4E07-8DDF-1A31366DF545"
     url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
-    sha256 "e05f8ee9c1c650bb69eb051c053fa53cf45c1bbc1e3d89f8b1264cc49da244ee"
+    sha256 "1e7f463772417f97ea3358edc116c3aa57166b1b229931fc094601076c172c72"
   end
 
   appcast "https://developer.apple.com/safari/download/"


### PR DESCRIPTION
Version as reported by safaridriver --version:
Included with Safari Technology Preview (Release 137, 16613.1.11.8)

Source: https://developer.apple.com/safari/download/
Build: https://dev.azure.com/foolip/safari-technology-preview-updater/_build/results?buildId=3947&view=logs