### PR TITLE
Fix CSS `log()` and CSS `exp()` calculation

### DIFF
--- a/css/css-values/exp-log-compute.html
+++ b/css/css-values/exp-log-compute.html
@@ -19,7 +19,7 @@ test_math_used('calc(e - exp(1))', '0', {type:'number', approx:0.1});
 
 //General calculations
 test_math_used('calc(log( 1 + 1 + 2 /2 - 2) )', '0', {type:'number', approx:0.1});
-test_math_used('calc(log(1) + exp(0))', '2'), {type:'number', approx:0.1};
+test_math_used('calc(log(1) + exp(0))', '1'), {type:'number', approx:0.1};
 test_math_used('calc(exp(log(1) + exp(0)*2))', '7.4'), {type:'number', approx:0.1};
 test_math_used('calc(log(log(1) + exp(0)*10))', '2.3'), {type:'number', approx:0.1};
 test_math_used('calc(log(log(1) + exp(0)*20, 10))', '1.3'), {type:'number', approx:0.1};


### PR DESCRIPTION
See the following test:

```
test_math_used('log(1)', '0', {type:'number'});
test_math_used('exp(0)', '1', {type:'number'});
test_math_used('calc(log(1) + exp(0))', '2'), {type:'number', approx:0.1};
```

The first test `log(1)` return `0`. The second test `exp(0)` return `1`.

Next, we have a calculation that sums those two functions `log(1) + exp(0)`

According to the test should it should return `2`, but according to the first two separate tests it should return `1`.
