### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=238934

### DIFF
--- a/css/css-contain/container-queries/container-for-shadow-dom.html
+++ b/css/css-contain/container-queries/container-for-shadow-dom.html
@@ -231,6 +231,18 @@
 <script>
   setup(() => assert_implements_container_queries());
 
+  function attachShadowRoots(root) {
+    root.querySelectorAll("template[shadowroot]").forEach(template => {
+      const mode = template.getAttribute("shadowroot");
+      const shadowRoot = template.parentNode.attachShadow({ mode });
+      shadowRoot.appendChild(template.content);
+      template.remove();
+      attachShadowRoots(shadowRoot);
+    });
+  }
+  if (!document.querySelector("template[shadowroot]").parentNode.shadowRoot)
+    attachShadowRoots(document);
+
   const green = "rgb(0, 128, 0)";
 
   test(() => {


### PR DESCRIPTION
WebKit export from bug: [\[CSS Container Queries\] Evaluate against shadow-including ancestors](https://bugs.webkit.org/show_bug.cgi?id=238934)