### PR TITLE
Add test for setting video.currentTime out of bounds

### DIFF
--- a/html/semantics/embedded-content/media-elements/offsets-into-the-media-resource/currentTime.html
+++ b/html/semantics/embedded-content/media-elements/offsets-into-the-media-resource/currentTime.html
@@ -29,4 +29,17 @@ async_test(function(t) {
     t.done();
   });
 }, 'setting currentTime when readyState is greater than HAVE_NOTHING');
+
+async_test(function(t) {
+  var v = document.createElement('video');
+  v.src = getVideoURI('/media/movie_5');
+  v.onloadedmetadata = t.step_func(function() {
+    assert_greater_than(v.readyState, v.HAVE_NOTHING);
+    assert_false(v.seeking);
+    v.currentTime = Number.MAX_VALUE;
+    assert_equals(v.currentTime, v.duration);
+    assert_true(v.seeking);
+    t.done();
+  });
+}, 'setting currentTime out of bounds when readyState is greater than HAVE_NOTHING');
 </script>

--- a/html/semantics/embedded-content/media-elements/offsets-into-the-media-resource/currentTime.html
+++ b/html/semantics/embedded-content/media-elements/offsets-into-the-media-resource/currentTime.html
@@ -42,4 +42,17 @@ async_test(function(t) {
     t.done();
   });
 }, 'setting currentTime out of bounds when readyState is greater than HAVE_NOTHING');
+
+async_test(function(t) {
+  var v = document.createElement('video');
+  v.src = getVideoURI('/media/movie_5');
+  v.onloadedmetadata = t.step_func(function() {
+    assert_greater_than(v.readyState, v.HAVE_NOTHING);
+    assert_false(v.seeking);
+    v.currentTime = 0.12345678912367891;
+    assert_equals(v.currentTime, 0.12345678912367891);
+    assert_true(v.seeking);
+    t.done();
+  });
+}, 'setting currentTime to precise number when readyState is greater than HAVE_NOTHING');
 </script>


### PR DESCRIPTION
After setting `currentTime` to an out of bounds mark, `currentTime` should return the maximum play position–video duration. This fails in Safari, which returns the out of bounds value (assertion fail); it reverts to `duration` on the next tick (not captured in the test). Test passes in Chrome and Firefox stable.

---

Relevant spec: 

https://html.spec.whatwg.org/#dom-media-currenttime
https://html.spec.whatwg.org/#current-playback-position
https://html.spec.whatwg.org/#media-timeline

> it must set the official playback position to the new value and then seek to the new value.

> The official playback position is an approximation of the current playback position that is kept stable while scripts are running.

> The current playback position is a time on the media timeline.

> The origin of a timeline is its earliest defined position. The duration of a timeline is its last defined position.