### PR TITLE
Use a different value that is not prone to WebKit showing a float accuracy issue

### DIFF
--- a/css/css-animations/KeyframeEffect-getKeyframes.tentative.html
+++ b/css/css-animations/KeyframeEffect-getKeyframes.tentative.html
@@ -525,7 +525,7 @@ test(t => {
   const div = addDiv(t);
   div.style.textShadow = '1px 1px 2px rgb(0, 0, 0), ' +
                          '0 0 16px rgb(0, 0, 255), ' +
-                         '0 0 3.2px rgb(0, 0, 255)';
+                         '0 0 3.5px rgb(0, 0, 255)';
   div.style.animation = 'anim-text-shadow 100s';
 
   const frames = getKeyframes(div);
@@ -534,7 +534,7 @@ test(t => {
     { offset: 0, computedOffset: 0, easing: "ease", composite: "auto",
       textShadow: "rgb(0, 0, 0) 1px 1px 2px,"
                   + " rgb(0, 0, 255) 0px 0px 16px,"
-                  + " rgb(0, 0, 255) 0px 0px 3.2px" },
+                  + " rgb(0, 0, 255) 0px 0px 3.5px" },
     { offset: 1, computedOffset: 1, easing: "ease", composite: "auto",
       textShadow: "none" },
   ];


### PR DESCRIPTION
WebKit fails a `css/css-animations/KeyframeEffect-getKeyframes.tentative.html` test due to the way float values are parsed in WebKit and serialized out:

```
assert_equals: value for 'textShadow' on Keyframe #0 should match expected "rgb(0, 0, 0) 1px 1px 2px, rgb(0, 0, 255) 0px 0px 16px, rgb(0, 0, 255) 0px 0px 3.2px" but got "rgb(0, 0, 0) 1px 1px 2px, rgb(0, 0, 255) 0px 0px 16px, rgb(0, 0, 255) 0px 0px 3.200000047683716px"
```

The use of the value `3.2px` seems immaterial to this test, I suggest we use a different float value, if a float value must absolutely be used, which produces the expected output in all browsers.