### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=238451

### DIFF
--- a/css/selectors/invalidation/input-pseudo-classes-in-has.html
+++ b/css/selectors/invalidation/input-pseudo-classes-in-has.html
@@ -5,9 +5,6 @@
 <link rel="help" href="https://drafts.csswg.org/selectors/#relational">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-actions.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
 <style>
   .ancestor:has(#checkme:checked) { color: green }
   .ancestor:has(#checkme:indeterminate) { color: yellowgreen }
@@ -27,7 +24,10 @@
   <input id="numberinput" type="number" min="1" max="10" value="5">
 </div>
 <script>
-  test(() => {
+  test(function() {
+    this.add_cleanup(() => {
+      checkme.checked = false;
+    });
     checkme.checked = false;
     assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
                   "ancestor should be black");
@@ -37,51 +37,92 @@
     checkme.indeterminate = true;
     assert_equals(getComputedStyle(subject).color, "rgb(154, 205, 50)",
                   "ancestor should be yellowgreen");
+    const input = checkme;
     checkme.remove();
+    input.indeterminate = false;
     assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
                   "ancestor should be black");
 
-    {
-      const input = document.createElement('input');
-      input.id = 'checkme';
-      input.setAttribute('type', 'checkbox');
-      input.setAttribute('name', 'my-checkbox');
-      input.checked = true;
-      assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
-                    "ancestor should be black");
-      subject.prepend(input);
-      assert_equals(getComputedStyle(subject).color, "rgb(0, 128, 0)",
-                    "ancestor should be green");
-    }
+    subject.prepend(input);
+    checkme.checked = true;
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 128, 0)",
+                  "ancestor should be green");
+  }, ":checked & :indeterminate invalidation");
 
+  test(function() {
+    this.add_cleanup(() => {
+      checkme.disabled = false;
+    });
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
     checkme.disabled = true;
     assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 255)",
                   "ancestor should be blue");
+  }, ":disabled invalidation");
 
+  test(function() {
+    this.add_cleanup(() => {
+      textinput.readOnly = false;
+    });
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
     textinput.readOnly = true;
     assert_equals(getComputedStyle(subject).color, "rgb(135, 206, 235)",
                   "ancestor should be skyblue");
-    textinput.readOnly = false;
+  }, ":read-only invalidation");
 
-    textinput.placeholder = 'placeholder text';
-    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 128)",
-                  "ancestor should be navy");
-
-    radioinput.type = 'radio';
-    assert_equals(getComputedStyle(subject).color, "rgb(173, 216, 230)",
-                  "ancestor should be lightblue");
-
+  test(function() {
+    this.add_cleanup(() => {
+      textinput.value = "";
+    });
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
     textinput.value = "text input";
     assert_equals(getComputedStyle(subject).color, "rgb(144, 238, 144)",
                   "ancestor should be lightgreen");
+  }, ":valid invalidation");
 
-    numberinput.value = 12;
-    assert_equals(getComputedStyle(subject).color, "rgb(0, 100, 0)",
-                  "ancestor should be darkgreen");
+  test(function() {
+    this.add_cleanup(() => {
+      radioinput.removeAttribute("type");
+    });
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+    radioinput.type = 'radio';
+    assert_equals(getComputedStyle(subject).color, "rgb(173, 216, 230)",
+                  "ancestor should be lightblue");
+  }, ":default invalidation with input[type=radio]");
 
+  test(function() {
+    this.add_cleanup(() => {
+      numberinput.required = false;
+    });
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
     numberinput.required = true;
     assert_equals(getComputedStyle(subject).color, "rgb(255, 192, 203)",
                   "ancestor should be pink");
+  }, ":required invalidation");
 
-  });
+  test(function() {
+    this.add_cleanup(() => {
+      numberinput.value = 5;
+    });
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+    numberinput.value = 12;
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 100, 0)",
+                  "ancestor should be darkgreen");
+  }, ":out-of-range invalidation");
+
+  test(function() {
+    this.add_cleanup(() => {
+      textinput.removeAttribute("placeholder");
+    });
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+    textinput.placeholder = 'placeholder text';
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 128)",
+                  "ancestor should be navy");
+  }, ":placeholder-shown invalidation");
 </script>


### PR DESCRIPTION
WebKit export from bug: [\[:has() pseudo-class\] Support invalidation for more input pseudo classes](https://bugs.webkit.org/show_bug.cgi?id=238451)