### PR TITLE
Improve wptrunner dispatching mechanism

### DIFF
--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -346,7 +346,7 @@ def test_tests_affected_idlharness(capsys, manifest_dir):
             "webrtc-encoded-transform/idlharness.https.window.js\n" +
             "webrtc-identity/idlharness.https.window.js\n" +
             "webrtc-stats/idlharness.window.js\n" +
-            "webrtc-stats/supported-stats.html\n" +
+            "webrtc-stats/supported-stats.https.html\n" +
             "webrtc/idlharness.https.window.js\n") == out
 
 

--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -87,9 +87,7 @@ class Browser:
     """Abstract class serving as the basis for Browser implementations.
 
     The Browser is used in the TestRunnerManager to start and stop the browser
-    process, and to check the state of that process. This class also acts as a
-    context manager, enabling it to do browser-specific setup at the start of
-    the testrun and cleanup after the run is complete.
+    process, and to check the state of that process.
 
     :param logger: Structured logger to use for output.
     """
@@ -100,13 +98,6 @@ class Browser:
 
     def __init__(self, logger):
         self.logger = logger
-
-    def __enter__(self):
-        self.setup()
-        return self
-
-    def __exit__(self, *args, **kwargs):
-        self.cleanup()
 
     def setup(self):
         """Used for browser-specific setup that happens at the start of a test run"""

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -474,9 +474,8 @@ class BrowserInstance:
         return False
 
     def cleanup(self):
-        if self.runner:
-            self.runner.cleanup()
-            self.runner = None
+        self.runner.cleanup()
+        self.runner = None
 
 
 class FirefoxOutputHandler(OutputHandler):

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -474,8 +474,9 @@ class BrowserInstance:
         return False
 
     def cleanup(self):
-        self.runner.cleanup()
-        self.runner = None
+        if self.runner:
+            self.runner.cleanup()
+            self.runner = None
 
 
 class FirefoxOutputHandler(OutputHandler):

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -1,12 +1,13 @@
 # mypy: allow-untyped-defs
 
 import hashlib
+import itertools
 import json
 import os
 from urllib.parse import urlsplit
 from abc import ABCMeta, abstractmethod
 from queue import Empty
-from collections import defaultdict, deque
+from collections import defaultdict, deque, namedtuple
 
 from . import manifestinclude
 from . import manifestexpected
@@ -359,24 +360,26 @@ def get_test_src(**kwargs):
     return test_source_cls, test_source_kwargs, chunker_kwargs
 
 
+TestGroup = namedtuple("TestGroup", ["group", "test_type", "metadata"])
+
+
 class TestSource:
     __metaclass__ = ABCMeta
 
     def __init__(self, test_queue):
         self.test_queue = test_queue
-        self.current_group = None
-        self.current_metadata = None
+        self.current_group = TestGroup(None, None, None)
         self.logger = structured.get_default_logger()
         if self.logger is None:
             self.logger = structured.structuredlog.StructuredLogger("TestSource")
 
     @abstractmethod
     #@classmethod (doesn't compose with @abstractmethod in < 3.3)
-    def make_queue(cls, tests, **kwargs):  # noqa: N805
+    def make_queue(cls, tests_by_type, **kwargs):  # noqa: N805
         pass
 
     @abstractmethod
-    def tests_by_group(cls, tests, **kwargs):  # noqa: N805
+    def tests_by_group(cls, tests_by_type, **kwargs):  # noqa: N805
         pass
 
     @classmethod
@@ -384,42 +387,43 @@ class TestSource:
         return {"scope": "/"}
 
     def group(self):
-        if not self.current_group or len(self.current_group) == 0:
+        if not self.current_group.group or len(self.current_group.group) == 0:
             try:
-                self.current_group, self.current_metadata = self.test_queue.get(block=True, timeout=5)
+                self.current_group = self.test_queue.get(block=True, timeout=5)
             except Empty:
                 self.logger.warning("Timed out getting test group from queue")
-                return None, None
-        return self.current_group, self.current_metadata
+                return TestGroup(None, None, None)
+        return self.current_group
 
     @classmethod
     def add_sentinal(cls, test_queue, num_of_workers):
         # add one sentinal for each worker
         for _ in range(num_of_workers):
-            test_queue.put((None, None))
+            test_queue.put(TestGroup(None, None, None))
 
 
 class GroupedSource(TestSource):
     @classmethod
-    def new_group(cls, state, test, **kwargs):
+    def new_group(cls, state, test_type, test, **kwargs):
         raise NotImplementedError
 
     @classmethod
-    def make_queue(cls, tests, **kwargs):
+    def make_queue(cls, tests_by_type, **kwargs):
         mp = mpcontext.get_context()
         test_queue = mp.Queue()
         groups = []
 
         state = {}
 
