### PR TITLE
Improved precision of text-align-justifyall-00[1-6].html tests and 2 related reference files

### DIFF
--- a/css/css-text/text-align/reference/text-align-justifyall-ref-001.html
+++ b/css/css-text/text-align/reference/text-align-justifyall-ref-001.html
@@ -1,24 +1,18 @@
 <!DOCTYPE html>
-<html  lang="en" >
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>text-align: justify-all, direction: rtl</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style type='text/css'>
-.test, .ref { border: 1px solid orange;  margin: 20px; width: 402px; color: orange; font: 24px/24px Ahem; }
-.ref { text-align: right; position: relative; height:72px;  }
-.rb { position: absolute;  background-color: orange;  width: 72px; }
-.rb1 { top: 0; left: 0; height: 72px;  }
-.rb2 { top: 0; left: 110px; height: 48px; }
-.rb3 { top: 0; left: 220px; height: 48px; }
-.rb4 { top: 0; left: 330px; height: 72px; }
-.rb5 { top: 48px; left: 165px; height: 24px; }
+.ref { border: 1px solid orange; margin: 20px; width: 510px; color: orange; font: 30px/1 Ahem; word-spacing: 20px; }
+div.last-line { word-spacing: 90px; }
 </style>
 </head>
 <body>
 <div id='instructions'>Test passes if the shading in both orange boxes is identical.</div>
-<div class="ref"><div class="rb rb1"></div><div class="rb rb2"></div><div class="rb rb3"></div><div class="rb rb4"></div><div class="rb rb5"></div></div>
-<div class="ref"><div class="rb rb1"></div><div class="rb rb2"></div><div class="rb rb3"></div><div class="rb rb4"></div><div class="rb rb5"></div></div>
+<div class="ref"><div>REF REF REF REF</div><div>REF REF REF REF</div><div class="last-line">REF REF REF </div></div>
+<div class="ref"><div>REF REF REF REF</div><div>REF REF REF REF</div><div class="last-line">REF REF REF </div></div>
 </body>
 </html>

--- a/css/css-text/text-align/reference/text-align-justifyall-ref-002.html
+++ b/css/css-text/text-align/reference/text-align-justifyall-ref-002.html
@@ -1,26 +1,20 @@
 <!DOCTYPE html>
-<html  lang="en" >
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>text-align: justify-all, direction: ltr</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style type='text/css'>
-.test, .ref { border: 1px solid orange;  margin: 20px; width: 402px; color: orange; font: 24px/24px Ahem; }
-.ref { text-align: right; position: relative; height:72px;  }
-.rb { position: absolute;  background-color: orange;  width: 72px; }
-.rb1 { top: 0; right: 0; height: 72px;  }
-.rb2 { top: 0; right: 110px; height: 48px; }
-.rb3 { top: 0; right: 220px; height: 48px; }
-.rb4 { top: 0; right: 330px; height: 72px; }
-.rb5 { top: 48px; left: 165px; height: 24px; }
+.ref { border: 1px solid orange; margin: 20px; width: 510px; color: orange; font: 30px/1 Ahem; word-spacing: 20px; }
+div.last-line { word-spacing: 90px; }
 </style>
 </head>
 <body>
 <div id='instructions'>Test passes if the shading in both orange boxes is identical.</div>
 <div style="direction: rtl;">
-<div class="ref"><div class="rb rb1"></div><div class="rb rb2"></div><div class="rb rb3"></div><div class="rb rb4"></div><div class="rb rb5"></div></div>
-<div class="ref"><div class="rb rb1"></div><div class="rb rb2"></div><div class="rb rb3"></div><div class="rb rb4"></div><div class="rb rb5"></div></div>
+<div class="ref"><div>REF REF REF REF</div><div>REF REF REF REF</div><div class="last-line">REF REF REF </div></div>
+<div class="ref"><div>REF REF REF REF</div><div>REF REF REF REF</div><div class="last-line">REF REF REF </div></div>
 </div>
 </body>
 </html>

