### PR TITLE
Fix shadow realm detection code more

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -541,7 +541,7 @@
          * on the global object. that was set by the test harness when it
          * created the ShadowRealm.
          */
-        if (global_scope.GLOBAL.isShadowRealm()) {
+        if (global_scope.GLOBAL && global_scope.GLOBAL.isShadowRealm()) {
             return new ShadowRealmTestEnvironment();
         }
 


### PR DESCRIPTION
Beware: you MUST set globalThis.GLOBAL BEFORE loading testharness in
the shadow realm for detection to work.
