### PR TITLE
Fix typo in html/cross-origin-opener-policy/resources/fully-loaded.js

### DIFF
--- a/html/cross-origin-opener-policy/resources/fully-loaded.js
+++ b/html/cross-origin-opener-policy/resources/fully-loaded.js
@@ -1,4 +1,4 @@
-r// Return a promise, which resolves when new navigations aren't considered
+// Return a promise, which resolves when new navigations aren't considered
 // client-side redirects anymore.
 //
 // Note: A long `setTimeout` is used, because client-side redirect is an


### PR DESCRIPTION
There was a leading 'r' at the beginning of the file leading to JS errors.