### PR TITLE
Suppress aioquic INFO logs

### DIFF
--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -15,7 +15,7 @@ from aioquic.h3.connection import H3_ALPN, FrameType, H3Connection, ProtocolErro
 from aioquic.h3.events import H3Event, HeadersReceived, WebTransportStreamDataReceived, DatagramReceived, DataReceived  # type: ignore
 from aioquic.quic.configuration import QuicConfiguration  # type: ignore
 from aioquic.quic.connection import logger as quic_connection_logger  # type: ignore
-from aioquic.quic.connection import stream_is_unidirectional  # type: ignore
+from aioquic.quic.connection import stream_is_unidirectional
 from aioquic.quic.events import QuicEvent, ProtocolNegotiated, ConnectionTerminated, StreamReset  # type: ignore
 from aioquic.tls import SessionTicket  # type: ignore
 

--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -14,7 +14,7 @@ from aioquic.asyncio.client import connect  # type: ignore
 from aioquic.h3.connection import H3_ALPN, FrameType, H3Connection, ProtocolError, Setting  # type: ignore
 from aioquic.h3.events import H3Event, HeadersReceived, WebTransportStreamDataReceived, DatagramReceived, DataReceived  # type: ignore
 from aioquic.quic.configuration import QuicConfiguration  # type: ignore
-from aioquic.quic.connection import logger as quic_connection_logger
+from aioquic.quic.connection import logger as quic_connection_logger  # type: ignore
 from aioquic.quic.connection import stream_is_unidirectional  # type: ignore
 from aioquic.quic.events import QuicEvent, ProtocolNegotiated, ConnectionTerminated, StreamReset  # type: ignore
 from aioquic.tls import SessionTicket  # type: ignore

--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -14,7 +14,7 @@ from aioquic.asyncio.client import connect  # type: ignore
 from aioquic.h3.connection import H3_ALPN, FrameType, H3Connection, ProtocolError, Setting  # type: ignore
 from aioquic.h3.events import H3Event, HeadersReceived, WebTransportStreamDataReceived, DatagramReceived, DataReceived  # type: ignore
 from aioquic.quic.configuration import QuicConfiguration  # type: ignore
-from aioquic.quic.connection import logger as quic_connection_logger  # type: ignore
+from aioquic.quic.connection import logger as quic_connection_logger
 from aioquic.quic.connection import stream_is_unidirectional  # type: ignore
 from aioquic.quic.events import QuicEvent, ProtocolNegotiated, ConnectionTerminated, StreamReset  # type: ignore
 from aioquic.tls import SessionTicket  # type: ignore

--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -14,6 +14,7 @@ from aioquic.asyncio.client import connect  # type: ignore
 from aioquic.h3.connection import H3_ALPN, FrameType, H3Connection, ProtocolError, Setting  # type: ignore
 from aioquic.h3.events import H3Event, HeadersReceived, WebTransportStreamDataReceived, DatagramReceived, DataReceived  # type: ignore
 from aioquic.quic.configuration import QuicConfiguration  # type: ignore
+from aioquic.quic.connection import logger as quic_connection_logger  # type: ignore
 from aioquic.quic.connection import stream_is_unidirectional  # type: ignore
 from aioquic.quic.events import QuicEvent, ProtocolNegotiated, ConnectionTerminated, StreamReset  # type: ignore
 from aioquic.tls import SessionTicket  # type: ignore
@@ -34,6 +35,10 @@ SERVER_NAME = 'webtransport-h3-server'
 
 _logger: logging.Logger = logging.getLogger(__name__)
 _doc_root: str = ""
+
+# Set aioquic's log level to WARNING to suppress some INFO logs which are
+# recorded every connection close.
+quic_connection_logger.setLevel(logging.WARNING)
 
 
 class H3ConnectionWithDatagram04(H3Connection):


### PR DESCRIPTION
Some INFO logs are recorded every connection open and close. These
logs are not suitable for our server since we have a server health
check which is triggered every second and opens/closes a connection.