### PR TITLE
TypeError should be thrown when passing null as the listener and signal

### DIFF
--- a/dom/events/AddEventListenerOptions-signal.any.js
+++ b/dom/events/AddEventListenerOptions-signal.any.js
@@ -140,4 +140,4 @@ test(function() {
 test(function() {
   const et = new EventTarget();
   assert_throws_js(TypeError, () => { et.addEventListener("foo", null, { signal: null }); });
-}, "TypeError should be thrown when passing null as the listener and signal");
+}, "Passing null as the signal should throw (listener is also null)");

--- a/dom/events/AddEventListenerOptions-signal.any.js
+++ b/dom/events/AddEventListenerOptions-signal.any.js
@@ -136,3 +136,8 @@ test(function() {
   const et = new EventTarget();
   assert_throws_js(TypeError, () => { et.addEventListener("foo", () => {}, { signal: null }); });
 }, "Passing null as the signal should throw");
+
+test(function() {
+  const et = new EventTarget();
+  assert_throws_js(TypeError, () => { et.addEventListener("foo", null, { signal: null }); });
+}, "TypeError should be thrown when passing null as the listener and signal");


### PR DESCRIPTION
see https://github.com/denoland/deno/issues/14254  for detail