### PR TITLE
fetch/metadata: Rely on hosts[alt] for cross-site tests

### DIFF
--- a/fetch/metadata/embed.https.sub.tentative.html
+++ b/fetch/metadata/embed.https.sub.tentative.html
@@ -17,7 +17,7 @@
   const origins = {
     "same-origin": "https://{{host}}:{{ports[https][0]}}",
     "same-site":   "https://{{hosts[][www]}}:{{ports[https][0]}}",
-    "cross-site":  "https://{{hosts[alt][www]}}:{{ports[https][0]}}",
+    "cross-site":  "https://{{hosts[alt][]}}:{{ports[https][0]}}",
   };
 
   for (let site in origins) {

--- a/fetch/metadata/favicon.https.sub.html
+++ b/fetch/metadata/favicon.https.sub.html
@@ -53,7 +53,7 @@
       let e = document.createElement('link');
       e.rel = "icon";
       e.type = "image/png";
-      e.href = "https://{{hosts[alt][www]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;
+      e.href = "https://{{hosts[alt][]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;
       document.head.appendChild(e);
       t.step_timeout(_=> {
         let expected = {"site":"cross-site", "user":"", "mode": "no-cors", "dest": "image"};

--- a/fetch/metadata/fetch-preflight.https.sub.any.js
+++ b/fetch/metadata/fetch-preflight.https.sub.any.js
@@ -16,7 +16,7 @@ promise_test(t => {
 }, "Same-site fetch with preflight");
 
 promise_test(t => {
-  return validate_expectations_custom_url("https://{{hosts[alt][www]}}:{{ports[https][0]}}/fetch/metadata/resources/echo-as-json.py",
+  return validate_expectations_custom_url("https://{{hosts[alt][]}}:{{ports[https][0]}}/fetch/metadata/resources/echo-as-json.py",
                 {
                   mode: "cors",
                   headers: { 'x-test': 'testing' }

--- a/fetch/metadata/fetch.https.sub.any.js
+++ b/fetch/metadata/fetch.https.sub.any.js
@@ -21,7 +21,7 @@ promise_test(t => {
 }, "Same-site fetch");
 
 promise_test(t => {
-  return validate_expectations_custom_url("https://{{hosts[alt][www]}}:{{ports[https][0]}}/fetch/metadata/resources/echo-as-json.py", {}, {
+  return validate_expectations_custom_url("https://{{hosts[alt][]}}:{{ports[https][0]}}/fetch/metadata/resources/echo-as-json.py", {}, {
           "site": "cross-site",
           "user": "",
           "mode": "cors",

--- a/fetch/metadata/font.https.sub.html
+++ b/fetch/metadata/font.https.sub.html
@@ -34,7 +34,7 @@
   <style>
     @font-face {
       font-family: myThirdFont;
-      src: url(https://{{hosts[alt][www]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=font-cross-site);
+      src: url(https://{{hosts[alt][]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=font-cross-site);
     }
     #test3 {
       font-family: myThirdFont;

--- a/fetch/metadata/form.https.sub.html
+++ b/fetch/metadata/form.https.sub.html
@@ -55,7 +55,7 @@
     "dest": "document"
   });
 
-  create_test("{{hosts[alt][www]}}:{{ports[https][0]}}", FORCED, {
+  create_test("{{hosts[alt][]}}:{{ports[https][0]}}", FORCED, {
     "site": "cross-site",
     "user": "",
     "mode": "navigate",
@@ -76,7 +76,7 @@
     "dest": "document"
   });
 
-  create_test("{{hosts[alt][www]}}:{{ports[https][0]}}", USER, {
+  create_test("{{hosts[alt][]}}:{{ports[https][0]}}", USER, {
     "site": "cross-site",
     "user": "?1",
     "mode": "navigate",

--- a/fetch/metadata/history.https.sub.html
+++ b/fetch/metadata/history.https.sub.html
@@ -44,7 +44,7 @@ function add_test(description, report_host, go_back_host, expectations) {
 
 const same_origin_host = "{{host}}:{{ports[https][0]}}";
 const same_site_host = "{{hosts[][www]}}:{{ports[https][0]}}";
-const cross_site_host = "{{hosts[alt][www]}}:{{ports[https][0]}}";
+const cross_site_host = "{{hosts[alt][]}}:{{ports[https][0]}}";
 
 add_test(
   "back to same-origin-initiated navigation",

--- a/fetch/metadata/iframe.https.sub.html
+++ b/fetch/metadata/iframe.https.sub.html
@@ -55,7 +55,7 @@
     "dest": "iframe"
   });
 
-  create_test("{{hosts[alt][www]}}:{{ports[https][0]}}", FORCED, {
+  create_test("{{hosts[alt][]}}:{{ports[https][0]}}", FORCED, {
     "site": "cross-site",
     "user": "",
     "mode": "navigate",
@@ -76,7 +76,7 @@
     "dest": "iframe"
   });
 
-  create_test("{{hosts[alt][www]}}:{{ports[https][0]}}", USER, {
+  create_test("{{hosts[alt][]}}:{{ports[https][0]}}", USER, {
     "site": "cross-site",
     "user": "?1",
     "mode": "navigate",

--- a/fetch/metadata/iframe.sub.html
+++ b/fetch/metadata/iframe.sub.html
@@ -44,7 +44,7 @@
 
   async_test(t => {
     let i = document.createElement('iframe');
-    i.src = "http://{{hosts[alt][www]}}:{{ports[http][0]}}/fetch/metadata/resources/post-to-owner.py";
+    i.src = "http://{{hosts[alt][]}}:{{ports[http][0]}}/fetch/metadata/resources/post-to-owner.py";
     window.addEventListener('message', t.step_func(e => {
       if (e.source != i.contentWindow)
         return;

--- a/fetch/metadata/img.https.sub.html
+++ b/fetch/metadata/img.https.sub.html
@@ -53,7 +53,7 @@
 
   promise_test(() =>
     requestViaImage(
-      "https://{{hosts[alt][www]}}:{{ports[https][0]}}/common/security-features/subresource/image.py")
+      "https://{{hosts[alt][]}}:{{ports[https][0]}}/common/security-features/subresource/image.py")
     .then(result => {
         headers = result.headers;
         got = {

--- a/fetch/metadata/object.https.sub.html
+++ b/fetch/metadata/object.https.sub.html
@@ -48,7 +48,7 @@
       let key = "object-cross-site" + nonce;
 
       let e = document.createElement('object');
-      e.data = "https://{{hosts[alt][www]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;
+      e.data = "https://{{hosts[alt][]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;
       e.onload = e => {
         let expected = {"site":"cross-site", "user":"", "mode":"navigate", "dest": "object"};
         validate_expectations(key, expected, "Cross-Site object")

--- a/fetch/metadata/portal.https.sub.html
+++ b/fetch/metadata/portal.https.sub.html
@@ -41,7 +41,7 @@
     "dest": "iframe"
   });
 
-  create_test("{{hosts[alt][www]}}:{{ports[https][0]}}", {
+  create_test("{{hosts[alt][]}}:{{ports[https][0]}}", {
     "site": "cross-site",
     "user": "",
     "mode": "navigate",

--- a/fetch/metadata/prefetch.https.sub.html
+++ b/fetch/metadata/prefetch.https.sub.html
@@ -32,5 +32,5 @@
 
   create_test("{{host}}:{{ports[https][0]}}", {"site":"same-origin", "user":"", "mode": "cors", "dest": "empty"});
   create_test("{{hosts[][www]}}:{{ports[https][0]}}", {"site":"same-site", "user":"", "mode": "cors", "dest": "empty"});
-  create_test("{{hosts[alt][www]}}:{{ports[https][0]}}", {"site":"cross-site", "user":"", "mode": "cors", "dest": "empty"});
+  create_test("{{hosts[alt][]}}:{{ports[https][0]}}", {"site":"cross-site", "user":"", "mode": "cors", "dest": "empty"});
 </script>

--- a/fetch/metadata/preload.https.sub.html
+++ b/fetch/metadata/preload.https.sub.html
@@ -45,6 +45,6 @@
   as_tests.forEach(item => {
     create_test("{{host}}:{{ports[https][0]}}", item[0], {"site":"same-origin", "user":"", "mode": "cors", "dest": item[1]});
     create_test("{{hosts[][www]}}:{{ports[https][0]}}", item[0], {"site":"same-site", "user":"", "mode": "cors", "dest": item[1]});
-    create_test("{{hosts[alt][www]}}:{{ports[https][0]}}", item[0], {"site":"cross-site", "user":"", "mode": "cors", "dest": item[1]});
+    create_test("{{hosts[alt][]}}:{{ports[https][0]}}", item[0], {"site":"cross-site", "user":"", "mode": "cors", "dest": item[1]});
   });
 </script>

--- a/fetch/metadata/redirect/cross-site-redirect.https.sub.html
+++ b/fetch/metadata/redirect/cross-site-redirect.https.sub.html
@@ -14,7 +14,7 @@
       let key = "redirect-cross-site-same-origin" + nonce;
 
       let e = document.createElement('img');
-      e.src = "https://{{hosts[alt][www]}}:{{ports[https][0]}}/xhr/resources/redirect.py?location=https://{{host}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;
+      e.src = "https://{{hosts[alt][]}}:{{ports[https][0]}}/xhr/resources/redirect.py?location=https://{{host}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;
       let expected = {"site":"cross-site", "user":"", "mode": "no-cors", "dest": "image"};
       e.onload = e => {
         validate_expectations(key, expected, "Cross-Site -> Same-Origin redirect")
@@ -36,7 +36,7 @@
       let key = "redirect-cross-site-same-site" + nonce;
 
       let e = document.createElement('img');
-      e.src = "https://{{hosts[alt][www]}}:{{ports[https][0]}}/xhr/resources/redirect.py?location=https://{{hosts[][www]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;
+      e.src = "https://{{hosts[alt][]}}:{{ports[https][0]}}/xhr/resources/redirect.py?location=https://{{hosts[][www]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;
       let expected = {"site":"cross-site", "user":"", "mode": "no-cors", "dest": "image"};
       e.onload = e => {
         validate_expectations(key, expected, "Cross-Site -> Same-Site redirect")
@@ -58,7 +58,7 @@
       let key = "redirect-cross-site-cross-site" + nonce;
 
       let e = document.createElement('img');
-      e.src = "https://{{hosts[alt][www]}}:{{ports[https][0]}}/xhr/resources/redirect.py?location=https://{{hosts[alt][www]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;
+      e.src = "https://{{hosts[alt][]}}:{{ports[https][0]}}/xhr/resources/redirect.py?location=https://{{hosts[alt][]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;
       let expected = {"site":"cross-site", "user":"", "mode": "no-cors", "dest": "image"};
       e.onload = e => {
         validate_expectations(key, expected, "Cross-Site -> Cross-Site redirect")

--- a/fetch/metadata/redirect/multiple-redirect-cross-site.https.sub.html
+++ b/fetch/metadata/redirect/multiple-redirect-cross-site.https.sub.html
@@ -15,7 +15,7 @@
 
       let e = document.createElement('img');
       e.src = "https://{{host}}:{{ports[https][0]}}/xhr/resources/redirect.py?location=" +// same-origin
-      "https://{{hosts[alt][www]}}:{{ports[https][0]}}/xhr/resources/redirect.py?location=" +// cross-site
+      "https://{{hosts[alt][]}}:{{ports[https][0]}}/xhr/resources/redirect.py?location=" +// cross-site
       "https://{{host}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;// same-origin
       let expected = {"site":"cross-site", "user":"", "mode": "no-cors", "dest": "image"};
 

--- a/fetch/metadata/redirect/same-origin-redirect.https.sub.html
+++ b/fetch/metadata/redirect/same-origin-redirect.https.sub.html
@@ -60,7 +60,7 @@ promise_test(t => {
       let key = "redirect-same-origin-cross-site" + nonce;
 
       let e = document.createElement('img');
-      e.src = "/xhr/resources/redirect.py?location=https://{{hosts[alt][www]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;
+      e.src = "/xhr/resources/redirect.py?location=https://{{hosts[alt][]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;
       let expected = {"site":"cross-site", "user":"", "mode": "no-cors", "dest": "image"};
 
       e.onload = e => {

--- a/fetch/metadata/redirect/same-site-redirect.https.sub.html
+++ b/fetch/metadata/redirect/same-site-redirect.https.sub.html
@@ -60,7 +60,7 @@ promise_test(t => {
       let key = "redirect-same-site-cross-site" + nonce;
 
       let e = document.createElement('img');
-      e.src = "https://{{hosts[][www]}}:{{ports[https][0]}}/xhr/resources/redirect.py?location=https://{{hosts[alt][www]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;
+      e.src = "https://{{hosts[][www]}}:{{ports[https][0]}}/xhr/resources/redirect.py?location=https://{{hosts[alt][]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;
       let expected = {"site":"cross-site", "user":"", "mode": "no-cors", "dest": "image"};
 
       e.onload = e => {

--- a/fetch/metadata/report.https.sub.html.sub.headers
+++ b/fetch/metadata/report.https.sub.html.sub.headers
@@ -1,3 +1,3 @@
 Content-Security-Policy: style-src 'self' 'unsafe-inline'; report-uri /fetch/metadata/resources/record-header.py?file=report-same-origin
 Content-Security-Policy: style-src 'self' 'unsafe-inline'; report-uri https://{{hosts[][www]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=report-same-site
-Content-Security-Policy: style-src 'self' 'unsafe-inline'; report-uri https://{{hosts[alt][www]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=report-cross-site
+Content-Security-Policy: style-src 'self' 'unsafe-inline'; report-uri https://{{hosts[alt][]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=report-cross-site

--- a/fetch/metadata/script.https.sub.html
+++ b/fetch/metadata/script.https.sub.html
@@ -34,7 +34,7 @@
 </script>
 
 <!-- Cross-site script -->
-<script src="https://{{hosts[alt][www]}}:{{ports[https][0]}}/fetch/metadata/resources/echo-as-script.py"></script>
+<script src="https://{{hosts[alt][]}}:{{ports[https][0]}}/fetch/metadata/resources/echo-as-script.py"></script>
 <script>
   test(t => {
     t.add_cleanup(_ => { header = null; });

--- a/fetch/metadata/script.sub.html
+++ b/fetch/metadata/script.sub.html
@@ -34,7 +34,7 @@
 </script>
 
 <!-- Cross-site script -->
-<script src="http://{{hosts[alt][www]}}:{{ports[http][0]}}/fetch/metadata/resources/echo-as-script.py"></script>
+<script src="http://{{hosts[alt][]}}:{{ports[http][0]}}/fetch/metadata/resources/echo-as-script.py"></script>
 <script>
   test(t => {
     t.add_cleanup(_ => { header = null; });

--- a/fetch/metadata/style.https.sub.html
+++ b/fetch/metadata/style.https.sub.html
@@ -51,7 +51,7 @@
 
       let e = document.createElement('link');
       e.rel = "stylesheet";
-      e.href = "https://{{hosts[alt][www]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;
+      e.href = "https://{{hosts[alt][]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;
       e.onload = e => {
         let expected = {"site":"cross-site", "user":"", "mode": "no-cors", "dest": "style"};
         validate_expectations(key, expected, "Cross-Site style")

--- a/fetch/metadata/track.https.sub.html
+++ b/fetch/metadata/track.https.sub.html
@@ -75,7 +75,7 @@
       let key = "track-cross-site" + nonce;
       let video = createVideoElement();
       let el = createTrack();
-      el.src = "https://{{hosts[alt][www]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;
+      el.src = "https://{{hosts[alt][]}}:{{ports[https][0]}}/fetch/metadata/resources/record-header.py?file=" + key;
       el.onload = t.step_func(_ => {
         expected = {
           "site": "cross-site",

--- a/fetch/metadata/trailing-dot.https.sub.any.js
+++ b/fetch/metadata/trailing-dot.https.sub.any.js
@@ -21,7 +21,7 @@ promise_test(t => {
 }, "Fetching a resource from the same site, but spelled with a trailing dot.");
 
 promise_test(t => {
-  return validate_expectations_custom_url("https://{{hosts[alt][www]}}.:{{ports[https][0]}}/fetch/metadata/resources/echo-as-json.py", {}, {
+  return validate_expectations_custom_url("https://{{hosts[alt][]}}.:{{ports[https][0]}}/fetch/metadata/resources/echo-as-json.py", {}, {
           "site": "cross-site",
           "user": "",
           "mode": "cors",

--- a/fetch/metadata/window-open.https.sub.html
+++ b/fetch/metadata/window-open.https.sub.html
@@ -42,7 +42,7 @@
   }, "Same-site window, forced");
 
   async_test(t => {
-    let w = window.open("https://{{hosts[alt][www]}}:{{ports[https][0]}}/fetch/metadata/resources/post-to-owner.py");
+    let w = window.open("https://{{hosts[alt][]}}:{{ports[https][0]}}/fetch/metadata/resources/post-to-owner.py");
     t.add_cleanup(_ => w.close());
     window.addEventListener('message', t.step_func(e => {
       if (e.source != w)
@@ -107,7 +107,7 @@
   }, "Same-site window, forced, reloaded");
 
   async_test(t => {
-    let w = window.open("https://{{hosts[alt][www]}}:{{ports[https][0]}}/fetch/metadata/resources/post-to-owner.py");
+    let w = window.open("https://{{hosts[alt][]}}:{{ports[https][0]}}/fetch/metadata/resources/post-to-owner.py");
     t.add_cleanup(_ => w.close());
     let messages = 0;
     window.addEventListener('message', t.step_func(e => {
@@ -178,7 +178,7 @@
   async_test(t => {
     let b = document.createElement('button');
     b.onclick = t.step_func(_ => {
-      let w = window.open("https://{{hosts[alt][www]}}:{{ports[https][0]}}/fetch/metadata/resources/post-to-owner.py");
+      let w = window.open("https://{{hosts[alt][]}}:{{ports[https][0]}}/fetch/metadata/resources/post-to-owner.py");
       t.add_cleanup(_ => w.close());
       window.addEventListener('message', t.step_func(e => {
         if (e.source != w)


### PR DESCRIPTION
Using hosts[alt][www] simply results in failures in WebKit when ran locally and resolves to www.127.0.0.1.

hosts[alt][] is already considered cross-site so this doesn't change results elsewhere.