### PR TITLE
[@container] Support async painting for some tests

### DIFF
--- a/css/css-contain/container-queries/animation-container-size.html
+++ b/css/css-contain/container-queries/animation-container-size.html
@@ -32,14 +32,14 @@
   setup(() => assert_implements_container_queries());
 
   promise_test(async () => {
-    await waitForFrame();
+    if (waitForPolyfill) await waitForPolyfill();
     assert_equals(getComputedStyle(target).backgroundColor, 'rgb(0, 0, 255)');
 
     assert_equals(container.getAnimations().length, 1);
     let animation = container.getAnimations()[0];
     animation.currentTime = 500;
 
-    await waitForFrame();
+    if (waitForPolyfill) await waitForPolyfill();
     assert_equals(getComputedStyle(target).backgroundColor, 'rgb(0, 128, 0)');
   }, 'Animation affects container query evaluation');
 </script>

--- a/css/css-contain/container-queries/animation-container-size.html
+++ b/css/css-contain/container-queries/animation-container-size.html
@@ -31,13 +31,15 @@
 <script>
   setup(() => assert_implements_container_queries());
 
-  test(() => {
+  promise_test(async () => {
+    await waitForFrame();
     assert_equals(getComputedStyle(target).backgroundColor, 'rgb(0, 0, 255)');
 
     assert_equals(container.getAnimations().length, 1);
     let animation = container.getAnimations()[0];
     animation.currentTime = 500;
 
+    await waitForFrame();
     assert_equals(getComputedStyle(target).backgroundColor, 'rgb(0, 128, 0)');
   }, 'Animation affects container query evaluation');
 </script>

--- a/css/css-contain/container-queries/animation-container-type-dynamic.html
+++ b/css/css-contain/container-queries/animation-container-type-dynamic.html
@@ -51,18 +51,21 @@
 <script>
   setup(() => assert_implements_container_queries());
 
-  test(() => {
+  promise_test(async () => {
+    await waitForFrame();
     assert_equals(getComputedStyle(target).backgroundColor, 'rgb(0, 0, 255)');
 
     assert_equals(container.getAnimations().length, 1);
     let animation = container.getAnimations()[0];
 
     animation.currentTime = 600;
+    await waitForFrame();
     assert_equals(getComputedStyle(target).backgroundColor, 'rgb(0, 128, 0)');
 
     // Verify that #intermediate is queried by changing its width. The container
     // query will stop matching if #intermediate is the queried container.
     intermediate.style.width = '110px';
+    await waitForFrame();
     assert_equals(getComputedStyle(target).backgroundColor, 'rgb(255, 0, 0)');
   }, 'Animated container creating new container');
 </script>

--- a/css/css-contain/container-queries/animation-container-type-dynamic.html
+++ b/css/css-contain/container-queries/animation-container-type-dynamic.html
@@ -52,20 +52,20 @@
   setup(() => assert_implements_container_queries());
 
   promise_test(async () => {
-    await waitForFrame();
+    if (waitForPolyfill) await waitForPolyfill();
     assert_equals(getComputedStyle(target).backgroundColor, 'rgb(0, 0, 255)');
 
     assert_equals(container.getAnimations().length, 1);
     let animation = container.getAnimations()[0];
 
     animation.currentTime = 600;
-    await waitForFrame();
+    if (waitForPolyfill) await waitForPolyfill();
     assert_equals(getComputedStyle(target).backgroundColor, 'rgb(0, 128, 0)');
 
     // Verify that #intermediate is queried by changing its width. The container
     // query will stop matching if #intermediate is the queried container.
     intermediate.style.width = '110px';
-    await waitForFrame();
+    if (waitForPolyfill) await waitForPolyfill();
     assert_equals(getComputedStyle(target).backgroundColor, 'rgb(255, 0, 0)');
   }, 'Animated container creating new container');
 </script>

--- a/css/css-contain/container-queries/animation-nested-animation.html
+++ b/css/css-contain/container-queries/animation-nested-animation.html
@@ -35,13 +35,15 @@
 <script>
   setup(() => assert_implements_container_queries());
 
-  test(() => {
+  promise_test(async () => {
+    await waitForFrame();
     assert_equals(getComputedStyle(target).backgroundColor, 'rgb(0, 128, 0)');
 
     assert_equals(container.getAnimations().length, 1);
     let animation = container.getAnimations()[0];
     animation.currentTime = 600;
 
+    await waitForFrame();
     assert_equals(getComputedStyle(target).backgroundColor, 'rgb(0, 0, 255)');
   }, 'Animated container can create inner animation');
 </script>

--- a/css/css-contain/container-queries/animation-nested-animation.html
+++ b/css/css-contain/container-queries/animation-nested-animation.html
@@ -36,14 +36,14 @@
   setup(() => assert_implements_container_queries());
 
   promise_test(async () => {
-    await waitForFrame();
+    if (waitForPolyfill) await waitForPolyfill();
     assert_equals(getComputedStyle(target).backgroundColor, 'rgb(0, 128, 0)');
 
     assert_equals(container.getAnimations().length, 1);
     let animation = container.getAnimations()[0];
     animation.currentTime = 600;
 
-    await waitForFrame();
+    if (waitForPolyfill) await waitForPolyfill();
     assert_equals(getComputedStyle(target).backgroundColor, 'rgb(0, 0, 255)');
   }, 'Animated container can create inner animation');
 </script>

--- a/css/css-contain/container-queries/animation-nested-transition.html
+++ b/css/css-contain/container-queries/animation-nested-transition.html
@@ -32,13 +32,15 @@
 <script>
   setup(() => assert_implements_container_queries());
 
-  test(() => {
+  promise_test(async () => {
+    await waitForFrame();
     assert_equals(getComputedStyle(target).backgroundColor, 'rgb(100, 100, 100)');
 
     assert_equals(container.getAnimations().length, 1);
     let animation = container.getAnimations()[0];
     animation.currentTime = 600;
 
+    await waitForFrame();
     assert_equals(getComputedStyle(target).backgroundColor, 'rgb(150, 150, 150)');
   }, 'Animated container size triggers transition');
 </script>

--- a/css/css-contain/container-queries/animation-nested-transition.html
+++ b/css/css-contain/container-queries/animation-nested-transition.html
@@ -33,14 +33,14 @@
   setup(() => assert_implements_container_queries());
 
   promise_test(async () => {
-    await waitForFrame();
+    if (waitForPolyfill) await waitForPolyfill();
     assert_equals(getComputedStyle(target).backgroundColor, 'rgb(100, 100, 100)');
 
     assert_equals(container.getAnimations().length, 1);
     let animation = container.getAnimations()[0];
     animation.currentTime = 600;
 
-    await waitForFrame();
+    if (waitForPolyfill) await waitForPolyfill();
     assert_equals(getComputedStyle(target).backgroundColor, 'rgb(150, 150, 150)');
   }, 'Animated container size triggers transition');
 </script>

--- a/css/css-contain/container-queries/aspect-ratio-feature-evaluation.html
+++ b/css/css-contain/container-queries/aspect-ratio-feature-evaluation.html
@@ -33,7 +33,7 @@
   const size_span = document.querySelector("#size > span");
 
   promise_test(async () => {
-    await waitForFrame();
+    if (waitForPolyfill) await waitForPolyfill();
     assert_equals(getComputedStyle(inline_span).color, red,
                   "Should not match for inline-size containment");
     assert_equals(getComputedStyle(size_span).color, green,
@@ -44,7 +44,7 @@
 
   promise_test(async () => {
     document.querySelector("#size").style.width = "200px";
-    await waitForFrame();
+    if (waitForPolyfill) await waitForPolyfill();
     assert_equals(getComputedStyle(size_span).backgroundColor, lime,
                   "Should match 2/1 min-ratio");
   }, "@container query with aspect-ratio change after resize");

--- a/css/css-contain/container-queries/aspect-ratio-feature-evaluation.html
+++ b/css/css-contain/container-queries/aspect-ratio-feature-evaluation.html
@@ -32,7 +32,8 @@
   const inline_span = document.querySelector("#inline-size > span");
   const size_span = document.querySelector("#size > span");
 
-  test(() => {
+  promise_test(async () => {
+    await waitForFrame();
     assert_equals(getComputedStyle(inline_span).color, red,
                   "Should not match for inline-size containment");
     assert_equals(getComputedStyle(size_span).color, green,
@@ -41,8 +42,9 @@
                   "Square should not match 2/1 min-ratio");
   }, "@container queries with aspect-ratio and size containment");
 
-  test(() => {
+  promise_test(async () => {
     document.querySelector("#size").style.width = "200px";
+    await waitForFrame();
     assert_equals(getComputedStyle(size_span).backgroundColor, lime,
                   "Should match 2/1 min-ratio");
   }, "@container query with aspect-ratio change after resize");

--- a/css/css-contain/container-queries/backdrop-invalidation.html
+++ b/css/css-contain/container-queries/backdrop-invalidation.html
@@ -37,15 +37,15 @@
     try {
       dialog.showModal();
 
-      await waitForFrame();
+      if (waitForPolyfill) await waitForPolyfill();
       assert_equals(getComputedStyle(dialog, '::backdrop').backgroundColor, 'rgb(0, 0, 0)');
 
       container.style.width = '300px';
-      await waitForFrame();
+      if (waitForPolyfill) await waitForPolyfill();
       assert_equals(getComputedStyle(dialog, '::backdrop').backgroundColor, 'rgb(0, 128, 0)');
 
       container.style = '';
-      await waitForFrame();
+      if (waitForPolyfill) await waitForPolyfill();
       assert_equals(getComputedStyle(dialog, '::backdrop').backgroundColor, 'rgb(0, 0, 0)');
     } finally {
       dialog.close();

--- a/css/css-contain/container-queries/backdrop-invalidation.html
+++ b/css/css-contain/container-queries/backdrop-invalidation.html
@@ -33,16 +33,19 @@
 
   let dialog = document.querySelector('dialog');
 
-  test(function() {
+  promise_test(async () => {
     try {
       dialog.showModal();
 
+      await waitForFrame();
       assert_equals(getComputedStyle(dialog, '::backdrop').backgroundColor, 'rgb(0, 0, 0)');
 
       container.style.width = '300px';
+      await waitForFrame();
       assert_equals(getComputedStyle(dialog, '::backdrop').backgroundColor, 'rgb(0, 128, 0)');
 
       container.style = '';
+      await waitForFrame();
       assert_equals(getComputedStyle(dialog, '::backdrop').backgroundColor, 'rgb(0, 0, 0)');
     } finally {
       dialog.close();

--- a/css/css-contain/container-queries/canvas-as-container-005.html
+++ b/css/css-contain/container-queries/canvas-as-container-005.html
@@ -28,8 +28,9 @@
     assert_not_equals(document.activeElement, target);
   }, "Initially display:none, not focusable");
 
-  test(() => {
+  promise_test(async () => {
     canvas.style.width = "200px";
+    await waitForFrame();
     target.focus();
     assert_equals(document.activeElement, target);
   }, "Focusable after container size change");

--- a/css/css-contain/container-queries/canvas-as-container-005.html
+++ b/css/css-contain/container-queries/canvas-as-container-005.html
@@ -30,7 +30,7 @@
 
   promise_test(async () => {
     canvas.style.width = "200px";
-    await waitForFrame();
+    if (waitForPolyfill) await waitForPolyfill();
     target.focus();
     assert_equals(document.activeElement, target);
   }, "Focusable after container size change");

--- a/css/css-contain/container-queries/canvas-as-container-006.html
+++ b/css/css-contain/container-queries/canvas-as-container-006.html
@@ -29,8 +29,9 @@
     assert_not_equals(document.activeElement, target);
   }, "Initially display:none, not focusable");
 
-  test(() => {
+  promise_test(async () => {
     canvas.style.width = "200px";
+    await waitForFrame();
     target.focus();
     assert_equals(document.activeElement, target);
   }, "Focusable after container size change");

--- a/css/css-contain/container-queries/canvas-as-container-006.html
+++ b/css/css-contain/container-queries/canvas-as-container-006.html
@@ -31,7 +31,7 @@
 
   promise_test(async () => {
     canvas.style.width = "200px";
-    await waitForFrame();
+    if (waitForPolyfill) await waitForPolyfill();
     target.focus();
     assert_equals(document.activeElement, target);
   }, "Focusable after container size change");

--- a/css/css-contain/container-queries/support/cq-testcommon.js
+++ b/css/css-contain/container-queries/support/cq-testcommon.js
@@ -12,8 +12,24 @@ function polyfill_declarative_shadow_dom(root) {
   });
 }
 
-function waitForFrame() {
-  return new Promise((resolve, reject) => {
-    window.requestAnimationFrame(resolve);
-  });
+/**
+ * A Container Query polyfill will likely be implemented using asynchronous APIs
+ * like `MutationObserver` or `ResizeObserver`, meaning the effects of writes
+ * will not be synchronously observable.
+ * 
+ * By calling `window.setWaitForPolyfill`, a polyfill can provide a function that
+ * tests can use to wait until it's safe to read the effects of writes. Immediately
+ * prior to attempt to read any layout or style state, tests should await the function,
+ * if it is set:
+ * 
+ *     if (waitForPolyfill) await waitForPolyfill();
+ *     assert_equals(getComputedStyle(target), ...);
+ * 
+ * Note: Even though it would be safe to `await null`, an additional microtask could
+ * hide implementation bugs in browser implementations. Therefore, a test should always
+ * check and only wait `waitForPolyfill` is set.
+ */
+var waitForPolyfill = null;
+window.setWaitForPolyfill = function setWaitForPolyfill(impl) {
+  waitForPolyfill = impl;
 }

--- a/css/css-contain/container-queries/support/cq-testcommon.js
+++ b/css/css-contain/container-queries/support/cq-testcommon.js
@@ -19,15 +19,15 @@ function polyfill_declarative_shadow_dom(root) {
  * 
  * By calling `window.setWaitForPolyfill`, a polyfill can provide a function that
  * tests can use to wait until it's safe to read the effects of writes. Immediately
- * prior to attempt to read any layout or style state, tests should await the function,
- * if it is set:
+ * prior to attempt to read any layout or style state, tests should check if the
+ * function has been set, and if so, await it:
  * 
  *     if (waitForPolyfill) await waitForPolyfill();
  *     assert_equals(getComputedStyle(target), ...);
  * 
  * Note: Even though it would be safe to `await null`, an additional microtask could
- * hide implementation bugs in browser implementations. Therefore, a test should always
- * check and only wait `waitForPolyfill` is set.
+ * hide bugs in browser implementations. Therefore, a test should always check first,
+ * and only await if `waitForPolyfill` has been explicitly set.
  */
 var waitForPolyfill = null;
 window.setWaitForPolyfill = function setWaitForPolyfill(impl) {

--- a/css/css-contain/container-queries/support/cq-testcommon.js
+++ b/css/css-contain/container-queries/support/cq-testcommon.js
@@ -11,3 +11,9 @@ function polyfill_declarative_shadow_dom(root) {
     polyfill_declarative_shadow_dom(shadowRoot);
   });
 }
+
+function waitForFrame() {
+  return new Promise((resolve, reject) => {
+    window.requestAnimationFrame(resolve);
+  });
+}

--- a/css/css-contain/container-queries/support/cq-testcommon.js
+++ b/css/css-contain/container-queries/support/cq-testcommon.js
@@ -16,15 +16,15 @@ function polyfill_declarative_shadow_dom(root) {
  * A Container Query polyfill will likely be implemented using asynchronous APIs
  * like `MutationObserver` or `ResizeObserver`, meaning the effects of writes
  * will not be synchronously observable.
- * 
+ *
  * By calling `window.setWaitForPolyfill`, a polyfill can provide a function that
  * tests can use to wait until it's safe to read the effects of writes. Immediately
  * prior to attempt to read any layout or style state, tests should check if the
  * function has been set, and if so, await it:
- * 
+ *
  *     if (waitForPolyfill) await waitForPolyfill();
  *     assert_equals(getComputedStyle(target), ...);
- * 
+ *
  * Note: Even though it would be safe to `await null`, an additional microtask could
  * hide bugs in browser implementations. Therefore, a test should always check first,
  * and only await if `waitForPolyfill` has been explicitly set.


### PR DESCRIPTION
Updates several tests to wait a frame before attempting to read the side effects of writes.