### PR TITLE
Avoid OSError from --kill-safari stat'ing random paths

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/safari.py
+++ b/tools/wptrunner/wptrunner/browsers/safari.py
@@ -193,9 +193,11 @@ class SafariBrowser(WebDriverBrowser):
         if self.kill_safari:
             self.logger.debug("Going to stop Safari")
             for proc in psutil.process_iter(attrs=["exe"]):
+                if proc.info["exe"] is None:
+                    continue
+
                 try:
-                    if (proc.info["exe"] is None or
-                        not os.path.samefile(proc.info["exe"], self.safari_path)):
+                    if not os.path.samefile(proc.info["exe"], self.safari_path):
                         continue
                 except OSError:
                     continue

--- a/tools/wptrunner/wptrunner/browsers/safari.py
+++ b/tools/wptrunner/wptrunner/browsers/safari.py
@@ -193,15 +193,20 @@ class SafariBrowser(WebDriverBrowser):
         if self.kill_safari:
             self.logger.debug("Going to stop Safari")
             for proc in psutil.process_iter(attrs=["exe"]):
-                if (proc.info["exe"] is not None and
-                    os.path.samefile(proc.info["exe"], self.safari_path)):
-                    self.logger.debug("Stopping Safari %s" % proc.pid)
+                try:
+                    if (proc.info["exe"] is None or
+                        not os.path.samefile(proc.info["exe"], self.safari_path)):
+                        continue
+                except OSError:
+                    continue
+
+                self.logger.debug("Stopping Safari %s" % proc.pid)
+                try:
+                    proc.terminate()
                     try:
-                        proc.terminate()
-                        try:
-                            proc.wait(10)
-                        except psutil.TimeoutExpired:
-                            proc.kill()
-                            proc.wait(10)
-                    except psutil.NoSuchProcess:
-                        pass
+                        proc.wait(10)
+                    except psutil.TimeoutExpired:
+                        proc.kill()
+                        proc.wait(10)
+                except psutil.NoSuchProcess:
+                    pass


### PR DESCRIPTION
We call os.path.samefile on every process we can get the executable
path of; however, we might not be able to stat all of them, for
example raising PermissionError, thus we should handle this.