### PR TITLE
Revert "testharness.js: fix shadow realm detection"

### DIFF
--- a/cookie-store/serviceworker_cookieStore_cross_origin.js
+++ b/cookie-store/serviceworker_cookieStore_cross_origin.js
@@ -1,7 +1,6 @@
 self.GLOBAL = {
   isWindow: () => false,
   isWorker: () => false,
-  isShadowRealm: () => false,
 };
 
 self.addEventListener('message', async event => {

--- a/resources/idlharness-shadowrealm.js
+++ b/resources/idlharness-shadowrealm.js
@@ -29,15 +29,7 @@ function idl_test_shadowrealm(srcs, deps) {
     promise_setup(async t => {
         const realm = new ShadowRealm();
         // https://github.com/web-platform-tests/wpt/issues/31996
-        realm.evaluate("globalThis.self = globalThis; undefined;");
-
-        realm.evaluate(`
-            globalThis.self.GLOBAL = {
-                isWindow: function() { return false; },
-                isWorker: function() { return false; },
-                isShadowRealm: function() { return true; },
-            };
-        `);
+        realm.evaluate("globalThis.self = globalThis; undefined");
 
         const ss = await Promise.all(script_urls.map(url => fetch_text(url)));
         for (const s of ss) {

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -537,11 +537,13 @@
         }
         /* Shadow realm global objects are _ordinary_ objects (i.e. their prototype is
          * Object) so we don't have a nice `instanceof` test to use; instead, we
-         * check if the there is a GLOBAL.isShadowRealm() property
-         * on the global object. that was set by the test harness when it
-         * created the ShadowRealm.
+         * can look for the presence of web APIs that wouldn't be available in
+         * environments not listed above:
+         *
+         * As long as, within the shadow realm, we load the testharness before
+         * other libraries, this won't have any false positives, even in e.g. node
          */
-        if (global_scope.GLOBAL.isShadowRealm()) {
+        if ('AbortController' in global_scope) {
             return new ShadowRealmTestEnvironment();
         }
 

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -259,7 +259,6 @@ class AnyHtmlHandler(HtmlWrapperHandler):
 self.GLOBAL = {
   isWindow: function() { return true; },
   isWorker: function() { return false; },
-  isShadowRealm: function() { return false; },
 };
 </script>
 <script src="/resources/testharness.js"></script>
@@ -361,13 +360,12 @@ class ShadowRealmHandler(HtmlWrapperHandler):
   await new Promise(r.evaluate(`
     (resolve, reject) => {
       (async () => {
+        await import("/resources/testharness.js");
+        %(script)s
         globalThis.self.GLOBAL = {
           isWindow: function() { return false; },
           isWorker: function() { return false; },
-          isShadowRealm: function() { return true; },
         };
-        await import("/resources/testharness.js");
-        %(script)s
         await import("%(path)s");
       })().then(resolve, (e) => reject(e.toString()));
     }
@@ -413,7 +411,6 @@ class ClassicWorkerHandler(BaseWorkerHandler):
 self.GLOBAL = {
   isWindow: function() { return false; },
   isWorker: function() { return true; },
-  isShadowRealm: function() { return false; },
 };
 importScripts("/resources/testharness.js");
 %(script)s
@@ -431,7 +428,6 @@ class ModuleWorkerHandler(BaseWorkerHandler):
 self.GLOBAL = {
   isWindow: function() { return false; },
   isWorker: function() { return true; },
-  isShadowRealm: function() { return false; },
 };
 import "/resources/testharness.js";
 %(script)s

--- a/tools/wptserve/tests/functional/docroot/bar.any.worker.js
+++ b/tools/wptserve/tests/functional/docroot/bar.any.worker.js
@@ -2,7 +2,6 @@
 self.GLOBAL = {
   isWindow: function() { return false; },
   isWorker: function() { return true; },
-  isShadowRealm: function() { return false; },
 };
 importScripts("/resources/testharness.js");
 

--- a/tools/wptserve/tests/functional/docroot/foo.any.html
+++ b/tools/wptserve/tests/functional/docroot/foo.any.html
@@ -5,7 +5,6 @@
 self.GLOBAL = {
   isWindow: function() { return true; },
   isWorker: function() { return false; },
-  isShadowRealm: function() { return false; },
 };
 </script>
 <script src="/resources/testharness.js"></script>


### PR DESCRIPTION
Reverts web-platform-tests/wpt#33668

This commit actually broke just about as things as it fixed :sweat_smile:. `self.GLOBAL` is not present in all test types, so it can not be used for feature detection.