### PR TITLE
Upstream additions to css/css-color/parsing from WebKit

### DIFF
--- a/css/css-color/parsing/color-computed.html
+++ b/css/css-color/parsing/color-computed.html
@@ -38,26 +38,96 @@ test_computed_value("color", "rgb(100, 200, 300)", "rgb(100, 200, 255)");
 test_computed_value("color", "rgb(20, 10, 0, -10)", "rgba(20, 10, 0, 0)");
 test_computed_value("color", "rgb(100%, 200%, 300%)", "rgb(255, 255, 255)");
 
+test_computed_value("color", "rgb(none none none)", "rgb(0, 0, 0)");
+test_computed_value("color", "rgb(none none none / none)", "rgba(0, 0, 0, 0)");
+test_computed_value("color", "rgb(128 none none)", "rgb(128, 0, 0)");
+test_computed_value("color", "rgb(128 none none / none)", "rgba(128, 0, 0, 0)");
+test_computed_value("color", "rgb(none none none / .5)", "rgba(0, 0, 0, 0.5)");
+test_computed_value("color", "rgb(20% none none)", "rgb(51, 0, 0)");
+test_computed_value("color", "rgb(20% none none / none)", "rgba(51, 0, 0, 0)");
+test_computed_value("color", "rgb(none none none / 50%)", "rgba(0, 0, 0, 0.5)");
+test_computed_value("color", "rgba(none none none)", "rgb(0, 0, 0)");
+test_computed_value("color", "rgba(none none none / none)", "rgba(0, 0, 0, 0)");
+test_computed_value("color", "rgba(128 none none)", "rgb(128, 0, 0)");
+test_computed_value("color", "rgba(128 none none / none)", "rgba(128, 0, 0, 0)");
+test_computed_value("color", "rgba(none none none / .5)", "rgba(0, 0, 0, 0.5)");
+test_computed_value("color", "rgba(20% none none)", "rgb(51, 0, 0)");
+test_computed_value("color", "rgba(20% none none / none)", "rgba(51, 0, 0, 0)");
+test_computed_value("color", "rgba(none none none / 50%)", "rgba(0, 0, 0, 0.5)");
+
+test_computed_value("color", "hsl(120 30% 50%)", "rgb(89, 166, 89)");
+test_computed_value("color", "hsl(120 30% 50% / 0.5)", "rgba(89, 166, 89, 0.5)");
+test_computed_value("color", "hsl(none none none)", "rgb(0, 0, 0)");
+test_computed_value("color", "hsl(0 0% 0%)", "rgb(0, 0, 0)");
+test_computed_value("color", "hsl(none none none / none)", "rgba(0, 0, 0, 0)");
+test_computed_value("color", "hsl(0 0% 0% / 0)", "rgba(0, 0, 0, 0)");
+test_computed_value("color", "hsla(none none none)", "rgb(0, 0, 0)");
+test_computed_value("color", "hsla(0 0% 0%)", "rgb(0, 0, 0)");
+test_computed_value("color", "hsla(none none none / none)", "rgba(0, 0, 0, 0)");
+test_computed_value("color", "hsla(0 0% 0% / 0)", "rgba(0, 0, 0, 0)");
+test_computed_value("color", "hsl(120 none none)", "rgb(0, 0, 0)");
+test_computed_value("color", "hsl(120 0% 0%)", "rgb(0, 0, 0)");
+test_computed_value("color", "hsl(120 80% none)", "rgb(0, 0, 0)");
+test_computed_value("color", "hsl(120 80% 0%)", "rgb(0, 0, 0)");
+test_computed_value("color", "hsl(120 none 50%)", "rgb(128, 128, 128)");
+test_computed_value("color", "hsl(120 0% 50%)", "rgb(128, 128, 128)");
+test_computed_value("color", "hsl(120 100% 50% / none)", "rgba(0, 255, 0, 0)");
+test_computed_value("color", "hsl(120 100% 50% / 0)", "rgba(0, 255, 0, 0)");
+test_computed_value("color", "hsl(none 100% 50%)", "rgb(255, 0, 0)");
+test_computed_value("color", "hsl(0 100% 50%)", "rgb(255, 0, 0)");
+
+test_computed_value("color", "hwb(120 30% 50%)", "rgb(77, 128, 77)");
+test_computed_value("color", "hwb(120 30% 50% / 0.5)", "rgba(77, 128, 77, 0.5)");
+test_computed_value("color", "hwb(none none none)", "rgb(255, 0, 0)");
+test_computed_value("color", "hwb(0 0% 0%)", "rgb(255, 0, 0)");
+test_computed_value("color", "hwb(none none none / none)", "rgba(255, 0, 0, 0)");
+test_computed_value("color", "hwb(0 0% 0% / 0)", "rgba(255, 0, 0, 0)");
+test_computed_value("color", "hwb(120 none none)", "rgb(0, 255, 0)");
+test_computed_value("color", "hwb(120 0% 0%)", "rgb(0, 255, 0)");
+test_computed_value("color", "hwb(120 80% none)", "rgb(204, 255, 204)");
+test_computed_value("color", "hwb(120 80% 0%)", "rgb(204, 255, 204)");
+test_computed_value("color", "hwb(120 none 50%)", "rgb(0, 128, 0)");
+test_computed_value("color", "hwb(120 0% 50%)", "rgb(0, 128, 0)");
+test_computed_value("color", "hwb(120 30% 50% / none)", "rgba(77, 128, 77, 0)");
+test_computed_value("color", "hwb(120 30% 50% / 0)", "rgba(77, 128, 77, 0)");
+test_computed_value("color", "hwb(none 100% 50% / none)", "rgba(170, 170, 170, 0)");
+test_computed_value("color", "hwb(0 100% 50% / 0)", "rgba(170, 170, 170, 0)");
+
 for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb" ]) {
     test_computed_value("color", `color(${colorSpace} 0% 0% 0%)`, `color(${colorSpace} 0 0 0)`);
     test_computed_value("color", `color(${colorSpace} 10% 10% 10%)`, `color(${colorSpace} 0.1 0.1 0.1)`);
     test_computed_value("color", `color(${colorSpace} .2 .2 25%)`, `color(${colorSpace} 0.2 0.2 0.25)`);
     test_computed_value("color", `color(${colorSpace} 0 0 0 / 1)`, `color(${colorSpace} 0 0 0)`);
     test_computed_value("color", `color(${colorSpace} 0% 0 0 / 0.5)`, `color(${colorSpace} 0 0 0 / 0.5)`);
-    test_computed_value("color", `color(${colorSpace} 20% 0 10/0.5)`, `color(${colorSpace} 0.2 0 1 / 0.5)`);
-    test_computed_value("color", `color(${colorSpace} 20% 0 10/50%)`, `color(${colorSpace} 0.2 0 1 / 0.5)`);
-    test_computed_value("color", `color(${colorSpace} 400% 0 10/50%)`, `color(${colorSpace} 1 0 1 / 0.5)`);
-    test_computed_value("color", `color(${colorSpace} 50% -160 160)`, `color(${colorSpace} 0.5 0 1)`);
-    test_computed_value("color", `color(${colorSpace} 50% -200 200)`, `color(${colorSpace} 0.5 0 1)`);
+    test_computed_value("color", `color(${colorSpace} 20% 0 10/0.5)`, `color(${colorSpace} 0.2 0 10 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} 20% 0 10/50%)`, `color(${colorSpace} 0.2 0 10 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} 400% 0 10/50%)`, `color(${colorSpace} 4 0 10 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} 50% -160 160)`, `color(${colorSpace} 0.5 -160 160)`);
+    test_computed_value("color", `color(${colorSpace} 50% -200 200)`, `color(${colorSpace} 0.5 -200 200)`);
     test_computed_value("color", `color(${colorSpace} 0 0 0 / -10%)`, `color(${colorSpace} 0 0 0 / 0)`);
     test_computed_value("color", `color(${colorSpace} 0 0 0 / 110%)`, `color(${colorSpace} 0 0 0)`);
     test_computed_value("color", `color(${colorSpace} 0 0 0 / 300%)`, `color(${colorSpace} 0 0 0)`);
-    test_computed_value("color", `color(${colorSpace} 50% -200)`, `color(${colorSpace} 0.5 0 0)`);
+    test_computed_value("color", `color(${colorSpace} 50% -200)`, `color(${colorSpace} 0.5 -200 0)`);
     test_computed_value("color", `color(${colorSpace} 50%)`, `color(${colorSpace} 0.5 0 0)`);
     test_computed_value("color", `color(${colorSpace})`, `color(${colorSpace} 0 0 0)`);
-    test_computed_value("color", `color(${colorSpace} 50% -200 / 0.5)`, `color(${colorSpace} 0.5 0 0 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} 50% -200 / 0.5)`, `color(${colorSpace} 0.5 -200 0 / 0.5)`);
     test_computed_value("color", `color(${colorSpace} 50% / 0.5)`, `color(${colorSpace} 0.5 0 0 / 0.5)`);
     test_computed_value("color", `color(${colorSpace} / 0.5)`, `color(${colorSpace} 0 0 0 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} 200 200 200)`, `color(${colorSpace} 200 200 200)`);
+    test_computed_value("color", `color(${colorSpace} 200 200 200 / 200)`, `color(${colorSpace} 200 200 200)`);
+    test_computed_value("color", `color(${colorSpace} -200 -200 -200)`, `color(${colorSpace} -200 -200 -200)`);
+    test_computed_value("color", `color(${colorSpace} -200 -200 -200 / -200)`, `color(${colorSpace} -200 -200 -200 / 0)`);
+    test_computed_value("color", `color(${colorSpace} 200% 200% 200%)`, `color(${colorSpace} 2 2 2)`);
+    test_computed_value("color", `color(${colorSpace} 200% 200% 200% / 200%)`, `color(${colorSpace} 2 2 2)`);
+    test_computed_value("color", `color(${colorSpace} -200% -200% -200% / -200%)`, `color(${colorSpace} -2 -2 -2 / 0)`);
+    test_computed_value("color", `color(${colorSpace} calc(0.5 + 1) calc(0.5 - 1) calc(0.5) / calc(-0.5 + 1))`, `color(${colorSpace} 1.5 -0.5 0.5 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} calc(50% * 3) calc(-150% / 3) calc(50%) / calc(-50% * 3))`, `color(${colorSpace} 1.5 -0.5 0.5 / 0)`);
+
+    test_computed_value("color", `color(${colorSpace} none none none / none)`, `color(${colorSpace} none none none / none)`);
+    test_computed_value("color", `color(${colorSpace} none none none)`, `color(${colorSpace} none none none)`);
+    test_computed_value("color", `color(${colorSpace} 10% none none / none)`, `color(${colorSpace} 0.1 none none / none)`);
+    test_computed_value("color", `color(${colorSpace} none none none / 0.5)`, `color(${colorSpace} none none none / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} 0 0 0 / none)`, `color(${colorSpace} 0 0 0 / none)`);
 }
 
 for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
@@ -83,6 +153,13 @@ for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
     test_computed_value("color", `color(${colorSpace} 1 1 / .5)`, `color(${resultColorSpace} 1 1 0 / 0.5)`);
     test_computed_value("color", `color(${colorSpace} 1 / 0.5)`, `color(${resultColorSpace} 1 0 0 / 0.5)`);
     test_computed_value("color", `color(${colorSpace} / 50%)`, `color(${resultColorSpace} 0 0 0 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} calc(0.5 + 1) calc(0.5 - 1) calc(0.5) / calc(-0.5 + 1))`, `color(${resultColorSpace} 1.5 -0.5 0.5 / 0.5)`);
