### PR TITLE
Revert "Add command line arg to allow no restart test runner on new test groups"

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -261,7 +261,7 @@ class TestRunnerManager(threading.Thread):
     def __init__(self, suite_name, index, test_type, test_queue, test_source_cls, browser_cls,
                  browser_kwargs, executor_cls, executor_kwargs, stop_flag, rerun=1,
                  pause_after_test=False, pause_on_unexpected=False, restart_on_unexpected=True,
-                 debug_info=None, capture_stdio=True, restart_on_new_group=True, recording=None):
+                 debug_info=None, capture_stdio=True, recording=None):
         """Thread that owns a single TestRunner process and any processes required
         by the TestRunner (e.g. the Firefox binary).
 
@@ -332,7 +332,6 @@ class TestRunnerManager(threading.Thread):
         self.browser = None
 
         self.capture_stdio = capture_stdio
-        self.restart_on_new_group = restart_on_new_group
 
     def run(self):
         """Main loop for the TestRunnerManager.
@@ -723,10 +722,10 @@ class TestRunnerManager(threading.Thread):
             test, test_group, group_metadata = self.get_next_test()
             if test is None:
                 return RunnerManagerState.stop(force_stop)
-            restart = (self.restart_on_new_group and
-                       test_group is not self.state.test_group)
-            if restart:
+            if test_group is not self.state.test_group:
+                # We are starting a new group of tests, so force a restart
                 self.logger.info("Restarting browser for new test group")
+                restart = True
         else:
             test_group = self.state.test_group
             group_metadata = self.state.group_metadata
@@ -864,7 +863,6 @@ class ManagerGroup:
                  restart_on_unexpected=True,
                  debug_info=None,
                  capture_stdio=True,
-                 restart_on_new_group=True,
                  recording=None):
         self.suite_name = suite_name
         self.size = size
@@ -880,7 +878,6 @@ class ManagerGroup:
         self.debug_info = debug_info
         self.rerun = rerun
         self.capture_stdio = capture_stdio
-        self.restart_on_new_group = restart_on_new_group
         self.recording = recording
         assert recording is not None
 
@@ -923,7 +920,6 @@ class ManagerGroup:
                                         self.restart_on_unexpected,
                                         self.debug_info,
                                         self.capture_stdio,
