### PR TITLE
Update WSS over h2 metadata

### DIFF
--- a/infrastructure/metadata/infrastructure/server/http2-websocket.sub.h2.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/http2-websocket.sub.h2.any.js.ini
@@ -1,10 +1,10 @@
 [http2-websocket.sub.h2.any.html]
   [WSS over h2]
     expected:
-      if product == "safari" or product == "epiphany" or product == "webkit": FAIL
+      if product == "firefox" or product == "safari" or product == "epiphany" or product == "webkit": FAIL
 
 
 [http2-websocket.sub.h2.any.worker.html]
   [WSS over h2]
     expected:
-      if product == "safari" or product == "epiphany" or product == "webkit": FAIL
+      if product == "firefox" or product == "safari" or product == "epiphany" or product == "webkit": FAIL


### PR DESCRIPTION
Firefox has temporarily disabled this feature, so mark the tests as
failing until it's re-enabled.