### PR TITLE
Correct calculated sRGB result 

### DIFF
--- a/css/css-color/lab-005-ref.html
+++ b/css/css-color/lab-005-ref.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <style>
-    .test { background-color: rgb(10.7906% 75.5567% 66.3982%); width: 12em; height: 12em; } /* lab(70% -45 0) converted to sRGB */
+    .test { background-color: rgb(10.751% 75.558% 66.398%); width: 12em; height: 12em; } /* lab(70% -45 0) converted to sRGB */
 </style>
 <body>
     <p>Test passes if you see a single square, and not two rectangles of different colors.</p>

--- a/css/css-color/lab-005.html
+++ b/css/css-color/lab-005.html
@@ -7,7 +7,7 @@
 <meta name="assert" content="lab() with no alpha, negative a axis">
 <style>
     .test { background-color: red; width: 12em; height: 6em; margin-top: 0; }
-    .ref { background-color: rgb(10.7906% 75.5567% 66.3982%); width: 12em; height: 6em; margin-bottom: 0; } /* lab(70% -45 0) converted to sRGB */
+    .ref { background-color: rgb(10.751% 75.558% 66.398%); width: 12em; height: 6em; margin-bottom: 0; } /* lab(70% -45 0) converted to sRGB */
     .test { background-color: lab(70% -45 0); }
 </style>
 <body>


### PR DESCRIPTION
As [reported here](https://github.com/csstools/postcss-plugins/pull/70#issuecomment-1022366255) an implementer found a small error in this test.

[Investigation revealed](https://github.com/csstools/postcss-plugins/pull/70#issuecomment-1030688932) that it was the test, not their implementation, which was wrong. The cause was calculation of the D65 to D50 chromatic adaptation with an older, now incorrect value for the white points. 

This produced a small error, not visually perceptible, but enough to alter the rounded 0..255 result by 1 on one channel and thus cause test failure.