### PR TITLE
Update docker image for WebKitGTK dependencies (PAC proxy support)

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -57,7 +57,7 @@ tasks:
             owner: ${owner}
             source: ${event.repository.clone_url}
           payload:
-            image: webplatformtests/wpt:0.48
+            image: webplatformtests/wpt:0.52
             maxRunTime: 7200
             artifacts:
               public/results:

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -4,7 +4,7 @@ components:
     workerType: ci
     schedulerId: taskcluster-github
     deadline: "24 hours"
-    image: webplatformtests/wpt:0.48
+    image: webplatformtests/wpt:0.52
     maxRunTime: 7200
     artifacts:
       public/results:

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -16,9 +16,11 @@ RUN apt-get -qqy update \
     fluxbox \
     gdebi \
     git \
+    glib-networking-services \
     gstreamer1.0-plugins-bad \
     gstreamer1.0-gl \
     libosmesa6-dev \
+    libproxy1-plugin-webkit \
     libvirt-daemon-system \
     libvirt-clients \
     libunwind8 \


### PR DESCRIPTION
`libproxy1-plugin-webkit` and `glib-networking-services` are dependencies needed on the system that are required to have the support for configuring the WebKitWebDriver proxy via a PAC file, in order to pass the test `infrastructure/server/test-pac.html`

This is a D-Bus activated service, so it is not really a dependency of the browser.

If this two packages are installed and you run ```./wpt serve``` you can verify how the D-Bus service works as expected:
```
$ busctl --user call \
    org.gtk.GLib.PACRunner /org/gtk/GLib/PACRunner org.gtk.GLib.PACRunner Lookup ss \
        'http://web-platform.test:8000/infrastructure/server/resources/proxy.sub.pac' \
        'http://not-a-real-domain.wpt.test/infrastructure/resources/ok.txt'

as 1 "http://127.0.0.1:8000"
```
It replies to use proxy `http://127.0.0.1:8000` for a domain ending in `wpt.test` as per the `proxy.sub.pac` file instructs.

Without having the plugin for libproxy to interpret the pac file, this D-Bus method call doesn't work and the WebKitWebDriver doesn't correctly handle the pac proxy support