### PR TITLE
Improved precision of text-align-end-00[5-8].html and their reference files

### DIFF
--- a/css/css-text/text-align/reference/text-align-end-ref-005.html
+++ b/css/css-text/text-align/reference/text-align-end-ref-005.html
@@ -4,16 +4,14 @@
 <meta charset="utf-8">
 <title>text-align: end, direction: rtl</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style type='text/css'>
-.ref { border: 1px solid orange; margin: 20px; width: 300px; position: relative; height: 75px; }
-.rb1 { position: absolute; background-color: orange; width: 75px; height: 75px; }
-.rb2 { position: absolute; left: 100px; background-color: orange; width: 75px; height: 75px; }
-.rb3 { position: absolute; left: 200px; background-color: orange; width: 75px; height: 50px; }
+.ref { border: 1px solid orange; margin: 20px; width: 300px; color: orange; font: 25px/1 Ahem; }
 </style>
 </head>
 <body>
 <div id='instructions'>Test passes if the shading in both orange boxes looks the same.</div>
-<div class="ref"><div class="rb1"></div><div class="rb2"></div><div class="rb3"></div></div>
-<div class="ref"><div class="rb1"></div><div class="rb2"></div><div class="rb3"></div></div>
+<div class="ref">DIV CLA SS_ REF ___ HER E__ ___</div>
+<div class="ref">DIV CLA SS_ REF ___ HER E__ ___</div>
 </body>
 </html>

--- a/css/css-text/text-align/reference/text-align-end-ref-005.html
+++ b/css/css-text/text-align/reference/text-align-end-ref-005.html
@@ -1,16 +1,14 @@
 <!DOCTYPE html>
-<html  lang="en" >
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>text-align: end, direction: rtl</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style type='text/css'>
-.test, .ref { border: 1px solid orange;  margin: 20px; width: 290px; color: orange; font: 24px/24px Ahem; }
-.ref { position: relative;  height: 72px; }
-.rb1 { position: absolute; top: 0; left: 0; background-color: orange; width: 72px;  height: 72px; }
-.rb2 { position: absolute; top: 0; left: 96px; background-color: orange; width: 72px;  height: 72px; }
-.rb3 { position: absolute; top: 0; left: 192px; background-color: orange; width: 72px;  height: 48px; }
+.ref { border: 1px solid orange; margin: 20px; width: 300px; position: relative; height: 75px; }
+.rb1 { position: absolute; background-color: orange; width: 75px; height: 75px; }
+.rb2 { position: absolute; left: 100px; background-color: orange; width: 75px; height: 75px; }
+.rb3 { position: absolute; left: 200px; background-color: orange; width: 75px; height: 50px; }
 </style>
 </head>
 <body>

--- a/css/css-text/text-align/reference/text-align-end-ref-006.html
+++ b/css/css-text/text-align/reference/text-align-end-ref-006.html
@@ -4,18 +4,16 @@
 <meta charset="utf-8">
 <title>text-align: end, direction: ltr</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style type='text/css'>
-.ref { border: 1px solid orange; margin: 20px; width: 300px; position: relative; height: 75px; }
-.rb1 { position: absolute; background-color: orange; width: 75px; height: 75px; }
-.rb2 { position: absolute; right: 100px; background-color: orange; width: 75px; height: 75px; }
-.rb3 { position: absolute; right: 200px; background-color: orange; width: 75px; height: 50px; }
+.ref { border: 1px solid orange; margin: 20px; width: 300px; color: orange; font: 25px/1 Ahem; }
 </style>
 </head>
 <body>
 <div id='instructions'>Test passes if the shading in both orange boxes is identical.</div>
 <div style="direction: rtl;">
-<div class="ref"><div class="rb1"></div><div class="rb2"></div><div class="rb3"></div></div>
-<div class="ref"><div class="rb1"></div><div class="rb2"></div><div class="rb3"></div></div>
+<div class="ref">DIV CLA SS_ REF ___ HER E__ ___</div>
+<div class="ref">DIV CLA SS_ REF ___ HER E__ ___</div>
 </div>
 </body>
 </html>

--- a/css/css-text/text-align/reference/text-align-end-ref-006.html
+++ b/css/css-text/text-align/reference/text-align-end-ref-006.html
@@ -1,16 +1,14 @@
 <!DOCTYPE html>
