### PR TITLE
Add test for mixed number, percent, alpha in color()

### DIFF
--- a/css/css-color/parsing/color-mixed-num-pct.html
+++ b/css/css-color/parsing/color-mixed-num-pct.html
@@ -21,7 +21,7 @@
     testColorFunction("sRGB all numbers", "color(srgb 1.00 0.50 0.200)", "color(srgb 1 0.5 0.2)");
     testColorFunction("sRGB all percent", "color(srgb 100% 50% 20%)", "color(srgb 1 0.5 0.2)");
     testColorFunction("sRGB mixed number and percent", "color(srgb 100% 0.5 20%)", "color(srgb 1 0.5 0.2)");
-    testColorFunction("sRGB mixed number and percent", "color(srgb 1.00 50% 0.2)", "color(srgb 1 0.5 0.2)");
+    testColorFunction("sRGB mixed number and percent 2", "color(srgb 1.00 50% 0.2)", "color(srgb 1 0.5 0.2)");
     testColorFunction("sRGB all none", "color(srgb none none none)", "color(srgb 0 0 0)");
     testColorFunction("sRGB number and none", "color(srgb 1.00 none 0.2)", "color(srgb 1 0 0.2)");
     testColorFunction("sRGB percent and none", "color(srgb 100% none 20%)", "color(srgb 1 0 0.2)");
@@ -31,7 +31,7 @@
     testColorFunction("sRGB with alpha, all numbers", "color(srgb 1.00 0.50 0.200 / 0.6)", "color(srgb 1 0.5 0.2 / 0.6)");
     testColorFunction("sRGB with alpha, all percent", "color(srgb 100% 50% 20%)", "color(srgb 1 0.5 0.2 / 0.6)");
     testColorFunction("sRGB with alpha, mixed number and percent", "color(srgb 100% 0.5 20% / 0.6)", "color(srgb 1 0.5 0.2 / 0.6)");
-    testColorFunction("sRGB with alpha, mixed number and percent", "color(srgb 1.00 50% 0.2 / 60%)", "color(srgb 1 0.5 0.2 / 0.6)");
+    testColorFunction("sRGB with alpha, mixed number and percent 2", "color(srgb 1.00 50% 0.2 / 60%)", "color(srgb 1 0.5 0.2 / 0.6)");
     testColorFunction("sRGB with alpha, all none", "color(srgb none none none / none)", "color(srgb 0 0 0 / 0)");
     testColorFunction("sRGB with alpha, number and none", "color(srgb 1.00 none 0.2 / none)", "color(srgb 1 0 0.2 / 0)");
     testColorFunction("sRGB with alpha, percent and none", "color(srgb 100% none 20% / 30%)", "color(srgb 1 0 0.2 / 0.3)");
@@ -41,7 +41,7 @@
     testColorFunction("Display P3 all numbers", "color(display-p3 1.00 0.50 0.200)", "color(display-p3 1 0.5 0.2)");
     testColorFunction("Display P3 all percent", "color(display-p3 100% 50% 20%)", "color(display-p3 1 0.5 0.2)");
     testColorFunction("Display P3 mixed number and percent", "color(display-p3 100% 0.5 20%)", "color(display-p3 1 0.5 0.2)");
-    testColorFunction("Display P3 mixed number and percent", "color(display-p3 1.00 50% 0.2)", "color(display-p3 1 0.5 0.2)");
+    testColorFunction("Display P3 mixed number and percent 2", "color(display-p3 1.00 50% 0.2)", "color(display-p3 1 0.5 0.2)");
     testColorFunction("Display P3 all none", "color(display-p3 none none none)", "color(display-p3 0 0 0)");
     testColorFunction("Display P3 number and none", "color(display-p3 1.00 none 0.2)", "color(display-p3 1 0 0.2)");
     testColorFunction("Display P3 percent and none", "color(display-p3 100% none 20%)", "color(display-p3 1 0 0.2)");
@@ -51,7 +51,7 @@
     testColorFunction("Display P3 with alpha, all numbers", "color(display-p3 1.00 0.50 0.200 / 0.6)", "color(display-p3 1 0.5 0.2 / 0.6)");
     testColorFunction("Display P3 with alpha, all percent", "color(display-p3 100% 50% 20%)", "color(display-p3 1 0.5 0.2 / 0.6)");
     testColorFunction("Display P3 with alpha, mixed number and percent", "color(display-p3 100% 0.5 20% / 0.6)", "color(display-p3 1 0.5 0.2 / 0.6)");
