### PR TITLE
testharness.js: fix shadow realm detection

### DIFF
--- a/cookie-store/serviceworker_cookieStore_cross_origin.js
+++ b/cookie-store/serviceworker_cookieStore_cross_origin.js
@@ -1,6 +1,7 @@
 self.GLOBAL = {
   isWindow: () => false,
   isWorker: () => false,
+  isShadowRealm: () => false,
 };
 
 self.addEventListener('message', async event => {

--- a/resources/idlharness-shadowrealm.js
+++ b/resources/idlharness-shadowrealm.js
@@ -29,7 +29,15 @@ function idl_test_shadowrealm(srcs, deps) {
     promise_setup(async t => {
         const realm = new ShadowRealm();
         // https://github.com/web-platform-tests/wpt/issues/31996
-        realm.evaluate("globalThis.self = globalThis; undefined");
+        realm.evaluate("globalThis.self = globalThis; undefined;");
+
+        realm.evaluate(`
+            globalThis.self.GLOBAL = {
+                isWindow: function() { return false; },
+                isWorker: function() { return false; },
+                isShadowRealm: function() { return true; },
+            };
+        `);
 
         const ss = await Promise.all(script_urls.map(url => fetch_text(url)));
         for (const s of ss) {

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -537,13 +537,11 @@
         }
         /* Shadow realm global objects are _ordinary_ objects (i.e. their prototype is
          * Object) so we don't have a nice `instanceof` test to use; instead, we
-         * can look for the presence of web APIs that wouldn't be available in
-         * environments not listed above:
-         *
-         * As long as, within the shadow realm, we load the testharness before
-         * other libraries, this won't have any false positives, even in e.g. node
+         * check if the there is a TESTHARNESSJS_IS_INSIDE_SHADOW_REALM property
+         * on the global object. that was set by the test harness when it
+         * created the ShadowRealm.
          */
-        if ('AbortController' in global_scope) {
+        if (global_scope.TESTHARNESSJS_IS_INSIDE_SHADOW_REALM) {
             return new ShadowRealmTestEnvironment();
         }
 

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -537,11 +537,11 @@
         }
         /* Shadow realm global objects are _ordinary_ objects (i.e. their prototype is
          * Object) so we don't have a nice `instanceof` test to use; instead, we
-         * check if the there is a TESTHARNESSJS_IS_INSIDE_SHADOW_REALM property
+         * check if the there is a GLOBAL.isShadowRealm() property
          * on the global object. that was set by the test harness when it
          * created the ShadowRealm.
          */
-        if (global_scope.TESTHARNESSJS_IS_INSIDE_SHADOW_REALM) {
+        if (global_scope.GLOBAL.isShadowRealm()) {
             return new ShadowRealmTestEnvironment();
         }
 

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -259,6 +259,7 @@ class AnyHtmlHandler(HtmlWrapperHandler):
 self.GLOBAL = {
   isWindow: function() { return true; },
   isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
 };
 </script>
 <script src="/resources/testharness.js"></script>
@@ -360,13 +361,13 @@ class ShadowRealmHandler(HtmlWrapperHandler):
   await new Promise(r.evaluate(`
     (resolve, reject) => {
       (async () => {
-        globalThis.TESTHARNESSJS_IS_INSIDE_SHADOW_REALM = true;
-        await import("/resources/testharness.js");
-        %(script)s
         globalThis.self.GLOBAL = {
           isWindow: function() { return false; },
           isWorker: function() { return false; },
+          isShadowRealm: function() { return true; },
         };
+        await import("/resources/testharness.js");
+        %(script)s
         await import("%(path)s");
       })().then(resolve, (e) => reject(e.toString()));
     }
@@ -412,6 +413,7 @@ class ClassicWorkerHandler(BaseWorkerHandler):
 self.GLOBAL = {
   isWindow: function() { return false; },
   isWorker: function() { return true; },
+  isShadowRealm: function() { return false; },
 };
 importScripts("/resources/testharness.js");
 %(script)s
@@ -429,6 +431,7 @@ class ModuleWorkerHandler(BaseWorkerHandler):
 self.GLOBAL = {
   isWindow: function() { return false; },
   isWorker: function() { return true; },
+  isShadowRealm: function() { return false; },
 };
 import "/resources/testharness.js";
 %(script)s

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -360,6 +360,7 @@ class ShadowRealmHandler(HtmlWrapperHandler):
   await new Promise(r.evaluate(`
     (resolve, reject) => {
       (async () => {
+        globalThis.TESTHARNESSJS_IS_INSIDE_SHADOW_REALM = true;
         await import("/resources/testharness.js");
         %(script)s
         globalThis.self.GLOBAL = {

--- a/tools/wptserve/tests/functional/docroot/bar.any.worker.js
+++ b/tools/wptserve/tests/functional/docroot/bar.any.worker.js
@@ -2,6 +2,7 @@
 self.GLOBAL = {
   isWindow: function() { return false; },
   isWorker: function() { return true; },
+  isShadowRealm: function() { return false; },
 };
 importScripts("/resources/testharness.js");
 

--- a/tools/wptserve/tests/functional/docroot/foo.any.html
+++ b/tools/wptserve/tests/functional/docroot/foo.any.html
@@ -5,6 +5,7 @@
 self.GLOBAL = {
   isWindow: function() { return true; },
   isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
 };
 </script>
 <script src="/resources/testharness.js"></script>


### PR DESCRIPTION
This commit fixes shadow realm detection to not falsely discover the
Deno main thread as a shadow realm. Because there is no reliable way to
discover shadow realms in isolation, we add a a special global to inform
testharness.js that it is running in a ShadowRealm.

cc @jjgriego @Ms2ger 