### PR TITLE
Patch tools/third_party/hyper/ to work with Python 3.10

### DIFF
--- a/tools/third_party/hyper/hyper/common/headers.py
+++ b/tools/third_party/hyper/hyper/common/headers.py
@@ -5,12 +5,12 @@ hyper/common/headers
 
 Contains hyper's structures for storing and working with HTTP headers.
 """
-import collections
+import collections.abc
 
 from hyper.common.util import to_bytestring, to_bytestring_tuple
 
 
-class HTTPHeaderMap(collections.MutableMapping):
+class HTTPHeaderMap(collections.abc.MutableMapping):
     """
     A structure that contains HTTP headers.
 

--- a/tools/third_party/hyper/hyper/h2/settings.py
+++ b/tools/third_party/hyper/hyper/h2/settings.py
@@ -8,6 +8,7 @@ API for manipulating HTTP/2 settings, keeping track of both the current active
 state of the settings and the unacknowledged future values of the settings.
 """
 import collections
+import collections.abc
 import enum
 
 from hyperframe.frame import SettingsFrame
@@ -151,7 +152,7 @@ class ChangedSetting:
         )
 
 
-class Settings(collections.MutableMapping):
+class Settings(collections.abc.MutableMapping):
     """
     An object that encapsulates HTTP/2 settings state.
 

--- a/tools/third_party/hyper/hyper/http11/connection.py
+++ b/tools/third_party/hyper/hyper/http11/connection.py
@@ -10,7 +10,7 @@ import os
 import socket
 import base64
 
-from collections import Iterable, Mapping
+from collections.abc import Iterable, Mapping
 
 import collections
 from hyperframe.frame import SettingsFrame


### PR DESCRIPTION
Iterable, Mapping and MutableMapping moved from collections to
collections.abc and deprecated in their original location in Python 3.3,
and finally removed in 3.10.

hyper is no longer maintained, so we have no choice put to patch it.

Fixes https://github.com/web-platform-tests/wpt/issues/31315.