### PR TITLE
Two new tests for counter-scope

### DIFF
--- a/css/css-lists/counter-scope-001-ref.xht
+++ b/css/css-lists/counter-scope-001-ref.xht
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html  xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head>
+<meta charset="utf-8"/>
+<style>
+body {
+  font:20px/1 monospace;
+}
+</style>
+</head>
+<body>
+<div>0</div>
+<div>0.0</div>
+<div>0.1</div>
+<div>1</div>
+</body>
+</html>

--- a/css/css-lists/counter-scope-001.xht
+++ b/css/css-lists/counter-scope-001.xht
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html  xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head>
+ <meta charset="utf-8"/>
+ <title>Counter Scope test</title>
+ <link rel="match" href="counter-scope-001-ref.xht"/>
+ <link rel="help" href="https://drafts.csswg.org/css-lists-3/#inheriting-counters"/>
+ <link rel="author" href="mailto:mike@bfo.com"/>
+ <meta name="assert" content="Verifies that the counter scope rules inherit from the parent first, then the previous sibling"/>
+ <!--
+  In more detail, what this test is trying to verify is that the final <li>
+  element inherits the counter from its parent and the counter-value also
+  comes from its parent, not its previous sibling.
+
+  Specifically, referencing https://drafts.csswg.org/css-lists-3/#inheriting-counters
+
+  * step 3 requires that the counter inherited by the final <li>
+    is from the parent, not the previous sibling
+  * step 4 requires that the value for that counter is taken from the parent,
+    as it has a different creator from the counter in the previous step.
+
+  The values should be: 0, 0.1, 0.2, 1
+ -->
+ <style>
+body {
+  font:20px/1 monospace;
+}
+ol {
+  list-style: none inside;
+  padding: 0;
+}
+ol::before, li::before {
+  content: counters(list-item,".");
+}
+ </style>
+</head>
+<body>
+ <ol>
+  <ol>
+   <li></li>
+  </ol>
+  <li></li>
+ </ol>
+</body>
+</html>


### PR DESCRIPTION
Test for a subtlety in the spec which currently only Gecko passes, but which doesn't seem to be tested by any other tests in css-lists except for those also testing `reversed()`.

@MatsPalmgren if you get a chance to review to ensure I've understood correctly that would be great.