### PR TITLE
Test referrerpolicy with preload

### DIFF
--- a/preload/preload-referrer-policy.html
+++ b/preload/preload-referrer-policy.html
@@ -29,12 +29,12 @@ const loaders = {
         const done = new Promise(resolve => {
             window.addEventListener('message', ({data}) => {
                 if (id in data.referrers)
-                    resolve({actualReferrer: data.referrers[id]});
+                    resolve({actualReferrer: data.referrers[id], entries: data.entries});
             })
         });
         document.body.appendChild(iframe);
-        const {actualReferrer} = await done;
-        return {actualReferrer, unsafe: iframe.src};
+        const {actualReferrer, entries} = await done;
+        return {actualReferrer, unsafe: iframe.src, entries};
     },
     element: async (t, {preloadPolicy, resourcePolicy, href, id}) => {
         const link = document.createElement('link');
@@ -52,17 +52,17 @@ const loaders = {
         const loaded = new Promise(resolve => script.addEventListener('load', resolve));
         document.body.appendChild(script);
         await loaded;
-        return {unsafe: location.href, actualReferrer: window.referrers[id]}
+        return {unsafe: location.href, actualReferrer: window.referrers[id], entries: performance.getEntriesByName(script.src).length}
     },
-}
+};
+
 function test_referrer_policy(preloadPolicy, resourcePolicy, crossOrigin, type) {
     promise_test(async t => {
         const id = token();
         const href = `${crossOrigin ? REMOTE_ORIGIN : ''}/preload/resources/echo-referrer.py?uid=${id}`;
-        const {actualReferrer, unsafe} = await loaders[type](t, {preloadPolicy, resourcePolicy, id, href})
+        const {actualReferrer, unsafe, entries} = await loaders[type](t, {preloadPolicy, resourcePolicy, href, id})
+        assert_equals(entries, 1);
         const origin = window.origin + '/';
-//        if (type === 'header')
-//            assert_equals(actualReferrer, preloadPolicy === 'no-referrer' ? '' : crossOrigin ? origin : unsafe);
         switch (preloadPolicy) {
             case '':
                 assert_equals(actualReferrer, crossOrigin ? origin : unsafe);

--- a/preload/preload-referrer-policy.html
+++ b/preload/preload-referrer-policy.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Link headers do not support the referrerpolicy attribute</title>
+<meta name="timeout" content="long">
+<script src="resources/dummy.js?link-header-preload2"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/preload/resources/preload_helper.js"></script>
+<body>
+<script>
+window.referrers = {};
+const {REMOTE_ORIGIN} = get_host_info();
+const loaders = {
+    header: async (t, {preloadPolicy, resourcePolicy, href, id}) => {
+        const iframe = document.createElement('iframe');
+        const params = new URLSearchParams();
+        params.set('href', href);
+        params.set('resource-policy', resourcePolicy);
+        if (preloadPolicy === '')
+            params.set('preload-policy', '');
+        else
+            params.set('preload-policy', `referrerpolicy=${preloadPolicy}`);
+        iframe.src = `resources/link-header-referrer-policy.html?${params.toString()}`;
+        t.add_cleanup(() => iframe.remove());
+        const done = new Promise(resolve => {
+            window.addEventListener('message', ({data}) => {
+                if (id in data.referrers)
+                    resolve({actualReferrer: data.referrers[id]});
+            })
+        });
+        document.body.appendChild(iframe);
+        const {actualReferrer} = await done;
+        return {actualReferrer, unsafe: iframe.src};
+    },
+    element: async (t, {preloadPolicy, resourcePolicy, href, id}) => {
+        const link = document.createElement('link');
+        link.href = href;
+        link.as = 'script';
+        link.rel = 'preload';
+        link.referrerPolicy = preloadPolicy;
+        const preloaded = new Promise(resolve => link.addEventListener('load', resolve));
+        t.add_cleanup(() => link.remove());
+        document.head.appendChild(link);
+        await preloaded;
+        const script = document.createElement('script');
+        script.src = href;
+        script.referrerPolicy = resourcePolicy;
+        const loaded = new Promise(resolve => script.addEventListener('load', resolve));
+        document.body.appendChild(script);
+        await loaded;
+        return {unsafe: location.href, actualReferrer: window.referrers[id]}
+    },
+}
+function test_referrer_policy(preloadPolicy, resourcePolicy, crossOrigin, type) {
+    promise_test(async t => {
+        const id = token();
+        const href = `${crossOrigin ? REMOTE_ORIGIN : ''}/preload/resources/echo-referrer.py?uid=${id}`;
+        const {actualReferrer, unsafe} = await loaders[type](t, {preloadPolicy, resourcePolicy, id, href})
+        const origin = window.origin + '/';
+//        if (type === 'header')
+//            assert_equals(actualReferrer, preloadPolicy === 'no-referrer' ? '' : crossOrigin ? origin : unsafe);
+        switch (preloadPolicy) {
+            case '':
+                assert_equals(actualReferrer, crossOrigin ? origin : unsafe);
+                break;
+
+            case 'no-referrer':
+                assert_equals(actualReferrer, '');
+                break;
+
+            case 'same-origin':
+                assert_equals(actualReferrer, crossOrigin ? '' : unsafe);
+                break;
+
+            case 'origin-when-cross-origin':
+            case 'strict-origin-when-cross-origin':
+                assert_equals(actualReferrer, crossOrigin ? origin : unsafe);
+                break;
+
+            case 'origin':
+            case 'strict-origin':
+                assert_equals(actualReferrer, origin);
+                break;
+
+            case 'no-referrer-when-downgrade':
+            case 'unsafe-url':
+                assert_equals(actualReferrer, unsafe);
+                break;
+
+            default:
+                assert_equals(actualReferrer, '');
+                break;
+
+        }
+    }, `referrer policy (${preloadPolicy} -> ${resourcePolicy}, ${type}, ${crossOrigin ? 'cross-origin' : 'same-origin'})`)
+}
+const policies = [
+"",
+"no-referrer",
+"no-referrer-when-downgrade",
+"same-origin",
+"origin",
+"strict-origin",
+"origin-when-cross-origin",
+"strict-origin-when-cross-origin",
+"unsafe-url"]
+
+for (const preloadPolicy of policies) {
+    for (const resourcePolicy of policies) {
+        for (const type of ['element', 'header']) {
+            for (const crossOrigin of [true, false]) {
+                test_referrer_policy(preloadPolicy, resourcePolicy, crossOrigin, type);
+            }
+        }
+    }
+}
+
+</script>
+</body>

--- a/preload/preload-referrer-policy.html
+++ b/preload/preload-referrer-policy.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Link headers do not support the referrerpolicy attribute</title>
+<title>The preload's referrerpolicy attribute should be respected</title>
 <meta name="timeout" content="long">
 <script src="resources/dummy.js?link-header-preload2"></script>
 <script src="/common/get-host-info.sub.js"></script>
@@ -9,6 +9,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/preload/resources/preload_helper.js"></script>
 <body>
+    <p>The preload's referrerpolicy attribute should be respected,
+    and consumed regardless of consumer referrer policy</p>
 <script>
 window.referrers = {};
 const {REMOTE_ORIGIN} = get_host_info();

--- a/preload/preload-referrer-policy.html
+++ b/preload/preload-referrer-policy.html
@@ -82,11 +82,9 @@ function test_referrer_policy(preloadPolicy, resourcePolicy, crossOrigin, type) 
                 break;
 
             case 'origin':
-            case 'strict-origin':
                 assert_equals(actualReferrer, origin);
                 break;
 
-            case 'no-referrer-when-downgrade':
             case 'unsafe-url':
                 assert_equals(actualReferrer, unsafe);
                 break;
@@ -101,10 +99,8 @@ function test_referrer_policy(preloadPolicy, resourcePolicy, crossOrigin, type) 
 const policies = [
 "",
 "no-referrer",
-"no-referrer-when-downgrade",
 "same-origin",
 "origin",
-"strict-origin",
 "origin-when-cross-origin",
 "strict-origin-when-cross-origin",
 "unsafe-url"]

--- a/preload/resources/echo-referrer.py
+++ b/preload/resources/echo-referrer.py
@@ -1,0 +1,6 @@
+def main(request, response):
+    response_headers = [(b"Access-Control-Allow-Origin", b"*"), (b"Content-Type", b"text/javascript")]
+    body = b"""
+    window.referrers["%s"] = "%s";
+    """ % (request.GET.first(b"uid", b""), request.headers.get(b"referer", b""))
+    return (200, response_headers, body)

--- a/preload/resources/link-header-referrer-policy.html
+++ b/preload/resources/link-header-referrer-policy.html
@@ -6,7 +6,7 @@ window.referrers = {};
 const params = new URLSearchParams(location.search);
 const href = new URL(params.get('href'), location.href).toString();
 new PerformanceObserver(async list => {
-    const entries = list.getEntriesByName(href).length;
+    let entries = list.getEntriesByName(href).length;
     if (!entries)
         return;
 
@@ -16,6 +16,7 @@ new PerformanceObserver(async list => {
     const loaded = new Promise(resolve => script.addEventListener('load', resolve));
     document.body.appendChild(script);
     await loaded;
+    entries = performance.getEntriesByName(href).length;
     window.parent.postMessage({
         referrers: window.referrers,
         entries

--- a/preload/resources/link-header-referrer-policy.html
+++ b/preload/resources/link-header-referrer-policy.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<body>
+<script>
+window.referrers = {};
+const params = new URLSearchParams(location.search);
+const href = new URL(params.get('href'), location.href).toString();
+new PerformanceObserver(async list => {
+    if (!list.getEntriesByName(href).length)
+        return;
+
+    const script = document.createElement('script');
+    script.src = href;
+    script.referrerPolicy = params.get('resource-policy');
+    const loaded = new Promise(resolve => script.addEventListener('load', resolve));
+    document.body.appendChild(script);
+    await loaded;
+    window.parent.postMessage({
+        referrers: window.referrers
+    }, '*');
+}).observe({type: 'resource', buffered: true})
+</script>
+</body>

--- a/preload/resources/link-header-referrer-policy.html
+++ b/preload/resources/link-header-referrer-policy.html
@@ -6,7 +6,8 @@ window.referrers = {};
 const params = new URLSearchParams(location.search);
 const href = new URL(params.get('href'), location.href).toString();
 new PerformanceObserver(async list => {
-    if (!list.getEntriesByName(href).length)
+    const entries = list.getEntriesByName(href).length;
+    if (!entries)
         return;
 
     const script = document.createElement('script');
@@ -16,7 +17,8 @@ new PerformanceObserver(async list => {
     document.body.appendChild(script);
     await loaded;
     window.parent.postMessage({
-        referrers: window.referrers
+        referrers: window.referrers,
+        entries
     }, '*');
 }).observe({type: 'resource', buffered: true})
 </script>


### PR DESCRIPTION
When <preload referrerpolicy=> is used:
- The referrerpolicy should be respected
- It does not affect consuming the preload (e.g. the consumer can have a different referrerpolicy)
- Should work for link headers and elements