### PR TITLE
Fix incorrect expectation for css/css-transitions/transition-property-002.html

### DIFF
--- a/css/css-transitions/transition-property-002.html
+++ b/css/css-transitions/transition-property-002.html
@@ -27,8 +27,8 @@
 
             // syntax: none | [ all | <IDENT> ] [ ‘,’ [ all | <IDENT> ] ]*
             var values = {
-                'none, all' : 'none, all',
-                'all, none' : 'all, none',
+                'none, all' : 'all',
+                'all, none' : 'all',
                 'foobar' : 'foobar',
                 'all, foobar' : 'all, foobar',
                 'foobar, all' : 'foobar, all',


### PR DESCRIPTION
The [spec for `transition-property`](https://drafts.csswg.org/css-transitions/#transition-property-property) calls out specifically that `none` may not appear if there is more than one value specified:

> This means that none, inherit, and initial are not permitted as items within a list of more that one identifier; any list that uses them is syntactically invalid.

All browsers fail this test in a consistent manner, so I believe this test is clearly wrong and should be updated to assume `all` as the computed value for `none, all` and `all, none`. Another option would be to remove these values since this part of the spec is also covered by [css/css-transitions/parsing/transition-property-invalid.html](https://github.com/web-platform-tests/wpt/blob/master/css/css-transitions/parsing/transition-property-invalid.html).