### PR TITLE
Update log tests

### DIFF
--- a/webdriver/tests/bidi/__init__.py
+++ b/webdriver/tests/bidi/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Callable
 
 
 # Compares 2 objects recursively.
@@ -33,3 +33,15 @@ def any_string(actual: Any) -> None:
 
 def any_int(actual: Any) -> None:
     assert isinstance(actual, int)
+
+
+def any_list(actual: Any) -> None:
+    assert isinstance(actual, list)
+
+
+def int_interval(start: int, end: int) -> Callable[[Any], None]:
+    def _(actual: Any) -> None:
+        any_int(actual)
+        assert start <= actual <= end
+
+    return _

--- a/webdriver/tests/bidi/log/entry_added/__init__.py
+++ b/webdriver/tests/bidi/log/entry_added/__init__.py
@@ -1,32 +1,24 @@
 from webdriver.bidi.modules.script import ContextTarget
+from ... import any_int, any_list, any_string, recursive_compare
 
 
 def assert_base_entry(
     entry,
-    level=None,
-    text=None,
-    time_start=None,
-    time_end=None,
-    stacktrace=None,
-    realm=None,
+    level=any_string,
+    text=any_string,
+    timestamp=any_int,
+    realm=any_string,
     context=None,
+    stacktrace=None
 ):
-    assert "level" in entry
-    assert isinstance(entry["level"], str)
-    if level is not None:
-        assert entry["level"] == level
-
-    assert "text" in entry
-    assert isinstance(entry["text"], str)
-    if text is not None:
-        assert entry["text"] == text
-
-    assert "timestamp" in entry
-    assert isinstance(entry["timestamp"], int)
-    if time_start is not None:
-        assert entry["timestamp"] >= time_start
-    if time_end is not None:
-        assert entry["timestamp"] <= time_end
+    recursive_compare({
+        "level": level,
+        "text": text,
+        "timestamp": timestamp,
+        "source": {
+            "realm": realm
+        }
+    }, entry)
 
     if stacktrace is not None:
         assert "stackTrace" in entry
@@ -39,15 +31,7 @@ def assert_base_entry(
         for index in range(0, len(call_frames)):
             assert call_frames[index] == stacktrace[index]
 
-    assert "source" in entry
     source = entry["source"]
-
-    assert "realm" in source
-    assert isinstance(source["realm"], str)
-
-    if realm is not None:
-        assert source["realm"] == realm
-
     if context is not None:
         assert "context" in source
         assert source["context"] == context
@@ -55,52 +39,52 @@ def assert_base_entry(
 
 def assert_console_entry(
     entry,
-    method=None,
-    level=None,
-    text=None,
-    args=None,
-    time_start=None,
-    time_end=None,
-    realm=None,
-    stacktrace=None,
+    method=any_string,
+    level=any_string,
+    text=any_string,
+    args=any_list,
+    timestamp=any_int,
+    realm=any_string,
     context=None,
+    stacktrace=None
 ):
     assert_base_entry(
-        entry, level, text, time_start, time_end, stacktrace, realm, context
-    )
+        entry=entry,
+        level=level,
+        text=text,
+        timestamp=timestamp,
+        realm=realm,
+        context=context,
+        stacktrace=stacktrace)
 
-    assert "type" in entry
-    assert isinstance(entry["type"], str)
-    assert entry["type"] == "console"
-
-    assert "method" in entry
-    assert isinstance(entry["method"], str)
-    if method is not None:
-        assert entry["method"] == method
-
-    assert "args" in entry
-    assert isinstance(entry["args"], list)
-    if args is not None:
-        assert entry["args"] == args
+    recursive_compare({
+        "type": "console",
+        "method": method,
+        "args": args
+    }, entry)
 
 
 def assert_javascript_entry(
     entry,
-    level=None,
-    text=None,
-    time_start=None,
-    time_end=None,
-    stacktrace=None,
-    realm=None,
+    level=any_string,
+    text=any_string,
+    timestamp=any_int,
+    realm=any_string,
     context=None,
+    stacktrace=None
 ):
     assert_base_entry(
-        entry, level, text, time_start, time_end, stacktrace, realm, context
-    )
+        entry=entry,
+        level=level,
+        text=text,
+        timestamp=timestamp,
+        realm=realm,
+        stacktrace=stacktrace,
+        context=context)
 
-    assert "type" in entry
-    assert isinstance(entry["type"], str)
-    assert entry["type"] == "javascript"
+    recursive_compare({
+        "type": "javascript",
+    }, entry)
 
 
 async def create_console_api_message(bidi_session, context, text):

