### PR TITLE
Migrate text-indent tests from WebKit to WPT.

### DIFF
--- a/css/css-text/text-indent/reference/text-indent-each-line-hanging-ref.html
+++ b/css/css-text/text-indent/reference/text-indent-each-line-hanging-ref.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8">

--- a/css/css-text/text-indent/reference/text-indent-each-line-hanging-ref.html
+++ b/css/css-text/text-indent/reference/text-indent-each-line-hanging-ref.html
@@ -1,0 +1,47 @@
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>text-indent 'each-line' and 'hanging' modifiers</title>
+
+    <link rel="stylesheet" href="/fonts/ahem.css" />
+    <style>
+    div { width:80px; font: 10px Ahem; background-color:lightgray; }
+    .indent { color: blue; padding-left:4em; }
+    </style>
+</head>
+<body>
+All black boxes should be left-aligned. All blue boxes should be right-aligned.
+
+<div>
+<span class="indent">xxxx</span><br>xxxx<br>xxxx
+</div>
+<br>
+<div>
+<span class="indent">xxxx</span> xxxx xxxx
+</div>
+<br>
+<div>
+<span class="indent">xxxx</span><br><span class="indent">xxxx</span><br><span class="indent">xxxx</span>
+</div>
+<br>
+<div>
+<span class="indent">xxxx</span> xxxx<br><span class="indent">xxxx</span>
+</div>
+<br>
+<div>
+xxxx<br><span class="indent">xxxx</span><br><span class="indent">xxxx</span>
+</div>
+<br>
+<div>
+xxxx <span class="indent">xxxx</span> <span class="indent">xxxx</span>
+</div>
+<br>
+<div>
+xxxx<br>xxxx<br>xxxx
+</div>
+<br>
+<div>
+xxxx <span class="indent">xxxx</span><br>xxxx
+</div>
+</body>
+</html>

--- a/css/css-text/text-indent/reference/text-indent-with-absolute-pos-child-ref.html
+++ b/css/css-text/text-indent/reference/text-indent-with-absolute-pos-child-ref.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+<!DOCTYPE html>
 <html>
 <head>
 <meta charset="utf-8">

--- a/css/css-text/text-indent/reference/text-indent-with-absolute-pos-child-ref.html
+++ b/css/css-text/text-indent/reference/text-indent-with-absolute-pos-child-ref.html
@@ -1,0 +1,61 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8">
+<title>This tests that first line text-indent is applied properly when the child is a statically positioned out-of-flow renderer.</title>
+
+<link rel="stylesheet" href="/fonts/ahem.css" />
+<style>
+ body {
+  margin: 40px;
+ }
+
+.container {
+  display: block;
+  background-color: green;
+  width: 100px;
+  height: 20px;
+  color: green;
+  font-family: Ahem;
+  font-size: 10px;
+}
+
+.inner {
+  display: block;
+  background-color: blue;
+  width: 20px;
+  height: 20px;
+}
+</style>
+</head>
+<body>
+<div>
+<div class=container><div class=inner style="margin-left: 20px;"></div></div>
+<div class=container><div class=inner style="margin-left: 20px;"></div></div>
+<div class=container><div class=inner style="margin-left: 20px;"></div></div>
+<div class=container><div class=inner style="margin-left: 20px;"></div></div>
+<div class=container><div class=inner style="position: relative; left: 70px;"></div></div>
+<div class=container><div class=inner style="margin-left: -20px;"></div></div>
+<div class=container><div class=inner style="left: 40px;"></div></div>
+<div class=container><div class=inner></div></div>
+<div class=container><div class=inner></div></div>
+<div class=container><div class=inner style="position: relative; top: 10px"></div></div>
+<div class=container><div class=inner></div></div>
+</div>
+
+<div style="direction: rtl;">
+<div class=container><div class=inner style="margin-right: 20px;"></div></div>
+<div class=container><div class=inner style="margin-right: 20px;"></div></div>
+<div class=container><div class=inner style="margin-right: 20px;"></div></div>
+<div class=container><div class=inner style="margin-right: 20px;"></div></div>
+<div class=container><div class=inner style="position: relative; right: 70px;"></div></div>
+<div class=container><div class=inner style="margin-right: -20px;"></div></div>
+<div class=container><div class=inner style="right: 40px;"></div></div>
+<div class=container><div class=inner></div></div>
+<div class=container><div class=inner></div></div>
+<div class=container><div class=inner style="position: relative; top: 10px"></div></div>
+<div class=container><div class=inner></div></div>
+</div>
+
+</body>
+</html>

