### PR TITLE
Clean up fetch metadata build setup and docs

### DIFF
--- a/fetch/metadata/tools/README.md
+++ b/fetch/metadata/tools/README.md
@@ -33,29 +33,8 @@ this tool to build a test suite which spans the entire platform.
 
 ## Build script
 
-To generate the Fetch Metadata tests, use the `build.sh` script, which installs
-the dependencies and runs `generate.py` with the Fetch Metadata tests
-configuration file `fetch-metadata.conf.yml`, in a virtualenv.
-
-    $ build.sh
-
-If you don't want to use virtualenv, see the next two sections.
-
-## Setup instructions
-
-- [Install Python 3](https://www.python.org/download/releases/3.0/)
-- Install Python dependencies with the following command (issued from the
-  directory containing this document):
-
-      $ pip install -r ./requirements.txt
-
-## Execution
-
-Execute the following command to generate tests, making sure to replace
-`./path/to/configuration-file.yml` with a filesystem path to a valid
-configuration file (described in greater detail below):
-
-    $ python3 ./generate.py ./path/to/configuration-file.yml
+To generate the Fetch Metadata tests, run `./wpt update-built --include fetch`
+in the root of the repository.
 
 ## Configuration
 

--- a/fetch/metadata/tools/build.sh
+++ b/fetch/metadata/tools/build.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env sh
-set -ex
-
-cd "${0%/*}"
-virtualenv -p python3 .virtualenv
-.virtualenv/bin/pip install -r ./requirements.txt
-cd ..
-tools/.virtualenv/bin/python ./tools/generate.py ./tools/fetch-metadata.conf.yml

--- a/fetch/metadata/tools/generate.py
+++ b/fetch/metadata/tools/generate.py
@@ -112,7 +112,7 @@ def collection_filter(obj, title):
 
     members = []
     for name, value in obj.items():
-        if value is '':
+        if value == '':
             members.append(name)
         else:
             members.append('{}={}'.format(name, value))

--- a/fetch/metadata/tools/requirements.txt
+++ b/fetch/metadata/tools/requirements.txt
@@ -1,3 +1,0 @@
-Jinja2==2.11.3
-MarkupSafe==1.1.1
-PyYAML==5.4


### PR DESCRIPTION
Most of this was unused as it was integrated with the update-built
command. In particular the requirements.txt file is not used in CI, but
Dependabot is sending updates for it.