### PR TITLE
Use get-host-info.sub.js in screen-wake-lock tests

### DIFF
--- a/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub.html
+++ b/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub.html
@@ -3,13 +3,14 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script>
   "use strict";
 
   const same_origin_src =
     "/feature-policy/resources/feature-policy-screen-wakelock.html";
   const cross_origin_src =
-    "https://{{domains[www]}}:{{ports[https][0]}}" + same_origin_src;
+    get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
   promise_test(t => {
     return promise_rejects_dom(t, "NotAllowedError", navigator.wakeLock.request("screen"));

--- a/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub.html
+++ b/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub.html
@@ -3,6 +3,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script>
   "use strict";
 
@@ -10,7 +11,7 @@
   const base_src = "/feature-policy/resources/redirect-on-load.html#";
   const same_origin_src = base_src + relative_path;
   const cross_origin_src =
-    base_src + "https://{{domains[www]}}:{{ports[https][0]}}" + relative_path;
+    base_src + get_host_info().HTTPS_REMOTE_ORIGIN + relative_path;
 
   async_test(t => {
     test_feature_availability(

--- a/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute.https.sub.html
+++ b/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute.https.sub.html
@@ -3,13 +3,14 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script>
   "use strict";
 
   const same_origin_src =
     "/feature-policy/resources/feature-policy-screen-wakelock.html";
   const cross_origin_src =
-    "https://{{domains[www]}}:{{ports[https][0]}}" + same_origin_src;
+    get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
   async_test(t => {
     test_feature_availability(

--- a/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub.html
+++ b/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub.html
@@ -5,13 +5,14 @@
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script>
   "use strict";
 
   const same_origin_src =
     "/feature-policy/resources/feature-policy-screen-wakelock.html";
   const cross_origin_src =
-    "https://{{domains[www]}}:{{ports[https][0]}}" + same_origin_src;
+    get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
   promise_test(async t => {
     await test_driver.set_permission(

--- a/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub.html
+++ b/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub.html
@@ -5,6 +5,7 @@
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 
 <script>
   "use strict";
@@ -12,7 +13,7 @@
   const same_origin_src =
     "/feature-policy/resources/feature-policy-screen-wakelock.html";
   const cross_origin_src =
-    "https://{{domains[www]}}:{{ports[https][0]}}" + same_origin_src;
+    get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
   promise_test(async t => {
     await test_driver.set_permission(


### PR DESCRIPTION
Use get-host-info.sub.js in screen-wake-lock tests to make them compatible with the WebKit test infrastructure where we run tests over localhost.