### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=197960

### DIFF
--- a/custom-elements/form-associated/ElementInternals-target-element-is-held-strongly.html
+++ b/custom-elements/form-associated/ElementInternals-target-element-is-held-strongly.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>Target element of ElementsInternals is held strongly and doesn't get GCed if there are no other references</title>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/garbage-collect.js"></script>
+
+<script>
+customElements.define("x-foo", class extends HTMLElement {});
+
+promise_test(async t => {
+    const elementInternals = [];
+
+    for (let i = 0; i < 1e5; i++) {
+        const targetElement = document.createElement("x-foo");
+        targetElement.attachShadow({ mode: "open" });
+        elementInternals.push(targetElement.attachInternals());
+    }
+
+    await maybeGarbageCollectAsync();
+    await new Promise(r => t.step_timeout(r, 100));
+
+    const allShadowRootsAreAlive = elementInternals.every(eI => eI.shadowRoot instanceof ShadowRoot);
+    assert_true(allShadowRootsAreAlive);
+});
+</script>

--- a/custom-elements/resources/garbage-collect.js
+++ b/custom-elements/resources/garbage-collect.js
@@ -1,0 +1,19 @@
+async function maybeGarbageCollectAsync() {
+  if (typeof TestUtils !== 'undefined' && TestUtils.gc) {
+    await TestUtils.gc();
+  } else if (self.gc) {
+    // Use --expose_gc for V8 (and Node.js)
+    // to pass this flag at chrome launch use: --js-flags="--expose-gc"
+    // Exposed in SpiderMonkey shell as well
+    await self.gc();
+  } else if (self.GCController) {
+    // Present in some WebKit development environments
+    await GCController.collect();
+  } else {
+    /* eslint-disable no-console */
+    console.warn('Tests are running without the ability to do manual ' +
+                 'garbage collection. They will still work, but ' +
+                 'coverage will be suboptimal.');
+    /* eslint-enable no-console */
+  }
+}

--- a/lint.ignore
+++ b/lint.ignore
@@ -107,6 +107,7 @@ PRINT STATEMENT: webdriver/tests/support/helpers.py
 
 # semi-legitimate use of console.*
 CONSOLE: console/*
+CONSOLE: custom-elements/resources/garbage-collect.js
 CONSOLE: js/builtins/weakrefs/resources/maybe-garbage-collect.js
 CONSOLE: resources/check-layout-th.js
 CONSOLE: resources/chromium/*


### PR DESCRIPTION
This test ensures that target element of `ElementsInternals` is held strongly and doesn't get GCed if there are no other references.