--- a/css/css-text/text-indent/text-indent-each-line-hanging.html
+++ b/css/css-text/text-indent/text-indent-each-line-hanging.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>text-indent 'each-line' and 'hanging' modifiers</title>
+    <link rel="author" title="Jaehun Lim" href="mailto:ljaehun.lim@samsung.com">
+    <link rel="help" href="https://drafts.csswg.org/css-text-3/#text-indent-property">
+    <link rel="match" href="reference/text-indent-each-line-hanging-ref.html">
+    <meta name="assert" content="'each-line' and 'hanging' properly works">
+
+    <link rel="stylesheet" href="/fonts/ahem.css" />
+    <style>
+    div { width:80px; font: 10px Ahem; background-color:lightgray; }
+    .normal { text-indent: 4em; }
+    .eachline { text-indent: 4em each-line; }
+    .hanging { text-indent: 4em hanging; }
+    .eachlinehanging { text-indent: 4em each-line hanging; }
+    .indent { color: blue; }
+    </style>
+</head>
+<body>
+All black boxes should be left-aligned. All blue boxes should be right-aligned.
+
+<!-- normal text-indent -->
+<div class="normal">
+<span class="indent">xxxx</span> xxxx<br>xxxx
+</div>
+<br>
+<!-- each-line with a soft wrap break -->
+<div class="eachline">
+<span class="indent">xxxx</span> xxxx xxxx
+</div>
+<br>
+<!-- each-line with a forced line break -->
+<div class="eachline">
+<span class="indent">xxxx</span><br><span class="indent">xxxx</span><br><span class="indent">xxxx</span>
+</div>
+<br>
+<!-- each-line with a soft wrap break and a forced line break -->
+<div class="eachline">
+<span class="indent">xxxx</span> xxxx<br><span class="indent">xxxx</span>
+</div>
+<br>
+<!-- normal text-indent with hanging -->
+<div class="hanging">
+xxxx <span class="indent">xxxx</span><br><span class="indent">xxxx</span>
+</div>
+<br>
+<!-- each-line and hanging with a soft wrap break -->
+<div class="eachlinehanging">
+xxxx <span class="indent">xxxx</span> <span class="indent">xxxx</span>
+</div>
+<br>
+<!-- each-line and hanging with a forced line break -->
+<div class="eachlinehanging">
+xxxx<br>xxxx<br>xxxx
+</div>
+<br>
+<!-- each-line and hanging with a soft wrap break and a forced line break -->
+<div class="eachlinehanging">
+xxxx <span class="indent">xxxx</span><br>xxxx
+</div>
+</body>
+</html>

--- a/css/css-text/text-indent/text-indent-with-absolute-pos-child.html
+++ b/css/css-text/text-indent/text-indent-with-absolute-pos-child.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+<!DOCTYPE html>
 <html>
 <head>
 <meta charset="utf-8">

--- a/css/css-text/text-indent/text-indent-with-absolute-pos-child.html
+++ b/css/css-text/text-indent/text-indent-with-absolute-pos-child.html
@@ -1,0 +1,65 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8">
+<title>This tests that first line text-indent is applied properly when the child is a statically positioned out-of-flow renderer.</title>
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#text-indent-property">
+<link rel="match" href="reference/text-indent-with-absolute-pos-child-ref.html">
+<meta name="assert" content="First line text-indent is applied properly when the child is a statically positioned out-of-flow renderer.">
+
+<link rel="stylesheet" href="/fonts/ahem.css" />
+<style>
+  body {
+    margin: 40px;
+  }
+
+  .container {
+    display: block;
+    background-color: green;
+    width: 100px;
+    height: 20px;
+    color: green;
+    font-family: Ahem;
+    font-size: 10px;
+  }
+
+  .inner {
+    display: inline;
+    position: absolute;
+    background-color: blue;
+    width: 20px;
+    height: 20px;
+  }
+</style>
+</head>
+<body>
+<div>
+<div class=container style="text-indent: 20px"><div class=inner></div></div>
+<div class=container style="text-indent: 20px"><div class=inner style="display: inline-block;"></div></div>
+<div class=container style="text-indent: 20px"><div class=inner></div>foobar</div>
+<div class=container style="text-indent: 20px"><div class=inner style="text-indent: 20px;">f</div></div>
+<div class=container style="text-indent: 10px">foobar<div class=inner></div></div>
+<div class=container style="text-indent: -20px"><div class=inner></div></div>
+<div class=container style="text-indent: 20px"><div class=inner style="left: 40px;"></div></div>
+<div class=container style="text-indent: 20px"><div class=inner style="display: block;"></div></div>
+<div class=container style="text-indent: 20px"><div class=inner style="position: relative; display: block;"></div></div>
+<div class=container style="text-indent: 20px">foobar<br><div class=inner></div></div>
+<div class=container><div class=inner></div></div>
+</div>
+
+<div style="direction: rtl;">
+<div class=container style="text-indent: 20px"><div class=inner></div></div>
+<div class=container style="text-indent: 20px"><div class=inner style="display: inline-block;"></div></div>
+<div class=container style="text-indent: 20px"><div class=inner></div>foobar</div>
+<div class=container style="text-indent: 20px"><div class=inner style="text-indent: 20px;">f</div></div>
+<div class=container style="text-indent: 10px">foobar<div class=inner></div></div>
+<div class=container style="text-indent: -20px"><div class=inner></div></div>
+<div class=container style="text-indent: 20px"><div class=inner style="right: 40px;"></div></div>
+<div class=container style="text-indent: 20px"><div class=inner style="display: block;"></div></div>
+<div class=container style="text-indent: 20px"><div class=inner style="position: relative; display: block;"></div></div>
+<div class=container style="text-indent: 20px">foobar<br><div class=inner></div></div>
+<div class=container><div class=inner></div></div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Migrates existing text-indent tests from WebKit to WPT, most notably of which is a test for the `each-line` and `hanging` keywords. WebKit should support `each-line` once WebKit/WebKit#852 is merged.