### PR TITLE
Export extra test in FileAPI/url/url-with-fetch.any.js from WebKit

### DIFF
--- a/FileAPI/url/url-with-fetch.any.js
+++ b/FileAPI/url/url-with-fetch.any.js
@@ -1,5 +1,26 @@
 // META: script=resources/fetch-tests.js
 
+async function garbageCollect() {
+  if (typeof TestUtils !== 'undefined' && TestUtils.gc) {
+    await TestUtils.gc();
+  } else if (self.gc) {
+    await self.gc();
+  } else if (self.GCController) {
+    // Present in some WebKit development environments
+    await GCController.collect();
+  } else {
+    var gcRec = function (n) {
+      if (n < 1)
+        return {};
+      var temp = {i: "ab" + i + (i / 100000)};
+      temp += "foo";
+      gcRec(n-1);
+    };
+    for (var i = 0; i < 1000; i++)
+      gcRec(10);
+  }
+}
+
 function fetch_should_succeed(test, request) {
   return fetch(request).then(response => response.text());
 }
@@ -36,6 +57,24 @@ promise_test(t => {
     assert_equals(text, blob_contents);
   });
 }, 'Revoke blob URL after creating Request, will fetch');
+
+promise_test(async t => {
+  const blob_contents = 'test blob contents';
+  const blob = new Blob([blob_contents]);
+  const url = URL.createObjectURL(blob);
+  let request = new Request(url);
+
+  // Revoke the object URL.  Request should take a reference to the blob as
+  // soon as it receives it in open(), so the request succeeds even though we
+  // revoke the URL before calling fetch().
+  URL.revokeObjectURL(url);
+
+  request = request.clone();
+  await garbageCollect();
+
+  const text = await fetch_should_succeed(t, request);
+  assert_equals(text, blob_contents);
+}, 'Revoke blob URL after creating Request, then clone Request, will fetch');
 
 promise_test(function(t) {
   const blob_contents = 'test blob contents';


### PR DESCRIPTION
Export extra test in FileAPI/url/url-with-fetch.any.js from WebKit:
https://github.com/WebKit/WebKit/pull/3306

The test makes sure that the blob URL is kept alive even after
cloning the fetch Request.