### PR TITLE
Met AttributeError due to screenshot returns None

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -631,7 +631,7 @@ class WebDriverRefTestExecutor(RefTestExecutor):
 
         screenshot = self.protocol.webdriver.screenshot()
         if screenshot is None:
-            raise ValueErrori('screenshot is None')
+            raise ValueError('screenshot is None')
 
         # strip off the data:img/png, part of the url
         if screenshot.startswith("data:image/png;base64,"):

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -631,7 +631,7 @@ class WebDriverRefTestExecutor(RefTestExecutor):
 
         screenshot = self.protocol.webdriver.screenshot()
         if screenshot is None:
-            raise error.UnknownErrorException()
+            raise ValueErrori('screenshot is None')
 
         # strip off the data:img/png, part of the url
         if screenshot.startswith("data:image/png;base64,"):

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -630,6 +630,8 @@ class WebDriverRefTestExecutor(RefTestExecutor):
         self.protocol.base.execute_script(self.wait_script, True)
 
         screenshot = self.protocol.webdriver.screenshot()
+        if screenshot is None:
+            raise error.UnknownErrorException()
 
         # strip off the data:img/png, part of the url
         if screenshot.startswith("data:image/png;base64,"):


### PR DESCRIPTION
Stack trace as belw:
File "/b/s/w/ir/third_party/wpt_tools/wpt/tools/wptrunner/wptrunner/executors/executorwebdriver.py", line 405, in run_func
    self.result = True, self.func(self.protocol, self.url, self.timeout)
File "/b/s/w/ir/third_party/wpt_tools/wpt/tools/wptrunner/wptrunner/executors/executorwebdriver.py", line 620, in _screenshot
    if screenshot.startswith("data:image/png;base64,"):
AttributeError: 'NoneType' object has no attribute 'startswith'