-    testColorFunction("Display P3 with alpha, mixed number and percent", "color(display-p3 1.00 50% 0.2 / 60%)", "color(display-p3 1 0.5 0.2 / 0.6)");
+    testColorFunction("Display P3 with alpha, mixed number and percent 2", "color(display-p3 1.00 50% 0.2 / 60%)", "color(display-p3 1 0.5 0.2 / 0.6)");
     testColorFunction("Display P3 with alpha, all none", "color(display-p3 none none none / none)", "color(display-p3 0 0 0 / 0)");
     testColorFunction("Display P3 with alpha, number and none", "color(display-p3 1.00 none 0.2 / none)", "color(display-p3 1 0 0.2 / 0)");
     testColorFunction("Display P3 with alpha, percent and none", "color(display-p3 100% none 20% / 30%)", "color(display-p3 1 0 0.2 / 0.3)");
@@ -61,7 +61,7 @@
     testColorFunction("Rec BT.2020 all numbers", "color(rec2020 1.00 0.50 0.200)", "color(rec2020 1 0.5 0.2)");
     testColorFunction("Rec BT.2020 all percent", "color(rec2020 100% 50% 20%)", "color(rec2020 1 0.5 0.2)");
     testColorFunction("Rec BT.2020 mixed number and percent", "color(rec2020 100% 0.5 20%)", "color(rec2020 1 0.5 0.2)");
-    testColorFunction("Rec BT.2020 mixed number and percent", "color(rec2020 1.00 50% 0.2)", "color(rec2020 1 0.5 0.2)");
+    testColorFunction("Rec BT.2020 mixed number and percent 2", "color(rec2020 1.00 50% 0.2)", "color(rec2020 1 0.5 0.2)");
     testColorFunction("Rec BT.2020 all none", "color(rec2020 none none none)", "color(rec2020 0 0 0)");
     testColorFunction("Rec BT.2020 number and none", "color(rec2020 1.00 none 0.2)", "color(rec2020 1 0 0.2)");
     testColorFunction("Rec BT.2020 percent and none", "color(rec2020 100% none 20%)", "color(rec2020 1 0 0.2)");
@@ -71,7 +71,7 @@
     testColorFunction("Rec BT.2020 with alpha, all numbers", "color(rec2020 1.00 0.50 0.200 / 0.6)", "color(rec2020 1 0.5 0.2 / 0.6)");
     testColorFunction("Rec BT.2020 with alpha, all percent", "color(rec2020 100% 50% 20%)", "color(rec2020 1 0.5 0.2 / 0.6)");
     testColorFunction("Rec BT.2020 with alpha, mixed number and percent", "color(rec2020 100% 0.5 20% / 0.6)", "color(rec2020 1 0.5 0.2 / 0.6)");
-    testColorFunction("Rec BT.2020 with alpha, mixed number and percent", "color(rec2020 1.00 50% 0.2 / 60%)", "color(rec2020 1 0.5 0.2 / 0.6)");
+    testColorFunction("Rec BT.2020 with alpha, mixed number and percent 2", "color(rec2020 1.00 50% 0.2 / 60%)", "color(rec2020 1 0.5 0.2 / 0.6)");
     testColorFunction("Rec BT.2020 with alpha, all none", "color(rec2020 none none none / none)", "color(rec2020 0 0 0 / 0)");
     testColorFunction("Rec BT.2020 with alpha, number and none", "color(rec2020 1.00 none 0.2 / none)", "color(rec2020 1 0 0.2 / 0)");
     testColorFunction("Rec BT.2020 with alpha, percent and none", "color(rec2020 100% none 20% / 30%)", "color(rec2020 1 0 0.2 / 0.3)");

--- a/css/css-color/parsing/color-mixed-num-pct.html
+++ b/css/css-color/parsing/color-mixed-num-pct.html
@@ -37,6 +37,26 @@
     testColorFunction("sRGB with alpha, percent and none", "color(srgb 100% none 20% / 30%)", "color(srgb 1 0 0.2 / 0.3)");
     testColorFunction("sRGB with alpha, number, percent and none", "color(srgb 100% none 0.2 / 23.7%)", "color(srgb 1 0 0.2 / 0.237)");
 
