### PR TITLE
Pass the right arguments to make FedCM tests work

### DIFF
--- a/credential-management/fedcm-iframe.https.html
+++ b/credential-management/fedcm-iframe.https.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <link rel="help" href="https://wicg.github.io/FedCM">
+<meta name="pac" content="/common/proxy-all.sub.pac">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/common/get-host-info.sub.js"></script>

--- a/credential-management/fedcm-network-requests.sub.https.html
+++ b/credential-management/fedcm-network-requests.sub.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Federated Credential Management API network request tests.</title>
 <link rel="help" href="https://fedidcg.github.io/FedCM">
+<meta name="pac" content="/common/proxy-all.sub.pac">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 

--- a/infrastructure/server/test-pac-https.sub.html
+++ b/infrastructure/server/test-pac-https.sub.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML>
+<title>test behavior of PROXY configuration (PAC)</title>
+<meta name="pac" content="resources/proxy.sub.pac">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    promise_test(async t => {
+        const response = await fetch('http://not-a-real-domain.wpt.test/infrastructure/resources/ok.txt');
+        const text = await response.text();
+        assert_equals(text, 'OK');
+    }, 'test that PAC metadata is respected');
+</script>

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -792,9 +792,10 @@ def start_http_server(logger, host, port, paths, routes, bind_address, config, *
                                      rewrites=rewrites,
                                      bind_address=bind_address,
                                      config=config,
-                                     use_ssl=False,
-                                     key_file=None,
-                                     certificate=None,
+                                     use_ssl=True,
+                                     key_file=config.ssl_config["key_path"],
+                                     certificate=config.ssl_config["cert_path"],
+                                     encrypt_after_connect=True,
                                      latency=kwargs.get("latency"))
     except Exception:
         startup_failed(logger)

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -78,6 +78,8 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     chrome_options["args"].append("--autoplay-policy=no-user-gesture-required")
     # Allow WebRTC tests to call getUserMedia.
     chrome_options["args"].append("--use-fake-device-for-media-stream")
+    # Use a fake UI for FedCM to allow testing it.
+    chrome_options["args"].append("--use-fake-ui-for-fedcm")
     # Shorten delay for Reporting <https://w3c.github.io/reporting/>.
     chrome_options["args"].append("--short-reporting-delay")
     # Point all .test domains to localhost for Chrome

--- a/tools/wptrunner/wptrunner/browsers/edgechromium.py
+++ b/tools/wptrunner/wptrunner/browsers/edgechromium.py
@@ -69,6 +69,7 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
         if "--headless" not in capabilities["ms:edgeOptions"]["args"]:
             capabilities["ms:edgeOptions"]["args"].append("--headless")
         capabilities["ms:edgeOptions"]["args"].append("--use-fake-device-for-media-stream")
+        capabilities["ms:edgeOptions"]["args"].append("--use-fake-ui-for-fedcm")
 
     executor_kwargs["capabilities"] = capabilities
 

--- a/tools/wptserve/wptserve/config.py
+++ b/tools/wptserve/wptserve/config.py
@@ -137,7 +137,7 @@ class ConfigBuilder:
         "bind_address": True,
         "ssl": {
             "type": "none",
-            "encrypt_after_connect": False,
+            "encrypt_after_connect": True,
             "none": {},
             "openssl": {
                 "openssl_binary": "openssl",


### PR DESCRIPTION
This effectively ports these Chromium patches to wptrunner:
https://chromium-review.googlesource.com/c/chromium/src/+/3671447/3/content/web_test/browser/web_test_browser_main_runner.cc
https://chromium-review.googlesource.com/c/chromium/src/+/3546261

We need to map :443 to the WPT port because of the root manifest part
of the FedCM spec:
https://fedidcg.github.io/FedCM/#check-the-root-manifest