### PR TITLE
Made text assert of word-spacing-computed-001.html test a bit more precise

### DIFF
--- a/css/css-text/word-spacing/word-spacing-computed-001.html
+++ b/css/css-text/word-spacing/word-spacing-computed-001.html
@@ -7,7 +7,7 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#word-spacing-property">
 
-  <meta content="This test checks that the computed value of 'normal' for the property word-spacing is zero. We also check the computed value of various &lt;length&gt;." name="assert">
+  <meta content="This test checks that the computed value of 'normal' for the property word-spacing is '0px'. We also check the computed value of various &lt;length&gt;." name="assert">
 
   <script src="/resources/testharness.js"></script>
 


### PR DESCRIPTION
This spun from a comment I made in [PR27412](https://github.com/web-platform-tests/wpt/pull/27412#issuecomment-900373950) in which I stated that the text assert should be a bit more precise. Nothing more.