### PR TITLE
Output Chromium log on `shutdown`, not `suite_end`

### DIFF
--- a/tools/wptrunner/wptrunner/formatters/chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/chromium.py
@@ -200,8 +200,9 @@ class ChromiumFormatter(base.BaseFormatter):  # type: ignore
     def suite_start(self, data):
         # |data| contains a timestamp in microseconds, while time.time() gives
         # it in seconds.
-        self.start_timestamp_seconds = (float(data["time"]) / 1000 if "time" in data
-                                        else time.time())
+        if self.start_timestamp_seconds is None:
+            self.start_timestamp_seconds = (float(data["time"]) / 1000 if "time" in data
+                                            else time.time())
 
     def test_status(self, data):
         test_name = data["test"]
@@ -257,7 +258,7 @@ class ChromiumFormatter(base.BaseFormatter):  # type: ignore
         # New test, new browser logs.
         self.browser_log = []
 
-    def suite_end(self, data):
+    def shutdown(self, data):
         # Create the final result dictionary
         final_result = {
             # There are some required fields that we just hard-code.

--- a/tools/wptrunner/wptrunner/formatters/chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/chromium.py
@@ -198,11 +198,13 @@ class ChromiumFormatter(base.BaseFormatter):  # type: ignore
         return expected_statuses
 
     def suite_start(self, data):
-        # |data| contains a timestamp in microseconds, while time.time() gives
+        # |data| contains a timestamp in milliseconds, while time.time() gives
         # it in seconds.
         if self.start_timestamp_seconds is None:
-            self.start_timestamp_seconds = (float(data["time"]) / 1000 if "time" in data
-                                            else time.time())
+            if 'time' in data:
+                self.start_timestamp_seconds = float(data["time"]) / 1000
+            else:
+                self.start_timestamp_seconds = time.time()
 
     def test_status(self, data):
         test_name = data["test"]

--- a/tools/wptrunner/wptrunner/formatters/tests/test_chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/tests/test_chromium.py
@@ -15,6 +15,7 @@ def test_chromium_required_fields(capfd):
     # Set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
 
     # output a bunch of stuff
@@ -22,6 +23,7 @@ def test_chromium_required_fields(capfd):
     logger.test_start("test-id-1")
     logger.test_end("test-id-1", status="PASS", expected="PASS")
     logger.suite_end()
+    logger.shutdown()
 
     # check nothing got output to stdout/stderr
     # (note that mozlog outputs exceptions during handling to stderr!)
@@ -52,6 +54,7 @@ def test_chromium_test_name_trie(capfd):
     # Set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
 
     # output a bunch of stuff
@@ -62,6 +65,7 @@ def test_chromium_test_name_trie(capfd):
     logger.test_start("/foo/test-id-2")
     logger.test_end("/foo/test-id-2", status="ERROR", expected="TIMEOUT")
     logger.suite_end()
+    logger.shutdown()
 
     # check nothing got output to stdout/stderr
     # (note that mozlog outputs exceptions during handling to stderr!)
@@ -91,6 +95,7 @@ def test_num_failures_by_type(capfd):
     # Set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
 
     # Run some tests with different statuses: 3 passes, 1 timeout
@@ -104,6 +109,7 @@ def test_num_failures_by_type(capfd):
     logger.test_start("t4")
     logger.test_end("t4", status="TIMEOUT", expected="CRASH")
     logger.suite_end()
+    logger.shutdown()
 
     # check nothing got output to stdout/stderr
     # (note that mozlog outputs exceptions during handling to stderr!)
@@ -127,6 +133,7 @@ def test_subtest_messages(capfd):
     # Set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
 
     # Run two tests with subtest messages. The subtest name should be included
@@ -145,6 +152,7 @@ def test_subtest_messages(capfd):
     logger.test_end("t2", status="TIMEOUT", expected="PASS",
                     message="t2_message")
     logger.suite_end()
+    logger.shutdown()
 
     # check nothing got output to stdout/stderr
     # (note that mozlog outputs exceptions during handling to stderr!)
@@ -184,6 +192,7 @@ def test_subtest_failure(capfd):
     # Set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     formatter = ChromiumFormatter()
     logger.add_handler(handlers.StreamHandler(output, formatter))
 
@@ -204,6 +213,7 @@ def test_subtest_failure(capfd):
     # run the test to completion.
     logger.test_end("t1", status="PASS", expected="PASS", message="top_message")
     logger.suite_end()
+    logger.shutdown()
 
     # check nothing got output to stdout/stderr
     # (note that mozlog outputs exceptions during handling to stderr!)
@@ -246,6 +256,7 @@ def test_expected_subtest_failure(capfd):
     # Set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     formatter = ChromiumFormatter()
     logger.add_handler(handlers.StreamHandler(output, formatter))
 
@@ -267,6 +278,7 @@ def test_expected_subtest_failure(capfd):
     # run the test to completion.
     logger.test_end("t1", status="OK", expected="OK")
     logger.suite_end()
+    logger.shutdown()
 
     # check nothing got output to stdout/stderr
     # (note that mozlog outputs exceptions during handling to stderr!)
@@ -302,6 +314,7 @@ def test_unexpected_subtest_pass(capfd):
     # Set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     formatter = ChromiumFormatter()
     logger.add_handler(handlers.StreamHandler(output, formatter))
 
@@ -319,6 +332,7 @@ def test_unexpected_subtest_pass(capfd):
     # run the test to completion.
     logger.test_end("t1", status="PASS", expected="PASS")
     logger.suite_end()
+    logger.shutdown()
 
     # check nothing got output to stdout/stderr
     # (note that mozlog outputs exceptions during handling to stderr!)
@@ -355,6 +369,7 @@ def test_expected_test_fail(capfd):
     # Set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
 
     # Run some tests with different statuses: 3 passes, 1 timeout
@@ -362,6 +377,7 @@ def test_expected_test_fail(capfd):
     logger.test_start("t1")
     logger.test_end("t1", status="ERROR", expected="ERROR")
     logger.suite_end()
+    logger.shutdown()
 
     # check nothing got output to stdout/stderr
     # (note that mozlog outputs exceptions during handling to stderr!)
@@ -389,6 +405,7 @@ def test_unexpected_test_fail(capfd):
     # Set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
 
     # Run some tests with different statuses: 3 passes, 1 timeout
@@ -396,6 +413,7 @@ def test_unexpected_test_fail(capfd):
     logger.test_start("t1")
     logger.test_end("t1", status="ERROR", expected="OK")
     logger.suite_end()
+    logger.shutdown()
 
     # check nothing got output to stdout/stderr
     # (note that mozlog outputs exceptions during handling to stderr!)
@@ -424,6 +442,7 @@ def test_flaky_test_expected(capfd):
     # set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
 
     # Run a test that is known to be flaky
@@ -431,6 +450,7 @@ def test_flaky_test_expected(capfd):
     logger.test_start("t1")
     logger.test_end("t1", status="ERROR", expected="OK", known_intermittent=["ERROR", "TIMEOUT"])
     logger.suite_end()
+    logger.shutdown()
 
     # check nothing got output to stdout/stderr
     # (note that mozlog outputs exceptions during handling to stderr!)
@@ -460,6 +480,7 @@ def test_flaky_test_unexpected(capfd):
     # set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
 
     # Run a test that is known to be flaky
@@ -467,6 +488,7 @@ def test_flaky_test_unexpected(capfd):
     logger.test_start("t1")
     logger.test_end("t1", status="ERROR", expected="OK", known_intermittent=["TIMEOUT"])
     logger.suite_end()
+    logger.shutdown()
 
     # check nothing got output to stdout/stderr
     # (note that mozlog outputs exceptions during handling to stderr!)
@@ -495,6 +517,7 @@ def test_precondition_failed(capfd):
     # set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
 
     # Run a test with a precondition failure
@@ -502,6 +525,7 @@ def test_precondition_failed(capfd):
     logger.test_start("t1")
     logger.test_end("t1", status="PRECONDITION_FAILED", expected="OK")
     logger.suite_end()
+    logger.shutdown()
 
     # check nothing got output to stdout/stderr
     # (note that mozlog outputs exceptions during handling to stderr!)
@@ -523,6 +547,45 @@ def test_precondition_failed(capfd):
     assert test_obj["is_unexpected"] is True
 
 
+def test_repeated_runs(capfd):
+    # Check that the logger outputs one report after multiple test suite runs.
+
+    # Set up the handler.
+    output = StringIO()
+    logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
+    logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
+
+    # Run a test suite for the first time.
+    logger.suite_start(["t1"], run_info={}, time=123)
+    logger.test_start("t1")
+    logger.test_end("t1", status="PASS", expected="PASS", known_intermittent=[])
+    logger.suite_end()
+
+    # Run the test suite for the second time.
+    logger.suite_start(["t1"], run_info={}, time=456)
+    logger.test_start("t1")
+    logger.test_end("t1", status="FAIL", expected="PASS", known_intermittent=[])
+    logger.suite_end()
+
+    logger.shutdown()
+
+    # check nothing got output to stdout/stderr
+    # (note that mozlog outputs exceptions during handling to stderr!)
+    captured = capfd.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+    # check the actual output of the formatter
+    output.seek(0)
+    output_json = json.load(output)
+
+    # The latest status (FAIL) replaces the earlier one (PASS).
+    test_obj = output_json["tests"]["t1"]
+    assert test_obj["actual"] == "FAIL"
+    assert test_obj["expected"] == "PASS"
+
+
 def test_known_intermittent_empty(capfd):
     # If the known_intermittent list is empty, we want to ensure we don't append
     # any extraneous characters to the output.
@@ -530,6 +593,7 @@ def test_known_intermittent_empty(capfd):
     # set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
 
     # Run a test and include an empty known_intermittent list
@@ -537,6 +601,7 @@ def test_known_intermittent_empty(capfd):
     logger.test_start("t1")
     logger.test_end("t1", status="OK", expected="OK", known_intermittent=[])
     logger.suite_end()
+    logger.shutdown()
 
     # check nothing got output to stdout/stderr
     # (note that mozlog outputs exceptions during handling to stderr!)
@@ -561,6 +626,7 @@ def test_known_intermittent_duplicate(capfd):
     # Set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
 
     # There are two duplications in this input:
@@ -571,6 +637,7 @@ def test_known_intermittent_duplicate(capfd):
     logger.test_start("t1")
     logger.test_end("t1", status="ERROR", expected="ERROR", known_intermittent=["FAIL", "ERROR"])
     logger.suite_end()
+    logger.shutdown()
 
     # Check nothing got output to stdout/stderr.
     # (Note that mozlog outputs exceptions during handling to stderr!)
@@ -594,6 +661,7 @@ def test_reftest_screenshots(capfd):
     # Set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
 
     # Run a reftest with reftest_screenshots.
@@ -607,6 +675,7 @@ def test_reftest_screenshots(capfd):
         ]
     })
     logger.suite_end()
