### PR TITLE
Ensure meaningful test coverage with MQ4 unsupported

### DIFF
--- a/css/mediaqueries/resources/matchmedia-utils.js
+++ b/css/mediaqueries/resources/matchmedia-utils.js
@@ -49,11 +49,11 @@ function query_should_not_be_js_parseable(query) {
 }
 
 function query_is_known(query) {
-  return window.matchMedia(`(${query}) or (not (${query}))`).matches;
+  return window.matchMedia(`${query}, not all and ${query}`).matches;
 }
 
 function query_is_unknown(query) {
-  return !window.matchMedia(`(${query}) or (not (${query}))`).matches;
+  return !window.matchMedia(`${query}, not all and ${query}`).matches;
 }
 
 function query_should_be_known(query) {
@@ -68,6 +68,9 @@ function query_should_be_unknown(query) {
   test(() => {
     assert_true(query_is_js_parseable(query), "Can parse with JS");
     assert_true(query_is_css_parseable(query), "Can parse with CSS");
+  }, "Should be parseable: '" + query + "'");
+
+  test(() => {
     assert_true(query_is_unknown(query));
   }, "Should be unknown: '" + query + "'");
 }

--- a/css/mediaqueries/test_media_queries.html
+++ b/css/mediaqueries/test_media_queries.html
@@ -90,20 +90,22 @@ setup({ "explicit_done": true });
      * https://drafts.csswg.org/mediaqueries-4/#evaluating
      */
 
-    function expression_is_known(e) {
-      return query_is_parseable(`(${e})`) && query_applies(`(${e}) or (not (${e}))`);
+    function expression_is_parseable(e) {
+      return query_is_parseable(`(${e})`);
     }
 
-    function expression_is_unknown(e) {
-      return query_is_parseable(`(${e})`) && !query_applies(`(${e}) or (not (${e}))`);
+    function expression_is_known(e) {
+      return query_applies(`(${e}), not all and (${e})`);
     }
 
     function expression_should_be_known(e) {
+      // We don't bother with expression_is_parseable here, because it must be parseable to be known
       test_predicate(e, expression_is_known, "expression_should_be_known");
     }
 
     function expression_should_be_unknown(e) {
-      test_predicate(e, expression_is_unknown, "expression_should_be_unknown");
+      test_predicate(e, expression_is_parseable, "expression_should_be_parseable");
+      test_predicate(e, not(expression_is_known), "expression_should_be_unknown");
     }
 
     // The no-type syntax doesn't mix with the not and only keywords.


### PR DESCRIPTION
b3c9f2b7fb modified the media queries tests as a number of them are no
longer correct (per level 4) in asserting that invalid expression
values cause the entire media query to fail to parse.

However, it also went a bit too far in practically removing test
coverage of the non-matching behaviour of such media queries. The
modified tests required that the media query both parses and doesn't
match in a single test, which could allow regressions in the
non-matching behaviour to slip in for implementations still following
the level 3 parse-error behaviour.

As a result, this splits the unknown tests into two separate tests:
one that they parse correctly (as required by level 4, and contrary to
level 3), and another that they do not match (required by both
levels).

In addition, this removes some needless dependency on level 4 syntax.