### PR TITLE
Add command line arg to allow no restart test runner on new test groups

### DIFF
--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -411,7 +411,7 @@ class GroupedSource(TestSource):
             group.append(test)
             test.update_metadata(metadata)
 
-        for item in sorted(groups, key=lambda x: len(x[0]), reverse=True):
+        for item in groups:
             test_queue.put(item)
         return test_queue
 

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -411,7 +411,7 @@ class GroupedSource(TestSource):
             group.append(test)
             test.update_metadata(metadata)
 
-        for item in groups:
+        for item in sorted(groups, key=lambda x: len(x[0]), reverse=True):
             test_queue.put(item)
         return test_queue
 

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -75,6 +75,10 @@ scheme host and port.""")
                         default=True,
                         dest="fail_on_unexpected_pass",
                         help="Exit with status code 0 when all unexpected results are PASS")
+    parser.add_argument("--no-restart-on-new-group", action="store_false",
+                        default=True,
+                        dest="restart_on_new_group",
+                        help="Don't restart test runner when start a new test group")
 
     mode_group = parser.add_argument_group("Mode")
     mode_group.add_argument("--list-test-groups", action="store_true",

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -230,6 +230,7 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
                           run_test_kwargs["restart_on_unexpected"],
                           run_test_kwargs["debug_info"],
                           not run_test_kwargs["no_capture_stdio"],
+                          run_test_kwargs["restart_on_new_group"],
                           recording=recording) as manager_group:
             try:
                 manager_group.run(test_type, run_tests)


### PR DESCRIPTION
With this we can reduce the number of restart needed and speed up the test.
We plan to add retry mechanism in wptrunner to handle flakiness instead.