### PR TITLE
Test hyperlink auditing headers

### DIFF
--- a/html/semantics/links/hyperlink-auditing/headers.optional.html
+++ b/html/semantics/links/hyperlink-auditing/headers.optional.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+
+<iframe id="i" src="/common/blank.html"></iframe>
+
+<!-- Test is optional because hyperlink auditing is optional. -->
+
+<script>
+promise_test(async t => {
+  await new Promise(resolve => window.onload = resolve);
+
+  const id = token();
+
+  const el = document.createElement("a");
+  el.ping = new URL(`resources/stash-headers.py?id=${id}`, location.href); // this will be a POST
+  el.href = "/common/blank.html?1";
+
+  i.contentDocument.body.append(el);
+  el.click();
+
+  let headers;
+  await pollForConditionFunc(t, async () => {
+    const res = await fetch(el.ping); // this will be a GET
+    const json = await res.json();
+
+    if (json !== "no headers yet") {
+      headers = json;
+      return true;
+    }
+    return false;
+  });
+
+  assert_equals(headers["content-type"], "text/ping", "content-type");
+  assert_equals(headers["ping-from"], i.src, "ping-from");
+  assert_equals(headers["ping-to"], el.href, "ping-to");
+});
+
+async function pollForConditionFunc(t, func, timeout = 3000, interval = 100) {
+  let remaining = Math.ceil(timeout / interval);
+
+  while (remaining > 0) {
+    --remaining;
+    await new Promise(resolve => t.step_timeout(resolve, interval));
+
+    if (await func()) {
+      return;
+    }
+  }
+
+  assert_true(false, "Condition never became true");
+}
+</script>

--- a/html/semantics/links/hyperlink-auditing/resources/stash-headers.py
+++ b/html/semantics/links/hyperlink-auditing/resources/stash-headers.py
@@ -1,0 +1,27 @@
+import json
+from wptserve.utils import isomorphic_decode
+
+def main(request, response):
+    key = request.GET[b"id"]
+
+    if request.method == "POST":
+      content_type = request.headers.get(b"content-type", b"no content-type header")
+      ping_from = request.headers.get(b"ping-from", b"no ping-from header")
+      ping_to = request.headers.get(b"ping-to", b"no ping-to header")
+
+      value = json.dumps({
+        'content-type': isomorphic_decode(content_type),
+        'ping-from': isomorphic_decode(ping_from),
+        'ping-to': isomorphic_decode(ping_to)
+      })
+      request.server.stash.put(key, value)
+
+      return (204, [], "")
+
+    elif request.method == "GET":
+      value = request.server.stash.take(key)
+      if value is None:
+        value = "\"no headers yet\""
+      return (200, [("Content-Type", "application/json")], str(value))
+
+    return (405, [], "")


### PR DESCRIPTION
For https://github.com/whatwg/html/pull/7481.

This does not test the complicated conditional in https://html.spec.whatwg.org/#hyperlink-auditing step 5, but instead just the simple case. Given that https://github.com/whatwg/html/pull/7481 is mostly just a bugfix I thought this would be sufficient and someone could try to expand this in the future.