### PR TITLE
event-before-promise.html won't be passed if initial orientation type is landscape.

### DIFF
--- a/screen-orientation/event-before-promise.html
+++ b/screen-orientation/event-before-promise.html
@@ -19,8 +19,12 @@
       screen.orientation.addEventListener("change", resolve);
     });
 
+    const newOrientationType =
+      screen.orientation.type.includes("portrait") ? "landscape" :
+                                                     "portrait";
+
     const result = await Promise.race([
-      screen.orientation.lock("landscape"),
+      screen.orientation.lock(newOrientationType),
       promiseToChange,
     ]);
 


### PR DESCRIPTION
If initial orientation type is `landscape`, `lock("landscape")` doesn't fired 
`change` event, so this test won't work well.

So if initial type is `landscape`, we should use `lock("portrait")` instead.