### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=235500

### DIFF
--- a/domxpath/xpath-evaluate-crash.html
+++ b/domxpath/xpath-evaluate-crash.html
@@ -3,7 +3,6 @@
 <title>Evaluating XPath expressions with orhpaned Attr as context node doesn't crash</title>
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://bugs.chromium.org/p/chromium/issues/detail?id=1236967">
-<script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
 <script>
@@ -15,10 +14,7 @@ for (const expression of [
     "following::*",
     "preceding::*",
 ]) {
-    test(() => {
-        const orphanedAttr = document.createAttribute("foo");
-        const result = new XPathEvaluator().evaluate(expression, orphanedAttr, null, 2);
-        assert_true(result instanceof XPathResult);
-    }, `"${expression}"`);
+    const orphanedAttr = document.createAttribute("foo");
+    new XPathEvaluator().evaluate(expression, orphanedAttr, null, 2);
 }
 </script>

--- a/domxpath/xpath-evaluate-crash.html
+++ b/domxpath/xpath-evaluate-crash.html
@@ -1,11 +1,24 @@
 <!DOCTYPE html>
+<meta charset="utf-8">
+<title>Evaluating XPath expressions with orhpaned Attr as context node doesn't crash</title>
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://bugs.chromium.org/p/chromium/issues/detail?id=1236967">
-
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <body>
 <script>
-const domParser = new DOMParser();
-const doc = domParser.parseFromString(undefined, 'text/html', {includeShadowRoots: false});
-const attribute = doc.createAttribute("test");
-new XPathEvaluator().evaluate("..", attribute, null, 2, null);
+for (const expression of [
+    "..",
+    "parent",
+    "ancestor::*",
+    "ancestor-or-self::*",
+    "following::*",
+    "preceding::*",
+]) {
+    test(() => {
+        const orphanedAttr = document.createAttribute("foo");
+        const result = new XPathEvaluator().evaluate(expression, orphanedAttr, null, 2);
+        assert_true(result instanceof XPathResult);
+    }, `"${expression}"`);
+}
 </script>


### PR DESCRIPTION
This upstream reviewed change adds tests like https://github.com/web-platform-tests/wpt/commit/de56190405f17faca84a09cfd21bb25405f9382c for other axises, ensuring a browser doesn't crash for orphaned `Attr` as a context node.

_CC_ @josepharhar 