### PR TITLE
Streams: test interaction between autoAllocateChunkSize and respondWithNewView

### DIFF
--- a/streams/readable-byte-streams/bad-buffers-and-views.any.js
+++ b/streams/readable-byte-streams/bad-buffers-and-views.any.js
@@ -251,6 +251,23 @@ async_test(t => {
    'different length (in the readable state)');
 
 async_test(t => {
+  // Tests https://github.com/nodejs/node/issues/41886
+  const stream = new ReadableStream({
+    pull: t.step_func_done(c => {
+      const view = new Uint8Array(new ArrayBuffer(11), 0, 3);
+
+      assert_throws_js(RangeError, () => c.byobRequest.respondWithNewView(view));
+    }),
+    type: 'bytes',
+    autoAllocateChunkSize: 10
+  });
+  const reader = stream.getReader();
+
+  reader.read();
+}, 'ReadableStream with byte source: respondWithNewView() throws if the supplied view\'s buffer has a ' +
+   'different length (autoAllocateChunkSize)');
+
+async_test(t => {
   const stream = new ReadableStream({
     pull: t.step_func_done(c => {
       const view = new Uint8Array(c.byobRequest.view.buffer, 0, 4);


### PR DESCRIPTION
See https://github.com/whatwg/streams/pull/1216 for context.

Upstreamed from https://github.com/nodejs/node/pull/41887.