### PR TITLE
[tools] Supports symlinks on utils.unzip()

### DIFF
--- a/tools/wpt/utils.py
+++ b/tools/wpt/utils.py
@@ -1,6 +1,7 @@
 import errno
 import logging
 import os
+import sys
 import shutil
 import stat
 import subprocess
@@ -55,9 +56,39 @@ def unzip(fileobj, dest=None, limit=None):
         for info in zip_data.infolist():
             if limit is not None and info.filename not in limit:
                 continue
-            zip_data.extract(info, path=dest)
-            perm = info.external_attr >> 16 & 0x1FF
-            os.chmod(os.path.join(dest, info.filename), perm)
+            # external_attr has a size of 4 bytes and the info it contains depends on the system where the ZIP file was created.
+            # - If the Zipfile was created on an UNIX environment, then the 2 highest bytes represent UNIX permissions and file
+            #   type bits (sys/stat.h st_mode entry on struct stat) and the lowest byte represents DOS FAT compatibility attributes
+            #   (used mainly to store the directory bit).
+            # - If the ZipFile was created on a WIN/DOS environment then the lowest byte represents DOS FAT file attributes
+            #   (those attributes are: directory bit, hidden bit, read-only bit, system-file bit, etc).
+            # More info at https://unix.stackexchange.com/a/14727 and https://forensicswiki.xyz/page/ZIP
+            # So, we can ignore the DOS FAT attributes because python ZipFile.extract() already takes care of creating the directories
+            # as needed (both on win and *nix) and the other DOS FAT attributes (hidden/read-only/system-file/etc) are not interesting
+            # here (not even on Windows, since we don't care about setting those extra attributes for our use case).
+            # So we do this:
+            #   1. When uncompressing on a Windows system we just call to extract().
+            #   2. When uncompressing on an Unix-like system we only take care of the attributes if the zip file was created on an
+            #      Unix-like system, otherwise we don't have any info about the file permissions other than the DOS FAT attributes,
+            #      which are useless here, so just call to extract() without setting any specific file permission in that case.
+            if info.create_system == 0 or sys.platform == 'win32':
+                zip_data.extract(info, path=dest)
+            else:
+                stat_st_mode = info.external_attr >> 16
+                info_dst_path = os.path.join(dest, info.filename)
+                if stat.S_ISLNK(stat_st_mode):
+                    # Symlinks are stored in the ZIP file as text files that contain inside the target filename of the symlink.
+                    # Recreate the symlink instead of calling extract() when an entry with the attribute stat.S_IFLNK is detected.
+                    link_src_path = zip_data.read(info)
+                    link_dst_dir = os.path.dirname(info_dst_path)
+                    if not os.path.isdir(link_dst_dir):
+                        os.makedirs(link_dst_dir)
+                    os.symlink(link_src_path, info_dst_path)
+                else:
+                    zip_data.extract(info, path=dest)
+                    # Preserve bits 0-8 only: rwxrwxrwx (no sticky/setuid/setgid bits).
+                    perm = stat_st_mode & 0x1FF
+                    os.chmod(info_dst_path, perm)
 
 
 def get(url):


### PR DESCRIPTION
* Python `ZipFile.extract()` doesn't support symlinks and instead of creating the symlink it creates a text file with the path to the target symlink.

* Implement the support for creating the symlinks by manually calling `os.symlink()` when the file attributes indicate it is a symlink.

* This fixes the WebKitGTK runs on wpt.fyi that broke recently when the MiniBrowser WebKitGTK bundles have started to include symlinks inside the zip files.
* See, [for example this log](https://community-tc.services.mozilla.com/tasks/OcTp6RoNSMCe5d-wTCC0Mg/runs/0/logs/public/logs/live.log):
```
/home/test/web-platform-tests/_venv3/browsers/nightly/webkitgtk_minibrowser/bin/WebKitWebDriver: error while loading shared libraries: /home/test/web-platform-tests/_venv3/browsers/nightly/webkitgtk_minibrowser/sys/lib/libgio-2.0.so.0: file too short
```
This `file too short` error is caused because the libraries that link with the binary are text files instead of symlinks.
The zip file [MiniBrowser_gtk_r249711@main.zip](https://webkitgtk.org/built-products/x86_64/release/nightly/Ubuntu-20.04/MiniBrowser/MiniBrowser_gtk_r249711@main.zip) contains [inside this libraries and symlinks](http://sprunge.us/H0U5X0) but the current code to unzip the files[ is creating this](http://sprunge.us/pd3z4M) (text files instead of symlinks)
