### PR TITLE
[SPC] Test permission policy for SPC authentication

### DIFF
--- a/secure-payment-confirmation/authentication-in-iframe.sub.https.html
+++ b/secure-payment-confirmation/authentication-in-iframe.sub.https.html
@@ -69,6 +69,8 @@ promise_test(async t => {
 
   const result = await resultPromise;
 
+  assert_not_own_property(result, 'error');
+
   assert_equals(result.id, credential.id);
   assert_equals(result.clientDataJSON.origin, 'https://{{hosts[alt][]}}:{{ports[https][0]}}');
   assert_equals(result.clientDataJSON.payment.topOrigin, window.location.origin);
@@ -77,4 +79,68 @@ promise_test(async t => {
   // The payeeOrigin should be unrelated to what the origin and topOrigin are.
   assert_equals(result.clientDataJSON.payment.payeeOrigin, 'https://merchant.com');
 }, 'SPC authentication ceremony in cross-origin iframe');
+
+promise_test(async t => {
+  // Make sure that we are testing calling SPC in a cross-origin iframe.
+  assert_not_equals(window.location.hostname, '{{hosts[alt][]}}',
+      'This test must not be run on the alt hostname.');
+
+  const authenticator = await window.test_driver.add_virtual_authenticator(
+      AUTHENTICATOR_OPTS);
+  t.add_cleanup(() => {
+    return window.test_driver.remove_virtual_authenticator(authenticator);
+  });
+
+  await window.test_driver.set_spc_transaction_mode('autoaccept');
+  t.add_cleanup(() => {
+    return window.test_driver.set_spc_transaction_mode('none');
+  });
+
+  const credential = await createCredential();
+
+  const frame = document.createElement('iframe');
+  // This iframe does *not* have a payments permission specified on it, and so
+  // should not allow SPC authentication.
+  frame.src = 'https://{{hosts[alt][]}}:{{ports[https][0]}}' +
+      '/secure-payment-confirmation/resources/iframe-authenticate.html';
+
+  // Wait for the iframe to load.
+  const readyPromise = new Promise(resolve => {
+      window.addEventListener('message', function handler(evt) {
+        if (evt.source === frame.contentWindow && evt.data.type == 'loaded') {
+          window.removeEventListener('message', handler);
+
+          resolve(evt.data);
+        }
+      });
+  });
+  document.body.appendChild(frame);
+  await readyPromise;
+
+  // Setup the result promise before triggering authentication, to avoid a
+  // race.
+  const resultPromise = new Promise(resolve => {
+      window.addEventListener('message', function handler(evt) {
+        if (evt.source === frame.contentWindow && evt.data.type == 'spc_result') {
+          // We're done with the child iframe now.
+          document.body.removeChild(frame);
+          window.removeEventListener('message', handler);
+
+          resolve(evt.data);
+        }
+      });
+  });
+
+  const rpId = window.location.hostname;
+  frame.contentWindow.postMessage([credential.rawId, rpId], '*');
+
+  const result = await resultPromise;
+
+  assert_own_property(result, 'error');
+  assert_true(result.error instanceof DOMException);
+  assert_equals(result.error.name, 'SecurityError');
+
+  assert_not_own_property(result, 'id');
+  assert_not_own_property(result, 'clientDataJSON');
+}, 'SPC authentication ceremony in cross-origin iframe without payment permission');
 </script>

--- a/secure-payment-confirmation/resources/iframe-authenticate.html
+++ b/secure-payment-confirmation/resources/iframe-authenticate.html
@@ -19,34 +19,39 @@ window.addEventListener('message', async function handler(evt) {
   const challenge = 'server challenge';
   const payeeOrigin = 'https://merchant.com';
   const displayName = 'Troycard ***1234';
-  const request = new PaymentRequest([{
-    supportedMethods: 'secure-payment-confirmation',
-    data: {
-      credentialIds: [credentialId],
-      challenge: Uint8Array.from(challenge, c => c.charCodeAt(0)),
-      payeeOrigin,
-      rpId,
-      timeout: 60000,
-      instrument: {
-        displayName,
-        icon: ICON_URL,
-      },
-    }
-  }], PAYMENT_DETAILS);
 
-  test_driver.set_test_context(window.parent);
-  await test_driver.bless('user activation');
-  const responsePromise = request.show();
+  try {
+    const request = new PaymentRequest([{
+      supportedMethods: 'secure-payment-confirmation',
+      data: {
+        credentialIds: [credentialId],
+        challenge: Uint8Array.from(challenge, c => c.charCodeAt(0)),
+        payeeOrigin,
+        rpId,
+        timeout: 60000,
+        instrument: {
+          displayName,
+          icon: ICON_URL,
+        },
+      }
+    }], PAYMENT_DETAILS);
 
-  const response = await responsePromise;
-  await response.complete('success');
+    test_driver.set_test_context(window.parent);
+    await test_driver.bless('user activation');
+    const responsePromise = request.show();
 
-  const cred = response.details;
+    const response = await responsePromise;
+    await response.complete('success');
 
-  // Let our parent know the results. Some WebAuthn fields cannot be cloned, so
-  // we have to do some teardown ourselves.
-  const clientDataJSON = JSON.parse(arrayBufferToString(cred.response.clientDataJSON))
-  window.parent.postMessage({ type: 'spc_result', id: cred.id, clientDataJSON }, '*');
+    const cred = response.details;
+
+    // Let our parent know the results. Some WebAuthn fields cannot be cloned, so
+    // we have to do some teardown ourselves.
+    const clientDataJSON = JSON.parse(arrayBufferToString(cred.response.clientDataJSON))
+    window.parent.postMessage({ type: 'spc_result', id: cred.id, clientDataJSON }, '*');
+  } catch (e) {
+    window.parent.postMessage({ type: 'spc_result', error: e }, '*');
+  }
 });
 
 // Now let our parent know that we are ready to receive the credential ID.


### PR DESCRIPTION
This is technically already tested by the PaymentRequest tests, but adding a
test for SPC makes it explicit that a payment policy is required. This will be
particularly helpful if we ever move away from the PaymentRequest API.