### PR TITLE
Add aspect-ratio test for failing images

### DIFF
--- a/css/css-sizing/aspect-ratio/replaced-element-036.html
+++ b/css/css-sizing/aspect-ratio/replaced-element-036.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>CSS aspect-ratio: img</title>
+<link rel="author" title="Jake Archibald" href="jakearchibald@google.com" />
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="log"></div>
+
+<img
+  id="test"
+  src="error.png"
+  style="width: 100px; aspect-ratio: 1/2; background: green; display: block"
+  alt="Should be 200px high"
+/>
+
+<script>
+  onload = () => {
+    test(() => {
+      assert_equals(document.getElementById("test").offsetHeight, 200);
+    });
+  };
+</script>

--- a/css/css-sizing/aspect-ratio/replaced-element-036.html
+++ b/css/css-sizing/aspect-ratio/replaced-element-036.html
@@ -4,20 +4,37 @@
 <link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-
+<style>
+  img {
+    width: 100px;
+    aspect-ratio: 1/2;
+    background: green;
+  }
+</style>
 <div id="log"></div>
 
 <img
-  id="test"
   src="error.png"
-  style="width: 100px; aspect-ratio: 1/2; background: green; display: block"
-  alt="Should be 200px high"
+  style="display: block"
+  alt="display:block img should be 200px high"
+/>
+
+<img
+  src="error.png"
+  style="display: inline-block"
+  alt="display:inline-block img should be 200px high"
 />
 
 <script>
+  setup({ explicit_done: true });
+
   onload = () => {
-    test(() => {
-      assert_equals(document.getElementById("test").offsetHeight, 200);
-    });
+    for (const [i, img] of [...document.images].entries()) {
+      test(() => {
+        assert_equals(img.offsetHeight, 200);
+      }, img.alt);
+    }
+
+    done();
   };
 </script>

--- a/css/css-sizing/aspect-ratio/replaced-element-036.html
+++ b/css/css-sizing/aspect-ratio/replaced-element-036.html
@@ -29,7 +29,7 @@
   setup({ explicit_done: true });
 
   onload = () => {
-    for (const [i, img] of [...document.images].entries()) {
+    for (const img of document.images) {
       test(() => {
         assert_equals(img.offsetHeight, 200);
       }, img.alt);


### PR DESCRIPTION
http://wpt.live/css/css-sizing/aspect-ratio/replaced-element-028.html - this asserts that `aspect-ratio` is not applied to images if the image fails to load.

However, I think it _should_ apply if the image is `display:block` or `display:inline-block`.

@tabatkins @fantasai can you confirm that this is test is correct?

Safari currently fails this test. It renders the image with a 1:1 ratio.