### PR TITLE
Add ways to disable experimental flags

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -383,11 +383,11 @@ class Chrome(BrowserSetup):
         if browser_channel in self.experimental_channels:
             # HACK(Hexcles): work around https://github.com/web-platform-tests/wpt/issues/16448
             kwargs["webdriver_args"].append("--disable-build-check")
-            if not kwargs["no_enable_experimental"]:
+            if kwargs["enable_experimental"] is None:
                 logger.info(
                     "Automatically turning on experimental features for Chrome Dev/Canary or Chromium trunk")
-                kwargs["binary_args"].append("--enable-experimental-web-platform-features")
-            if not kwargs["no_enable_webtransport_h3"]:
+                kwargs["enable_experimental"] = True
+            if kwargs["enable_webtransport_h3"] is None:
                 # To start the WebTransport over HTTP/3 test server.
                 kwargs["enable_webtransport_h3"] = True
         if os.getenv("TASKCLUSTER_ROOT_URL"):
@@ -447,9 +447,9 @@ class ChromeAndroid(ChromeAndroidBase):
         if kwargs["browser_channel"] in self.experimental_channels:
             # HACK(Hexcles): work around https://github.com/web-platform-tests/wpt/issues/16448
             kwargs["webdriver_args"].append("--disable-build-check")
-            if not kwargs["no_enable_experimental"]:
+            if kwargs["enable_experimental"] is None:
                 logger.info("Automatically turning on experimental features for Chrome Dev/Canary")
-                kwargs["binary_args"].append("--enable-experimental-web-platform-features")
+                kwargs["enable_experimental"] = True
 
 
 class ChromeiOS(BrowserSetup):
@@ -467,9 +467,9 @@ class AndroidWeblayer(ChromeAndroidBase):
 
     def setup_kwargs(self, kwargs):
         super().setup_kwargs(kwargs)
-        if kwargs["browser_channel"] in self.experimental_channels and not kwargs["no_enable_experimental"]:
+        if kwargs["browser_channel"] in self.experimental_channels and kwargs["enable_experimental"] is None:
             logger.info("Automatically turning on experimental features for WebLayer Dev/Canary")
-            kwargs["binary_args"].append("--enable-experimental-web-platform-features")
+            kwargs["enable_experimental"] = True
 
 
 class AndroidWebview(ChromeAndroidBase):
@@ -541,9 +541,9 @@ class EdgeChromium(BrowserSetup):
                 kwargs["webdriver_binary"] = webdriver_binary
             else:
                 raise WptrunError("Unable to locate or install msedgedriver binary")
-        if browser_channel in ("dev", "canary") and not kwargs["no_enable_experimental"]:
+        if browser_channel in ("dev", "canary") and kwargs["enable_experimental"] is None:
             logger.info("Automatically turning on experimental features for Edge Dev/Canary")
-            kwargs["binary_args"].append("--enable-experimental-web-platform-features")
+            kwargs["enable_experimental"] = True
 
 
 class Edge(BrowserSetup):

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -381,13 +381,15 @@ class Chrome(BrowserSetup):
             else:
                 raise WptrunError("Unable to locate or install matching ChromeDriver binary")
         if browser_channel in self.experimental_channels:
-            logger.info(
-                "Automatically turning on experimental features for Chrome Dev/Canary or Chromium trunk")
-            kwargs["binary_args"].append("--enable-experimental-web-platform-features")
             # HACK(Hexcles): work around https://github.com/web-platform-tests/wpt/issues/16448
             kwargs["webdriver_args"].append("--disable-build-check")
-            # To start the WebTransport over HTTP/3 test server.
-            kwargs["enable_webtransport_h3"] = True
+            if not kwargs["no_enable_experimental"]:
+                logger.info(
+                    "Automatically turning on experimental features for Chrome Dev/Canary or Chromium trunk")
+                kwargs["binary_args"].append("--enable-experimental-web-platform-features")
+            if not kwargs["no_enable_webtransport_h3"]:
+                # To start the WebTransport over HTTP/3 test server.
+                kwargs["enable_webtransport_h3"] = True
         if os.getenv("TASKCLUSTER_ROOT_URL"):
             # We are on Taskcluster, where our Docker container does not have
             # enough capabilities to run Chrome with sandboxing. (gh-20133)
@@ -443,10 +445,11 @@ class ChromeAndroid(ChromeAndroidBase):
     def setup_kwargs(self, kwargs):
         super().setup_kwargs(kwargs)
         if kwargs["browser_channel"] in self.experimental_channels:
-            logger.info("Automatically turning on experimental features for Chrome Dev/Canary")
-            kwargs["binary_args"].append("--enable-experimental-web-platform-features")
             # HACK(Hexcles): work around https://github.com/web-platform-tests/wpt/issues/16448
             kwargs["webdriver_args"].append("--disable-build-check")
+            if not kwargs["no_enable_experimental"]:
+                logger.info("Automatically turning on experimental features for Chrome Dev/Canary")
+                kwargs["binary_args"].append("--enable-experimental-web-platform-features")
 
 
 class ChromeiOS(BrowserSetup):
