### PR TITLE
Add a test to cover using ResizeObserver on SVG elements

### DIFF
--- a/resize-observer/svg.html
+++ b/resize-observer/svg.html
@@ -590,6 +590,31 @@ function test17() {
   return helper.start();
 }
 
+function test18() {
+  let target = document.querySelector('svg');
+  let helper = new ResizeTestHelper(
+    "test18: observe svg",
+  [
+    {
+      setup: observer => {
+        observer.observe(target);
+      },
+      notify: (entries, observer) => {
+        return true;  // Delay next step
+      }
+    },
+    {
+      setup: observer => {
+        target.setAttribute('height', 500);
+      },
+      notify: (entries, observer) => {
+        assert_equals(entries.length, 1);
+      }
+    }
+  ]);
+  return helper.start();
+}
+
 let guard;
 test(_ => {
   assert_own_property(window, "ResizeObserver");
@@ -614,6 +639,7 @@ test0()
   .then(() => { return test15(); })
   .then(() => { return test16(); })
   .then(() => { return test17(); })
+  .then(() => { return test18(); })
   .then(() => { guard.done(); });
 
 </script>


### PR DESCRIPTION
This PR adds a test to see if ResizeObserver correctly fires events when the SVG elements themselves are resized. All major browsers I've tested failed this test, but spec seems to support this usage (see https://www.w3.org/TR/resize-observer/#calculate-box-size and https://github.com/w3c/csswg-drafts/issues/4032#issuecomment-510137495).