### PR TITLE
Test that serializing rethrows exceptions thrown from property getters

### DIFF
--- a/html/webappapis/structured-clone/structured-clone-battery-of-tests.js
+++ b/html/webappapis/structured-clone/structured-clone-battery-of-tests.js
@@ -485,7 +485,7 @@ structuredCloneBatteryOfTests.push({
   description: 'Object with a getter that throws',
   async f(runner, t) {
     const exception = new Error();
-    const test = {
+    const testObject = {
       get testProperty() {
         throw exception;
       }
@@ -493,7 +493,7 @@ structuredCloneBatteryOfTests.push({
     await promise_rejects_exactly(
       t,
       exception,
-      runner.structuredClone(test)
+      runner.structuredClone(testObject)
     );
   }
 });

--- a/html/webappapis/structured-clone/structured-clone-battery-of-tests.js
+++ b/html/webappapis/structured-clone/structured-clone-battery-of-tests.js
@@ -481,6 +481,23 @@ check('Object with non-configurable property', function() {
   return rv;
 }, compare_Object(check_configurable_property('foo')));
 
+structuredCloneBatteryOfTests.push({
+  description: 'Object with a getter that throws',
+  async f(runner, t) {
+    const exception = new Error();
+    const test = {
+      get testProperty() {
+        throw exception;
+      }
+    };
+    await promise_rejects_exactly(
+      t,
+      exception,
+      runner.structuredClone(test)
+    );
+  }
+});
+
 /* The tests below are inspired by @zcorpan’s work but got some
 more substantial changed due to their previous async setup */
 


### PR DESCRIPTION
When serializing an object with structured clone, its properties are iterated and serialized in order, and their value is obtained with the `? value.[[Get]](key, value)` ECMAScript operation, which can throw. Such an exception isn't caught anywhere in the structured clone algorithm (that is, it is not turned into a `DataCloneError`), which means it is thrown as is. This change adds a test for that behavior.