@@ -464,7 +467,7 @@ class AndroidWeblayer(ChromeAndroidBase):
 
     def setup_kwargs(self, kwargs):
         super().setup_kwargs(kwargs)
-        if kwargs["browser_channel"] in self.experimental_channels:
+        if kwargs["browser_channel"] in self.experimental_channels and not kwargs["no_enable_experimental"]:
             logger.info("Automatically turning on experimental features for WebLayer Dev/Canary")
             kwargs["binary_args"].append("--enable-experimental-web-platform-features")
 
@@ -538,7 +541,7 @@ class EdgeChromium(BrowserSetup):
                 kwargs["webdriver_binary"] = webdriver_binary
             else:
                 raise WptrunError("Unable to locate or install msedgedriver binary")
-        if browser_channel in ("dev", "canary"):
+        if browser_channel in ("dev", "canary") and not kwargs["no_enable_experimental"]:
             logger.info("Automatically turning on experimental features for Edge Dev/Canary")
             kwargs["binary_args"].append("--enable-experimental-web-platform-features")
 

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -112,6 +112,9 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
         # https://chromium.googlesource.com/chromium/src/+/HEAD/docs/gpu/swiftshader.md
         chrome_options["args"].extend(["--use-gl=angle", "--use-angle=swiftshader"])
 
+    if kwargs["enable_experimental"]:
+        chrome_options["args"].extend(["--enable-experimental-web-platform-features"])
+
     # Copy over any other flags that were passed in via --binary_args
     if kwargs["binary_args"] is not None:
         chrome_options["args"].extend(kwargs["binary_args"])

--- a/tools/wptrunner/wptrunner/browsers/edgechromium.py
+++ b/tools/wptrunner/wptrunner/browsers/edgechromium.py
@@ -70,6 +70,9 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
             capabilities["ms:edgeOptions"]["args"].append("--headless")
         capabilities["ms:edgeOptions"]["args"].append("--use-fake-device-for-media-stream")
 
+    if kwargs["enable_experimental"]:
+        capabilities["ms:edgeOptions"]["args"].append("--enable-experimental-web-platform-features")
+
     executor_kwargs["capabilities"] = capabilities
 
     return executor_kwargs

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -159,8 +159,11 @@ scheme host and port.""")
     # TODO(bashi): Remove this when WebTransport over HTTP/3 server is enabled by default.
     test_selection_group.add_argument("--enable-webtransport-h3",
                                       action="store_true",
-                                      default=False,
+                                      dest="enable_webtransport_h3",
+                                      default=None,
                                       help="Enable tests that require WebTransport over HTTP/3 server (default: false)")
+    test_selection_group.add_argument("--no-enable-webtransport-h3", action="store_false", dest="enable_webtransport_h3",
+                                      help="Do not enable WebTransport tests on experimental channels")
     test_selection_group.add_argument("--tag", action="append", dest="tags",
                                       help="Labels applied to tests to include in the run. "
                                            "Labels starting dir: are equivalent to top-level directories.")
@@ -348,11 +351,11 @@ scheme host and port.""")
     chrome_group.add_argument("--enable-swiftshader", action="store_true", default=False,
                              help="Enable SwiftShader for CPU-based 3D graphics. This can be used "
                              "in environments with no hardware GPU available.")
-    config_group.add_argument("--no-enable-experimental", action="store_true",
+    chrome_group.add_argument("--enable-experimental", action="store_true", dest="enable_experimental",
+                              help="Enable --enable-experimental-web-platform-features flag", default=None)
+    chrome_group.add_argument("--no-enable-experimental", action="store_false", dest="enable_experimental",
                               help="Do not enable --enable-experimental-web-platform-features flag "
-                              "on experimental channels", default=False)
-    config_group.add_argument("--no-enable-webtransport-h3", action="store_true", default=False,
-                              help="Do not enable WebTransport tests on experimental channels")
+                              "on experimental channels")
 
     sauce_group = parser.add_argument_group("Sauce Labs-specific")
     sauce_group.add_argument("--sauce-browser", dest="sauce_browser",

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -348,6 +348,11 @@ scheme host and port.""")
     chrome_group.add_argument("--enable-swiftshader", action="store_true", default=False,
                              help="Enable SwiftShader for CPU-based 3D graphics. This can be used "
                              "in environments with no hardware GPU available.")
+    config_group.add_argument("--no-enable-experimental", action="store_true",
+                              help="Do not enable --enable-experimental-web-platform-features flag "
+                              "on experimental channels", default=False)
+    config_group.add_argument("--no-enable-webtransport-h3", action="store_true", default=False,
+                              help="Do not enable WebTransport tests on experimental channels")
 
     sauce_group = parser.add_argument_group("Sauce Labs-specific")
     sauce_group.add_argument("--sauce-browser", dest="sauce_browser",


### PR DESCRIPTION
This adds `--no-enable-experimental` and `--no-enable-webtransport-h3` for Chrome/Chromium dev/canary. The former is mainly for #32381 which depends on that flag, and the latter is for #34443.