### PR TITLE
Add second eventsource/format-field-retry-bogus.any.js test with diff…

### DIFF
--- a/eventsource/format-field-retry-bogus-2.any.js
+++ b/eventsource/format-field-retry-bogus-2.any.js
@@ -1,0 +1,19 @@
+// META: title=EventSource: "retry" field (bogus)
+      var test = async_test()
+      test.step(function() {
+        var timeoutms = 1000,
+            source = new EventSource("resources/message.py?message=retry%3A1000%0Aretry%3A5000x%0Adata%3Ax"),
+            opened = 0
+        source.onopen = function() {
+          test.step(function() {
+            if(opened == 0) {
+              opened = new Date().getTime()
+            } else {
+              var diff = (new Date().getTime()) - opened 
+              assert_true(Math.abs(1 - diff / timeoutms) < 0.25) // allow 25% difference
+              this.close();
+              test.done()
+            }
+          }, this)
+        }
+      })


### PR DESCRIPTION
…erent timeouts

Add second eventsource/format-field-retry-bogus.any.js test with different timeouts
to better validate the WebKit / Blink implementation. WebKit and Blink have a
concept of defaultReconnectDelay which is 3 seconds so it is useful to use another
delay value in the test to check if we fell back to using the default delay or not
when parsing failed.