### PR TITLE
wptrunner: fix restarting

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -719,12 +719,12 @@ class TestRunnerManager(threading.Thread):
         # Mixing manual reruns and automatic reruns is confusing; we currently assume
         # that as long as we've done at least the automatic run count in total we can
         # continue with the next test.
-        restart = force_restart or (self.restart_on_new_group and
-                                    test_group is not self.state.test_group)
         if not force_rerun and self.run_count >= self.rerun:
             test, test_group, group_metadata = self.get_next_test()
             if test is None:
                 return RunnerManagerState.stop(force_stop)
+            restart = force_restart or (self.restart_on_new_group and
+                                        test_group is not self.state.test_group)
             if restart:
                 self.logger.info("Restarting browser for new test group")
         else:

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -714,17 +714,17 @@ class TestRunnerManager(threading.Thread):
         # post-stop processing
         return self.after_test_end(self.state.test, not rerun, force_rerun=rerun)
 
-    def after_test_end(self, test, restart, force_rerun=False, force_stop=False):
+    def after_test_end(self, test, force_restart, force_rerun=False, force_stop=False):
         assert isinstance(self.state, RunnerManagerState.running)
         # Mixing manual reruns and automatic reruns is confusing; we currently assume
         # that as long as we've done at least the automatic run count in total we can
         # continue with the next test.
+        restart = force_restart or (self.restart_on_new_group and
+                                    test_group is not self.state.test_group)
         if not force_rerun and self.run_count >= self.rerun:
             test, test_group, group_metadata = self.get_next_test()
             if test is None:
                 return RunnerManagerState.stop(force_stop)
-            restart = (self.restart_on_new_group and
-                       test_group is not self.state.test_group)
             if restart:
                 self.logger.info("Restarting browser for new test group")
         else:


### PR DESCRIPTION
In PR #34133 caused a regression which will reset the parameter
'restart' to false, cause the browser is not restarted when there
is a crash or timeout, etc.

Make a change per the suggestion in PR #34479