### PR TITLE
Update Safari Technology Preview to 139

### DIFF
--- a/infrastructure/metadata/infrastructure/server/wpt-server-websocket.sub.html.ini
+++ b/infrastructure/metadata/infrastructure/server/wpt-server-websocket.sub.html.ini
@@ -1,45 +1,41 @@
 [wpt-server-websocket.sub.html]
-  [WSS protocol, no subdomain]
-    expected:
-      if product == "safari": FAIL
-
   [WSS protocol, www subdomain #3]
     expected:
-      if product == "epiphany" or product == "webkit" or product == "safari": FAIL
+      if product == "epiphany" or product == "webkit": FAIL
 
   [WSS protocol, punycode subdomain #1]
     expected:
-      if product == "epiphany" or product == "webkit" or product == "safari": FAIL
+      if product == "epiphany" or product == "webkit": FAIL
 
   [WSS protocol, punycode subdomain #2]
     expected:
-      if product == "epiphany" or product == "webkit" or product == "safari": FAIL
+      if product == "epiphany" or product == "webkit": FAIL
 
   [WSS protocol, www subdomain #1]
     expected:
-      if product == "epiphany" or product == "webkit" or product == "safari": FAIL
+      if product == "epiphany" or product == "webkit": FAIL
 
   [WSS protocol, www subdomain #2]
     expected:
-      if product == "epiphany" or product == "webkit" or product == "safari": FAIL
+      if product == "epiphany" or product == "webkit": FAIL
 
   [WSS protocol, www subdomain #3]
     expected:
-      if product == "epiphany" or product == "webkit" or product == "safari": FAIL
+      if product == "epiphany" or product == "webkit": FAIL
 
   [WSS protocol, punycode subdomain #1]
     expected:
-      if product == "epiphany" or product == "webkit" or product == "safari": FAIL
+      if product == "epiphany" or product == "webkit": FAIL
 
   [WSS protocol, punycode subdomain #2]
     expected:
-      if product == "epiphany" or product == "webkit" or product == "safari": FAIL
+      if product == "epiphany" or product == "webkit": FAIL
 
   [WSS protocol, www subdomain #1]
     expected:
-      if product == "epiphany" or product == "webkit" or product == "safari": FAIL
+      if product == "epiphany" or product == "webkit": FAIL
 
   [WSS protocol, www subdomain #2]
     expected:
-      if product == "epiphany" or product == "webkit" or product == "safari": FAIL
+      if product == "epiphany" or product == "webkit": FAIL
 

--- a/tools/ci/azure/safari-technology-preview.rb
+++ b/tools/ci/azure/safari-technology-preview.rb
@@ -1,12 +1,12 @@
 cask "safari-technology-preview" do
   if MacOS.version == :monterey
-    version "138,002-53074-20220120-2EE93579-3CD2-412B-A423-AF28E0B94E23"
+    version "139,002-59992-20220126-823233C2-9DB2-4979-B624-A53C03FF510B"
     url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
-    sha256 "14c96db851602d38f27496afa898328d526e483995e53c047c4f710cead28faf"
+    sha256 "eababa5779b1c172d5953c487896790588abd59a7931d32f309f57a2c912d396"
   elsif MacOS.version == :big_sur
-    version "138,002-53460-20220120-34CD386B-BA62-47FB-83C2-588954B76959"
+    version "139,002-57185-20220126-79EAC0D9-22A9-4371-8D67-7EC97D934766"
     url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
-    sha256 "19c30fcf5519afc1e2de01f5d340789aef469c7b1176e895f923b97c71073618"
+    sha256 "50ef5f5e87eeb4c246e2d8989b3fed73b4d4a14275bc5f23d9923f0b2dc6fe40"
   end
 
   appcast "https://developer.apple.com/safari/download/"


### PR DESCRIPTION
Version as reported by safaridriver --version:
Included with Safari Technology Preview (Release 139, 16613.1.14.41.2)

Source: https://developer.apple.com/safari/download/
Build: https://dev.azure.com/foolip/safari-technology-preview-updater/_build/results?buildId=4097&view=logs