### PR TITLE
[wptmanifest] Improve parser/serializer comment support

### DIFF
--- a/tools/wptrunner/wptrunner/wptmanifest/node.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/node.py
@@ -10,10 +10,11 @@ class NodeVisitor:
 
 
 class Node:
-    def __init__(self, data=None):
+    def __init__(self, data=None, comments=None):
         self.data = data
         self.parent = None
         self.children = []
+        self.comments = comments or []
 
     def append(self, other):
         other.parent = self
@@ -42,7 +43,7 @@ class Node:
         return True
 
     def copy(self):
-        new = self.__class__(self.data)
+        new = self.__class__(self.data, self.comments)
         for item in self.children:
             new.append(item.copy())
         return new

--- a/tools/wptrunner/wptrunner/wptmanifest/parser.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/parser.py
@@ -12,7 +12,6 @@
 #      PASS
 #
 
-# TODO: keep comments in the tree
 
 from io import BytesIO
 
@@ -59,7 +58,30 @@ def precedence(operator_node):
 
 class TokenTypes:
     def __init__(self) -> None:
-        for type in ["group_start", "group_end", "paren", "list_start", "list_end", "separator", "ident", "string", "number", "atom", "eof"]:
+        for type in [
+            "group_start",
+            "group_end",
+            "paren",
+            "list_start",
+            "list_end",
+            "separator",
+            "ident",
+            "string",
+            "number",
+            "atom",
+            # Without an end-of-line token type, we need two different comment
+            # token types to distinguish between:
+            #   [heading1]  # Comment attached to heading 1
+            #   [heading2]
+            #
+            # and
+            #   [heading1]
+            #   # Comment attached to heading 2
+            #   [heading2]
+            "comment",
+            "inline_comment",
+            "eof",
+        ]:
             setattr(self, type, type)
 
 token_types = TokenTypes()
@@ -146,7 +168,10 @@ class Tokenizer:
             if self.index != self.indent_levels[-1]:
                 raise ParseError(self.filename, self.line_number, "Unexpected indent")
 
-        self.state = self.next_state
+        if self.char() == "#":
+            self.state = self.comment_state
+        else:
+            self.state = self.next_state
 
     def data_line_state(self):
         if self.char() == "[":
@@ -202,12 +227,9 @@ class Tokenizer:
     def after_key_state(self):
         self.skip_whitespace()
         c = self.char()
-        if c == "#":
+        if c in {"#", eol}:
             self.next_state = self.expr_or_value_state
-            self.state = self.comment_state
-        elif c == eol:
-            self.next_state = self.expr_or_value_state
-            self.state = self.eol_state
+            self.state = self.line_end_state
         elif c == "[":
             self.state = self.list_start_state
         else:
@@ -216,12 +238,9 @@ class Tokenizer:
     def after_expr_state(self):
         self.skip_whitespace()
         c = self.char()
-        if c == "#":
+        if c in {"#", eol}:
             self.next_state = self.after_expr_state
-            self.state = self.comment_state
-        elif c == eol:
-            self.next_state = self.after_expr_state
-            self.state = self.eol_state
+            self.state = self.line_end_state
         elif c == "[":
             self.state = self.list_start_state
         else:
@@ -246,12 +265,9 @@ class Tokenizer:
             elif self.char() != ",":
                 raise ParseError(self.filename, self.line_number, "Junk after quoted string")
             self.consume()
-        elif self.char() == "#":
-            self.state = self.comment_state
+        elif self.char() in {"#", eol}:
+            self.state = self.line_end_state
             self.next_line_state = self.list_value_start_state
-        elif self.char() == eol:
-            self.next_line_state = self.list_value_start_state
-            self.state = self.eol_state
         elif self.char() == ",":
             raise ParseError(self.filename, self.line_number, "List item started with separator")
         elif self.char() == "@":
@@ -308,10 +324,7 @@ class Tokenizer:
             quote_char = self.char()
             self.consume()
             yield (token_types.string, self.consume_string(quote_char))
-            if self.char() == "#":
-                self.state = self.comment_state
-            else:
-                self.state = self.line_end_state
+            self.state = self.line_end_state
         elif c == "@":
             self.consume()
             for _, value in self.value_inner_state():
@@ -328,16 +341,13 @@ class Tokenizer:
             c = self.char()
             if c == "\\":
                 rv += self.consume_escape()
