### PR TITLE
Respect custom `--adb-binary` for `chrome_android`-derived products

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -952,6 +952,7 @@ class ChromeAndroidBase(Browser):
     def __init__(self, logger):
         super().__init__(logger)
         self.device_serial = None
+        self.adb_binary = "adb"
 
     def download(self, dest=None, channel=None, rename=None):
         raise NotImplementedError
@@ -977,7 +978,7 @@ class ChromeAndroidBase(Browser):
             self.logger.warning("No package name provided.")
             return None
 
-        command = ['adb']
+        command = [self.adb_binary]
         if self.device_serial:
             # Assume we have same version of browser on all devices
             command.extend(['-s', self.device_serial[0]])
@@ -1036,7 +1037,7 @@ class AndroidWebview(ChromeAndroidBase):
         # For WebView, it is not trivial to change the WebView provider, so
         # we will just grab whatever is available.
         # https://chromium.googlesource.com/chromium/src/+/HEAD/android_webview/docs/channels.md
-        command = ['adb']
+        command = [self.adb_binary]
         if self.device_serial:
             command.extend(['-s', self.device_serial[0]])
         command.extend(['shell', 'dumpsys', 'webviewupdate'])

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -404,6 +404,8 @@ class ChromeAndroidBase(BrowserSetup):
     def setup_kwargs(self, kwargs):
         if kwargs.get("device_serial"):
             self.browser.device_serial = kwargs["device_serial"]
