### PR TITLE
Add test for :has(:target) change

### DIFF
--- a/css/selectors/invalidation/target-pseudo-in-has.html
+++ b/css/selectors/invalidation/target-pseudo-in-has.html
@@ -5,8 +5,8 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>
-  #parent1 { color: green }
-  #parent1:has(:target) { color: yellowgreen }
+  #parent1 { color: green; }
+  #parent1:has(:target) { color: yellowgreen; }
 </style>
 <div id="parent1">
   <div id="fragment">parent color must be yellow green when containing :target</div>
@@ -23,12 +23,12 @@
 
     assert_equals(getComputedStyle(parent1).color, "rgb(0, 128, 0)", "parent should be green");
 
-    toFragment.click()
+    toFragment.click();
 
     assert_true(fragment.matches(":target"));
     assert_equals(getComputedStyle(parent1).color, "rgb(154, 205, 50)", "parent should be yellowgreen on fragment click");
 
-    toTop.click()
+    toTop.click();
 
     assert_equals(location.hash, "");
     assert_equals(getComputedStyle(parent1).color, "rgb(0, 128, 0)", "parent should be green without :target");

--- a/css/selectors/invalidation/target-pseudo-in-has.html
+++ b/css/selectors/invalidation/target-pseudo-in-has.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>CSS Selectors Invalidation: target pseudo in :has() argument</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#relational">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #parent1 { color: green }
+  #parent1:has(:target) { color: yellowgreen }
+</style>
+<div id="parent1">
+  <div id="fragment">parent color must be yellow green when containing :target</div>
+  <a href="#fragment">link to #fragment</a>
+  <a href="#">link to #</a>
+</div>
+<script>
+  test((t) => {
+    var fragment = document.querySelector('#fragment')
+    var toFragment = document.querySelector('a[href="#fragment"]')
+    var toTop = document.querySelector('a[href="#"]')
+
+    location.hash = ''
+
+    assert_equals(getComputedStyle(parent1).color, 'rgb(0, 128, 0)', "parent should be green");
+
+    toFragment.click()
+
+    assert_true(fragment.matches(':target'));
+    assert_equals(getComputedStyle(parent1).color, "rgb(154, 205, 50)", "parent should be yellowgreen on fragment click");
+
+    toTop.click()
+
+    assert_equals(location.hash, '');
+    assert_equals(getComputedStyle(parent1).color, "rgb(0, 128, 0)", "parent should be green without :target");
+  });
+</script>

--- a/css/selectors/invalidation/target-pseudo-in-has.html
+++ b/css/selectors/invalidation/target-pseudo-in-has.html
@@ -15,22 +15,22 @@
 </div>
 <script>
   test((t) => {
-    var fragment = document.querySelector('#fragment')
-    var toFragment = document.querySelector('a[href="#fragment"]')
-    var toTop = document.querySelector('a[href="#"]')
+    const fragment = document.querySelector("#fragment");
+    const toFragment = document.querySelector(`a[href="#fragment"]`);
+    const toTop = document.querySelector(`a[href="#"]`);
 
-    location.hash = ''
+    location.hash = "";
 
-    assert_equals(getComputedStyle(parent1).color, 'rgb(0, 128, 0)', "parent should be green");
+    assert_equals(getComputedStyle(parent1).color, "rgb(0, 128, 0)", "parent should be green");
 
     toFragment.click()
 
-    assert_true(fragment.matches(':target'));
+    assert_true(fragment.matches(":target"));
     assert_equals(getComputedStyle(parent1).color, "rgb(154, 205, 50)", "parent should be yellowgreen on fragment click");
 
     toTop.click()
 
-    assert_equals(location.hash, '');
+    assert_equals(location.hash, "");
     assert_equals(getComputedStyle(parent1).color, "rgb(0, 128, 0)", "parent should be green without :target");
   });
 </script>


### PR DESCRIPTION
When `:target` changes, CSS properties via `:has(:target)` don't seem to be applied.

Here's a video demonstrating the problem in Safari Version 15.4 (17613.1.17.1.13).

https://user-images.githubusercontent.com/1153134/166135614-32d261e8-b4ff-48ac-aa5a-9dd10280fa84.mov

As shown, the rules are there, but the page only updates when I manually edit the stylesheet via inspector.

---

It does not work on the following browser/versions I've tested with:

- Safari Version 15.4 (17613.1.17.1.13)
- Safari Technology Preview, Release 143 (Safari 15.4, WebKit 17614.1.7.7)
- Chrome Beta Version 102.0.5005.27 with Experimental Web Platform features enabled

Worth noting–on the test page, if I manually click the fragment links, the text colors would not update (which is what this test is for); but while running the automatic test, the text color is updated on `:target` change, even though the assertion does still fail. 