### PR TITLE
Fix use of testharness.js/testharnessreport.js in *.window.js tests

### DIFF
--- a/bluetooth/idl/idl-Bluetooth.https.window.js
+++ b/bluetooth/idl/idl-Bluetooth.https.window.js
@@ -1,5 +1,5 @@
 // META: script=/resources/testdriver.js
-// META: script=/resources/testharnessreport.js
+// META: script=/resources/testdriver-vendor.js
 'use strict';
 const test_desc = 'Bluetooth IDL test';
 

--- a/bluetooth/idl/idl-BluetoothDevice.https.window.js
+++ b/bluetooth/idl/idl-BluetoothDevice.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/idl/idl-BluetoothUUID.window.js
+++ b/bluetooth/idl/idl-BluetoothUUID.window.js
@@ -1,5 +1,5 @@
 // META: script=/resources/testdriver.js
-// META: script=/resources/testharnessreport.js
+// META: script=/resources/testdriver-vendor.js
 'use strict'
 
 var base_uuid = '00000000-0000-1000-8000-00805f9b34fb'

--- a/bluetooth/idl/idl-NavigatorBluetooth.https.window.js
+++ b/bluetooth/idl/idl-NavigatorBluetooth.https.window.js
@@ -1,5 +1,5 @@
 // META: script=/resources/testdriver.js
-// META: script=/resources/testharnessreport.js
+// META: script=/resources/testdriver-vendor.js
 'use strict';
 const test_desc = '[SameObject] test for navigator.bluetooth';
 

--- a/bluetooth/idl/idl-NavigatorBluetooth.window.js
+++ b/bluetooth/idl/idl-NavigatorBluetooth.window.js
@@ -1,5 +1,5 @@
 // META: script=/resources/testdriver.js