+    logger.shutdown()
 
     # check nothing got output to stdout/stderr
     # (note that mozlog outputs exceptions during handling to stderr!)
@@ -631,6 +700,7 @@ def test_process_output_crashing_test(capfd):
     # Set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
 
     logger.suite_start(["t1", "t2", "t3"], run_info={}, time=123)
@@ -652,6 +722,7 @@ def test_process_output_crashing_test(capfd):
     logger.test_end("t3", status="FAIL", expected="PASS")
 
     logger.suite_end()
+    logger.shutdown()
 
     # check nothing got output to stdout/stderr
     # (note that mozlog outputs exceptions during handling to stderr!)

--- a/tools/wptrunner/wptrunner/tests/test_formatters.py
+++ b/tools/wptrunner/wptrunner/tests/test_formatters.py
@@ -12,7 +12,6 @@ def test_wptreport_runtime(capfd):
     # setup the logger
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
-    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, WptreportFormatter()))
 
     # output a bunch of stuff
@@ -42,7 +41,6 @@ def test_wptreport_run_info_optional(capfd):
     # setup the logger
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
-    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, WptreportFormatter()))
 
     # output a bunch of stuff
@@ -66,7 +64,6 @@ def test_wptreport_run_info_optional(capfd):
 def test_wptreport_lone_surrogate(capfd):
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
-    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, WptreportFormatter()))
 
     # output a bunch of stuff
