### PR TITLE
fetch: add tests for data and about:blank with a range request

### DIFF
--- a/fetch/api/basic/scheme-about.any.js
+++ b/fetch/api/basic/scheme-about.any.js
@@ -16,3 +16,11 @@ checkNetworkError("about:blank", "POST");
 checkNetworkError("about:invalid.com");
 checkNetworkError("about:config");
 checkNetworkError("about:unicorn");
+
+promise_test(function(test) {
+  var promise = fetch("about:blank", {
+    "method": "GET",
+    "Range": "bytes=1-10"
+  });
+  return promise_rejects_js(test, TypeError, promise);
+}, "Fetching about:blank with range header does not affect behavior");

--- a/fetch/range/data.any.js
+++ b/fetch/range/data.any.js
@@ -1,0 +1,29 @@
+// META: script=/common/utils.js
+
+promise_test(async () => {
+  return fetch("data:text/plain;charset=US-ASCII,paddingHello%2C%20World%21padding", {
+    "method": "GET",
+    "Range": "bytes=13-26"
+  }).then(function(resp) {
+    assert_equals(resp.status, 200, "HTTP status is 200");
+    assert_equals(resp.type, "basic", "response type is basic");
+    assert_equals(resp.headers.get("Content-Type"), "text/plain;charset=US-ASCII", "Content-Type is " + resp.headers.get("Content-Type"));
+    return resp.text();
+  }).then(function(text) {
+    assert_equals(text, 'paddingHello, World!padding', "Response's body ignores range");
+  });
+}, "data: URL and Range header");
+
+promise_test(async () => {
+  return fetch("data:text/plain;charset=US-ASCII,paddingHello%2C%20paddingWorld%21padding", {
+    "method": "GET",
+    "Range": "bytes=7-14,21-27"
+  }).then(function(resp) {
+    assert_equals(resp.status, 200, "HTTP status is 200");
+    assert_equals(resp.type, "basic", "response type is basic");
+    assert_equals(resp.headers.get("Content-Type"), "text/plain;charset=US-ASCII", "Content-Type is " + resp.headers.get("Content-Type"));
+    return resp.text();
+  }).then(function(text) {
+    assert_equals(text, 'paddingHello, paddingWorld!padding', "Response's body ignores range");
+  });
+}, "data: URL and Range header with multiple ranges");


### PR DESCRIPTION
Add tests for range requests for `data:` and `about:blank`.

I tested on Firefox, Chrome, and Safari and all tests passed. Please let me know if I've missed something :smile: 

Related to: https://github.com/whatwg/fetch/issues/1070