### PR TITLE
Add globla=window-module for .any.js. (#35511)

### DIFF
--- a/docs/writing-tests/testharness.md
+++ b/docs/writing-tests/testharness.md
@@ -150,6 +150,10 @@ It is possible to customize the set of scopes with a metadata comment, such as
 //       ==> would run in the dedicated worker scope as a module
 // META: global=worker
 //       ==> would run in the dedicated, shared, and service worker scopes
+// META: global=window
+//       ==> would run the test script as a classic script.
+// META: global=window-module
+         ==> would run the test script as a module script.
 ```
 
 For a test file <code><var>x</var>.any.js</code>, the available scope keywords
@@ -157,6 +161,7 @@ are:
 
 * `window` (default): to be run at <code><var>x</var>.any.html</code>
 * `dedicatedworker` (default): to be run at <code><var>x</var>.any.worker.html</code>
+* `window-module`: to be run at <code><var>x</var>.any.window-module.html</code>
 * `dedicatedworker-module` to be run at <code><var>x</var>.any.worker-module.html</code>
 * `serviceworker`: to be run at <code><var>x</var>.any.serviceworker.html</code> (`.https` is
   implied)

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -83,6 +83,7 @@ def read_script_metadata(f, regexp):
 
 _any_variants = {
     "window": {"suffix": ".any.html"},
+    "window-module": {"suffix": ".any.window-module.html"},
     "serviceworker": {"force_https": True},
     "serviceworker-module": {"force_https": True},
     "sharedworker": {},

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -358,6 +358,7 @@ test()"""
 
 @pytest.mark.parametrize("input,expected", [
     (b"window", {"window"}),
+    (b"window-module", {"window-module"}),
     (b"sharedworker", {"sharedworker"}),
     (b"sharedworker,serviceworker", {"serviceworker", "sharedworker"}),
     (b"worker", {"dedicatedworker", "serviceworker", "sharedworker"}),
@@ -386,6 +387,7 @@ test()""" % input
         "serviceworker": "/html/test.any.serviceworker.html",
         "sharedworker": "/html/test.any.sharedworker.html",
         "window": "/html/test.any.html",
+        "window-module": "/html/test.any.window-module.html"
     }
 
     expected_urls = sorted(urls[ty] for ty in expected)

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -315,6 +315,19 @@ class WindowHandler(HtmlWrapperHandler):
 """
 
 
+class WindowModulesHandler(HtmlWrapperHandler):
+    path_replace = [(".any.window-module.html", ".any.js")]
+    wrapper = """<!doctype html>
+<meta charset=utf-8>
+%(meta)s
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+%(script)s
+<div id=log></div>
+<script src="%(path)s" type="module"></script>
+"""
+
+
 class AnyHtmlHandler(HtmlWrapperHandler):
     global_type = "window"
     path_replace = [(".any.html", ".any.js")]
@@ -561,6 +574,7 @@ class RoutesBuilder:
             ("GET", "*.worker-module.html", WorkerModulesHandler),
             ("GET", "*.window.html", WindowHandler),
             ("GET", "*.any.html", AnyHtmlHandler),
+            ("GET", "*.any.window-module.html", WindowModulesHandler),
             ("GET", "*.any.sharedworker.html", SharedWorkersHandler),
             ("GET", "*.any.sharedworker-module.html", SharedWorkerModulesHandler),
             ("GET", "*.any.serviceworker.html", ServiceWorkersHandler),


### PR DESCRIPTION
This allows .any.js could be loaded as a ES module script, whereas
'global=window' loads the script as a classic JS script.