### PR TITLE
Mypy errors fix

### DIFF
--- a/tools/wptrunner/wptrunner/tests/test_metadata.py
+++ b/tools/wptrunner/wptrunner/tests/test_metadata.py
@@ -13,9 +13,9 @@ def write_properties(tmp_path, data):  # type: ignore
     return path
 
 @pytest.mark.parametrize("data",
-                         [{"properties": ["prop1"]},
+                         [{"properties": ["prop1"]},  # type: ignore
                           {"properties": ["prop1"], "dependents": {"prop1": ["prop2"]}},
-                          ])  # type: ignore
+                          ])
 def test_get_properties_file_valid(tmp_path, data):
     path = write_properties(tmp_path, data)
     expected = data["properties"], data.get("dependents", {})
@@ -23,7 +23,7 @@ def test_get_properties_file_valid(tmp_path, data):
     assert actual == expected
 
 @pytest.mark.parametrize("data",
-                         [{},
+                         [{},  # type: ignore
                           {"properties": "prop1"},
                           {"properties": None},
                           {"properties": ["prop1", 1]},
@@ -32,7 +32,7 @@ def test_get_properties_file_valid(tmp_path, data):
                           {"properties": "prop1", "dependents": None},
                           {"properties": "prop1", "dependents": {"prop1": ["prop2", 2]}},
                           {"properties": ["prop1"], "dependents": {"prop2": ["prop3"]}},
-                          ])  # type: ignore
+                          ])
 def test_get_properties_file_invalid(tmp_path, data):
     path = write_properties(tmp_path, data)
     with pytest.raises(ValueError):

--- a/tools/wptrunner/wptrunner/tests/test_metadata.py
+++ b/tools/wptrunner/wptrunner/tests/test_metadata.py
@@ -15,8 +15,8 @@ def write_properties(tmp_path, data):  # type: ignore
 @pytest.mark.parametrize("data",
                          [{"properties": ["prop1"]},
                           {"properties": ["prop1"], "dependents": {"prop1": ["prop2"]}},
-                          ])
-def test_get_properties_file_valid(tmp_path, data):  # type: ignore
+                          ])  # type: ignore
+def test_get_properties_file_valid(tmp_path, data):
     path = write_properties(tmp_path, data)
     expected = data["properties"], data.get("dependents", {})
     actual = metadata.get_properties(properties_file=path)
@@ -32,8 +32,8 @@ def test_get_properties_file_valid(tmp_path, data):  # type: ignore
                           {"properties": "prop1", "dependents": None},
                           {"properties": "prop1", "dependents": {"prop1": ["prop2", 2]}},
                           {"properties": ["prop1"], "dependents": {"prop2": ["prop3"]}},
-                          ])
-def test_get_properties_file_invalid(tmp_path, data):  # type: ignore
+                          ])  # type: ignore
+def test_get_properties_file_invalid(tmp_path, data):
     path = write_properties(tmp_path, data)
     with pytest.raises(ValueError):
         metadata.get_properties(properties_file=path)

--- a/tools/wptrunner/wptrunner/tests/test_metadata.py
+++ b/tools/wptrunner/wptrunner/tests/test_metadata.py
@@ -6,7 +6,7 @@ import pytest
 from .. import metadata
 
 
-def write_properties(tmp_path, data):
+def write_properties(tmp_path, data):  # type: ignore
     path = os.path.join(tmp_path, "update_properties.json")
     with open(path, "w") as f:
         json.dump(data, f)
@@ -16,7 +16,7 @@ def write_properties(tmp_path, data):
                          [{"properties": ["prop1"]},
                           {"properties": ["prop1"], "dependents": {"prop1": ["prop2"]}},
                           ])
-def test_get_properties_file_valid(tmp_path, data):
+def test_get_properties_file_valid(tmp_path, data):  # type: ignore
     path = write_properties(tmp_path, data)
     expected = data["properties"], data.get("dependents", {})
     actual = metadata.get_properties(properties_file=path)
@@ -33,13 +33,13 @@ def test_get_properties_file_valid(tmp_path, data):
                           {"properties": "prop1", "dependents": {"prop1": ["prop2", 2]}},
                           {"properties": ["prop1"], "dependents": {"prop2": ["prop3"]}},
                           ])
-def test_get_properties_file_invalid(tmp_path, data):
+def test_get_properties_file_invalid(tmp_path, data):  # type: ignore
     path = write_properties(tmp_path, data)
     with pytest.raises(ValueError):
         metadata.get_properties(properties_file=path)
 
 
-def test_extra_properties(tmp_path):
+def test_extra_properties(tmp_path):  # type: ignore
     data = {"properties": ["prop1"], "dependents": {"prop1": ["prop2"]}}
     path = write_properties(tmp_path, data)
     actual = metadata.get_properties(properties_file=path, extra_properties=["prop4"])


### PR DESCRIPTION
Mypy errors exist in the repo currently and cause unrelated errors in any PR that runs the `tools/ unittests` checks.