-            elif c == "#":
-                self.state = self.comment_state
+            elif c in {"#", eol}:
+                self.state = self.line_end_state
                 break
             elif c == " ":
                 # prevent whitespace before comments from being included in the value
                 spaces += 1
                 self.consume()
-            elif c == eol:
-                self.state = self.line_end_state
-                break
             else:
                 rv += " " * spaces
                 spaces = 0
@@ -352,16 +362,28 @@ class Tokenizer:
                              "(expressions must start on a newline and be indented)")
         yield (token_types.string, rv)
 
-    def comment_state(self):
+    def _consume_comment(self):
+        assert self.char() == "#"
+        self.consume()
+        comment = ''
         while self.char() is not eol:
+            comment += self.char()
             self.consume()
+        return comment
+
+    def comment_state(self):
+        yield (token_types.comment, self._consume_comment())
+        self.state = self.eol_state
+
+    def inline_comment_state(self):
+        yield (token_types.inline_comment, self._consume_comment())
         self.state = self.eol_state
 
     def line_end_state(self):
         self.skip_whitespace()
         c = self.char()
         if c == "#":
-            self.state = self.comment_state
+            self.state = self.inline_comment_state
         elif c == eol:
             self.state = self.eol_state
         else:
@@ -529,6 +551,7 @@ class Parser:
         self.tree = Treebuilder(DataNode(None))
         self.expr_builder = None
         self.expr_builders = []
+        self.comments = []
 
     def parse(self, input):
         try:
@@ -558,31 +581,54 @@ class Parser:
 
         self.consume()
 
+    def maybe_consume_inline_comment(self):
+        if self.token[0] == token_types.inline_comment:
+            self.comments.append(self.token)
+            self.consume()
+
+    def consume_comments(self):
+        while self.token[0] == token_types.comment:
+            self.comments.append(self.token)
+            self.consume()
+
+    def flush_comments(self, node=None):
+        (node or self.tree.node).comments.extend(self.comments)
+        self.comments.clear()
+
     def manifest(self):
         self.data_block()
         self.expect(token_types.eof)
 
     def data_block(self):
-        while self.token[0] == token_types.string:
-            self.tree.append(KeyValueNode(self.token[1]))
-            self.consume()
-            self.expect(token_types.separator)
-            self.value_block()
-            self.tree.pop()
-
-        while self.token == (token_types.paren, "["):
-            self.consume()
-            if self.token[0] != token_types.string:
-                raise ParseError(self.tokenizer.filename, self.tokenizer.line_number,
-                                 f"Token '{self.token[0]}' is not a string")
-            self.tree.append(DataNode(self.token[1]))
-            self.consume()
-            self.expect(token_types.paren, "]")
-            if self.token[0] == token_types.group_start:
+        while self.token[0] in {token_types.comment, token_types.string,
+                                token_types.paren}:
+            if self.token[0] == token_types.comment:
+                self.consume_comments()
+            elif self.token[0] == token_types.string:
+                self.tree.append(KeyValueNode(self.token[1]))
                 self.consume()
-                self.data_block()
-                self.eof_or_end_group()
-            self.tree.pop()
+                self.expect(token_types.separator)
+                self.maybe_consume_inline_comment()
+                self.flush_comments()
+                self.value_block()
+                self.flush_comments()
+                self.tree.pop()
+            else:
+                self.expect(token_types.paren, "[")
+                if self.token[0] != token_types.string:
+                    raise ParseError(self.tokenizer.filename,
+                                     self.tokenizer.line_number,
+                                     f"Token '{self.token[0]}' is not a string")
+                self.tree.append(DataNode(self.token[1]))
+                self.consume()
+                self.expect(token_types.paren, "]")
+                self.maybe_consume_inline_comment()
+                self.flush_comments()
+                if self.token[0] == token_types.group_start:
+                    self.consume()
+                    self.data_block()
+                    self.eof_or_end_group()
+                self.tree.pop()
 
     def eof_or_end_group(self):
         if self.token[0] != token_types.eof:
@@ -597,13 +643,19 @@ class Parser:
         elif self.token[0] == token_types.group_start:
             self.consume()
             self.expression_values()
+            default_value = None
             if self.token[0] == token_types.string:
-                self.value()
+                default_value = self.value
             elif self.token[0] == token_types.atom:
