### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=237610

### DIFF
--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -1424,7 +1424,7 @@ function testAnimationSamples(animation, idlName, testSamples) {
   const target = animation.effect.target;
   for (const testSample of testSamples) {
     animation.currentTime = testSample.time;
-    assert_equals(getComputedStyle(target, pseudoType)[idlName],
+    assert_equals(getComputedStyle(target, pseudoType)[idlName].toLowerCase(),
                   testSample.expected,
                   `The value should be ${testSample.expected}` +
                   ` at ${testSample.time}ms`);


### PR DESCRIPTION
WebKit export from bug: [\[web-animations\] color-interpolation should support discrete animation](https://bugs.webkit.org/show_bug.cgi?id=237610)