### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=243815

### DIFF
--- a/shadow-dom/imperative-slot-api.html
+++ b/shadow-dom/imperative-slot-api.html
@@ -285,4 +285,19 @@ test(() => {
   assert_equals(tTree.c2.assignedSlot, tTree.s1);
 }, 'Removing a node from the document does not break manually assigned slot linkage.');
 
+test(() => {
+  const inputValues = [
+    ['Attr', document.createAttribute('bar')],
+    ['Comment', document.createComment('bar')],
+    ['DocumentFragment', document.createDocumentFragment()],
+    ['DocumentType', document.implementation.createDocumentType('html', '', '')]
+  ];
+  for (const [label, input] of inputValues) {
+    assert_throws_js(TypeError, () => {
+      const slot = document.createElement('slot');
+      slot.assign(input);
+    }, label);
+  }
+}, 'throw TypeError if the passed values are neither Element nor Text');
+
 </script>


### PR DESCRIPTION
This test checks `HTMLSlotElement.assign()` should throw if the passed values are neither `Element` nor `Text`.