### PR TITLE
Add test to confirm calling Request constructor without `new` throws an error

### DIFF
--- a/fetch/api/request/request-error.any.js
+++ b/fetch/api/request/request-error.any.js
@@ -14,6 +14,14 @@ for (const { args, testName } of badRequestArgTests) {
 }
 
 test(function() {
+  assert_throws_js(
+      TypeError,
+      () => Request(),
+      "Calling Request constructor without 'new' must throw"
+    );
+});
+
+test(function() {
   var initialHeaders = new Headers([["Content-Type", "potato"]]);
   var initialRequest = new Request("", {"headers" : initialHeaders});
   var request = new Request(initialRequest);

--- a/fetch/api/request/request-error.any.js
+++ b/fetch/api/request/request-error.any.js
@@ -16,7 +16,7 @@ for (const { args, testName } of badRequestArgTests) {
 test(function() {
   assert_throws_js(
       TypeError,
-      () => Request(),
+      () => Request("about:blank"),
       "Calling Request constructor without 'new' must throw"
     );
 });


### PR DESCRIPTION
The Request interface defines a Web IDL constructor and the Web IDL constructor definition states:

>If the interface is declared with a constructor operation, then the interface object can be called as a constructor to create an object that implements that interface. **Calling that interface as a function will throw an exception.**
> https://webidl.spec.whatwg.org/#interface-object

This commit adds a test to ensure that calling Request as a function will throw an exception.

I couldn't find an already existing test case for this, which is why I have created this pull-request.
If this test case addition is correct, I can add test cases for other interfaces which are missing this type of test case