### PR TITLE
Some screen orientation API tests won't be passed since the order of event and promise is incorrect.

### DIFF
--- a/screen-orientation/onchange-event.html
+++ b/screen-orientation/onchange-event.html
@@ -41,8 +41,10 @@ promise_test(async t => {
   const orientationWatcher = new EventWatcher(t, screen.orientation, 'change');
 
   for (const orientation of orientations) {
-    await screen.orientation.lock(orientation);
+    // change event is fired before resolving promise by lock.
+    const promise = screen.orientation.lock(orientation);
     await orientationWatcher.wait_for('change');
+    await promise;
     assert_equals(screen.orientation.type, orientation);
   }
 }, "Test that orientationchange event is fired when the orientation changes.");

--- a/screen-orientation/orientation-reading.html
+++ b/screen-orientation/orientation-reading.html
@@ -96,13 +96,14 @@ promise_test(async t => {
   const orientationAngle = screen.orientation.angle;
   const orientationWatcher = new EventWatcher(t, orientation, "change");
 
-  if (orientationType.includes("portrait")) {
-    await orientation.lock("landscape-primary");
-  } else {
-    await orientation.lock("portrait-primary");
-  }
+  const newOrientationType =
+    orientationType.includes("portrait") ? "landscape-primary" :
+                                           "portrait-primary";
+  const promise = orientation.lock(newOrientationType);
 
+  // change event is fired before resolving promise by lock.
   await orientationWatcher.wait_for("change");
+  await promise;
   assert_equals(screen.orientation, orientation);
   assert_equals(screen.orientation.type, orientation.type);
   assert_equals(screen.orientation.angle, orientation.angle);


### PR DESCRIPTION
https://w3c.github.io/screen-orientation/#Screen-orientation-change

> 7.5 Screen orientation change
> ...
> 5. Fire an event named change at doc's Screen.orientation object.
> 6.1. Resolve doc's [[orientationPendingPromise]] with undefined.

`change` event is fired before the promise by `lock()` is resolved.
But `onchange-event.html` and `orientation-reading.html` wait for `change`
event after the promise is resolved.

So we shouldn't wait for the promise before calling `wait_for`.