### PR TITLE
Remove jsshell annotations from streams/

### DIFF
--- a/streams/piping/abort.any.js
+++ b/streams/piping/abort.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/recording-streams.js
 // META: script=../resources/test-utils.js
 'use strict';

--- a/streams/piping/close-propagation-backward.any.js
+++ b/streams/piping/close-propagation-backward.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/recording-streams.js
 'use strict';
 

--- a/streams/piping/close-propagation-forward.any.js
+++ b/streams/piping/close-propagation-forward.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/test-utils.js
 // META: script=../resources/recording-streams.js
 'use strict';

--- a/streams/piping/error-propagation-backward.any.js
+++ b/streams/piping/error-propagation-backward.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/test-utils.js
 // META: script=../resources/recording-streams.js
 'use strict';

--- a/streams/piping/error-propagation-forward.any.js
+++ b/streams/piping/error-propagation-forward.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/test-utils.js
 // META: script=../resources/recording-streams.js
 'use strict';

--- a/streams/piping/flow-control.any.js
+++ b/streams/piping/flow-control.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/test-utils.js
 // META: script=../resources/rs-utils.js
 // META: script=../resources/recording-streams.js

--- a/streams/piping/general.any.js
+++ b/streams/piping/general.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/test-utils.js
 // META: script=../resources/recording-streams.js
 'use strict';

--- a/streams/piping/multiple-propagation.any.js
+++ b/streams/piping/multiple-propagation.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/test-utils.js
 // META: script=../resources/recording-streams.js
 'use strict';

--- a/streams/piping/pipe-through.any.js
+++ b/streams/piping/pipe-through.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/rs-utils.js
 // META: script=../resources/test-utils.js
 // META: script=../resources/recording-streams.js

--- a/streams/piping/then-interception.any.js
+++ b/streams/piping/then-interception.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/test-utils.js
 // META: script=../resources/recording-streams.js
 'use strict';

