### PR TITLE
Hotfix stability changes to not fail inconsequentially when no tests are run

### DIFF
--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -292,6 +292,7 @@ def run_step(logger, iterations, restart_after_iteration, kwargs_extras, **kwarg
     # if the runs were stopped to avoid hitting the maximum run time.
     _, test_status = wptrunner.run_tests(**kwargs)
     iterations = test_status.repeated_runs
+    all_skipped = test_status.all_skipped
 
     logger._state.handlers = initial_handlers
     logger._state.running_tests = set()
@@ -299,7 +300,7 @@ def run_step(logger, iterations, restart_after_iteration, kwargs_extras, **kwarg
 
     log.seek(0)
     results, inconsistent, slow = process_results(log, iterations)
-    return results, inconsistent, slow, iterations
+    return results, inconsistent, slow, iterations, all_skipped
 
 
 def get_steps(logger, repeat_loop, repeat_restart, kwargs_extras):
@@ -374,9 +375,9 @@ def check_stability(logger, repeat_loop=10, repeat_restart=5, chaos_mode=True, m
         logger.info(':::')
         logger.info('::: Running test verification step "%s"...' % desc)
         logger.info(':::')
-        results, inconsistent, slow, iterations = step_func(**kwargs)
+        results, inconsistent, slow, iterations, all_skipped = step_func(**kwargs)
 
-        if iterations <= 1 and expected_iterations > 1:
+        if iterations <= 1 and expected_iterations > 1 and not all_skipped:
             step_results.append((desc, "FAIL"))
             logger.info("::: Reached iteration timeout before finishing 2 or more repeat runs.")
             logger.info("::: At least 2 successful repeat runs are required to validate stability.")

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -276,6 +276,7 @@ class TestStatus:
         self.unexpected_pass = 0
         self.repeated_runs = 0
         self.expected_repeated_runs = 0
+        self.all_skipped = False
 
 
 def run_tests(config, test_paths, product, **kwargs):
@@ -417,6 +418,7 @@ def run_tests(config, test_paths, product, **kwargs):
                 if repeat_until_unexpected and test_status.unexpected > 0:
                     break
                 if test_status.repeated_runs == 1 and len(test_loader.test_ids) == test_status.skipped:
+                    test_status.all_skipped = True
                     break
 
     # Return the evaluation of the runs and the number of repeated iterations that were run.


### PR DESCRIPTION
There are cases where no tests are run in wptrunner and the repeated test loop will stop. The new changes to stability runs were now treating these instances as failures because they do not have more than 1 test suite iteration run (which is needed to truly get valid stability results). This change adds a detection to see if all tests were skipped, and if they were, the checks will not be considered a failure.