### PR TITLE
Add `resultOwnership` tests for `script.evaluate`

### DIFF
--- a/webdriver/tests/bidi/script/__init__.py
+++ b/webdriver/tests/bidi/script/__init__.py
@@ -3,6 +3,14 @@ from typing import Any
 from .. import any_int, any_string
 
 
+def assert_handle(obj, should_contain_handle):
+    if should_contain_handle:
+        assert "handle" in obj, f"Result should contain `handle`. Actual: {obj}"
+        assert isinstance(obj["handle"], str), f"`handle` should be a string, but was {type(obj['handle'])}"
+    else:
+        assert "handle" not in obj, f"Result should not contain `handle`. Actual: {obj}"
+
+
 def any_stack_trace(actual: Any) -> None:
     assert type(actual) is dict
     assert "callFrames" in actual

--- a/webdriver/tests/bidi/script/call_function/result_ownership.py
+++ b/webdriver/tests/bidi/script/call_function/result_ownership.py
@@ -1,14 +1,7 @@
 import pytest
 
 from webdriver.bidi.modules.script import ContextTarget, ScriptEvaluateResultException
-
-
-def assert_handle(obj, should_contain_handle):
-    if should_contain_handle:
-        assert "handle" in obj, f"Exception should contain `handle`. Actual: {obj}"
-        assert isinstance(obj["handle"], str), f"`handle` should be a string, but was {type(obj['handle'])}"
-    else:
-        assert "handle" not in obj, f"Exception should not contain `handle`. Actual: {obj}"
+from .. import assert_handle
 
 
 @pytest.mark.asyncio

--- a/webdriver/tests/bidi/script/evaluate/exception_details.py
+++ b/webdriver/tests/bidi/script/evaluate/exception_details.py
@@ -17,9 +17,7 @@ async def test_invalid_script(bidi_session, top_context):
         'realm': any_string,
         'exceptionDetails': {
             'columnNumber': any_int,
-            'exception': {
-                'handle': any_string,
-                'type': 'error'},
+            'exception': {'type': 'error'},
             'lineNumber': any_int,
             'stackTrace': any_stack_trace,
             'text': any_string}},
@@ -68,9 +66,7 @@ async def test_reject_error(bidi_session, top_context):
             "realm": any_string,
             "exceptionDetails": {
                 "columnNumber": any_int,
-                "exception": {
-                    "handle": any_string,
-                    "type": "error"},
+                "exception": {"type": "error"},
                 "lineNumber": any_int,
                 "stackTrace": any_stack_trace,
                 "text": any_string,
@@ -92,9 +88,7 @@ async def test_throw_error(bidi_session, top_context):
         'realm': any_string,
         'exceptionDetails': {
             'columnNumber': any_int,
-            'exception': {
-                'handle': any_string,
-                'type': 'error'},
+            'exception': {'type': 'error'},
             'lineNumber': any_int,
             'stackTrace': any_stack_trace,
             'text': any_string}},

--- a/webdriver/tests/bidi/script/evaluate/result_ownership.py
+++ b/webdriver/tests/bidi/script/evaluate/result_ownership.py
@@ -1,14 +1,7 @@
 import pytest
 
 from webdriver.bidi.modules.script import ContextTarget, ScriptEvaluateResultException
-
-
-def assert_handle(obj, should_contain_handle):
-    if should_contain_handle:
-        assert "handle" in obj, f"Result should contain `handle`. Actual: {obj}"
-        assert isinstance(obj["handle"], str), f"`handle` should be a string, but was {type(obj['handle'])}"
-    else:
-        assert "handle" not in obj, f"Result should not contain `handle`. Actual: {obj}"
+from .. import assert_handle
 
 
 @pytest.mark.asyncio

--- a/webdriver/tests/bidi/script/evaluate/result_ownership.py
+++ b/webdriver/tests/bidi/script/evaluate/result_ownership.py
@@ -1,0 +1,67 @@
+import pytest
+
+from webdriver.bidi.modules.script import ContextTarget, ScriptEvaluateResultException
+
+
+def assert_handle(obj, should_contain_handle):
+    if should_contain_handle:
+        assert "handle" in obj, f"Result should contain `handle`. Actual: {obj}"
+        assert isinstance(obj["handle"], str), f"`handle` should be a string, but was {type(obj['handle'])}"
+    else:
+        assert "handle" not in obj, f"Result should not contain `handle`. Actual: {obj}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result_ownership, should_contain_handle",
+                         [("root", True), ("none", False), (None, False)])
+async def test_throw_exception(bidi_session, top_context, result_ownership, should_contain_handle):
+    with pytest.raises(ScriptEvaluateResultException) as exception:
+        await bidi_session.script.evaluate(
+            expression='throw {a:1}',
+            await_promise=False,
+            result_ownership=result_ownership,
+            target=ContextTarget(top_context["context"]))
+
+    assert_handle(exception.value.result["exceptionDetails"]["exception"], should_contain_handle)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result_ownership, should_contain_handle",
+                         [("root", True), ("none", False), (None, False)])
+async def test_invalid_script(bidi_session, top_context, result_ownership, should_contain_handle):
+    with pytest.raises(ScriptEvaluateResultException) as exception:
+        await bidi_session.script.evaluate(
+            expression="))) !!@@## some invalid JS script (((",
+            await_promise=False,
+            result_ownership=result_ownership,
+            target=ContextTarget(top_context["context"]))
+
+    assert_handle(exception.value.result["exceptionDetails"]["exception"], should_contain_handle)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result_ownership, should_contain_handle",
+                         [("root", True), ("none", False), (None, False)])
+async def test_rejected_promise(bidi_session, top_context, result_ownership, should_contain_handle):
+    with pytest.raises(ScriptEvaluateResultException) as exception:
+        await bidi_session.script.evaluate(
+            expression="Promise.reject({a:1})",
+            await_promise=True,
+            result_ownership=result_ownership,
+            target=ContextTarget(top_context["context"]))
+
+    assert_handle(exception.value.result["exceptionDetails"]["exception"], should_contain_handle)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("await_promise", [True, False])
+@pytest.mark.parametrize("result_ownership, should_contain_handle",
+                         [("root", True), ("none", False), (None, False)])
+async def test_return_value(bidi_session, top_context, await_promise, result_ownership, should_contain_handle):
+    result = await bidi_session.script.evaluate(
+        expression="Promise.resolve({a:1})",
+        await_promise=await_promise,
+        result_ownership=result_ownership,
+        target=ContextTarget(top_context["context"]))
+
+    assert_handle(result, should_contain_handle)


### PR DESCRIPTION
Added tests for `resultOwnership` parameter of `script.evaluate`: `script/evaluate/result_ownership.py`