### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=236431

### DIFF
--- a/css/selectors/parsing/parse-has.html
+++ b/css/selectors/parsing/parse-has.html
@@ -33,4 +33,7 @@
   test_valid_selector('*|*:has(*)', ':has(*)');
   test_valid_selector(':has(*|*)', ':has(*)');
   test_invalid_selector('.a:has()');
+  test_invalid_selector(':has');
+  test_invalid_selector('.a:has');
+  test_invalid_selector('.a:has b');
 </script>


### PR DESCRIPTION
WebKit export from bug: [\[:has() pseudo-class\] Nullptr crash with non-function :has](https://bugs.webkit.org/show_bug.cgi?id=236431)