### PR TITLE
Create dedicated tests for script.callFunction awaitPromise

### DIFF
--- a/webdriver/tests/bidi/script/call_function/await_promise.py
+++ b/webdriver/tests/bidi/script/call_function/await_promise.py
@@ -1,0 +1,48 @@
+import pytest
+
+from webdriver.bidi.modules.script import ContextTarget, ScriptEvaluateResultException
+
+from ... import any_int, any_string, recursive_compare
+from .. import any_stack_trace
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("await_promise", [True, False])
+async def test_await_promise_delayed(bidi_session, top_context, await_promise):
+    result = await bidi_session.script.call_function(
+        function_declaration="""
+          async function() {{
+            await new Promise(r => setTimeout(() => r(), 0));
+            return "SOME_DELAYED_RESULT";
+          }}
+        """,
+        await_promise=await_promise,
+        target=ContextTarget(top_context["context"]),
+    )
+
+    if await_promise:
+        assert result == {
+            "type": "string",
+            "value": "SOME_DELAYED_RESULT"}
+    else:
+        recursive_compare({
+            "type": "promise"},
+            result)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("await_promise", [True, False])
+async def test_await_promise_async_arrow(bidi_session, top_context, await_promise):
+    result = await bidi_session.script.call_function(
+        function_declaration="async ()=>{return 'SOME_VALUE'}",
+        await_promise=await_promise,
+        target=ContextTarget(top_context["context"]))
+
+    if await_promise:
+        assert result == {
+            "type": "string",
+            "value": "SOME_VALUE"}
+    else:
+        recursive_compare({
+            "type": "promise"},
+            result)

--- a/webdriver/tests/bidi/script/call_function/call_function.py
+++ b/webdriver/tests/bidi/script/call_function/call_function.py
@@ -147,39 +147,3 @@ async def test_remote_value_argument(bidi_session, top_context):
     assert result == {
         "type": "string",
         "value": "SOME_VALUE"}
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("await_promise", [True, False])
-async def test_async_arrow_await_promise(bidi_session, top_context, await_promise):
-    result = await bidi_session.script.call_function(
-        function_declaration="async ()=>{return 'SOME_VALUE'}",
-        await_promise=await_promise,
-        target=ContextTarget(top_context["context"]))
-
-    if await_promise:
-        assert result == {
-            "type": "string",
-            "value": "SOME_VALUE"}
-    else:
-        recursive_compare({
-            "type": "promise"},
-            result)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("await_promise", [True, False])
-async def test_async_classic_await_promise(bidi_session, top_context, await_promise):
-    result = await bidi_session.script.call_function(
-        function_declaration="async function(){return 'SOME_VALUE'}",
-        await_promise=await_promise,
-        target=ContextTarget(top_context["context"]))
-
-    if await_promise:
-        assert result == {
-            "type": "string",
-            "value": "SOME_VALUE"}
-    else:
-        recursive_compare({
-            "type": "promise"},
-            result)

--- a/webdriver/tests/bidi/script/call_function/result.py
+++ b/webdriver/tests/bidi/script/call_function/result.py
@@ -2,8 +2,9 @@ import pytest
 
 from webdriver.bidi.modules.script import ContextTarget
 
+pytestmark = pytest.mark.asyncio
 
-@pytest.mark.asyncio
+@pytest.mark.parametrize("await_promise", [True, False])
 @pytest.mark.parametrize(
     "expression, expected",
     [
@@ -22,17 +23,21 @@ from webdriver.bidi.modules.script import ContextTarget
         ("42n", {"type": "bigint", "value": "42"}),
     ],
 )
-async def test_primitive_values(bidi_session, top_context, expression, expected):
+async def test_primitive_values(bidi_session, top_context, await_promise, expression, expected):
+    function_declaration = f"()=>{expression}"
+    if await_promise:
+        function_declaration = "async" + function_declaration
+
     result = await bidi_session.script.call_function(
-        function_declaration=f"() => {expression}",
-        await_promise=False,
+        function_declaration=function_declaration,
+        await_promise=await_promise,
         target=ContextTarget(top_context["context"]),
     )
 
     assert result == expected
 
 
-@pytest.mark.asyncio
+@pytest.mark.parametrize("await_promise", [True, False])
 @pytest.mark.parametrize(
     "expression, expected",
     [
@@ -115,7 +120,6 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
         # TODO(sadym): add `iterator` test.
         # TODO(sadym): add `generator` test.
         # TODO(sadym): add `proxy` test.
-        ("Promise.resolve()", {"type": "promise"}),
         ("new Int32Array()", {"type": "typedarray"}),
         ("new ArrayBuffer()", {"type": "arraybuffer"}),
         (
@@ -137,11 +141,35 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
         ("window", {"type": "window"}),
     ],
 )
-async def test_remote_values(bidi_session, top_context, expression, expected):
+async def test_remote_values(bidi_session, top_context, await_promise, expression, expected):
+    function_declaration = f"()=>{expression}"
+    if await_promise:
+        function_declaration = "async" + function_declaration
+
     result = await bidi_session.script.call_function(
-        function_declaration=f"() => {expression}",
-        await_promise=False,
+        function_declaration=function_declaration,
+        await_promise=await_promise,
         target=ContextTarget(top_context["context"]),
     )
 
     assert result == expected
+
+
+async def test_remote_value_promise_await(bidi_session, top_context):
+    result = await bidi_session.script.call_function(
+        function_declaration="()=>Promise.resolve(42)",
+        await_promise=True,
+        target=ContextTarget(top_context["context"]),
+    )
+
+    assert result == {"type": "number", "value": 42}
+
+
+async def test_remote_value_promise_no_await(bidi_session, top_context):
+    result = await bidi_session.script.call_function(
+        function_declaration="()=>Promise.resolve(42)",
+        await_promise=False,
+        target=ContextTarget(top_context["context"]),
+    )
+
+    assert result == {"type": "promise"}


### PR DESCRIPTION
Add more coverage for call_function with await_promise set to true. 

Moving the dedicated tests from call_function to a new dedicated file.
To test return values, rather than duplicating what we already have in result.py, we are parametrizing `test_remote_values` to test both sync and async variants.

The promise test case is extracted to two dedicated tests because the result will be different if await_promise is true or not.  