+
+    test_computed_value("color", `color(${colorSpace} none none none / none)`, `color(${resultColorSpace} none none none / none)`);
+    test_computed_value("color", `color(${colorSpace} none none none)`, `color(${resultColorSpace} none none none)`);
+    test_computed_value("color", `color(${colorSpace} 0.2 none none / none)`, `color(${resultColorSpace} 0.2 none none / none)`);
+    test_computed_value("color", `color(${colorSpace} none none none / 0.5)`, `color(${resultColorSpace} none none none / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} 0 0 0 / none)`, `color(${resultColorSpace} 0 0 0 / none)`);
 }
 
 for (const colorSpace of [ "lab", "oklab" ]) {
@@ -100,6 +177,14 @@ for (const colorSpace of [ "lab", "oklab" ]) {
     test_computed_value("color", `${colorSpace}(-40% 0 0)`, `${colorSpace}(0% 0 0)`);
     test_computed_value("color", `${colorSpace}(50% -20 0)`, `${colorSpace}(50% -20 0)`);
     test_computed_value("color", `${colorSpace}(50% 0 -20)`, `${colorSpace}(50% 0 -20)`);
+    test_computed_value("color", `${colorSpace}(calc(50% * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))`, `${colorSpace}(150% -0.5 1.5 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(calc(-50% * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))`, `${colorSpace}(0% 1.5 -1.5 / 0)`);
+
+    test_computed_value("color", `${colorSpace}(none none none / none)`, `${colorSpace}(none none none / none)`);
+    test_computed_value("color", `${colorSpace}(none none none)`, `${colorSpace}(none none none)`);
+    test_computed_value("color", `${colorSpace}(20% none none / none)`, `${colorSpace}(20% none none / none)`);
+    test_computed_value("color", `${colorSpace}(none none none / 0.5)`, `${colorSpace}(none none none / 0.5)`);
+    test_computed_value("color", `${colorSpace}(0% 0 0 / none)`, `${colorSpace}(0% 0 0 / none)`);
 }
 
 for (const colorSpace of [ "lch", "oklch" ]) {
@@ -121,6 +206,14 @@ for (const colorSpace of [ "lch", "oklch" ]) {
     test_computed_value("color", `${colorSpace}(0% 0 0 / 0.5)`, `${colorSpace}(0% 0 0 / 0.5)`);
     test_computed_value("color", `${colorSpace}(10% 20 20 / 110%)`, `${colorSpace}(10% 20 20)`);
     test_computed_value("color", `${colorSpace}(10% 20 -700)`, `${colorSpace}(10% 20 20)`);
+    test_computed_value("color", `${colorSpace}(calc(50% * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))`, `${colorSpace}(150% 0 40 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(calc(-50% * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))`, `${colorSpace}(0% 1.5 320 / 0)`);
+
+    test_computed_value("color", `${colorSpace}(none none none / none)`, `${colorSpace}(none none none / none)`);
+    test_computed_value("color", `${colorSpace}(none none none)`, `${colorSpace}(none none none)`);
+    test_computed_value("color", `${colorSpace}(20% none none / none)`, `${colorSpace}(20% none none / none)`);
+    test_computed_value("color", `${colorSpace}(none none none / 0.5)`, `${colorSpace}(none none none / 0.5)`);
+    test_computed_value("color", `${colorSpace}(0% 0 0 / none)`, `${colorSpace}(0% 0 0 / none)`);
 }
 </script>
 </body>

--- a/css/css-color/parsing/color-invalid.html
+++ b/css/css-color/parsing/color-invalid.html
@@ -22,6 +22,14 @@ test_invalid_value("color", "rgb(1,2,3,4,5)");
 test_invalid_value("color", "hsla(1,2,3,4,5)");
 test_invalid_value("color", "rgb(10%, 20, 30%)");
 test_invalid_value("color", "rgba(-2, 300, 400%, -0.5)");
+test_invalid_value("color", "rgb(none, none, none)");
+test_invalid_value("color", "rgba(none, none, none, none)");
+test_invalid_value("color", "rgb(128, 0, none)");
+test_invalid_value("color", "rgb(255, 255, 255, none)");
+test_invalid_value("color", "hsl(none, none, none)");
+test_invalid_value("color", "hsla(none, none, none, none)");
+test_invalid_value("color", "hsl(none, 100%, 50%)");
+test_invalid_value("color", "hsla(120, 100%, 50%, none)");
 
 for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb" ]) {
     test_invalid_value("color", `color(${colorSpace} 0 0 0 0)`);

--- a/css/css-color/parsing/color-mix-computed.html
+++ b/css/css-color/parsing/color-mix-computed.html
@@ -86,6 +86,28 @@
     test_computed_value(`color`, `color-mix(in hsl specified hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))`, canonicalize(`hsl(170deg 50% 50%)`));
     test_computed_value(`color`, `color-mix(in hsl specified hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))`, canonicalize(`hsl(170deg 50% 50%)`));
 
+    test_computed_value(`color`, `color-mix(in hsl, hsl(none none none), hsl(none none none))`, canonicalize(`hsl(none none none)`));
+    test_computed_value(`color`, `color-mix(in hsl, hsl(none none none), hsl(30deg 40% 80%))`, canonicalize(`hsl(30deg 40% 80%)`));
+    test_computed_value(`color`, `color-mix(in hsl, hsl(120deg 20% 40%), hsl(none none none))`, canonicalize(`hsl(120deg 20% 40%)`));
+    test_computed_value(`color`, `color-mix(in hsl, hsl(120deg 20% none), hsl(30deg 40% 60%))`, canonicalize(`hsl(75deg 30% 60%)`));
+    test_computed_value(`color`, `color-mix(in hsl, hsl(120deg 20% 40%), hsl(30deg 20% none))`, canonicalize(`hsl(75deg 20% 40%)`));
+    test_computed_value(`color`, `color-mix(in hsl, hsl(none 20% 40%), hsl(30deg none 80%))`, canonicalize(`hsl(30deg 20% 60%)`));
+
+    test_computed_value(`color`, `color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40%))`, canonicalize(`hsl(60deg 40% 40%)`));
+    test_computed_value(`color`, `color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40% / 0.5))`, canonicalize(`hsl(60deg 40% 40% / 0.5)`));
+    test_computed_value(`color`, `color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40% / none))`, canonicalize(`hsl(60deg 40% 40% / none)`));
+
+    test_computed_value(`color`, `color-mix(in hsl, color(display-p3 0 1 0) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
+    test_computed_value(`color`, `color-mix(in hsl, lab(100% 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_computed_value(`color`, `color-mix(in hsl, lab(0% 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_computed_value(`color`, `color-mix(in hsl, lch(100% 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_computed_value(`color`, `color-mix(in hsl, lch(0% 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_computed_value(`color`, `color-mix(in hsl, oklab(100% 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+    test_computed_value(`color`, `color-mix(in hsl, oklab(0% 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+    test_computed_value(`color`, `color-mix(in hsl, oklch(100% 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+    test_computed_value(`color`, `color-mix(in hsl, oklch(0% 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
+
+
     test_computed_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%))`, `rgb(147, 179, 52)`);
     test_computed_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20%) 25%, hwb(30deg 30% 40%))`, `rgb(166, 153, 64)`);
     test_computed_value(`color`, `color-mix(in hwb, 25% hwb(120deg 10% 20%), hwb(30deg 30% 40%))`, `rgb(166, 153, 64)`);
@@ -147,6 +169,26 @@
     test_computed_value(`color`, `color-mix(in hwb specified hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))`, canonicalize(`hwb(190deg 30% 40%)`));
     test_computed_value(`color`, `color-mix(in hwb specified hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))`, canonicalize(`hwb(170deg 30% 40%)`));
     test_computed_value(`color`, `color-mix(in hwb specified hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))`, canonicalize(`hwb(170deg 30% 40%)`));
+
+    test_computed_value(`color`, `color-mix(in hwb, hwb(none none none), hwb(none none none))`, canonicalize(`hwb(none none none)`));
+    test_computed_value(`color`, `color-mix(in hwb, hwb(none none none), hwb(30deg 30% 40%))`, canonicalize(`hwb(30deg 30% 40%)`));
+    test_computed_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20%), hwb(none none none))`, canonicalize(`hwb(120deg 10% 20%)`));
+    test_computed_value(`color`, `color-mix(in hwb, hwb(120deg 10% none), hwb(30deg 30% 40%))`, canonicalize(`hwb(75deg 20% 40%)`));
+    test_computed_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% none))`, canonicalize(`hwb(75deg 20% 20%)`));
+    test_computed_value(`color`, `color-mix(in hwb, hwb(none 10% 20%), hwb(30deg none 40%))`, canonicalize(`hwb(30deg 10% 30%)`));
+    test_computed_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40%))`, canonicalize(`hwb(75deg 20% 30%)`));
+    test_computed_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / 0.5))`, canonicalize(`hwb(75deg 20% 30% / 0.5)`));
+    test_computed_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / none))`, canonicalize(`hwb(75deg 20% 30% / none)`));
+
+    test_computed_value(`color`, `color-mix(in hwb, color(display-p3 0 1 0) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
+    test_computed_value(`color`, `color-mix(in hwb, lab(100% 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_computed_value(`color`, `color-mix(in hwb, lab(0% 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_computed_value(`color`, `color-mix(in hwb, lch(100% 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_computed_value(`color`, `color-mix(in hwb, lch(0% 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_computed_value(`color`, `color-mix(in hwb, oklab(100% 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+    test_computed_value(`color`, `color-mix(in hwb, oklab(0% 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+    test_computed_value(`color`, `color-mix(in hwb, oklch(100% 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+    test_computed_value(`color`, `color-mix(in hwb, oklch(0% 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
 
     for (const colorSpace of [ "lch", "oklch" ]) {
         test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg), ${colorSpace}(50% 60 70deg))`, `${colorSpace}(30% 40 50)`);
@@ -210,6 +252,16 @@
         test_computed_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100% 0 330deg), ${colorSpace}(100% 0 50deg))`, `${colorSpace}(100% 0 190)`);
         test_computed_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100% 0 20deg), ${colorSpace}(100% 0 320deg))`, `${colorSpace}(100% 0 170)`);
         test_computed_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100% 0 320deg), ${colorSpace}(100% 0 20deg))`, `${colorSpace}(100% 0 170)`);
+
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(none none none))`, `${colorSpace}(none none none)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(50% 60 70deg))`, `${colorSpace}(50% 60 70)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg), ${colorSpace}(none none none))`, `${colorSpace}(10% 20 30)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 none), ${colorSpace}(50% 60 70deg))`, `${colorSpace}(30% 40 70)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg), ${colorSpace}(50% 60 none))`, `${colorSpace}(30% 40 30)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none 20 30deg), ${colorSpace}(50% none 70deg))`, `${colorSpace}(50% 20 50)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / none), ${colorSpace}(50% 60 70deg))`, `${colorSpace}(30% 40 50)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / none), ${colorSpace}(50% 60 70deg / 0.5))`, `${colorSpace}(30% 40 50 / 0.5)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / none), ${colorSpace}(50% 60 70deg / none))`, `${colorSpace}(30% 40 50 / none)`);
     }
 
     for (const colorSpace of [ "lab", "oklab" ]) {
@@ -232,6 +284,16 @@
         test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4) 30%, ${colorSpace}(50% 60 70 / .8) 90%)`, `${colorSpace}(44.285713% 54.285717 64.28571 / 0.7)`); // Scale down > 100% sum.
         test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4) 12.5%, ${colorSpace}(50% 60 70 / .8) 37.5%)`, `${colorSpace}(44.285713% 54.285717 64.28571 / 0.35)`); // Scale up < 100% sum, causes alpha multiplication.
         test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4) 0%, ${colorSpace}(50% 60 70 / .8))`, `${colorSpace}(50% 60 70 / 0.8)`);
+
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(none none none))`, `${colorSpace}(none none none)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(50% 60 70))`, `${colorSpace}(50% 60 70)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30), ${colorSpace}(none none none))`, `${colorSpace}(10% 20 30)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 none), ${colorSpace}(50% 60 70))`, `${colorSpace}(30% 40 70)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30), ${colorSpace}(50% 60 none))`, `${colorSpace}(30% 40 30)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none 20 30), ${colorSpace}(50% none 70))`, `${colorSpace}(50% 20 50)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / none), ${colorSpace}(50% 60 70))`, `${colorSpace}(30% 40 50)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / none), ${colorSpace}(50% 60 70 / 0.5))`, `${colorSpace}(30% 40 50 / 0.5)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / none), ${colorSpace}(50% 60 70 / none))`, `${colorSpace}(30% 40 50 / none)`);
     }
 
     for (const colorSpace of [ "srgb", "srgb-linear", "xyz", "xyz-d50", "xyz-d65" ]) {
@@ -256,6 +318,20 @@
         test_computed_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / .4) 30%, color(${colorSpace} .5 .6 .7 / .8) 90%)`, `color(${resultColorSpace} 0.44285715 0.54285717 0.64285713 / 0.7)`); // Scale down > 100% sum.
         test_computed_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / .4) 12.5%, color(${colorSpace} .5 .6 .7 / .8) 37.5%)`, `color(${resultColorSpace} 0.44285715 0.54285717 0.64285713 / 0.35)`); // Scale up < 100% sum, causes alpha multiplication.
         test_computed_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / .4) 0%, color(${colorSpace} .5 .6 .7 / .8))`, `color(${resultColorSpace} 0.5 0.6 0.7 / 0.8)`);
+
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} 2 3 4 / 5), color(${colorSpace} 4 6 8 / 10))`, `color(${resultColorSpace} 3 4.5 6)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} -2 -3 -4), color(${colorSpace} -4 -6 -8))`, `color(${resultColorSpace} -3 -4.5 -6)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} -2 -3 -4 / -5), color(${colorSpace} -4 -6 -8 / -10))`, `color(${resultColorSpace} 0 0 0 / 0)`);
+
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} none none none), color(${colorSpace} none none none))`, `color(${resultColorSpace} none none none)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} none none none), color(${colorSpace} .5 .6 .7))`, `color(${resultColorSpace} 0.5 0.6 0.7)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3), color(${colorSpace} none none none))`, `color(${resultColorSpace} 0.1 0.2 0.3)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 none), color(${colorSpace} .5 .6 .7))`, `color(${resultColorSpace} 0.3 0.4 0.7)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3), color(${colorSpace} .5 .6 none))`, `color(${resultColorSpace} 0.3 0.4 0.3)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} none .2 .3), color(${colorSpace} .5 none .7))`, `color(${resultColorSpace} 0.5 0.2 0.5)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / none), color(${colorSpace} .5 .6 .7))`, `color(${resultColorSpace} 0.3 0.4 0.5)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / none), color(${colorSpace} .5 .6 .7 / 0.5))`, `color(${resultColorSpace} 0.3 0.4 0.5 / 0.5)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / none), color(${colorSpace} .5 .6 .7 / none))`, `color(${resultColorSpace} 0.3 0.4 0.5 / none)`);
     }
 </script>
 </body>

--- a/css/css-color/parsing/color-mix-valid.html
+++ b/css/css-color/parsing/color-mix-valid.html
@@ -86,6 +86,28 @@
     test_valid_value(`color`, `color-mix(in hsl specified hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))`, canonicalize(`hsl(170deg 50% 50%)`));
     test_valid_value(`color`, `color-mix(in hsl specified hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))`, canonicalize(`hsl(170deg 50% 50%)`));
 
+    test_valid_value(`color`, `color-mix(in hsl, hsl(none none none), hsl(none none none))`, canonicalize(`hsl(none none none)`));
+    test_valid_value(`color`, `color-mix(in hsl, hsl(none none none), hsl(30deg 40% 80%))`, canonicalize(`hsl(30deg 40% 80%)`));
+    test_valid_value(`color`, `color-mix(in hsl, hsl(120deg 20% 40%), hsl(none none none))`, canonicalize(`hsl(120deg 20% 40%)`));
+    test_valid_value(`color`, `color-mix(in hsl, hsl(120deg 20% none), hsl(30deg 40% 60%))`, canonicalize(`hsl(75deg 30% 60%)`));
+    test_valid_value(`color`, `color-mix(in hsl, hsl(120deg 20% 40%), hsl(30deg 20% none))`, canonicalize(`hsl(75deg 20% 40%)`));
+    test_valid_value(`color`, `color-mix(in hsl, hsl(none 20% 40%), hsl(30deg none 80%))`, canonicalize(`hsl(30deg 20% 60%)`));
+
+    test_valid_value(`color`, `color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40%))`, canonicalize(`hsl(60deg 40% 40%)`));
+    test_valid_value(`color`, `color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40% / 0.5))`, canonicalize(`hsl(60deg 40% 40% / 0.5)`));
+    test_valid_value(`color`, `color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40% / none))`, canonicalize(`hsl(60deg 40% 40% / none)`));
+
+    test_valid_value(`color`, `color-mix(in hsl, color(display-p3 0 1 0) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
+    test_valid_value(`color`, `color-mix(in hsl, lab(100% 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `color-mix(in hsl, lab(0% 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `color-mix(in hsl, lch(100% 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `color-mix(in hsl, lch(0% 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `color-mix(in hsl, oklab(100% 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+    test_valid_value(`color`, `color-mix(in hsl, oklab(0% 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+    test_valid_value(`color`, `color-mix(in hsl, oklch(100% 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+    test_valid_value(`color`, `color-mix(in hsl, oklch(0% 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
+
+
     test_valid_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%))`, `rgb(147, 179, 52)`);
     test_valid_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20%) 25%, hwb(30deg 30% 40%))`, `rgb(166, 153, 64)`);
     test_valid_value(`color`, `color-mix(in hwb, 25% hwb(120deg 10% 20%), hwb(30deg 30% 40%))`, `rgb(166, 153, 64)`);
@@ -147,6 +169,26 @@
     test_valid_value(`color`, `color-mix(in hwb specified hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))`, canonicalize(`hwb(190deg 30% 40%)`));
     test_valid_value(`color`, `color-mix(in hwb specified hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))`, canonicalize(`hwb(170deg 30% 40%)`));
     test_valid_value(`color`, `color-mix(in hwb specified hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))`, canonicalize(`hwb(170deg 30% 40%)`));
+
+    test_valid_value(`color`, `color-mix(in hwb, hwb(none none none), hwb(none none none))`, canonicalize(`hwb(none none none)`));
+    test_valid_value(`color`, `color-mix(in hwb, hwb(none none none), hwb(30deg 30% 40%))`, canonicalize(`hwb(30deg 30% 40%)`));
+    test_valid_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20%), hwb(none none none))`, canonicalize(`hwb(120deg 10% 20%)`));
+    test_valid_value(`color`, `color-mix(in hwb, hwb(120deg 10% none), hwb(30deg 30% 40%))`, canonicalize(`hwb(75deg 20% 40%)`));
+    test_valid_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% none))`, canonicalize(`hwb(75deg 20% 20%)`));
+    test_valid_value(`color`, `color-mix(in hwb, hwb(none 10% 20%), hwb(30deg none 40%))`, canonicalize(`hwb(30deg 10% 30%)`));
+    test_valid_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40%))`, canonicalize(`hwb(75deg 20% 30%)`));
+    test_valid_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / 0.5))`, canonicalize(`hwb(75deg 20% 30% / 0.5)`));
+    test_valid_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / none))`, canonicalize(`hwb(75deg 20% 30% / none)`));
+
+    test_valid_value(`color`, `color-mix(in hwb, color(display-p3 0 1 0) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
+    test_valid_value(`color`, `color-mix(in hwb, lab(100% 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `color-mix(in hwb, lab(0% 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `color-mix(in hwb, lch(100% 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `color-mix(in hwb, lch(0% 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `color-mix(in hwb, oklab(100% 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+    test_valid_value(`color`, `color-mix(in hwb, oklab(0% 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+    test_valid_value(`color`, `color-mix(in hwb, oklch(100% 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+    test_valid_value(`color`, `color-mix(in hwb, oklch(0% 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
 
     for (const colorSpace of [ "lch", "oklch" ]) {
         test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg), ${colorSpace}(50% 60 70deg))`, `${colorSpace}(30% 40 50)`);
@@ -210,6 +252,16 @@
         test_valid_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100% 0 330deg), ${colorSpace}(100% 0 50deg))`, `${colorSpace}(100% 0 190)`);
         test_valid_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100% 0 20deg), ${colorSpace}(100% 0 320deg))`, `${colorSpace}(100% 0 170)`);
         test_valid_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100% 0 320deg), ${colorSpace}(100% 0 20deg))`, `${colorSpace}(100% 0 170)`);
+
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(none none none))`, `${colorSpace}(none none none)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(50% 60 70deg))`, `${colorSpace}(50% 60 70)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg), ${colorSpace}(none none none))`, `${colorSpace}(10% 20 30)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 none), ${colorSpace}(50% 60 70deg))`, `${colorSpace}(30% 40 70)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg), ${colorSpace}(50% 60 none))`, `${colorSpace}(30% 40 30)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none 20 30deg), ${colorSpace}(50% none 70deg))`, `${colorSpace}(50% 20 50)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / none), ${colorSpace}(50% 60 70deg))`, `${colorSpace}(30% 40 50)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / none), ${colorSpace}(50% 60 70deg / 0.5))`, `${colorSpace}(30% 40 50 / 0.5)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / none), ${colorSpace}(50% 60 70deg / none))`, `${colorSpace}(30% 40 50 / none)`);
     }
 
     for (const colorSpace of [ "lab", "oklab" ]) {
@@ -232,6 +284,16 @@
         test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4) 30%, ${colorSpace}(50% 60 70 / .8) 90%)`, `${colorSpace}(44.285713% 54.285717 64.28571 / 0.7)`); // Scale down > 100% sum.
         test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4) 12.5%, ${colorSpace}(50% 60 70 / .8) 37.5%)`, `${colorSpace}(44.285713% 54.285717 64.28571 / 0.35)`); // Scale up < 100% sum, causes alpha multiplication.
         test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4) 0%, ${colorSpace}(50% 60 70 / .8))`, `${colorSpace}(50% 60 70 / 0.8)`);
