### PR TITLE
Add CSS values test for mixed units in calc & media query

### DIFF
--- a/css/css-values/calc-in-media-queries-with-mixed-units.html
+++ b/css/css-values/calc-in-media-queries-with-mixed-units.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>test calc with mixed units</title>
+    <title>test calc with mixed units in media queries</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <link rel="help" href="https://www.w3.org/TR/css3-values/#calc-computed-value">
@@ -22,7 +22,7 @@
             assert_equals(actual, "rgb(255, 165, 0)");
             t.done();
           }));
-        }, `background should be orange if the calculation between ${frame.title} was correct`);
+        }, `box should be orange if the calc between ${frame.title} in @media was correct`);
       }
     </script>
   </body>

--- a/css/css-values/calc-mixed-units.html
+++ b/css/css-values/calc-mixed-units.html
@@ -1,0 +1,30 @@
+<html lang="en">
+  <head>
+    <style>
+      .box {
+        background: rgb(0, 0, 255);
+        width: 100vw;
+        height: 10px;
+      }
+
+      @media (min-width: calc(100vw - 1em)) {
+        .box {
+          background: rgb(255, 165, 0);
+        }
+      }
+    </style>
+    <title>test calc with mixed units</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div class="box"></div>
+    <script>
+      const box = document.querySelector(".box");
+      test(function() {
+        const actual = getComputedStyle(box).getPropertyValue("background-color");
+        assert_equals(actual, "rgb(255, 165, 0)");
+      }, "background-color should be orange because media query is matched");
+    </script>
+  </body>
+</html>

--- a/css/css-values/calc-mixed-units.html
+++ b/css/css-values/calc-mixed-units.html
@@ -16,6 +16,7 @@
     <title>test calc with mixed units</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
+    <link rel="help" href="https://www.w3.org/TR/css3-values/#calc-computed-value">
   </head>
   <body>
     <div class="box"></div>

--- a/css/css-values/calc-mixed-units.html
+++ b/css/css-values/calc-mixed-units.html
@@ -1,31 +1,29 @@
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <style>
-      .box {
-        background: rgb(0, 0, 255);
-        width: 100vw;
-        height: 10px;
-      }
-
-      @media (min-width: calc(100vw - 1em)) {
-        .box {
-          background: rgb(255, 165, 0);
-        }
-      }
-    </style>
     <title>test calc with mixed units</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <link rel="help" href="https://www.w3.org/TR/css3-values/#calc-computed-value">
   </head>
   <body>
-    <div class="box"></div>
+    <iframe src="./support/mixed-units-01.html" title="px/em" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-02.html" title="vh/em" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-03.html" title="vw/em" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-04.html" title="vw/vh" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-05.html" title="vh/px" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-06.html" title="vw/px" frameborder="0" height="10" width="100"></iframe>
     <script>
-      const box = document.querySelector(".box");
-      test(function() {
-        const actual = getComputedStyle(box).getPropertyValue("background-color");
-        assert_equals(actual, "rgb(255, 165, 0)");
-      }, "background-color should be orange because media query is matched");
+      for (const frame of document.querySelectorAll('iframe')) {
+        async_test((t) => {
+          frame.addEventListener("load", t.step_func(() => {
+            const box = frame.contentWindow.document.querySelector('.box');
+            const actual = frame.contentWindow.getComputedStyle(box).getPropertyValue("background-color");
+            assert_equals(actual, "rgb(255, 165, 0)");
+            t.done()
+          }));
+        }, `background should be orange if the calculation between ${frame.title} was correct`);
+      }
     </script>
   </body>
 </html>

--- a/css/css-values/calc-mixed-units.html
+++ b/css/css-values/calc-mixed-units.html
@@ -14,13 +14,13 @@
     <iframe src="./support/mixed-units-05.html" title="vh/px" frameborder="0" height="10" width="100"></iframe>
     <iframe src="./support/mixed-units-06.html" title="vw/px" frameborder="0" height="10" width="100"></iframe>
     <script>
