### PR TITLE
[PaymentHandler] Add user activations to can-make-payment-event.https…

### DIFF
--- a/payment-handler/can-make-payment-event.https.html
+++ b/payment-handler/can-make-payment-event.https.html
@@ -5,6 +5,8 @@
 <link rel="manifest" href="manifest.json">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script>
 const instrumentKey = 'instrument-key';
 
@@ -121,6 +123,8 @@ promise_test(async t => {
     paymentRequestCanMakePaymentResult,
     'canMakePayment() must return false.',
   );
+
+  await test_driver.bless('PaymentRequest.show() requires user activation');
   await promise_rejects_dom(t, 'NotSupportedError', request.show());
 }, 'If a payment handler is not installed, then the payment method is not supported.');
 
@@ -143,6 +147,8 @@ promise_test(async t => {
     paymentRequestCanMakePaymentResult,
     'canMakePayment() must return false.',
   );
+
+  await test_driver.bless('PaymentRequest.show() requires user activation');
   await promise_rejects_dom(t, 'NotSupportedError', request.show());
 }, 'If CanMakePaymentEvent.respondWith(false) is called, then the payment method is not supported.');
 
@@ -165,6 +171,8 @@ promise_test(async t => {
     paymentRequestCanMakePaymentResult,
     'canMakePayment() must return false.',
   );
+
+  await test_driver.bless('PaymentRequest.show() requires user activation');
   await promise_rejects_dom(t, 'NotSupportedError', request.show());
 }, 'If CanMakePaymentEvent.respondWith(Promise.resolve(false)) is called, then the payment method is not supported.');
 
@@ -187,6 +195,8 @@ promise_test(async t => {
     paymentRequestCanMakePaymentResult,
     'canMakePayment() must return true.',
   );
+
+  await test_driver.bless('PaymentRequest.show() requires user activation');
   const acceptPromise = request.show();
   await request.abort();
   await promise_rejects_dom(t, 'AbortError', acceptPromise);
@@ -211,6 +221,8 @@ promise_test(async t => {
     paymentRequestCanMakePaymentResult,
     'canMakePayment() must return true.',
   );
+
+  await test_driver.bless('PaymentRequest.show() requires user activation');
   const acceptPromise = request.show();
   await request.abort();
   await promise_rejects_dom(t, 'AbortError', acceptPromise);
@@ -235,6 +247,8 @@ promise_test(async t => {
     paymentRequestCanMakePaymentResult,
     'canMakePayment() must return false.',
   );
+
+  await test_driver.bless('PaymentRequest.show() requires user activation');
   await promise_rejects_dom(t, 'NotSupportedError', request.show());
 }, 'If CanMakePaymentEvent.respondWith(Promise.reject(error)) is called, then the payment method is not supported.');
 </script>


### PR DESCRIPTION
….html

This test calls PaymentRequest.show(), which requires a user activation.