### PR TITLE
Streams: test whether pipe stop pulling on abort

### DIFF
--- a/streams/piping/abort.any.js
+++ b/streams/piping/abort.any.js
@@ -477,6 +477,63 @@ promise_test(async t => {
 
   const abortController = new AbortController();
   const signal = abortController.signal;
+  const pipeToPromise = rs.pipeTo(ws, { signal, preventCancel: true });
+
+  // The pipe must start writing the first chunk.
+  await writeCalledPromise;
+  assert_array_equals(ws.events, ['write', 'a'], 'write() must have been called once');
+  // The pipe must immediately try to read the next chunk, since the destination desired more chunks.
+  await pullCalledPromise;
+  assert_array_equals(rs.events, ['pull'], 'pull() must have been called once');
+
+  // Abort the pipe.
+  // Any chunks enqueued after aborting must not be piped to the destination.
+  abortController.abort(error1);
+  rs.controller.enqueue('b');
+  await flushAsyncEvents();
+
+  // Finish the current write, allowing the pipe to complete.
+  resolveWrite();
+
+  await promise_rejects_exactly(t, error1, pipeToPromise, 'pipeTo() should reject with abort reason');
+  assert_array_equals(rs.events, ['pull'], 'pull() must have been called once');
+  assert_array_equals(ws.events, ['write', 'a', 'abort', error1], 'write() and abort() must have been called');
+
+  const reader = rs.getReader();
+  const result = await reader.read();
+  assert_object_equals(result, { value: 'b', done: false }, 'first read after pipeTo() should be correct');
+}, 'abort should stop pulling from source; preventCancel = true');
+
+promise_test(async t => {
+  let resolvePullCalled;
+  const pullCalledPromise = new Promise(resolve => {
+    resolvePullCalled = resolve;
+  });
+  const rs = recordingReadableStream({
+    pull: t.step_func(() => {
+      resolvePullCalled();
+    })
+  }, { highWaterMark: 0 });
+
+  let resolveWriteCalled;
+  const writeCalledPromise = new Promise(resolve => {
+    resolveWriteCalled = resolve;
+  });
+  let resolveWrite;
+  const ws = recordingWritableStream({
+    write: t.step_func(() => {
+      resolveWriteCalled();
+      return new Promise(resolve => {
+        resolveWrite = resolve;
+      });
+    }),
+  }, { highWaterMark: Infinity });
+
+  rs.controller.enqueue('a');
+  assert_array_equals(rs.events, [], 'pull() has not yet been called');
+
+  const abortController = new AbortController();
+  const signal = abortController.signal;
   const pipeToPromise = rs.pipeTo(ws, { signal, preventCancel: true, preventAbort: true });
 
   // The pipe must start writing the first chunk.

--- a/streams/piping/abort.any.js
+++ b/streams/piping/abort.any.js
@@ -463,12 +463,13 @@ promise_test(async t => {
     resolveWriteCalled = resolve;
   });
   let resolveWrite;
+  const writePromise = new Promise(resolve => {
+    resolveWrite = resolve;
+  });
   const ws = recordingWritableStream({
     write: t.step_func(() => {
       resolveWriteCalled();
-      return new Promise(resolve => {
-        resolveWrite = resolve;
-      });
+      return writePromise;
     }),
   }, { highWaterMark: Infinity });
 
@@ -499,6 +500,7 @@ promise_test(async t => {
   assert_array_equals(rs.events, ['pull'], 'pull() must have been called once');
   assert_array_equals(ws.events, ['write', 'a', 'abort', error1], 'write() and abort() must have been called');
 
+  rs.controller.close();
   const reader = rs.getReader();
   const result = await reader.read();
   assert_object_equals(result, { value: 'b', done: false }, 'first read after pipeTo() should be correct');
@@ -520,12 +522,13 @@ promise_test(async t => {
     resolveWriteCalled = resolve;
   });
   let resolveWrite;
+  const writePromise = new Promise(resolve => {
+    resolveWrite = resolve;
+  });
   const ws = recordingWritableStream({
     write: t.step_func(() => {
       resolveWriteCalled();
-      return new Promise(resolve => {
-        resolveWrite = resolve;
-      });
+      return writePromise;
     }),
   }, { highWaterMark: Infinity });
 
@@ -556,6 +559,7 @@ promise_test(async t => {
   assert_array_equals(rs.events, ['pull'], 'pull() must have been called once');
   assert_array_equals(ws.events, ['write', 'a'], 'write() must have been called once');
 
+  rs.controller.close();
   const reader = rs.getReader();
   const result = await reader.read();
   assert_object_equals(result, { value: 'b', done: false }, 'first read after pipeTo() should be correct');

--- a/streams/piping/abort.any.js
+++ b/streams/piping/abort.any.js
@@ -446,3 +446,60 @@ promise_test(async t => {
   await delay(0);
   assert_true(aborted, "pipeTo should be aborted now");
 }, "pipeTo on a teed readable byte stream should only be aborted when both branches are aborted");
+
+promise_test(async t => {
+  let resolvePullCalled;
+  const pullCalledPromise = new Promise(resolve => {
+    resolvePullCalled = resolve;
+  });
+  const rs = recordingReadableStream({
+    pull: t.step_func(() => {
+      resolvePullCalled();
+    })
+  }, { highWaterMark: 0 });
+
+  let resolveWriteCalled;
+  const writeCalledPromise = new Promise(resolve => {
+    resolveWriteCalled = resolve;
+  });
+  let resolveWrite;
+  const ws = recordingWritableStream({
+    write: t.step_func(() => {
+      resolveWriteCalled();
+      return new Promise(resolve => {
+        resolveWrite = resolve;
+      });
+    }),
+  }, { highWaterMark: Infinity });
+
+  rs.controller.enqueue('a');
+  assert_array_equals(rs.events, [], 'pull() has not yet been called');
+
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+  const pipeToPromise = rs.pipeTo(ws, { signal, preventCancel: true, preventAbort: true });
+
+  // The pipe must start writing the first chunk.
+  await writeCalledPromise;
+  assert_array_equals(ws.events, ['write', 'a'], 'write() must have been called once');
+  // The pipe must immediately try to read the next chunk, since the destination desired more chunks.
+  await pullCalledPromise;
+  assert_array_equals(rs.events, ['pull'], 'pull() must have been called once');
+
+  // Abort the pipe.
+  // Any chunks enqueued after aborting must not be piped to the destination.
+  abortController.abort(error1);
+  rs.controller.enqueue('b');
+  await flushAsyncEvents();
+
+  // Finish the current write, allowing the pipe to complete.
+  resolveWrite();
+
+  await promise_rejects_exactly(t, error1, pipeToPromise, 'pipeTo() should reject with abort reason');
+  assert_array_equals(rs.events, ['pull'], 'pull() must have been called once');
+  assert_array_equals(ws.events, ['write', 'a'], 'write() must have been called once');
+
+  const reader = rs.getReader();
+  const result = await reader.read();
+  assert_object_equals(result, { value: 'b', done: false }, 'first read after pipeTo() should be correct');
+}, 'abort should stop pulling from source; preventCancel = true, preventAbort = true');


### PR DESCRIPTION
See whatwg/streams#1208 for the accompanying spec change.

These tests demonstrates one way how `pipeTo()` can ~inadvertently drop a chunk~ continue reading for too long.
1. The source starts with one chunk `'a'` in its queue.
1. The destination has `highWaterMark = Infinity`, so `writer.ready` is always resolved.
1. We start a pipe with `preventCancel = true` and a given `AbortSignal`.
1. The pipe reads the first chunk from the source's queue. It starts writing it to the destination.
1. The pipe starts a read request for the second chunk, which is not yet available.
1. We abort the `AbortSignal`.
1. We enqueue a second chunk `'b'`.
1. The pending write (for `'a'`) completes.

Expected behavior:
* The pipe promise rejects with the signal's abort reason.
* The destination receives only chunk `'a'`.
* The source's queue contains the chunk `'b'`.

Actual behavior:
* The pipe promise rejects with the signal's abort reason.
* The destination receives both chunk `'a'` and `'b'`.
* The source's queue is empty.