-      for (const frame of document.querySelectorAll('iframe')) {
+      for (const frame of document.querySelectorAll("iframe")) {
         async_test((t) => {
           frame.addEventListener("load", t.step_func(() => {
-            const box = frame.contentWindow.document.querySelector('.box');
+            const box = frame.contentWindow.document.querySelector(".box");
             const actual = frame.contentWindow.getComputedStyle(box).getPropertyValue("background-color");
             assert_equals(actual, "rgb(255, 165, 0)");
-            t.done()
+            t.done();
           }));
         }, `background should be orange if the calculation between ${frame.title} was correct`);
       }

--- a/css/css-values/support/mixed-units-01.html
+++ b/css/css-values/support/mixed-units-01.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        margin: 0;
+        font-size: 16px;
+      }
+      .box {
+        background: rgb(0, 0, 255);
+        width: 100%;
+        height: 10px;
+      }
+
+      @media (width: calc(116px - 1em)) {
+        .box {
+          background: rgb(255, 165, 0);
+        }
+      }
+    </style>
+  </head>
+  <div class="box"></div>
+</html>

--- a/css/css-values/support/mixed-units-02.html
+++ b/css/css-values/support/mixed-units-02.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        margin: 0;
+        font-size: 16px;
+      }
+      .box {
+        background: rgb(0, 0, 255);
+        width: 100%;
+        height: 10px;
+      }
+
+      @media (width: calc(200vh + 5em)) {
+        .box {
+          background: rgb(255, 165, 0);
+        }
+      }
+    </style>
+  </head>
+  <div class="box"></div>
+</html>

--- a/css/css-values/support/mixed-units-03.html
+++ b/css/css-values/support/mixed-units-03.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        margin: 0;
+        font-size: 16px;
+      }
+      .box {
+        background: rgb(0, 0, 255);
+        width: 100%;
+        height: 10px;
+      }
+
+      @media (height: calc(100vw - 5.625em)) {
+        .box {
+          background: rgb(255, 165, 0);
+        }
+      }
+    </style>
+  </head>
+  <div class="box"></div>
+</html>

--- a/css/css-values/support/mixed-units-04.html
+++ b/css/css-values/support/mixed-units-04.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        margin: 0;
+        font-size: 16px;
+      }
+      .box {
+        background: rgb(0, 0, 255);
+        width: 100%;
+        height: 10px;
+      }
+
+      @media (width: calc(10vw + 900vh)) {
+        .box {
+          background: rgb(255, 165, 0);
+        }
+      }
+    </style>
+  </head>
+  <div class="box"></div>
+</html>

--- a/css/css-values/support/mixed-units-05.html
+++ b/css/css-values/support/mixed-units-05.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        margin: 0;
+        font-size: 16px;
+      }
+      .box {
+        background: rgb(0, 0, 255);
+        width: 100%;
+        height: 10px;
+      }
+
+      @media (width: calc(900vh + 10px)) {
+        .box {
+          background: rgb(255, 165, 0);
+        }
+      }
+    </style>
+  </head>
+  <div class="box"></div>
+</html>

--- a/css/css-values/support/mixed-units-06.html
+++ b/css/css-values/support/mixed-units-06.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        margin: 0;
+        font-size: 16px;
+      }
+      .box {
+        background: rgb(0, 0, 255);
+        width: 100%;
+        height: 10px;
+      }
+
+      @media (width: calc(90vw + 10px)) {
+        .box {
+          background: rgb(255, 165, 0);
+        }
+      }
+    </style>
+  </head>
+  <div class="box"></div>
+</html>


### PR DESCRIPTION
This is a test for a bug in Chrome [as reported](https://bugs.chromium.org/p/chromium/issues/detail?id=843584).

This works in Firefox and Safari.

|Chrome|Firefox|Safari|
|-|-|-|
|![Chrome: an orange bar is shown](https://user-images.githubusercontent.com/1153134/179395629-5cf3c023-6866-4c46-b45d-2047aa3d9014.png)|![Firefox: a blue bar is shown](https://user-images.githubusercontent.com/1153134/179395623-dd72661c-8337-4e51-8ec9-49bf5c7d0cf9.png)|![Safari: a blue bar is shown](https://user-images.githubusercontent.com/1153134/179395616-dccf2d44-7489-4bf8-9a65-3e59af03085f.png)|