### PR TITLE
Remove invalid non-integer step test from the-input-element/range.html

### DIFF
--- a/html/semantics/forms/the-input-element/range.html
+++ b/html/semantics/forms/the-input-element/range.html
@@ -33,7 +33,6 @@
       <input type="range" id="max_smaller_than_min" min=2 max=-3 />
       <input type="range" id="default_step_scale_factor_1" min=5 max=12.6 value=6.7 />
       <input type="range" id="default_step_scale_factor_2" min=5.3 max=12 value=6.7 />
-      <input type="range" id="default_step_scale_factor_3"min=5 max=12.6 step=0.5 value=6.7 />
       <input type="range" id="float_step_scale_factor" min=5.3 max=12 step=0.5 value=6.7 />
       <input type="range" id="stepup" min=3 max=14 value=6 step=3 />
       <input type="range" id="stepdown" min=3 max=11 value=9 step=3 />
@@ -162,13 +161,6 @@
           assert_equals(document.getElementById('default_step_scale_factor_2').value, "6.3")
         },
         "Step scale factor behavior when min attribute has integer value but max attribute is non-integer "
-      );
-
-      test(
-        function() {
-          assert_equals(document.getElementById('default_step_scale_factor_3').step, "1")
-        },
-        "The default scale factor is 1 even if step attribute is explicitly set to non-integer value, unless min attribute has non-integer value"
       );
 
       test(


### PR DESCRIPTION
The spec says that the  IDL attribute simply reflects the DOM attribute of the same name. https://html.spec.whatwg.org/multipage/input.html#dom-input-step