### PR TITLE
Change selection-not-application-textarea.html test to accommodate

### DIFF
--- a/html/semantics/forms/textfieldselection/selection-not-application-textarea.html
+++ b/html/semantics/forms/textfieldselection/selection-not-application-textarea.html
@@ -31,6 +31,10 @@
     el.setSelectionRange(0, 1);
     assert_equals(el.selectionStart, 0, "final selectionStart");
     assert_equals(el.selectionEnd, 1, "final selectionEnd");
-    assert_equals(el.selectionDirection, "forward", "final selectionDirection");
+    assert_in_array(el.selectionDirection, ["none", "forward"]);
+
+    const finalDirection = el.selectionDirection;
+    el.finalDirection = "forward";
+    assert_equals(el.selectionDirection, finalDirection);
   }, "text field selection for the input textarea");
 </script>


### PR DESCRIPTION
platforms with different default selection direction values.

The test calls setSelectionRange(start, end [, direction]) API with
the direction argument ommitted. As per spec at
https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#textFieldSelection,
If the direction is omitted, it will be reset to be the platform default (none or forward).
The existing test script expects the direction to be "forward" only.

This patch updates the test script to be in line with spec.