### PR TITLE
Add DisplayMediaStreamConstraints.surfaceSwitching tests

### DIFF
--- a/screen-capture/getdisplaymedia.https.html
+++ b/screen-capture/getdisplaymedia.https.html
@@ -60,6 +60,8 @@ promise_test( async t => {
  {video: true, audio: false},
  {audio: false},
  {audio: true},
+ {surfaceSwitching: "include"},
+ {surfaceSwitching: "exclude"},
  {},
  undefined
 ].forEach(constraints => promise_test(async t => {


### PR DESCRIPTION
Following up on https://chromium-review.googlesource.com/c/chromium/src/+/3834593/, this CL adds tests for DisplayMediaStreamConstraints.surfaceSwitching that verifies that adding this hint to the constraints doesn't cause the function to throw.