### PR TITLE
Test that serializing a `WebAssembly.Memory`-backed buffer works

### DIFF
--- a/wasm/serialization/arraybuffer/transfer.window.js
+++ b/wasm/serialization/arraybuffer/transfer.window.js
@@ -1,6 +1,11 @@
 test(() => {
   const buffer = new WebAssembly.Memory({initial: 4}).buffer;
+  postMessage(buffer, '*');
+}, "Serializing a WebAssembly.Memory-backed ArrayBuffer works");
+
+test(() => {
+  const buffer = new WebAssembly.Memory({initial: 4}).buffer;
   assert_throws_js(TypeError, () => {
     postMessage('foo', '*', [buffer]);
   });
-});
+}, "Transfering a WebAssembly.Memory-backed ArrayBuffer throws");


### PR DESCRIPTION
The existing test makes sure that transfering the buffer throws a `TypeError` exception, but V8 currently also throws when serializing it, which should not be the case.