### PR TITLE
Rename `window.event` test to `*.window.js`

### DIFF
--- a/dom/events/event-global-set-before-handleEvent-lookup.window.js
+++ b/dom/events/event-global-set-before-handleEvent-lookup.window.js
@@ -7,7 +7,7 @@ test(() => {
   let currentEvent;
   eventTarget.addEventListener("foo", {
     get handleEvent() {
-      currentEvent = self.event;
+      currentEvent = window.event;
       return () => {};
     }
   });
@@ -16,4 +16,4 @@ test(() => {
   eventTarget.dispatchEvent(event);
 
   assert_equals(currentEvent, event);
-}, "self.event is set before 'handleEvent' lookup");
+}, "window.event is set before 'handleEvent' lookup");


### PR DESCRIPTION
While it works as `*.any.js`, it doesn't make sense as global `event` is defined only for Window: https://dom.spec.whatwg.org/#window-current-event.

Follow-up of #31894.