### PR TITLE
Add `registerProtocolHandler` tests for FTP.

### DIFF
--- a/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol-handler-path-credentials-manual.https.html
+++ b/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol-handler-path-credentials-manual.https.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<!-- Tests that embedded credentials are removed when invoking a custom
+  protocol handler registered via registerProtocolHandler. -->
+<meta charset=windows-1254>
+<meta name=timeout content=long>
+<title>registerProtocolHandler() and a handler with %s in the path</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/service-workers/service-worker/resources/test-helpers.sub.js></script>
+<script>
+
+// Configure expectations for individual test
+window.type = "path";
+window.noSW = false;
+window.scheme = 'ftp';
+
+function runCredentialstest() {
+  runTest({
+    credentialsPart: "username:password",
+    hostPart: "hostname.example"
+  });
+}
+</script>
+<script src=resources/handler-tools.js></script>
+<ol>
+ <li><p>First, register the handler: <button onclick='register()'>Register</button>.
+ <li><p>Then, run the test: <button onclick='runCredentialstest()'>Run</button>.
+</ol>
+<div id=log></div>

--- a/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol.https.html
+++ b/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol.https.html
@@ -104,7 +104,6 @@ test(() => {
   'cid',
   'data',
   'file',
-  'ftp',
   'http',
   'https',
   'javascript',
@@ -170,6 +169,8 @@ test(() => {
   /* safelisted schemes listed in
    * https://html.spec.whatwg.org/multipage/system-state.html#safelisted-scheme */
   'bitcoin',
+  'ftp',
+  'ftps',
   'geo',
   'im',
   'irc',
@@ -181,6 +182,7 @@ test(() => {
   'news',
   'nntp',
   'openpgp4fpr',
+  'sftp',
   'sip',
   'sms',
   'smsto',

--- a/html/webappapis/system-state-and-capabilities/the-navigator-object/resources/handler-tools.js
+++ b/html/webappapis/system-state-and-capabilities/the-navigator-object/resources/handler-tools.js
@@ -67,4 +67,3 @@ function runTest({ includeNull = false, credentialsPart = "", hostPart = "" } = 
 function stringBetweenMarkers(string, start, end) {
   return string.substring(string.indexOf(start) + start.length, string.indexOf(end));
 }
-

--- a/html/webappapis/system-state-and-capabilities/the-navigator-object/resources/handler-tools.js
+++ b/html/webappapis/system-state-and-capabilities/the-navigator-object/resources/handler-tools.js
@@ -12,14 +12,17 @@ const handler = {
   "query": "?QES\u2020QEEPSS%sPSE#FES\u2020FEE",
   "fragment": "?QES\u2020QEE#FES\u2020FEEPSS%sPSE"
 }[type];
-const scheme = `web+wpt${type}${swString}`;
+
+if (!window.hasOwnProperty('scheme')) {
+  window.scheme = `web+wpt${type}${swString}`;
+}
 
 function register() {
   const handlerURL = noSW ? `resources/handler.html${handler}${type}` : `resources/handler/${type}/${handler}`;
   navigator.registerProtocolHandler(scheme, handlerURL, `WPT ${type} handler${noSW ? ", without service worker" : ""}`);
 }
 
-function runTest({ includeNull = false } = {}) {
+function runTest({ includeNull = false, credentialsPart = "", hostPart = "" } = {}) {
   promise_test(async t => {
     const bc = new BroadcastChannel(`protocol-handler-${type}${swString}`);
     if (!noSW) {
@@ -33,15 +36,28 @@ function runTest({ includeNull = false } = {}) {
     for (; i < 0x82; i++) {
       codePoints.push(String.fromCharCode(i));
     }
-    a.href = `${scheme}:${codePoints.join("")}`;
+
+    const targetUrlParts = [
+      scheme, ":",
+      hostPart ? "//" : "",
+      hostPart && credentialsPart ? `${credentialsPart}@` : "",
+      hostPart ? `${hostPart}/` : "",
+      codePoints.join("")
+    ];
+    const expectedUrlParts = [
+      encodeURIComponent(scheme), "%3A",
+      hostPart ? `%2F%2F${encodeURIComponent(hostPart)}%2F` : "",
+      `${includeNull ? "%2500" : ""}%2501%2502%2503%2504%2505%2506%2507%2508%250B%250C%250E%250F%2510%2511%2512%2513%2514%2515%2516%2517%2518%2519%251A%251B%251C%251D%251E%251F%20!%22%23%24%25%26${type === "query" ? "%27" : "'"}()*%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~%257F%25C2%2580%25C2%2581`
+    ];
+
+    a.href = targetUrlParts.join("");
     a.target = "_blank";
     a.click();
     await new Promise(resolve => {
       bc.onmessage = t.step_func(e => {
         resultingURL = e.data;
-        assert_equals(stringBetweenMarkers(resultingURL, "QES", "QEE"), "%86", "query baseline");
-        assert_equals(stringBetweenMarkers(resultingURL, "FES", "FEE"), "%E2%80%A0", "fragment baseline");
-        assert_equals(stringBetweenMarkers(resultingURL, "PSS", "PSE"), `${encodeURIComponent(scheme)}%3A${includeNull ? "%2500" : ""}%2501%2502%2503%2504%2505%2506%2507%2508%250B%250C%250E%250F%2510%2511%2512%2513%2514%2515%2516%2517%2518%2519%251A%251B%251C%251D%251E%251F%20!%22%23%24%25%26${type === "query" ? "%27" : "'"}()*%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~%257F%25C2%2580%25C2%2581`, "actual test");
+        assert_equals(stringBetweenMarkers(resultingURL, "QES", "QEE"), "%86", "query baseline"); assert_equals(stringBetweenMarkers(resultingURL, "FES", "FEE"), "%E2%80%A0", "fragment baseline");
+        assert_equals(stringBetweenMarkers(resultingURL, "PSS", "PSE"), expectedUrlParts.join(""), "actual test");
         resolve();
       });
     });
@@ -51,3 +67,4 @@ function runTest({ includeNull = false } = {}) {
 function stringBetweenMarkers(string, start, end) {
   return string.substring(string.indexOf(start) + start.length, string.indexOf(end));
 }
+


### PR DESCRIPTION
`registerProtocolHandler` allows registering `ftp`, `ftps`, and `sftp`
protocols as of https://github.com/whatwg/html/pull/6584.

This change adds tests to ensure that `registerProtocolHandler` allows
registering those protocols and to ensure that embedded credentials are
removed prior to invoking the custom protocol handler.