### PR TITLE
Add multiple tests for prefetch behavior

### DIFF
--- a/preload/prefetch-cache.html
+++ b/preload/prefetch-cache.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>Ensures that prefetch respects HTTP cache semantics</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="resources/prefetch-helper.js"></script>
+<body>
+<script>
+
+async function prefetch_and_count(cacheControl, t) {
+    const {href} = await prefetch({"cache-control": cacheControl, "type": "text/plain", content: "123"}, t);
+    await fetch(href);
+    const info = await get_prefetch_info(href);
+    return info.length;
+}
+
+promise_test(async t => {
+    const result = await prefetch_and_count("max-age=604800", t);
+    assert_equals(result, 1);
+}, "Prefetch should populate the HTTP cache");
+
+for (const cacheControl of ["no-cache", "no-store", "max-age=0"]) {
+    promise_test(async t => {
+        const result = await prefetch_and_count(cacheControl, t);
+        assert_equals(result, 2);
+    }, `Prefetch should not respsect cache-control: ${cacheControl}`);
+}
+</script>
+</body>

--- a/preload/prefetch-cache.html
+++ b/preload/prefetch-cache.html
@@ -15,7 +15,12 @@ async function prefetch_and_count(cacheControl, t) {
 }
 
 promise_test(async t => {
-    const result = await prefetch_and_count("max-age=604800", t);
+    let result = 0;
+    // Sometimes the HTTP cache is not reliable. We want to see that the prefetch is reused in at
+    // least 1 out of 10 tries.
+    for (let i = 0; i < 10 && result !== 1; ++i) {
+        result = await prefetch_and_count("max-age=604800", t);
+    }
     assert_equals(result, 1);
 }, "Prefetch should populate the HTTP cache");
 

--- a/preload/prefetch-cache.html
+++ b/preload/prefetch-cache.html
@@ -8,19 +8,22 @@
 <script>
 
 async function prefetch_and_count(cacheControl, t) {
-    const {href} = await prefetch({"cache-control": cacheControl, "type": "text/plain", content: "123"}, t);
-    await fetch(href);
+    const {href} = await prefetch({
+        "cache-control": cacheControl,
+        "type": "application/javascript",
+        content: "/**/"}, t);
+    const script = document.createElement("script");
+    script.src = href;
+    t.add_cleanup(() => script.remove());
+    const loaded = new Promise(resolve => script.addEventListener("load", resolve));
+    document.body.appendChild(script);
+    await loaded;
     const info = await get_prefetch_info(href);
     return info.length;
 }
 
 promise_test(async t => {
-    let result = 0;
-    // Sometimes the HTTP cache is not reliable. We want to see that the prefetch is reused in at
-    // least 1 out of 10 tries.
-    for (let i = 0; i < 10 && result !== 1; ++i) {
-        result = await prefetch_and_count("max-age=604800", t);
-    }
+    const result = await prefetch_and_count("max-age=604800", t);
     assert_equals(result, 1);
 }, "Prefetch should populate the HTTP cache");
 

--- a/preload/prefetch-cache.html
+++ b/preload/prefetch-cache.html
@@ -23,7 +23,7 @@ for (const cacheControl of ["no-cache", "no-store", "max-age=0"]) {
     promise_test(async t => {
         const result = await prefetch_and_count(cacheControl, t);
         assert_equals(result, 2);
-    }, `Prefetch should not respsect cache-control: ${cacheControl}`);
+    }, `Prefetch should respect cache-control: ${cacheControl}`);
 }
 </script>
 </body>

