### PR TITLE
Create wpt manifests with selected files or directories

### DIFF
--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -389,7 +389,7 @@ def load_and_update(tests_root,  # type: Text
                     write_manifest=True,  # type: bool
                     allow_cached=True,  # type: bool
                     parallel=True,  # type: bool
-                    sub_dirs=None, # type: Optional[List]
+                    sub_dirs=None,  # type: Optional[list[str]]
                     ):
     # type: (...) -> Manifest
 

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -388,7 +388,8 @@ def load_and_update(tests_root,  # type: Text
                     types=None,  # type: Optional[Container[Text]]
                     write_manifest=True,  # type: bool
                     allow_cached=True,  # type: bool
-                    parallel=True  # type: bool
+                    parallel=True,  # type: bool
+                    sub_dirs=None, # type: Optional[List]
                     ):
     # type: (...) -> Manifest
 
@@ -421,7 +422,7 @@ def load_and_update(tests_root,  # type: Text
         for retry in range(2):
             try:
                 tree = vcs.get_tree(tests_root, manifest, manifest_path, cache_root,
-                                    working_copy, rebuild)
+                                    working_copy, rebuild, sub_dirs)
                 changed = manifest.update(tree, parallel)
                 break
             except InvalidCacheError:

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -30,6 +30,7 @@ if MYPY:
     from typing import IO
     from typing import Iterator
     from typing import Iterable
+    from typing import List
     from typing import Optional
     from typing import Set
     from typing import Text
@@ -389,7 +390,7 @@ def load_and_update(tests_root,  # type: Text
                     write_manifest=True,  # type: bool
                     allow_cached=True,  # type: bool
                     parallel=True,  # type: bool
-                    sub_dirs=None,  # type: Optional[list[str]]
+                    sub_dirs=None,  # type: Optional[List[str]]
                     ):
     # type: (...) -> Manifest
 

--- a/tools/manifest/update.py
+++ b/tools/manifest/update.py
@@ -27,14 +27,15 @@ def update(tests_root,  # type: str
            working_copy=True,  # type: bool
            cache_root=None,  # type: Optional[str]
            rebuild=False,  # type: bool
-           parallel=True  # type: bool
+           parallel=True, # type: bool
+           sub_dirs=None # type: Optional[list]
            ):
     # type: (...) -> bool
     logger.warning("Deprecated; use manifest.load_and_update instead")
     logger.info("Updating manifest")
 
     tree = vcs.get_tree(tests_root, manifest, manifest_path, cache_root,
-                        working_copy, rebuild)
+                        working_copy, rebuild, sub_dirs)
     return manifest.update(tree, parallel)
 
 
@@ -53,7 +54,8 @@ def update_from_cli(**kwargs):
                              update=True,
                              rebuild=kwargs["rebuild"],
                              cache_root=kwargs["cache_root"],
-                             parallel=kwargs["parallel"])
+                             parallel=kwargs["parallel"],
+                             sub_dirs=kwargs["dirs"])
 
 
 def abs_path(path):
@@ -86,6 +88,8 @@ def create_parser():
     parser.add_argument(
         "--no-parallel", dest="parallel", action="store_false", default=True,
         help="Do not parallelize building the manifest")
+    parser.add_argument('dirs', nargs='*', default=[],
+                        help='sub directories or files relative to the tests root to update.')
     return parser
 
 

--- a/tools/manifest/update.py
+++ b/tools/manifest/update.py
@@ -27,8 +27,8 @@ def update(tests_root,  # type: str
            working_copy=True,  # type: bool
            cache_root=None,  # type: Optional[str]
            rebuild=False,  # type: bool
-           parallel=True, # type: bool
-           sub_dirs=None # type: Optional[list]
+           parallel=True,  # type: bool
+           sub_dirs=None  # type: Optional[list[str]]
            ):
     # type: (...) -> bool
     logger.warning("Deprecated; use manifest.load_and_update instead")

--- a/tools/manifest/update.py
+++ b/tools/manifest/update.py
@@ -17,6 +17,7 @@ MYPY = False
 if MYPY:
     # MYPY is set to True when run under Mypy.
     from typing import Any
+    from typing import List
     from typing import Optional
     from .manifest import Manifest  # avoid cyclic import
 
@@ -28,7 +29,7 @@ def update(tests_root,  # type: str
            cache_root=None,  # type: Optional[str]
            rebuild=False,  # type: bool
            parallel=True,  # type: bool
-           sub_dirs=None  # type: Optional[list[str]]
+           sub_dirs=None  # type: Optional[List[str]]
            ):
     # type: (...) -> bool
     logger.warning("Deprecated; use manifest.load_and_update instead")

