### PR TITLE
Add --paths-file option and fix check_git_ignore

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -227,8 +227,10 @@ def check_tentative_directories(repo_root, path):
 def check_git_ignore(repo_root, paths):
     # type: (Text, List[Text]) -> List[rules.Error]
     errors = []
-    with tempfile.TemporaryFile('w+') as f:
-        f.write('\n'.join(paths))
+
+    with tempfile.TemporaryFile('w+', newline='') as f:
+        for path in paths:
+            f.write('%s\n' % os.path.join(repo_root, path))
         f.seek(0)
         try:
             matches = subprocess.check_output(
@@ -934,6 +936,16 @@ def lint_paths(kwargs, wpt_root):
                 paths.append(os.path.relpath(os.path.abspath(path), wpt_root))
     elif kwargs["all"]:
         paths = list(all_filesystem_paths(wpt_root))
+    elif kwargs["rspfile"]:
+        paths = []
+        with open(kwargs["rspfile"], 'r', newline='') as f:
+            for line in f.readlines():
+                path = line.strip()
+                if os.path.isdir(path):
+                    path_dir = list(all_filesystem_paths(wpt_root, path))
+                    paths.extend(path_dir)
+                elif os.path.isfile(path):
+                    paths.append(os.path.relpath(os.path.abspath(path), wpt_root))
     else:
         changed_paths = changed_files(wpt_root)
         force_all = False
@@ -970,6 +982,7 @@ def create_parser():
                         help="Path to GitHub checks output file for Taskcluster runs")
     parser.add_argument("-j", "--jobs", type=int, default=0,
                         help="Level to parallelism to use (defaults to 0, which detects the number of CPUs)")
+    parser.add_argument("--rspfile", help="File containing a list of files to lint, one per line")
     return parser
 
 

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -936,9 +936,9 @@ def lint_paths(kwargs, wpt_root):
                 paths.append(os.path.relpath(os.path.abspath(path), wpt_root))
     elif kwargs["all"]:
         paths = list(all_filesystem_paths(wpt_root))
-    elif kwargs["rspfile"]:
+    elif kwargs["paths_file"]:
         paths = []
-        with open(kwargs["rspfile"], 'r', newline='') as f:
+        with open(kwargs["paths_file"], 'r', newline='') as f:
             for line in f.readlines():
                 path = line.strip()
                 if os.path.isdir(path):
@@ -982,7 +982,7 @@ def create_parser():
                         help="Path to GitHub checks output file for Taskcluster runs")
     parser.add_argument("-j", "--jobs", type=int, default=0,
                         help="Level to parallelism to use (defaults to 0, which detects the number of CPUs)")
-    parser.add_argument("--rspfile", help="File containing a list of files to lint, one per line")
+    parser.add_argument("--paths-file", help="File containing a list of files to lint, one per line")
     return parser
 
 


### PR DESCRIPTION
Windows command-line limits mean that only a few dozen file names can be
passed on the command line to the linting tool. This prevents effective
parallelism, and causes the startup cost to be paid tens of thousands of
time when this tool is used in Chromium. Using an rspfile to hold the
parameters lets linting run roughly 50x as fast.

While testing this it was found that the paths used in check_git_ignore
were incorrect. This was leading to problems being missed, and on
Windows also led to orders of magnitude slowdown - on the order of eight
minutes.

With these two changes linting time for Chromium goes from ~50 minutes
little more than 50 seconds.

See crrev.com/c/3582902 for more discussion and the other half of this
change.