### PR TITLE
Update spec URL of Largest Contentful Paint in META.yml

### DIFF
--- a/largest-contentful-paint/META.yml
+++ b/largest-contentful-paint/META.yml
@@ -1,4 +1,4 @@
-spec: https://wicg.github.io/largest-contentful-paint/
+spec: https://w3c.github.io/largest-contentful-paint/
 suggested_reviewers:
         - npm1
         - yoavweiss


### PR DESCRIPTION
Spec migrated out of WICG. Using the new URL facilitates mapping between spec and the WPT folder.