### PR TITLE
Fix issues with get_computed_label and get_computed_role WebDriver tests

### DIFF
--- a/webdriver/tests/get_computed_label/get.py
+++ b/webdriver/tests/get_computed_label/get.py
@@ -25,11 +25,6 @@ def test_stale_element_reference(session, stale_element, as_frame):
     assert_error(response, "stale element reference")
 
 
-def test_no_user_prompt(session):
-    response = get_computed_label(session, "foo")
-    assert_error(response, "no such alert")
-
-
 @pytest.mark.parametrize("html,tag,label", [
     ("<button>ok</button>", "button", "ok"),
     ("<button aria-labelledby=\"one two\"></button><div id=one>ok</div><div id=two>go</div>", "button", "ok go"),
@@ -37,7 +32,7 @@ def test_no_user_prompt(session):
     ("<label><input> foo</label>", "input", "foo"),
     ("<label for=b>foo<label><input id=b>", "input", "foo")])
 def test_get_computed_label(session, inline, html, tag, label):
-    session.url = inline("{0}".format(tag))
+    session.url = inline(html)
     element = session.find.css(tag, all=False)
     result = get_computed_label(session, element.id)
     assert_success(result, label)

--- a/webdriver/tests/get_computed_role/get.py
+++ b/webdriver/tests/get_computed_role/get.py
@@ -25,13 +25,8 @@ def test_stale_element_reference(session, stale_element, as_frame):
     assert_error(response, "stale element reference")
 
 
-def test_no_user_prompt(session):
-    response = get_computed_role(session, "foo")
-    assert_error(response, "no such alert")
-
-
 @pytest.mark.parametrize("html,tag,expected", [
-    ("<li role=menuitem>foo", "li", "menu"),
+    ("<li role=menuitem>foo", "li", "menuitem"),
     ("<input role=searchbox>", "input", "searchbox"),
     ("<img role=presentation>", "img", "presentation")])
 def test_computed_roles(session, inline, html, tag, expected):


### PR DESCRIPTION
Both tests contain a subtest that appears to have been a copy-paste holdover from an alert test, and will not pass
because these commands will not return "no such alert". get_compute_role also incorrectly expects an element with the
role 'menuitem' to return a role of 'menu'. get_computed_label failed to correctly test the command because it is not
actually loading the defined html for testing, but instead trying to only load the tag name.