### PR TITLE
cc Add tests for enterkeyhint attribute

### DIFF
--- a/conformance-checkers/html/attributes/enterkeyhint/value-bad-novalid.html
+++ b/conformance-checkers/html/attributes/enterkeyhint/value-bad-novalid.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang=en>
+<head>
+<meta charset=utf-8>
+<title>enterkeyhint attribute with invalid values</title>
+</head>
+<body>
+<input enterkeyhint>
+<input enterkeyhint="">
+<input enterkeyhint=foo>
+<input enterkeyhint="enter search">
+</body>
+</html>

--- a/conformance-checkers/html/attributes/enterkeyhint/value-isvalid.html
+++ b/conformance-checkers/html/attributes/enterkeyhint/value-isvalid.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang=en>
+<head>
+<meta charset=utf-8>
+<title>enterkeyhint attribute with valid values</title>
+</head>
+<body>
+<input enterkeyhint=enter>
+<input enterkeyhint=done>
+<input enterkeyhint=go>
+<input enterkeyhint=next>
+<input enterkeyhint=previous>
+<input enterkeyhint=search>
+<input enterkeyhint=send>
+</body>
+</html>

--- a/conformance-checkers/messages.json
+++ b/conformance-checkers/messages.json
@@ -97,6 +97,7 @@
     "html/attributes/accesskey/multi-character-key-label-novalid.html": "Bad value \u201ca b \u307b\u3052\u201d for attribute \u201caccesskey\u201d on element \u201ca\u201d: Bad key label list: Key label has multiple characters. Each key label must be a single character.",
     "html/attributes/data/no-characters-after-hyphen-novalid.html": "Attribute \u201cdata-\u201d not allowed on element \u201cp\u201d at this point.",
     "html/attributes/data/not-xml-serializable-novalid.html": "\u201cdata-*\u201d attribute names must be XML 1.0 4th ed. plus Namespaces NCNames.",
+    "html/attributes/enterkeyhint/value-bad-novalid.html": "Attribute \u201centerkeyhint\u201d not allowed on element \u201cinput\u201d at this point.",
     "html/attributes/lang/deprecated-tag-haswarn.html": "Bad value \u201cmo\u201d for attribute \u201clang\u201d on element \u201cbody\u201d: Bad language tag: The language subtag \u201cmo\u201d is deprecated. Use \u201cro\u201d instead.",
     "html/attributes/lang/extlang-bad-novalid.html": "Bad value \u201cbat-smg\u201d for attribute \u201clang\u201d on element \u201cbody\u201d: Bad language tag: Bad extlang subtag \u201csmg\u201d.",
     "html/attributes/lang/xmllang-different-value-novalid.html": "When the attribute \u201cxml:lang\u201d in no namespace is specified, the element must also have the attribute \u201clang\u201d present with the same value.",


### PR DESCRIPTION
This PR adds enterkeyhint attribute tests for conformance checkers.

Ref: https://github.com/validator/validator/issues/831
Ref: https://github.com/whatwg/html/commit/a5422d984d9b7b8a4e0ad7a0ad237b07f190cc93
Ref: https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-enterkeyhint-attribute

Note: Changes for conformance checker will follow.