### PR TITLE
[PaymentHandler] Allow canMakePayment tests to abort() the PaymentReq…

### DIFF
--- a/payment-handler/app-can-make-payment.js
+++ b/payment-handler/app-can-make-payment.js
@@ -105,3 +105,9 @@ self.addEventListener('canmakepayment', event => {
       break;
   }
 });
+
+// Respond 'true' to the 'abortpayment' event to allow tests to use abort() to
+// close an ongoing PaymentRequest.
+self.addEventListener('abortpayment', event => {
+  event.respondWith(true);
+});


### PR DESCRIPTION
…uest

Some tests were failing to abort() an ongoing payment request, because the
installed payment handler didn't have an abortpayment event listener. Adding
this allows those tests to properly abort() the ongoing request.