### PR TITLE
Update chrome ios wpt runner file

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome_ios.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_ios.py
@@ -54,5 +54,5 @@ class ChromeiOSBrowser(WebDriverBrowser):
     init_timeout = 120
 
     def make_command(self):
-        return [self.webdriver_binary, f"--port={self.port}"] \
-               + self.webdriver_args
+        return ([self.webdriver_binary, f"--port={self.port}"] +
+                self.webdriver_args)

--- a/tools/wptrunner/wptrunner/browsers/chrome_ios.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_ios.py
@@ -42,7 +42,8 @@ def env_extras(**kwargs):
 
 
 def env_options():
-    return {}
+    # allow the use of host-resolver-rules in lieu of modifying /etc/hosts file
+    return {"server_host": "127.0.0.1"}
 
 
 class ChromeiOSBrowser(WebDriverBrowser):
@@ -53,4 +54,5 @@ class ChromeiOSBrowser(WebDriverBrowser):
     init_timeout = 120
 
     def make_command(self):
-        return [self.binary, f"--port={self.port}"] + self.webdriver_args
+        return [self.webdriver_binary, f"--port={self.port}"] \
+               + self.webdriver_args


### PR DESCRIPTION
Update the chrome ios wpt runner file.
So this current set up could use a script passed by the flag --webdriver-binary to begin the IOS binary.