### PR TITLE
 Event: add test to confirm calling Event constructor without new throws an error

### DIFF
--- a/dom/events/Event-constructors.any.js
+++ b/dom/events/Event-constructors.any.js
@@ -1,6 +1,12 @@
 // META: title=Event constructors
 
 test(function() {
+  assert_throws_js(
+    TypeError,
+    () => Event(""),
+    "Calling Event constructor without 'new' must throw")
+})
+test(function() {
   assert_throws_js(TypeError, function() {
     new Event()
   })


### PR DESCRIPTION
This cannot be tested generically (see #34157 for work on that) as the first argument is required.