### PR TITLE
Test longtask/event-loop interactions

### DIFF
--- a/longtask-timing/longtask-sync-xhr.html
+++ b/longtask-timing/longtask-sync-xhr.html
@@ -1,0 +1,28 @@
+<!DOCTYPE HTML>
+<meta charset=utf-8>
+<title>LongTask Timing: synchronous XHR</title>
+<body>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/utils.js"></script>
+
+<h1>Long Task: synchronous XHR</h1>
+<div id="log"></div>
+<script>
+setup(() => assert_implements(window.PerformanceLongTaskTiming, 'Longtasks are not supported.'));
+
+promise_test(async t => {
+    const receivedLongTask = new Promise(resolve =>
+    new PerformanceObserver(entries => resolve(entries.getEntries())).observe({entryTypes: ['longtask']}));
+    await new Promise(resolve => window.addEventListener('load', () => {
+        const xhr = new XMLHttpRequest();
+        xhr.open('GET', '/resource-timing/resources/delay-css.py?delay=100', false /* synchronous xhr */);
+        xhr.send();
+        resolve();
+    }));
+    const entries = await receivedLongTask;
+    assert_equals(entries.length, 1);
+}, 'A long synchronous XHR is a longtask');
+</script>
+</body>

--- a/longtask-timing/spin-eventloop-not-longtask.html
+++ b/longtask-timing/spin-eventloop-not-longtask.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML>
+<meta charset=utf-8>
+<title>LongTask Timing: synchronous XHR</title>
+<body>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/utils.js"></script>
+<link rel="stylesheet" href="/resource-timing/resources/delay-css.py?delay=1000" />
+<h1>Long Task: Spin event loop</h1>
+<div id="log"></div>
+<script>
+setup(() => assert_implements(window.PerformanceLongTaskTiming, 'Longtasks are not supported.'));
+
+promise_test(async t => {
+    const didReceiveLongTask = false;
+    new PerformanceObserver(() => {
+        didReceiveLongTask = true;
+    }).observe({entryTypes: ['longtask']});
+
+    await new Promise(resolve => window.addEventListener('load', resolve));
+    assert_false(didReceiveLongTask);
+}, 'Waiting for load event (spinning an event loop), is not a longtask');
+</script>
+</body>


### PR DESCRIPTION
- sync XHR should contribute to longtask timing
- A long split task, such as waiting for window load event, is not a longtask

See https://github.com/w3c/longtasks/issues/76