### PR TITLE
Fix contain-size-select-001.html & contain-size-select-002.html

### DIFF
--- a/css/css-contain/contain-size-select-001.html
+++ b/css/css-contain/contain-size-select-001.html
@@ -7,7 +7,7 @@
 <meta name=assert content="<select> elements with 'contain: size' should be treated as having no contents.">
 <style>
 select {
-  color: white;
+  color: transparent;
   background: white;
   contain: size;
 }

--- a/css/css-contain/contain-size-select-002.html
+++ b/css/css-contain/contain-size-select-002.html
@@ -8,7 +8,7 @@
 <meta name=assert content="Check that setting 'contain: size' on a <select> elements causes it to be sized as having no contents.">
 <style>
 select {
-  color: white;
+  color: transparent;
   background: white;
 }
 </style>

--- a/css/css-contain/reference/contain-size-select-001-ref.html
+++ b/css/css-contain/reference/contain-size-select-001-ref.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <style>
 select {
-  color: white;
+  color: transparent;
   background: white;
 }
 </style>


### PR DESCRIPTION
This test assumes that white color on white background is invisible text, except WebKit has its own appearance when you apply `background: white;` so we use `color: transparent` which is more accurate (and also used by other contain-size-select-elem-*.html tests).