### PR TITLE
Add `shadowrealm` global support for any.js tests

### DIFF
--- a/docs/writing-tests/testharness.md
+++ b/docs/writing-tests/testharness.md
@@ -167,6 +167,9 @@ are:
 * `jsshell`: to be run in a JavaScript shell, without access to the DOM
   (currently only supported in SpiderMonkey, and skipped in wptrunner)
 * `worker`: shorthand for the dedicated, shared, and service worker scopes
+* `shadowrealm`: runs the test code in a
+  [ShadowRealm](https://github.com/tc39/proposal-shadowrealm) context hosted in
+  an ordinary Window context; to be run at <code><var>x</var>.any.shadowrealm.html</code>
 
 To check if your test is run from a window or worker you can use the following two methods that will
 be made available by the framework:

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -91,6 +91,7 @@ _any_variants = {
     "dedicatedworker-module": {"suffix": ".any.worker-module.html"},
     "worker": {"longhand": {"dedicatedworker", "sharedworker", "serviceworker"}},
     "worker-module": {},
+    "shadowrealm": {},
     "jsshell": {"suffix": ".any.js"},
 }  # type: Dict[Text, Dict[Text, Any]]
 

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -356,7 +356,7 @@ class ShadowRealmHandler(HtmlWrapperHandler):
 <script src="/resources/testharnessreport.js"></script>
 <script>
 (async function() {
-  const r = new ShadowRealm;
+  const r = new ShadowRealm();
   const results = JSON.parse(await new Promise(r.evaluate(`
     (resolve, reject) => {
       (async () => {
@@ -388,6 +388,7 @@ class ShadowRealmHandler(HtmlWrapperHandler):
 })();
 </script>
 """
+
     def _script_replacement(self, key, value):
         if key == "script":
             return 'await import("%s");' % value

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -362,7 +362,6 @@ class ShadowRealmHandler(HtmlWrapperHandler):
       (async () => {
         await import("/resources/testharness.js");
         %(script)s
-        globalThis.self = globalThis;
         globalThis.self.GLOBAL = {
           isWindow: function() { return false; },
           isWorker: function() { return false; },


### PR DESCRIPTION
I'm assuming that this is desirable (please let me know if not!)--adding some
web API functionality to shadow realms suggests to me that we should be running
as many of the same tests as possible also in a shadow realms context; so, this
patches in support for that to the existing rewrite/wrapper functionality; using
the approach already in idlharness-shadowrealm.js

Tested w/ WebKit (patched to expose URL, URLSearchParams) and some of the tests
in the `url` suite, I'll also put that patch up if the approach is OK.

---

Aside: I am not sure, in the case that we want to support running
`any.shadowrealm` tests, if we should run them in multiple enclosing contexts,
or if it is comfortable enough to run them in a window alone. That is, you could
imagine running `shadowrealm` (ShadowRealm in Window),
`shadowrealm-worker` (ShadowRealm in dedicated worker), and other variants.
Maybe we wait until there is evidence that different enclosing scopes raise
compatibility concerns?