### PR TITLE
Add tests for worker behavior while prerendering

### DIFF
--- a/speculation-rules/prerender/resources/eval-channel.html
+++ b/speculation-rules/prerender/resources/eval-channel.html
@@ -26,7 +26,7 @@
       }
 
       window.addEventListener('error', error =>
-        logChannel.postMessage('[Prerendered Page Error]', {message: error.message, stack: error.stack}));
+        logChannel.postMessage(['[Prerendered Page Error]', {message: error.message, stack: error.stack}]));
 
       window.prerender_log('Channel Created');
       new PrerenderChannel(uuid, 'ready').postMessage({});

--- a/speculation-rules/prerender/resources/shared-worker-post-timeOrigin.js
+++ b/speculation-rules/prerender/resources/shared-worker-post-timeOrigin.js
@@ -1,3 +1,2 @@
-onconnect = ({ports: [port]}) => 
+onconnect = ({ports: [port]}) =>
     port.postMessage(performance.timeOrigin);
-

--- a/speculation-rules/prerender/resources/shared-worker-post-timeOrigin.js
+++ b/speculation-rules/prerender/resources/shared-worker-post-timeOrigin.js
@@ -1,0 +1,3 @@
+onconnect = ({ports: [port]}) => 
+    port.postMessage(performance.timeOrigin);
+

--- a/speculation-rules/prerender/resources/shared-worker-post-timeOrigin.js
+++ b/speculation-rules/prerender/resources/shared-worker-post-timeOrigin.js
@@ -1,2 +1,0 @@
-onconnect = ({ports: [port]}) =>
-    port.postMessage(performance.timeOrigin);

--- a/speculation-rules/prerender/resources/shared-worker.py
+++ b/speculation-rules/prerender/resources/shared-worker.py
@@ -3,7 +3,7 @@ def main(request, response):
         with request.server.stash.lock:
             result = request.server.stash.take(request.GET[b"id"])
             response.headers.set(b"Content-Type", b"text/plain")
-            return result            
+            return result
     else:
         with request.server.stash.lock:
             request.server.stash.put(request.GET[b"id"], "ok")

--- a/speculation-rules/prerender/resources/shared-worker.py
+++ b/speculation-rules/prerender/resources/shared-worker.py
@@ -1,0 +1,11 @@
+def main(request, response):
+    if b"check" in request.GET:
+        with request.server.stash.lock:
+            result = request.server.stash.take(request.GET[b"id"])
+            response.headers.set(b"Content-Type", b"text/plain")
+            return result            
+    else:
+        with request.server.stash.lock:
+            request.server.stash.put(request.GET[b"id"], "ok")
+            response.headers.set(b"Content-Type", b"text/javascript")
+        return u"onconnect = ({ports: [port]}) => port.postMessage(performance.timeOrigin);"

--- a/speculation-rules/prerender/resources/utils.js
+++ b/speculation-rules/prerender/resources/utils.js
@@ -234,7 +234,7 @@ function test_prerender_restricted(fn, expected, label) {
   }, label);
 }
 
-function test_prerender_defer(fn, label, timeout = delay) {
+function test_prerender_defer(fn, label) {
   promise_test(async t => {
     const {exec, activate} = await create_prerendered_page(t);
     let activated = false;
@@ -246,7 +246,6 @@ function test_prerender_defer(fn, label, timeout = delay) {
         resolve(result);
       }));
 
-    await new Promise(resolve => t.step_timeout(resolve, delay));
     await activate();
     activated = true;
     await post;

--- a/speculation-rules/prerender/resources/utils.js
+++ b/speculation-rules/prerender/resources/utils.js
@@ -234,7 +234,7 @@ function test_prerender_restricted(fn, expected, label) {
   }, label);
 }
 
-function test_prerender_defer(fn, label) {
+function test_prerender_defer(fn, label, timeout = delay) {
   promise_test(async t => {
     const {exec, activate} = await create_prerendered_page(t);
     let activated = false;
@@ -246,7 +246,7 @@ function test_prerender_defer(fn, label) {
         resolve(result);
       }));
 
-    await new Promise(resolve => t.step_timeout(resolve, 100));
+    await new Promise(resolve => t.step_timeout(resolve, delay));
     await activate();
     activated = true;
     await post;

--- a/speculation-rules/prerender/resources/worker-post-timeOrigin.js
+++ b/speculation-rules/prerender/resources/worker-post-timeOrigin.js
@@ -1,0 +1,1 @@
+postMessage(performance.timeOrigin);

--- a/speculation-rules/prerender/workers.html
+++ b/speculation-rules/prerender/workers.html
@@ -24,6 +24,8 @@ promise_test(async t => {
     }), workerURL);
   }, workerURL);
 
