### PR TITLE
@container rules should support not without parentheses

### DIFF
--- a/css/css-contain/container-queries/at-container-parsing.html
+++ b/css/css-contain/container-queries/at-container-parsing.html
@@ -21,6 +21,14 @@
     main.append(style);
     return style;
   }
+  
+  function test_rule_valid(query) {
+    test(t => {
+      t.add_cleanup(cleanup_main);
+      let style = set_style(`@container ${query} {}`);
+      assert_equals(style.sheet.rules.length, 1);
+    }, query);
+  }
 
   function test_query_invalid(query) {
     test(t => {
@@ -150,8 +158,10 @@
   test_query_invalid('(width: 100px), (height: 100px)');
   test_query_invalid('(width: 100px) and (height: 100px)');
   test_query_invalid('(width: 100px) or (height: 100px)');
-  test_query_invalid('not (width: 100px)');
   test_query_invalid('foo (width: 100px)');
+  
+  test_rule_valid('name not (width <= 500px)');
+  test_rule_valid('not (width <= 500px)');
 
   test_container_selector_valid('foo');
   test_container_selector_valid(' foo');

--- a/css/css-contain/container-queries/at-container-parsing.html
+++ b/css/css-contain/container-queries/at-container-parsing.html
@@ -21,7 +21,7 @@
     main.append(style);
     return style;
   }
-  
+
   function test_rule_valid(query) {
     test(t => {
       t.add_cleanup(cleanup_main);
@@ -159,7 +159,7 @@
   test_query_invalid('(width: 100px) and (height: 100px)');
   test_query_invalid('(width: 100px) or (height: 100px)');
   test_query_invalid('foo (width: 100px)');
-  
+
   test_rule_valid('name not (width <= 500px)');
   test_rule_valid('not (width <= 500px)');
 


### PR DESCRIPTION
See https://github.com/w3c/csswg-drafts/issues/7203#issuecomment-1183737711

The grammar in the spec requires that `not` be treated as part of the container condition rather than as part of the name, and parentheses are not required. This updates one previous test that was incorrect, and adds a new one. A new helper was necessary because `test_query_valid` also adds a second rule with more complex logic that wouldn't work in this case.