### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=234636

### DIFF
--- a/css/selectors/invalidation/has-pseudo-class.html
+++ b/css/selectors/invalidation/has-pseudo-class.html
@@ -6,15 +6,24 @@
 <script src="/resources/testharnessreport.js"></script>
 <link rel="help" href="https://drafts.csswg.org/selectors/#relational">
 <style>
-div, main { color: grey }
+main:has(input) div { color: grey }
 main:has(#checkbox:checked) > #subject { color: red }
-main:has(#option:checked) > #subject { color: green }
+main:has(#option:checked) > #subject { color: red }
+main:has(#checkbox:disabled) > #subject { color: green }
+main:has(#option:disabled) > :is(#subject, #subject2) { color: green }
+main:has(#optgroup:disabled) > #subject { color: blue }
+main:not(:has(#checkbox:enabled)) > #subject3 { color: green }
+main:not(:has(#option:enabled)) :is(#subject3, #subject4) { color: green }
+main:not(:has(#optgroup:enabled)) > #subject3 { color: blue }
 </style>
 
 <main id=main>
     <input type=checkbox id=checkbox></input>
-    <select><option>a</option><option id=option>b</option></select>
+    <select id=select><optgroup id=optgroup><option>a</option><option id=option>b</option></optgroup></select>
     <div id=subject></div>
+    <div id=subject2></div>
+    <div id=subject3></div>
+    <div id=subject4></div>
 </main>
 
 <script>
@@ -26,22 +35,43 @@ const yellow = 'rgb(255, 255, 0)';
 const purple = 'rgb(128, 0, 128)';
 const pink = 'rgb(255, 192, 203)';
 
-function testColor(test_name, color) {
+function testColor(test_name, subject_element, color) {
     test(function() {
-        assert_equals(getComputedStyle(subject).color, color);
+        assert_equals(getComputedStyle(subject_element).color, color);
     }, test_name);
 }
 
-function testPseudoClassChange(element, property, expectedColor)
+function testPseudoClassChange(element, property, subject_element, expectedColor)
 {
+    testColor(`Before set ${property} on ${element.id}, testing ${subject_element.id}`, subject_element, grey);
+
     element[property] = true;
-    testColor(`Set ${property} on ${element.id}`, expectedColor);
+    testColor(`Set ${property} on ${element.id}, testing ${subject_element.id}`, subject_element, expectedColor);
+
     element[property] = false;
-    testColor(`Unset ${property} on ${element.id}`, grey);
+    testColor(`Unset ${property} on ${element.id}, testing ${subject_element.id}`, subject_element, grey);
 }
 
-testColor('Initial color', grey);
+function testSelectedChange(option, subject_element, expectedColor)
+{
+    const oldOption = select.selectedOptions[0];
+    option.selected = true;
+    testColor(`Set select on ${option.id}`, subject_element, expectedColor);
+    oldOption.selected = true;
+    testColor(`Reset select`, subject, grey);
+}
 
-testPseudoClassChange(checkbox, "checked", red);
-testPseudoClassChange(option, "selected", green);
+testPseudoClassChange(checkbox, "checked", subject, red);
+testSelectedChange(option, subject, red);
+
+testPseudoClassChange(checkbox, "disabled", subject, green);
+testPseudoClassChange(checkbox, "disabled", subject3, green);
+testPseudoClassChange(option, "disabled", subject, green);
+testPseudoClassChange(option, "disabled", subject3, green);
+
+testPseudoClassChange(optgroup, "disabled", subject, blue);
+testPseudoClassChange(optgroup, "disabled", subject2, green);
+testPseudoClassChange(optgroup, "disabled", subject3, blue);
+testPseudoClassChange(optgroup, "disabled", subject4, green);
+
 </script>


### PR DESCRIPTION
WebKit export from bug: [\[:has() pseudo-class\] Support :disabled pseudo-class invalidation](https://bugs.webkit.org/show_bug.cgi?id=234636)