### PR TITLE
Port two more COOP tests from the legacy report-to header to Reportin…

### DIFF
--- a/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-coop-navigated-opener.https.html
+++ b/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-coop-navigated-opener.https.html
@@ -17,7 +17,7 @@ let escapeComma = url => url.replace(/,/g, '\\,');
 
 promise_test(async t => {
   // The test window.
- const this_window_token = token();
+  const this_window_token = token();
 
   // The "opener" window.
   const opener_token = token();
@@ -30,7 +30,7 @@ promise_test(async t => {
   // The "final" url the opener will navigate to. It has COOP and a reporter.
   const final_report_token= token();
   const final_token = token();
-  const final_reportTo = reportToHeaders(final_report_token);
+  const final_reportTo = reportingEndpointsHeaders(final_report_token);
   const final_url =  same_origin + executor_path + final_reportTo.header +
     final_reportTo.coopSameOriginHeader +`&uuid=${final_token}`;
 

--- a/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-redirect-with-same-origin-allow-popups.https.html
+++ b/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-redirect-with-same-origin-allow-popups.https.html
@@ -52,7 +52,7 @@ function redirect_test( popup_origin ) {
     // reporter.
     const opener_report_token= token();
     const opener_token = token();
-    const opener_reportTo = reportToHeaders(opener_report_token);
+    const opener_reportTo = reportingEndpointsHeaders(opener_report_token);
     const opener_url = same_origin.host + executor_path +
       opener_reportTo.header + opener_reportTo.coopSameOriginAllowPopupsHeader +
       `&uuid=${opener_token}`;


### PR DESCRIPTION
…g-Endpoints

These two COOP tests were still using the legacy report-to header instead of the modern Reporting-Endpoints one. WebKit is adding support for Reporting-Endpoints but doesn't support report-to.