### PR TITLE
Test aspect-ratio affects the min/max sizes

### DIFF
--- a/css/css-sizing/aspect-ratio/block-aspect-ratio-038.html
+++ b/css/css-sizing/aspect-ratio/block-aspect-ratio-038.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS aspect-ratio: The definite max-width should win the automatic content-based minimum width</title>
+<link rel="author" title="Cathie Chen" href="mailto:cchen@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-minimum">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
+<meta name="assert" content="The definite max-width should win the automatic content-based minimum width.">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div style="background: green; height: 100px; aspect-ratio: 2 / 1; max-width: 100px;">
+    <div style="width:200px;"></div>
+</div>

--- a/css/css-sizing/aspect-ratio/block-aspect-ratio-039.html
+++ b/css/css-sizing/aspect-ratio/block-aspect-ratio-039.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS aspect-ratio: The definite max-height should win the automatic content-based minimum height</title>
+<link rel="author" title="Cathie Chen" href="mailto:cchen@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-minimum">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
+<meta name="assert" content="The definite max-height should win the automatic content-based minimum height.">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div style="background: green; width: 100px; aspect-ratio: 1 / 2; max-height: 100px;">
+    <div style="height:200px;"></div>
+</div>

--- a/css/css-sizing/aspect-ratio/block-aspect-ratio-040.html
+++ b/css/css-sizing/aspect-ratio/block-aspect-ratio-040.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<title>CSS aspect-ratio: The definite max-height should win the transferred minimum height</title>
+<title>CSS aspect-ratio: The definite max-height should win the transferred maximum height</title>
 <link rel="author" title="Cathie Chen" href="mailto:cchen@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-minimum">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers">
 <link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
-<meta name="assert" content="CSS aspect-ratio: The definite max-height should win the transferred minimum height.">
+<meta name="assert" content="CSS aspect-ratio: The definite max-height should win the transferred maximum height.">
 
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 

--- a/css/css-sizing/aspect-ratio/block-aspect-ratio-040.html
+++ b/css/css-sizing/aspect-ratio/block-aspect-ratio-040.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<title>CSS aspect-ratio: The definite max-height should win the transferred minimum height</title>
+<link rel="author" title="Cathie Chen" href="mailto:cchen@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-minimum">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
+<meta name="assert" content="CSS aspect-ratio: The definite max-height should win the transferred minimum height.">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div style="background: green; width: 200px; aspect-ratio: 1 / 2; max-width: 100px; max-height: 100px;"></div>

--- a/css/css-sizing/aspect-ratio/block-aspect-ratio-041.html
+++ b/css/css-sizing/aspect-ratio/block-aspect-ratio-041.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<title>CSS aspect-ratio: The definite max-width should win the transferred minimum width</title>
+<link rel="author" title="Cathie Chen" href="mailto:cchen@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-minimum">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
+<meta name="assert" content="The definite max-width should win the transferred minimum width.">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div style="background: green; height: 200px; aspect-ratio: 2 / 1; max-height: 100px; max-width: 100px;"></div>

--- a/css/css-sizing/aspect-ratio/block-aspect-ratio-041.html
+++ b/css/css-sizing/aspect-ratio/block-aspect-ratio-041.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<title>CSS aspect-ratio: The definite max-width should win the transferred minimum width</title>
+<title>CSS aspect-ratio: The definite max-width should win the transferred maximum width</title>
 <link rel="author" title="Cathie Chen" href="mailto:cchen@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-minimum">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers">
 <link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
-<meta name="assert" content="The definite max-width should win the transferred minimum width.">
+<meta name="assert" content="The definite max-width should win the transferred maximum width.">
 
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 

--- a/css/css-sizing/aspect-ratio/block-aspect-ratio-042.html
+++ b/css/css-sizing/aspect-ratio/block-aspect-ratio-042.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS aspect-ratio: The transferred minimum height beats the automatic content-based minimum height</title>
+<link rel="author" title="Cathie Chen" href="mailto:cchen@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-minimum">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
+<meta name="assert" content="The transferred minimum height beats the automatic content-based minimum height.">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div style="background: green; width: 200px; aspect-ratio: 1 / 1; max-width: 100px;">
+    <div style="height:200px;"></div>
+</div>

--- a/css/css-sizing/aspect-ratio/block-aspect-ratio-042.html
+++ b/css/css-sizing/aspect-ratio/block-aspect-ratio-042.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<title>CSS aspect-ratio: The transferred minimum height beats the automatic content-based minimum height</title>
+<title>CSS aspect-ratio: The transferred maximum height beats the automatic content-based minimum height</title>
 <link rel="author" title="Cathie Chen" href="mailto:cchen@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-minimum">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers">
 <link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
-<meta name="assert" content="The transferred minimum height beats the automatic content-based minimum height.">
+<meta name="assert" content="The transferred maximum height beats the automatic content-based minimum height.">
 
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 

--- a/css/css-sizing/aspect-ratio/block-aspect-ratio-043.html
+++ b/css/css-sizing/aspect-ratio/block-aspect-ratio-043.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<title>CSS aspect-ratio: The transferred minimum width beats the automatic content-based minimum width</title>
+<title>CSS aspect-ratio: The transferred maximum width beats the automatic content-based minimum width</title>
 <link rel="author" title="Cathie Chen" href="mailto:cchen@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-minimum">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers">
 <link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
-<meta name="assert" content="The transferred minimum width beats the automatic content-based minimum width.">
+<meta name="assert" content="The transferred maximum width beats the automatic content-based minimum width.">
 
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 

--- a/css/css-sizing/aspect-ratio/block-aspect-ratio-043.html
+++ b/css/css-sizing/aspect-ratio/block-aspect-ratio-043.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS aspect-ratio: The transferred minimum width beats the automatic content-based minimum width</title>
+<link rel="author" title="Cathie Chen" href="mailto:cchen@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-minimum">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
+<meta name="assert" content="The transferred minimum width beats the automatic content-based minimum width.">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div style="background: green; height: 200px; aspect-ratio: 1 / 1; max-height: 100px;">
+    <div style="width:200px;"></div>
+</div>


### PR DESCRIPTION
Hi,
This patch adds tests for the discussion in https://github.com/w3c/csswg-drafts/issues/7461

According to the discussion, we have this priorities order list:
  - [automatic minimum size](https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size) (Need to be capped by the maximum size)
  - [Transferred Min/Max Sizes](https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers) (Affect the maximum size)
  - The definite minimum/maximum sizes (Beats [Transferred Min/Max Sizes](https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers))
