### PR TITLE
Add `shadowrealm` support in testharness.js

### DIFF
--- a/docs/writing-tests/testharness.md
+++ b/docs/writing-tests/testharness.md
@@ -167,6 +167,9 @@ are:
 * `jsshell`: to be run in a JavaScript shell, without access to the DOM
   (currently only supported in SpiderMonkey, and skipped in wptrunner)
 * `worker`: shorthand for the dedicated, shared, and service worker scopes
+* `shadowrealm`: runs the test code in a
+  [ShadowRealm](https://github.com/tc39/proposal-shadowrealm) context hosted in
+  an ordinary Window context; to be run at <code><var>x</var>.any.shadowrealm.html</code>
 
 To check if your test is run from a window or worker you can use the following two methods that will
 be made available by the framework:

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -425,6 +425,53 @@
     };
 
     /*
+     * Shadow realms.
+     * https://github.com/tc39/proposal-shadowrealm
+     *
+     * This class is used as the test_environment when testharness is running
+     * inside a shadow realm.
+     */
+    function ShadowRealmTestEnvironment() {
+        WorkerTestEnvironment.call(this);
+        this.all_loaded = false;
+        this.on_loaded_callback = null;
+    }
+
+    ShadowRealmTestEnvironment.prototype = Object.create(WorkerTestEnvironment.prototype);
+
+    /**
+     * Signal to the test environment that the tests are ready and the on-loaded
+     * callback should be run.
+     *
+     * Shadow realms are not *really* a DOM context: they have no `onload` or similar
+     * event for us to use to set up the test environment; so, instead, this method
+     * is manually triggered from the incubating realm
+     *
+     * @param {Function} message_destination - a function that receives JSON-serializable
+     * data to send to the incubating realm, in the same format as used by RemoteContext
+     */
+    ShadowRealmTestEnvironment.prototype.begin = function(message_destination) {
+        if (this.all_loaded) {
+            throw new Error("Tried to start a shadow realm test environment after it has already started");
+        }
+        var fakeMessagePort = {};
+        fakeMessagePort.postMessage = message_destination;
+        this._add_message_port(fakeMessagePort);
+        this.all_loaded = true;
+        if (this.on_loaded_callback) {
+            this.on_loaded_callback();
+        }
+    };
+
+    ShadowRealmTestEnvironment.prototype.add_on_loaded_callback = function(callback) {
+        if (this.all_loaded) {
+            callback();
+        } else {
+            this.on_loaded_callback = callback;
+        }
+    };
+
+    /*
      * JavaScript shells.
      *
      * This class is used as the test_environment when testharness is running
@@ -487,6 +534,17 @@
         if ('WorkerGlobalScope' in global_scope &&
             global_scope instanceof WorkerGlobalScope) {
             return new DedicatedWorkerTestEnvironment();
+        }
+        /* Shadow realm global objects are _ordinary_ objects (i.e. their prototype is
+         * Object) so we don't have a nice `instanceof` test to use; instead, we
+         * can look for the presence of web APIs that wouldn't be available in
+         * environments not listed above:
+         *
+         * As long as, within the shadow realm, we load the testharness before
+         * other libraries, this won't have any false positives, even in e.g. node
+         */
+        if ('AbortController' in global_scope) {
+            return new ShadowRealmTestEnvironment();
         }
 
         return new ShellTestEnvironment();