--- a/streams/piping/throwing-options.any.js
+++ b/streams/piping/throwing-options.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 'use strict';
 
 class ThrowingOptions {

--- a/streams/piping/transform-streams.any.js
+++ b/streams/piping/transform-streams.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 'use strict';
 
 promise_test(() => {

--- a/streams/readable-byte-streams/bad-buffers-and-views.any.js
+++ b/streams/readable-byte-streams/bad-buffers-and-views.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 'use strict';
 
 promise_test(() => {

--- a/streams/readable-byte-streams/construct-byob-request.any.js
+++ b/streams/readable-byte-streams/construct-byob-request.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/rs-utils.js
 'use strict';
 

--- a/streams/readable-byte-streams/general.any.js
+++ b/streams/readable-byte-streams/general.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/rs-utils.js
 // META: script=../resources/test-utils.js
 'use strict';

--- a/streams/readable-byte-streams/non-transferable-buffers.any.js
+++ b/streams/readable-byte-streams/non-transferable-buffers.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 'use strict';
 
 promise_test(async t => {

--- a/streams/readable-byte-streams/respond-after-enqueue.any.js
+++ b/streams/readable-byte-streams/respond-after-enqueue.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 
 'use strict';
 

--- a/streams/readable-byte-streams/tee.any.js
+++ b/streams/readable-byte-streams/tee.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/rs-utils.js
 // META: script=../resources/test-utils.js
 // META: script=../resources/recording-streams.js

--- a/streams/transform-streams/backpressure.any.js
+++ b/streams/transform-streams/backpressure.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/recording-streams.js
 // META: script=../resources/test-utils.js
 'use strict';

--- a/streams/transform-streams/errors.any.js
+++ b/streams/transform-streams/errors.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/test-utils.js
 'use strict';
 

--- a/streams/transform-streams/flush.any.js
+++ b/streams/transform-streams/flush.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/test-utils.js
 'use strict';
 

--- a/streams/transform-streams/general.any.js
+++ b/streams/transform-streams/general.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/test-utils.js
 // META: script=../resources/rs-utils.js
 'use strict';

--- a/streams/transform-streams/lipfuzz.any.js
+++ b/streams/transform-streams/lipfuzz.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 'use strict';
 
 class LipFuzzTransformer {

--- a/streams/transform-streams/patched-global.any.js
+++ b/streams/transform-streams/patched-global.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 'use strict';
 
 // Tests which patch the global environment are kept separate to avoid

--- a/streams/transform-streams/properties.any.js
+++ b/streams/transform-streams/properties.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 'use strict';
 
 const transformerMethods = {

--- a/streams/transform-streams/reentrant-strategies.any.js
+++ b/streams/transform-streams/reentrant-strategies.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/recording-streams.js
 // META: script=../resources/rs-utils.js
 // META: script=../resources/test-utils.js

--- a/streams/transform-streams/strategies.any.js
+++ b/streams/transform-streams/strategies.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/recording-streams.js
 // META: script=../resources/test-utils.js
 'use strict';

--- a/streams/transform-streams/terminate.any.js
+++ b/streams/transform-streams/terminate.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/recording-streams.js
 // META: script=../resources/test-utils.js
 'use strict';

--- a/streams/writable-streams/aborting.any.js
+++ b/streams/writable-streams/aborting.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/test-utils.js
 // META: script=../resources/recording-streams.js
 'use strict';

--- a/streams/writable-streams/bad-strategies.any.js
+++ b/streams/writable-streams/bad-strategies.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 'use strict';
 
 const error1 = new Error('a unique string');

--- a/streams/writable-streams/bad-underlying-sinks.any.js
+++ b/streams/writable-streams/bad-underlying-sinks.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/test-utils.js
 // META: script=../resources/recording-streams.js
 'use strict';

--- a/streams/writable-streams/byte-length-queuing-strategy.any.js
+++ b/streams/writable-streams/byte-length-queuing-strategy.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 'use strict';
 
 promise_test(t => {

--- a/streams/writable-streams/close.any.js
+++ b/streams/writable-streams/close.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/test-utils.js
 // META: script=../resources/recording-streams.js
 'use strict';

--- a/streams/writable-streams/constructor.any.js
+++ b/streams/writable-streams/constructor.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 'use strict';
 
 const error1 = new Error('error1');

--- a/streams/writable-streams/count-queuing-strategy.any.js
+++ b/streams/writable-streams/count-queuing-strategy.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 'use strict';
 
 test(() => {

--- a/streams/writable-streams/error.any.js
+++ b/streams/writable-streams/error.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 'use strict';
 
 const error1 = new Error('error1');

--- a/streams/writable-streams/floating-point-total-queue-size.any.js
+++ b/streams/writable-streams/floating-point-total-queue-size.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 'use strict';
 
 // Due to the limitations of floating-point precision, the calculation of desiredSize sometimes gives different answers

--- a/streams/writable-streams/general.any.js
+++ b/streams/writable-streams/general.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 'use strict';
 
 test(() => {

--- a/streams/writable-streams/properties.any.js
+++ b/streams/writable-streams/properties.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 'use strict';
 
 const sinkMethods = {

--- a/streams/writable-streams/reentrant-strategy.any.js
+++ b/streams/writable-streams/reentrant-strategy.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/test-utils.js
 // META: script=../resources/recording-streams.js
 'use strict';

--- a/streams/writable-streams/start.any.js
+++ b/streams/writable-streams/start.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/test-utils.js
 // META: script=../resources/recording-streams.js
 'use strict';

--- a/streams/writable-streams/write.any.js
+++ b/streams/writable-streams/write.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker
 // META: script=../resources/test-utils.js
 // META: script=../resources/recording-streams.js
 'use strict';


### PR DESCRIPTION
They are no longer helpful for their original consumer (Gecko) and cause wpt.fyi to display spurious failures (https://github.com/web-platform-tests/wpt.fyi/issues/1469).

c894f0086c99ab5efc37691ac60f33a2b37c2e7c removed some but not all.

Closes #34795.