### PR TITLE
Adjust URL of Device Memory spec in META file

### DIFF
--- a/device-memory/META.yml
+++ b/device-memory/META.yml
@@ -1,3 +1,3 @@
-spec: https://w3c.github.io/device-memory/
+spec: https://www.w3.org/TR/device-memory/
 suggested_reviewers:
   - npm1


### PR DESCRIPTION
The Working Draft now points at itself for the Editor's Draft. In other words, the canonical URL for the Editor's Draft has become the /TR URL https://www.w3.org/TR/device-memory/