### PR TITLE
Add tests for "script.getRealms" command.

### DIFF
--- a/tools/webdriver/webdriver/bidi/modules/_module.py
+++ b/tools/webdriver/webdriver/bidi/modules/_module.py
@@ -60,7 +60,7 @@ class command:
 
         @functools.wraps(params_fn)
         async def inner(self: Any, **kwargs: Any) -> Any:
-            raw_response = kwargs.pop("raw_response", False)
+            raw_result = kwargs.pop("raw_result", False)
             params = params_fn(self, **kwargs)
 
             # Convert the classname and the method name to a bidi command name
@@ -72,7 +72,7 @@ class command:
             future = await self.session.send_command(cmd_name, params)
             result = await future
 
-            if result_fn is not None and not raw_response:
+            if result_fn is not None and not raw_result:
                 # Convert the result if we have a conversion function defined
                 result = result_fn(self, result)
             return result

--- a/webdriver/tests/bidi/conftest.py
+++ b/webdriver/tests/bidi/conftest.py
@@ -2,6 +2,16 @@ import pytest
 
 
 @pytest.fixture
+def test_origin(url):
+    return url("")
+
+
+@pytest.fixture
+def test_alt_origin(url):
+    return url("", domain="alt")
+
+
+@pytest.fixture
 def test_page(inline):
     return inline("<div>foo</div>")
 
@@ -18,7 +28,9 @@ def test_page_cross_origin(inline):
 
 @pytest.fixture
 def test_page_multiple_frames(inline, test_page, test_page2):
-    return inline(f"<iframe src='{test_page}'></iframe><iframe src='{test_page2}'></iframe>")
+    return inline(
+        f"<iframe src='{test_page}'></iframe><iframe src='{test_page2}'></iframe>"
+    )
 
 
 @pytest.fixture

--- a/webdriver/tests/bidi/script/get_realms/context.py
+++ b/webdriver/tests/bidi/script/get_realms/context.py
@@ -20,7 +20,8 @@ async def test_context(
     )
 
     # Evaluate to get realm id