@@ -100,7 +97,6 @@ def test_wptreport_lone_surrogate(capfd):
 def test_wptreport_known_intermittent(capfd):
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
-    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, WptreportFormatter()))
 
     # output a bunch of stuff

--- a/tools/wptrunner/wptrunner/tests/test_formatters.py
+++ b/tools/wptrunner/wptrunner/tests/test_formatters.py
@@ -12,6 +12,7 @@ def test_wptreport_runtime(capfd):
     # setup the logger
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, WptreportFormatter()))
 
     # output a bunch of stuff
@@ -41,6 +42,7 @@ def test_wptreport_run_info_optional(capfd):
     # setup the logger
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, WptreportFormatter()))
 
     # output a bunch of stuff
@@ -64,6 +66,7 @@ def test_wptreport_run_info_optional(capfd):
 def test_wptreport_lone_surrogate(capfd):
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, WptreportFormatter()))
 
     # output a bunch of stuff
@@ -97,6 +100,7 @@ def test_wptreport_lone_surrogate(capfd):
 def test_wptreport_known_intermittent(capfd):
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
+    logger.reset_state()
     logger.add_handler(handlers.StreamHandler(output, WptreportFormatter()))
 
     # output a bunch of stuff

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -153,18 +153,25 @@ def get_pause_after_test(test_loader, **kwargs):
     return kwargs["pause_after_test"]
 
 
