### PR TITLE
Use loop index to decide which emulator to use

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -255,10 +255,10 @@ RunnerManagerState = _RunnerManagerState()
 
 
 class TestRunnerManager(threading.Thread):
-    def __init__(self, suite_name, index, test_queue, test_source_cls, browser_cls, browser_kwargs,
-                 executor_cls, executor_kwargs, stop_flag, rerun=1, pause_after_test=False,
-                 pause_on_unexpected=False, restart_on_unexpected=True, debug_info=None,
-                 capture_stdio=True, recording=None):
+    def __init__(self, suite_name, index, test_type, test_queue, test_source_cls, browser_cls,
+                 browser_kwargs, executor_cls, executor_kwargs, stop_flag, rerun=1,
+                 pause_after_test=False, pause_on_unexpected=False, restart_on_unexpected=True,
+                 debug_info=None, capture_stdio=True, recording=None):
         """Thread that owns a single TestRunner process and any processes required
         by the TestRunner (e.g. the Firefox binary).
 
@@ -278,7 +278,7 @@ class TestRunnerManager(threading.Thread):
 
         self.test_source = test_source_cls(test_queue)
 
-        self.manager_number = index + 1
+        self.manager_number = index
         self.browser_cls = browser_cls
         self.browser_kwargs = browser_kwargs.copy()
         if self.browser_kwargs.get("device_serial"):
@@ -310,7 +310,7 @@ class TestRunnerManager(threading.Thread):
 
         self.test_runner_proc = None
 
-        threading.Thread.__init__(self, name="TestRunnerManager-%i" % self.manager_number)
+        threading.Thread.__init__(self, name="TestRunnerManager-%s-%i" % (test_type, index))
         # This is started in the actual new thread
         self.logger = None
 
@@ -889,10 +889,10 @@ class ManagerGroup(object):
 
         test_queue = make_test_queue(type_tests, self.test_source_cls, **self.test_source_kwargs)
 
-        # Ensure TestRunnerManager index is always in 1 ... self.size inclusively.
         for idx in range(self.size):
             manager = TestRunnerManager(self.suite_name,
                                         idx,
+                                        test_type,
                                         test_queue,
                                         self.test_source_cls,
                                         self.browser_cls,

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -898,6 +898,9 @@ class ManagerGroup(object):
 
         test_queue = make_test_queue(type_tests, self.test_source_cls, **self.test_source_kwargs)
 
+        # Ensure TestRunnerManager index is always in 1 ... self.size inclusively.
+        global manager_count
+        manager_count = 0
         for _ in range(self.size):
             manager = TestRunnerManager(self.suite_name,
                                         test_queue,

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -279,6 +279,7 @@ class TestRunnerManager(threading.Thread):
         self.test_source = test_source_cls(test_queue)
 
         self.manager_number = index
+        self.test_type = test_type
         self.browser_cls = browser_cls
         self.browser_kwargs = browser_kwargs.copy()
         if self.browser_kwargs.get("device_serial"):
@@ -505,7 +506,8 @@ class TestRunnerManager(threading.Thread):
         mp = mpcontext.get_context()
         self.test_runner_proc = mp.Process(target=start_runner,
                                            args=args,
-                                           name="TestRunner-%i" % self.manager_number)
+                                           name="TestRunner-%s-%i" % (
+                                               self.test_type, self.manager_number))
         self.test_runner_proc.start()
         self.logger.debug("Test runner started")
         # Now we wait for either an init_succeeded event or an init_failed event


### PR DESCRIPTION
We are using the index of the TestRunnerManager to decide which
emulator to use. An index larger than the number of processes will
cause an error.

Pass in the loop counter to TestRunnerManager, and use that as the
index to the emulator.