### PR TITLE
Avoid race condition in loading events of the new tab

### DIFF
--- a/webdriver/tests/support/fixtures_bidi.py
+++ b/webdriver/tests/support/fixtures_bidi.py
@@ -10,6 +10,8 @@ CONTEXT_LOAD_EVENT = "browsingContext.load"
 @pytest.fixture
 async def new_tab(bidi_session, wait_for_event):
     """Open and focus a new tab to run the test in a foreground tab."""
+
+    # Subscribe to the load event to wait for the newly created tab to be loaded.
     await bidi_session.session.subscribe(events=[CONTEXT_LOAD_EVENT])
     new_tab = await bidi_session.browsing_context.create(type_hint='tab')
     await wait_for_event(CONTEXT_LOAD_EVENT,


### PR DESCRIPTION
Trying to address https://github.com/web-platform-tests/wpt/issues/35846 ~by adding an additional navigation when a new tab is created.~
* Wait for the new tab to be fully loaded