-<html  lang="en" >
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>text-align: end, direction: ltr</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style type='text/css'>
-.test, .ref { border: 1px solid orange;  margin: 20px; width: 290px; color: orange; font: 24px/24px Ahem; }
-.ref { position: relative;  height: 72px; }
-.rb1 { position: absolute; top: 0; right: 0; background-color: orange; width: 72px;  height: 72px; }
-.rb2 { position: absolute; top: 0; right: 96px; background-color: orange; width: 72px;  height: 72px; }
-.rb3 { position: absolute; top: 0; right: 192px; background-color: orange; width: 72px;  height: 48px; }
+.ref { border: 1px solid orange; margin: 20px; width: 300px; position: relative; height: 75px; }
+.rb1 { position: absolute; background-color: orange; width: 75px; height: 75px; }
+.rb2 { position: absolute; right: 100px; background-color: orange; width: 75px; height: 75px; }
+.rb3 { position: absolute; right: 200px; background-color: orange; width: 75px; height: 50px; }
 </style>
 </head>
 <body>

--- a/css/css-text/text-align/reference/text-align-end-ref-007.html
+++ b/css/css-text/text-align/reference/text-align-end-ref-007.html
@@ -1,16 +1,15 @@
 <!DOCTYPE html>
-<html  lang="en" >
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>text-align: end, dir=rtl</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style type='text/css'>
-.test, .ref { border: 1px solid orange;  margin: 20px; width: 290px; color: orange; font: 24px/24px Ahem; }
-.ref { position: relative;  height: 72px; }
-.rb1 { position: absolute; top: 0; left: 0; background-color: orange; width: 72px;  height: 72px; }
-.rb2 { position: absolute; top: 0; left: 96px; background-color: orange; width: 72px;  height: 72px; }
-.rb3 { position: absolute; top: 0; left: 192px; background-color: orange; width: 72px;  height: 48px; }
+.ref { border: 1px solid orange; margin: 20px; width: 300px; position: relative; height: 75px; }
+.rb1 { position: absolute; background-color: orange; width: 75px; height: 75px; }
+.rb2 { position: absolute; left: 100px; background-color: orange; width: 75px; height: 75px; }
+.rb3 { position: absolute; left: 200px; background-color: orange; width: 75px; height: 50px; }
 </style>
 </head>
 <body>

--- a/css/css-text/text-align/reference/text-align-end-ref-007.html
+++ b/css/css-text/text-align/reference/text-align-end-ref-007.html
@@ -4,17 +4,14 @@
 <meta charset="utf-8">
 <title>text-align: end, dir=rtl</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style type='text/css'>
-.ref { border: 1px solid orange; margin: 20px; width: 300px; position: relative; height: 75px; }
-.rb1 { position: absolute; background-color: orange; width: 75px; height: 75px; }
-.rb2 { position: absolute; left: 100px; background-color: orange; width: 75px; height: 75px; }
-.rb3 { position: absolute; left: 200px; background-color: orange; width: 75px; height: 50px; }
+.ref { border: 1px solid orange; margin: 20px; width: 300px; color: orange; font: 25px/1 Ahem; }
 </style>
 </head>
 <body>
 <div id='instructions'>Test passes if the shading in both orange boxes looks the same.</div>
-<div class="ref"><div class="rb1"></div><div class="rb2"></div><div class="rb3"></div></div>
-<div class="ref"><div class="rb1"></div><div class="rb2"></div><div class="rb3"></div></div>
+<div class="ref">DIV CLA SS_ REF ___ HER E__ ___</div>
+<div class="ref">DIV CLA SS_ REF ___ HER E__ ___</div>
 </body>
 </html>

--- a/css/css-text/text-align/reference/text-align-end-ref-008.html
+++ b/css/css-text/text-align/reference/text-align-end-ref-008.html
@@ -4,18 +4,16 @@
 <meta charset="utf-8">
 <title>text-align: end, dir=ltr</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style type='text/css'>
-.ref { border: 1px solid orange; margin: 20px; width: 300px; position: relative; height: 75px; }
-.rb1 { position: absolute; background-color: orange; width: 75px; height: 75px; }
-.rb2 { position: absolute; right: 100px; background-color: orange; width: 75px; height: 75px; }
-.rb3 { position: absolute; right: 200px; background-color: orange; width: 75px; height: 50px; }
+.ref { border: 1px solid orange; margin: 20px; width: 300px; color: orange; font: 25px/1 Ahem; }
 </style>
 </head>
 <body>
 <div id='instructions'>Test passes if shading in both orange boxes is identical.</div>
 <div dir="rtl">