-// META: script=/resources/testharnessreport.js
+// META: script=/resources/testdriver-vendor.js
 'use strict';
 
 test(() => {

--- a/bluetooth/requestDevice/acceptAllDevices/device-with-empty-name.https.window.js
+++ b/bluetooth/requestDevice/acceptAllDevices/device-with-empty-name.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/acceptAllDevices/device-with-name.https.window.js
+++ b/bluetooth/requestDevice/acceptAllDevices/device-with-name.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/acceptAllDevices/optional-services-missing.https.window.js
+++ b/bluetooth/requestDevice/acceptAllDevices/optional-services-missing.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/acceptAllDevices/optional-services-present.https.window.js
+++ b/bluetooth/requestDevice/acceptAllDevices/optional-services-present.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/blocklisted-manufacturer-data-in-filter.https.window.js
+++ b/bluetooth/requestDevice/blocklisted-manufacturer-data-in-filter.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/blocklisted-service-in-filter.https.window.js
+++ b/bluetooth/requestDevice/blocklisted-service-in-filter.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/blocklisted-service-in-optionalServices.https.window.js
+++ b/bluetooth/requestDevice/blocklisted-service-in-optionalServices.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/data-prefix-and-mask-size.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/data-prefix-and-mask-size.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/device-name-longer-than-29-bytes.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/device-name-longer-than-29-bytes.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/empty-filter.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/empty-filter.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/empty-filters-member.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/empty-filters-member.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/empty-manufacturerData-member.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/empty-manufacturerData-member.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/empty-namePrefix.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/empty-namePrefix.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/empty-services-member.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/empty-services-member.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/filters-xor-acceptAllDevices.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/filters-xor-acceptAllDevices.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/max-length-exceeded-name-unicode.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/max-length-exceeded-name-unicode.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/max-length-exceeded-name.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/max-length-exceeded-name.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/max-length-exceeded-namePrefix-unicode.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/max-length-exceeded-namePrefix-unicode.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/max-length-exceeded-namePrefix.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/max-length-exceeded-namePrefix.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/max-length-name-unicode.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/max-length-name-unicode.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/max-length-name.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/max-length-name.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/max-length-namePrefix-unicode.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/max-length-namePrefix-unicode.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/max-length-namePrefix.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/max-length-namePrefix.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/no-arguments.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/no-arguments.https.window.js
@@ -1,6 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharness-helpers.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/same-company-identifier.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/same-company-identifier.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/unicode-valid-length-name-name.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/unicode-valid-length-name-name.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/unicode-valid-length-name-namePrefix.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/unicode-valid-length-name-namePrefix.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-optionalServices-member.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-optionalServices-member.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-services-member.https.window.js
+++ b/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-services-member.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/cross-origin-iframe.sub.https.window.js
+++ b/bluetooth/requestDevice/cross-origin-iframe.sub.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/discovery-succeeds.https.window.js
+++ b/bluetooth/requestDevice/discovery-succeeds.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/doesnt-consume-user-gesture.https.window.js
+++ b/bluetooth/requestDevice/doesnt-consume-user-gesture.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/filter-matches.https.window.js
+++ b/bluetooth/requestDevice/filter-matches.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/le-not-supported.https.window.js
+++ b/bluetooth/requestDevice/le-not-supported.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/manufacturer-data-filter-matches.https.window.js
+++ b/bluetooth/requestDevice/manufacturer-data-filter-matches.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/name-empty-device-from-name-empty-filter.https.window.js
+++ b/bluetooth/requestDevice/name-empty-device-from-name-empty-filter.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/not-processing-user-gesture.https.window.js
+++ b/bluetooth/requestDevice/not-processing-user-gesture.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/radio-not-present.https.window.js
+++ b/bluetooth/requestDevice/radio-not-present.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/request-from-iframe.https.window.js
+++ b/bluetooth/requestDevice/request-from-iframe.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/request-from-sandboxed-iframe.https.window.js
+++ b/bluetooth/requestDevice/request-from-sandboxed-iframe.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/same-device.https.window.js
+++ b/bluetooth/requestDevice/same-device.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/requestDevice/single-filter-single-service.https.window.js
+++ b/bluetooth/requestDevice/single-filter-single-service.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/server/connect/connection-succeeds.https.window.js
+++ b/bluetooth/server/connect/connection-succeeds.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/server/connect/garbage-collection-ran-during-success.https.window.js
+++ b/bluetooth/server/connect/garbage-collection-ran-during-success.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/server/connect/get-same-gatt-server.https.window.js
+++ b/bluetooth/server/connect/get-same-gatt-server.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/server/device-same-object.https.window.js
+++ b/bluetooth/server/device-same-object.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/server/disconnect/connect-disconnect-twice.https.window.js
+++ b/bluetooth/server/disconnect/connect-disconnect-twice.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/server/disconnect/detach-gc.https.window.js
+++ b/bluetooth/server/disconnect/detach-gc.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/server/disconnect/disconnect-twice-in-a-row.https.window.js
+++ b/bluetooth/server/disconnect/disconnect-twice-in-a-row.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/server/disconnect/gc-detach.https.window.js
+++ b/bluetooth/server/disconnect/gc-detach.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/server/getPrimaryService/service-found.https.window.js
+++ b/bluetooth/server/getPrimaryService/service-found.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/server/getPrimaryService/two-iframes-from-same-origin.https.window.js
+++ b/bluetooth/server/getPrimaryService/two-iframes-from-same-origin.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/server/getPrimaryServices/blocklisted-services-with-uuid.https.window.js
+++ b/bluetooth/server/getPrimaryServices/blocklisted-services-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/server/getPrimaryServices/blocklisted-services.https.window.js
+++ b/bluetooth/server/getPrimaryServices/blocklisted-services.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/server/getPrimaryServices/correct-services.https.window.js
+++ b/bluetooth/server/getPrimaryServices/correct-services.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/server/getPrimaryServices/services-found-with-uuid.https.window.js
+++ b/bluetooth/server/getPrimaryServices/services-found-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/server/getPrimaryServices/services-found.https.window.js
+++ b/bluetooth/server/getPrimaryServices/services-found.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/server/getPrimaryServices/services-not-found.https.window.js
+++ b/bluetooth/server/getPrimaryServices/services-not-found.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/service/device-same-from-2-services.https.window.js
+++ b/bluetooth/service/device-same-from-2-services.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/service/device-same-object.https.window.js
+++ b/bluetooth/service/device-same-object.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/service/getCharacteristic/characteristic-found.https.window.js
+++ b/bluetooth/service/getCharacteristic/characteristic-found.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/service/getCharacteristics/blocklisted-characteristics.https.window.js
+++ b/bluetooth/service/getCharacteristics/blocklisted-characteristics.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/service/getCharacteristics/characteristics-found-with-uuid.https.window.js
+++ b/bluetooth/service/getCharacteristics/characteristics-found-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/service/getCharacteristics/characteristics-found.https.window.js
+++ b/bluetooth/service/getCharacteristics/characteristics-found.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/bluetooth/service/getCharacteristics/characteristics-not-found.https.window.js
+++ b/bluetooth/service/getCharacteristics/characteristics-not-found.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-test.js

--- a/html/browsers/browsing-the-web/navigating-across-documents/cross-origin-top-navigation-with-user-activation-in-parent.window.js
+++ b/html/browsers/browsing-the-web/navigating-across-documents/cross-origin-top-navigation-with-user-activation-in-parent.window.js
@@ -1,6 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
-
 async_test(t => {
   addEventListener('message', t.step_func_done(e => {
     assert_equals(e.data, 'Denied');

--- a/html/browsers/browsing-the-web/navigating-across-documents/cross-origin-top-navigation-without-user-activation.window.js
+++ b/html/browsers/browsing-the-web/navigating-across-documents/cross-origin-top-navigation-without-user-activation.window.js
@@ -1,6 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
-
 async_test(t => {
   addEventListener('message', t.step_func_done(e => {
     assert_equals(e.data, 'Denied');

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/addHTML.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/addHTML.window.js
@@ -2,8 +2,6 @@
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 // META: script=./resources/test-helper.js
 

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/addIframe.window.js
@@ -2,8 +2,6 @@
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 // META: script=./resources/test-helper.js
 

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/addScripts.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/addScripts.window.js
@@ -2,8 +2,6 @@
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 // META: script=./resources/test-helper.js
 

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-defaults.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-defaults.window.js
@@ -2,8 +2,6 @@
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 // META: script=./resources/test-helper.js
 

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-extra-config.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-extra-config.window.js
@@ -2,8 +2,6 @@
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 // META: script=./resources/test-helper.js
 

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-features.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-features.window.js
@@ -2,8 +2,6 @@
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 // META: script=./resources/test-helper.js
 

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-invalid-origin.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-invalid-origin.window.js
@@ -2,8 +2,6 @@
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 // META: script=./resources/test-helper.js
 

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-startOn.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-startOn.window.js
@@ -2,8 +2,6 @@
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 // META: script=./resources/test-helper.js
 

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-target.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/addWindow-target.window.js
@@ -2,8 +2,6 @@
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 // META: script=./resources/test-helper.js
 

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/addWorker.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/addWorker.window.js
@@ -2,8 +2,6 @@
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 // META: script=./resources/test-helper.js
 

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/constructor.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/constructor.window.js
@@ -2,8 +2,6 @@
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 // META: script=./resources/test-helper.js
 

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/createContext-bad-executorCreator.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/createContext-bad-executorCreator.window.js
@@ -2,8 +2,6 @@
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 
 'use strict';

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/navigateToNew.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/navigateToNew.window.js
@@ -2,8 +2,6 @@
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 // META: script=./resources/test-helper.js
 

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-bfcache.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-bfcache.window.js
@@ -2,8 +2,6 @@
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 // META: script=./resources/test-helper.js
 

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-helpers.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-helpers.window.js
@@ -2,10 +2,9 @@
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 // META: script=./resources/test-helper.js
+// META: timeout=long
 
 'use strict';
 

--- a/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-same-document.window.js
+++ b/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-same-document.window.js
@@ -2,8 +2,6 @@
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 // META: script=./resources/test-helper.js
 

--- a/html/browsers/browsing-the-web/unloading-documents/unload/unload-main-frame-cross-origin.window.js
+++ b/html/browsers/browsing-the-web/unloading-documents/unload/unload-main-frame-cross-origin.window.js
@@ -3,8 +3,6 @@
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 
 promise_test(async t => {
   const rcHelper = new RemoteContextHelper();

--- a/html/browsers/browsing-the-web/unloading-documents/unload/unload-main-frame-same-origin.window.js
+++ b/html/browsers/browsing-the-web/unloading-documents/unload/unload-main-frame-same-origin.window.js
@@ -3,8 +3,6 @@
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 
 promise_test(async t => {
   const rcHelper = new RemoteContextHelper();

--- a/loading/early-hints/invalid-headers-in-early-hints.h2.window.js
+++ b/loading/early-hints/invalid-headers-in-early-hints.h2.window.js
@@ -1,6 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
-
 async function testInvalidHeader(t, header_value) {
     const params = new URLSearchParams();
     params.set("header-value", header_value);

--- a/mediacapture-image/takePhoto-without-PhotoCapabilities.https.window.js
+++ b/mediacapture-image/takePhoto-without-PhotoCapabilities.https.window.js
@@ -1,6 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
-
 promise_test(async t => {
   const track = new MediaStreamTrackGenerator('video');
   const capturer = new ImageCapture(track);

--- a/pending_beacon/pending_beacon-basic.tentative.window.js
+++ b/pending_beacon/pending_beacon-basic.tentative.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=./resources/pending_beacon-helper.js
 
 'use strict';

--- a/pending_beacon/pending_beacon-deactivate.tentative.window.js
+++ b/pending_beacon/pending_beacon-deactivate.tentative.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=./resources/pending_beacon-helper.js
 
 'use strict';

--- a/pending_beacon/pending_beacon-sendnow.tentative.window.js
+++ b/pending_beacon/pending_beacon-sendnow.tentative.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/common/utils.js
 // META: script=./resources/pending_beacon-helper.js
 

--- a/pending_beacon/pending_get_beacon-cors.tentative.https.window.js
+++ b/pending_beacon/pending_get_beacon-cors.tentative.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
 // META: script=./resources/pending_beacon-helper.js

--- a/pending_beacon/pending_get_beacon-send.tentative.window.js
+++ b/pending_beacon/pending_get_beacon-send.tentative.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/common/utils.js
 // META: script=./resources/pending_beacon-helper.js
 

--- a/pending_beacon/pending_post_beacon-cors.tentative.https.window.js
+++ b/pending_beacon/pending_post_beacon-cors.tentative.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
 // META: script=./resources/pending_beacon-helper.js

--- a/pending_beacon/pending_post_beacon-sendwithdata.tentative.window.js
+++ b/pending_beacon/pending_post_beacon-sendwithdata.tentative.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/common/utils.js
 // META: script=./resources/pending_beacon-helper.js
 

--- a/permissions-policy/experimental-features/unload-allowed-by-default.tentative.window.js
+++ b/permissions-policy/experimental-features/unload-allowed-by-default.tentative.window.js
@@ -1,10 +1,9 @@
 // META: title='unload' Policy : allowed by default
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 // META: script=./resources/unload-helper.js
+// META: timeout=long
 
 'use strict';
 

--- a/permissions-policy/experimental-features/unload-disallowed-subframe.tentative.window.js
+++ b/permissions-policy/experimental-features/unload-disallowed-subframe.tentative.window.js
@@ -1,10 +1,9 @@
 // META: title='unload' Policy : allowed in main frame but disallowed in subframe
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 // META: script=./resources/unload-helper.js
+// META: timeout=long
 
 'use strict';
 

--- a/permissions-policy/experimental-features/unload-disallowed.tentative.window.js
+++ b/permissions-policy/experimental-features/unload-disallowed.tentative.window.js
@@ -1,10 +1,9 @@
 // META: title='unload' Policy : disallowed when header is ()
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/utils.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
 // META: script=./resources/unload-helper.js
+// META: timeout=long
 
 'use strict';
 

--- a/web-nfc/NDEFReader_make-read-only.https.window.js
+++ b/web-nfc/NDEFReader_make-read-only.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=resources/nfc-helpers.js
 
 // NDEFReader.makeReadOnly method

--- a/web-nfc/NDEFRecord_constructor.https.window.js
+++ b/web-nfc/NDEFRecord_constructor.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=resources/nfc-helpers.js
 
 // NDEFRecord constructor


### PR DESCRIPTION
These scripts are already included in the template that turns
*.window.js into *.window.html. Including the twice leads to the error
"Identifier 'MessageQueue' has already been declared" in these tests
when run using wptrunner. MessageQueue is a class declared here:
https://github.com/web-platform-tests/wpt/blob/master/tools/wptrunner/wptrunner/testharnessreport.js

There's also one case of testharness-helpers.js being removed. That file
doesn't exist, and the assert_promise_rejects_with_message helper is
defined by /bluetooth/resources/bluetooth-test.js.

Add timeout=long for tests that took close to 10 seconds run and then 
passed. These were flagged as slow tests by the Taskcluster stability 
checks.