### PR TITLE
Fix compute-kind-widget fallback test reference

### DIFF
--- a/css/css-ui/compute-kind-widget-no-fallback-ref.html
+++ b/css/css-ui/compute-kind-widget-no-fallback-ref.html
@@ -3,6 +3,8 @@
 <title>Reference: Compute kind of widget - no fallback</title>
 <style>
     #container { width: 500px; }
+    #container > #search-text-input { appearance: textfield; }
+    #container > #select-menulist-button { appearance: none; appearance: menulist-button; }
 </style>
 <div id="container">
     <a>a</a>


### PR DESCRIPTION
The reference for compute-kind-widget-no-fallback-props-001.html and compute-kind-widget-fallback-props-revert-001.html make two incorrect assumptions, causing the test to fail in Blink and WebKit:

1. `<input type=search>` and `<input type=text>` look the same.
2. `appearance: menulist` and `appearance: menulist-button` on `<select>` elements look the same.

To fix, specify `appearance` in the reference to match the tests.