### PR TITLE
Make ./wpt manifest / manifest-download require zstandard

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -202,6 +202,9 @@ jobs:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.7'
+  - template: tools/ci/azure/pip_install.yml
+    parameters:
+      packages: virtualenv
   - template: tools/ci/azure/install_chrome.yml
   - template: tools/ci/azure/install_firefox.yml
   - template: tools/ci/azure/update_hosts.yml
@@ -222,6 +225,9 @@ jobs:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.9'
+  - template: tools/ci/azure/pip_install.yml
+    parameters:
+      packages: virtualenv
   - template: tools/ci/azure/install_chrome.yml
   - template: tools/ci/azure/install_firefox.yml
   - template: tools/ci/azure/update_hosts.yml
@@ -312,6 +318,9 @@ jobs:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.6'
+  - template: tools/ci/azure/pip_install.yml
+    parameters:
+      packages: virtualenv
   # currently just using the outdated Chrome/Firefox on the VM rather than
   # figuring out how to install Chrome Dev channel on Windows
   # - template: tools/ci/azure/install_chrome.yml
@@ -334,6 +343,9 @@ jobs:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.9'
+  - template: tools/ci/azure/pip_install.yml
+    parameters:
+      packages: virtualenv
   # currently just using the outdated Chrome/Firefox on the VM rather than
   # figuring out how to install Chrome Dev channel on Windows
   # - template: tools/ci/azure/install_chrome.yml

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -22,6 +22,7 @@ jobs:
       run: |
         sudo apt-get -qqy install zstd
         pip install -r tools/wpt/requirements.txt
+        pip install virtualenv
     - name: Run manifest_build.py
       # Use a conditional step instead of a conditional job to work around #20700.
       if: github.repository == 'web-platform-tests/wpt'

--- a/tools/manifest/commands.json
+++ b/tools/manifest/commands.json
@@ -4,14 +4,20 @@
     "script": "run",
     "parser": "create_parser",
     "help": "Update the MANIFEST.json file",
-    "virtualenv": false
+    "virtualenv": true,
+    "requirements": [
+      "requirements.txt"
+    ]
   },
   "manifest-download": {
     "path": "download.py",
     "script": "run",
     "parser": "create_parser",
     "help": "Download recent pregenerated MANIFEST.json file",
-    "virtualenv": false
+    "virtualenv": true,
+    "requirements": [
+      "requirements.txt"
+    ]
   },
   "test-paths": {
     "path": "testpaths.py",

--- a/tools/manifest/download.py
+++ b/tools/manifest/download.py
@@ -197,8 +197,8 @@ def download_from_github(path, tests_root, force=False):
                              force=force)
 
 
-def run(**kwargs):
-    # type: (**Any) -> int
+def run(venv, **kwargs):
+    # type: (Any, **Any) -> int
     if kwargs["path"] is None:
         path = os.path.join(kwargs["tests_root"], "MANIFEST.json")
     else:


### PR DESCRIPTION
As it was, `./wpt run` would install zstandard, but running
`./wpt manifest` would not, but would use it if already installed.

Leave the code that handles zstandard being missing, to not have to
worry about vendor CI systems using this code without zstandard.