### PR TITLE
[css-typed-om] Test unit checks in CSSNumericValue.{min,max}

### DIFF
--- a/css/css-typed-om/stylevalue-subclasses/numeric-objects/arithmetic.tentative.html
+++ b/css/css-typed-om/stylevalue-subclasses/numeric-objects/arithmetic.tentative.html
@@ -150,15 +150,11 @@ test(() => {
   assert_throws_js(RangeError, () => CSS.number(2).div(CSS.number(0), CSS.number(0)));
 }, 'Can not divide with CSSUnitValue which has zero value and number type');
 
-test(() => {
-  assert_throws_js(TypeError, () => CSS.number(3).add(CSS.px(10) ,CSS.number(0)));
-  assert_throws_js(TypeError, () => CSS.px(2).add(CSS.deg(10)));
-}, 'CSSNumericValue.add should throw TypeError when the types are different.');
-
-test(() => {
-  assert_throws_js(TypeError, () => CSS.number(3).sub(CSS.px(10) ,CSS.number(0)));
-  assert_throws_js(TypeError, () => CSS.px(2).sub(CSS.deg(10)));
-}, 'CSSNumericValue.sub should throw TypeError when the types are different.');
-
+for (const methodName of ["add", "sub", "max", "min"]) {
+    test(() => {
+      assert_throws_js(TypeError, () => CSS.number(3)[methodName](CSS.px(10) ,CSS.number(0)));
+      assert_throws_js(TypeError, () => CSS.px(2)[methodName](CSS.deg(10)));
+    }, 'CSSNumericValue.' + methodName + ' should throw TypeError when the types are different.');
+}
 
 </script>


### PR DESCRIPTION
This is in the spec in https://drafts.css-houdini.org/css-typed-om/#dom-cssnumericvalue-min and https://drafts.css-houdini.org/css-typed-om/#dom-cssnumericvalue-max and makes sense to have, but is not implemented in Chromium.  Test from https://github.com/WebKit/WebKit/pull/713