### PR TITLE
Created ruby-abs-pos-001 test and its reference file

### DIFF
--- a/css/css-ruby/reference/ruby-abs-pos-001-ref.html
+++ b/css/css-ruby/reference/ruby-abs-pos-001-ref.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference File</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+  <style>
+  body
+    {
+      font-family: Ahem;
+      font-size: 60px;
+      line-height: 1;
+    }
+
+  div.wrapper
+    {
+      border: black dotted 2px;
+      margin-bottom: 8px;
+    }
+
+  div.fontsize30px
+    {
+      font-size: 0.5em;
+    }
+
+  div.fontsize60px
+    {
+      padding-bottom: 0.5em;
+    }
+  </style>
+
+  <div id="first" class="wrapper">
+
+    <div class="fontsize30px" style="color: lime; padding-left: 60px;">C</div>
+
+    <div class="fontsize60px"><span style="color: blue; padding-right: 30px;">A</span><span style="color: orange;">B</span></div>
+
+  </div>
+
+
+  <div id="second" class="wrapper">
+
+    <div class="fontsize30px" style="color: orange; padding-left: 120px;">G</div>
+
+    <div class="fontsize60px"><span style="color: blue;">E</span><span style="color: lime;">F</span><span style="color: blue;">H</span></div>
+
+  </div>
+
+
+  <div id="third" class="wrapper">
+
+    <div class="fontsize30px" style="color: lime; padding-left: 60px;">K</div>
+
+    <div class="fontsize60px"><span style="color: blue;">I</span><span style="color: orange; position: relative; left: -30px;">J</span><span style="color: blue; position: relative; left: -30px;">L</span></div>
+
+  </div>
+
+
+  <div id="second" class="wrapper">
+
+    <div class="fontsize30px" style="color: orange; padding-left: 90px;">O</div>
+
+    <div class="fontsize60px"><span style="color: blue;">M</span><span style="color: lime;">N</span><span style="color: blue;">Q</span></div>
+
+  </div>

--- a/css/css-ruby/reference/ruby-abs-pos-001-ref.html
+++ b/css/css-ruby/reference/ruby-abs-pos-001-ref.html
@@ -59,7 +59,7 @@
   </div>
 
 
-  <div id="second" class="wrapper">
+  <div id="fourth" class="wrapper">
 
     <div class="fontsize30px" style="color: orange; padding-left: 90px;">O</div>
 

--- a/css/css-ruby/ruby-abs-pos-001.html
+++ b/css/css-ruby/ruby-abs-pos-001.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Ruby Test: absolutely positioned ruby base unit boxes and absolutely positioned ruby text unit boxes inside a relatively positioned ruby container element</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-ruby-1/#formatting-context">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+  <link rel="match" href="reference/ruby-abs-pos-001-ref.html">
+
+  <meta content="" name="flags">
+  <meta content="This test checks that the containing block for internal ruby boxes (ruby base units and ruby text units) when the ruby container element is relatively positioned is the ruby container element itself.">
+
+  <style>
+  body
+    {
+      font-family: Ahem;
+    }
+
+  div , ruby
+    {
+      position: relative;
+    }
+
+  div
+    {
+      border: black dotted 2px;
+      color: blue;
+      font-size: 60px;
+      line-height: 2;
+      margin-bottom: 8px;
+    }
+
+  ruby
+    {
+      color: lime;
+    }
+
+  rb#first-subtest, rt#second-subtest
+    {
+      color: orange;
+      left: 100%;
+      position: absolute;
+    }
+
+  rb#third-subtest, rt#fourth-subtest
+    {
+      color: orange;
+      position: absolute;
+      right: 0%;
+    }
+
+  /*
+
+    Color meaning
+    -------------
+
+    A blue rectangle == a glyph before or after a ruby container element.
+    Such glyph may be overlapped by an absolutely positioned internal ruby
+    unit box.
+
+    A lime square == a statically positioned ruby base unit or ruby text unit
+
+    An orange square == an absolutely positioned ruby base unit or ruby text unit
+
+  */
+
+  </style>
+
+  <div id="first">A<ruby><rb id="first-subtest">B<rt>C</ruby>D</div>
+
+  <div id="second">E<ruby><rb>F<rt id="second-subtest">G</ruby>H</div>
+
+  <div id="third">I<ruby><rb id="third-subtest">J<rt>K</ruby>L</div>
+
+  <div id="fourth">M<ruby><rb>N<rt id="fourth-subtest">O</ruby>Q</div>


### PR DESCRIPTION
This is a followup-to [PR29482](https://github.com/web-platform-tests/wpt/pull/29482)

@fantasai wrote over there:

> The abspos test... it's correct, but it's only testing that the abspos isn't trapped by the ruby. To really test the case of abspos within ruby, we'd need to check what happens **when the DIV has 'position: relative' and when the ruby element itself has 'position: relative'**. (But also this last case needs to be made a little clearer in the spec, I think. It should behave as for inlines as specced in https://www.w3.org/TR/CSS2/visudet.html#containing-block-details probably.)
(...)

@fantasai also suggested to use percentage offsets (instead of pixel offsets) like this:
`left: 50%;`
`right: 50%;`
in my old ruby-abs-pos-002.html and ruby-abs-pos-003.html tests over in [PR29482](https://github.com/web-platform-tests/wpt/pull/29482)

After considerable time and efforts, I am confident and happy to come up with this commit.

Over at my website, the test is:

http://www.gtalbot.org/BrowserBugsSection/CSS3Ruby/ruby-abs-pos-004.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Ruby/reference/ruby-abs-pos-004-ref.html