### PR TITLE
Add WPT test for case where an anchor has a click handler that naviga…

### DIFF
--- a/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/tentative/anchor-fragment-history-back-on-click.html
+++ b/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/tentative/anchor-fragment-history-back-on-click.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(async t => {
+  // Wait for after the load event so that the navigation doesn't get converted
+  // into a replace navigation.
+  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+
+  location.hash = "#1";
+  assert_equals(location.hash, "#1");
+  location.hash = "#2";
+  assert_equals(location.hash, "#2");
+
+  let anchor = document.createElement("a");
+  anchor.href = "#3";
+  anchor.onclick = () => {
+    history.back();
+  };
+
+  let navigations = [];
+  let navigationsPromise = new Promise(resolve => {
+    onpopstate = () => {
+      navigations.push(location.hash);
+      if (navigations.length == 2)
+          resolve();
+    }
+  });
+
+  anchor.click();
+  await navigationsPromise;
+
+  // We were on #2 when history.back() was called so we should be on #1 now.
+  assert_equals(location.hash, "#1");
+
+  // While the history navigation back to "#1" was pending, we should have navigated to "#3".
+  assert_array_equals(navigations, ["#3", "#1"]);
+}, "Anchor with a fragment href and a click handler that navigates back");
+</script>


### PR DESCRIPTION
…tes back and a target that does a fragment navigation

This is a test to for https://bugs.webkit.org/show_bug.cgi?id=237451. The HOME link on weather.gov was broken in WebKit
but working in Blink & Gecko. This test mimics what the weather.gov page does and passes in both Blink/Gecko.