-        for test in tests:
-            if cls.new_group(state, test, **kwargs):
-                group_metadata = cls.group_metadata(state)
-                groups.append((deque(), group_metadata))
+        for test_type, tests in tests_by_type.items():
+            for test in tests:
+                if cls.new_group(state, test_type, test, **kwargs):
+                    group_metadata = cls.group_metadata(state)
+                    groups.append(TestGroup(deque(), test_type, group_metadata))
 
-            group, metadata = groups[-1]
-            group.append(test)
-            test.update_metadata(metadata)
+                group, _, metadata = groups[-1]
+                group.append(test)
+                test.update_metadata(metadata)
 
         for item in groups:
             test_queue.put(item)
@@ -427,51 +431,57 @@ class GroupedSource(TestSource):
         return test_queue
 
     @classmethod
-    def tests_by_group(cls, tests, **kwargs):
+    def tests_by_group(cls, tests_by_type, **kwargs):
         groups = defaultdict(list)
         state = {}
         current = None
-        for test in tests:
-            if cls.new_group(state, test, **kwargs):
-                current = cls.group_metadata(state)['scope']
-            groups[current].append(test.id)
+        for test_type, tests in tests_by_type.items():
+            for test in tests:
+                if cls.new_group(state, test_type, test, **kwargs):
+                    current = cls.group_metadata(state)['scope']
+                groups[current].append(test.id)
         return groups
 
 
 class SingleTestSource(TestSource):
     @classmethod
-    def make_queue(cls, tests, **kwargs):
+    def make_queue(cls, tests_by_type, **kwargs):
         mp = mpcontext.get_context()
         test_queue = mp.Queue()
-        processes = kwargs["processes"]
-        queues = [deque([]) for _ in range(processes)]
-        metadatas = [cls.group_metadata(None) for _ in range(processes)]
-        for test in tests:
-            idx = hash(test.id) % processes
-            group = queues[idx]
-            metadata = metadatas[idx]
-            group.append(test)
-            test.update_metadata(metadata)
+        for test_type, tests in tests_by_type.items():
+            processes = kwargs["processes"]
+            queues = [deque([]) for _ in range(processes)]
+            metadatas = [cls.group_metadata(None) for _ in range(processes)]
+            for test in tests:
+                idx = hash(test.id) % processes
+                group = queues[idx]
+                metadata = metadatas[idx]
+                group.append(test)
+                test.update_metadata(metadata)
 
-        for item in zip(queues, metadatas):
-            test_queue.put(item)
+            for item in zip(queues, itertools.repeat(test_type), metadatas):
+                if len(item[0]) > 0:
+                    test_queue.put(TestGroup(*item))
         cls.add_sentinal(test_queue, kwargs["processes"])
 
         return test_queue
 
     @classmethod
-    def tests_by_group(cls, tests, **kwargs):
-        return {cls.group_metadata(None)['scope']: [t.id for t in tests]}
+    def tests_by_group(cls, tests_by_type, **kwargs):
+        return {cls.group_metadata(None)['scope']:
+                [t.id for t in itertools.chain.from_iterable(tests_by_type.values())]}
 
 
 class PathGroupedSource(GroupedSource):
     @classmethod
-    def new_group(cls, state, test, **kwargs):
+    def new_group(cls, state, test_type, test, **kwargs):
         depth = kwargs.get("depth")
         if depth is True or depth == 0:
             depth = None
         path = urlsplit(test.url).path.split("/")[1:-1][:depth]
-        rv = path != state.get("prev_path")
+        rv = (test_type != state.get("prev_test_type") or
+              path != state.get("prev_path"))
+        state["prev_test_type"] = test_type
         state["prev_path"] = path
         return rv
 
@@ -482,36 +492,38 @@ class PathGroupedSource(GroupedSource):
 
 class GroupFileTestSource(TestSource):
     @classmethod
-    def make_queue(cls, tests, **kwargs):
-        tests_by_group = cls.tests_by_group(tests, **kwargs)
-
-        ids_to_tests = {test.id: test for test in tests}
-
+    def make_queue(cls, tests_by_type, **kwargs):
         mp = mpcontext.get_context()
         test_queue = mp.Queue()
 
-        for group_name, test_ids in tests_by_group.items():
-            group_metadata = {"scope": group_name}
-            group = deque()
+        for test_type, tests in tests_by_type.items():
+            tests_by_group = cls.tests_by_group({test_type: tests},
+                                                **kwargs)
 
-            for test_id in test_ids:
-                test = ids_to_tests[test_id]
-                group.append(test)
-                test.update_metadata(group_metadata)
+            ids_to_tests = {test.id: test for test in tests}
 
