### PR TITLE
feat: add `@keyframes` name parsing

### DIFF
--- a/css/css-animations/parsing/keyframes-name-invalid.html
+++ b/css/css-animations/parsing/keyframes-name-invalid.html
@@ -15,34 +15,6 @@
         <main id="main"></main>
     </div>
     <script>
-        function cleanup_main() {
-            while (main.firstChild)
-                main.firstChild.remove();
-        }
-
-        function set_style(text) {
-            let style = document.createElement('style');
-            style.innerText = text;
-            main.append(style);
-            return style;
-        }
-
-        function test_keyframes_name_invalid(keyframes_name) {
-            test(t => {
-                t.add_cleanup(cleanup_main);
-                let style = set_style(`@keyframes ${keyframes_name} {}`);
-                assert_equals(style.sheet.rules.length, 0);
-            }, `invalid: @keyframes ${keyframes_name} { }`);
-        }
-
-        function test_keyframes_name_valid(keyframes_name) {
-            test(t => {
-                t.add_cleanup(cleanup_main);
-                let style = set_style(`@keyframes ${keyframes_name} {}`);
-                assert_equals(style.sheet.rules.length, 1);
-            }, `valid: @keyframes ${keyframes_name} { }`);
-        }
-
         test_keyframes_name_invalid('none');
 
         // The CSS-wide keywords are not valid <custom-ident>s. The default keyword is reserved and is also not a valid <custom-ident>.
@@ -52,12 +24,15 @@
         test_keyframes_name_invalid('inherit');
         test_keyframes_name_invalid('unset');
         test_keyframes_name_invalid('revert');
-        test_keyframes_name_invalid('revert-layer');        
+        test_keyframes_name_invalid('revert-layer');
+
         test_keyframes_name_invalid('12');
         test_keyframes_name_invalid('-12');
         test_keyframes_name_invalid('12foo');
         test_keyframes_name_invalid('foo.bar');
         test_keyframes_name_invalid('one two');
+        test_keyframes_name_invalid('one, two');
+
         test_keyframes_name_invalid('one, initial');
         test_keyframes_name_invalid('one, inherit');
         test_keyframes_name_invalid('one, unset');

--- a/css/css-animations/parsing/keyframes-name-invalid.html
+++ b/css/css-animations/parsing/keyframes-name-invalid.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>CSS Animations: parsing @keyframes name with invalid values</title>
+    <link rel="author" title="yisibl(一丝)" href="https://github.com/yisibl"/>
+    <link rel="help" href="https://drafts.csswg.org/css-animations/#typedef-keyframes-name">
+    <meta name="assert" content="@keyframes name supports the full grammar '<custom-ident> | <string>'.">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+    <div>
+        <main id="main"></main>
+    </div>
+    <script>
+        function cleanup_main() {
+            while (main.firstChild)
+                main.firstChild.remove();
+        }
+
+        function set_style(text) {
+            let style = document.createElement('style');
+            style.innerText = text;
+            main.append(style);
+            return style;
+        }
+
+        function test_keyframes_name_invalid(keyframes_name) {
+            test(t => {
+                t.add_cleanup(cleanup_main);
+                let style = set_style(`@keyframes ${keyframes_name} {}`);
+                assert_equals(style.sheet.rules.length, 0);
+            }, `invalid: @keyframes ${keyframes_name} { }`);
+        }
+
+        function test_keyframes_name_valid(keyframes_name) {
+            test(t => {
+                t.add_cleanup(cleanup_main);
+                let style = set_style(`@keyframes ${keyframes_name} {}`);
+                assert_equals(style.sheet.rules.length, 1);
+            }, `valid: @keyframes ${keyframes_name} { }`);
+        }
+
+        test_keyframes_name_invalid('none');
+
+        // The CSS-wide keywords are not valid <custom-ident>s. The default keyword is reserved and is also not a valid <custom-ident>.
+        // Spec: https://drafts.csswg.org/css-values-4/#identifier-value
+        test_keyframes_name_invalid('default');
+        test_keyframes_name_invalid('initial');
+        test_keyframes_name_invalid('inherit');
+        test_keyframes_name_invalid('unset');
+        test_keyframes_name_invalid('revert');
+        test_keyframes_name_invalid('revert-layer');        
+        test_keyframes_name_invalid('12');
+        test_keyframes_name_invalid('-12');
+        test_keyframes_name_invalid('12foo');
+        test_keyframes_name_invalid('foo.bar');
+        test_keyframes_name_invalid('one two');
+        test_keyframes_name_invalid('one, initial');
+        test_keyframes_name_invalid('one, inherit');
+        test_keyframes_name_invalid('one, unset');
+        test_keyframes_name_invalid('default, two');
+        test_keyframes_name_invalid('revert, three');
+        test_keyframes_name_invalid('revert-layer, four');
+        // TODO: https://bugs.chromium.org/p/chromium/issues/detail?id=1342609
+        // test_keyframes_name_invalid('--foo');
+    </script>
+</body>
+</html>