@@ -3786,6 +3844,45 @@
     expose(fetch_tests_from_window, 'fetch_tests_from_window');
 
     /**
+     * Get test results from a shadow realm and include them in the current test.
+     *
+     * @param {ShadowRealm} realm - A shadow realm also running the test harness
+     * @returns {Promise} - A promise that's resolved once all the remote tests are complete.
+     */
+    function fetch_tests_from_shadow_realm(realm) {
+        var chan = new MessageChannel();
+        function recieveMessage(msg_json) {
+            chan.port1.postMessage(JSON.parse(msg_json));
+        }
+        var done = tests.fetch_tests_from_worker(chan.port2);
+        realm.evaluate(`begin_shadow_realm_tests`)(recieveMessage);
+        chan.port2.start();
+        return done;
+    }
+    expose(fetch_tests_from_shadow_realm, 'fetch_tests_from_shadow_realm');
+
+    /**
+     * Begin running tests in this shadow realm test harness.
+     *
+     * To be called after all tests have been loaded; it is an error to call
+     * this more than once or in a non-Shadow Realm environment
+     *
+     * @param {Function} postMessage - A function to send test updates to the
+     * incubating realm-- accepts JSON-encoded messages in the format used by
+     * RemoteContext
+     */
+    function begin_shadow_realm_tests(postMessage) {
+        if (!(test_environment instanceof ShadowRealmTestEnvironment)) {
+            throw new Error("beign_shadow_realm_tests called in non-Shadow Realm environment");
+        }
+
+        test_environment.begin(function (msg) {
+            postMessage(JSON.stringify(msg));
+        });
+    }
+    expose(begin_shadow_realm_tests, 'begin_shadow_realm_tests');
+
+    /**
      * Timeout the tests.
      *
      * This only has an effect when ``explict_timeout`` has been set
@@ -3963,7 +4060,7 @@
 
     Output.prototype.show_status = function() {
         if (this.phase < this.STARTED) {
-            this.init();
+            this.init({});
         }
         if (!this.enabled || this.phase === this.COMPLETE) {
             return;

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -3851,11 +3851,11 @@
      */
     function fetch_tests_from_shadow_realm(realm) {
         var chan = new MessageChannel();
-        function recieveMessage(msg_json) {
+        function receiveMessage(msg_json) {
             chan.port1.postMessage(JSON.parse(msg_json));
         }
         var done = tests.fetch_tests_from_worker(chan.port2);
-        realm.evaluate(`begin_shadow_realm_tests`)(recieveMessage);
+        realm.evaluate("begin_shadow_realm_tests")(receiveMessage);
         chan.port2.start();
         return done;
     }

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -91,6 +91,7 @@ _any_variants = {
     "dedicatedworker-module": {"suffix": ".any.worker-module.html"},
     "worker": {"longhand": {"dedicatedworker", "sharedworker", "serviceworker"}},
     "worker-module": {},
+    "shadowrealm": {},
     "jsshell": {"suffix": ".any.js"},
 }  # type: Dict[Text, Dict[Text, Any]]
 

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -345,6 +345,44 @@ class ServiceWorkerModulesHandler(HtmlWrapperHandler):
 </script>
 """
 
+class ShadowRealmHandler(HtmlWrapperHandler):
+    global_type = "shadowrealm"
+    path_replace = [(".any.shadowrealm.html", ".any.js")]
+
+    wrapper = """<!doctype html>
+<meta charset=utf-8>
+%(meta)s
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+(async function() {
+  const r = new ShadowRealm();
+
+  await new Promise(r.evaluate(`
+    (resolve, reject) => {
+      (async () => {
+        await import("/resources/testharness.js");
+        %(script)s
+        globalThis.self.GLOBAL = {
+          isWindow: function() { return false; },
+          isWorker: function() { return false; },
+        };
+        await import("%(path)s");
+      })().then(resolve, (e) => reject(e.toString()));
+    }
+  `));
+
+  await fetch_tests_from_shadow_realm(r);
+  done();
+})();
+</script>
+"""
+
+    def _script_replacement(self, key, value):
+        if key == "script":
+            return 'await import("%s");' % value
+        return None
+
 
 class BaseWorkerHandler(WrapperHandler):
     headers = [('Content-Type', 'text/javascript')]
@@ -454,6 +492,7 @@ class RoutesBuilder(object):
             ("GET", "*.any.sharedworker-module.html", SharedWorkerModulesHandler),
             ("GET", "*.any.serviceworker.html", ServiceWorkersHandler),
             ("GET", "*.any.serviceworker-module.html", ServiceWorkerModulesHandler),
+            ("GET", "*.any.shadowrealm.html", ShadowRealmHandler),
             ("GET", "*.any.worker.js", ClassicWorkerHandler),
             ("GET", "*.any.worker-module.js", ModuleWorkerHandler),
             ("GET", "*.asis", handlers.AsIsHandler),


### PR DESCRIPTION
This commit adds support to run `any.js` tests in Shadow
Realm (https://github.com/tc39/proposal-shadowrealm) contexts--

(As an alternative to https://github.com/web-platform-tests/wpt/pull/32956 ;
this offers more robust support for reporting promise rejections and timeouts

If desired, I will open an RFC to this effect; the text would be substantially the same
as this commit message, though)

Shadow realms are a new sandboxing primitive, currently a stage 3 proposal in
TC39 and in the process of being integrated into relevant Web specifications;
part of this extends some pure/non-rendering/purely computational Web interfaces to shadow
realms (which otherwise do not have browser APIs and more closely resemble a
vanilla JS shell environment.) I think it makes sense to extend WPT tests for
these interfaces to also run in shadow realm contexts, so we can be assured they
still work there.

---

To accomplish this, I add a new `ShadowRealmTestEnvironment` to `testharness.js`
that reuses the existing machinery to run tests remotely in e.g. dedicated
workers. There are however, two main differences:

- Shadow realms are not DOM contexts and so have no `onload` or similar event
for us to use to actually begin test aggregation; instead, I add a new hook for
the incubating realm to directly call to signal that all desired tests have been
loaded.

- The actual message port used to communicate test results back to a
`RemoteContext` requires JSON-serialization of the mesasges (primitive values
and callables may cross between a shadow- and incubating realm, but not
arbitrary objects): it *happens* that this works correctly given the current
encodings of Test, harness state, etc. are JSON-round-trippable, but this would
become a hard requirement from this point forward.

---

There's also one loose end at present: it's unclear (to me) given the current
state of the way Shadow Realms are integrated into the HTML spec how we might be
able to deal with unhandled promise rejections. It happens, for now, that they
will be handed by the incubating `Window`'s `unhandledrejection` handler, which
is installed by the parent test harness, and prints to the console. This seems
acceptable for the time being, but may need to change as the spec is clarified.