### PR TITLE
Fix documentation build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ sphinx-argparse==0.3.1
 sphinx-autobuild==0.7.1
 sphinx-js==3.1.2
 sphinx==4.4.0
+markupsafe==2.0.1


### PR DESCRIPTION
It turns out that markupsafe 2.1 removed a function that's used by
Jinja2, which in turn in used by Sphinx. Since Jinja2 just installs
the latest version of markupsafe, this breaks everything.

For now, explicitly pin the version of markupsafe to a known good
version to unbreak the docs build.