### PR TITLE
Increase timeout for WebTransport over HTTP/3 server checks

### DIFF
--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -281,7 +281,7 @@ class TestEnvironment:
             for scheme, servers in self.servers.items():
                 for port, server in servers:
                     if scheme == "webtransport-h3":
-                        if not webtranport_h3_server_is_running(host, port, timeout=1.0):
+                        if not webtranport_h3_server_is_running(host, port, timeout=5.0):
                             # TODO(bashi): Consider supporting retry.
                             failed.append((host, port))
                         continue


### PR DESCRIPTION
At the current setting, we're seeing occasional unexpected timeouts when checking if the server is running, and these timeouts seem to be more prevalent on Python 3.10.

1.0 -> 5.0 change is arbitrary and might be too large of an increase, but does seem to eliminate the issue.