### PR TITLE
geolocation-API: Stop creating video and audio elements in idlharness test

### DIFF
--- a/geolocation-API/idlharness.https.window.js
+++ b/geolocation-API/idlharness.https.window.js
@@ -7,8 +7,6 @@ idl_test(
   ['geolocation'],
   ['hr-time', 'html'],
   idl_array => {
-    self.audio = document.createElement('audio');
-    self.video = document.createElement('video');
     idl_array.add_objects({
       Navigator: ['navigator'],
       Geolocation: ['navigator.geolocation'],


### PR DESCRIPTION
These were likely added copy-pasted by mistake in #18677.
