### PR TITLE
Make a speech synthesis test fail fast and tinker with others

### DIFF
--- a/speech-api/SpeechSynthesis-speak-events.html
+++ b/speech-api/SpeechSynthesis-speak-events.html
@@ -8,7 +8,7 @@
 async function runStartEndTest(t, utterance) {
   const eventWatcher = new EventWatcher(t, utterance, ['start', 'end', 'error']);
   await test_driver.bless('speechSynthesis.speak',
-      () => speechSynthesis.speak(utterance));
+      () => { speechSynthesis.speak(utterance) });
   await eventWatcher.wait_for(['start', 'end']);
 }
 promise_test(async (t) => {

--- a/speech-api/SpeechSynthesis-speak-twice.html
+++ b/speech-api/SpeechSynthesis-speak-twice.html
@@ -11,6 +11,7 @@ async_test(t => {
   test_driver.bless('speechSynthesis.speak', t.step_func(() => {
     // the utterance is short to make the test faster
     const utter = new SpeechSynthesisUtterance('1');
+    utter.onerror = t.unreached_func('error event');
     speechSynthesis.speak(utter);
     utter.onend = t.step_func(() => {
       speechSynthesis.speak(utter);

--- a/speech-api/SpeechSynthesis-speak-without-activation-fails.tentative.html
+++ b/speech-api/SpeechSynthesis-speak-without-activation-fails.tentative.html
@@ -10,7 +10,7 @@ async_test(t => {
   utter.onerror = t.step_func_done((e) => {
     assert_equals(e.error, "not-allowed");
   });
-  utter.onend = t.step_func_done(() => assert_unreached());
+  utter.onend = t.unreached_func('end event');
   speechSynthesis.speak(utter);
 }, 'speechSynthesis.speak requires user activation');
 </script>


### PR DESCRIPTION
This applies a nit from https://github.com/web-platform-tests/wpt/pull/34710
and makes the "unexpected event" bits more consistent.