-def load_test_groups(test_loader, test_source_cls, test_source_kwargs):
+def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source_cls, run_info,
+                       recording, test_environment, product, run_test_kwargs):
+    """Runs the entire test suite.
+    This is called for each repeat run requested."""
     tests = []
     for test_type in test_loader.test_types:
         tests.extend(test_loader.tests[test_type])
-    test_groups = test_source_cls.tests_by_group(tests, **test_source_kwargs)
-    return test_groups
 
+    try:
+        test_groups = test_source_cls.tests_by_group(
+            tests, **test_source_kwargs)
+    except Exception:
+        logger.critical("Loading tests failed")
+        return False
 
-def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source_cls, test_groups,
-                       run_info, recording, test_environment, product, run_test_kwargs):
-    """Runs the entire test suite.
-    This is called for each repeat run requested."""
+    logger.suite_start(test_groups,
+                       name='web-platform-test',
+                       run_info=run_info,
+                       extra={"run_by_dir": run_test_kwargs["run_by_dir"]})
     for test_type in run_test_kwargs["test_types"]:
         logger.info(f"Running {test_type} tests")
 
@@ -375,16 +382,6 @@ def run_tests(config, test_paths, product, **kwargs):
             # so that the runs can be stopped to avoid a possible TC timeout.
             longest_iteration_time = timedelta()
 
-            try:
-                test_groups = load_test_groups(test_loader, test_source_cls, test_source_kwargs)
-            except Exception:
-                logger.critical("Loading tests failed")
-                return False, test_status
-            logger.suite_start(test_groups,
-                               name="web-platform-test",
-                               run_info=run_info,
-                               extra={"run_by_dir": kwargs["run_by_dir"]})
-
             while test_status.repeated_runs < repeat or repeat_until_unexpected:
                 # if the next repeat run could cause the TC timeout to be reached,
                 # stop now and use the test results we have.
@@ -404,7 +401,7 @@ def run_tests(config, test_paths, product, **kwargs):
                     logger.info(f"Repetition {test_status.repeated_runs} / {repeat}")
 
                 iter_success = run_test_iteration(test_status, test_loader, test_source_kwargs,
-                                                  test_source_cls, test_groups, run_info, recording,
+                                                  test_source_cls, run_info, recording,
                                                   test_environment, product, kwargs)
                 # if there were issues with the suite run(tests not loaded, etc.) return
                 if not iter_success:
@@ -412,6 +409,7 @@ def run_tests(config, test_paths, product, **kwargs):
                 recording.set(["after-end"])
                 logger.info(f"Got {test_status.unexpected} unexpected results, "
                     f"with {test_status.unexpected_pass} unexpected passes")
+                logger.suite_end()
 
                 # Note this iteration's runtime
                 iteration_runtime = datetime.now() - iteration_start
@@ -424,8 +422,6 @@ def run_tests(config, test_paths, product, **kwargs):
                 if test_status.repeated_runs == 1 and len(test_loader.test_ids) == test_status.skipped:
                     test_status.all_skipped = True
                     break
-
-            logger.suite_end()
 
     # Return the evaluation of the runs and the number of repeated iterations that were run.
     return evaluate_runs(test_status, kwargs), test_status
@@ -470,6 +466,7 @@ def start(**kwargs):
         else:
             rv = not run_tests(**kwargs)[0] or logged_critical.has_log
     finally:
+        logger.shutdown()
         logger.remove_handler(handler)
     return rv
 


### PR DESCRIPTION
Fixes #33064

It seems that `logger.suite_start` and `logger.suite_end` are running too often (at least for Chromium, where the test report is cumulative).

I'm not sure how widely the `--repeat` flag is used in practice with a value >1. This change may impact downstream users who rely on the current behavior of logging every repetition.