### PR TITLE
Fix idlharness-shadowrealm.js when tests don't immediately fail

### DIFF
--- a/resources/idlharness-shadowrealm.js
+++ b/resources/idlharness-shadowrealm.js
@@ -58,7 +58,6 @@ function idl_test_shadowrealm(srcs, deps) {
                       idl_array.add_dependency_idls(idls[i]);
                   }
                   idl_array.test();
-                  console.log('eek!');
               }, "setup");
           }`)
         ));

--- a/resources/idlharness-shadowrealm.js
+++ b/resources/idlharness-shadowrealm.js
@@ -39,31 +39,32 @@ function idl_test_shadowrealm(srcs, deps) {
             return fetch_text("/interfaces/" + spec + ".idl");
         }));
         const idls = JSON.stringify(specs);
-        const code = `
-            const idls = ${idls};
-            let results;
-            add_completion_callback(function (tests, harness_status, asserts_run) {
-                results = tests;
-            });
 
-            // Without the wrapping test, testharness.js will think it's done after it has run
-            // the first idlharness test.
-            test(() => {
-                const idl_array = new IdlArray();
-                for (let i = 0; i < ${srcs.length}; i++) {
-                    idl_array.add_idls(idls[i]);
-                }
-                for (let i = ${srcs.length}; i < ${srcs.length + deps.length}; i++) {
-                    idl_array.add_dependency_idls(idls[i]);
-                }
-                idl_array.test();
-            }, "setup");
-            String(JSON.stringify(results))
-        `;
+        const results = JSON.parse(await new Promise(
+          realm.evaluate(`(resolve,reject) => {
+              const idls = ${idls};
+              add_completion_callback(function (tests, harness_status, asserts_run) {
+                resolve(JSON.stringify(tests));
+              });
+
+              // Without the wrapping test, testharness.js will think it's done after it has run
+              // the first idlharness test.
+              test(() => {
+                  const idl_array = new IdlArray();
+                  for (let i = 0; i < ${srcs.length}; i++) {
+                      idl_array.add_idls(idls[i]);
+                  }
+                  for (let i = ${srcs.length}; i < ${srcs.length + deps.length}; i++) {
+                      idl_array.add_dependency_idls(idls[i]);
+                  }
+                  idl_array.test();
+                  console.log('eek!');
+              }, "setup");
+          }`)
+        ));
 
         // We ran the tests in the ShadowRealm and gathered the results. Now treat them as if
         // we'd run them directly here, so we can see them.
-        const results = JSON.parse(realm.evaluate(code));
         for (const {name, status, message} of results) {
             // TODO: make this an API in testharness.js - needs RFC?
             promise_test(t => {t.set_status(status, message); t.phase = t.phases.HAS_RESULT; t.done()}, name);


### PR DESCRIPTION
If the completion callback does not immediately execute, we return `undefined`
for results and the harness code blows up; just tweak the code that runs in the
shadow realm context to be explicitly async.

Admittedly not really sure why any of the test code should not immediately return, so, please
let me know if it really should be non-async.

cc/ @Ms2ger 