### PR TITLE
Nav Timing: unloadEvent duration with iframes

### DIFF
--- a/navigation-timing/nested_unload_timing.html
+++ b/navigation-timing/nested_unload_timing.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Navigation Timing: unload event with nested contexts</title>
+    <link rel="help" href="https://w3c.github.io/navigation-timing/"/>
+    <script src="/common/utils.js"></script>
+    <script src="/common/dispatcher/dispatcher.js"></script>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <meta name="timeout" content="long">
+</head>
+<body>
+<script>
+
+    const dummyURL = () => `/navigation-timing/resources/blank_page_green.html?uid=${token()}`;
+
+    promise_test(async t => {
+        const mainWindowUnloadDuration = 100;
+        const iframeUnloadDuration = 400;
+        const popupUid = token();
+        const iframeUid = token();
+        const finalUid = token();
+        const popup = window.open(`resources/exec.html?uuid=${popupUid}`);
+        t.add_cleanup(() => popup.close());
+        const popupContext = new RemoteContext(popupUid);
+        const iframeContext = new RemoteContext(iframeUid);
+        const finalContext = new RemoteContext(finalUid);
+        const busyWait = duration => window.addEventListener('unload', () => {
+            const buffer = 3;
+            const timeoutEnd = performance.now() + duration + buffer;
+            while (timeoutEnd > performance.now()) {}
+        });
+
+        await popupContext.execute_script(busyWait, [mainWindowUnloadDuration]);
+
+        const loadIframe = iframeContext.execute_script(busyWait, [iframeUnloadDuration]);
+        const unloadIframe = iframeContext.execute_script(() => window.addEventListener('unload', () => busyWait(iframeUnloadDuration)));
+        const loadPopup = popupContext.execute_script(async iframeUid => {
+            const iframe = document.createElement('iframe');
+            iframe.src = `./exec.html?uuid=${iframeUid}`;
+            document.body.appendChild(iframe);
+            await new Promise(resolve => iframe.addEventListener('load', resolve));
+        }, [iframeUid]);
+
+        await Promise.all([loadIframe, unloadIframe, loadPopup]);
+        await popupContext.execute_script((uid) => location.href = `./exec.html?uuid=${uid}`, [finalUid]);
+        const navigationTimingEntry = await finalContext.execute_script(() => performance.getEntriesByType('navigation')[0].toJSON());
+        const unloadDuration = navigationTimingEntry.unloadEventEnd - navigationTimingEntry.unloadEventStart;
+        assert_greater_than_equal(unloadDuration, mainWindowUnloadDuration);
+        assert_less_than(unloadDuration, mainWindowUnloadDuration + iframeUnloadDuration);
+    });
+</script>
+</body>

--- a/navigation-timing/nested_unload_timing.html
+++ b/navigation-timing/nested_unload_timing.html
@@ -2,13 +2,13 @@
 <html>
 <head>
     <meta charset="utf-8" />
+    <meta name="timeout" content="long">
     <title>Navigation Timing: unload event with nested contexts</title>
     <link rel="help" href="https://w3c.github.io/navigation-timing/"/>
     <script src="/common/utils.js"></script>
     <script src="/common/dispatcher/dispatcher.js"></script>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <meta name="timeout" content="long">
 </head>
 <body>
 <script>

