### PR TITLE
[SPC] Avoid trampling on testdriver's message handling

### DIFF
--- a/secure-payment-confirmation/authentication-cross-origin.sub.https.html
+++ b/secure-payment-confirmation/authentication-cross-origin.sub.https.html
@@ -28,6 +28,7 @@ promise_test(async t => {
 
   // Create a credential for the WPT alt domain.
   const credential = await createCredentialForAltDomain();
+  assert_equals(credential.error, null);
 
   const challenge = 'server challenge';
   const payeeOrigin = 'https://merchant.com';

--- a/secure-payment-confirmation/enrollment-in-iframe.sub.https.html
+++ b/secure-payment-confirmation/enrollment-in-iframe.sub.https.html
@@ -42,7 +42,7 @@ promise_test(async t => {
 
   const resultPromise = new Promise(resolve => {
       window.addEventListener('message', function handler(evt) {
-        if (evt.source === frame.contentWindow) {
+        if (evt.source === frame.contentWindow && evt.data.type == 'spc_result') {
           window.removeEventListener('message', handler);
           document.body.removeChild(frame);
           resolve(evt.data);
@@ -91,7 +91,7 @@ promise_test(async t => {
 
   const resultPromise = new Promise(resolve => {
       window.addEventListener('message', function handler(evt) {
-        if (evt.source === frame.contentWindow) {
+        if (evt.source === frame.contentWindow && evt.data.type == 'spc_result') {
           window.removeEventListener('message', handler);
           document.body.removeChild(frame);
           resolve(evt.data);
@@ -141,7 +141,7 @@ promise_test(async t => {
 
   const resultPromise = new Promise(resolve => {
       window.addEventListener('message', function handler(evt) {
-        if (evt.source === frame.contentWindow) {
+        if (evt.source === frame.contentWindow && evt.data.type == 'spc_result') {
           window.removeEventListener('message', handler);
           document.body.removeChild(frame);
           resolve(evt.data);

--- a/secure-payment-confirmation/resources/iframe-enroll.html
+++ b/secure-payment-confirmation/resources/iframe-enroll.html
@@ -17,9 +17,9 @@ window.addEventListener('message', async function handler(evt) {
   }
   // Assume that our parent has already created a virtual authenticator device.
   await createCredential().then(credential => {
-    parent.postMessage({id: credential.id, rawId: credential.rawId, error: null}, '*');
+    parent.postMessage({type: 'spc_result', id: credential.id, rawId: credential.rawId, error: null}, '*');
   }).catch(e => {
-    parent.postMessage({error: e}, '*');
+    parent.postMessage({type: 'spc_result', error: e}, '*');
   });
 });
 

--- a/secure-payment-confirmation/utils.sub.js
+++ b/secure-payment-confirmation/utils.sub.js
@@ -80,7 +80,7 @@ async function createCredentialForAltDomain() {
   // Setup the result promise, and then trigger credential creation.
   const resultPromise = new Promise(resolve => {
       window.addEventListener('message', function handler(evt) {
-        if (evt.source === frame.contentWindow) {
+        if (evt.source === frame.contentWindow && evt.data.type == 'spc_result') {
           document.body.removeChild(frame);
           window.removeEventListener('message', handler);
 


### PR DESCRIPTION
It turns out that these tests were accidentally responding to postMessages sent
by testdriver (instead of the ones sent by the test), and deleting the iframe
whilst it was still in use - which then caused webdriver errors. Fix this by
adding an explicit tag on the SPC-related messages and filtering for that.

This did expose another issue, which is that bless() seems not to be working
reliably (at all?) inside an iframe.

Fixes https://github.com/web-platform-tests/wpt/issues/33690