### PR TITLE
Fix a bug in this test that the host wasn't getting focused.

### DIFF
--- a/css/selectors/focus-visible-020.html
+++ b/css/selectors/focus-visible-020.html
@@ -45,6 +45,7 @@
   test_valid_selector(':focus-visible');
 
   async_test((t) => {
+    host.focus();
     window.requestAnimationFrame(t.step_func_done(() => {
       assert_not_equals(getComputedStyle(host).backgroundColor, "rgb(255, 0, 0)", `backgroundColor for ${host.tagName}#${host.id} should NOT be red`);
 


### PR DESCRIPTION
HTML defines steps to run when an element is inserted into a document (i.e. document tree),
not anytime an element is connected to a document:
https://html.spec.whatwg.org/multipage/interaction.html#the-autofocus-attribute