--- a/preload/prefetch-document.html
+++ b/preload/prefetch-document.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<title>Ensures that prefetch works with documents</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="resources/prefetch-helper.js"></script>
+<body>
+<script>
+
+const {ORIGIN, REMOTE_ORIGIN, HTTP_NOTSAMESITE_ORIGIN} = get_host_info();
+const origins = {
+    "same origin": ORIGIN,
+    "same site": REMOTE_ORIGIN,
+    "different site": HTTP_NOTSAMESITE_ORIGIN
+}
+const loaders = {
+    image: {
+        file: 'square.png',
+        type: 'image/png',
+        load: href => {
+            const image = document.createElement('img');
+            image.src = href;
+            document.body.appendChild(image);
+            return new Promise(resolve => image.addEventListener('load', resolve));
+        }
+    },
+    script: {
+        file: 'dummy.js',
+        type: 'application/javascript',
+        load: href => {
+            const script = document.createElement('script');
+            script.src = href;
+            document.body.appendChild(script);
+            return new Promise(resolve => script.addEventListener('load', resolve));
+        }
+    },
+    style: {
+        file: 'dummy.css',
+        type: 'text/css',
+        load: href => {
+            const link = document.createElement('link');
+            link.href = href;
+            link.rel = "stylesheet";
+            document.body.appendChild(link);
+            return new Promise(resolve => link.addEventListener('load', resolve));
+        }
+    },
+    document: {
+        file: 'empty.html',
+        type: 'text/html',
+        load: href => {
+            const iframe = document.createElement("iframe");
+            iframe.src = href;
+            document.body.appendChild(iframe);
+            return new Promise(resolve => iframe.addEventListener("load", resolve));
+        }
+    }
+};
+
+async function prefetch_document(origin, as, t) {
+    const {href, uid} = await prefetch({
+        file: "prefetch-exec.html",
+        type: "text/html",
+        corssOrigin: "anonymous",
+        origin: origins[origin], as});
+    const popup = window.open(href);
+    const remoteContext = new RemoteContext(uid);
+    t.add_cleanup(() => popup.close());
+    const result = await remoteContext.execute_script(() => "OK");
+    assert_equals(result, "OK");
+    return await get_prefetch_info(href);
+}
+
+async function test_prefetch_document({origin, as}, expected) {
+    promise_test(async t => {
+        const requests = await prefetch_document(origin, as, t);
+        const did_consume = requests.length === 1 ? "consumed" : "not consumed";
+        assert_equals(did_consume, expected);
+    }, `Prefetching a document (${origin}, as="${as}") should be ${expected}`);
+}
+
+test_prefetch_document({origin: "same origin"}, "consumed");
+test_prefetch_document({origin: "same site"}, "consumed");
+test_prefetch_document({as: "document", origin: "different site"}, "not consumed");
+
+promise_test(async t => {
+    const {href, uid} = await prefetch({
+        file: "prefetch-exec.html",
+        type: "text/html",
+        corssOrigin: "anonymous",
+        origin: ORIGIN});
+    const popup = window.open(href + "&cache_bust=" + token());
+    const remoteContext = new RemoteContext(uid);
+    t.add_cleanup(() => popup.close());
+    await remoteContext.execute_script(() => "OK");
+    const results = await get_prefetch_info(href);
+    assert_equals(results.length, 2);
+    assert_equals(results[0].headers.accept, results[1].headers.accept);
+}, "Document prefetch should send the exact Accept header as navigation")
+
+</script>
+</body>

--- a/preload/prefetch-document.html
+++ b/preload/prefetch-document.html
@@ -59,23 +59,22 @@ const loaders = {
     }
 };
 
