### PR TITLE
Add tests to deserialize remote references

### DIFF
--- a/webdriver/tests/bidi/script/conftest.py
+++ b/webdriver/tests/bidi/script/conftest.py
@@ -1,16 +1,18 @@
 import pytest
 from typing import Any, List, Mapping
 
-from webdriver.bidi.modules.script import ContextTarget
+from webdriver.bidi.modules.script import ContextTarget, OwnershipModel
 
 
 @pytest.fixture
 def call_function(bidi_session, top_context):
     async def call_function(
         function_declaration: str,
-        arguments: List[Mapping[str, Any]],
+        arguments: List[Mapping[str, Any]] = [],
+        this: Any = None,
         context: str = top_context["context"],
         sandbox: str = None,
+        result_ownership: OwnershipModel = OwnershipModel.NONE.value,
     ) -> Mapping[str, Any]:
         if sandbox is None:
             target = ContextTarget(top_context["context"])
@@ -20,7 +22,9 @@ def call_function(bidi_session, top_context):
         result = await bidi_session.script.call_function(
             function_declaration=function_declaration,
             arguments=arguments,
+            this=this,
             await_promise=False,
+            result_ownership=result_ownership,
             target=target,
         )
         return result
@@ -32,3 +36,27 @@ def call_function(bidi_session, top_context):
 async def default_realm(bidi_session, top_context):
     realms = await bidi_session.script.get_realms(context=top_context["context"])
     return realms[0]["realm"]
+
+
+@pytest.fixture
+def evaluate(bidi_session, top_context):
+    async def evaluate(
+        expression: str,
+        context: str = top_context["context"],
+        sandbox: str = None,
+        result_ownership: OwnershipModel = OwnershipModel.NONE.value,
+    ) -> Mapping[str, Any]:
+        if sandbox is None:
+            target = ContextTarget(top_context["context"])
+        else:
+            target = ContextTarget(top_context["context"], sandbox)
+
+        result = await bidi_session.script.evaluate(
+            expression=expression,
+            await_promise=False,
+            result_ownership=result_ownership,
+            target=target,
+        )
+        return result
+
+    return evaluate

--- a/webdriver/tests/bidi/script/disown/handles.py
+++ b/webdriver/tests/bidi/script/disown/handles.py
@@ -114,6 +114,12 @@ async def test_multiple_handles_for_same_object(
     result = await call_function("arg => arg.a", [remote_value2])
     assert result == {"type": "number", "value": 1}
 
+    # Check that both handles point to the same value
+    result = await call_function(
+        "(arg1, arg2) => arg1 === arg2", [remote_value1, remote_value2]
+    )
+    assert result == {"type": "boolean", "value": True}
+
     # Disown the handle 1
     await bidi_session.script.disown(
         handles=[remote_value1["handle"]], target=ContextTarget(top_context["context"])


### PR DESCRIPTION
Note that this is based on the approved changes from the bidi-script-target-realm branch, reviewed at https://github.com/web-platform-tests/wpt/pull/35878

On mozilla's side, this was reviewed at https://phabricator.services.mozilla.com/D156531