### PR TITLE
Ensure correct depdencies for tools/wave and tools/wpt tests

### DIFF
--- a/tools/wave/tox.ini
+++ b/tools/wave/tox.ini
@@ -6,6 +6,7 @@ skip_missing_interpreters = False
 [testenv]
 deps =
   -r{toxinidir}/../requirements_pytest.txt
+  -r{toxinidir}/requirements.txt
   -r{toxinidir}/../wptrunner/requirements.txt
   -r{toxinidir}/../wptrunner/requirements_chromium.txt
   -r{toxinidir}/../wptrunner/requirements_firefox.txt

--- a/tools/wpt/requirements.txt
+++ b/tools/wpt/requirements.txt
@@ -1,2 +1,1 @@
 requests==2.27.1
-mozinfo==1.2.2  # https://bugzilla.mozilla.org/show_bug.cgi?id=1621226

--- a/tools/wpt/tox.ini
+++ b/tools/wpt/tox.ini
@@ -6,6 +6,7 @@ skip_missing_interpreters = False
 [testenv]
 deps =
   -r{toxinidir}/../requirements_pytest.txt
+  -r{toxinidir}/requirements.txt
   -r{toxinidir}/../wptrunner/requirements.txt
   -r{toxinidir}/../wptrunner/requirements_chromium.txt
   -r{toxinidir}/../wptrunner/requirements_firefox.txt


### PR DESCRIPTION
The requirements.txt files were unused, and we must have been depending
on depdencies being already installed. This was noticed when trying to
support Python 3.10.

mozinfo isn't used in tools/wpt/, so drop that dependency.