### PR TITLE
Fix Safari harness timeout in css/css-transitions/before-load-001.html

### DIFF
--- a/css/css-transitions/before-load-001.html
+++ b/css/css-transitions/before-load-001.html
@@ -41,6 +41,6 @@ async_test(t => {
 });
 </script>
 
-<img src="support/cat.png?pipe=trickle(d100)" id="cat">
+<img src="support/cat.png?pipe=trickle(d1)" id="cat">
 </body>
 </html>

--- a/html/semantics/embedded-content/the-img-element/delay-load-event-until-move-to-empty-source.html
+++ b/html/semantics/embedded-content/the-img-element/delay-load-event-until-move-to-empty-source.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Inline image element blocks load until source is changed to empty source</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<img src="/images/blue.png?pipe=trickle(d100)">
+<script>
+
+async_test(t => {
+  const image = document.querySelector("img");
+
+  assert_false(image.complete, "The image is loading initially");
+
+  // Complete the test as soon as we obtained the window "load" event,
+  // which should happen as soon as the image stops loading by moving
+  // to an empty source.
+  window.addEventListener("load", t.step_func_done(() => {
+      assert_true(image.complete, "The image is no longer loading once the window 'load' event is dispatched");
+  }));
+
+  // Stop loading the image.
+  image.src = "";
+}, "Image element delays window's load event until the image changes to empty source");
+
+</script>


### PR DESCRIPTION
The test css/css-transitions/before-load-001.html relies on loading an image where the load is set to 100 seconds such that the window `load` event dispatch is delayed until a CSS Transition is ran. At that point, the image's source is set to the empty string to stop the image load and have the window `load` event dispatched.

Safari has an issue where an <img> pointing to a long-loading resource will continue delaying dispatch of the `load` event on the window even when the image source has been reset. This issue is tracked by https://bugs.webkit.org/show_bug.cgi?id=241676.

As a result, css/css-transitions/before-load-001.html causes a harness timeout in Safari even though the ability to run a CSS Transition before the window `load` event has been dispatched works correctly and the test assertions pass.

We work around that issue by lowering the load duration for the image to 1 second instead of 100. This doesn't changed the functionality that this test is explicitly testing. And to explicitly test that resetting a long-loading image source no longer delays the dispatch of the window `load` event, a new dedicated test is added, which will itself cause a timeout in Safari, but that is what is expected.

Addresses https://github.com/web-platform-tests/wpt/issues/34444.