### PR TITLE
Created ruby-floats-001 test and its reference file

### DIFF
--- a/css/css-ruby/reference/ruby-floats-001-ref.html
+++ b/css/css-ruby/reference/ruby-floats-001-ref.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference File</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      font-size: 32px;
+      line-height: 3;
+    }
+
+  div.floated-right
+    {
+      float: right;
+    }
+
+  div.fontsize16px
+    {
+      font-size: 16px;
+      line-height: 1;
+    }
+  </style>
+
+  <div>a<ruby><rb>&nbsp;</rb><rt>b</ruby>c
+    <div class="floated-right">Far Right</div>
+  </div>
+
+  <div class="floated-right fontsize16px">Far Right</div>
+
+  <div>def</div>
+
+  <div class="floated-right">g<ruby><rb>&nbsp;</rb><rt>h</ruby>i</div>
+
+  <div>Far Left</div>
+
+  <div class="floated-right">jkm</div>
+
+  <div class="fontsize16px">Far Left</div>

--- a/css/css-ruby/ruby-floats-001.html
+++ b/css/css-ruby/ruby-floats-001.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Ruby Test: floating ruby base unit boxes and floating ruby text unit boxes</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-ruby-1/#formatting-context">
+  <link rel="match" href="reference/ruby-floats-001-ref.html">
+
+  <meta content="" name="flags">
+  <meta content="This test checks that the containing block for internal ruby boxes (ruby base units and ruby text units) is the containing block of its own ruby container. This is true for floating ruby base unit boxes and for ruby text unit boxes.">
+
+  <style>
+  div
+    {
+      font-size: 32px;
+      line-height: 3;
+    }
+
+  rb#first-subtest, rt#second-subtest
+    {
+      float: right;
+    }
+
+  rb#third-subtest, rt#fourth-subtest
+    {
+      float: left;
+    }
+
+  div#third, div#fourth
+    {
+      text-align: right;
+    }
+  </style>
+
+  <div>a<ruby><rb id="first-subtest">Far Right<rt>b</ruby>c</div>
+
+  <div>d<ruby><rb>e<rt id="second-subtest">Far Right</ruby>f</div>
+
+  <div id="third">g<ruby><rb id="third-subtest">Far Left<rt>h</ruby>i</div>
+
+  <div id="fourth">j<ruby><rb>k<rt id="fourth-subtest">Far Left</ruby>m</div>


### PR DESCRIPTION
This is a followup-to [PR29482](https://github.com/web-platform-tests/wpt/pull/29482).

@fantasai wrote over there:
> The floats test is correct. However, I think it would benefit from some subtests of floats inside the base and annotation (in addition to floats being the base and annotation).

this (subtests of floats inside the base and annotation in which the base and the annotation are themselves floated too) will be done in other(s) distinct and separate PRs.

Over at my website:

http://www.gtalbot.org/BrowserBugsSection/CSS3Ruby/ruby-floats-001.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Ruby/reference/ruby-floats-001-ref.html