### PR TITLE
Add back idlharness.js tests after split from HTML

### DIFF
--- a/html/dom/idlharness.https.html
+++ b/html/dom/idlharness.https.html
@@ -211,9 +211,6 @@ idl_test(
       MediaStreamEvent: [],
       ErrorEvent: [],
       EventSource: ['new EventSource("http://invalid")'],
-      // https://web-platform-tests.org/writing-tests/server-features.html?tests-involving-multiple-origins
-      WebSocket: ['new WebSocket("wss://nonexistent.' + get_host_info().ORIGINAL_HOST + '")'],
-      CloseEvent: ['new CloseEvent("close")'],
       AbstractWorker: [],
       Worker: [],
       SharedWorker: [],

--- a/html/dom/idlharness.worker.js
+++ b/html/dom/idlharness.worker.js
@@ -12,8 +12,6 @@ idl_test(
       WorkerLocation: ['self.location'],
       WorkerNavigator: ['self.navigator'],
       EventSource: ['new EventSource("http://invalid")'],
-      WebSocket: ['new WebSocket("ws://invalid")'],
-      CloseEvent: ['new CloseEvent("close")'],
       Worker: [],
       MessageEvent: ['new MessageEvent("message", { data: 5 })'],
       DedicatedWorkerGlobalScope: ['self'],

--- a/websockets/META.yml
+++ b/websockets/META.yml
@@ -1,4 +1,6 @@
-spec: https://html.spec.whatwg.org/multipage/web-sockets.html
+spec: https://websockets.spec.whatwg.org/
 suggested_reviewers:
-  - zqzhang
   - jdm
+  - ricea
+  - yutakahirano
+  - zqzhang

--- a/websockets/idlharness.any.js
+++ b/websockets/idlharness.any.js
@@ -1,0 +1,17 @@
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+// https://websockets.spec.whatwg.org/
+
+"use strict";
+
+idl_test(
+  ['websockets'],
+  ['dom'],
+  idl_array => {
+    idl_array.add_objects({
+      WebSocket: ['new WebSocket("ws://invalid")'],
+      CloseEvent: ['new CloseEvent("close")'],
+    });
+  }
+);

--- a/websockets/idlharness.any.js
+++ b/websockets/idlharness.any.js
@@ -7,7 +7,7 @@
 
 idl_test(
   ['websockets'],
-  ['dom'],
+  ['html', 'dom'],
   idl_array => {
     idl_array.add_objects({
       WebSocket: ['new WebSocket("ws://invalid")'],

--- a/workers/semantics/interface-objects/001.worker.js
+++ b/workers/semantics/interface-objects/001.worker.js
@@ -19,9 +19,10 @@ var expected = [
   "Path2D",
   "PromiseRejectionEvent",
   "EventSource",
+  "BroadcastChannel",
+  // https://websockets.spec.whatwg.org/
   "WebSocket",
   "CloseEvent",
-  "BroadcastChannel",
   // https://tc39.github.io/ecma262/
   "ArrayBuffer",
   "Int8Array",

--- a/workers/semantics/interface-objects/003.any.js
+++ b/workers/semantics/interface-objects/003.any.js
@@ -20,9 +20,10 @@ var expected = [
   "Path2D",
   "PromiseRejectionEvent",
   "EventSource",
+  "BroadcastChannel",
+  // https://websockets.spec.whatwg.org/
   "WebSocket",
   "CloseEvent",
-  "BroadcastChannel",
   // https://tc39.github.io/ecma262/
   "ArrayBuffer",
   "Int8Array",


### PR DESCRIPTION
The tests were removed with a @webref/idl sync:
https://github.com/web-platform-tests/wpt/pull/32965

Add back the tests and make some other changes to adapt to the split.