### PR TITLE
Add async condition support to step_wait_func

### DIFF
--- a/resources/test/tests/functional/step_wait.html
+++ b/resources/test/tests/functional/step_wait.html
@@ -25,6 +25,22 @@ promise_test(async t => {
 promise_test(async t => {
   await t.step_wait(); // Throws
 }, "step_wait() takes an argument");
+
+promise_test(async t => {
+  function wait(ms) {
+    return new Promise(resolve => step_timeout(resolve, ms));
+  }
+  let x = 1;
+  step_timeout(() => {
+    ++x;
+  }, 100);
+
+  await t.step_wait(async () => {
+    await wait(1);
+    return x === 2;
+  });
+  assert_equals(x, 2);
+}, "async step_wait()");
 </script>
 <script type="text/json" id="expected">
 {
@@ -46,6 +62,12 @@ promise_test(async t => {
       "message": "cond is not a function",
       "properties": {},
       "status_string": "FAIL"
+    },
+    {
+      "name": "async step_wait()",
+      "message": null,
+      "properties": {},
+      "status_string": "PASS"
     }
   ],
   "type": "complete",

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -2729,8 +2729,9 @@
      * speed when the condition is quickly met.
      *
      * @param {Function} cond A function taking no arguments and
-     *                        returning a boolean. The callback is called
-     *                        when this function returns true.
+     *                        returning a boolean or a Promise. The callback is
+     *                        called when this function returns true, or the
+     *                        returned Promise is resolved with true.
      * @param {Function} func A function taking no arguments to call once
      *                        the condition is met.
      * @param {string} [description] Error message to add to assert in case of
@@ -2746,17 +2747,23 @@
         var remaining = Math.ceil(timeout_full / interval);
         var test_this = this;
 
-        var wait_for_inner = test_this.step_func(() => {
-            if (cond()) {
+        const step = test_this.step_func((result) => {
+            if (result) {
                 func();
             } else {
-                if(remaining === 0) {
+                if (remaining === 0) {
                     assert(false, "step_wait_func", description,
                            "Timed out waiting on condition");
                 }
                 remaining--;
                 setTimeout(wait_for_inner, interval);
             }
+        });
+
+        var wait_for_inner = test_this.step_func(() => {
+            Promise.resolve(cond()).then(
+                step,
+                test_this.unreached_func("step_wait_func"));
         });
 
         wait_for_inner();
@@ -2784,8 +2791,9 @@
      * }, "Navigating a popup to about:blank");
      *
      * @param {Function} cond A function taking no arguments and
-     *                        returning a boolean. The callback is called
-     *                        when this function returns true.
+     *                        returning a boolean or a Promise. The callback is
+     *                        called when this function returns true, or the
+     *                        returned Promise is resolved with true.
      * @param {Function} func A function taking no arguments to call once
      *                        the condition is met.
      * @param {string} [description] Error message to add to assert in case of
@@ -2821,7 +2829,7 @@
      * }, "");
      *
      * @param {Function} cond A function taking no arguments and
-     *                        returning a boolean.
+     *                        returning a boolean or a Promise.
      * @param {string} [description] Error message to add to assert in case of
      *                              failure.
      * @param {number} timeout Timeout in ms. This is multiplied by the global


### PR DESCRIPTION
Allow async condition function in step_wait_func. We'll be able to
write something like:

```js
await step_wait(async () => (await fetch(url)).status === 200);
```