### PR TITLE
Add `resultOwnership` tests for `script.callFunction`

### DIFF
--- a/webdriver/tests/bidi/__init__.py
+++ b/webdriver/tests/bidi/__init__.py
@@ -4,7 +4,6 @@ from typing import Any
 # Compares 2 objects recursively.
 # Actual value can have more keys as part of the forwards-compat design.
 # Expected value can be a callable delegate, asserting the value.
-# Expected value can be `missing`, in which case the function asserts there is no such a key in the actual object.
 def recursive_compare(expected: Any, actual: Any) -> None:
     if callable(expected):
         expected(actual)
@@ -19,26 +18,13 @@ def recursive_compare(expected: Any, actual: Any) -> None:
 
     if type(expected) is dict:
         # Actual dict can have more keys as part of the forwards-compat design.
-        expected_missing_keys = set(filter(
-            lambda k: expected[k] == missing,
-            expected.keys()))
-        expected_present_keys = set(expected.keys() - expected_missing_keys)
-
-        assert expected_present_keys <= actual.keys(), \
-            f"Key set should be present: {expected_present_keys - set(actual.keys())}"
-
-        for key in expected_missing_keys:
-            assert key not in actual, f"Key '{key}' should not be present in {actual}"
-
-        for key in expected_present_keys:
+        assert expected.keys() <= actual.keys(), \
+            f"Key set should be present: {set(expected.keys()) - set(actual.keys())}"
+        for key in expected.keys():
             recursive_compare(expected[key], actual[key])
         return
 
     assert expected == actual
-
-
-def missing() -> None:
-    pass
 
 
 def any_string(actual: Any) -> None:

--- a/webdriver/tests/bidi/__init__.py
+++ b/webdriver/tests/bidi/__init__.py
@@ -4,6 +4,7 @@ from typing import Any
 # Compares 2 objects recursively.
 # Actual value can have more keys as part of the forwards-compat design.
 # Expected value can be a callable delegate, asserting the value.
+# Expected value can be `missing`, in which case the function asserts there is not such a key in the actual object.
 def recursive_compare(expected: Any, actual: Any) -> None:
     if callable(expected):
         expected(actual)
@@ -18,13 +19,26 @@ def recursive_compare(expected: Any, actual: Any) -> None:
 
     if type(expected) is dict:
         # Actual dict can have more keys as part of the forwards-compat design.
-        assert expected.keys() <= actual.keys(), \
-            f"Key set should be present: {set(expected.keys()) - set(actual.keys())}"
-        for key in expected.keys():
+        expected_missing_keys = set(filter(
+            lambda k: expected[k] == missing,
+            expected.keys()))
+        expected_present_keys = set(expected.keys() - expected_missing_keys)
+
+        assert expected_present_keys <= actual.keys(), \
+            f"Key set should be present: {expected_present_keys - set(actual.keys())}"
+
+        for key in expected_missing_keys:
+            assert key not in actual, f"Key '{key}' should not be present in {actual}"
+
+        for key in expected_present_keys:
             recursive_compare(expected[key], actual[key])
         return
 
     assert expected == actual
+
+
+def missing() -> None:
+    pass
 
 
 def any_string(actual: Any) -> None:

--- a/webdriver/tests/bidi/__init__.py
+++ b/webdriver/tests/bidi/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 # Compares 2 objects recursively.
 # Actual value can have more keys as part of the forwards-compat design.
 # Expected value can be a callable delegate, asserting the value.
-# Expected value can be `missing`, in which case the function asserts there is not such a key in the actual object.
+# Expected value can be `missing`, in which case the function asserts there is no such a key in the actual object.
 def recursive_compare(expected: Any, actual: Any) -> None:
     if callable(expected):
         expected(actual)

--- a/webdriver/tests/bidi/script/call_function/call_function.py
+++ b/webdriver/tests/bidi/script/call_function/call_function.py
@@ -9,40 +9,40 @@ from .. import any_stack_trace
 async def test_exception(bidi_session, top_context):
     with pytest.raises(ScriptEvaluateResultException) as exception:
         await bidi_session.script.call_function(
-            function_declaration="()=>{throw 1}",
+            function_declaration='()=>{throw 1}',
             await_promise=False,
             target=ContextTarget(top_context["context"]))
 
     recursive_compare({
-        "realm": any_string,
-        "exceptionDetails": {
-            "columnNumber": any_int,
-            "exception": {
-                "value": 1,
-                "type": "number"},
-            "lineNumber": any_int,
-            "stackTrace": any_stack_trace,
-            "text": any_string}
-    }, exception.value.result)
+        'realm': any_string,
+        'exceptionDetails': {
+            'columnNumber': any_int,
+            'exception': {
+                'value': 1,
+                'type': 'number'},
+            'lineNumber': any_int,
+            'stackTrace': any_stack_trace,
+            'text': any_string}},
+        exception.value.result)
 
 
 @pytest.mark.asyncio
 async def test_invalid_function(bidi_session, top_context):
     with pytest.raises(ScriptEvaluateResultException) as exception:
         await bidi_session.script.call_function(
-            function_declaration="))) !!@@## some invalid JS script (((",
+            function_declaration='))) !!@@## some invalid JS script (((',
             await_promise=False,
             target=ContextTarget(top_context["context"]))
     recursive_compare({
-        "realm": any_string,
-        "exceptionDetails": {
-            "columnNumber": any_int,
-            "exception": {
-                "type": "error"},
-            "lineNumber": any_int,
-            "stackTrace": any_stack_trace,
-            "text": any_string}
-    }, exception.value.result)
+        'realm': any_string,
+        'exceptionDetails': {
+            'columnNumber': any_int,
+            'exception': {
+                'type': 'error'},
+            'lineNumber': any_int,
+            'stackTrace': any_stack_trace,
+            'text': any_string}},
+        exception.value.result)
 
 
 @pytest.mark.asyncio
