### PR TITLE
Add dependency to permission API IDL in gum IDL test

### DIFF
--- a/mediacapture-streams/idlharness.https.window.js
+++ b/mediacapture-streams/idlharness.https.window.js
@@ -8,7 +8,7 @@
 
 idl_test(
   ['mediacapture-streams'],
-  ['webidl', 'dom', 'html'],
+  ['webidl', 'dom', 'html', 'permissions'],
   async idl_array => {
     const inputDevices = [];
     const outputDevices = [];


### PR DESCRIPTION
Fixes the error ' PROMISE_REJECT(object “DevicePermissionDescriptor inherits PermissionDescriptor, but PermissionDescriptor is undefined.”) ' in test results