### PR TITLE
[intersection-observer] Add a test for clip-path being accounted for

### DIFF
--- a/intersection-observer/clip-path.html
+++ b/intersection-observer/clip-path.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/intersection-observer-test-utils.js"></script>
+
+<style>
+body { margin: 0 }
+pre, #log {
+  position: absolute;
+  top: 0;
+  left: 200px;
+}
+#target {
+  background-color: green;
+  width: 100px;
+  height: 100px;
+}
+#container {
+  padding: 8px;
+  width: 0px;
+  height: 0px;
+}
+</style>
+
+<div id="container">
+  <div id="target"></div>
+</div>
+
+<script>
+var vw = document.documentElement.clientWidth;
+var vh = document.documentElement.clientHeight;
+
+var entries = [];
+
+promise_test(async function(t) {
+  var target = document.getElementById("target");
+  var container = document.getElementById("container");
+  var root = document.getElementById("root");
+  var observer = new IntersectionObserver(function(changes) {
+    entries = entries.concat(changes)
+  });
+  observer.observe(target);
+  entries = entries.concat(observer.takeRecords());
+  assert_equals(entries.length, 0, "No initial notifications.");
+
+  await waitForNotification();
+
+  checkLastEntry(
+    entries,
+    0,
+    [8, 108, 8, 108, 8, 108, 8, 108, 0, vw, 0, vh, true],
+    "IntersectionObserver notification after first rAF",
+  );
+  container.style.clipPath = "inset(1000px)";
+
+  await waitForNotification();
+
+  checkLastEntry(
+    entries,
+    1,
+    [8, 108, 8, 108, 0, 0, 0, 0, 0, vw, 0, vh, false],
+    "IntersectionObserver should send a not-intersecting notification for a target that gets fully clipped by clip-path.",
+  );
+
+  container.style.clipPath = "";
+
+  await waitForNotification();
+
+  checkLastEntry(
+    entries,
+    2,
+    [8, 108, 8, 108, 8, 108, 8, 108, 0, vw, 0, vh, true],
+    "Intersecting notification after removing display:none on target.",
+  );
+});
+</script>

--- a/intersection-observer/display-none.html
+++ b/intersection-observer/display-none.html
@@ -25,7 +25,7 @@ var vh = document.documentElement.clientHeight;
 
 var entries = [];
 
-runTestCycle(function() {
+promise_test(async function(t) {
   var target = document.getElementById("target");
   var root = document.getElementById("root");
   var observer = new IntersectionObserver(function(changes) {
@@ -34,22 +34,35 @@ runTestCycle(function() {
   observer.observe(target);
   entries = entries.concat(observer.takeRecords());
   assert_equals(entries.length, 0, "No initial notifications.");
-  runTestCycle(step0, "Intersecting notification after first rAF.");
-}, "IntersectionObserver should send a not-intersecting notification for a target that gets display:none.");
 
-function step0() {
-  runTestCycle(step1, "Not-intersecting notification after setting display:none on target.");
-  checkLastEntry(entries, 0, [8, 108, 8, 108, 8, 108, 8, 108, 0, vw, 0, vh, true]);
+  await waitForNotification();
+
+  checkLastEntry(
+    entries,
+    0,
+    [8, 108, 8, 108, 8, 108, 8, 108, 0, vw, 0, vh, true],
+    "IntersectionObserver notification after first rAF",
+  );
   target.style.display = "none";
-}
 
-function step1() {
-  runTestCycle(step2, "Intersecting notification after removing display:none on target.");
-  checkLastEntry(entries, 1, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false]);
+  await waitForNotification();
+
+  checkLastEntry(
+    entries,
+    1,
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false],
+    "IntersectionObserver should send a not-intersecting notification for a target that gets display:none.",
+  );
+
   target.style.display = "";
-}
 
-function step2() {
-  checkLastEntry(entries, 2, [8, 108, 8, 108, 8, 108, 8, 108, 0, vw, 0, vh, true]);
-}
+  await waitForNotification();
+
+  checkLastEntry(
+    entries,
+    2,
+    [8, 108, 8, 108, 8, 108, 8, 108, 0, vw, 0, vh, true],
+    "Intersecting notification after removing display:none on target.",
+  );
+});
 </script>

--- a/intersection-observer/resources/intersection-observer-test-utils.js
+++ b/intersection-observer/resources/intersection-observer-test-utils.js
@@ -71,16 +71,37 @@
 //     - At this point, observer.takeRecords will get the second batch of
 //       notifications.
 function waitForNotification(t, f) {
-  requestAnimationFrame(function() {
-    requestAnimationFrame(function() { t.step_timeout(f, 0); });
+  return new Promise(resolve => {
+    requestAnimationFrame(function() {
+      requestAnimationFrame(function() {
+        let callback = function() {
+          resolve();
+          if (f) {
+            f();
+          }
+        };
+        if (t) {
+          t.step_timeout(callback);
+        } else {
+          setTimeout(callback);
+        }
+      });
+    });
   });
 }
 
 // If you need to wait until the IntersectionObserver algorithm has a chance
 // to run, but don't need to wait for delivery of the notifications...
 function waitForFrame(t, f) {
-  requestAnimationFrame(function() {
-    t.step_timeout(f, 0);
+  return new Promise(resolve => {
+    requestAnimationFrame(function() {
+      t.step_timeout(function() {
+        resolve();
+        if (f) {
+          f();
+        }
+      });
+    });
   });
 }
 


### PR DESCRIPTION
From https://w3c.github.io/IntersectionObserver/#calculate-intersection-rect-algo
step 3.3:

> If container has a content clip or a css clip-path property, update
> intersectionRect by applying container’s clip.