### PR TITLE
Revert "Stop propagating inertness into nested browsing contexts"

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/inert-focus-in-frames.html
+++ b/html/semantics/interactive-elements/the-dialog-element/inert-focus-in-frames.html
@@ -37,11 +37,7 @@ promise_test(async () => {
     let focusedElement = null;
     element.addEventListener('focus', function() { focusedElement = element; }, false);
     element.focus();
-    if (expectFocus) {
-      assert_equals(focusedElement, element, element.id);
-    } else {
-      assert_not_equals(focusedElement, element, element.id);
-    }
+    assert_equals(focusedElement === element, expectFocus, element.id);
   }
 
   // Opening a modal dialog in frame1. It blocks other nodes in its document.
@@ -50,7 +46,7 @@ promise_test(async () => {
 
   testFocus(frame1.querySelector('.target'), false);
   const iframe = frame1.querySelector('#iframe1').contentDocument;
-  testFocus(iframe.querySelector('.target'), true);
+  testFocus(iframe.querySelector('.target'), false);
 
   // Even a modal dialog in the iframe is blocked by the modal dialog in the parent frame1.
   iframe.querySelector('dialog').showModal();

--- a/html/semantics/interactive-elements/the-dialog-element/inertness-with-modal-dialogs-and-iframes.html
+++ b/html/semantics/interactive-elements/the-dialog-element/inertness-with-modal-dialogs-and-iframes.html
@@ -4,8 +4,9 @@
 <link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#inert">
 <meta name="assert" content="Checks that a modal dialog marks outer nodes as inert,
-  but only in its document, not in the parent browsing context,
-  nor in nested browsing contexts.">
+  but only in its document, not in the parent browsing context.
+  Also, when an iframe is marked as inert by a modal dialog,
+  all contents in the nested browsing context are marked as inert too.">
 <div id="log"></div>
 <div id="wrapper">
   (main document: outer text)
@@ -102,30 +103,30 @@ promise_test(async function() {
 
   checkSelection(window, "(main document: dialog)");
   checkSelection(innerIframeWindow, "(inner iframe: outer text)(inner iframe: dialog)");
-  checkSelection(outerIframeWindow, "(outer iframe: outer text)(outer iframe: dialog)");
-}, "Modal dialog in the main document marks outer nodes as inert. Contents of the outer iframe aren't marked as inert.");
+  checkSelection(outerIframeWindow, "");
+}, "Modal dialog in the main document marks outer nodes as inert. All contents of the outer iframe are also marked as inert.");
 
 promise_test(async function() {
   showModals(this, [innerIframeWindow, window]);
 
   checkSelection(window, "(main document: dialog)");
   checkSelection(innerIframeWindow, "(inner iframe: dialog)");
-  checkSelection(outerIframeWindow, "(outer iframe: outer text)(outer iframe: dialog)");
-}, "Modal dialogs in the main document and inner iframe mark outer nodes as inert. Contents of the outer iframe aren't marked as inert.");
+  checkSelection(outerIframeWindow, "");
+}, "Modal dialogs in the main document and inner iframe mark outer nodes as inert. All contents of the outer iframe are also marked as inert.");
 
 promise_test(async function() {
   showModals(this, [outerIframeWindow, window]);
 
   checkSelection(window, "(main document: dialog)");
   checkSelection(innerIframeWindow, "(inner iframe: outer text)(inner iframe: dialog)");
-  checkSelection(outerIframeWindow, "(outer iframe: dialog)");
-}, "Modal dialogs in the main document and outer iframe mark outer nodes as inert. Contents of the outer iframe aren't marked as inert.");
+  checkSelection(outerIframeWindow, "");
+}, "Modal dialogs in the main document and outer iframe mark outer nodes as inert. All contents of the outer iframe are also marked as inert.");
 
 promise_test(async function() {
   showModals(this, [innerIframeWindow, outerIframeWindow, window]);
 
   checkSelection(window, "(main document: dialog)");
   checkSelection(innerIframeWindow, "(inner iframe: dialog)");
-  checkSelection(outerIframeWindow, "(outer iframe: dialog)");
-}, "Modal dialogs in the main document and both iframes mark outer nodes as inert. Contents of the outer iframe aren't marked as inert.");
+  checkSelection(outerIframeWindow, "");
+}, "Modal dialogs in the main document and both iframes mark outer nodes as inert. All contents of the outer iframe are also marked as inert.");
 </script>


### PR DESCRIPTION
Reverts web-platform-tests/wpt#32817

The same change is merged to chromium through https://chromium-review.googlesource.com/c/chromium/src/+/3302103/.

Revert this to resolve conflicts in wpt importer and exporter. Exporter will export the same change in future.