### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=238542

### DIFF
--- a/css/css-contain/container-queries/at-container-serialization.html
+++ b/css/css-contain/container-queries/at-container-serialization.html
@@ -12,6 +12,18 @@
     }
     #id { color: green }
   }
+  @container (  wiDTh  ) { }
+  @container (width:100px) { }
+  @container (min-width:  100px) { }
+  @container (   MAX-WIDTH:100px  ) { }
+  @container (width > 100px) { }
+  @container (width < 100px) { }
+  @container (widTH >= 100px) { }
+  @container (width <= 100px) { }
+  @container (10px < width < 100px) { }
+  @container (10px <=  width  <=  100px) { }
+  @container (100px>WIDTH>10px) { }
+  @container (  100px >= width >= 10px  ) { }
 </style>
 <script>
   setup(() => assert_implements_container_queries());
@@ -19,7 +31,7 @@
   let rules = testSheet.sheet.cssRules;
 
   test(() => {
-    assert_equals(rules.length, 1);
+    assert_equals(rules.length, 13);
     assert_equals(rules[0].cssRules.length, 2);
 
     assert_equals(rules[0].conditionText, "(width = 100px)");
@@ -34,4 +46,24 @@
     assert_equals(rules[0].cssText, "@container (width = 100px) {\n  @container \\!-name (inline-size > 200px) {\n  #id { color: lime; }\n}\n  #id { color: green; }\n}");
   }, "Serialization of nested @container rule");
 
+  test(() => {
+    assert_equals(rules[1].conditionText, "(width)");
+  }, "Serialization of boolean condition syntax");
+
+  test(() => {
+    assert_equals(rules[2].conditionText, "(width: 100px)");
+    assert_equals(rules[3].conditionText, "(min-width: 100px)");
+    assert_equals(rules[4].conditionText, "(max-width: 100px)");
+  }, "Serialization of colon condition syntax");
+
+  test(() => {
+    assert_equals(rules[5].conditionText, "(width > 100px)");
+    assert_equals(rules[6].conditionText, "(width < 100px)");
+    assert_equals(rules[7].conditionText, "(width >= 100px)");
+    assert_equals(rules[8].conditionText, "(width <= 100px)");
+    assert_equals(rules[9].conditionText, "(10px < width < 100px)");
+    assert_equals(rules[10].conditionText, "(10px <= width <= 100px)");
+    assert_equals(rules[11].conditionText, "(100px > width > 10px)");
+    assert_equals(rules[12].conditionText, "(100px >= width >= 10px)");
+  }, "Serialization of range condition syntax");
 </script>


### PR DESCRIPTION
WebKit export from bug: [\[CSS Container Queries\] Keep colon syntax when serializing container condition](https://bugs.webkit.org/show_bug.cgi?id=238542)