+        self.browser.adb_binary = kwargs.get("adb_binary",
+                                             self.browser.adb_binary)
         browser_channel = kwargs["browser_channel"]
         if kwargs["package_name"] is None:
             kwargs["package_name"] = self.browser.find_binary(

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -404,8 +404,8 @@ class ChromeAndroidBase(BrowserSetup):
     def setup_kwargs(self, kwargs):
         if kwargs.get("device_serial"):
             self.browser.device_serial = kwargs["device_serial"]
-        self.browser.adb_binary = kwargs.get("adb_binary",
-                                             self.browser.adb_binary)
+        if kwargs.get("adb_binary"):
+            self.browser.adb_binary = kwargs["adb_binary"]
         browser_channel = kwargs["browser_channel"]
         if kwargs["package_name"] is None:
             kwargs["package_name"] = self.browser.find_binary(

--- a/tools/wptrunner/wptrunner/browsers/android_weblayer.py
+++ b/tools/wptrunner/wptrunner/browsers/android_weblayer.py
@@ -34,6 +34,7 @@ def check_args(**kwargs):
 
 def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
     return {"binary": kwargs["binary"],
+            "adb_binary": kwargs["adb_binary"],
             "device_serial": kwargs["device_serial"],
             "webdriver_binary": kwargs["webdriver_binary"],
             "webdriver_args": kwargs.get("webdriver_args"),
@@ -86,6 +87,7 @@ class WeblayerShell(ChromeAndroidBrowserBase):
 
     def __init__(self, logger, binary,
                  webdriver_binary="chromedriver",
+                 adb_binary="adb",
                  remote_queue=None,
                  device_serial=None,
                  webdriver_args=None,
@@ -94,7 +96,8 @@ class WeblayerShell(ChromeAndroidBrowserBase):
         """Creates a new representation of Chrome.  The `binary` argument gives
         the browser binary to use for testing."""
         super().__init__(logger,
-                         webdriver_binary, remote_queue, device_serial,
-                         webdriver_args, stackwalk_binary, symbols_path)
+                         webdriver_binary, adb_binary, remote_queue,
+                         device_serial, webdriver_args, stackwalk_binary,
+                         symbols_path)
         self.binary = binary
         self.wptserver_ports = _wptserve_ports

--- a/tools/wptrunner/wptrunner/browsers/android_webview.py
+++ b/tools/wptrunner/wptrunner/browsers/android_webview.py
@@ -33,6 +33,7 @@ def check_args(**kwargs):
 
 def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
     return {"binary": kwargs["binary"],
+            "adb_binary": kwargs["adb_binary"],
             "device_serial": kwargs["device_serial"],
             "webdriver_binary": kwargs["webdriver_binary"],
             "webdriver_args": kwargs.get("webdriver_args"),
@@ -84,6 +85,7 @@ class SystemWebViewShell(ChromeAndroidBrowserBase):
     """
 
     def __init__(self, logger, binary, webdriver_binary="chromedriver",
+                 adb_binary="adb",
                  remote_queue=None,
                  device_serial=None,
                  webdriver_args=None,
@@ -92,7 +94,8 @@ class SystemWebViewShell(ChromeAndroidBrowserBase):
         """Creates a new representation of Chrome.  The `binary` argument gives
         the browser binary to use for testing."""
         super().__init__(logger,
-                         webdriver_binary, remote_queue, device_serial,
-                         webdriver_args, stackwalk_binary, symbols_path)
+                         webdriver_binary, adb_binary, remote_queue,
+                         device_serial, webdriver_args, stackwalk_binary,
+                         symbols_path)
         self.binary = binary
         self.wptserver_ports = _wptserve_ports

--- a/tools/wptrunner/wptrunner/browsers/chrome_android.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_android.py
@@ -36,6 +36,7 @@ def check_args(**kwargs):
 
 def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
     return {"package_name": kwargs["package_name"],
+            "adb_binary": kwargs["adb_binary"],
             "device_serial": kwargs["device_serial"],
             "webdriver_binary": kwargs["webdriver_binary"],
             "webdriver_args": kwargs.get("webdriver_args"),
@@ -131,6 +132,7 @@ class ChromeAndroidBrowserBase(WebDriverBrowser):
     def __init__(self,
                  logger,
                  webdriver_binary="chromedriver",
+                 adb_binary="adb",
                  remote_queue=None,
                  device_serial=None,
                  webdriver_args=None,
@@ -140,6 +142,7 @@ class ChromeAndroidBrowserBase(WebDriverBrowser):
                          binary=None,
                          webdriver_binary=webdriver_binary,
                          webdriver_args=webdriver_args,)
+        self.adb_binary = adb_binary
         self.device_serial = device_serial
         self.stackwalk_binary = stackwalk_binary
         self.symbols_path = symbols_path
@@ -154,7 +157,7 @@ class ChromeAndroidBrowserBase(WebDriverBrowser):
             self.logcat_runner.start()
 
     def _adb_run(self, args):
-        cmd = ['adb']
+        cmd = [self.adb_binary]
         if self.device_serial:
             cmd.extend(['-s', self.device_serial])
         cmd.extend(args)
@@ -187,7 +190,7 @@ class ChromeAndroidBrowserBase(WebDriverBrowser):
         self._adb_run(['logcat', '-c'])
 
     def logcat_cmd(self):
-        cmd = ['adb']
+        cmd = [self.adb_binary]
         if self.device_serial:
             cmd.extend(['-s', self.device_serial])
         cmd.extend(['logcat', '*:D'])
@@ -225,13 +228,15 @@ class ChromeAndroidBrowser(ChromeAndroidBrowserBase):
 
     def __init__(self, logger, package_name,
                  webdriver_binary="chromedriver",
+                 adb_binary="adb",
                  remote_queue = None,
                  device_serial=None,
                  webdriver_args=None,
                  stackwalk_binary=None,
                  symbols_path=None):
         super().__init__(logger,
-                         webdriver_binary, remote_queue, device_serial,
-                         webdriver_args, stackwalk_binary, symbols_path)
+                         webdriver_binary, adb_binary, remote_queue,
+                         device_serial, webdriver_args, stackwalk_binary,
+                         symbols_path)
         self.package_name = package_name
         self.wptserver_ports = _wptserve_ports


### PR DESCRIPTION
Previously, `chrome_android`-derived products depended on finding a generic `adb` on the `PATH`. The Chromium infrastructure was changed to use `--adb-binary` instead of `PATH` pollution, but the option did not work as documented because wptrunner did not pass the option all the way through.

Context: https://chromium-review.googlesource.com/c/chromium/src/+/3578461. The Android wpt trybot I was using masked the bug: https://ci.chromium.org/ui/p/chromium/builders/try/android-weblayer-pie-x86-wpt-smoketest/2036/overview

I've tried this change in `chromium/src` in a shell without `adb` in `PATH` and verified that this change fixes the immediate error for `chrome_android`, `android_webview`, and `android_weblayer`. Looking at `grep -R "[\"']adb[\"']" --exclude-dir='*venv' tools`, I think there are no more instances of hardcoded generic `adb`.