### PR TITLE
Expect `OK` for `wheelScroll.html` on Safari/WebKit

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/actions/wheelScroll.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/wheelScroll.html.ini
@@ -1,3 +1,3 @@
 [wheelScroll.html]
   expected:
-    if product == "firefox" or product == "safari" or product == "epiphany" or product == "webkit": ERROR
+    if product == "firefox" or product == "epiphany": ERROR


### PR DESCRIPTION
Speculatively fixes #35974