### PR TITLE
Add DisplayMediaStreamConstraints.selfBrowserSurface tests

### DIFF
--- a/screen-capture/getdisplaymedia.https.html
+++ b/screen-capture/getdisplaymedia.https.html
@@ -58,10 +58,10 @@ promise_test( async t => {
 [
  {video: true},
  {video: true, audio: false},
- {video: true, selfBrowserSurface: "include"},
- {video: true, selfBrowserSurface: "exclude"},
  {audio: false},
  {audio: true},
+ {selfBrowserSurface: "include"},
+ {selfBrowserSurface: "exclude"},
  {},
  undefined
 ].forEach(constraints => promise_test(async t => {

--- a/screen-capture/getdisplaymedia.https.html
+++ b/screen-capture/getdisplaymedia.https.html
@@ -58,6 +58,8 @@ promise_test( async t => {
 [
  {video: true},
  {video: true, audio: false},
+ {video: true, selfBrowserSurface: "include"},
+ {video: true, selfBrowserSurface: "exclude"},
  {audio: false},
  {audio: true},
  {},


### PR DESCRIPTION
Following up on https://chromium-review.googlesource.com/c/chromium/src/+/3819650/comments/c12457fb_cc13e722, this CL adds tests for DisplayMediaStreamConstraints.selfBrowserSurface that verifies that adding this hint to the constraints doesn't cause the function to throw.