-<div class="ref"><div class="rb1"></div><div class="rb2"></div><div class="rb3"></div></div>
-<div class="ref"><div class="rb1"></div><div class="rb2"></div><div class="rb3"></div></div>
+<div class="ref">DIV CLA SS_ REF ___ HER E__ ___</div>
+<div class="ref">DIV CLA SS_ REF ___ HER E__ ___</div>
 </div>
 </body>
 </html>

--- a/css/css-text/text-align/reference/text-align-end-ref-008.html
+++ b/css/css-text/text-align/reference/text-align-end-ref-008.html
@@ -1,16 +1,14 @@
 <!DOCTYPE html>
-<html  lang="en" >
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>text-align: end, dir=ltr</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style type='text/css'>
-.test, .ref { border: 1px solid orange;  margin: 20px; width: 290px; color: orange; font: 24px/24px Ahem; }
-.ref { position: relative;  height: 72px; }
-.rb1 { position: absolute; top: 0; right: 0; background-color: orange; width: 72px;  height: 72px; }
-.rb2 { position: absolute; top: 0; right: 96px; background-color: orange; width: 72px;  height: 72px; }
-.rb3 { position: absolute; top: 0; right: 192px; background-color: orange; width: 72px;  height: 48px; }
+.ref { border: 1px solid orange; margin: 20px; width: 300px; position: relative; height: 75px; }
+.rb1 { position: absolute; background-color: orange; width: 75px; height: 75px; }
+.rb2 { position: absolute; right: 100px; background-color: orange; width: 75px; height: 75px; }
+.rb3 { position: absolute; right: 200px; background-color: orange; width: 75px; height: 50px; }
 </style>
 </head>
 <body>

--- a/css/css-text/text-align/text-align-end-005.html
+++ b/css/css-text/text-align/text-align-end-005.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html  lang="en" >
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>text-align: end, direction: rtl</title>
@@ -11,11 +11,11 @@
 <style type='text/css'>
 .test { text-align: end; direction: rtl; }
 /* the CSS below is not part of the test */
-.test, .ref { border: 1px solid orange;  margin: 20px; width: 290px; color: orange; font: 24px/24px Ahem; }
-.ref { position: relative;  height: 72px; }
-#rb1 { position: absolute; top: 0; left: 0; background-color: orange; width: 72px;  height: 72px; }
-#rb2 { position: absolute; top: 0; left: 96px; background-color: orange; width: 72px;  height: 72px; }
-#rb3 { position: absolute; top: 0; left: 192px; background-color: orange; width: 72px;  height: 48px; }
+.test, .ref { border: 1px solid orange; margin: 20px; width: 300px; color: orange; font: 25px/1 Ahem; }
+.ref { position: relative; height: 75px; }
+#rb1 { position: absolute; background-color: orange; width: 75px; height: 75px; }
+#rb2 { position: absolute; left: 100px; background-color: orange; width: 75px; height: 75px; }
+#rb3 { position: absolute; left: 200px; background-color: orange; width: 75px; height: 50px; }
 </style>
 </head>
 <body>

--- a/css/css-text/text-align/text-align-end-005.html
+++ b/css/css-text/text-align/text-align-end-005.html
@@ -7,20 +7,16 @@
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
 <link rel='match' href='reference/text-align-end-ref-005.html'>
 <meta name="assert" content="text-align:end aligns inline-level content to the end edge of the line box – ie. left when direction is horizontal, rtl.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style type='text/css'>
 .test { text-align: end; direction: rtl; }
 /* the CSS below is not part of the test */
 .test, .ref { border: 1px solid orange; margin: 20px; width: 300px; color: orange; font: 25px/1 Ahem; }
-.ref { position: relative; height: 75px; }
-#rb1 { position: absolute; background-color: orange; width: 75px; height: 75px; }
-#rb2 { position: absolute; left: 100px; background-color: orange; width: 75px; height: 75px; }
-#rb3 { position: absolute; left: 200px; background-color: orange; width: 75px; height: 50px; }
 </style>
 </head>
 <body>
 <div id='instructions'>Test passes if the shading in both orange boxes looks the same.</div>
-<div class="test">XXX XXX XXX XXX XXX XXX XXX XXX</div>
-<div class="ref"><div id="rb1"></div><div id="rb2"></div><div id="rb3"></div></div>
+<div class="test">DIV CLA SS_ TES T__ HER E__ ___</div>
+<div class="ref">DIV CLA SS_ REF ___ HER E__ ___</div>
 </body>
 </html>