@@ -73,12 +73,12 @@ async def test_arguments(bidi_session, top_context):
     recursive_compare({
         "type": "array",
         "value": [{
-            "type": "string",
-            "value": "ARGUMENT_STRING_VALUE"
+            "type": 'string',
+            "value": 'ARGUMENT_STRING_VALUE'
         }, {
-            "type": "number",
-            "value": 42}]
-    }, result)
+            "type": 'number',
+            "value": 42}]},
+        result)
 
 
 @pytest.mark.asyncio
@@ -110,8 +110,8 @@ async def test_this(bidi_session, top_context):
         target=ContextTarget(top_context["context"]))
 
     assert result == {
-        "type": "number",
-        "value": 42}
+        'type': 'number',
+        'value': 42}
 
 
 @pytest.mark.asyncio
@@ -123,7 +123,7 @@ async def test_default_this(bidi_session, top_context):
 
     # Note: https://github.com/w3c/webdriver-bidi/issues/251
     recursive_compare({
-        "type": "window",
+        "type": 'window',
     }, result)
 
 
@@ -163,8 +163,8 @@ async def test_async_arrow_await_promise(bidi_session, top_context, await_promis
             "value": "SOME_VALUE"}
     else:
         recursive_compare({
-            "type": "promise"
-        }, result)
+            "type": "promise"},
+            result)
 
 
 @pytest.mark.asyncio
@@ -181,5 +181,5 @@ async def test_async_classic_await_promise(bidi_session, top_context, await_prom
             "value": "SOME_VALUE"}
     else:
         recursive_compare({
-            "type": "promise"
-        }, result)
+            "type": "promise"},
+            result)