+
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(none none none))`, `${colorSpace}(none none none)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(50% 60 70))`, `${colorSpace}(50% 60 70)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30), ${colorSpace}(none none none))`, `${colorSpace}(10% 20 30)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 none), ${colorSpace}(50% 60 70))`, `${colorSpace}(30% 40 70)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30), ${colorSpace}(50% 60 none))`, `${colorSpace}(30% 40 30)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none 20 30), ${colorSpace}(50% none 70))`, `${colorSpace}(50% 20 50)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / none), ${colorSpace}(50% 60 70))`, `${colorSpace}(30% 40 50)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / none), ${colorSpace}(50% 60 70 / 0.5))`, `${colorSpace}(30% 40 50 / 0.5)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / none), ${colorSpace}(50% 60 70 / none))`, `${colorSpace}(30% 40 50 / none)`);
     }
 
     for (const colorSpace of [ "srgb", "srgb-linear", "xyz", "xyz-d50", "xyz-d65" ]) {
@@ -256,6 +318,20 @@
         test_valid_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / .4) 30%, color(${colorSpace} .5 .6 .7 / .8) 90%)`, `color(${resultColorSpace} 0.44285715 0.54285717 0.64285713 / 0.7)`); // Scale down > 100% sum.
         test_valid_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / .4) 12.5%, color(${colorSpace} .5 .6 .7 / .8) 37.5%)`, `color(${resultColorSpace} 0.44285715 0.54285717 0.64285713 / 0.35)`); // Scale up < 100% sum, causes alpha multiplication.
         test_valid_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / .4) 0%, color(${colorSpace} .5 .6 .7 / .8))`, `color(${resultColorSpace} 0.5 0.6 0.7 / 0.8)`);
+
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} 2 3 4 / 5), color(${colorSpace} 4 6 8 / 10))`, `color(${resultColorSpace} 3 4.5 6)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} -2 -3 -4), color(${colorSpace} -4 -6 -8))`, `color(${resultColorSpace} -3 -4.5 -6)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} -2 -3 -4 / -5), color(${colorSpace} -4 -6 -8 / -10))`, `color(${resultColorSpace} 0 0 0 / 0)`);
+
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} none none none), color(${colorSpace} none none none))`, `color(${resultColorSpace} none none none)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} none none none), color(${colorSpace} .5 .6 .7))`, `color(${resultColorSpace} 0.5 0.6 0.7)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3), color(${colorSpace} none none none))`, `color(${resultColorSpace} 0.1 0.2 0.3)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 none), color(${colorSpace} .5 .6 .7))`, `color(${resultColorSpace} 0.3 0.4 0.7)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3), color(${colorSpace} .5 .6 none))`, `color(${resultColorSpace} 0.3 0.4 0.3)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} none .2 .3), color(${colorSpace} .5 none .7))`, `color(${resultColorSpace} 0.5 0.2 0.5)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / none), color(${colorSpace} .5 .6 .7))`, `color(${resultColorSpace} 0.3 0.4 0.5)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / none), color(${colorSpace} .5 .6 .7 / 0.5))`, `color(${resultColorSpace} 0.3 0.4 0.5 / 0.5)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / none), color(${colorSpace} .5 .6 .7 / none))`, `color(${resultColorSpace} 0.3 0.4 0.5 / none)`);
     }
 </script>
 </body>

--- a/css/css-color/parsing/color-valid.html
+++ b/css/css-color/parsing/color-valid.html
@@ -29,26 +29,97 @@ test_valid_value("color", "rgb(100, 200, 300)", "rgb(100, 200, 255)");
 test_valid_value("color", "rgb(20, 10, 0, -10)", "rgba(20, 10, 0, 0)");
 test_valid_value("color", "rgb(100%, 200%, 300%)", "rgb(255, 255, 255)");
 