+    // Opaque linear-light sRGB in color()
+    testColorFunction("Linear-light sRGB all numbers", "color(srgb-linear 1.00 0.50 0.200)", "color(srgb-linear 1 0.5 0.2)");
+    testColorFunction("Linear-light sRGB all percent", "color(srgb-linear 100% 50% 20%)", "color(srgb-linear 1 0.5 0.2)");
+    testColorFunction("Linear-light sRGB mixed number and percent", "color(srgb-linear 100% 0.5 20%)", "color(srgb-linear 1 0.5 0.2)");
+    testColorFunction("Linear-light sRGB mixed number and percent 2", "color(srgb-linear 1.00 50% 0.2)", "color(srgb-linear 1 0.5 0.2)");
+    testColorFunction("Linear-light sRGB all none", "color(srgb-linear none none none)", "color(srgb-linear 0 0 0)");
+    testColorFunction("Linear-light sRGB number and none", "color(srgb-linear 1.00 none 0.2)", "color(srgb-linear 1 0 0.2)");
+    testColorFunction("Linear-light sRGB percent and none", "color(srgb-linear 100% none 20%)", "color(srgb-linear 1 0 0.2)");
+    testColorFunction("Linear-light sRGB number, percent and none", "color(srgb-linear 100% none 0.2)", "color(srgb-linear 1 0 0.2)");
+
+    // non-unity alpha, linear-light sRGB in  color()
+    testColorFunction("Linear-light sRGB with alpha, all numbers", "color(srgb-linear 1.00 0.50 0.200 / 0.6)", "color(srgb-linear 1 0.5 0.2 / 0.6)");
+    testColorFunction("Linear-light sRGB with alpha, all percent", "color(srgb-linear 100% 50% 20%)", "color(srgb-linear 1 0.5 0.2 / 0.6)");
+    testColorFunction("Linear-light sRGB with alpha, mixed number and percent", "color(srgb-linear 100% 0.5 20% / 0.6)", "color(srgb-linear 1 0.5 0.2 / 0.6)");
+    testColorFunction("Linear-light sRGB with alpha, mixed number and percent 2", "color(srgb-linear 1.00 50% 0.2 / 60%)", "color(srgb-linear 1 0.5 0.2 / 0.6)");
+    testColorFunction("Linear-light sRGB with alpha, all none", "color(srgb-linear none none none / none)", "color(srgb-linear 0 0 0 / 0)");
+    testColorFunction("Linear-light sRGB with alpha, number and none", "color(srgb-linear 1.00 none 0.2 / none)", "color(srgb-linear 1 0 0.2 / 0)");
+    testColorFunction("Linear-light sRGB with alpha, percent and none", "color(srgb-linear 100% none 20% / 30%)", "color(srgb-linear 1 0 0.2 / 0.3)");
+    testColorFunction("Linear-light sRGB with alpha, number, percent and none", "color(srgb-linear 100% none 0.2 / 23.7%)", "color(srgb-linear 1 0 0.2 / 0.237)");
+
     // Opaque Display P3 in color()
     testColorFunction("Display P3 all numbers", "color(display-p3 1.00 0.50 0.200)", "color(display-p3 1 0.5 0.2)");
     testColorFunction("Display P3 all percent", "color(display-p3 100% 50% 20%)", "color(display-p3 1 0.5 0.2)");
@@ -57,6 +77,46 @@
     testColorFunction("Display P3 with alpha, percent and none", "color(display-p3 100% none 20% / 30%)", "color(display-p3 1 0 0.2 / 0.3)");
     testColorFunction("Display P3 with alpha, number, percent and none", "color(display-p3 100% none 0.2 / 23.7%)", "color(display-p3 1 0 0.2 / 0.237)");
 
