### PR TITLE
Inline mypy configuration per file as much as possible

### DIFF
--- a/tools/ci/jobs.py
+++ b/tools/ci/jobs.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import argparse
 import os
 import re

--- a/tools/ci/make_hosts_file.py
+++ b/tools/ci/make_hosts_file.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import argparse
 import os
 

--- a/tools/ci/manifest_build.py
+++ b/tools/ci/manifest_build.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 import logging
 import os

--- a/tools/ci/regen_certs.py
+++ b/tools/ci/regen_certs.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import argparse
 import base64
 import logging

--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# mypy: allow-untyped-defs
 
 """Wrapper script for running jobs in Taskcluster
 

--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# mypy: allow-untyped-defs
 
 import argparse
 import gzip

--- a/tools/ci/tc/decision.py
+++ b/tools/ci/tc/decision.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import argparse
 import json
 import logging

--- a/tools/ci/tc/download.py
+++ b/tools/ci/tc/download.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import argparse
 import os
 import logging

--- a/tools/ci/tc/sink_task.py
+++ b/tools/ci/tc/sink_task.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import argparse
 import logging
 import os

--- a/tools/ci/tc/taskgraph.py
+++ b/tools/ci/tc/taskgraph.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 import os
 import re

--- a/tools/ci/tc/tests/test_decision.py
+++ b/tools/ci/tc/tests/test_decision.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from unittest import mock
 
 import pytest

--- a/tools/ci/tc/tests/test_taskgraph.py
+++ b/tools/ci/tc/tests/test_taskgraph.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import pytest
 import yaml
 

--- a/tools/ci/tc/tests/test_valid.py
+++ b/tools/ci/tc/tests/test_valid.py
@@ -1,3 +1,5 @@
+# mypy: ignore-errors
+
 import json
 import os
 from unittest import mock

--- a/tools/ci/tests/test_jobs.py
+++ b/tools/ci/tests/test_jobs.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from tools.ci import jobs
 
 all_jobs = {

--- a/tools/ci/update_built.py
+++ b/tools/ci/update_built.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import logging
 import os
 import subprocess

--- a/tools/docker/frontend.py
+++ b/tools/docker/frontend.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import argparse
 import logging
 import os

--- a/tools/gitignore/tests/test_gitignore.py
+++ b/tools/gitignore/tests/test_gitignore.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import pytest
 
 from ..gitignore import fnmatch_translate, PathFilter

--- a/tools/lint/tests/base.py
+++ b/tools/lint/tests/base.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 def check_errors(errors):
     for e in errors:
         error_type, description, path, line_number = e

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from ..lint import check_file_contents
 from .base import check_errors
 import io

--- a/tools/lint/tests/test_lint.py
+++ b/tools/lint/tests/test_lint.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import io
 import os
 import sys

--- a/tools/lint/tests/test_path_lints.py
+++ b/tools/lint/tests/test_path_lints.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 from unittest import mock
 

--- a/tools/manifest/tests/test_XMLParser.py
+++ b/tools/manifest/tests/test_XMLParser.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from xml.etree.ElementTree import ParseError
 
 import pytest

--- a/tools/manifest/tests/test_item.py
+++ b/tools/manifest/tests/test_item.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import inspect
 import json
 

--- a/tools/manifest/tests/test_manifest.py
+++ b/tools/manifest/tests/test_manifest.py
@@ -1,3 +1,5 @@
+# mypy: ignore-errors
+
 import os
 from unittest import mock
 

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 
 import pytest

--- a/tools/manifest/tests/test_utils.py
+++ b/tools/manifest/tests/test_utils.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 import subprocess
 from unittest import mock

--- a/tools/mypy.ini
+++ b/tools/mypy.ini
@@ -1,13 +1,12 @@
 [mypy]
-# Everything that can be ignored at package level (further below) should be.
 # Here some paths are excluded from even being parsed, working around cases of
 # invalid syntax we can't fix (yet) or where the code isn't in a package and
 # there's no good place to add __init__.py files. The following are excluded:
-# - tools/runner/ (written in Python 2)
 # - tools/third_party/ (vendored dependencies)
-# - All conftest.py and setup.py files
-# - tests+docs directly under wptrunner+wptserve, which aren't packages.
-exclude = (^tools/runner/|^tools/third_party/|/(conftest|setup)\.py$|^tools/wptrunner/test/|^tools/wptserve/docs/|^tools/wptserve/tests/)
+# - All setup.py files (avoiding duplicate module named "setup")
+# - tools/wptserve/docs/conf.py (generated code)
+# - tools/wptserve/tests/ (deliberately invalid syntax)
+exclude = (^tools/third_party/|/setup\.py$|^tools/wptserve/docs/conf.py|^tools/wptserve/tests/)
 #check_untyped_defs = True
 disallow_any_generics = True
 disallow_incomplete_defs = True
@@ -40,6 +39,9 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-hyperframe.*]
+ignore_missing_imports = True
+
+[mypy-hypothesis.*]
 ignore_missing_imports = True
 
 [mypy-marionette_driver.*]
@@ -107,63 +109,3 @@ ignore_missing_imports = True
 
 [mypy-zstandard.*]
 ignore_missing_imports = True
-
-# Ignore errors in tests.
-
-[mypy-tools.ci.tests.*]
-ignore_errors = True
-
-[mypy-tools.ci.tc.tests.*]
-ignore_errors = True
-
-[mypy-tools.gitignore.tests.*]
-ignore_errors = True
-
-[mypy-tools.lint.tests.*]
-ignore_errors = True
-
-[mypy-tools.manifest.tests.*]
-ignore_errors = True
-
-[mypy-tools.wpt.tests.*]
-ignore_errors = True
-
-[mypy-wptrunner.tests.*]
-ignore_errors = True
-
-[mypy-wptrunner.formatters.tests.*]
-ignore_errors = True
-
-[mypy-wptrunner.wptmanifest.tests.*]
-ignore_errors = True
-
-# Ignore errors in parts of the code which don't have type annotations or where
-# mypy has never been run. TODO: Enable mypy for all of the below.
-
-[mypy-tools.ci.*]
-disallow_untyped_defs = False
-
-[mypy-tools.docker.*]
-disallow_untyped_defs = False
-
-[mypy-tools.serve.*]
-disallow_untyped_defs = False
-
-[mypy-tools.wave.*]
-disallow_untyped_defs = False
-
-[mypy-tools.wpt.*]
-disallow_untyped_defs = False
-
-[mypy-webdriver.*]
-disallow_untyped_defs = False
-
-[mypy-wptrunner.*]
-disallow_untyped_defs = False
-
-[mypy-wptserve.*]
-disallow_untyped_defs = False
-
-[mypy-tools.webtransport.*]
-disallow_subclassing_any = False
-warn_return_any = False

--- a/tools/runner/report.py
+++ b/tools/runner/report.py
@@ -1,4 +1,5 @@
 # flake8: noqa
+# mypy: ignore-errors
 
 import argparse
 import json

--- a/tools/runner/update_manifest.py
+++ b/tools/runner/update_manifest.py
@@ -1,3 +1,5 @@
+# mypy: ignore-errors
+
 import imp
 import json
 import os

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import abc
 import argparse
 import importlib

--- a/tools/serve/test_functional.py
+++ b/tools/serve/test_functional.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 try:
     from importlib import reload
 except ImportError:

--- a/tools/serve/test_serve.py
+++ b/tools/serve/test_serve.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import logging
 import os
 import pickle

--- a/tools/wave/configuration_loader.py
+++ b/tools/wave/configuration_loader.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 import os
 

--- a/tools/wave/data/client.py
+++ b/tools/wave/data/client.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 class Client:
     def __init__(self, session_token):
         self.session_token = session_token

--- a/tools/wave/data/device.py
+++ b/tools/wave/data/device.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 class Device:
     def __init__(self, token, user_agent, name, last_active):
         self.token = token

--- a/tools/wave/data/event_listener.py
+++ b/tools/wave/data/event_listener.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 class EventListener:
     def __init__(self, dispatcher_token):
         super().__init__()

--- a/tools/wave/data/http_polling_client.py
+++ b/tools/wave/data/http_polling_client.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from .client import Client
 
 

--- a/tools/wave/data/http_polling_event_listener.py
+++ b/tools/wave/data/http_polling_event_listener.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from .event_listener import EventListener
 
 class HttpPollingEventListener(EventListener):

--- a/tools/wave/data/session.py
+++ b/tools/wave/data/session.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from ..testing.test_loader import MANUAL, AUTOMATIC
 
 PAUSED = "paused"

--- a/tools/wave/network/api/api_handler.py
+++ b/tools/wave/network/api/api_handler.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 import sys
 import traceback

--- a/tools/wave/network/api/devices_api_handler.py
+++ b/tools/wave/network/api/devices_api_handler.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 import threading
 

--- a/tools/wave/network/api/general_api_handler.py
+++ b/tools/wave/network/api/general_api_handler.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from .api_handler import ApiHandler
 
 TOKEN_LENGTH = 36

--- a/tools/wave/network/api/results_api_handler.py
+++ b/tools/wave/network/api/results_api_handler.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 
 from .api_handler import ApiHandler

--- a/tools/wave/network/api/sessions_api_handler.py
+++ b/tools/wave/network/api/sessions_api_handler.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 import threading
 

--- a/tools/wave/network/api/tests_api_handler.py
+++ b/tools/wave/network/api/tests_api_handler.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 
 from urllib.parse import urlunsplit

--- a/tools/wave/network/http_handler.py
+++ b/tools/wave/network/http_handler.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import http.client as httplib
 import sys
 import logging

--- a/tools/wave/network/static_handler.py
+++ b/tools/wave/network/static_handler.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 
 

--- a/tools/wave/testing/devices_manager.py
+++ b/tools/wave/testing/devices_manager.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import time
 import uuid
 

--- a/tools/wave/testing/event_dispatcher.py
+++ b/tools/wave/testing/event_dispatcher.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import uuid
 import time
 from threading import Timer

--- a/tools/wave/testing/results_manager.py
+++ b/tools/wave/testing/results_manager.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 import shutil
 import re

--- a/tools/wave/testing/sessions_manager.py
+++ b/tools/wave/testing/sessions_manager.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import uuid
 import time
 import os

--- a/tools/wave/testing/test_loader.py
+++ b/tools/wave/testing/test_loader.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 import re
 

--- a/tools/wave/testing/tests_manager.py
+++ b/tools/wave/testing/tests_manager.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import re
 from threading import Timer
 

--- a/tools/wave/testing/wpt_report.py
+++ b/tools/wave/testing/wpt_report.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import subprocess
 import os
 import ntpath

--- a/tools/wave/tests/test_wave.py
+++ b/tools/wave/tests/test_wave.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import errno
 import os
 import socket

--- a/tools/wave/utils/deserializer.py
+++ b/tools/wave/utils/deserializer.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from ..data.session import Session, UNKNOWN
 from datetime import datetime
 import dateutil.parser

--- a/tools/wave/utils/serializer.py
+++ b/tools/wave/utils/serializer.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from datetime import datetime
 
 

--- a/tools/wave/utils/user_agent_parser.py
+++ b/tools/wave/utils/user_agent_parser.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from ua_parser import user_agent_parser
 
 

--- a/tools/wave/wave_server.py
+++ b/tools/wave/wave_server.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 import logging
 

--- a/tools/webdriver/webdriver/bidi/client.py
+++ b/tools/webdriver/webdriver/bidi/client.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import asyncio
 from collections import defaultdict
 from typing import Any, Awaitable, Callable, List, Optional, Mapping, MutableMapping

--- a/tools/webdriver/webdriver/bidi/error.py
+++ b/tools/webdriver/webdriver/bidi/error.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import collections
 
 from typing import ClassVar, DefaultDict, Optional, Type

--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from typing import Dict
 from urllib import parse as urlparse
 

--- a/tools/webdriver/webdriver/error.py
+++ b/tools/webdriver/webdriver/error.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import collections
 import json
 

--- a/tools/webdriver/webdriver/protocol.py
+++ b/tools/webdriver/webdriver/protocol.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 
 import webdriver

--- a/tools/webdriver/webdriver/transport.py
+++ b/tools/webdriver/webdriver/transport.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 import select
 

--- a/tools/webtransport/h3/capsule.py
+++ b/tools/webtransport/h3/capsule.py
@@ -1,3 +1,5 @@
+# mypy: no-warn-return-any
+
 from enum import IntEnum
 from typing import Iterator, Optional
 

--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -1,3 +1,5 @@
+# mypy: allow-subclassing-any, no-warn-return-any
+
 import asyncio
 import logging
 import os

--- a/tools/wpt/android.py
+++ b/tools/wpt/android.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import argparse
 import os
 import platform

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 import platform
 import re

--- a/tools/wpt/create.py
+++ b/tools/wpt/create.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import subprocess
 import os
 

--- a/tools/wpt/install.py
+++ b/tools/wpt/install.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import argparse
 from . import browser
 

--- a/tools/wpt/markdown.py
+++ b/tools/wpt/markdown.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from functools import reduce
 
 def format_comment_title(product):

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import argparse
 import os
 import platform

--- a/tools/wpt/tests/test_browser.py
+++ b/tools/wpt/tests/test_browser.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import logging
 import inspect
 import subprocess

--- a/tools/wpt/tests/test_install.py
+++ b/tools/wpt/tests/test_install.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import logging
 import os
 import sys

--- a/tools/wpt/tests/test_markdown.py
+++ b/tools/wpt/tests/test_markdown.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from tools.wpt import markdown
 
 def test_format_comment_title():

--- a/tools/wpt/tests/test_revlist.py
+++ b/tools/wpt/tests/test_revlist.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from unittest import mock
 
 from tools.wpt import revlist

--- a/tools/wpt/tests/test_run.py
+++ b/tools/wpt/tests/test_run.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import tempfile
 import shutil
 import sys

--- a/tools/wpt/tests/test_testfiles.py
+++ b/tools/wpt/tests/test_testfiles.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os.path
 from unittest.mock import patch
 

--- a/tools/wpt/tests/test_update_expectations.py
+++ b/tools/wpt/tests/test_update_expectations.py
@@ -1,3 +1,5 @@
+# mypy: ignore-errors
+
 import json
 import os
 

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import errno
 import os
 import shutil

--- a/tools/wpt/update.py
+++ b/tools/wpt/update.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 import sys
 

--- a/tools/wpt/utils.py
+++ b/tools/wpt/utils.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import errno
 import logging
 import os

--- a/tools/wpt/virtualenv.py
+++ b/tools/wpt/virtualenv.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 import shutil
 import sys

--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import argparse
 import json
 import logging

--- a/tools/wptrunner/wptrunner/browsers/android_weblayer.py
+++ b/tools/wptrunner/wptrunner/browsers/android_weblayer.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from .base import NullBrowser  # noqa: F401
 from .base import require_arg
 from .base import get_timeout_multiplier  # noqa: F401

--- a/tools/wptrunner/wptrunner/browsers/android_webview.py
+++ b/tools/wptrunner/wptrunner/browsers/android_webview.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from .base import NullBrowser   # noqa: F401
 from .base import require_arg
 from .base import get_timeout_multiplier   # noqa: F401

--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import enum
 import errno
 import os

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from . import chrome_spki_certs
 from .base import WebDriverBrowser, require_arg
 from .base import NullBrowser  # noqa: F401

--- a/tools/wptrunner/wptrunner/browsers/chrome_android.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_android.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import mozprocess
 import subprocess
 

--- a/tools/wptrunner/wptrunner/browsers/chrome_ios.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_ios.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from .base import WebDriverBrowser, require_arg
 from .base import get_timeout_multiplier   # noqa: F401
 from ..executors import executor_kwargs as base_executor_kwargs

--- a/tools/wptrunner/wptrunner/browsers/chromium.py
+++ b/tools/wptrunner/wptrunner/browsers/chromium.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from . import chrome
 from .base import NullBrowser  # noqa: F401
 from .base import get_timeout_multiplier   # noqa: F401

--- a/tools/wptrunner/wptrunner/browsers/edge.py
+++ b/tools/wptrunner/wptrunner/browsers/edge.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import time
 import subprocess
 from .base import require_arg

--- a/tools/wptrunner/wptrunner/browsers/edgechromium.py
+++ b/tools/wptrunner/wptrunner/browsers/edgechromium.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from .base import cmd_arg, require_arg
 from .base import WebDriverBrowser
 from .base import get_timeout_multiplier   # noqa: F401

--- a/tools/wptrunner/wptrunner/browsers/epiphany.py
+++ b/tools/wptrunner/wptrunner/browsers/epiphany.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from .base import (NullBrowser,  # noqa: F401
                    certificate_domain_list,
                    get_timeout_multiplier,  # noqa: F401

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 import os
 import platform

--- a/tools/wptrunner/wptrunner/browsers/firefox_android.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox_android.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 
 import moznetwork

--- a/tools/wptrunner/wptrunner/browsers/ie.py
+++ b/tools/wptrunner/wptrunner/browsers/ie.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from .base import require_arg, WebDriverBrowser
 from .base import get_timeout_multiplier  # noqa: F401
 from ..executors import executor_kwargs as base_executor_kwargs

--- a/tools/wptrunner/wptrunner/browsers/opera.py
+++ b/tools/wptrunner/wptrunner/browsers/opera.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from .base import require_arg
 from .base import get_timeout_multiplier   # noqa: F401
 from .chrome import ChromeBrowser

--- a/tools/wptrunner/wptrunner/browsers/safari.py
+++ b/tools/wptrunner/wptrunner/browsers/safari.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 import plistlib
 from distutils.spawn import find_executable

--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import glob
 import os
 import shutil

--- a/tools/wptrunner/wptrunner/browsers/servo.py
+++ b/tools/wptrunner/wptrunner/browsers/servo.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 
 from .base import ExecutorBrowser, NullBrowser, WebDriverBrowser, require_arg

--- a/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 import subprocess
 import tempfile

--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from .base import WebDriverBrowser, require_arg
 from .base import get_timeout_multiplier, certificate_domain_list  # noqa: F401
 from ..executors import executor_kwargs as base_executor_kwargs

--- a/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
+++ b/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from .base import (NullBrowser,  # noqa: F401
                    certificate_domain_list,
                    get_timeout_multiplier,  # noqa: F401

--- a/tools/wptrunner/wptrunner/config.py
+++ b/tools/wptrunner/wptrunner/config.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from configparser import ConfigParser
 import os
 import sys

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import errno
 import json
 import os

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 class ClickAction:
     name = "click"
 

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import base64
 import hashlib
 import io

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 import traceback
 

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 import os
 import threading

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 import os
 import socket

--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import base64
 import json
 import os

--- a/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 import os
 import socket

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 import os
 import socket

--- a/tools/wptrunner/wptrunner/executors/process.py
+++ b/tools/wptrunner/wptrunner/executors/process.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from .base import TestExecutor
 
 

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import traceback
 from http.client import HTTPConnection
 

--- a/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
+++ b/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 """
 Provides interface to deal with pytest.
 

