### PR TITLE
Make form validation subtests consistent cross-browser

### DIFF
--- a/html/semantics/forms/constraints/support/validator.js
+++ b/html/semantics/forms/constraints/support/validator.js
@@ -319,12 +319,6 @@ var validator = {
     }, data.name + " (in a form)");
   },
 
-  test_support_type: function(ctl, typ, testName) {
-    test(function () {
-      assert_equals(ctl.type, typ, "The " + typ + " type should be supported.");
-    }, testName);
-  },
-
   set_conditions: function(ctl, obj) {
     [
       "checked",
@@ -461,12 +455,6 @@ var validator = {
           }
 
           prefix = "[" + testee[i].tag.toUpperCase() + " in " + testee[i].types[typ].toUpperCase() + " status] ";
-
-          this.test_support_type(
-            ele,
-            testee[i].types[typ],
-            prefix + "The " + testee[i].types[typ] + " type must be supported."
-          );
 
           for (var j = 0; j < testee[i].testData.length; j++) {
             testee[i].testData[j].name = testee[i].testData[j].name.replace(/\[.*\]\s/g, prefix);

--- a/html/semantics/forms/constraints/support/validator.js
+++ b/html/semantics/forms/constraints/support/validator.js
@@ -461,14 +461,12 @@ var validator = {
           }
 
           prefix = "[" + testee[i].tag.toUpperCase() + " in " + testee[i].types[typ].toUpperCase() + " status] ";
-          if (ele.type != testee[i].types[typ]) {
-            this.test_support_type(
-              ele,
-              testee[i].types[typ],
-              prefix + "The " + testee[i].types[typ] + " type must be supported."
-            );
-            continue;
-          }
+
+          this.test_support_type(
+            ele,
+            testee[i].types[typ],
+            prefix + "The " + testee[i].types[typ] + " type must be supported."
+          );
 
           for (var j = 0; j < testee[i].testData.length; j++) {
             testee[i].testData[j].name = testee[i].testData[j].name.replace(/\[.*\]\s/g, prefix);


### PR DESCRIPTION
This test was creating a failing subtest and skipping others if the
input type wasn't supported. This leads to different subtests depending
on browser support status, making cross-browser comparisons harder.

assert_implements_optional could have been used here if these input
types were optional in the spec, but they're not.