+    // Opaque A98 RGB in color()
+    testColorFunction("A98 RGB all numbers", "color(a98-rgb 1.00 0.50 0.200)", "color(a98-rgb 1 0.5 0.2)");
+    testColorFunction("A98 RGB all percent", "color(a98-rgb 100% 50% 20%)", "color(a98-rgb 1 0.5 0.2)");
+    testColorFunction("A98 RGB mixed number and percent", "color(a98-rgb 100% 0.5 20%)", "color(a98-rgb 1 0.5 0.2)");
+    testColorFunction("A98 RGB mixed number and percent 2", "color(a98-rgb 1.00 50% 0.2)", "color(a98-rgb 1 0.5 0.2)");
+    testColorFunction("A98 RGB all none", "color(a98-rgb none none none)", "color(a98-rgb 0 0 0)");
+    testColorFunction("A98 RGB number and none", "color(a98-rgb 1.00 none 0.2)", "color(a98-rgb 1 0 0.2)");
+    testColorFunction("A98 RGB percent and none", "color(a98-rgb 100% none 20%)", "color(a98-rgb 1 0 0.2)");
+    testColorFunction("A98 RGB number, percent and none", "color(a98-rgb 100% none 0.2)", "color(a98-rgb 1 0 0.2)");
+
+    // non-unity alpha, A98 RGB in  color()
+    testColorFunction("A98 RGB with alpha, all numbers", "color(a98-rgb 1.00 0.50 0.200 / 0.6)", "color(a98-rgb 1 0.5 0.2 / 0.6)");
+    testColorFunction("A98 RGB with alpha, all percent", "color(a98-rgb 100% 50% 20%)", "color(a98-rgb 1 0.5 0.2 / 0.6)");
+    testColorFunction("A98 RGB with alpha, mixed number and percent", "color(a98-rgb 100% 0.5 20% / 0.6)", "color(a98-rgb 1 0.5 0.2 / 0.6)");
+    testColorFunction("A98 RGB with alpha, mixed number and percent 2", "color(a98-rgb 1.00 50% 0.2 / 60%)", "color(a98-rgb 1 0.5 0.2 / 0.6)");
+    testColorFunction("A98 RGB with alpha, all none", "color(a98-rgb none none none / none)", "color(a98-rgb 0 0 0 / 0)");
+    testColorFunction("A98 RGB with alpha, number and none", "color(a98-rgb 1.00 none 0.2 / none)", "color(a98-rgb 1 0 0.2 / 0)");
+    testColorFunction("A98 RGB with alpha, percent and none", "color(a98-rgb 100% none 20% / 30%)", "color(a98-rgb 1 0 0.2 / 0.3)");
+    testColorFunction("A98 RGB with alpha, number, percent and none", "color(a98-rgb 100% none 0.2 / 23.7%)", "color(a98-rgb 1 0 0.2 / 0.237)");
+
+    // Opaque ProPhoto RGB in color()
+    testColorFunction("ProPhoto RGB all numbers", "color(prophoto-rgb 1.00 0.50 0.200)", "color(prophoto-rgb 1 0.5 0.2)");
+    testColorFunction("ProPhoto RGB all percent", "color(prophoto-rgb 100% 50% 20%)", "color(prophoto-rgb 1 0.5 0.2)");
+    testColorFunction("ProPhoto RGB mixed number and percent", "color(prophoto-rgb 100% 0.5 20%)", "color(prophoto-rgb 1 0.5 0.2)");
+    testColorFunction("ProPhoto RGB mixed number and percent 2", "color(prophoto-rgb 1.00 50% 0.2)", "color(prophoto-rgb 1 0.5 0.2)");
+    testColorFunction("ProPhoto RGB all none", "color(prophoto-rgb none none none)", "color(prophoto-rgb 0 0 0)");
+    testColorFunction("ProPhoto RGB number and none", "color(prophoto-rgb 1.00 none 0.2)", "color(prophoto-rgb 1 0 0.2)");
+    testColorFunction("ProPhoto RGB percent and none", "color(prophoto-rgb 100% none 20%)", "color(prophoto-rgb 1 0 0.2)");
+    testColorFunction("ProPhoto RGB number, percent and none", "color(prophoto-rgb 100% none 0.2)", "color(prophoto-rgb 1 0 0.2)");
+
+    // non-unity alpha, ProPhoto RGB in  color()
+    testColorFunction("ProPhoto RGB with alpha, all numbers", "color(prophoto-rgb 1.00 0.50 0.200 / 0.6)", "color(prophoto-rgb 1 0.5 0.2 / 0.6)");
+    testColorFunction("ProPhoto RGB with alpha, all percent", "color(prophoto-rgb 100% 50% 20%)", "color(prophoto-rgb 1 0.5 0.2 / 0.6)");
+    testColorFunction("ProPhoto RGB with alpha, mixed number and percent", "color(prophoto-rgb 100% 0.5 20% / 0.6)", "color(prophoto-rgb 1 0.5 0.2 / 0.6)");
+    testColorFunction("ProPhoto RGB with alpha, mixed number and percent 2", "color(prophoto-rgb 1.00 50% 0.2 / 60%)", "color(prophoto-rgb 1 0.5 0.2 / 0.6)");
+    testColorFunction("ProPhoto RGB with alpha, all none", "color(prophoto-rgb none none none / none)", "color(prophoto-rgb 0 0 0 / 0)");
+    testColorFunction("ProPhoto RGB with alpha, number and none", "color(prophoto-rgb 1.00 none 0.2 / none)", "color(prophoto-rgb 1 0 0.2 / 0)");
+    testColorFunction("ProPhoto RGB with alpha, percent and none", "color(prophoto-rgb 100% none 20% / 30%)", "color(prophoto-rgb 1 0 0.2 / 0.3)");
+    testColorFunction("ProPhoto RGB with alpha, number, percent and none", "color(prophoto-rgb 100% none 0.2 / 23.7%)", "color(prophoto-rgb 1 0 0.2 / 0.237)");
+
     // Opaque Rec BT.2020 in  color()
     testColorFunction("Rec BT.2020 all numbers", "color(rec2020 1.00 0.50 0.200)", "color(rec2020 1 0.5 0.2)");
     testColorFunction("Rec BT.2020 all percent", "color(rec2020 100% 50% 20%)", "color(rec2020 1 0.5 0.2)");
