### PR TITLE
Remove errant whitespace from STP download URL

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1601,7 +1601,7 @@ class Safari(Browser):
                     else:
                         spec = SpecifierSet(f"=={version}.*")
 
-                    stp_downloads.append((spec, link.attrib["href"]))
+                    stp_downloads.append((spec, link.attrib["href"].strip()))
                     break
             else:
                 self.logger.debug(


### PR DESCRIPTION
This change fixes widespread failures in CI: https://dev.azure.com/web-platform-tests/wpt/_build/results?buildId=87608&view=logs&jobId=bf8f5026-3d1f-5955-26be-17f9e1ef0bb3&j=bf8f5026-3d1f-5955-26be-17f9e1ef0bb3&t=fb374013-b51a-5838-c2f2-591e11e493ab