--- a/tools/wptrunner/wptrunner/expected.py
+++ b/tools/wptrunner/wptrunner/expected.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 
 

--- a/tools/wptrunner/wptrunner/expectedtree.py
+++ b/tools/wptrunner/wptrunner/expectedtree.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from math import log
 from collections import defaultdict
 

--- a/tools/wptrunner/wptrunner/font.py
+++ b/tools/wptrunner/wptrunner/font.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import ctypes
 import os
 import platform

--- a/tools/wptrunner/wptrunner/formatters/chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/chromium.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 import time
 

--- a/tools/wptrunner/wptrunner/formatters/tests/test_chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/tests/test_chromium.py
@@ -1,3 +1,5 @@
+# mypy: ignore-errors
+
 import json
 import sys
 from os.path import dirname, join

--- a/tools/wptrunner/wptrunner/formatters/wptreport.py
+++ b/tools/wptrunner/wptrunner/formatters/wptreport.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 import re
 

--- a/tools/wptrunner/wptrunner/formatters/wptscreenshot.py
+++ b/tools/wptrunner/wptrunner/formatters/wptscreenshot.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import requests
 from mozlog.structured.formatters.base import BaseFormatter
 

--- a/tools/wptrunner/wptrunner/instruments.py
+++ b/tools/wptrunner/wptrunner/instruments.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import time
 import threading
 

