### PR TITLE
geolocation-API: Call test_driver.set_permission() in tests that depend on permissions

### DIFF
--- a/geolocation-API/getCurrentPosition_permission_allow.https.html
+++ b/geolocation-API/getCurrentPosition_permission_allow.https.html
@@ -4,31 +4,25 @@
 <link rel='help' href='http://www.w3.org/TR/geolocation-API/#get-current-position'>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
+<script src='/resources/testdriver.js'></script>
+<script src='/resources/testdriver-vendor.js'></script>
 <script src='support.js'></script>
-
-<p>Clear all Geolocation permissions before running this test. If prompted for permission, please allow.</p>
-<div id='log'></div>
-
 <script>
 // Rewrite http://dev.w3.org/geo/api/test-suite/t.html?00002
-var t = async_test('User allows access, check that success callback is called or error callback is called with correct code.'),
-    onSuccess, onError, hasMethodReturned = false;
+promise_test(async t => {
+  await test_driver.set_permission({name: 'geolocation'}, 'granted');
 
-t.step(function() {
-  onSuccess = t.step_func_done(function(pos) {
-    // Rewrite http://dev.w3.org/geo/api/test-suite/t.html?00031
+  let hasMethodReturned = false;
+
+  return new Promise(resolve => {
+    geo.getCurrentPosition(resolve, resolve);
+    hasMethodReturned = true;
+  }).then(() => {
     assert_true(hasMethodReturned);
-  });
-
-  onError = t.step_func_done(function(err) {
-    // Rewrite http://dev.w3.org/geo/api/test-suite/t.html?00031
+  }).catch(err => {
     assert_true(hasMethodReturned);
     assert_false(isUsingPreemptivePermission);
     assert_equals(err.code, err.POSITION_UNAVAILABLE, errorToString(err));
   });
-
-  geo.getCurrentPosition(onSuccess, onError);
-  hasMethodReturned = true;
-});
-
+}, 'User allows access, check that success callback is called or error callback is called with correct code.');
 </script>

--- a/geolocation-API/getCurrentPosition_permission_deny.https.html
+++ b/geolocation-API/getCurrentPosition_permission_deny.https.html
@@ -4,29 +4,25 @@
 <link rel='help' href='http://www.w3.org/TR/geolocation-API/#privacy_for_uas'>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
+<script src='/resources/testdriver.js'></script>
+<script src='/resources/testdriver-vendor.js'></script>
 <script src='support.js'></script>
-
-<p>Clear all Geolocation permissions before running this test. If prompted for permission, please deny.</p>
-<div id='log'></div>
-
 <script>
 // Rewrite http://dev.w3.org/geo/api/test-suite/t.html?00001
-var t = async_test('User denies access, check that error callback is called with correct code'),
-    onSuccess, onError, hasMethodReturned = false;
+promise_test(async () => {
+  await test_driver.set_permission({name: 'geolocation'}, 'denied');
 
-t.step(function() {
-  onSuccess = t.step_func_done(function(pos) {
+  let hasMethodReturned = false;
+
+  return new Promise((resolve, reject) => {
+    geo.getCurrentPosition(resolve, reject);
+    hasMethodReturned = true;
+  }).then(pos => {
     assert_unreached('A success callback was invoked unexpectedly with position ' + positionToString(pos));
-  });
-
-  onError =  t.step_func_done(function(err) {
+  }).catch(err => {
     // http://dev.w3.org/geo/api/test-suite/t.html?00031
     assert_true(hasMethodReturned, 'Check that getCurrentPosition returns synchronously before any callbacks are invoked');
     assert_equals(err.code, err.PERMISSION_DENIED, errorToString(err));
   });
-
-  geo.getCurrentPosition(onSuccess, onError);
-  hasMethodReturned = true;
-});
-
+}, 'User denies access, check that error callback is called with correct code');
 </script>

--- a/geolocation-API/watchPosition_permission_deny.https.html
+++ b/geolocation-API/watchPosition_permission_deny.https.html
@@ -4,30 +4,28 @@
 <link rel='help' href='http://www.w3.org/TR/geolocation-API/#watch-position'>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
+<script src='/resources/testdriver.js'></script>
+<script src='/resources/testdriver-vendor.js'></script>
 <script src='support.js'></script>
-
-<p>Clear all Geolocation permissions before running this test. If prompted for permission, please deny.</p>
-<div id='log'></div>
-
 <script>
 // Rewrite http://dev.w3.org/geo/api/test-suite/t.html?00062
-var t = async_test('Check that watchPosition returns synchronously before any callbacks are invoked.'),
-    id, checkMethodHasReturned, hasMethodReturned = false;
+promise_test(async t => {
+  await test_driver.set_permission({name: 'geolocation'}, 'denied');
 
-checkMethodHasReturned = t.step_func_done(function() {
-  assert_true(hasMethodReturned);
-});
+  let hasMethodReturned = false;
+  let id = null;
 
-try {
-  id = geo.watchPosition(checkMethodHasReturned, checkMethodHasReturned);
-  hasMethodReturned = true;
-} catch(e) {
-  t.unreached_func('An exception was thrown unexpectedly: ' + e.message);
-}
+  return new Promise((resolve, reject) => {
+    id = geo.watchPosition(resolve, reject);
+    hasMethodReturned = true;
+  }).then(() => {
+    assert_true(hasMethodReturned);
+  }).catch(() => {
+    assert_true(hasMethodReturned);
 
-// Rewrite http://dev.w3.org/geo/api/test-suite/t.html?00151
-test(function() {
-  assert_greater_than_equal(id, -2147483648);
-  assert_less_than_equal(id, 2147483647);
-}, 'Check that watchPosition returns a long');
+    // Rewrite http://dev.w3.org/geo/api/test-suite/t.html?00151
+    assert_greater_than_equal(id, -2147483648);
+    assert_less_than_equal(id, 2147483647);
+  });
+}, 'Check that watchPosition returns synchronously before any callbacks are invoked.');
 </script>


### PR DESCRIPTION
Some tests were timing out in https://wpt.fyi because they depended on
geolocation requests either being granted or denied by default but did not
call `test_driver.set_permission()`. In this case, they were depending on
browser defaults, which are usually to prompt for geolocation access.

While here, make the tests `promise_test()`s so that calling
`test_driver.set_permission()` actually works and modernize the code to make
it more readable.

Tests relying on geolocation requests being allowed are still timing out on
at least Chrome and Edge because they need some geolocation data to be
provided as far as I can see.

This should help with w3c/geolocation-api#120.
