### PR TITLE
Return value instead of key from Stash example

### DIFF
--- a/tools/wptserve/docs/stash.rst
+++ b/tools/wptserve/docs/stash.rst
@@ -22,7 +22,7 @@ A typical example of using a stash to store state might be::
       else:
           value = request.server.stash.take(key)
           assert request.server.stash.take(key) is None
-          return key
+          return value
 
 :mod:`Interface <wptserve.stash>`
 ---------------------------------


### PR DESCRIPTION
Otherwise, the value is unused.