### PR TITLE
Add test for CompressionStream constructor error cases

### DIFF
--- a/compression/compression-constructor-error.tentative.any.js
+++ b/compression/compression-constructor-error.tentative.any.js
@@ -1,0 +1,15 @@
+// META: global=window,worker
+
+'use strict';
+
+test(t => {
+  assert_throws_js(TypeError, () => new CompressionStream('a'), 'constructor should throw');
+}, '"a" should cause the constructor to throw');
+
+test(t => {
+  assert_throws_js(TypeError, () => new CompressionStream(), 'constructor should throw');
+}, 'no input should cause the constructor to throw');
+
+test(t => {
+  assert_throws_js(Error, () => new CompressionStream({ toString() { throw Error(); } }), 'constructor should throw');
+}, 'non-string input should cause the constructor to throw');


### PR DESCRIPTION
Add test for CompressionStream constructor error cases, similarly to the one we already have for DecompressionStream.