### PR TITLE
wptrunner: fix restarting when testrunner requests

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -723,9 +723,12 @@ class TestRunnerManager(threading.Thread):
             test, test_group, group_metadata = self.get_next_test()
             if test is None:
                 return RunnerManagerState.stop(force_stop)
-            restart = (self.restart_on_new_group and
-                       test_group is not self.state.test_group)
-            if restart:
+            if (
+                not restart and
+                self.restart_on_new_group and
+                test_group is not self.state.test_group
+            ):
+                restart = True
                 self.logger.info("Restarting browser for new test group")
         else:
             test_group = self.state.test_group


### PR DESCRIPTION
After 62c3bc7f30 (Add command line arg to allow no restart test runner
on new test groups (#34133), 2022-06-13), we set restart
unconditionally based on self.restart_on_new_group, totally overriding
the restart argument provided. This changed behaviour meant that
several cases, including external timeouts, no longer triggered a
restart.

Fixes #34474.