### PR TITLE
Fix content-visibility-044.html for WebKit

### DIFF
--- a/css/css-contain/content-visibility/content-visibility-044.html
+++ b/css/css-contain/content-visibility/content-visibility-044.html
@@ -12,7 +12,7 @@
 <body style="margin: 0">
 
 <div id=host>
-<input id=slotted>
+<input id=slotted style="margin: 0">
 <script>
 
 async_test((t) => {


### PR DESCRIPTION
WebKit styles inputs with a 2px margin depending on the font-size.
This is not done in a stylesheet so hard to avoid. So, just make sure
the margin is 0px on the input.