### PR TITLE
[css-fonts] Fixes for font palette tests

### DIFF
--- a/css/css-fonts/font-palette-modify-notref.html
+++ b/css/css-fonts/font-palette-modify-notref.html
@@ -11,19 +11,13 @@
     src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
 }
 
-@font-palette-values MyPalette {
+@font-palette-values --MyPalette {
     font-family: "COLR-test-font";
     base-palette: 1;
-}
-
-@font-palette-values MyPalette2 {
-    font-family: "COLR-test-font";
-    base-palette: 0;
-    override-color: 1 #00FF00;
 }
 </style>
 </head>
 <body>
-<div id="target" style="font: 48px 'COLR-test-font'; font-palette: MyPalette;">A</div>
+<div id="target" style="font: 48px 'COLR-test-font'; font-palette: --MyPalette;">A</div>
 </body>
 </html>

--- a/css/css-fonts/font-palette-modify.html
+++ b/css/css-fonts/font-palette-modify.html
@@ -20,7 +20,8 @@
 @font-palette-values --MyPalette2 {
     font-family: "COLR-test-font";
     base-palette: 0;
-    override-colors: 1 #00FF00;
+    /* Glyph 'A' uses palette indices 3 and 7. */
+    override-colors: 3 #00FF00;
 }
 </style>
 </head>

--- a/css/css-fonts/font-palette-remove-notref.html
+++ b/css/css-fonts/font-palette-remove-notref.html
@@ -11,13 +11,13 @@
     src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
 }
 
-@font-palette-values MyPalette {
+@font-palette-values --MyPalette {
     font-family: "COLR-test-font";
     base-palette: 1;
 }
 </style>
 </head>
 <body>
-<div id="target" style="font: 48px 'COLR-test-font'; font-palette: MyPalette;">A</div>
+<div id="target" style="font: 48px 'COLR-test-font'; font-palette: --MyPalette;">A</div>
 </body>
 </html>

--- a/css/css-fonts/palette-values-rule-delete-notref.html
+++ b/css/css-fonts/palette-values-rule-delete-notref.html
@@ -11,13 +11,13 @@
     src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
 }
 
-@font-palette-values MyPalette {
+@font-palette-values --MyPalette {
     font-family: "COLR-test-font";
     base-palette: 1;
 }
 </style>
 </head>
 <body>
-<div style="font: 48px 'COLR-test-font'; font-palette: MyPalette;">A</div>
+<div style="font: 48px 'COLR-test-font'; font-palette: --MyPalette;">A</div>
 </body>
 </html>


### PR DESCRIPTION
Expectations files where using palette names not prefixed with dashes,
font-palette-modify.html needs to use an index that's used in the glyph.