@@ -76,5 +136,65 @@
     testColorFunction("Rec BT.2020 with alpha, number and none", "color(rec2020 1.00 none 0.2 / none)", "color(rec2020 1 0 0.2 / 0)");
     testColorFunction("Rec BT.2020 with alpha, percent and none", "color(rec2020 100% none 20% / 30%)", "color(rec2020 1 0 0.2 / 0.3)");
     testColorFunction("Rec BT.2020 with alpha, number, percent and none", "color(rec2020 100% none 0.2 / 23.7%)", "color(rec2020 1 0 0.2 / 0.237)");
+
+    // Opaque CIE XYZ D50 in color()
+    testColorFunction("CIE XYZ D50 all numbers", "color(xyz-d50 1.00 0.50 0.200)", "color(xyz-d50 1 0.5 0.2)");
+    testColorFunction("CIE XYZ D50 all percent", "color(xyz-d50 100% 50% 20%)", "color(xyz-d50 1 0.5 0.2)");
+    testColorFunction("CIE XYZ D50 mixed number and percent", "color(xyz-d50 100% 0.5 20%)", "color(xyz-d50 1 0.5 0.2)");
+    testColorFunction("CIE XYZ D50 mixed number and percent 2", "color(xyz-d50 1.00 50% 0.2)", "color(xyz-d50 1 0.5 0.2)");
+    testColorFunction("CIE XYZ D50 all none", "color(xyz-d50 none none none)", "color(xyz-d50 0 0 0)");
+    testColorFunction("CIE XYZ D50 number and none", "color(xyz-d50 1.00 none 0.2)", "color(xyz-d50 1 0 0.2)");
+    testColorFunction("CIE XYZ D50 percent and none", "color(xyz-d50 100% none 20%)", "color(xyz-d50 1 0 0.2)");
+    testColorFunction("CIE XYZ D50 number, percent and none", "color(xyz-d50 100% none 0.2)", "color(xyz-d50 1 0 0.2)");
+
+    // non-unity alpha, CIE XYZ D50 in  color()
+    testColorFunction("CIE XYZ D50 with alpha, all numbers", "color(xyz-d50 1.00 0.50 0.200 / 0.6)", "color(xyz-d50 1 0.5 0.2 / 0.6)");
+    testColorFunction("CIE XYZ D50 with alpha, all percent", "color(xyz-d50 100% 50% 20%)", "color(xyz-d50 1 0.5 0.2 / 0.6)");
+    testColorFunction("CIE XYZ D50 with alpha, mixed number and percent", "color(xyz-d50 100% 0.5 20% / 0.6)", "color(xyz-d50 1 0.5 0.2 / 0.6)");
+    testColorFunction("CIE XYZ D50 with alpha, mixed number and percent 2", "color(xyz-d50 1.00 50% 0.2 / 60%)", "color(xyz-d50 1 0.5 0.2 / 0.6)");
+    testColorFunction("CIE XYZ D50 with alpha, all none", "color(xyz-d50 none none none / none)", "color(xyz-d50 0 0 0 / 0)");
+    testColorFunction("CIE XYZ D50 with alpha, number and none", "color(xyz-d50 1.00 none 0.2 / none)", "color(xyz-d50 1 0 0.2 / 0)");
+    testColorFunction("CIE XYZ D50 with alpha, percent and none", "color(xyz-d50 100% none 20% / 30%)", "color(xyz-d50 1 0 0.2 / 0.3)");
+    testColorFunction("CIE XYZ D50 with alpha, number, percent and none", "color(xyz-d50 100% none 0.2 / 23.7%)", "color(xyz-d50 1 0 0.2 / 0.237)");
+
+    // Opaque CIE XYZ D65 in color()
+    testColorFunction("CIE XYZ D65 all numbers", "color(xyz-d65 1.00 0.50 0.200)", "color(xyz-d65 1 0.5 0.2)");
+    testColorFunction("CIE XYZ D65 all percent", "color(xyz-d65 100% 50% 20%)", "color(xyz-d65 1 0.5 0.2)");
+    testColorFunction("CIE XYZ D65 mixed number and percent", "color(xyz-d65 100% 0.5 20%)", "color(xyz-d65 1 0.5 0.2)");
+    testColorFunction("CIE XYZ D65 mixed number and percent 2", "color(xyz-d65 1.00 50% 0.2)", "color(xyz-d65 1 0.5 0.2)");
+    testColorFunction("CIE XYZ D65 all none", "color(xyz-d65 none none none)", "color(xyz-d65 0 0 0)");
+    testColorFunction("CIE XYZ D65 number and none", "color(xyz-d65 1.00 none 0.2)", "color(xyz-d65 1 0 0.2)");
+    testColorFunction("CIE XYZ D65 percent and none", "color(xyz-d65 100% none 20%)", "color(xyz-d65 1 0 0.2)");
+    testColorFunction("CIE XYZ D65 number, percent and none", "color(xyz-d65 100% none 0.2)", "color(xyz-d65 1 0 0.2)");
+
+    // non-unity alpha, CIE XYZ D65 in  color()
+    testColorFunction("CIE XYZ D65 with alpha, all numbers", "color(xyz-d65 1.00 0.50 0.200 / 0.6)", "color(xyz-d65 1 0.5 0.2 / 0.6)");
+    testColorFunction("CIE XYZ D65 with alpha, all percent", "color(xyz-d65 100% 50% 20%)", "color(xyz-d65 1 0.5 0.2 / 0.6)");
+    testColorFunction("CIE XYZ D65 with alpha, mixed number and percent", "color(xyz-d65 100% 0.5 20% / 0.6)", "color(xyz-d65 1 0.5 0.2 / 0.6)");
+    testColorFunction("CIE XYZ D65 with alpha, mixed number and percent 2", "color(xyz-d65 1.00 50% 0.2 / 60%)", "color(xyz-d65 1 0.5 0.2 / 0.6)");
+    testColorFunction("CIE XYZ D65 with alpha, all none", "color(xyz-d65 none none none / none)", "color(xyz-d65 0 0 0 / 0)");
+    testColorFunction("CIE XYZ D65 with alpha, number and none", "color(xyz-d65 1.00 none 0.2 / none)", "color(xyz-d65 1 0 0.2 / 0)");
+    testColorFunction("CIE XYZ D65 with alpha, percent and none", "color(xyz-d65 100% none 20% / 30%)", "color(xyz-d65 1 0 0.2 / 0.3)");
+    testColorFunction("CIE XYZ D65 with alpha, number, percent and none", "color(xyz-d65 100% none 0.2 / 23.7%)", "color(xyz-d65 1 0 0.2 / 0.237)");
+
+    // Opaque CIE XYZ (implicit D65) in color()
+    testColorFunction("CIE XYZ (implicit D65) all numbers", "color(xyz 1.00 0.50 0.200)", "color(xyz-d65 1 0.5 0.2)");
+    testColorFunction("CIE XYZ (implicit D65) all percent", "color(xyz 100% 50% 20%)", "color(xyz-d65 1 0.5 0.2)");
+    testColorFunction("CIE XYZ (implicit D65) mixed number and percent", "color(xyz 100% 0.5 20%)", "color(xyz-d65 1 0.5 0.2)");
+    testColorFunction("CIE XYZ (implicit D65) mixed number and percent 2", "color(xyz 1.00 50% 0.2)", "color(xyz-d65 1 0.5 0.2)");
+    testColorFunction("CIE XYZ (implicit D65) all none", "color(xyz none none none)", "color(xyz-d65 0 0 0)");
+    testColorFunction("CIE XYZ (implicit D65) number and none", "color(xyz 1.00 none 0.2)", "color(xyz-d65 1 0 0.2)");
+    testColorFunction("CIE XYZ (implicit D65) percent and none", "color(xyz 100% none 20%)", "color(xyz-d65 1 0 0.2)");
+    testColorFunction("CIE XYZ (implicit D65) number, percent and none", "color(xyz 100% none 0.2)", "color(xyz-d65 1 0 0.2)");
+
+    // non-unity alpha, CIE XYZ (implicit D65) in  color()
+    testColorFunction("CIE XYZ (implicit D65) with alpha, all numbers", "color(xyz 1.00 0.50 0.200 / 0.6)", "color(xyz-d65 1 0.5 0.2 / 0.6)");
+    testColorFunction("CIE XYZ (implicit D65) with alpha, all percent", "color(xyz 100% 50% 20%)", "color(xyz-d65 1 0.5 0.2 / 0.6)");
+    testColorFunction("CIE XYZ (implicit D65) with alpha, mixed number and percent", "color(xyz 100% 0.5 20% / 0.6)", "color(xyz-d65 1 0.5 0.2 / 0.6)");
+    testColorFunction("CIE XYZ (implicit D65) with alpha, mixed number and percent 2", "color(xyz 1.00 50% 0.2 / 60%)", "color(xyz-d65 1 0.5 0.2 / 0.6)");
+    testColorFunction("CIE XYZ (implicit D65) with alpha, all none", "color(xyz none none none / none)", "color(xyz-d65 0 0 0 / 0)");
+    testColorFunction("CIE XYZ (implicit D65) with alpha, number and none", "color(xyz 1.00 none 0.2 / none)", "color(xyz-d65 1 0 0.2 / 0)");
+    testColorFunction("CIE XYZ (implicit D65) with alpha, percent and none", "color(xyz 100% none 20% / 30%)", "color(xyz-d65 1 0 0.2 / 0.3)");
+    testColorFunction("CIE XYZ (implicit D65) with alpha, number, percent and none", "color(xyz 100% none 0.2 / 23.7%)", "color(xyz-d65 1 0 0.2 / 0.237)");
 
 </script>

