### PR TITLE
Add missing call to reportToken() in reporting-redirect-with-same-ori…

### DIFF
--- a/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-redirect-with-same-origin-allow-popups.https.html
+++ b/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-redirect-with-same-origin-allow-popups.https.html
@@ -50,7 +50,7 @@ function redirect_test( popup_origin ) {
 
     // The "opener" window. This has COOP same-origin-allow-popups and a
     // reporter.
-    const opener_report_token= token();
+    const opener_report_token = reportToken();
     const opener_token = reportToken();
     const opener_reportTo = reportingEndpointsHeaders(opener_report_token);
     const opener_url = same_origin.host + executor_path +


### PR DESCRIPTION
…gin-allow-popups.https.html

reportToken() was recently introduced but one call site was not updated. This would cause a `assert_true: Use reportToken() instead. expected true got false` in the test.