--- a/css/css-text/text-align/text-align-end-006.html
+++ b/css/css-text/text-align/text-align-end-006.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html  lang="en" >
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>text-align: end, direction: ltr</title>
@@ -11,11 +11,11 @@
 <style type='text/css'>
 .test { text-align: end; direction: ltr; }
 /* the CSS below is not part of the test */
-.test, .ref { border: 1px solid orange;  margin: 20px; width: 290px; color: orange; font: 24px/24px Ahem; }
-.ref { position: relative;  height: 72px; }
-#rb1 { position: absolute; top: 0; right: 0; background-color: orange; width: 72px;  height: 72px; }
-#rb2 { position: absolute; top: 0; right: 96px; background-color: orange; width: 72px;  height: 72px; }
-#rb3 { position: absolute; top: 0; right: 192px; background-color: orange; width: 72px;  height: 48px; }
+.test, .ref { border: 1px solid orange; margin: 20px; width: 300px; color: orange; font: 25px/1 Ahem; }
+.ref { position: relative; height: 75px; }
+#rb1 { position: absolute; background-color: orange; width: 75px; height: 75px; }
+#rb2 { position: absolute; right: 100px; background-color: orange; width: 75px; height: 75px; }
+#rb3 { position: absolute; right: 200px; background-color: orange; width: 75px; height: 50px; }
 </style>
 </head>
 <body>

--- a/css/css-text/text-align/text-align-end-006.html
+++ b/css/css-text/text-align/text-align-end-006.html
@@ -7,22 +7,18 @@
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
 <link rel='match' href='reference/text-align-end-ref-006.html'>
 <meta name="assert" content="text-align:end aligns inline-level content to the end edge of the line box – ie. right when direction is horizontal, ltr.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style type='text/css'>
 .test { text-align: end; direction: ltr; }
 /* the CSS below is not part of the test */
 .test, .ref { border: 1px solid orange; margin: 20px; width: 300px; color: orange; font: 25px/1 Ahem; }
-.ref { position: relative; height: 75px; }
-#rb1 { position: absolute; background-color: orange; width: 75px; height: 75px; }
-#rb2 { position: absolute; right: 100px; background-color: orange; width: 75px; height: 75px; }
-#rb3 { position: absolute; right: 200px; background-color: orange; width: 75px; height: 50px; }
 </style>
 </head>
 <body>
 <div id='instructions'>Test passes if the shading in both orange boxes is identical.</div>
 <div style="direction: rtl;">
-<div class="test">XXX XXX XXX XXX XXX XXX XXX XXX</div>
-<div class="ref"><div id="rb1"></div><div id="rb2"></div><div id="rb3"></div></div>
+<div class="test">DIV CLA SS_ TES T__ HER E__ ___</div>
+<div class="ref">DIV CLA SS_ REF ___ HER E__ ___</div>
 </div>
 </body>
 </html>

--- a/css/css-text/text-align/text-align-end-007.html
+++ b/css/css-text/text-align/text-align-end-007.html
@@ -7,20 +7,16 @@
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
 <link rel='match' href='reference/text-align-end-ref-007.html'>
 <meta name="assert" content="text-align:end aligns inline-level content to the end edge of the line box – ie. left when direction is horizontal, rtl.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style type='text/css'>
 .test { text-align: end; }
 /* the CSS below is not part of the test */
 .test, .ref { border: 1px solid orange; margin: 20px; width: 300px; color: orange; font: 25px/1 Ahem; }
-.ref { position: relative; height: 75px; }
-#rb1 { position: absolute; background-color: orange; width: 75px; height: 75px; }
-#rb2 { position: absolute; left: 100px; background-color: orange; width: 75px; height: 75px; }
-#rb3 { position: absolute; left: 200px; background-color: orange; width: 75px; height: 50px; }
 </style>
 </head>
 <body>
 <div id='instructions'>Test passes if the shading in both orange boxes looks the same.</div>
-<div class="test" dir="rtl">XXX XXX XXX XXX XXX XXX XXX XXX</div>
-<div class="ref"><div id="rb1"></div><div id="rb2"></div><div id="rb3"></div></div>
+<div class="test" dir="rtl">DIV CLA SS_ TES T__ HER E__ ___</div>
+<div class="ref">DIV CLA SS_ REF ___ HER E__ ___</div>
 </body>
 </html>