--- a/css/css-animations/parsing/keyframes-name-valid.html
+++ b/css/css-animations/parsing/keyframes-name-valid.html
@@ -15,34 +15,6 @@
         <main id="main"></main>
     </div>
     <script>
-        function cleanup_main() {
-            while (main.firstChild)
-                main.firstChild.remove();
-        }
-
-        function set_style(text) {
-            let style = document.createElement('style');
-            style.innerText = text;
-            main.append(style);
-            return style;
-        }
-
-        function test_keyframes_name_invalid(keyframes_name) {
-            test(t => {
-                t.add_cleanup(cleanup_main);
-                let style = set_style(`@keyframes ${keyframes_name} {}`);
-                assert_equals(style.sheet.rules.length, 0);
-            }, `invalid: @keyframes ${keyframes_name} { }`);
-        }
-
-        function test_keyframes_name_valid(keyframes_name) {
-            test(t => {
-                t.add_cleanup(cleanup_main);
-                let style = set_style(`@keyframes ${keyframes_name} {}`);
-                assert_equals(style.sheet.rules.length, 1);
-            }, `valid: @keyframes ${keyframes_name} { }`);
-        }
-
         // Test <custom-ident>
         test_keyframes_name_valid(' foo ');
         test_keyframes_name_valid('  foo');
@@ -58,7 +30,8 @@
         test_keyframes_name_valid('and');
         test_keyframes_name_valid('all');
         test_keyframes_name_valid('or');
-        // <custom-ident> may disable the `auto/normal` keywords in the future 
+
+        // <custom-ident> may disable the `auto/normal` keywords in the future
         // https://github.com/w3c/csswg-drafts/issues/7431
         test_keyframes_name_valid('auto');
         test_keyframes_name_valid('normal');
@@ -74,13 +47,18 @@
         test_keyframes_name_valid('"example"');
         test_keyframes_name_valid('"EXAMPLE"');
 
+        test_keyframes_name_valid('"one two"');
+        test_keyframes_name_valid('"one, two"');
+
         test_keyframes_name_valid('"not"');
         test_keyframes_name_valid('"and"');
         test_keyframes_name_valid('"all"');
         test_keyframes_name_valid('"or"');
+
         test_keyframes_name_valid('"auto"');
         test_keyframes_name_valid('"normal"');
         test_keyframes_name_valid('"none"');
+
         test_keyframes_name_valid('"default"');
         test_keyframes_name_valid('"initial"');
         test_keyframes_name_valid('"inherit"');

