### PR TITLE
checking iteration timing fix (do not merge)

### DIFF
--- a/css/CSS2/borders/border-001.xht
+++ b/css/CSS2/borders/border-001.xht
@@ -9,7 +9,6 @@
         <link rel="help" href="http://www.w3.org/TR/css3-background/#borders"/>
         <link rel="help" href="http://www.w3.org/TR/css3-background/#the-border-shorthands"/>
         <link rel="match" href="border-001-ref.xht"/>
-        <meta name="flags" content=""/>
         <meta name="assert" content="The 'border' shorthand property properly accepts and sets border-width."/>
         <style type="text/css">
             div

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -272,6 +272,7 @@ def run_step(logger, iterations, restart_after_iteration, kwargs_extras, **kwarg
         kwargs["rerun"] = iterations
 
     kwargs["pause_after_test"] = False
+    kwargs["max_time"] = kwargs["verify_max_time"]
     kwargs.update(kwargs_extras)
 
     def wrap_handler(x):

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -346,6 +346,10 @@ def check_stability(logger, repeat_loop=10, repeat_restart=5, chaos_mode=True, m
     start_time = datetime.now()
     step_results = []
 
+    logger.info("DANIEL - max time")
+    logger.info(f"{max_time=}")
+    logger.info(f"{type(max_time)=}")
+
     github_checks_outputter = get_gh_checks_outputter(kwargs["github_checks_text_file"])
 
     for desc, step_func in steps:

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -287,9 +287,7 @@ def run_step(logger, iterations, restart_after_iteration, kwargs_extras, **kwarg
     # Setup logging for wptrunner that keeps process output and
     # warning+ level logs only
     logger.add_handler(StreamHandler(log, JSONFormatter()))
-    print("DANIEL - run_tests kwargs")
-    print(f"{kwargs=}")
-    print(f"{kwargs_extras=}")
+
     wptrunner.run_tests(**kwargs)
 
     logger._state.handlers = initial_handlers

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -4,7 +4,7 @@ import imp
 import io
 import os
 from collections import OrderedDict, defaultdict
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from mozlog import reader
 from mozlog.formatters import JSONFormatter
@@ -353,7 +353,7 @@ def check_stability(logger, repeat_loop=10, repeat_restart=5, chaos_mode=True, m
     github_checks_outputter = get_gh_checks_outputter(kwargs["github_checks_text_file"])
 
     for desc, step_func in steps:
-        if max_time and datetime.now() - start_time > max_time:
+        if max_time and datetime.now() - start_time > timedelta(minutes=max_time):
             logger.info("::: Test verification is taking too long: Giving up!")
             logger.info("::: So far, all checks passed, but not all checks were run.")
             write_summary(logger, step_results, "TIMEOUT")

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -272,7 +272,8 @@ def run_step(logger, iterations, restart_after_iteration, kwargs_extras, **kwarg
         kwargs["rerun"] = iterations
 
     kwargs["pause_after_test"] = False
-    kwargs["max_time"] = kwargs["verify_max_time"]
+    if "max_time" in kwargs:
+        kwargs["max_time"] = timedelta(minutes=kwargs["verify_max_time"])
     kwargs.update(kwargs_extras)
 
     def wrap_handler(x):

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -305,8 +305,10 @@ def run_step(logger, iterations, restart_after_iteration,
     logger.add_handler(StreamHandler(log, JSONFormatter()))
 
     wptrunner.run_tests(**kwargs)
-    print("Daniel - avoided timeout")
-    print(kwargs["avoided_timeout"])
+
+    # use the number of repeated test suites that were run
+    # to process the results if the runs were stopped to
+    # avoid hitting a TC timeout.
     if kwargs["avoided_timeout"]["did_avoid"]:
         iterations = kwargs["avoided_timeout"]["iterations_run"]
 

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -302,11 +302,16 @@ def run_step(logger, iterations, restart_after_iteration, kwargs_extras, **kwarg
     print(f"{results=}")
     print(f"{inconsistent=}")
     print(f"{slow=}")
+    print(f"{iterations=}")
     return results, inconsistent, slow, iterations
 
 
 def get_steps(logger, repeat_loop, repeat_restart, kwargs_extras):
     steps = []
+    print("DANIEL - kwargs extras")
+    print(f"{kwargs_extras=}")
+    print(f"{repeat_loop=}")
+    print(f"{repeat_restart}")
     for kwargs_extra in kwargs_extras:
         if kwargs_extra:
             flags_string = " with flags %s" % " ".join(
@@ -369,6 +374,7 @@ def check_stability(logger, repeat_loop=10, repeat_restart=5, chaos_mode=True, m
         logger.info('::: Running test verification step "%s"...' % desc)
         logger.info(':::')
         results, inconsistent, slow, iterations = step_func(**kwargs)
+        print("finished step func in check_stability")
         if output_results:
             write_results(logger.info, results, iterations)
 
@@ -390,4 +396,5 @@ def check_stability(logger, repeat_loop=10, repeat_restart=5, chaos_mode=True, m
 
         step_results.append((desc, "PASS"))
 
+    print(f"{step_results=}")
     write_summary(logger, step_results, "PASS")

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -1,5 +1,3 @@
-from wpt.markdown import markdown_adjust, table  # type: ignore
-from ci.tc.github_checks_output import get_gh_checks_outputter  # type: ignore
 import copy
 import functools
 import imp
@@ -15,6 +13,8 @@ from mozlog.handlers import BaseHandler, StreamHandler, LogLevelFilter
 here = os.path.dirname(__file__)
 localpaths = imp.load_source("localpaths", os.path.abspath(
     os.path.join(here, os.pardir, os.pardir, "localpaths.py")))
+from ci.tc.github_checks_output import get_gh_checks_outputter  # type: ignore
+from wpt.markdown import markdown_adjust, table  # type: ignore
 
 
 # If a test takes more than (FLAKY_THRESHOLD*timeout) and does not consistently

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -141,11 +141,14 @@ def process_results(log, iterations):
     handler = LogHandler()
     reader.handle_log(reader.read(log), handler)
     results = handler.results
+
     print("Daniel - process_results")
-    # print(f"{results=}")
-    print(f"{dir(handler)=}")
-    print(f"{type(log)=}")
-    print(f"{log=}")
+    print(results)
+    print(dir(handler))
+    print(type(handler))
+    print(type(log))
+    print(log)
+
     for test_name, test in results.items():
         if is_inconsistent(test["status"], iterations):
             inconsistent.append((test_name, None, test["status"], []))

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -143,6 +143,9 @@ def process_results(log, iterations):
     results = handler.results
     print("Daniel - process_results")
     print(f"{results=}")
+    print(f"{dir(handler)}")
+    print(f"{type(log)=}")
+    print(f"{log=}")
     for test_name, test in results.items():
         if is_inconsistent(test["status"], iterations):
             inconsistent.append((test_name, None, test["status"], []))

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -296,7 +296,10 @@ def run_step(logger, iterations, restart_after_iteration, kwargs_extras, **kwarg
     # warning+ level logs only
     logger.add_handler(StreamHandler(log, JSONFormatter()))
 
-    wptrunner.run_tests(**kwargs)
+    _, quit_early_iterations = wptrunner.run_tests(**kwargs)
+
+    if quit_early_iterations:
+        iterations = quit_early_iterations
 
     logger._state.handlers = initial_handlers
     logger._state.running_tests = set()

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -142,8 +142,8 @@ def process_results(log, iterations):
     reader.handle_log(reader.read(log), handler)
     results = handler.results
     print("Daniel - process_results")
-    print(f"{results=}")
-    print(f"{dir(handler)}")
+    # print(f"{results=}")
+    print(f"{dir(handler)=}")
     print(f"{type(log)=}")
     print(f"{log=}")
     for test_name, test in results.items():

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -287,7 +287,9 @@ def run_step(logger, iterations, restart_after_iteration, kwargs_extras, **kwarg
     # Setup logging for wptrunner that keeps process output and
     # warning+ level logs only
     logger.add_handler(StreamHandler(log, JSONFormatter()))
-
+    print("DANIEL - run_tests kwargs")
+    print(f"{kwargs=}")
+    print(f"{kwargs_extras=}")
     wptrunner.run_tests(**kwargs)
 
     logger._state.handlers = initial_handlers

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -137,7 +137,8 @@ def find_slow_status(test):
 
 
 def process_results(log, iterations):
-    """Process test log and return overall results and list of inconsistent tests."""
+    """Process test log and return overall results
+    and list of inconsistent tests."""
     inconsistent = []
     slow = []
     handler = LogHandler()
@@ -150,7 +151,8 @@ def process_results(log, iterations):
         for subtest_name, subtest in test["subtests"].items():
             if is_inconsistent(subtest["status"], iterations):
                 inconsistent.append(
-                    (test_name, subtest_name, subtest["status"], subtest["messages"]))
+                    (test_name, subtest_name, subtest["status"],
+                     subtest["messages"]))
 
         slow_status = find_slow_status(test)
         if slow_status is not None:
@@ -173,7 +175,8 @@ def err_string(results_dict, iterations):
     else:
         for key, value in sorted(results_dict.items()):
             rv.append("%s%s" %
-                      (key, ": %s/%s" % (value, iterations) if value != iterations else ""))
+                      (key, ": %s/%s" % (value, iterations)
+                       if value != iterations else ""))
     if total_results < iterations:
         rv.append("MISSING: %s/%s" % (iterations - total_results, iterations))
     rv = ", ".join(rv)
@@ -187,8 +190,8 @@ def write_github_checks_summary_inconsistent(log, inconsistent, iterations):
     log("Some affected tests had inconsistent (flaky) results:\n")
     write_inconsistent(log, inconsistent, iterations)
     log("\n")
-    log("These may be pre-existing or new flakes. Please try to reproduce (see "
-        "the above WPT command, though some flags may not be needed when "
+    log("These may be pre-existing or new flakes. Please try to reproduce (see"
+        " the above WPT command, though some flags may not be needed when "
         "running locally) and determine if your change introduced the flake. "
         "If you are unable to reproduce the problem, please tag "
         "`@web-platform-tests/wpt-core-team` in a comment for help.\n")
@@ -213,7 +216,8 @@ def write_inconsistent(log, inconsistent, iterations):
         "`%s`" % markdown_adjust(test),
         ("`%s`" % markdown_adjust(subtest)) if subtest else "",
         err_string(results, iterations),
-        ("`%s`" % markdown_adjust(";".join(messages))) if len(messages) else "")
+        ("`%s`" % markdown_adjust(";".join(messages)))
+        if len(messages) else "")
         for test, subtest, results, messages in inconsistent]
     table(["Test", "Subtest", "Results", "Messages"], strings, log)
 
@@ -227,7 +231,8 @@ def write_slow_tests(log, slow):
         "`%.0f`" % duration,
         "`%.0f`" % timeout)
         for test, status, duration, timeout in slow]
-    table(["Test", "Result", "Longest duration (ms)", "Timeout (ms)"], strings, log)
+    table(["Test", "Result", "Longest duration (ms)", "Timeout (ms)"],
+          strings, log)
 
 
 def write_results(log, results, iterations, pr_number=None, use_details=False):
@@ -256,7 +261,8 @@ def write_results(log, results, iterations, pr_number=None, use_details=False):
         strings.extend(((
             ("`%s`" % markdown_adjust(subtest_name)) if subtest else "",
             err_string(subtest["status"], iterations),
-            ("`%s`" % markdown_adjust(';'.join(subtest["messages"]))) if len(subtest["messages"]) else "")
+            ("`%s`" % markdown_adjust(';'.join(subtest["messages"])))
+            if len(subtest["messages"]) else "")
             for subtest_name, subtest in test["subtests"].items()))
         table(["Subtest", "Results", "Messages"], strings, log)
         if use_details:
@@ -266,7 +272,8 @@ def write_results(log, results, iterations, pr_number=None, use_details=False):
         log("</details>\n")
 
 
-def run_step(logger, iterations, restart_after_iteration, kwargs_extras, **kwargs):
+def run_step(logger, iterations, restart_after_iteration,
+             kwargs_extras, **kwargs):
     from . import wptrunner
     kwargs = copy.deepcopy(kwargs)
 
@@ -329,8 +336,8 @@ def get_steps(logger, repeat_loop, repeat_restart, kwargs_extras):
                 run_step, logger, repeat_loop, False, kwargs_extra)))
 
         if repeat_restart:
-            desc = "Running tests in a loop with restarts %s times%s" % (repeat_restart,
-                                                                         flags_string)
+            desc = "Running tests in a loop with restarts %s times%s" % (
+                repeat_restart, flags_string)
             steps.append((desc, functools.partial(
                 run_step, logger, repeat_restart, True, kwargs_extra)))
 
@@ -352,8 +359,8 @@ def write_summary(logger, step_results, final_result):
     logger.info(':::')
 
 
-def check_stability(logger, repeat_loop=10, repeat_restart=5, chaos_mode=True, max_time=None,
-                    output_results=True, **kwargs):
+def check_stability(logger, repeat_loop=10, repeat_restart=5, chaos_mode=True,
+                    max_time=None, output_results=True, **kwargs):
     kwargs_extras = [{}]
     if chaos_mode and kwargs["product"] == "firefox":
         kwargs_extras.append({"chaos_mode_flags": "0xfb"})
@@ -367,7 +374,8 @@ def check_stability(logger, repeat_loop=10, repeat_restart=5, chaos_mode=True, m
         kwargs["github_checks_text_file"])
 
     for desc, step_func in steps:
-        if max_time and datetime.now() - start_time > timedelta(minutes=max_time):
+        if max_time and \
+                datetime.now() - start_time > timedelta(minutes=max_time):
             logger.info("::: Test verification is taking too long: Giving up!")
             logger.info(
                 "::: So far, all checks passed, but not all checks were run.")

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -141,6 +141,8 @@ def process_results(log, iterations):
     handler = LogHandler()
     reader.handle_log(reader.read(log), handler)
     results = handler.results
+    print("Daniel - process_results")
+    print(f"{results=}")
     for test_name, test in results.items():
         if is_inconsistent(test["status"], iterations):
             inconsistent.append((test_name, None, test["status"], []))
@@ -296,6 +298,10 @@ def run_step(logger, iterations, restart_after_iteration, kwargs_extras, **kwarg
 
     log.seek(0)
     results, inconsistent, slow = process_results(log, iterations)
+    print("Daniel - results")
+    print(f"{results=}")
+    print(f"{inconsistent=}")
+    print(f"{slow=}")
     return results, inconsistent, slow, iterations
 
 

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -315,9 +315,13 @@ def run_step(logger, iterations, restart_after_iteration, kwargs_extras, **kwarg
 def get_steps(logger, repeat_loop, repeat_restart, kwargs_extras):
     steps = []
     print("DANIEL - kwargs extras")
-    print(f"{kwargs_extras=}")
-    print(f"{repeat_loop=}")
-    print(f"{repeat_restart}")
+    print("kwargs_extras")
+    print(kwargs_extras)
+    print("repeat_loop")
+    print(repeat_loop)
+    print("repeat_restart")
+    print(repeat_restart)
+
     for kwargs_extra in kwargs_extras:
         if kwargs_extra:
             flags_string = " with flags %s" % " ".join(
@@ -363,9 +367,9 @@ def check_stability(logger, repeat_loop=10, repeat_restart=5, chaos_mode=True, m
     start_time = datetime.now()
     step_results = []
 
-    logger.info("DANIEL - max time")
-    logger.info(f"{max_time=}")
-    logger.info(f"{type(max_time)=}")
+    # logger.info("DANIEL - max time")
+    # logger.info(f"{max_time=}")
+    # logger.info(f"{type(max_time)=}")
 
     github_checks_outputter = get_gh_checks_outputter(kwargs["github_checks_text_file"])
 
@@ -402,5 +406,6 @@ def check_stability(logger, repeat_loop=10, repeat_restart=5, chaos_mode=True, m
 
         step_results.append((desc, "PASS"))
 
-    print(f"{step_results=}")
+    print("step_results")
+    print(step_results)
     write_summary(logger, step_results, "PASS")

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -301,11 +301,11 @@ def run_step(logger, iterations, restart_after_iteration, kwargs_extras, **kwarg
 
     log.seek(0)
     results, inconsistent, slow = process_results(log, iterations)
-    print("Daniel - results")
-    print(f"{results=}")
-    print(f"{inconsistent=}")
-    print(f"{slow=}")
-    print(f"{iterations=}")
+    # print("Daniel - results")
+    # print(f"{results=}")
+    # print(f"{inconsistent=}")
+    # print(f"{slow=}")
+    # print(f"{iterations=}")
     return results, inconsistent, slow, iterations
 
 

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -142,13 +142,6 @@ def process_results(log, iterations):
     reader.handle_log(reader.read(log), handler)
     results = handler.results
 
-    print("Daniel - process_results")
-    print(results)
-    print(dir(handler))
-    print(type(handler))
-    print(type(log))
-    print(log)
-
     for test_name, test in results.items():
         if is_inconsistent(test["status"], iterations):
             inconsistent.append((test_name, None, test["status"], []))
@@ -307,23 +300,11 @@ def run_step(logger, iterations, restart_after_iteration, kwargs_extras, **kwarg
 
     log.seek(0)
     results, inconsistent, slow = process_results(log, iterations)
-    # print("Daniel - results")
-    # print(f"{results=}")
-    # print(f"{inconsistent=}")
-    # print(f"{slow=}")
-    # print(f"{iterations=}")
     return results, inconsistent, slow, iterations
 
 
 def get_steps(logger, repeat_loop, repeat_restart, kwargs_extras):
     steps = []
-    print("DANIEL - kwargs extras")
-    print("kwargs_extras")
-    print(kwargs_extras)
-    print("repeat_loop")
-    print(repeat_loop)
-    print("repeat_restart")
-    print(repeat_restart)
 
     for kwargs_extra in kwargs_extras:
         if kwargs_extra:
@@ -370,10 +351,6 @@ def check_stability(logger, repeat_loop=10, repeat_restart=5, chaos_mode=True, m
     start_time = datetime.now()
     step_results = []
 
-    # logger.info("DANIEL - max time")
-    # logger.info(f"{max_time=}")
-    # logger.info(f"{type(max_time)=}")
-
     github_checks_outputter = get_gh_checks_outputter(kwargs["github_checks_text_file"])
 
     for desc, step_func in steps:
@@ -387,7 +364,6 @@ def check_stability(logger, repeat_loop=10, repeat_restart=5, chaos_mode=True, m
         logger.info('::: Running test verification step "%s"...' % desc)
         logger.info(':::')
         results, inconsistent, slow, iterations = step_func(**kwargs)
-        print("finished step func in check_stability")
         if output_results:
             write_results(logger.info, results, iterations)
 
@@ -409,6 +385,4 @@ def check_stability(logger, repeat_loop=10, repeat_restart=5, chaos_mode=True, m
 
         step_results.append((desc, "PASS"))
 
-    print("step_results")
-    print(step_results)
     write_summary(logger, step_results, "PASS")

--- a/tools/wptrunner/wptrunner/tests/test_stability.py
+++ b/tools/wptrunner/wptrunner/tests/test_stability.py
@@ -45,6 +45,9 @@ def test_get_steps():
     flag_value = 'y'
     steps = stability.get_steps(logger, repeat_loop, 0, [
                                 {flag_name: flag_value}])
+    print("DANIEL - steps")
+    print(steps)
+
     assert len(steps) == 1
     assert steps[0][0] == "Running tests in a loop %d times with flags %s=%s" % (
         repeat_loop, flag_name, flag_value)
@@ -55,6 +58,9 @@ def test_get_steps():
     flag_value = 'n'
     steps = stability.get_steps(logger, repeat_loop, repeat_restart, [
                                 {flag_name: flag_value}])
+    print("DANIEL - steps")
+    print(steps)
+
     assert len(steps) == 1
     assert steps[0][0] == "Running tests in a loop with restarts %d times with flags %s=%s" % (
         repeat_restart, flag_name, flag_value)
@@ -62,6 +68,8 @@ def test_get_steps():
     repeat_loop = 10
     repeat_restart = 5
     steps = stability.get_steps(logger, repeat_loop, repeat_restart, [{}])
+    print("DANIEL - steps")
+    print(steps)
     assert len(steps) == 2
     assert steps[0][0] == "Running tests in a loop %d times" % repeat_loop
     assert steps[1][0] == (

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -3,7 +3,6 @@ import os
 import sys
 from collections import OrderedDict
 from distutils.spawn import find_executable
-from datetime import timedelta
 
 from . import config
 from . import wpttest

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -113,9 +113,9 @@ scheme host and port.""")
                                   dest="verify_chaos_mode",
                                   help="Enable chaos mode when running on Firefox")
     mode_group.add_argument("--verify-max-time", action="store",
-                            default=100,
+                            default=None,
                             help="The maximum number of minutes for the job to run",
-                            type=int
+                            type=int)
     output_results_group = mode_group.add_mutually_exclusive_group()
     output_results_group.add_argument("--verify-no-output-results", action="store_false",
                                       dest="verify_output_results",

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -113,7 +113,7 @@ scheme host and port.""")
                                   dest="verify_chaos_mode",
                                   help="Enable chaos mode when running on Firefox")
     mode_group.add_argument("--verify-max-time", action="store",
-                            default=None,
+                            default=100,
                             help="The maximum number of minutes for the job to run",
                             type=int)
     output_results_group = mode_group.add_mutually_exclusive_group()

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -115,7 +115,7 @@ scheme host and port.""")
     mode_group.add_argument("--verify-max-time", action="store",
                             default=100,
                             help="The maximum number of minutes for the job to run",
-                            type=lambda x: timedelta(minutes=float(x)))
+                            type=int
     output_results_group = mode_group.add_mutually_exclusive_group()
     output_results_group.add_argument("--verify-no-output-results", action="store_false",
                                       dest="verify_output_results",

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -113,7 +113,7 @@ scheme host and port.""")
                                   dest="verify_chaos_mode",
                                   help="Enable chaos mode when running on Firefox")
     mode_group.add_argument("--verify-max-time", action="store",
-                            default=None,
+                            default=100,
                             help="The maximum number of minutes for the job to run",
                             type=lambda x: timedelta(minutes=float(x)))
     output_results_group = mode_group.add_mutually_exclusive_group()

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -180,8 +180,8 @@ def run_test_iteration(
         test_groups = test_source_cls.tests_by_group(
             tests, **test_source_kwargs)
     except Exception:
-        logger.critical("Loading tests failed")
-        return False
+
+        return "Loading tests failed"
 
     logger.suite_start(test_groups,
                        name='web-platform-test',
@@ -256,7 +256,7 @@ def run_test_iteration(
             unexpected_count += manager_group.unexpected_count()
             unexpected_pass_count += manager_group.unexpected_pass_count()
 
-    return test_count, unexpected_count, unexpected_pass_count, skipped_tests
+    return None, test_count, unexpected_count, unexpected_pass_count, skipped_tests
 
 
 def run_tests(config, test_paths, product, max_time=None, **kwargs):
@@ -382,7 +382,7 @@ def run_tests(config, test_paths, product, max_time=None, **kwargs):
                     datetime.now() - iteration_start)
                 recording.set(["after-end"])
 
-                test_count, unexpected_count, unexpected_pass_count, skips = run_test_iteration(
+                fail_msg, test_count, unexpected_count, unexpected_pass_count, skips = run_test_iteration(
                     test_loader,
                     test_source_kwargs,
                     test_source_cls,
@@ -392,6 +392,9 @@ def run_tests(config, test_paths, product, max_time=None, **kwargs):
                     product,
                     kwargs
                 )
+                if fail_msg:
+                    logger.critical(fail_msg)
+                    return False
                 test_total += test_count
                 unexpected_total += unexpected_count
                 unexpected_pass_total += unexpected_pass_count

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -392,7 +392,7 @@ def run_tests(config, test_paths, product, **kwargs):
                     unexpected_pass_total)
         return True
 
-    return unexpected_total == 0
+    return unexpected_total == 0, repeat_count
 
 
 def check_stability(**kwargs):

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -295,6 +295,7 @@ def evaluate_runs(counts, avoided_timeout, kwargs):
     # the number of iterations that were run need to be returned
     # so that the test results can be processed appropriately.
     if avoided_timeout:
+        print("Daniel - we did avoid")
         kwargs["avoided_timeout"]["did_avoid"] = True
         kwargs["avoided_timeout"]["iterations_run"] = counts["repeat"]
     return counts["unexpected"] == 0

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import wptserve
 from wptserve import sslutils
@@ -358,6 +358,7 @@ def run_tests(config, test_paths, product, max_time=None, **kwargs):
             repeat = kwargs["repeat"]
             repeat_count = 0
             repeat_until_unexpected = kwargs["repeat_until_unexpected"]
+            longest_iteration_time = timedelta()
 
             while repeat_count < repeat or repeat_until_unexpected:
                 # if the next repeat run could cause the TC timeout to be reached,

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -269,7 +269,7 @@ def run_test_iteration(counts, test_loader, test_source_kwargs,
 def evaluate_runs(counts, avoided_timeout, kwargs):
     """Evaluates the test counts after the
     given number of repeat runs has finished"""
-    if counts["total_tests"]:
+    if counts["total_tests"] == 0:
         if counts["skipped"] > 0:
             logger.warning("All requested tests were skipped")
         else:

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -351,7 +351,7 @@ def run_tests(config, test_paths, product, **kwargs):
                         test_count += manager_group.test_count()
                         unexpected_count += manager_group.unexpected_count()
                         unexpected_pass_count += manager_group.unexpected_pass_count()
-                logger.info("Test suite iteration finished.")
+                logger.info(f"Test suite iteration {repeat_count} finished.")
                 logger.info(f"{longest_iteration_time=}")
                 logger.info(f"{(datetime.now() - iteration_start)=}")
                 longest_iteration_time = max(longest_iteration_time, datetime.now() - iteration_start)
@@ -362,6 +362,9 @@ def run_tests(config, test_paths, product, **kwargs):
                 logger.info("Got %i unexpected results, with %i unexpected passes" %
                             (unexpected_count, unexpected_pass_count))
                 logger.suite_end()
+                if repeat_count == 8:
+                    logger.info("ran 8 iterations. What will happen quitting early?")
+                    break
                 if repeat_until_unexpected and unexpected_total > 0:
                     break
                 if repeat_count == 1 and len(test_loader.test_ids) == skipped_tests:

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -295,7 +295,6 @@ def evaluate_runs(counts, avoided_timeout, kwargs):
     # the number of iterations that were run need to be returned
     # so that the test results can be processed appropriately.
     if avoided_timeout:
-        print("Daniel - we did avoid")
         kwargs["avoided_timeout"]["did_avoid"] = True
         kwargs["avoided_timeout"]["iterations_run"] = counts["repeat"]
     return counts["unexpected"] == 0

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -247,7 +247,7 @@ def run_tests(config, test_paths, product, **kwargs):
             repeat_until_unexpected = kwargs["repeat_until_unexpected"]
 
             longest_iteration_time = timedelta()
-            max_time = kwargs['verify_max_time']
+            max_time = timedelta(minutes=kwargs['verify_max_time'])
             print("DANIEL - max time")
             print(f"{max_time=}")
             print(f"{type(max_time)=}")

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -268,9 +268,6 @@ def run_tests(config, test_paths, product, max_time=None, **kwargs):
     else:
         recorder = instruments.Instrument(kwargs["instrument_to_file"])
 
-    if kwargs["max_time"]:
-        max_time = kwargs["max_time"]
-
     with recorder as recording, capture.CaptureIO(logger,
                                                   not kwargs["no_capture_stdio"],
                                                   mp_context=mp):

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -75,11 +75,12 @@ def get_loader(test_paths, product, debug=None, run_info_extras=None, chunker_kw
         include = testloader.update_include_for_groups(test_groups, include)
 
     if include or kwargs["exclude"] or kwargs["include_manifest"] or kwargs["default_exclude"]:
-        manifest_filters.append(testloader.TestFilter(include=include,
-                                                      exclude=kwargs["exclude"],
-                                                      manifest_path=kwargs["include_manifest"],
-                                                      test_manifests=test_manifests,
-                                                      explicit=kwargs["default_exclude"]))
+        manifest_filters.append(
+            testloader.TestFilter(include=include,
+                                  exclude=kwargs["exclude"],
+                                  manifest_path=kwargs["include_manifest"],
+                                  test_manifests=test_manifests,
+                                  explicit=kwargs["default_exclude"]))
 
     ssl_enabled = sslutils.get_cls(kwargs["ssl_type"]).ssl_enabled
     h2_enabled = wptserve.utils.http2_compatible()
@@ -106,7 +107,8 @@ def list_test_groups(test_paths, product, **kwargs):
         kwargs["config"], product).run_info_extras(**kwargs)
 
     run_info, test_loader = get_loader(test_paths, product,
-                                       run_info_extras=run_info_extras, **kwargs)
+                                       run_info_extras=run_info_extras,
+                                       **kwargs)
 
     for item in sorted(test_loader.groups(kwargs["test_types"])):
         print(item)
@@ -121,7 +123,8 @@ def list_disabled(test_paths, product, **kwargs):
         kwargs["config"], product).run_info_extras(**kwargs)
 
     run_info, test_loader = get_loader(test_paths, product,
-                                       run_info_extras=run_info_extras, **kwargs)
+                                       run_info_extras=run_info_extras,
+                                       **kwargs)
 
     for test_type, tests in test_loader.disabled_tests.items():
         for test in tests:
@@ -136,7 +139,8 @@ def list_tests(test_paths, product, **kwargs):
         kwargs["config"], product).run_info_extras(**kwargs)
 
     run_info, test_loader = get_loader(test_paths, product,
-                                       run_info_extras=run_info_extras, **kwargs)
+                                       run_info_extras=run_info_extras,
+                                       **kwargs)
 
     for test in test_loader.test_ids:
         print(test)
@@ -151,9 +155,11 @@ def get_pause_after_test(test_loader, **kwargs):
         if kwargs["debug_test"]:
             return True
         tests = test_loader.tests
-        is_single_testharness = (sum(len(item) for item in tests.values()) == 1 and
-                                 len(tests.get("testharness", [])) == 1)
-        if kwargs["repeat"] == 1 and kwargs["rerun"] == 1 and is_single_testharness:
+        is_single_testharness = (
+            sum(len(item) for item in tests.values()) == 1 and
+            len(tests.get("testharness", [])) == 1)
+        if kwargs["repeat"] == 1 and kwargs["rerun"] == 1 \
+                and is_single_testharness:
             return True
         return False
     return kwargs["pause_after_test"]
@@ -463,7 +469,8 @@ def check_stability(**kwargs):
         kwargs['verify_max_time'] = None
         kwargs['verify_chaos_mode'] = False
         kwargs['verify_repeat_loop'] = 0
-        kwargs['verify_repeat_restart'] = 10 if kwargs['repeat'] == 1 else kwargs['repeat']
+        kwargs['verify_repeat_restart'] = 10 \
+            if kwargs['repeat'] == 1 else kwargs['repeat']
         kwargs['verify_output_results'] = True
 
     return stability.check_stability(

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -46,23 +46,26 @@ def setup_logging(*args, **kwargs):
     return logger
 
 
-def get_loader(test_paths, product, debug=None, run_info_extras=None, chunker_kwargs=None,
-               test_groups=None, **kwargs):
+def get_loader(test_paths, product, debug=None, run_info_extras=None,
+               chunker_kwargs=None, test_groups=None, **kwargs):
     if run_info_extras is None:
         run_info_extras = {}
 
-    run_info = wpttest.get_run_info(kwargs["run_info"], product,
-                                    browser_version=kwargs.get(
-                                        "browser_version"),
-                                    browser_channel=kwargs.get(
-                                        "browser_channel"),
-                                    verify=kwargs.get("verify"),
-                                    debug=debug,
-                                    extras=run_info_extras,
-                                    enable_webrender=kwargs.get("enable_webrender"))
+    run_info = \
+        wpttest.get_run_info(kwargs["run_info"], product,
+                             browser_version=kwargs.get("browser_version"),
+                             browser_channel=kwargs.get("browser_channel"),
+                             verify=kwargs.get("verify"),
+                             debug=debug,
+                             extras=run_info_extras,
+                             enable_webrender=kwargs.get("enable_webrender"))
 
-    test_manifests = testloader.ManifestLoader(test_paths, force_manifest_update=kwargs["manifest_update"],
-                                               manifest_download=kwargs["manifest_download"]).load()
+    test_manifests = \
+        testloader.ManifestLoader(test_paths,
+                                  force_manifest_update=kwargs[
+                                      "manifest_update"],
+                                  manifest_download=kwargs[
+                                      "manifest_download"]).load()
 
     manifest_filters = []
 
@@ -74,7 +77,8 @@ def get_loader(test_paths, product, debug=None, run_info_extras=None, chunker_kw
     if test_groups:
         include = testloader.update_include_for_groups(test_groups, include)
 
-    if include or kwargs["exclude"] or kwargs["include_manifest"] or kwargs["default_exclude"]:
+    if include or kwargs["exclude"] \
+            or kwargs["include_manifest"] or kwargs["default_exclude"]:
         manifest_filters.append(
             testloader.TestFilter(include=include,
                                   exclude=kwargs["exclude"],
@@ -84,19 +88,22 @@ def get_loader(test_paths, product, debug=None, run_info_extras=None, chunker_kw
 
     ssl_enabled = sslutils.get_cls(kwargs["ssl_type"]).ssl_enabled
     h2_enabled = wptserve.utils.http2_compatible()
-    test_loader = testloader.TestLoader(test_manifests,
-                                        kwargs["test_types"],
-                                        run_info,
-                                        manifest_filters=manifest_filters,
-                                        chunk_type=kwargs["chunk_type"],
-                                        total_chunks=kwargs["total_chunks"],
-                                        chunk_number=kwargs["this_chunk"],
-                                        include_https=ssl_enabled,
-                                        include_h2=h2_enabled,
-                                        include_webtransport_h3=kwargs["enable_webtransport_h3"],
-                                        skip_timeout=kwargs["skip_timeout"],
-                                        skip_implementation_status=kwargs["skip_implementation_status"],
-                                        chunker_kwargs=chunker_kwargs)
+    test_loader = \
+        testloader.TestLoader(test_manifests,
+                              kwargs["test_types"],
+                              run_info,
+                              manifest_filters=manifest_filters,
+                              chunk_type=kwargs["chunk_type"],
+                              total_chunks=kwargs["total_chunks"],
+                              chunk_number=kwargs["this_chunk"],
+                              include_https=ssl_enabled,
+                              include_h2=h2_enabled,
+                              include_webtransport_h3=kwargs[
+                                  "enable_webtransport_h3"],
+                              skip_timeout=kwargs["skip_timeout"],
+                              skip_implementation_status=kwargs[
+                                  "skip_implementation_status"],
+                              chunker_kwargs=chunker_kwargs)
     return run_info, test_loader
 
 


### PR DESCRIPTION
adding a max time to stability checks to be 100 minutes and timing longest repeat of test suite. Bailing on tests if the next iteration is projected to take the full run past the 100 minute (or user defined) timeout