### PR TITLE
Adjust URL of Navigation History in META.yml

### DIFF
--- a/app-history/META.yml
+++ b/app-history/META.yml
@@ -1,4 +1,4 @@
-spec: https://wicg.github.io/app-history/
+spec: https://wicg.github.io/navigation-api/
 suggested_reviewers:
   - domenic
   - natechapin


### PR DESCRIPTION
This follows from change of spec name and title:
https://github.com/WICG/navigation-api/issues/83