### PR TITLE
Test webrtc/content-security-policy integration

### DIFF
--- a/content-security-policy/webrtc/webrtc-allowed-default-src-none.html
+++ b/content-security-policy/webrtc/webrtc-allowed-default-src-none.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; script-src 'self' 'unsafe-inline'">
+    <title>webrtc allowed with default-src 'none'</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="webrtc.js"></script>
+</head>
+
+<body>
+    <script>
+        expectAllow();
+    </script>
+    <div id="log"></div>
+</body>
+
+</html>

--- a/content-security-policy/webrtc/webrtc-allowed-explicit.html
+++ b/content-security-policy/webrtc/webrtc-allowed-explicit.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="webrtc 'allow';">
+    <title>webrtc allowed with an explicit webrtc allowed policy</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="webrtc.js"></script>
+</head>
+
+<body>
+    <script>
+        expectAllow();
+    </script>
+    <div id="log"></div>
+</body>
+
+</html>

--- a/content-security-policy/webrtc/webrtc-allowed-nopolicy.html
+++ b/content-security-policy/webrtc/webrtc-allowed-nopolicy.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>webrtc allowed with no policy</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="webrtc.js"></script>
+</head>
+
+<body>
+    <script>
+        expectAllow();
+    </script>
+    <div id="log"></div>
+</body>
+
+</html>

--- a/content-security-policy/webrtc/webrtc-blocked-explicit.html
+++ b/content-security-policy/webrtc/webrtc-blocked-explicit.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="webrtc 'block';">
+    <title>webrtc blocked with an explicit webrtc blocked policy</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="webrtc.js"></script>
+</head>
+
+<body>
+    <script>
+        expectBlock();
+    </script>
+    <div id="log"></div>
+</body>
+
+</html>

--- a/content-security-policy/webrtc/webrtc-blocked-unknown.html
+++ b/content-security-policy/webrtc/webrtc-blocked-unknown.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="webrtc 'unrecognized';">
+    <title>webrtc blocked with an unrecognized explicit webrtc policy</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="webrtc.js"></script>
+</head>
+
+<body>
+    <script>
+        expectBlock();
+    </script>
+    <div id="log"></div>
+</body>
+
+</html>

