### PR TITLE
Handle unhandled promise rejection for requestFullscreen to avoid Harness status: ERROR

### DIFF
--- a/fullscreen/api/element-request-fullscreen-and-remove-iframe-manual.html
+++ b/fullscreen/api/element-request-fullscreen-and-remove-iframe-manual.html
@@ -16,7 +16,10 @@ async_test(t => {
   iframeDocument.onfullscreenerror = t.unreached_func("iframe fullscreenerror event");
 
   trusted_click(t, () => {
-    iframeDocument.body.requestFullscreen();
+    iframeDocument.body.requestFullscreen().then(t.unreached_func("promise should be rejected"),
+    () => {
+      assert_true(true, "promise is rejected correctly");
+    });
     iframe.remove();
     // No events will be fired, end test after 100ms.
     step_timeout(t.step_func_done(() => {

--- a/fullscreen/api/element-request-fullscreen-and-remove-manual.html
+++ b/fullscreen/api/element-request-fullscreen-and-remove-manual.html
@@ -16,7 +16,10 @@ async_test(t => {
   });
 
   trusted_click(t, () => {
-    target.requestFullscreen();
+    target.requestFullscreen().then(t.unreached_func("promise should be rejected"),
+    () => {
+      assert_true(true, "promise is rejected correctly");
+    });
     target.remove();
   }, document.body);
 });


### PR DESCRIPTION
When running `fullscreen/api/element-request-fullscreen-and-remove-manual.html` in Chrome and Firefox, Harness status is ERROR since this test doesn't handle the promise of `requestFullscreen`. So we should handle it.