### PR TITLE
Fetch geckodriver-macos-aarch64 on M1 Mac

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -156,6 +156,8 @@ class Firefox(Browser):
 
         if self.platform in ("linux", "win"):
             bits = "64" if uname[4] == "x86_64" else "32"
+        elif self.platform == "macos" and uname.machine == "arm64":
+            bits = "-aarch64"
         else:
             bits = ""
 


### PR DESCRIPTION
https://github.com/mozilla/geckodriver/releases/tag/v0.31.0 shows the latest filename is `geckodriver-v0.31.0-macos-aarch64.tar.gz`.