### PR TITLE
Update Safari Technology Preview to 143

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/actions/eventOrder.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/eventOrder.html.ini
@@ -1,4 +1,3 @@
 [eventOrder.html]
   expected:
     if (product == "epiphany") or (product == "webkit"): ERROR
-    if product == "safari": CRASH

--- a/infrastructure/metadata/infrastructure/testdriver/bless.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/bless.html.ini
@@ -1,3 +1,0 @@
-[bless.html]
-  expected:
-    if product == "safari": CRASH

--- a/infrastructure/metadata/infrastructure/testdriver/click-multiple.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/click-multiple.html.ini
@@ -1,3 +1,0 @@
-[click-multiple.html]
-  expected:
-    if product == "safari": CRASH

--- a/infrastructure/metadata/infrastructure/testdriver/click.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/click.html.ini
@@ -1,3 +1,0 @@
-[click.html]
-  expected:
-    if product == "safari": CRASH

--- a/infrastructure/metadata/infrastructure/testdriver/click_iframe.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/click_iframe.html.ini
@@ -1,3 +1,0 @@
-[click_iframe.html]
-  expected:
-    if product == "safari": CRASH

--- a/infrastructure/metadata/infrastructure/testdriver/click_iframe_crossorigin.sub.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/click_iframe_crossorigin.sub.html.ini
@@ -1,6 +1,4 @@
 [click_iframe_crossorigin.sub.html]
-  expected:
-    if product == "safari": CRASH
   [TestDriver click on a document in an iframe]
     expected:
       if product == "chrome": [PASS, FAIL]  # https://github.com/web-platform-tests/wpt/issues/26295

--- a/infrastructure/metadata/infrastructure/testdriver/click_nested.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/click_nested.html.ini
@@ -1,3 +1,0 @@
-[click_nested.html]
-  expected:
-    if product == "safari": CRASH

--- a/infrastructure/metadata/infrastructure/testdriver/click_nested_crossorigin.sub.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/click_nested_crossorigin.sub.html.ini
@@ -1,3 +1,0 @@
-[click_nested_crossorigin.sub.html]
-  expected:
-    if product == "safari": CRASH

--- a/infrastructure/metadata/infrastructure/testdriver/click_window.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/click_window.html.ini
@@ -1,3 +1,0 @@
-[click_window.html]
-  expected:
-    if product == "safari": CRASH

--- a/infrastructure/metadata/infrastructure/testdriver/send_keys.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/send_keys.html.ini
@@ -1,3 +1,0 @@
-[send_keys.html]
-  expected:
-    if product == "safari": ERROR

--- a/tools/ci/azure/safari-technology-preview.rb
+++ b/tools/ci/azure/safari-technology-preview.rb
@@ -1,12 +1,12 @@
 cask "safari-technology-preview" do
   if MacOS.version == :monterey
-    version "142,002-82680-20220323-EE9263E9-C759-49B5-A9D3-A3B5253707E9"
+    version "143,002-86658-20220407-A2BE5BCC-1B72-4CA4-B24F-6E442EEDF14A"
     url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
-    sha256 "219ee300b824ea727a8c02e5f98f70bf8c2e7932d2817eade7fae352c35d4641"
+    sha256 "894a86bcbcb08b04177a1606138a5f27cecf9276fe2dd7c9f15af34a6ba9cb1c"
   elsif MacOS.version == :big_sur
-    version "142,002-82679-20220323-94BD2443-23C7-4BBF-8BA4-66E13372BDB2"
+    version "143,002-86656-20220407-CC5B940B-17D8-47CA-8EEF-5B2ECA3240B0"
     url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
-    sha256 "2c3f3d238d465d627dc95f7dc0a066ddc8c2de6c31b2de2079d1b764aa2694e8"
+    sha256 "b86bbbe2d692e5b5adf87949e12add27dc50f20615739339f77383756a4d2707"
   end
 
   appcast "https://developer.apple.com/safari/download/"


### PR DESCRIPTION
Version as reported by safaridriver --version:
Included with Safari Technology Preview (Release 143, 16614.1.7.7)

Source: https://developer.apple.com/safari/download/
Build: https://dev.azure.com/foolip/safari-technology-preview-updater/_build/results?buildId=4391&view=logs