### PR TITLE
Check for existing symlink in unzip helper

### DIFF
--- a/tools/wpt/utils.py
+++ b/tools/wpt/utils.py
@@ -83,6 +83,10 @@ def unzip(fileobj, dest=None, limit=None):
                     link_dst_dir = os.path.dirname(info_dst_path)
                     if not os.path.isdir(link_dst_dir):
                         os.makedirs(link_dst_dir)
+
+                    # Remove existing link if exists.
+                    if os.path.islink(info_dst_path):
+                        os.unlink(info_dst_path)
                     os.symlink(link_src_path, info_dst_path)
                 else:
                     zip_data.extract(info, path=dest)


### PR DESCRIPTION
I was trying to update my Chromium binary locally and ran across this new error:
```
FileExistsError: [Errno 17] File exists: b'Versions/Current/Resources' -> '/Users/danielrsmith/projects/wpt/_venv3/browsers/nightly/chrome-mac/Chromium.app/Contents/Frameworks/Chromium Framework.framework/Resources'
```
It seems to be caused by trying to establish a symlink that already exists. Unlinking before trying to establish a new symlink resolves the issue.