### PR TITLE
[Azure Pipelines] Run Edge Canary only once a week

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -421,7 +421,7 @@ jobs:
 - job: results_edge_canary
   displayName: 'all tests: Edge Canary'
   condition: |
-    or(eq(variables['Build.SourceBranch'], 'refs/heads/epochs/three_hourly'),
+    or(eq(variables['Build.SourceBranch'], 'refs/heads/epochs/weekly'),
        eq(variables['Build.SourceBranch'], 'refs/heads/triggers/edge_canary'),
        and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_edge_canary']))
   strategy:


### PR DESCRIPTION
We currently trigger 5*8=40 jobs daily, and 3*8=24 of those trigger
every 3 hours, while we only have 20 parallel jobs.

We don't show the Edge Canary results on wpt.fyi by default, so reduce
them to once a week to reduce load.

Helps with https://github.com/web-platform-tests/wpt/issues/33980.