### PR TITLE
Make the timeout value of webtransport-h3 less limiting

### DIFF
--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -284,7 +284,7 @@ class TestEnvironment:
             for scheme, servers in self.servers.items():
                 for port, server in servers:
                     if scheme == "webtransport-h3":
-                        if not webtranport_h3_server_is_running(host, port, timeout=5.0):
+                        if not webtranport_h3_server_is_running(host, port, timeout=30.0):
                             # TODO(bashi): Consider supporting retry.
                             failed.append((host, port))
                         continue


### PR DESCRIPTION
5s is way too short, it timeouts too frequently on my local Surface Pro 7.