### PR TITLE
Get the elements from queue in block mode

### DIFF
--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -388,7 +388,7 @@ class TestSource:
             try:
                 self.current_group, self.current_metadata = self.test_queue.get(block=True, timeout=5)
             except Empty:
-                self.logger.warning("Timed out to get test group from queue")
+                self.logger.warning("Timed out getting test group from queue")
                 return None, None
         return self.current_group, self.current_metadata
 

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -366,6 +366,9 @@ class TestSource:
         self.test_queue = test_queue
         self.current_group = None
         self.current_metadata = None
+        self.logger = structured.get_default_logger()
+        if self.logger is None:
+            self.logger = structured.structuredlog.StructuredLogger("TestSource")
 
     @abstractmethod
     #@classmethod (doesn't compose with @abstractmethod in < 3.3)
@@ -385,6 +388,7 @@ class TestSource:
             try:
                 self.current_group, self.current_metadata = self.test_queue.get(block=True, timeout=5)
             except Empty:
+                self.logger.warning("Timed out to get test group from queue")
                 return None, None
         return self.current_group, self.current_metadata
 

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -383,7 +383,7 @@ class TestSource:
     def group(self):
         if not self.current_group or len(self.current_group) == 0:
             try:
-                self.current_group, self.current_metadata = self.test_queue.get(block=False)
+                self.current_group, self.current_metadata = self.test_queue.get(block=True)
             except Empty:
                 return None, None
         return self.current_group, self.current_metadata
@@ -413,6 +413,8 @@ class GroupedSource(TestSource):
 
         for item in groups:
             test_queue.put(item)
+        for _ in range(kwargs["processes"]):
+            test_queue.put((None, None))
         return test_queue
 
     @classmethod
@@ -444,6 +446,8 @@ class SingleTestSource(TestSource):
 
         for item in zip(queues, metadatas):
             test_queue.put(item)
+        for _ in range(kwargs["processes"]):
+            test_queue.put((None, None))
 
         return test_queue
 
@@ -488,6 +492,9 @@ class GroupFileTestSource(TestSource):
                 test.update_metadata(group_metadata)
 
             test_queue.put((group, group_metadata))
+
+        for _ in range(kwargs["processes"]):
+            test_queue.put((None, None))
 
         return test_queue
 

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -388,7 +388,8 @@ class TestSource:
                 return None, None
         return self.current_group, self.current_metadata
 
-    def add_sentinal(self, test_queue, num_of_workers):
+    @classmethod
+    def add_sentinal(cls, test_queue, num_of_workers):
         # add one sentinal for each worker
         for _ in range(num_of_workers):
             test_queue.put((None, None))
@@ -418,7 +419,7 @@ class GroupedSource(TestSource):
 
         for item in groups:
             test_queue.put(item)
-        self.add_sentinal(test_queue, kwargs["processes"])
+        cls.add_sentinal(test_queue, kwargs["processes"])
         return test_queue
 
     @classmethod
@@ -450,7 +451,7 @@ class SingleTestSource(TestSource):
 
         for item in zip(queues, metadatas):
             test_queue.put(item)
-        self.add_sentinal(test_queue, kwargs["processes"])
+        cls.add_sentinal(test_queue, kwargs["processes"])
 
         return test_queue
 
@@ -496,7 +497,7 @@ class GroupFileTestSource(TestSource):
 
             test_queue.put((group, group_metadata))
 
-        self.add_sentinal(test_queue, kwargs["processes"])
+        cls.add_sentinal(test_queue, kwargs["processes"])
 
         return test_queue
 


### PR DESCRIPTION
Previously there are cases a worker get no more tests to run
and quit early where there are still groups in the queue. This
is because poll from Queue in unblock mode is not safe.

Now poll in block mode and add a sentinal for each worker at
the end of queue.