### PR TITLE
Update script result_ownership tests to handle id is only on root

### DIFF
--- a/webdriver/tests/bidi/script/__init__.py
+++ b/webdriver/tests/bidi/script/__init__.py
@@ -7,6 +7,18 @@ def assert_handle(obj: Mapping[str, Any], should_contain_handle: bool) -> None:
     if should_contain_handle:
         assert "handle" in obj, f"Result should contain `handle`. Actual: {obj}"
         assert isinstance(obj["handle"], str), f"`handle` should be a string, but was {type(obj['handle'])}"
+
+        # Recursively check that handle is not found in any of the nested values.
+        if "value" in obj:
+            value = obj["value"]
+            if type(value) is list:
+                for v in value:
+                    assert_handle(v, False)
+
+            if type(value) is dict:
+                for v in value.values():
+                    assert_handle(v, False)
+
     else:
         assert "handle" not in obj, f"Result should not contain `handle`. Actual: {obj}"
 

--- a/webdriver/tests/bidi/script/call_function/result_ownership.py
+++ b/webdriver/tests/bidi/script/call_function/result_ownership.py
@@ -52,7 +52,7 @@ async def test_rejected_promise(bidi_session, top_context, result_ownership, sho
                          [("root", True), ("none", False), (None, False)])
 async def test_return_value(bidi_session, top_context, await_promise, result_ownership, should_contain_handle):
     result = await bidi_session.script.call_function(
-        function_declaration="async function(){return {a:1}}",
+        function_declaration="async function(){return {a: {b:1}}}",
         await_promise=await_promise,
         result_ownership=result_ownership,
         target=ContextTarget(top_context["context"]))

--- a/webdriver/tests/bidi/script/evaluate/result_ownership.py
+++ b/webdriver/tests/bidi/script/evaluate/result_ownership.py
@@ -52,7 +52,7 @@ async def test_rejected_promise(bidi_session, top_context, result_ownership, sho
                          [("root", True), ("none", False), (None, False)])
 async def test_return_value(bidi_session, top_context, await_promise, result_ownership, should_contain_handle):
     result = await bidi_session.script.evaluate(
-        expression="Promise.resolve({a:1})",
+        expression="Promise.resolve({a: {b:1}})",
         await_promise=await_promise,
         result_ownership=result_ownership,
         target=ContextTarget(top_context["context"]))


### PR DESCRIPTION
Per serialization spec, child ownership is always set to "none" before serializing values. This means that only the root can ever have a handle id set.

Our current tests for resultOwnership="root" assert that a handle is set on the root remote value, but not that nested remote values do not have a handle id.