### PR TITLE
Stop tagging commits pushed to epoch branches

### DIFF
--- a/docs/admin/index.md
+++ b/docs/admin/index.md
@@ -29,11 +29,22 @@ infrastructure which makes the project possible.
 * :ref:`search`
 ```
 
-## Secrets
+## Coordinating different CI systems
 
-SSL certificates for all HTTPS-enabled domains are retrieved via [Let's
-Encrypt](https://letsencrypt.org/), so that data does not represent an
-explicitly-managed secret.
+Multiple CI systems are used to run tests and upload results to
+[wpt.fyi](https://wpt.fyi/). In order to ensure the same commit is
+used across CI systems, there are "epoch branches" like
+`epochs/daily` and `epochs/weekly` which can be used to trigger such
+runs.
+
+These branches are update by a [workflow](https://github.com/web-platform-tests/wpt/blob/master/.github/workflows/epochs.yml)
+using the `./wpt rev-list` command. This command can also be used to
+show what commits these branches have pointed to in the past, e.g., to
+show what the `epochs/daily` branch has been the past 10 days:
+
+```bash
+./wpt rev-list --epoch 1d --max-count 10
+```
 
 ## Third-party account owners
 

--- a/tools/ci/epochs_update.sh
+++ b/tools/ci/epochs_update.sh
@@ -32,18 +32,11 @@ main () {
             exit 1
         fi
         git branch "${EPOCH_BRANCH_NAME}" "${EPOCH_SHA}"
-
-        # Only set epoch tag if is not already tagged from a previous run.
-        if ! git tag --points-at "${EPOCH_SHA}" | grep "${EPOCH_BRANCH_NAME}"; then
-            EPOCH_STAMP="$(date +%Y-%m-%d_%HH)"
-            git tag "${EPOCH_BRANCH_NAME}/${EPOCH_STAMP}" "${EPOCH_SHA}"
-        fi
-
         ALL_BRANCHES_NAMES="${ALL_BRANCHES_NAMES} ${EPOCH_BRANCH_NAME}"
     done
     # This is safe because `git push` will by default fail for a non-fast-forward
     # push, for example if the remote branch is ahead of the local branch.
-    git push --tags ${REMOTE} ${ALL_BRANCHES_NAMES}
+    git push ${REMOTE} ${ALL_BRANCHES_NAMES}
 }
 
 cd $WPT_ROOT


### PR DESCRIPTION
This reverts https://github.com/web-platform-tests/wpt/pull/26122.

Document the epoch branches and how to debug them locally to remove the 
need for these tags.

Fixes https://github.com/web-platform-tests/wpt/pull/26122.