### PR TITLE
Add missing step_func() in a couple of cookie tests

### DIFF
--- a/cookies/path/default.html
+++ b/cookies/path/default.html
@@ -31,13 +31,13 @@ async_test(function (t) {
       !!iframe.contentWindow.isCookieSet('cookies-path-default'),
       'cookie can be retrieved from expected path'
     );
-    iframe.contentWindow.expireCookies().then(() => {
+    iframe.contentWindow.expireCookies().then(t.step_func(function () {
       assert_false(
         !!iframe.contentWindow.isCookieSet('cookies-path-default'),
         'cookie can be referenced using the expected path'
       );
       t.done();
-    });
+    }));
   });
 
   createIframe('/cookies/resources/echo-cookie.html', t.step_func(function (_iframe) {

--- a/cookies/path/match.html
+++ b/cookies/path/match.html
@@ -41,14 +41,14 @@ var testCookiePathFromHeader = function (testCase, test) {
     iframe.contentWindow.fetchCookieThen('header-' + testCase.name, testCase.path).then(test.step_func(function (response) {
       assert_true(response.ok);
       var cookieSet = iframe.contentWindow.isCookieSet('header-' + testCase.name, testCase.path);
-      iframe.contentWindow.expireCookies().then(() => {
+      iframe.contentWindow.expireCookies().then(test.step_func(function () {
         if (testCase.match === false) {
           assert_equals(cookieSet, null);
         } else {
           assert_not_equals(cookieSet, null, "Cookie path from header should not be `null`");
         }
         test.done();
-      });
+      }));
     })).catch(test.unreached_func());
   }));
 };


### PR DESCRIPTION
Without this, any subtest failure would result in a rejected promise
which would cause the test to time out.