+test_valid_value("color", "rgb(none none none)", "rgb(0, 0, 0)");
+test_valid_value("color", "rgb(none none none / none)", "rgba(0, 0, 0, 0)");
+test_valid_value("color", "rgb(128 none none)", "rgb(128, 0, 0)");
+test_valid_value("color", "rgb(128 none none / none)", "rgba(128, 0, 0, 0)");
+test_valid_value("color", "rgb(none none none / .5)", "rgba(0, 0, 0, 0.5)");
+test_valid_value("color", "rgb(20% none none)", "rgb(51, 0, 0)");
+test_valid_value("color", "rgb(20% none none / none)", "rgba(51, 0, 0, 0)");
+test_valid_value("color", "rgb(none none none / 50%)", "rgba(0, 0, 0, 0.5)");
+test_valid_value("color", "rgba(none none none)", "rgb(0, 0, 0)");
+test_valid_value("color", "rgba(none none none / none)", "rgba(0, 0, 0, 0)");
+test_valid_value("color", "rgba(128 none none)", "rgb(128, 0, 0)");
+test_valid_value("color", "rgba(128 none none / none)", "rgba(128, 0, 0, 0)");
+test_valid_value("color", "rgba(none none none / .5)", "rgba(0, 0, 0, 0.5)");
+test_valid_value("color", "rgba(20% none none)", "rgb(51, 0, 0)");
+test_valid_value("color", "rgba(20% none none / none)", "rgba(51, 0, 0, 0)");
+test_valid_value("color", "rgba(none none none / 50%)", "rgba(0, 0, 0, 0.5)");
+
+test_valid_value("color", "hsl(120 30% 50%)", "rgb(89, 166, 89)");
+test_valid_value("color", "hsl(120 30% 50% / 0.5)", "rgba(89, 166, 89, 0.5)");
+test_valid_value("color", "hsl(none none none)", "rgb(0, 0, 0)");
+test_valid_value("color", "hsl(0 0% 0%)", "rgb(0, 0, 0)");
+test_valid_value("color", "hsl(none none none / none)", "rgba(0, 0, 0, 0)");
+test_valid_value("color", "hsl(0 0% 0% / 0)", "rgba(0, 0, 0, 0)");
+test_valid_value("color", "hsla(none none none)", "rgb(0, 0, 0)");
+test_valid_value("color", "hsla(0 0% 0%)", "rgb(0, 0, 0)");
+test_valid_value("color", "hsla(none none none / none)", "rgba(0, 0, 0, 0)");
+test_valid_value("color", "hsla(0 0% 0% / 0)", "rgba(0, 0, 0, 0)");
+test_valid_value("color", "hsl(120 none none)", "rgb(0, 0, 0)");
+test_valid_value("color", "hsl(120 0% 0%)", "rgb(0, 0, 0)");
+test_valid_value("color", "hsl(120 80% none)", "rgb(0, 0, 0)");
+test_valid_value("color", "hsl(120 80% 0%)", "rgb(0, 0, 0)");
+test_valid_value("color", "hsl(120 none 50%)", "rgb(128, 128, 128)");
+test_valid_value("color", "hsl(120 0% 50%)", "rgb(128, 128, 128)");
+test_valid_value("color", "hsl(120 100% 50% / none)", "rgba(0, 255, 0, 0)");
+test_valid_value("color", "hsl(120 100% 50% / 0)", "rgba(0, 255, 0, 0)");
+test_valid_value("color", "hsl(none 100% 50%)", "rgb(255, 0, 0)");
+test_valid_value("color", "hsl(0 100% 50%)", "rgb(255, 0, 0)");
+
+test_valid_value("color", "hwb(120 30% 50%)", "rgb(77, 128, 77)");
+test_valid_value("color", "hwb(120 30% 50% / 0.5)", "rgba(77, 128, 77, 0.5)");
+test_valid_value("color", "hwb(none none none)", "rgb(255, 0, 0)");
+test_valid_value("color", "hwb(0 0% 0%)", "rgb(255, 0, 0)");
+test_valid_value("color", "hwb(none none none / none)", "rgba(255, 0, 0, 0)");
+test_valid_value("color", "hwb(0 0% 0% / 0)", "rgba(255, 0, 0, 0)");
+test_valid_value("color", "hwb(120 none none)", "rgb(0, 255, 0)");
+test_valid_value("color", "hwb(120 0% 0%)", "rgb(0, 255, 0)");
+test_valid_value("color", "hwb(120 80% none)", "rgb(204, 255, 204)");
+test_valid_value("color", "hwb(120 80% 0%)", "rgb(204, 255, 204)");
+test_valid_value("color", "hwb(120 none 50%)", "rgb(0, 128, 0)");
+test_valid_value("color", "hwb(120 0% 50%)", "rgb(0, 128, 0)");
+test_valid_value("color", "hwb(120 30% 50% / none)", "rgba(77, 128, 77, 0)");
+test_valid_value("color", "hwb(120 30% 50% / 0)", "rgba(77, 128, 77, 0)");
+test_valid_value("color", "hwb(none 100% 50% / none)", "rgba(170, 170, 170, 0)");
+test_valid_value("color", "hwb(0 100% 50% / 0)", "rgba(170, 170, 170, 0)");
+
+
 for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb" ]) {
     test_valid_value("color", `color(${colorSpace} 0% 0% 0%)`, `color(${colorSpace} 0 0 0)`);
     test_valid_value("color", `color(${colorSpace} 10% 10% 10%)`, `color(${colorSpace} 0.1 0.1 0.1)`);
     test_valid_value("color", `color(${colorSpace} .2 .2 25%)`, `color(${colorSpace} 0.2 0.2 0.25)`);
     test_valid_value("color", `color(${colorSpace} 0 0 0 / 1)`, `color(${colorSpace} 0 0 0)`);
     test_valid_value("color", `color(${colorSpace} 0% 0 0 / 0.5)`, `color(${colorSpace} 0 0 0 / 0.5)`);
-    test_valid_value("color", `color(${colorSpace} 20% 0 10/0.5)`, `color(${colorSpace} 0.2 0 1 / 0.5)`);
-    test_valid_value("color", `color(${colorSpace} 20% 0 10/50%)`, `color(${colorSpace} 0.2 0 1 / 0.5)`);
-    test_valid_value("color", `color(${colorSpace} 400% 0 10/50%)`, `color(${colorSpace} 1 0 1 / 0.5)`);
-    test_valid_value("color", `color(${colorSpace} 50% -160 160)`, `color(${colorSpace} 0.5 0 1)`);
-    test_valid_value("color", `color(${colorSpace} 50% -200 200)`, `color(${colorSpace} 0.5 0 1)`);
+    test_valid_value("color", `color(${colorSpace} 20% 0 10/0.5)`, `color(${colorSpace} 0.2 0 10 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} 20% 0 10/50%)`, `color(${colorSpace} 0.2 0 10 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} 400% 0 10/50%)`, `color(${colorSpace} 4 0 10 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} 50% -160 160)`, `color(${colorSpace} 0.5 -160 160)`);
+    test_valid_value("color", `color(${colorSpace} 50% -200 200)`, `color(${colorSpace} 0.5 -200 200)`);
     test_valid_value("color", `color(${colorSpace} 0 0 0 / -10%)`, `color(${colorSpace} 0 0 0 / 0)`);
     test_valid_value("color", `color(${colorSpace} 0 0 0 / 110%)`, `color(${colorSpace} 0 0 0)`);
     test_valid_value("color", `color(${colorSpace} 0 0 0 / 300%)`, `color(${colorSpace} 0 0 0)`);
-    test_valid_value("color", `color(${colorSpace} 50% -200)`, `color(${colorSpace} 0.5 0 0)`);
+    test_valid_value("color", `color(${colorSpace} 50% -200)`, `color(${colorSpace} 0.5 -200 0)`);
     test_valid_value("color", `color(${colorSpace} 50%)`, `color(${colorSpace} 0.5 0 0)`);
     test_valid_value("color", `color(${colorSpace})`, `color(${colorSpace} 0 0 0)`);
-    test_valid_value("color", `color(${colorSpace} 50% -200 / 0.5)`, `color(${colorSpace} 0.5 0 0 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} 50% -200 / 0.5)`, `color(${colorSpace} 0.5 -200 0 / 0.5)`);
     test_valid_value("color", `color(${colorSpace} 50% / 0.5)`, `color(${colorSpace} 0.5 0 0 / 0.5)`);
     test_valid_value("color", `color(${colorSpace} / 0.5)`, `color(${colorSpace} 0 0 0 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} 200 200 200)`, `color(${colorSpace} 200 200 200)`);
+    test_valid_value("color", `color(${colorSpace} 200 200 200 / 200)`, `color(${colorSpace} 200 200 200)`);
+    test_valid_value("color", `color(${colorSpace} -200 -200 -200)`, `color(${colorSpace} -200 -200 -200)`);
+    test_valid_value("color", `color(${colorSpace} -200 -200 -200 / -200)`, `color(${colorSpace} -200 -200 -200 / 0)`);
+    test_valid_value("color", `color(${colorSpace} 200% 200% 200%)`, `color(${colorSpace} 2 2 2)`);
+    test_valid_value("color", `color(${colorSpace} 200% 200% 200% / 200%)`, `color(${colorSpace} 2 2 2)`);
+    test_valid_value("color", `color(${colorSpace} -200% -200% -200% / -200%)`, `color(${colorSpace} -2 -2 -2 / 0)`);
+    test_valid_value("color", `color(${colorSpace} calc(0.5 + 1) calc(0.5 - 1) calc(0.5) / calc(-0.5 + 1))`, `color(${colorSpace} 1.5 -0.5 0.5 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} calc(50% * 3) calc(-150% / 3) calc(50%) / calc(-50% * 3))`, `color(${colorSpace} 1.5 -0.5 0.5 / 0)`);
+
+    test_valid_value("color", `color(${colorSpace} none none none / none)`, `color(${colorSpace} none none none / none)`);
+    test_valid_value("color", `color(${colorSpace} none none none)`, `color(${colorSpace} none none none)`);
+    test_valid_value("color", `color(${colorSpace} 10% none none / none)`, `color(${colorSpace} 0.1 none none / none)`);
+    test_valid_value("color", `color(${colorSpace} none none none / 0.5)`, `color(${colorSpace} none none none / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} 0 0 0 / none)`, `color(${colorSpace} 0 0 0 / none)`);
 }
 
 for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
@@ -74,6 +145,13 @@ for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
     test_valid_value("color", `color(${colorSpace} 1 1 / .5)`, `color(${resultColorSpace} 1 1 0 / 0.5)`);
     test_valid_value("color", `color(${colorSpace} 1 / 0.5)`, `color(${resultColorSpace} 1 0 0 / 0.5)`);
     test_valid_value("color", `color(${colorSpace} / 50%)`, `color(${resultColorSpace} 0 0 0 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} calc(0.5 + 1) calc(0.5 - 1) calc(0.5) / calc(-0.5 + 1))`, `color(${resultColorSpace} 1.5 -0.5 0.5 / 0.5)`);