-                                        self.restart_on_new_group,
                                         recording=self.recording)
             manager.start()
             self.pool.add(manager)

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -75,10 +75,6 @@ scheme host and port.""")
                         default=True,
                         dest="fail_on_unexpected_pass",
                         help="Exit with status code 0 when all unexpected results are PASS")
-    parser.add_argument("--no-restart-on-new-group", action="store_false",
-                        default=True,
-                        dest="restart_on_new_group",
-                        help="Don't restart test runner when start a new test group")
 
     mode_group = parser.add_argument_group("Mode")
     mode_group.add_argument("--list-test-groups", action="store_true",

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -230,7 +230,6 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
                           run_test_kwargs["restart_on_unexpected"],
                           run_test_kwargs["debug_info"],
                           not run_test_kwargs["no_capture_stdio"],
-                          run_test_kwargs["restart_on_new_group"],
                           recording=recording) as manager_group:
             try:
                 manager_group.run(test_type, run_tests)


### PR DESCRIPTION
Reverts web-platform-tests/wpt#34133.

To quote https://github.com/web-platform-tests/wpt/issues/34474#issuecomment-1158391107:

> Previously:
> 
> ```
>  0:19.03 TEST_START: /css/cssom-view/scroll-behavior-smooth-navigation.html
>  0:37.04 INFO Got timeout in harness
>  0:37.04 DEBUG Got command: 'test_ended'
>  0:37.04 DEBUG Unexpected count in this thread 1
>  0:37.04 TEST_END: TIMEOUT, expected ERROR - TestRunner hit external timeout (this may indicate a hang)
>  0:37.04 DEBUG new state: restarting
>  0:37.04 DEBUG Dispatch restart_runner
>  0:37.04 DEBUG Stopping WebDriver
>  0:37.07 DEBUG OutputHandler.after_process_stop
>  0:37.07 DEBUG Going to stop Safari
>  0:37.14 DEBUG Stopping Safari 46683
>  0:37.17 DEBUG ensure_runner_stopped
>  0:37.17 DEBUG Stopping WebDriver
>  0:37.17 DEBUG Going to stop Safari
>  0:37.23 DEBUG waiting for runner process to end
>  0:37.23 DEBUG After join
>  0:37.23 DEBUG Runner process exited with code 0
>  0:37.23 DEBUG TestRunnerManager cleanup
>  0:37.06 WARNING Traceback (most recent call last):
>   File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/base.py", line 301, in run_test
>     result = self.do_test(test)
>   File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorwebdriver.py", line 459, in do_test
>     success, data = WebDriverRun(self.logger,
>   File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/base.py", line 205, in run
>     if self.protocol.is_alive():
>   File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorwebdriver.py", line 385, in is_alive
>     self.webdriver.send_session_command("GET", "window", timeout=2)
>   File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/webdriver/webdriver/client.py", line 661, in send_session_command
>     return self.send_command(method, url, body, timeout)
>   File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/webdriver/webdriver/client.py", line 613, in send_command
>     response = self.transport.send(
>   File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/webdriver/webdriver/transport.py", line 234, in send
>     response = self._request(method, uri, payload, headers, timeout=None)
>   File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/webdriver/webdriver/transport.py", line 259, in _request
>     response = self.connection.getresponse()
>   File "Python.framework/Versions/3.9/lib/python3.9/http/client.py", line 1349, in getresponse
>     response.begin()
>   File "Python.framework/Versions/3.9/lib/python3.9/http/client.py", line 316, in begin
>     version, status, reason = self._read_status()
>   File "Python.framework/Versions/3.9/lib/python3.9/http/client.py", line 285, in _read_status
>     raise RemoteDisconnected("Remote end closed connection without"
> http.client.RemoteDisconnected: Remote end closed connection without response
> 
>  0:37.23 WARNING Command left in command_queue during cleanup: 'test_ended', (<wptrunner.wpttest.TestharnessTest /css/cssom-view/scroll-behavior-smooth-navigation.html>, (<wptrunner.wpttest.TestharnessResult INTERNAL-ERROR>, []))
>  0:37.06 DEBUG Hanging up on WebDriver session
>  0:37.06 INFO Closing logging queue
>  0:37.06 INFO queue closed
>  0:37.23 DEBUG new state: initializing
>  0:37.23 DEBUG Dispatch init
>  0:37.23 DEBUG Init called, starting browser and runner
>  0:37.23 DEBUG Starting browser with settings {}
>  0:37.23 DEBUG Starting WebDriver: /Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver --port=58923
>  0:37.24 DEBUG OutputHandler.after_process_start
>  0:37.24 DEBUG Trying to connect to 127.0.0.1:58923
>  0:37.74 DEBUG Connected to 127.0.0.1:58923
>  0:37.74 DEBUG OutputHandler.start
>  0:37.74 DEBUG _run complete
>  0:37.74 INFO Starting runner
>  0:37.75 DEBUG Test runner started
>  0:38.96 DEBUG Got command: 'log'
>  0:38.95 DEBUG Executor setup
>  0:38.96 DEBUG Got command: 'log'
>  0:38.95 DEBUG Connecting to WebDriver on URL: http://127.0.0.1:58923/
>  0:40.26 DEBUG Got command: 'log'
>  0:40.26 DEBUG Loading http://web-platform.test:8000/testharness_runner.html
>  0:40.34 DEBUG Got command: 'init_succeeded'
>  0:40.34 DEBUG new state: running
>  0:40.34 DEBUG Dispatch run_test
>  0:40.34 TEST_START: /css/cssom-view/window-screen-width.html
>  0:40.34 DEBUG Got command: 'log'
>  0:40.34 DEBUG Executor setup done
>  0:40.63 DEBUG Got command: 'log'
>  0:40.63 DEBUG Got async callback: complete
>  0:40.71 DEBUG Got command: 'test_ended'
>  0:40.71 TEST_END: Test OK. Subtests passed 3/3. Unexpected 0
>  ```
>  
>  After 62c3bc7f3084a16f66bd2d8ea345e86dc750e620 (https://github.com/web-platform-tests/wpt/pull/34133):
>  
>  ```
>   0:31.30 TEST_START: /css/cssom-view/scroll-behavior-smooth-navigation.html
>  0:49.30 INFO Got timeout in harness
>  0:49.30 DEBUG Got command: 'test_ended'
>  0:49.30 DEBUG Unexpected count in this thread 1
>  0:49.30 TEST_END: TIMEOUT, expected ERROR - TestRunner hit external timeout (this may indicate a hang)
>  0:49.30 DEBUG new state: running
>  0:49.30 DEBUG Dispatch run_test
>  0:49.30 TEST_START: /css/cssom-view/window-screen-width.html
>  1:04.80 INFO Got timeout in harness
>  1:04.80 DEBUG Got command: 'test_ended'
>  1:04.80 DEBUG Unexpected count in this thread 2
>  1:04.80 TEST_END: TIMEOUT, expected OK - TestRunner hit external timeout (this may indicate a hang)
> ```
> 
> Thus we see a change in behaviour with external timeouts following #34133, reverting that.

I'm not sure what's wrong with the change in #34133, but this is completely reproducible locally when the test times out.