### PR TITLE
Ensure that the call to kill the WebDriver always returns within a deadline

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -362,10 +362,13 @@ class WebDriverBrowser(Browser):
         self.logger.debug("Stopping WebDriver")
         clean = True
         if self.is_alive():
-            kill_result = self._proc.kill()
+            # Pass a timeout value to mozprocess Processhandler.kill()
+            # to ensure it always returns within it.
+            # See https://bugzilla.mozilla.org/show_bug.cgi?id=1760080
+            kill_result = self._proc.kill(timeout=5)
             if force and kill_result != 0:
                 clean = False
-                self._proc.kill(9)
+                self._proc.kill(9, timeout=5)
         success = not self.is_alive()
         if success and self._output_handler is not None:
             # Only try to do output post-processing if we managed to shut down


### PR DESCRIPTION
There is a [bug on `mozprocess ProcessHandler.kill` that may cause it to hang when the process to be killed has daemonized childs](https://bugzilla.mozilla.org/show_bug.cgi?id=1760080).

To avoid this situation, pass the timeout parameter to `ProcessHandler.kil`l to ensure it always returns within it.
So `wptrunner` can continue executing other tests and the whole test suite doesn't hang.

Fixes: https://github.com/web-platform-tests/wpt/issues/33186