### PR TITLE
Update idlharness.js, so that it is tests calling for all interfaces with constructors as regular functions

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -1529,12 +1529,12 @@ IdlInterface.prototype.test_self = function()
         // https://github.com/heycam/webidl/issues/698
         assert_true(isConstructor(this.get_interface_object()), "interface object must pass IsConstructor check");
 
+        var interface_object = this.get_interface_object();
+        assert_throws_js(globalOf(interface_object).TypeError, function() {
+            interface_object();
+        }, "interface object didn't throw TypeError when called as a function");
+
         if (!this.constructors().length) {
-            // "If I was not declared with a constructor operation, then throw a TypeError."
-            var interface_object = this.get_interface_object();
-            assert_throws_js(globalOf(interface_object).TypeError, function() {
-                interface_object();
-            }, "interface object didn't throw TypeError when called as a function");
             assert_throws_js(globalOf(interface_object).TypeError, function() {
                 new interface_object();
             }, "interface object didn't throw TypeError when called as a constructor");

--- a/resources/test/tests/functional/idlharness/IdlInterface/test_exposed_wildcard.html
+++ b/resources/test/tests/functional/idlharness/IdlInterface/test_exposed_wildcard.html
@@ -90,7 +90,7 @@ idlArray.test();
         {
             "name": "A interface: existence and properties of interface object",
             "properties": {},
-            "message": "assert_throws_js: interface object didn't throw TypeError when called as a function function \"function() {\n                interface_object();\n            }\" did not throw",
+            "message": "assert_throws_js: interface object didn't throw TypeError when called as a function function \"function() {\n            interface_object();\n        }\" did not throw",
             "status_string": "FAIL"
         },
         {
@@ -132,7 +132,7 @@ idlArray.test();
         {
             "name": "C interface: existence and properties of interface object",
             "properties": {},
-            "message": "assert_throws_js: interface object didn't throw TypeError when called as a function function \"function() {\n                interface_object();\n            }\" did not throw",
+            "message": "assert_throws_js: interface object didn't throw TypeError when called as a function function \"function() {\n            interface_object();\n        }\" did not throw",
             "status_string": "FAIL"
         },
         {
@@ -168,7 +168,7 @@ idlArray.test();
         {
             "name": "D interface: existence and properties of interface object",
             "properties": {},
-            "message": "assert_throws_js: interface object didn't throw TypeError when called as a function function \"function() {\n                interface_object();\n            }\" did not throw",
+            "message": "assert_throws_js: interface object didn't throw TypeError when called as a function function \"function() {\n            interface_object();\n        }\" did not throw",
             "status_string": "FAIL"
         },
         {

--- a/resources/test/tests/functional/idlharness/IdlInterface/test_immutable_prototype.html
+++ b/resources/test/tests/functional/idlharness/IdlInterface/test_immutable_prototype.html
@@ -16,7 +16,11 @@ Object.defineProperty(window, "Foo", {
     enumerable: false,
     writable: true,
     configurable: true,
-    value: function Foo() {}
+    value: function Foo() {
+        if (!new.target) {
+            throw new TypeError('Foo() must be called with new');
+        }
+    }
   });
 Object.defineProperty(window.Foo, "prototype", {
     writable: false,

--- a/resources/test/tests/functional/idlharness/IdlInterface/test_primary_interface_of.html
+++ b/resources/test/tests/functional/idlharness/IdlInterface/test_primary_interface_of.html
@@ -14,12 +14,20 @@ objects but skipped for "untested" interface objects.</p>
 <script>
 "use strict";
 
-function FooParent() {}
+function FooParent() {
+    if (!new.target) {
+        throw new TypeError('FooParent() must be called with new');
+    }
+}
 Object.defineProperty(window, "Foo", {
     enumerable: false,
     writable: true,
     configurable: true,
-    value: function Foo() {}
+    value: function Foo() {
+        if (!new.target) {
+            throw new TypeError('Foo() must be called with new');
+        }
+    }
   });
 Object.defineProperty(window.Foo, "prototype", {
     writable: false,


### PR DESCRIPTION
This is the part of WebIDL that is being exercised by these tests:
>If the interface is declared with a constructor operation, then the interface object can be called as a constructor to create an object that implements that interface. **Calling that interface as a function will throw an exception.**
> https://webidl.spec.whatwg.org/#interface-object
