### PR TITLE
URL: Add test for hostnames which get IDNA-mapped to 'localhost' in file URLs

### DIFF
--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -8124,6 +8124,21 @@
     "search": "",
     "hash": ""
   },
+  "IDNA hostnames which get mapped to 'localhost'",
+  {
+    "input": "file://loC𝐀𝐋𝐇𝐨𝐬𝐭/usr/bin",
+    "base": "about:blank",
+    "href": "file:///usr/bin",
+    "protocol": "file:",
+    "username": "",
+    "password": "",
+    "host": "",
+    "hostname": "",
+    "port": "",
+    "pathname": "/usr/bin",
+    "search": "",
+    "hash": ""
+  },
   "Empty host after the domain to ASCII",
   {
     "input": "file://\u00ad/p",


### PR DESCRIPTION
I noticed that, while we have coverage that regular ASCII "localhost" gets normalized to an empty hostname in file URLs, we don't have any coverage for that post-IDNA. There are some Unicode strings which get mapped to "localhost", so it's worth a check that nobody forgot this check on the Unicode path of their host parsers.

JSDOM and Safari already do the right thing: https://jsdom.github.io/whatwg-url/#url=ZmlsZTovL2xvQ/CdkIDwnZCL8J2Qh/CdkKjwnZCs8J2QrS91c3IvYmlu&base=YWJvdXQ6Ymxhbms=