### PR TITLE
Docs: Add await to action.send() examples

### DIFF
--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -167,7 +167,7 @@ let actions = new test_driver.Actions()
     .setContext(frames[0])
     .keyDown("p")
     .keyUp("p");
-actions.send();
+await actions.send();
 ```
 
 Note that if an action uses an element reference, the context will be

--- a/resources/testdriver-actions.js
+++ b/resources/testdriver-actions.js
@@ -29,7 +29,7 @@
    *    .keyDown("p")
    *    .keyUp("p");
    *
-   * actions.send();
+   * await actions.send();
    *
    * @param {number} [defaultTickDuration] - The default duration of a
    * tick. Be default this is set ot 16ms, which is one frame time

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -648,7 +648,7 @@
     /**
      * Create a promise test.
      *
-     * Promise tests are tests which are represeted by a promise
+     * Promise tests are tests which are represented by a promise
      * object. If the promise is fulfilled the test passes, if it's
      * rejected the test fails, otherwise the test passes.
      *


### PR DESCRIPTION
Add `await` to the actions.send examples in the docs to clarify that `send()` returns a promise and is not synchronous.

Also fix a minor type in the testharness docs