--- a/webdriver/tests/bidi/script/call_function/call_function.py
+++ b/webdriver/tests/bidi/script/call_function/call_function.py
@@ -16,19 +16,19 @@ async def test_exception(bidi_session, top_context, result_ownership, expected_h
             target=ContextTarget(top_context["context"]))
 
     recursive_compare({
-        'realm': any_string,
-        'exceptionDetails': {
-            'columnNumber': any_int,
-            'exception': {
-                'type': 'object',
-                'handle': expected_handle,
-                'value': [[
-                    'a', {
-                        "type": 'number',
+        "realm": any_string,
+        "exceptionDetails": {
+            "columnNumber": any_int,
+            "exception": {
+                "type": "object",
+                "handle": expected_handle,
+                "value": [[
+                    "a", {
+                        "type": "number",
                         "value": 1}]]},
-            'lineNumber': any_int,
-            'stackTrace': any_stack_trace,
-            'text': any_string}
+            "lineNumber": any_int,
+            "stackTrace": any_stack_trace,
+            "text": any_string}
     }, exception.value.result)
 
 
@@ -37,20 +37,20 @@ async def test_exception(bidi_session, top_context, result_ownership, expected_h
 async def test_invalid_function(bidi_session, top_context, result_ownership, expected_handle):
     with pytest.raises(ScriptEvaluateResultException) as exception:
         await bidi_session.script.call_function(
-            function_declaration='))) !!@@## some invalid JS script (((',
+            function_declaration="))) !!@@## some invalid JS script (((",
             await_promise=False,
             result_ownership=result_ownership,
             target=ContextTarget(top_context["context"]))
     recursive_compare({
-        'realm': any_string,
-        'exceptionDetails': {
-            'columnNumber': any_int,
-            'exception': {
-                'handle': expected_handle,
-                'type': 'error'},
-            'lineNumber': any_int,
-            'stackTrace': any_stack_trace,
-            'text': any_string}
+        "realm": any_string,
+        "exceptionDetails": {
+            "columnNumber": any_int,
+            "exception": {
+                "handle": expected_handle,
+                "type": "error"},
+            "lineNumber": any_int,
+            "stackTrace": any_stack_trace,
+            "text": any_string}
     }, exception.value.result)
 
 
@@ -67,8 +67,8 @@ async def test_arrow_function(bidi_session, top_context, result_ownership, expec
         "type": "object",
         "handle": expected_handle,
         "value": [[
-            'a', {
-                "type": 'number',
+            "a", {
+                "type": "number",
                 "value": 1}]]
     }, result)
 
@@ -92,10 +92,10 @@ async def test_arguments(bidi_session, top_context, result_ownership, expected_h
         "type": "array",
         "handle": expected_handle,
         "value": [{
-            "type": 'string',
-            "value": 'ARGUMENT_STRING_VALUE'
+            "type": "string",
+            "value": "ARGUMENT_STRING_VALUE"
         }, {
-            "type": 'number',
+            "type": "number",
             "value": 42}]
     }, result)
 
@@ -111,7 +111,7 @@ async def test_default_arguments(bidi_session, top_context, result_ownership, ex
 
     recursive_compare({
         "type": "array",
-        'handle': expected_handle,
+        "handle": expected_handle,
         "value": []
     }, result)
 
@@ -134,13 +134,13 @@ async def test_this(bidi_session, top_context, result_ownership, expected_handle
         target=ContextTarget(top_context["context"]))
 
     recursive_compare({
-        'type': 'object',
-        'handle': expected_handle,
-        'value': [[
-            'some_property',
+        "type": "object",
+        "handle": expected_handle,
+        "value": [[
+            "some_property",
             {
-                'type': 'number',
-                'value': 42}]]
+                "type": "number",
+                "value": 42}]]
     }, result)
 
 
@@ -155,8 +155,8 @@ async def test_default_this(bidi_session, top_context, result_ownership, expecte
 
     # Note: https://github.com/w3c/webdriver-bidi/issues/251
     recursive_compare({
-        "type": 'window',
-        'handle': expected_handle,
+        "type": "window",
+        "handle": expected_handle,
     }, result)
 
 
@@ -179,13 +179,13 @@ async def test_remote_value_argument(bidi_session, top_context, result_ownership
         target=ContextTarget(top_context["context"]))
 
     recursive_compare({
-        'type': 'object',
+        "type": "object",
         "handle": expected_handle,
-        'value': [[
-            'SOME_PROPERTY',
+        "value": [[
+            "SOME_PROPERTY",
             {
-                'type': 'string',
-                'value': 'SOME_VALUE'}]]
+                "type": "string",
+                "value": "SOME_VALUE"}]]
     }, result)
 
 
@@ -201,8 +201,8 @@ async def test_async_arrow_await_promise(bidi_session, top_context, await_promis
 
     if await_promise:
         recursive_compare({
-            'type': 'object',
-            'value': [],
+            "type": "object",
+            "value": [],
             "handle": expected_handle
         }, result)
     else:
@@ -224,8 +224,8 @@ async def test_async_classic_await_promise(bidi_session, top_context, await_prom
 
     if await_promise:
         recursive_compare({
-            'type': 'object',
-            'value': [],
+            "type": "object",
+            "value": [],
             "handle": expected_handle
         }, result)
     else:

--- a/webdriver/tests/bidi/script/call_function/call_function.py
+++ b/webdriver/tests/bidi/script/call_function/call_function.py
@@ -9,41 +9,40 @@ from .. import any_stack_trace
 async def test_exception(bidi_session, top_context):
     with pytest.raises(ScriptEvaluateResultException) as exception:
         await bidi_session.script.call_function(
-            function_declaration='()=>{throw 1}',
+            function_declaration="()=>{throw 1}",
             await_promise=False,
             target=ContextTarget(top_context["context"]))
 
     recursive_compare({
-        'realm': any_string,
-        'exceptionDetails': {
-            'columnNumber': any_int,
-            'exception': {
-                'value': 1,
-                'type': 'number'},
-            'lineNumber': any_int,
-            'stackTrace': any_stack_trace,
-            'text': any_string}},
-        exception.value.result)
+        "realm": any_string,
+        "exceptionDetails": {
+            "columnNumber": any_int,
+            "exception": {
+                "value": 1,
+                "type": "number"},
+            "lineNumber": any_int,
+            "stackTrace": any_stack_trace,
+            "text": any_string}
+    }, exception.value.result)
 
 
 @pytest.mark.asyncio
 async def test_invalid_function(bidi_session, top_context):
     with pytest.raises(ScriptEvaluateResultException) as exception:
         await bidi_session.script.call_function(
-            function_declaration='))) !!@@## some invalid JS script (((',
+            function_declaration="))) !!@@## some invalid JS script (((",
             await_promise=False,
             target=ContextTarget(top_context["context"]))
     recursive_compare({
-        'realm': any_string,
-        'exceptionDetails': {
-            'columnNumber': any_int,
-            'exception': {
-                'handle': any_string,
-                'type': 'error'},
-            'lineNumber': any_int,
-            'stackTrace': any_stack_trace,
-            'text': any_string}},
-        exception.value.result)
+        "realm": any_string,
+        "exceptionDetails": {
+            "columnNumber": any_int,
+            "exception": {
+                "type": "error"},
+            "lineNumber": any_int,
+            "stackTrace": any_stack_trace,
+            "text": any_string}
+    }, exception.value.result)
 
 
 @pytest.mark.asyncio
@@ -73,14 +72,13 @@ async def test_arguments(bidi_session, top_context):
 
     recursive_compare({
         "type": "array",
-        "handle": any_string,
         "value": [{
-            "type": 'string',
-            "value": 'ARGUMENT_STRING_VALUE'
+            "type": "string",
+            "value": "ARGUMENT_STRING_VALUE"
         }, {
-            "type": 'number',
-            "value": 42}]},
-        result)
+            "type": "number",
+            "value": 42}]
+    }, result)
 
 
 @pytest.mark.asyncio
