### PR TITLE
Docs: correct tutorial ToC

### DIFF
--- a/docs/writing-tests/testharness-tutorial.md
+++ b/docs/writing-tests/testharness-tutorial.md
@@ -1,11 +1,5 @@
 # testharness.js tutorial
 
-.. contents:: Table of Contents
-   :depth: 3
-   :local:
-   :backlinks: none
-```
-
 <!--
 Note to maintainers:
 
@@ -31,8 +25,10 @@ purposes of this guide, we'll only consider the features we need to test the
 behavior of `fetch`.
 
 ```eval_rst
-.. contents::
+.. contents:: Table of Contents
+   :depth: 3
    :local:
+   :backlinks: none
 ```
 
 ## Setting up your workspace


### PR DESCRIPTION
d7de25c4ac8a0185b2e8f39eb3a0e1c780b04e9c was probably the result of a rebase gone bad.