### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=245194

### DIFF
--- a/css/css-flexbox/flexbox-definite-cross-size-constrained-percentage-ref.html
+++ b/css/css-flexbox/flexbox-definite-cross-size-constrained-percentage-ref.html
@@ -1,0 +1,17 @@
+<html>
+    <meta charset="utf-8">
+    <link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+    <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#min-size-auto">
+    <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#definite">
+    <link rel="help" href="https://www.w3.org/TR/css-sizing-3/#definite">
+    <title>Flex item cross size set by definite flex container size with percentage height</title>
+    <style>
+        img {
+            width: 25px;
+            height: 25px;
+        }
+    </style>
+    <body>
+        <img src="support/60x60-green.png">
+    </body>
+</html>

--- a/css/css-flexbox/flexbox-definite-cross-size-constrained-percentage.html
+++ b/css/css-flexbox/flexbox-definite-cross-size-constrained-percentage.html
@@ -1,0 +1,26 @@
+<html>
+    <meta charset="utf-8">
+    <link rel="match" href="flexbox-definite-cross-size-constrained-percentage-ref.html">
+    <link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+    <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#min-size-auto">
+    <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#definite">
+    <link rel="help" href="https://www.w3.org/TR/css-sizing-3/#definite">
+    <title>Flex item cross size set by definite flex container size with percentage height</title>
+    <style>
+        .constraining-container {
+            height: 50px;
+        }
+
+        .flex-container {
+            height: 50%;
+            display: flex;
+        }
+    </style>
+    <body>
+        <div class="constraining-container">
+            <div class="flex-container">
+                <img src="support/60x60-green.png">
+            </div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
When computing the transferred size suggestion for the minimum size of flex items, we need to use the intrinsic aspect ratio and the definite cross size. From the CSS Flexbox Module:

If a single-line flex container has a definite cross size, the outer
cross size of any stretched flex items is the flex container’s inner
cross size (clamped to the flex item’s min and max cross size) and is
considered definite.