### PR TITLE
Support the --reftest-screenshot command line argument in the reftest implementation used by all browsers 

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -126,7 +126,6 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
         capabilities["pageLoadStrategy"] = "eager"
     if test_type in ("reftest", "print-reftest"):
         executor_kwargs["reftest_internal"] = kwargs["reftest_internal"]
-        executor_kwargs["reftest_screenshot"] = kwargs["reftest_screenshot"]
     if test_type == "wdspec":
         options = {"args": []}
         if kwargs["binary"]:

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -554,8 +554,8 @@ class RefTestImplementation(object):
                 if success:
                     screenshots[i] = screenshot
 
-        test_result =  {"status": "FAIL",
-                        "message": "\n".join(self.message)}
+        test_result = {"status": "FAIL",
+                       "message": "\n".join(self.message)}
         if (self.reftest_screenshot in ("always", "fail") or
             self.reftest_screenshot == "unexpected" and
             test.expected() != "FAIL"):

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -358,7 +358,7 @@ class RefTestExecutor(TestExecutor):
     is_print = False
 
     def __init__(self, logger, browser, server_config, timeout_multiplier=1, screenshot_cache=None,
-                 debug_info=None, reftest_screenshot=None, **kwargs):
+                 debug_info=None, reftest_screenshot="unexpected", **kwargs):
         TestExecutor.__init__(self, logger, browser, server_config,
                               timeout_multiplier=timeout_multiplier,
                               debug_info=debug_info)

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -432,7 +432,7 @@ class RefTestImplementation(object):
 
         if len(lhs_hashes) != len(rhs_hashes):
             self.logger.info("Got different number of pages")
-            return relation == "!=", None
+            return relation == "!=", -1
 
         assert len(lhs_screenshots) == len(lhs_hashes) == len(rhs_screenshots) == len(rhs_hashes)
 
@@ -526,10 +526,10 @@ class RefTestImplementation(object):
             is_pass, page_idx = self.check_pass(hashes, screenshots, urls, relation, fuzzy)
             log_data = [
                 {"url": urls[0], "screenshot": screenshots[0][page_idx],
-                  "hash": hashes[0][page_idx]},
+                 "hash": hashes[0][page_idx]},
                 relation,
                 {"url": urls[1], "screenshot": screenshots[1][page_idx],
-                "hash": hashes[1][page_idx]}
+                 "hash": hashes[1][page_idx]}
             ]
 
             if is_pass:

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -540,8 +540,8 @@ class RefTestImplementation(object):
                 else:
                     test_result = {"status": "PASS", "message": None}
                     if (self.reftest_screenshot == "always" or
-                            self.reftest_screenshot == "unexpected" and
-                            test.expected() != "PASS"):
+                        self.reftest_screenshot == "unexpected" and
+                        test.expected() != "PASS"):
                         test_result["extra"] = {"reftest_screenshots": log_data}
                     # We passed
                     return test_result
@@ -557,8 +557,8 @@ class RefTestImplementation(object):
         test_result =  {"status": "FAIL",
                         "message": "\n".join(self.message)}
         if (self.reftest_screenshot in ("always", "fail") or
-                self.reftest_screenshot == "unexpected" and
-                test.expected() != "FAIL"):
+            self.reftest_screenshot == "unexpected" and
+            test.expected() != "FAIL"):
             test_result["extra"] = {"reftest_screenshots": log_data}
         return test_result
 

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -551,15 +551,18 @@ class WebDriverRefTestExecutor(RefTestExecutor):
 
     def __init__(self, logger, browser, server_config, timeout_multiplier=1,
                  screenshot_cache=None, close_after_done=True,
-                 debug_info=None, capabilities=None, debug_test=False, **kwargs):
+                 debug_info=None, capabilities=None, debug_test=False,
+                 add_all_screenshots_to_artifacts=False, **kwargs):
         """WebDriver-based executor for reftests"""
