### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=243887

### DIFF
--- a/css/css-flexbox/flex-item-transferred-sizes-padding-border-sizing.html
+++ b/css/css-flexbox/flex-item-transferred-sizes-padding-border-sizing.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com" />
+    <link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers" />
+    <link rel="help" href="https://drafts.csswg.org/css-sizing-3/#min-width" />
+    <link rel="help" href="https://drafts.csswg.org/css-sizing/#box-sizing" />
+    <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=243887" />
+    <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
+  </head>
+  <!-- The box should be a 100px x 100px green square. The initial width should
+       be 90px due to the  transferred min-width constraint from the specified
+       min-height. Since box-sizing is border-box, 10px will be removed from
+       the min-height (padding on the top and bottom of the box), and 90px will
+       be used to compute the transferred min-width. 5px of padding will then
+       be added on all sides of the 90px x 90px box to give it a resulting
+       size of 100px x 100px. -->
+  <style>
+    .flexContainer {
+      display: flex;
+      flex-direction: column;
+      float: left;
+    }
+    .item {
+      background: green;
+      padding-left: 25px;
+      padding-right: 25px;
+      box-sizing: border-box;
+    }
+  </style>
+  <body>
+    <div class="flexContainer">
+      <div class="item" style="min-height:100px; aspect-ratio: 1/1;"></div>
+    </div>
+  </body>
+</html>

--- a/css/css-flexbox/flex-item-transferred-sizes-padding-content-sizing.html
+++ b/css/css-flexbox/flex-item-transferred-sizes-padding-content-sizing.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com" />
+    <link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers" />
+    <link rel="help" href="https://drafts.csswg.org/css-sizing-3/#min-width" />
+    <link rel="help" href="https://drafts.csswg.org/css-sizing/#box-sizing" />
+    <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=243887" />
+    <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
+  </head>
+  <!-- Item div should be a 100px x 100px square. Content width will be 90px,
+       which comes from the min-height constraint being transferred to the
+       min-width. 5px padding on all sides will give the box a resulting
+       size of 100x x 100px. -->
+  <style>
+    .flexContainer {
+      display: flex;
+      flex-direction: column;
+      float: left;
+    }
+    .item {
+      background: green;
+      padding: 5px 5px 5px 5px;
+    }
+  </style>
+  <body>
+    <div class="flexContainer">
+      <div class="item" style="min-height:90px; aspect-ratio: 1/1;"></div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
There was a WebKit bug which was causing border and padding to be incorrectly
added when the size of a flex item was computed through the transferred
constraints. These two tests check that the sizes of these boxes are computed
correctly in both the content-box and border-box cases.

https://bugs.webkit.org/show_bug.cgi?id=243887