### PR TITLE
Use logger.warning instead of deprecated logger.warn

### DIFF
--- a/resources/test/wptserver.py
+++ b/resources/test/wptserver.py
@@ -38,7 +38,7 @@ class WPTServer(object):
             time.sleep(2 ** retry)
             exit_code = self.proc.poll()
             if exit_code != None:
-                logging.warn('Command "%s" exited with %s', ' '.join(wptserve_cmd), exit_code)
+                logging.warning('Command "%s" exited with %s', ' '.join(wptserve_cmd), exit_code)
                 break
             try:
                 urllib.request.urlopen(self.base_url, timeout=1)


### PR DESCRIPTION
This shows up in CI logs as:

> DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead