### PR TITLE
Remove Mozilla Public License notices

### DIFF
--- a/html/semantics/embedded-content/the-iframe-element/stash.py
+++ b/html/semantics/embedded-content/the-iframe-element/stash.py
@@ -1,8 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-
 def main(request, response):
     if request.method == u'POST':
         request.server.stash.put(request.GET[b"id"], request.body)

--- a/mathml/tools/operator-dictionary.xsl
+++ b/mathml/tools/operator-dictionary.xsl
@@ -1,7 +1,4 @@
 <!-- -*- Mode: nXML; tab-width: 2; indent-tabs-mode: nil; -*- -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
-   - License, v. 2.0. If a copy of the MPL was not distributed with this
-   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
   <xsl:strip-space elements="*"/>

--- a/tools/wptrunner/setup.py
+++ b/tools/wptrunner/setup.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this file,
-# You can obtain one at http://mozilla.org/MPL/2.0/.
-
 import glob
 import os
 import sys

--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this file,
-# You can obtain one at http://mozilla.org/MPL/2.0/.
-
 import glob
 import os
 import shutil


### PR DESCRIPTION
These files were probably contributed from Mozilla source code, but in
doing so they were contributed under the WPT license terms, making them
now effectively dual license.

Drop these notices to avoid doubt about whether the WPT license applies.

This is similar to https://github.com/web-platform-tests/wpt/pull/28677.