-        RefTestExecutor.__init__(self,
-                                 logger,
-                                 browser,
-                                 server_config,
-                                 screenshot_cache=screenshot_cache,
-                                 timeout_multiplier=timeout_multiplier,
-                                 debug_info=debug_info)
+        RefTestExecutor.__init__(
+            self,
+            logger,
+            browser,
+            server_config,
+            screenshot_cache=screenshot_cache,
+            timeout_multiplier=timeout_multiplier,
+            debug_info=debug_info,
+            add_all_screenshots_to_artifacts=add_all_screenshots_to_artifacts)
         self.protocol = self.protocol_cls(self,
                                           browser,
                                           capabilities=capabilities)

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -552,7 +552,7 @@ class WebDriverRefTestExecutor(RefTestExecutor):
     def __init__(self, logger, browser, server_config, timeout_multiplier=1,
                  screenshot_cache=None, close_after_done=True,
                  debug_info=None, capabilities=None, debug_test=False,
-                 reftest_screenshot=None, **kwargs):
+                 reftest_screenshot="unexpected", **kwargs):
         """WebDriver-based executor for reftests"""
         RefTestExecutor.__init__(self,
                                  logger,

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -552,17 +552,16 @@ class WebDriverRefTestExecutor(RefTestExecutor):
     def __init__(self, logger, browser, server_config, timeout_multiplier=1,
                  screenshot_cache=None, close_after_done=True,
                  debug_info=None, capabilities=None, debug_test=False,
-                 add_all_screenshots_to_artifacts=False, **kwargs):
+                 reftest_screenshot=None, **kwargs):
         """WebDriver-based executor for reftests"""
-        RefTestExecutor.__init__(
-            self,
-            logger,
-            browser,
-            server_config,
-            screenshot_cache=screenshot_cache,
-            timeout_multiplier=timeout_multiplier,
-            debug_info=debug_info,
-            add_all_screenshots_to_artifacts=add_all_screenshots_to_artifacts)
+        RefTestExecutor.__init__(self,
+                                 logger,
+                                 browser,
+                                 server_config,
+                                 screenshot_cache=screenshot_cache,
+                                 timeout_multiplier=timeout_multiplier,
+                                 debug_info=debug_info,
+                                 reftest_screenshot=reftest_screenshot)
         self.protocol = self.protocol_cls(self,
                                           browser,
                                           capabilities=capabilities)

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -165,8 +165,6 @@ scheme host and port.""")
                                            "program will exit with status code 0.")
 
     debugging_group = parser.add_argument_group("Debugging")
-    debugging_group.add_argument("--add-all-screenshots-to-artifacts", action="store_true",
-                                 help="Add all screenshots from reftests to test artifacts")
     debugging_group.add_argument('--debugger', const="__default__", nargs="?",
                                  help="run under a debugger, e.g. gdb or valgrind")
     debugging_group.add_argument('--debugger-args', help="arguments to the debugger")

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -165,6 +165,8 @@ scheme host and port.""")
                                            "program will exit with status code 0.")
 
     debugging_group = parser.add_argument_group("Debugging")
+    debugging_group.add_argument("--add-all-screenshots-to-artifacts", action="store_true",
+                                 help="Add all screenshots from reftests to test artifacts")
     debugging_group.add_argument('--debugger', const="__default__", nargs="?",
                                  help="run under a debugger, e.g. gdb or valgrind")
     debugging_group.add_argument('--debugger-args', help="arguments to the debugger")


### PR DESCRIPTION
I am writing a test for Chromium where I need screenshots from passing reftests. The reftest will run after test data is loaded into Chromium's user directory. After the reftest runs, I need to compare the screenshots generated during the test run to baselines created from the last known good run of the reftest where the test data was not loaded. I can use the --reftest-screenshot command line argument to make the wpt test harness add screenshots made during passing reftests to the test results.

Bug:crbug/1285152