### PR TITLE
Remove nonce from reflection tests

### DIFF
--- a/html/dom/elements-misc.js
+++ b/html/dom/elements-misc.js
@@ -14,7 +14,6 @@ var miscElements = {
     // TODO: async attribute (complicated).
     defer: "boolean",
     crossOrigin: {type: "enum", keywords: ["anonymous", "use-credentials"], nonCanon:{"": "anonymous"}, isNullable: true, defaultVal: null, invalidVal: "anonymous"},
-    nonce: "string",
     integrity: "string",
 
     // Obsolete


### PR DESCRIPTION
The nonce attribute is special and modern browsers hide it by default.

This behavior is already well tested in the `content-security-policy/nonce-hiding`
tests.

So it is counter productive to test that the attribute isn't hidden here.