### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=235084

### DIFF
--- a/css/css-transforms/2d-rotate-001.html
+++ b/css/css-transforms/2d-rotate-001.html
@@ -5,7 +5,7 @@
 	    <link rel="author" title="Rick Hurst" href="http://mrkn.co/axegs">
 	    <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
 	    <link rel="match" href="2d-rotate-ref.html">
-	    <meta name="fuzzy" content="maxDifference=87-159;totalPixels=643-1193">
+	    <meta name="fuzzy" content="maxDifference=87-159;totalPixels=643-1224">
 	    <meta name="flags" content="svg">
 	    <meta name="assert" content="asserting that you can rotate an element with CSS">
 	    <style type="text/css">

--- a/css/css-transforms/perspective-transforms-equivalence.html
+++ b/css/css-transforms/perspective-transforms-equivalence.html
@@ -9,7 +9,7 @@
 Perspective with different transforms can have small anti-aliasing
 pixel differences, so the test should fuzzy patch to the ref.
 -->
-<meta name="fuzzy" content="maxDifference=0-27;totalPixels=0-235">
+<meta name="fuzzy" content="maxDifference=0-29;totalPixels=0-235">
 <style>
 
 #container {

--- a/css/css-transforms/preserve3d-and-filter-with-perspective.html
+++ b/css/css-transforms/preserve3d-and-filter-with-perspective.html
@@ -6,6 +6,8 @@
 <link rel="help" href="https://drafts.fxtf.org/filter-effects/#FilterProperty">
 <meta name="assert" content="The filtered element is rendered correctly without clipping, despite the interesting transform.">
 <link rel="match" href="preserve3d-and-filter-with-perspective-ref.html">
+<meta name="fuzzy" content="maxDifference=4;totalPixels=26">
+
 
 <style>
 

--- a/css/css-transforms/skew-test1.html
+++ b/css/css-transforms/skew-test1.html
@@ -8,7 +8,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#svg-transform">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <link rel="match" href="reference/skew-test1-ref.html">
-    <meta name="fuzzy" content="maxDifference=17-233;totalPixels=96-771">
+    <meta name="fuzzy" content="maxDifference=17-233;totalPixels=90-771">
     <meta name="flags" content="svg">
     <meta name="assert" content="The lime square in this test has a skew method applied : 30deg on x and 20deg on y. The red polygon should be totally hidden by the lime skewed square. Both start at 0,0">
   <style>

--- a/css/css-transforms/transform-background-001.html
+++ b/css/css-transforms/transform-background-001.html
@@ -9,7 +9,7 @@
     border box, so they need to be transformed along with it.">
     <meta name="flags" content="svg">
     <link rel="match" href="transform-background-ref-1.html">
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-400">
+    <meta name="fuzzy" content="maxDifference=0-4;totalPixels=0-400">
     <style>
       div {
         width: 100px;

--- a/css/css-transforms/transform-background-002.html
+++ b/css/css-transforms/transform-background-002.html
@@ -9,7 +9,7 @@
     border box, so they need to be transformed along with it.">
     <meta name="flags" content="svg">
     <link rel="match" href="transform-background-ref-1.html">
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-400">
+    <meta name="fuzzy" content="maxDifference=0-5;totalPixels=0-400">
     <style>
       div {
         width: 100px;

--- a/css/css-transforms/transform-table-009.html
+++ b/css/css-transforms/transform-table-009.html
@@ -9,6 +9,7 @@
     &lt;tbody&gt;, so nothing should vanish.">
     <link rel="match" href="transform-table-009-ref.html">
     <link rel="mismatch" href="transform-table-009-notref.html">
+    <meta name="fuzzy" content="maxDifference=50;totalPixels=3">
     <style>
       table, tbody, tr, td {
         margin: 0;

--- a/css/css-transforms/transform-table-010.html
+++ b/css/css-transforms/transform-table-010.html
@@ -11,6 +11,7 @@
     display (mirrored).">
     <link rel="match" href="transform-table-009-ref.html">
     <link rel="mismatch" href="transform-table-010-notref.html">
+    <meta name="fuzzy" content="maxDifference=50;totalPixels=3">
     <style>
       body > div {
         transform: rotateX(90deg);

--- a/css/css-transforms/transform-table-011.html
+++ b/css/css-transforms/transform-table-011.html
@@ -11,6 +11,7 @@
     preserve-3d specified, so the text should not vanish.">
     <link rel="match" href="transform-table-009-ref.html">
     <link rel="mismatch" href="transform-table-011-notref.html">
+    <meta name="fuzzy" content="maxDifference=50;totalPixels=3">
     <style>
       body > div {
         transform: rotateX(90deg);

--- a/css/css-transforms/transforms-skewX.html
+++ b/css/css-transforms/transforms-skewX.html
@@ -7,7 +7,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <link rel="match" href="reference/transforms-skewX-ref.html">
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-200">
+    <meta name="fuzzy" content="maxDifference=0-9;totalPixels=0-200">
     <meta name="assert" content="If the skew for X axis not provided, greenSquare will not cover redSquare.">
     <style type="text/css">
       .greenSquare  {


### PR DESCRIPTION
WebKit export from bug: [\[macOS arm64\] imported/w3c/web-platform-tests/css/css-transforms/perspective-transforms-equivalence.html is consistently failing](https://bugs.webkit.org/show_bug.cgi?id=235084)