### PR TITLE
Fix Chromium Nightly daily runs

### DIFF
--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -19,7 +19,7 @@ def get_browser_args(product, channel):
         return ["--install-browser", "--install-webdriver"]
     if product == "servo":
         return ["--install-browser", "--processes=12"]
-    if product == "chrome":
+    if product == "chrome" or product == "chromium":
         # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
         args = ["--enable-swiftshader"]
         if channel == "nightly":


### PR DESCRIPTION
Fixes #33863

Makes sure Chromium is downloaded as needed when running these tests. Running with this change seems to [fix the tests from failing](https://github.com/web-platform-tests/wpt/runs/7101571461).