### PR TITLE
Add some documentation on testing interacting features

### DIFF
--- a/docs/writing-tests/general-guidelines.md
+++ b/docs/writing-tests/general-guidelines.md
@@ -223,6 +223,7 @@ for CSS have some additional requirements for:
 [css-metadata]: css-metadata
 [css-user-styles]: css-user-styles
 [file-name-flags]: file-names
+[interacting-features]: interacting-features
 [mozilla-firefox]: https://mozilla.org/firefox
 [google-chrome]: https://google.com/chrome/browser/desktop/
 [apple-safari]: https://apple.com/safari

--- a/docs/writing-tests/general-guidelines.md
+++ b/docs/writing-tests/general-guidelines.md
@@ -116,8 +116,7 @@ no [parse errors](https://validator.nu).
 This is not, however, to discourage testing of edge cases or
 interactions between multiple features; such tests are an essential
 part of ensuring interoperability of the web platform. When possible, use the
-canonical support libraries provided by features; see [here][interacting-features]
-for more information.
+canonical support libraries provided by features; for more information, see the documentation on [testing interactions between features][interacting-features].
 
 Tests should pass when the feature under test exposes the expected behavior,
 and they should fail when the feature under test is not implemented or is

--- a/docs/writing-tests/general-guidelines.md
+++ b/docs/writing-tests/general-guidelines.md
@@ -115,7 +115,9 @@ no [parse errors](https://validator.nu).
 
 This is not, however, to discourage testing of edge cases or
 interactions between multiple features; such tests are an essential
-part of ensuring interoperability of the web platform.
+part of ensuring interoperability of the web platform. When possible, use the
+canonical support libraries provided by features; see [here][interacting-features]
+for more information.
 
 Tests should pass when the feature under test exposes the expected behavior,
 and they should fail when the feature under test is not implemented or is

--- a/docs/writing-tests/interacting-features.md
+++ b/docs/writing-tests/interacting-features.md
@@ -10,16 +10,16 @@ This allows the tests for a feature to be decoupled as much as possible from the
 
 ### Common
 
-There are several useful utilities in the /common/ directory
+There are several useful utilities in the `/common/` directory
 
 ### Cookies
 
-Features which need to test their interaction with cookies can use the scripts in cookies/resources to control which cookies are set on a given request.
+Features which need to test their interaction with cookies can use the scripts in `cookies/resources` to control which cookies are set on a given request.
 
 ### Permissions Policy
 
-Features which integrate with Permissions Policy can make use of the permissions-policy.js support library to generate a set of tests for that integration.
+Features which integrate with Permissions Policy can make use of the `permissions-policy.js` support library to generate a set of tests for that integration.
 
 ### Reporting
 
-Testing integration with the Reporting API can be done with the help of the common report collector. This service will collect reports sent from tests and provides an API to retrieve them. See documentation at reporting/resources/README.md
+Testing integration with the Reporting API can be done with the help of the common report collector. This service will collect reports sent from tests and provides an API to retrieve them. See documentation at `reporting/resources/README.md`.

--- a/docs/writing-tests/interacting-features.md
+++ b/docs/writing-tests/interacting-features.md
@@ -1,6 +1,6 @@
 # Testing interactions between features
 
-Web platform features do not exist in isolation. Often testing the interaction between two features is necessary in tests.
+Web platform features do not exist in isolation. Often, testing the interaction between two features is necessary in tests.
 To support this, many directories contain libraries which are intended to be used from other directories.
 
 These are not WPT server features, but are canonical usage of one feature intended for other features to test against.

--- a/docs/writing-tests/interacting-features.md
+++ b/docs/writing-tests/interacting-features.md
@@ -1,0 +1,25 @@
+# Testing interactions between features
+
+Web platform features do not exist in isolation. Often testing the interaction between two features is necessary in tests.
+To support this, many directories contain libraries which are intended to be used from other directories.
+
+These are not WPT server features, but are canonical usage of one feature intended for other features to test against.
+This allows the tests for a feature to be decoupled as much as possible from the specifics of another feature which it should integrate with.
+
+## Web Platform Feature Testing Support Libraries
+
+### Common
+
+There are several useful utilities in the /common/ directory
+
+### Cookies
+
+Features which need to test their interaction with cookies can use the scripts in cookies/resources to control which cookies are set on a given request.
+
+### Permissions Policy
+
+Features which integrate with Permissions Policy can make use of the permissions-policy.js support library to generate a set of tests for that integration.
+
+### Reporting
+
+Testing integration with the Reporting API can be done with the help of the common report collector. This service will collect reports sent from tests and provides an API to retrieve them. See documentation at reporting/resources/README.md


### PR DESCRIPTION
There are several support libraries provided in different directories across WPT which are useful for testing interactions between features, but only if test authors are aware of them. This adds a page under writing-tests where I have started to collect those libraries.