### PR TITLE
Remove inconsistent test

### DIFF
--- a/webdriver/tests/bidi/browsing_context/navigate/error.py
+++ b/webdriver/tests/bidi/browsing_context/navigate/error.py
@@ -20,12 +20,3 @@ pytestmark = pytest.mark.asyncio
 )
 async def test_invalid_address(bidi_session, new_tab, url):
     await navigate_and_assert(bidi_session, new_tab, url, expected_error=True)
-
-
-async def test_invalid_content_encoding(bidi_session, new_tab, inline):
-    await navigate_and_assert(
-        bidi_session,
-        new_tab,
-        f"{inline('<div>foo')}&pipe=header(Content-Encoding,gzip)",
-        expected_error=True
-    )


### PR DESCRIPTION
It looks like Chromium doesn't consider the request faulty, and waits till the load is fully loaded, which never happens. Can we remove the test? 
In Chromium, the step 10 "Let ... be **await** given «`event name`, 'download started', 'navigation aborted', 'navigation failed'»" of [await a navigation](https://w3c.github.io/webdriver-bidi/#await-a-navigation) never happens, which leads to the test hangs till timeout.