### PR TITLE
Add test for <link rel=preconnect>

### DIFF
--- a/common/proxy-all.sub.pac
+++ b/common/proxy-all.sub.pac
@@ -1,0 +1,3 @@
+function FindProxyForURL(url, host) {
+    return "PROXY {{host}}:{{ports[http][0]}}"
+}

--- a/preload/preconnect.html
+++ b/preload/preconnect.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<title>Makes sure that preloaded resources trigger the onerror event</title>
+<meta name="timeout" content="long">
+<meta name="pac" content="/common/proxy-all.sub.pac">
+<script src="/common/utils.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+
+<body>
+<script>
+    const FAKE_PORT = 30303;
+    promise_test(async t => {
+        const fake_remote_origin = `http://${token()}.wpt:${FAKE_PORT}`;
+        const link = document.createElement('link');
+        link.rel = "preconnect";
+        link.href = fake_remote_origin;
+        document.head.appendChild(link);
+        await new Promise(r => t.step_timeout(r, 1000));
+        const url = `${fake_remote_origin}/images/smiley.png`;
+        const entryPromise = new Promise(resolve => {
+            new PerformanceObserver(list => {
+                const entries = list.getEntriesByName(url);
+                if (entries.length)
+                    resolve(entries[0]);
+            }).observe({type: "resource"});
+        });
+
+        const img = document.createElement('img');
+        img.src = url;
+        document.body.appendChild(img);
+        const entry = await entryPromise;
+        assert_equals(entry.domainLookupStart, entry.domainLookupEnd);
+        assert_equals(entry.domainLookupStart, entry.connectStart);
+        assert_equals(entry.domainLookupStart, entry.connectEnd);
+    }, "Test that preconnect reduces connection time to zero");
+</script>
+</body>
+</html>

--- a/preload/preconnect.html
+++ b/preload/preconnect.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<title>Makes sure that preloaded resources trigger the onerror event</title>
+<title>Makes sure that preloaded resources reduce connection time to zero</title>
 <meta name="timeout" content="long">
 <meta name="pac" content="/common/proxy-all.sub.pac">
 <script src="/common/utils.js"></script>

--- a/preload/preconnect.html
+++ b/preload/preconnect.html
@@ -6,7 +6,6 @@
 <script src="/common/utils.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
 
 <body>
 <script>


### PR DESCRIPTION
Spec: https://html.spec.whatwg.org/multipage/links.html#link-type-preconnect
This is now possible since tests can specify a proxy - which allows running each test with a fresh top-level registrable domain, avoiding cache to affect the result between test runs.