@@ -92,7 +90,6 @@ async def test_default_arguments(bidi_session, top_context):
 
     recursive_compare({
         "type": "array",
-        "handle": any_string,
         "value": []
     }, result)
 
@@ -113,8 +110,8 @@ async def test_this(bidi_session, top_context):
         target=ContextTarget(top_context["context"]))
 
     assert result == {
-        'type': 'number',
-        'value': 42}
+        "type": "number",
+        "value": 42}
 
 
 @pytest.mark.asyncio
@@ -126,8 +123,7 @@ async def test_default_this(bidi_session, top_context):
 
     # Note: https://github.com/w3c/webdriver-bidi/issues/251
     recursive_compare({
-        "type": 'window',
-        "handle": any_string,
+        "type": "window",
     }, result)
 
 
@@ -136,6 +132,7 @@ async def test_remote_value_argument(bidi_session, top_context):
     remote_value_result = await bidi_session.script.evaluate(
         expression="({SOME_PROPERTY:'SOME_VALUE'})",
         await_promise=False,
+        result_ownership="root",
         target=ContextTarget(top_context["context"]))
 
     remote_value_handle = remote_value_result["handle"]
@@ -166,9 +163,8 @@ async def test_async_arrow_await_promise(bidi_session, top_context, await_promis
             "value": "SOME_VALUE"}
     else:
         recursive_compare({
-            "type": "promise",
-            "handle": any_string},
-            result)
+            "type": "promise"
+        }, result)
 
 
 @pytest.mark.asyncio
@@ -185,6 +181,5 @@ async def test_async_classic_await_promise(bidi_session, top_context, await_prom
             "value": "SOME_VALUE"}
     else:
         recursive_compare({
-            "type": "promise",
-            "handle": any_string},
-            result)
+            "type": "promise"
+        }, result)

