### PR TITLE
WebAssembly.Table's second argument is not stray

### DIFF
--- a/wasm/jsapi/table/constructor.any.js
+++ b/wasm/jsapi/table/constructor.any.js
@@ -89,7 +89,7 @@ test(() => {
 
 test(() => {
   const argument = { "element": "anyfunc", "initial": 0 };
-  const table = new WebAssembly.Table(argument, {});
+  const table = new WebAssembly.Table(argument, null, {});
   assert_Table(table, { "length": 0 });
 }, "Stray argument");
 


### PR DESCRIPTION
It is used for an initial value for the table. Currently, we are using "anyfunc" with normal object,
and according to the spec, it throws TypeError. To test stray argument, we should pass null to the
second and pass third stray argument.

[1]: https://webassembly.github.io/spec/js-api/index.html#dom-table-table