--- a/css/css-color/parsing/color-mixed-num-pct.html
+++ b/css/css-color/parsing/color-mixed-num-pct.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: color() parsing, mixed number, percent and none</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#color-function">
+<link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
+<meta name="assert" content="number, percent and none can be freely intermixed in color function">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="test"></div>
+<script>
+    const div = document.querySelector("#test");
+    function testColorFunction(description, rule, expectedValue) {
+        test(function() {
+            div.style.color = "black";
+            div.style.color = rule;
+            assert_equals(getComputedStyle(div).color, expectedValue);
+        }, description);
+    }
+
+    // Opaque sRGB in color()
+    testColorFunction("sRGB all numbers", "color(srgb 1.00 0.50 0.200)", "color(srgb 1 0.5 0.2)");
+    testColorFunction("sRGB all percent", "color(srgb 100% 50% 20%)", "color(srgb 1 0.5 0.2)");
+    testColorFunction("sRGB mixed number and percent", "color(srgb 100% 0.5 20%)", "color(srgb 1 0.5 0.2)");
+    testColorFunction("sRGB mixed number and percent", "color(srgb 1.00 50% 0.2)", "color(srgb 1 0.5 0.2)");
+    testColorFunction("sRGB all none", "color(srgb none none none)", "color(srgb 0 0 0)");
+    testColorFunction("sRGB number and none", "color(srgb 1.00 none 0.2)", "color(srgb 1 0 0.2)");
+    testColorFunction("sRGB percent and none", "color(srgb 100% none 20%)", "color(srgb 1 0 0.2)");
+    testColorFunction("sRGB number, percent and none", "color(srgb 100% none 0.2)", "color(srgb 1 0 0.2)");
+
+    // non-unity alpha, sRGB in  color()
+    testColorFunction("sRGB with alpha, all numbers", "color(srgb 1.00 0.50 0.200 / 0.6)", "color(srgb 1 0.5 0.2 / 0.6)");
+    testColorFunction("sRGB with alpha, all percent", "color(srgb 100% 50% 20%)", "color(srgb 1 0.5 0.2 / 0.6)");
+    testColorFunction("sRGB with alpha, mixed number and percent", "color(srgb 100% 0.5 20% / 0.6)", "color(srgb 1 0.5 0.2 / 0.6)");
+    testColorFunction("sRGB with alpha, mixed number and percent", "color(srgb 1.00 50% 0.2 / 60%)", "color(srgb 1 0.5 0.2 / 0.6)");
+    testColorFunction("sRGB with alpha, all none", "color(srgb none none none / none)", "color(srgb 0 0 0 / 0)");
+    testColorFunction("sRGB with alpha, number and none", "color(srgb 1.00 none 0.2 / none)", "color(srgb 1 0 0.2 / 0)");
+    testColorFunction("sRGB with alpha, percent and none", "color(srgb 100% none 20% / 30%)", "color(srgb 1 0 0.2 / 0.3)");
+    testColorFunction("sRGB with alpha, number, percent and none", "color(srgb 100% none 0.2 / 23.7%)", "color(srgb 1 0 0.2 / 0.237)");
+
+    // Opaque Display P3 in color()
+    testColorFunction("Display P3 all numbers", "color(display-p3 1.00 0.50 0.200)", "color(display-p3 1 0.5 0.2)");
+    testColorFunction("Display P3 all percent", "color(display-p3 100% 50% 20%)", "color(display-p3 1 0.5 0.2)");
+    testColorFunction("Display P3 mixed number and percent", "color(display-p3 100% 0.5 20%)", "color(display-p3 1 0.5 0.2)");
+    testColorFunction("Display P3 mixed number and percent", "color(display-p3 1.00 50% 0.2)", "color(display-p3 1 0.5 0.2)");
+    testColorFunction("Display P3 all none", "color(display-p3 none none none)", "color(display-p3 0 0 0)");
+    testColorFunction("Display P3 number and none", "color(display-p3 1.00 none 0.2)", "color(display-p3 1 0 0.2)");
+    testColorFunction("Display P3 percent and none", "color(display-p3 100% none 20%)", "color(display-p3 1 0 0.2)");
+    testColorFunction("Display P3 number, percent and none", "color(display-p3 100% none 0.2)", "color(display-p3 1 0 0.2)");
+
+    // non-unity alpha, Display P3 in  color()
+    testColorFunction("Display P3 with alpha, all numbers", "color(display-p3 1.00 0.50 0.200 / 0.6)", "color(display-p3 1 0.5 0.2 / 0.6)");
+    testColorFunction("Display P3 with alpha, all percent", "color(display-p3 100% 50% 20%)", "color(display-p3 1 0.5 0.2 / 0.6)");
+    testColorFunction("Display P3 with alpha, mixed number and percent", "color(display-p3 100% 0.5 20% / 0.6)", "color(display-p3 1 0.5 0.2 / 0.6)");
+    testColorFunction("Display P3 with alpha, mixed number and percent", "color(display-p3 1.00 50% 0.2 / 60%)", "color(display-p3 1 0.5 0.2 / 0.6)");
+    testColorFunction("Display P3 with alpha, all none", "color(display-p3 none none none / none)", "color(display-p3 0 0 0 / 0)");
+    testColorFunction("Display P3 with alpha, number and none", "color(display-p3 1.00 none 0.2 / none)", "color(display-p3 1 0 0.2 / 0)");
+    testColorFunction("Display P3 with alpha, percent and none", "color(display-p3 100% none 20% / 30%)", "color(display-p3 1 0 0.2 / 0.3)");
+    testColorFunction("Display P3 with alpha, number, percent and none", "color(display-p3 100% none 0.2 / 23.7%)", "color(display-p3 1 0 0.2 / 0.237)");
+
+    // Opaque Rec BT.2020 in  color()
+    testColorFunction("Rec BT.2020 all numbers", "color(rec2020 1.00 0.50 0.200)", "color(rec2020 1 0.5 0.2)");
+    testColorFunction("Rec BT.2020 all percent", "color(rec2020 100% 50% 20%)", "color(rec2020 1 0.5 0.2)");
+    testColorFunction("Rec BT.2020 mixed number and percent", "color(rec2020 100% 0.5 20%)", "color(rec2020 1 0.5 0.2)");
+    testColorFunction("Rec BT.2020 mixed number and percent", "color(rec2020 1.00 50% 0.2)", "color(rec2020 1 0.5 0.2)");
+    testColorFunction("Rec BT.2020 all none", "color(rec2020 none none none)", "color(rec2020 0 0 0)");
+    testColorFunction("Rec BT.2020 number and none", "color(rec2020 1.00 none 0.2)", "color(rec2020 1 0 0.2)");
+    testColorFunction("Rec BT.2020 percent and none", "color(rec2020 100% none 20%)", "color(rec2020 1 0 0.2)");
+    testColorFunction("Rec BT.2020 number, percent and none", "color(rec2020 100% none 0.2)", "color(rec2020 1 0 0.2)");
+
+    // non-unity alpha, Rec BT.2020 in  color()
+    testColorFunction("Rec BT.2020 with alpha, all numbers", "color(rec2020 1.00 0.50 0.200 / 0.6)", "color(rec2020 1 0.5 0.2 / 0.6)");
+    testColorFunction("Rec BT.2020 with alpha, all percent", "color(rec2020 100% 50% 20%)", "color(rec2020 1 0.5 0.2 / 0.6)");
+    testColorFunction("Rec BT.2020 with alpha, mixed number and percent", "color(rec2020 100% 0.5 20% / 0.6)", "color(rec2020 1 0.5 0.2 / 0.6)");
+    testColorFunction("Rec BT.2020 with alpha, mixed number and percent", "color(rec2020 1.00 50% 0.2 / 60%)", "color(rec2020 1 0.5 0.2 / 0.6)");
+    testColorFunction("Rec BT.2020 with alpha, all none", "color(rec2020 none none none / none)", "color(rec2020 0 0 0 / 0)");
+    testColorFunction("Rec BT.2020 with alpha, number and none", "color(rec2020 1.00 none 0.2 / none)", "color(rec2020 1 0 0.2 / 0)");
+    testColorFunction("Rec BT.2020 with alpha, percent and none", "color(rec2020 100% none 20% / 30%)", "color(rec2020 1 0 0.2 / 0.3)");
+    testColorFunction("Rec BT.2020 with alpha, number, percent and none", "color(rec2020 100% none 0.2 / 23.7%)", "color(rec2020 1 0 0.2 / 0.237)");
+
+</script>


### PR DESCRIPTION
Grammar for [CSS Color 4 `color()` function](https://drafts.csswg.org/css-color-4/#color-function) allows freely mixing `<number>`, `<percentage>` and `none` for color components and for alpha, but this was so far untested in WPT.

Expected values per [resolving color values](https://drafts.csswg.org/css-color-4/#resolving-color-values).

Earlier drafts of CSS Color 4 required using either all number or all percent, so older implementations might not have been updated.

CSS Color 5 allowed free mixing as part of [Relative Color Syntax](https://drafts.csswg.org/css-color-5/#relative-color-function) and a subset of [that grammar](https://drafts.csswg.org/css-color-5/#color-function) was then back-ported to CSS Color 4.