### PR TITLE
Fix exporter

### DIFF
--- a/html/cross-origin-opener-policy/popup-redirect-cache.https.html
+++ b/html/cross-origin-opener-policy/popup-redirect-cache.https.html
@@ -19,20 +19,18 @@
 
 function url_test_cache(t, url, responseToken, iframeToken, hasOpener) {
   return new Promise(async (resolve, reject) => {
-    const w = window.open(url, responseToken);
-    // The popup is closed by dispatcher_url_test.
     try {
-      var payload = await receive(responseToken);
-      payload = JSON.parse(payload);
-      assert_equals('error' in payload, false, 'Unexpected error response received');
-      validate_results(resolve, t, w, responseToken, hasOpener, undefined /* OpenerDomAccess */, payload)
+      await dispatcher_url_test(t, url, responseToken, iframeToken, hasOpener, undefined /* OpenerDomAccess */, resolve);
     } catch(e) {
       reject(e);
     }
   }).then(() => {
-    // test the same url for cache.
     return new Promise(async (resolve, reject) => {
       try {
+        // Test the same url for cache.
+        // Note that at this point the popup from the first
+        // `dispatcher_url_test()` call hasn't been closed yet, but once this
+        // test has finished both will be cleaned up.
         await dispatcher_url_test(t, url, responseToken, iframeToken, hasOpener, undefined /* OpenerDomAccess */, resolve);
       } catch(e) {
         reject(e);

--- a/html/cross-origin-opener-policy/popup-redirect-cache.https.html
+++ b/html/cross-origin-opener-policy/popup-redirect-cache.https.html
@@ -8,40 +8,52 @@
 <meta name="variant" content="?8-last">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
 <script src="/common/get-host-info.sub.js"></script>
 <script src="/common/subset-tests.js"></script>
+<script src="/common/utils.js"></script>
 <script src="resources/common.js"></script>
 
 <div id=log></div>
 <script>
 
-function url_test_cache(t, url, channelName, hasOpener) {
-  const bc = new BroadcastChannel(channelName);
-  bc.onmessage = t.step_func(event => {
-    const payload = event.data;
-    validate_results(() => {
-      bc.close()
-      // test the same url for cache
-      url_test(t, url, channelName, hasOpener);
-    }, t, w, channelName, hasOpener, undefined /* OpenerDomAccess */, payload)
+function url_test_cache(t, url, responseToken, iframeToken, hasOpener) {
+  return new Promise(async (resolve, reject) => {
+    const w = window.open(url, responseToken);
+    // The popup is closed by dispatcher_url_test.
+    try {
+      var payload = await receive(responseToken);
+      payload = JSON.parse(payload);
+      assert_equals('error' in payload, false, 'Unexpected error response received');
+      validate_results(resolve, t, w, responseToken, hasOpener, undefined /* OpenerDomAccess */, payload)
+    } catch(e) {
+      reject(e);
+    }
+  }).then(() => {
+    // test the same url for cache.
+    return new Promise(async (resolve, reject) => {
+      try {
+        await dispatcher_url_test(t, url, responseToken, iframeToken, hasOpener, undefined /* OpenerDomAccess */, resolve);
+      } catch(e) {
+        reject(e);
+      }
+    });
   });
-
-  const w = window.open(url, channelName);
-
-  // The popup is closed by url_test.
 }
 
 // Redirect from hostA to hostB with same coop and coep.
 // Cache the hostA page if redirectCache is true.
 // Cache the hostB page if destCache is true.
-function coop_redirect_cache_test(t, hostA, hostB, coop, coep, redirectCache, destCache, channelName, hasOpener) {
+function coop_redirect_cache_test(t, hostA, hostB, coop, coep, redirectCache, destCache, hasOpener) {
   let redirectUrl = `${hostA.origin}/html/cross-origin-opener-policy/resources/coop-coep.py`;
   let redirectCacheString = redirectCache ? "&cache=1" : "";
   let destCacheString = destCache ? "&cache=1" : "";
-  let destUrl = `${hostB.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=${coop}&coep=${coep}${destCacheString}&channel=${channelName}`;
+  let responseToken = token();
+  let iframeToken = token();
+  let destUrl = `${hostB.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=${coop}&coep=${coep}${destCacheString}&responseToken=${responseToken}&iframeToken=${iframeToken}`;
   let url = `${redirectUrl}?coop=${coop}&coep=${coep}${redirectCacheString}&redirect=${encodeURIComponent(destUrl)}`;
 
-  url_test_cache(t, url, channelName, hasOpener);
+  return url_test_cache(t, url, responseToken, iframeToken, hasOpener);
 }
 
 function run_redirect_cache_tests(documentCOOPValueTitle, testArray) {
@@ -51,10 +63,8 @@ function run_redirect_cache_tests(documentCOOPValueTitle, testArray) {
       return;
     }
 
-    async_test(t => {
-      // Use a consistent channel name for deterministic failure output
-      let channelName = `${test[0].name}_${test[1].name}${test[2] ? "" : "_not"}_cache_redirect${test[3] ? "" : "_not"}_cache_destination`;
-      coop_redirect_cache_test(t, test[0], test[1], "same-origin", "require-corp", test[2], test[3], channelName, test[4]);
+    promise_test(t => {
+      return coop_redirect_cache_test(t, test[0], test[1], "same-origin", "require-corp", test[2], test[3], test[4]);
     }, `${documentCOOPValueTitle} document opening popup redirect from ${test[0].origin} to ${test[1].origin} with redirectCache ${test[2]} and destCache ${test[3]}`);
   });
 }

--- a/html/cross-origin-opener-policy/resources/coop-coep.py
+++ b/html/cross-origin-opener-policy/resources/coop-coep.py
@@ -29,11 +29,10 @@ def main(request, response):
 
     # Collect relevant params to be visible to response JS
     params = {}
-    for key in (b"navHistory", b"avoidBackAndForth", b"navigate", b"channel"):
+    for key in (b"navHistory", b"avoidBackAndForth", b"navigate", b"channel", b"responseToken", b"iframeToken"):
         value = requestData.first(key, None)
         params[key.decode()] = value and value.decode()
 
-    # This uses an <iframe> as BroadcastChannel is same-origin bound.
     response.content = b"""
 <!doctype html>
 <meta charset=utf-8>
@@ -72,7 +71,12 @@ def main(request, response):
       iframe.contentWindow.postMessage(payload, "*");
     };
     const channelName = params.channel;
-    iframe.src = `${get_host_info().HTTPS_ORIGIN}/html/cross-origin-opener-policy/resources/postback.html?channel=${encodeURIComponent(channelName)}`;
+    const responseToken = params.responseToken;
+    const iframeToken = params.iframeToken;
+    iframe.src = `${get_host_info().HTTPS_ORIGIN}/html/cross-origin-opener-policy/resources/postback.html` +
+                 `?channel=${encodeURIComponent(channelName)}` +
+                 `&responseToken=${responseToken}` +
+                 `&iframeToken=${iframeToken}`;
     document.body.appendChild(iframe);
   }
 </script>

--- a/html/cross-origin-opener-policy/resources/postback.html
+++ b/html/cross-origin-opener-policy/resources/postback.html
@@ -1,19 +1,45 @@
 <!doctype html>
 <meta charset=utf-8>
+<script src="/common/dispatcher/dispatcher.js"></script>
 <script>
-const channelName = new URL(location).searchParams.get("channel");
-const bc = new BroadcastChannel(channelName);
+const params = new URL(location).searchParams;
+const channelName = params.get("channel");
+const responseToken = params.get("responseToken");
+const iframeToken = params.get("iframeToken");
 
-// Handle the close message from the test-cleanup, forwarding it to the
-// top level document, as this iframe and the opening document might not
-// be able to close the popup.
-bc.onmessage = event => {
-  if (event.data == "close") {
-    top.postMessage("close", "*");
+// If the channel parameter is set, use the BroadcastChannel-based communication
+// method. Otherwise, use the dispatcher (useful in cases where this is embedded
+// in a third-party iframe that doesn't share a partition with the top-level
+// site).
+if (channelName != "null") {
+  const bc = new BroadcastChannel(channelName);
+  // Handle the close message from the test-cleanup, forwarding it to the
+  // top level document, as this iframe and the opening document might not
+  // be able to close the popup.
+  bc.onmessage = event => {
+    if (event.data == "close") {
+       top.postMessage("close", "*");
+     }
+  };
+
+  window.addEventListener("message", event => {
+    bc.postMessage(event.data);
+  });
+
+} else {
+  window.addEventListener("message", event => {
+    send(responseToken, JSON.stringify(event.data));
+  });
+
+  async function waitToClose() {
+    response = await receive(iframeToken);
+    // Handle the close message from the test-cleanup, forwarding it to the
+    // top level document, as this iframe and the opening document might not
+    // be able to close the popup.
+    if (response == "close") {
+      top.postMessage("close", "*");
+    }
   }
-};
-
-window.addEventListener("message", event => {
-  bc.postMessage(event.data);
-});
+  waitToClose();
+}
 </script>


### PR DESCRIPTION
Ensure that all popups get closed for popup-redirect-cache.https.html

In my earlier refactor of popup-redirect-cache.https.html I
overlooked that the one BroadcastChannel "close" message was
being used to clean up two windows for each test... To get the
same functionality using the dispatcher, we need to add two
close messages to the queue instead of one. This changes makes
the two parts of the test identical, allowing us to remove
some duplicated code.

Also, I'm hoping this fixes some WPT timeouts in Firefox
related to the previous CL:
https://github.com/web-platform-tests/wpt/pull/35570

Bug: [1354602](https://bugs.chromium.org/p/chromium/issues/detail?id=1354602)
Change-Id: Ie8b883b7003cd233747ba4fe6e0f2508ee057144
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3855346
Reviewed-by: Arthur Hemery <[ahemery@chromium.org](mailto:ahemery@chromium.org)>
Commit-Queue: Andrew Williams <[awillia@google.com](mailto:awillia@google.com)>
Cr-Commit-Position: refs/heads/main@{#1039267}