### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=234568

### DIFF
--- a/html/webappapis/scripting/events/event-handler-processing-algorithm-error/body-element-synthetic-errorevent.html
+++ b/html/webappapis/scripting/events/event-handler-processing-algorithm-error/body-element-synthetic-errorevent.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Event handlers processing algorithm: error events</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-event-handler-processing-algorithm">
+
+<div id="log"></div>
+
+<script>
+"use strict";
+setup({ allow_uncaught_exception: true });
+
+promise_test(t => {
+  document.body.onerror = t.step_func((...args) => {
+    assert_greater_than(args.length, 1);
+    return true;
+  });
+
+  const eventWatcher = new EventWatcher(t, window, "error");
+  const promise = eventWatcher.wait_for("error").then(e => {
+    assert_equals(e.defaultPrevented, true);
+  });
+
+  document.body.dispatchEvent(new ErrorEvent("error", { bubbles: true, cancelable: true }));
+
+  return promise;
+}, "error event is weird (return true cancels; many args) on Window, with a synthetic ErrorEvent");
+
+promise_test(t => {
+  const theError = { the: "error object" };
+
+  document.body.onerror = t.step_func(function (message, filename, lineno, colno, error) {
+    assert_equals(arguments.length, 5, "There must be exactly 5 arguments");
+    assert_equals(message, "message");
+    assert_equals(filename, "filename");
+    assert_equals(lineno, 1);
+    assert_equals(colno, 2);
+    assert_equals(error, theError);
+    return true;
+  });
+
+  const eventWatcher = new EventWatcher(t, window, "error");
+  const promise = eventWatcher.wait_for("error");
+
+  document.body.dispatchEvent(new ErrorEvent("error", {
+    bubbles: true,
+    message: "message",
+    filename: "filename",
+    lineno: 1,
+    colno: 2,
+    error: theError
+  }));
+
+  return promise;
+}, "error event has the right 5 args on Window, with a synthetic ErrorEvent");
+</script>

--- a/html/webappapis/scripting/events/event-handler-processing-algorithm-error/body-element-synthetic-event.html
+++ b/html/webappapis/scripting/events/event-handler-processing-algorithm-error/body-element-synthetic-event.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Event handlers processing algorithm: error events</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-event-handler-processing-algorithm">
+
+<div id="log"></div>
+
+<script>
+"use strict";
+setup({ allow_uncaught_exception: true });
+
+promise_test(t => {
+  document.body.onerror = t.step_func((...args) => {
+    assert_equals(args.length, 1);
+    return true;
+  });
+
+  const eventWatcher = new EventWatcher(t, window, "error");
+  const promise = eventWatcher.wait_for("error").then(e => {
+    assert_equals(e.defaultPrevented, false);
+  });
+
+  document.body.dispatchEvent(new Event("error", { bubbles: true, cancelable: true }));
+
+  return promise;
+}, "error event is normal (return true does not cancel; one arg) on Window, with a synthetic Event");
+</script>

--- a/html/webappapis/scripting/events/event-handler-processing-algorithm-error/frameset-element-synthetic-errorevent.html
+++ b/html/webappapis/scripting/events/event-handler-processing-algorithm-error/frameset-element-synthetic-errorevent.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Event handlers processing algorithm: error events</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-event-handler-processing-algorithm">
+
+<iframe name="framesetWindow" src="resources/frameset-frame.html"></iframe>
+<div id="log"></div>
+
+<script>
+"use strict";
+setup({ allow_uncaught_exception: true });
+
+window.onload = () => {
+
+const frameset = framesetWindow.document.querySelector("frameset");
+
+promise_test(t => {
+  frameset.onerror = t.step_func((...args) => {
+    assert_greater_than(args.length, 1);
+    return true;
+  });
+
+  const eventWatcher = new EventWatcher(t, framesetWindow, "error");
+  const promise = eventWatcher.wait_for("error").then(e => {
+    assert_equals(e.defaultPrevented, true);
+  });
+
+  frameset.dispatchEvent(new ErrorEvent("error", { bubbles: true, cancelable: true }));
+
+  return promise;
+}, "error event is weird (return true cancels; many args) on Window, with a synthetic ErrorEvent");
+
+promise_test(t => {
+  const theError = { the: "error object" };
+
+  frameset.onerror = t.step_func(function (message, filename, lineno, colno, error) {
+    assert_equals(arguments.length, 5, "There must be exactly 5 arguments");
+    assert_equals(message, "message");
+    assert_equals(filename, "filename");
+    assert_equals(lineno, 1);
+    assert_equals(colno, 2);
+    assert_equals(error, theError);
+    return true;
+  });
+
+  const eventWatcher = new EventWatcher(t, framesetWindow, "error");
+  const promise = eventWatcher.wait_for("error");
+
+  frameset.dispatchEvent(new ErrorEvent("error", {
+    bubbles: true,
+    message: "message",
+    filename: "filename",
+    lineno: 1,
+    colno: 2,
+    error: theError
+  }));
+
+  return promise;
+}, "error event has the right 5 args on Window, with a synthetic ErrorEvent");
+
+};
+</script>

--- a/html/webappapis/scripting/events/event-handler-processing-algorithm-error/frameset-element-synthetic-event.html
+++ b/html/webappapis/scripting/events/event-handler-processing-algorithm-error/frameset-element-synthetic-event.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Event handlers processing algorithm: error events</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-event-handler-processing-algorithm">
+
+<iframe name="framesetWindow" src="resources/frameset-frame.html"></iframe>
+<div id="log"></div>
+
+<script>
+"use strict";
+setup({ allow_uncaught_exception: true });
+
+window.onload = () => {
+
+const frameset = framesetWindow.document.querySelector("frameset");
+
+promise_test(t => {
+  frameset.onerror = t.step_func((...args) => {
+    assert_equals(args.length, 1);
+    return true;
+  });
+
+  const eventWatcher = new EventWatcher(t, framesetWindow, "error");
+  const promise = eventWatcher.wait_for("error").then(e => {
+    assert_equals(e.defaultPrevented, false);
+  });
+
+  frameset.dispatchEvent(new Event("error", { bubbles: true, cancelable: true }));
+
+  return promise;
+}, "error event is normal (return true does not cancel; one arg) on Window, with a synthetic Event");
+
+};
+</script>

--- a/html/webappapis/scripting/events/event-handler-processing-algorithm-error/resources/frameset-frame.html
+++ b/html/webappapis/scripting/events/event-handler-processing-algorithm-error/resources/frameset-frame.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+
+<frameset></frameset>


### PR DESCRIPTION
This upstream reviewed change tests that `onerror` event listener, that was installed via `document.body.onerror` setter, is invoked with 5 arguments for an `ErrorEvent`.