### PR TITLE
lock-sandboxed-iframe.html should set window to full screen

### DIFF
--- a/screen-orientation/lock-sandboxed-iframe.html
+++ b/screen-orientation/lock-sandboxed-iframe.html
@@ -1,28 +1,45 @@
 <!DOCTYPE html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 
-<iframe id="allowedIframe" sandbox="allow-scripts allow-same-origin allow-orientation-lock" style="display:none">
+<iframe id="allowedIframe" sandbox="allow-scripts allow-same-origin allow-orientation-lock" allowfullscreen>
 </iframe>
 
-<iframe id="disallowedIframe" sandbox="allow-scripts allow-same-origin" style="display:none">
+<iframe id="disallowedIframe" sandbox="allow-scripts allow-same-origin" allowfullscreen>
 </iframe>
 <script>
+function wait_result() {
+  return new Promise(resolve => {
+    function callback (evt) {
+      if (evt.data.type != "result") {
+        // test_driver.bless in child frame posted a message.
+        return;
+      }
+      window.removeEventListener("message", callback);
+      resolve(evt.data.msg);
+    }
+
+    window.addEventListener("message", callback);
+  });
+}
+
 promise_test(async t => {
-  const messageWatcher = new EventWatcher(t, window, "message");
   const disallowedIframe = document.getElementById("disallowedIframe");
   disallowedIframe.src = "resources/sandboxed-iframe-locking.html";
 
-  const message = await messageWatcher.wait_for("message");
-  assert_equals(message.data, "SecurityError", "screen.lockOrientation() throws a SecurityError");
+  const message = await wait_result();
+
+  assert_equals(message, "SecurityError", "screen.lockOrientation() throws a SecurityError");
 }, "Test without 'allow-orientation-lock' sandboxing directive");
 
 promise_test(async t => {
-  const messageWatcher = new EventWatcher(t, window, "message");
   const disallowedIframe = document.getElementById("allowedIframe");
   disallowedIframe.src = "resources/sandboxed-iframe-locking.html";
 
-  const message = await messageWatcher.wait_for("message");
-  assert_equals(message.data, "portrait-primary", "screen.orientation lock to portrait-primary");
+  const message = await wait_result();
+
+  assert_equals(message, "portrait-primary", "screen.orientation lock to portrait-primary");
 }, "Test with 'allow-orientation-lock' sandboxing directive");
 </script>

--- a/screen-orientation/resources/sandboxed-iframe-locking.html
+++ b/screen-orientation/resources/sandboxed-iframe-locking.html
@@ -1,11 +1,24 @@
+<!DOCTYPE html>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script>
-let msg = "";
-screen.orientation.lock("portrait-primary")
-.then(() => {
-  msg = screen.orientation.type;
-}).catch(error => {
-  msg = error.name;
-}).finally(() => {
-  parent.window.postMessage(msg, "*");
+test_driver.set_test_context(parent);
+test_driver.bless("request full screen", async () => {
+  await document.documentElement.requestFullscreen();
+
+  let msg = "";
+  try {
+    await screen.orientation.lock("portrait-primary")
+    msg = screen.orientation.type;
+  } catch (error) {
+    msg = error.name;
+  }
+
+  try {
+    screen.orientation.unlock();
+    await document.exitFullscreen();
+  } catch (error) {
+  }
+  parent.window.postMessage({ type: "result", msg }, "*");
 });
 </script>


### PR DESCRIPTION
Browser implementations (Blink and Gecko) requires full screen to call `orientaiton.lock`. So `orientaiton.lock` tests calls `requestFullScreen` before staring test. But this test doesn't set content to full screen.

So I re-write this test to use full screen window.