### PR TITLE
Remove unused ConditionalValue.set_value

### DIFF
--- a/tools/wptrunner/wptrunner/wptmanifest/backends/conditional.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/backends/conditional.py
@@ -1,5 +1,4 @@
 import operator
-from six import ensure_text
 
 from ..node import NodeVisitor, DataNode, ConditionalNode, KeyValueNode, ListNode, ValueNode, BinaryExpressionNode, VariableNode
 from ..parser import parse
@@ -41,9 +40,6 @@ class ConditionalValue:
 
     def __call__(self, run_info):
         return self.condition_func(run_info)
-
-    def set_value(self, value):
-        self.value = ensure_text(value)
 
     def value_as(self, type_func):
         """Get value and convert to a given type.


### PR DESCRIPTION
This is by all appearances unused, with no other matches for "set_value"
in the code base.

This removal brings along with it a use of six.ensure_text.

Part of https://github.com/web-platform-tests/wpt/issues/28776.