### PR TITLE
Remove the test cases that are not specified by the spec.

### DIFF
--- a/html/semantics/forms/the-input-element/type-change-state.html
+++ b/html/semantics/forms/the-input-element/type-change-state.html
@@ -130,6 +130,7 @@
 
             input.type = types[j].type;  // change state
 
+            var preSanitizeValue = expected;
             // type[j] sanitization
             if (types[j].sanitizer) {
               expected = types[j].sanitizer(expected);
@@ -146,9 +147,12 @@
 
             if (nowSelectable) {
               if (previouslySelectable) {
-                assert_equals(input.selectionStart, selectionStart, "selectionStart should be unchanged");
-                assert_equals(input.selectionEnd, selectionEnd, "selectionEnd should be unchanged");
-                assert_equals(input.selectionDirection, selectionDirection, "selectionDirection should be unchanged");
+                // Value might change after sanitization. The following checks are only valid when the value stays the same.
+                if (preSanitizeValue === expected) {
+                  assert_equals(input.selectionStart, selectionStart, "selectionStart should be unchanged");
+                  assert_equals(input.selectionEnd, selectionEnd, "selectionEnd should be unchanged");
+                  assert_equals(input.selectionDirection, selectionDirection, "selectionDirection should be unchanged");
+                }
               } else {
                 assert_equals(input.selectionStart, 0, "selectionStart should be 0");
                 assert_equals(input.selectionEnd, 0, "selectionEnd should be 0");


### PR DESCRIPTION
These test cases were introduced while adding test cases for
step 7-9 https://html.spec.whatwg.org/multipage/input.html#input-type-change
with commit at
https://github.com/web-platform-tests/wpt/commit/ed63c8c97b001265daf5e2fa8af9cdfe69c7b771

It is correct with test cases for step 7-9. However, for cases that don't meet the requirement
for step 7-9, it assume that the selectionStart/selectionEnd stay as they are. This is not
always true. For example, selectionStart/selectionEnd could change when previouslySelectable and
nowSelectable are both true due to the value changes caused by sensitization.