### PR TITLE
Fix fuzzy match data for backdrop-animate-002.html and revert 5eca98b

### DIFF
--- a/css/css-pseudo/backdrop-animate-002-ref.html
+++ b/css/css-pseudo/backdrop-animate-002-ref.html
@@ -5,7 +5,6 @@
 #target::backdrop {
   opacity: 0.1;
   background-color: green;
-  will-change: transform;
 }
 </style>
 <script>

--- a/css/css-pseudo/backdrop-animate-002.html
+++ b/css/css-pseudo/backdrop-animate-002.html
@@ -1,18 +1,11 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
 <meta charset="utf-8">
 <title>CSS Test: A Web Animations on ::backdrop</title>
 <link rel="help" href="https://fullscreen.spec.whatwg.org/#::backdrop-pseudo-element">
 <link rel="match" href="backdrop-animate-002-ref.html">
 <dialog id="target">Dialog contents</dialog>
-<!-- This test fails on WPT.fyi with off-by-one on the green background: -->
-<meta name=fuzzy content="maxDifference=1;totalPixels=472272">
-
-<style>
-#target::backdrop {
-  will-change: transform;
-}
-</style>
+<!-- This test fails on WPT.fyi with off-by-one on the green background (Chrome-only): -->
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-472272">
 <script>
 const target = document.getElementById("target");
 target.showModal();
@@ -22,10 +15,5 @@ target.animate({
 }, {
   pseudoElement: "::backdrop",
   duration: Infinity
-});
-requestAnimationFrame(() => {
-  requestAnimationFrame(() => {
-    document.documentElement.classList.remove("reftest-wait");
-  });
 });
 </script>


### PR DESCRIPTION
Commit 5eca98b did not actually make the test pass in Chrome, the fuzzy data from 3238a6a did. Let's undo the former, since it's extra unnecessary code.

Also fix fuzzy data since Safari fully passes this test with 0 difference.