-    new_context_result = await bidi_session.script.evaluate_raw(
+    new_context_result = await bidi_session.script.evaluate(
+        raw_response=True,
         expression="1 + 2",
         target=ContextTarget(new_context["context"]),
         await_promise=False,
@@ -47,7 +48,8 @@ async def test_context(
     frame_context = frames[0]["context"]
 
     # Evaluate to get realm id
-    frame_context_result = await bidi_session.script.evaluate_raw(
+    frame_context_result = await bidi_session.script.evaluate(
+        raw_response=True,
         expression="1 + 2",
         target=ContextTarget(frame_context),
         await_promise=False,

--- a/webdriver/tests/bidi/script/get_realms/context.py
+++ b/webdriver/tests/bidi/script/get_realms/context.py
@@ -21,7 +21,7 @@ async def test_context(
 
     # Evaluate to get realm id
     new_context_result = await bidi_session.script.evaluate(
-        raw_response=True,
+        raw_result=True,
         expression="1 + 2",
         target=ContextTarget(new_context["context"]),
         await_promise=False,
@@ -49,7 +49,7 @@ async def test_context(
 
     # Evaluate to get realm id
     frame_context_result = await bidi_session.script.evaluate(
-        raw_response=True,
+        raw_result=True,
         expression="1 + 2",
         target=ContextTarget(frame_context),
         await_promise=False,

--- a/webdriver/tests/bidi/script/get_realms/context.py
+++ b/webdriver/tests/bidi/script/get_realms/context.py
@@ -1,0 +1,68 @@
+import pytest
+
+from webdriver.bidi.modules.script import ContextTarget
+
+from ... import recursive_compare
+
+
+@pytest.mark.asyncio
+async def test_context(
+    bidi_session,
+    test_alt_origin,
+    test_origin,
+    test_page_cross_origin_frame,
+):
+    new_context = await bidi_session.browsing_context.create(type_hint="tab")
+    await bidi_session.browsing_context.navigate(
+        context=new_context["context"],
+        url=test_page_cross_origin_frame,
+        wait="complete",
+    )
+
+    # Evaluate to get realm id
+    new_context_result = await bidi_session.script.evaluate_raw(
+        expression="1 + 2",
+        target=ContextTarget(new_context["context"]),
+        await_promise=False,
+    )
+
+    result = await bidi_session.script.get_realms(context=new_context["context"])
+
+    recursive_compare(
+        [
+            {
+                "context": new_context["context"],
+                "origin": test_origin,
+                "realm": new_context_result["realm"],
+                "type": "window",
+            },
+        ],
+        result,
+    )
+
+    contexts = await bidi_session.browsing_context.get_tree(root=new_context["context"])
+    assert len(contexts) == 1
+    frames = contexts[0]["children"]
+    assert len(frames) == 1
+    frame_context = frames[0]["context"]
+
+    # Evaluate to get realm id
+    frame_context_result = await bidi_session.script.evaluate_raw(
+        expression="1 + 2",
+        target=ContextTarget(frame_context),
+        await_promise=False,
+    )
+
+    result = await bidi_session.script.get_realms(context=frame_context)
+
+    recursive_compare(
+        [
+            {
+                "context": frame_context,
+                "origin": test_alt_origin,
+                "realm": frame_context_result["realm"],
+                "type": "window",
+            },
+        ],
+        result,
+    )

--- a/webdriver/tests/bidi/script/get_realms/get_realms.py
+++ b/webdriver/tests/bidi/script/get_realms/get_realms.py
@@ -54,12 +54,14 @@ async def test_multiple_top_level_contexts(bidi_session, top_context, type_hint)
     result = await bidi_session.script.get_realms()
 
     # Evaluate to get realm ids
-    top_context_result = await bidi_session.script.evaluate_raw(
+    top_context_result = await bidi_session.script.evaluate(
+        raw_response=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"]),
         await_promise=False,
     )
-    new_context_result = await bidi_session.script.evaluate_raw(
+    new_context_result = await bidi_session.script.evaluate(
+        raw_response=True,
         expression="1 + 2",
         target=ContextTarget(new_context["context"]),
         await_promise=False,
@@ -101,7 +103,8 @@ async def test_iframes(
     result = await bidi_session.script.get_realms()
 
     # Evaluate to get realm id
-    top_context_result = await bidi_session.script.evaluate_raw(
+    top_context_result = await bidi_session.script.evaluate(
+        raw_response=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"]),
         await_promise=False,
@@ -114,7 +117,8 @@ async def test_iframes(
     frame_context = frames[0]["context"]
 
     # Evaluate to get realm id
-    frame_context_result = await bidi_session.script.evaluate_raw(
+    frame_context_result = await bidi_session.script.evaluate(
+        raw_response=True,
         expression="1 + 2",
         target=ContextTarget(frame_context),
         await_promise=False,
@@ -154,7 +158,8 @@ async def test_origin(bidi_session, inline, top_context, test_origin):
     result = await bidi_session.script.get_realms()
 
     # Evaluate to get realm id
-    top_context_result = await bidi_session.script.evaluate_raw(
+    top_context_result = await bidi_session.script.evaluate(
+        raw_response=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"]),
         await_promise=False,

--- a/webdriver/tests/bidi/script/get_realms/get_realms.py
+++ b/webdriver/tests/bidi/script/get_realms/get_realms.py
@@ -25,7 +25,7 @@ async def test_payload_types(bidi_session):
 
 
 @pytest.mark.asyncio
-async def test_realm_is_consisnent_when_calling_twice(bidi_session):
+async def test_realm_is_consistent_when_calling_twice(bidi_session):
     result = await bidi_session.script.get_realms()
 
     result_calling_again = await bidi_session.script.get_realms()

--- a/webdriver/tests/bidi/script/get_realms/get_realms.py
+++ b/webdriver/tests/bidi/script/get_realms/get_realms.py
@@ -55,13 +55,13 @@ async def test_multiple_top_level_contexts(bidi_session, top_context, type_hint)
 
     # Evaluate to get realm ids
     top_context_result = await bidi_session.script.evaluate(
-        raw_response=True,
+        raw_result=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"]),
         await_promise=False,
     )
     new_context_result = await bidi_session.script.evaluate(
-        raw_response=True,
+        raw_result=True,
         expression="1 + 2",
         target=ContextTarget(new_context["context"]),
         await_promise=False,
@@ -104,7 +104,7 @@ async def test_iframes(
 
     # Evaluate to get realm id
     top_context_result = await bidi_session.script.evaluate(
-        raw_response=True,
+        raw_result=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"]),
         await_promise=False,
@@ -118,7 +118,7 @@ async def test_iframes(
 
     # Evaluate to get realm id
     frame_context_result = await bidi_session.script.evaluate(
-        raw_response=True,
+        raw_result=True,
         expression="1 + 2",
         target=ContextTarget(frame_context),
         await_promise=False,
@@ -159,7 +159,7 @@ async def test_origin(bidi_session, inline, top_context, test_origin):
 
     # Evaluate to get realm id
     top_context_result = await bidi_session.script.evaluate(
-        raw_response=True,
+        raw_result=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"]),
         await_promise=False,

--- a/webdriver/tests/bidi/script/get_realms/get_realms.py
+++ b/webdriver/tests/bidi/script/get_realms/get_realms.py
@@ -25,7 +25,7 @@ async def test_payload_types(bidi_session):
 
 
 @pytest.mark.asyncio
-async def test_calling_twice(bidi_session):
+async def test_realm_is_consisnent_when_calling_twice(bidi_session):
     result = await bidi_session.script.get_realms()
 
     result_calling_again = await bidi_session.script.get_realms()
@@ -34,7 +34,7 @@ async def test_calling_twice(bidi_session):
 
 
 @pytest.mark.asyncio
-async def test_reload(bidi_session, top_context):
+async def test_realm_is_different_after_reload(bidi_session, top_context):
     result = await bidi_session.script.get_realms()
 
     # Reload the page

--- a/webdriver/tests/bidi/script/get_realms/get_realms.py
+++ b/webdriver/tests/bidi/script/get_realms/get_realms.py
@@ -1,0 +1,178 @@
+import pytest
+
+from webdriver.bidi.modules.script import ContextTarget
+
+from ... import any_string, recursive_compare
+
+PAGE_ABOUT_BLANK = "about:blank"
+
+
+@pytest.mark.asyncio
+async def test_payload_types(bidi_session):
+    result = await bidi_session.script.get_realms()
+
+    recursive_compare(
+        [
+            {
+                "context": any_string,
+                "origin": any_string,
+                "realm": any_string,
+                "type": any_string,
+            }
+        ],
+        result,
+    )
+
+
+@pytest.mark.asyncio
+async def test_calling_twice(bidi_session):
+    result = await bidi_session.script.get_realms()
+
+    result_calling_again = await bidi_session.script.get_realms()
+
+    assert result[0]["realm"] == result_calling_again[0]["realm"]
+
+
+@pytest.mark.asyncio
+async def test_reload(bidi_session, top_context):
+    result = await bidi_session.script.get_realms()
+
+    # Reload the page
+    await bidi_session.browsing_context.navigate(
+        context=top_context["context"], url=PAGE_ABOUT_BLANK, wait="complete"
+    )
+
+    result_after_reload = await bidi_session.script.get_realms()
+
+    assert result[0]["realm"] != result_after_reload[0]["realm"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("type_hint", ["tab", "window"])
+async def test_multiple_top_level_contexts(bidi_session, top_context, type_hint):
+    new_context = await bidi_session.browsing_context.create(type_hint=type_hint)
+    result = await bidi_session.script.get_realms()
+
+    # Evaluate to get realm ids
+    top_context_result = await bidi_session.script.evaluate_raw(
+        expression="1 + 2",
+        target=ContextTarget(top_context["context"]),
+        await_promise=False,
+    )
+    new_context_result = await bidi_session.script.evaluate_raw(
+        expression="1 + 2",
+        target=ContextTarget(new_context["context"]),
+        await_promise=False,
+    )
+
+    recursive_compare(
+        [
+            {
+                "context": top_context["context"],
+                "origin": "null",
+                "realm": top_context_result["realm"],
+                "type": "window",
+            },
+            {
+                "context": new_context["context"],
+                "origin": "null",
+                "realm": new_context_result["realm"],
+                "type": "window",
+            },
+        ],
+        result,
+    )
+
+
+@pytest.mark.asyncio
+async def test_iframes(
+    bidi_session,
+    top_context,
+    test_alt_origin,
+    test_origin,
+    test_page_cross_origin_frame,
+):
+    await bidi_session.browsing_context.navigate(
+        context=top_context["context"],
+        url=test_page_cross_origin_frame,
+        wait="complete",
+    )
+
+    result = await bidi_session.script.get_realms()
+
+    # Evaluate to get realm id
+    top_context_result = await bidi_session.script.evaluate_raw(
+        expression="1 + 2",
+        target=ContextTarget(top_context["context"]),
+        await_promise=False,
+    )
+
+    contexts = await bidi_session.browsing_context.get_tree(root=top_context["context"])
+    assert len(contexts) == 1
+    frames = contexts[0]["children"]
+    assert len(frames) == 1
+    frame_context = frames[0]["context"]
+
+    # Evaluate to get realm id
+    frame_context_result = await bidi_session.script.evaluate_raw(
+        expression="1 + 2",
+        target=ContextTarget(frame_context),
+        await_promise=False,
+    )
+
+    recursive_compare(
+        [
+            {
+                "context": top_context["context"],
+                "origin": test_origin,
+                "realm": top_context_result["realm"],
+                "type": "window",
+            },
+            {
+                "context": frame_context,
+                "origin": test_alt_origin,
+                "realm": frame_context_result["realm"],
+                "type": "window",
+            },
+        ],
+        result,
+    )
+
+    # Clean up origin
+    await bidi_session.browsing_context.navigate(
+        context=top_context["context"], url=PAGE_ABOUT_BLANK, wait="complete"
+    )
+
+
+@pytest.mark.asyncio
+async def test_origin(bidi_session, inline, top_context, test_origin):
+    url = inline("<div>foo</div>")
+    await bidi_session.browsing_context.navigate(
+        context=top_context["context"], url=url, wait="complete"
+    )
+
+    result = await bidi_session.script.get_realms()
+
+    # Evaluate to get realm id
+    top_context_result = await bidi_session.script.evaluate_raw(
+        expression="1 + 2",
+        target=ContextTarget(top_context["context"]),
+        await_promise=False,
+    )
+
+    recursive_compare(
+        [
+            {
+                "context": top_context["context"],
+                "origin": test_origin,
+                "realm": top_context_result["realm"],
+                "type": "window",
+            }
+        ],
+        result,
+    )
+
+    # Clean up origin
+    await bidi_session.browsing_context.navigate(
+        context=top_context["context"], url=PAGE_ABOUT_BLANK, wait="complete"
+    )

--- a/webdriver/tests/bidi/script/get_realms/invalid.py
+++ b/webdriver/tests/bidi/script/get_realms/invalid.py
@@ -1,0 +1,26 @@
+import pytest
+import webdriver.bidi.error as error
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.mark.parametrize("context", [False, 42, {}, []])
+async def test_params_context_invalid_type(bidi_session, context):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.script.get_realms(context=context)
+
+
+async def test_params_context_invalid_value(bidi_session):
+    with pytest.raises(error.NoSuchFrameException):
+        await bidi_session.script.get_realms(context="foo")
+
+
+@pytest.mark.parametrize("type", [False, 42, {}, []])
+async def test_params_type_invalid_type(bidi_session, type):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.script.get_realms(type=type)
+
+
+async def test_params_type_invalid_value(bidi_session):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.script.get_realms(type="foo")

--- a/webdriver/tests/bidi/script/get_realms/sandbox.py
+++ b/webdriver/tests/bidi/script/get_realms/sandbox.py
@@ -10,7 +10,7 @@ PAGE_ABOUT_BLANK = "about:blank"
 @pytest.mark.asyncio
 async def test_sandbox(bidi_session, top_context):
     evaluate_result = await bidi_session.script.evaluate(
-        raw_response=True,
+        raw_result=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"]),
         await_promise=False,
@@ -18,7 +18,7 @@ async def test_sandbox(bidi_session, top_context):
 
     # Create a sandbox
     evaluate_in_sandbox_result = await bidi_session.script.evaluate(
-        raw_response=True,
+        raw_result=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"], "sandbox"),
         await_promise=False,
@@ -59,7 +59,7 @@ async def test_origin(bidi_session, inline, top_context, test_origin):
     )
 
     evaluate_result = await bidi_session.script.evaluate(
-        raw_response=True,
+        raw_result=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"]),
         await_promise=False,
@@ -67,7 +67,7 @@ async def test_origin(bidi_session, inline, top_context, test_origin):
 
     # Create a sandbox
     evaluate_in_sandbox_result = await bidi_session.script.evaluate(
-        raw_response=True,
+        raw_result=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"], "sandbox"),
         await_promise=False,
@@ -103,7 +103,7 @@ async def test_origin(bidi_session, inline, top_context, test_origin):
 @pytest.mark.asyncio
 async def test_type(bidi_session, top_context):
     evaluate_result = await bidi_session.script.evaluate(
-        raw_response=True,
+        raw_result=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"]),
         await_promise=False,
@@ -111,7 +111,7 @@ async def test_type(bidi_session, top_context):
 
     # Create a sandbox
     evaluate_in_sandbox_result = await bidi_session.script.evaluate(
-        raw_response=True,
+        raw_result=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"], "sandbox"),
         await_promise=False,
@@ -162,7 +162,7 @@ async def test_multiple_top_level_contexts(
     )
 
     evaluate_result = await bidi_session.script.evaluate(
-        raw_response=True,
+        raw_result=True,
         expression="1 + 2",
         target=ContextTarget(new_context["context"]),
         await_promise=False,
@@ -170,7 +170,7 @@ async def test_multiple_top_level_contexts(
 
     # Create a sandbox
     evaluate_in_sandbox_result = await bidi_session.script.evaluate(
-        raw_response=True,
+        raw_result=True,
         expression="1 + 2",
         target=ContextTarget(new_context["context"], "sandbox"),
         await_promise=False,
@@ -203,7 +203,7 @@ async def test_multiple_top_level_contexts(
     frame_context = frames[0]["context"]
 
     evaluate_result = await bidi_session.script.evaluate(
-        raw_response=True,
+        raw_result=True,
         expression="1 + 2",
         target=ContextTarget(frame_context),
         await_promise=False,
@@ -211,7 +211,7 @@ async def test_multiple_top_level_contexts(
 
     # Create a sandbox in iframe
     evaluate_in_sandbox_result = await bidi_session.script.evaluate(
-        raw_response=True,
+        raw_result=True,
         expression="1 + 2",
         target=ContextTarget(frame_context, "sandbox"),
         await_promise=False,

--- a/webdriver/tests/bidi/script/get_realms/sandbox.py
+++ b/webdriver/tests/bidi/script/get_realms/sandbox.py
@@ -1,0 +1,228 @@
+import pytest
+
+from webdriver.bidi.modules.script import ContextTarget
+
+from ... import recursive_compare
+
+PAGE_ABOUT_BLANK = "about:blank"
+
+
+@pytest.mark.asyncio
+async def test_sandbox(bidi_session, top_context):
+    evaluate_result = await bidi_session.script.evaluate_raw(
+        expression="1 + 2",
+        target=ContextTarget(top_context["context"]),
+        await_promise=False,
+    )
+
+    # Create a sandbox
+    evaluate_in_sandbox_result = await bidi_session.script.evaluate_raw(
+        expression="1 + 2",
+        target=ContextTarget(top_context["context"], "sandbox"),
+        await_promise=False,
+    )
+
+    result = await bidi_session.script.get_realms()
+
+    recursive_compare(
+        [
+            {
+                "context": top_context["context"],
+                "origin": "null",
+                "realm": evaluate_result["realm"],
+                "type": "window",
+            },
+            {
+                "context": top_context["context"],
+                "origin": "null",
+                "realm": evaluate_in_sandbox_result["realm"],
+                "sandbox": "sandbox",
+                "type": "window",
+            },
+        ],
+        result,
+    )
+
+    # Reload to clean up sandboxes
+    await bidi_session.browsing_context.navigate(
+        context=top_context["context"], url=PAGE_ABOUT_BLANK, wait="complete"
+    )
+
+
+@pytest.mark.asyncio
+async def test_origin(bidi_session, inline, top_context, test_origin):
+    url = inline("<div>foo</div>")
+    await bidi_session.browsing_context.navigate(
+        context=top_context["context"], url=url, wait="complete"
+    )
+
+    evaluate_result = await bidi_session.script.evaluate_raw(
+        expression="1 + 2",
+        target=ContextTarget(top_context["context"]),
+        await_promise=False,
+    )
+
+    # Create a sandbox
+    evaluate_in_sandbox_result = await bidi_session.script.evaluate_raw(
+        expression="1 + 2",
+        target=ContextTarget(top_context["context"], "sandbox"),
+        await_promise=False,
+    )
+
+    result = await bidi_session.script.get_realms()
+
+    recursive_compare(
+        [
+            {
+                "context": top_context["context"],
+                "origin": test_origin,
+                "realm": evaluate_result["realm"],
+                "type": "window",
+            },
+            {
+                "context": top_context["context"],
+                "origin": test_origin,
+                "realm": evaluate_in_sandbox_result["realm"],
+                "sandbox": "sandbox",
+                "type": "window",
+            },
+        ],
+        result,
+    )
+
+    # Reload to clean up sandboxes
+    await bidi_session.browsing_context.navigate(
+        context=top_context["context"], url=PAGE_ABOUT_BLANK, wait="complete"
+    )
+
+
+@pytest.mark.asyncio
+async def test_type(bidi_session, top_context):
+    evaluate_result = await bidi_session.script.evaluate_raw(
+        expression="1 + 2",
+        target=ContextTarget(top_context["context"]),
+        await_promise=False,
+    )
+
+    # Create a sandbox
+    evaluate_in_sandbox_result = await bidi_session.script.evaluate_raw(
+        expression="1 + 2",
+        target=ContextTarget(top_context["context"], "sandbox"),
+        await_promise=False,
+    )
+
+    # Should be extended when more types are supported
+    result = await bidi_session.script.get_realms(type="window")
+
+    recursive_compare(
+        [
+            {
+                "context": top_context["context"],
+                "origin": "null",
+                "realm": evaluate_result["realm"],
+                "type": "window",
+            },
+            {
+                "context": top_context["context"],
+                "origin": "null",
+                "realm": evaluate_in_sandbox_result["realm"],
+                "sandbox": "sandbox",
+                "type": "window",
+            },
+        ],
+        result,
+    )
+
+    # Reload to clean up sandboxes
+    await bidi_session.browsing_context.navigate(
+        context=top_context["context"], url=PAGE_ABOUT_BLANK, wait="complete"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("type_hint", ["tab", "window"])
+async def test_multiple_top_level_contexts(
+    bidi_session,
+    test_alt_origin,
+    test_origin,
+    test_page_cross_origin_frame,
+    type_hint,
+):
+    new_context = await bidi_session.browsing_context.create(type_hint=type_hint)
+    await bidi_session.browsing_context.navigate(
+        context=new_context["context"],
+        url=test_page_cross_origin_frame,
+        wait="complete",
+    )
+
+    evaluate_result = await bidi_session.script.evaluate_raw(
+        expression="1 + 2",
+        target=ContextTarget(new_context["context"]),
+        await_promise=False,
+    )
+
+    # Create a sandbox
+    evaluate_in_sandbox_result = await bidi_session.script.evaluate_raw(
+        expression="1 + 2",
+        target=ContextTarget(new_context["context"], "sandbox"),
+        await_promise=False,
+    )
+
+    result = await bidi_session.script.get_realms(context=new_context["context"])
+    recursive_compare(
+        [
+            {
+                "context": new_context["context"],
+                "origin": test_origin,
+                "realm": evaluate_result["realm"],
+                "type": "window",
+            },
+            {
+                "context": new_context["context"],
+                "origin": test_origin,
+                "realm": evaluate_in_sandbox_result["realm"],
+                "sandbox": "sandbox",
+                "type": "window",
+            },
+        ],
+        result,
+    )
+
+    contexts = await bidi_session.browsing_context.get_tree(root=new_context["context"])
+    assert len(contexts) == 1
+    frames = contexts[0]["children"]
+    assert len(frames) == 1
+    frame_context = frames[0]["context"]
+
+    evaluate_result = await bidi_session.script.evaluate_raw(
+        expression="1 + 2",
+        target=ContextTarget(frame_context),
+        await_promise=False,
+    )
+
+    # Create a sandbox in iframe
+    evaluate_in_sandbox_result = await bidi_session.script.evaluate_raw(
+        expression="1 + 2",
+        target=ContextTarget(frame_context, "sandbox"),
+        await_promise=False,
+    )
+
+    result = await bidi_session.script.get_realms(context=frame_context)
+    recursive_compare(
+        [
+            {
+                "context": frame_context,
+                "origin": test_alt_origin,
+                "realm": evaluate_result["realm"],
+                "type": "window",
+            },
+            {
+                "context": frame_context,
+                "origin": test_alt_origin,
+                "realm": evaluate_in_sandbox_result["realm"],
+                "sandbox": "sandbox",
+                "type": "window",
+            },
+        ],
+        result,
+    )

--- a/webdriver/tests/bidi/script/get_realms/sandbox.py
+++ b/webdriver/tests/bidi/script/get_realms/sandbox.py
@@ -9,14 +9,16 @@ PAGE_ABOUT_BLANK = "about:blank"
 
 @pytest.mark.asyncio
 async def test_sandbox(bidi_session, top_context):
-    evaluate_result = await bidi_session.script.evaluate_raw(
+    evaluate_result = await bidi_session.script.evaluate(
+        raw_response=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"]),
         await_promise=False,
     )
 
     # Create a sandbox
-    evaluate_in_sandbox_result = await bidi_session.script.evaluate_raw(
+    evaluate_in_sandbox_result = await bidi_session.script.evaluate(
+        raw_response=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"], "sandbox"),
         await_promise=False,
@@ -56,14 +58,16 @@ async def test_origin(bidi_session, inline, top_context, test_origin):
         context=top_context["context"], url=url, wait="complete"
     )
 
-    evaluate_result = await bidi_session.script.evaluate_raw(
+    evaluate_result = await bidi_session.script.evaluate(
+        raw_response=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"]),
         await_promise=False,
     )
 
     # Create a sandbox
-    evaluate_in_sandbox_result = await bidi_session.script.evaluate_raw(
+    evaluate_in_sandbox_result = await bidi_session.script.evaluate(
+        raw_response=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"], "sandbox"),
         await_promise=False,
@@ -98,14 +102,16 @@ async def test_origin(bidi_session, inline, top_context, test_origin):
 
 @pytest.mark.asyncio
 async def test_type(bidi_session, top_context):
-    evaluate_result = await bidi_session.script.evaluate_raw(
+    evaluate_result = await bidi_session.script.evaluate(
+        raw_response=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"]),
         await_promise=False,
     )
 
     # Create a sandbox
-    evaluate_in_sandbox_result = await bidi_session.script.evaluate_raw(
+    evaluate_in_sandbox_result = await bidi_session.script.evaluate(
+        raw_response=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"], "sandbox"),
         await_promise=False,
@@ -155,14 +161,16 @@ async def test_multiple_top_level_contexts(
         wait="complete",
     )
 
-    evaluate_result = await bidi_session.script.evaluate_raw(
+    evaluate_result = await bidi_session.script.evaluate(
+        raw_response=True,
         expression="1 + 2",
         target=ContextTarget(new_context["context"]),
         await_promise=False,
     )
 
     # Create a sandbox
-    evaluate_in_sandbox_result = await bidi_session.script.evaluate_raw(
+    evaluate_in_sandbox_result = await bidi_session.script.evaluate(
+        raw_response=True,
         expression="1 + 2",
         target=ContextTarget(new_context["context"], "sandbox"),
         await_promise=False,
@@ -194,14 +202,16 @@ async def test_multiple_top_level_contexts(
     assert len(frames) == 1
     frame_context = frames[0]["context"]
 
-    evaluate_result = await bidi_session.script.evaluate_raw(
+    evaluate_result = await bidi_session.script.evaluate(
+        raw_response=True,
         expression="1 + 2",
         target=ContextTarget(frame_context),
         await_promise=False,
     )
 
     # Create a sandbox in iframe
-    evaluate_in_sandbox_result = await bidi_session.script.evaluate_raw(
+    evaluate_in_sandbox_result = await bidi_session.script.evaluate(
+        raw_response=True,
         expression="1 + 2",
         target=ContextTarget(frame_context, "sandbox"),
         await_promise=False,

--- a/webdriver/tests/bidi/script/get_realms/type.py
+++ b/webdriver/tests/bidi/script/get_realms/type.py
@@ -15,7 +15,7 @@ async def test_type(bidi_session, top_context, type):
 
     # Evaluate to get realm id
     top_context_result = await bidi_session.script.evaluate(
-        raw_response=True,
+        raw_result=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"]),
         await_promise=False,

--- a/webdriver/tests/bidi/script/get_realms/type.py
+++ b/webdriver/tests/bidi/script/get_realms/type.py
@@ -14,7 +14,8 @@ async def test_type(bidi_session, top_context, type):
     result = await bidi_session.script.get_realms(type=type)
 
     # Evaluate to get realm id
-    top_context_result = await bidi_session.script.evaluate_raw(
+    top_context_result = await bidi_session.script.evaluate(
+        raw_response=True,
         expression="1 + 2",
         target=ContextTarget(top_context["context"]),
         await_promise=False,

--- a/webdriver/tests/bidi/script/get_realms/type.py
+++ b/webdriver/tests/bidi/script/get_realms/type.py
@@ -1,0 +1,33 @@
+import pytest
+
+from webdriver.bidi.modules.script import ContextTarget
+
+from ... import recursive_compare
+
+PAGE_ABOUT_BLANK = "about:blank"
+
+
+@pytest.mark.asyncio
+# Should be extended when more types are supported
+@pytest.mark.parametrize("type", ["window"])
+async def test_type(bidi_session, top_context, type):
+    result = await bidi_session.script.get_realms(type=type)
+
+    # Evaluate to get realm id
+    top_context_result = await bidi_session.script.evaluate_raw(
+        expression="1 + 2",
+        target=ContextTarget(top_context["context"]),
+        await_promise=False,
+    )
+
+    recursive_compare(
+        [
+            {
+                "context": top_context["context"],
+                "origin": "null",
+                "realm": top_context_result["realm"],
+                "type": type,
+            }
+        ],
+        result,
+    )


### PR DESCRIPTION
- adds support for "script.getRealms" command
- adds the version of commands which returns the result without post-processing, to get `realm` from `script.evaluate`
- adds tests for "script.getRealms" command.

The PR takes already into account [this changes to the spec](https://github.com/w3c/webdriver-bidi/pull/270).