+
+    test_valid_value("color", `color(${colorSpace} none none none / none)`, `color(${resultColorSpace} none none none / none)`);
+    test_valid_value("color", `color(${colorSpace} none none none)`, `color(${resultColorSpace} none none none)`);
+    test_valid_value("color", `color(${colorSpace} 0.2 none none / none)`, `color(${resultColorSpace} 0.2 none none / none)`);
+    test_valid_value("color", `color(${colorSpace} none none none / 0.5)`, `color(${resultColorSpace} none none none / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} 0 0 0 / none)`, `color(${resultColorSpace} 0 0 0 / none)`);
 }
 
 for (const colorSpace of [ "lab", "oklab" ]) {
@@ -91,6 +169,14 @@ for (const colorSpace of [ "lab", "oklab" ]) {
     test_valid_value("color", `${colorSpace}(-40% 0 0)`, `${colorSpace}(0% 0 0)`);
     test_valid_value("color", `${colorSpace}(50% -20 0)`, `${colorSpace}(50% -20 0)`);
     test_valid_value("color", `${colorSpace}(50% 0 -20)`, `${colorSpace}(50% 0 -20)`);
+    test_valid_value("color", `${colorSpace}(calc(50% * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))`, `${colorSpace}(150% -0.5 1.5 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(calc(-50% * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))`, `${colorSpace}(0% 1.5 -1.5 / 0)`);
+
+    test_valid_value("color", `${colorSpace}(none none none / none)`, `${colorSpace}(none none none / none)`);
+    test_valid_value("color", `${colorSpace}(none none none)`, `${colorSpace}(none none none)`);
+    test_valid_value("color", `${colorSpace}(20% none none / none)`, `${colorSpace}(20% none none / none)`);
+    test_valid_value("color", `${colorSpace}(none none none / 0.5)`, `${colorSpace}(none none none / 0.5)`);
+    test_valid_value("color", `${colorSpace}(0% 0 0 / none)`, `${colorSpace}(0% 0 0 / none)`);
 }
 
 for (const colorSpace of [ "lch", "oklch" ]) {
@@ -112,6 +198,14 @@ for (const colorSpace of [ "lch", "oklch" ]) {
     test_valid_value("color", `${colorSpace}(0% 0 0 / 0.5)`, `${colorSpace}(0% 0 0 / 0.5)`);
     test_valid_value("color", `${colorSpace}(10% 20 20 / 110%)`, `${colorSpace}(10% 20 20)`);
     test_valid_value("color", `${colorSpace}(10% 20 -700)`, `${colorSpace}(10% 20 20)`);
+    test_valid_value("color", `${colorSpace}(calc(50% * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))`, `${colorSpace}(150% 0 40 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(calc(-50% * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))`, `${colorSpace}(0% 1.5 320 / 0)`);
+
+    test_valid_value("color", `${colorSpace}(none none none / none)`, `${colorSpace}(none none none / none)`);
+    test_valid_value("color", `${colorSpace}(none none none)`, `${colorSpace}(none none none)`);
+    test_valid_value("color", `${colorSpace}(20% none none / none)`, `${colorSpace}(20% none none / none)`);
+    test_valid_value("color", `${colorSpace}(none none none / 0.5)`, `${colorSpace}(none none none / 0.5)`);
+    test_valid_value("color", `${colorSpace}(0% 0 0 / none)`, `${colorSpace}(0% 0 0 / none)`);
 }
 </script>
 </body>

--- a/css/css-color/parsing/relative-color-computed.html
+++ b/css/css-color/parsing/relative-color-computed.html
@@ -33,8 +33,16 @@
     // Test nesting relative colors.
     test_computed_value(`color`, `rgb(from rgb(from rebeccapurple r g b) r g b)`, `rgb(102, 51, 153)`);
 
-    // Testing non-sRGB origin colors to see gamut clipping.
-    test_computed_value(`color`, `rgb(from color(display-p3 0 1 0) r g b / alpha)`, `rgb(0, 255, 0)`);
+    // Testing non-sRGB origin colors to see gamut mapping.
+    test_computed_value(`color`, `rgb(from color(display-p3 0 1 0) r g b / alpha)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
+    test_computed_value(`color`, `rgb(from lab(100% 104.3 -50.9) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_computed_value(`color`, `rgb(from lab(0% 104.3 -50.9) r g b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_computed_value(`color`, `rgb(from lch(100% 116 334) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_computed_value(`color`, `rgb(from lch(0% 116 334) r g b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_computed_value(`color`, `rgb(from oklab(100% 0.365 -0.16) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+    test_computed_value(`color`, `rgb(from oklab(0% 0.365 -0.16) r g b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+    test_computed_value(`color`, `rgb(from oklch(100% 0.399 336.3) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+    test_computed_value(`color`, `rgb(from oklch(0% 0.399 336.3) r g b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
 
     // Testing replacement with 0.
     test_computed_value(`color`, `rgb(from rebeccapurple 0 0 0)`, `rgb(0, 0, 0)`);
@@ -105,6 +113,20 @@
     test_computed_value(`color`, `rgb(from rebeccapurple r calc(b * .5 - g * .5) 10)`, `rgb(102, 51, 10)`);
     test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) calc(r) calc(g) calc(b) / calc(alpha))`, `rgba(51, 102, 153, 0.8)`);
 
+    // Testing with 'none'.
+    // NOTE: Serialization of rgb() with 'none' components is still under discussion - https://github.com/w3c/csswg-drafts/issues/6959
+    test_computed_value(`color`, `rgb(from rebeccapurple none none none)`,                         `rgb(0, 0, 0)`);
+    test_computed_value(`color`, `rgb(from rebeccapurple none none none / none)`,                  `rgba(0, 0, 0, 0)`);
+    test_computed_value(`color`, `rgb(from rebeccapurple r g none)`,                               `rgb(102, 51, 0)`);
+    test_computed_value(`color`, `rgb(from rebeccapurple r g none / alpha)`,                       `rgb(102, 51, 0)`);
+    test_computed_value(`color`, `rgb(from rebeccapurple r g b / none)`,                           `rgba(102, 51, 153, 0)`);
+    test_computed_value(`color`, `rgb(from rgb(20% 40% 60% / 80%) r g none / alpha)`,              `rgba(51, 102, 0, 0.8)`);
+    test_computed_value(`color`, `rgb(from rgb(20% 40% 60% / 80%) r g b / none)`,                  `rgba(51, 102, 153, 0)`);
+    // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+    test_computed_value(`color`, `rgb(from rgb(none none none) r g b)`,                            `rgb(0, 0, 0)`);
+    test_computed_value(`color`, `rgb(from rgb(none none none / none) r g b / alpha)`,             `rgba(0, 0, 0, 0)`);
+    test_computed_value(`color`, `rgb(from rgb(20% none 60%) r g b)`,                              `rgb(51, 0, 153)`);
+    test_computed_value(`color`, `rgb(from rgb(20% 40% 60% / none) r g b / alpha)`,                `rgba(51, 102, 153, 0)`);
 
     // hsl(from ...)
 
@@ -117,8 +139,16 @@
     // Test nesting relative colors.
     test_computed_value(`color`, `hsl(from hsl(from rebeccapurple h s l) h s l)`, `rgb(102, 51, 153)`);
 
-    // Testing non-sRGB origin colors to see gamut clipping.
-    test_computed_value(`color`, `hsl(from color(display-p3 0 1 0) h s l / alpha)`, `rgb(0, 255, 0)`);
+    // Testing non-sRGB origin colors to see gamut mapping.
+    test_computed_value(`color`, `hsl(from color(display-p3 0 1 0) h s l / alpha)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
+    test_computed_value(`color`, `hsl(from lab(100% 104.3 -50.9) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_computed_value(`color`, `hsl(from lab(0% 104.3 -50.9) h s l)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_computed_value(`color`, `hsl(from lch(100% 116 334) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_computed_value(`color`, `hsl(from lch(0% 116 334) h s l)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_computed_value(`color`, `hsl(from oklab(100% 0.365 -0.16) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+    test_computed_value(`color`, `hsl(from oklab(0% 0.365 -0.16) h s l)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+    test_computed_value(`color`, `hsl(from oklch(100% 0.399 336.3) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+    test_computed_value(`color`, `hsl(from oklch(0% 0.399 336.3) h s l)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
 
     // Testing replacement with 0.
     test_computed_value(`color`, `hsl(from rebeccapurple 0 0% 0%)`, `rgb(0, 0, 0)`);
@@ -162,6 +192,22 @@
     test_computed_value(`color`, `hsl(from rebeccapurple calc(h) calc(s) calc(l))`, `rgb(102, 51, 153)`);
     test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) calc(h) calc(s) calc(l) / calc(alpha))`, `rgba(51, 102, 153, 0.8)`);
 
+    // Testing with 'none'.
+    test_computed_value(`color`, `hsl(from rebeccapurple none none none)`,                         `rgb(0, 0, 0)`);
+    test_computed_value(`color`, `hsl(from rebeccapurple none none none / none)`,                  `rgba(0, 0, 0, 0)`);
+    test_computed_value(`color`, `hsl(from rebeccapurple h s none)`,                               `rgb(0, 0, 0)`);
+    test_computed_value(`color`, `hsl(from rebeccapurple h s none / alpha)`,                       `rgb(0, 0, 0)`);
+    test_computed_value(`color`, `hsl(from rebeccapurple h s l / none)`,                           `rgba(102, 51, 153, 0)`);
+    test_computed_value(`color`, `hsl(from rebeccapurple none s l / alpha)`,                       `rgb(153, 51, 51)`);
+    test_computed_value(`color`, `hsl(from hsl(120deg 20% 50% / .5) h s none / alpha)`,            `rgba(0, 0, 0, 0.5)`);
+    test_computed_value(`color`, `hsl(from hsl(120deg 20% 50% / .5) h s l / none)`,                `rgba(102, 153, 102, 0)`);
+    test_computed_value(`color`, `hsl(from hsl(120deg 20% 50% / .5) none s l / alpha)`,            `rgba(153, 102, 102, 0.5)`);
+    // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+    test_computed_value(`color`, `hsl(from hsl(none none none) h s l)`,                            `rgb(0, 0, 0)`);
+    test_computed_value(`color`, `hsl(from hsl(none none none / none) h s l / alpha)`,             `rgba(0, 0, 0, 0)`);
+    test_computed_value(`color`, `hsl(from hsl(120deg none 50% / .5) h s l)`,                      `rgb(128, 128, 128)`);
+    test_computed_value(`color`, `hsl(from hsl(120deg 20% 50% / none) h s l / alpha)`,             `rgba(102, 153, 102, 0)`);
+    test_computed_value(`color`, `hsl(from hsl(none 20% 50% / .5) h s l / alpha)`,                 `rgba(153, 102, 102, 0.5)`);
 
     // hwb(from ...)
 
@@ -174,8 +220,16 @@
     // Test nesting relative colors.
     test_computed_value(`color`, `hwb(from hwb(from rebeccapurple h w b) h w b)`, `rgb(102, 51, 153)`);
 
-    // Testing non-sRGB origin colors to see gamut clipping.
-    test_computed_value(`color`, `hwb(from color(display-p3 0 1 0) h w b / alpha)`, `rgb(0, 255, 0)`);
+    // Testing non-sRGB origin colors to see gamut mapping.
+    test_computed_value(`color`, `hwb(from color(display-p3 0 1 0) h w b / alpha)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
+    test_computed_value(`color`, `hwb(from lab(100% 104.3 -50.9) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_computed_value(`color`, `hwb(from lab(0% 104.3 -50.9) h w b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_computed_value(`color`, `hwb(from lch(100% 116 334) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_computed_value(`color`, `hwb(from lch(0% 116 334) h w b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_computed_value(`color`, `hwb(from oklab(100% 0.365 -0.16) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+    test_computed_value(`color`, `hwb(from oklab(0% 0.365 -0.16) h w b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+    test_computed_value(`color`, `hwb(from oklch(100% 0.399 336.3) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+    test_computed_value(`color`, `hwb(from oklch(0% 0.399 336.3) h w b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
 
     // Testing replacement with 0.
     test_computed_value(`color`, `hwb(from rebeccapurple 0 0% 0%)`, `rgb(255, 0, 0)`);
@@ -219,11 +273,30 @@
     test_computed_value(`color`, `hwb(from rebeccapurple calc(h) calc(w) calc(b))`, `rgb(102, 51, 153)`);
     test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) calc(h) calc(w) calc(b) / calc(alpha))`, `rgba(51, 102, 153, 0.8)`);
 
+    // Testing with 'none'.
+    test_computed_value(`color`, `hwb(from rebeccapurple none none none)`,                         `rgb(255, 0, 0)`);
+    test_computed_value(`color`, `hwb(from rebeccapurple none none none / none)`,                  `rgba(255, 0, 0, 0)`);
+    test_computed_value(`color`, `hwb(from rebeccapurple h w none)`,                               `rgb(153, 51, 255)`);
+    test_computed_value(`color`, `hwb(from rebeccapurple h w none / alpha)`,                       `rgb(153, 51, 255)`);
+    test_computed_value(`color`, `hwb(from rebeccapurple h w b / none)`,                           `rgba(102, 51, 153, 0)`);
+    test_computed_value(`color`, `hwb(from rebeccapurple none w b / alpha)`,                       `rgb(153, 51, 51)`);
+    test_computed_value(`color`, `hwb(from hwb(120deg 20% 50% / .5) h w none / alpha)`,            `rgba(51, 255, 51, 0.5)`);
+    test_computed_value(`color`, `hwb(from hwb(120deg 20% 50% / .5) h w b / none)`,                `rgba(51, 128, 51, 0)`);
+    test_computed_value(`color`, `hwb(from hwb(120deg 20% 50% / .5) none w b / alpha)`,            `rgba(128, 51, 51, 0.5)`);
+    // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+    test_computed_value(`color`, `hwb(from hwb(none none none) h w b)`,                            `rgb(255, 0, 0)`);
+    test_computed_value(`color`, `hwb(from hwb(none none none / none) h w b / alpha)`,             `rgba(255, 0, 0, 0)`);
+    test_computed_value(`color`, `hwb(from hwb(120deg none 50% / .5) h w b)`,                      `rgb(0, 128, 0)`);
+    test_computed_value(`color`, `hwb(from hwb(120deg 20% 50% / none) h w b / alpha)`,             `rgba(51, 128, 51, 0)`);
+    test_computed_value(`color`, `hwb(from hwb(none 20% 50% / .5) h w b / alpha)`,                 `rgba(128, 51, 51, 0.5)`);
+
     for (const colorSpace of [ "lab", "oklab" ]) {
         // Testing no modifications.
         test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a b)`, `${colorSpace}(25% 20 50)`);
         test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a b / alpha)`, `${colorSpace}(25% 20 50)`);
         test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a b / alpha)`, `${colorSpace}(25% 20 50 / 0.4)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(200% 300 400 / 500%) l a b / alpha)`, `${colorSpace}(200% 300 400)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(-200% -300 -400 / -500%) l a b / alpha)`, `${colorSpace}(0% -300 -400 / 0)`);
 
         // Test nesting relative colors.
         test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(from ${colorSpace}(25% 20 50) l a b) l a b)`, `${colorSpace}(25% 20 50)`);
@@ -252,6 +325,8 @@
         test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l 35 b / alpha)`, `${colorSpace}(25% 35 50 / 0.4)`);
         test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a 35 / alpha)`, `${colorSpace}(25% 20 35 / 0.4)`);
         test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a b / .35)`, `${colorSpace}(25% 20 50 / 0.35)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 200% 300 400 / 500)`, `${colorSpace}(200% 300 400)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) -200% -300 -400 / -500)`, `${colorSpace}(0% -300 -400 / 0)`);
 
         // Testing valid permutation (types match).
         test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l b a)`, `${colorSpace}(25% 50 20)`);
@@ -262,6 +337,20 @@
         // Testing with calc().
         test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) calc(l) calc(a) calc(b))`, `${colorSpace}(25% 20 50)`);
         test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) calc(l) calc(a) calc(b) / calc(alpha))`, `${colorSpace}(25% 20 50 / 0.4)`);
+
+        // Testing with 'none'.
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) none none none)`, `${colorSpace}(none none none)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) none none none / none)`, `${colorSpace}(none none none / none)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a none)`, `${colorSpace}(25% 20 none)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a none / alpha)`, `${colorSpace}(25% 20 none)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a b / none)`, `${colorSpace}(25% 20 50 / none)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a none / alpha)`, `${colorSpace}(25% 20 none / 0.4)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a b / none)`, `${colorSpace}(25% 20 50 / none)`);
+        // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(none none none) l a b)`, `${colorSpace}(0% 0 0)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(none none none / none) l a b / alpha)`, `${colorSpace}(0% 0 0 / 0)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% none 50) l a b)`, `${colorSpace}(25% 0 50)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / none) l a b / alpha)`, `${colorSpace}(25% 20 50 / 0)`);
     }
 
     for (const colorSpace of [ "lch", "oklch" ]) {
@@ -270,12 +359,14 @@
         // Testing no modifications.
         test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c h)`, `${colorSpace}(70% 45 30)`);
         test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c h / alpha)`, `${colorSpace}(70% 45 30)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c h/ alpha)`, `${colorSpace}(70% 45 30 / 0.4)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c h / alpha)`, `${colorSpace}(70% 45 30 / 0.4)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(200% 300 400 / 500%) l c h / alpha)`, `${colorSpace}(200% 300 40)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(-200% -300 -400 / -500%) l c h / alpha)`, `${colorSpace}(0% 0 320 / 0)`);
 
         // Test nesting relative colors.
         test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(from ${colorSpace}(70% 45 30) l c h) l c h)`, `${colorSpace}(70% 45 30)`);
 
-        // Testing non-sRGB origin colors to see gamut clipping.
+        // Testing non-sRGB origin colors (no gamut mapping will happen since the destination is not a bounded RGB color space).
         test_computed_value(`color`, `${colorSpace}(from color(display-p3 0 0 0) l c h / alpha)`, `${colorSpace}(0% 0 0)`);
         test_computed_value(`color`, `${colorSpace}(from ${rectangularForm}(70% 45 30) l c h / alpha)`, `${colorSpace}(70% 54.08327 33.690067)`);
 
@@ -306,6 +397,10 @@
         test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c 25 / alpha)`, `${colorSpace}(70% 45 25 / 0.4)`);
         test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c 25deg / alpha)`, `${colorSpace}(70% 45 25 / 0.4)`);
         test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c h / .25)`, `${colorSpace}(70% 45 30 / 0.25)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 200% 300 400 / 500)`, `${colorSpace}(200% 300 40)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) -200% -300 -400 / -500)`, `${colorSpace}(0% 0 320 / 0)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 50% 120 400deg / 500)`, `${colorSpace}(50% 120 40)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 50% 120 -400deg / -500)`, `${colorSpace}(50% 120 320 / 0)`);
 
         // Testing valid permutation (types match).
         // NOTE: 'c' is a vaild hue, as hue is <angle>|<number>.
