### PR TITLE
Fix #34926: set SYSTEM_VERSION_COMPAT=0 when installing STP

### DIFF
--- a/tools/ci/azure/install_safari.yml
+++ b/tools/ci/azure/install_safari.yml
@@ -9,6 +9,7 @@ steps:
 - ${{ if eq(parameters.channel, 'preview') }}:
   - script: |
       set -eux -o pipefail
+      export SYSTEM_VERSION_COMPAT=0
       ./wpt install --channel preview --download-only -d . --rename STP safari browser
       sudo installer -pkg STP.pkg -target LocalSystem
       # Workaround for `sudo safardriver --enable` not working on Catalina:


### PR DESCRIPTION
Presumably Azure Pipelines (temporarily?) had an image which didn't set SYSTEM_VERSION_COMPAT=1 by default, hence this previously appeared to work without this.

Fixes #34926.