### PR TITLE
import.meta.url should include the URL fragment

### DIFF
--- a/workers/modules/shared-worker-import-meta.html
+++ b/workers/modules/shared-worker-import-meta.html
@@ -43,7 +43,7 @@ promise_test(() => {
         worker.port.postMessage('./' + script_url + '#1');
         return new Promise(resolve => worker.port.onmessage = resolve);
       })
-      .then(msg_event => assert_true(msg_event.data.endsWith(script_url)));
+      .then(msg_event => assert_true(msg_event.data.endsWith(script_url + "#1")));
 }, 'Test import.meta.url on the imported module script with a fragment.');
 
 </script>


### PR DESCRIPTION
Update workers/modules/shared-worker-import-meta.html to expect import.meta.url to include
the URL fragment. This matches the behavior of both WebKit and Blink.
See https://github.com/whatwg/html/issues/5162 for more information.