-                self.atom()
+                default_value = self.atom
             elif self.token[0] == token_types.list_start:
                 self.consume()
-                self.list_value()
+                default_value = self.list_value
+            if default_value:
+                default_value()
+            self.consume_comments()
+            self.flush_comments(
+                self.tree.node.children[-1] if default_value else None)
             self.eof_or_end_group()
         elif self.token[0] == token_types.atom:
             self.atom()
@@ -619,20 +671,25 @@ class Parser:
             else:
                 self.value()
         self.expect(token_types.list_end)
+        self.maybe_consume_inline_comment()
         self.tree.pop()
 
     def expression_values(self):
+        self.consume_comments()
         while self.token == (token_types.ident, "if"):
             self.consume()
             self.tree.append(ConditionalNode())
             self.expr_start()
             self.expect(token_types.separator)
             self.value_block()
+            self.flush_comments()
             self.tree.pop()
+            self.consume_comments()
 
     def value(self):
         self.tree.append(ValueNode(self.token[1]))
         self.consume()
+        self.maybe_consume_inline_comment()
         self.tree.pop()
 
     def atom(self):
@@ -640,6 +697,7 @@ class Parser:
             raise ParseError(self.tokenizer.filename, self.tokenizer.line_number, "Unrecognised symbol @%s" % self.token[1])
         self.tree.append(AtomNode(atoms[self.token[1]]))
         self.consume()
+        self.maybe_consume_inline_comment()
         self.tree.pop()
 
     def expr_start(self):

--- a/tools/wptrunner/wptrunner/wptmanifest/parser.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/parser.py
@@ -153,6 +153,9 @@ class Tokenizer:
         if self.char() == eol:
             self.state = self.eol_state
             return
+        if self.char() == "#":
+            self.state = self.comment_state
+            return
         if self.index > self.indent_levels[-1]:
             self.indent_levels.append(self.index)
             yield (token_types.group_start, None)
@@ -168,10 +171,7 @@ class Tokenizer:
             if self.index != self.indent_levels[-1]:
                 raise ParseError(self.filename, self.line_number, "Unexpected indent")
 
-        if self.char() == "#":
-            self.state = self.comment_state
-        else:
-            self.state = self.next_state
+        self.state = self.next_state
 
     def data_line_state(self):
         if self.char() == "[":
@@ -610,6 +610,7 @@ class Parser:
                 self.expect(token_types.separator)
                 self.maybe_consume_inline_comment()
                 self.flush_comments()
+                self.consume_comments()
                 self.value_block()
                 self.flush_comments()
                 self.tree.pop()
@@ -624,6 +625,7 @@ class Parser:
                 self.expect(token_types.paren, "]")
                 self.maybe_consume_inline_comment()
                 self.flush_comments()
+                self.consume_comments()
                 if self.token[0] == token_types.group_start:
                     self.consume()
                     self.data_block()

--- a/tools/wptrunner/wptrunner/wptmanifest/serializer.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/serializer.py
@@ -3,7 +3,7 @@
 from six import ensure_text
 
 from .node import NodeVisitor, ValueNode, ListNode, BinaryExpressionNode
-from .parser import atoms, precedence
+from .parser import atoms, precedence, token_types
 
 atom_names = {v: "@%s" % k for (k,v) in atoms.items()}
 
@@ -40,6 +40,19 @@ class ManifestSerializer(NodeVisitor):
             rv = rv + "\n"
         return rv
 
+    def visit(self, node):
+        lines = super().visit(node)
+        comments = [f"#{comment}" for _, comment in node.comments]
+        # Simply checking if the first line contains '#' is less than ideal; the
+        # character might be escaped or within a string.
+        if lines and "#" not in lines[0]:
+            for i, (token_type, comment) in enumerate(node.comments):
+                if token_type == token_types.inline_comment:
+                    lines[0] += " " * 2 + f"#{comment}"
+                    comments.pop(i)
+                    break
+        return comments + lines
+
     def visit_DataNode(self, node):
         rv = []
         if not self.skip_empty_data or node.children:
@@ -65,7 +78,7 @@ class ManifestSerializer(NodeVisitor):
             rv[0] += " %s" % self.visit(node.children[0])[0]
         else:
             for child in node.children:
-                rv.append(indent + self.visit(child)[0])
+                rv.extend(indent + line for line in self.visit(child))
 
         return rv
 

