### PR TITLE
Fix exception in idlharness-shadowrealm.js.

### DIFF
--- a/resources/idlharness-shadowrealm.js
+++ b/resources/idlharness-shadowrealm.js
@@ -36,7 +36,7 @@ function idl_test_shadowrealm(srcs, deps) {
                 isWindow: function() { return false; },
                 isWorker: function() { return false; },
                 isShadowRealm: function() { return true; },
-            };
+            }; undefined;
         `);
 
         const ss = await Promise.all(script_urls.map(url => fetch_text(url)));


### PR DESCRIPTION
The code evaluated to an object, which can't be passed to the parent global.

Ref #34221.