### PR TITLE
Add debug-report routes to RoutesBuilder

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -571,7 +571,9 @@ class RoutesBuilder:
             ("GET", "*.asis", handlers.AsIsHandler),
             ("GET", "/.well-known/origin-policy", handlers.PythonScriptHandler),
             ("*", "/.well-known/attribution-reporting/report-event-attribution", handlers.PythonScriptHandler),
+            ("*", "/.well-known/attribution-reporting/debug/report-event-attribution", handlers.PythonScriptHandler),
             ("*", "/.well-known/attribution-reporting/report-aggregate-attribution", handlers.PythonScriptHandler),
+            ("*", "/.well-known/attribution-reporting/debug/report-aggregate-attribution", handlers.PythonScriptHandler),
             ("*", "*.py", handlers.PythonScriptHandler),
             ("GET", "*", handlers.FileHandler)
         ]

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -570,7 +570,10 @@ class RoutesBuilder:
             ("GET", "*.any.worker-module.js", ModuleWorkerHandler),
             ("GET", "*.asis", handlers.AsIsHandler),
             ("GET", "/.well-known/origin-policy", handlers.PythonScriptHandler),
-            ("*", "/.well-known/attribution-reporting/*", handlers.PythonScriptHandler),
+            ("*", "/.well-known/attribution-reporting/report-event-attribution", handlers.PythonScriptHandler),
+            ("*", "/.well-known/attribution-reporting/debug/report-event-attribution", handlers.PythonScriptHandler),
+            ("*", "/.well-known/attribution-reporting/report-aggregate-attribution", handlers.PythonScriptHandler),
+            ("*", "/.well-known/attribution-reporting/debug/report-aggregate-attribution", handlers.PythonScriptHandler),
             ("*", "*.py", handlers.PythonScriptHandler),
             ("GET", "*", handlers.FileHandler)
         ]

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -570,10 +570,7 @@ class RoutesBuilder:
             ("GET", "*.any.worker-module.js", ModuleWorkerHandler),
             ("GET", "*.asis", handlers.AsIsHandler),
             ("GET", "/.well-known/origin-policy", handlers.PythonScriptHandler),
-            ("*", "/.well-known/attribution-reporting/report-event-attribution", handlers.PythonScriptHandler),
-            ("*", "/.well-known/attribution-reporting/debug/report-event-attribution", handlers.PythonScriptHandler),
-            ("*", "/.well-known/attribution-reporting/report-aggregate-attribution", handlers.PythonScriptHandler),
-            ("*", "/.well-known/attribution-reporting/debug/report-aggregate-attribution", handlers.PythonScriptHandler),
+            ("*", "/.well-known/attribution-reporting/*", handlers.PythonScriptHandler),
             ("*", "*.py", handlers.PythonScriptHandler),
             ("GET", "*", handlers.FileHandler)
         ]


### PR DESCRIPTION
# Description

This is a follow up to https://github.com/web-platform-tests/wpt/pull/34220 
Attribution Reporting API supports collecting debug reports. Adding debug reports routes as a well-known route to the `RoutesBuilder` so that the WPT server can receive and return debug reports.