### PR TITLE
Update SVG transform rotate(45) tests to avoid box border

### DIFF
--- a/css/css-transforms/rotate/svg-rotate-angle-45-001.html
+++ b/css/css-transforms/rotate/svg-rotate-angle-45-001.html
@@ -22,8 +22,8 @@
 <body>
     <p>The test passes if there is a green square and no red.</p>
     <svg>
-        <path d="M 142,2 210,71 142,139 73,71 Z" fill="red"/>
-        <rect x="100" y="-100" width="100" height="100" fill="green" transform="rotate(45)"/>
+        <path d="M 106,37 175,106 106,175 37,106 Z" fill="red"/>
+        <rect x="100" y="-50" width="100" height="100" fill="green" transform="rotate(45)"/>
     </svg>
 </body>
 </html>

--- a/css/css-transforms/rotate/svg-rotate-angle-45-011.html
+++ b/css/css-transforms/rotate/svg-rotate-angle-45-011.html
@@ -22,8 +22,8 @@
 <body>
     <p>The test passes if there is a green square and no red.</p>
     <svg>
-        <path d="M 142,2 210,71 142,139 73,71 Z" fill="red"/>
-        <rect x="100" y="-100" width="100" height="100" fill="green" transform="rotate(405)"/>
+        <path d="M 106,37 175,106 106,175 37,106 Z" fill="red"/>
+        <rect x="100" y="-50" width="100" height="100" fill="green" transform="rotate(405)"/>
     </svg>
 </body>
 </html>

--- a/css/css-transforms/rotate/svg-rotate-angle-45-022.html
+++ b/css/css-transforms/rotate/svg-rotate-angle-45-022.html
@@ -22,8 +22,8 @@
 <body>
     <p>The test passes if there is a green square and no red.</p>
     <svg>
-        <path d="M 142,2 210,71 142,139 73,71 Z" fill="red"/>
-        <rect x="100" y="-100" width="100" height="100" fill="green" transform="rotate(450e-1)"/>
+        <path d="M 106,37 175,106 106,175 37,106 Z" fill="red"/>
+        <rect x="100" y="-50" width="100" height="100" fill="green" transform="rotate(450e-1)"/>
     </svg>
 </body>
 </html>


### PR DESCRIPTION
These tests had one (transformed) coordinate right on the edge of the
SVG box. Tweak the rect so that it ends up well inside of the box.

The new coordinates for the path were computed using code like this:

```js
var rot = new DOMMatrix().rotateSelf(45);
rot.transformPoint({x:100, y:-50});
```

That gives coordinates (106.06601717798213, 35.35533905932736), and they
were inset to give >1px margin, which was the case before as well. It's
still close enough that a rotation of 44 or 46 degrees would fail the
test.

Fixes https://github.com/web-platform-tests/wpt/issues/35945.
