### PR TITLE
Stop updating JavaScript dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,23 +5,8 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 1000
-- package-ecosystem: npm
-  directory: webrtc/tools/
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 1000
-- package-ecosystem: npm
-  directory: tools/scripts/
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 1000
 - package-ecosystem: pip
   directory: css/
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 1000
-- package-ecosystem: npm
-  directory: css/css-writing-modes/tools/generators/
   schedule:
     interval: weekly
   open-pull-requests-limit: 1000


### PR DESCRIPTION
None of this code is run in CI, and the updates are merely creating noise.