### PR TITLE
Fix exception type of WebAssembly.Global for v128

### DIFF
--- a/wasm/jsapi/global/constructor.any.js
+++ b/wasm/jsapi/global/constructor.any.js
@@ -89,7 +89,7 @@ test(() => {
 
 test(() => {
   const argument = { "value": "v128" };
-  assert_throws_js(WebAssembly.LinkError, () => new WebAssembly.Global(argument));
+  assert_throws_js(TypeError, () => new WebAssembly.Global(argument));
 }, "Construct v128 global");
 
 test(() => {


### PR DESCRIPTION
The exception type was incorrect and got fixed recently in https://github.com/WebAssembly/spec/pull/1472