### PR TITLE
Set the androidKeepAppDataDir ChromeDriver capability for all Android browsers

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/android_weblayer.py
+++ b/tools/wptrunner/wptrunner/browsers/android_weblayer.py
@@ -55,6 +55,8 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     capabilities["goog:chromeOptions"]["androidPackage"] = \
         "org.chromium.weblayer.shell"
     capabilities["goog:chromeOptions"]["androidActivity"] = ".WebLayerShellActivity"
+    capabilities["goog:chromeOptions"]["androidKeepAppDataDir"] = \
+        kwargs.get("keep_app_data_directory")
 
     # Workaround: driver.quit() cannot quit WeblayerShell.
     executor_kwargs["pause_after_test"] = False

--- a/tools/wptrunner/wptrunner/browsers/chrome_android.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_android.py
@@ -55,8 +55,11 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     del executor_kwargs["capabilities"]["goog:chromeOptions"]["prefs"]
 
     assert kwargs["package_name"], "missing --package-name"
-    executor_kwargs["capabilities"]["goog:chromeOptions"]["androidPackage"] = \
+    capabilities = executor_kwargs["capabilities"]
+    capabilities["goog:chromeOptions"]["androidPackage"] = \
         kwargs["package_name"]
+    capabilities["goog:chromeOptions"]["androidKeepAppDataDir"] = \
+        kwargs.get("keep_app_data_directory")
 
     return executor_kwargs
 


### PR DESCRIPTION
This CL will make the wptrunner set the androidKeepAppDataDir ChromeDriver capability for all Android browsers which will keep it from clearing out the browser's data directory. This will allow us to load browser test data into the browser's user directory. 

Bug: crbug.com/1233679