### PR TITLE
Geolocation: additional tests for spec changes

### DIFF
--- a/geolocation-API/getCurrentPosition_TypeError.https.html
+++ b/geolocation-API/getCurrentPosition_TypeError.https.html
@@ -47,4 +47,15 @@ test(function() {
     navigator.geolocation.getCurrentPosition(()=>{}, ()=>{}, 4);
   });
 }, 'Call getCurrentPosition() with wrong type for third argument. Exception expected.');
+
+test(function () {
+  const handleEvent = ()=>{};
+  assert_throws_js(TypeError, function () {
+    navigator.geolocation.getCurrentPosition({ handleEvent });
+  });
+
+  assert_throws_js(TypeError, function () {
+    navigator.geolocation.getCurrentPosition(()=>{}, { handleEvent });
+  });
+}, "Calling getCurrentPosition() with a legacy event handler objects.");
 </script>

--- a/geolocation-API/getCurrentPosition_permission_allow.https.html
+++ b/geolocation-API/getCurrentPosition_permission_allow.https.html
@@ -31,4 +31,22 @@
       "Expected GeolocationPosition"
     );
   }, "User allows access, check that success callback is called.");
+
+  promise_test(async (t) => {
+    t.add_cleanup(() => {
+      return test_driver.set_permission({ name: "geolocation" }, "prompt");
+    });
+    await test_driver.set_permission({ name: "geolocation" }, "granted");
+    const position = await new Promise((resolve, reject) => {
+      try {
+        navigator.geolocation.getCurrentPosition(resolve, null);
+      } catch (err) {
+        reject(err);
+      }
+    });
+    assert_true(
+      position instanceof GeolocationPosition,
+      "Expected GeolocationPosition"
+    );
+  }, "Error callback is nullable for getCurrentPosition().");
 </script>

--- a/geolocation-API/watchPosition_TypeError.https.html
+++ b/geolocation-API/watchPosition_TypeError.https.html
@@ -51,4 +51,15 @@
       );
     });
   }, "Call watchPosition() with wrong type for third argument. Exception expected.");
+
+  test(function () {
+    const handleEvent = function(){};
+    assert_throws_js(TypeError, function () {
+      navigator.geolocation.watchPosition({ handleEvent });
+    });
+
+    assert_throws_js(TypeError, function () {
+      navigator.geolocation.watchPosition(()=>{}, { handleEvent });
+    });
+  }, "Calling watchPosition() with a legacy event handler objects.");
 </script>

--- a/geolocation-API/watchPosition_TypeError.https.html
+++ b/geolocation-API/watchPosition_TypeError.https.html
@@ -61,5 +61,5 @@
     assert_throws_js(TypeError, function () {
       navigator.geolocation.watchPosition(()=>{}, { handleEvent });
     });
-  }, "Calling watchPosition() with a legacy event handler objects.");
+  }, "Calling watchPosition() with a legacy event handler object.");
 </script>


### PR DESCRIPTION
Covers the following changes we made to the spec since 2016 that were not fully or explicitly tested:

- "The `errorCallback` is now nullable"
- "The callbacks are no longer treated as "EventHandler" objects (i.e., objects that have a .handleEvent() method), but are now exclusively treated as IDL callback functions."

To be fair, these are by IDL harness to a degree... this just makes a few things more explicit.  