### PR TITLE
Adds well-known routes for attribution reporting APIs WPTs.

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -570,6 +570,8 @@ class RoutesBuilder:
             ("GET", "*.any.worker-module.js", ModuleWorkerHandler),
             ("GET", "*.asis", handlers.AsIsHandler),
             ("GET", "/.well-known/origin-policy", handlers.PythonScriptHandler),
+            ("*", "/.well-known/attribution-reporting/report-event-attribution", handlers.PythonScriptHandler),
+            ("*", "/.well-known/attribution-reporting/report-aggregate-attribution", handlers.PythonScriptHandler),
             ("*", "*.py", handlers.PythonScriptHandler),
             ("GET", "*", handlers.FileHandler)
         ]


### PR DESCRIPTION
# Description

Attribution Reporting with event-level reports and aggregatable reports Web Platform tests are going to be added. The browser POSTs the event level reports to `/.well-known/attribution-reporting/report-event-attribution` and aggregate reports to `/.well-known/attribution-reporting/report-aggregate-attribution` respectively. In order to Implement dynamic handling of these routes in WPT, we need to register these routes in the `add_mount_point`.
[Event level Reports](https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md)
[Aggregatable Reports](https://github.com/WICG/conversion-measurement-api/blob/main/AGGREGATE.md)