--- a/css/css-text/text-align/text-align-justifyall-001.html
+++ b/css/css-text/text-align/text-align-justifyall-001.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html  lang="en" >
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>text-align: justify-all, direction: rtl</title>
@@ -7,23 +7,18 @@
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
 <link rel='match' href='reference/text-align-justifyall-ref-001.html'>
 <meta name="assert" content="text-align:justify-all aligns text in order to exactly fill the line box, forcing the last line to justify as well.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style type='text/css'>
 .test { text-align: justify-all; direction: rtl; }
 /* the CSS below is not part of the test */
-.test, .ref { border: 1px solid orange;  margin: 20px; width: 402px; color: orange; font: 24px/24px Ahem; }
-.ref { text-align: right; position: relative; height:72px;  }
-.rb { position: absolute;  background-color: orange;  width: 72px; }
-#rb1 { top: 0; left: 0; height: 72px;  }
-#rb2 { top: 0; left: 110px; height: 48px; }
-#rb3 { top: 0; left: 220px; height: 48px; }
-#rb4 { top: 0; left: 330px; height: 72px; }
-#rb5 { top: 48px; left: 165px; height: 24px; }
+.test, .ref { border: 1px solid orange; margin: 20px; width: 510px; color: orange; font: 30px/1 Ahem; }
+.ref { word-spacing: 20px; }
+.last-line { word-spacing: 90px; }
 </style>
 </head>
 <body>
 <div id='instructions'>Test passes if the shading in both orange boxes is identical.</div>
-<div class="test">XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX </div>
-<div class="ref"><div class="rb" id="rb1"></div><div class="rb" id="rb2"></div><div class="rb" id="rb3"></div><div class="rb" id="rb4"></div><div class="rb" id="rb5"></div></div>
+<div class="test">TES TES TES TES TES TES TES TES TES TES TES </div>
+<div class="ref"><div>REF REF REF REF</div><div>REF REF REF REF</div><div class="last-line">REF REF REF </div></div>
 </body>
 </html>

--- a/css/css-text/text-align/text-align-justifyall-002.html
+++ b/css/css-text/text-align/text-align-justifyall-002.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html  lang="en" >
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>text-align: justify-all, direction: ltr</title>
@@ -7,25 +7,20 @@
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
 <link rel='match' href='reference/text-align-justifyall-ref-002.html'>
 <meta name="assert" content="text-align:justify-all aligns text in order to exactly fill the line box, forcing the last line to justify as well.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style type='text/css'>
 .test { text-align: justify-all; direction: ltr; }
 /* the CSS below is not part of the test */
-.test, .ref { border: 1px solid orange;  margin: 20px; width: 402px; color: orange; font: 24px/24px Ahem; }
-.ref { text-align: right; position: relative; height:72px;  }
-.rb { position: absolute;  background-color: orange;  width: 72px; }
-#rb1 { top: 0; right: 0; height: 72px;  }
-#rb2 { top: 0; right: 110px; height: 48px; }
-#rb3 { top: 0; right: 220px; height: 48px; }
-#rb4 { top: 0; right: 330px; height: 72px; }
-#rb5 { top: 48px; left: 165px; height: 24px; }
+.test, .ref { border: 1px solid orange; margin: 20px; width: 510px; color: orange; font: 30px/1 Ahem; }
+.ref { word-spacing: 20px; }
+.last-line { word-spacing: 90px; }
 </style>
 </head>
 <body>
 <div id='instructions'>Test passes if the shading in both orange boxes is identical.</div>
 <div style="direction: rtl;">
-<div class="test">XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX </div>
-<div class="ref"><div class="rb" id="rb1"></div><div class="rb" id="rb2"></div><div class="rb" id="rb3"></div><div class="rb" id="rb4"></div><div class="rb" id="rb5"></div></div>
+<div class="test">TES TES TES TES TES TES TES TES TES TES TES </div>
+<div class="ref"><div>REF REF REF REF</div><div>REF REF REF REF</div><div class="last-line">REF REF REF </div></div>
 </div>
 </body>
 </html>

--- a/css/css-text/text-align/text-align-justifyall-003.html
+++ b/css/css-text/text-align/text-align-justifyall-003.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html  lang="en" >
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>text-align: justify-all, dir=rtl</title>
@@ -7,23 +7,18 @@
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
 <link rel='match' href='reference/text-align-justifyall-ref-001.html'>
 <meta name="assert" content="text-align:justify-all aligns text in order to exactly fill the line box, forcing the last line to justify as well.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style type='text/css'>
 .test { text-align: justify-all; }
 /* the CSS below is not part of the test */
