### PR TITLE
Don't read product list from wptrunner.ini file

### DIFF
--- a/tools/wptrunner/wptrunner/products.py
+++ b/tools/wptrunner/wptrunner/products.py
@@ -4,16 +4,8 @@ import imp
 from .browsers import product_list
 
 
-def products_enabled(config):
-    names = config.get("products", {}).keys()
-    if not names:
-        return product_list
-    else:
-        return names
-
-
 def product_module(config, product):
-    if product not in products_enabled(config):
+    if product not in product_list:
         raise ValueError("Unknown product %s" % product)
 
     path = config.get("products", {}).get(product, None)

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -38,8 +38,7 @@ def create_parser(product_choices=None):
     from . import products
 
     if product_choices is None:
-        config_data = config.load()
-        product_choices = products.products_enabled(config_data)
+        product_choices = products.product_list
 
     parser = argparse.ArgumentParser(description="""Runner for web-platform-tests tests.""",
                                      usage="""%(prog)s [OPTION]... [TEST]...
@@ -659,8 +658,7 @@ def create_parser_update(product_choices=None):
     from . import products
 
     if product_choices is None:
-        config_data = config.load()
-        product_choices = products.products_enabled(config_data)
+        product_choices = products.product_list
 
     parser = argparse.ArgumentParser("web-platform-tests-update",
                                      description="Update script for web-platform-tests tests.")


### PR DESCRIPTION
This wasn't very useful; frontends that just support a single
product can directly populate product_choices