--- a/css/css-animations/parsing/keyframes-name-valid.html
+++ b/css/css-animations/parsing/keyframes-name-valid.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>CSS Animations: parsing @keyframes name with valid values</title>
+    <link rel="author" title="yisibl(一丝)" href="https://github.com/yisibl"/>
+    <link rel="help" href="https://drafts.csswg.org/css-animations/#typedef-keyframes-name">
+    <meta name="assert" content="@keyframes name supports the full grammar '<custom-ident> | <string>'.">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+    <div>
+        <main id="main"></main>
+    </div>
+    <script>
+        function cleanup_main() {
+            while (main.firstChild)
+                main.firstChild.remove();
+        }
+
+        function set_style(text) {
+            let style = document.createElement('style');
+            style.innerText = text;
+            main.append(style);
+            return style;
+        }
+
+        function test_keyframes_name_invalid(keyframes_name) {
+            test(t => {
+                t.add_cleanup(cleanup_main);
+                let style = set_style(`@keyframes ${keyframes_name} {}`);
+                assert_equals(style.sheet.rules.length, 0);
+            }, `invalid: @keyframes ${keyframes_name} { }`);
+        }
+
+        function test_keyframes_name_valid(keyframes_name) {
+            test(t => {
+                t.add_cleanup(cleanup_main);
+                let style = set_style(`@keyframes ${keyframes_name} {}`);
+                assert_equals(style.sheet.rules.length, 1);
+            }, `valid: @keyframes ${keyframes_name} { }`);
+        }
+
+        // Test <custom-ident>
+        test_keyframes_name_valid(' foo ');
+        test_keyframes_name_valid('  foo');
+        test_keyframes_name_valid('-foo');
+        test_keyframes_name_valid('_bar');
+        test_keyframes_name_valid('__bar');
+        test_keyframes_name_valid('__bar__');
+        test_keyframes_name_valid('ease-out');
+        test_keyframes_name_valid('example');
+        test_keyframes_name_valid('EXAMPLE');
+
+        test_keyframes_name_valid('not');
+        test_keyframes_name_valid('and');
+        test_keyframes_name_valid('all');
+        test_keyframes_name_valid('or');
+        // <custom-ident> may disable the `auto/normal` keywords in the future 
+        // https://github.com/w3c/csswg-drafts/issues/7431
+        test_keyframes_name_valid('auto');
+        test_keyframes_name_valid('normal');
+
+        // Test <string>
+        test_keyframes_name_valid('" foo "');
+        test_keyframes_name_valid('"  foo"');
+        test_keyframes_name_valid('"-foo"');
+        test_keyframes_name_valid('"_bar"');
+        test_keyframes_name_valid('"__bar"');
+        test_keyframes_name_valid('"__bar__"');
+        test_keyframes_name_valid('"ease-out"');
+        test_keyframes_name_valid('"example"');
+        test_keyframes_name_valid('"EXAMPLE"');
+
+        test_keyframes_name_valid('"not"');
+        test_keyframes_name_valid('"and"');
+        test_keyframes_name_valid('"all"');
+        test_keyframes_name_valid('"or"');
+        test_keyframes_name_valid('"auto"');
+        test_keyframes_name_valid('"normal"');
+        test_keyframes_name_valid('"none"');
+        test_keyframes_name_valid('"default"');
+        test_keyframes_name_valid('"initial"');
+        test_keyframes_name_valid('"inherit"');
+        test_keyframes_name_valid('"unset"');
+        test_keyframes_name_valid('"revert"');
+        test_keyframes_name_valid('"revert-layer"');
+    </script>
+</body>
+</html>

--- a/css/support/parsing-testcommon.js
+++ b/css/support/parsing-testcommon.js
@@ -141,3 +141,26 @@ function test_invalid_rule(rule) {
           rule + " should throw in insertRule");
     }, rule + " should be an invalid rule");
 }
+
+function _set_style(rule) {
+    const style = document.createElement('style');
+    style.innerText = rule;
+    document.head.append(style);
+    const { sheet } = style;
+    document.head.removeChild(style);
+    return sheet;
+}
+
+function test_keyframes_name_valid(keyframes_name) {
+    test(t => {
+        const sheet = _set_style(`@keyframes ${keyframes_name} {}`);
+        assert_equals(sheet.cssRules.length, 1);
+    }, `valid: @keyframes ${keyframes_name} { }`);
+}
+
+function test_keyframes_name_invalid(keyframes_name) {
+    test(t => {
+        const sheet = _set_style(`@keyframes ${keyframes_name} {}`);
+        assert_equals(sheet.cssRules.length, 0);
+    }, `invalid: @keyframes ${keyframes_name} { }`);
+}


### PR DESCRIPTION
I and @CGQAQ are working on implementing interoperability of `<keyframes-name>` across browsers

The [Chromium patch](https://chromium-review.googlesource.com/c/chromium/src/+/3865188) requires this test
