### PR TITLE
log the stack trace for unhandled rejection in promise_test

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -756,6 +756,11 @@
                             if (value instanceof AssertionError) {
                                 throw value;
                             }
+                            // Adding the stack to the assert message is messy because it's a multi-line string.
+                            // Logging to the console makes it clickable.
+                            console.error("Unhandled rejection", value.stack);
+                            assert(false, "promise_test", null,
+                               "Unhandled rejection with value: ${value}", {value:value});
                             assert(false, "promise_test", null,
                                    "Unhandled rejection with value: ${value}", {value:value});
                         }))


### PR DESCRIPTION
Currently we get no information about where the rejection occurred. This makes developing promise_tests painful.

With this change the stack is logged to the console.

An alternative is to insert it into the message but it's a multi-line string, so that's ugly and stacks on the console are more useful (click to open the file etc).