### PR TITLE
Document better the enctype-specific form submission tests

### DIFF
--- a/html/semantics/forms/form-submission-0/enctypes-helper.js
+++ b/html/semantics/forms/form-submission-0/enctypes-helper.js
@@ -136,6 +136,13 @@
     enctype,
     expectedBuilder = (expected) => expected
   ) => {
+    // `name` and `value` are the form entry's name and value – `name` must be a
+    // string, `value` can be either a string or a `File` object.
+    // `expected` is the expected form body – usually a `string`, but it can be
+    // anything depending on the `expectedBuilder` passed to
+    // `formSubmissionTemplate`.
+    // `formEncoding` is the character encoding used for submitting the form.
+    // `description` will be used as part of the testharness test's description.
     function form({
       name,
       value,

--- a/html/semantics/forms/form-submission-0/enctypes-helper.js
+++ b/html/semantics/forms/form-submission-0/enctypes-helper.js
@@ -1,3 +1,36 @@
+// This file exposes the `formSubmissionTemplate` function, which can be used
+// to create tests for the form submission encoding of various enctypes:
+//
+//   const urlencodedTest = formSubmissionTemplate(
+//     "application/x-www-form-urlencoded",
+//     (expected, _actualFormBody) => expected
+//   );
+//
+//   urlencodedTest({
+//     name: "a",
+//     value: "b",
+//     expected: "a=b",
+//     formEncoding: "UTF-8", // optional
+//     description: "Simple urlencoded test"
+//   });
+//
+// The above call to `urlencodedTest` tests the urlencoded form submission for a
+// form whose entry list contains a single entry with name "a" and value "b",
+// and it checks that the form payload matches the `expected` property after
+// isomorphic-encoding.
+//
+// Since per the spec no normalization of the form entries should happen before
+// the actual form encoding, each call to `urlencodedTest` will in fact add two
+// tests: one submitting the entry as a form control (marked "normal form"), and
+// one adding the entry through the `formdata` event (marked "formdata event").
+// Both cases are compared against the same expected value.
+//
+// Since multipart/form-data boundary strings can't be predicted ahead of time,
+// the second parameter of `formSubmissionTemplate` allows transforming the
+// expected value passed to each test. The second argument of that callback
+// is the actual form body (isomorphic-decoded). When this callback is used, the
+// `expected` property need not be a string.
+
 (() => {
   // Using echo-content-escaped.py rather than
   // /fetch/api/resources/echo-content.py to work around WebKit not
@@ -7,7 +40,7 @@
 
   const IFRAME_NAME = "formtargetframe";
 
-  // Undoes the escapes from /fetch/api/resources/echo-content.py
+  // Undoes the escapes from echo-content-escaped.py
   function unescape(str) {
     return str
       .replace(/\r\n?|\n/g, "\r\n")
@@ -18,9 +51,12 @@
       .replace(/\\\\/g, "\\");
   }
 
+  // Tests the form submission of an entry list containing a single entry.
+  //
   // `expectedBuilder` is a function that takes in the actual form body
   // (necessary to get the multipart/form-data payload) and returns the form
   // body that should be expected.
+  //
   // If `testFormData` is false, the form entry will be submitted in for
   // controls. If it is true, it will submitted by modifying the entry list
   // during the `formdata` event.
@@ -90,12 +126,16 @@
 
   // This function returns a function to add individual form tests corresponding
   // to some enctype.
-  // `expectedBuilder` is a function that takes two parameters: `expected` (the
-  // `expected` value of a test) and `serialized` (the actual form body
-  // submitted by the browser), and returns the correct form body that should
-  // have been submitted. This is necessary in order to account for th
+  // `expectedBuilder` is an optional callback that takes two parameters:
+  // `expected` (the `expected` property passed to a test) and `serialized` (the
+  // actual form body submitted by the browser, isomorphic-decoded). It must
+  // return the correct form body that should have been submitted,
+  // isomorphic-encoded. This is necessary in order to account for the
   // multipart/form-data boundary.
-  window.formSubmissionTemplate = (enctype, expectedBuilder) => {
+  window.formSubmissionTemplate = (
+    enctype,
+    expectedBuilder = (expected) => expected
+  ) => {
     function form({
       name,
       value,

--- a/html/semantics/forms/form-submission-0/enctypes-helper.js
+++ b/html/semantics/forms/form-submission-0/enctypes-helper.js
@@ -29,7 +29,7 @@
 // the second parameter of `formSubmissionTemplate` allows transforming the
 // expected value passed to each test. The second argument of that callback
 // is the actual form body (isomorphic-decoded). When this callback is used, the
-// `expected` property need not be a string.
+// `expected` property doesn't need to be a string.
 
 (() => {
   // Using echo-content-escaped.py rather than
@@ -127,22 +127,24 @@
   // This function returns a function to add individual form tests corresponding
   // to some enctype.
   // `expectedBuilder` is an optional callback that takes two parameters:
-  // `expected` (the `expected` property passed to a test) and `serialized` (the
-  // actual form body submitted by the browser, isomorphic-decoded). It must
-  // return the correct form body that should have been submitted,
+  // `expected` (the `expected` property passed to a test) and `actualFormBody`
+  // (the actual form body submitted by the browser, isomorphic-decoded). It
+  // must return the correct form body that should have been submitted,
   // isomorphic-encoded. This is necessary in order to account for the
   // multipart/form-data boundary.
+  //
+  // The returned function takes an object with the following properties:
+  // - `name`, the form entry's name. Must be a string.
+  // - `value`, the form entry's value, either a string or a `File` object.
+  // - `expected`, the expected form body. Usually a string, but it can be
+  //   anything depending on `expectedBuilder`.
+  // - `formEncoding` (optional), the character encoding used for submitting the
+  //   form.
+  // - `description`, used as part of the testharness test's description.
   window.formSubmissionTemplate = (
     enctype,
     expectedBuilder = (expected) => expected
   ) => {
-    // `name` and `value` are the form entry's name and value – `name` must be a
-    // string, `value` can be either a string or a `File` object.
-    // `expected` is the expected form body – usually a `string`, but it can be
-    // anything depending on the `expectedBuilder` passed to
-    // `formSubmissionTemplate`.
-    // `formEncoding` is the character encoding used for submitting the form.
-    // `description` will be used as part of the testharness test's description.
     function form({
       name,
       value,

--- a/html/semantics/forms/form-submission-0/multipart-formdata.window.js
+++ b/html/semantics/forms/form-submission-0/multipart-formdata.window.js
@@ -3,7 +3,10 @@
 // Form submissions in multipart/form-data are also tested in
 // /FileAPI/file/send-file*
 
-const form = formSubmissionTemplate(
+// The `expected` property of objects passed to `formTest` must be an object
+// with `name`, `value` and optionally `filename` properties, which represent
+// the corresponding data in a multipart/form-data part.
+const formTest = formSubmissionTemplate(
   "multipart/form-data",
   ({ name, filename, value }, serialized) => {
     let headers;
@@ -29,7 +32,7 @@ const form = formSubmissionTemplate(
   },
 );
 
-form({
+formTest({
   name: "basic",
   value: "test",
   expected: {
@@ -39,7 +42,7 @@ form({
   description: "Basic test",
 });
 
-form({
+formTest({
   name: "basic",
   value: new File([], "file-test.txt", { type: "text/plain" }),
   expected: {
@@ -50,7 +53,7 @@ form({
   description: "Basic File test",
 });
 
-form({
+formTest({
   name: "a\0b",
   value: "c",
   expected: {
@@ -60,7 +63,7 @@ form({
   description: "0x00 in name",
 });
 
-form({
+formTest({
   name: "a",
   value: "b\0c",
   expected: {
@@ -70,7 +73,7 @@ form({
   description: "0x00 in value",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b\0c", { type: "text/plain" }),
   expected: {
@@ -81,7 +84,7 @@ form({
   description: "0x00 in filename",
 });
 
-form({
+formTest({
   name: "a\nb",
   value: "c",
   expected: {
@@ -91,7 +94,7 @@ form({
   description: "\\n in name",
 });
 
-form({
+formTest({
   name: "a\rb",
   value: "c",
   expected: {
@@ -101,7 +104,7 @@ form({
   description: "\\r in name",
 });
 
-form({
+formTest({
   name: "a\r\nb",
   value: "c",
   expected: {
@@ -111,7 +114,7 @@ form({
   description: "\\r\\n in name",
 });
 
-form({
+formTest({
   name: "a\n\rb",
   value: "c",
   expected: {
@@ -121,7 +124,7 @@ form({
   description: "\\n\\r in name",
 });
 
-form({
+formTest({
   name: "a",
   value: "b\nc",
   expected: {
@@ -131,7 +134,7 @@ form({
   description: "\\n in value",
 });
 
-form({
+formTest({
   name: "a",
   value: "b\rc",
   expected: {
@@ -141,7 +144,7 @@ form({
   description: "\\r in value",
 });
 
-form({
+formTest({
   name: "a",
   value: "b\r\nc",
   expected: {
@@ -151,7 +154,7 @@ form({
   description: "\\r\\n in value",
 });
 
-form({
+formTest({
   name: "a",
   value: "b\n\rc",
   expected: {
@@ -161,7 +164,7 @@ form({
   description: "\\n\\r in value",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b\nc", { type: "text/plain" }),
   expected: {
@@ -172,7 +175,7 @@ form({
   description: "\\n in filename",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b\rc", { type: "text/plain" }),
   expected: {
@@ -183,7 +186,7 @@ form({
   description: "\\r in filename",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b\r\nc", { type: "text/plain" }),
   expected: {
@@ -194,7 +197,7 @@ form({
   description: "\\r\\n in filename",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b\n\rc", { type: "text/plain" }),
   expected: {
@@ -205,7 +208,7 @@ form({
   description: "\\n\\r in filename",
 });
 
-form({
+formTest({
   name: 'a"b',
   value: "c",
   expected: {
@@ -215,7 +218,7 @@ form({
   description: "double quote in name",
 });
 
-form({
+formTest({
   name: "a",
   value: 'b"c',
   expected: {
@@ -225,7 +228,7 @@ form({
   description: "double quote in value",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], 'b"c', { type: "text/plain" }),
   expected: {
@@ -236,7 +239,7 @@ form({
   description: "double quote in filename",
 });
 
-form({
+formTest({
   name: "a'b",
   value: "c",
   expected: {
@@ -246,7 +249,7 @@ form({
   description: "single quote in name",
 });
 
-form({
+formTest({
   name: "a",
   value: "b'c",
   expected: {
@@ -256,7 +259,7 @@ form({
   description: "single quote in value",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b'c", { type: "text/plain" }),
   expected: {
@@ -267,7 +270,7 @@ form({
   description: "single quote in filename",
 });
 
-form({
+formTest({
   name: "a\\b",
   value: "c",
   expected: {
@@ -277,7 +280,7 @@ form({
   description: "backslash in name",
 });
 
-form({
+formTest({
   name: "a",
   value: "b\\c",
   expected: {
@@ -287,7 +290,7 @@ form({
   description: "backslash in value",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b\\c", { type: "text/plain" }),
   expected: {
@@ -298,7 +301,7 @@ form({
   description: "backslash in filename",
 });
 
-form({
+formTest({
   name: "áb",
   value: "ç",
   expected: {
@@ -308,7 +311,7 @@ form({
   description: "non-ASCII in name and value",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "ə.txt", { type: "text/plain" }),
   expected: {
@@ -319,7 +322,7 @@ form({
   description: "non-ASCII in filename",
 });
 
-form({
+formTest({
   name: "aəb",
   value: "c\uFFFDd",
   formEncoding: "windows-1252",
@@ -330,7 +333,7 @@ form({
   description: "characters not in encoding in name and value",
 });
 
-form({
+formTest({
   name: "á",
   value: new File([], "💩", { type: "text/plain" }),
   formEncoding: "windows-1252",

--- a/html/semantics/forms/form-submission-0/text-plain.window.js
+++ b/html/semantics/forms/form-submission-0/text-plain.window.js
@@ -1,207 +1,204 @@
 // META: script=enctypes-helper.js
 
-const form = formSubmissionTemplate(
-  "text/plain",
-  (expected) => expected,
-);
+const formTest = formSubmissionTemplate("text/plain");
 
-form({
+formTest({
   name: "basic",
   value: "test",
   expected: "basic=test\r\n",
   description: "Basic test",
 });
 
-form({
+formTest({
   name: "basic",
   value: new File([], "file-test.txt"),
   expected: "basic=file-test.txt\r\n",
   description: "Basic File test",
 });
 
-form({
+formTest({
   name: "a\0b",
   value: "c",
   expected: "a\0b=c\r\n",
   description: "0x00 in name",
 });
 
-form({
+formTest({
   name: "a",
   value: "b\0c",
   expected: "a=b\0c\r\n",
   description: "0x00 in value",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b\0c"),
   expected: "a=b\0c\r\n",
   description: "0x00 in filename",
 });
 
-form({
+formTest({
   name: "a\nb",
   value: "c",
   expected: "a\r\nb=c\r\n",
   description: "\\n in name",
 });
 
-form({
+formTest({
   name: "a\rb",
   value: "c",
   expected: "a\r\nb=c\r\n",
   description: "\\r in name",
 });
 
-form({
+formTest({
   name: "a\r\nb",
   value: "c",
   expected: "a\r\nb=c\r\n",
   description: "\\r\\n in name",
 });
 
-form({
+formTest({
   name: "a\n\rb",
   value: "c",
   expected: "a\r\n\r\nb=c\r\n",
   description: "\\n\\r in name",
 });
 
-form({
+formTest({
   name: "a",
   value: "b\nc",
   expected: "a=b\r\nc\r\n",
   description: "\\n in value",
 });
 
-form({
+formTest({
   name: "a",
   value: "b\rc",
   expected: "a=b\r\nc\r\n",
   description: "\\r in value",
 });
 
-form({
+formTest({
   name: "a",
   value: "b\r\nc",
   expected: "a=b\r\nc\r\n",
   description: "\\r\\n in value",
 });
 
-form({
+formTest({
   name: "a",
   value: "b\n\rc",
   expected: "a=b\r\n\r\nc\r\n",
   description: "\\n\\r in value",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b\nc"),
   expected: "a=b\r\nc\r\n",
   description: "\\n in filename",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b\rc"),
   expected: "a=b\r\nc\r\n",
   description: "\\r in filename",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b\r\nc"),
   expected: "a=b\r\nc\r\n",
   description: "\\r\\n in filename",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b\n\rc"),
   expected: "a=b\r\n\r\nc\r\n",
   description: "\\n\\r in filename",
 });
 
-form({
+formTest({
   name: 'a"b',
   value: "c",
   expected: 'a"b=c\r\n',
   description: "double quote in name",
 });
 
-form({
+formTest({
   name: "a",
   value: 'b"c',
   expected: 'a=b"c\r\n',
   description: "double quote in value",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], 'b"c'),
   expected: 'a=b"c\r\n',
   description: "double quote in filename",
 });
 
-form({
+formTest({
   name: "a'b",
   value: "c",
   expected: "a'b=c\r\n",
   description: "single quote in name",
 });
 
-form({
+formTest({
   name: "a",
   value: "b'c",
   expected: "a=b'c\r\n",
   description: "single quote in value",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b'c"),
   expected: "a=b'c\r\n",
   description: "single quote in filename",
 });
 
-form({
+formTest({
   name: "a\\b",
   value: "c",
   expected: "a\\b=c\r\n",
   description: "backslash in name",
 });
 
-form({
+formTest({
   name: "a",
   value: "b\\c",
   expected: "a=b\\c\r\n",
   description: "backslash in value",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b\\c"),
   expected: "a=b\\c\r\n",
   description: "backslash in filename",
 });
 
-form({
+formTest({
   name: "áb",
   value: "ç",
   expected: "\xC3\xA1b=\xC3\xA7\r\n",
   description: "non-ASCII in name and value",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "ə.txt"),
   expected: "a=\xC9\x99.txt\r\n",
   description: "non-ASCII in filename",
 });
 
-form({
+formTest({
   name: "aəb",
   value: "c\uFFFDd",
   formEncoding: "windows-1252",
@@ -209,7 +206,7 @@ form({
   description: "characters not in encoding in name and value",
 });
 
-form({
+formTest({
   name: "á",
   value: new File([], "💩"),
   formEncoding: "windows-1252",

--- a/html/semantics/forms/form-submission-0/urlencoded2.window.js
+++ b/html/semantics/forms/form-submission-0/urlencoded2.window.js
@@ -1,207 +1,204 @@
 // META: script=enctypes-helper.js
 
-const form = formSubmissionTemplate(
-  "application/x-www-form-urlencoded",
-  (expected) => expected,
-);
+const formTest = formSubmissionTemplate("application/x-www-form-urlencoded");
 
-form({
+formTest({
   name: "basic",
   value: "test",
   expected: "basic=test",
   description: "Basic test",
 });
 
-form({
+formTest({
   name: "basic",
   value: new File([], "file-test.txt"),
   expected: "basic=file-test.txt",
   description: "Basic File test",
 });
 
-form({
+formTest({
   name: "a\0b",
   value: "c",
   expected: "a%00b=c",
   description: "0x00 in name",
 });
 
-form({
+formTest({
   name: "a",
   value: "b\0c",
   expected: "a=b%00c",
   description: "0x00 in value",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b\0c"),
   expected: "a=b%00c",
   description: "0x00 in filename",
 });
 
-form({
+formTest({
   name: "a\nb",
   value: "c",
   expected: "a%0D%0Ab=c",
   description: "\\n in name",
 });
 
-form({
+formTest({
   name: "a\rb",
   value: "c",
   expected: "a%0D%0Ab=c",
   description: "\\r in name",
 });
 
-form({
+formTest({
   name: "a\r\nb",
   value: "c",
   expected: "a%0D%0Ab=c",
   description: "\\r\\n in name",
 });
 
-form({
+formTest({
   name: "a\n\rb",
   value: "c",
   expected: "a%0D%0A%0D%0Ab=c",
   description: "\\n\\r in name",
 });
 
-form({
+formTest({
   name: "a",
   value: "b\nc",
   expected: "a=b%0D%0Ac",
   description: "\\n in value",
 });
 
-form({
+formTest({
   name: "a",
   value: "b\rc",
   expected: "a=b%0D%0Ac",
   description: "\\r in value",
 });
 
-form({
+formTest({
   name: "a",
   value: "b\r\nc",
   expected: "a=b%0D%0Ac",
   description: "\\r\\n in value",
 });
 
-form({
+formTest({
   name: "a",
   value: "b\n\rc",
   expected: "a=b%0D%0A%0D%0Ac",
   description: "\\n\\r in value",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b\nc"),
   expected: "a=b%0D%0Ac",
   description: "\\n in filename",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b\rc"),
   expected: "a=b%0D%0Ac",
   description: "\\r in filename",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b\r\nc"),
   expected: "a=b%0D%0Ac",
   description: "\\r\\n in filename",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b\n\rc"),
   expected: "a=b%0D%0A%0D%0Ac",
   description: "\\n\\r in filename",
 });
 
-form({
+formTest({
   name: 'a"b',
   value: "c",
   expected: "a%22b=c",
   description: "double quote in name",
 });
 
-form({
+formTest({
   name: "a",
   value: 'b"c',
   expected: "a=b%22c",
   description: "double quote in value",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], 'b"c'),
   expected: "a=b%22c",
   description: "double quote in filename",
 });
 
-form({
+formTest({
   name: "a'b",
   value: "c",
   expected: "a%27b=c",
   description: "single quote in name",
 });
 
-form({
+formTest({
   name: "a",
   value: "b'c",
   expected: "a=b%27c",
   description: "single quote in value",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b'c"),
   expected: "a=b%27c",
   description: "single quote in filename",
 });
 
-form({
+formTest({
   name: "a\\b",
   value: "c",
   expected: "a%5Cb=c",
   description: "backslash in name",
 });
 
-form({
+formTest({
   name: "a",
   value: "b\\c",
   expected: "a=b%5Cc",
   description: "backslash in value",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "b\\c"),
   expected: "a=b%5Cc",
   description: "backslash in filename",
 });
 
-form({
+formTest({
   name: "áb",
   value: "ç",
   expected: "%C3%A1b=%C3%A7",
   description: "non-ASCII in name and value",
 });
 
-form({
+formTest({
   name: "a",
   value: new File([], "ə.txt"),
   expected: "a=%C9%99.txt",
   description: "non-ASCII in filename",
 });
 
-form({
+formTest({
   name: "aəb",
   value: "c\uFFFDd",
   formEncoding: "windows-1252",
@@ -209,7 +206,7 @@ form({
   description: "characters not in encoding in name and value",
 });
 
-form({
+formTest({
   name: "á",
   value: new File([], "💩"),
   formEncoding: "windows-1252",


### PR DESCRIPTION
This also changes the second parameter to `formSubmissionTemplate` to be optional.

cc @smaug----