@@ -321,6 +416,20 @@
         // Testing with calc().
         test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) calc(l) calc(c) calc(h))`, `${colorSpace}(70% 45 30)`);
         test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) calc(l) calc(c) calc(h) / calc(alpha))`, `${colorSpace}(70% 45 30 / 0.4)`);
+
+        // Testing with 'none'.
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) none none none)`,                                   `${colorSpace}(none none none)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) none none none / none)`,                            `${colorSpace}(none none none / none)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c none)`,                                         `${colorSpace}(70% 45 none)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c none / alpha)`,                                 `${colorSpace}(70% 45 none)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c h / none)`,                                     `${colorSpace}(70% 45 30 / none)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c none / alpha)`,                           `${colorSpace}(70% 45 none / 0.4)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c h / none)`,                               `${colorSpace}(70% 45 30 / none)`);
+        // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(none none none) l c h)`,                                       `${colorSpace}(0% 0 0)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(none none none / none) l c h / alpha)`,                        `${colorSpace}(0% 0 0 / 0)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% none 30) l c h)`,                                          `${colorSpace}(70% 0 30)`);
+        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / none) l c h / alpha)`,                             `${colorSpace}(70% 45 30 / 0)`);
     }
 
     for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb" ]) {
@@ -362,6 +471,14 @@
         test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g 20% / alpha)`,              `color(${colorSpace} 0.7 0.5 0.2 / 0.4)`);
         test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g b / 0.2)`,                  `color(${colorSpace} 0.7 0.5 0.3 / 0.2)`);
         test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g b / 20%)`,                  `color(${colorSpace} 0.7 0.5 0.3 / 0.2)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 2 3 4)`,                              `color(${colorSpace} 2 3 4)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 2 3 4 / 5)`,                          `color(${colorSpace} 2 3 4)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} -2 -3 -4)`,                           `color(${colorSpace} -2 -3 -4)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} -2 -3 -4 / -5)`,                      `color(${colorSpace} -2 -3 -4 / 0)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 200% 300% 400%)`,                     `color(${colorSpace} 2 3 4)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 200% 300% 400% / 500%)`,              `color(${colorSpace} 2 3 4)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} -200% -300% -400%)`,                  `color(${colorSpace} -2 -3 -4)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} -200% -300% -400% / -500%)`,          `color(${colorSpace} -2 -3 -4 / 0)`);
 
         // Testing valid permutation (types match).
         test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} g b r)`,                              `color(${colorSpace} 0.5 0.3 0.7)`);
@@ -373,9 +490,33 @@
         test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r r r / r)`,                    `color(${colorSpace} 0.7 0.7 0.7 / 0.7)`);
         test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} alpha alpha alpha / alpha)`,    `color(${colorSpace} 0.4 0.4 0.4 / 0.4)`);
 
+        // Testing out of gamut components.
+        test_computed_value(`color`, `color(from color(${colorSpace} 1.7 1.5 1.3) ${colorSpace} r g b)`,                              `color(${colorSpace} 1.7 1.5 1.3)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 1.7 1.5 1.3) ${colorSpace} r g b / alpha)`,                      `color(${colorSpace} 1.7 1.5 1.3)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 1.7 1.5 1.3 / 140%) ${colorSpace} r g b)`,                       `color(${colorSpace} 1.7 1.5 1.3)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 1.7 1.5 1.3 / 140%) ${colorSpace} r g b / alpha)`,               `color(${colorSpace} 1.7 1.5 1.3)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} -0.7 -0.5 -0.3) ${colorSpace} r g b)`,                           `color(${colorSpace} -0.7 -0.5 -0.3)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} -0.7 -0.5 -0.3) ${colorSpace} r g b / alpha)`,                   `color(${colorSpace} -0.7 -0.5 -0.3)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} -0.7 -0.5 -0.3 / -40%) ${colorSpace} r g b)`,                    `color(${colorSpace} -0.7 -0.5 -0.3)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} -0.7 -0.5 -0.3 / -40%) ${colorSpace} r g b / alpha)`,            `color(${colorSpace} -0.7 -0.5 -0.3 / 0)`);
+
         // Testing with calc().
         test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} calc(r) calc(g) calc(b))`,                        `color(${colorSpace} 0.7 0.5 0.3)`);
         test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} calc(r) calc(g) calc(b) / calc(alpha))`,    `color(${colorSpace} 0.7 0.5 0.3 / 0.4)`);
+
+        // Testing with 'none'.
+        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} none none none)`,                     `color(${colorSpace} none none none)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} none none none / none)`,              `color(${colorSpace} none none none / none)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g none)`,                           `color(${colorSpace} 0.7 0.5 none)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g none / alpha)`,                   `color(${colorSpace} 0.7 0.5 none)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b / none)`,                       `color(${colorSpace} 0.7 0.5 0.3 / none)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g none / alpha)`,             `color(${colorSpace} 0.7 0.5 none / 0.4)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g b / none)`,                 `color(${colorSpace} 0.7 0.5 0.3 / none)`);
+        // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+        test_computed_value(`color`, `color(from color(${colorSpace} none none none) ${colorSpace} r g b)`,                           `color(${colorSpace} 0 0 0)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} none none none / none) ${colorSpace} r g b / alpha)`,            `color(${colorSpace} 0 0 0 / 0)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 none 0.3) ${colorSpace} r g b)`,                             `color(${colorSpace} 0.7 0 0.3)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / none) ${colorSpace} r g b / alpha)`,               `color(${colorSpace} 0.7 0.5 0.3 / 0)`);
     }
 
     for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
@@ -422,6 +563,20 @@
         // Testing with calc().
         test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} calc(x) calc(y) calc(z))`,                        `color(${resultColorSpace} 7 -20.5 100)`);
         test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} calc(x) calc(y) calc(z) / calc(alpha))`,    `color(${resultColorSpace} 7 -20.5 100 / 0.4)`);
+
+        // Testing with 'none'.
+        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} none none none)`,                     `color(${resultColorSpace} none none none)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} none none none / none)`,              `color(${resultColorSpace} none none none / none)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y none)`,                           `color(${resultColorSpace} 7 -20.5 none)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y none / alpha)`,                   `color(${resultColorSpace} 7 -20.5 none)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y z / none)`,                       `color(${resultColorSpace} 7 -20.5 100 / none)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y none / alpha)`,             `color(${resultColorSpace} 7 -20.5 none / 0.4)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y z / none)`,                 `color(${resultColorSpace} 7 -20.5 100 / none)`);
+        // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+        test_computed_value(`color`, `color(from color(${colorSpace} none none none) ${colorSpace} x y z)`,                           `color(${resultColorSpace} 0 0 0)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} none none none / none) ${colorSpace} x y z / alpha)`,            `color(${resultColorSpace} 0 0 0 / 0)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 7 none 100) ${colorSpace} x y z)`,                               `color(${resultColorSpace} 7 0 100)`);
+        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / none) ${colorSpace} x y z / alpha)`,               `color(${resultColorSpace} 7 -20.5 100 / 0)`);
     }
 
     // Spec Examples

--- a/css/css-color/parsing/relative-color-invalid.html
+++ b/css/css-color/parsing/relative-color-invalid.html
@@ -27,6 +27,10 @@
     test_invalid_value(`color`, `rgb(from rebeccapurple l g b)`);
     test_invalid_value(`color`, `rgb(from rebeccapurple h g b)`);
 
+    // Testing invalid function name variation (only rgb() is valid, rgba() is invalid)
+    test_invalid_value(`color`, `rgba(from rebeccapurple r g b)`);
+    test_invalid_value(`color`, `rgba(from rgb(10%, 20%, 30%, 40%) r g b / alpha)`);
+
 
     // hsl(from ...)
 
@@ -53,6 +57,9 @@
     test_invalid_value(`color`, `hsl(from rebeccapurple x s l)`);
     test_invalid_value(`color`, `hsl(from rebeccapurple h g b)`);
 
+    // Testing invalid function name variation (only hsl() is valid, hsla() is invalid)
+    test_invalid_value(`color`, `hsla(from rebeccapurple h s l)`);
+    test_invalid_value(`color`, `hsla(from rgb(10%, 20%, 30%, 40%) h s l / alpha)`);
 
     // hwb(from ...)
 
@@ -125,34 +132,34 @@
 
     for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb" ]) {
         // Testing invalid values.
-        test_invalid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 10deg g b)`,                          `rgba(0, 0, 0, 0)`);
-        test_invalid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r 10deg b)`,                          `rgba(0, 0, 0, 0)`);
-        test_invalid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g 10deg)`,                          `rgba(0, 0, 0, 0)`);
-        test_invalid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b / 10deg)`,                      `rgba(0, 0, 0, 0)`);
+        test_invalid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 10deg g b)`);
+        test_invalid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r 10deg b)`);
+        test_invalid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g 10deg)`);
+        test_invalid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b / 10deg)`);
 
         // Testing invalid component names
