### PR TITLE
Continue all infrastructure_mac tests

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -112,15 +112,18 @@ jobs:
   - script: |
       set -eux -o pipefail
       ./wpt run --yes --no-manifest-update --manifest MANIFEST.json --metadata infrastructure/metadata/ --log-mach - --log-mach-level info --channel dev chrome infrastructure/
+    condition: succeededOrFailed()
     displayName: 'Run tests (Chrome Dev)'
   - script: |
       set -eux -o pipefail
       ./wpt run --yes --no-manifest-update --manifest MANIFEST.json --metadata infrastructure/metadata/ --log-mach - --log-mach-level info --channel nightly firefox infrastructure/
+    condition: succeededOrFailed()
     displayName: 'Run tests (Firefox Nightly)'
   - script: |
       set -eux -o pipefail
       export SYSTEM_VERSION_COMPAT=0
       ./wpt run --yes --no-manifest-update --manifest MANIFEST.json --metadata infrastructure/metadata/ --log-mach - --log-mach-level info --channel preview safari infrastructure/
+    condition: succeededOrFailed()
     displayName: 'Run tests (Safari Technology Preview)'
   - template: tools/ci/azure/publish_logs.yml
 


### PR DESCRIPTION
Allow these steps to run even if the job has already failed; this means we should always try to run the infrastructure tests for each browser even if an earlier step has failed (including installing the browser! unfortunately!).