### PR TITLE
fetch: Add Set-Cookie as an invalid request header

### DIFF
--- a/fetch/api/request/request-headers.any.js
+++ b/fetch/api/request/request-headers.any.js
@@ -8,6 +8,7 @@ var validRequestHeaders = [
   ["proxya", "OK"],
   ["sec", "OK"],
   ["secb", "OK"],
+  ["Set-Cookie2", "OK"],
 ];
 var invalidRequestHeaders = [
   ["Accept-Charset", "KO"],
@@ -27,6 +28,7 @@ var invalidRequestHeaders = [
   ["Keep-Alive", "KO"],
   ["Origin", "KO"],
   ["Referer", "KO"],
+  ["Set-Cookie", "KO"],
   ["TE", "KO"],
   ["Trailer", "KO"],
   ["Transfer-Encoding", "KO"],


### PR DESCRIPTION
The corresponding test change for https://github.com/whatwg/fetch/pull/1453.