### PR TITLE
Split partitioned cookies test with/without CookieStore

### DIFF
--- a/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html
+++ b/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html
@@ -8,6 +8,8 @@
 <script src="/common/get-host-info.sub.js"></script>
 <script src="/cookies/resources/cookie-helper.sub.js"></script>
 <script src="/cookies/partitioned-cookies/resources/test-helpers.js"></script>
+<meta name="variant" content="">
+<meta name="variant" content="?cookiestore">
 
 <body>
 <script>
@@ -24,32 +26,40 @@ document.body.onload = async () => {
   const domCookieName = "__Host-pcdom";
   document.cookie = `${domCookieName}=foobar;${attributes}`;
 
-  // Set another partitioned cookie using the CookieStore API.
-  const cookieStoreCookieName = "__Host-pccookistore";
-  await cookieStore.set({
-    name: cookieStoreCookieName,
-    value: "foobar",
-    path: "/",
-    sameSite: "none",
-    partitioned: true,
-  });
+  let cookieNames = [httpCookieName, domCookieName];
+
+  if (location.search == "?cookiestore") {
+    // Set another partitioned cookie using the CookieStore API.
+    const cookieStoreCookieName = "__Host-pccookistore";
+    await cookieStore.set({
+      name: cookieStoreCookieName,
+      value: "foobar",
+      path: "/",
+      sameSite: "none",
+      partitioned: true,
+    });
+    cookieNames.push(cookieStoreCookieName);
+  }
 
   // Verify that the cookies are sent in requests from this top-level site.
   testHttpPartitionedCookies({
     origin: self.origin,
-    cookieNames: [httpCookieName, domCookieName, cookieStoreCookieName],
+    cookieNames: cookieNames,
     expectsCookie: true,
   });
 
   // Verify that the cookies are exposed to the DOM on this top-level site.
   testDomPartitionedCookies({
-    cookieNames: [httpCookieName, domCookieName, cookieStoreCookieName],
+    cookieNames: cookieNames,
     expectsCookie: true,
   });
-  testCookieStorePartitionedCookies({
-    cookieNames: [httpCookieName, domCookieName, cookieStoreCookieName],
-    expectsCookie: true,
-  });
+
+  if (location.search == "?cookiestore") {
+    testCookieStorePartitionedCookies({
+      cookieNames: cookieNames,
+      expectsCookie: true,
+    });
+  }
 
   // Open a cross-site window which will make a request to this window's origin.
   // If partitioned cookies are disabled, then the cookies set above will still


### PR DESCRIPTION
https://wpt.fyi/results/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html?label=experimental&label=master&product=chrome&product=firefox&product=safari&product=webkitgtk&aligned isn't currently super useful given everything except Chrome gives an ERROR due to lack of support for CookieStore