-        test_invalid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} red g b)`,                            `rgba(0, 0, 0, 0)`);
-        test_invalid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} x g b)`,                              `rgba(0, 0, 0, 0)`);
-        test_invalid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} l g b)`,                              `rgba(0, 0, 0, 0)`);
+        test_invalid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} red g b)`);
+        test_invalid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} x g b)`);
+        test_invalid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} l g b)`);
     }
 
     for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
         // Testing invalid permutation (types don't match).
-        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} z alpha x / y)`,                      `rgba(0, 0, 0, 0)`);
-        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} alpha alpha alpha / alpha)`,          `rgba(0, 0, 0, 0)`);
-        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} z alpha x / y)`,                `rgba(0, 0, 0, 0)`);
-        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} alpha alpha alpha / alpha)`,    `rgba(0, 0, 0, 0)`);
+        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} z alpha x / y)`);
+        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} alpha alpha alpha / alpha)`);
+        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} z alpha x / y)`);
+        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} alpha alpha alpha / alpha)`);
 
         // Testing invalid values.
-        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} 10deg y z)`,                          `rgba(0, 0, 0, 0)`);
-        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x 10deg z)`,                          `rgba(0, 0, 0, 0)`);
-        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y 10deg)`,                          `rgba(0, 0, 0, 0)`);
-        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y z / 10deg)`,                      `rgba(0, 0, 0, 0)`);
+        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} 10deg y z)`);
+        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x 10deg z)`);
+        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y 10deg)`);
+        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y z / 10deg)`);
 
         // Testing invalid component names
-        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} red y)`,                              `rgba(0, 0, 0, 0)`);
-        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} r y z)`,                              `rgba(0, 0, 0, 0)`);
-        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} l y z)`,                              `rgba(0, 0, 0, 0)`);
+        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} red y)`);
+        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} r y z)`);
+        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} l y z)`);
     }
 </script>
 </body>

--- a/css/css-color/parsing/relative-color-valid.html
+++ b/css/css-color/parsing/relative-color-valid.html
@@ -32,8 +32,16 @@
     // Test nesting relative colors.
     test_valid_value(`color`, `rgb(from rgb(from rebeccapurple r g b) r g b)`, `rgb(102, 51, 153)`);
 
-    // Testing non-sRGB origin colors to see gamut clipping.
-    test_valid_value(`color`, `rgb(from color(display-p3 0 1 0) r g b / alpha)`, `rgb(0, 255, 0)`);
+    // Testing non-sRGB origin colors to see gamut mapping.
+    test_valid_value(`color`, `rgb(from color(display-p3 0 1 0) r g b / alpha)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
+    test_valid_value(`color`, `rgb(from lab(100% 104.3 -50.9) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `rgb(from lab(0% 104.3 -50.9) r g b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `rgb(from lch(100% 116 334) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `rgb(from lch(0% 116 334) r g b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `rgb(from oklab(100% 0.365 -0.16) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+    test_valid_value(`color`, `rgb(from oklab(0% 0.365 -0.16) r g b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+    test_valid_value(`color`, `rgb(from oklch(100% 0.399 336.3) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+    test_valid_value(`color`, `rgb(from oklch(0% 0.399 336.3) r g b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
 
     // Testing replacement with 0.
     test_valid_value(`color`, `rgb(from rebeccapurple 0 0 0)`, `rgb(0, 0, 0)`);
@@ -104,6 +112,20 @@
     test_valid_value(`color`, `rgb(from rebeccapurple r calc(b * .5 - g * .5) 10)`, `rgb(102, 51, 10)`);
     test_valid_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) calc(r) calc(g) calc(b) / calc(alpha))`, `rgba(51, 102, 153, 0.8)`);
 
+    // Testing with 'none'.
+    test_valid_value(`color`, `rgb(from rebeccapurple none none none)`,                         `rgb(0, 0, 0)`);
+    test_valid_value(`color`, `rgb(from rebeccapurple none none none / none)`,                  `rgba(0, 0, 0, 0)`);
+    test_valid_value(`color`, `rgb(from rebeccapurple r g none)`,                               `rgb(102, 51, 0)`);
+    test_valid_value(`color`, `rgb(from rebeccapurple r g none / alpha)`,                       `rgb(102, 51, 0)`);
+    test_valid_value(`color`, `rgb(from rebeccapurple r g b / none)`,                           `rgba(102, 51, 153, 0)`);
+    test_valid_value(`color`, `rgb(from rgb(20% 40% 60% / 80%) r g none / alpha)`,              `rgba(51, 102, 0, 0.8)`);
+    test_valid_value(`color`, `rgb(from rgb(20% 40% 60% / 80%) r g b / none)`,                  `rgba(51, 102, 153, 0)`);
+    // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+    test_valid_value(`color`, `rgb(from rgb(none none none) r g b)`,                            `rgb(0, 0, 0)`);
+    test_valid_value(`color`, `rgb(from rgb(none none none / none) r g b / alpha)`,             `rgba(0, 0, 0, 0)`);
+    test_valid_value(`color`, `rgb(from rgb(20% none 60%) r g b)`,                              `rgb(51, 0, 153)`);
+    test_valid_value(`color`, `rgb(from rgb(20% 40% 60% / none) r g b / alpha)`,                `rgba(51, 102, 153, 0)`);
+
 
     // hsl(from ...)
 
@@ -116,8 +138,16 @@
     // Test nesting relative colors.
     test_valid_value(`color`, `hsl(from hsl(from rebeccapurple h s l) h s l)`, `rgb(102, 51, 153)`);
 
-    // Testing non-sRGB origin colors to see gamut clipping.
-    test_valid_value(`color`, `hsl(from color(display-p3 0 1 0) h s l / alpha)`, `rgb(0, 255, 0)`);
+    // Testing non-sRGB origin colors to see gamut mapping.
+    test_valid_value(`color`, `hsl(from color(display-p3 0 1 0) h s l / alpha)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
+    test_valid_value(`color`, `hsl(from lab(100% 104.3 -50.9) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `hsl(from lab(0% 104.3 -50.9) h s l)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `hsl(from lch(100% 116 334) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `hsl(from lch(0% 116 334) h s l)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `hsl(from oklab(100% 0.365 -0.16) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+    test_valid_value(`color`, `hsl(from oklab(0% 0.365 -0.16) h s l)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+    test_valid_value(`color`, `hsl(from oklch(100% 0.399 336.3) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+    test_valid_value(`color`, `hsl(from oklch(0% 0.399 336.3) h s l)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
 
     // Testing replacement with 0.
     test_valid_value(`color`, `hsl(from rebeccapurple 0 0% 0%)`, `rgb(0, 0, 0)`);
@@ -161,6 +191,22 @@
     test_valid_value(`color`, `hsl(from rebeccapurple calc(h) calc(s) calc(l))`, `rgb(102, 51, 153)`);
     test_valid_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) calc(h) calc(s) calc(l) / calc(alpha))`, `rgba(51, 102, 153, 0.8)`);
 
+    // Testing with 'none'.
+    test_valid_value(`color`, `hsl(from rebeccapurple none none none)`,                         `rgb(0, 0, 0)`);
+    test_valid_value(`color`, `hsl(from rebeccapurple none none none / none)`,                  `rgba(0, 0, 0, 0)`);
+    test_valid_value(`color`, `hsl(from rebeccapurple h s none)`,                               `rgb(0, 0, 0)`);
+    test_valid_value(`color`, `hsl(from rebeccapurple h s none / alpha)`,                       `rgb(0, 0, 0)`);
+    test_valid_value(`color`, `hsl(from rebeccapurple h s l / none)`,                           `rgba(102, 51, 153, 0)`);
+    test_valid_value(`color`, `hsl(from rebeccapurple none s l / alpha)`,                       `rgb(153, 51, 51)`);
+    test_valid_value(`color`, `hsl(from hsl(120deg 20% 50% / .5) h s none / alpha)`,            `rgba(0, 0, 0, 0.5)`);
+    test_valid_value(`color`, `hsl(from hsl(120deg 20% 50% / .5) h s l / none)`,                `rgba(102, 153, 102, 0)`);
+    test_valid_value(`color`, `hsl(from hsl(120deg 20% 50% / .5) none s l / alpha)`,            `rgba(153, 102, 102, 0.5)`);
+    // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+    test_valid_value(`color`, `hsl(from hsl(none none none) h s l)`,                            `rgb(0, 0, 0)`);
+    test_valid_value(`color`, `hsl(from hsl(none none none / none) h s l / alpha)`,             `rgba(0, 0, 0, 0)`);
+    test_valid_value(`color`, `hsl(from hsl(120deg none 50% / .5) h s l)`,                      `rgb(128, 128, 128)`);
+    test_valid_value(`color`, `hsl(from hsl(120deg 20% 50% / none) h s l / alpha)`,             `rgba(102, 153, 102, 0)`);
+    test_valid_value(`color`, `hsl(from hsl(none 20% 50% / .5) h s l / alpha)`,                 `rgba(153, 102, 102, 0.5)`);
 
     // hwb(from ...)
 
@@ -173,8 +219,16 @@
     // Test nesting relative colors.
     test_valid_value(`color`, `hwb(from hwb(from rebeccapurple h w b) h w b)`, `rgb(102, 51, 153)`);
 
-    // Testing non-sRGB origin colors to see gamut clipping.
-    test_valid_value(`color`, `hwb(from color(display-p3 0 1 0) h w b / alpha)`, `rgb(0, 255, 0)`);
+    // Testing non-sRGB origin colors to see gamut mapping.
+    test_valid_value(`color`, `hwb(from color(display-p3 0 1 0) h w b / alpha)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
+    test_valid_value(`color`, `hwb(from lab(100% 104.3 -50.9) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `hwb(from lab(0% 104.3 -50.9) h w b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `hwb(from lch(100% 116 334) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `hwb(from lch(0% 116 334) h w b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `hwb(from oklab(100% 0.365 -0.16) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+    test_valid_value(`color`, `hwb(from oklab(0% 0.365 -0.16) h w b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+    test_valid_value(`color`, `hwb(from oklch(100% 0.399 336.3) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+    test_valid_value(`color`, `hwb(from oklch(0% 0.399 336.3) h w b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
 
     // Testing replacement with 0.
     test_valid_value(`color`, `hwb(from rebeccapurple 0 0% 0%)`, `rgb(255, 0, 0)`);
@@ -218,11 +272,30 @@
     test_valid_value(`color`, `hwb(from rebeccapurple calc(h) calc(w) calc(b))`, `rgb(102, 51, 153)`);
     test_valid_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) calc(h) calc(w) calc(b) / calc(alpha))`, `rgba(51, 102, 153, 0.8)`);
 
+    // Testing with 'none'.
+    test_valid_value(`color`, `hwb(from rebeccapurple none none none)`,                         `rgb(255, 0, 0)`);
+    test_valid_value(`color`, `hwb(from rebeccapurple none none none / none)`,                  `rgba(255, 0, 0, 0)`);
+    test_valid_value(`color`, `hwb(from rebeccapurple h w none)`,                               `rgb(153, 51, 255)`);
+    test_valid_value(`color`, `hwb(from rebeccapurple h w none / alpha)`,                       `rgb(153, 51, 255)`);
+    test_valid_value(`color`, `hwb(from rebeccapurple h w b / none)`,                           `rgba(102, 51, 153, 0)`);
+    test_valid_value(`color`, `hwb(from rebeccapurple none w b / alpha)`,                       `rgb(153, 51, 51)`);
+    test_valid_value(`color`, `hwb(from hwb(120deg 20% 50% / .5) h w none / alpha)`,            `rgba(51, 255, 51, 0.5)`);
+    test_valid_value(`color`, `hwb(from hwb(120deg 20% 50% / .5) h w b / none)`,                `rgba(51, 128, 51, 0)`);
+    test_valid_value(`color`, `hwb(from hwb(120deg 20% 50% / .5) none w b / alpha)`,            `rgba(128, 51, 51, 0.5)`);
+    // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+    test_valid_value(`color`, `hwb(from hwb(none none none) h w b)`,                            `rgb(255, 0, 0)`);
+    test_valid_value(`color`, `hwb(from hwb(none none none / none) h w b / alpha)`,             `rgba(255, 0, 0, 0)`);
+    test_valid_value(`color`, `hwb(from hwb(120deg none 50% / .5) h w b)`,                      `rgb(0, 128, 0)`);
+    test_valid_value(`color`, `hwb(from hwb(120deg 20% 50% / none) h w b / alpha)`,             `rgba(51, 128, 51, 0)`);
+    test_valid_value(`color`, `hwb(from hwb(none 20% 50% / .5) h w b / alpha)`,                 `rgba(128, 51, 51, 0.5)`);
+
     for (const colorSpace of [ "lab", "oklab" ]) {
         // Testing no modifications.
         test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a b)`, `${colorSpace}(25% 20 50)`);
         test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a b / alpha)`, `${colorSpace}(25% 20 50)`);
         test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a b / alpha)`, `${colorSpace}(25% 20 50 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(200% 300 400 / 500%) l a b / alpha)`, `${colorSpace}(200% 300 400)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(-200% -300 -400 / -500%) l a b / alpha)`, `${colorSpace}(0% -300 -400 / 0)`);
 
         // Test nesting relative colors.
         test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(from ${colorSpace}(25% 20 50) l a b) l a b)`, `${colorSpace}(25% 20 50)`);
@@ -251,6 +324,8 @@
         test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l 35 b / alpha)`, `${colorSpace}(25% 35 50 / 0.4)`);
         test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a 35 / alpha)`, `${colorSpace}(25% 20 35 / 0.4)`);
         test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a b / .35)`, `${colorSpace}(25% 20 50 / 0.35)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 200% 300 400 / 500)`, `${colorSpace}(200% 300 400)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) -200% -300 -400 / -500)`, `${colorSpace}(0% -300 -400 / 0)`);
 
         // Testing valid permutation (types match).
         test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l b a)`, `${colorSpace}(25% 50 20)`);
@@ -261,6 +336,20 @@
         // Testing with calc().
         test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) calc(l) calc(a) calc(b))`, `${colorSpace}(25% 20 50)`);
         test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) calc(l) calc(a) calc(b) / calc(alpha))`, `${colorSpace}(25% 20 50 / 0.4)`);
+
+        // Testing with 'none'.
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) none none none)`, `${colorSpace}(none none none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) none none none / none)`, `${colorSpace}(none none none / none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a none)`, `${colorSpace}(25% 20 none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a none / alpha)`, `${colorSpace}(25% 20 none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a b / none)`, `${colorSpace}(25% 20 50 / none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a none / alpha)`, `${colorSpace}(25% 20 none / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a b / none)`, `${colorSpace}(25% 20 50 / none)`);
+        // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(none none none) l a b)`, `${colorSpace}(0% 0 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(none none none / none) l a b / alpha)`, `${colorSpace}(0% 0 0 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% none 50) l a b)`, `${colorSpace}(25% 0 50)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / none) l a b / alpha)`, `${colorSpace}(25% 20 50 / 0)`);
     }
 
     for (const colorSpace of [ "lch", "oklch" ]) {
@@ -269,12 +358,14 @@
         // Testing no modifications.
         test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c h)`, `${colorSpace}(70% 45 30)`);
         test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c h / alpha)`, `${colorSpace}(70% 45 30)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c h/ alpha)`, `${colorSpace}(70% 45 30 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c h / alpha)`, `${colorSpace}(70% 45 30 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(200% 300 400 / 500%) l c h / alpha)`, `${colorSpace}(200% 300 40)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(-200% -300 -400 / -500%) l c h / alpha)`, `${colorSpace}(0% 0 320 / 0)`);
 
         // Test nesting relative colors.
         test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(from ${colorSpace}(70% 45 30) l c h) l c h)`, `${colorSpace}(70% 45 30)`);
 
-        // Testing non-sRGB origin colors to see gamut clipping.
+        // Testing non-sRGB origin colors (no gamut mapping will happen since the destination is not a bounded RGB color space).
         test_valid_value(`color`, `${colorSpace}(from color(display-p3 0 0 0) l c h / alpha)`, `${colorSpace}(0% 0 0)`);
         test_valid_value(`color`, `${colorSpace}(from ${rectangularForm}(70% 45 30) l c h / alpha)`, `${colorSpace}(70% 54.08327 33.690067)`);
 
@@ -305,6 +396,10 @@
         test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c 25 / alpha)`, `${colorSpace}(70% 45 25 / 0.4)`);
         test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c 25deg / alpha)`, `${colorSpace}(70% 45 25 / 0.4)`);
         test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c h / .25)`, `${colorSpace}(70% 45 30 / 0.25)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 200% 300 400 / 500)`, `${colorSpace}(200% 300 40)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) -200% -300 -400 / -500)`, `${colorSpace}(0% 0 320 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 50% 120 400deg / 500)`, `${colorSpace}(50% 120 40)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 50% 120 -400deg / -500)`, `${colorSpace}(50% 120 320 / 0)`);
 
         // Testing valid permutation (types match).
         // NOTE: 'c' is a vaild hue, as hue is <angle>|<number>.
