### PR TITLE
Use httpx instead of requests in tests

### DIFF
--- a/tools/ci/tc/tests/test_valid.py
+++ b/tools/ci/tc/tests/test_valid.py
@@ -2,9 +2,9 @@ import json
 import os
 from unittest import mock
 
+import httpx
 import jsone
 import pytest
-import requests
 import yaml
 from jsonschema import validate
 
@@ -63,11 +63,11 @@ def test_verify_payload():
     """Verify that the decision task produces tasks with a valid payload"""
     from tools.ci.tc.decision import decide
 
-    r = requests.get("https://community-tc.services.mozilla.com/schemas/queue/v1/create-task-request.json")
+    r = httpx.get("https://community-tc.services.mozilla.com/schemas/queue/v1/create-task-request.json")
     r.raise_for_status()
     create_task_schema = r.json()
 
-    r = requests.get("https://community-tc.services.mozilla.com/references/schemas/docker-worker/v1/payload.json")
+    r = httpx.get("https://community-tc.services.mozilla.com/references/schemas/docker-worker/v1/payload.json")
     r.raise_for_status()
     payload_schema = r.json()
 

--- a/tools/requirements_tests.txt
+++ b/tools/requirements_tests.txt
@@ -2,5 +2,4 @@ httpx[http2]==0.22.0
 json-e==4.4.3
 jsonschema==3.2.0
 pyyaml==6.0
-requests==2.27.1
 taskcluster==44.8.4


### PR DESCRIPTION
Following https://github.com/web-platform-tests/wpt/pull/33113, there
was only one minor use of requests left in test code. requests is still
a depdendency of a lot of code under test, but this at least simplifies
requirements_tests.txt.