### PR TITLE
Fix modal-dialog-in-table-column.html & modal-dialog-in-replaced-rend…

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/modal-dialog-in-replaced-renderer-ref.html
+++ b/html/semantics/interactive-elements/the-dialog-element/modal-dialog-in-replaced-renderer-ref.html
@@ -12,13 +12,7 @@ div {
 </style>
 </head>
 <body>
-<p>Bug <a href="http://webkit.org/b/103477">103477</a>: Make
-NodeRenderingContext::parentRenderer and nextRenderer top layer aware
-<p>The test passes if you see a green square near the top and green rectangle in the center of the viewport.
+<p>The test passes if you see a green square near the top of the viewport.
 <div></div>
-<dialog id="dialog"></dialog>
-<script>
-document.getElementById('dialog').showModal();
-</script>
 </body>
 </html>

--- a/html/semantics/interactive-elements/the-dialog-element/modal-dialog-in-replaced-renderer.html
+++ b/html/semantics/interactive-elements/the-dialog-element/modal-dialog-in-replaced-renderer.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<title>Modal dialog inside replaced renderer should not generate box</title>
 <link rel="match" href="modal-dialog-in-replaced-renderer-ref.html">
 <link rel="help" href="https://fullscreen.spec.whatwg.org/#new-stacking-layer">
 <style>
@@ -14,9 +15,7 @@ div {
 </style>
 </head>
 <body>
-<p>Bug <a href="http://webkit.org/b/103477">103477</a>: Make
-NodeRenderingContext::parentRenderer and nextRenderer top layer aware
-<p>The test passes if you see a green square near the top and green rectangle in the center of the viewport.
+<p>The test passes if you see a green square near the top of the viewport.
 <div>
 <dialog id="dialog"></dialog>
 </div>

--- a/html/semantics/interactive-elements/the-dialog-element/modal-dialog-in-table-column-ref.html
+++ b/html/semantics/interactive-elements/the-dialog-element/modal-dialog-in-table-column-ref.html
@@ -9,12 +9,6 @@ dialog {
 </style>
 </head>
 <body>
-<p>Bug <a href="http://webkit.org/b/103477">103477</a>: Make
-NodeRenderingContext::parentRenderer and nextRenderer top layer aware
-<p>The test passes if you see a green rectangle in the center of the viewport.
-<dialog id="dialog"></dialog>
-<script>
-document.getElementById('dialog').showModal();
-</script>
+<p>The test passes if you see no green rectangle.
 </body>
 </html>

--- a/html/semantics/interactive-elements/the-dialog-element/modal-dialog-in-table-column.html
+++ b/html/semantics/interactive-elements/the-dialog-element/modal-dialog-in-table-column.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<title>Modal dialog inside display: table-column should not generate box</title>
 <link rel="match" href="modal-dialog-in-table-column-ref.html">
 <link rel="help" href="https://fullscreen.spec.whatwg.org/#new-stacking-layer">
 <style>
@@ -14,9 +15,7 @@ div {
 </style>
 </head>
 <body>
-<p>Bug <a href="http://webkit.org/b/103477">103477</a>: Make
-NodeRenderingContext::parentRenderer and nextRenderer top layer aware
-<p>The test passes if you see a green rectangle in the center of the viewport.
+<p>The test passes if you see no green rectangle.
 <div>
 <dialog id="dialog"></dialog>
 </div>


### PR DESCRIPTION
…erer.html to match Gecko & WebKit behavior

Gecko & WebKit do not generate boxes for modal dialogs in replaced renderers, and nothing in the spec really says this is the wanted behavior.

Blink follows the 'reparent in box tree' logic, but it can be argued that since no box is generated in the first place (like for display: none),
there is nothing to reparent, hence no box should be displayed.

This is the consensus of a CSSWG meeting: https://github.com/w3c/csswg-drafts/issues/6939#issuecomment-1016671534