--- a/tools/wptrunner/wptrunner/manifestexpected.py
+++ b/tools/wptrunner/wptrunner/manifestexpected.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 from collections import deque
 from urllib.parse import urljoin

--- a/tools/wptrunner/wptrunner/manifestinclude.py
+++ b/tools/wptrunner/wptrunner/manifestinclude.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 """Manifest structure used to store paths that should be included in a test run.
 
 The manifest is represented by a tree of IncludeManifest objects, the root

--- a/tools/wptrunner/wptrunner/manifestupdate.py
+++ b/tools/wptrunner/wptrunner/manifestupdate.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 from urllib.parse import urljoin, urlsplit
 from collections import namedtuple, defaultdict, deque

--- a/tools/wptrunner/wptrunner/metadata.py
+++ b/tools/wptrunner/wptrunner/metadata.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import array
 import os
 from collections import defaultdict, namedtuple

--- a/tools/wptrunner/wptrunner/mpcontext.py
+++ b/tools/wptrunner/wptrunner/mpcontext.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import multiprocessing
 
 _context = None

--- a/tools/wptrunner/wptrunner/products.py
+++ b/tools/wptrunner/wptrunner/products.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import importlib
 import imp
 

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import copy
 import functools
 import imp

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import hashlib
 import json
 import os

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import threading
 import traceback
 from queue import Empty

--- a/tools/wptrunner/wptrunner/tests/__init__.py
+++ b/tools/wptrunner/wptrunner/tests/__init__.py
@@ -1,3 +1,5 @@
+# mypy: ignore-errors
+
 import os
 import sys
 

--- a/tools/wptrunner/wptrunner/tests/base.py
+++ b/tools/wptrunner/wptrunner/tests/base.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 import sys
 

--- a/tools/wptrunner/wptrunner/tests/browsers/test_sauce.py
+++ b/tools/wptrunner/wptrunner/tests/browsers/test_sauce.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import logging
 import sys
 from unittest import mock

--- a/tools/wptrunner/wptrunner/tests/browsers/test_webkitgtk.py
+++ b/tools/wptrunner/wptrunner/tests/browsers/test_webkitgtk.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs, allow-untyped-calls
+
 import logging
 from os.path import join, dirname
 

--- a/tools/wptrunner/wptrunner/tests/test_executors.py
+++ b/tools/wptrunner/wptrunner/tests/test_executors.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import pytest
 
 from ..executors import base

--- a/tools/wptrunner/wptrunner/tests/test_expectedtree.py
+++ b/tools/wptrunner/wptrunner/tests/test_expectedtree.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from .. import expectedtree, metadata
 from collections import defaultdict
 

--- a/tools/wptrunner/wptrunner/tests/test_formatters.py
+++ b/tools/wptrunner/wptrunner/tests/test_formatters.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 import time
 from io import StringIO

--- a/tools/wptrunner/wptrunner/tests/test_manifestexpected.py
+++ b/tools/wptrunner/wptrunner/tests/test_manifestexpected.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from io import BytesIO
 
 import pytest

--- a/tools/wptrunner/wptrunner/tests/test_products.py
+++ b/tools/wptrunner/wptrunner/tests/test_products.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs, allow-untyped-calls
+
 from os.path import join, dirname
 from unittest import mock
 

--- a/tools/wptrunner/wptrunner/tests/test_stability.py
+++ b/tools/wptrunner/wptrunner/tests/test_stability.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import sys
 from collections import OrderedDict, defaultdict
 from unittest import mock

--- a/tools/wptrunner/wptrunner/tests/test_testloader.py
+++ b/tools/wptrunner/wptrunner/tests/test_testloader.py
@@ -1,3 +1,5 @@
+# mypy: ignore-errors
+
 import os
 import sys
 import tempfile

--- a/tools/wptrunner/wptrunner/tests/test_update.py
+++ b/tools/wptrunner/wptrunner/tests/test_update.py
@@ -1,3 +1,5 @@
+# mypy: ignore-errors
+
 import json
 import os
 import sys

--- a/tools/wptrunner/wptrunner/tests/test_wpttest.py
+++ b/tools/wptrunner/wptrunner/tests/test_wpttest.py
@@ -1,3 +1,5 @@
+# mypy: ignore-errors
+
 from io import BytesIO
 from unittest import mock
 

--- a/tools/wptrunner/wptrunner/update/__init__.py
+++ b/tools/wptrunner/wptrunner/update/__init__.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import sys
 
 from mozlog.structured import structuredlog, commandline

--- a/tools/wptrunner/wptrunner/update/base.py
+++ b/tools/wptrunner/wptrunner/update/base.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from typing import ClassVar, List, Type
 
 exit_unclean = object()

--- a/tools/wptrunner/wptrunner/update/metadata.py
+++ b/tools/wptrunner/wptrunner/update/metadata.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 
 from .. import metadata, products

--- a/tools/wptrunner/wptrunner/update/state.py
+++ b/tools/wptrunner/wptrunner/update/state.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 import pickle
 

--- a/tools/wptrunner/wptrunner/update/sync.py
+++ b/tools/wptrunner/wptrunner/update/sync.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import fnmatch
 import os
 import re

--- a/tools/wptrunner/wptrunner/update/tree.py
+++ b/tools/wptrunner/wptrunner/update/tree.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 import re
 import subprocess

--- a/tools/wptrunner/wptrunner/update/update.py
+++ b/tools/wptrunner/wptrunner/update/update.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 import sys
 

--- a/tools/wptrunner/wptrunner/vcs.py
+++ b/tools/wptrunner/wptrunner/vcs.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import subprocess
 from functools import partial
 from typing import Callable

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import argparse
 import os
 import sys

--- a/tools/wptrunner/wptrunner/wptlogging.py
+++ b/tools/wptrunner/wptrunner/wptlogging.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import logging
 from threading import Thread
 

--- a/tools/wptrunner/wptrunner/wptmanifest/backends/base.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/backends/base.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import abc
 
 from ..node import NodeVisitor

--- a/tools/wptrunner/wptrunner/wptmanifest/backends/conditional.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/backends/conditional.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import operator
 
 from ..node import NodeVisitor, DataNode, ConditionalNode, KeyValueNode, ListNode, ValueNode, BinaryExpressionNode, VariableNode

--- a/tools/wptrunner/wptrunner/wptmanifest/backends/static.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/backends/static.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import operator
 
 from . import base

--- a/tools/wptrunner/wptrunner/wptmanifest/node.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/node.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 class NodeVisitor:
     def visit(self, node):
         # This is ugly as hell, but we don't have multimethods and

--- a/tools/wptrunner/wptrunner/wptmanifest/parser.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/parser.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 #default_value:foo
 #include: other.manifest
 #

--- a/tools/wptrunner/wptrunner/wptmanifest/serializer.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/serializer.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from six import ensure_text
 
 from .node import NodeVisitor, ValueNode, ListNode, BinaryExpressionNode

--- a/tools/wptrunner/wptrunner/wptmanifest/tests/test_conditional.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/tests/test_conditional.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import unittest
 
 from ..backends import conditional

--- a/tools/wptrunner/wptrunner/wptmanifest/tests/test_parser.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/tests/test_parser.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import unittest
 
 from .. import parser

--- a/tools/wptrunner/wptrunner/wptmanifest/tests/test_serializer.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/tests/test_serializer.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import unittest
 
 from .. import parser, serializer

--- a/tools/wptrunner/wptrunner/wptmanifest/tests/test_static.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/tests/test_static.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import unittest
 
 from ..backends import static

--- a/tools/wptrunner/wptrunner/wptmanifest/tests/test_tokenizer.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/tests/test_tokenizer.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import unittest
 
 from .. import parser

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 import os
 import sys

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import os
 import subprocess
 import sys

--- a/tools/wptserve/wptserve/config.py
+++ b/tools/wptserve/wptserve/config.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import copy
 import os
 from collections import defaultdict

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import json
 import os
 import traceback

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from collections import deque
 import base64
 import gzip as gzip_module

--- a/tools/wptserve/wptserve/ranges.py
+++ b/tools/wptserve/wptserve/ranges.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from .utils import HTTPException
 
 

--- a/tools/wptserve/wptserve/request.py
+++ b/tools/wptserve/wptserve/request.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import base64
 import cgi
 import tempfile

--- a/tools/wptserve/wptserve/response.py
+++ b/tools/wptserve/wptserve/response.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from io import BytesIO

--- a/tools/wptserve/wptserve/router.py
+++ b/tools/wptserve/wptserve/router.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import itertools
 import re
 import sys

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import errno
 import http.server
 import os

--- a/tools/wptserve/wptserve/sslutils/__init__.py
+++ b/tools/wptserve/wptserve/sslutils/__init__.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 from .base import NoSSLEnvironment
 from .openssl import OpenSSLEnvironment
 from .pregenerated import PregeneratedSSLEnvironment

--- a/tools/wptserve/wptserve/sslutils/base.py
+++ b/tools/wptserve/wptserve/sslutils/base.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 class NoSSLEnvironment:
     ssl_enabled = False
 

--- a/tools/wptserve/wptserve/sslutils/openssl.py
+++ b/tools/wptserve/wptserve/sslutils/openssl.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import functools
 import os
 import random

--- a/tools/wptserve/wptserve/sslutils/pregenerated.py
+++ b/tools/wptserve/wptserve/sslutils/pregenerated.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 class PregeneratedSSLEnvironment:
     """SSL environment to use with existing key/certificate files
     e.g. when running on a server with a public domain name

--- a/tools/wptserve/wptserve/stash.py
+++ b/tools/wptserve/wptserve/stash.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 import base64
 import json
 import os

--- a/tools/wptserve/wptserve/wptserve.py
+++ b/tools/wptserve/wptserve/wptserve.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# mypy: allow-untyped-defs
+
 import argparse
 import os
 

--- a/tools/wptserve/wptserve/ws_h2_handshake.py
+++ b/tools/wptserve/wptserve/ws_h2_handshake.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 """This file provides the opening handshake processor for the Bootstrapping
 WebSockets with HTTP/2 protocol (RFC 8441).
 


### PR DESCRIPTION
See https://mypy.readthedocs.io/en/stable/inline_config.html

This makes it possible to enable mypy at a more granular level. In
tools/, there are now 185 files with some kind of inline mypy config,
but also 107 that don't have any, notably the files annotated here:
https://github.com/web-platform-tests/wpt/pull/33367