--- a/navigation-timing/nested_unload_timing.html
+++ b/navigation-timing/nested_unload_timing.html
@@ -19,8 +19,10 @@
         const mainWindowUnloadDuration = 100;
         const iframeUnloadDuration = 400;
         /*
-            We create 3 contexts: one for the document to unload, one for the iframe in that document,
-            and one for the document that's loaded after the unload.
+            We create 3 contexts: One for a popup window that will load a document and then later
+            unload it, one for an iframe inside that popup window, that will unload with the parent
+            document as well, and one for document the popup window will load in order to trigger
+            those previous unload events.
 
             The iframe is going to busy-wait on unload for 400ms, and the unloading top-level
             document is going to busy-wait on unload for 100ms.
@@ -33,16 +35,15 @@
         const finalContext = new RemoteContext(token());
         const popup = window.open(`resources/exec.html?uuid=${popupContext.context_id}`);
         t.add_cleanup(() => popup.close());
-        const busyWait = duration => window.addEventListener('unload', () => {
+        const registerBusyWaitUnload = duration => window.addEventListener('unload', () => {
             const buffer = 3;
             const timeoutEnd = performance.now() + duration + buffer;
             while (timeoutEnd > performance.now()) {}
         });
 
-        await popupContext.execute_script(busyWait, [mainWindowUnloadDuration]);
+        await popupContext.execute_script(registerBusyWaitUnload, [mainWindowUnloadDuration]);
 
-        const loadIframe = iframeContext.execute_script(busyWait, [iframeUnloadDuration]);
-        const unloadIframe = iframeContext.execute_script(() => window.addEventListener('unload', () => busyWait(iframeUnloadDuration)));
+        const unloadIframe = iframeContext.execute_script(registerBusyWaitUnload, [iframeUnloadDuration]);
         const loadPopup = popupContext.execute_script(async iframeUid => {
             const iframe = document.createElement('iframe');
             iframe.src = `./exec.html?uuid=${iframeUid}`;
@@ -50,7 +51,7 @@
             await new Promise(resolve => iframe.addEventListener('load', resolve));
         }, [iframeContext.context_id]);
 
-        await Promise.all([loadIframe, unloadIframe, loadPopup]);
+        await Promise.all([unloadIframe, loadPopup]);
         await popupContext.execute_script((uid) => location.href = `./exec.html?uuid=${uid}`, [finalContext.context_id]);
         const navigationTimingEntry = await finalContext.execute_script(() => performance.getEntriesByType('navigation')[0].toJSON());
         const unloadDuration = navigationTimingEntry.unloadEventEnd - navigationTimingEntry.unloadEventStart;

--- a/navigation-timing/nested_unload_timing.html
+++ b/navigation-timing/nested_unload_timing.html
@@ -18,14 +18,21 @@
     promise_test(async t => {
         const mainWindowUnloadDuration = 100;
         const iframeUnloadDuration = 400;
-        const popupUid = token();
-        const iframeUid = token();
-        const finalUid = token();
-        const popup = window.open(`resources/exec.html?uuid=${popupUid}`);
+        /*
+            We create 3 contexts: one for the document to unload, one for the iframe in that document,
+            and one for the document that's loaded after the unload.
+
+            The iframe is going to busy-wait on unload for 400ms, and the unloading top-level
+            document is going to busy-wait on unload for 100ms.
+
+            We verify that the total unloadEvent duration measured at the final document is ~100 but
+            less than 500ms - does not include the unload event duration from the iframe.
+        */
+        const popupContext = new RemoteContext(token());
+        const iframeContext = new RemoteContext(token());
+        const finalContext = new RemoteContext(token());
+        const popup = window.open(`resources/exec.html?uuid=${popupContext.context_id}`);
         t.add_cleanup(() => popup.close());
-        const popupContext = new RemoteContext(popupUid);
-        const iframeContext = new RemoteContext(iframeUid);
-        const finalContext = new RemoteContext(finalUid);
         const busyWait = duration => window.addEventListener('unload', () => {
             const buffer = 3;
             const timeoutEnd = performance.now() + duration + buffer;
@@ -41,10 +48,10 @@
             iframe.src = `./exec.html?uuid=${iframeUid}`;
             document.body.appendChild(iframe);
             await new Promise(resolve => iframe.addEventListener('load', resolve));
-        }, [iframeUid]);
+        }, [iframeContext.context_id]);
 
         await Promise.all([loadIframe, unloadIframe, loadPopup]);
-        await popupContext.execute_script((uid) => location.href = `./exec.html?uuid=${uid}`, [finalUid]);
+        await popupContext.execute_script((uid) => location.href = `./exec.html?uuid=${uid}`, [finalContext.context_id]);
         const navigationTimingEntry = await finalContext.execute_script(() => performance.getEntriesByType('navigation')[0].toJSON());
         const unloadDuration = navigationTimingEntry.unloadEventEnd - navigationTimingEntry.unloadEventStart;
         assert_greater_than_equal(unloadDuration, mainWindowUnloadDuration);

--- a/navigation-timing/resources/exec.html
+++ b/navigation-timing/resources/exec.html
@@ -1,0 +1,7 @@
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script>
+  const params = new URLSearchParams(window.location.search);
+  const uuid = params.get("uuid");
+  const executor = new Executor(uuid);
+  executor.execute();
+</script>


### PR DESCRIPTION
unloadEventEnd/Start times should include time spent in same-window
unload event handling, but should not include time spent unloading
iframes.

Closes https://github.com/w3c/navigation-timing/issues/83