-async function prefetch_document(origin, as, t) {
-    const {href, uid} = await prefetch({
-        file: "prefetch-exec.html",
-        type: "text/html",
-        corssOrigin: "anonymous",
-        origin: origins[origin], as});
-    const popup = window.open(href);
-    const remoteContext = new RemoteContext(uid);
-    t.add_cleanup(() => popup.close());
-    const result = await remoteContext.execute_script(() => "OK");
-    assert_equals(result, "OK");
-    return await get_prefetch_info(href);
-}
-
 async function test_prefetch_document({origin, as}, expected) {
     promise_test(async t => {
-        const requests = await prefetch_document(origin, as, t);
+        const {href, uid} = await prefetch({
+            file: "prefetch-exec.html",
+            type: "text/html",
+            corssOrigin: "anonymous",
+            origin: origins[origin],
+            as});
+
+        const popup = window.open(href);
+        const remoteContext = new RemoteContext(uid);
+        t.add_cleanup(() => popup.close());
+        const result = await remoteContext.execute_script(() => "OK");
+        assert_equals(result, "OK");
+
+        const requests =  await get_prefetch_info(href);
         const did_consume = requests.length === 1 ? "consumed" : "not consumed";
         assert_equals(did_consume, expected);
     }, `Prefetching a document (${origin}, as="${as}") should be ${expected}`);

--- a/preload/prefetch-document.html
+++ b/preload/prefetch-document.html
@@ -10,11 +10,6 @@
 <script>
 
 const {ORIGIN, REMOTE_ORIGIN, HTTP_NOTSAMESITE_ORIGIN} = get_host_info();
-const origins = {
-    "same origin": ORIGIN,
-    "same site": REMOTE_ORIGIN,
-    "different site": HTTP_NOTSAMESITE_ORIGIN
-}
 const loaders = {
     image: {
         file: 'square.png',
@@ -59,30 +54,36 @@ const loaders = {
     }
 };
 
-async function test_prefetch_document({origin, as}, expected) {
-    promise_test(async t => {
-        const {href, uid} = await prefetch({
-            file: "prefetch-exec.html",
-            type: "text/html",
-            corssOrigin: "anonymous",
-            origin: origins[origin],
-            as});
-
-        const popup = window.open(href);
-        const remoteContext = new RemoteContext(uid);
-        t.add_cleanup(() => popup.close());
-        const result = await remoteContext.execute_script(() => "OK");
-        assert_equals(result, "OK");
-
-        const requests =  await get_prefetch_info(href);
-        const did_consume = requests.length === 1 ? "consumed" : "not consumed";
-        assert_equals(did_consume, expected);
-    }, `Prefetching a document (${origin}, as="${as}") should be ${expected}`);
+async function prefetch_document_and_count_fetches(options, t) {
+    const {href, uid} = await prefetch({
+        file: "prefetch-exec.html",
+        type: "text/html",
+        corssOrigin: "anonymous",
+        ...options});
+    const popup = window.open(href);
+    const remoteContext = new RemoteContext(uid);
+    t.add_cleanup(() => popup.close());
+    const result = await remoteContext.execute_script(() => "OK");
+    assert_equals(result, "OK");
+    const requests = await get_prefetch_info(href);
+    return requests.length;
 }
 
-test_prefetch_document({origin: "same origin"}, "consumed");
-test_prefetch_document({origin: "same site"}, "consumed");
-test_prefetch_document({as: "document", origin: "different site"}, "not consumed");
+promise_test(async t => {
+    assert_equals(await prefetch_document_and_count_fetches({origin: ORIGIN}, t), 1);
+}, "same origin document prefetch without 'as' should be consumed");
+
+promise_test(async t => {
+    assert_equals(await prefetch_document_and_count_fetches({origin: REMOTE_ORIGIN}, t), 1);
+}, "same-site different-origin document prefetch without 'as' should be consumed");
+
+promise_test(async t => {
+    assert_equals(await prefetch_document_and_count_fetches({origin: HTTP_NOTSAMESITE_ORIGIN}, t), 2);
+}, "different-site document prefetch without 'as' should not be consumed");
+
+promise_test(async t => {
+    assert_equals(await prefetch_document_and_count_fetches({origin: HTTP_NOTSAMESITE_ORIGIN, as: "document"}, t), 2);
+}, "different-site document prefetch with 'as=document' should not be consumed");
 
 promise_test(async t => {
     const {href, uid} = await prefetch({
@@ -98,6 +99,5 @@ promise_test(async t => {
     assert_equals(results.length, 2);
     assert_equals(results[0].headers.accept, results[1].headers.accept);
 }, "Document prefetch should send the exact Accept header as navigation")
-
 </script>
 </body>

--- a/preload/prefetch-events.html
+++ b/preload/prefetch-events.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<title>Ensures that prefetch respects HTTP cache semantics</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="resources/prefetch-helper.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<body>
+<script>
+const {REMOTE_ORIGIN} = get_host_info();
+async function prefetch(link, uid) {
+    link.rel = "prefetch";
+    document.head.appendChild(link);
+    const event = new Promise(resolve => {
+        link.addEventListener("error", () => resolve("error"));
+        link.addEventListener("load", () => resolve("load"));
+        setTimeout(() => resolve("timeout"), 1000);
+    });
+    return await event;
+}
+
+promise_test(async t => {
+    const uid = token();
+    const link = document.createElement("link");
+    link.href = `/preload/resources/prefetch-info.py?key=${uid}`;
+    const event = await prefetch(link, uid);
+    assert_equals(event, "load");
+}, "Prefetch should fire the load event");
+
+promise_test(async t => {
+    const uid = token();
+    const link = document.createElement("link");
+    link.href = `/preload/resources/prefetch-info.py?key=${uid}&status=404`;
+    const event = await prefetch(link, uid);
+    assert_equals(event, "error");
+}, "Prefetch should fire the error event for 404");
+
+promise_test(async t => {
+    const uid = token();
+    const link = document.createElement("link");
+    link.href = `/preload/resources/prefetch-info.py?key=${uid}&status=500`;
+    const event = await prefetch(link, uid);
+    assert_equals(event, "error");
+}, "Prefetch should fire the error event for 500");
+
+promise_test(async t => {
+    const uid = token();
+    const link = document.createElement("link");
+    link.crossOrigin = "anonymous";
+    link.href = `${REMOTE_ORIGIN}/preload/resources/prefetch-info.py?key=${uid}&cors=false`;
+    const event = await prefetch(link, uid);
+    assert_equals(event, "error");
+}, "Prefetch should fire the error event for network errors");
+
+promise_test(async t => {
+    const uid = token();
+    const link = document.createElement("link");
+    link.crossOrigin = "anonymous";
+    const event = await prefetch(link, uid);
+    assert_equals(event, "timeout");
+}, "Prefetch should do nothing with an empty href");
+
+promise_test(async t => {
+    const uid = token();
+    const link = document.createElement("link");
+    link.href = "https://example.com\u0000mozilla.org";
+    link.crossOrigin = "anonymous";
+    const event = await prefetch(link, uid);
+    assert_equals(event, "timeout");
+}, "Prefetch should do nothing with an invalid href");
+</script>
+</body>

--- a/preload/prefetch-events.html
+++ b/preload/prefetch-events.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <title>Ensures that prefetch respects HTTP cache semantics</title>
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/common/utils.js"></script>
@@ -8,13 +9,13 @@
 <body>
 <script>
 const {REMOTE_ORIGIN} = get_host_info();
-async function prefetch(link, uid) {
+async function prefetch(link, uid, t) {
     link.rel = "prefetch";
     document.head.appendChild(link);
     const event = new Promise(resolve => {
         link.addEventListener("error", () => resolve("error"));
         link.addEventListener("load", () => resolve("load"));
-        setTimeout(() => resolve("timeout"), 1000);
+        t.step_timeout(() => resolve("timeout"), 1000);
     });
     return await event;
 }
@@ -23,23 +24,39 @@ promise_test(async t => {
     const uid = token();
     const link = document.createElement("link");
     link.href = `/preload/resources/prefetch-info.py?key=${uid}`;
-    const event = await prefetch(link, uid);
+    const event = await prefetch(link, uid, t);
     assert_equals(event, "load");
 }, "Prefetch should fire the load event");
 
 promise_test(async t => {
     const uid = token();
     const link = document.createElement("link");
+    link.href = `${REMOTE_ORIGIN}/preload/resources/prefetch-info.py?key=${uid}`;
+    const event = await prefetch(link, uid, t);
+    assert_equals(event, "load");
+}, "Cross-origin prefetch should fire the load event");
+
+promise_test(async t => {
+    const uid = token();
+    const link = document.createElement("link");
     link.href = `/preload/resources/prefetch-info.py?key=${uid}&status=404`;
-    const event = await prefetch(link, uid);
+    const event = await prefetch(link, uid, t);
     assert_equals(event, "error");
 }, "Prefetch should fire the error event for 404");
 
 promise_test(async t => {
     const uid = token();
     const link = document.createElement("link");
+    link.href = `${REMOTE_ORIGIN}/preload/resources/prefetch-info.py?key=${uid}&status=404`;
+    const event = await prefetch(link, uid, t);
+    assert_equals(event, "error");
+}, "Cross-origin prefetch should fire the error event for 404");
+
+promise_test(async t => {
+    const uid = token();
+    const link = document.createElement("link");
     link.href = `/preload/resources/prefetch-info.py?key=${uid}&status=500`;
-    const event = await prefetch(link, uid);
+    const event = await prefetch(link, uid, t);
     assert_equals(event, "error");
 }, "Prefetch should fire the error event for 500");
 
@@ -48,7 +65,7 @@ promise_test(async t => {
     const link = document.createElement("link");
     link.crossOrigin = "anonymous";
     link.href = `${REMOTE_ORIGIN}/preload/resources/prefetch-info.py?key=${uid}&cors=false`;
-    const event = await prefetch(link, uid);
+    const event = await prefetch(link, uid, t);
     assert_equals(event, "error");
 }, "Prefetch should fire the error event for network errors");
 
@@ -56,7 +73,7 @@ promise_test(async t => {
     const uid = token();
     const link = document.createElement("link");
     link.crossOrigin = "anonymous";
-    const event = await prefetch(link, uid);
+    const event = await prefetch(link, uid, t);
     assert_equals(event, "timeout");
 }, "Prefetch should do nothing with an empty href");
 
@@ -65,7 +82,7 @@ promise_test(async t => {
     const link = document.createElement("link");
     link.href = "https://example.com\u0000mozilla.org";
     link.crossOrigin = "anonymous";
-    const event = await prefetch(link, uid);
+    const event = await prefetch(link, uid, t);
     assert_equals(event, "timeout");
 }, "Prefetch should do nothing with an invalid href");
 </script>

--- a/preload/prefetch-events.html
+++ b/preload/prefetch-events.html
@@ -41,40 +41,32 @@ promise_test(async t => {
     const link = document.createElement("link");
     link.href = `/preload/resources/prefetch-info.py?key=${uid}&status=404`;
     const event = await prefetch(link, uid, t);
-    assert_equals(event, "error");
-}, "Prefetch should fire the error event for 404");
+    assert_equals(event, "load");
+}, "Prefetch should fire the load event for 404");
 
 promise_test(async t => {
     const uid = token();
     const link = document.createElement("link");
     link.href = `${REMOTE_ORIGIN}/preload/resources/prefetch-info.py?key=${uid}&status=404`;
     const event = await prefetch(link, uid, t);
-    assert_equals(event, "error");
-}, "Prefetch should fire the error event for 404 (cross-origin)");
-
-promise_test(async t => {
-    const uid = token();
-    const link = document.createElement("link");
-    link.href = `${REMOTE_ORIGIN}/preload/resources/prefetch-info.py?key=${uid}&status=404`;
-    const event = await prefetch(link, uid, t);
-    assert_equals(event, "error");
-}, "Cross-origin prefetch should fire the error event for 404");
+    assert_equals(event, "load");
+}, "Prefetch should fire the load event for 404 (cross-origin)");
 
 promise_test(async t => {
     const uid = token();
     const link = document.createElement("link");
     link.href = `/preload/resources/prefetch-info.py?key=${uid}&status=500`;
     const event = await prefetch(link, uid, t);
-    assert_equals(event, "error");
-}, "Prefetch should fire the error event for 500");
+    assert_equals(event, "load");
+}, "Prefetch should fire the load event for 500");
 
 promise_test(async t => {
     const uid = token();
     const link = document.createElement("link");
     link.href = `${REMOTE_ORIGIN}/preload/resources/prefetch-info.py?key=${uid}&status=500`;
     const event = await prefetch(link, uid, t);
-    assert_equals(event, "error");
-}, "Cross-origin prefetch should fire the error event for 500");
+    assert_equals(event, "load");
+}, "Cross-origin prefetch should fire the load event for 500");
 
 promise_test(async t => {
     const uid = token();

--- a/preload/prefetch-events.html
+++ b/preload/prefetch-events.html
@@ -50,6 +50,14 @@ promise_test(async t => {
     link.href = `${REMOTE_ORIGIN}/preload/resources/prefetch-info.py?key=${uid}&status=404`;
     const event = await prefetch(link, uid, t);
     assert_equals(event, "error");
+}, "Prefetch should fire the error event for 404 (cross-origin)");
+
+promise_test(async t => {
+    const uid = token();
+    const link = document.createElement("link");
+    link.href = `${REMOTE_ORIGIN}/preload/resources/prefetch-info.py?key=${uid}&status=404`;
+    const event = await prefetch(link, uid, t);
+    assert_equals(event, "error");
 }, "Cross-origin prefetch should fire the error event for 404");
 
 promise_test(async t => {
@@ -59,6 +67,14 @@ promise_test(async t => {
     const event = await prefetch(link, uid, t);
     assert_equals(event, "error");
 }, "Prefetch should fire the error event for 500");
+
+promise_test(async t => {
+    const uid = token();
+    const link = document.createElement("link");
+    link.href = `${REMOTE_ORIGIN}/preload/resources/prefetch-info.py?key=${uid}&status=500`;
+    const event = await prefetch(link, uid, t);
+    assert_equals(event, "error");
+}, "Cross-origin prefetch should fire the error event for 500");
 
 promise_test(async t => {
     const uid = token();

--- a/preload/prefetch-headers.html
+++ b/preload/prefetch-headers.html
@@ -13,14 +13,22 @@ promise_test(async t => {
     const {headers} = info;
     assert_equals(headers["sec-fetch-dest"], "empty");
     assert_equals(headers["sec-purpose"], "prefetch");
-    assert_equals(headers["Origin"], undefined);
+    assert_false("origin" in headers);
 }, "Prefetch should include Sec-Purpose=prefetch and Sec-Fetch-Dest=empty headers");
+
+promise_test(async t => {
+    const {href} = await prefetch({"type": "image/png", file: "../../images/green.png"}, t);
+    const [info] = await get_prefetch_info(href);
+    const {headers} = info;
+    assert_false("purpose" in headers);
+    assert_false("x-moz" in headers);
+}, "Prefetch should not include proprietary headers (X-moz/Purpose)");
 
 promise_test(async t => {
     const {href} = await prefetch({"type": "image/png", file: "../../images/green.png", crossOrigin: "anonymous"}, t);
     const [info] = await get_prefetch_info(href);
     const {headers} = info;
-    assert_equals(headers["Origin"], document.origin);
+    assert_equals(headers["origin"], document.origin);
 }, "Prefetch should respect CORS mode");
 
 </script>

--- a/preload/prefetch-headers.html
+++ b/preload/prefetch-headers.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>Ensures that prefetch sends headers as per-spec</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="resources/prefetch-helper.js"></script>
+<body>
+<script>
+
+promise_test(async t => {
+    const {href} = await prefetch({"type": "image/png", file: "../../images/green.png"}, t);
+    const [info] = await get_prefetch_info(href);
+    const {headers} = info;
+    assert_equals(headers["sec-fetch-dest"], "empty");
+    assert_equals(headers["sec-purpose"], "prefetch");
+    assert_equals(headers["Origin"], undefined);
+}, "Prefetch should include Sec-Purpose=prefetch and Sec-Fetch-Dest=empty headers");
+
+promise_test(async t => {
+    const {href} = await prefetch({"type": "image/png", file: "../../images/green.png", crossOrigin: "anonymous"}, t);
+    const [info] = await get_prefetch_info(href);
+    const {headers} = info;
+    assert_equals(headers["Origin"], document.origin);
+}, "Prefetch should respect CORS mode");
+
+</script>
+</body>

--- a/preload/prefetch-load-event.html
+++ b/preload/prefetch-load-event.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<title>Ensures that prefetch respects cache headers</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/common/utils.js"></script>

--- a/preload/prefetch-load-event.html
+++ b/preload/prefetch-load-event.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>Ensures that prefetch respects cache headers</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<link rel="prefetch" href="/xhr/resources/delay.py?ms=100000">
+<body>
+<script>
+
+promise_test(() => new Promise(resolve => window.addEventListener("load", resolve)),
+    "Prefetch should not block the load event");
+
+</script>
+</body>

--- a/preload/prefetch-types.html
+++ b/preload/prefetch-types.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<title>Ensures that prefetch is not specific to resource types</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="resources/prefetch-helper.js"></script>
+<body>
+<script>
+const loaders = {
+    image: {
+        file: '../../images/green.png',
+        type: 'image/png',
+        load: href => {
+            const image = document.createElement('img');
+            image.src = href;
+            document.body.appendChild(image);
+            return new Promise(resolve => image.addEventListener('load', resolve));
+        }
+    },
+    script: {
+        file: 'dummy.js',
+        type: 'application/javascript',
+        load: href => {
+            const script = document.createElement('script');
+            script.src = href;
+            document.body.appendChild(script);
+            return new Promise(resolve => script.addEventListener('load', resolve));
+        }
+    },
+    style: {
+        file: 'dummy.css',
+        type: 'text/css',
+        load: href => {
+            const link = document.createElement('link');
+            link.href = href;
+            link.rel = "stylesheet";
+            document.body.appendChild(link);
+            return new Promise(resolve => link.addEventListener('load', resolve));
+        }
+    },
+    document: {
+        file: 'empty.html',
+        type: 'text/html',
+        load: href => {
+            const iframe = document.createElement("iframe");
+            iframe.src = href;
+            document.body.appendChild(iframe);
+            return new Promise(resolve => iframe.addEventListener("load", resolve));
+        }
+    }
+};
+
+for (const as in loaders) {
+    for (const consumer in loaders) {
+        const {file, type, load} = loaders[as]
+        promise_test(async t => {
+            const {href} = await prefetch({file, type, as, origin: host_info[origin]});
+            const requests = await get_prefetch_info(href);
+            assert_equals(requests.length, 1);
+        }, `Prefetch as=${as} should work when consumed as ${consumer} (${origin})`);
+    }
+}
+
+</script>
+</body>

--- a/preload/prefetch-types.html
+++ b/preload/prefetch-types.html
@@ -3,10 +3,17 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/common/utils.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script src="resources/prefetch-helper.js"></script>
 <body>
 <script>
+    const host_info = get_host_info();
 const loaders = {
+    "": {
+        file: "../../common/dummy.xml",
+        type: "text/xml",
+        load: fetch
+    },
     image: {
         file: '../../images/green.png',
         type: 'image/png',
@@ -57,6 +64,7 @@ for (const as in loaders) {
             const {href} = await prefetch({file, type, as, origin: host_info[origin]});
             const requests = await get_prefetch_info(href);
             assert_equals(requests.length, 1);
+            assert_equals(requests[0].headers["sec-fetch-dest"], "empty");
         }, `Prefetch as=${as} should work when consumed as ${consumer} (${origin})`);
     }
 }

--- a/preload/resources/prefetch-helper.js
+++ b/preload/resources/prefetch-helper.js
@@ -14,7 +14,7 @@ async function prefetch(p = {}, t) {
     params.set("key", uid);
     for (const key in p)
         params.set(key, p[key]);
-    const origin = p.origin || '.';
+    const origin = p.origin || '';
     link.href = `${origin}/preload/resources/prefetch-info.py?${params.toString()}`;
     document.head.appendChild(link);
     while (!(await get_prefetch_info(link.href)).length) { }

--- a/preload/resources/prefetch-helper.js
+++ b/preload/resources/prefetch-helper.js
@@ -6,8 +6,7 @@ async function get_prefetch_info(href) {
 async function prefetch(p = {}, t) {
     const link = document.createElement("link");
     link.rel = "prefetch";
-    if (p.as !== undefined)
-        link.as = p.as;
+    link.as = p.as;
     if (p.crossOrigin)
         link.setAttribute("crossorigin", p.crossOrigin);
     const uid = token();

--- a/preload/resources/prefetch-helper.js
+++ b/preload/resources/prefetch-helper.js
@@ -6,6 +6,7 @@ async function get_prefetch_info(href) {
 async function prefetch(p = {}, t) {
     const link = document.createElement("link");
     link.rel = "prefetch";
+    link.as = p.as;
     if (p.crossOrigin)
         link.setAttribute("crossorigin", p.crossOrigin);
     const uid = token();
@@ -13,7 +14,7 @@ async function prefetch(p = {}, t) {
     params.set("key", uid);
     for (const key in p)
         params.set(key, p[key]);
-    const origin = p.origin || '';
+    const origin = p.origin || '.';
     link.href = `${origin}/preload/resources/prefetch-info.py?${params.toString()}`;
     document.head.appendChild(link);
     while (!(await get_prefetch_info(link.href)).length) { }

--- a/preload/resources/prefetch-helper.js
+++ b/preload/resources/prefetch-helper.js
@@ -6,7 +6,8 @@ async function get_prefetch_info(href) {
 async function prefetch(p = {}, t) {
     const link = document.createElement("link");
     link.rel = "prefetch";
-    link.as = p.as;
+    if (p.as !== undefined)
+        link.as = p.as;
     if (p.crossOrigin)
         link.setAttribute("crossorigin", p.crossOrigin);
     const uid = token();


### PR DESCRIPTION
See https://github.com/whatwg/html/pull/8111#issuecomment-1229907894

Tests that:
* preload/prefetch-cache.html
  No 5 minute rule (cache headers must be respected)

* preload/prefetch-document.html
  No special treatment of as=document
  Whether Accept is left as its default value.
  Storage partitioning is applied, including for documents

* preload/prefetch-load-event.html
  Does not block the load event

* preload/prefetch-headers.html
  `Sec-Purpose` and `Sec-Destination` are correct
* preload/prefetch-types.html
  Always uses prefetch destination, and ignores as=""
  
* preload/prefetch-events.html
  Load & error events are fired, and invalid/empty hrefs are ignored.