-.test, .ref { border: 1px solid orange;  margin: 20px; width: 402px; color: orange; font: 24px/24px Ahem; }
-.ref { text-align: right; position: relative; height:72px;  }
-.rb { position: absolute;  background-color: orange;  width: 72px; }
-#rb1 { top: 0; left: 0; height: 72px;  }
-#rb2 { top: 0; left: 110px; height: 48px; }
-#rb3 { top: 0; left: 220px; height: 48px; }
-#rb4 { top: 0; left: 330px; height: 72px; }
-#rb5 { top: 48px; right: 165px; height: 24px; }
+.test, .ref { border: 1px solid orange; margin: 20px; width: 510px; color: orange; font: 30px/1 Ahem; }
+.ref { word-spacing: 20px; }
+.last-line { word-spacing: 90px; }
 </style>
 </head>
 <body>
 <div id='instructions'>Test passes if the shading in both orange boxes is identical.</div>
-<div class="test" dir="rtl">XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX </div>
-<div class="ref"><div class="rb" id="rb1"></div><div class="rb" id="rb2"></div><div class="rb" id="rb3"></div><div class="rb" id="rb4"></div><div class="rb" id="rb5"></div></div>
+<div class="test" dir="rtl">TES TES TES TES TES TES TES TES TES TES TES </div>
+<div class="ref"><div>REF REF REF REF</div><div>REF REF REF REF</div><div class="last-line">REF REF REF </div></div>
 </body>
 </html>

--- a/css/css-text/text-align/text-align-justifyall-004.html
+++ b/css/css-text/text-align/text-align-justifyall-004.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html  lang="en" >
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>text-align: justify-all, dir=ltr</title>
@@ -7,25 +7,20 @@
 <link rel='match' href='reference/text-align-justifyall-ref-002.html'>
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
 <meta name="assert" content="text-align:justify-all aligns text in order to exactly fill the line box, forcing the last line to justify as well.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style type='text/css'>
 .test { text-align: justify-all; }
 /* the CSS below is not part of the test */
-.test, .ref { border: 1px solid orange;  margin: 20px; width: 402px; color: orange; font: 24px/24px Ahem; }
-.ref { text-align: right; position: relative; height:72px;  }
-.rb { position: absolute;  background-color: orange;  width: 72px; }
-#rb1 { top: 0; right: 0; height: 72px;  }
-#rb2 { top: 0; right: 110px; height: 48px; }
-#rb3 { top: 0; right: 220px; height: 48px; }
-#rb4 { top: 0; right: 330px; height: 72px; }
-#rb5 { top: 48px; left: 165px; height: 24px; }
+.test, .ref { border: 1px solid orange; margin: 20px; width: 510px; color: orange; font: 30px/1 Ahem; }
+.ref { word-spacing: 20px; }
+.last-line { word-spacing: 90px; }
 </style>
 </head>
 <body>
 <div id='instructions'>Test passes if the shading in both orange boxes is identical.</div>
 <div dir="rtl">
-<div class="test" dir="ltr">XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX </div>
-<div class="ref"><div class="rb" id="rb1"></div><div class="rb" id="rb2"></div><div class="rb" id="rb3"></div><div class="rb" id="rb4"></div><div class="rb" id="rb5"></div></div>
+<div class="test">TES TES TES TES TES TES TES TES TES TES TES </div>
+<div class="ref"><div>REF REF REF REF</div><div>REF REF REF REF</div><div class="last-line">REF REF REF </div></div>
 </div>
 </body>
 </html>

--- a/css/css-text/text-align/text-align-justifyall-005.html
+++ b/css/css-text/text-align/text-align-justifyall-005.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html  lang="en" >
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>text-align: justify-all, dir=auto, RTL first strong</title>
@@ -7,23 +7,18 @@
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
 <link rel='match' href='reference/text-align-justifyall-ref-001.html'>
 <meta name="assert" content="text-align:justify-all aligns text in order to exactly fill the line box, forcing the last line to justify as well.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style type='text/css'>
 .test { text-align: justify-all; }
 /* the CSS below is not part of the test */