--- a/tools/wptrunner/wptrunner/wptmanifest/serializer.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/serializer.py
@@ -48,7 +48,7 @@ class ManifestSerializer(NodeVisitor):
         if lines and "#" not in lines[0]:
             for i, (token_type, comment) in enumerate(node.comments):
                 if token_type == token_types.inline_comment:
-                    lines[0] += " " * 2 + f"#{comment}"
+                    lines[0] += f"  #{comment}"
                     comments.pop(i)
                     break
         return comments + lines

--- a/tools/wptrunner/wptrunner/wptmanifest/tests/test_serializer.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/tests/test_serializer.py
@@ -264,9 +264,21 @@ class TokenizerTest(unittest.TestCase):
 
                 # Attached to the second heading.
                 [test2.html]
+                # Attached to subheading.
+                    # Also attached to subheading.
+                  [subheading]  # Also attached to subheading (inline).
+                """).encode(),
+            textwrap.dedent(
+                """\
+                # Attached to the first heading.
+                [test1.html]
+
+                # Attached to the second heading.
+                [test2.html]
                   # Attached to subheading.
-                  [subheading]  # Also attached to subheading.
-                """).encode())
+                  # Also attached to subheading.
+                  [subheading]  # Also attached to subheading (inline).
+                """))
 
     def test_comments_inline(self):
         self.compare(
@@ -295,12 +307,12 @@ class TokenizerTest(unittest.TestCase):
             textwrap.dedent(
                 """\
                 key:
-                  # cond 1
+                # cond 1
                   if cond == 1: value
                   # cond 2
                   if cond == 2: value  # cond 2
-                  # cond 3
-                  # cond 3
+                # cond 3
+                    # cond 3
                   if cond == 3: value
                   # default 0
                   default  # default 1

--- a/tools/wptrunner/wptrunner/wptmanifest/tests/test_serializer.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/tests/test_serializer.py
@@ -6,7 +6,7 @@ import unittest
 from .. import parser, serializer
 
 
-class TokenizerTest(unittest.TestCase):
+class SerializerTest(unittest.TestCase):
     def setUp(self):
         self.serializer = serializer.ManifestSerializer()
         self.parser = parser.Parser()
@@ -284,29 +284,35 @@ class TokenizerTest(unittest.TestCase):
         self.compare(
             textwrap.dedent(
                 """\
-                key:            # inline after key
+                key1:           # inline after key
                   value         # inline after string value
+                key2:
+                  [value]       # inline after list in group
                 [test.html]     # inline after heading
                   key1: @True   # inline after atom
-                  key2: [
-                    value1,     # inline after list element
+                  key2: [       # inline after list start
+                    @False,     # inline after atom in list
+                    value1,     # inline after value in list
                     value2]     # inline after list end
                 """).encode(),
             textwrap.dedent(
                 """\
                 # inline after key
-                key: value  # inline after string value
+                key1: value  # inline after string value
+                key2: [value]  # inline after list in group
                 [test.html]  # inline after heading
                   key1: @True  # inline after atom
+                  # inline after atom in list
+                  # inline after value in list
                   # inline after list end
-                  key2: [value1, value2]  # inline after list element
+                  key2: [@False, value1, value2]  # inline after list start
                 """))
 
     def test_comments_conditions(self):
         self.compare(
             textwrap.dedent(
                 """\
-                key:
+                key1:
                 # cond 1
                   if cond == 1: value
                   # cond 2
@@ -318,10 +324,17 @@ class TokenizerTest(unittest.TestCase):
                   default  # default 1
                   # default 2
                   # default 3
+                key2:
+                  if cond == 1: value
+                  [value]
+                  # list default
+                key3:
+                  if cond == 1: value
+                  # no default
                 """).encode(),
             textwrap.dedent(
                 """\
-                key:
+                key1:
                   # cond 1
                   if cond == 1: value
                   # cond 2
@@ -333,4 +346,11 @@ class TokenizerTest(unittest.TestCase):
                   # default 2
                   # default 3
                   default  # default 1
+                key2:
+                  if cond == 1: value
+                  # list default
+                  [value]
+                # no default
+                key3:
+                  if cond == 1: value
                 """))

--- a/tools/wptrunner/wptrunner/wptmanifest/tests/test_tokenizer.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/tests/test_tokenizer.py
@@ -350,9 +350,7 @@ key:
              (token_types.paren, "["),
              (token_types.string, "Heading"),
              (token_types.paren, "]"),
-             (token_types.group_start, None),
              (token_types.comment, " comment 1"),
-             (token_types.group_end, None),
              (token_types.comment, " comment 2")])
 
     def test_comment_inline(self):
@@ -361,6 +359,7 @@ key:
                 """\
                 [Heading]          # after heading
                 key:               # after key
+                # before group start
                   if cond: value1  # after value1
                   value2           # after value2
                 """).encode(),
@@ -371,6 +370,7 @@ key:
              (token_types.string, "key"),
              (token_types.separator, ":"),
              (token_types.inline_comment, " after key"),
+             (token_types.comment, " before group start"),
              (token_types.group_start, None),
              (token_types.ident, "if"),
              (token_types.ident, "cond"),

--- a/tools/wptrunner/wptrunner/wptmanifest/tests/test_tokenizer.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/tests/test_tokenizer.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 
+import textwrap
 import unittest
 
 from .. import parser
@@ -54,7 +55,8 @@ class TokenizerTest(unittest.TestCase):
         self.compare(br"""[Heading [\]text] #comment""",
                      [(token_types.paren, "["),
                       (token_types.string, "Heading []text"),
-                      (token_types.paren, "]")])
+                      (token_types.paren, "]"),
+                      (token_types.inline_comment, "comment")])
 
     def test_heading_6(self):
         self.compare(br"""[Heading \ttext]""",
@@ -84,7 +86,8 @@ class TokenizerTest(unittest.TestCase):
         self.compare(b"""key: value#comment""",
                      [(token_types.string, "key"),
                       (token_types.separator, ":"),
-                      (token_types.string, "value")])
+                      (token_types.string, "value"),
+                      (token_types.inline_comment, "comment")])
 
     def test_key_4(self):
         with self.assertRaises(parser.ParseError):
