### PR TITLE
Remove BroadcastChannel dependency from speculation-rules

### DIFF
--- a/speculation-rules/prerender/about-blank-iframes.html
+++ b/speculation-rules/prerender/about-blank-iframes.html
@@ -7,6 +7,7 @@ and prerenderingchange event.
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
 <script src="resources/utils.js"></script>
 <body>
 <script>
@@ -14,7 +15,8 @@ and prerenderingchange event.
 setup(() => assertSpeculationRulesIsSupported());
 
 promise_test(async t => {
-  const channel = new BroadcastChannel('test-channel');
+  const uid = token();
+  const channel = new PrerenderChannel('test-channel', uid);
 
   const gotMessage = new Promise(resolve => {
     channel.addEventListener('message', e => {
@@ -23,7 +25,7 @@ promise_test(async t => {
   });
 
   // Make the window to start the prerender.
-  const url = `resources/about-blank-iframes.html`;
+  const url = `resources/about-blank-iframes.html?uid=${uid}`;
   window.open(url, '_blank', 'noopener');
 
   const msg = await gotMessage;

--- a/speculation-rules/prerender/activation-start.html
+++ b/speculation-rules/prerender/activation-start.html
@@ -3,21 +3,22 @@
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
 <script src="resources/utils.js"></script>
 <body>
 <script>
 
 setup(() => assertSpeculationRulesIsSupported());
-
 promise_test(async t => {
-  const testChannel = new BroadcastChannel('test-channel');
+  const uid = token();
+  const testChannel = new PrerenderChannel('test-channel', uid);
   t.add_cleanup(() => {
     testChannel.close();
   });
   const gotMessage = new Promise(resolve => {
     testChannel.addEventListener('message', e => resolve(e.data), {once: true});
   });
-  window.open('resources/activation-start.html', '_blank', 'noopener');
+  window.open(`resources/activation-start.html?uid=${uid}`, '_blank', 'noopener');
   assert_equals(await gotMessage, 'Done');
 }, 'PerformanceNavigationTiming.activationStart in prerendered page');
 

--- a/speculation-rules/prerender/cross-origin-isolated.https.html
+++ b/speculation-rules/prerender/cross-origin-isolated.https.html
@@ -3,6 +3,7 @@
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
 <script src="resources/utils.js"></script>
 <body>
 <script>
@@ -10,7 +11,8 @@
 setup(() => assertSpeculationRulesIsSupported());
 
 promise_test(async t => {
-  const testChannel = new BroadcastChannel('test-channel');
+  const uid = token();
+  const testChannel = new PrerenderChannel('test-channel', uid);
   t.add_cleanup(() => {
     testChannel.close();
   });
@@ -18,7 +20,7 @@ promise_test(async t => {
     testChannel.addEventListener('message', e => resolve(e.data), {once: true});
   });
 
-  startPrerendering('resources/cross-origin-isolated.https.html');
+  startPrerendering(`resources/cross-origin-isolated.https.html?uid=${uid}`);
   assert_true(await gotMessage);
 }, 'Allow crossOriginIsolated in prerendered page');
 

--- a/speculation-rules/prerender/iframe-added-post-activation.html
+++ b/speculation-rules/prerender/iframe-added-post-activation.html
@@ -7,6 +7,7 @@ document.prerendering false.
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
 <script src="resources/utils.js"></script>
 <body>
 <script>
@@ -14,12 +15,13 @@ document.prerendering false.
 setup(() => assertSpeculationRulesIsSupported());
 
 promise_test(async t => {
-  const channel = new BroadcastChannel('test-channel');
+  const uid = token();
+  const channel = new PrerenderChannel('test-channel', uid);
   const messageQueue = new BroadcastMessageQueue(channel);
   t.add_cleanup(_ => channel.close());
 
   // Make the window to start the prerender.
-  const url = `resources/iframe-added-post-activation.html`;
+  const url = `resources/iframe-added-post-activation.html?uid=${uid}`;
   window.open(url, '_blank', 'noopener');
 
   // Wait for done.

--- a/speculation-rules/prerender/resources/about-blank-iframes.html
+++ b/speculation-rules/prerender/resources/about-blank-iframes.html
@@ -85,7 +85,7 @@ async function main() {
   });
 
   // Ask to activate.
-  const prerenderChannel = new BroadcastChannel('prerender-channel');
+  const prerenderChannel = new PrerenderChannel('prerender-channel');
   prerenderChannel.postMessage('readyToActivate');
 
   // Test document.prerendering post-activation for each document.
@@ -104,7 +104,7 @@ if (!isPrerendering) {
 } else {
   // For the prerendering page, run main() then message the test page with the
   // result.
-  const testChannel = new BroadcastChannel('test-channel');
+  const testChannel = new PrerenderChannel('test-channel');
   main().then(() => {
     testChannel.postMessage('PASS');
   }).catch((e) => {

--- a/speculation-rules/prerender/resources/activation-start.html
+++ b/speculation-rules/prerender/resources/activation-start.html
@@ -20,7 +20,7 @@ function getActivationStart() {
 }
 
 (async () => {
-  const testChannel = new BroadcastChannel('test-channel');
+  const testChannel = new PrerenderChannel('test-channel');
   const params = new URLSearchParams(location.search);
   const isPrerenderingMainFrame = params.has('prerendering') &&
                                   !params.has('iframe');
@@ -36,9 +36,9 @@ function getActivationStart() {
   // 3. The prerendering document opens the iframe document (isIframe).
   try {
     if (isInitiator) {
-      // We use a BroadcastChannel to receive a message from the prerendering
+      // We use a PrerenderChannel to receive a message from the prerendering
       // iframe.
-      const prerenderChannel = new BroadcastChannel('prerender-channel');
+      const prerenderChannel = new PrerenderChannel('prerender-channel');
       const prerendering_url = new URL(document.URL);
       prerendering_url.searchParams.set('prerendering', '');
       startPrerendering(prerendering_url);
@@ -80,7 +80,7 @@ function getActivationStart() {
       // Finishes the test.
       testChannel.postMessage('Done');
     } else if (isIframe) {
-      const prerenderChannel = new BroadcastChannel('prerender-channel');
+      const prerenderChannel = new PrerenderChannel('prerender-channel');
       const initial_value = getActivationStart();
       const activation_start_promise = new Promise(resolve => {
         document.addEventListener('prerenderingchange', () => {

--- a/speculation-rules/prerender/resources/cross-origin-isolated.https.html
+++ b/speculation-rules/prerender/resources/cross-origin-isolated.https.html
@@ -8,7 +8,7 @@ window.onmessage = function(e) {
   assert_equals(e.data.name, 'crossOriginIsolated');
   assert_true(e.data.value);
 
-  const testChannel = new BroadcastChannel('test-channel');
+  const testChannel = new PrerenderChannel('test-channel');
   testChannel.postMessage(self.crossOriginIsolated);
   testChannel.close();
 };

--- a/speculation-rules/prerender/resources/deferred-promise-utils.js
+++ b/speculation-rules/prerender/resources/deferred-promise-utils.js
@@ -23,6 +23,9 @@
 class PrerenderEventCollector {
   constructor() {
     this.eventsSeen_ = [];
+    new PrerenderChannel('close').addEventListener('message', () => {
+      window.close();
+    });
   }
 
   // Adds an event to `eventsSeen_` along with the prerendering state of the
@@ -49,11 +52,9 @@ class PrerenderEventCollector {
             })
         .finally(() => {
           // Used to communicate with the main test page.
-          const testChannel = new BroadcastChannel('test-channel');
+          const testChannel = new PrerenderChannel('test-channel');
           // Send the observed events back to the main test page.
           testChannel.postMessage(this.eventsSeen_);
-          testChannel.close();
-          window.close();
         });
     document.addEventListener('prerenderingchange', () => {
       this.addEvent('prerendering change');
@@ -63,10 +64,9 @@ class PrerenderEventCollector {
     // resolves a promise without waiting for activation.
     setTimeout(() => {
       // Used to communicate with the initiator page.
-      const prerenderChannel = new BroadcastChannel('prerender-channel');
+      const prerenderChannel = new PrerenderChannel('prerender-channel');
       // Inform the initiator page that this page is ready to be activated.
       prerenderChannel.postMessage('readyToActivate');
-      prerenderChannel.close();
     }, 0);
   }
 }

--- a/speculation-rules/prerender/resources/deprecated-broadcast-channel.py
+++ b/speculation-rules/prerender/resources/deprecated-broadcast-channel.py
@@ -1,0 +1,28 @@
+import json
+import time
+def main(request, response):
+    uid = request.GET.first(b"uid")
+    name = request.GET.first(b"name")
+    time.sleep(0.1)
+
+    messagesByName = []
+    if request.method == 'POST':
+        with request.server.stash.lock:
+            messages = request.server.stash.take(uid) or {}
+            if name in messages:
+                messagesByName = messages[name]
+
+            messagesByName.append(json.loads(request.body))
+            messages[name] = messagesByName
+            request.server.stash.put(uid, messages)
+        response.status = 204
+    else:
+        with request.server.stash.lock:
+            messages = request.server.stash.take(uid) or {}
+            if name in messages:
+                messagesByName = messages[name]
+
+            request.server.stash.put(uid, messages)
+            response.status = 200
+            response.headers['Content-Type'] = 'application/json'
+            response.content = json.dumps(messagesByName)

--- a/speculation-rules/prerender/resources/iframe-added-post-activation.html
+++ b/speculation-rules/prerender/resources/iframe-added-post-activation.html
@@ -29,7 +29,7 @@ async function main() {
   });
 
   // Ask to activate.
-  const prerenderChannel = new BroadcastChannel('prerender-channel');
+  const prerenderChannel = new PrerenderChannel('prerender-channel');
   prerenderChannel.postMessage('readyToActivate');
 
   // Check that document.prerendering is false in the iframe.
@@ -46,7 +46,7 @@ if (!isPrerendering) {
 } else {
   // For the prerendering page, run main() then message the test page with the
   // result.
-  const testChannel = new BroadcastChannel('test-channel');
+  const testChannel = new PrerenderChannel('test-channel');
   main().then(() => {
     testChannel.postMessage('PASS');
   }).catch((e) => {

--- a/speculation-rules/prerender/resources/notification.html
+++ b/speculation-rules/prerender/resources/notification.html
@@ -13,9 +13,9 @@ if (!isPrerendering) {
   loadInitiatorPage();
 } else {
   // Used to communicate with the initiator page.
-  const prerenderChannel = new BroadcastChannel('prerender-channel');
+  const prerenderChannel = new PrerenderChannel('prerender-channel');
   // Used to communicate with the main test page.
-  const testChannel = new BroadcastChannel('test-channel');
+  const testChannel = new PrerenderChannel('test-channel');
 
   window.addEventListener('load', () => {
     // Inform the initiator page that this page is ready to be activated.

--- a/speculation-rules/prerender/resources/presentation-request.html
+++ b/speculation-rules/prerender/resources/presentation-request.html
@@ -6,7 +6,7 @@
 assert_true(document.prerendering);
 
 async function startPresentationRequest() {
-  const bc = new BroadcastChannel('prerender-channel');
+  const bc = new PrerenderChannel('prerender-channel');
   const presentationRequest = new PresentationRequest(
       'https://example.com/presentation.html');
 

--- a/speculation-rules/prerender/resources/storage-foundation-access.https.html
+++ b/speculation-rules/prerender/resources/storage-foundation-access.https.html
@@ -20,7 +20,7 @@ async function writeToFile(f) {
 }
 
 async function readWriteTest() {
-  const bc = new BroadcastChannel('prerender-channel');
+  const bc = new PrerenderChannel('prerender-channel');
   assert_true(document.prerendering);
 
   let f = await storageFoundation.open('test_file');

--- a/speculation-rules/prerender/resources/web-database-access.html
+++ b/speculation-rules/prerender/resources/web-database-access.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="utils.js"></script>
 <script>
 
-const bc = new BroadcastChannel('prerender-channel');
+const bc = new PrerenderChannel('prerender-channel');
 assert_true(document.prerendering);
 
 let result = "Success";

--- a/speculation-rules/prerender/resources/window-move.html
+++ b/speculation-rules/prerender/resources/window-move.html
@@ -15,7 +15,7 @@ function tryRun(func) {
   try {
     func();
   } catch (e) {
-    const testChannel = new BroadcastChannel('test-channel');
+    const testChannel = new PrerenderChannel('test-channel');
     testChannel.postMessage({status: 'FAIL: ' + e});
   }
 }
@@ -50,7 +50,7 @@ if (!isPrerendering) {
       }
   );
 
-  const bc = new BroadcastChannel('test-channel');
+  const bc = new PrerenderChannel('test-channel');
   bc.postMessage({
     'status': 'PASS',
     'prevPosition': prevPosition,

--- a/speculation-rules/prerender/resources/window-open-during-prerendering.html
+++ b/speculation-rules/prerender/resources/window-open-during-prerendering.html
@@ -9,10 +9,10 @@
 
 function runAsTriggerPage() {
   assert_false(document.prerendering);
-  startPrerendering(location.href + '?prerendering');
+  startPrerendering(location.href + '&prerendering=true');
 
   // Close this window for cleanup after the prerendering page runs the test.
-  const bc = new BroadcastChannel('result');
+  const bc = new PrerenderChannel('result');
   bc.onmessage = e => window.close();
 }
 
@@ -23,7 +23,7 @@ function runAsPrerenderingPage() {
   const win = window.open('empty.html', '_blank');
 
   // Send the result to the test runner page.
-  const bc = new BroadcastChannel('result');
+  const bc = new PrerenderChannel('result');
   if (win) {
     bc.postMessage('opened');
     win.close();
@@ -32,7 +32,7 @@ function runAsPrerenderingPage() {
   }
 }
 
-if (location.search === '?prerendering') {
+if (new URLSearchParams(location.search).has('prerendering')) {
   runAsPrerenderingPage();
 } else {
   runAsTriggerPage();

--- a/speculation-rules/prerender/resources/window-open-in-prerenderingchange.html
+++ b/speculation-rules/prerender/resources/window-open-in-prerenderingchange.html
@@ -14,12 +14,12 @@ function runAsTriggerPage() {
   assert_false(document.prerendering);
 
   // Start prerendering.
-  const prerendering_url = location.href + '?prerendering';
+  const prerendering_url = location.href + '&prerendering=true';
   startPrerendering(prerendering_url);
 
   // Activate the prerendering page once it gets ready.
-  const bc = new BroadcastChannel('activation-ready');
-  bc.onmessage = () => window.location = prerendering_url;
+  const bc = new PrerenderChannel('activation-ready');
+  bc.onmessage = () => { window.location = prerendering_url };
 }
 
 // Runs as prerendeirng page. First this page waits for the load event and
@@ -32,10 +32,13 @@ function runAsPrerenderingPage() {
     assert_true(document.prerendering);
 
     // Notify the trigger page of activation ready.
-    const bc = new BroadcastChannel('activation-ready');
+    const bc = new PrerenderChannel('activation-ready');
     bc.postMessage('ready for activation');
   }
 
+  new PrerenderChannel('close').addEventListener('message', () => {
+    window.close();
+  });
   document.onprerenderingchange = () => {
     assert_false(document.prerendering);
 
@@ -43,20 +46,17 @@ function runAsPrerenderingPage() {
     const win = window.open('empty.html', '_blank');
 
     // Send the result to the test runner page.
-    const bc = new BroadcastChannel('result');
+    const bc = new PrerenderChannel('result');
     if (win) {
       bc.postMessage('opened');
       win.close();
     } else {
       bc.postMessage('failed to open');
     }
-
-    // Close this window for cleanup.
-    window.close();
   };
 }
 
-if (location.search === '?prerendering') {
+if (new URLSearchParams(location.search).has('prerendering')) {
   runAsPrerenderingPage();
 } else {
   runAsTriggerPage();

--- a/speculation-rules/prerender/resources/window-resize.html
+++ b/speculation-rules/prerender/resources/window-resize.html
@@ -8,7 +8,7 @@ function tryRun(func) {
   try {
     func();
   } catch (e) {
-    const testChannel = new BroadcastChannel('test-channel');
+    const testChannel = new PrerenderChannel('test-channel');
     testChannel.postMessage({status: 'FAIL: ' + e});
   }
 }
@@ -52,7 +52,7 @@ if (!isPrerendering) {
     }
   });
 
-  const bc = new BroadcastChannel('test-channel');
+  const bc = new PrerenderChannel('test-channel');
   bc.postMessage({
     'status': 'PASS',
     'prevRect': prevRect,

--- a/speculation-rules/prerender/restriction-focus.html
+++ b/speculation-rules/prerender/restriction-focus.html
@@ -13,8 +13,6 @@
 setup(() => assertSpeculationRulesIsSupported());
 
 promise_test(async t => {
-  const bc = new BroadcastChannel('prerender-channel');
-
   document.getElementById('prerenderTextField').focus();
   assert_true(
       document.hasFocus(),

--- a/speculation-rules/prerender/restriction-notification.https.html
+++ b/speculation-rules/prerender/restriction-notification.https.html
@@ -11,6 +11,7 @@ TODO(https://crbug.com/1198110): Add the following tests:
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
+<script src="/common/utils.js"></script>
 <script src="resources/utils.js"></script>
 <body>
 <script>
@@ -18,7 +19,8 @@ TODO(https://crbug.com/1198110): Add the following tests:
 setup(() => assertSpeculationRulesIsSupported());
 
 promise_test(async t => {
-  const bc = new BroadcastChannel('test-channel');
+  const uid = token();
+  const bc = new PrerenderChannel('test-channel', uid);
   t.add_cleanup(_ => bc.close());
 
   await test_driver.set_permission({name: 'notifications'}, 'granted', true);
@@ -29,7 +31,7 @@ promise_test(async t => {
       once: true
     });
   });
-  const url = `resources/notification.html`;
+  const url = `resources/notification.html?uid=${uid}`;
   window.open(url, '_blank', 'noopener');
 
   const result = await gotMessage;

--- a/speculation-rules/prerender/restriction-presentation-request.https.html
+++ b/speculation-rules/prerender/restriction-presentation-request.https.html
@@ -3,6 +3,7 @@
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
 <script src="resources/utils.js"></script>
 <body>
 <script>
@@ -10,7 +11,8 @@
 setup(() => assertSpeculationRulesIsSupported());
 
 promise_test(async t => {
-  const bc = new BroadcastChannel('prerender-channel');
+  const uid = token();
+  const bc = new PrerenderChannel('prerender-channel', uid);
 
   const gotMessage = new Promise(resolve => {
     bc.addEventListener('message', e => {
@@ -21,7 +23,7 @@ promise_test(async t => {
   });
 
   // Start prerendering a page that attempts to start presentation.
-  startPrerendering(`resources/presentation-request.html`);
+  startPrerendering(`resources/presentation-request.html?uid=${uid}`);
 
   const result = await gotMessage;
   assert_equals(result, 'request failed');

--- a/speculation-rules/prerender/restriction-window-move.html
+++ b/speculation-rules/prerender/restriction-window-move.html
@@ -2,6 +2,7 @@
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
 <script src="resources/utils.js"></script>
 <body>
 <script>
@@ -12,7 +13,8 @@ setup(() => assertSpeculationRulesIsSupported());
 // See https://github.com/jeremyroman/alternate-loading-modes/issues/73.
 ['moveTo', 'moveBy'].forEach(moveFunc => {
   promise_test(async t => {
-    const bc = new BroadcastChannel('test-channel');
+    const uid = token();
+    const bc = new PrerenderChannel('test-channel', uid);
     t.add_cleanup(_ => bc.close());
 
     const gotMessage = new Promise(resolve => {
@@ -21,7 +23,7 @@ setup(() => assertSpeculationRulesIsSupported());
       }, {once: true});
     });
 
-    const url = `resources/window-move.html?move=${moveFunc}`;
+    const url = `resources/window-move.html?move=${moveFunc}&uid=${uid}`;
 
     // We have to open a new window to run the test, since a window that was
     // not created by window.open() cannot be moved.

--- a/speculation-rules/prerender/restriction-window-open.html
+++ b/speculation-rules/prerender/restriction-window-open.html
@@ -2,6 +2,7 @@
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
 <script src="resources/utils.js"></script>
 <body>
 <script>
@@ -10,15 +11,17 @@ setup(() => assertSpeculationRulesIsSupported());
 
 function runTest(test_file, expectation, description) {
   promise_test(async t => {
+    const uid = token();
     // Run test in a new window for test isolation.
-    window.open(test_file, '_blank', 'noopener');
+    window.open(`${test_file}?uid=${uid}`, '_blank', 'noopener');
 
     // Wait until the prerendered page sends the result.
-    const bc = new BroadcastChannel('result');
-    const gotMessage = new Promise(r => bc.onmessage = e => r(e.data));
-    const result = await gotMessage;
-
-    assert_equals(await gotMessage, expectation);
+    const bc = new PrerenderChannel('result', uid);
+    t.add_cleanup(() => {
+      new PrerenderChannel('close', uid).postMessage('close');
+    })
+    const result = await new Promise(r => bc.addEventListener('message', e => r(e.data)));
+    assert_equals(result, expectation);
   }, description);
 }
 

--- a/speculation-rules/prerender/restriction-window-resize.html
+++ b/speculation-rules/prerender/restriction-window-resize.html
@@ -2,6 +2,7 @@
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
 <script src="resources/utils.js"></script>
 <body>
 <script>
@@ -13,7 +14,8 @@ setup(() => assertSpeculationRulesIsSupported());
 ['resizeTo', 'resizeBy'].forEach(resizeFunc => {
   promise_test(
       async t => {
-        const bc = new BroadcastChannel('test-channel');
+        const uid = token();
+        const bc = new PrerenderChannel('test-channel', uid);
         t.add_cleanup(_ => bc.close());
 
         const gotMessage = new Promise(resolve => {
@@ -22,7 +24,7 @@ setup(() => assertSpeculationRulesIsSupported());
           }, {once: true});
         });
 
-        const url = `resources/window-resize.html?resize=${resizeFunc}`;
+        const url = `resources/window-resize.html?resize=${resizeFunc}&uid=${uid}`;
 
         // We have to open a new window to run the test, since a window that was
         // not created by window.open() cannot be resized.

--- a/speculation-rules/prerender/storage-foundation.https.html
+++ b/speculation-rules/prerender/storage-foundation.https.html
@@ -3,6 +3,7 @@
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
 <script src="resources/utils.js"></script>
 <body>
 <script>
@@ -32,7 +33,8 @@ async function readFromFile() {
 }
 
 promise_test(async t => {
-  const bc = new BroadcastChannel('prerender-channel');
+  const uid = token();
+  const bc = new PrerenderChannel('prerender-channel', uid);
 
   const gotMessage = new Promise(resolve => {
     bc.addEventListener('message', e => {

--- a/speculation-rules/prerender/visibility-state.html
+++ b/speculation-rules/prerender/visibility-state.html
@@ -3,6 +3,7 @@
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
 <script src="resources/utils.js"></script>
 <body>
 <script>
@@ -10,7 +11,8 @@
 setup(() => assertSpeculationRulesIsSupported());
 
 promise_test(async t => {
-  const bc = new BroadcastChannel('test-channel');
+  const uid = token();
+  const bc = new PrerenderChannel('test-channel', uid);
 
   const gotMessage = new Promise(resolve => {
     bc.addEventListener('message', e => {
@@ -19,7 +21,7 @@ promise_test(async t => {
       once: true
     });
   });
-  const url = `resources/visibility-state-check.html`;
+  const url = `resources/visibility-state-check.html?uid=${uid}`;
   window.open(url, '_blank', 'noopener');
 
   const result = await gotMessage;
@@ -47,6 +49,8 @@ promise_test(async t => {
     assert_equals(result[i].prerendering, expected[i].prerendering,
       `prerendering${i}`);
   }
+
+  new PrerenderChannel('close', uid).postMessage('')
 }, 'The visibilityState must be updated after prerendering.');
 
 </script>

--- a/speculation-rules/prerender/web-database.html
+++ b/speculation-rules/prerender/web-database.html
@@ -3,6 +3,7 @@
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
 <script src="resources/utils.js"></script>
 <body>
 <script>
@@ -38,7 +39,8 @@ async function selectQuery() {
 }
 
 promise_test(async t => {
-  const bc = new BroadcastChannel('prerender-channel');
+  const uid = token();
+  const bc = new PrerenderChannel('prerender-channel', uid);
 
   const gotMessage = new Promise(resolve => {
     bc.addEventListener('message', e => {
@@ -53,7 +55,7 @@ promise_test(async t => {
         'primary page should be able to execute statements from Web Database.');
 
   // Start prerendering a page that attempts to access Web Database.
-  startPrerendering('resources/web-database-access.html');
+  startPrerendering(`resources/web-database-access.html?uid=${uid}`);
   const result = await gotMessage;
 
   assert_equals(


### PR DESCRIPTION
Using a crude fetch-based channel for old tests to mimic `BroadcastChannel` behavior, and `dispatcher` for new tests.
Please don't use the legacy channel for any new test