### PR TITLE
Make sure the NaN and Infinity scripts are served with a JavaScript M…

### DIFF
--- a/workers/constructors/SharedWorker/Infinity.headers
+++ b/workers/constructors/SharedWorker/Infinity.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/workers/constructors/SharedWorker/NaN.headers
+++ b/workers/constructors/SharedWorker/NaN.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8


### PR DESCRIPTION
…IME type

Those scripts are being loaded by shared worker tests (workers/constructors/SharedWorker/Infinity-arguments.html
and workers/constructors/SharedWorker/NaN-arguments.html). As per the specification [1], the worker script load
script should only succeed if the MIME type is a JavaScript MIME type.

[1] https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script (step 6)