### PR TITLE
refactor BrowserSetup classes in tools/wpt/run.py

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -661,7 +661,7 @@ class Chrome(Browser):
     def find_webdriver(self, venv_path=None, channel=None, browser_binary=None):
         return find_executable("chromedriver")
 
-    def webdriver_supports_browser(self, webdriver_binary, browser_binary, browser_channel):
+    def webdriver_supports_browser(self, webdriver_binary, browser_binary, channel=None):
         chromedriver_version = self.webdriver_version(webdriver_binary)
         if not chromedriver_version:
             self.logger.warning(
@@ -682,7 +682,7 @@ class Chrome(Browser):
             # There is no official ChromeDriver release for the dev channel -
             # it switches between beta and tip-of-tree, so we accept version+1
             # too for dev.
-            if browser_channel == "dev" and chromedriver_major == (browser_major + 1):
+            if channel == "dev" and chromedriver_major == (browser_major + 1):
                 self.logger.debug(
                     "Accepting ChromeDriver %s for Chrome/Chromium Dev %s" %
                     (chromedriver_version, browser_version))
@@ -795,6 +795,10 @@ class Chrome(Browser):
         return m.group(1)
 
     def webdriver_version(self, webdriver_binary):
+        if webdriver_binary is None:
+            self.logger.debug("Attempted to get version of webdriver, but webdriver not provided.")
+            return None
+
         if uname[0] == "Windows":
             return _get_fileversion(webdriver_binary, self.logger)
 
@@ -1090,7 +1094,7 @@ class EdgeChromium(Browser):
     def find_webdriver(self, venv_path=None, channel=None):
         return find_executable("msedgedriver")
 
-    def webdriver_supports_browser(self, webdriver_binary, browser_binary):
+    def webdriver_supports_browser(self, webdriver_binary, browser_binary, channel=None):
         edgedriver_version = self.webdriver_version(webdriver_binary)
         if not edgedriver_version:
             self.logger.warning(
@@ -1191,6 +1195,10 @@ class EdgeChromium(Browser):
         return m.group(1)
 
     def webdriver_version(self, webdriver_binary):
+        if webdriver_binary is None:
+            self.logger.debug("Attempted to get version of webdriver, but webdriver not provided.")
+            return None
+
         if self.platform == "win":
             return _get_fileversion(webdriver_binary, self.logger)
 

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -337,11 +337,6 @@ class ChromiumBasedBrowser(BrowserSetup):
             else:
                 raise WptrunError(f"Unable to locate {self.name.capitalize()} binary")
 
-            if os.getenv("TASKCLUSTER_ROOT_URL"):
-                # We are on Taskcluster, where our Docker container does not have
-                # enough capabilities to run Chrome with sandboxing. (gh-20133)
-                kwargs["binary_args"].append("--no-sandbox")
-
         if kwargs["webdriver_binary"] is None:
             webdriver_binary = None
             if not kwargs["install_webdriver"]:
@@ -368,8 +363,8 @@ class ChromiumBasedBrowser(BrowserSetup):
             else:
                 raise WptrunError("Unable to locate or install matching webdriver binary")
 
-        # Enable/install MojoJS for Chrome/Chromium
         if self.name in ("chrome", "chromium"):
+            # Enable/install MojoJS for Chrome/Chromium
             if kwargs["mojojs_path"]:
                 kwargs["enable_mojojs"] = True
                 logger.info("--mojojs-path is provided, enabling MojoJS")
@@ -385,6 +380,11 @@ class ChromiumBasedBrowser(BrowserSetup):
                     logger.info("MojoJS enabled automatically (mojojs_path: %s)" % path)
                 except Exception as e:
                     logger.error("Cannot enable MojoJS: %s" % e)
+
+            if os.getenv("TASKCLUSTER_ROOT_URL"):
+                # We are on Taskcluster, where our Docker container does not have
+                # enough capabilities to run Chrome with sandboxing. (gh-20133)
+                kwargs["binary_args"].append("--no-sandbox")
 
         if browser_channel in self.experimental_channels:
             logger.info("Automatically turning on experimental features for "


### PR DESCRIPTION
- Browser classes and experimental channels are now passed as arguments in the constructor to BrowserSetup classes. This removes the need to create new BrowserSetup classes with different attributes only (e.g. EdgeWebdriver and ServoDriver).
- Chrome's and Edge's BrowserSetup class has been merged into a single ChromiumBasedBrowser class, as their setups are very similar. This will also be used by Chromium when it is implemented as a new product.