+  // We want to wait until the worker is initiated, but since its operation is delayed we
+  // can't wait for its message - so we wait for a time period that should be sufficient.
   await new Promise(resolve => t.step_timeout(resolve, 300));
   await activate();
   const {workerStart, activationStart, workerLoad, prerendering } = await exec(() => window.waitForWorker);

--- a/speculation-rules/prerender/workers.html
+++ b/speculation-rules/prerender/workers.html
@@ -34,10 +34,14 @@ promise_test(async t => {
 
 promise_test(async t => {
   const {exec, activate} = await create_prerendered_page(t);
-  const workerURL = new URL('resources/shared-worker-post-timeOrigin.js', location.href).toString();
+  const workerURL = new URL(`resources/shared-worker.py?id=${token()}`, location.href).toString();
   await exec(workerURL => {
     window.worker = new SharedWorker(workerURL, 'dummy');
     window.worker.port.start();
+    window.waitForSharedWorkerLoadingReport = 
+      fetch(workerURL + "&check=true")
+        .then(r => t.text())
+        .then(text => text === 'ok' && document.prerendering);
     window.waitForWorker = new Promise(resolve => worker.port.addEventListener('message', e => {
         resolve({
           prerendering: document.prerendering,
@@ -49,14 +53,16 @@ promise_test(async t => {
   await new Promise(resolve => t.step_timeout(resolve, 300));
   await activate();
   const {workerStart, activationStart, workerLoad, prerendering } = await exec(() => window.waitForWorker);
-  assert_equals(prerendering, false);
+  const loadedWhilePrerendering = await exec(() => window.loadedWhilePrerendering);
+  assert_true(loadedWhilePrerendering, "The shared worker should be loaded (but suspended) while prerendering");
+  assert_false(prerendering, "SharedWorker should be suspended until activated");
   assert_greater_than(workerStart, activationStart, "Starting the worker should be delayed");
   // TODO: check SharedWorker loading. This is not yet possible due to SharedWorkers not reporting timing.
 }, "Shared workers should be loaded in suspended state until activated");
 
 promise_test(async t => {
   const {exec, activate} = await create_prerendered_page(t);
-  const workerURL = new URL('resources/shared-worker-post-timeOrigin.js', location.href).toString();
+  const workerURL = new URL(`resources/shared-worker.py?id=${token()}`, location.href).toString();
   const workerStartTime1 = await new Promise(resolve => {
     const worker = new SharedWorker(workerURL, 'worker');
     worker.port.start();
@@ -77,10 +83,9 @@ promise_test(async t => {
   await new Promise(resolve => t.step_timeout(resolve, 300));
   await activate();
   const {workerStartTime2, activationStart, workerLoad, prerendering } = await exec(() => window.waitForWorker);
-  assert_equals(prerendering, true, "An existing SharedWorker should be accessible while prerendering");
-  assert_equals(workerStartTime2, workerStartTime2);
+  assert_true(prerendering, "An existing SharedWorker should be accessible while prerendering");
+  assert_equals(workerStartTime1, workerStartTime2);
   assert_greater_than(workerStart, activationStart, "Starting the worker should be delayed");
-  // TODO: check SharedWorker loading. This is not yet possible due to SharedWorkers not reporting timing.
 }, "Existing shared workers should be accessible before activation");
 
 </script>

--- a/speculation-rules/prerender/workers.html
+++ b/speculation-rules/prerender/workers.html
@@ -24,9 +24,9 @@ promise_test(async t => {
     }), workerURL);
   }, workerURL);
 
-  // We want to wait until the worker is initiated, but since its operation is delayed we
-  // can't wait for its message - so we wait for a time period that should be sufficient.
-  await new Promise(resolve => t.step_timeout(resolve, 300));
+  // We want to prevent false success by waiting for enough time to make sure the worker is not
+  // yet initialized
+  await new Promise(resolve => t.step_timeout(resolve, 500));
   await activate();
   const {workerStart, activationStart, workerLoad, prerendering } = await exec(() => window.waitForWorker);
   assert_equals(prerendering, false);

--- a/speculation-rules/prerender/workers.html
+++ b/speculation-rules/prerender/workers.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<title>Same-origin prerendering can access localStorage</title>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="resources/utils.js"></script>
+<body>
+<script>
+
+setup(() => assertSpeculationRulesIsSupported());
+
+promise_test(async t => {
+  const {exec, activate} = await create_prerendered_page(t);
+  const workerURL = new URL('resources/worker-post-timeOrigin.js', location.href).toString();
+  await exec(workerURL => {
+    window.worker = new Worker(workerURL);
+    window.waitForWorker = new Promise(resolve => worker.addEventListener('message', e => {
+        resolve({
+          prerendering: document.prerendering,
+          activationStart: performance.getEntriesByType('navigation')[0].activationStart,
+          workerLoad: performance.getEntriesByName(workerURL)[0].startTime,
+          workerStart: e.data});
+    }), workerURL);
+  }, workerURL);
+
+  await new Promise(resolve => t.step_timeout(resolve, 300));
+  await activate();
+  const {workerStart, activationStart, workerLoad, prerendering } = await exec(() => window.waitForWorker);
+  assert_equals(prerendering, false);
+  assert_greater_than(activationStart, workerLoad, "Loading the worker script should not be delayed");
+  assert_greater_than(workerStart, activationStart, "Starting the worker should be delayed");
+}, "Dedicated workers should be loaded in suspended state until activated");
+
+promise_test(async t => {
+  const {exec, activate} = await create_prerendered_page(t);
+  const workerURL = new URL('resources/shared-worker-post-timeOrigin.js', location.href).toString();
+  await exec(workerURL => {
+    window.worker = new SharedWorker(workerURL, 'dummy');
+    window.worker.port.start();
+    window.waitForWorker = new Promise(resolve => worker.port.addEventListener('message', e => {
+        resolve({
+          prerendering: document.prerendering,
+          activationStart: performance.getEntriesByType('navigation')[0].activationStart,
+          workerStart: e.data});
+    }), workerURL);
+  }, workerURL);
+
+  await new Promise(resolve => t.step_timeout(resolve, 300));
+  await activate();
+  const {workerStart, activationStart, workerLoad, prerendering } = await exec(() => window.waitForWorker);
+  assert_equals(prerendering, false);
+  assert_greater_than(workerStart, activationStart, "Starting the worker should be delayed");
+  // TODO: check SharedWorker loading. This is not yet possible due to SharedWorkers not reporting timing.
+}, "Shared workers should be loaded in suspended state until activated");
+
+promise_test(async t => {
+  const {exec, activate} = await create_prerendered_page(t);
+  const workerURL = new URL('resources/shared-worker-post-timeOrigin.js', location.href).toString();
+  const workerStartTime1 = await new Promise(resolve => {
+    const worker = new SharedWorker(workerURL, 'worker');
+    worker.port.start();
+    worker.port.addEventListener('message', e => resolve(e.data));
+  });
+
+  await exec(workerURL => {
+    window.worker = new SharedWorker(workerURL, 'worker');
+    window.worker.port.start();
+    window.waitForWorker = new Promise(resolve => worker.port.addEventListener('message', e => {
+        resolve({
+          prerendering: document.prerendering,
+          activationStart: performance.getEntriesByType('navigation')[0].activationStart,
+          workerStartTime2: e.data});
+    }), workerURL);
+  }, workerURL);
+
+  await new Promise(resolve => t.step_timeout(resolve, 300));
+  await activate();
+  const {workerStartTime2, activationStart, workerLoad, prerendering } = await exec(() => window.waitForWorker);
+  assert_equals(prerendering, true, "An existing SharedWorker should be accessible while prerendering");
+  assert_equals(workerStartTime2, workerStartTime2);
+  assert_greater_than(workerStart, activationStart, "Starting the worker should be delayed");
+  // TODO: check SharedWorker loading. This is not yet possible due to SharedWorkers not reporting timing.
+}, "Existing shared workers should be accessible before activation");
+
+</script>
+</body>

--- a/speculation-rules/prerender/workers.html
+++ b/speculation-rules/prerender/workers.html
@@ -38,7 +38,7 @@ promise_test(async t => {
   await exec(workerURL => {
     window.worker = new SharedWorker(workerURL, 'dummy');
     window.worker.port.start();
-    window.waitForSharedWorkerLoadingReport = 
+    window.waitForSharedWorkerLoadingReport =
       fetch(workerURL + "&check=true")
         .then(r => t.text())
         .then(text => text === 'ok' && document.prerendering);


### PR DESCRIPTION
Corresponds to https://github.com/WICG/nav-speculation/pull/128
- Workers should be loaded and suspended while in prerendering mode, resumed upon activation
- If a SharedWorker is already running, it should be accessible