### PR TITLE
HTML parser should ignore head start tags in "in head noscript" state

### DIFF
--- a/html/syntax/parsing/inhead-noscript-head.html
+++ b/html/syntax/parsing/inhead-noscript-head.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Test that when the scripting flag is disabled, a head start tag in "in head noscript" mode is ignored</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+promise_test(async function(t) {
+    let iframe = document.createElement("iframe");
+    iframe.srcdoc = "<!DOCTYPE html><head><noscript><head><style></style>";
+    iframe.sandbox = "allow-same-origin";
+    let loaded = new Promise(resolve => iframe.onload = resolve);
+    document.body.append(iframe);
+    await loaded;
+    assert_equals(String(iframe.contentDocument.querySelector("noscript").firstChild), "[object HTMLStyleElement]");
+}, "When the scripting flag is disabled, a head start tag in \"in head noscript\" mode should be ignored");
+</script>


### PR DESCRIPTION
Exported from https://bugs.webkit.org/show_bug.cgi?id=243976