-            test_queue.put((group, group_metadata))
+            for group_name, test_ids in tests_by_group.items():
+                group_metadata = {"scope": group_name}
+                group = deque()
+
+                for test_id in test_ids:
+                    test = ids_to_tests[test_id]
+                    group.append(test)
+                    test.update_metadata(group_metadata)
+
+                test_queue.put(TestGroup(group, test_type, group_metadata))
 
         cls.add_sentinal(test_queue, kwargs["processes"])
 
         return test_queue
 
     @classmethod
-    def tests_by_group(cls, tests, **kwargs):
+    def tests_by_group(cls, tests_by_type, **kwargs):
         logger = kwargs["logger"]
         test_groups = kwargs["test_groups"]
 
         tests_by_group = defaultdict(list)
-        for test in tests:
+        for test in itertools.chain.from_iterable(tests_by_type.values()):
             try:
                 group = test_groups.group_by_test[test.id]
             except KeyError:

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -399,8 +399,8 @@ class TestRunnerManager(threading.Thread):
             raise
         finally:
             self.logger.debug("TestRunnerManager main loop terminating, starting cleanup")
-            force_stop = (not isinstance(self.state, RunnerManagerState.stop)
-                          or self.state.force_stop)
+            force_stop = (not isinstance(self.state, RunnerManagerState.stop) or
+                          self.state.force_stop)
             self.stop_runner(force=force_stop)
             self.teardown()
         self.logger.debug("TestRunnerManager main loop terminated")

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -24,6 +24,11 @@ def release_mozlog_lock():
         pass
 
 
+TestImplementation = namedtuple('TestImplementation',
+                                ['executor_cls', 'executor_kwargs',
+                                 'browser_cls', 'browser_kwargs'])
+
+
 class LogMessageHandler:
     def __init__(self, send_message):
         self.send_message = send_message
@@ -234,6 +239,7 @@ class BrowserManager:
         self.started = False
 
     def cleanup(self):
+        self.browser.cleanup()
         if self.init_timer is not None:
             self.init_timer.cancel()
 
@@ -247,9 +253,11 @@ class BrowserManager:
 class _RunnerManagerState:
     before_init = namedtuple("before_init", [])
     initializing = namedtuple("initializing",
-                              ["test", "test_group", "group_metadata", "failure_count"])
-    running = namedtuple("running", ["test", "test_group", "group_metadata"])
-    restarting = namedtuple("restarting", ["test", "test_group", "group_metadata", "force_stop"])
+                              ["test_type", "test", "test_group",
+                               "group_metadata", "failure_count"])
+    running = namedtuple("running", ["test_type", "test", "test_group", "group_metadata"])
+    restarting = namedtuple("restarting", ["test_type", "test", "test_group",
+                                           "group_metadata", "force_stop"])
     error = namedtuple("error", [])
     stop = namedtuple("stop", ["force_stop"])
 
@@ -258,10 +266,11 @@ RunnerManagerState = _RunnerManagerState()
 
 
 class TestRunnerManager(threading.Thread):
-    def __init__(self, suite_name, index, test_type, test_queue, test_source_cls, browser_cls,
-                 browser_kwargs, executor_cls, executor_kwargs, stop_flag, rerun=1,
-                 pause_after_test=False, pause_on_unexpected=False, restart_on_unexpected=True,
-                 debug_info=None, capture_stdio=True, restart_on_new_group=True, recording=None):
+    def __init__(self, suite_name, index, test_queue, test_source_cls,
+                 test_implementation_by_type, stop_flag, rerun=1,
+                 pause_after_test=False, pause_on_unexpected=False,
+                 restart_on_unexpected=True, debug_info=None,
+                 capture_stdio=True, restart_on_new_group=True, recording=None):
         """Thread that owns a single TestRunner process and any processes required
         by the TestRunner (e.g. the Firefox binary).
 
@@ -282,16 +291,22 @@ class TestRunnerManager(threading.Thread):
         self.test_source = test_source_cls(test_queue)
 
         self.manager_number = index
-        self.test_type = test_type
-        self.browser_cls = browser_cls
-        self.browser_kwargs = browser_kwargs.copy()
-        if self.browser_kwargs.get("device_serial"):
-            # Assign Android device to runner according to current manager index
-            self.browser_kwargs["device_serial"] = (
-                self.browser_kwargs["device_serial"][index])
+        self.test_type = None
 
-        self.executor_cls = executor_cls
-        self.executor_kwargs = executor_kwargs
+        self.test_implementation_by_type = {}
+        for test_type, test_implementation in test_implementation_by_type.items():
+            kwargs = test_implementation.browser_kwargs
+            if kwargs.get("device_serial"):
+                kwargs = kwargs.copy()
+                # Assign Android device to runner according to current manager index
+                kwargs["device_serial"] = kwargs["device_serial"][index]
+                self.test_implementation_by_type[test_type] = TestImplementation(
+                    test_implementation.executor_cls,
+                    test_implementation.executor_kwargs,
+                    test_implementation.browser_cls,
+                    kwargs)
+            else:
+                self.test_implementation_by_type[test_type] = test_implementation
 
         mp = mpcontext.get_context()
 
@@ -345,54 +360,49 @@ class TestRunnerManager(threading.Thread):
         spins."""
         self.recording.set(["testrunner", "startup"])
         self.logger = structuredlog.StructuredLogger(self.suite_name)
