### PR TITLE
Fix expected results for video loading from multiple origins

### DIFF
--- a/service-workers/service-worker/fetch-canvas-tainting-video-with-range-request.https.html
+++ b/service-workers/service-worker/fetch-canvas-tainting-video-with-range-request.https.html
@@ -63,12 +63,11 @@ range_request_test(
 
 // (3) Range responses come from multiple origins. The first response comes from
 //     cross-origin (and without CORS sharing, so is opaque). Subsequent
-//     responses come from same-origin. The canvas should be tainted (but in
-//     Chrome this is a LOAD_ERROR since it disallows range responses from
-//     multiple origins, period).
+//     responses come from same-origin. This should result in a load error, as regardless of canvas
+//     loading range requests from multiple opaque origins can reveal information across those origins.
 range_request_test(
   'resources/range-request-to-different-origins-worker.js',
-  'TAINTED',
+  'LOAD_ERROR',
   'range responses from multiple origins (cross-origin first)');
 
 // (4) Range responses come from multiple origins. The first response comes from


### PR DESCRIPTION
See https://github.com/whatwg/html/pull/7655

When loading video from multiple opaque origins (by a middleman service-worker),
video loading should fail rather than be alllowed and taint the canvas.

That's because some of the video responses may contain metadata such as duration that
would leak to the subsequent requests.

See https://github.com/whatwg/html/pull/2814#issuecomment-760982616 for further details.

This change makes the test case pass in all browsers.