### PR TITLE
DOM: Remove TouchEvent from someNonCreateableEvents

### DIFF
--- a/dom/nodes/Document-createEvent.https.html
+++ b/dom/nodes/Document-createEvent.https.html
@@ -143,7 +143,6 @@ var someNonCreateableEvents = [
   "SpeechSynthesisEvent",
   "SyncEvent",
   "TimeEvent",
-  "TouchEvent",
   "TrackEvent",
   "TransitionEvent",
   "WebGLContextEvent",


### PR DESCRIPTION
The test `Should throw NOT_SUPPORTED_ERR for non-legacy event interface "TouchEvent"`
was incorrect for UAs where "expose legacy touch event APIs" is true.