### PR TITLE
Fix adb command to find webview package

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1038,7 +1038,7 @@ class AndroidWebview(ChromeAndroidBase):
         # https://chromium.googlesource.com/chromium/src/+/HEAD/android_webview/docs/channels.md
         command = ['adb']
         if self.device_serial:
-            command.extend(['-s', self.device_serial])
+            command.extend(['-s', self.device_serial[0]])
         command.extend(['shell', 'dumpsys', 'webviewupdate'])
         try:
             output = call(*command)


### PR DESCRIPTION
wptrunner's `--device-serial` option became repeatable in #31634 (`str -> list[str]`), but seems like we forgot to update an `adb` command.

Chromium CI passes `--browser-version` for WebView, so this code path doesn't run (would have raised an exception).