### PR TITLE
Updates css/css-color/predefined-016.html to use the new name for xyz-d50

### DIFF
--- a/css/css-color/predefined-016.html
+++ b/css/css-color/predefined-016.html
@@ -4,11 +4,11 @@
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#predefined">
 <link rel="match" href="greensquare-090-ref.html">
-<meta name="assert" content="Color function with explicit XYZ value matches sRGB #009900">
+<meta name="assert" content="Color function with explicit xyz-d50 value matches sRGB #009900">
 <style>
     .test { background-color: red; width: 12em; height: 6em; margin-top:0}
     .ref { background-color: #009900; width: 12em; height: 6em; margin-bottom: 0}
-    .test {background-color: color(xyz 0.12266 0.22836 0.03093)}
+    .test {background-color: color(xyz-d50 0.12266 0.22836 0.03093)}
 </style>
 <body>
     <p>Test passes if you see a green square, and no red.</p>


### PR DESCRIPTION
Updates css/css-color/predefined-016.html to use the new name for XYZ with a D50 white point, xyz-d50, rather than the old, xyz, which now uses a D65 white point.