### PR TITLE
Allow fuzzy matching for plus-lighter tests

### DIFF
--- a/css/compositing/background-blending/background-blend-mode-plus-lighter.html
+++ b/css/compositing/background-blending/background-blend-mode-plus-lighter.html
@@ -3,6 +3,7 @@
 <link rel="author" title="Jake Archibald" href="mailto:jakearchibald@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/compositing-2/#background-blend-mode">
 <link rel="match" href="reference/background-blend-mode-plus-lighter-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-4294967295">
 <style>
   .test {
     width: 100px;

--- a/css/compositing/mix-blend-mode/mix-blend-mode-plus-lighter-svg.html
+++ b/css/compositing/mix-blend-mode/mix-blend-mode-plus-lighter-svg.html
@@ -3,6 +3,7 @@
 <link rel="author" title="Jake Archibald" href="mailto:jakearchibald@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/compositing-2/#mix-blend-mode">
 <link rel="match" href="reference/mix-blend-mode-plus-lighter-svg-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-4294967295">
 <style>
   .blend-group {
     isolation: isolate;

--- a/css/compositing/mix-blend-mode/mix-blend-mode-plus-lighter.html
+++ b/css/compositing/mix-blend-mode/mix-blend-mode-plus-lighter.html
@@ -3,6 +3,7 @@
 <link rel="author" title="Jake Archibald" href="mailto:jakearchibald@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/compositing-2/#mix-blend-mode">
 <link rel="match" href="reference/mix-blend-mode-plus-lighter-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-4294967295">
 <style>
   .test {
     width: 100px;


### PR DESCRIPTION
These tests use a JS function to perform the compositing, but it seems like some browsers use a lower precision meaning some results are off-by-one. The lower precision isn't an issue, so I've allowed colors to be off-by-one.

@tabatkins happy with this? I just used a really big number for the number of pixels affected. It doesn't seem like there's a way to say that any pixel can be off by 1.