### PR TITLE
[wptrunner] Implement `--retry-unexpected`

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -321,6 +321,7 @@ class TestRunnerManager(threading.Thread):
         self.test_count = 0
         self.unexpected_count = 0
         self.unexpected_pass_count = 0
+        self.unexpected_tests = set()
 
         # This may not really be what we want
         self.daemon = True
@@ -673,6 +674,9 @@ class TestRunnerManager(threading.Thread):
         if is_unexpected_pass:
             self.unexpected_pass_count += 1
 
+        if is_unexpected or subtest_unexpected:
+            self.unexpected_tests.add(test.id)
+
         if "assertion_count" in file_result.extra:
             assertion_count = file_result.extra["assertion_count"]
             if assertion_count is not None and assertion_count > 0:
@@ -948,3 +952,6 @@ class ManagerGroup:
 
     def unexpected_pass_count(self):
         return sum(manager.unexpected_pass_count for manager in self.pool)
+
+    def unexpected_tests(self):
+        return set().union(*(manager.unexpected_tests for manager in self.pool))

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -903,12 +903,11 @@ class ManagerGroup:
     def run(self, test_type, tests):
         """Start all managers in the group"""
         self.logger.debug("Using %i processes" % self.size)
-        type_tests = tests[test_type]
-        if not type_tests:
+        if not tests:
             self.logger.info("No %s tests to run" % test_type)
             return
 
-        test_queue = make_test_queue(type_tests, self.test_source_cls, **self.test_source_kwargs)
+        test_queue = make_test_queue(tests, self.test_source_cls, **self.test_source_kwargs)
 
         for idx in range(self.size):
             manager = TestRunnerManager(self.suite_name,

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -181,7 +181,7 @@ scheme host and port.""")
     debugging_group.add_argument("--repeat-until-unexpected", action="store_true", default=None,
                                  help="Run tests in a loop until one returns an unexpected result")
     debugging_group.add_argument('--no-repeat-expected', action='store_true',
-                                 help='Do not run a test in a later restart once that test runs as expected.')
+                                 help='Skip a test in a later repetition once that test runs as expected.')
     debugging_group.add_argument('--pause-after-test', action="store_true", default=None,
                                  help="Halt the test runner after each test (this happens by default if only a single test is run)")
     debugging_group.add_argument('--no-pause-after-test', dest="pause_after_test", action="store_false",

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -180,6 +180,8 @@ scheme host and port.""")
                                  help="Number of times to run the tests, restarting between each run")
     debugging_group.add_argument("--repeat-until-unexpected", action="store_true", default=None,
                                  help="Run tests in a loop until one returns an unexpected result")
+    debugging_group.add_argument('--no-repeat-expected', action='store_true',
+                                 help='Do not run a test in a later restart once that test runs as expected.')
     debugging_group.add_argument('--pause-after-test', action="store_true", default=None,
                                  help="Halt the test runner after each test (this happens by default if only a single test is run)")
     debugging_group.add_argument('--no-pause-after-test', dest="pause_after_test", action="store_false",

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -181,11 +181,11 @@ scheme host and port.""")
     debugging_group.add_argument("--repeat-until-unexpected", action="store_true", default=None,
                                  help="Run tests in a loop until one returns an unexpected result")
     debugging_group.add_argument('--retry-unexpected', type=int, default=0,
-                                 help=('Maximum number of times to rerun '
+                                 help=('Maximum number of times to retry '
                                        'each test that consistently runs '
                                        'unexpectedly in the initial repeat '
                                        'loop. A retried test takes any '
-                                       'expected status as the final result.'))
+                                       'expected status as its final result.'))
     debugging_group.add_argument('--pause-after-test', action="store_true", default=None,
                                  help="Halt the test runner after each test (this happens by default if only a single test is run)")
     debugging_group.add_argument('--no-pause-after-test', dest="pause_after_test", action="store_false",

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -180,8 +180,12 @@ scheme host and port.""")
                                  help="Number of times to run the tests, restarting between each run")
     debugging_group.add_argument("--repeat-until-unexpected", action="store_true", default=None,
                                  help="Run tests in a loop until one returns an unexpected result")
-    debugging_group.add_argument('--no-repeat-expected', action='store_true',
-                                 help='Skip a test in a later repetition once that test runs as expected.')
+    debugging_group.add_argument('--retry-unexpected', type=int, default=0,
+                                 help=('Maximum number of times to rerun '
+                                       'each test that consistently runs '
+                                       'unexpectedly in the initial repeat '
+                                       'loop. A retried test takes any '
+                                       'expected status as the final result.'))
     debugging_group.add_argument('--pause-after-test', action="store_true", default=None,
                                  help="Halt the test runner after each test (this happens by default if only a single test is run)")
     debugging_group.add_argument('--no-pause-after-test', dest="pause_after_test", action="store_false",

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -444,7 +444,7 @@ def run_tests(config, test_paths, product, **kwargs):
                     test_status.all_skipped = True
                     break
 
-            if not test_status.all_skipped:
+            if not test_status.all_skipped and kwargs["retry_unexpected"] > 0:
                 retry_success = retry_unexpected_tests(test_status, test_loader,
                                                        test_source_kwargs,
                                                        test_source_cls, run_info,
@@ -461,7 +461,7 @@ def retry_unexpected_tests(test_status, test_loader, test_source_kwargs,
                            test_source_cls, run_info, recording,
                            test_environment, product, kwargs):
     kwargs["rerun"] = 1
-    max_retries = max(0, kwargs["retry_unexpected"])
+    max_retries = kwargs["retry_unexpected"]
     test_status.retries_remaining = max_retries
     while (test_status.retries_remaining > 0 and not
            evaluate_runs(test_status, kwargs)):

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -170,6 +170,11 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
         logger.critical("Loading tests failed")
         return False
 
+    if test_status.retries_remaining:
+        for test_type, tests in dict(test_groups).items():
+            test_groups[test_type] = [test for test in tests
+                                      if test in test_status.unexpected_tests]
+
     unexpected_tests = set()
     logger.suite_start(test_groups,
                        name='web-platform-test',
@@ -458,8 +463,8 @@ def retry_unexpected_tests(test_status, test_loader, test_source_kwargs,
     kwargs["rerun"] = 1
     max_retries = max(0, kwargs["retry_unexpected"])
     test_status.retries_remaining = max_retries
-    while (test_status.retries_remaining > 0
-            and not evaluate_runs(test_status, kwargs)):
+    while (test_status.retries_remaining > 0 and not
+           evaluate_runs(test_status, kwargs)):
         logger.info(f"Retry {max_retries - test_status.retries_remaining + 1}")
         test_status.total_tests = 0
         test_status.skipped = 0


### PR DESCRIPTION
This PR implements: https://github.com/web-platform-tests/rfcs/blob/master/rfcs/retry_unexpected.md

It appears `wptrunner.wptrunner` has no automated tests, so I tested this change manually by making `xhr/abort-after-stop.window.js` a randomly passing test:

```js
test(t => {
  assert_less_than(Math.random(), 0.2, "this test flakes");
});
```

Then trying (with `chrome`):
```
./wpt run ... xhr/abort-after-stop.window.js badging/badge-success.https.html --retry-unexpected=20 --repeat=2 --rerun=5
./wpt run ... xhr/abort-after-stop.window.js badging/badge-success.https.html --retry-unexpected=20 --no-fail-on-unexpected
```

* The first command probably retries only `xhr/abort-after-stop.window.js`, but eventually succeeds.
* The second command retries no tests.