### PR TITLE
Add interpolation tests for text-align-last and text-justify

### DIFF
--- a/css/css-text/text-align/text-align-last-interpolation.html
+++ b/css/css-text/text-align/text-align-last-interpolation.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>text-align-last interpolation</title>
+    <link rel="author" title="Kiet Ho" href="mailto:tho22@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-text/#text-align-last-property">
+    <meta name="assert" content="text-align-last supports discrete animation">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/css/support/interpolation-testcommon.js"></script>
+  </head>
+  <body>
+    <script>
+      test_no_interpolation({
+        property: 'text-align-last',
+        from: 'auto',
+        to: 'start'
+      });
+
+      test_no_interpolation({
+        property: 'text-align-last',
+        from: 'justify',
+        to: 'center'
+      });
+
+      test_no_interpolation({
+        property: 'text-align-last',
+        from: 'left',
+        to: 'right'
+      });
+
+      test_no_interpolation({
+        property: 'text-align-last',
+        from: 'end',
+        to: 'match-parent'
+      });
+    </script>
+  </body>
+</html>

--- a/css/css-text/text-justify/text-justify-interpolation.html
+++ b/css/css-text/text-justify/text-justify-interpolation.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>text-justify interpolation</title>
+    <link rel="author" title="Kiet Ho" href="mailto:tho22@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-text/#text-justify-property">
+    <meta name="assert" content="text-justify supports discrete animation">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/css/support/interpolation-testcommon.js"></script>
+  </head>
+  <body>
+    <script>
+      test_no_interpolation({
+        property: 'text-justify',
+        from: 'auto',
+        to: 'inter-word'
+      });
+
+      test_no_interpolation({
+        property: 'text-justify',
+        from: 'auto',
+        to: 'inter-character'
+      });
+
+      test_no_interpolation({
+        property: 'text-justify',
+        from: 'inter-character',
+        to: 'distribute'
+      });
+
+      test_no_interpolation({
+        property: 'text-justify',
+        from: 'inter-word',
+        to: 'distribute'
+      });
+
+      test_no_interpolation({
+        property: 'text-justify',
+        from: 'distribute',
+        to: 'none'
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Add CSS animation interpolation tests for `text-align-last` and `text-justify`.

Testing results:
* WebKit currently does not support animation for those properties, tracked in https://bugs.webkit.org/show_bug.cgi?id=240591.
* Chrome Dev 103.0.5060.13: tests using `inter-character` (in `text-justify`) and `match-parent` (in text-align-last`) fails, presumably because Chrome doesn't support those values.
* Firefox Nightly 102.0a1 (2022-05-24): tests using `match-parent` fails, probably because Firefox also doesn't support it.