### PR TITLE
Fix regex for STP downloads

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1478,7 +1478,7 @@ class Safari(Browser):
         Input: Safari Technology Preview<br>for macOS&nbsp;Ventura
         Output: Safari Technology Previewfor macOS Ventura
         """
-        stp_link_text = re.compile(r"^\s*Safari\s+Technology\s+Preview\s*(?:[0-9]+\s+)?for\s+macOS")
+        stp_link_text = re.compile(r"^\s*Safari\s+Technology\s+Preview\s*(?:[0-9]+\s*)?for\s+macOS")
         requirement = re.compile(
             r"Requires\s+macOS\s+([0-9\.]+)\s+(?:or\s+later|beta)."
         )

--- a/tools/wpt/tests/safari_downloads_page_stp_section.html
+++ b/tools/wpt/tests/safari_downloads_page_stp_section.html
@@ -1,3 +1,12 @@
+<!--
+    This test file demonstrates the state of STP section as of June 29, 2022.
+
+    Example:
+    Safari Technology Preview<br>for macOS
+
+    After running the text_content function in browser.py, it becomes:
+    Safari Technology Previewfor macOS
+-->
 <div class="column large-6 medium-12 small-12">
     <div class="callout">
         <figure class="app-icon large-icon safari-preview-icon" aria-hidden="true" data-hires-status="pending"></figure>

--- a/tools/wpt/tests/safari_downloads_page_stp_section_version_incl.html
+++ b/tools/wpt/tests/safari_downloads_page_stp_section_version_incl.html
@@ -1,0 +1,32 @@
+<!--
+    This test file demonstrates the state of STP section as of July 14, 2022.
+    Each version has a certain format which now inclues the version number.
+
+    Example:
+    Safari Technology Preview 148<br />for macOS
+
+    After running the text_content function in browser.py, it becomes:
+    Safari Technology Preview 148for macOS
+-->
+<div class="column large-6 medium-12 small-12">
+    <div class="callout">
+        <figure class="app-icon large-icon safari-preview-icon" aria-hidden="true"></figure>
+        <h4>Safari Technology Preview</h4>
+        <p class="margin-bottom-small">Get a sneak peek at upcoming web technologies in macOS and iOS with <a href="/safari/technology-preview/" class="nowrap">Safari Technology Preview</a> and experiment with these technologies in your websites and extensions.</p>
+        <ul class="links small">
+            <li class="dmg"><a class="inline" href="https://secure-appldnld.apple.com/STP/012-38225-20220706-237860CD-5766-4F53-AAC7-1CE26023A959/SafariTechnologyPreview.dmg">Safari Technology Preview 148<br />for macOS&nbsp;Ventura</a><br /><span class="smaller lighter nowrap nowrap-small">Requires macOS&nbsp;13 beta&nbsp;3 or later.</span></li>
+            <li class="dmg margin-top-small"><a class="inline" href="https://secure-appldnld.apple.com/STP/012-38074-20220715-4851625A-8AC7-4155-84C0-AEB4B88F08FE/SafariTechnologyPreview.dmg">Safari Technology Preview 149<br />for macOS&nbsp;Monterey</a><br /><span class="smaller lighter">Requires macOS&nbsp;12.3 or later.</span></li>
+            <li class="document margin-top-small"><a href="/safari/technology-preview/release-notes/">Release Notes</a></li>
+        </ul>
+        <div class="row gutter text-left">
+            <div class="column">
+                <p class="sosumi no-margin-bottom margin-top-small">Release</p>
+                <p class="smaller lighter no-margin">149</p>
+            </div>
+            <div class="column">
+                <p class="sosumi no-margin-bottom margin-top-small">Posted</p>
+                <p class="smaller lighter no-margin">July 14, 2022</p>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
On July 14, 2022, the page was updated.

Example of STP line item previously:
`Safari Technology Preview<br>for macOS&nbsp;Ventura`

Example of STP line item now:
`Safari Technology Preview 148<br />for macOS&nbsp;Ventura`

Changes:
- Change regex to work with the format while maintaining backwards
  compatibility in case the old format comes back
- Add a test case to cover the new format
- Reformat tests to loop through the various test data files to test
  both new and previous formats

Fixes #34875