### PR TITLE
Make WebCryptoAPI/getRandomValues test more strict

### DIFF
--- a/WebCryptoAPI/getRandomValues.any.js
+++ b/WebCryptoAPI/getRandomValues.any.js
@@ -8,12 +8,24 @@ test(function() {
     }, "Float64Array")
 
     assert_throws_dom("TypeMismatchError", function() {
-        self.crypto.getRandomValues(new Float32Array(65537))
+        const len = 65536 / Float32Array.BYTES_PER_ELEMENT + 1;
+        self.crypto.getRandomValues(new Float32Array(len));
     }, "Float32Array (too long)")
     assert_throws_dom("TypeMismatchError", function() {
-        self.crypto.getRandomValues(new Float64Array(65537))
+        const len = 65536 / Float64Array.BYTES_PER_ELEMENT + 1;
+        self.crypto.getRandomValues(new Float64Array(len))
     }, "Float64Array (too long)")
-}, "Float arrays")
+}, "Float arrays");
+
+test(function() {
+    assert_throws_dom("TypeMismatchError", function() {
+        self.crypto.getRandomValues(new DataView(new ArrayBuffer(6)))
+    }, "DataView")
+
+    assert_throws_dom("TypeMismatchError", function() {
+        self.crypto.getRandomValues(new DataView(new ArrayBuffer(65536 + 1)))
+    }, "DataView (too long)")
+}, "DataView");
 
 const arrays = [
     'Int8Array',


### PR DESCRIPTION
- test if passing `DataView` object as argument is prohibited
According to [W3C specs](https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues), `TypeMismatchError` must be thrown for both `Float##Array` and `DataView`.
- adjust amount of floats needed to exceed quota
`getRandomValues` throws `QuotaExceededError` if `byteLength` of its argument is more than 65536.
While `new Float##Array(65537)` in this test works as intended, it looks very misleading: byte lengths of these arrays are actually 262148 and 524296.