### PR TITLE
Point at wpt.live instead of w3c-test.org

### DIFF
--- a/IndexedDB/README.md
+++ b/IndexedDB/README.md
@@ -1,6 +1,6 @@
 This directory contains the Indexed Database API test suite.
 
-To run the tests in this test suite within a browser, go to: <https://w3c-test.org/IndexedDB/>.
+To run the tests in this test suite within a browser, go to: <https://wpt.live/IndexedDB/>.
 
 The latest Editor's Draft of Indexed Database API is: <https://w3c.github.io/IndexedDB/>.
 

--- a/docs/writing-tests/general-guidelines.md
+++ b/docs/writing-tests/general-guidelines.md
@@ -160,9 +160,9 @@ should be used.
 ### Be Self-Contained
 
 Tests must not depend on external network resources. When these tests
-are run on CI systems they are typically configured with access to
+are run on CI systems, they are typically configured with access to
 external resources disabled, so tests that try to access them will
-fail. Where tests want to use multiple hosts this is possible through
+fail. Where tests want to use multiple hosts, this is possible through
 a known set of subdomains and the [text substitution features of
 wptserve](server-features).
 

--- a/docs/writing-tests/general-guidelines.md
+++ b/docs/writing-tests/general-guidelines.md
@@ -159,12 +159,12 @@ should be used.
 
 ### Be Self-Contained
 
-Tests must not depend on external network resources, including
-w3c-test.org. When these tests are run on CI systems they are
-typically configured with access to external resources disabled, so
-tests that try to access them will fail. Where tests want to use
-multiple hosts this is possible through a known set of subdomains and
-the [text substitution features of wptserve](server-features).
+Tests must not depend on external network resources. When these tests
+are run on CI systems they are typically configured with access to
+external resources disabled, so tests that try to access them will
+fail. Where tests want to use multiple hosts this is possible through
+a known set of subdomains and the [text substitution features of
+wptserve](server-features).
 
 
 ### Be Self-Describing

--- a/docs/writing-tests/submission-process.md
+++ b/docs/writing-tests/submission-process.md
@@ -35,28 +35,6 @@ channel][matrix] if you have an issue.  There is no need to announce
 your review request; as soon as you make a Pull Request, GitHub will
 inform interested parties.
 
-## Previews
-
-The website [http://w3c-test.org](http://w3c-test.org) exists to help
-contributors demonstrate their proposed changes to others. If you are [a GitHub
-collaborator](https://help.github.com/en/articles/permission-levels-for-a-user-account-repository)
-on WPT, then the content of your pull requests will be available at
-`http://w3c-test.org/submissions/{{pull request ID}}`, where "pull request ID"
-is the numeric identifier for the pull request.
-
-For example, a pull request at https://github.com/web-platform-tests/wpt/pull/3
-has a pull request ID `3`. Its contents can be viewed at
-http://w3c-test.org/submissions/3.
-
-If you are *not* a GitHub collaborator, then your submission may be made
-available if a collaborator makes the following comment on your pull request:
-"w3c-test:mirror".
-
-Previews are not created automatically for non-collaborators because the WPT
-server will execute Python code in the mirrored submissions. Collaborators are
-encouraged to enable the preview by making the special comment only if they
-trust the authors not to submit malicious code.
-
 [repo]: https://github.com/web-platform-tests/wpt/
 [github flow]: https://guides.github.com/introduction/flow/
 [public-test-infra]: https://lists.w3.org/Archives/Public/public-test-infra/

--- a/entries-api/README.md
+++ b/entries-api/README.md
@@ -5,5 +5,5 @@ Tests for the [Files and Directory Entries API](https://github.com/wicg/entries-
 
 Unfortunately, most of the tests are **manual** and require drag-and-drop of test
 data files, which can be found in the `entries-api/support` directory. The tests
-can be run via [w3c-test.org](http://w3c-test.org/entries-api/), but a local clone
+can be run via [wpt.live](http://wpt.live/entries-api/), but a local clone
 of the repo is required for access to the test data files.

--- a/storage/README.md
+++ b/storage/README.md
@@ -1,6 +1,6 @@
 This directory contains the Storage test suite.
 
-To run the tests in this test suite within a browser, go to: <https://w3c-test.org/storage/>.
+To run the tests in this test suite within a browser, go to: <https://wpt.live/storage/>.
 
 The living standard is: <https://storage.spec.whatwg.org/>
 

--- a/uievents/README.md
+++ b/uievents/README.md
@@ -1,3 +1,3 @@
 To run the UIEvents tests, go to:
 
-http://w3c-test.org/uievents/order-of-events/mouse-events/
+http://wpt.live/uievents/order-of-events/mouse-events/


### PR DESCRIPTION
The automatic mirroring for contributors no longer happens and it looks
like people have not been using the "w3c-test:mirror" comment since
2019, so remove this documentation from submission-process.md.

Elsewhere, point to wpt.live instead.