### PR TITLE
Do not use `_get_fileversion()` in `webdriver_version()` on Windows

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -746,8 +746,6 @@ class ChromeChromiumBase(Browser):
         if webdriver_binary is None:
             self.logger.warning("No valid webdriver supplied to detect version.")
             return None
-        if uname[0] == "Windows":
-            return _get_fileversion(webdriver_binary, self.logger)
 
         try:
             version_string = call(webdriver_binary, "--version").strip()


### PR DESCRIPTION
For whatever reason chromedriver does not have a version descriptor. This causes version detection failure and leads to new download for every wpt run.

![image](https://user-images.githubusercontent.com/3396686/173596110-9d14d555-2e54-4f2d-a2e1-92469a39b285.png)

`--version` still works, so use that instead.

```
> ./chromedriver --version
ChromeDriver 102.0.5005.61 (0e59bcc00cc4985ce39ad31c150065f159d95ad3-refs/branch-heads/5005@{#819})
```