### PR TITLE
[css-color] Fix color computation test

### DIFF
--- a/css/css-color/system-color-compute.html
+++ b/css/css-color/system-color-compute.html
@@ -99,13 +99,13 @@
         let inherited_value =
           getComputedStyle(document.getElementById("inherited"))
             .getPropertyValue(property);
-        assert_equals(inherited_value, specified_value);
-    }, "System color computes to itself on " + property);
+        assert_not_equals(inherited_value, specified_value);
+    }, "System color doesn't compute to itself on " + property);
     test(function() {
       let inherited_value =
         document.getElementById("inherited").computedStyleMap()
           .get(property);
-      assert_regexp_match(inherited_value, /menu/i);
+      assert_false(/menu/i.test(inherited_value));
     }, "Inherited system color keyword is observable on " + property);
   }
 </script>


### PR DESCRIPTION
In https://github.com/w3c/csswg-drafts/issues/6773 it was decided to
change how system colors computed to not inherit as themselves.