### PR TITLE
Add MediaTrackConstraintSet.displaySurface tests

### DIFF
--- a/screen-capture/getdisplaymedia.https.html
+++ b/screen-capture/getdisplaymedia.https.html
@@ -208,4 +208,16 @@ promise_test(async t => {
   assert_any(assert_equals, settings.cursor, ['never', 'always', 'motion']);
 }, 'getDisplayMedia() with getSettings');
 
+[
+ {video: {displaySurface: "monitor"}},
+ {video: {displaySurface: "browser"}},
+ {video: {displaySurface: "window"}},
+].forEach(constraints => promise_test(async t => {
+  const stream = await getDisplayMedia(constraints);
+  t.add_cleanup(() => stopTracks(stream));
+  assert_equals(stream.getTracks().length, 1);
+  assert_equals(stream.getVideoTracks().length, 1);
+  assert_equals(stream.getAudioTracks().length, 0);
+}, `getDisplayMedia(${j(constraints)}) must succeed with displaySurface`));
+  
 </script>


### PR DESCRIPTION
Following https://chromium-review.googlesource.com/c/chromium/src/+/3826279/, this CL adds tests for MediaTrackConstraintSet.displaySurface that verifies that adding this hint to the constraints doesn't cause the function to throw.