### PR TITLE
add tests for SharedWorker constructor which error

### DIFF
--- a/workers/constructors/SharedWorker/SharedWorker-constructor.html
+++ b/workers/constructors/SharedWorker/SharedWorker-constructor.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<title>Test SharedWorker constructor functionality.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  assert_throws_js(Error,
+                   function() {
+                     new SharedWorker({toString:function(){throw new Error()}})},
+                   'toString exception should be propagated');
+}, 'Test toString propagation exception.');
+
+test(() => {
+  try {
+    var foo = {toString:function(){new SharedWorker(foo)}};
+    new SharedWorker(foo);
+  } catch(ex) {
+    assert_true(true, 'trying to create Sharedworkers recursively should result in an: ' +
+                ex + 'exception.')
+  }
+}, 'Test recursive SharedWorker creation.');
+
+test(() => {
+  assert_throws_js(TypeError,
+                   function() { new SharedWorker(); },
+                   'invoking SharedWorker constructor without arguments should result ' +
+                   'in an exception.')
+}, 'Test Sharedworker creation with no arguments');
+
+
+test(() => {
+  assert_throws_dom("SyntaxError",
+                    function() { var Sharedworker = new SharedWorker('http://invalid:123$'); },
+                    'Invoking SharedWorker constructor with invalid script URL should ' +
+                    'result in an exception.');
+}, 'Test invalid script URL.');
+
+</script>

--- a/workers/constructors/SharedWorker/SharedWorker-constructor.html
+++ b/workers/constructors/SharedWorker/SharedWorker-constructor.html
@@ -11,16 +11,6 @@ test(() => {
 }, 'Test toString propagation exception.');
 
 test(() => {
-  try {
-    var foo = {toString:function(){new SharedWorker(foo)}};
-    new SharedWorker(foo);
-  } catch(ex) {
-    assert_true(true, 'trying to create Sharedworkers recursively should result in an: ' +
-                ex + 'exception.')
-  }
-}, 'Test recursive SharedWorker creation.');
-
-test(() => {
   assert_throws_js(TypeError,
                    function() { new SharedWorker(); },
                    'invoking SharedWorker constructor without arguments should result ' +


### PR DESCRIPTION
I was looking into SharedWorker and noticed that it was missing some constructor tests that Worker has.
This commit add the same tests for SharedWorker that exist in the below file for Worker:
https://github.com/web-platform-tests/wpt/blob/master/workers/constructors/Worker/Worker-constructor.html