### PR TITLE
WebIDL Constructors: add tests to constructors with required arguments which, when called as functions, throw an error

### DIFF
--- a/css/css-pseudo/marker-computed-content.html
+++ b/css/css-pseudo/marker-computed-content.html
@@ -51,7 +51,6 @@ const expectations = {
 for (const target of document.querySelectorAll('.list > li')) {
   const {content} = getComputedStyle(target, '::marker');
   test(() => {
-    debugger;
     assert_equals(content, expectations[target.className]);
   }, `Computed 'content' for list-item ::marker, variant ${target.className}`);
 }

--- a/eventsource/dedicated-worker/eventsource-constructor-no-new.any.js
+++ b/eventsource/dedicated-worker/eventsource-constructor-no-new.any.js
@@ -1,0 +1,7 @@
+test(function() {
+  assert_throws_js(TypeError,
+  function() {
+    EventSource('');
+  },
+  "Calling EventSource constructor without 'new' must throw");
+})

--- a/html/browsers/browsing-the-web/history-traversal/PopStateEvent.html
+++ b/html/browsers/browsing-the-web/history-traversal/PopStateEvent.html
@@ -5,6 +5,14 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
+test(function() {
+  assert_throws_js(
+    TypeError,
+    () => PopStateEvent(''),
+    "Calling PopStateEvent constructor without 'new' must throw"
+  );
+}, "PopStateEvent constructor called as normal function");
+
 test(function () {
   assert_false('initPopStateEvent' in PopStateEvent.prototype,
                'There should be no PopStateEvent#initPopStateEvent');

--- a/html/canvas/element/pixel-manipulation/2d.imageData.object.ctor.basics.html
+++ b/html/canvas/element/pixel-manipulation/2d.imageData.object.ctor.basics.html
@@ -63,6 +63,7 @@ var testColor = [0, 255, 255, 128];
 setRGBA(imageData.data, 4, testColor);
 assertArrayEquals(getRGBA(imageData.data, 4), testColor);
 
+assert_throws_js(TypeError, function() { ImageData(1, 1); });
 assert_throws_js(TypeError, function() { new ImageData(10); });
 assert_throws_dom("INDEX_SIZE_ERR", function() { new ImageData(0, 10); });
 assert_throws_dom("INDEX_SIZE_ERR", function() { new ImageData(10, 0); });

--- a/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.constructor.html
+++ b/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.constructor.html
@@ -6,6 +6,14 @@
 <script>
 
 test(function() {
+  assert_throws_js(
+    TypeError,
+    () => OffscreenCanvas(100, 50),
+    "Calling OffscreenCanvas constructor without 'new' must throw"
+  );
+}, "OffscreenCanvas constructor called as normal function");
+
+test(function() {
     var offscreenCanvas = new OffscreenCanvas(100, 50);
     assert_equals(offscreenCanvas.width, 100);
     assert_equals(offscreenCanvas.height, 50);

--- a/html/canvas/tools/yaml-new/pixel-manipulation.yaml
+++ b/html/canvas/tools/yaml-new/pixel-manipulation.yaml
@@ -563,6 +563,7 @@
     setRGBA(imageData.data, 4, testColor);
     assertArrayEquals(getRGBA(imageData.data, 4), testColor);
 
+    @assert throws TypeError ImageData(1, 1);
     @assert throws TypeError new ImageData(10);
     @assert throws INDEX_SIZE_ERR new ImageData(0, 10);
     @assert throws INDEX_SIZE_ERR new ImageData(10, 0);

--- a/html/semantics/forms/form-submission-0/FormDataEvent.window.js
+++ b/html/semantics/forms/form-submission-0/FormDataEvent.window.js
@@ -2,6 +2,7 @@
 
 test(() => {
   let fd = new FormData();
+  assert_throws_js(TypeError, () => { FormDataEvent('', {formData:fd}) }, "Calling FormDataEvent constructor without 'new' must throw");
   assert_throws_js(TypeError, () => { new FormDataEvent() }, '0 arguments');
   assert_throws_js(TypeError, () => { new FormDataEvent('foo') }, '1 argument');
   assert_throws_js(TypeError, () => { new FormDataEvent(fd, fd) }, '2 invalid arguments');

--- a/html/webappapis/scripting/events/messageevent-constructor.https.html
+++ b/html/webappapis/scripting/events/messageevent-constructor.https.html
@@ -5,6 +5,14 @@
 <script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
 <script>
 test(function() {
+    assert_throws_js(
+        TypeError,
+        () => MessageEvent(""),
+        "Calling MessageEvent constructor without 'new' must throw"
+    );
+}, "MessageEvent constructor called as normal function");
+
+test(function() {
   var ev = new MessageEvent("test")
   assert_equals(ev.type, "test", "type attribute")
   assert_equals(ev.target, null, "target attribute")

--- a/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-event-constructor.html
+++ b/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-event-constructor.html
@@ -9,6 +9,12 @@
 test(function() {
   var p = new Promise(function(resolve, reject) {});
 
+  assert_throws_js(TypeError,
+                   function() {
+                     PromiseRejectionEvent('', { promise: p });
+                   },
+                   "Calling PromiseRejectionEvent constructor without 'new' must throw");
+
   // No custom options are passed (besides required promise).
   assert_equals(new PromiseRejectionEvent('eventType', { promise: p }).bubbles, false);
   assert_equals(new PromiseRejectionEvent('eventType', { promise: p }).cancelable, false);

--- a/webaudio/resources/audit.js
+++ b/webaudio/resources/audit.js
@@ -878,8 +878,6 @@ window.Audit = (function() {
       let absExpected = this._expected ? Math.abs(this._expected) : 1;
       let error = Math.abs(this._actual - this._expected) / absExpected;
 
-      // debugger;
-
       return this._assert(
           error <= this._options.threshold,
           '${actual} is ${expected} within an error of ${threshold}.',

--- a/webmessaging/broadcastchannel/basics.any.js
+++ b/webmessaging/broadcastchannel/basics.any.js
@@ -1,3 +1,11 @@
+test(function() {
+  assert_throws_js(
+      TypeError,
+      () => BroadcastChannel(""),
+      "Calling BroadcastChannel constructor without 'new' must throw"
+    );
+}, "BroadcastChannel constructor called as normal function");
+
 async_test(t => {
     let c1 = new BroadcastChannel('eventType');
     let c2 = new BroadcastChannel('eventType');

--- a/webstorage/event_constructor.window.js
+++ b/webstorage/event_constructor.window.js
@@ -1,4 +1,12 @@
 test(function() {
+    assert_throws_js(
+        TypeError,
+        () => StorageEvent(""),
+        "Calling StorageEvent constructor without 'new' must throw"
+    );
+}, "StorageEvent constructor called as normal function");
+
+test(function() {
     assert_throws_js(TypeError, () => new StorageEvent());
     // should be redundant, but .length can be wrong with custom bindings
     assert_equals(StorageEvent.length, 1, 'StorageEvent.length');

--- a/workers/Worker_dispatchEvent_ErrorEvent.htm
+++ b/workers/Worker_dispatchEvent_ErrorEvent.htm
@@ -28,4 +28,12 @@ test(function() {
   var e = new ErrorEvent("error");
   assert_false("initErrorEvent" in e, "should not be supported");
 }, "initErrorEvent");
+
+test(function() {
+  assert_throws_js(
+    TypeError,
+    () => ErrorEvent(''),
+    "Calling ErrorEvent constructor without 'new' must throw"
+  );
+}, "ErrorEvent constructor called as normal function");
 </script>


### PR DESCRIPTION
This cannot be tested generically (see #34157 for work on that) as the first argument is required.