-        with self.browser_cls(self.logger, remote_queue=self.command_queue,
-                              **self.browser_kwargs) as browser:
-            self.browser = BrowserManager(self.logger,
-                                          browser,
-                                          self.command_queue,
-                                          no_timeout=self.debug_info is not None)
-            dispatch = {
-                RunnerManagerState.before_init: self.start_init,
-                RunnerManagerState.initializing: self.init,
-                RunnerManagerState.running: self.run_test,
-                RunnerManagerState.restarting: self.restart_runner,
-            }
+        dispatch = {
+            RunnerManagerState.before_init: self.start_init,
+            RunnerManagerState.initializing: self.init,
+            RunnerManagerState.running: self.run_test,
+            RunnerManagerState.restarting: self.restart_runner,
+        }
 
-            self.state = RunnerManagerState.before_init()
-            end_states = (RunnerManagerState.stop,
-                          RunnerManagerState.error)
+        self.state = RunnerManagerState.before_init()
+        end_states = (RunnerManagerState.stop,
+                      RunnerManagerState.error)
 
-            try:
-                while not isinstance(self.state, end_states):
-                    f = dispatch.get(self.state.__class__)
-                    while f:
-                        self.logger.debug("Dispatch %s" % f.__name__)
-                        if self.should_stop():
-                            return
-                        new_state = f()
-                        if new_state is None:
-                            break
-                        self.state = new_state
-                        self.logger.debug("new state: %s" % self.state.__class__.__name__)
-                        if isinstance(self.state, end_states):
-                            return
-                        f = dispatch.get(self.state.__class__)
-
-                    new_state = None
-                    while new_state is None:
-                        new_state = self.wait_event()
-                        if self.should_stop():
-                            return
+        try:
+            while not isinstance(self.state, end_states):
+                f = dispatch.get(self.state.__class__)
+                while f:
+                    self.logger.debug(f"Dispatch {f.__name__}")
+                    if self.should_stop():
+                        return
+                    new_state = f()
+                    if new_state is None:
+                        break
                     self.state = new_state
-                    self.logger.debug("new state: %s" % self.state.__class__.__name__)
-            except Exception:
-                self.logger.error(traceback.format_exc())
-                raise
-            finally:
-                self.logger.debug("TestRunnerManager main loop terminating, starting cleanup")
-                force_stop = not isinstance(self.state, RunnerManagerState.stop) or self.state.force_stop
-                self.stop_runner(force=force_stop)
-                self.teardown()
+                    self.logger.debug(f"new state: {self.state.__class__.__name__}")
+                    if isinstance(self.state, end_states):
+                        return
+                    f = dispatch.get(self.state.__class__)
+
+                new_state = None
+                while new_state is None:
+                    new_state = self.wait_event()
+                    if self.should_stop():
+                        return
+                self.state = new_state
+                self.logger.debug(f"new state: {self.state.__class__.__name__}")
+        except Exception:
+            self.logger.error(traceback.format_exc())
+            raise
+        finally:
+            self.logger.debug("TestRunnerManager main loop terminating, starting cleanup")
+            force_stop = (not isinstance(self.state, RunnerManagerState.stop)
+                          or self.state.force_stop)
+            self.stop_runner(force=force_stop)
+            self.teardown()
         self.logger.debug("TestRunnerManager main loop terminated")
 
     def wait_event(self):
@@ -422,7 +432,8 @@ class TestRunnerManager(threading.Thread):
             self.logger.debug("Got command: %r" % command)
         except OSError:
             self.logger.error("Got IOError from poll")