--- a/content-security-policy/webrtc/webrtc.js
+++ b/content-security-policy/webrtc/webrtc.js
@@ -4,9 +4,8 @@
 // blocked on both sides and "inconsistent" in the event that the
 // result is not the same on both sides (should never happen).
 async function tryConnect() {
-    const iceServers = [{urls: "stun:stun.l.google.com:19302"}];
-    const pc1 = new RTCPeerConnection({iceServers});
-    const pc2 = new RTCPeerConnection({iceServers});
+    const pc1 = new RTCPeerConnection();
+    const pc2 = new RTCPeerConnection();
 
     // Returns a promise which resolves to a boolean which is true
     // if and only if pc.iceConnectionState settles in the "failed"

--- a/content-security-policy/webrtc/webrtc.js
+++ b/content-security-policy/webrtc/webrtc.js
@@ -13,9 +13,6 @@ async function tryConnect() {
     // state, and never transitions to any state other than "new"
     // or "failed."
     const pcFailed = (pc) => {
-        pc.onicecandidate = ({candidate}) => {
-            pc.addIceCandidate(candidate);
-        };
         return new Promise((resolve, _reject) => {
             pc.onicegatheringstatechange = (e) => {
                 if(pc.iceGatheringState === "complete") {
@@ -33,6 +30,8 @@ async function tryConnect() {
     const channel = pc1.createDataChannel('test');
 
     // Usual webrtc signaling dance:
+    pc1.onicecandidate = ({candidate}) => pc2.addIceCandidate(candidate);
+    pc2.onicecandidate = ({candidate}) => pc1.addIceCandidate(candidate);
     const offer = await pc1.createOffer();
     await pc1.setLocalDescription(offer);
     await pc2.setRemoteDescription(pc1.localDescription);

--- a/content-security-policy/webrtc/webrtc.js
+++ b/content-security-policy/webrtc/webrtc.js
@@ -14,7 +14,7 @@ async function tryConnect() {
     // or "failed."
     const pcFailed = (pc) => {
         return new Promise((resolve, _reject) => {
-            pc.onicegatheringstatechange = (e) => {
+            pc.oniceconnectionstatechange = (e) => {
                 if(pc.iceGatheringState === "complete") {
                     resolve(pc.iceConnectionState === "failed");
                 } else if(pc.iceConnectionState !== "new") {

--- a/content-security-policy/webrtc/webrtc.js
+++ b/content-security-policy/webrtc/webrtc.js
@@ -1,0 +1,62 @@
+
+// Creates two RTCPeerConnection and tries to connect them. Returns
+// "allowed" if the connection is permitted, "blocked" if it is
+// blocked on both sides and "inconsistent" in the even that the
+// result is the same on both sides (should never happen).
+async function tryConnect() {
+    const iceServers = [{urls: "stun:stun.l.google.com:19302"}];
+    const pc1 = new RTCPeerConnection({iceServers});
+    const pc2 = new RTCPeerConnection({iceServers});
+
+    // Returns a promise which resolves to a boolean which is true
+    // if and only if pc.iceConnectionState settles in the "failed"
+    // state, and never transitions to any state other than "new"
+    // or "failed."
+    const pcFailed = (pc) => {
+        pc.onicecandidate = ({candidate}) => {
+            pc.addIceCandidate(candidate);
+        };
+        return new Promise((resolve, _reject) => {
+            pc.onicegatheringstatechange = (e) => {
+                if(pc.iceGatheringState === "complete") {
+                    resolve(pc.iceConnectionState === "failed");
+                } else if(pc.iceConnectionState !== "new") {
+                    resolve(false);
+                }
+            };
+        });
+    }
+    pc1Failed = pcFailed(pc1);
+    pc2Failed = pcFailed(pc2);
+
+    // Creating a data channel is necessary to induce negotiation:
+    const channel = pc1.createDataChannel('test');
+
+    // Usual webrtc signaling dance:
+    const offer = await pc1.createOffer();
+    await pc1.setLocalDescription(offer);
+    await pc2.setRemoteDescription(pc1.localDescription);
+    const answer = await pc2.createAnswer();
+    await pc2.setLocalDescription(answer);
+    await pc1.setRemoteDescription(pc2.localDescription);
+
+    const failed1 = await pc1Failed;
+    const failed2 = await pc2Failed;
+    if(failed1 && failed2) {
+        return 'blocked';
+    } else if(!failed1 && !failed2) {
+        return 'allowed';
+    } else {
+        return 'inconsistent';
+    }
+}
+
+async function expectAllow() {
+    promise_test(async () => assert_equals(await tryConnect(), 'allowed'));
+}
+
+async function expectBlock() {
+    promise_test(async () => assert_equals(await tryConnect(), 'blocked'));
+}
+
+// vim: set ts=4 sw=4 et :

--- a/content-security-policy/webrtc/webrtc.js
+++ b/content-security-policy/webrtc/webrtc.js
@@ -14,11 +14,7 @@ async function tryConnect() {
     const pcFailed = (pc) => {
         return new Promise((resolve, _reject) => {
             pc.oniceconnectionstatechange = (e) => {
-                if(pc.iceGatheringState === "complete") {
-                    resolve(pc.iceConnectionState === "failed");
-                } else if(pc.iceConnectionState !== "new") {
-                    resolve(false);
-                }
+                resolve(pc.iceConnectionState == "failed");
             };
         });
     }

--- a/content-security-policy/webrtc/webrtc.js
+++ b/content-security-policy/webrtc/webrtc.js
@@ -1,8 +1,8 @@
 
 // Creates two RTCPeerConnection and tries to connect them. Returns
 // "allowed" if the connection is permitted, "blocked" if it is
-// blocked on both sides and "inconsistent" in the even that the
-// result is the same on both sides (should never happen).
+// blocked on both sides and "inconsistent" in the event that the
+// result is not the same on both sides (should never happen).
 async function tryConnect() {
     const iceServers = [{urls: "stun:stun.l.google.com:19302"}];
     const pc1 = new RTCPeerConnection({iceServers});


### PR DESCRIPTION
...as specified in:

- https://github.com/w3c/webappsec-csp/pull/457
- https://github.com/w3c/webrtc-extensions/pull/81

---

This is a work in progress; in particular:

- Right now all of the "allow" tests fail with:

```
  ▶ ERROR [expected OK] /content-security-policy/webrtc/webrtc-allowed-nopolicy.html
  └   → Unhandled rejection: Unknown ufrag (3a846ca3)
```

If I silence that one rejection they pass (and the "blocked" tests still fail), but I don't know the right approach to make sure that event doesn't fire before we can handle it.

- I'm very fuzzy on whether this is actually the right approach; right now this tries to monitor the ice agent's transitions and make sure it goes straight from new to failed, but my grasp of the intricacies of webrtc is still somewhat tenuous, so I would not be surprised if the logic for this was wrong in some critical way.

I would appreciate feedback.

cc: @jan-ivar @alvestrand @annevk @antosart 