### PR TITLE
Set body margin to 0

### DIFF
--- a/css/CSS2/pagination/float-page-break-inside-avoid-2-print-ref.html
+++ b/css/CSS2/pagination/float-page-break-inside-avoid-2-print-ref.html
@@ -6,6 +6,7 @@
   <meta name="flags" content="paged">
 <style type="text/css">
 @page { size:5in 3in; margin:0.5in; }
+body { margin: 0 }
 p { height: 1in; width: 1in; margin:0; background-color:blue; }
 .test { float:left; }
 </style>

--- a/css/CSS2/pagination/float-page-break-inside-avoid-2-print.html
+++ b/css/CSS2/pagination/float-page-break-inside-avoid-2-print.html
@@ -8,6 +8,7 @@
   <meta name="flags" content="paged">
 <style type="text/css">
 @page { size:5in 3in; margin:0.5in; }
+body { margin: 0 }
 p { height: 1in; width: 1in; margin:0; background-color:blue; }
 .test { float:left; page-break-inside:avoid; }
 </style>


### PR DESCRIPTION
The 8px default margin on the body means the float with "3" in it overruns the first page, onto page 2. As the next float (with "4" in it) has a `break-before: page`, it should be rendered on page 3.

Currently it's not in Chrome or Firefox, but that's an implementation issue and doesn't mean the test is correct.

This sets the body margin to 0, to ensure the reftest only renders onto two pages.

