### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=238291

### DIFF
--- a/wasm/webapi/esm-integration/resources/worker-helper.js
+++ b/wasm/webapi/esm-integration/resources/worker-helper.js
@@ -1,1 +1,1 @@
-export const pm = DedicatedWorkerGlobalScope.postMessage;
+export function pm(x) { postMessage(x); }

--- a/wasm/webapi/esm-integration/worker-import.tentative.html
+++ b/wasm/webapi/esm-integration/worker-import.tentative.html
@@ -7,7 +7,7 @@
 setup({ single_test: true });
 const worker = new Worker("resources/worker.js", { type: "module" });
 worker.onmessage = (msg) => {
-  assert_equals(msg, 42);
+  assert_equals(msg.data, 42);
   done();
 }
 </script>


### PR DESCRIPTION
WebKit export from this bug: https://bugs.webkit.org/show_bug.cgi?id=238291

The upstream patch has already landed. It fixes a few issues with the tentative Wasm ES Module integration proposal tests.