### PR TITLE
[css-ruby] Adding japanese .woff font resource into block-ruby-001 test and reference

### DIFF
--- a/css/css-ruby/block-ruby-001-ref.html
+++ b/css/css-ruby/block-ruby-001-ref.html
@@ -3,11 +3,22 @@
      Any copyright is dedicated to the Public Domain.
      http://creativecommons.org/publicdomain/zero/1.0/
   -->
-<html>
+<html lang="ja">
 <meta charset="utf-8">
 <title>CSS Ruby Reference: basic 'block ruby' layout.</title>
 <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <style>
+@font-face
+{
+  font-family: "mplus-1p-regular";
+  src: url("/fonts/mplus-1p-regular.woff") format("woff");
+}
+
+html
+{
+  font-family: "mplus-1p-regular";
+}
+
 .b { background: lightblue; }
 .mbp {
   margin: 1px 3px 5px 7px;
@@ -27,29 +38,11 @@ rbc {
 }
 .w { white-space: nowrap; width:2.5em; margin: 1em 0em; }
 </style>
-
-  <!--
-
-  In the original test,
-
-  D was べ
-  E was る
-  H was H
-  K was K
-  M was M
-  R was R
-  S was 五
-  T was 六
-  W was 七
-  Z was 八
-
-  -->
-
-A<div class=b><ruby>D<rt>E</rt></ruby></div>B
-A<div class="mbp b"><ruby>D<rt>E</rt></ruby></div>B
-<div class=columns>A<div class="mbp b"><ruby>D<rt>E</rt> D<rt>E</rt>  D<rt>E</rt> D<rt>E</rt> D<rt>E</rt></ruby></div>B</div>
+A<div class="b"><ruby>べ<rt>る</rt></ruby></div>B
+A<div class="mbp b"><ruby>べ<rt>る</rt></ruby></div>B
+<div class="columns">A<div class="mbp b"><ruby>べ<rt>る</rt> べ<rt>る</rt>  べ<rt>る</rt> べ<rt>る</rt> べ<rt>る</rt></ruby></div>B</div>
 <div style="width:2.5em; border:1px solid;">
-    <div class="w b"><ruby><rb>H<rb>K<rb>M<rb>R<rb>S<rb>T<rb>W<rb>Z</ruby></div>
-    <div class="w b"><ruby><rbc>H</rbc><rbc>K</rbc><rbc>M</rbc><rbc>R</rbc><rbc>S</rbc><rbc>T</rbc><rbc>W</rbc><rbc>Z</rbc></ruby></div>
+    <div class="w b"><ruby><rb>一<rb>二<rb>三<rb>四<rb>五<rb>六<rb>七<rb>八</ruby></div>
+    <div class="w b"><ruby><rbc>一</rbc><rbc>二</rbc><rbc>三</rbc><rbc>四</rbc><rbc>五</rbc><rbc>六</rbc><rbc>七</rbc><rbc>八</rbc></ruby></div>
 </div>
 </html>

--- a/css/css-ruby/block-ruby-001-ref.html
+++ b/css/css-ruby/block-ruby-001-ref.html
@@ -3,7 +3,7 @@
      Any copyright is dedicated to the Public Domain.
      http://creativecommons.org/publicdomain/zero/1.0/
   -->
-<html lang="ja">
+<html>
 <meta charset="utf-8">
 <title>CSS Ruby Reference: basic 'block ruby' layout.</title>
 <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
@@ -25,13 +25,31 @@ rbc {
   display: ruby-base-container;
   unicode-bidi: isolate;
 }
-.w { white-space: nowrap; width:2.5em; }
+.w { white-space: nowrap; width:2.5em; margin: 1em 0em; }
 </style>
-A<div class=b><ruby>べ<rt>る</rt></ruby></div>B
-A<div class="mbp b"><ruby>べ<rt>る</rt></ruby></div>B
-<div class=columns>A<div class="mbp b"><ruby>べ<rt>る</rt> べ<rt>る</rt>  べ<rt>る</rt> べ<rt>る</rt> べ<rt>る</rt></ruby></div>B</div>
-<div style="width:2.5em; border:1px solid; text-align: center">
-    <p><div class="w b"><ruby><rb>一<rb>二<rb>三<rb>四<rb>五<rb>六<rb>七<rb>八</ruby></div></p>
-    <p><div class="w b"><ruby><rbc>一</rbc><rbc>二</rbc><rbc>三</rbc><rbc>四</rbc><rbc>五</rbc><rbc>六</rbc><rbc>七</rbc><rbc>八</rbc></ruby></div></p>
+
+  <!--
+
+  In the original test,
+
+  D was べ
+  E was る
+  H was H
+  K was K
+  M was M
+  R was R
+  S was 五
+  T was 六
+  W was 七
+  Z was 八
+
+  -->
+
+A<div class=b><ruby>D<rt>E</rt></ruby></div>B
+A<div class="mbp b"><ruby>D<rt>E</rt></ruby></div>B
+<div class=columns>A<div class="mbp b"><ruby>D<rt>E</rt> D<rt>E</rt>  D<rt>E</rt> D<rt>E</rt> D<rt>E</rt></ruby></div>B</div>
+<div style="width:2.5em; border:1px solid;">
+    <div class="w b"><ruby><rb>H<rb>K<rb>M<rb>R<rb>S<rb>T<rb>W<rb>Z</ruby></div>
+    <div class="w b"><ruby><rbc>H</rbc><rbc>K</rbc><rbc>M</rbc><rbc>R</rbc><rbc>S</rbc><rbc>T</rbc><rbc>W</rbc><rbc>Z</rbc></ruby></div>
 </div>
 </html>

--- a/css/css-ruby/block-ruby-001.html
+++ b/css/css-ruby/block-ruby-001.html
@@ -3,7 +3,7 @@
      Any copyright is dedicated to the Public Domain.
      http://creativecommons.org/publicdomain/zero/1.0/
   -->
-<html>
+<html lang="ja">
 <meta charset="utf-8">
 <title>CSS Ruby Test: basic 'block ruby' layout.</title>
 <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
@@ -11,6 +11,17 @@
 <link rel="help" href="https://drafts.csswg.org/css-ruby-1/#ruby-layout">
 <link rel="match" href="block-ruby-001-ref.html">
 <style>
+@font-face
+{
+  font-family: "mplus-1p-regular";
+  src: url("/fonts/mplus-1p-regular.woff") format("woff");
+}
+
+html
+{
+  font-family: "mplus-1p-regular";
+}
+
 ruby { display: block ruby; background: lightblue; }
 .mbp {
   margin: 1px 3px 5px 7px;
@@ -29,29 +40,11 @@ rbc {
   unicode-bidi: isolate;
 }
 </style>
-
-  <!--
-
-  In the original test,
-
-  D was べ
-  E was る
-  H was 一
-  K was 二
-  M was 三
-  R was 四
-  S was 五
-  T was 六
-  W was 七
-  Z was 八
-
-  -->
-
-A<ruby>D<rt>E</rt></ruby>B
-A<ruby class=mbp>D<rt>E</rt></ruby>B
-<div class=columns>A<ruby class=mbp>D<rt>E</rt> D<rt>E</rt>  D<rt>E</rt> D<rt>E</rt> D<rt>E</rt></ruby>B</div>
+A<ruby>べ<rt>る</rt></ruby>B
+A<ruby class="mbp">べ<rt>る</rt></ruby>B
+<div class="columns">A<ruby class=mbp>べ<rt>る</rt> べ<rt>る</rt>  べ<rt>る</rt> べ<rt>る</rt> べ<rt>る</rt></ruby>B</div>
 <div style="width:2.5em; border:1px solid;">
-    <ruby style="margin: 1em 0em;"><rb>H<rb>K<rb>M<rb>R<rb>S<rb>T<rb>W<rb>Z</ruby>
-    <ruby style="margin: 1em 0em;"><rbc>H</rbc><rbc>K</rbc><rbc>M</rbc><rbc>R</rbc><rbc>S</rbc><rbc>T</rbc><rbc>W</rbc><rbc>Z</rbc></ruby>
+    <ruby style="margin: 1em 0em;"><rb>一<rb>二<rb>三<rb>四<rb>五<rb>六<rb>七<rb>八</ruby>
+    <ruby style="margin: 1em 0em;"><rbc>一</rbc><rbc>二</rbc><rbc>三</rbc><rbc>四</rbc><rbc>五</rbc><rbc>六</rbc><rbc>七</rbc><rbc>八</rbc></ruby>
 </div>
 </html>

--- a/css/css-ruby/block-ruby-001.html
+++ b/css/css-ruby/block-ruby-001.html
@@ -3,7 +3,7 @@
      Any copyright is dedicated to the Public Domain.
      http://creativecommons.org/publicdomain/zero/1.0/
   -->
-<html lang="ja">
+<html>
 <meta charset="utf-8">
 <title>CSS Ruby Test: basic 'block ruby' layout.</title>
 <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
@@ -29,11 +29,29 @@ rbc {
   unicode-bidi: isolate;
 }
 </style>
-A<ruby>べ<rt>る</rt></ruby>B
-A<ruby class=mbp>べ<rt>る</rt></ruby>B
-<div class=columns>A<ruby class=mbp>べ<rt>る</rt> べ<rt>る</rt>  べ<rt>る</rt> べ<rt>る</rt> べ<rt>る</rt></ruby>B</div>
-<div style="width:2.5em; border:1px solid; text-align: center">
-    <p><ruby><rb>一<rb>二<rb>三<rb>四<rb>五<rb>六<rb>七<rb>八</ruby></p>
-    <p><ruby><rbc>一</rbc><rbc>二</rbc><rbc>三</rbc><rbc>四</rbc><rbc>五</rbc><rbc>六</rbc><rbc>七</rbc><rbc>八</rbc></ruby></p>
+
+  <!--
+
+  In the original test,
+
+  D was べ
+  E was る
+  H was 一
+  K was 二
+  M was 三
+  R was 四
+  S was 五
+  T was 六
+  W was 七
+  Z was 八
+
+  -->
+
+A<ruby>D<rt>E</rt></ruby>B
+A<ruby class=mbp>D<rt>E</rt></ruby>B
+<div class=columns>A<ruby class=mbp>D<rt>E</rt> D<rt>E</rt>  D<rt>E</rt> D<rt>E</rt> D<rt>E</rt></ruby>B</div>
+<div style="width:2.5em; border:1px solid;">
+    <ruby style="margin: 1em 0em;"><rb>H<rb>K<rb>M<rb>R<rb>S<rb>T<rb>W<rb>Z</ruby>
+    <ruby style="margin: 1em 0em;"><rbc>H</rbc><rbc>K</rbc><rbc>M</rbc><rbc>R</rbc><rbc>S</rbc><rbc>T</rbc><rbc>W</rbc><rbc>Z</rbc></ruby>
 </div>
 </html>


### PR DESCRIPTION
This is a follow-up of [pull request 29806](https://github.com/web-platform-tests/wpt/pull/29806).

On my website:

http://www.gtalbot.org/BrowserBugsSection/CSS3Ruby/block-ruby-001-final.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Ruby/block-ruby-001-ref-final.html
