### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=245114

### DIFF
--- a/css/css-flexbox/flex-item-transferred-sizes-padding-border-sizing.html
+++ b/css/css-flexbox/flex-item-transferred-sizes-padding-border-sizing.html
@@ -6,7 +6,7 @@
     <link rel="help" href="https://drafts.csswg.org/css-sizing-3/#min-width" />
     <link rel="help" href="https://drafts.csswg.org/css-sizing/#box-sizing" />
     <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=243887" />
-    <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
+    <link rel="match" href="../reference/ref-filled-green-100px-square-only.html" />
   </head>
   <!-- The box should be a 100px x 100px green square. The initial width should
        be 90px due to the  transferred min-width constraint from the specified
@@ -29,8 +29,10 @@
     }
   </style>
   <body>
+    <p>Test passes if there is a filled green square.</p>
     <div class="flexContainer">
       <div class="item" style="min-height:100px; aspect-ratio: 1/1;"></div>
     </div>
   </body>
 </html>
+

--- a/css/css-flexbox/flex-item-transferred-sizes-padding-content-sizing.html
+++ b/css/css-flexbox/flex-item-transferred-sizes-padding-content-sizing.html
@@ -6,7 +6,7 @@
     <link rel="help" href="https://drafts.csswg.org/css-sizing-3/#min-width" />
     <link rel="help" href="https://drafts.csswg.org/css-sizing/#box-sizing" />
     <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=243887" />
-    <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
+    <link rel="match" href="../reference/ref-filled-green-100px-square-only.html" />
   </head>
   <!-- Item div should be a 100px x 100px square. Content width will be 90px,
        which comes from the min-height constraint being transferred to the
@@ -24,8 +24,10 @@
     }
   </style>
   <body>
+    <p>Test passes if there is a filled green square.</p>
     <div class="flexContainer">
       <div class="item" style="min-height:90px; aspect-ratio: 1/1;"></div>
     </div>
   </body>
 </html>
+


### PR DESCRIPTION
The original version of these tests were referencing an expectation
that had some extra text that were not in the test files. This was
causing the tests to fail on all engines on WPT. However, since our
expectation did not have the test, we were passing it outside of
WPT. The change now links to a test with just the green square and
without the text.