### PR TITLE
Update Python string formatting using pyupgrade

### DIFF
--- a/tools/ci/manifest_build.py
+++ b/tools/ci/manifest_build.py
@@ -70,7 +70,7 @@ def request(url, desc, method=None, data=None, json_data=None, params=None, head
         resp = method(url, **kwargs)
 
     except Exception as e:
-        logger.error("%s failed:\n%s" % (desc, e))
+        logger.error(f"{desc} failed:\n{e}")
         return None
 
     try:
@@ -107,8 +107,8 @@ def get_pr(owner, repo, sha):
 
 
 def create_release(manifest_path, owner, repo, sha, tag, body):
-    logger.info("Creating a release for tag='%s', target_commitish='%s'" % (tag, sha))
-    create_url = "https://api.github.com/repos/%s/%s/releases" % (owner, repo)
+    logger.info(f"Creating a release for tag='{tag}', target_commitish='{sha}'")
+    create_url = f"https://api.github.com/repos/{owner}/{repo}/releases"
     create_data = {"tag_name": tag,
                    "target_commitish": sha,
                    "name": tag,
@@ -123,11 +123,11 @@ def create_release(manifest_path, owner, repo, sha, tag, body):
 
     upload_exts = [".gz", ".bz2", ".zst"]
     for upload_ext in upload_exts:
-        upload_filename = "MANIFEST-%s.json%s" % (sha, upload_ext)
+        upload_filename = f"MANIFEST-{sha}.json{upload_ext}"
         params = {"name": upload_filename,
                   "label": "MANIFEST.json%s" % upload_ext}
 
-        with open("%s%s" % (manifest_path, upload_ext), "rb") as f:
+        with open(f"{manifest_path}{upload_ext}", "rb") as f:
             upload_data = f.read()
 
         logger.info("Uploading %s bytes" % len(upload_data))
@@ -138,7 +138,7 @@ def create_release(manifest_path, owner, repo, sha, tag, body):
             return False
 
     release_id = create_resp["id"]
-    edit_url = "https://api.github.com/repos/%s/%s/releases/%s" % (owner, repo, release_id)
+    edit_url = f"https://api.github.com/repos/{owner}/{repo}/releases/{release_id}"
     edit_data = create_data.copy()
     edit_data["draft"] = False
     edit_resp = request(edit_url, "Release publishing", method=requests.patch, json_data=edit_data)

--- a/tools/ci/tc/tests/test_valid.py
+++ b/tools/ci/tc/tests/test_valid.py
@@ -91,7 +91,7 @@ def test_verify_payload():
                 validate(instance=task_data, schema=create_task_schema)
                 validate(instance=task_data["payload"], schema=payload_schema)
             except Exception as e:
-                print("Validation failed for task '%s':\n%s" % (name, json.dumps(task_data, indent=2)))
+                print(f"Validation failed for task '{name}':\n{json.dumps(task_data, indent=2)}")
                 raise e
 
 

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -853,7 +853,7 @@ def output_errors_text(log, errors):
         pos_string = path
         if line_number:
             pos_string += ":%s" % line_number
-        log("%s: %s (%s)" % (pos_string, description, error_type))
+        log(f"{pos_string}: {description} ({error_type})")
 
 
 def output_errors_markdown(log, errors):
@@ -870,7 +870,7 @@ def output_errors_markdown(log, errors):
         pos_string = path
         if line_number:
             pos_string += ":%s" % line_number
-        log("%s | %s | %s |" % (error_type, pos_string, description))
+        log(f"{error_type} | {pos_string} | {description} |")
 
 
 def output_errors_json(log, errors):
@@ -912,7 +912,7 @@ def output_error_count(error_count):
     count = sum(error_count.values())
     logger.info("")
     if count == 1:
-        logger.info("There was 1 error (%s)" % (by_type,))
+        logger.info(f"There was 1 error ({by_type})")
     else:
         logger.info("There were %d errors (%s)" % (count, by_type))
 

--- a/tools/lint/tests/test_path_lints.py
+++ b/tools/lint/tests/test_path_lints.py
@@ -22,7 +22,7 @@ def test_forbidden_path_length():
 
     for idx in range(5, 10):
         filename = basename + idx * "a"
-        message = "/%s longer than maximum path length (%s > 150)" % (filename, 146 + idx)
+        message = f"/{filename} longer than maximum path length ({146 + idx} > 150)"
 
         errors = check_path("/foo/", filename)
         check_errors(errors)
@@ -46,7 +46,7 @@ def test_forbidden_path_endings(path_ending, generated):
 def test_file_type():
     path = "test/test"
 
-    message = "/%s is an unsupported file type (symlink)" % (path,)
+    message = f"/{path} is an unsupported file type (symlink)"
 
     with mock.patch("os.path.islink", returnvalue=True):
         errors = check_path("/foo/", path)

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -83,7 +83,7 @@ class ManifestItem(metaclass=ManifestItemMeta):
 
     def __repr__(self):
         # type: () -> str
-        return "<%s.%s id=%r, path=%r>" % (self.__module__, self.__class__.__name__, self.id, self.path)
+        return f"<{self.__module__}.{self.__class__.__name__} id={self.id!r}, path={self.path!r}>"
 
     def to_json(self):
         # type: () -> Tuple[Any, ...]

--- a/tools/manifest/typedata.py
+++ b/tools/manifest/typedata.py
@@ -128,7 +128,7 @@ class TypeData(TypeDataType):
         for i, pathseg in enumerate(key[:-1]):
             node = node.setdefault(pathseg, {})
             if not isinstance(node, dict):
-                raise KeyError("%r is a child of a test (%r)" % (key, key[:i+1]))
+                raise KeyError(f"{key!r} is a child of a test ({key[:i+1]!r})")
         node[key[-1]] = value
 
     def __delitem__(self, key):

--- a/tools/webdriver/webdriver/error.py
+++ b/tools/webdriver/webdriver/error.py
@@ -24,10 +24,10 @@ class WebDriverException(Exception):
         self.stacktrace = stacktrace
 
     def __repr__(self):
-        return "<%s http_status=%s>" % (self.__class__.__name__, self.http_status)
+        return f"<{self.__class__.__name__} http_status={self.http_status}>"
 
     def __str__(self):
-        message = "%s (%s)" % (self.status_code, self.http_status)
+        message = f"{self.status_code} ({self.http_status})"
 
         if self.message is not None:
             message += ": %s" % self.message

--- a/tools/webdriver/webdriver/transport.py
+++ b/tools/webdriver/webdriver/transport.py
@@ -71,8 +71,8 @@ class Response:
     def __repr__(self):
         cls_name = self.__class__.__name__
         if self.error:
-            return "<%s status=%s error=%s>" % (cls_name, self.status, repr(self.error))
-        return "<% status=%s body=%s>" % (cls_name, self.status, json.dumps(self.body))
+            return f"<{cls_name} status={self.status} error={repr(self.error)}>"
+        return f"<{cls_name: }tatus={self.status} body={json.dumps(self.body)}>"
 
     def __str__(self):
         return json.dumps(self.body, indent=2)

--- a/tools/wpt/android.py
+++ b/tools/wpt/android.py
@@ -66,7 +66,7 @@ def install_sdk(logger, dest=None):
     # TODO: either always use the latest version or have some way to
     # configure a per-product version if there are strong requirements
     # to use a specific version.
-    url = 'https://dl.google.com/android/repository/sdk-tools-%s-4333796.zip' % (os_name,)
+    url = f'https://dl.google.com/android/repository/sdk-tools-{os_name}-4333796.zip'
 
     logger.info("Getting SDK from %s" % url)
     temp_path = os.path.join(sdk_path, url.rsplit("/", 1)[1])

--- a/tools/wpt/create.py
+++ b/tools/wpt/create.py
@@ -122,8 +122,8 @@ def run(_venv, **kwargs):
     proc = None
     if editor:
         if ref_path:
-            path = "%s %s" % (path, ref_path)
-        proc = subprocess.Popen("%s %s" % (editor, path), shell=True)
+            path = f"{path} {ref_path}"
+        proc = subprocess.Popen(f"{editor} {path}", shell=True)
     else:
         print("Created test %s" % path)
 

--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -121,7 +121,7 @@ def branch_point():
         merge_base = git("merge-base", "HEAD", "origin/master")
         if (branch_point is None or
             (branch_point != merge_base and
-             not git("log", "--oneline", "%s..%s" % (merge_base, branch_point)).strip())):
+             not git("log", "--oneline", f"{merge_base}..{branch_point}").strip())):
             logger.debug("Using merge-base as the branch point")
             branch_point = merge_base
         else:

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -260,7 +260,7 @@ def test_run_verify_unstable(temp_test):
 def test_files_changed(capsys):
     commit = "9047ac1d9f51b1e9faa4f9fad9c47d109609ab09"
     with pytest.raises(SystemExit) as excinfo:
-        wpt.main(argv=["files-changed", "%s~..%s" % (commit, commit)])
+        wpt.main(argv=["files-changed", f"{commit}~..{commit}"])
     assert excinfo.value.code == 0
     out, err = capsys.readouterr()
     expected = """html/browsers/offline/appcache/workers/appcache-worker.html
@@ -278,7 +278,7 @@ html/browsers/offline/appcache/workers/resources/appcache-worker.py
 def test_files_changed_null(capsys):
     commit = "9047ac1d9f51b1e9faa4f9fad9c47d109609ab09"
     with pytest.raises(SystemExit) as excinfo:
-        wpt.main(argv=["files-changed", "--null", "%s~..%s" % (commit, commit)])
+        wpt.main(argv=["files-changed", "--null", f"{commit}~..{commit}"])
     assert excinfo.value.code == 0
     out, err = capsys.readouterr()
     expected = "\0".join(["html/browsers/offline/appcache/workers/appcache-worker.html",
@@ -323,7 +323,7 @@ def test_tests_affected(capsys, manifest_dir):
     # The test will fail if the file we assert is renamed, so we choose a stable one.
     commit = "3a055e818218f548db240c316654f3cc1aeeb733"
     with pytest.raises(SystemExit) as excinfo:
-        wpt.main(argv=["tests-affected", "--metadata", manifest_dir, "%s~..%s" % (commit, commit)])
+        wpt.main(argv=["tests-affected", "--metadata", manifest_dir, f"{commit}~..{commit}"])
     assert excinfo.value.code == 0
     out, err = capsys.readouterr()
     assert "infrastructure/reftest-wait.html" in out
@@ -337,7 +337,7 @@ def test_tests_affected(capsys, manifest_dir):
 def test_tests_affected_idlharness(capsys, manifest_dir):
     commit = "47cea8c38b88c0ddd3854e4edec0c5b6f2697e62"
     with pytest.raises(SystemExit) as excinfo:
-        wpt.main(argv=["tests-affected", "--metadata", manifest_dir, "%s~..%s" % (commit, commit)])
+        wpt.main(argv=["tests-affected", "--metadata", manifest_dir, f"{commit}~..{commit}"])
     assert excinfo.value.code == 0
     out, err = capsys.readouterr()
     assert ("mst-content-hint/idlharness.window.js\n" +
@@ -360,7 +360,7 @@ def test_tests_affected_null(capsys, manifest_dir):
     # The test will fail if the file we assert is renamed, so we choose a stable one.
     commit = "2614e3316f1d3d1a744ed3af088d19516552a5de"
     with pytest.raises(SystemExit) as excinfo:
-        wpt.main(argv=["tests-affected", "--null", "--metadata", manifest_dir, "%s~..%s" % (commit, commit)])
+        wpt.main(argv=["tests-affected", "--null", "--metadata", manifest_dir, f"{commit}~..{commit}"])
     assert excinfo.value.code == 0
     out, err = capsys.readouterr()
 

--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -100,7 +100,7 @@ def import_command(prog, command, props):
     script = getattr(mod, props["script"])
     if props["parser"] is not None:
         parser = getattr(mod, props["parser"])()
-        parser.prog = "%s %s" % (os.path.basename(prog), command)
+        parser.prog = f"{os.path.basename(prog)} {command}"
     else:
         parser = None
 

--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -55,7 +55,7 @@ def get_capabilities(**kwargs):
         "browserName": browser_name,
         "build": build,
         "disablePopupHandler": True,
-        "name": "%s %s on %s" % (browser_name, version, platform),
+        "name": f"{browser_name} {version} on {platform}",
         "platform": platform,
         "public": "public",
         "selenium-version": "3.3.1",
@@ -73,7 +73,7 @@ def get_sauce_config(**kwargs):
     sauce_user = kwargs["sauce_user"]
     sauce_key = kwargs["sauce_key"]
 
-    hub_url = "%s:%s@localhost:4445" % (sauce_user, sauce_key)
+    hub_url = f"{sauce_user}:{sauce_key}@localhost:4445"
     data = {
         "url": "http://%s/wd/hub" % hub_url,
         "browserName": browser_name,
@@ -193,7 +193,7 @@ class SauceConnect():
 
     def upload_prerun_exec(self, file_name):
         auth = (self.sauce_user, self.sauce_key)
-        url = "https://saucelabs.com/rest/v1/storage/%s/%s?overwrite=true" % (self.sauce_user, file_name)
+        url = f"https://saucelabs.com/rest/v1/storage/{self.sauce_user}/{file_name}?overwrite=true"
 
         with open(os.path.join(here, 'sauce_setup', file_name), 'rb') as f:
             requests.post(url, data=f, auth=auth)

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -415,7 +415,7 @@ class RefTestImplementation:
         else:
             rv = self.screenshot_cache[key]
 
-        self.message.append("%s %s" % (test.url, rv[0]))
+        self.message.append(f"{test.url} {rv[0]}")
         return True, rv
 
     def reset(self):
@@ -493,7 +493,7 @@ class RefTestImplementation:
         extrema = image.getextrema()
         if all(min == max for min, max in extrema):
             color = ''.join('%02X' % value for value, _ in extrema)
-            self.message.append("Screenshot is solid color 0x%s for %s\n" % (color, url))
+            self.message.append(f"Screenshot is solid color 0x{color} for {url}\n")
 
     def run_test(self, test):
         viewport_size = test.viewport_size
@@ -745,7 +745,7 @@ class CallbackHandler:
             self._send_message(cmd_id, "complete", "error")
             raise
         else:
-            self.logger.debug("Action %s completed with result %s" % (action, result))
+            self.logger.debug(f"Action {action} completed with result {result}")
             return_message = {"result": result}
             self._send_message(cmd_id, "complete", "success", json.dumps(return_message))
 

--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -43,7 +43,7 @@ def build_servo_command(test, test_url_func, browser, binary, pause_after_test, 
     for stylesheet in browser.user_stylesheets:
         args += ["--user-stylesheet", stylesheet]
     for pref, value in test.environment.get('prefs', {}).items():
-        args += ["--pref", "%s=%s" % (pref, value)]
+        args += ["--pref", f"{pref}={value}"]
     if browser.ca_certificate_path:
         args += ["--certificate-path", browser.ca_certificate_path]
     if extra_args:

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -301,7 +301,7 @@ class WebDriverVirtualAuthenticatorProtocolPart(VirtualAuthenticatorProtocolPart
         return self.webdriver.send_session_command("GET", "webauthn/authenticator/%s/credentials" % authenticator_id)
 
     def remove_credential(self, authenticator_id, credential_id):
-        return self.webdriver.send_session_command("DELETE", "webauthn/authenticator/%s/credentials/%s" % (authenticator_id, credential_id))
+        return self.webdriver.send_session_command("DELETE", f"webauthn/authenticator/{authenticator_id}/credentials/{credential_id}")
 
     def remove_all_credentials(self, authenticator_id):
         return self.webdriver.send_session_command("DELETE", "webauthn/authenticator/%s/credentials" % authenticator_id)

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -269,9 +269,9 @@ class SelectorProtocolPart(ProtocolPart):
     def element_by_selector(self, element_selector):
         elements = self.elements_by_selector(element_selector)
         if len(elements) == 0:
-            raise ValueError("Selector '%s' matches no elements" % (element_selector,))
+            raise ValueError(f"Selector '{element_selector}' matches no elements")
         elif len(elements) > 1:
-            raise ValueError("Selector '%s' matches multiple elements" % (element_selector,))
+            raise ValueError(f"Selector '{element_selector}' matches multiple elements")
         return elements[0]
 
     @abstractmethod

--- a/tools/wptrunner/wptrunner/font.py
+++ b/tools/wptrunner/wptrunner/font.py
@@ -111,7 +111,7 @@ class FontInstaller:
         if self.created_dir:
             rmtree(self.font_dir)
         else:
-            os.remove('%s/%s' % (self.font_dir, font_name))
+            os.remove(f'{self.font_dir}/{font_name}')
         try:
             fc_cache_returncode = call('fc-cache')
             return not fc_cache_returncode

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -648,7 +648,7 @@ class TestRunnerManager(threading.Thread):
                 self.logger.info("Found a crash dump file; changing status to CRASH")
                 status = "CRASH"
             else:
-                self.logger.warning("Found a crash dump; should change status from %s to CRASH but this causes instability" % (status,))
+                self.logger.warning(f"Found a crash dump; should change status from {status} to CRASH but this causes instability")
 
         # We have a couple of status codes that are used internally, but not exposed to the
         # user. These are used to indicate that some possibly-broken state was reached
@@ -830,11 +830,11 @@ class TestRunnerManager(threading.Thread):
                     # to stop the TestRunner in `stop_runner`.
                     pass
                 else:
-                    self.logger.warning("Command left in command_queue during cleanup: %r, %r" % (cmd, data))
+                    self.logger.warning(f"Command left in command_queue during cleanup: {cmd!r}, {data!r}")
         while True:
             try:
                 cmd, data = self.remote_queue.get_nowait()
-                self.logger.warning("Command left in remote_queue during cleanup: %r, %r" % (cmd, data))
+                self.logger.warning(f"Command left in remote_queue during cleanup: {cmd!r}, {data!r}")
             except Empty:
                 break
 

--- a/tools/wptrunner/wptrunner/tests/test_expectedtree.py
+++ b/tools/wptrunner/wptrunner/tests/test_expectedtree.py
@@ -10,10 +10,10 @@ def dump_tree(tree):
         if not node.prop:
             data = "root"
         else:
-            data = "%s:%s" % (node.prop, node.value)
+            data = f"{node.prop}:{node.value}"
         if node.result_values:
             data += " result_values:%s" % (",".join(sorted(node.result_values)))
-        rv.append("%s<%s>" % (prefix, data))
+        rv.append(f"{prefix}<{data}>")
         for child in sorted(node.children, key=lambda x:x.value):
             dump_node(child, indent + 2)
     dump_node(tree)

--- a/tools/wptrunner/wptrunner/update/base.py
+++ b/tools/wptrunner/wptrunner/update/base.py
@@ -35,13 +35,13 @@ class Step:
             assert set(self.provides).issubset(set(state.keys()))
             state.steps = state.steps + [name]
         else:
-            raise ValueError("Expected a %s step, got a %s step" % (name, stored_step))
+            raise ValueError(f"Expected a {name} step, got a {stored_step} step")
 
     def create(self, data):
         raise NotImplementedError
 
     def restore(self, state):
-        self.logger.debug("Step %s using stored state" % (self.__class__.__name__,))
+        self.logger.debug(f"Step {self.__class__.__name__} using stored state")
         for key in self.provides:
             assert key in state
 

--- a/tools/wptrunner/wptrunner/update/metadata.py
+++ b/tools/wptrunner/wptrunner/update/metadata.py
@@ -37,7 +37,7 @@ class CreateMetadataPatch(Step):
 
         if sync_tree is not None:
             name = "web-platform-tests_update_%s_metadata" % sync_tree.rev
-            message = "Update %s expected data to revision %s" % (state.suite_name, sync_tree.rev)
+            message = f"Update {state.suite_name} expected data to revision {sync_tree.rev}"
         else:
             name = "web-platform-tests_update_metadata"
             message = "Update %s expected data" % state.suite_name

--- a/tools/wptrunner/wptrunner/update/state.py
+++ b/tools/wptrunner/wptrunner/update/state.py
@@ -100,7 +100,7 @@ class SavedState(BaseState):
             with open(cls.filename, "rb") as f:
                 try:
                     rv = pickle.load(f)
-                    logger.debug("Loading data %r" % (rv._data,))
+                    logger.debug(f"Loading data {rv._data!r}")
                     rv._logger = logger
                     rv._index = 0
                     return rv

--- a/tools/wptrunner/wptrunner/update/sync.py
+++ b/tools/wptrunner/wptrunner/update/sync.py
@@ -127,7 +127,7 @@ class CreateSyncPatch(Step):
         sync_tree = state.sync_tree
 
         local_tree.create_patch("web-platform-tests_update_%s" % sync_tree.rev,
-                                "Update %s to revision %s" % (state.suite_name, sync_tree.rev))
+                                f"Update {state.suite_name} to revision {sync_tree.rev}")
         test_prefix = os.path.relpath(state.tests_path, local_tree.root)
         local_tree.add_new(test_prefix)
         local_tree.add_ignored(sync_tree, test_prefix)

--- a/tools/wptrunner/wptrunner/update/tree.py
+++ b/tools/wptrunner/wptrunner/update/tree.py
@@ -17,7 +17,7 @@ def get_unique_name(existing, initial):
     if initial not in existing:
         return initial
     for i in range(len(existing) + 1):
-        test = "%s_%s" % (initial, i + 1)
+        test = f"{initial}_{i + 1}"
         if test not in existing:
             return test
     assert False
@@ -318,7 +318,7 @@ class GitTree:
         if not vcs.is_git_root(self.root):
             self.init()
         self.git("clean", "-xdf")
-        self.git("fetch", remote, "%s:%s" % (remote_branch, local_branch))
+        self.git("fetch", remote, f"{remote_branch}:{local_branch}")
         self.checkout(local_branch)
         self.git("submodule", "update", "--init", "--recursive")
 

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -507,11 +507,11 @@ def check_paths(kwargs):
                 path = os.path.dirname(path)
 
             if not os.path.exists(path):
-                print("Fatal: %s path %s does not exist" % (name, path))
+                print(f"Fatal: {name} path {path} does not exist")
                 sys.exit(1)
 
             if not os.path.isdir(path):
-                print("Fatal: %s path %s is not a directory" % (name, path))
+                print(f"Fatal: {name} path {path} is not a directory")
                 sys.exit(1)
 
 

--- a/tools/wptrunner/wptrunner/wptmanifest/backends/base.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/backends/base.py
@@ -130,7 +130,7 @@ class ManifestItem:
         self._data = {}
 
     def __repr__(self):
-        return "<%s %s>" % (self.__class__, self.node.data)
+        return f"<{self.__class__} {self.node.data}>"
 
     def __str__(self):
         rv = [repr(self)]

--- a/tools/wptrunner/wptrunner/wptmanifest/node.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/node.py
@@ -21,7 +21,7 @@ class Node:
         self.parent.children.remove(self)
 
     def __repr__(self):
-        return "<%s %s>" % (self.__class__.__name__, self.data)
+        return f"<{self.__class__.__name__} {self.data}>"
 
     def __str__(self):
         rv = [repr(self)]

--- a/tools/wptrunner/wptrunner/wptmanifest/parser.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/parser.py
@@ -25,7 +25,7 @@ class ParseError(Exception):
         self.line = line
         self.filename = filename
         self.detail = detail
-        self.message = "%s: %s line %s" % (self.detail, self.filename, self.line)
+        self.message = f"{self.detail}: {self.filename} line {self.line}"
         Exception.__init__(self, self.message)
 
 eol = object

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -29,7 +29,7 @@ class Result:
         self.stack = stack
 
     def __repr__(self):
-        return "<%s.%s %s>" % (self.__module__, self.__class__.__name__, self.status)
+        return f"<{self.__module__}.{self.__class__.__name__} {self.status}>"
 
 
 class SubtestResult:
@@ -44,7 +44,7 @@ class SubtestResult:
         self.known_intermittent = known_intermittent if known_intermittent is not None else []
 
     def __repr__(self):
-        return "<%s.%s %s %s>" % (self.__module__, self.__class__.__name__, self.name, self.status)
+        return f"<{self.__module__}.{self.__class__.__name__} {self.name} {self.status}>"
 
 
 class TestharnessResult(Result):
@@ -446,7 +446,7 @@ class Test:
             return False
 
     def __repr__(self):
-        return "<%s.%s %s>" % (self.__module__, self.__class__.__name__, self.id)
+        return f"<{self.__module__}.{self.__class__.__name__} {self.id}>"
 
 
 class TestharnessTest(Test):

--- a/tools/wptserve/wptserve/ranges.py
+++ b/tools/wptserve/wptserve/ranges.py
@@ -9,7 +9,7 @@ class RangeParser:
             raise HTTPException(400, "Non-ASCII range header value")
         prefix = "bytes="
         if not header.startswith(prefix):
-            raise HTTPException(416, message="Unrecognised range type %s" % (header,))
+            raise HTTPException(416, message=f"Unrecognised range type {header}")
 
         parts = header[len(prefix):].split(",")
         ranges = []
@@ -57,7 +57,7 @@ class Range:
             raise ValueError
 
     def __repr__(self):
-        return "<Range %s-%s>" % (self.lower, self.upper)
+        return f"<Range {self.lower}-{self.upper}>"
 
     def __lt__(self, other):
         return self.lower < other.lower

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -232,7 +232,7 @@ class WebTestServer(ThreadingMixIn, http.server.HTTPServer):
             pass  # remote hang up before the result is sent
         else:
             msg = traceback.format_exc()
-            self.logger.error("%s %s" % (type(error), error))
+            self.logger.error(f"{type(error)} {error}")
             self.logger.info(msg)
 
 
@@ -259,7 +259,7 @@ class BaseWebTestRequestHandler(http.server.BaseHTTPRequestHandler):
             response.write()
             return
 
-        self.logger.debug("%s %s" % (request.method, request.request_path))
+        self.logger.debug(f"{request.method} {request.request_path}")
         handler = self.server.router.get_handler(request)
         self.finish_handling(request, response, handler)
 
@@ -416,11 +416,11 @@ class Http2WebTestRequestHandler(BaseWebTestRequestHandler):
                             del stream_queues[frame.stream_id]
 
         except OSError as e:
-            self.logger.error('(%s) Closing Connection - \n%s' % (self.uid, str(e)))
+            self.logger.error(f'({self.uid}) Closing Connection - \n{str(e)}')
             if not self.close_connection:
                 self.close_connection = True
         except Exception as e:
-            self.logger.error('(%s) Unexpected Error - \n%s' % (self.uid, str(e)))
+            self.logger.error(f'({self.uid}) Unexpected Error - \n{str(e)}')
         finally:
             for stream_id, (thread, queue) in stream_queues.items():
                 queue.put(None)
@@ -440,7 +440,7 @@ class Http2WebTestRequestHandler(BaseWebTestRequestHandler):
                 protocol = isomorphic_encode(value)
                 break
         if protocol != b"websocket":
-            raise ProtocolError("Invalid protocol %s with CONNECT METHOD" % (protocol,))
+            raise ProtocolError(f"Invalid protocol {protocol} with CONNECT METHOD")
 
         return True
 
@@ -531,7 +531,7 @@ class Http2WebTestRequestHandler(BaseWebTestRequestHandler):
                     raise NotImplementedError("frame.stream_ended")
                     wfile.close()
             elif frame is None or isinstance(frame, (StreamReset, StreamEnded, ConnectionTerminated)):
-                self.logger.debug('(%s - %s) Stream Reset, Thread Closing' % (self.uid, stream_id))
+                self.logger.debug(f'({self.uid} - {stream_id}) Stream Reset, Thread Closing')
                 break
 
         t.join()
@@ -576,7 +576,7 @@ class Http2WebTestRequestHandler(BaseWebTestRequestHandler):
                 # Restart to check for close_connection
                 continue
 
-            self.logger.debug('(%s - %s) %s' % (self.uid, stream_id, str(frame)))
+            self.logger.debug(f'({self.uid} - {stream_id}) {str(frame)}')
 
             if isinstance(frame, RequestReceived):
                 rfile, wfile = os.pipe()
@@ -606,7 +606,7 @@ class Http2WebTestRequestHandler(BaseWebTestRequestHandler):
                 if frame.stream_ended:
                     wfile.close()
             elif frame is None or isinstance(frame, (StreamReset, StreamEnded, ConnectionTerminated)):
-                self.logger.debug('(%s - %s) Stream Reset, Thread Closing' % (self.uid, stream_id))
+                self.logger.debug(f'({self.uid} - {stream_id}) Stream Reset, Thread Closing')
                 break
 
             if request is not None:
@@ -839,7 +839,7 @@ class WebTestHttpd:
         :param block: True to run the server on the current thread, blocking,
                       False to run on a separate thread."""
         http_type = "http2" if self.http2 else "https" if self.use_ssl else "http"
-        self.logger.info("Starting %s server on %s:%s" % (http_type, self.host, self.port))
+        self.logger.info(f"Starting {http_type} server on {self.host}:{self.port}")
         self.started = True
         self.server_thread = threading.Thread(target=self.httpd.serve_forever)
         self.server_thread.setDaemon(True)  # don't hang on exit
@@ -857,7 +857,7 @@ class WebTestHttpd:
                 self.httpd.server_close()
                 self.server_thread.join()
                 self.server_thread = None
-                self.logger.info("Stopped http server on %s:%s" % (self.host, self.port))
+                self.logger.info(f"Stopped http server on {self.host}:{self.port}")
             except AttributeError:
                 pass
             self.started = False
@@ -868,7 +868,7 @@ class WebTestHttpd:
             return None
 
         return urlunsplit(("http" if not self.use_ssl else "https",
-                           "%s:%s" % (self.host, self.port),
+                           f"{self.host}:{self.port}",
                            path, query, fragment))
 
 


### PR DESCRIPTION
Follow-up to #29301

Updates `.py` files in the `tools/` directory that still contain strings with percent formatting, replacing with f-strings and the `.format()` method syntax.

command used:
```find tools -name '*.py' | grep -v third_party | xargs pyupgrade --py36-plus```