@@ -320,6 +415,20 @@
         // Testing with calc().
         test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) calc(l) calc(c) calc(h))`, `${colorSpace}(70% 45 30)`);
         test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) calc(l) calc(c) calc(h) / calc(alpha))`, `${colorSpace}(70% 45 30 / 0.4)`);
+
+        // Testing with 'none'.
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) none none none)`,                                   `${colorSpace}(none none none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) none none none / none)`,                            `${colorSpace}(none none none / none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c none)`,                                         `${colorSpace}(70% 45 none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c none / alpha)`,                                 `${colorSpace}(70% 45 none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c h / none)`,                                     `${colorSpace}(70% 45 30 / none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c none / alpha)`,                           `${colorSpace}(70% 45 none / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c h / none)`,                               `${colorSpace}(70% 45 30 / none)`);
+        // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(none none none) l c h)`,                                       `${colorSpace}(0% 0 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(none none none / none) l c h / alpha)`,                        `${colorSpace}(0% 0 0 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% none 30) l c h)`,                                          `${colorSpace}(70% 0 30)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / none) l c h / alpha)`,                             `${colorSpace}(70% 45 30 / 0)`);
     }
 
     for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb" ]) {
@@ -361,6 +470,14 @@
         test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g 20% / alpha)`,              `color(${colorSpace} 0.7 0.5 0.2 / 0.4)`);
         test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g b / 0.2)`,                  `color(${colorSpace} 0.7 0.5 0.3 / 0.2)`);
         test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g b / 20%)`,                  `color(${colorSpace} 0.7 0.5 0.3 / 0.2)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 2 3 4)`,                              `color(${colorSpace} 2 3 4)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 2 3 4 / 5)`,                          `color(${colorSpace} 2 3 4)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} -2 -3 -4)`,                           `color(${colorSpace} -2 -3 -4)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} -2 -3 -4 / -5)`,                      `color(${colorSpace} -2 -3 -4 / 0)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 200% 300% 400%)`,                     `color(${colorSpace} 2 3 4)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 200% 300% 400% / 500%)`,              `color(${colorSpace} 2 3 4)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} -200% -300% -400%)`,                  `color(${colorSpace} -2 -3 -4)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} -200% -300% -400% / -500%)`,          `color(${colorSpace} -2 -3 -4 / 0)`);
 
         // Testing valid permutation (types match).
         test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} g b r)`,                              `color(${colorSpace} 0.5 0.3 0.7)`);
@@ -372,9 +489,33 @@
         test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r r r / r)`,                    `color(${colorSpace} 0.7 0.7 0.7 / 0.7)`);
         test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} alpha alpha alpha / alpha)`,    `color(${colorSpace} 0.4 0.4 0.4 / 0.4)`);
 
+        // Testing out of gamut components.
+        test_valid_value(`color`, `color(from color(${colorSpace} 1.7 1.5 1.3) ${colorSpace} r g b)`,                              `color(${colorSpace} 1.7 1.5 1.3)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 1.7 1.5 1.3) ${colorSpace} r g b / alpha)`,                      `color(${colorSpace} 1.7 1.5 1.3)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 1.7 1.5 1.3 / 140%) ${colorSpace} r g b)`,                       `color(${colorSpace} 1.7 1.5 1.3)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 1.7 1.5 1.3 / 140%) ${colorSpace} r g b / alpha)`,               `color(${colorSpace} 1.7 1.5 1.3)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} -0.7 -0.5 -0.3) ${colorSpace} r g b)`,                           `color(${colorSpace} -0.7 -0.5 -0.3)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} -0.7 -0.5 -0.3) ${colorSpace} r g b / alpha)`,                   `color(${colorSpace} -0.7 -0.5 -0.3)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} -0.7 -0.5 -0.3 / -40%) ${colorSpace} r g b)`,                    `color(${colorSpace} -0.7 -0.5 -0.3)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} -0.7 -0.5 -0.3 / -40%) ${colorSpace} r g b / alpha)`,            `color(${colorSpace} -0.7 -0.5 -0.3 / 0)`);
+
         // Testing with calc().
         test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} calc(r) calc(g) calc(b))`,                        `color(${colorSpace} 0.7 0.5 0.3)`);
         test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} calc(r) calc(g) calc(b) / calc(alpha))`,    `color(${colorSpace} 0.7 0.5 0.3 / 0.4)`);
+
+        // Testing with 'none'.
+        test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} none none none)`,                     `color(${colorSpace} none none none)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} none none none / none)`,              `color(${colorSpace} none none none / none)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g none)`,                           `color(${colorSpace} 0.7 0.5 none)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g none / alpha)`,                   `color(${colorSpace} 0.7 0.5 none)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b / none)`,                       `color(${colorSpace} 0.7 0.5 0.3 / none)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g none / alpha)`,             `color(${colorSpace} 0.7 0.5 none / 0.4)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g b / none)`,                 `color(${colorSpace} 0.7 0.5 0.3 / none)`);
+        // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+        test_valid_value(`color`, `color(from color(${colorSpace} none none none) ${colorSpace} r g b)`,                           `color(${colorSpace} 0 0 0)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} none none none / none) ${colorSpace} r g b / alpha)`,            `color(${colorSpace} 0 0 0 / 0)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 0.7 none 0.3) ${colorSpace} r g b)`,                             `color(${colorSpace} 0.7 0 0.3)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / none) ${colorSpace} r g b / alpha)`,               `color(${colorSpace} 0.7 0.5 0.3 / 0)`);
     }
 
     for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
@@ -391,7 +532,7 @@
 
         // Testing replacement with 0.
         test_valid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} 0 0 0)`,                              `color(${resultColorSpace} 0 0 0)`);
-    test_valid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} 0 0 0 / 0)`,                          `color(${resultColorSpace} 0 0 0 / 0)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} 0 0 0 / 0)`,                          `color(${resultColorSpace} 0 0 0 / 0)`);
         test_valid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} 0 y z / alpha)`,                      `color(${resultColorSpace} 0 -20.5 100)`);
         test_valid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x 0 z / alpha)`,                      `color(${resultColorSpace} 7 0 100)`);
         test_valid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y 0 / alpha)`,                      `color(${resultColorSpace} 7 -20.5 0)`);
@@ -421,6 +562,20 @@
         // Testing with calc().
         test_valid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} calc(x) calc(y) calc(z))`,                        `color(${resultColorSpace} 7 -20.5 100)`);
         test_valid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} calc(x) calc(y) calc(z) / calc(alpha))`,    `color(${resultColorSpace} 7 -20.5 100 / 0.4)`);
+
+        // Testing with 'none'.
+        test_valid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} none none none)`,                     `color(${resultColorSpace} none none none)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} none none none / none)`,              `color(${resultColorSpace} none none none / none)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y none)`,                           `color(${resultColorSpace} 7 -20.5 none)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y none / alpha)`,                   `color(${resultColorSpace} 7 -20.5 none)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y z / none)`,                       `color(${resultColorSpace} 7 -20.5 100 / none)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y none / alpha)`,             `color(${resultColorSpace} 7 -20.5 none / 0.4)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y z / none)`,                 `color(${resultColorSpace} 7 -20.5 100 / none)`);
+        // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+        test_valid_value(`color`, `color(from color(${colorSpace} none none none) ${colorSpace} x y z)`,                           `color(${resultColorSpace} 0 0 0)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} none none none / none) ${colorSpace} x y z / alpha)`,            `color(${resultColorSpace} 0 0 0 / 0)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 7 none 100) ${colorSpace} x y z)`,                               `color(${resultColorSpace} 7 0 100)`);
+        test_valid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / none) ${colorSpace} x y z / alpha)`,               `color(${resultColorSpace} 7 -20.5 100 / 0)`);
     }
 
     // Spec Examples


### PR DESCRIPTION
This upstreams a few changes made to css/css-color/parsing in WebKit repository while implementing more of CSS Color 4 and 5. It includes additions for:

- Testing parsing and serialization of 'none' in colors including valid and invalid forms.
- Testing interpolation of colors with 'none' components using color-mix().
- Updating results of serialization to no longer clamp between 0 and 1 for color() with RGB types (e.g. `color(srgb 400% 0 0)` serializes as `color(srgb 4 0 0)` not `color(srgb 1 0 0)`.
- Correct gamut mapping using the CSS gamut mapping algorithm for out of gamut colors when using relative color syntax with `rgb()`, `hsl()` or `hwb()` or `color-mix()` with the `hsl` or `hwb` interpolation methods. 
- Testing that `hsla(from ...)` and `rgba(from ...)` are not valid in the relative color syntax (but `rgb(from ...)` and `hsl(from ...)` are). _Would like confirmation that this is correct_