### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=244939

### DIFF
--- a/webidl/ecmascript-binding/default-toJSON-cross-realm.html
+++ b/webidl/ecmascript-binding/default-toJSON-cross-realm.html
@@ -23,3 +23,4 @@ promise_test(async t => {
     assert_equals(Object.getPrototypeOf(json.p1), DOMPoint.prototype);
 }, "Cross-realm [Default] toJSON() converts its interface attributes to ECMAScript values of correct realm");
 </script>
+</body>

--- a/webidl/ecmascript-binding/default-toJSON-cross-realm.html
+++ b/webidl/ecmascript-binding/default-toJSON-cross-realm.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Cross-realm [Default] toJSON() creates result object in its realm</title>
+<link rel="help" href="https://webidl.spec.whatwg.org/#default-tojson-steps">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/create-realm.js"></script>
+
+<body>
+<script>
+promise_test(async t => {
+    const other = await createRealm(t);
+    const json = other.DOMRectReadOnly.prototype.toJSON.call(new DOMRectReadOnly());
+
+    assert_equals(Object.getPrototypeOf(json), other.Object.prototype);
+}, "Cross-realm [Default] toJSON() creates result object in its realm");
+
+promise_test(async t => {
+    const other = await createRealm(t);
+    const json = other.DOMQuad.prototype.toJSON.call(new DOMQuad());
+
+    assert_equals(Object.getPrototypeOf(json.p1), DOMPoint.prototype);
+}, "Cross-realm [Default] toJSON() converts its interface attributes to ECMAScript values of correct realm");
+</script>


### PR DESCRIPTION
This upstream reviewed test ensures that cross-realm `[Default]` `toJSON()` creates result object in its realm.