### PR TITLE
Fix "Skip ASCII whitespace within input" test

### DIFF
--- a/html/semantics/forms/the-input-element/range.html
+++ b/html/semantics/forms/the-input-element/range.html
@@ -41,7 +41,7 @@
       <input type="range" id="stepdown_beyond_min" min=3 max=11 value=6 step=3 />
       <input type="range" id="illegal_min_and_max" min="ab" max="f" />
       <input type="range" id="illegal_value_and_step" min=0 max=5 value="ppp" step="xyz" />
-      <input type="range" id="should_skip_whitespace" value=" 123"/>
+      <input type="range" id="should_skip_whitespace" value=" 50"/>
       <input type="range" id="exponent_value1" value=""/>
       <input type="range" id="exponent_value2" value=""/>
     </div>
@@ -222,7 +222,7 @@
       test(
         function() {
           var e = document.getElementById('should_skip_whitespace');
-          assert_equals(e.value, "123")
+          assert_equals(e.value, "50")
         }, "Skip ASCII whitespace within input"
       );
 

--- a/html/semantics/forms/the-input-element/range.html
+++ b/html/semantics/forms/the-input-element/range.html
@@ -223,7 +223,7 @@
         function() {
           var e = document.getElementById('should_skip_whitespace');
           assert_equals(e.value, "50")
-        }, "Skip ASCII whitespace within input"
+        }, "Input should be reset to the default value when value attribute has whitespace"
       );
 
       test(

--- a/html/semantics/forms/the-input-element/range.html
+++ b/html/semantics/forms/the-input-element/range.html
@@ -41,7 +41,7 @@
       <input type="range" id="stepdown_beyond_min" min=3 max=11 value=6 step=3 />
       <input type="range" id="illegal_min_and_max" min="ab" max="f" />
       <input type="range" id="illegal_value_and_step" min=0 max=5 value="ppp" step="xyz" />
-      <input type="range" id="should_skip_whitespace" value=" 49"/>
+      <input type="range" id="should_skip_whitespace" value=" 123"/>
       <input type="range" id="exponent_value1" value=""/>
       <input type="range" id="exponent_value2" value=""/>
     </div>
@@ -222,7 +222,7 @@
       test(
         function() {
           var e = document.getElementById('should_skip_whitespace');
-          assert_equals(e.value, "49")
+          assert_equals(e.value, "50")
         }, "Skip ASCII whitespace within input"
       );
 

--- a/html/semantics/forms/the-input-element/range.html
+++ b/html/semantics/forms/the-input-element/range.html
@@ -41,7 +41,7 @@
       <input type="range" id="stepdown_beyond_min" min=3 max=11 value=6 step=3 />
       <input type="range" id="illegal_min_and_max" min="ab" max="f" />
       <input type="range" id="illegal_value_and_step" min=0 max=5 value="ppp" step="xyz" />
-      <input type="range" id="should_skip_whitespace" value=" 50"/>
+      <input type="range" id="should_skip_whitespace" value=" 49"/>
       <input type="range" id="exponent_value1" value=""/>
       <input type="range" id="exponent_value2" value=""/>
     </div>
@@ -222,7 +222,7 @@
       test(
         function() {
           var e = document.getElementById('should_skip_whitespace');
-          assert_equals(e.value, "50")
+          assert_equals(e.value, "49")
         }, "Skip ASCII whitespace within input"
       );
 


### PR DESCRIPTION
This test sets the range input's value greater than the default maximum,
causing the value not to be set properly. By changing it to 50, the
value will be set properly.

The underlying test of skipping whitespace should still work fine since
the value assigned into the input is " 50".

This was identified in https://github.com/web-platform-tests/interop/issues/107