### PR TITLE
Add a few cases to preload SRI

### DIFF
--- a/preload/subresource-integrity.html
+++ b/preload/subresource-integrity.html
@@ -323,12 +323,23 @@
       SRIPreloadTest(
         true,
         true,
-        `Same-origin ${destination} with matching digest does not reuse preload with matching but different digest.`,
+        `Same-origin ${destination} with matching digest does not reuse preload with matching but weaker digest.`,
         2,
         destination,
         same_origin_prefix + destination + ext + `?${token()}`,
         {integrity: sha384},
         {integrity: sha256},
+      )
+
+      SRIPreloadTest(
+        true,
+        true,
+        `Same-origin ${destination} with matching digest does not reuse preload with matching but stronger digest.`,
+        2,
+        destination,
+        same_origin_prefix + destination + ext + `?${token()}`,
+        {integrity: sha256},
+        {integrity: sha384},
       )
 
     } // if.

--- a/preload/subresource-integrity.html
+++ b/preload/subresource-integrity.html
@@ -320,10 +320,11 @@
         {integrity: sha256}
       )
 
+      // This is an acceptable failure
       SRIPreloadTest(
         true,
         true,
-        `Same-origin ${destination} with matching digest does not reuse preload with matching but weaker digest.`,
+        `[Tentative] Same-origin ${destination} with matching digest does not reuse preload with matching but stronger digest.`,
         2,
         destination,
         same_origin_prefix + destination + ext + `?${token()}`,
@@ -334,12 +335,23 @@
       SRIPreloadTest(
         true,
         true,
-        `Same-origin ${destination} with matching digest does not reuse preload with matching but stronger digest.`,
+        `Same-origin ${destination} with matching digest does not reuse preload with matching but weaker digest.`,
         2,
         destination,
         same_origin_prefix + destination + ext + `?${token()}`,
         {integrity: sha256},
         {integrity: sha384},
+      )
+
+      SRIPreloadTest(
+        true,
+        false,
+        `Same-origin ${destination} with non-matching digest reuses preload with no digest but fails.`,
+        2,
+        destination,
+        same_origin_prefix + destination + ext + `?${token()}`,
+        {},
+        {integrity: "sha256-sha256-deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdead"},
       )
 
     } // if.

--- a/preload/subresource-integrity.html
+++ b/preload/subresource-integrity.html
@@ -309,6 +309,28 @@
         {integrity: "sha256-deaddeadbeefYHFvsYdWumweeFAw0hJDTFt9seErghA="}
       )
 
+      SRIPreloadTest(
+        true,
+        true,
+        `Same-origin ${destination} with matching digest does not reuse preload without digest.`,
+        2,
+        destination,
+        same_origin_prefix + destination + ext + `?${token()}`,
+        {},
+        {integrity: sha256}
+      )
+
+      SRIPreloadTest(
+        true,
+        true,
+        `Same-origin ${destination} with matching digest does not reuse preload with matching but different digest.`,
+        2,
+        destination,
+        same_origin_prefix + destination + ext + `?${token()}`,
+        {integrity: sha384},
+        {integrity: sha256},
+      )
+
     } // if.
 
   } // for-of.

--- a/service-workers/service-worker/fetch-canvas-tainting-video-with-range-request.https.html
+++ b/service-workers/service-worker/fetch-canvas-tainting-video-with-range-request.https.html
@@ -63,12 +63,11 @@ range_request_test(
 
 // (3) Range responses come from multiple origins. The first response comes from
 //     cross-origin (and without CORS sharing, so is opaque). Subsequent
-//     responses come from same-origin. The canvas should be tainted (but in
-//     Chrome this is a LOAD_ERROR since it disallows range responses from
-//     multiple origins, period).
+//     responses come from same-origin. This should result in a load error, as regardless of canvas
+//     loading range requests from multiple opaque origins can reveal information across those origins.
 range_request_test(
   'resources/range-request-to-different-origins-worker.js',
-  'TAINTED',
+  'LOAD_ERROR',
   'range responses from multiple origins (cross-origin first)');
 
 // (4) Range responses come from multiple origins. The first response comes from


### PR DESCRIPTION
1. preload without SRI, resource with matching SRI
2. Both preload and resource with matching SRI, but different algorithm

These two cases don't show the same results across browsers.
- In Chromium both would not reuse the preload
- In WebKit they both reuse the preload
- In Gecko the first one does not reuse and the second one does.

Note that in webkit most of the tests in this file currently fail, WebKit does not perform SRI matching on preload/consume.

The test results in this PR match chromium, but they are not necessarily "correct".