### PR TITLE
Quiet mypy warnings in test_metadata.py.

### DIFF
--- a/tools/wptrunner/wptrunner/tests/test_metadata.py
+++ b/tools/wptrunner/wptrunner/tests/test_metadata.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import json
 import os
 


### PR DESCRIPTION
This adds the relevant mypy config to ignore untyped definitions (in line with the rest of wptrunner).