--- a/webdriver/tests/bidi/log/entry_added/console.py
+++ b/webdriver/tests/bidi/log/entry_added/console.py
@@ -2,6 +2,7 @@ import pytest
 from webdriver.bidi.modules.script import ContextTarget
 
 from . import assert_console_entry, create_console_api_message_for_primitive_value
+from ... import any_string, int_interval, recursive_compare
 
 
 @pytest.mark.asyncio
@@ -10,11 +11,15 @@ from . import assert_console_entry, create_console_api_message_for_primitive_val
     [
         ("'TEST'", "TEST"),
         ("'TWO', 'PARAMETERS'", "TWO PARAMETERS"),
+        ("{}", any_string),
+        ("['1', '2', '3']", any_string),
         ("null, undefined", "null undefined"),
     ],
     ids=[
         "single string",
         "two strings",
+        "empty object",
+        "array of strings",
         "null and undefined",
     ],
 )
@@ -92,9 +97,7 @@ async def test_timestamp(bidi_session, top_context, wait_for_event, current_time
 
     time_end = await current_time_bidi()
 
-    assert_console_entry(
-        event_data, text="foo", time_start=time_start, time_end=time_end
-    )
+    assert_console_entry(event_data, text="foo", timestamp=int_interval(time_start, time_end))
 
 
 @pytest.mark.asyncio

--- a/webdriver/tests/bidi/log/entry_added/console.py
+++ b/webdriver/tests/bidi/log/entry_added/console.py
@@ -1,6 +1,3 @@
-import math
-import time
-
 import pytest
 from webdriver.bidi.modules.script import ContextTarget
 
@@ -13,15 +10,11 @@ from . import assert_console_entry, create_console_api_message_for_primitive_val
     [
         ("'TEST'", "TEST"),
         ("'TWO', 'PARAMETERS'", "TWO PARAMETERS"),
-        ("{}", "[object Object]"),
-        ("['1', '2', '3']", "1,2,3"),
         ("null, undefined", "null undefined"),
     ],
     ids=[
         "single string",
         "two strings",
-        "empty object",
-        "array of strings",
         "null and undefined",
     ],
 )
