### PR TITLE
Update tests to match ARIA 1.2 global states and property list

### DIFF
--- a/core-aam/aria-disabled_false-manual.html
+++ b/core-aam/aria-disabled_false-manual.html
@@ -61,7 +61,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for aria-disabled=false.</p>
-    <div role='group' id='test' aria-disabled='false'>content</div>
+    <div role='button' id='test' aria-disabled='false'>content</div>
 
   <div id="manualMode"></div>
   <div id="log"></div>

--- a/core-aam/aria-errormessage_aria-invalid_false-manual.html
+++ b/core-aam/aria-errormessage_aria-invalid_false-manual.html
@@ -84,7 +84,7 @@
   </head>
   <body>
   <p>User agents must not expose aria-errormessage for an object with aria-invalid false.</p>
-    <div role='group' id='test' aria-errormessage='error' aria-invalid='false'>content</div>
+    <div role='checkbox' id='test' aria-errormessage='error' aria-invalid='false'>content</div>
   <div id='error'>hello world</div>
 
   <div id="manualMode"></div>

--- a/core-aam/aria-errormessage_aria-invalid_true-manual.html
+++ b/core-aam/aria-errormessage_aria-invalid_true-manual.html
@@ -84,7 +84,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for aria-errormessage.</p>
-    <div role='group' id='test' aria-errormessage='error' aria-invalid='true'>content</div>
+    <div role='checkbox' id='test' aria-errormessage='error' aria-invalid='true'>content</div>
   <div id='error'>hello world</div>
 
   <div id="manualMode"></div>

--- a/core-aam/aria-haspopup_dialog-manual.html
+++ b/core-aam/aria-haspopup_dialog-manual.html
@@ -81,7 +81,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for aria-haspopup=dialog.</p>
-    <div role='group' id='test' aria-haspopup='dialog'>content</div>
+    <div role='button' id='test' aria-haspopup='dialog'>content</div>
 
   <div id="manualMode"></div>
   <div id="log"></div>

--- a/core-aam/aria-haspopup_false-manual.html
+++ b/core-aam/aria-haspopup_false-manual.html
@@ -53,7 +53,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for aria-haspopup=false.</p>
-    <div role='group' id='test' aria-haspopup='false'>content</div>
+    <div role='button' id='test' aria-haspopup='false'>content</div>
 
   <div id="manualMode"></div>
   <div id="log"></div>

--- a/core-aam/aria-haspopup_listbox-manual.html
+++ b/core-aam/aria-haspopup_listbox-manual.html
@@ -81,7 +81,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for aria-haspopup=listbox NEW.</p>
-    <div role='group' id='test' aria-haspopup='listbox'>content</div>
+    <div role='button' id='test' aria-haspopup='listbox'>content</div>
 
   <div id="manualMode"></div>
   <div id="log"></div>

--- a/core-aam/aria-haspopup_menu-manual.html
+++ b/core-aam/aria-haspopup_menu-manual.html
@@ -81,7 +81,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for aria-haspopup=menu.</p>
-    <div role='group' id='test' aria-haspopup='menu'>content</div>
+    <div role='button' id='test' aria-haspopup='menu'>content</div>
 
   <div id="manualMode"></div>
   <div id="log"></div>

--- a/core-aam/aria-haspopup_tree-manual.html
+++ b/core-aam/aria-haspopup_tree-manual.html
@@ -81,7 +81,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for aria-haspopup=tree.</p>
-    <div role='group' id='test' aria-haspopup='tree'>content</div>
+    <div role='button' id='test' aria-haspopup='tree'>content</div>
 
   <div id="manualMode"></div>
   <div id="log"></div>

--- a/core-aam/aria-haspopup_true-manual.html
+++ b/core-aam/aria-haspopup_true-manual.html
@@ -81,7 +81,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for aria-haspopup=true.</p>
-    <div role='group' id='test' aria-haspopup='true'>content</div>
+    <div role='button' id='test' aria-haspopup='true'>content</div>
 
   <div id="manualMode"></div>
   <div id="log"></div>

--- a/core-aam/aria-invalid_false-manual.html
+++ b/core-aam/aria-invalid_false-manual.html
@@ -61,7 +61,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for aria-invalid=false.</p>
-    <div role='group' id='test' aria-invalid='false'>content</div>
+    <div role='textbox' id='test' aria-invalid='false'>content</div>
 
   <div id="manualMode"></div>
   <div id="log"></div>

--- a/core-aam/aria-invalid_grammar-manual.html
+++ b/core-aam/aria-invalid_grammar-manual.html
@@ -73,7 +73,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for aria-invalid=grammar.</p>
-    <div role='group' id='test' aria-invalid='grammar'>content</div>
+    <div role='textbox' id='test' aria-invalid='grammar'>content</div>
 
   <div id="manualMode"></div>
   <div id="log"></div>

--- a/core-aam/aria-invalid_spelling-manual.html
+++ b/core-aam/aria-invalid_spelling-manual.html
@@ -73,7 +73,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for aria-invalid=spelling.</p>
-    <div role='group' id='test' aria-invalid='spelling'>content</div>
+    <div role='textbox' id='test' aria-invalid='spelling'>content</div>
 
   <div id="manualMode"></div>
   <div id="log"></div>

--- a/core-aam/aria-invalid_true-manual.html
+++ b/core-aam/aria-invalid_true-manual.html
@@ -73,7 +73,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for aria-invalid=true.</p>
-    <div role='group' id='test' aria-invalid='true'>content</div>
+    <div role='textbox' id='test' aria-invalid='true'>content</div>
 
   <div id="manualMode"></div>
   <div id="log"></div>

--- a/core-aam/aria-invalid_with_unrecognized_value-manual.html
+++ b/core-aam/aria-invalid_with_unrecognized_value-manual.html
@@ -73,7 +73,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for aria-invalid with unrecognized value.</p>
-    <div role='group' id='test' aria-invalid='foo'>content</div>
+    <div role='textbox' id='test' aria-invalid='foo'>content</div>
 
   <div id="manualMode"></div>
   <div id="log"></div>

--- a/core-aam/include_element_referenced_by_global_aria-errormessage-manual.html
+++ b/core-aam/include_element_referenced_by_global_aria-errormessage-manual.html
@@ -61,7 +61,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for Include element referenced by global aria-errormessage.</p>
-    <div role='group' aria-errormessage='test' aria-invalid='true'>content</div>
+    <div role='checkbox' aria-errormessage='test' aria-invalid='true'>content</div>
   <div id='test'>hello world</div>
 
   <div id="manualMode"></div>


### PR DESCRIPTION
The following 4 attributes were removed from global attributes:
* aria-disabled
* aria-errormessage
* aria-haspopup
* aria-invalid

Tests of these attributes are now on elements which support each
role.

See: https://github.com/w3c/aria/commit/484483e2