### PR TITLE
Avoid ElementNotInteractable exception in inert-svg-hittest.html

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest.html
+++ b/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest.html
@@ -38,8 +38,9 @@ promise_test(async function() {
         reachedTarget = true;
     }, { once: true });
 
+    let wrapperRect = wrapper.getBoundingClientRect();
     await new test_driver.Actions()
-        .pointerMove(0, 0, { origin: wrapper })
+        .pointerMove(wrapperRect.x + 1, wrapperRect.y + 1, { origin: "viewport" })
         .pointerDown()
         .send();
 
@@ -56,8 +57,9 @@ promise_test(async function() {
         reachedTarget = true;
     }, { once: true });
 
+    let wrapperRect = wrapper.getBoundingClientRect();
     await new test_driver.Actions()
-        .pointerMove(0, 0, { origin: wrapper })
+        .pointerMove(wrapperRect.x + 1, wrapperRect.y + 1, { origin: "viewport" })
         .pointerDown()
         .send();
 

--- a/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest.html
+++ b/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest.html
@@ -57,9 +57,8 @@ promise_test(async function() {
         reachedTarget = true;
     }, { once: true });
 
-    let wrapperRect = wrapper.getBoundingClientRect();
     await new test_driver.Actions()
-        .pointerMove(wrapperRect.x + 1, wrapperRect.y + 1, { origin: "viewport" })
+        .pointerMove(0, 0, { origin: wrapper })
         .pointerDown()
         .send();
 

--- a/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest.html
+++ b/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest.html
@@ -42,7 +42,6 @@ promise_test(async function() {
         .pointerMove(0, 0, { origin: wrapper })
         .pointerDown()
         .send();
-    this.add_cleanup(() => test_driver.click(document.body));
 
     assert_false(target.matches(":active"), "target is not active");
     assert_false(target.matches(":hover"), "target is not hovered");
@@ -61,7 +60,6 @@ promise_test(async function() {
         .pointerMove(0, 0, { origin: wrapper })
         .pointerDown()
         .send();
-    this.add_cleanup(() => test_driver.click(document.body));
 
     assert_true(target.matches(":active"), "target is active");
     assert_true(reachedTarget, "target got event");


### PR DESCRIPTION
1. `test_driver.click(document.body)` is causing this exception because the body isn't interactable, since it was just blocked by a modal dialog. It's also not strictly necessary to reset the :active/:hover states.

2. `pointerMove()` apparently cannot take an non-interactable element as origin