### PR TITLE
Remove @zqzhang from META.yml in specs owned by the DAS WG.

### DIFF
--- a/accelerometer/META.yml
+++ b/accelerometer/META.yml
@@ -1,6 +1,5 @@
 spec: https://w3c.github.io/accelerometer/
 suggested_reviewers:
-  - zqzhang
   - riju
   - Honry
   - rakuco

--- a/ambient-light/META.yml
+++ b/ambient-light/META.yml
@@ -1,6 +1,5 @@
 spec: https://w3c.github.io/ambient-light/
 suggested_reviewers:
-  - zqzhang
   - riju
   - rakuco
   - Honry

--- a/battery-status/META.yml
+++ b/battery-status/META.yml
@@ -1,5 +1,4 @@
 spec: https://w3c.github.io/battery/
 suggested_reviewers:
   - anssiko
-  - zqzhang
   - Honry

--- a/generic-sensor/META.yml
+++ b/generic-sensor/META.yml
@@ -1,6 +1,5 @@
 spec: https://w3c.github.io/sensors/
 suggested_reviewers:
-  - zqzhang
   - riju
   - rakuco
   - Honry

--- a/gyroscope/META.yml
+++ b/gyroscope/META.yml
@@ -1,6 +1,5 @@
 spec: https://w3c.github.io/gyroscope/
 suggested_reviewers:
-  - zqzhang
   - riju
   - Honry
   - rakuco

--- a/html-media-capture/META.yml
+++ b/html-media-capture/META.yml
@@ -1,3 +1,3 @@
 spec: https://w3c.github.io/html-media-capture/
 suggested_reviewers:
-  - zqzhang
+  - anssiko

--- a/magnetometer/META.yml
+++ b/magnetometer/META.yml
@@ -1,6 +1,5 @@
 spec: https://w3c.github.io/magnetometer/
 suggested_reviewers:
-  - zqzhang
   - riju
   - Honry
   - rakuco

--- a/orientation-sensor/META.yml
+++ b/orientation-sensor/META.yml
@@ -1,6 +1,5 @@
 spec: https://w3c.github.io/orientation-sensor/
 suggested_reviewers:
-  - zqzhang
   - riju
   - Honry
   - rakuco

--- a/proximity/META.yml
+++ b/proximity/META.yml
@@ -1,5 +1,4 @@
 spec: https://w3c.github.io/proximity/
 suggested_reviewers:
-  - zqzhang
   - Honry
   - rakuco

--- a/vibration/META.yml
+++ b/vibration/META.yml
@@ -1,3 +1,3 @@
 spec: https://w3c.github.io/vibration/
 suggested_reviewers:
-  - zqzhang
+  - anssiko


### PR DESCRIPTION
They have not been involved in the Devices and Sensors WG for years, so
remove them from the list of owners for these tests.

In cases where the directories had a single owner, switch to @anssiko,
co-chair of the WG.
