### PR TITLE
[inert] Expand tests for interactivity of inert frames

### DIFF
--- a/inert/inert-iframe-hittest.tentative.html
+++ b/inert/inert-iframe-hittest.tentative.html
@@ -15,6 +15,10 @@
 </div>
 
 <script>
+const events = [
+  "mousedown", "mouseenter", "mousemove", "mouseover",
+  "pointerdown", "pointerenter", "pointermove", "pointerover",
+];
 const iframe = document.getElementById("iframe");
 let iframeDoc;
 let target;
@@ -34,57 +38,64 @@ promise_setup(async () => {
   });
 });
 
-promise_test(async function() {
-  let reachedTarget = false;
-  target.addEventListener("mousedown", () => {
-    reachedTarget = true;
-  }, { once: true });
-
-  let reachedWrapper = false;
-  wrapper.addEventListener("mousedown", () => {
-    reachedWrapper = true;
-  }, { once: true });
+async function mouseDownAndGetEvents(test) {
+  const receivedEvents = {
+    target: [],
+    wrapper: [],
+  };
+  for (let event of events) {
+    target.addEventListener(event, () => {
+      receivedEvents.target.push(event);
+    }, { once: true, capture: true });
+    wrapper.addEventListener(event, () => {
+      receivedEvents.wrapper.push(event);
+    }, { once: true, capture: true });
+  }
 
   await new test_driver.Actions()
      .pointerMove(0, 0, { origin: wrapper })
      .pointerDown()
      .send();
-  this.add_cleanup(() => test_driver.click(document.body));
+  test.add_cleanup(() => test_driver.click(document.body));
+
+  // Exact order of events is not interoperable.
+  receivedEvents.target.sort();
+  receivedEvents.wrapper.sort();
+  return receivedEvents;
+}
+
+promise_test(async function() {
+  const receivedEvents = await mouseDownAndGetEvents(this);
+  assert_array_equals(receivedEvents.target, [], "target got no event");
+  assert_array_equals(receivedEvents.wrapper, events, "wrapper got all events");
 
   assert_false(target.matches(":focus"), "target is not focused");
   assert_false(target.matches(":active"), "target is not active");
   assert_false(target.matches(":hover"), "target is not hovered");
-  assert_false(reachedTarget, "target didn't get event");
-
   assert_true(wrapper.matches(":hover"), "wrapper is hovered");
-  assert_true(reachedWrapper, "wrapper got event");
 }, "Hit-testing doesn't reach contents of an inert iframe");
 
 promise_test(async function() {
   iframe.inert = false;
 
-  let reachedTarget = false;
-  target.addEventListener("mousedown", () => {
-    reachedTarget = true;
-  }, { once: true });
-
-  let reachedWrapper = false;
-  wrapper.addEventListener("mousedown", () => {
-    reachedWrapper = true;
-  }, { once: true });
-
-  await new test_driver.Actions()
-     .pointerMove(0, 0, { origin: wrapper })
-     .pointerDown()
-     .send();
-  this.add_cleanup(() => test_driver.click(document.body));
+  const receivedEvents = await mouseDownAndGetEvents(this);
+  assert_array_equals(receivedEvents.target, events, "target got all events");
+  if (receivedEvents.wrapper.length === 2) {
+    // Firefox is unstable, sometimes missing the mouse events.
+    assert_array_equals(
+      receivedEvents.wrapper,
+      ["pointerenter", "pointerover"],
+      "wrapper got enter and over pointer events");
+  } else {
+    assert_array_equals(
+      receivedEvents.wrapper,
+      ["mouseenter", "mouseover", "pointerenter", "pointerover"],
+      "wrapper got enter and over events");
+  }
 
   assert_true(target.matches(":focus"), "target is focused");
   assert_true(target.matches(":active"), "target is active");
   assert_true(target.matches(":hover"), "target is hovered");
-  assert_true(reachedTarget, "target got event");
-
   assert_true(wrapper.matches(":hover"), "wrapper is hovered");
-  assert_false(reachedWrapper, "wrapper didn't get event");
 }, "Hit-testing can reach contents of a no longer inert iframe");
 </script>

--- a/inert/inert-iframe-tabbing.tentative.html
+++ b/inert/inert-iframe-tabbing.tentative.html
@@ -4,63 +4,120 @@
 <link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#inert">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation">
-<meta assert="assert" content="Contents of an inert iframe can't be focused by tabbing">
+<meta assert="assert" content="Tabbing can't enter an inert iframe from the outside, but can move within it and can leave it if focus is already there.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 
-<div id="start" tabindex="0">start</div>
+<div id="before" tabindex="0">before</div>
 <div id="inert" inert>
   <iframe id="iframe"></iframe>
 </div>
-<div id="end" tabindex="0">start</a>
+<div id="after" tabindex="0">after</a>
 
 <script>
 const tabKey = "\uE004";
-const start = document.getElementById("start");
+const before = document.getElementById("before");
 const inert = document.getElementById("inert");
-const end = document.getElementById("end");
+const after = document.getElementById("after");
 const iframe = document.getElementById("iframe");
 let iframeDoc;
-let target;
+let start;
+let end;
 
 promise_setup(async () => {
   await new Promise(resolve => {
     iframe.addEventListener("load", resolve, { once: true });
-    iframe.srcdoc = `<div id="target" tabindex="0">target</div>`;
+    iframe.srcdoc = `
+      <div id="start" tabindex="0">target</div>
+      <div id="end" tabindex="0">target</div>
+    `;
   });
   iframeDoc = iframe.contentDocument;
-  target = iframeDoc.getElementById("target");
+  start = iframeDoc.getElementById("start");
+  end = iframeDoc.getElementById("end");
 });
 
 promise_test(async function() {
-  start.focus();
-  assert_equals(document.activeElement, start, "start got focus");
+  before.focus();
+  assert_equals(document.activeElement, before, "#before got outer focus");
   assert_false(iframeDoc.hasFocus(), "iframeDoc doesn't have focus");
 
   await test_driver.send_keys(document.activeElement, tabKey);
-  assert_equals(document.activeElement, end, "end got focus");
+  assert_equals(document.activeElement, after, "#after got outer focus");
   assert_false(iframeDoc.hasFocus(), "iframeDoc still doesn't have focus");
-}, "Sequential navigation skips contents of inert iframe");
+}, "Sequential navigation can't enter an inert iframe");
 
 promise_test(async function() {
   start.focus();
-  assert_equals(document.activeElement, start, "start got focus");
-  assert_false(iframeDoc.hasFocus(), "iframeDoc doesn't have focus");
+  assert_equals(document.activeElement, iframe, "#iframe got outer focus");
+  assert_equals(iframeDoc.activeElement, start, "#start got inner focus");
+  assert_true(iframeDoc.hasFocus(), "iframeDoc has focus");
 
+  await test_driver.send_keys(iframeDoc.activeElement, tabKey);
+  assert_equals(document.activeElement, iframe, "#iframe still has outer focus");
+  assert_equals(iframeDoc.activeElement, end, "#end got inner focus");
+  assert_true(iframeDoc.hasFocus(), "iframeDoc still has focus");
+}, "Sequential navigation can move within an inert iframe");
+
+promise_test(async function() {
+  end.focus();
+  assert_equals(document.activeElement, iframe, "#iframe got outer focus");
+  assert_equals(iframeDoc.activeElement, end, "#end got inner focus");
+  assert_true(iframeDoc.hasFocus(), "iframeDoc has focus");
+
+  await test_driver.send_keys(iframeDoc.activeElement, tabKey);
+  assert_equals(document.activeElement, after, "#after got outer focus");
+  assert_false(iframeDoc.hasFocus(), "iframeDoc doesn't have focus");
+}, "Sequential navigation can leave an inert iframe");
+
+// Test again without inertness.
+
+promise_test(async function() {
   inert.inert = false;
 
+  before.focus();
+  assert_equals(document.activeElement, before, "#before got outer focus");
+  assert_false(iframeDoc.hasFocus(), "iframeDoc doesn't have focus");
+
   await test_driver.send_keys(document.activeElement, tabKey);
-  assert_equals(document.activeElement, iframe, "iframe got focus");
+  assert_equals(document.activeElement, iframe, "#iframe got outer focus");
   assert_true(iframeDoc.hasFocus(), "iframeDoc has focus");
 
   // The document element is also focusable in Firefox.
   if (iframeDoc.activeElement === iframeDoc.documentElement) {
     await test_driver.send_keys(document.activeElement, tabKey);
-    assert_equals(document.activeElement, iframe, "iframe got focus");
+    assert_equals(document.activeElement, iframe, "#iframe got outer focus");
     assert_true(iframeDoc.hasFocus(), "iframeDoc has focus");
   }
-  assert_equals(iframeDoc.activeElement, target, "target got focus");
-}, "Sequential navigation can pick contents of a no longer inert iframe");
+  assert_equals(iframeDoc.activeElement, start, "#start got inner focus");
+}, "Sequential navigation can enter a no longer inert iframe");
+
+promise_test(async function() {
+  inert.inert = false;
+
+  start.focus();
+  assert_equals(document.activeElement, iframe, "#iframe got outer focus");
+  assert_equals(iframeDoc.activeElement, start, "#start got inner focus");
+  assert_true(iframeDoc.hasFocus(), "iframeDoc has focus");
+
+  await test_driver.send_keys(iframeDoc.activeElement, tabKey);
+  assert_equals(document.activeElement, iframe, "#iframe still has outer focus");
+  assert_equals(iframeDoc.activeElement, end, "#end got inner focus");
+  assert_true(iframeDoc.hasFocus(), "iframeDoc still has focus");
+}, "Sequential navigation can move within a no longer inert iframe");
+
+promise_test(async function() {
+  inert.inert = false;
+
+  end.focus();
+  assert_equals(document.activeElement, iframe, "#iframe got outer focus");
+  assert_equals(iframeDoc.activeElement, end, "#end got inner focus");
+  assert_true(iframeDoc.hasFocus(), "iframeDoc has focus");
+
+  await test_driver.send_keys(iframeDoc.activeElement, tabKey);
+  assert_equals(document.activeElement, after, "#after got outer focus");
+  assert_false(iframeDoc.hasFocus(), "iframeDoc doesn't have focus");
+}, "Sequential navigation can leave a no longer inert iframe");
 </script>


### PR DESCRIPTION
inert-iframe-hittest.tentative.html now checks for more events.

inert-iframe-tabbing.tentative.html now checks that tabbing can move
within an inert frame and leave it, if focus is already there.