### PR TITLE
Use `None` to signal `adb` binary default for `chrome_android`-related products

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/android_weblayer.py
+++ b/tools/wptrunner/wptrunner/browsers/android_weblayer.py
@@ -87,7 +87,7 @@ class WeblayerShell(ChromeAndroidBrowserBase):
 
     def __init__(self, logger, binary,
                  webdriver_binary="chromedriver",
-                 adb_binary="adb",
+                 adb_binary=None,
                  remote_queue=None,
                  device_serial=None,
                  webdriver_args=None,

--- a/tools/wptrunner/wptrunner/browsers/android_webview.py
+++ b/tools/wptrunner/wptrunner/browsers/android_webview.py
@@ -85,7 +85,7 @@ class SystemWebViewShell(ChromeAndroidBrowserBase):
     """
 
     def __init__(self, logger, binary, webdriver_binary="chromedriver",
-                 adb_binary="adb",
+                 adb_binary=None,
                  remote_queue=None,
                  device_serial=None,
                  webdriver_args=None,

--- a/tools/wptrunner/wptrunner/browsers/chrome_android.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_android.py
@@ -132,7 +132,7 @@ class ChromeAndroidBrowserBase(WebDriverBrowser):
     def __init__(self,
                  logger,
                  webdriver_binary="chromedriver",
-                 adb_binary="adb",
+                 adb_binary=None,
                  remote_queue=None,
                  device_serial=None,
                  webdriver_args=None,
@@ -142,7 +142,7 @@ class ChromeAndroidBrowserBase(WebDriverBrowser):
                          binary=None,
                          webdriver_binary=webdriver_binary,
                          webdriver_args=webdriver_args,)
-        self.adb_binary = adb_binary
+        self.adb_binary = adb_binary or "adb"
         self.device_serial = device_serial
         self.stackwalk_binary = stackwalk_binary
         self.symbols_path = symbols_path
@@ -228,7 +228,7 @@ class ChromeAndroidBrowser(ChromeAndroidBrowserBase):
 
     def __init__(self, logger, package_name,
                  webdriver_binary="chromedriver",
-                 adb_binary="adb",
+                 adb_binary=None,
                  remote_queue = None,
                  device_serial=None,
                  webdriver_args=None,


### PR DESCRIPTION
The change #33654 caused `chrome_android`-related runs without `--adb-binary` to fail because the corresponding kwarg was `None` but present. Constructing the browser overwrote the kwarg default.

This change fixes that bug by using `None` to signal default `adb` usage.

This time, I tested the change on the `run_monochrome_webview_finch_smoke_tests` target in Chromium as well, which does not pass `--adb-binary` to wptrunner.