### PR TITLE
readonly attribute should still affect constraint validation on 'unsupported' types

### DIFF
--- a/html/semantics/forms/constraints/form-validation-willValidate.html
+++ b/html/semantics/forms/constraints/form-validation-willValidate.html
@@ -41,8 +41,7 @@
     },
     //If an element is disabled, it is barred from constraint validation.
     //The willValidate attribute must be true if an element is mutable
-    //If the readonly attribute is specified on an INPUT element, the element is barred from constraint validation
-    //(with the assumption that the readonly attribute applies).
+    //If the readonly attribute is specified on an INPUT element, the element is barred from constraint validation.
     {
       tag: "input",
       types: ["text", "search", "tel", "url", "email", "password", "datetime-local", "date", "month", "week", "time"],
@@ -53,14 +52,14 @@
         {conditions: {disabled: false, readOnly: false}, expected: false, name: "[target] The willValidate attribute must be false if it has a datalist ancestor", ancestor: "datalist"},
       ]
     },
-    //In the following cases, the readonly attribute does not apply.
+    //In the following cases, the readonly attribute does not apply, however we should still bar the element from constraint validation.
     {
       tag: "input",
       types: ["color", "file", "submit"],
       testData: [
         {conditions: {disabled: true}, expected: false, name: "[target] Must be barred from the constraint validation if it is disabled"},
         {conditions: {disabled: false, readOnly: false}, expected: true, name: "[target] The willValidate attribute must be true if an element is mutable"},
-        {conditions: {readOnly: true}, expected: true, name: "[target] Must be not barred from the constraint validation even if it is readonly"},
+        {conditions: {readOnly: true}, expected: false, name: "[target] Must be barred from the constraint validation if it is readonly"},
         {conditions: {disabled: false, readOnly: false}, expected: false, name: "[target] The willValidate attribute must be false if it has a datalist ancestor", ancestor: "datalist"},
       ]
     },


### PR DESCRIPTION
See https://github.com/whatwg/html/issues/8133 and https://github.com/whatwg/html/issues/8089