### PR TITLE
Update Safari Technology Preview to 146

### DIFF
--- a/tools/ci/azure/safari-technology-preview.rb
+++ b/tools/ci/azure/safari-technology-preview.rb
@@ -1,12 +1,12 @@
 cask "safari-technology-preview" do
   if MacOS.version == :monterey
-    version "145,012-01341-20220511-067B826E-7921-4625-8D92-E8648B6351C3"
+    version "146,012-08405-20220525-72BCCE23-C6E8-460A-851A-A29AC9C9BCF7"
     url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
-    sha256 "0e986721a7eb5ec91615eda72e7f93a467ba97989e439eafc3592d99b4b6c021"
+    sha256 "3cd3652691cc89d71c69db118323b0fe7bb62b49275ad4e49680ba2e1378c341"
   elsif MacOS.version == :big_sur
-    version "145,012-02933-20220511-B69DC656-4904-4957-BB27-0CD4E65770E0"
+    version "146,012-08529-20220525-85875EC7-E4B8-4F5A-9571-85C51D6E381D"
     url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
-    sha256 "2dc800b17529e7ad75f0656921bd24c1acb9659acf17ede62a63486e259e8671"
+    sha256 "4b46f0d073bf401807b0e2e5064096040fc976926983e54d03c82b854b9f4f17"
   end
 
   appcast "https://developer.apple.com/safari/download/"


### PR DESCRIPTION
Version as reported by safaridriver --version:
Included with Safari Technology Preview (Release 146, 16614.1.14.10.6)

Source: https://developer.apple.com/safari/download/
Build: https://dev.azure.com/foolip/safari-technology-preview-updater/_build/results?buildId=4592&view=logs