### PR TITLE
Added 2 manual tests on 'overflow: auto' and table-cell box

### DIFF
--- a/css/CSS2/visufx/overflow-auto-applies-to-table-cell-001-manual.html
+++ b/css/CSS2/visufx/overflow-auto-applies-to-table-cell-001-manual.html
@@ -43,22 +43,28 @@
 
   div#parent100x100
     {
-      background-color: blue;
       height: 100px;
       width: 100px;
     }
 
   div#child200x200
     {
-      background-color: orange;
-      height: 200px;
-      width: 200px;
+      background-color: green;
+      border-bottom: red solid 100px;
+      border-right: red solid 100px;
+      height: 100px;
+      width: 100px;
     }
   </style>
 
-  <body>
+  <p>Test passes if
 
-  <p>Test passes if there is an orange rectangle with both an active vertical scroll bar and an active horizontal scroll bar.
+  <ul>
+
+    <li>there is a filled green square with both an active vertical scroll bar and an active horizontal scroll bar
+    <li>there is <strong>no red</strong> <em>unless one of the scroll bars is used</em>.
+
+  </ul>
 
   <table>
 

--- a/css/CSS2/visufx/overflow-auto-applies-to-table-cell-001-manual.html
+++ b/css/CSS2/visufx/overflow-auto-applies-to-table-cell-001-manual.html
@@ -16,7 +16,7 @@
   https://bugzilla.mozilla.org/show_bug.cgi?id=221154
 
   Date created: May 6th 2020
-  Date modified: August 15th 2022
+  Date modified: October 10th 2022
 
   -->
 
@@ -28,6 +28,13 @@
   <meta name="flags" content="scroll">
 
   <style>
+  table
+    {
+      border-spacing: 0px;
+      table-layout: fixed;
+      width: 100px;
+    }
+
   td
     {
       overflow: auto;

--- a/css/CSS2/visufx/overflow-auto-applies-to-table-cell-001-manual.html
+++ b/css/CSS2/visufx/overflow-auto-applies-to-table-cell-001-manual.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <!--
+
+  Related tests:
+
+  http://wpt.live/css/css-backgrounds/table-cell-background-local.html
+
+  Overflow applies to table cell
+  http://test.csswg.org/suites/css21_dev/nightly-unstable/html4/overflow-applies-to-007.htm
+  but this test only tested 'overflow: hidden' and not 'overflow: auto' or 'overflow: scroll'
+
+  Mozilla Bug report 221154: table cells do not support 'overflow' correctly
+  https://bugzilla.mozilla.org/show_bug.cgi?id=221154
+
+  Date created: May 6th 2020
+  Date modified: August 15th 2022
+
+  -->
+
+  <title>CSS 2.2 Test: 'overflow: auto' applies to a table cell</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/CSS22/visufx.html#overflow">
+
+  <meta name="flags" content="scroll">
+
+  <style>
+  td
+    {
+      overflow: auto;
+      padding: 0px;
+    }
+
+  div#parent100x100
+    {
+      background-color: blue;
+      height: 100px;
+      width: 100px;
+    }
+
+  div#child200x200
+    {
+      background-color: orange;
+      height: 200px;
+      width: 200px;
+    }
+  </style>
+
+  <body>
+
+  <p>Test passes if there is an orange rectangle with both an active vertical scroll bar and an active horizontal scroll bar.
+
+  <table>
+
+    <tr>
+
+      <td>
+
+        <div id="parent100x100">
+          <div id="child200x200"></div>
+        </div>
+
+  </table>

--- a/css/CSS2/visufx/overflow-auto-applies-to-table-cell-002-manual.html
+++ b/css/CSS2/visufx/overflow-auto-applies-to-table-cell-002-manual.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <!--
+
+  Related tests:
+
+  http://wpt.live/css/css-backgrounds/table-cell-background-local.html
+
+  Overflow applies to table cell
+  http://test.csswg.org/suites/css21_dev/nightly-unstable/html4/overflow-applies-to-007.htm
+  but this test only tested 'overflow: hidden' and not 'overflow: auto' or 'overflow: scroll'
+
+  Mozilla Bug report 221154: table cells do not support 'overflow' correctly
+  https://bugzilla.mozilla.org/show_bug.cgi?id=221154
+
+  Date created: May 6th 2020
+  Date modified: August 15th 2022
+
+  -->
+
+  <title>CSS 2.2 Test: 'overflow: auto' applies to a table cell</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+  <link rel="help" href="https://www.w3.org/TR/CSS22/visufx.html#overflow">
+
+  <meta name="flags" content="scroll">
+
+  <style type="text/css">
+  table
+    {
+      border-spacing: 0px;
+      color: red;
+      font-family: Ahem;
+      font-size: 100px;
+      line-height: 1;
+      table-layout: fixed;
+      width: 1em;
+    }
+
+  td
+    {
+      overflow: auto;
+      padding: 0px;
+      white-space: nowrap;
+    }
+
+  span#overflowed
+    {
+      color: green;
+    }
+  </style>
+
+  <script type="text/javascript">
+  function startTest()
+  {
+  document.getElementById("target").scrollLeft = 100;
+  }
+  </script>
+
+  <body onload="startTest();">
+
+  <p>Test passes if
+
+  <ul>
+
+    <li>there is a short horizontal scroll bar
+    <li>there is a filled green square
+    <li>there is <strong>no red</strong> <em>unless the short horizontal scroll bar is used</em>.
+
+  </ul>
+
+  <table>
+
+    <tr>
+
+      <td id="target"><span>A</span><span id="overflowed">Z</span>
+
+  </table>


### PR DESCRIPTION
At my website:

http://www.gtalbot.org/BrowserBugsSection/css22testsuite/overflow-auto-applies-to-table-cell-001-manual.html

http://www.gtalbot.org/BrowserBugsSection/css22testsuite/overflow-auto-applies-to-table-cell-002-manual.html

I tried to create reference files for these 2 but failed. The nr1 reason is that scrollbar width is unpredictable as it can be customized. But there is another reason: `overflow: auto` behaves differently for table cells in comparison with `overflow: auto` applied to block-level block boxes. Maybe there is a way to create reliable references for the 2 tests (or by creating another test, precisely designed) but I have not found how so far.

2 additional comments.
- These 2 tests compensate for a hole in the current test suite tests. **There are currently no test specifically testing `overflow: auto` (or `overflow: scroll`) for table cells.**
- [Mozilla Bug report 221154: table cells do not support 'overflow' correctly](https://bugzilla.mozilla.org/show_bug.cgi?id=221154)  