### PR TITLE
[Azure Pipelines] Adjust parallel jobs of Edge and Safari

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -349,7 +349,7 @@ jobs:
        eq(variables['Build.SourceBranch'], 'refs/heads/triggers/edge_stable'),
        and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_edge_stable']))
   strategy:
-    parallel: 10 # chosen to make runtime ~2h
+    parallel: 8 # chosen to make runtime ~2h
   timeoutInMinutes: 180
   pool:
     vmImage: 'windows-2019'
@@ -387,7 +387,7 @@ jobs:
        eq(variables['Build.SourceBranch'], 'refs/heads/triggers/edge_dev'),
        and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_edge_dev']))
   strategy:
-    parallel: 10 # chosen to make runtime ~2h
+    parallel: 8 # chosen to make runtime ~2h
   timeoutInMinutes: 180
   pool:
     vmImage: 'windows-2019'
@@ -425,7 +425,7 @@ jobs:
        eq(variables['Build.SourceBranch'], 'refs/heads/triggers/edge_canary'),
        and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_edge_canary']))
   strategy:
-    parallel: 10 # chosen to make runtime ~2h
+    parallel: 8 # chosen to make runtime ~2h
   timeoutInMinutes: 180
   pool:
     vmImage: 'windows-2019'
@@ -462,7 +462,7 @@ jobs:
        eq(variables['Build.SourceBranch'], 'refs/heads/triggers/safari_stable'),
        and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_safari']))
   strategy:
-    parallel: 7 # chosen to make runtime ~2h
+    parallel: 8 # chosen to make runtime ~2h
   timeoutInMinutes: 180
   pool:
     vmImage: 'macOS-11'
@@ -502,7 +502,7 @@ jobs:
        eq(variables['Build.SourceBranch'], 'refs/heads/triggers/safari_preview'),
        and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_safari_preview']))
   strategy:
-    parallel: 7 # chosen to make runtime ~2h
+    parallel: 8 # chosen to make runtime ~2h
   timeoutInMinutes: 180
   pool:
     vmImage: 'macOS-11'


### PR DESCRIPTION
Duration was taken from the latest run:
https://dev.azure.com/web-platform-tests/wpt/_build/results?buildId=80974&view=results

The slowest Edge job was 96 minutes and the slowest Safari job was 130
minutes. Based on the assumption that the slowest job will change in
proportion to job count, using 8 jobs everywhere should bring both Edge
and Safari closer to 2 hours.

These jobs are all triggered at the same time every UTC midnight, and
this change reduces the resulting job count from 44 to 40.