### PR TITLE
Add COOP+COEP headers to encoding tests using SharedArrayBuffer

### DIFF
--- a/encoding/encodeInto.any.js.headers
+++ b/encoding/encodeInto.any.js.headers
@@ -1,0 +1,2 @@
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp

--- a/encoding/streams/decode-utf8.any.js.headers
+++ b/encoding/streams/decode-utf8.any.js.headers
@@ -1,0 +1,2 @@
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp

--- a/encoding/textdecoder-copy.any.js.headers
+++ b/encoding/textdecoder-copy.any.js.headers
@@ -1,0 +1,2 @@
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp

--- a/encoding/textdecoder-streaming.any.js.headers
+++ b/encoding/textdecoder-streaming.any.js.headers
@@ -1,0 +1,2 @@
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp


### PR DESCRIPTION
These tests aren't actually about the SAB restrictions, so let's avoid inadvertently testing them here.