### PR TITLE
Increase the tolerance a bit in webaudio/the-audio-api/the-biquadfilt…

### DIFF
--- a/webaudio/the-audio-api/the-biquadfilternode-interface/no-dezippering.html
+++ b/webaudio/the-audio-api/the-biquadfilternode-interface/no-dezippering.html
@@ -155,7 +155,7 @@
                   let match =
                       should(actual, 'Output from ' + f.type + ' filter')
                           .beCloseToArray(
-                              expected, {absoluteThreshold: 5.9607e-7});
+                              expected, {absoluteThreshold: 6.8546e-7});
                   should(match, 'Output matches JS filter results').beTrue();
                 })
                 .then(() => task.done());


### PR DESCRIPTION
…ernode-interface/no-dezippering.html

This test was failing on WebKit on one of our ARM platforms because the values were very slightly outside the
interval of tolerance. Since we believe the output to be correct and this seems to be variation based on
hardware (note that we use vectorization), updating the threshold in the test seems like the right thing to
do.