### PR TITLE
Install python3.6-distutils for running anything with tox

### DIFF
--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -112,6 +112,10 @@ components:
     env:
       TOXENV: py36
       PY_COLORS: 0
+    install:
+      - python3.6
+      - python3.6-distutils
+      - python3.6-dev
 
   tox-python3_9:
     env:
@@ -413,9 +417,6 @@ tasks:
         - trigger-pr
         - tox-python3_6
       command: ./tools/ci/ci_tools_unittest.sh
-      install:
-        - python3.6
-        - python3.6-dev
       env:
         HYPOTHESIS_PROFILE: ci
       schedule-if:
@@ -446,8 +447,6 @@ tasks:
       command: ./tools/ci/ci_tools_integration_test.sh
       install:
         - libnss3-tools
-        - python3.6
-        - python3.6-dev
       options:
         oom-killer: true
         browser:
@@ -492,8 +491,6 @@ tasks:
       command: ./tools/ci/ci_resources_unittest.sh
       install:
         - libnss3-tools
-        - python3.6
-        - python3.6-dev
       options:
         browser:
           - firefox


### PR DESCRIPTION
This makes the 3.6 and 3.9 setup more similar.

Fixes https://github.com/web-platform-tests/wpt/issues/33776.