### PR TITLE
Make text-shadow-orientation-upright-001-ref.html avoid sub-pixel anti-alias issue

### DIFF
--- a/css/css-writing-modes/reference/text-shadow-orientation-upright-001-ref.html
+++ b/css/css-writing-modes/reference/text-shadow-orientation-upright-001-ref.html
@@ -9,38 +9,50 @@
   <style>
   div
     {
-      height: 100px;
-      margin-left: 100px;
-      width: 100px;
+      color: transparent;
+      font-family: Ahem;
+      font-size: 100px;
+      line-height: 1;
     }
 
   div#purple
     {
-      background-color: purple;
-    }
-
-  img
-    {
-      height: 100px;
-      vertical-align: top;
-      width: 100px;
+      text-shadow: 1em 0em purple;
     }
 
   div#orange-blue
     {
-      background-color: blue;
-      margin-left: 0px;
-      width: 300px;
+      color: yellow;
+      margin-left: 1em;
+      text-shadow: -1em 0em orange, 1em 0em blue;
     }
 
   div#fuchsia
     {
-      background-color: fuchsia;
+     text-shadow: 1em 0em fuchsia;
     }
   </style>
 
-  <div id="purple"></div>
+  <div id="purple">U</div>
 
-  <div id="orange-blue"><img src="../support/swatch-orange.png" alt="Image download support must be enabled"><img src="../support/swatch-yellow.png" alt="Image download support must be enabled"></div>
+  <div id="orange-blue">B</div>
 
-  <div id="fuchsia"></div>
+  <div id="fuchsia">F</div>
+
+  <!--
+
+                  .........
+                  .       .
+                  .       . <-purple
+                  .       .
+           .......................
+           .      .       .      .
+  orange-> .      .  yel  .      . <-blue
+           .      .  low  .      .
+           .......................
+                  .       .
+                  .       . <-fuchsia
+                  .       .
+                  .........
+
+  -->

--- a/css/css-writing-modes/reference/text-shadow-orientation-upright-001-ref.html
+++ b/css/css-writing-modes/reference/text-shadow-orientation-upright-001-ref.html
@@ -4,6 +4,7 @@
 
   <title>CSS Reference Test</title>
 
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
 
   <style>


### PR DESCRIPTION
This is a followup-to [a comment in PR27770](https://github.com/web-platform-tests/wpt/pull/27770#issuecomment-954686285) which went like this:

> I'm a little bit concerned that the text will have anti-aliasing but the image reference won't, so probably a better reference would be to have a horizontal-mode copy of the text-shadow test code.
https://wpt.fyi/results/css/css-writing-modes/text-shadow-orientation-upright-001.html?label=experimental&label=master&aligned
There is indeed a failure in Edge 96 due to anti-aliasing but only in Edge 96.

The proposed modification to 

/css/css-writing-mode/reference/text-shadow-orientation-upright-001-ref.html

creates an horizontal-mode only copy of the text-shadow test code.

Over at my website:

http://www.gtalbot.org/BrowserBugsSection/CSS3WritingModes/s76-text-shadow-orientation-upright-002.html

New reference:
http://www.gtalbot.org/BrowserBugsSection/CSS3WritingModes/reference/text-shadow-orientation-upright-002-ref-new.html