### PR TITLE
Move Acid3 to HTTPS

### DIFF
--- a/acid/acid3/test.html
+++ b/acid/acid3/test.html
@@ -140,6 +140,13 @@
   #\  #result, #\  #score { position: fixed; top: 10%; left: 10%; width: 4em; z-index: 1; color: yellow; font-size: 50px; background: fuchsia; border: solid 1em purple; }
  </style>
 
+ <!-- not part of the tests -->
+ <script type="text/javascript">
+  if (window.location.protocol != "https:" && window.location.hostname.toLowerCase() != "localhost") {
+   window.location.href = window.location.href.replace(/^http:/, "https:");
+  }
+ </script>
+
  <!-- part of the HTTP tests -->
  <link rel="stylesheet" href="empty.css"><!-- text/html file (should be ignored, <h1> will go red if it isn't) -->
 
@@ -2300,7 +2307,7 @@
       var obj2 = document.createElement('object');
       obj2.setAttribute('data', './test.html');
       assertEquals(obj1.data, obj2.data, "object elements didn't resolve URIs correctly");
-      assert(obj1.data.match(/^http:/), "object.data isn't absolute");
+      assert(obj1.data.match(/^https:/), "object.data isn't absolute");
       obj1.appendChild(document.createElement('param'));
       assertEquals(obj1.getElementsByTagName('param').length, 1, "object is missing its only child");
       // non-existent attributes


### PR DESCRIPTION
Fix test 64 for running under https and redirect to HTTPS for this test.

There's an alternative here that might be simpler: change test 64 to look for window.location.protocol using indexOf() === 0, but I think that this version will produce a better outcome for all involved.

I haven't investigated it, but there is an outside chance that HSTS on the server is cleaner.  Given the amount of stuff that server serves, I doubt that that change would be trivial though.

I wasn't sure how far to go with the localhost detection piece; if this needs to include matching 127/8 and ::1, then I'm happy to adjust.