### PR TITLE
Add tests for SharedWorker having no RT entries

### DIFF
--- a/resource-timing/resources/shared-worker.js
+++ b/resource-timing/resources/shared-worker.js
@@ -1,0 +1,3 @@
+self.onconnect = e => {
+  e.ports[0].postMessage(performance.timeOrigin);
+}

--- a/resource-timing/shared-worker-rt-entry.html
+++ b/resource-timing/shared-worker-rt-entry.html
@@ -13,7 +13,7 @@
     promise_test(async () => {
         const url = new URL(`resources/shared-worker.js?${token()}`, location.href).toString();
         const worker = new SharedWorker(url, 'name');
-        const {data} = await new Promise(resolve => { 
+        const {data} = await new Promise(resolve => {
             worker.port.onmessage = resolve;
         });
 

--- a/resource-timing/shared-worker-rt-entry.html
+++ b/resource-timing/shared-worker-rt-entry.html
@@ -19,9 +19,8 @@
 
         const timeOrigin = data;
         const entries = performance.getEntriesByName(url);
-        assert_equals(entries.length, 1, "SharedWorker should have a ResourceTiming entry");
-        assert_greater_than(timeOrigin, entries[0].startTime + entries[0].duration + performance.timeOrigin, "SharedWorker timeOrigin should be after the response arrived");
-    }, "Shared workers should generate Resource Timing Entries");
+        assert_equals(entries.length, 0, "SharedWorker should not create a ResourceTiming entry");
+    }, "Shared workers should not generate Resource Timing Entries");
 </script>
 </body>
 </html>

--- a/resource-timing/shared-worker-rt-entry.html
+++ b/resource-timing/shared-worker-rt-entry.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Resource Timing Entry for Shared Workers</title>
+<link rel="help" href="https://w3c.github.io/resource-timing/"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+</head>
+<body>
+<script>
+    promise_test(async () => {
+        const url = new URL(`resources/shared-worker.js?${token()}`, location.href).toString();
+        const worker = new SharedWorker(url, 'name');
+        const {data} = await new Promise(resolve => { 
+            worker.port.onmessage = resolve;
+        });
+
+        const timeOrigin = data;
+        const entries = performance.getEntriesByName(url);
+        assert_equals(entries.length, 1, "SharedWorker should have a ResourceTiming entry");
+        assert_greater_than(timeOrigin, entries[0].startTime + entries[0].duration + performance.timeOrigin, "SharedWorker timeOrigin should be after the response arrived");
+    }, "Shared workers should generate Resource Timing Entries");
+</script>
+</body>
+</html>


### PR DESCRIPTION
The SharedWorker script is fetched without an originating global object (the fetch client is the SharedWorker manager). So the reported timing should not be accessible by any of the documents requesting the shared worker.