### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=238016

### DIFF
--- a/css/css-position/sticky/position-sticky-overflow-clip-container-ref.html
+++ b/css/css-position/sticky/position-sticky-overflow-clip-container-ref.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<title>Sticky elements should not consider overflow: clip containers as possible scroll ancestor</title>
+<style>
+body {
+  margin: 0;
+  overflow: hidden; /* hide scrollbars */
+}
+
+#container {
+  height: 300px;
+  overflow-y: scroll;
+}
+
+#overflowClipContainer {
+  overflow: visible;
+  height: 600px;
+}
+
+#sticky {
+  position: sticky;
+  top: 0;
+  height: 50px;
+  background-color: yellow;
+}
+</style>
+<script>
+function doTest()
+{
+  container.scrollTo(0, 50);
+}
+window.addEventListener('load', doTest, false);
+</script>
+<div id="container">
+  <div id="overflowClipContainer">
+    <div id="sticky"></div>
+  </div>
+</div>

--- a/css/css-position/sticky/position-sticky-overflow-clip-container.html
+++ b/css/css-position/sticky/position-sticky-overflow-clip-container.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<title>Sticky elements should not consider overflow: clip containers as possible scroll ancestor</title>
+<link rel="match" href="position-sticky-overflow-clip-container-ref.html" />
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#sticky-pos" />
+<meta name="assert" content="This test checks that sticky elements do not consider overflow:clip containers as possible scroll ancestor"/>
+<style>
+body {
+  margin: 0;
+  overflow: hidden; /* hide scrollbars */
+}
+
+#container {
+  height: 300px;
+  overflow: auto;
+}
+
+#overflowClipContainer {
+  overflow: clip;
+  height: 600px;
+}
+
+#sticky {
+  position: sticky;
+  top: 0;
+  height: 50px;
+  background-color: yellow;
+}
+</style>
+<script>
+function doTest()
+{
+  container.scrollTo(0, 50);
+}
+window.addEventListener('load', doTest, false);
+</script>
+<div id="container">
+  <div id="overflowClipContainer">
+    <div id="sticky"></div>
+  </div>
+</div>


### PR DESCRIPTION
Sticky elements should not consider overflow: clip containers as possible scroll ancestor