--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -26,7 +26,7 @@ else:
 
 def get_tree(tests_root, manifest, manifest_path, cache_root,
              working_copy=True, rebuild=False, sub_dirs=None):
-  # type: (Text, Manifest, Optional[Text], Optional[Text], bool, bool, Optional[list[str]]) -> FileSystem
+    # type: (Text, Manifest, Optional[Text], Optional[Text], bool, bool, Optional[list[str]]) -> FileSystem
     tree = None
     if cache_root is None:
         cache_root = os.path.join(tests_root, ".wptcache")

--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -26,8 +26,7 @@ else:
 
 def get_tree(tests_root, manifest, manifest_path, cache_root,
              working_copy=True, rebuild=False, sub_dirs=None):
-    # type: (Text, Manifest, Optional[Text], Optional[Text], bool, bool,
-    # Optional[list]) -> FileSystem
+  # type: (Text, Manifest, Optional[Text], Optional[Text], bool, bool, Optional[list[str]]) -> FileSystem
     tree = None
     if cache_root is None:
         cache_root = os.path.join(tests_root, ".wptcache")
@@ -89,7 +88,7 @@ class GitHasher:
 
 class FileSystem:
     def __init__(self, tests_root, url_base, cache_path, manifest_path=None, rebuild=False, sub_dirs=None):
-        # type: (Text, Text, Optional[Text], Optional[Text], bool, Optional[list]) -> None
+        # type: (Text, Text, Optional[Text], Optional[Text], bool, Optional[list[str]]) -> None
         self.tests_root = tests_root
         self.sub_dirs = sub_dirs or ['']
         self.url_base = url_base
@@ -110,6 +109,7 @@ class FileSystem:
     def __iter__(self):
         # type: () -> Iterator[Tuple[Text, Optional[Text], bool]]
         def path_and_hash(mtime_cache, path, path_stat):
+            # type: (Optional[MtimeCache], str, os.stat_result) -> tuple[str, Optional[str], bool]
             if mtime_cache is None or mtime_cache.updated(path, path_stat):
                 file_hash = self.hash_cache.get(path, None)
                 return path, file_hash, True

--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -26,7 +26,7 @@ else:
 
 def get_tree(tests_root, manifest, manifest_path, cache_root,
              working_copy=True, rebuild=False, sub_dirs=None):
-    # type: (Text, Manifest, Optional[Text], Optional[Text], bool, bool, Optional[list[str]]) -> FileSystem
+    # type: (Text, Manifest, Optional[Text], Optional[Text], bool, bool, Optional[List[str]]) -> FileSystem
     tree = None
     if cache_root is None:
         cache_root = os.path.join(tests_root, ".wptcache")
@@ -88,7 +88,7 @@ class GitHasher:
 
 class FileSystem:
     def __init__(self, tests_root, url_base, cache_path, manifest_path=None, rebuild=False, sub_dirs=None):
-        # type: (Text, Text, Optional[Text], Optional[Text], bool, Optional[list[str]]) -> None
+        # type: (Text, Text, Optional[Text], Optional[Text], bool, Optional[List[str]]) -> None
         self.tests_root = tests_root
         self.sub_dirs = sub_dirs or ['']
         self.url_base = url_base
@@ -109,7 +109,7 @@ class FileSystem:
     def __iter__(self):
         # type: () -> Iterator[Tuple[Text, Optional[Text], bool]]
         def path_and_hash(mtime_cache, path, path_stat):
-            # type: (Optional[MtimeCache], str, os.stat_result) -> tuple[str, Optional[str], bool]
+            # type: (Optional[MtimeCache], str, os.stat_result) -> Tuple[str, Optional[str], bool]
             if mtime_cache is None or mtime_cache.updated(path, path_stat):
                 file_hash = self.hash_cache.get(path, None)
                 return path, file_hash, True


### PR DESCRIPTION
wpt manifest now accepts a paramter --tests-root, then scans and adds all
the files under tests root to the manifest. With this change we can
selectively add sub directories to the manifest.

Reason: we now have public wpt, internal wpt and legacy tests under the
same top test folder. We want to set the tests root to the top folder,
but do not include the legacy tests in the manifest.

We will generate the manifest in a wrapper, and pass
'--no-manifest-update' to wpt run when running the tests.