@@ -177,6 +180,7 @@ key: [a, #b]
              (token_types.separator, ":"),
              (token_types.list_start, "["),
              (token_types.string, "a"),
+             (token_types.inline_comment, "b]"),
              (token_types.string, "c"),
              (token_types.list_end, "]")])
 
@@ -332,6 +336,50 @@ key:
              (token_types.number, "1."),
              (token_types.separator, ":"),
              (token_types.string, "value")])
+
+    def test_comment_with_indents(self):
+        self.compare(
+            textwrap.dedent(
+                """\
+                # comment 0
+                [Heading]
+                  # comment 1
+                # comment 2
+                """).encode(),
+            [(token_types.comment, " comment 0"),
+             (token_types.paren, "["),
+             (token_types.string, "Heading"),
+             (token_types.paren, "]"),
+             (token_types.group_start, None),
+             (token_types.comment, " comment 1"),
+             (token_types.group_end, None),
+             (token_types.comment, " comment 2")])
+
+    def test_comment_inline(self):
+        self.compare(
+            textwrap.dedent(
+                """\
+                [Heading]          # after heading
+                key:               # after key
+                  if cond: value1  # after value1
+                  value2           # after value2
+                """).encode(),
+            [(token_types.paren, "["),
+             (token_types.string, "Heading"),
+             (token_types.paren, "]"),
+             (token_types.inline_comment, " after heading"),
+             (token_types.string, "key"),
+             (token_types.separator, ":"),
+             (token_types.inline_comment, " after key"),
+             (token_types.group_start, None),
+             (token_types.ident, "if"),
+             (token_types.ident, "cond"),
+             (token_types.separator, ":"),
+             (token_types.string, "value1"),
+             (token_types.inline_comment, " after value1"),
+             (token_types.string, "value2"),
+             (token_types.inline_comment, " after value2")])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This change enables the metadata parser/serializer to preserve comments
documenting test expectations. Currently, the parser ignores comments,
which are lost when updating metadata from logs.

* The tokenizer now allows comments on their own lines.
* The tokenizer emits tokens for comments.
* The parser attaches comments to AST nodes. Comments are not AST nodes
  themselves, since operations on ASTs expect certain shapes.
* The serializer formats comment lines on a best-effort basis, like so:

  ```
  # <comment 1>
  # ...
  <node>  # <optional inline comment>
  ```

  The `<node>` can be a key, heading, condition, or list/value when used
  as the default after a list of conditions.