### PR TITLE
Encoding: windows-936-2000 is not supported

### DIFF
--- a/encoding/unsupported-labels.window.js
+++ b/encoding/unsupported-labels.window.js
@@ -100,6 +100,7 @@
   "utf-7",
   "utf-32",
   "viscii",
+  "windows-936-2000",
   "windows-sami-2",
   "ws2",
   "x-chinese-cns",


### PR DESCRIPTION
See https://bugs.chromium.org/p/chromium/issues/detail?id=1081315.