-            return RunnerManagerState.restarting(self.state.test,
+            return RunnerManagerState.restarting(self.state.test_type,
+                                                 self.state.test,
                                                  self.state.test_group,
                                                  self.state.group_metadata,
                                                  False)
@@ -450,7 +461,8 @@ class TestRunnerManager(threading.Thread):
                     self.logger.critical("Last test did not complete")
                     return RunnerManagerState.error()
                 self.logger.warning("More tests found, but runner process died, restarting")
-                return RunnerManagerState.restarting(self.state.test,
+                return RunnerManagerState.restarting(self.state.test_type,
+                                                     self.state.test,
                                                      self.state.test_group,
                                                      self.state.group_metadata,
                                                      False)
@@ -467,12 +479,12 @@ class TestRunnerManager(threading.Thread):
         return self.child_stop_flag.is_set() or self.parent_stop_flag.is_set()
 
     def start_init(self):
-        test, test_group, group_metadata = self.get_next_test()
+        test_type, test, test_group, group_metadata = self.get_next_test()
         self.recording.set(["testrunner", "init"])
         if test is None:
             return RunnerManagerState.stop(True)
         else:
-            return RunnerManagerState.initializing(test, test_group, group_metadata, 0)
+            return RunnerManagerState.initializing(test_type, test, test_group, group_metadata, 0)
 
     def init(self):
         assert isinstance(self.state, RunnerManagerState.initializing)
@@ -480,19 +492,32 @@ class TestRunnerManager(threading.Thread):
             self.logger.critical("Max restarts exceeded")
             return RunnerManagerState.error()
 
+        if self.state.test_type != self.test_type:
+            if self.browser is not None:
+                self.browser.cleanup()
+            _, _, browser_cls, browser_kwargs = self.test_implementation_by_type[
+                self.state.test_type]
+            browser = browser_cls(self.logger, remote_queue=self.command_queue,
+                                  **browser_kwargs)
+            browser.setup()
+            self.browser = BrowserManager(self.logger,
+                                          browser,
+                                          self.command_queue,
+                                          no_timeout=self.debug_info is not None)
+            self.test_type = self.state.test_type
+
         self.browser.update_settings(self.state.test)
 
         result = self.browser.init(self.state.group_metadata)
         if result is Stop:
             return RunnerManagerState.error()
         elif not result:
-            return RunnerManagerState.initializing(self.state.test,
+            return RunnerManagerState.initializing(self.state.test_type,
+                                                   self.state.test,
                                                    self.state.test_group,
                                                    self.state.group_metadata,
                                                    self.state.failure_count + 1)
         else:
-            self.executor_kwargs["group_metadata"] = self.state.group_metadata
-            self.executor_kwargs["browser_settings"] = self.browser.browser_settings
             self.start_test_runner()
 
     def start_test_runner(self):
@@ -503,6 +528,10 @@ class TestRunnerManager(threading.Thread):
         assert self.command_queue is not None
         assert self.remote_queue is not None
         self.logger.info("Starting runner")
+        self.executor_cls, self.executor_kwargs, _, _ = self.test_implementation_by_type[
+            self.state.test_type]
+        self.executor_kwargs["group_metadata"] = self.state.group_metadata
+        self.executor_kwargs["browser_settings"] = self.browser.browser_settings
         executor_browser_cls, executor_browser_kwargs = self.browser.browser.executor_browser()
 
         args = (self.remote_queue,
@@ -527,7 +556,8 @@ class TestRunnerManager(threading.Thread):
     def init_succeeded(self):
         assert isinstance(self.state, RunnerManagerState.initializing)
         self.browser.after_init()
-        return RunnerManagerState.running(self.state.test,
+        return RunnerManagerState.running(self.state.test_type,
+                                          self.state.test,
                                           self.state.test_group,
                                           self.state.group_metadata)
 
@@ -536,22 +566,25 @@ class TestRunnerManager(threading.Thread):
         self.browser.check_crash(None)
         self.browser.after_init()
         self.stop_runner(force=True)
-        return RunnerManagerState.initializing(self.state.test,
+        return RunnerManagerState.initializing(self.state.test_type,
+                                               self.state.test,
                                                self.state.test_group,
                                                self.state.group_metadata,
                                                self.state.failure_count + 1)
 
-    def get_next_test(self, test_group=None):
+    def get_next_test(self):
+        # returns test_type, test, test_group, group_metadata
         test = None
+        test_group = None
         while test is None:
             while test_group is None or len(test_group) == 0:
-                test_group, group_metadata = self.test_source.group()
+                test_group, test_type, group_metadata = self.test_source.group()
                 if test_group is None:
                     self.logger.info("No more tests")
-                    return None, None, None
+                    return None, None, None, None
             test = test_group.popleft()
         self.run_count = 0
-        return test, test_group, group_metadata
+        return test_type, test, test_group, group_metadata
 
     def run_test(self):
         assert isinstance(self.state, RunnerManagerState.running)
@@ -559,7 +592,8 @@ class TestRunnerManager(threading.Thread):
 
         if self.browser.update_settings(self.state.test):
             self.logger.info("Restarting browser for new test environment")
-            return RunnerManagerState.restarting(self.state.test,
+            return RunnerManagerState.restarting(self.state.test_type,
+                                                 self.state.test,
                                                  self.state.test_group,
                                                  self.state.group_metadata,
                                                  False)
@@ -718,26 +752,34 @@ class TestRunnerManager(threading.Thread):
         # that as long as we've done at least the automatic run count in total we can
         # continue with the next test.
         if not force_rerun and self.run_count >= self.rerun:
-            test, test_group, group_metadata = self.get_next_test()
+            test_type, test, test_group, group_metadata = self.get_next_test()
             if test is None:
                 return RunnerManagerState.stop(force_stop)
-            if self.restart_on_new_group and test_group is not self.state.test_group:
+            if test_type != self.state.test_type:
+                self.logger.info(f"Restarting browser for new test type:{test_type}")
+                restart = True
+            elif self.restart_on_new_group and test_group is not self.state.test_group:
                 self.logger.info("Restarting browser for new test group")
                 restart = True
         else:
+            test_type = self.state.test_type
             test_group = self.state.test_group
             group_metadata = self.state.group_metadata
 
         if restart:
-            return RunnerManagerState.restarting(test, test_group, group_metadata, force_stop)
+            return RunnerManagerState.restarting(
+                test_type, test, test_group, group_metadata, force_stop)
         else:
-            return RunnerManagerState.running(test, test_group, group_metadata)
+            return RunnerManagerState.running(
+                test_type, test, test_group, group_metadata)
 
     def restart_runner(self):
         """Stop and restart the TestRunner"""
         assert isinstance(self.state, RunnerManagerState.restarting)
         self.stop_runner(force=self.state.force_stop)
-        return RunnerManagerState.initializing(self.state.test, self.state.test_group, self.state.group_metadata, 0)
+        return RunnerManagerState.initializing(
+            self.state.test_type, self.state.test,
+            self.state.test_group, self.state.group_metadata, 0)
 
     def log(self, data):
         self.logger.log_raw(data)
@@ -762,6 +804,8 @@ class TestRunnerManager(threading.Thread):
 
     def teardown(self):
         self.logger.debug("TestRunnerManager teardown")
+        if self.browser is not None:
+            self.browser.cleanup()
         self.test_runner_proc = None
         self.command_queue.close()
         self.remote_queue.close()
@@ -854,8 +898,7 @@ def make_test_queue(tests, test_source_cls, **test_source_kwargs):
 class ManagerGroup:
     """Main thread object that owns all the TestRunnerManager threads."""
     def __init__(self, suite_name, size, test_source_cls, test_source_kwargs,
-                 browser_cls, browser_kwargs,
-                 executor_cls, executor_kwargs,
+                 test_implementation_by_type,
                  rerun=1,
                  pause_after_test=False,
                  pause_on_unexpected=False,
@@ -868,10 +911,7 @@ class ManagerGroup:
         self.size = size
         self.test_source_cls = test_source_cls
         self.test_source_kwargs = test_source_kwargs
-        self.browser_cls = browser_cls
-        self.browser_kwargs = browser_kwargs
-        self.executor_cls = executor_cls
-        self.executor_kwargs = executor_kwargs
+        self.test_implementation_by_type = test_implementation_by_type
         self.pause_after_test = pause_after_test
         self.pause_on_unexpected = pause_on_unexpected
         self.restart_on_unexpected = restart_on_unexpected
@@ -894,25 +934,18 @@ class ManagerGroup:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop()
 
-    def run(self, test_type, tests):
+    def run(self, tests):
         """Start all managers in the group"""
         self.logger.debug("Using %i processes" % self.size)
-        if not tests:
-            self.logger.info("No %s tests to run" % test_type)
-            return
 
         test_queue = make_test_queue(tests, self.test_source_cls, **self.test_source_kwargs)
 
         for idx in range(self.size):
             manager = TestRunnerManager(self.suite_name,
                                         idx,
-                                        test_type,
                                         test_queue,
                                         self.test_source_cls,
-                                        self.browser_cls,
-                                        self.browser_kwargs,
-                                        self.executor_cls,
-                                        self.executor_kwargs,
+                                        self.test_implementation_by_type,
                                         self.stop_flag,
                                         self.rerun,
                                         self.pause_after_test,

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -239,9 +239,6 @@ class BrowserManager:
         self.started = False
 
     def cleanup(self):
-        if self.browser:
-            self.browser.cleanup()
-            self.browser = None
         if self.init_timer is not None:
             self.init_timer.cancel()
 
@@ -405,6 +402,9 @@ class TestRunnerManager(threading.Thread):
                           self.state.force_stop)
             self.stop_runner(force=force_stop)
             self.teardown()
+            if self.browser is not None:
+                assert self.browser.browser is not None
+                self.browser.browser.cleanup()
         self.logger.debug("TestRunnerManager main loop terminated")
 
     def wait_event(self):
@@ -496,7 +496,8 @@ class TestRunnerManager(threading.Thread):
 
         if self.state.test_type != self.test_type:
             if self.browser is not None:
-                self.browser.cleanup()
+                assert self.browser.browser is not None
+                self.browser.browser.cleanup()
             _, _, browser_cls, browser_kwargs = self.test_implementation_by_type[
                 self.state.test_type]
             browser = browser_cls(self.logger, remote_queue=self.command_queue,
@@ -508,6 +509,7 @@ class TestRunnerManager(threading.Thread):
                                           no_timeout=self.debug_info is not None)
             self.test_type = self.state.test_type
 
+        assert self.browser is not None
         self.browser.update_settings(self.state.test)
 
         result = self.browser.init(self.state.group_metadata)

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -498,10 +498,9 @@ class TestRunnerManager(threading.Thread):
             if self.browser is not None:
                 assert self.browser.browser is not None
                 self.browser.browser.cleanup()
-            _, _, browser_cls, browser_kwargs = self.test_implementation_by_type[
-                self.state.test_type]
-            browser = browser_cls(self.logger, remote_queue=self.command_queue,
-                                  **browser_kwargs)
+            impl = self.test_implementation_by_type[self.state.test_type]
+            browser = impl.browser_cls(self.logger, remote_queue=self.command_queue,
+                                       **impl.browser_kwargs)
             browser.setup()
             self.browser = BrowserManager(self.logger,
                                           browser,
@@ -532,8 +531,9 @@ class TestRunnerManager(threading.Thread):
         assert self.command_queue is not None
         assert self.remote_queue is not None
         self.logger.info("Starting runner")
-        self.executor_cls, self.executor_kwargs, _, _ = self.test_implementation_by_type[
-            self.state.test_type]
+        impl = self.test_implementation_by_type[self.state.test_type]
+        self.executor_cls = impl.executor_cls
+        self.executor_kwargs = impl.executor_kwargs
         self.executor_kwargs["group_metadata"] = self.state.group_metadata
         self.executor_kwargs["browser_settings"] = self.browser.browser_settings
         executor_browser_cls, executor_browser_kwargs = self.browser.browser.executor_browser()

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -239,7 +239,9 @@ class BrowserManager:
         self.started = False
 
     def cleanup(self):
-        self.browser.cleanup()
+        if self.browser:
+            self.browser.cleanup()
+            self.browser = None
         if self.init_timer is not None:
             self.init_timer.cancel()
 
@@ -804,8 +806,6 @@ class TestRunnerManager(threading.Thread):
 
     def teardown(self):
         self.logger.debug("TestRunnerManager teardown")
-        if self.browser is not None:
-            self.browser.cleanup()
         self.test_runner_proc = None
         self.command_queue.close()
         self.remote_queue.close()

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+from collections import defaultdict
 from datetime import datetime, timedelta
 
 import wptserve
@@ -18,7 +19,7 @@ from . import wptlogging
 from . import wpttest
 from mozlog import capture, handlers
 from .font import FontInstaller
-from .testrunner import ManagerGroup
+from .testrunner import ManagerGroup, TestImplementation
 
 here = os.path.dirname(__file__)
 
@@ -158,13 +159,13 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
                        recording, test_environment, product, run_test_kwargs):
     """Runs the entire test suite.
     This is called for each repeat or retry run requested."""
-    tests = []
+    tests_by_type = defaultdict(list)
     for test_type in test_loader.test_types:
-        tests.extend(test_loader.tests[test_type])
+        tests_by_type[test_type].extend(test_loader.tests[test_type])
 
     try:
         test_groups = test_source_cls.tests_by_group(
-            tests, **test_source_kwargs)
+            tests_by_type, **test_source_kwargs)
     except Exception:
         logger.critical("Loading tests failed")
         return False
@@ -174,14 +175,23 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
             test_groups[test_type] = [test for test in tests
                                       if test in test_status.unexpected_tests]
 
-    unexpected_tests = set()
     logger.suite_start(test_groups,
                        name='web-platform-test',
                        run_info=run_info,
                        extra={"run_by_dir": run_test_kwargs["run_by_dir"]})
-    for test_type in sorted(run_test_kwargs["test_types"]):
-        logger.info(f"Running {test_type} tests")
 
+    test_implementation_by_type = {}
+
+    for test_type in run_test_kwargs["test_types"]:
+        executor_cls = product.executor_classes.get(test_type)
+        if executor_cls is None:
+            logger.warning(f"Unsupported test type {test_type} for product {product.name}")
+            continue
+        executor_kwargs = product.get_executor_kwargs(logger,
+                                                      test_type,
+                                                      test_environment,
+                                                      run_info,
+                                                      **run_test_kwargs)
         browser_cls = product.get_browser_cls(test_type)
         browser_kwargs = product.get_browser_kwargs(logger,
                                                     test_type,
@@ -189,17 +199,14 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
                                                     config=test_environment.config,
                                                     num_test_groups=len(test_groups),
                                                     **run_test_kwargs)
+        test_implementation_by_type[test_type] = TestImplementation(executor_cls,
+                                                                    executor_kwargs,
+                                                                    browser_cls,
+                                                                    browser_kwargs)
 
-        executor_cls = product.executor_classes.get(test_type)
-        executor_kwargs = product.get_executor_kwargs(logger,
-                                                      test_type,
-                                                      test_environment,
-                                                      run_info,
-                                                      **run_test_kwargs)
-
-        if executor_cls is None:
-            logger.error(f"Unsupported test type {test_type} for product {product.name}")
-            continue
+    tests_to_run = {}
+    for test_type, test_implementation in test_implementation_by_type.items():
+        executor_cls = test_implementation.executor_cls
 
         for test in test_loader.disabled_tests[test_type]:
             logger.test_start(test.id)
@@ -207,53 +214,50 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
             test_status.skipped += 1
 
         if test_type == "testharness":
-            tests_to_run = []
-            for test in test_loader.tests["testharness"]:
+            tests_to_run[test_type] = []
+            for test in test_loader.tests[test_type]:
                 if ((test.testdriver and not executor_cls.supports_testdriver) or
                         (test.jsshell and not executor_cls.supports_jsshell)):
                     logger.test_start(test.id)
                     logger.test_end(test.id, status="SKIP")
                     test_status.skipped += 1
                 else:
-                    tests_to_run.append(test)
+                    tests_to_run[test_type].append(test)
         else:
-            tests_to_run = test_loader.tests[test_type]
+            tests_to_run[test_type] = test_loader.tests[test_type]
+
         if test_status.retries_remaining:
-            tests_to_run = [test for test in tests_to_run
+            tests_to_run[test_type] = [test for test in tests_to_run[test_type]
                             if test.id in test_status.unexpected_tests]
 
-        recording.pause()
-        with ManagerGroup("web-platform-tests",
-                          run_test_kwargs["processes"],
-                          test_source_cls,
-                          test_source_kwargs,
-                          browser_cls,
-                          browser_kwargs,
-                          executor_cls,
-                          executor_kwargs,
-                          run_test_kwargs["rerun"],
-                          run_test_kwargs["pause_after_test"],
-                          run_test_kwargs["pause_on_unexpected"],
-                          run_test_kwargs["restart_on_unexpected"],
-                          run_test_kwargs["debug_info"],
-                          not run_test_kwargs["no_capture_stdio"],
-                          run_test_kwargs["restart_on_new_group"],
-                          recording=recording) as manager_group:
-            try:
-                manager_group.run(test_type, tests_to_run)
-            except KeyboardInterrupt:
-                logger.critical("Main thread got signal")
-                manager_group.stop()
-                raise
-            test_status.total_tests += manager_group.test_count()
-            test_status.unexpected += manager_group.unexpected_count()
-            test_status.unexpected_pass += manager_group.unexpected_pass_count()
-            unexpected_tests.update(manager_group.unexpected_tests())
+    recording.pause()
+    with ManagerGroup("web-platform-tests",
+                      run_test_kwargs["processes"],
+                      test_source_cls,
+                      test_source_kwargs,
+                      test_implementation_by_type,
+                      run_test_kwargs["rerun"],
+                      run_test_kwargs["pause_after_test"],
+                      run_test_kwargs["pause_on_unexpected"],
+                      run_test_kwargs["restart_on_unexpected"],
+                      run_test_kwargs["debug_info"],
+                      not run_test_kwargs["no_capture_stdio"],
+                      run_test_kwargs["restart_on_new_group"],
+                      recording=recording) as manager_group:
+        try:
+            manager_group.run(tests_to_run)
+        except KeyboardInterrupt:
+            logger.critical("Main thread got signal")
+            manager_group.stop()
+            raise
+        test_status.total_tests += manager_group.test_count()
+        test_status.unexpected += manager_group.unexpected_count()
+        test_status.unexpected_pass += manager_group.unexpected_pass_count()
 
     if test_status.repeated_runs == 1:
-        test_status.unexpected_tests = unexpected_tests
+        test_status.unexpected_tests = manager_group.unexpected_tests()
     else:
-        test_status.unexpected_tests &= unexpected_tests
+        test_status.unexpected_tests &= manager_group.unexpected_tests()
 
     return True
 

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -228,7 +228,7 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
 
         if test_status.retries_remaining:
             tests_to_run[test_type] = [test for test in tests_to_run[test_type]
-                            if test.id in test_status.unexpected_tests]
+                                       if test.id in test_status.unexpected_tests]
 
     recording.pause()
     with ManagerGroup("web-platform-tests",


### PR DESCRIPTION
Currently wptrunner is running different type of tests in different rounds. At the end of each round there will be time spent to wait for all workers to finish.

With this change, wptrunner can run all different type of tests in one loop. The TestSource class now emits test type together with the test, and test runner then picks the executor class and the parameters to run the test.

Preliminary results shows this reduced total run time by 10%.