### PR TITLE
Fix the stp downloads: Mac OS Monterey and Mac OS Ventura

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1472,7 +1472,13 @@ class Safari(Browser):
             if {"download", "dmg", "zip"} & class_names:
                 downloads.append(candidate)
 
-        stp_link_text = re.compile(r"^\s*Safari\s+Technology\s+Preview\s+(?:[0-9]+\s+)?for\s+macOS")
+        """
+        When converting to string with text_content, it converts <br> to no space.
+        For example:
+        Input: Safari Technology Preview<br>for macOS&nbsp;Ventura
+        Output: Safari Technology Previewfor macOS Ventura
+        """
+        stp_link_text = re.compile(r"^\s*Safari\s+Technology\s+Preview\s*(?:[0-9]+\s+)?for\s+macOS")
         requirement = re.compile(
             r"Requires\s+macOS\s+([0-9\.]+)\s+(?:or\s+later|beta)."
         )

--- a/tools/wpt/tests/safari_downloads_page_stp_section.html
+++ b/tools/wpt/tests/safari_downloads_page_stp_section.html
@@ -1,0 +1,22 @@
+<div class="column large-6 medium-12 small-12">
+    <div class="callout">
+        <figure class="app-icon large-icon safari-preview-icon" aria-hidden="true" data-hires-status="pending"></figure>
+        <h4>Safari Technology Preview</h4>
+        <p class="margin-bottom-small">Get a sneak peek at upcoming web technologies in macOS and iOS with <a href="/safari/technology-preview/" class="nowrap">Safari Technology Preview</a> and experiment with these technologies in your websites and extensions.</p>
+        <ul class="links small">
+            <li class="dmg" data-hires-status="pending"><a class="inline" href="https://secure-appldnld.apple.com/STP/012-38225-20220706-237860CD-5766-4F53-AAC7-1CE26023A959/SafariTechnologyPreview.dmg">Safari Technology Preview<br>for macOS&nbsp;Ventura</a><br><span class="smaller lighter nowrap nowrap-small">Requires macOS&nbsp;13 beta&nbsp;3 or later.</span></li>
+            <li class="dmg margin-top-small" data-hires-status="pending"><a class="inline" href="https://secure-appldnld.apple.com/STP/012-32918-20220629-B3452905-0138-4CA9-A4E6-334B63585653/SafariTechnologyPreview.dmg">Safari Technology Preview<br>for macOS&nbsp;Monterey</a><br><span class="smaller lighter">Requires macOS&nbsp;12.3 or later.</span></li>
+            <li class="document margin-top-small" data-hires-status="pending"><a href="/safari/technology-preview/release-notes/">Release Notes</a></li>
+        </ul>
+        <div class="row gutter text-left">
+            <div class="column">
+                <p class="sosumi no-margin-bottom margin-top-small">Release</p>
+                <p class="smaller lighter no-margin">148</p>
+            </div>
+            <div class="column">
+                <p class="sosumi no-margin-bottom margin-top-small">Posted</p>
+                <p class="smaller lighter no-margin">June 29, 2022</p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/tools/wpt/tests/test_browser.py
+++ b/tools/wpt/tests/test_browser.py
@@ -2,12 +2,14 @@
 
 import logging
 import inspect
+import requests
 import subprocess
 import sys
 from unittest import mock
 
 import pytest
 
+from packaging.specifiers import SpecifierSet
 from tools.wpt import browser
 
 
@@ -192,6 +194,45 @@ def test_safari_version_errors(mocked_check_output):
     mocked_check_output.return_value = b'dummy'
     mocked_check_output.side_effect = subprocess.CalledProcessError(1, 'cmd')
     assert safari.version(webdriver_binary="safaridriver") is None
+
+@mock.patch('tools.wpt.browser.get')
+def test_safari_find_downloads_stp(mocked_get):
+    safari = browser.Safari(logger)
+    response = requests.models.Response()
+    response.status_code = 200
+
+    content = """
+        <div class="column large-6 medium-12 small-12">
+            <div class="callout">
+                <figure class="app-icon large-icon safari-preview-icon" aria-hidden="true" data-hires-status="pending"></figure>
+                <h4>Safari Technology Preview</h4>
+                <p class="margin-bottom-small">Get a sneak peek at upcoming web technologies in macOS and iOS with <a href="/safari/technology-preview/" class="nowrap">Safari Technology Preview</a> and experiment with these technologies in your websites and extensions.</p>
+                <ul class="links small">
+                    <li class="dmg" data-hires-status="pending"><a class="inline" href="https://secure-appldnld.apple.com/STP/012-38225-20220706-237860CD-5766-4F53-AAC7-1CE26023A959/SafariTechnologyPreview.dmg">Safari Technology Preview<br>for macOS&nbsp;Ventura</a><br><span class="smaller lighter nowrap nowrap-small">Requires macOS&nbsp;13 beta&nbsp;3 or later.</span></li>
+                    <li class="dmg margin-top-small" data-hires-status="pending"><a class="inline" href="https://secure-appldnld.apple.com/STP/012-32918-20220629-B3452905-0138-4CA9-A4E6-334B63585653/SafariTechnologyPreview.dmg">Safari Technology Preview<br>for macOS&nbsp;Monterey</a><br><span class="smaller lighter">Requires macOS&nbsp;12.3 or later.</span></li>
+                    <li class="document margin-top-small" data-hires-status="pending"><a href="/safari/technology-preview/release-notes/">Release Notes</a></li>
+                </ul>
+                <div class="row gutter text-left">
+                    <div class="column">
+                        <p class="sosumi no-margin-bottom margin-top-small">Release</p>
+                        <p class="smaller lighter no-margin">148</p>
+                    </div>
+                    <div class="column">
+                        <p class="sosumi no-margin-bottom margin-top-small">Posted</p>
+                        <p class="smaller lighter no-margin">June 29, 2022</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    """
+    response._content = str.encode(content)
+    mocked_get.return_value = response
+    downloads = safari._find_downloads()
+    assert len(downloads) == 2
+
+    assert downloads[0][0] == SpecifierSet(f"==13.*") # Needs to be ~=13.3
+    assert downloads[1][0] == SpecifierSet(f"~=12.3")
+    assert "12.4" in downloads[1][0]
 
 
 @mock.patch('subprocess.check_output')


### PR DESCRIPTION
- Fix the STP regex to pick up the links for STP.

Why we need this:

1. When converting to string with text_content, it converts <br> to no space. For example:
  - Input: `Safari Technology Preview<br>for macOS&nbsp;Ventura`
  - Output: `Safari Technology Previewfor macOS Ventura`
As a result, the \s+ needs to be changed to \s*

Fixes #34752