### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=235262

### DIFF
--- a/wasm/jsapi/interface.any.js
+++ b/wasm/jsapi/interface.any.js
@@ -143,7 +143,7 @@ test_attributes(WebAssembly.Memory.prototype, "WebAssembly.Memory", [
 test_operations(WebAssembly.Table.prototype, "WebAssembly.Table", [
   ["grow", 1],
   ["get", 1],
-  ["set", 2],
+  ["set", 1],
 ]);
 
 test_attributes(WebAssembly.Table.prototype, "WebAssembly.Table", [

--- a/wasm/jsapi/table/constructor.any.js
+++ b/wasm/jsapi/table/constructor.any.js
@@ -89,7 +89,7 @@ test(() => {
 
 test(() => {
   const argument = { "element": "anyfunc", "initial": 0 };
-  const table = new WebAssembly.Table(argument, {});
+  const table = new WebAssembly.Table(argument, null, {});
   assert_Table(table, { "length": 0 });
 }, "Stray argument");
 


### PR DESCRIPTION
Fix WebAssembly.Table constructor (second argument is no longer stray),
and fix WebAssembly.Table.set (length should be 1 since the second parameter becomes optional).