### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=236122

### DIFF
--- a/css/css-grid/subgrid/line-names-002-ref.html
+++ b/css/css-grid/subgrid/line-names-002-ref.html
@@ -5,10 +5,8 @@
 -->
 <html><head>
   <meta charset="utf-8">
-  <title>CSS Grid Test: subgrid item using line names from outer grid</title>
+  <title>Reference: subgrid item using line names from outer grid</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
-  <link rel="help" href="https://drafts.csswg.org/css-grid-2">
-  <link rel="match" href="line-names-002-ref.html">
   <style>
 html,body {
   color:black; background-color:white; font:24px/1 monospace; padding:0; margin:0;
@@ -16,14 +14,14 @@ html,body {
 
 .grid {
   display: grid;
-  grid: auto / repeat(10, 10px) repeat(10, [a] 10px) [a];
+  grid: auto / [a] 50px 40px [a] 10px 50px [a];
   padding: 20px 10px;
 }
 
 .subgrid {
   display: grid;
   grid: 50px / subgrid;
-  grid-column: span 10;
+  grid-column: span 3;
 }
 
 x { background: grey; }
@@ -34,7 +32,7 @@ x { background: grey; }
 
 <div class="grid">
   <div class="subgrid">
-    <x style="grid-column: span a / a 8"></x>
+    <x style="grid-column: 3 / 4"></x>
   </div>
 </div>
 

--- a/css/css-grid/subgrid/line-names-005-ref.html
+++ b/css/css-grid/subgrid/line-names-005-ref.html
@@ -115,7 +115,7 @@ x {
 <div style="display:grid; width:500px; grid-auto-columns: 50px;">
 <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
   <div class="subgrid2">
-    <x style="grid-column: span 4 / 11">x</x>
+    <x style="grid-column: span 3 / 11">x</x>
   </div>
 </div>
 
@@ -129,7 +129,7 @@ x {
 <div style="display:grid; grid: auto / repeat(10, 50px) repeat(10, [a] 50px) [a]">
 <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
   <div style="display:grid; grid:auto/subgrid; grid-column: span 10; grid-row:2">
-    <x style="grid-column: 1 / 11">x</x>
+    <x style="grid-column: 10 / 11">x</x>
   </div>
 </div>
 


### PR DESCRIPTION
This updates the tests to match the expected behaviour after the clarifications in [https://github.com/w3c/csswg-drafts/issues/6905](https://github.com/w3c/csswg-drafts/issues/6905) were made.

Note that I left cases where `grid-template-columns: subgrid` was specified without any line list, since this is really common, and I don't think it should override an explicit `grid-column: span 10` declaration.