### PR TITLE
Add tests for `script.evaluate` for serialization of complex objects with simple value field.

### DIFF
--- a/webdriver/tests/bidi/script/evaluate/serialization.py
+++ b/webdriver/tests/bidi/script/evaluate/serialization.py
@@ -52,12 +52,12 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
             },
         ),
         (
-            "[1, '2', true, new RegExp(/foo/g), [1]]",
+            "[1, 'foo', true, new RegExp(/foo/g), [1]]",
             {
                 "type": "array",
                 "value": [
                     {"type": "number", "value": 1},
-                    {"type": "string", "value": "2"},
+                    {"type": "string", "value": "foo"},
                     {"type": "boolean", "value": True},
                     {
                         "type": "regexp",
@@ -71,7 +71,7 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
             },
         ),
         (
-            "new Map([[1, 2], ['2', '3'], [true, false], ['4', [1]]])",
+            "new Map([[1, 2], ['foo', 'bar'], [true, false], ['baz', [1]]])",
             {
                 "type": "map",
                 "value": [
@@ -79,22 +79,22 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
                         {"type": "number", "value": 1},
                         {"type": "number", "value": 2},
                     ],
-                    ["2", {"type": "string", "value": "3"}],
+                    ["foo", {"type": "string", "value": "bar"}],
                     [
                         {"type": "boolean", "value": True},
                         {"type": "boolean", "value": False},
                     ],
-                    ["4", {"type": "array"}],
+                    ["baz", {"type": "array"}],
                 ],
             },
         ),
         (
-            "new Set([1, '2', true, [1]])",
+            "new Set([1, 'foo', true, [1]])",
             {
                 "type": "set",
                 "value": [
                     {"type": "number", "value": 1},
-                    {"type": "string", "value": "2"},
+                    {"type": "string", "value": "foo"},
                     {"type": "boolean", "value": True},
                     {"type": "array"},
                 ],

--- a/webdriver/tests/bidi/script/evaluate/serialization.py
+++ b/webdriver/tests/bidi/script/evaluate/serialization.py
@@ -101,7 +101,7 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
             },
         ),
         (
-            "{'foo': {'bar': 'baz'}, 'qux': 'quux'}",
+            "({'foo': {'bar': 'baz'}, 'qux': 'quux'})",
             {
                 "type": "object",
                 "value": [

--- a/webdriver/tests/bidi/script/evaluate/serialization.py
+++ b/webdriver/tests/bidi/script/evaluate/serialization.py
@@ -9,6 +9,7 @@ from webdriver.bidi.modules.script import ContextTarget
         ("undefined", {"type": "undefined"}),
         ("null", {"type": "null"}),
         ("'foobar'", {"type": "string", "value": "foobar"}),
+        ("'2'", {"type": "string", "value": "2"}),
         ("Number.NaN", {"type": "number", "value": "NaN"}),
         ("-0", {"type": "number", "value": "-0"}),
         ("Infinity", {"type": "number", "value": "+Infinity"}),

--- a/webdriver/tests/bidi/script/evaluate/serialization.py
+++ b/webdriver/tests/bidi/script/evaluate/serialization.py
@@ -28,3 +28,96 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
     )
 
     assert result == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "expression, expected",
+    [
+        (
+            "new RegExp(/foo/)",
+            {
+                "type": "regexp",
+                "value": {
+                    "pattern": "foo",
+                    "flags": "",
+                },
+            },
+        ),
+        (
+            "new Date(1654004849000)",
+            {
+                "type": "date",
+                "value": "2022-05-31T13:47:29.000Z",
+            },
+        ),
+        (
+            "[1, '2', true, new RegExp(/foo/g), [1]]",
+            {
+                "type": "array",
+                "value": [
+                    {"type": "number", "value": 1},
+                    {"type": "string", "value": "2"},
+                    {"type": "boolean", "value": True},
+                    {
+                        "type": "regexp",
+                        "value": {
+                            "pattern": "foo",
+                            "flags": "g",
+                        },
+                    },
+                    {"type": "array"},
+                ],
+            },
+        ),
+        (
+            "new Map([[1, 2], ['2', '3'], [true, false], ['4', [1]]])",
+            {
+                "type": "map",
+                "value": [
+                    [
+                        {"type": "number", "value": 1},
+                        {"type": "number", "value": 2},
+                    ],
+                    ["2", {"type": "string", "value": "3"}],
+                    [
+                        {"type": "boolean", "value": True},
+                        {"type": "boolean", "value": False},
+                    ],
+                    ["4", {"type": "array"}],
+                ],
+            },
+        ),
+        (
+            "new Set([1, '2', true, [1]])",
+            {
+                "type": "set",
+                "value": [
+                    {"type": "number", "value": 1},
+                    {"type": "string", "value": "2"},
+                    {"type": "boolean", "value": True},
+                    {"type": "array"},
+                ],
+            },
+        ),
+        (
+            "{'foo': {'bar': 'baz'}, 'qux': 'quux'}",
+            {
+                "type": "object",
+                "value": [
+                    ["foo", {"type": "object"}],
+                    ["qux", {"type": "string", "value": "quux"}],
+                ],
+            },
+        ),
+    ],
+    ids=["regexp", "date", "array", "map", "set", "object"],
+)
+async def test_remote_values(bidi_session, top_context, expression, expected):
+    result = await bidi_session.script.evaluate(
+        expression=expression,
+        target=ContextTarget(top_context["context"]),
+        await_promise=True,
+    )
+
+    assert result == expected

--- a/webdriver/tests/bidi/script/evaluate/serialization.py
+++ b/webdriver/tests/bidi/script/evaluate/serialization.py
@@ -36,12 +36,12 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
     "expression, expected",
     [
         (
-            "new RegExp(/foo/)",
+            "new RegExp(/foo/g)",
             {
                 "type": "regexp",
                 "value": {
                     "pattern": "foo",
-                    "flags": "",
+                    "flags": "g",
                 },
             },
         ),

--- a/webdriver/tests/bidi/script/evaluate/serialization.py
+++ b/webdriver/tests/bidi/script/evaluate/serialization.py
@@ -90,7 +90,7 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
             },
         ),
         (
-            "new Set([1, 'foo', true, [1]])",
+            "new Set([1, 'foo', true, [1], new Map([[1,2]])])",
             {
                 "type": "set",
                 "value": [
@@ -98,6 +98,7 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
                     {"type": "string", "value": "foo"},
                     {"type": "boolean", "value": True},
                     {"type": "array"},
+                    {"type": "map"},
                 ],
             },
         ),


### PR DESCRIPTION
Add tests for `script.evaluate` for serialization of complex objects with simple value field (objects which don't require strong reference)