### PR TITLE
Upstream some restriction tests for prerender

### DIFF
--- a/speculation-rules/prerender/fetch-blob.html
+++ b/speculation-rules/prerender/fetch-blob.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<title>Same-origin prerendering can access localStorage</title>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="resources/utils.js"></script>
+<body>
+<script>
+
+setup(() => assertSpeculationRulesIsSupported());
+
+promise_test(async t => {
+  const {exec} = await create_prerendered_page(t);
+  const result = await exec(async () => {
+    const blob = await (await fetch('cache.txt')).blob();
+    const reader = new FileReader();
+    reader.readAsText(blob);
+    return new Promise(function(resolve, reject) {
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => reject(reader.error);
+    });
+  });
+  const expected = "Hello, Prerender API!";
+
+  // Start prerendering a page that attempts to access the blob.
+  assert_equals(
+    result, expected,
+    'prerendering page should be able to read from blobs.');
+}, 'prerendering page should be able to access blobs');
+
+</script>
+</body>

--- a/speculation-rules/prerender/restrictions.html
+++ b/speculation-rules/prerender/restrictions.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<title>Same-origin prerendering can access localStorage</title>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="resources/utils.js"></script>
+<body>
+<script>
+
+setup(() => assertSpeculationRulesIsSupported());
+
+test_prerender_restricted(
+  () => navigator.clipboard.writeText(location.href), 
+  "NotAllowedError", "prerendering pages should not be able to access the clipboard via the Async Clipboard API");
+
+test_prerender_restricted(async () => {
+  const canvas = document.createElement('canvas');
+  document.body.appendChild(canvas);
+  await canvas.requestPointerLock();
+}, "WrongDocumentError", "prerendering pages should not be able to access the pointer-lock API");
+
+test_prerender_restricted(async () => {
+  const div = document.createElement('div');
+  document.body.appendChild(div);
+  await div.requestFullscreen();
+}, "TypeError", "prerendering pages should not be able to access the FullScreen API");
+  
+test_prerender_defer(() => new Promise(
+  resolve => navigator.geolocation.getCurrentPosition(p => resolve(p.toString()))), 
+  "Geolocation API should be deferred");
+  
+</script>
+</body>

--- a/speculation-rules/prerender/restrictions.html
+++ b/speculation-rules/prerender/restrictions.html
@@ -11,7 +11,7 @@
 setup(() => assertSpeculationRulesIsSupported());
 
 test_prerender_restricted(
-  () => navigator.clipboard.writeText(location.href), 
+  () => navigator.clipboard.writeText(location.href),
   "NotAllowedError", "prerendering pages should not be able to access the clipboard via the Async Clipboard API");
 
 test_prerender_restricted(async () => {
@@ -25,10 +25,10 @@ test_prerender_restricted(async () => {
   document.body.appendChild(div);
   await div.requestFullscreen();
 }, "TypeError", "prerendering pages should not be able to access the FullScreen API");
-  
+
 test_prerender_defer(() => new Promise(
-  resolve => navigator.geolocation.getCurrentPosition(p => resolve(p.toString()))), 
+  resolve => navigator.geolocation.getCurrentPosition(p => resolve(p.toString()))),
   "Geolocation API should be deferred");
-  
+
 </script>
 </body>


### PR DESCRIPTION
This uses the previously merged prerender infra to test different scenarios of delay/failure when prerendering. See https://wicg.github.io/nav-speculation/prerendering.html#intrusive-behaviors