@@ -75,12 +68,12 @@ async def test_level(
 
 
 @pytest.mark.asyncio
-async def test_timestamp(bidi_session, top_context, wait_for_event, current_time):
+async def test_timestamp(bidi_session, top_context, wait_for_event, current_time_bidi):
     await bidi_session.session.subscribe(events=["log.entryAdded"])
 
     on_entry_added = wait_for_event("log.entryAdded")
 
-    time_start = current_time()
+    time_start = await current_time_bidi()
 
     script = """new Promise(resolve => {
             setTimeout(() => {
@@ -97,7 +90,7 @@ async def test_timestamp(bidi_session, top_context, wait_for_event, current_time
 
     event_data = await on_entry_added
 
-    time_end = current_time()
+    time_end = await current_time_bidi()
 
     assert_console_entry(
         event_data, text="foo", time_start=time_start, time_end=time_end

--- a/webdriver/tests/bidi/log/entry_added/console.py
+++ b/webdriver/tests/bidi/log/entry_added/console.py
@@ -73,12 +73,12 @@ async def test_level(
 
 
 @pytest.mark.asyncio
-async def test_timestamp(bidi_session, top_context, wait_for_event, current_time_bidi):
+async def test_timestamp(bidi_session, top_context, wait_for_event, current_time):
     await bidi_session.session.subscribe(events=["log.entryAdded"])
 
     on_entry_added = wait_for_event("log.entryAdded")
 
-    time_start = await current_time_bidi()
+    time_start = await current_time()
 
     script = """new Promise(resolve => {
             setTimeout(() => {
@@ -95,7 +95,7 @@ async def test_timestamp(bidi_session, top_context, wait_for_event, current_time
 
     event_data = await on_entry_added
 
-    time_end = await current_time_bidi()
+    time_end = await current_time()
 
     assert_console_entry(event_data, text="foo", timestamp=int_interval(time_start, time_end))
 

--- a/webdriver/tests/bidi/log/entry_added/javascript.py
+++ b/webdriver/tests/bidi/log/entry_added/javascript.py
@@ -4,6 +4,7 @@ import time
 import pytest
 
 from . import assert_javascript_entry, create_log
+from ... import int_interval
 
 
 @pytest.mark.asyncio
@@ -25,7 +26,6 @@ async def test_types_and_values(
         event_data,
         level="error",
         text=expected_text,
-        time_start=time_start,
-        time_end=time_end,
+        timestamp=int_interval(time_start, time_end),
         context=top_context["context"],
     )

--- a/webdriver/tests/bidi/log/entry_added/javascript.py
+++ b/webdriver/tests/bidi/log/entry_added/javascript.py
@@ -8,18 +8,18 @@ from . import assert_javascript_entry, create_log
 
 @pytest.mark.asyncio
 async def test_types_and_values(
-    bidi_session, current_time, inline, top_context, wait_for_event
+    bidi_session, current_time_bidi, inline, top_context, wait_for_event
 ):
     await bidi_session.session.subscribe(events=["log.entryAdded"])
 
     on_entry_added = wait_for_event("log.entryAdded")
 
-    time_start = current_time()
+    time_start = await current_time_bidi()
 
     expected_text = await create_log(bidi_session, top_context, "javascript_error", "cached_message")
     event_data = await on_entry_added
 
-    time_end = current_time()
+    time_end = await current_time_bidi()
 
     assert_javascript_entry(
         event_data,

--- a/webdriver/tests/bidi/log/entry_added/javascript.py
+++ b/webdriver/tests/bidi/log/entry_added/javascript.py
@@ -9,18 +9,18 @@ from ... import int_interval
 
 @pytest.mark.asyncio
 async def test_types_and_values(
-    bidi_session, current_time_bidi, inline, top_context, wait_for_event
+    bidi_session, current_time, inline, top_context, wait_for_event
 ):
     await bidi_session.session.subscribe(events=["log.entryAdded"])
 
     on_entry_added = wait_for_event("log.entryAdded")
 
-    time_start = await current_time_bidi()
+    time_start = await current_time()
 
     expected_text = await create_log(bidi_session, top_context, "javascript_error", "cached_message")
     event_data = await on_entry_added
 
-    time_end = await current_time_bidi()
+    time_end = await current_time()
 
     assert_javascript_entry(
         event_data,

--- a/webdriver/tests/support/fixtures_bidi.py
+++ b/webdriver/tests/support/fixtures_bidi.py
@@ -40,17 +40,17 @@ def wait_for_event(bidi_session, event_loop):
     return wait_for_event
 
 @pytest.fixture
-def current_time_bidi(bidi_session, top_context):
+def current_time(bidi_session, top_context):
     """Get the current time stamp in ms from the remote end.
 
     This is required especially when tests are run on different devices like
     for Android, where it's not guaranteed that both machines are in sync.
     """
-    async def _timestamp():
+    async def _():
         result = await bidi_session.script.evaluate(
             expression="Date.now()",
             target=ContextTarget(top_context["context"]),
             await_promise=True)
         return result["value"]
 
-    return _timestamp
+    return _

--- a/webdriver/tests/support/fixtures_bidi.py
+++ b/webdriver/tests/support/fixtures_bidi.py
@@ -3,6 +3,7 @@ from typing import Any, Mapping
 
 import pytest
 import webdriver
+from webdriver.bidi.modules.script import ContextTarget
 
 
 @pytest.fixture
@@ -37,3 +38,19 @@ def wait_for_event(bidi_session, event_loop):
 
         return future
     return wait_for_event
+
+@pytest.fixture
+def current_time_bidi(bidi_session, top_context):
+    """Get the current time stamp in ms from the remote end.
+
+    This is required especially when tests are run on different devices like
+    for Android, where it's not guaranteed that both machines are in sync.
+    """
+    async def _timestamp():
+        result = await bidi_session.script.evaluate(
+            expression="Date.now()",
+            target=ContextTarget(top_context["context"]),
+            await_promise=True)
+        return result["value"]
+
+    return _timestamp

--- a/webdriver/tests/support/fixtures_http.py
+++ b/webdriver/tests/support/fixtures_http.py
@@ -153,19 +153,6 @@ def create_frame(session):
 
 
 @pytest.fixture
-def current_time(current_session):
-    """Get the current time stamp in ms from the remote end.
-
-    This is required especially when tests are run on different devices like
-    for Android, where it's not guaranteed that both machines are in sync.
-    """
-    def _timestamp():
-        return current_session.execute_script("return Date.now();")
-
-    return _timestamp
-
-
-@pytest.fixture
 def stale_element(current_session, iframe, inline):
     """Create a stale element reference
 


### PR DESCRIPTION
* Remove implementation-defined tests. [`log.entryAdded`](https://w3c.github.io/webdriver-bidi/#event-log-entryAdded) handler in step 5.2 says:
> If arg is a [primitive ECMAScript value](https://tc39.es/ecma262/#sec-primitive-value), append [ToString](https://tc39.es/ecma262/#sec-tostring)(arg) to text. Otherwise append an implementation-defined string to text.
* Switch from classic `current_time` to BiDi `current_time_bidi`.