--- a/webdriver/tests/bidi/script/call_function/call_function.py
+++ b/webdriver/tests/bidi/script/call_function/call_function.py
@@ -6,7 +6,7 @@ from .. import any_stack_trace
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing), (None, missing)])
 async def test_exception(bidi_session, top_context, result_ownership, expected_handle):
     with pytest.raises(ScriptEvaluateResultException) as exception:
         await bidi_session.script.call_function(
@@ -33,7 +33,7 @@ async def test_exception(bidi_session, top_context, result_ownership, expected_h
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing), (None, missing)])
 async def test_invalid_function(bidi_session, top_context, result_ownership, expected_handle):
     with pytest.raises(ScriptEvaluateResultException) as exception:
         await bidi_session.script.call_function(
@@ -55,7 +55,7 @@ async def test_invalid_function(bidi_session, top_context, result_ownership, exp
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing), (None, missing)])
 async def test_arrow_function(bidi_session, top_context, result_ownership, expected_handle):
     result = await bidi_session.script.call_function(
         function_declaration="()=>{return {a:1};}",
@@ -74,7 +74,7 @@ async def test_arrow_function(bidi_session, top_context, result_ownership, expec
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing), (None, missing)])
 async def test_arguments(bidi_session, top_context, result_ownership, expected_handle):
     result = await bidi_session.script.call_function(
         function_declaration="(...args)=>{return args}",
@@ -101,7 +101,7 @@ async def test_arguments(bidi_session, top_context, result_ownership, expected_h
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing), (None, missing)])
 async def test_default_arguments(bidi_session, top_context, result_ownership, expected_handle):
     result = await bidi_session.script.call_function(
         function_declaration="(...args)=>{return args}",
@@ -117,7 +117,7 @@ async def test_default_arguments(bidi_session, top_context, result_ownership, ex
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing), (None, missing)])
 async def test_this(bidi_session, top_context, result_ownership, expected_handle):
     result = await bidi_session.script.call_function(
         function_declaration="function(){return this}",
@@ -145,7 +145,7 @@ async def test_this(bidi_session, top_context, result_ownership, expected_handle
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing), (None, missing)])
 async def test_default_this(bidi_session, top_context, result_ownership, expected_handle):
     result = await bidi_session.script.call_function(
         function_declaration="function(){return this}",
@@ -161,7 +161,7 @@ async def test_default_this(bidi_session, top_context, result_ownership, expecte
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing), (None, missing)])
 async def test_remote_value_argument(bidi_session, top_context, result_ownership, expected_handle):
     remote_value_result = await bidi_session.script.evaluate(
         expression="({SOME_PROPERTY:'SOME_VALUE'})",
@@ -191,7 +191,7 @@ async def test_remote_value_argument(bidi_session, top_context, result_ownership
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("await_promise", [True, False])
-@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing), (None, missing)])
 async def test_async_arrow_await_promise(bidi_session, top_context, await_promise, result_ownership, expected_handle):
     result = await bidi_session.script.call_function(
         function_declaration="async ()=>{return {a:1}}",
@@ -217,7 +217,7 @@ async def test_async_arrow_await_promise(bidi_session, top_context, await_promis
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("await_promise", [True, False])
-@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing), (None, missing)])
 async def test_async_classic_await_promise(bidi_session, top_context, await_promise, result_ownership, expected_handle):
     result = await bidi_session.script.call_function(
         function_declaration="async function(){return {a:1}}",

--- a/webdriver/tests/bidi/script/call_function/call_function.py
+++ b/webdriver/tests/bidi/script/call_function/call_function.py
@@ -194,7 +194,7 @@ async def test_remote_value_argument(bidi_session, top_context, result_ownership
 @pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
 async def test_async_arrow_await_promise(bidi_session, top_context, await_promise, result_ownership, expected_handle):
     result = await bidi_session.script.call_function(
-        function_declaration="async ()=>{return {}}",
+        function_declaration="async ()=>{return {a:1}}",
         await_promise=await_promise,
         result_ownership=result_ownership,
         target=ContextTarget(top_context["context"]))
@@ -202,7 +202,10 @@ async def test_async_arrow_await_promise(bidi_session, top_context, await_promis
     if await_promise:
         recursive_compare({
             "type": "object",
-            "value": [],
+            "value": [[
+                "a", {
+                    "type": "number",
+                    "value": 1}]],
             "handle": expected_handle
         }, result)
     else:
@@ -217,7 +220,7 @@ async def test_async_arrow_await_promise(bidi_session, top_context, await_promis
 @pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
 async def test_async_classic_await_promise(bidi_session, top_context, await_promise, result_ownership, expected_handle):
     result = await bidi_session.script.call_function(
-        function_declaration="async function(){return {}}",
+        function_declaration="async function(){return {a:1}}",
         await_promise=await_promise,
         result_ownership=result_ownership,
         target=ContextTarget(top_context["context"]))
@@ -225,7 +228,10 @@ async def test_async_classic_await_promise(bidi_session, top_context, await_prom
     if await_promise:
         recursive_compare({
             "type": "object",
-            "value": [],
+            "value": [[
+                "a", {
+                    "type": "number",
+                    "value": 1}]],
             "handle": expected_handle
         }, result)
     else:

--- a/webdriver/tests/bidi/script/call_function/call_function.py
+++ b/webdriver/tests/bidi/script/call_function/call_function.py
@@ -6,8 +6,8 @@ from .. import any_stack_trace
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("result_ownership, expect_handle", [("root", any_string), ("none", missing)])
-async def test_exception(bidi_session, top_context, result_ownership, expect_handle):
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+async def test_exception(bidi_session, top_context, result_ownership, expected_handle):
     with pytest.raises(ScriptEvaluateResultException) as exception:
         await bidi_session.script.call_function(
             function_declaration='()=>{throw {a:1}}',
@@ -21,7 +21,7 @@ async def test_exception(bidi_session, top_context, result_ownership, expect_han
             'columnNumber': any_int,
             'exception': {
                 'type': 'object',
-                'handle': expect_handle,
+                'handle': expected_handle,
                 'value': [[
                     'a', {
                         "type": 'number',
@@ -33,8 +33,8 @@ async def test_exception(bidi_session, top_context, result_ownership, expect_han
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("result_ownership, expect_handle", [("root", any_string), ("none", missing)])
-async def test_invalid_function(bidi_session, top_context, result_ownership, expect_handle):
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+async def test_invalid_function(bidi_session, top_context, result_ownership, expected_handle):
     with pytest.raises(ScriptEvaluateResultException) as exception:
         await bidi_session.script.call_function(
             function_declaration='))) !!@@## some invalid JS script (((',
@@ -46,7 +46,7 @@ async def test_invalid_function(bidi_session, top_context, result_ownership, exp
         'exceptionDetails': {
             'columnNumber': any_int,
             'exception': {
-                'handle': expect_handle,
+                'handle': expected_handle,
                 'type': 'error'},
             'lineNumber': any_int,
             'stackTrace': any_stack_trace,
@@ -55,8 +55,8 @@ async def test_invalid_function(bidi_session, top_context, result_ownership, exp
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("result_ownership, expect_handle", [("root", any_string), ("none", missing)])
-async def test_arrow_function(bidi_session, top_context, result_ownership, expect_handle):
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+async def test_arrow_function(bidi_session, top_context, result_ownership, expected_handle):
     result = await bidi_session.script.call_function(
         function_declaration="()=>{return {a:1};}",
         await_promise=False,
@@ -65,7 +65,7 @@ async def test_arrow_function(bidi_session, top_context, result_ownership, expec
 
     recursive_compare({
         "type": "object",
-        "handle": expect_handle,
+        "handle": expected_handle,
         "value": [[
             'a', {
                 "type": 'number',
@@ -74,8 +74,8 @@ async def test_arrow_function(bidi_session, top_context, result_ownership, expec
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("result_ownership, expect_handle", [("root", any_string), ("none", missing)])
-async def test_arguments(bidi_session, top_context, result_ownership, expect_handle):
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+async def test_arguments(bidi_session, top_context, result_ownership, expected_handle):
     result = await bidi_session.script.call_function(
         function_declaration="(...args)=>{return args}",
         arguments=[{
@@ -90,7 +90,7 @@ async def test_arguments(bidi_session, top_context, result_ownership, expect_han
 
     recursive_compare({
         "type": "array",
-        "handle": expect_handle,
+        "handle": expected_handle,
         "value": [{
             "type": 'string',
             "value": 'ARGUMENT_STRING_VALUE'
@@ -101,8 +101,8 @@ async def test_arguments(bidi_session, top_context, result_ownership, expect_han
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("result_ownership, expect_handle", [("root", any_string), ("none", missing)])
-async def test_default_arguments(bidi_session, top_context, result_ownership, expect_handle):
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+async def test_default_arguments(bidi_session, top_context, result_ownership, expected_handle):
     result = await bidi_session.script.call_function(
         function_declaration="(...args)=>{return args}",
         await_promise=False,
@@ -111,14 +111,14 @@ async def test_default_arguments(bidi_session, top_context, result_ownership, ex
 
     recursive_compare({
         "type": "array",
-        'handle': expect_handle,
+        'handle': expected_handle,
         "value": []
     }, result)
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("result_ownership, expect_handle", [("root", any_string), ("none", missing)])
-async def test_this(bidi_session, top_context, result_ownership, expect_handle):
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+async def test_this(bidi_session, top_context, result_ownership, expected_handle):
     result = await bidi_session.script.call_function(
         function_declaration="function(){return this}",
         this={
@@ -135,7 +135,7 @@ async def test_this(bidi_session, top_context, result_ownership, expect_handle):
 
     recursive_compare({
         'type': 'object',
-        'handle': expect_handle,
+        'handle': expected_handle,
         'value': [[
             'some_property',
             {
@@ -145,8 +145,8 @@ async def test_this(bidi_session, top_context, result_ownership, expect_handle):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("result_ownership, expect_handle", [("root", any_string), ("none", missing)])
-async def test_default_this(bidi_session, top_context, result_ownership, expect_handle):
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+async def test_default_this(bidi_session, top_context, result_ownership, expected_handle):
     result = await bidi_session.script.call_function(
         function_declaration="function(){return this}",
         await_promise=False,
@@ -156,13 +156,13 @@ async def test_default_this(bidi_session, top_context, result_ownership, expect_
     # Note: https://github.com/w3c/webdriver-bidi/issues/251
     recursive_compare({
         "type": 'window',
-        'handle': expect_handle,
+        'handle': expected_handle,
     }, result)
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("result_ownership, expect_handle", [("root", any_string), ("none", missing)])
-async def test_remote_value_argument(bidi_session, top_context, result_ownership, expect_handle):
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+async def test_remote_value_argument(bidi_session, top_context, result_ownership, expected_handle):
     remote_value_result = await bidi_session.script.evaluate(
         expression="({SOME_PROPERTY:'SOME_VALUE'})",
         await_promise=False,
@@ -180,7 +180,7 @@ async def test_remote_value_argument(bidi_session, top_context, result_ownership
 
     recursive_compare({
         'type': 'object',
-        "handle": expect_handle,
+        "handle": expected_handle,
         'value': [[
             'SOME_PROPERTY',
             {
@@ -191,8 +191,8 @@ async def test_remote_value_argument(bidi_session, top_context, result_ownership
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("await_promise", [True, False])
-@pytest.mark.parametrize("result_ownership, expect_handle", [("root", any_string), ("none", missing)])
-async def test_async_arrow_await_promise(bidi_session, top_context, await_promise, result_ownership, expect_handle):
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+async def test_async_arrow_await_promise(bidi_session, top_context, await_promise, result_ownership, expected_handle):
     result = await bidi_session.script.call_function(
         function_declaration="async ()=>{return {}}",
         await_promise=await_promise,
@@ -203,19 +203,19 @@ async def test_async_arrow_await_promise(bidi_session, top_context, await_promis
         recursive_compare({
             'type': 'object',
             'value': [],
-            "handle": expect_handle
+            "handle": expected_handle
         }, result)
     else:
         recursive_compare({
             "type": "promise",
-            "handle": expect_handle
+            "handle": expected_handle
         }, result)
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("await_promise", [True, False])
-@pytest.mark.parametrize("result_ownership, expect_handle", [("root", any_string), ("none", missing)])
-async def test_async_classic_await_promise(bidi_session, top_context, await_promise, result_ownership, expect_handle):
+@pytest.mark.parametrize("result_ownership, expected_handle", [("root", any_string), ("none", missing)])
+async def test_async_classic_await_promise(bidi_session, top_context, await_promise, result_ownership, expected_handle):
     result = await bidi_session.script.call_function(
         function_declaration="async function(){return {}}",
         await_promise=await_promise,
@@ -226,10 +226,10 @@ async def test_async_classic_await_promise(bidi_session, top_context, await_prom
         recursive_compare({
             'type': 'object',
             'value': [],
-            "handle": expect_handle
+            "handle": expected_handle
         }, result)
     else:
         recursive_compare({
             "type": "promise",
-            "handle": expect_handle,
+            "handle": expected_handle,
         }, result)

--- a/webdriver/tests/bidi/script/call_function/result_ownership.py
+++ b/webdriver/tests/bidi/script/call_function/result_ownership.py
@@ -3,6 +3,14 @@ import pytest
 from webdriver.bidi.modules.script import ContextTarget, ScriptEvaluateResultException
 
 
+def assert_handle(obj, should_contain_handle):
+    if should_contain_handle:
+        assert "handle" in obj, f"Exception should contain `handle`. Actual: {obj}"
+        assert isinstance(obj["handle"], str), f"`handle` should be a string, but was {type(obj['handle'])}"
+    else:
+        assert "handle" not in obj, f"Exception should not contain `handle`. Actual: {obj}"
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("result_ownership, should_contain_handle",
                          [("root", True), ("none", False), (None, False)])
@@ -14,12 +22,7 @@ async def test_throw_exception(bidi_session, top_context, result_ownership, shou
             result_ownership=result_ownership,
             target=ContextTarget(top_context["context"]))
 
-    if should_contain_handle:
-        assert "handle" in exception.value.result["exceptionDetails"]["exception"], \
-            f"Exception should contain `handle`. Actual: {exception.value.result['exceptionDetails']['exception']}"
-    else:
-        assert "handle" not in exception.value.result["exceptionDetails"]["exception"], \
-            f"Exception should not contain `handle`. Actual: {exception.value.result['exceptionDetails']['exception']}"
+    assert_handle(exception.value.result["exceptionDetails"]["exception"], should_contain_handle)
 
 
 @pytest.mark.asyncio
@@ -33,12 +36,7 @@ async def test_invalid_script(bidi_session, top_context, result_ownership, shoul
             result_ownership=result_ownership,
             target=ContextTarget(top_context["context"]))
 
-    if should_contain_handle:
-        assert "handle" in exception.value.result["exceptionDetails"]["exception"], \
-            f"Exception should contain `handle`. Actual: {exception.value.result['exceptionDetails']['exception']}"
-    else:
-        assert "handle" not in exception.value.result["exceptionDetails"]["exception"], \
-            f"Exception should not contain `handle`. Actual: {exception.value.result['exceptionDetails']['exception']}"
+    assert_handle(exception.value.result["exceptionDetails"]["exception"], should_contain_handle)
 
 
 @pytest.mark.asyncio
@@ -52,12 +50,7 @@ async def test_rejected_promise(bidi_session, top_context, result_ownership, sho
             result_ownership=result_ownership,
             target=ContextTarget(top_context["context"]))
 
-    if should_contain_handle:
-        assert "handle" in exception.value.result["exceptionDetails"]["exception"], \
-            f"Exception should contain `handle`. Actual: {exception.value.result['exceptionDetails']['exception']}"
-    else:
-        assert "handle" not in exception.value.result["exceptionDetails"]["exception"], \
-            f"Exception should not contain `handle`. Actual: {exception.value.result['exceptionDetails']['exception']}"
+    assert_handle(exception.value.result["exceptionDetails"]["exception"], should_contain_handle)
 
 
 @pytest.mark.asyncio
@@ -71,9 +64,4 @@ async def test_return_value(bidi_session, top_context, await_promise, result_own
         result_ownership=result_ownership,
         target=ContextTarget(top_context["context"]))
 
-    if should_contain_handle:
-        assert "handle" in result, \
-            f"Result should contain `handle`. Actual: {result}"
-    else:
-        assert "handle" not in result, \
-            f"Result should not contain `handle`. Actual: {result}"
+    assert_handle(result, should_contain_handle)

--- a/webdriver/tests/bidi/script/call_function/result_ownership.py
+++ b/webdriver/tests/bidi/script/call_function/result_ownership.py
@@ -75,7 +75,7 @@ async def test_return_value(bidi_session, top_context, await_promise, result_own
 
     if should_contain_handle:
         assert "handle" in result, \
-            f"Result should contain `handle`. Actual: {exception.value.result['exceptionDetails']['exception']}"
+            f"Result should contain `handle`. Actual: {result}"
     else:
         assert "handle" not in result, \
-            f"Result should not contain `handle`. Actual: {exception.value.result['exceptionDetails']['exception']}"
+            f"Result should not contain `handle`. Actual: {result}"

--- a/webdriver/tests/bidi/script/call_function/result_ownership.py
+++ b/webdriver/tests/bidi/script/call_function/result_ownership.py
@@ -1,0 +1,81 @@
+import pytest
+
+from webdriver.bidi.modules.script import ContextTarget, ScriptEvaluateResultException
+from ... import recursive_compare, any_string, any_int
+from .. import any_stack_trace
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result_ownership, should_contain_handle",
+                         [("root", True), ("none", False), (None, False)])
+async def test_throw_exception(bidi_session, top_context, result_ownership, should_contain_handle):
+    with pytest.raises(ScriptEvaluateResultException) as exception:
+        await bidi_session.script.call_function(
+            function_declaration='()=>{throw {a:1}}',
+            await_promise=False,
+            result_ownership=result_ownership,
+            target=ContextTarget(top_context["context"]))
+
+    if should_contain_handle:
+        assert "handle" in exception.value.result["exceptionDetails"]["exception"], \
+            f"Exception should contain `handle`. Actual: {exception.value.result['exceptionDetails']['exception']}"
+    else:
+        assert "handle" not in exception.value.result["exceptionDetails"]["exception"], \
+            f"Exception should not contain `handle`. Actual: {exception.value.result['exceptionDetails']['exception']}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result_ownership, should_contain_handle",
+                         [("root", True), ("none", False), (None, False)])
+async def test_invalid_script(bidi_session, top_context, result_ownership, should_contain_handle):
+    with pytest.raises(ScriptEvaluateResultException) as exception:
+        await bidi_session.script.call_function(
+            function_declaration="))) !!@@## some invalid JS script (((",
+            await_promise=False,
+            result_ownership=result_ownership,
+            target=ContextTarget(top_context["context"]))
+
+    if should_contain_handle:
+        assert "handle" in exception.value.result["exceptionDetails"]["exception"], \
+            f"Exception should contain `handle`. Actual: {exception.value.result['exceptionDetails']['exception']}"
+    else:
+        assert "handle" not in exception.value.result["exceptionDetails"]["exception"], \
+            f"Exception should not contain `handle`. Actual: {exception.value.result['exceptionDetails']['exception']}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result_ownership, should_contain_handle",
+                         [("root", True), ("none", False), (None, False)])
+async def test_rejected_promise(bidi_session, top_context, result_ownership, should_contain_handle):
+    with pytest.raises(ScriptEvaluateResultException) as exception:
+        await bidi_session.script.call_function(
+            function_declaration="()=>{return Promise.reject({a:1})}",
+            await_promise=True,
+            result_ownership=result_ownership,
+            target=ContextTarget(top_context["context"]))
+
+    if should_contain_handle:
+        assert "handle" in exception.value.result["exceptionDetails"]["exception"], \
+            f"Exception should contain `handle`. Actual: {exception.value.result['exceptionDetails']['exception']}"
+    else:
+        assert "handle" not in exception.value.result["exceptionDetails"]["exception"], \
+            f"Exception should not contain `handle`. Actual: {exception.value.result['exceptionDetails']['exception']}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("await_promise", [True, False])
+@pytest.mark.parametrize("result_ownership, should_contain_handle",
+                         [("root", True), ("none", False), (None, False)])
+async def test_return_value(bidi_session, top_context, await_promise, result_ownership, should_contain_handle):
+    result = await bidi_session.script.call_function(
+        function_declaration="async function(){return {a:1}}",
+        await_promise=await_promise,
+        result_ownership=result_ownership,
+        target=ContextTarget(top_context["context"]))
+
+    if should_contain_handle:
+        assert "handle" in result, \
+            f"Result should contain `handle`. Actual: {exception.value.result['exceptionDetails']['exception']}"
+    else:
+        assert "handle" not in result, \
+            f"Result should not contain `handle`. Actual: {exception.value.result['exceptionDetails']['exception']}"

--- a/webdriver/tests/bidi/script/call_function/result_ownership.py
+++ b/webdriver/tests/bidi/script/call_function/result_ownership.py
@@ -1,8 +1,6 @@
 import pytest
 
 from webdriver.bidi.modules.script import ContextTarget, ScriptEvaluateResultException
-from ... import recursive_compare, any_string, any_int
-from .. import any_stack_trace
 
 
 @pytest.mark.asyncio

--- a/webdriver/tests/bidi/script/evaluate/await_promise.py
+++ b/webdriver/tests/bidi/script/evaluate/await_promise.py
@@ -203,7 +203,7 @@ async def test_no_await_promise_rejected(bidi_session, top_context):
         await_promise=False,
     )
 
-    recursive_compare({"type": "promise", "handle": any_string}, result)
+    recursive_compare({"type": "promise"}, result)
 
 
 @pytest.mark.asyncio
@@ -214,4 +214,4 @@ async def test_no_await_promise_resolved(bidi_session, top_context):
         await_promise=False,
     )
 
-    recursive_compare({"type": "promise", "handle": any_string}, result)
+    recursive_compare({"type": "promise"}, result)


### PR DESCRIPTION
* ~~Added `missing` option to expected object in `recursive_compare`, which verifies the actual object does not have such a property.~~
* Added tests for `resultOwnership` parameter of `script.callFunction`: `script/call_function/result_ownership.py`
* Updated tests `script/call_function/call_function.py` and `script/evaluate/await_promise.py `to align with spec and not to wait for `handle`.