### PR TITLE
Change fetch/metadata/download test to have reliable output

### DIFF
--- a/fetch/metadata/download.https.sub.html
+++ b/fetch/metadata/download.https.sub.html
@@ -12,7 +12,7 @@
       let nonce = token();
       let a = document.createElement('a');
       a.download = '';
-      a.text = nonce;
+      a.text = 'Download URL';
 
       let url = `https://${host}/fetch/metadata/resources/record-header.py?file=download` + nonce;
       a.href = url;


### PR DESCRIPTION
Using the nonce in the output means WebKit can't make use of it for its automated testing which requires consistent output to compare against expectations.