-.test, .ref { border: 1px solid orange;  margin: 20px; width: 402px; color: orange; font: 24px/24px Ahem; }
-.ref { text-align: right; position: relative; height:72px;  }
-.rb { position: absolute;  background-color: orange;  width: 72px; }
-#rb1 { top: 0; left: 0; height: 72px;  }
-#rb2 { top: 0; left: 110px; height: 48px; }
-#rb3 { top: 0; left: 220px; height: 48px; }
-#rb4 { top: 0; left: 330px; height: 72px; }
-#rb5 { top: 48px; right: 165px; height: 24px; }
+.test, .ref { border: 1px solid orange; margin: 20px; width: 510px; color: orange; font: 30px/1 Ahem; }
+.ref { word-spacing: 20px; }
+.last-line { word-spacing: 90px; }
 </style>
 </head>
 <body>
 <div id='instructions'>Test passes if the shading in both orange boxes is identical.</div>
-<div dir="auto" class="test">&rlm;XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX</div>
-<div class="ref"><div class="rb" id="rb1"></div><div class="rb" id="rb2"></div><div class="rb" id="rb3"></div><div class="rb" id="rb4"></div><div class="rb" id="rb5"></div></div>
+<div dir="auto" class="test">&rlm;TES TES TES TES TES TES TES TES TES TES TES</div>
+<div class="ref"><div>REF REF REF REF</div><div>REF REF REF REF</div><div class="last-line">REF REF REF </div></div>
 </body>
 </html>

--- a/css/css-text/text-align/text-align-justifyall-006.html
+++ b/css/css-text/text-align/text-align-justifyall-006.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html  lang="en" >
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>text-align: justify-all, dir=auto, LTR first strong</title>
@@ -7,25 +7,20 @@
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-align-property'>
 <link rel='match' href='reference/text-align-justifyall-ref-002.html'>
 <meta name="assert" content="text-align:justify-all aligns text in order to exactly fill the line box, forcing the last line to justify as well.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style type='text/css'>
 .test { text-align: justify-all; }
 /* the CSS below is not part of the test */
-.test, .ref { border: 1px solid orange;  margin: 20px; width: 402px; color: orange; font: 24px/24px Ahem; }
-.ref { text-align: right; position: relative; height:72px;  }
-.rb { position: absolute;  background-color: orange;  width: 72px; }
-#rb1 { top: 0; right: 0; height: 72px;  }
-#rb2 { top: 0; right: 110px; height: 48px; }
-#rb3 { top: 0; right: 220px; height: 48px; }
-#rb4 { top: 0; right: 330px; height: 72px; }
-#rb5 { top: 48px; left: 165px; height: 24px; }
+.test, .ref { border: 1px solid orange; margin: 20px; width: 510px; color: orange; font: 30px/1 Ahem; }
+.ref { word-spacing: 20px; }
+.last-line { word-spacing: 90px; }
 </style>
 </head>
 <body>
 <div id='instructions'>Test passes if the shading in both orange boxes is identical.</div>
 <div dir="rtl">
-<div dir="auto" class="test">XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX</div>
-<div class="ref"><div class="rb" id="rb1"></div><div class="rb" id="rb2"></div><div class="rb" id="rb3"></div><div class="rb" id="rb4"></div><div class="rb" id="rb5"></div></div>
+<div dir="auto" class="test">TES TES TES TES TES TES TES TES TES TES TES</div>
+<div class="ref"><div>REF REF REF REF</div><div>REF REF REF REF</div><div class="last-line">REF REF REF </div></div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
On my website (6 tests and 2 correspondent reference files):

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/text-align/text-align-justifyall-001-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/text-align/reference/text-align-justifyall-ref-001-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/text-align/text-align-justifyall-002-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/text-align/reference/text-align-justifyall-ref-002-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/text-align/text-align-justifyall-003-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/text-align/text-align-justifyall-004-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/text-align/text-align-justifyall-005-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/text-align/text-align-justifyall-006-GT.html

