### PR TITLE
SubmitEvent: add test to confirm calling SubmitEvent constructor with out new throws an error

### DIFF
--- a/html/semantics/forms/form-submission-0/SubmitEvent.window.js
+++ b/html/semantics/forms/form-submission-0/SubmitEvent.window.js
@@ -1,7 +1,7 @@
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-submitevent-interface
 
 test(() => {
-  let button = document.createElement('button');
+  assert_throws_js(TypeError, () => SubmitEvent(""), "Calling SubmitEvent constructor without 'new' must throw");
   assert_throws_js(TypeError, () => { new SubmitEvent() }, '0 arguments');
   assert_throws_js(TypeError, () => { new SubmitEvent('foo', { submitter: 'bar' }) }, 'Wrong type of submitter');
 }, 'Failing SubmitEvent constructor');


### PR DESCRIPTION
This cannot be tested generically (see #34157 for work on that) as the first argument is required.