### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=236338

### DIFF
--- a/css/css-grid/subgrid/line-names-008.html
+++ b/css/css-grid/subgrid/line-names-008.html
@@ -146,14 +146,14 @@ x {
   </div>
 </div>
 
-<div class="grid" style="grid-template-columns: repeat(3,30px) [a] 30px repeat(7,30px)">
+<div class="grid" style="grid-template-columns: 30px [a] repeat(2,30px) [a] 30px repeat(7,30px)">
 <n></n><n></n><n></n><n></n><n></n><n></n><n></n><n></n><n></n><n></n>
   <div class="hr" style="grid-template-columns: subgrid [] [] [] [] [a]; grid-column:2/span 6">
     <x style="grid-column: a/span a">x</x>
   </div>
 </div>
 
-<div class="grid" style="grid-template-columns: repeat(3,30px) [a] 30px repeat(7,30px)">
+<div class="grid" style="grid-template-columns: 30px [a] repeat(2,30px) [a] 30px repeat(7,30px)">
 <n></n><n></n><n></n><n></n><n></n><n></n><n></n><n></n><n></n><n></n>
   <div class="hr" style="grid-template-columns: subgrid [] [] [] [] [a]; grid-column:2/span 6">
     <x style="grid-column: a/a 2">x</x>


### PR DESCRIPTION
My understanding is that the line 'a' in the parent grid, and the line 'a' in the subgrid both end up naming the same line (since the subgrid is RTL).

The placement of the child x would then fail to resolve the end line ('a 2'), and would fallback to 'auto' (since it's abs-pos) and thus cover the padding area of the subgrid.

The expected file for this test has it not covering the padding area, so this change adds an extra named line `a` to be at the end (left edge) of the subgrid, so that we can match it directly.