### PR TITLE
Add tests for script.callFunction for serialization of complex objects with simple value field.

### DIFF
--- a/webdriver/tests/bidi/script/call_function/result.py
+++ b/webdriver/tests/bidi/script/call_function/result.py
@@ -30,3 +30,97 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
     )
 
     assert result == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "expression, expected",
+    [
+        (
+            "new RegExp(/foo/g)",
+            {
+                "type": "regexp",
+                "value": {
+                    "pattern": "foo",
+                    "flags": "g",
+                },
+            },
+        ),
+        (
+            "new Date(1654004849000)",
+            {
+                "type": "date",
+                "value": "2022-05-31T13:47:29.000Z",
+            },
+        ),
+        (
+            "[1, 'foo', true, new RegExp(/foo/g), [1]]",
+            {
+                "type": "array",
+                "value": [
+                    {"type": "number", "value": 1},
+                    {"type": "string", "value": "foo"},
+                    {"type": "boolean", "value": True},
+                    {
+                        "type": "regexp",
+                        "value": {
+                            "pattern": "foo",
+                            "flags": "g",
+                        },
+                    },
+                    {"type": "array"},
+                ],
+            },
+        ),
+        (
+            "new Map([[1, 2], ['foo', 'bar'], [true, false], ['baz', [1]]])",
+            {
+                "type": "map",
+                "value": [
+                    [
+                        {"type": "number", "value": 1},
+                        {"type": "number", "value": 2},
+                    ],
+                    ["foo", {"type": "string", "value": "bar"}],
+                    [
+                        {"type": "boolean", "value": True},
+                        {"type": "boolean", "value": False},
+                    ],
+                    ["baz", {"type": "array"}],
+                ],
+            },
+        ),
+        (
+            "new Set([1, 'foo', true, [1], new Map([[1,2]])])",
+            {
+                "type": "set",
+                "value": [
+                    {"type": "number", "value": 1},
+                    {"type": "string", "value": "foo"},
+                    {"type": "boolean", "value": True},
+                    {"type": "array"},
+                    {"type": "map"},
+                ],
+            },
+        ),
+        (
+            "({'foo': {'bar': 'baz'}, 'qux': 'quux'})",
+            {
+                "type": "object",
+                "value": [
+                    ["foo", {"type": "object"}],
+                    ["qux", {"type": "string", "value": "quux"}],
+                ],
+            },
+        ),
+    ],
+    ids=["regexp", "date", "array", "map", "set", "object"],
+)
+async def test_remote_values(bidi_session, top_context, expression, expected):
+    result = await bidi_session.script.call_function(
+        function_declaration=f"() => {expression}",
+        await_promise=False,
+        target=ContextTarget(top_context["context"]),
+    )
+
+    assert result == expected

--- a/webdriver/tests/bidi/script/call_function/result.py
+++ b/webdriver/tests/bidi/script/call_function/result.py
@@ -36,23 +36,7 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
 @pytest.mark.parametrize(
     "expression, expected",
     [
-        (
-            "new RegExp(/foo/g)",
-            {
-                "type": "regexp",
-                "value": {
-                    "pattern": "foo",
-                    "flags": "g",
-                },
-            },
-        ),
-        (
-            "new Date(1654004849000)",
-            {
-                "type": "date",
-                "value": "2022-05-31T13:47:29.000Z",
-            },
-        ),
+        ("(Symbol('foo'))", {"type": "symbol"}),
         (
             "[1, 'foo', true, new RegExp(/foo/g), [1]]",
             {
@@ -71,6 +55,28 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
                     {"type": "array"},
                 ],
             },
+        ),
+        (
+            "({'foo': {'bar': 'baz'}, 'qux': 'quux'})",
+            {
+                "type": "object",
+                "value": [
+                    ["foo", {"type": "object"}],
+                    ["qux", {"type": "string", "value": "quux"}],
+                ],
+            },
+        ),
+        ("(()=>{})", {"type": "function"}),
+        ("(function(){})", {"type": "function"}),
+        ("(async ()=>{})", {"type": "function"}),
+        ("(async function(){})", {"type": "function"}),
+        (
+            "new RegExp(/foo/g)",
+            {"type": "regexp", "value": {"pattern": "foo", "flags": "g"}},
+        ),
+        (
+            "new Date(1654004849000)",
+            {"type": "date", "value": "2022-05-31T13:47:29.000Z"},
         ),
         (
             "new Map([[1, 2], ['foo', 'bar'], [true, false], ['baz', [1]]])",
@@ -103,18 +109,33 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
                 ],
             },
         ),
+        ("new WeakMap()", {"type": "weakmap"}),
+        ("new WeakSet()", {"type": "weakset"}),
+        ("new Error('SOME_ERROR_TEXT')", {"type": "error"}),
+        # TODO(sadym): add `iterator` test.
+        # TODO(sadym): add `generator` test.
+        # TODO(sadym): add `proxy` test.
+        ("Promise.resolve()", {"type": "promise"}),
+        ("new Int32Array()", {"type": "typedarray"}),
+        ("new ArrayBuffer()", {"type": "arraybuffer"}),
         (
-            "({'foo': {'bar': 'baz'}, 'qux': 'quux'})",
+            "document.createElement('div')",
             {
-                "type": "object",
-                "value": [
-                    ["foo", {"type": "object"}],
-                    ["qux", {"type": "string", "value": "quux"}],
-                ],
+                "type": "node",
+                "value": {
+                    "attributes": {},
+                    "childNodeCount": 0,
+                    "children": [],
+                    "localName": "div",
+                    "namespaceURI": "http://www.w3.org/1999/xhtml",
+                    "nodeName": "",
+                    "nodeType": 1,
+                    "nodeValue": "",
+                },
             },
         ),
+        ("window", {"type": "window"}),
     ],
-    ids=["regexp", "date", "array", "map", "set", "object"],
 )
 async def test_remote_values(bidi_session, top_context, expression, expected):
     result = await bidi_session.script.call_function(


### PR DESCRIPTION
Add tests for script.callFunction for serialization of complex objects with simple value field (objects which don't require strong reference)