--- a/css/css-text/text-align/text-align-end-007.html
+++ b/css/css-text/text-align/text-align-end-007.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html  lang="en" >
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>text-align: end, dir=rtl</title>
@@ -11,11 +11,11 @@
 <style type='text/css'>
 .test { text-align: end; }
 /* the CSS below is not part of the test */
-.test, .ref { border: 1px solid orange;  margin: 20px; width: 290px; color: orange; font: 24px/24px Ahem; }
-.ref { position: relative;  height: 72px; }
-#rb1 { position: absolute; top: 0; left: 0; background-color: orange; width: 72px;  height: 72px; }
-#rb2 { position: absolute; top: 0; left: 96px; background-color: orange; width: 72px;  height: 72px; }
-#rb3 { position: absolute; top: 0; left: 192px; background-color: orange; width: 72px;  height: 48px; }
+.test, .ref { border: 1px solid orange; margin: 20px; width: 300px; color: orange; font: 25px/1 Ahem; }
+.ref { position: relative; height: 75px; }
+#rb1 { position: absolute; background-color: orange; width: 75px; height: 75px; }
+#rb2 { position: absolute; left: 100px; background-color: orange; width: 75px; height: 75px; }
+#rb3 { position: absolute; left: 200px; background-color: orange; width: 75px; height: 50px; }
 </style>
 </head>
 <body>

--- a/css/css-text/text-align/text-align-end-008.html
+++ b/css/css-text/text-align/text-align-end-008.html
@@ -7,22 +7,18 @@
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
 <link rel='match' href='reference/text-align-end-ref-008.html'>
 <meta name="assert" content="text-align:end aligns inline-level content to the end edge of the line box – ie. right when direction is horizontal, ltr.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style type='text/css'>
 .test { text-align: end; }
 /* the CSS below is not part of the test */
 .test, .ref { border: 1px solid orange; margin: 20px; width: 300px; color: orange; font: 25px/1 Ahem; }
-.ref { position: relative; height: 75px; }
-#rb1 { position: absolute; background-color: orange; width: 75px; height: 75px; }
-#rb2 { position: absolute; right: 100px; background-color: orange; width: 75px; height: 75px; }
-#rb3 { position: absolute; right: 200px; background-color: orange; width: 75px; height: 50px; }
 </style>
 </head>
 <body>
 <div id='instructions'>Test passes if shading in both orange boxes is identical.</div>
 <div dir="rtl">
-<div class="test" dir="ltr">XXX XXX XXX XXX XXX XXX XXX XXX</div>
-<div class="ref"><div id="rb1"></div><div id="rb2"></div><div id="rb3"></div></div>
+<div class="test" dir="ltr">DIV CLA SS_ TES T__ HER E__ ___</div>
+<div class="ref">DIV CLA SS_ REF ___ HER E__ ___</div>
 </div>
 </body>
 </html>

--- a/css/css-text/text-align/text-align-end-008.html
+++ b/css/css-text/text-align/text-align-end-008.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html  lang="en" >
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>text-align: end, dir=ltr</title>
@@ -11,11 +11,11 @@
 <style type='text/css'>
 .test { text-align: end; }
 /* the CSS below is not part of the test */
-.test, .ref { border: 1px solid orange;  margin: 20px; width: 290px; color: orange; font: 24px/24px Ahem; }
-.ref { position: relative;  height: 72px; }
-#rb1 { position: absolute; top: 0; right: 0; background-color: orange; width: 72px;  height: 72px; }
-#rb2 { position: absolute; top: 0; right: 96px; background-color: orange; width: 72px;  height: 72px; }
-#rb3 { position: absolute; top: 0; right: 192px; background-color: orange; width: 72px;  height: 48px; }
+.test, .ref { border: 1px solid orange; margin: 20px; width: 300px; color: orange; font: 25px/1 Ahem; }
+.ref { position: relative; height: 75px; }
+#rb1 { position: absolute; background-color: orange; width: 75px; height: 75px; }
+#rb2 { position: absolute; right: 100px; background-color: orange; width: 75px; height: 75px; }
+#rb3 { position: absolute; right: 200px; background-color: orange; width: 75px; height: 50px; }
 </style>
 </head>
 <body>


### PR DESCRIPTION
On my website:

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/text-align/text-align-end-005-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/text-align/reference/text-align-end-ref-005-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/text-align/text-align-end-006-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/text-align/reference/text-align-end-ref-006-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/text-align/text-align-end-007-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/text-align/reference/text-align-end-ref-007-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/text-align/text-align-end-008-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/text-align/reference/text-align-end-ref-008-GT.html