### PR TITLE
[css-color-4] Update parsing tests to account for change in serialization rules

### DIFF
--- a/css/css-color/color-function-parsing.html
+++ b/css/css-color/color-function-parsing.html
@@ -31,6 +31,10 @@
     testColorFunction("Display P3 color", "color(display-p3 0.6 0.7 0.8)", "color(display-p3 0.6 0.7 0.8)");
     testColorFunction("Different case for Display P3", "color(dIspLaY-P3 0.6 0.7 0.8)", "color(display-p3 0.6 0.7 0.8)");
 
+    testColorFunction("sRGB color with negative component should not clamp to 0", "color(srgb -0.25 0.5 0.75)", "color(srgb -0.25 0.5 0.75)");
+    testColorFunction("sRGB color with component > 1 should not clamp", "color(srgb 0.25 1.5 0.75)", "color(srgb 0.25 1.5 0.75)");
+    testColorFunction("Display P3 color with negative component should not clamp to 0", "color(display-p3 0.5 -199 0.75)", "color(display-p3 0.5 -199 0.75)");
+    testColorFunction("Display P3 color with component > 1 should not clamp", "color(display-p3 184 1.00001 2347329746587)", "color(display-p3 184 1.00001 2347329700000)");
     testColorFunction("Alpha > 1 should clamp", "color(srgb 0.1 0.2 0.3 / 1.9)", "color(srgb 0.1 0.2 0.3)");
     testColorFunction("Negative alpha should clamp", "color(srgb 1 1 1 / -0.2)", "color(srgb 1 1 1 / 0)");
 

--- a/css/css-color/parsing/color-computed.html
+++ b/css/css-color/parsing/color-computed.html
@@ -97,7 +97,7 @@ test_computed_value("color", "hwb(120 30% 50% / 0%)", "rgba(77, 128, 77, 0)");
 test_computed_value("color", "hwb(none 100% 50% / none)", "rgba(170, 170, 170, 0)");
 test_computed_value("color", "hwb(0 100% 50% / 0)", "rgba(170, 170, 170, 0)");
 
-for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb" ]) {
+for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb", "display-p3" ]) {
     test_computed_value("color", `color(${colorSpace} 0% 0% 0%)`, `color(${colorSpace} 0 0 0)`);
     test_computed_value("color", `color(${colorSpace} 10% 10% 10%)`, `color(${colorSpace} 0.1 0.1 0.1)`);
     test_computed_value("color", `color(${colorSpace} .2 .2 25%)`, `color(${colorSpace} 0.2 0.2 0.25)`);
@@ -167,57 +167,57 @@ for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
 }
 
 for (const colorSpace of [ "lab", "oklab" ]) {
-    test_computed_value("color", `${colorSpace}(0% 0 0)`, `${colorSpace}(0% 0 0)`);
-    test_computed_value("color", `${colorSpace}(0% 0 0 / 1)`, `${colorSpace}(0% 0 0)`);
-    test_computed_value("color", `${colorSpace}(0% 0 0 / 0.5)`, `${colorSpace}(0% 0 0 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(20% 0 10/0.5)`, `${colorSpace}(20% 0 10 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(20% 0 10/50%)`, `${colorSpace}(20% 0 10 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(400% 0 10/50%)`, `${colorSpace}(400% 0 10 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(50% -160 160)`, `${colorSpace}(50% -160 160)`);
-    test_computed_value("color", `${colorSpace}(50% -200 200)`, `${colorSpace}(50% -200 200)`);
-    test_computed_value("color", `${colorSpace}(0% 0 0 / -10%)`, `${colorSpace}(0% 0 0 / 0)`);
-    test_computed_value("color", `${colorSpace}(0% 0 0 / 110%)`, `${colorSpace}(0% 0 0)`);
-    test_computed_value("color", `${colorSpace}(0% 0 0 / 300%)`, `${colorSpace}(0% 0 0)`);
-    test_computed_value("color", `${colorSpace}(-40% 0 0)`, `${colorSpace}(0% 0 0)`);
-    test_computed_value("color", `${colorSpace}(50% -20 0)`, `${colorSpace}(50% -20 0)`);
-    test_computed_value("color", `${colorSpace}(50% 0 -20)`, `${colorSpace}(50% 0 -20)`);
-    test_computed_value("color", `${colorSpace}(calc(50% * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))`, `${colorSpace}(150% -0.5 1.5 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(calc(-50% * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))`, `${colorSpace}(0% 1.5 -1.5 / 0)`);
+    test_computed_value("color", `${colorSpace}(0 0 0)`, `${colorSpace}(0 0 0)`);
+    test_computed_value("color", `${colorSpace}(0 0 0 / 1)`, `${colorSpace}(0 0 0)`);
+    test_computed_value("color", `${colorSpace}(0 0 0 / 0.5)`, `${colorSpace}(0 0 0 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(20 0 10/0.5)`, `${colorSpace}(20 0 10 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(20 0 10/50%)`, `${colorSpace}(20 0 10 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(400 0 10/50%)`, `${colorSpace}(400 0 10 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(50 -160 160)`, `${colorSpace}(50 -160 160)`);
+    test_computed_value("color", `${colorSpace}(50 -200 200)`, `${colorSpace}(50 -200 200)`);
+    test_computed_value("color", `${colorSpace}(0 0 0 / -10%)`, `${colorSpace}(0 0 0 / 0)`);
+    test_computed_value("color", `${colorSpace}(0 0 0 / 110%)`, `${colorSpace}(0 0 0)`);
+    test_computed_value("color", `${colorSpace}(0 0 0 / 300%)`, `${colorSpace}(0 0 0)`);
+    test_computed_value("color", `${colorSpace}(-40 0 0)`, `${colorSpace}(0 0 0)`);
+    test_computed_value("color", `${colorSpace}(50 -20 0)`, `${colorSpace}(50 -20 0)`);
+    test_computed_value("color", `${colorSpace}(50 0 -20)`, `${colorSpace}(50 0 -20)`);
+    test_computed_value("color", `${colorSpace}(calc(50 * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))`, `${colorSpace}(150 -0.5 1.5 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(calc(-50 * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))`, `${colorSpace}(0 1.5 -1.5 / 0)`);
 
     test_computed_value("color", `${colorSpace}(none none none / none)`, `${colorSpace}(none none none / none)`);
     test_computed_value("color", `${colorSpace}(none none none)`, `${colorSpace}(none none none)`);
-    test_computed_value("color", `${colorSpace}(20% none none / none)`, `${colorSpace}(20% none none / none)`);
+    test_computed_value("color", `${colorSpace}(20 none none / none)`, `${colorSpace}(20 none none / none)`);
     test_computed_value("color", `${colorSpace}(none none none / 0.5)`, `${colorSpace}(none none none / 0.5)`);
-    test_computed_value("color", `${colorSpace}(0% 0 0 / none)`, `${colorSpace}(0% 0 0 / none)`);
+    test_computed_value("color", `${colorSpace}(0 0 0 / none)`, `${colorSpace}(0 0 0 / none)`);
 }
 
 for (const colorSpace of [ "lch", "oklch" ]) {
-    test_computed_value("color", `${colorSpace}(0% 0 0deg)`, `${colorSpace}(0% 0 0)`);
-    test_computed_value("color", `${colorSpace}(0% 0 0deg / 1)`, `${colorSpace}(0% 0 0)`);
-    test_computed_value("color", `${colorSpace}(0% 0 0deg / 0.5)`, `${colorSpace}(0% 0 0 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(100% 230 0deg / 0.5)`, `${colorSpace}(100% 230 0 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(20% 50 20deg/0.5)`, `${colorSpace}(20% 50 20 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(20% 50 20deg/50%)`, `${colorSpace}(20% 50 20 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(10% 20 20deg / -10%)`, `${colorSpace}(10% 20 20 / 0)`);
-    test_computed_value("color", `${colorSpace}(10% 20 20deg / 110%)`, `${colorSpace}(10% 20 20)`);
-    test_computed_value("color", `${colorSpace}(10% 20 1.28rad)`, `${colorSpace}(10% 20 73.3386)`);
-    test_computed_value("color", `${colorSpace}(10% 20 380deg)`, `${colorSpace}(10% 20 20)`);
-    test_computed_value("color", `${colorSpace}(10% 20 -340deg)`, `${colorSpace}(10% 20 20)`);
-    test_computed_value("color", `${colorSpace}(10% 20 740deg)`, `${colorSpace}(10% 20 20)`);
-    test_computed_value("color", `${colorSpace}(10% 20 -700deg)`, `${colorSpace}(10% 20 20)`);
-    test_computed_value("color", `${colorSpace}(-40% 0 0)`, `${colorSpace}(0% 0 0)`);
-    test_computed_value("color", `${colorSpace}(20% -20 0)`, `${colorSpace}(20% 0 0)`);
-    test_computed_value("color", `${colorSpace}(0% 0 0 / 0.5)`, `${colorSpace}(0% 0 0 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(10% 20 20 / 110%)`, `${colorSpace}(10% 20 20)`);
-    test_computed_value("color", `${colorSpace}(10% 20 -700)`, `${colorSpace}(10% 20 20)`);
-    test_computed_value("color", `${colorSpace}(calc(50% * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))`, `${colorSpace}(150% 0 40 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(calc(-50% * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))`, `${colorSpace}(0% 1.5 320 / 0)`);
+    test_computed_value("color", `${colorSpace}(0 0 0deg)`, `${colorSpace}(0 0 0)`);
+    test_computed_value("color", `${colorSpace}(0 0 0deg / 1)`, `${colorSpace}(0 0 0)`);
+    test_computed_value("color", `${colorSpace}(0 0 0deg / 0.5)`, `${colorSpace}(0 0 0 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(100 230 0deg / 0.5)`, `${colorSpace}(100 230 0 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(20 50 20deg/0.5)`, `${colorSpace}(20 50 20 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(20 50 20deg/50%)`, `${colorSpace}(20 50 20 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(10 20 20deg / -10%)`, `${colorSpace}(10 20 20 / 0)`);
+    test_computed_value("color", `${colorSpace}(10 20 20deg / 110%)`, `${colorSpace}(10 20 20)`);
+    test_computed_value("color", `${colorSpace}(10 20 1.28rad)`, `${colorSpace}(10 20 73.3386)`);
+    test_computed_value("color", `${colorSpace}(10 20 380deg)`, `${colorSpace}(10 20 20)`);
+    test_computed_value("color", `${colorSpace}(10 20 -340deg)`, `${colorSpace}(10 20 20)`);
+    test_computed_value("color", `${colorSpace}(10 20 740deg)`, `${colorSpace}(10 20 20)`);
+    test_computed_value("color", `${colorSpace}(10 20 -700deg)`, `${colorSpace}(10 20 20)`);
+    test_computed_value("color", `${colorSpace}(-40 0 0)`, `${colorSpace}(0 0 0)`);
+    test_computed_value("color", `${colorSpace}(20 -20 0)`, `${colorSpace}(20 0 0)`);
+    test_computed_value("color", `${colorSpace}(0 0 0 / 0.5)`, `${colorSpace}(0 0 0 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(10 20 20 / 110%)`, `${colorSpace}(10 20 20)`);
+    test_computed_value("color", `${colorSpace}(10 20 -700)`, `${colorSpace}(10 20 20)`);
+    test_computed_value("color", `${colorSpace}(calc(50 * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))`, `${colorSpace}(150 0 40 / 0.5)`);
+    test_computed_value("color", `${colorSpace}(calc(-50 * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))`, `${colorSpace}(0 1.5 320 / 0)`);
 
     test_computed_value("color", `${colorSpace}(none none none / none)`, `${colorSpace}(none none none / none)`);
     test_computed_value("color", `${colorSpace}(none none none)`, `${colorSpace}(none none none)`);
-    test_computed_value("color", `${colorSpace}(20% none none / none)`, `${colorSpace}(20% none none / none)`);
+    test_computed_value("color", `${colorSpace}(20 none none / none)`, `${colorSpace}(20 none none / none)`);
     test_computed_value("color", `${colorSpace}(none none none / 0.5)`, `${colorSpace}(none none none / 0.5)`);
-    test_computed_value("color", `${colorSpace}(0% 0 0 / none)`, `${colorSpace}(0% 0 0 / none)`);
+    test_computed_value("color", `${colorSpace}(0 0 0 / none)`, `${colorSpace}(0 0 0 / none)`);
 }
 </script>
 </body>

--- a/css/css-color/parsing/color-contrast-computed.html
+++ b/css/css-color/parsing/color-contrast-computed.html
@@ -39,8 +39,11 @@
     // Test non-sRGB colors.
     test_computed_value(`color`, `color-contrast(green vs color(display-p3 0 1 0), color(display-p3 0 0 1))`, `color(display-p3 0 1 0)`);
     test_computed_value(`color`, `color-contrast(color(display-p3 1 1 0) vs color(display-p3 0 1 0), color(display-p3 0 0 1))`, `color(display-p3 0 0 1)`);
-    test_computed_value(`color`, `color-contrast(green vs lab(50% -160 160), lch(20% 50 20deg))`, `lch(20% 50 20)`);
-    test_computed_value(`color`, `color-contrast(lab(50% -160 160) vs green, lch(20% 50 20deg))`, `lch(20% 50 20)`);
+    test_computed_value(`color`, `color-contrast(green vs lab(50% -160 160), lch(0.2 50 20deg))`, `lch(0.2 50 20)`);
+    test_computed_value(`color`, `color-contrast(lab(50% -160 160) vs green, lch(0.2 50 20deg))`, `lch(0.2 50 20)`);
+
+    // Test with extra whitespace
+    test_computed_value(`color`, `color-contrast( white vs red, blue )`, `rgb(0, 0, 255)`);
 </script>
 </body>
 </html>

--- a/css/css-color/parsing/color-contrast-valid.html
+++ b/css/css-color/parsing/color-contrast-valid.html
@@ -38,8 +38,8 @@
     // Test non-sRGB colors.
     test_valid_value(`color`, `color-contrast(green vs color(display-p3 0 1 0), color(display-p3 0 0 1))`, `color(display-p3 0 1 0)`);
     test_valid_value(`color`, `color-contrast(color(display-p3 1 1 0) vs color(display-p3 0 1 0), color(display-p3 0 0 1))`, `color(display-p3 0 0 1)`);
-    test_valid_value(`color`, `color-contrast(green vs lab(50% -160 160), lch(20% 50 20deg))`, `lch(20% 50 20)`);
-    test_valid_value(`color`, `color-contrast(lab(50% -160 160) vs green, lch(20% 50 20deg))`, `lch(20% 50 20)`);
+    test_valid_value(`color`, `color-contrast(green vs lab(50% -160 160), lch(0.2 50 20deg))`, `lch(0.2 50 20)`);
+    test_valid_value(`color`, `color-contrast(lab(50% -160 160) vs green, lch(0.2 50 20deg))`, `lch(0.2 50 20)`);
 
     // Test with extra whitespace
     test_valid_value(`color`, `color-contrast( white vs red, blue )`, `rgb(0, 0, 255)`);

--- a/css/css-color/parsing/color-mix-computed.html
+++ b/css/css-color/parsing/color-mix-computed.html
@@ -98,14 +98,14 @@
     test_computed_value(`color`, `color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40% / none))`, canonicalize(`hsl(60deg 40% 40% / none)`));
 
     test_computed_value(`color`, `color-mix(in hsl, color(display-p3 0 1 0) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
-    test_computed_value(`color`, `color-mix(in hsl, lab(100% 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_computed_value(`color`, `color-mix(in hsl, lab(0% 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_computed_value(`color`, `color-mix(in hsl, lch(100% 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_computed_value(`color`, `color-mix(in hsl, lch(0% 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_computed_value(`color`, `color-mix(in hsl, oklab(100% 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
-    test_computed_value(`color`, `color-mix(in hsl, oklab(0% 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
-    test_computed_value(`color`, `color-mix(in hsl, oklch(100% 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
-    test_computed_value(`color`, `color-mix(in hsl, oklch(0% 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
+    test_computed_value(`color`, `color-mix(in hsl, lab(100 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_computed_value(`color`, `color-mix(in hsl, lab(0 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_computed_value(`color`, `color-mix(in hsl, lch(100 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_computed_value(`color`, `color-mix(in hsl, lch(0 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_computed_value(`color`, `color-mix(in hsl, oklab(100 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+    test_computed_value(`color`, `color-mix(in hsl, oklab(0 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+    test_computed_value(`color`, `color-mix(in hsl, oklch(100 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+    test_computed_value(`color`, `color-mix(in hsl, oklch(0 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
 
 
     test_computed_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%))`, `rgb(147, 179, 52)`);
@@ -181,119 +181,119 @@
     test_computed_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / none))`, canonicalize(`hwb(75deg 20% 30% / none)`));
 
     test_computed_value(`color`, `color-mix(in hwb, color(display-p3 0 1 0) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
-    test_computed_value(`color`, `color-mix(in hwb, lab(100% 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_computed_value(`color`, `color-mix(in hwb, lab(0% 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_computed_value(`color`, `color-mix(in hwb, lch(100% 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_computed_value(`color`, `color-mix(in hwb, lch(0% 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_computed_value(`color`, `color-mix(in hwb, oklab(100% 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
-    test_computed_value(`color`, `color-mix(in hwb, oklab(0% 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
-    test_computed_value(`color`, `color-mix(in hwb, oklch(100% 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
-    test_computed_value(`color`, `color-mix(in hwb, oklch(0% 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
+    test_computed_value(`color`, `color-mix(in hwb, lab(100 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_computed_value(`color`, `color-mix(in hwb, lab(0 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_computed_value(`color`, `color-mix(in hwb, lch(100 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_computed_value(`color`, `color-mix(in hwb, lch(0 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_computed_value(`color`, `color-mix(in hwb, oklab(100 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+    test_computed_value(`color`, `color-mix(in hwb, oklab(0 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+    test_computed_value(`color`, `color-mix(in hwb, oklch(100 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+    test_computed_value(`color`, `color-mix(in hwb, oklch(0 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
 
     for (const colorSpace of [ "lch", "oklch" ]) {
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg), ${colorSpace}(50% 60 70deg))`, `${colorSpace}(30% 40 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg) 25%, ${colorSpace}(50% 60 70deg))`, `${colorSpace}(40% 50 60)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10% 20 30deg), ${colorSpace}(50% 60 70deg))`, `${colorSpace}(40% 50 60)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg), 25% ${colorSpace}(50% 60 70deg))`, `${colorSpace}(20% 30 40)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg), ${colorSpace}(50% 60 70deg) 25%)`, `${colorSpace}(20% 30 40)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg) 25%, ${colorSpace}(50% 60 70deg) 75%)`, `${colorSpace}(40% 50 60)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg) 30%, ${colorSpace}(50% 60 70deg) 90%)`, `${colorSpace}(40% 50 60)`); // Scale down > 100% sum.
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg) 12.5%, ${colorSpace}(50% 60 70deg) 37.5%)`, `${colorSpace}(40% 50 60 / 0.5)`); // Scale up < 100% sum, causes alpha multiplication.
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg) 0%, ${colorSpace}(50% 60 70deg))`, `${colorSpace}(50% 60 70)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), ${colorSpace}(50 60 70deg))`, `${colorSpace}(30 40 50)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 25%, ${colorSpace}(50 60 70deg))`, `${colorSpace}(40 50 60)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10 20 30deg), ${colorSpace}(50 60 70deg))`, `${colorSpace}(40 50 60)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), 25% ${colorSpace}(50 60 70deg))`, `${colorSpace}(20 30 40)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), ${colorSpace}(50 60 70deg) 25%)`, `${colorSpace}(20 30 40)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 25%, ${colorSpace}(50 60 70deg) 75%)`, `${colorSpace}(40 50 60)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 30%, ${colorSpace}(50 60 70deg) 90%)`, `${colorSpace}(40 50 60)`); // Scale down > 100% sum.
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 12.5%, ${colorSpace}(50 60 70deg) 37.5%)`, `${colorSpace}(40 50 60 / 0.5)`); // Scale up < 100% sum, causes alpha multiplication.
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 0%, ${colorSpace}(50 60 70deg))`, `${colorSpace}(50 60 70)`);
 
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / .4), ${colorSpace}(50% 60 70deg / .8))`, `${colorSpace}(36.666664% 46.666664 50 / 0.6)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / .4) 25%, ${colorSpace}(50% 60 70deg / .8))`, `${colorSpace}(44.285713% 54.285717 60 / 0.7)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10% 20 30deg / .4), ${colorSpace}(50% 60 70deg / .8))`, `${colorSpace}(44.285713% 54.285717 60 / 0.7)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / .4), 25% ${colorSpace}(50% 60 70deg / .8))`, `${colorSpace}(26% 36 40 / 0.5)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / .4), ${colorSpace}(50% 60 70deg / .8) 25%)`, `${colorSpace}(26% 36 40 / 0.5)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / .4) 25%, ${colorSpace}(50% 60 70deg / .8) 75%)`, `${colorSpace}(44.285713% 54.285717 60 / 0.7)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / .4) 30%, ${colorSpace}(50% 60 70deg / .8) 90%)`, `${colorSpace}(44.285713% 54.285717 60 / 0.7)`); // Scale down > 100% sum.
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / .4) 12.5%, ${colorSpace}(50% 60 70deg / .8) 37.5%)`, `${colorSpace}(44.285713% 54.285717 60 / 0.35)`); // Scale up < 100% sum, causes alpha multiplication.
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / .4) 0%, ${colorSpace}(50% 60 70deg / .8))`, `${colorSpace}(50% 60 70 / 0.8)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4), ${colorSpace}(50 60 70deg / .8))`, `${colorSpace}(36.666664 46.666664 50 / 0.6)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 25%, ${colorSpace}(50 60 70deg / .8))`, `${colorSpace}(44.285713 54.285717 60 / 0.7)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10 20 30deg / .4), ${colorSpace}(50 60 70deg / .8))`, `${colorSpace}(44.285713 54.285717 60 / 0.7)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4), 25% ${colorSpace}(50 60 70deg / .8))`, `${colorSpace}(26 36 40 / 0.5)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4), ${colorSpace}(50 60 70deg / .8) 25%)`, `${colorSpace}(26 36 40 / 0.5)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 25%, ${colorSpace}(50 60 70deg / .8) 75%)`, `${colorSpace}(44.285713 54.285717 60 / 0.7)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 30%, ${colorSpace}(50 60 70deg / .8) 90%)`, `${colorSpace}(44.285713 54.285717 60 / 0.7)`); // Scale down > 100% sum.
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 12.5%, ${colorSpace}(50 60 70deg / .8) 37.5%)`, `${colorSpace}(44.285713 54.285717 60 / 0.35)`); // Scale up < 100% sum, causes alpha multiplication.
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 0%, ${colorSpace}(50 60 70deg / .8))`, `${colorSpace}(50 60 70 / 0.8)`);
 
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100% 0 40deg), ${colorSpace}(100% 0 60deg))`, `${colorSpace}(100% 0 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100% 0 60deg), ${colorSpace}(100% 0 40deg))`, `${colorSpace}(100% 0 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100% 0 50deg), ${colorSpace}(100% 0 330deg))`, `${colorSpace}(100% 0 10)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100% 0 330deg), ${colorSpace}(100% 0 50deg))`, `${colorSpace}(100% 0 10)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100% 0 20deg), ${colorSpace}(100% 0 320deg))`, `${colorSpace}(100% 0 350)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100% 0 320deg), ${colorSpace}(100% 0 20deg))`, `${colorSpace}(100% 0 350)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `${colorSpace}(100 0 50)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `${colorSpace}(100 0 50)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `${colorSpace}(100 0 10)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `${colorSpace}(100 0 10)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `${colorSpace}(100 0 350)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `${colorSpace}(100 0 350)`);
 
-        test_computed_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100% 0 40deg), ${colorSpace}(100% 0 60deg))`, `${colorSpace}(100% 0 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100% 0 60deg), ${colorSpace}(100% 0 40deg))`, `${colorSpace}(100% 0 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100% 0 50deg), ${colorSpace}(100% 0 330deg))`, `${colorSpace}(100% 0 10)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100% 0 330deg), ${colorSpace}(100% 0 50deg))`, `${colorSpace}(100% 0 10)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100% 0 20deg), ${colorSpace}(100% 0 320deg))`, `${colorSpace}(100% 0 350)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100% 0 320deg), ${colorSpace}(100% 0 20deg))`, `${colorSpace}(100% 0 350)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `${colorSpace}(100 0 50)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `${colorSpace}(100 0 50)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `${colorSpace}(100 0 10)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `${colorSpace}(100 0 10)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `${colorSpace}(100 0 350)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `${colorSpace}(100 0 350)`);
 
-        test_computed_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100% 0 40deg), ${colorSpace}(100% 0 60deg))`, `${colorSpace}(100% 0 230)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100% 0 60deg), ${colorSpace}(100% 0 40deg))`, `${colorSpace}(100% 0 230)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100% 0 50deg), ${colorSpace}(100% 0 330deg))`, `${colorSpace}(100% 0 190)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100% 0 330deg), ${colorSpace}(100% 0 50deg))`, `${colorSpace}(100% 0 190)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100% 0 20deg), ${colorSpace}(100% 0 320deg))`, `${colorSpace}(100% 0 170)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100% 0 320deg), ${colorSpace}(100% 0 20deg))`, `${colorSpace}(100% 0 170)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `${colorSpace}(100 0 230)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `${colorSpace}(100 0 230)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `${colorSpace}(100 0 190)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `${colorSpace}(100 0 190)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `${colorSpace}(100 0 170)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `${colorSpace}(100 0 170)`);
 
-        test_computed_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100% 0 40deg), ${colorSpace}(100% 0 60deg))`, `${colorSpace}(100% 0 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100% 0 60deg), ${colorSpace}(100% 0 40deg))`, `${colorSpace}(100% 0 230)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100% 0 50deg), ${colorSpace}(100% 0 330deg))`, `${colorSpace}(100% 0 190)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100% 0 330deg), ${colorSpace}(100% 0 50deg))`, `${colorSpace}(100% 0 10)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100% 0 20deg), ${colorSpace}(100% 0 320deg))`, `${colorSpace}(100% 0 170)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100% 0 320deg), ${colorSpace}(100% 0 20deg))`, `${colorSpace}(100% 0 350)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `${colorSpace}(100 0 50)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `${colorSpace}(100 0 230)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `${colorSpace}(100 0 190)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `${colorSpace}(100 0 10)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `${colorSpace}(100 0 170)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `${colorSpace}(100 0 350)`);
 
-        test_computed_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100% 0 40deg), ${colorSpace}(100% 0 60deg))`, `${colorSpace}(100% 0 230)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100% 0 60deg), ${colorSpace}(100% 0 40deg))`, `${colorSpace}(100% 0 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100% 0 50deg), ${colorSpace}(100% 0 330deg))`, `${colorSpace}(100% 0 10)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100% 0 330deg), ${colorSpace}(100% 0 50deg))`, `${colorSpace}(100% 0 190)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100% 0 20deg), ${colorSpace}(100% 0 320deg))`, `${colorSpace}(100% 0 350)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100% 0 320deg), ${colorSpace}(100% 0 20deg))`, `${colorSpace}(100% 0 170)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `${colorSpace}(100 0 230)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `${colorSpace}(100 0 50)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `${colorSpace}(100 0 10)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `${colorSpace}(100 0 190)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `${colorSpace}(100 0 350)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `${colorSpace}(100 0 170)`);
 
-        test_computed_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100% 0 40deg), ${colorSpace}(100% 0 60deg))`, `${colorSpace}(100% 0 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100% 0 60deg), ${colorSpace}(100% 0 40deg))`, `${colorSpace}(100% 0 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100% 0 50deg), ${colorSpace}(100% 0 330deg))`, `${colorSpace}(100% 0 190)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100% 0 330deg), ${colorSpace}(100% 0 50deg))`, `${colorSpace}(100% 0 190)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100% 0 20deg), ${colorSpace}(100% 0 320deg))`, `${colorSpace}(100% 0 170)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100% 0 320deg), ${colorSpace}(100% 0 20deg))`, `${colorSpace}(100% 0 170)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `${colorSpace}(100 0 50)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `${colorSpace}(100 0 50)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `${colorSpace}(100 0 190)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `${colorSpace}(100 0 190)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `${colorSpace}(100 0 170)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `${colorSpace}(100 0 170)`);
 
         test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(none none none))`, `${colorSpace}(none none none)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(50% 60 70deg))`, `${colorSpace}(50% 60 70)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg), ${colorSpace}(none none none))`, `${colorSpace}(10% 20 30)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 none), ${colorSpace}(50% 60 70deg))`, `${colorSpace}(30% 40 70)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg), ${colorSpace}(50% 60 none))`, `${colorSpace}(30% 40 30)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none 20 30deg), ${colorSpace}(50% none 70deg))`, `${colorSpace}(50% 20 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / none), ${colorSpace}(50% 60 70deg))`, `${colorSpace}(30% 40 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / none), ${colorSpace}(50% 60 70deg / 0.5))`, `${colorSpace}(30% 40 50 / 0.5)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / none), ${colorSpace}(50% 60 70deg / none))`, `${colorSpace}(30% 40 50 / none)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(50 60 70deg))`, `${colorSpace}(50 60 70)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), ${colorSpace}(none none none))`, `${colorSpace}(10 20 30)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 none), ${colorSpace}(50 60 70deg))`, `${colorSpace}(30 40 70)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), ${colorSpace}(50 60 none))`, `${colorSpace}(30 40 30)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none 20 30deg), ${colorSpace}(50 none 70deg))`, `${colorSpace}(50 20 50)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / none), ${colorSpace}(50 60 70deg))`, `${colorSpace}(30 40 50)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / none), ${colorSpace}(50 60 70deg / 0.5))`, `${colorSpace}(30 40 50 / 0.5)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / none), ${colorSpace}(50 60 70deg / none))`, `${colorSpace}(30 40 50 / none)`);
     }
 
     for (const colorSpace of [ "lab", "oklab" ]) {
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30), ${colorSpace}(50% 60 70))`, `${colorSpace}(30% 40 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30) 25%, ${colorSpace}(50% 60 70))`, `${colorSpace}(40% 50 60)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10% 20 30), ${colorSpace}(50% 60 70))`, `${colorSpace}(40% 50 60)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30), 25% ${colorSpace}(50% 60 70))`, `${colorSpace}(20% 30 40)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30), ${colorSpace}(50% 60 70) 25%)`, `${colorSpace}(20% 30 40)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30) 25%, ${colorSpace}(50% 60 70) 75%)`, `${colorSpace}(40% 50 60)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30) 30%, ${colorSpace}(50% 60 70) 90%)`, `${colorSpace}(40% 50 60)`); // Scale down > 100% sum.
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30) 12.5%, ${colorSpace}(50% 60 70) 37.5%)`, `${colorSpace}(40% 50 60 / 0.5)`); // Scale up < 100% sum, causes alpha multiplication.
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30) 0%, ${colorSpace}(50% 60 70))`, `${colorSpace}(50% 60 70)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 70))`, `${colorSpace}(30 40 50)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 25%, ${colorSpace}(50 60 70))`, `${colorSpace}(40 50 60)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10 20 30), ${colorSpace}(50 60 70))`, `${colorSpace}(40 50 60)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), 25% ${colorSpace}(50 60 70))`, `${colorSpace}(20 30 40)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 70) 25%)`, `${colorSpace}(20 30 40)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 25%, ${colorSpace}(50 60 70) 75%)`, `${colorSpace}(40 50 60)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 30%, ${colorSpace}(50 60 70) 90%)`, `${colorSpace}(40 50 60)`); // Scale down > 100% sum.
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 12.5%, ${colorSpace}(50 60 70) 37.5%)`, `${colorSpace}(40 50 60 / 0.5)`); // Scale up < 100% sum, causes alpha multiplication.
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 0%, ${colorSpace}(50 60 70))`, `${colorSpace}(50 60 70)`);
 
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4), ${colorSpace}(50% 60 70 / .8))`, `${colorSpace}(36.666664% 46.666664 56.666664 / 0.6)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4) 25%, ${colorSpace}(50% 60 70 / .8))`, `${colorSpace}(44.285713% 54.285717 64.28571 / 0.7)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10% 20 30 / .4), ${colorSpace}(50% 60 70 / .8))`, `${colorSpace}(44.285713% 54.285717 64.28571 / 0.7)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4), 25% ${colorSpace}(50% 60 70 / .8))`, `${colorSpace}(26% 36 46 / 0.5)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4), ${colorSpace}(50% 60 70 / .8) 25%)`, `${colorSpace}(26% 36 46 / 0.5)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4) 25%, ${colorSpace}(50% 60 70 / .8) 75%)`, `${colorSpace}(44.285713% 54.285717 64.28571 / 0.7)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4) 30%, ${colorSpace}(50% 60 70 / .8) 90%)`, `${colorSpace}(44.285713% 54.285717 64.28571 / 0.7)`); // Scale down > 100% sum.
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4) 12.5%, ${colorSpace}(50% 60 70 / .8) 37.5%)`, `${colorSpace}(44.285713% 54.285717 64.28571 / 0.35)`); // Scale up < 100% sum, causes alpha multiplication.
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4) 0%, ${colorSpace}(50% 60 70 / .8))`, `${colorSpace}(50% 60 70 / 0.8)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4), ${colorSpace}(50 60 70 / .8))`, `${colorSpace}(36.666664 46.666664 56.666664 / 0.6)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 25%, ${colorSpace}(50 60 70 / .8))`, `${colorSpace}(44.285713 54.285717 64.28571 / 0.7)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10 20 30 / .4), ${colorSpace}(50 60 70 / .8))`, `${colorSpace}(44.285713 54.285717 64.28571 / 0.7)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4), 25% ${colorSpace}(50 60 70 / .8))`, `${colorSpace}(26 36 46 / 0.5)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4), ${colorSpace}(50 60 70 / .8) 25%)`, `${colorSpace}(26 36 46 / 0.5)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 25%, ${colorSpace}(50 60 70 / .8) 75%)`, `${colorSpace}(44.285713 54.285717 64.28571 / 0.7)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 30%, ${colorSpace}(50 60 70 / .8) 90%)`, `${colorSpace}(44.285713 54.285717 64.28571 / 0.7)`); // Scale down > 100% sum.
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 12.5%, ${colorSpace}(50 60 70 / .8) 37.5%)`, `${colorSpace}(44.285713 54.285717 64.28571 / 0.35)`); // Scale up < 100% sum, causes alpha multiplication.
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 0%, ${colorSpace}(50 60 70 / .8))`, `${colorSpace}(50 60 70 / 0.8)`);
 
         test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(none none none))`, `${colorSpace}(none none none)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(50% 60 70))`, `${colorSpace}(50% 60 70)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30), ${colorSpace}(none none none))`, `${colorSpace}(10% 20 30)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 none), ${colorSpace}(50% 60 70))`, `${colorSpace}(30% 40 70)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30), ${colorSpace}(50% 60 none))`, `${colorSpace}(30% 40 30)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none 20 30), ${colorSpace}(50% none 70))`, `${colorSpace}(50% 20 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / none), ${colorSpace}(50% 60 70))`, `${colorSpace}(30% 40 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / none), ${colorSpace}(50% 60 70 / 0.5))`, `${colorSpace}(30% 40 50 / 0.5)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / none), ${colorSpace}(50% 60 70 / none))`, `${colorSpace}(30% 40 50 / none)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(50 60 70))`, `${colorSpace}(50 60 70)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(none none none))`, `${colorSpace}(10 20 30)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 none), ${colorSpace}(50 60 70))`, `${colorSpace}(30 40 70)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 none))`, `${colorSpace}(30 40 30)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none 20 30), ${colorSpace}(50 none 70))`, `${colorSpace}(50 20 50)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / none), ${colorSpace}(50 60 70))`, `${colorSpace}(30 40 50)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / none), ${colorSpace}(50 60 70 / 0.5))`, `${colorSpace}(30 40 50 / 0.5)`);
+        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / none), ${colorSpace}(50 60 70 / none))`, `${colorSpace}(30 40 50 / none)`);
     }
 
     for (const colorSpace of [ "srgb", "srgb-linear", "xyz", "xyz-d50", "xyz-d65" ]) {

--- a/css/css-color/parsing/color-mix-valid.html
+++ b/css/css-color/parsing/color-mix-valid.html
@@ -98,14 +98,14 @@
     test_valid_value(`color`, `color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40% / none))`, canonicalize(`hsl(60deg 40% 40% / none)`));
 
     test_valid_value(`color`, `color-mix(in hsl, color(display-p3 0 1 0) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
-    test_valid_value(`color`, `color-mix(in hsl, lab(100% 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_valid_value(`color`, `color-mix(in hsl, lab(0% 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_valid_value(`color`, `color-mix(in hsl, lch(100% 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_valid_value(`color`, `color-mix(in hsl, lch(0% 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_valid_value(`color`, `color-mix(in hsl, oklab(100% 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
-    test_valid_value(`color`, `color-mix(in hsl, oklab(0% 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
-    test_valid_value(`color`, `color-mix(in hsl, oklch(100% 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
-    test_valid_value(`color`, `color-mix(in hsl, oklch(0% 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
+    test_valid_value(`color`, `color-mix(in hsl, lab(100 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `color-mix(in hsl, lab(0 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `color-mix(in hsl, lch(100 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `color-mix(in hsl, lch(0 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `color-mix(in hsl, oklab(100 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+    test_valid_value(`color`, `color-mix(in hsl, oklab(0 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+    test_valid_value(`color`, `color-mix(in hsl, oklch(100 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+    test_valid_value(`color`, `color-mix(in hsl, oklch(0 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
 
 
     test_valid_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%))`, `rgb(147, 179, 52)`);
@@ -181,119 +181,119 @@
     test_valid_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / none))`, canonicalize(`hwb(75deg 20% 30% / none)`));
 
     test_valid_value(`color`, `color-mix(in hwb, color(display-p3 0 1 0) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
-    test_valid_value(`color`, `color-mix(in hwb, lab(100% 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_valid_value(`color`, `color-mix(in hwb, lab(0% 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_valid_value(`color`, `color-mix(in hwb, lch(100% 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_valid_value(`color`, `color-mix(in hwb, lch(0% 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_valid_value(`color`, `color-mix(in hwb, oklab(100% 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
-    test_valid_value(`color`, `color-mix(in hwb, oklab(0% 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
-    test_valid_value(`color`, `color-mix(in hwb, oklch(100% 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
-    test_valid_value(`color`, `color-mix(in hwb, oklch(0% 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
+    test_valid_value(`color`, `color-mix(in hwb, lab(100 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `color-mix(in hwb, lab(0 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `color-mix(in hwb, lch(100 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `color-mix(in hwb, lch(0 116 334) 100%, rgb(0, 0, 0) 0%)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `color-mix(in hwb, oklab(100 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+    test_valid_value(`color`, `color-mix(in hwb, oklab(0 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+    test_valid_value(`color`, `color-mix(in hwb, oklch(100 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+    test_valid_value(`color`, `color-mix(in hwb, oklch(0 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
 
     for (const colorSpace of [ "lch", "oklch" ]) {
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg), ${colorSpace}(50% 60 70deg))`, `${colorSpace}(30% 40 50)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg) 25%, ${colorSpace}(50% 60 70deg))`, `${colorSpace}(40% 50 60)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10% 20 30deg), ${colorSpace}(50% 60 70deg))`, `${colorSpace}(40% 50 60)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg), 25% ${colorSpace}(50% 60 70deg))`, `${colorSpace}(20% 30 40)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg), ${colorSpace}(50% 60 70deg) 25%)`, `${colorSpace}(20% 30 40)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg) 25%, ${colorSpace}(50% 60 70deg) 75%)`, `${colorSpace}(40% 50 60)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg) 30%, ${colorSpace}(50% 60 70deg) 90%)`, `${colorSpace}(40% 50 60)`); // Scale down > 100% sum.
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg) 12.5%, ${colorSpace}(50% 60 70deg) 37.5%)`, `${colorSpace}(40% 50 60 / 0.5)`); // Scale up < 100% sum, causes alpha multiplication.
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg) 0%, ${colorSpace}(50% 60 70deg))`, `${colorSpace}(50% 60 70)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), ${colorSpace}(50 60 70deg))`, `${colorSpace}(30 40 50)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 25%, ${colorSpace}(50 60 70deg))`, `${colorSpace}(40 50 60)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10 20 30deg), ${colorSpace}(50 60 70deg))`, `${colorSpace}(40 50 60)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), 25% ${colorSpace}(50 60 70deg))`, `${colorSpace}(20 30 40)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), ${colorSpace}(50 60 70deg) 25%)`, `${colorSpace}(20 30 40)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 25%, ${colorSpace}(50 60 70deg) 75%)`, `${colorSpace}(40 50 60)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 30%, ${colorSpace}(50 60 70deg) 90%)`, `${colorSpace}(40 50 60)`); // Scale down > 100% sum.
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 12.5%, ${colorSpace}(50 60 70deg) 37.5%)`, `${colorSpace}(40 50 60 / 0.5)`); // Scale up < 100% sum, causes alpha multiplication.
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 0%, ${colorSpace}(50 60 70deg))`, `${colorSpace}(50 60 70)`);
 
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / .4), ${colorSpace}(50% 60 70deg / .8))`, `${colorSpace}(36.666664% 46.666664 50 / 0.6)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / .4) 25%, ${colorSpace}(50% 60 70deg / .8))`, `${colorSpace}(44.285713% 54.285717 60 / 0.7)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10% 20 30deg / .4), ${colorSpace}(50% 60 70deg / .8))`, `${colorSpace}(44.285713% 54.285717 60 / 0.7)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / .4), 25% ${colorSpace}(50% 60 70deg / .8))`, `${colorSpace}(26% 36 40 / 0.5)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / .4), ${colorSpace}(50% 60 70deg / .8) 25%)`, `${colorSpace}(26% 36 40 / 0.5)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / .4) 25%, ${colorSpace}(50% 60 70deg / .8) 75%)`, `${colorSpace}(44.285713% 54.285717 60 / 0.7)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / .4) 30%, ${colorSpace}(50% 60 70deg / .8) 90%)`, `${colorSpace}(44.285713% 54.285717 60 / 0.7)`); // Scale down > 100% sum.
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / .4) 12.5%, ${colorSpace}(50% 60 70deg / .8) 37.5%)`, `${colorSpace}(44.285713% 54.285717 60 / 0.35)`); // Scale up < 100% sum, causes alpha multiplication.
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / .4) 0%, ${colorSpace}(50% 60 70deg / .8))`, `${colorSpace}(50% 60 70 / 0.8)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4), ${colorSpace}(50 60 70deg / .8))`, `${colorSpace}(36.666664 46.666664 50 / 0.6)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 25%, ${colorSpace}(50 60 70deg / .8))`, `${colorSpace}(44.285713 54.285717 60 / 0.7)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10 20 30deg / .4), ${colorSpace}(50 60 70deg / .8))`, `${colorSpace}(44.285713 54.285717 60 / 0.7)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4), 25% ${colorSpace}(50 60 70deg / .8))`, `${colorSpace}(26 36 40 / 0.5)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4), ${colorSpace}(50 60 70deg / .8) 25%)`, `${colorSpace}(26 36 40 / 0.5)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 25%, ${colorSpace}(50 60 70deg / .8) 75%)`, `${colorSpace}(44.285713 54.285717 60 / 0.7)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 30%, ${colorSpace}(50 60 70deg / .8) 90%)`, `${colorSpace}(44.285713 54.285717 60 / 0.7)`); // Scale down > 100% sum.
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 12.5%, ${colorSpace}(50 60 70deg / .8) 37.5%)`, `${colorSpace}(44.285713 54.285717 60 / 0.35)`); // Scale up < 100% sum, causes alpha multiplication.
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 0%, ${colorSpace}(50 60 70deg / .8))`, `${colorSpace}(50 60 70 / 0.8)`);
 
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100% 0 40deg), ${colorSpace}(100% 0 60deg))`, `${colorSpace}(100% 0 50)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100% 0 60deg), ${colorSpace}(100% 0 40deg))`, `${colorSpace}(100% 0 50)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100% 0 50deg), ${colorSpace}(100% 0 330deg))`, `${colorSpace}(100% 0 10)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100% 0 330deg), ${colorSpace}(100% 0 50deg))`, `${colorSpace}(100% 0 10)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100% 0 20deg), ${colorSpace}(100% 0 320deg))`, `${colorSpace}(100% 0 350)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100% 0 320deg), ${colorSpace}(100% 0 20deg))`, `${colorSpace}(100% 0 350)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `${colorSpace}(100 0 50)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `${colorSpace}(100 0 50)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `${colorSpace}(100 0 10)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `${colorSpace}(100 0 10)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `${colorSpace}(100 0 350)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `${colorSpace}(100 0 350)`);
 
-        test_valid_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100% 0 40deg), ${colorSpace}(100% 0 60deg))`, `${colorSpace}(100% 0 50)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100% 0 60deg), ${colorSpace}(100% 0 40deg))`, `${colorSpace}(100% 0 50)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100% 0 50deg), ${colorSpace}(100% 0 330deg))`, `${colorSpace}(100% 0 10)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100% 0 330deg), ${colorSpace}(100% 0 50deg))`, `${colorSpace}(100% 0 10)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100% 0 20deg), ${colorSpace}(100% 0 320deg))`, `${colorSpace}(100% 0 350)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100% 0 320deg), ${colorSpace}(100% 0 20deg))`, `${colorSpace}(100% 0 350)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `${colorSpace}(100 0 50)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `${colorSpace}(100 0 50)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `${colorSpace}(100 0 10)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `${colorSpace}(100 0 10)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `${colorSpace}(100 0 350)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `${colorSpace}(100 0 350)`);
 
-        test_valid_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100% 0 40deg), ${colorSpace}(100% 0 60deg))`, `${colorSpace}(100% 0 230)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100% 0 60deg), ${colorSpace}(100% 0 40deg))`, `${colorSpace}(100% 0 230)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100% 0 50deg), ${colorSpace}(100% 0 330deg))`, `${colorSpace}(100% 0 190)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100% 0 330deg), ${colorSpace}(100% 0 50deg))`, `${colorSpace}(100% 0 190)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100% 0 20deg), ${colorSpace}(100% 0 320deg))`, `${colorSpace}(100% 0 170)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100% 0 320deg), ${colorSpace}(100% 0 20deg))`, `${colorSpace}(100% 0 170)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `${colorSpace}(100 0 230)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `${colorSpace}(100 0 230)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `${colorSpace}(100 0 190)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `${colorSpace}(100 0 190)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `${colorSpace}(100 0 170)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `${colorSpace}(100 0 170)`);
 
-        test_valid_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100% 0 40deg), ${colorSpace}(100% 0 60deg))`, `${colorSpace}(100% 0 50)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100% 0 60deg), ${colorSpace}(100% 0 40deg))`, `${colorSpace}(100% 0 230)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100% 0 50deg), ${colorSpace}(100% 0 330deg))`, `${colorSpace}(100% 0 190)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100% 0 330deg), ${colorSpace}(100% 0 50deg))`, `${colorSpace}(100% 0 10)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100% 0 20deg), ${colorSpace}(100% 0 320deg))`, `${colorSpace}(100% 0 170)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100% 0 320deg), ${colorSpace}(100% 0 20deg))`, `${colorSpace}(100% 0 350)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `${colorSpace}(100 0 50)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `${colorSpace}(100 0 230)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `${colorSpace}(100 0 190)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `${colorSpace}(100 0 10)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `${colorSpace}(100 0 170)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `${colorSpace}(100 0 350)`);
 
-        test_valid_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100% 0 40deg), ${colorSpace}(100% 0 60deg))`, `${colorSpace}(100% 0 230)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100% 0 60deg), ${colorSpace}(100% 0 40deg))`, `${colorSpace}(100% 0 50)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100% 0 50deg), ${colorSpace}(100% 0 330deg))`, `${colorSpace}(100% 0 10)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100% 0 330deg), ${colorSpace}(100% 0 50deg))`, `${colorSpace}(100% 0 190)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100% 0 20deg), ${colorSpace}(100% 0 320deg))`, `${colorSpace}(100% 0 350)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100% 0 320deg), ${colorSpace}(100% 0 20deg))`, `${colorSpace}(100% 0 170)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `${colorSpace}(100 0 230)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `${colorSpace}(100 0 50)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `${colorSpace}(100 0 10)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `${colorSpace}(100 0 190)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `${colorSpace}(100 0 350)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `${colorSpace}(100 0 170)`);
 
-        test_valid_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100% 0 40deg), ${colorSpace}(100% 0 60deg))`, `${colorSpace}(100% 0 50)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100% 0 60deg), ${colorSpace}(100% 0 40deg))`, `${colorSpace}(100% 0 50)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100% 0 50deg), ${colorSpace}(100% 0 330deg))`, `${colorSpace}(100% 0 190)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100% 0 330deg), ${colorSpace}(100% 0 50deg))`, `${colorSpace}(100% 0 190)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100% 0 20deg), ${colorSpace}(100% 0 320deg))`, `${colorSpace}(100% 0 170)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100% 0 320deg), ${colorSpace}(100% 0 20deg))`, `${colorSpace}(100% 0 170)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `${colorSpace}(100 0 50)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `${colorSpace}(100 0 50)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `${colorSpace}(100 0 190)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `${colorSpace}(100 0 190)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `${colorSpace}(100 0 170)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace} specified hue, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `${colorSpace}(100 0 170)`);
 
         test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(none none none))`, `${colorSpace}(none none none)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(50% 60 70deg))`, `${colorSpace}(50% 60 70)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg), ${colorSpace}(none none none))`, `${colorSpace}(10% 20 30)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 none), ${colorSpace}(50% 60 70deg))`, `${colorSpace}(30% 40 70)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg), ${colorSpace}(50% 60 none))`, `${colorSpace}(30% 40 30)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none 20 30deg), ${colorSpace}(50% none 70deg))`, `${colorSpace}(50% 20 50)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / none), ${colorSpace}(50% 60 70deg))`, `${colorSpace}(30% 40 50)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / none), ${colorSpace}(50% 60 70deg / 0.5))`, `${colorSpace}(30% 40 50 / 0.5)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30deg / none), ${colorSpace}(50% 60 70deg / none))`, `${colorSpace}(30% 40 50 / none)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(50 60 70deg))`, `${colorSpace}(50 60 70)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), ${colorSpace}(none none none))`, `${colorSpace}(10 20 30)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 none), ${colorSpace}(50 60 70deg))`, `${colorSpace}(30 40 70)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), ${colorSpace}(50 60 none))`, `${colorSpace}(30 40 30)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none 20 30deg), ${colorSpace}(50 none 70deg))`, `${colorSpace}(50 20 50)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / none), ${colorSpace}(50 60 70deg))`, `${colorSpace}(30 40 50)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / none), ${colorSpace}(50 60 70deg / 0.5))`, `${colorSpace}(30 40 50 / 0.5)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / none), ${colorSpace}(50 60 70deg / none))`, `${colorSpace}(30 40 50 / none)`);
     }
 
     for (const colorSpace of [ "lab", "oklab" ]) {
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30), ${colorSpace}(50% 60 70))`, `${colorSpace}(30% 40 50)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30) 25%, ${colorSpace}(50% 60 70))`, `${colorSpace}(40% 50 60)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10% 20 30), ${colorSpace}(50% 60 70))`, `${colorSpace}(40% 50 60)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30), 25% ${colorSpace}(50% 60 70))`, `${colorSpace}(20% 30 40)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30), ${colorSpace}(50% 60 70) 25%)`, `${colorSpace}(20% 30 40)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30) 25%, ${colorSpace}(50% 60 70) 75%)`, `${colorSpace}(40% 50 60)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30) 30%, ${colorSpace}(50% 60 70) 90%)`, `${colorSpace}(40% 50 60)`); // Scale down > 100% sum.
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30) 12.5%, ${colorSpace}(50% 60 70) 37.5%)`, `${colorSpace}(40% 50 60 / 0.5)`); // Scale up < 100% sum, causes alpha multiplication.
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30) 0%, ${colorSpace}(50% 60 70))`, `${colorSpace}(50% 60 70)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 70))`, `${colorSpace}(30 40 50)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 25%, ${colorSpace}(50 60 70))`, `${colorSpace}(40 50 60)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10 20 30), ${colorSpace}(50 60 70))`, `${colorSpace}(40 50 60)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), 25% ${colorSpace}(50 60 70))`, `${colorSpace}(20 30 40)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 70) 25%)`, `${colorSpace}(20 30 40)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 25%, ${colorSpace}(50 60 70) 75%)`, `${colorSpace}(40 50 60)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 30%, ${colorSpace}(50 60 70) 90%)`, `${colorSpace}(40 50 60)`); // Scale down > 100% sum.
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 12.5%, ${colorSpace}(50 60 70) 37.5%)`, `${colorSpace}(40 50 60 / 0.5)`); // Scale up < 100% sum, causes alpha multiplication.
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 0%, ${colorSpace}(50 60 70))`, `${colorSpace}(50 60 70)`);
 
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4), ${colorSpace}(50% 60 70 / .8))`, `${colorSpace}(36.666664% 46.666664 56.666664 / 0.6)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4) 25%, ${colorSpace}(50% 60 70 / .8))`, `${colorSpace}(44.285713% 54.285717 64.28571 / 0.7)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10% 20 30 / .4), ${colorSpace}(50% 60 70 / .8))`, `${colorSpace}(44.285713% 54.285717 64.28571 / 0.7)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4), 25% ${colorSpace}(50% 60 70 / .8))`, `${colorSpace}(26% 36 46 / 0.5)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4), ${colorSpace}(50% 60 70 / .8) 25%)`, `${colorSpace}(26% 36 46 / 0.5)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4) 25%, ${colorSpace}(50% 60 70 / .8) 75%)`, `${colorSpace}(44.285713% 54.285717 64.28571 / 0.7)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4) 30%, ${colorSpace}(50% 60 70 / .8) 90%)`, `${colorSpace}(44.285713% 54.285717 64.28571 / 0.7)`); // Scale down > 100% sum.
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4) 12.5%, ${colorSpace}(50% 60 70 / .8) 37.5%)`, `${colorSpace}(44.285713% 54.285717 64.28571 / 0.35)`); // Scale up < 100% sum, causes alpha multiplication.
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / .4) 0%, ${colorSpace}(50% 60 70 / .8))`, `${colorSpace}(50% 60 70 / 0.8)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4), ${colorSpace}(50 60 70 / .8))`, `${colorSpace}(36.666664 46.666664 56.666664 / 0.6)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 25%, ${colorSpace}(50 60 70 / .8))`, `${colorSpace}(44.285713 54.285717 64.28571 / 0.7)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10 20 30 / .4), ${colorSpace}(50 60 70 / .8))`, `${colorSpace}(44.285713 54.285717 64.28571 / 0.7)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4), 25% ${colorSpace}(50 60 70 / .8))`, `${colorSpace}(26 36 46 / 0.5)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4), ${colorSpace}(50 60 70 / .8) 25%)`, `${colorSpace}(26 36 46 / 0.5)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 25%, ${colorSpace}(50 60 70 / .8) 75%)`, `${colorSpace}(44.285713 54.285717 64.28571 / 0.7)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 30%, ${colorSpace}(50 60 70 / .8) 90%)`, `${colorSpace}(44.285713 54.285717 64.28571 / 0.7)`); // Scale down > 100% sum.
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 12.5%, ${colorSpace}(50 60 70 / .8) 37.5%)`, `${colorSpace}(44.285713 54.285717 64.28571 / 0.35)`); // Scale up < 100% sum, causes alpha multiplication.
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 0%, ${colorSpace}(50 60 70 / .8))`, `${colorSpace}(50 60 70 / 0.8)`);
 
         test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(none none none))`, `${colorSpace}(none none none)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(50% 60 70))`, `${colorSpace}(50% 60 70)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30), ${colorSpace}(none none none))`, `${colorSpace}(10% 20 30)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 none), ${colorSpace}(50% 60 70))`, `${colorSpace}(30% 40 70)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30), ${colorSpace}(50% 60 none))`, `${colorSpace}(30% 40 30)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none 20 30), ${colorSpace}(50% none 70))`, `${colorSpace}(50% 20 50)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / none), ${colorSpace}(50% 60 70))`, `${colorSpace}(30% 40 50)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / none), ${colorSpace}(50% 60 70 / 0.5))`, `${colorSpace}(30% 40 50 / 0.5)`);
-        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10% 20 30 / none), ${colorSpace}(50% 60 70 / none))`, `${colorSpace}(30% 40 50 / none)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(50 60 70))`, `${colorSpace}(50 60 70)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(none none none))`, `${colorSpace}(10 20 30)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 none), ${colorSpace}(50 60 70))`, `${colorSpace}(30 40 70)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 none))`, `${colorSpace}(30 40 30)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none 20 30), ${colorSpace}(50 none 70))`, `${colorSpace}(50 20 50)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / none), ${colorSpace}(50 60 70))`, `${colorSpace}(30 40 50)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / none), ${colorSpace}(50 60 70 / 0.5))`, `${colorSpace}(30 40 50 / 0.5)`);
+        test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / none), ${colorSpace}(50 60 70 / none))`, `${colorSpace}(30 40 50 / none)`);
     }
 
     for (const colorSpace of [ "srgb", "srgb-linear", "xyz", "xyz-d50", "xyz-d65" ]) {

--- a/css/css-color/parsing/color-valid.html
+++ b/css/css-color/parsing/color-valid.html
@@ -84,10 +84,6 @@ test_valid_value("color", "hwb(120 30% 50% / 0)", "rgba(77, 128, 77, 0)");
 test_valid_value("color", "hwb(none 100% 50% / none)", "rgba(170, 170, 170, 0)");
 test_valid_value("color", "hwb(0 100% 50% / 0)", "rgba(170, 170, 170, 0)");
 
-test_valid_value("color", "hsl(72deg 22% 77%)", "rgb(204, 209, 183)");
-test_valid_value("color", "hwb(160grad 30% 17%)", "rgb(77, 212, 131)");
-test_valid_value("color", "hsl(3.77rad 43% 24%)", "rgb(35, 56, 88)");
-test_valid_value("color", "hwb(0.8turn 29% 6%)", "rgb(207, 74, 240)");
 
 for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb", "display-p3" ]) {
     test_valid_value("color", `color(${colorSpace} 0% 0% 0%)`, `color(${colorSpace} 0 0 0)`);
@@ -159,65 +155,57 @@ for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
 }
 
 for (const colorSpace of [ "lab", "oklab" ]) {
-    test_valid_value("color", `${colorSpace}(0% 0 0)`, `${colorSpace}(0% 0 0)`);
     test_valid_value("color", `${colorSpace}(0 0 0)`, `${colorSpace}(0 0 0)`);
-    test_valid_value("color", `${colorSpace}(0% 0 0 / 1)`, `${colorSpace}(0% 0 0)`);
-    test_valid_value("color", `${colorSpace}(0% 0 0 / 0.5)`, `${colorSpace}(0% 0 0 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(20% 0 10/0.5)`, `${colorSpace}(20% 0 10 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(20% 0 10/50%)`, `${colorSpace}(20% 0 10 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(400% 0 10/50%)`, `${colorSpace}(400% 0 10 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(50% -160 160)`, `${colorSpace}(50% -160 160)`);
-    test_valid_value("color", `${colorSpace}(50% -200 200)`, `${colorSpace}(50% -200 200)`);
+    test_valid_value("color", `${colorSpace}(0 0 0 / 1)`, `${colorSpace}(0 0 0)`);
+    test_valid_value("color", `${colorSpace}(0 0 0 / 0.5)`, `${colorSpace}(0 0 0 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(20 0 10/0.5)`, `${colorSpace}(20 0 10 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(20 0 10/50%)`, `${colorSpace}(20 0 10 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(400 0 10/50%)`, `${colorSpace}(400 0 10 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(50 -160 160)`, `${colorSpace}(50 -160 160)`);
     test_valid_value("color", `${colorSpace}(50 -200 200)`, `${colorSpace}(50 -200 200)`);
-    test_valid_value("color", `${colorSpace}(0% 0 0 / -10%)`, `${colorSpace}(0% 0 0 / 0)`);
-    test_valid_value("color", `${colorSpace}(0% 0 0 / 110%)`, `${colorSpace}(0% 0 0)`);
-    test_valid_value("color", `${colorSpace}(0% 0 0 / 300%)`, `${colorSpace}(0% 0 0)`);
-    test_valid_value("color", `${colorSpace}(-40% 0 0)`, `${colorSpace}(0% 0 0)`);
-    test_valid_value("color", `${colorSpace}(50% -20 0)`, `${colorSpace}(50% -20 0)`);
-    test_valid_value("color", `${colorSpace}(50% 0 -20)`, `${colorSpace}(50% 0 -20)`);
-    test_valid_value("color", `${colorSpace}(calc(50% * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))`, `${colorSpace}(150% -0.5 1.5 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(calc(-50% * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))`, `${colorSpace}(0% 1.5 -1.5 / 0)`);
+    test_valid_value("color", `${colorSpace}(0 0 0 / -10%)`, `${colorSpace}(0 0 0 / 0)`);
+    test_valid_value("color", `${colorSpace}(0 0 0 / 110%)`, `${colorSpace}(0 0 0)`);
+    test_valid_value("color", `${colorSpace}(0 0 0 / 300%)`, `${colorSpace}(0 0 0)`);
+    test_valid_value("color", `${colorSpace}(-40 0 0)`, `${colorSpace}(0 0 0)`);
+    test_valid_value("color", `${colorSpace}(50 -20 0)`, `${colorSpace}(50 -20 0)`);
+    test_valid_value("color", `${colorSpace}(50 0 -20)`, `${colorSpace}(50 0 -20)`);
+    test_valid_value("color", `${colorSpace}(calc(50 * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))`, `${colorSpace}(150 -0.5 1.5 / 0.5)`);
     test_valid_value("color", `${colorSpace}(calc(-50 * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))`, `${colorSpace}(0 1.5 -1.5 / 0)`);
 
     test_valid_value("color", `${colorSpace}(none none none / none)`, `${colorSpace}(none none none / none)`);
     test_valid_value("color", `${colorSpace}(none none none)`, `${colorSpace}(none none none)`);
-    test_valid_value("color", `${colorSpace}(20% none none / none)`, `${colorSpace}(20% none none / none)`);
+    test_valid_value("color", `${colorSpace}(20 none none / none)`, `${colorSpace}(20 none none / none)`);
     test_valid_value("color", `${colorSpace}(none none none / 0.5)`, `${colorSpace}(none none none / 0.5)`);
-    test_valid_value("color", `${colorSpace}(0% 0 0 / none)`, `${colorSpace}(0% 0 0 / none)`);
-    test_valid_value("color", `${colorSpace}(10 0 0 / none)`, `${colorSpace}(10 0 0 / none)`);
+    test_valid_value("color", `${colorSpace}(0 0 0 / none)`, `${colorSpace}(0 0 0 / none)`);
 }
 
 for (const colorSpace of [ "lch", "oklch" ]) {
-    test_valid_value("color", `${colorSpace}(0% 0 0deg)`, `${colorSpace}(0% 0 0)`);
     test_valid_value("color", `${colorSpace}(0 0 0deg)`, `${colorSpace}(0 0 0)`);
-    test_valid_value("color", `${colorSpace}(0% 0 0deg / 1)`, `${colorSpace}(0% 0 0)`);
-    test_valid_value("color", `${colorSpace}(0% 0 0deg / 0.5)`, `${colorSpace}(0% 0 0 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(100% 230 0deg / 0.5)`, `${colorSpace}(100% 230 0 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(20% 50 20deg/0.5)`, `${colorSpace}(20% 50 20 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(20% 50 20deg/50%)`, `${colorSpace}(20% 50 20 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(10% 20 20deg / -10%)`, `${colorSpace}(10% 20 20 / 0)`);
-    test_valid_value("color", `${colorSpace}(10% 20 20deg / 110%)`, `${colorSpace}(10% 20 20)`);
-    test_valid_value("color", `${colorSpace}(10% 20 1.28rad)`, `${colorSpace}(10% 20 73.3386)`);
-    test_valid_value("color", `${colorSpace}(10% 20 380deg)`, `${colorSpace}(10% 20 20)`);
-    test_valid_value("color", `${colorSpace}(10% 20 -340deg)`, `${colorSpace}(10% 20 20)`);
-    test_valid_value("color", `${colorSpace}(10% 20 740deg)`, `${colorSpace}(10% 20 20)`);
-    test_valid_value("color", `${colorSpace}(10% 20 -700deg)`, `${colorSpace}(10% 20 20)`);
+    test_valid_value("color", `${colorSpace}(0 0 0deg / 1)`, `${colorSpace}(0 0 0)`);
+    test_valid_value("color", `${colorSpace}(0 0 0deg / 0.5)`, `${colorSpace}(0 0 0 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(100 230 0deg / 0.5)`, `${colorSpace}(100 230 0 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(20 50 20deg/0.5)`, `${colorSpace}(20 50 20 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(20 50 20deg/50%)`, `${colorSpace}(20 50 20 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(10 20 20deg / -10%)`, `${colorSpace}(10 20 20 / 0)`);
+    test_valid_value("color", `${colorSpace}(10 20 20deg / 110%)`, `${colorSpace}(10 20 20)`);
+    test_valid_value("color", `${colorSpace}(10 20 1.28rad)`, `${colorSpace}(10 20 73.3386)`);
+    test_valid_value("color", `${colorSpace}(10 20 380deg)`, `${colorSpace}(10 20 20)`);
+    test_valid_value("color", `${colorSpace}(10 20 -340deg)`, `${colorSpace}(10 20 20)`);
+    test_valid_value("color", `${colorSpace}(10 20 740deg)`, `${colorSpace}(10 20 20)`);
     test_valid_value("color", `${colorSpace}(10 20 -700deg)`, `${colorSpace}(10 20 20)`);
-    test_valid_value("color", `${colorSpace}(-40% 0 0)`, `${colorSpace}(0% 0 0)`);
-    test_valid_value("color", `${colorSpace}(20% -20 0)`, `${colorSpace}(20% 0 0)`);
-    test_valid_value("color", `${colorSpace}(0% 0 0 / 0.5)`, `${colorSpace}(0% 0 0 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(10% 20 20 / 110%)`, `${colorSpace}(10% 20 20)`);
-    test_valid_value("color", `${colorSpace}(10% 20 -700)`, `${colorSpace}(10% 20 20)`);
-    test_valid_value("color", `${colorSpace}(calc(50% * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))`, `${colorSpace}(150% 0 40 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(calc(-50% * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))`, `${colorSpace}(0% 1.5 320 / 0)`);
+    test_valid_value("color", `${colorSpace}(-40 0 0)`, `${colorSpace}(0 0 0)`);
+    test_valid_value("color", `${colorSpace}(20 -20 0)`, `${colorSpace}(20 0 0)`);
+    test_valid_value("color", `${colorSpace}(0 0 0 / 0.5)`, `${colorSpace}(0 0 0 / 0.5)`);
+    test_valid_value("color", `${colorSpace}(10 20 20 / 110%)`, `${colorSpace}(10 20 20)`);
+    test_valid_value("color", `${colorSpace}(10 20 -700)`, `${colorSpace}(10 20 20)`);
+    test_valid_value("color", `${colorSpace}(calc(50 * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))`, `${colorSpace}(150 0 40 / 0.5)`);
     test_valid_value("color", `${colorSpace}(calc(-50 * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))`, `${colorSpace}(0 1.5 320 / 0)`);
 
     test_valid_value("color", `${colorSpace}(none none none / none)`, `${colorSpace}(none none none / none)`);
     test_valid_value("color", `${colorSpace}(none none none)`, `${colorSpace}(none none none)`);
-    test_valid_value("color", `${colorSpace}(20% none none / none)`, `${colorSpace}(20% none none / none)`);
+    test_valid_value("color", `${colorSpace}(20 none none / none)`, `${colorSpace}(20 none none / none)`);
     test_valid_value("color", `${colorSpace}(none none none / 0.5)`, `${colorSpace}(none none none / 0.5)`);
-    test_valid_value("color", `${colorSpace}(0% 0 0 / none)`, `${colorSpace}(0% 0 0 / none)`);
-    test_valid_value("color", `${colorSpace}(10 0 0 / none)`, `${colorSpace}(10 0 0 / none)`);
+    test_valid_value("color", `${colorSpace}(0 0 0 / none)`, `${colorSpace}(0 0 0 / none)`);
 }
 </script>
 </body>

--- a/css/css-color/parsing/relative-color-computed.html
+++ b/css/css-color/parsing/relative-color-computed.html
@@ -24,560 +24,585 @@
 <script>
     // rgb(from ...)
 
-    // Testing no modifications.
-    test_computed_value(`color`, `rgb(from rebeccapurple r g b)`, `rgb(102, 51, 153)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r g b / alpha)`, `rgb(102, 51, 153)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r g b / alpha)`, `rgba(51, 102, 153, 0.8)`);
-    test_computed_value(`color`, `rgb(from hsl(120deg 20% 50% / .5) r g b / alpha)`, `rgba(102, 153, 102, 0.5)`);
+  // Testing no modifications.
+  test_computed_value(`color`, `rgb(from rebeccapurple r g b)`, `rgb(102, 51, 153)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r g b / alpha)`, `rgb(102, 51, 153)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r g b / alpha)`, `rgba(51, 102, 153, 0.8)`);
+  test_computed_value(`color`, `rgb(from hsl(120deg 20% 50% / .5) r g b / alpha)`, `rgba(102, 153, 102, 0.5)`);
 
-    // Test nesting relative colors.
-    test_computed_value(`color`, `rgb(from rgb(from rebeccapurple r g b) r g b)`, `rgb(102, 51, 153)`);
+  // Test nesting relative colors.
+  test_computed_value(`color`, `rgb(from rgb(from rebeccapurple r g b) r g b)`, `rgb(102, 51, 153)`);
 
-    // Testing non-sRGB origin colors to see gamut mapping.
-    test_computed_value(`color`, `rgb(from color(display-p3 0 1 0) r g b / alpha)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
-    test_computed_value(`color`, `rgb(from lab(100% 104.3 -50.9) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_computed_value(`color`, `rgb(from lab(0% 104.3 -50.9) r g b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_computed_value(`color`, `rgb(from lch(100% 116 334) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_computed_value(`color`, `rgb(from lch(0% 116 334) r g b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_computed_value(`color`, `rgb(from oklab(100% 0.365 -0.16) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
-    test_computed_value(`color`, `rgb(from oklab(0% 0.365 -0.16) r g b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
-    test_computed_value(`color`, `rgb(from oklch(100% 0.399 336.3) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
-    test_computed_value(`color`, `rgb(from oklch(0% 0.399 336.3) r g b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
+  // Testing non-sRGB origin colors to see gamut mapping.
+  test_computed_value(`color`, `rgb(from color(display-p3 0 1 0) r g b / alpha)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
+  test_computed_value(`color`, `rgb(from lab(100 104.3 -50.9) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+  test_computed_value(`color`, `rgb(from lab(0 104.3 -50.9) r g b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+  test_computed_value(`color`, `rgb(from lch(100 116 334) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+  test_computed_value(`color`, `rgb(from lch(0 116 334) r g b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+  test_computed_value(`color`, `rgb(from oklab(100 0.365 -0.16) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+  test_computed_value(`color`, `rgb(from oklab(0 0.365 -0.16) r g b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+  test_computed_value(`color`, `rgb(from oklch(100 0.399 336.3) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+  test_computed_value(`color`, `rgb(from oklch(0 0.399 336.3) r g b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
 
-    // Testing replacement with 0.
-    test_computed_value(`color`, `rgb(from rebeccapurple 0 0 0)`, `rgb(0, 0, 0)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple 0 0 0 / 0)`, `rgba(0, 0, 0, 0)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple 0 g b / alpha)`, `rgb(0, 51, 153)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r 0 b / alpha)`, `rgb(102, 0, 153)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r g 0 / alpha)`, `rgb(102, 51, 0)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r g b / 0)`, `rgba(102, 51, 153, 0)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) 0 g b / alpha)`, `rgba(0, 102, 153, 0.8)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r 0 b / alpha)`, `rgba(51, 0, 153, 0.8)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r g 0 / alpha)`, `rgba(51, 102, 0, 0.8)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r g b / 0)`, `rgba(51, 102, 153, 0)`);
+  // Testing replacement with 0.
+  test_computed_value(`color`, `rgb(from rebeccapurple 0 0 0)`, `rgb(0, 0, 0)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple 0 0 0 / 0)`, `rgba(0, 0, 0, 0)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple 0 g b / alpha)`, `rgb(0, 51, 153)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r 0 b / alpha)`, `rgb(102, 0, 153)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r g 0 / alpha)`, `rgb(102, 51, 0)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r g b / 0)`, `rgba(102, 51, 153, 0)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) 0 g b / alpha)`, `rgba(0, 102, 153, 0.8)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r 0 b / alpha)`, `rgba(51, 0, 153, 0.8)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r g 0 / alpha)`, `rgba(51, 102, 0, 0.8)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r g b / 0)`, `rgba(51, 102, 153, 0)`);
 
-    // Testing replacement with a number.
-    test_computed_value(`color`, `rgb(from rebeccapurple 25 g b / alpha)`, `rgb(25, 51, 153)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r 25 b / alpha)`, `rgb(102, 25, 153)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r g 25 / alpha)`, `rgb(102, 51, 25)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r g b / .25)`, `rgba(102, 51, 153, 0.25)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) 25 g b / alpha)`, `rgba(25, 102, 153, 0.8)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r 25 b / alpha)`, `rgba(51, 25, 153, 0.8)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r g 25 / alpha)`, `rgba(51, 102, 25, 0.8)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r g b / .20)`, `rgba(51, 102, 153, 0.2)`);
+  // Testing replacement with a number.
+  test_computed_value(`color`, `rgb(from rebeccapurple 25 g b / alpha)`, `rgb(25, 51, 153)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r 25 b / alpha)`, `rgb(102, 25, 153)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r g 25 / alpha)`, `rgb(102, 51, 25)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r g b / .25)`, `rgba(102, 51, 153, 0.25)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) 25 g b / alpha)`, `rgba(25, 102, 153, 0.8)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r 25 b / alpha)`, `rgba(51, 25, 153, 0.8)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r g 25 / alpha)`, `rgba(51, 102, 25, 0.8)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r g b / .20)`, `rgba(51, 102, 153, 0.2)`);
 
-    // Testing replacement with a percentage.
-    test_computed_value(`color`, `rgb(from rebeccapurple 20% g b / alpha)`, `rgb(51, 51, 153)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r 20% b / alpha)`, `rgb(102, 51, 153)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r g 20% / alpha)`, `rgb(102, 51, 51)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r g b / 20%)`, `rgba(102, 51, 153, 0.2)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) 20% g b / alpha)`, `rgba(51, 102, 153, 0.8)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r 20% b / alpha)`, `rgba(51, 51, 153, 0.8)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r g 20% / alpha)`, `rgba(51, 102, 51, 0.8)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r g b / 20%)`, `rgba(51, 102, 153, 0.2)`);
+  // Testing replacement with a percentage.
+  test_computed_value(`color`, `rgb(from rebeccapurple 20% g b / alpha)`, `rgb(51, 51, 153)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r 20% b / alpha)`, `rgb(102, 51, 153)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r g 20% / alpha)`, `rgb(102, 51, 51)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r g b / 20%)`, `rgba(102, 51, 153, 0.2)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) 20% g b / alpha)`, `rgba(51, 102, 153, 0.8)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r 20% b / alpha)`, `rgba(51, 51, 153, 0.8)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r g 20% / alpha)`, `rgba(51, 102, 51, 0.8)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r g b / 20%)`, `rgba(51, 102, 153, 0.2)`);
 
-    // Testing replacement with a number for r, g, b but percent for alpha.
-    test_computed_value(`color`, `rgb(from rebeccapurple 25 g b / 25%)`, `rgba(25, 51, 153, 0.25)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r 25 b / 25%)`, `rgba(102, 25, 153, 0.25)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r g 25 / 25%)`, `rgba(102, 51, 25, 0.25)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) 25 g b / 25%)`, `rgba(25, 102, 153, 0.25)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r 25 b / 25%)`, `rgba(51, 25, 153, 0.25)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r g 25 / 25%)`, `rgba(51, 102, 25, 0.25)`);
+  // Testing replacement with a number for r, g, b but percent for alpha.
+  test_computed_value(`color`, `rgb(from rebeccapurple 25 g b / 25%)`, `rgba(25, 51, 153, 0.25)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r 25 b / 25%)`, `rgba(102, 25, 153, 0.25)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r g 25 / 25%)`, `rgba(102, 51, 25, 0.25)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) 25 g b / 25%)`, `rgba(25, 102, 153, 0.25)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r 25 b / 25%)`, `rgba(51, 25, 153, 0.25)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r g 25 / 25%)`, `rgba(51, 102, 25, 0.25)`);
 
-    // Testing permutation.
-    test_computed_value(`color`, `rgb(from rebeccapurple g b r)`, `rgb(51, 153, 102)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple b alpha r / g)`, `rgba(153, 255, 102, 0.2)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r r r / r)`, `rgba(102, 102, 102, 0.4)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple alpha alpha alpha / alpha)`, `rgb(255, 255, 255)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) g b r)`, `rgb(102, 153, 51)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) b alpha r / g)`, `rgba(153, 204, 51, 0.4)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r r r / r)`, `rgba(51, 51, 51, 0.2)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) alpha alpha alpha / alpha)`, `rgba(204, 204, 204, 0.8)`);
+  // Testing permutation.
+  test_computed_value(`color`, `rgb(from rebeccapurple g b r)`, `rgb(51, 153, 102)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple b alpha r / g)`, `rgba(153, 255, 102, 0.2)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r r r / r)`, `rgba(102, 102, 102, 0.4)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple alpha alpha alpha / alpha)`, `rgb(255, 255, 255)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) g b r)`, `rgb(102, 153, 51)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) b alpha r / g)`, `rgba(153, 204, 51, 0.4)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r r r / r)`, `rgba(51, 51, 51, 0.2)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) alpha alpha alpha / alpha)`, `rgba(204, 204, 204, 0.8)`);
 
-    // Testing mixes of number and percentage. (These would not be allowed in the non-relative syntax).
-    test_computed_value(`color`, `rgb(from rebeccapurple r 20% 10)`, `rgb(102, 51, 10)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r 10 20%)`, `rgb(102, 10, 51)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple 0% 10 10)`, `rgb(0, 10, 10)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r 20% 10)`, `rgb(51, 51, 10)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r 10 20%)`, `rgb(51, 10, 51)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) 0% 10 10)`, `rgb(0, 10, 10)`);
+  // Testing mixes of number and percentage. (These would not be allowed in the non-relative syntax).
+  test_computed_value(`color`, `rgb(from rebeccapurple r 20% 10)`, `rgb(102, 51, 10)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r 10 20%)`, `rgb(102, 10, 51)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple 0% 10 10)`, `rgb(0, 10, 10)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r 20% 10)`, `rgb(51, 51, 10)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) r 10 20%)`, `rgb(51, 10, 51)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) 0% 10 10)`, `rgb(0, 10, 10)`);
 
-        // r    g    b
-        // 102  51   153
-        // 40%  20%  60%)
-    // Testing with calc().
-    test_computed_value(`color`, `rgb(from rebeccapurple calc(r) calc(g) calc(b))`, `rgb(102, 51, 153)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r calc(g * 2) 10)`, `rgb(102, 102, 10)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple b calc(r * .5) 10)`, `rgb(153, 51, 10)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r calc(g * .5 + g * .5) 10)`, `rgb(102, 51, 10)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r calc(b * .5 - g * .5) 10)`, `rgb(102, 51, 10)`);
-    test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) calc(r) calc(g) calc(b) / calc(alpha))`, `rgba(51, 102, 153, 0.8)`);
+      // r    g    b
+      // 102  51   153
+      // 40%  20%  60%)
+  // Testing with calc().
+  test_computed_value(`color`, `rgb(from rebeccapurple calc(r) calc(g) calc(b))`, `rgb(102, 51, 153)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r calc(g * 2) 10)`, `rgb(102, 102, 10)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple b calc(r * .5) 10)`, `rgb(153, 51, 10)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r calc(g * .5 + g * .5) 10)`, `rgb(102, 51, 10)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r calc(b * .5 - g * .5) 10)`, `rgb(102, 51, 10)`);
+  test_computed_value(`color`, `rgb(from rgb(20%, 40%, 60%, 80%) calc(r) calc(g) calc(b) / calc(alpha))`, `rgba(51, 102, 153, 0.8)`);
 
-    // Testing with 'none'.
-    // NOTE: Serialization of rgb() with 'none' components is still under discussion - https://github.com/w3c/csswg-drafts/issues/6959
-    test_computed_value(`color`, `rgb(from rebeccapurple none none none)`,                         `rgb(0, 0, 0)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple none none none / none)`,                  `rgba(0, 0, 0, 0)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r g none)`,                               `rgb(102, 51, 0)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r g none / alpha)`,                       `rgb(102, 51, 0)`);
-    test_computed_value(`color`, `rgb(from rebeccapurple r g b / none)`,                           `rgba(102, 51, 153, 0)`);
-    test_computed_value(`color`, `rgb(from rgb(20% 40% 60% / 80%) r g none / alpha)`,              `rgba(51, 102, 0, 0.8)`);
-    test_computed_value(`color`, `rgb(from rgb(20% 40% 60% / 80%) r g b / none)`,                  `rgba(51, 102, 153, 0)`);
-    // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
-    test_computed_value(`color`, `rgb(from rgb(none none none) r g b)`,                            `rgb(0, 0, 0)`);
-    test_computed_value(`color`, `rgb(from rgb(none none none / none) r g b / alpha)`,             `rgba(0, 0, 0, 0)`);
-    test_computed_value(`color`, `rgb(from rgb(20% none 60%) r g b)`,                              `rgb(51, 0, 153)`);
-    test_computed_value(`color`, `rgb(from rgb(20% 40% 60% / none) r g b / alpha)`,                `rgba(51, 102, 153, 0)`);
+  // Testing with 'none'.
+  test_computed_value(`color`, `rgb(from rebeccapurple none none none)`,                         `rgb(0, 0, 0)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple none none none / none)`,                  `rgba(0, 0, 0, 0)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r g none)`,                               `rgb(102, 51, 0)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r g none / alpha)`,                       `rgb(102, 51, 0)`);
+  test_computed_value(`color`, `rgb(from rebeccapurple r g b / none)`,                           `rgba(102, 51, 153, 0)`);
+  test_computed_value(`color`, `rgb(from rgb(20% 40% 60% / 80%) r g none / alpha)`,              `rgba(51, 102, 0, 0.8)`);
+  test_computed_value(`color`, `rgb(from rgb(20% 40% 60% / 80%) r g b / none)`,                  `rgba(51, 102, 153, 0)`);
+  // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+  test_computed_value(`color`, `rgb(from rgb(none none none) r g b)`,                            `rgb(0, 0, 0)`);
+  test_computed_value(`color`, `rgb(from rgb(none none none / none) r g b / alpha)`,             `rgba(0, 0, 0, 0)`);
+  test_computed_value(`color`, `rgb(from rgb(20% none 60%) r g b)`,                              `rgb(51, 0, 153)`);
+  test_computed_value(`color`, `rgb(from rgb(20% 40% 60% / none) r g b / alpha)`,                `rgba(51, 102, 153, 0)`);
 
-    // hsl(from ...)
 
-    // Testing no modifications.
-    test_computed_value(`color`, `hsl(from rebeccapurple h s l)`, `rgb(102, 51, 153)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple h s l / alpha)`, `rgb(102, 51, 153)`);
-    test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h s l / alpha)`, `rgba(51, 102, 153, 0.8)`);
-    test_computed_value(`color`, `hsl(from hsl(120deg 20% 50% / .5) h s l / alpha)`, `rgba(102, 153, 102, 0.5)`);
+  // hsl(from ...)
 
-    // Test nesting relative colors.
-    test_computed_value(`color`, `hsl(from hsl(from rebeccapurple h s l) h s l)`, `rgb(102, 51, 153)`);
+  // Testing no modifications.
+  test_computed_value(`color`, `hsl(from rebeccapurple h s l)`, `rgb(102, 51, 153)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple h s l / alpha)`, `rgb(102, 51, 153)`);
+  test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h s l / alpha)`, `rgba(51, 102, 153, 0.8)`);
+  test_computed_value(`color`, `hsl(from hsl(120deg 20% 50% / .5) h s l / alpha)`, `rgba(102, 153, 102, 0.5)`);
 
-    // Testing non-sRGB origin colors to see gamut mapping.
-    test_computed_value(`color`, `hsl(from color(display-p3 0 1 0) h s l / alpha)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
-    test_computed_value(`color`, `hsl(from lab(100% 104.3 -50.9) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_computed_value(`color`, `hsl(from lab(0% 104.3 -50.9) h s l)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_computed_value(`color`, `hsl(from lch(100% 116 334) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_computed_value(`color`, `hsl(from lch(0% 116 334) h s l)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_computed_value(`color`, `hsl(from oklab(100% 0.365 -0.16) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
-    test_computed_value(`color`, `hsl(from oklab(0% 0.365 -0.16) h s l)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
-    test_computed_value(`color`, `hsl(from oklch(100% 0.399 336.3) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
-    test_computed_value(`color`, `hsl(from oklch(0% 0.399 336.3) h s l)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
+  // Test nesting relative colors.
+  test_computed_value(`color`, `hsl(from hsl(from rebeccapurple h s l) h s l)`, `rgb(102, 51, 153)`);
 
-    // Testing replacement with 0.
-    test_computed_value(`color`, `hsl(from rebeccapurple 0 0% 0%)`, `rgb(0, 0, 0)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple 0deg 0% 0%)`, `rgb(0, 0, 0)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple 0 0% 0% / 0)`, `rgba(0, 0, 0, 0)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple 0deg 0% 0% / 0)`, `rgba(0, 0, 0, 0)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple 0 s l / alpha)`, `rgb(153, 51, 51)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple 0deg s l / alpha)`, `rgb(153, 51, 51)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple h 0% l / alpha)`, `rgb(102, 102, 102)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple h s 0% / alpha)`, `rgb(0, 0, 0)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple h s l / 0)`, `rgba(102, 51, 153, 0)`);
-    test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) 0 s l / alpha)`, `rgba(153, 51, 51, 0.8)`);
-    test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) 0deg s l / alpha)`, `rgba(153, 51, 51, 0.8)`);
-    test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h 0% l / alpha)`, `rgba(102, 102, 102, 0.8)`);
-    test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h s 0% / alpha)`, `rgba(0, 0, 0, 0.8)`);
-    test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h s l / 0)`, `rgba(51, 102, 153, 0)`);
+  // Testing non-sRGB origin colors to see gamut mapping.
+  test_computed_value(`color`, `hsl(from color(display-p3 0 1 0) h s l / alpha)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
+  test_computed_value(`color`, `hsl(from lab(100 104.3 -50.9) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+  test_computed_value(`color`, `hsl(from lab(0 104.3 -50.9) h s l)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+  test_computed_value(`color`, `hsl(from lch(100 116 334) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+  test_computed_value(`color`, `hsl(from lch(0 116 334) h s l)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+  test_computed_value(`color`, `hsl(from oklab(100 0.365 -0.16) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+  test_computed_value(`color`, `hsl(from oklab(0 0.365 -0.16) h s l)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+  test_computed_value(`color`, `hsl(from oklch(100 0.399 336.3) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+  test_computed_value(`color`, `hsl(from oklch(0 0.399 336.3) h s l)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
 
-    // Testing replacement with a constant.
-    test_computed_value(`color`, `hsl(from rebeccapurple 25 s l / alpha)`, `rgb(153, 94, 51)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple 25deg s l / alpha)`, `rgb(153, 94, 51)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple h 20% l / alpha)`, `rgb(102, 82, 122)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple h s 20% / alpha)`, `rgb(51, 25, 77)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple h s l / .25)`, `rgba(102, 51, 153, 0.25)`);
-    test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) 25 s l / alpha)`, `rgba(153, 94, 51, 0.8)`);
-    test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) 25deg s l / alpha)`, `rgba(153, 94, 51, 0.8)`);
-    test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h 20% l / alpha)`, `rgba(82, 102, 122, 0.8)`);
-    test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h s 20% / alpha)`, `rgba(25, 51, 77, 0.8)`);
-    test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h s l / .2)`, `rgba(51, 102, 153, 0.2)`);
+  // Testing replacement with 0.
+  test_computed_value(`color`, `hsl(from rebeccapurple 0 0% 0%)`, `rgb(0, 0, 0)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple 0deg 0% 0%)`, `rgb(0, 0, 0)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple 0 0% 0% / 0)`, `rgba(0, 0, 0, 0)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple 0deg 0% 0% / 0)`, `rgba(0, 0, 0, 0)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple 0 s l / alpha)`, `rgb(153, 51, 51)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple 0deg s l / alpha)`, `rgb(153, 51, 51)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple h 0% l / alpha)`, `rgb(102, 102, 102)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple h s 0% / alpha)`, `rgb(0, 0, 0)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple h s l / 0)`, `rgba(102, 51, 153, 0)`);
+  test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) 0 s l / alpha)`, `rgba(153, 51, 51, 0.8)`);
+  test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) 0deg s l / alpha)`, `rgba(153, 51, 51, 0.8)`);
+  test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h 0% l / alpha)`, `rgba(102, 102, 102, 0.8)`);
+  test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h s 0% / alpha)`, `rgba(0, 0, 0, 0.8)`);
+  test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h s l / 0)`, `rgba(51, 102, 153, 0)`);
 
-    // Testing valid permutation (types match).
-    test_computed_value(`color`, `hsl(from rebeccapurple h l s)`, `rgb(128, 77, 179)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple h alpha l / s)`, `rgba(102, 0, 204, 0.5)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple h l l / l)`, `rgba(102, 61, 143, 0.4)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple h alpha alpha / alpha)`, `rgb(255, 255, 255)`);
-    test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h l s)`, `rgb(77, 128, 179)`);
-    test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h alpha l / s)`, `rgba(20, 102, 184, 0.5)`);
-    test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h l l / l)`, `rgba(61, 102, 143, 0.4)`);
-    test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h alpha alpha / alpha)`, `rgba(163, 204, 245, 0.8)`);
+  // Testing replacement with a constant.
+  test_computed_value(`color`, `hsl(from rebeccapurple 25 s l / alpha)`, `rgb(153, 94, 51)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple 25deg s l / alpha)`, `rgb(153, 94, 51)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple h 20% l / alpha)`, `rgb(102, 82, 122)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple h s 20% / alpha)`, `rgb(51, 25, 77)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple h s l / .25)`, `rgba(102, 51, 153, 0.25)`);
+  test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) 25 s l / alpha)`, `rgba(153, 94, 51, 0.8)`);
+  test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) 25deg s l / alpha)`, `rgba(153, 94, 51, 0.8)`);
+  test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h 20% l / alpha)`, `rgba(82, 102, 122, 0.8)`);
+  test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h s 20% / alpha)`, `rgba(25, 51, 77, 0.8)`);
+  test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h s l / .2)`, `rgba(51, 102, 153, 0.2)`);
 
-    // Testing with calc().
-    test_computed_value(`color`, `hsl(from rebeccapurple calc(h) calc(s) calc(l))`, `rgb(102, 51, 153)`);
-    test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) calc(h) calc(s) calc(l) / calc(alpha))`, `rgba(51, 102, 153, 0.8)`);
+  // Testing valid permutation (types match).
+  test_computed_value(`color`, `hsl(from rebeccapurple h l s)`, `rgb(128, 77, 179)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple h alpha l / s)`, `rgba(102, 0, 204, 0.5)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple h l l / l)`, `rgba(102, 61, 143, 0.4)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple h alpha alpha / alpha)`, `rgb(255, 255, 255)`);
+  test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h l s)`, `rgb(77, 128, 179)`);
+  test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h alpha l / s)`, `rgba(20, 102, 184, 0.5)`);
+  test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h l l / l)`, `rgba(61, 102, 143, 0.4)`);
+  test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) h alpha alpha / alpha)`, `rgba(163, 204, 245, 0.8)`);
 
-    // Testing with 'none'.
-    test_computed_value(`color`, `hsl(from rebeccapurple none none none)`,                         `rgb(0, 0, 0)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple none none none / none)`,                  `rgba(0, 0, 0, 0)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple h s none)`,                               `rgb(0, 0, 0)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple h s none / alpha)`,                       `rgb(0, 0, 0)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple h s l / none)`,                           `rgba(102, 51, 153, 0)`);
-    test_computed_value(`color`, `hsl(from rebeccapurple none s l / alpha)`,                       `rgb(153, 51, 51)`);
-    test_computed_value(`color`, `hsl(from hsl(120deg 20% 50% / .5) h s none / alpha)`,            `rgba(0, 0, 0, 0.5)`);
-    test_computed_value(`color`, `hsl(from hsl(120deg 20% 50% / .5) h s l / none)`,                `rgba(102, 153, 102, 0)`);
-    test_computed_value(`color`, `hsl(from hsl(120deg 20% 50% / .5) none s l / alpha)`,            `rgba(153, 102, 102, 0.5)`);
-    // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
-    test_computed_value(`color`, `hsl(from hsl(none none none) h s l)`,                            `rgb(0, 0, 0)`);
-    test_computed_value(`color`, `hsl(from hsl(none none none / none) h s l / alpha)`,             `rgba(0, 0, 0, 0)`);
-    test_computed_value(`color`, `hsl(from hsl(120deg none 50% / .5) h s l)`,                      `rgb(128, 128, 128)`);
-    test_computed_value(`color`, `hsl(from hsl(120deg 20% 50% / none) h s l / alpha)`,             `rgba(102, 153, 102, 0)`);
-    test_computed_value(`color`, `hsl(from hsl(none 20% 50% / .5) h s l / alpha)`,                 `rgba(153, 102, 102, 0.5)`);
+  // Testing with calc().
+  test_computed_value(`color`, `hsl(from rebeccapurple calc(h) calc(s) calc(l))`, `rgb(102, 51, 153)`);
+  test_computed_value(`color`, `hsl(from rgb(20%, 40%, 60%, 80%) calc(h) calc(s) calc(l) / calc(alpha))`, `rgba(51, 102, 153, 0.8)`);
 
-    // hwb(from ...)
+  // Testing with 'none'.
+  test_computed_value(`color`, `hsl(from rebeccapurple none none none)`,                         `rgb(0, 0, 0)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple none none none / none)`,                  `rgba(0, 0, 0, 0)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple h s none)`,                               `rgb(0, 0, 0)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple h s none / alpha)`,                       `rgb(0, 0, 0)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple h s l / none)`,                           `rgba(102, 51, 153, 0)`);
+  test_computed_value(`color`, `hsl(from rebeccapurple none s l / alpha)`,                       `rgb(153, 51, 51)`);
+  test_computed_value(`color`, `hsl(from hsl(120deg 20% 50% / .5) h s none / alpha)`,            `rgba(0, 0, 0, 0.5)`);
+  test_computed_value(`color`, `hsl(from hsl(120deg 20% 50% / .5) h s l / none)`,                `rgba(102, 153, 102, 0)`);
+  test_computed_value(`color`, `hsl(from hsl(120deg 20% 50% / .5) none s l / alpha)`,            `rgba(153, 102, 102, 0.5)`);
+  // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+  test_computed_value(`color`, `hsl(from hsl(none none none) h s l)`,                            `rgb(0, 0, 0)`);
+  test_computed_value(`color`, `hsl(from hsl(none none none / none) h s l / alpha)`,             `rgba(0, 0, 0, 0)`);
+  test_computed_value(`color`, `hsl(from hsl(120deg none 50% / .5) h s l)`,                      `rgb(128, 128, 128)`);
+  test_computed_value(`color`, `hsl(from hsl(120deg 20% 50% / none) h s l / alpha)`,             `rgba(102, 153, 102, 0)`);
+  test_computed_value(`color`, `hsl(from hsl(none 20% 50% / .5) h s l / alpha)`,                 `rgba(153, 102, 102, 0.5)`);
 
-    // Testing no modifications.
-    test_computed_value(`color`, `hwb(from rebeccapurple h w b)`, `rgb(102, 51, 153)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple h w b / alpha)`, `rgb(102, 51, 153)`);
-    test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h w b / alpha)`, `rgba(51, 102, 153, 0.8)`);
-    test_computed_value(`color`, `hwb(from hsl(120deg 20% 50% / .5) h w b / alpha)`, `rgba(102, 153, 102, 0.5)`);
+  // hwb(from ...)
 
-    // Test nesting relative colors.
-    test_computed_value(`color`, `hwb(from hwb(from rebeccapurple h w b) h w b)`, `rgb(102, 51, 153)`);
+  // Testing no modifications.
+  test_computed_value(`color`, `hwb(from rebeccapurple h w b)`, `rgb(102, 51, 153)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple h w b / alpha)`, `rgb(102, 51, 153)`);
+  test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h w b / alpha)`, `rgba(51, 102, 153, 0.8)`);
+  test_computed_value(`color`, `hwb(from hsl(120deg 20% 50% / .5) h w b / alpha)`, `rgba(102, 153, 102, 0.5)`);
 
-    // Testing non-sRGB origin colors to see gamut mapping.
-    test_computed_value(`color`, `hwb(from color(display-p3 0 1 0) h w b / alpha)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
-    test_computed_value(`color`, `hwb(from lab(100% 104.3 -50.9) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_computed_value(`color`, `hwb(from lab(0% 104.3 -50.9) h w b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_computed_value(`color`, `hwb(from lch(100% 116 334) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_computed_value(`color`, `hwb(from lch(0% 116 334) h w b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_computed_value(`color`, `hwb(from oklab(100% 0.365 -0.16) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
-    test_computed_value(`color`, `hwb(from oklab(0% 0.365 -0.16) h w b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
-    test_computed_value(`color`, `hwb(from oklch(100% 0.399 336.3) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
-    test_computed_value(`color`, `hwb(from oklch(0% 0.399 336.3) h w b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
+  // Test nesting relative colors.
+  test_computed_value(`color`, `hwb(from hwb(from rebeccapurple h w b) h w b)`, `rgb(102, 51, 153)`);
 
-    // Testing replacement with 0.
-    test_computed_value(`color`, `hwb(from rebeccapurple 0 0% 0%)`, `rgb(255, 0, 0)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple 0deg 0% 0%)`, `rgb(255, 0, 0)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple 0 0% 0% / 0)`, `rgba(255, 0, 0, 0)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple 0deg 0% 0% / 0)`, `rgba(255, 0, 0, 0)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple 0 w b / alpha)`, `rgb(153, 51, 51)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple 0deg w b / alpha)`, `rgb(153, 51, 51)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple h 0% b / alpha)`, `rgb(77, 0, 153)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple h w 0% / alpha)`, `rgb(153, 51, 255)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple h w b / 0)`, `rgba(102, 51, 153, 0)`);
-    test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) 0 w b / alpha)`, `rgba(153, 51, 51, 0.8)`);
-    test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) 0deg w b / alpha)`, `rgba(153, 51, 51, 0.8)`);
-    test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h 0% b / alpha)`, `rgba(0, 77, 153, 0.8)`);
-    test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h w 0% / alpha)`, `rgba(51, 153, 255, 0.8)`);
-    test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h w b / 0)`, `rgba(51, 102, 153, 0)`);
+  // Testing non-sRGB origin colors to see gamut mapping.
+  test_computed_value(`color`, `hwb(from color(display-p3 0 1 0) h w b / alpha)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
+  test_computed_value(`color`, `hwb(from lab(100 104.3 -50.9) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+  test_computed_value(`color`, `hwb(from lab(0 104.3 -50.9) h w b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+  test_computed_value(`color`, `hwb(from lch(100 116 334) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+  test_computed_value(`color`, `hwb(from lch(0 116 334) h w b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+  test_computed_value(`color`, `hwb(from oklab(100 0.365 -0.16) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+  test_computed_value(`color`, `hwb(from oklab(0 0.365 -0.16) h w b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+  test_computed_value(`color`, `hwb(from oklch(100 0.399 336.3) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+  test_computed_value(`color`, `hwb(from oklch(0 0.399 336.3) h w b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
 
-    // Testing replacement with a constant.
-    test_computed_value(`color`, `hwb(from rebeccapurple 25 w b / alpha)`, `rgb(153, 94, 51)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple 25deg w b / alpha)`, `rgb(153, 94, 51)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple h 20% b / alpha)`, `rgb(102, 51, 153)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple h w 20% / alpha)`, `rgb(128, 51, 204)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple h w b / .2)`, `rgba(102, 51, 153, 0.2)`);
-    test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) 25 w b / alpha)`, `rgba(153, 94, 51, 0.8)`);
-    test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) 25deg w b / alpha)`, `rgba(153, 94, 51, 0.8)`);
-    test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h 20% b / alpha)`, `rgba(51, 102, 153, 0.8)`);
-    test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h w 20% / alpha)`, `rgba(51, 128, 204, 0.8)`);
-    test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h w b / .2)`, `rgba(51, 102, 153, 0.2)`);
+  // Testing replacement with 0.
+  test_computed_value(`color`, `hwb(from rebeccapurple 0 0% 0%)`, `rgb(255, 0, 0)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple 0deg 0% 0%)`, `rgb(255, 0, 0)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple 0 0% 0% / 0)`, `rgba(255, 0, 0, 0)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple 0deg 0% 0% / 0)`, `rgba(255, 0, 0, 0)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple 0 w b / alpha)`, `rgb(153, 51, 51)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple 0deg w b / alpha)`, `rgb(153, 51, 51)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple h 0% b / alpha)`, `rgb(77, 0, 153)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple h w 0% / alpha)`, `rgb(153, 51, 255)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple h w b / 0)`, `rgba(102, 51, 153, 0)`);
+  test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) 0 w b / alpha)`, `rgba(153, 51, 51, 0.8)`);
+  test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) 0deg w b / alpha)`, `rgba(153, 51, 51, 0.8)`);
+  test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h 0% b / alpha)`, `rgba(0, 77, 153, 0.8)`);
+  test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h w 0% / alpha)`, `rgba(51, 153, 255, 0.8)`);
+  test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h w b / 0)`, `rgba(51, 102, 153, 0)`);
 
-    // Testing valid permutation (types match).
-    test_computed_value(`color`, `hwb(from rebeccapurple h b w)`, `rgb(153, 102, 204)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple h alpha w / b)`, `rgba(213, 213, 213, 0.4)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple h w w / w)`, `rgba(128, 51, 204, 0.2)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple h alpha alpha / alpha)`, `rgb(128, 128, 128)`);
-    test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h b w)`, `rgb(102, 153, 204)`);
-    test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h alpha w / b)`, `rgba(204, 204, 204, 0.4)`);
-    test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h w w / w)`, `rgba(51, 128, 204, 0.2)`);
-    test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h alpha alpha / alpha)`, `rgba(128, 128, 128, 0.8)`);
+  // Testing replacement with a constant.
+  test_computed_value(`color`, `hwb(from rebeccapurple 25 w b / alpha)`, `rgb(153, 94, 51)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple 25deg w b / alpha)`, `rgb(153, 94, 51)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple h 20% b / alpha)`, `rgb(102, 51, 153)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple h w 20% / alpha)`, `rgb(128, 51, 204)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple h w b / .2)`, `rgba(102, 51, 153, 0.2)`);
+  test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) 25 w b / alpha)`, `rgba(153, 94, 51, 0.8)`);
+  test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) 25deg w b / alpha)`, `rgba(153, 94, 51, 0.8)`);
+  test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h 20% b / alpha)`, `rgba(51, 102, 153, 0.8)`);
+  test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h w 20% / alpha)`, `rgba(51, 128, 204, 0.8)`);
+  test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h w b / .2)`, `rgba(51, 102, 153, 0.2)`);
 
-    // Testing with calc().
-    test_computed_value(`color`, `hwb(from rebeccapurple calc(h) calc(w) calc(b))`, `rgb(102, 51, 153)`);
-    test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) calc(h) calc(w) calc(b) / calc(alpha))`, `rgba(51, 102, 153, 0.8)`);
+  // Testing valid permutation (types match).
+  test_computed_value(`color`, `hwb(from rebeccapurple h b w)`, `rgb(153, 102, 204)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple h alpha w / b)`, `rgba(213, 213, 213, 0.4)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple h w w / w)`, `rgba(128, 51, 204, 0.2)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple h alpha alpha / alpha)`, `rgb(128, 128, 128)`);
+  test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h b w)`, `rgb(102, 153, 204)`);
+  test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h alpha w / b)`, `rgba(204, 204, 204, 0.4)`);
+  test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h w w / w)`, `rgba(51, 128, 204, 0.2)`);
+  test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) h alpha alpha / alpha)`, `rgba(128, 128, 128, 0.8)`);
 
-    // Testing with 'none'.
-    test_computed_value(`color`, `hwb(from rebeccapurple none none none)`,                         `rgb(255, 0, 0)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple none none none / none)`,                  `rgba(255, 0, 0, 0)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple h w none)`,                               `rgb(153, 51, 255)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple h w none / alpha)`,                       `rgb(153, 51, 255)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple h w b / none)`,                           `rgba(102, 51, 153, 0)`);
-    test_computed_value(`color`, `hwb(from rebeccapurple none w b / alpha)`,                       `rgb(153, 51, 51)`);
-    test_computed_value(`color`, `hwb(from hwb(120deg 20% 50% / .5) h w none / alpha)`,            `rgba(51, 255, 51, 0.5)`);
-    test_computed_value(`color`, `hwb(from hwb(120deg 20% 50% / .5) h w b / none)`,                `rgba(51, 128, 51, 0)`);
-    test_computed_value(`color`, `hwb(from hwb(120deg 20% 50% / .5) none w b / alpha)`,            `rgba(128, 51, 51, 0.5)`);
-    // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
-    test_computed_value(`color`, `hwb(from hwb(none none none) h w b)`,                            `rgb(255, 0, 0)`);
-    test_computed_value(`color`, `hwb(from hwb(none none none / none) h w b / alpha)`,             `rgba(255, 0, 0, 0)`);
-    test_computed_value(`color`, `hwb(from hwb(120deg none 50% / .5) h w b)`,                      `rgb(0, 128, 0)`);
-    test_computed_value(`color`, `hwb(from hwb(120deg 20% 50% / none) h w b / alpha)`,             `rgba(51, 128, 51, 0)`);
-    test_computed_value(`color`, `hwb(from hwb(none 20% 50% / .5) h w b / alpha)`,                 `rgba(128, 51, 51, 0.5)`);
+  // Testing with calc().
+  test_computed_value(`color`, `hwb(from rebeccapurple calc(h) calc(w) calc(b))`, `rgb(102, 51, 153)`);
+  test_computed_value(`color`, `hwb(from rgb(20%, 40%, 60%, 80%) calc(h) calc(w) calc(b) / calc(alpha))`, `rgba(51, 102, 153, 0.8)`);
 
-    for (const colorSpace of [ "lab", "oklab" ]) {
-        // Testing no modifications.
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a b)`, `${colorSpace}(25% 20 50)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a b / alpha)`, `${colorSpace}(25% 20 50)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a b / alpha)`, `${colorSpace}(25% 20 50 / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(200% 300 400 / 500%) l a b / alpha)`, `${colorSpace}(200% 300 400)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(-200% -300 -400 / -500%) l a b / alpha)`, `${colorSpace}(0% -300 -400 / 0)`);
+  // Testing with 'none'.
+  test_computed_value(`color`, `hwb(from rebeccapurple none none none)`,                         `rgb(255, 0, 0)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple none none none / none)`,                  `rgba(255, 0, 0, 0)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple h w none)`,                               `rgb(153, 51, 255)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple h w none / alpha)`,                       `rgb(153, 51, 255)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple h w b / none)`,                           `rgba(102, 51, 153, 0)`);
+  test_computed_value(`color`, `hwb(from rebeccapurple none w b / alpha)`,                       `rgb(153, 51, 51)`);
+  test_computed_value(`color`, `hwb(from hwb(120deg 20% 50% / .5) h w none / alpha)`,            `rgba(51, 255, 51, 0.5)`);
+  test_computed_value(`color`, `hwb(from hwb(120deg 20% 50% / .5) h w b / none)`,                `rgba(51, 128, 51, 0)`);
+  test_computed_value(`color`, `hwb(from hwb(120deg 20% 50% / .5) none w b / alpha)`,            `rgba(128, 51, 51, 0.5)`);
+  // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+  test_computed_value(`color`, `hwb(from hwb(none none none) h w b)`,                            `rgb(255, 0, 0)`);
+  test_computed_value(`color`, `hwb(from hwb(none none none / none) h w b / alpha)`,             `rgba(255, 0, 0, 0)`);
+  test_computed_value(`color`, `hwb(from hwb(120deg none 50% / .5) h w b)`,                      `rgb(0, 128, 0)`);
+  test_computed_value(`color`, `hwb(from hwb(120deg 20% 50% / none) h w b / alpha)`,             `rgba(51, 128, 51, 0)`);
+  test_computed_value(`color`, `hwb(from hwb(none 20% 50% / .5) h w b / alpha)`,                 `rgba(128, 51, 51, 0.5)`);
 
-        // Test nesting relative colors.
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(from ${colorSpace}(25% 20 50) l a b) l a b)`, `${colorSpace}(25% 20 50)`);
+  for (const colorSpace of [ "lab", "oklab" ]) {
+      // Testing no modifications.
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b)`, `${colorSpace}(25 20 50)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b / alpha)`, `${colorSpace}(25 20 50)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a b / alpha)`, `${colorSpace}(25 20 50 / 0.4)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(200 300 400 / 500%) l a b / alpha)`, `${colorSpace}(200 300 400)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(-200 -300 -400 / -500%) l a b / alpha)`, `${colorSpace}(0 -300 -400 / 0)`);
 
-        // Testing non-${colorSpace} origin to see conversion.
-        test_computed_value(`color`, `${colorSpace}(from color(display-p3 0 0 0) l a b / alpha)`, `${colorSpace}(0% 0 0)`);
+      // Test nesting relative colors.
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(from ${colorSpace}(25 20 50) l a b) l a b)`, `${colorSpace}(25 20 50)`);
 
-        // Testing replacement with 0.
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) 0% 0 0)`, `${colorSpace}(0% 0 0)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) 0% 0 0 / 0)`, `${colorSpace}(0% 0 0 / 0)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) 0% a b / alpha)`, `${colorSpace}(0% 20 50)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l 0 b / alpha)`, `${colorSpace}(25% 0 50)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a 0 / alpha)`, `${colorSpace}(25% 20 0)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a b / 0)`, `${colorSpace}(25% 20 50 / 0)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) 0% a b / alpha)`, `${colorSpace}(0% 20 50 / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l 0 b / alpha)`, `${colorSpace}(25% 0 50 / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a 0 / alpha)`, `${colorSpace}(25% 20 0 / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a b / 0)`, `${colorSpace}(25% 20 50 / 0)`);
+      // Testing non-${colorSpace} origin to see conversion.
+      test_computed_value(`color`, `${colorSpace}(from color(display-p3 0 0 0) l a b / alpha)`, `${colorSpace}(0 0 0)`);
 
-        // Testing replacement with a constant.
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) 35% a b / alpha)`, `${colorSpace}(35% 20 50)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l 35 b / alpha)`, `${colorSpace}(25% 35 50)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a 35 / alpha)`, `${colorSpace}(25% 20 35)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a b / .35)`, `${colorSpace}(25% 20 50 / 0.35)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) 35% a b / alpha)`, `${colorSpace}(35% 20 50 / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l 35 b / alpha)`, `${colorSpace}(25% 35 50 / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a 35 / alpha)`, `${colorSpace}(25% 20 35 / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a b / .35)`, `${colorSpace}(25% 20 50 / 0.35)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 200% 300 400 / 500)`, `${colorSpace}(200% 300 400)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) -200% -300 -400 / -500)`, `${colorSpace}(0% -300 -400 / 0)`);
+      // Testing replacement with 0.
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) 0 0 0)`, `${colorSpace}(0 0 0)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) 0 0 0 / 0)`, `${colorSpace}(0 0 0 / 0)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) 0 a b / alpha)`, `${colorSpace}(0 20 50)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l 0 b / alpha)`, `${colorSpace}(25 0 50)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a 0 / alpha)`, `${colorSpace}(25 20 0)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b / 0)`, `${colorSpace}(25 20 50 / 0)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) 0 a b / alpha)`, `${colorSpace}(0 20 50 / 0.4)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l 0 b / alpha)`, `${colorSpace}(25 0 50 / 0.4)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a 0 / alpha)`, `${colorSpace}(25 20 0 / 0.4)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a b / 0)`, `${colorSpace}(25 20 50 / 0)`);
 
-        // Testing valid permutation (types match).
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l b a)`, `${colorSpace}(25% 50 20)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a a / a)`, `${colorSpace}(25% 20 20)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l b a)`, `${colorSpace}(25% 50 20)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a a / a)`, `${colorSpace}(25% 20 20)`);
+      // Testing replacement with a constant.
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) 35 a b / alpha)`, `${colorSpace}(35 20 50)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l 35 b / alpha)`, `${colorSpace}(25 35 50)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a 35 / alpha)`, `${colorSpace}(25 20 35)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b / .35)`, `${colorSpace}(25 20 50 / 0.35)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) 35 a b / alpha)`, `${colorSpace}(35 20 50 / 0.4)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l 35 b / alpha)`, `${colorSpace}(25 35 50 / 0.4)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a 35 / alpha)`, `${colorSpace}(25 20 35 / 0.4)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a b / .35)`, `${colorSpace}(25 20 50 / 0.35)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 200 300 400 / 500)`, `${colorSpace}(200 300 400)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) -200 -300 -400 / -500)`, `${colorSpace}(0 -300 -400 / 0)`);
 
-        // Testing with calc().
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) calc(l) calc(a) calc(b))`, `${colorSpace}(25% 20 50)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) calc(l) calc(a) calc(b) / calc(alpha))`, `${colorSpace}(25% 20 50 / 0.4)`);
+      // Testing valid permutation (types match).
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l b a)`, `${colorSpace}(25 50 20)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a a / a)`, `${colorSpace}(25 20 20)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l b a)`, `${colorSpace}(25 50 20)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a a / a)`, `${colorSpace}(25 20 20)`);
 
-        // Testing with 'none'.
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) none none none)`, `${colorSpace}(none none none)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) none none none / none)`, `${colorSpace}(none none none / none)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a none)`, `${colorSpace}(25% 20 none)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a none / alpha)`, `${colorSpace}(25% 20 none)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a b / none)`, `${colorSpace}(25% 20 50 / none)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a none / alpha)`, `${colorSpace}(25% 20 none / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a b / none)`, `${colorSpace}(25% 20 50 / none)`);
-        // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(none none none) l a b)`, `${colorSpace}(0% 0 0)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(none none none / none) l a b / alpha)`, `${colorSpace}(0% 0 0 / 0)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% none 50) l a b)`, `${colorSpace}(25% 0 50)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / none) l a b / alpha)`, `${colorSpace}(25% 20 50 / 0)`);
-    }
+      // Testing with calc().
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) calc(l) calc(a) calc(b))`, `${colorSpace}(25 20 50)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) calc(l) calc(a) calc(b) / calc(alpha))`, `${colorSpace}(25 20 50 / 0.4)`);
 
-    for (const colorSpace of [ "lch", "oklch" ]) {
-        const rectangularForm = colorSpace == "lch" ? "lab" : "oklab";
+      // Testing with 'none'.
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) none none none)`, `${colorSpace}(none none none)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) none none none / none)`, `${colorSpace}(none none none / none)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a none)`, `${colorSpace}(25 20 none)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a none / alpha)`, `${colorSpace}(25 20 none)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b / none)`, `${colorSpace}(25 20 50 / none)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a none / alpha)`, `${colorSpace}(25 20 none / 0.4)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a b / none)`, `${colorSpace}(25 20 50 / none)`);
+      // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(none none none) l a b)`, `${colorSpace}(0 0 0)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(none none none / none) l a b / alpha)`, `${colorSpace}(0 0 0 / 0)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 none 50) l a b)`, `${colorSpace}(25 0 50)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / none) l a b / alpha)`, `${colorSpace}(25 20 50 / 0)`);
+  }
 
-        // Testing no modifications.
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c h)`, `${colorSpace}(70% 45 30)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c h / alpha)`, `${colorSpace}(70% 45 30)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c h / alpha)`, `${colorSpace}(70% 45 30 / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(200% 300 400 / 500%) l c h / alpha)`, `${colorSpace}(200% 300 40)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(-200% -300 -400 / -500%) l c h / alpha)`, `${colorSpace}(0% 0 320 / 0)`);
+  // lab and oklab tests that require different results due to percent scaling differences.
+  test_computed_value(`color`, `lab(from lab(.7 45 30) alpha b a / l)`, `lab(100 30 45 / 0.7)`);
+  test_computed_value(`color`, `lab(from lab(.7 45 30) alpha a b / alpha)`, `lab(100 45 30)`);
+  test_computed_value(`color`, `lab(from lab(.7 45 30) alpha a a / alpha)`, `lab(100 45 45)`);
+  test_computed_value(`color`, `lab(from lab(.7 45 30 / 40%) alpha b a / l)`, `lab(40 30 45 / 0.7)`);
+  test_computed_value(`color`, `lab(from lab(.7 45 30 / 40%) alpha a b / alpha)`, `lab(40 45 30 / 0.4)`);
+  test_computed_value(`color`, `lab(from lab(.7 45 30 / 40%) alpha a a / alpha)`, `lab(40 45 45 / 0.4)`);
 
-        // Test nesting relative colors.
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(from ${colorSpace}(70% 45 30) l c h) l c h)`, `${colorSpace}(70% 45 30)`);
+  test_computed_value(`color`, `oklab(from oklab(.7 45 30) alpha b a / l)`, `oklab(1 30 45 / 0.7)`);
+  test_computed_value(`color`, `oklab(from oklab(.7 45 30) alpha a b / alpha)`, `oklab(1 45 30)`);
+  test_computed_value(`color`, `oklab(from oklab(.7 45 30) alpha a a / alpha)`, `oklab(1 45 45)`);
+  test_computed_value(`color`, `oklab(from oklab(.7 45 30 / 40%) alpha b a / l)`, `oklab(0.4 30 45 / 0.7)`);
+  test_computed_value(`color`, `oklab(from oklab(.7 45 30 / 40%) alpha a b / alpha)`, `oklab(0.4 45 30 / 0.4)`);
+  test_computed_value(`color`, `oklab(from oklab(.7 45 30 / 40%) alpha a a / alpha)`, `oklab(0.4 45 45 / 0.4)`);
 
-        // Testing non-sRGB origin colors (no gamut mapping will happen since the destination is not a bounded RGB color space).
-        test_computed_value(`color`, `${colorSpace}(from color(display-p3 0 0 0) l c h / alpha)`, `${colorSpace}(0% 0 0)`);
-        test_computed_value(`color`, `${colorSpace}(from ${rectangularForm}(70% 45 30) l c h / alpha)`, `${colorSpace}(70% 54.08327 33.690067)`);
+  for (const colorSpace of [ "lch", "oklch" ]) {
+      const rectangularForm = colorSpace == "lch" ? "lab" : "oklab";
 
-        // Testing replacement with 0.
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) 0% 0 0)`, `${colorSpace}(0% 0 0)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) 0% 0 0deg)`, `${colorSpace}(0% 0 0)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) 0% 0 0 / 0)`, `${colorSpace}(0% 0 0 / 0)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) 0% 0 0deg / 0)`, `${colorSpace}(0% 0 0 / 0)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) 0% c h / alpha)`, `${colorSpace}(0% 45 30)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l 0 h / alpha)`, `${colorSpace}(70% 0 30)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c 0 / alpha)`, `${colorSpace}(70% 45 0)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c 0deg / alpha)`, `${colorSpace}(70% 45 0)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c h / 0)`, `${colorSpace}(70% 45 30 / 0)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 0% c h / alpha)`, `${colorSpace}(0% 45 30 / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l 0 h / alpha)`, `${colorSpace}(70% 0 30 / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c 0 / alpha)`, `${colorSpace}(70% 45 0 / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c 0deg / alpha)`, `${colorSpace}(70% 45 0 / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c h / 0)`, `${colorSpace}(70% 45 30 / 0)`);
+      // Testing no modifications.
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h)`, `${colorSpace}(0.7 45 30)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h / alpha)`, `${colorSpace}(0.7 45 30)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c h / alpha)`, `${colorSpace}(0.7 45 30 / 0.4)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(200 300 400 / 500%) l c h / alpha)`, `${colorSpace}(200 300 40)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(-200 -300 -400 / -500%) l c h / alpha)`, `${colorSpace}(0 0 320 / 0)`);
 
-        // Testing replacement with a constant.
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) 25% c h / alpha)`, `${colorSpace}(25% 45 30)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l 25 h / alpha)`, `${colorSpace}(70% 25 30)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c 25 / alpha)`, `${colorSpace}(70% 45 25)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c 25deg / alpha)`, `${colorSpace}(70% 45 25)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c h / .25)`, `${colorSpace}(70% 45 30 / 0.25)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 25% c h / alpha)`, `${colorSpace}(25% 45 30 / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l 25 h / alpha)`, `${colorSpace}(70% 25 30 / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c 25 / alpha)`, `${colorSpace}(70% 45 25 / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c 25deg / alpha)`, `${colorSpace}(70% 45 25 / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c h / .25)`, `${colorSpace}(70% 45 30 / 0.25)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 200% 300 400 / 500)`, `${colorSpace}(200% 300 40)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) -200% -300 -400 / -500)`, `${colorSpace}(0% 0 320 / 0)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 50% 120 400deg / 500)`, `${colorSpace}(50% 120 40)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 50% 120 -400deg / -500)`, `${colorSpace}(50% 120 320 / 0)`);
+      // Test nesting relative colors.
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(from ${colorSpace}(0.7 45 30) l c h) l c h)`, `${colorSpace}(0.7 45 30)`);
 
-        // Testing valid permutation (types match).
-        // NOTE: 'c' is a vaild hue, as hue is <angle>|<number>.
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) alpha c h / l)`, `${colorSpace}(100% 45 30 / 0.7)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c c / alpha)`, `${colorSpace}(70% 45 45)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) alpha c h / alpha)`, `${colorSpace}(100% 45 30)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) alpha c c / alpha)`, `${colorSpace}(100% 45 45)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) alpha c h / l)`, `${colorSpace}(40% 45 30 / 0.7)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c c / alpha)`, `${colorSpace}(70% 45 45 / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) alpha c h / alpha)`, `${colorSpace}(40% 45 30 / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) alpha c c / alpha)`, `${colorSpace}(40% 45 45 / 0.4)`);
+      // Testing non-sRGB origin colors (no gamut mapping will happen since the destination is not a bounded RGB color space).
+      test_computed_value(`color`, `${colorSpace}(from color(display-p3 0 0 0) l c h / alpha)`, `${colorSpace}(0 0 0)`);
+      test_computed_value(`color`, `${colorSpace}(from ${rectangularForm}(0.7 45 30) l c h / alpha)`, `${colorSpace}(0.7 54.08327 33.690067)`);
 
-        // Testing with calc().
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) calc(l) calc(c) calc(h))`, `${colorSpace}(70% 45 30)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) calc(l) calc(c) calc(h) / calc(alpha))`, `${colorSpace}(70% 45 30 / 0.4)`);
+      // Testing replacement with 0.
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 0 0)`, `${colorSpace}(0 0 0)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 0 0deg)`, `${colorSpace}(0 0 0)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 0 0 / 0)`, `${colorSpace}(0 0 0 / 0)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 0 0deg / 0)`, `${colorSpace}(0 0 0 / 0)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 c h / alpha)`, `${colorSpace}(0 45 30)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l 0 h / alpha)`, `${colorSpace}(0.7 0 30)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c 0 / alpha)`, `${colorSpace}(0.7 45 0)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c 0deg / alpha)`, `${colorSpace}(0.7 45 0)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h / 0)`, `${colorSpace}(0.7 45 30 / 0)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 0 c h / alpha)`, `${colorSpace}(0 45 30 / 0.4)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l 0 h / alpha)`, `${colorSpace}(0.7 0 30 / 0.4)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c 0 / alpha)`, `${colorSpace}(0.7 45 0 / 0.4)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c 0deg / alpha)`, `${colorSpace}(0.7 45 0 / 0.4)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c h / 0)`, `${colorSpace}(0.7 45 30 / 0)`);
 
-        // Testing with 'none'.
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) none none none)`,                                   `${colorSpace}(none none none)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) none none none / none)`,                            `${colorSpace}(none none none / none)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c none)`,                                         `${colorSpace}(70% 45 none)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c none / alpha)`,                                 `${colorSpace}(70% 45 none)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c h / none)`,                                     `${colorSpace}(70% 45 30 / none)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c none / alpha)`,                           `${colorSpace}(70% 45 none / 0.4)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c h / none)`,                               `${colorSpace}(70% 45 30 / none)`);
-        // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(none none none) l c h)`,                                       `${colorSpace}(0% 0 0)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(none none none / none) l c h / alpha)`,                        `${colorSpace}(0% 0 0 / 0)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% none 30) l c h)`,                                          `${colorSpace}(70% 0 30)`);
-        test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / none) l c h / alpha)`,                             `${colorSpace}(70% 45 30 / 0)`);
-    }
+      // Testing replacement with a constant.
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 25 c h / alpha)`, `${colorSpace}(25 45 30)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l 25 h / alpha)`, `${colorSpace}(0.7 25 30)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c 25 / alpha)`, `${colorSpace}(0.7 45 25)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c 25deg / alpha)`, `${colorSpace}(0.7 45 25)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h / .25)`, `${colorSpace}(0.7 45 30 / 0.25)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 25 c h / alpha)`, `${colorSpace}(25 45 30 / 0.4)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l 25 h / alpha)`, `${colorSpace}(0.7 25 30 / 0.4)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c 25 / alpha)`, `${colorSpace}(0.7 45 25 / 0.4)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c 25deg / alpha)`, `${colorSpace}(0.7 45 25 / 0.4)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c h / .25)`, `${colorSpace}(0.7 45 30 / 0.25)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 200 300 400 / 500)`, `${colorSpace}(200 300 40)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) -200 -300 -400 / -500)`, `${colorSpace}(0 0 320 / 0)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 50 120 400deg / 500)`, `${colorSpace}(50 120 40)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 50 120 -400deg / -500)`, `${colorSpace}(50 120 320 / 0)`);
 
-    for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb" ]) {
-        // Testing no modifications.
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b)`,                              `color(${colorSpace} 0.7 0.5 0.3)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b / alpha)`,                      `color(${colorSpace} 0.7 0.5 0.3)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g b)`,                        `color(${colorSpace} 0.7 0.5 0.3)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g b / alpha)`,                `color(${colorSpace} 0.7 0.5 0.3 / 0.4)`);
+      // Testing valid permutation (types match).
+      // NOTE: 'c' is a vaild hue, as hue is <angle>|<number>.
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(.7 45 30) l c c / alpha)`, `${colorSpace}(0.7 45 45)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(.7 45 30 / 40%) l c c / alpha)`, `${colorSpace}(0.7 45 45 / 0.4)`);
 
-        // Test nesting relative colors.
-        test_computed_value(`color`, `color(from color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b) ${colorSpace} r g b)`,   `color(${colorSpace} 0.7 0.5 0.3)`);
+      // Testing with calc().
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) calc(l) calc(c) calc(h))`, `${colorSpace}(0.7 45 30)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) calc(l) calc(c) calc(h) / calc(alpha))`, `${colorSpace}(0.7 45 30 / 0.4)`);
 
-        // Testing replacement with 0.
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 0 0 0)`,                              `color(${colorSpace} 0 0 0)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 0 0 0 / 0)`,                          `color(${colorSpace} 0 0 0 / 0)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 0 g b / alpha)`,                      `color(${colorSpace} 0 0.5 0.3)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r 0 b / alpha)`,                      `color(${colorSpace} 0.7 0 0.3)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g 0 / alpha)`,                      `color(${colorSpace} 0.7 0.5 0)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b / 0)`,                          `color(${colorSpace} 0.7 0.5 0.3 / 0)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} 0 g b / alpha)`,                `color(${colorSpace} 0 0.5 0.3 / 0.4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r 0 b / alpha)`,                `color(${colorSpace} 0.7 0 0.3 / 0.4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g 0 / alpha)`,                `color(${colorSpace} 0.7 0.5 0 / 0.4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g b / 0)`,                    `color(${colorSpace} 0.7 0.5 0.3 / 0)`);
+      // Testing with 'none'.
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) none none none)`,                                   `${colorSpace}(none none none)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) none none none / none)`,                            `${colorSpace}(none none none / none)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c none)`,                                         `${colorSpace}(0.7 45 none)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c none / alpha)`,                                 `${colorSpace}(0.7 45 none)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h / none)`,                                     `${colorSpace}(0.7 45 30 / none)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c none / alpha)`,                           `${colorSpace}(0.7 45 none / 0.4)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c h / none)`,                               `${colorSpace}(0.7 45 30 / none)`);
+      // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(none none none) l c h)`,                                       `${colorSpace}(0 0 0)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(none none none / none) l c h / alpha)`,                        `${colorSpace}(0 0 0 / 0)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 none 30) l c h)`,                                          `${colorSpace}(0.7 0 30)`);
+      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / none) l c h / alpha)`,                             `${colorSpace}(0.7 45 30 / 0)`);
+  }
 
-        // Testing replacement with a constant.
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 0.2 g b / alpha)`,                    `color(${colorSpace} 0.2 0.5 0.3)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 20% g b / alpha)`,                    `color(${colorSpace} 0.2 0.5 0.3)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r 0.2 b / alpha)`,                    `color(${colorSpace} 0.7 0.2 0.3)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r 20% b / alpha)`,                    `color(${colorSpace} 0.7 0.2 0.3)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g 0.2 / alpha)`,                    `color(${colorSpace} 0.7 0.5 0.2)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g 20% / alpha)`,                    `color(${colorSpace} 0.7 0.5 0.2)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b / 0.2)`,                        `color(${colorSpace} 0.7 0.5 0.3 / 0.2)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b / 20%)`,                        `color(${colorSpace} 0.7 0.5 0.3 / 0.2)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} 0.2 g b / alpha)`,              `color(${colorSpace} 0.2 0.5 0.3 / 0.4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} 20% g b / alpha)`,              `color(${colorSpace} 0.2 0.5 0.3 / 0.4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r 0.2 b / alpha)`,              `color(${colorSpace} 0.7 0.2 0.3 / 0.4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r 20% b / alpha)`,              `color(${colorSpace} 0.7 0.2 0.3 / 0.4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g 0.2 / alpha)`,              `color(${colorSpace} 0.7 0.5 0.2 / 0.4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g 20% / alpha)`,              `color(${colorSpace} 0.7 0.5 0.2 / 0.4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g b / 0.2)`,                  `color(${colorSpace} 0.7 0.5 0.3 / 0.2)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g b / 20%)`,                  `color(${colorSpace} 0.7 0.5 0.3 / 0.2)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 2 3 4)`,                              `color(${colorSpace} 2 3 4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 2 3 4 / 5)`,                          `color(${colorSpace} 2 3 4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} -2 -3 -4)`,                           `color(${colorSpace} -2 -3 -4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} -2 -3 -4 / -5)`,                      `color(${colorSpace} -2 -3 -4 / 0)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 200% 300% 400%)`,                     `color(${colorSpace} 2 3 4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 200% 300% 400% / 500%)`,              `color(${colorSpace} 2 3 4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} -200% -300% -400%)`,                  `color(${colorSpace} -2 -3 -4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} -200% -300% -400% / -500%)`,          `color(${colorSpace} -2 -3 -4 / 0)`);
+  // lch and oklch tests that require different results due to percent scaling differences.
+  test_computed_value(`color`, `lch(from lch(.7 45 30) alpha c h / l)`, `lch(100 45 30 / 0.7)`);
+  test_computed_value(`color`, `lch(from lch(.7 45 30) alpha c h / alpha)`, `lch(100 45 30)`);
+  test_computed_value(`color`, `lch(from lch(.7 45 30) alpha c c / alpha)`, `lch(100 45 45)`);
+  test_computed_value(`color`, `lch(from lch(.7 45 30 / 40%) alpha c h / l)`, `lch(40 45 30 / 0.7)`);
+  test_computed_value(`color`, `lch(from lch(.7 45 30 / 40%) alpha c h / alpha)`, `lch(40 45 30 / 0.4)`);
+  test_computed_value(`color`, `lch(from lch(.7 45 30 / 40%) alpha c c / alpha)`, `lch(40 45 45 / 0.4)`);
 
-        // Testing valid permutation (types match).
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} g b r)`,                              `color(${colorSpace} 0.5 0.3 0.7)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} b alpha r / g)`,                      `color(${colorSpace} 0.3 1 0.7 / 0.5)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r r r / r)`,                          `color(${colorSpace} 0.7 0.7 0.7 / 0.7)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} alpha alpha alpha / alpha)`,          `color(${colorSpace} 1 1 1)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} g b r)`,                        `color(${colorSpace} 0.5 0.3 0.7)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} b alpha r / g)`,                `color(${colorSpace} 0.3 0.4 0.7 / 0.5)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r r r / r)`,                    `color(${colorSpace} 0.7 0.7 0.7 / 0.7)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} alpha alpha alpha / alpha)`,    `color(${colorSpace} 0.4 0.4 0.4 / 0.4)`);
+  test_computed_value(`color`, `oklch(from oklch(.7 45 30) alpha c h / l)`, `oklch(1 45 30 / 0.7)`);
+  test_computed_value(`color`, `oklch(from oklch(.7 45 30) alpha c h / alpha)`, `oklch(1 45 30)`);
+  test_computed_value(`color`, `oklch(from oklch(.7 45 30) alpha c c / alpha)`, `oklch(1 45 45)`);
+  test_computed_value(`color`, `oklch(from oklch(.7 45 30 / 40%) alpha c h / l)`, `oklch(0.4 45 30 / 0.7)`);
+  test_computed_value(`color`, `oklch(from oklch(.7 45 30 / 40%) alpha c h / alpha)`, `oklch(0.4 45 30 / 0.4)`);
+  test_computed_value(`color`, `oklch(from oklch(.7 45 30 / 40%) alpha c c / alpha)`, `oklch(0.4 45 45 / 0.4)`);
 
-        // Testing out of gamut components.
-        test_computed_value(`color`, `color(from color(${colorSpace} 1.7 1.5 1.3) ${colorSpace} r g b)`,                              `color(${colorSpace} 1.7 1.5 1.3)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 1.7 1.5 1.3) ${colorSpace} r g b / alpha)`,                      `color(${colorSpace} 1.7 1.5 1.3)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 1.7 1.5 1.3 / 140%) ${colorSpace} r g b)`,                       `color(${colorSpace} 1.7 1.5 1.3)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 1.7 1.5 1.3 / 140%) ${colorSpace} r g b / alpha)`,               `color(${colorSpace} 1.7 1.5 1.3)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} -0.7 -0.5 -0.3) ${colorSpace} r g b)`,                           `color(${colorSpace} -0.7 -0.5 -0.3)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} -0.7 -0.5 -0.3) ${colorSpace} r g b / alpha)`,                   `color(${colorSpace} -0.7 -0.5 -0.3)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} -0.7 -0.5 -0.3 / -40%) ${colorSpace} r g b)`,                    `color(${colorSpace} -0.7 -0.5 -0.3)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} -0.7 -0.5 -0.3 / -40%) ${colorSpace} r g b / alpha)`,            `color(${colorSpace} -0.7 -0.5 -0.3 / 0)`);
 
-        // Testing with calc().
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} calc(r) calc(g) calc(b))`,                        `color(${colorSpace} 0.7 0.5 0.3)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} calc(r) calc(g) calc(b) / calc(alpha))`,    `color(${colorSpace} 0.7 0.5 0.3 / 0.4)`);
+  for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb", "display-p3" ]) {
+      // Testing no modifications.
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b)`,                              `color(${colorSpace} 0.7 0.5 0.3)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b / alpha)`,                      `color(${colorSpace} 0.7 0.5 0.3)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g b)`,                        `color(${colorSpace} 0.7 0.5 0.3)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g b / alpha)`,                `color(${colorSpace} 0.7 0.5 0.3 / 0.4)`);
 
-        // Testing with 'none'.
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} none none none)`,                     `color(${colorSpace} none none none)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} none none none / none)`,              `color(${colorSpace} none none none / none)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g none)`,                           `color(${colorSpace} 0.7 0.5 none)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g none / alpha)`,                   `color(${colorSpace} 0.7 0.5 none)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b / none)`,                       `color(${colorSpace} 0.7 0.5 0.3 / none)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g none / alpha)`,             `color(${colorSpace} 0.7 0.5 none / 0.4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g b / none)`,                 `color(${colorSpace} 0.7 0.5 0.3 / none)`);
-        // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
-        test_computed_value(`color`, `color(from color(${colorSpace} none none none) ${colorSpace} r g b)`,                           `color(${colorSpace} 0 0 0)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} none none none / none) ${colorSpace} r g b / alpha)`,            `color(${colorSpace} 0 0 0 / 0)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 none 0.3) ${colorSpace} r g b)`,                             `color(${colorSpace} 0.7 0 0.3)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / none) ${colorSpace} r g b / alpha)`,               `color(${colorSpace} 0.7 0.5 0.3 / 0)`);
-    }
+      // Test nesting relative colors.
+      test_computed_value(`color`, `color(from color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b) ${colorSpace} r g b)`,   `color(${colorSpace} 0.7 0.5 0.3)`);
 
-    for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
-        const resultColorSpace = colorSpace == "xyz" ? "xyz-d65" : colorSpace;
+      // Testing replacement with 0.
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 0 0 0)`,                              `color(${colorSpace} 0 0 0)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 0 0 0 / 0)`,                          `color(${colorSpace} 0 0 0 / 0)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 0 g b / alpha)`,                      `color(${colorSpace} 0 0.5 0.3)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r 0 b / alpha)`,                      `color(${colorSpace} 0.7 0 0.3)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g 0 / alpha)`,                      `color(${colorSpace} 0.7 0.5 0)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b / 0)`,                          `color(${colorSpace} 0.7 0.5 0.3 / 0)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} 0 g b / alpha)`,                `color(${colorSpace} 0 0.5 0.3 / 0.4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r 0 b / alpha)`,                `color(${colorSpace} 0.7 0 0.3 / 0.4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g 0 / alpha)`,                `color(${colorSpace} 0.7 0.5 0 / 0.4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g b / 0)`,                    `color(${colorSpace} 0.7 0.5 0.3 / 0)`);
 
-        // Testing no modifications.
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y z)`,                              `color(${resultColorSpace} 7 -20.5 100)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y z / alpha)`,                      `color(${resultColorSpace} 7 -20.5 100)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y z)`,                        `color(${resultColorSpace} 7 -20.5 100)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y z / alpha)`,                `color(${resultColorSpace} 7 -20.5 100 / 0.4)`);
+      // Testing replacement with a constant.
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 0.2 g b / alpha)`,                    `color(${colorSpace} 0.2 0.5 0.3)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 20% g b / alpha)`,                    `color(${colorSpace} 0.2 0.5 0.3)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r 0.2 b / alpha)`,                    `color(${colorSpace} 0.7 0.2 0.3)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r 20% b / alpha)`,                    `color(${colorSpace} 0.7 0.2 0.3)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g 0.2 / alpha)`,                    `color(${colorSpace} 0.7 0.5 0.2)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g 20% / alpha)`,                    `color(${colorSpace} 0.7 0.5 0.2)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b / 0.2)`,                        `color(${colorSpace} 0.7 0.5 0.3 / 0.2)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b / 20%)`,                        `color(${colorSpace} 0.7 0.5 0.3 / 0.2)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} 0.2 g b / alpha)`,              `color(${colorSpace} 0.2 0.5 0.3 / 0.4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} 20% g b / alpha)`,              `color(${colorSpace} 0.2 0.5 0.3 / 0.4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r 0.2 b / alpha)`,              `color(${colorSpace} 0.7 0.2 0.3 / 0.4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r 20% b / alpha)`,              `color(${colorSpace} 0.7 0.2 0.3 / 0.4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g 0.2 / alpha)`,              `color(${colorSpace} 0.7 0.5 0.2 / 0.4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g 20% / alpha)`,              `color(${colorSpace} 0.7 0.5 0.2 / 0.4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g b / 0.2)`,                  `color(${colorSpace} 0.7 0.5 0.3 / 0.2)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g b / 20%)`,                  `color(${colorSpace} 0.7 0.5 0.3 / 0.2)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 2 3 4)`,                              `color(${colorSpace} 2 3 4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 2 3 4 / 5)`,                          `color(${colorSpace} 2 3 4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} -2 -3 -4)`,                           `color(${colorSpace} -2 -3 -4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} -2 -3 -4 / -5)`,                      `color(${colorSpace} -2 -3 -4 / 0)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 200% 300% 400%)`,                     `color(${colorSpace} 2 3 4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 200% 300% 400% / 500%)`,              `color(${colorSpace} 2 3 4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} -200% -300% -400%)`,                  `color(${colorSpace} -2 -3 -4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} -200% -300% -400% / -500%)`,          `color(${colorSpace} -2 -3 -4 / 0)`);
 
-        // Test nesting relative colors.
-        test_computed_value(`color`, `color(from color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y z) ${colorSpace} x y z)`,        `color(${resultColorSpace} 7 -20.5 100)`);
+      // Testing valid permutation (types match).
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} g b r)`,                              `color(${colorSpace} 0.5 0.3 0.7)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} b alpha r / g)`,                      `color(${colorSpace} 0.3 1 0.7 / 0.5)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r r r / r)`,                          `color(${colorSpace} 0.7 0.7 0.7 / 0.7)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} alpha alpha alpha / alpha)`,          `color(${colorSpace} 1 1 1)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} g b r)`,                        `color(${colorSpace} 0.5 0.3 0.7)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} b alpha r / g)`,                `color(${colorSpace} 0.3 0.4 0.7 / 0.5)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r r r / r)`,                    `color(${colorSpace} 0.7 0.7 0.7 / 0.7)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} alpha alpha alpha / alpha)`,    `color(${colorSpace} 0.4 0.4 0.4 / 0.4)`);
 
-        // Testing replacement with 0.
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} 0 0 0)`,                              `color(${resultColorSpace} 0 0 0)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} 0 0 0 / 0)`,                          `color(${resultColorSpace} 0 0 0 / 0)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} 0 y z / alpha)`,                      `color(${resultColorSpace} 0 -20.5 100)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x 0 z / alpha)`,                      `color(${resultColorSpace} 7 0 100)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y 0 / alpha)`,                      `color(${resultColorSpace} 7 -20.5 0)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y z / 0)`,                          `color(${resultColorSpace} 7 -20.5 100 / 0)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} 0 y z / alpha)`,                `color(${resultColorSpace} 0 -20.5 100 / 0.4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x 0 z / alpha)`,                `color(${resultColorSpace} 7 0 100 / 0.4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y 0 / alpha)`,                `color(${resultColorSpace} 7 -20.5 0 / 0.4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y z / 0)`,                    `color(${resultColorSpace} 7 -20.5 100 / 0)`);
+      // Testing out of gamut components.
+      test_computed_value(`color`, `color(from color(${colorSpace} 1.7 1.5 1.3) ${colorSpace} r g b)`,                              `color(${colorSpace} 1.7 1.5 1.3)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 1.7 1.5 1.3) ${colorSpace} r g b / alpha)`,                      `color(${colorSpace} 1.7 1.5 1.3)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 1.7 1.5 1.3 / 140%) ${colorSpace} r g b)`,                       `color(${colorSpace} 1.7 1.5 1.3)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 1.7 1.5 1.3 / 140%) ${colorSpace} r g b / alpha)`,               `color(${colorSpace} 1.7 1.5 1.3)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} -0.7 -0.5 -0.3) ${colorSpace} r g b)`,                           `color(${colorSpace} -0.7 -0.5 -0.3)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} -0.7 -0.5 -0.3) ${colorSpace} r g b / alpha)`,                   `color(${colorSpace} -0.7 -0.5 -0.3)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} -0.7 -0.5 -0.3 / -40%) ${colorSpace} r g b)`,                    `color(${colorSpace} -0.7 -0.5 -0.3)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} -0.7 -0.5 -0.3 / -40%) ${colorSpace} r g b / alpha)`,            `color(${colorSpace} -0.7 -0.5 -0.3 / 0)`);
 
-        // Testing replacement with a constant.
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} 0.2 y z / alpha)`,                    `color(${resultColorSpace} 0.2 -20.5 100)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x 0.2 z / alpha)`,                    `color(${resultColorSpace} 7 0.2 100)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y 0.2 / alpha)`,                    `color(${resultColorSpace} 7 -20.5 0.2)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y z / 0.2)`,                        `color(${resultColorSpace} 7 -20.5 100 / 0.2)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y z / 20%)`,                        `color(${resultColorSpace} 7 -20.5 100 / 0.2)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} 0.2 y z / alpha)`,              `color(${resultColorSpace} 0.2 -20.5 100 / 0.4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x 0.2 z / alpha)`,              `color(${resultColorSpace} 7 0.2 100 / 0.4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y 0.2 / alpha)`,              `color(${resultColorSpace} 7 -20.5 0.2 / 0.4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y z / 0.2)`,                  `color(${resultColorSpace} 7 -20.5 100 / 0.2)`);
+      // Testing with calc().
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} calc(r) calc(g) calc(b))`,                        `color(${colorSpace} 0.7 0.5 0.3)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} calc(r) calc(g) calc(b) / calc(alpha))`,    `color(${colorSpace} 0.7 0.5 0.3 / 0.4)`);
 
-        // Testing valid permutation (types match).
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} y z x)`,                              `color(${resultColorSpace} -20.5 100 7)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x x x / x)`,                          `color(${resultColorSpace} 7 7 7)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} y z x)`,                        `color(${resultColorSpace} -20.5 100 7)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x x x / x)`,                    `color(${resultColorSpace} 7 7 7)`);
+      // Testing with 'none'.
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} none none none)`,                     `color(${colorSpace} none none none)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} none none none / none)`,              `color(${colorSpace} none none none / none)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g none)`,                           `color(${colorSpace} 0.7 0.5 none)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g none / alpha)`,                   `color(${colorSpace} 0.7 0.5 none)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b / none)`,                       `color(${colorSpace} 0.7 0.5 0.3 / none)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g none / alpha)`,             `color(${colorSpace} 0.7 0.5 none / 0.4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / 40%) ${colorSpace} r g b / none)`,                 `color(${colorSpace} 0.7 0.5 0.3 / none)`);
+      // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+      test_computed_value(`color`, `color(from color(${colorSpace} none none none) ${colorSpace} r g b)`,                           `color(${colorSpace} 0 0 0)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} none none none / none) ${colorSpace} r g b / alpha)`,            `color(${colorSpace} 0 0 0 / 0)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 none 0.3) ${colorSpace} r g b)`,                             `color(${colorSpace} 0.7 0 0.3)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3 / none) ${colorSpace} r g b / alpha)`,               `color(${colorSpace} 0.7 0.5 0.3 / 0)`);
+  }
 
-        // Testing with calc().
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} calc(x) calc(y) calc(z))`,                        `color(${resultColorSpace} 7 -20.5 100)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} calc(x) calc(y) calc(z) / calc(alpha))`,    `color(${resultColorSpace} 7 -20.5 100 / 0.4)`);
+  for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
+      const resultColorSpace = colorSpace == "xyz" ? "xyz-d65" : colorSpace;
 
-        // Testing with 'none'.
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} none none none)`,                     `color(${resultColorSpace} none none none)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} none none none / none)`,              `color(${resultColorSpace} none none none / none)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y none)`,                           `color(${resultColorSpace} 7 -20.5 none)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y none / alpha)`,                   `color(${resultColorSpace} 7 -20.5 none)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y z / none)`,                       `color(${resultColorSpace} 7 -20.5 100 / none)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y none / alpha)`,             `color(${resultColorSpace} 7 -20.5 none / 0.4)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y z / none)`,                 `color(${resultColorSpace} 7 -20.5 100 / none)`);
-        // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
-        test_computed_value(`color`, `color(from color(${colorSpace} none none none) ${colorSpace} x y z)`,                           `color(${resultColorSpace} 0 0 0)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} none none none / none) ${colorSpace} x y z / alpha)`,            `color(${resultColorSpace} 0 0 0 / 0)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 none 100) ${colorSpace} x y z)`,                               `color(${resultColorSpace} 7 0 100)`);
-        test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / none) ${colorSpace} x y z / alpha)`,               `color(${resultColorSpace} 7 -20.5 100 / 0)`);
-    }
+      // Testing no modifications.
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y z)`,                              `color(${resultColorSpace} 7 -20.5 100)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y z / alpha)`,                      `color(${resultColorSpace} 7 -20.5 100)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y z)`,                        `color(${resultColorSpace} 7 -20.5 100)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y z / alpha)`,                `color(${resultColorSpace} 7 -20.5 100 / 0.4)`);
+
+      // Test nesting relative colors.
+      test_computed_value(`color`, `color(from color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y z) ${colorSpace} x y z)`,        `color(${resultColorSpace} 7 -20.5 100)`);
+
+      // Testing replacement with 0.
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} 0 0 0)`,                              `color(${resultColorSpace} 0 0 0)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} 0 0 0 / 0)`,                          `color(${resultColorSpace} 0 0 0 / 0)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} 0 y z / alpha)`,                      `color(${resultColorSpace} 0 -20.5 100)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x 0 z / alpha)`,                      `color(${resultColorSpace} 7 0 100)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y 0 / alpha)`,                      `color(${resultColorSpace} 7 -20.5 0)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y z / 0)`,                          `color(${resultColorSpace} 7 -20.5 100 / 0)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} 0 y z / alpha)`,                `color(${resultColorSpace} 0 -20.5 100 / 0.4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x 0 z / alpha)`,                `color(${resultColorSpace} 7 0 100 / 0.4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y 0 / alpha)`,                `color(${resultColorSpace} 7 -20.5 0 / 0.4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y z / 0)`,                    `color(${resultColorSpace} 7 -20.5 100 / 0)`);
+
+      // Testing replacement with a constant.
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} 0.2 y z / alpha)`,                    `color(${resultColorSpace} 0.2 -20.5 100)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x 0.2 z / alpha)`,                    `color(${resultColorSpace} 7 0.2 100)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y 0.2 / alpha)`,                    `color(${resultColorSpace} 7 -20.5 0.2)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y z / 0.2)`,                        `color(${resultColorSpace} 7 -20.5 100 / 0.2)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y z / 20%)`,                        `color(${resultColorSpace} 7 -20.5 100 / 0.2)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} 0.2 y z / alpha)`,              `color(${resultColorSpace} 0.2 -20.5 100 / 0.4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x 0.2 z / alpha)`,              `color(${resultColorSpace} 7 0.2 100 / 0.4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y 0.2 / alpha)`,              `color(${resultColorSpace} 7 -20.5 0.2 / 0.4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y z / 0.2)`,                  `color(${resultColorSpace} 7 -20.5 100 / 0.2)`);
+
+      // Testing valid permutation (types match).
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} y z x)`,                              `color(${resultColorSpace} -20.5 100 7)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x x x / x)`,                          `color(${resultColorSpace} 7 7 7)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} y z x)`,                        `color(${resultColorSpace} -20.5 100 7)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x x x / x)`,                    `color(${resultColorSpace} 7 7 7)`);
+
+      // Testing with calc().
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} calc(x) calc(y) calc(z))`,                        `color(${resultColorSpace} 7 -20.5 100)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} calc(x) calc(y) calc(z) / calc(alpha))`,    `color(${resultColorSpace} 7 -20.5 100 / 0.4)`);
+
+      // Testing with 'none'.
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} none none none)`,                     `color(${resultColorSpace} none none none)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} none none none / none)`,              `color(${resultColorSpace} none none none / none)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y none)`,                           `color(${resultColorSpace} 7 -20.5 none)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y none / alpha)`,                   `color(${resultColorSpace} 7 -20.5 none)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x y z / none)`,                       `color(${resultColorSpace} 7 -20.5 100 / none)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y none / alpha)`,             `color(${resultColorSpace} 7 -20.5 none / 0.4)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} x y z / none)`,                 `color(${resultColorSpace} 7 -20.5 100 / none)`);
+      // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+      test_computed_value(`color`, `color(from color(${colorSpace} none none none) ${colorSpace} x y z)`,                           `color(${resultColorSpace} 0 0 0)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} none none none / none) ${colorSpace} x y z / alpha)`,            `color(${resultColorSpace} 0 0 0 / 0)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 none 100) ${colorSpace} x y z)`,                               `color(${resultColorSpace} 7 0 100)`);
+      test_computed_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / none) ${colorSpace} x y z / alpha)`,               `color(${resultColorSpace} 7 -20.5 100 / 0)`);
+  }
 
     // Spec Examples
 
@@ -585,11 +610,11 @@
     test_computed_value(`color`, `rgb(from var(--bg-color) r g b / 80%)`, `rgba(0, 0, 255, 0.8)`);
 
     // Example 12.
-    test_computed_value(`color`, `lch(from var(--color) calc(l / 2) c h)`, `lch(23.138971% 67.989716 134.39125)`);
+    test_computed_value(`color`, `lch(from var(--color) calc(l / 2) c h)`, `lch(23.138971 67.989716 134.39125)`);
 
     // Example 13.
     test_computed_value(`color`, `rgb(from var(--color) calc(r * .3 + g * .59 + b * .11) calc(r * .3 + g * .59 + b * .11) calc(r * .3 + g * .59 + b * .11))`, `rgb(76, 76, 76)`)
-    test_computed_value(`color`, `lch(from var(--color) l 0 h)`, `lch(46.277943% 0 134.39125)`)
+    test_computed_value(`color`, `lch(from var(--color) l 0 h)`, `lch(46.277943 0 134.39125)`)
 
     // Example 14.
     test_computed_value(`color`, `rgb(from indianred 255 g b)`, `rgb(255, 92, 92)`);
@@ -598,23 +623,23 @@
     test_computed_value(`color`, `hsl(from var(--accent) calc(h + 180deg) s l)`, `rgb(178, 32, 40)`);
 
     // Example 16.
-    test_computed_value(`color`, `lab(from var(--mycolor) l a b / 100%)`, `lab(62.751923% 52.45802 -34.117283)`);
-    test_computed_value(`color`, `lab(from var(--mycolor) l a b / calc(alpha * 0.8))`, `lab(62.751923% 52.45802 -34.117283 / 0.8)`);
-    test_computed_value(`color`, `lab(from var(--mycolor) l a b / calc(alpha - 20%))`, `lab(62.751923% 52.45802 -34.117283 / 0.8)`);
+    test_computed_value(`color`, `lab(from var(--mycolor) l a b / 100%)`, `lab(62.751923 52.45802 -34.117283)`);
+    test_computed_value(`color`, `lab(from var(--mycolor) l a b / calc(alpha * 0.8))`, `lab(62.751923 52.45802 -34.117283 / 0.8)`);
+    test_computed_value(`color`, `lab(from var(--mycolor) l a b / calc(alpha - 20%))`, `lab(62.751923 52.45802 -34.117283 / 0.8)`);
 
     // Example 17.
-    test_computed_value(`color`, `lab(from var(--mycolor) l 0 0)`, `lab(62.751923% 0 0)`);
+    test_computed_value(`color`, `lab(from var(--mycolor) l 0 0)`, `lab(62.751923 0 0)`);
 
     // Example 18.
-    test_computed_value(`color`, `lch(from peru calc(l * 0.8) c h)`, `lch(49.80138% 54.003296 63.680317)`);
+    test_computed_value(`color`, `lch(from peru calc(l * 0.8) c h)`, `lch(49.80138 54.003296 63.680317)`);
 
     // Example 19.
-    test_computed_value(`color`, `LCH(from var(--accent) l c calc(h + 180deg))`, `lch(65.49473% 39.446903 10.114471)`);
+    test_computed_value(`color`, `LCH(from var(--accent) l c calc(h + 180deg))`, `lch(65.49473 39.446903 10.114471)`);
 
     // Example 20.
-    test_computed_value(`color`, `lch(from var(--mycolor) l 0 h)`, `lch(62.751923% 0 326.96112)`);
-    test_computed_value(`color`, `var(--mygray)`, `lch(62.751923% 0 326.96112)`);
-    test_computed_value(`color`, `lch(from var(--mygray) l 30 h)`, `lch(62.751923% 30 326.96112)`);
+    test_computed_value(`color`, `lch(from var(--mycolor) l 0 h)`, `lch(62.751923 0 326.96112)`);
+    test_computed_value(`color`, `var(--mygray)`, `lch(62.751923 0 326.96112)`);
+    test_computed_value(`color`, `lch(from var(--mygray) l 30 h)`, `lch(62.751923 30 326.96112)`);
 </script>
 </body>
 </html>

--- a/css/css-color/parsing/relative-color-invalid.html
+++ b/css/css-color/parsing/relative-color-invalid.html
@@ -87,50 +87,42 @@
     test_invalid_value(`color`, `hwb(from rebeccapurple h g b)`);
 
     for (const colorSpace of [ "lab", "oklab" ]) {
-        // Testing invalid permutation (types don't match).
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l alpha a / b)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l alpha alpha / alpha)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l alpha a / b)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l alpha alpha / alpha)`);
-
         // Testing invalid values.
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l 10% 10)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l 10 10%)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) 10 a b)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l 10% 10)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l 10 10%)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) 10 a b)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.25 20 50) l 10deg 10)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.25 20 50) l 10 10deg)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.25 20 50) 10deg a b)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.25 20 50 / 40%) l 10deg 10)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.25 20 50 / 40%) l 10 10deg)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.25 20 50 / 40%) 10deg a b)`);
 
         // Testing invalid component names
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) lightness a b)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) x a b)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) h g b)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.25 20 50) lightness a b)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.25 20 50) x a b)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.25 20 50) h g b)`);
     }
 
     for (const colorSpace of [ "lch", "oklch" ]) {
         // Testing invalid permutation (types don't match).
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) h l c / alpha)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) c c c / c)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) alpha alpha alpha / alpha)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) h l c / alpha)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) c c c / c)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) alpha alpha alpha / alpha)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.70 45 30) h l c / alpha)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.70 45 30) alpha alpha alpha / alpha)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.70 45 30 / 40%) h l c / alpha)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.70 45 30 / 40%) alpha alpha alpha / alpha)`);
 
         // Testing invalid values.
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l 10% h)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c 10%)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) 10 c h)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l 10% h)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c 10%)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 10 c h)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.70 45 30) l 10deg h)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.70 45 30) l c 10%)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.70 45 30) 10deg c h)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.70 45 30 / 40%) l 10deg h)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.70 45 30 / 40%) l c 10%)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.70 45 30 / 40%) 10deg c h)`);
 
         // Testing invalid component names
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) lightness c h)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) x c h)`);
-        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l g b)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.70 45 30) lightness c h)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.70 45 30) x c h)`);
+        test_invalid_value(`color`, `${colorSpace}(from ${colorSpace}(.70 45 30) l g b)`);
     }
 
-    for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb" ]) {
+    for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb", "display-p3" ]) {
         // Testing invalid values.
         test_invalid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} 10deg g b)`);
         test_invalid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r 10deg b)`);
@@ -144,12 +136,6 @@
     }
 
     for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
-        // Testing invalid permutation (types don't match).
-        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} z alpha x / y)`);
-        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} alpha alpha alpha / alpha)`);
-        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} z alpha x / y)`);
-        test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100 / 40%) ${colorSpace} alpha alpha alpha / alpha)`);
-
         // Testing invalid values.
         test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} 10deg y z)`);
         test_invalid_value(`color`, `color(from color(${colorSpace} 7 -20.5 100) ${colorSpace} x 10deg z)`);

--- a/css/css-color/parsing/relative-color-valid.html
+++ b/css/css-color/parsing/relative-color-valid.html
@@ -34,14 +34,14 @@
 
     // Testing non-sRGB origin colors to see gamut mapping.
     test_valid_value(`color`, `rgb(from color(display-p3 0 1 0) r g b / alpha)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
-    test_valid_value(`color`, `rgb(from lab(100% 104.3 -50.9) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_valid_value(`color`, `rgb(from lab(0% 104.3 -50.9) r g b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_valid_value(`color`, `rgb(from lch(100% 116 334) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_valid_value(`color`, `rgb(from lch(0% 116 334) r g b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_valid_value(`color`, `rgb(from oklab(100% 0.365 -0.16) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
-    test_valid_value(`color`, `rgb(from oklab(0% 0.365 -0.16) r g b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
-    test_valid_value(`color`, `rgb(from oklch(100% 0.399 336.3) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
-    test_valid_value(`color`, `rgb(from oklch(0% 0.399 336.3) r g b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
+    test_valid_value(`color`, `rgb(from lab(100 104.3 -50.9) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `rgb(from lab(0 104.3 -50.9) r g b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `rgb(from lch(100 116 334) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `rgb(from lch(0 116 334) r g b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `rgb(from oklab(100 0.365 -0.16) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+    test_valid_value(`color`, `rgb(from oklab(0 0.365 -0.16) r g b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+    test_valid_value(`color`, `rgb(from oklch(100 0.399 336.3) r g b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+    test_valid_value(`color`, `rgb(from oklch(0 0.399 336.3) r g b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
 
     // Testing replacement with 0.
     test_valid_value(`color`, `rgb(from rebeccapurple 0 0 0)`, `rgb(0, 0, 0)`);
@@ -140,14 +140,14 @@
 
     // Testing non-sRGB origin colors to see gamut mapping.
     test_valid_value(`color`, `hsl(from color(display-p3 0 1 0) h s l / alpha)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
-    test_valid_value(`color`, `hsl(from lab(100% 104.3 -50.9) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_valid_value(`color`, `hsl(from lab(0% 104.3 -50.9) h s l)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_valid_value(`color`, `hsl(from lch(100% 116 334) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_valid_value(`color`, `hsl(from lch(0% 116 334) h s l)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_valid_value(`color`, `hsl(from oklab(100% 0.365 -0.16) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
-    test_valid_value(`color`, `hsl(from oklab(0% 0.365 -0.16) h s l)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
-    test_valid_value(`color`, `hsl(from oklch(100% 0.399 336.3) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
-    test_valid_value(`color`, `hsl(from oklch(0% 0.399 336.3) h s l)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
+    test_valid_value(`color`, `hsl(from lab(100 104.3 -50.9) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `hsl(from lab(0 104.3 -50.9) h s l)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `hsl(from lch(100 116 334) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `hsl(from lch(0 116 334) h s l)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `hsl(from oklab(100 0.365 -0.16) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+    test_valid_value(`color`, `hsl(from oklab(0 0.365 -0.16) h s l)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+    test_valid_value(`color`, `hsl(from oklch(100 0.399 336.3) h s l)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+    test_valid_value(`color`, `hsl(from oklch(0 0.399 336.3) h s l)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
 
     // Testing replacement with 0.
     test_valid_value(`color`, `hsl(from rebeccapurple 0 0% 0%)`, `rgb(0, 0, 0)`);
@@ -221,14 +221,14 @@
 
     // Testing non-sRGB origin colors to see gamut mapping.
     test_valid_value(`color`, `hwb(from color(display-p3 0 1 0) h w b / alpha)`, `rgb(0, 249, 66)`); // Naive clip based mapping would give rgb(0, 255, 0).
-    test_valid_value(`color`, `hwb(from lab(100% 104.3 -50.9) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_valid_value(`color`, `hwb(from lab(0% 104.3 -50.9) h w b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_valid_value(`color`, `hwb(from lch(100% 116 334) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
-    test_valid_value(`color`, `hwb(from lch(0% 116 334) h w b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
-    test_valid_value(`color`, `hwb(from oklab(100% 0.365 -0.16) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
-    test_valid_value(`color`, `hwb(from oklab(0% 0.365 -0.16) h w b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
-    test_valid_value(`color`, `hwb(from oklch(100% 0.399 336.3) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
-    test_valid_value(`color`, `hwb(from oklch(0% 0.399 336.3) h w b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
+    test_valid_value(`color`, `hwb(from lab(100 104.3 -50.9) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `hwb(from lab(0 104.3 -50.9) h w b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `hwb(from lch(100 116 334) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 150, 255).
+    test_valid_value(`color`, `hwb(from lch(0 116 334) h w b)`, `rgb(42, 0, 34)`); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
+    test_valid_value(`color`, `hwb(from oklab(100 0.365 -0.16) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 92, 255).
+    test_valid_value(`color`, `hwb(from oklab(0 0.365 -0.16) h w b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(19, 0, 24).
+    test_valid_value(`color`, `hwb(from oklch(100 0.399 336.3) h w b)`, `rgb(255, 255, 255)`); // Naive clip based mapping would give rgb(255, 91, 255).
+    test_valid_value(`color`, `hwb(from oklch(0 0.399 336.3) h w b)`, `rgb(0, 0, 0)`); // Naive clip based mapping would give rgb(20, 0, 24).
 
     // Testing replacement with 0.
     test_valid_value(`color`, `hwb(from rebeccapurple 0 0% 0%)`, `rgb(255, 0, 0)`);
@@ -291,147 +291,172 @@
 
     for (const colorSpace of [ "lab", "oklab" ]) {
         // Testing no modifications.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a b)`, `${colorSpace}(25% 20 50)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a b / alpha)`, `${colorSpace}(25% 20 50)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a b / alpha)`, `${colorSpace}(25% 20 50 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(200% 300 400 / 500%) l a b / alpha)`, `${colorSpace}(200% 300 400)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(-200% -300 -400 / -500%) l a b / alpha)`, `${colorSpace}(0% -300 -400 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b)`, `${colorSpace}(25 20 50)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b / alpha)`, `${colorSpace}(25 20 50)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a b / alpha)`, `${colorSpace}(25 20 50 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(200 300 400 / 500%) l a b / alpha)`, `${colorSpace}(200 300 400)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(-200 -300 -400 / -500%) l a b / alpha)`, `${colorSpace}(0 -300 -400 / 0)`);
 
         // Test nesting relative colors.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(from ${colorSpace}(25% 20 50) l a b) l a b)`, `${colorSpace}(25% 20 50)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(from ${colorSpace}(25 20 50) l a b) l a b)`, `${colorSpace}(25 20 50)`);
 
         // Testing non-${colorSpace} origin to see conversion.
-        test_valid_value(`color`, `${colorSpace}(from color(display-p3 0 0 0) l a b / alpha)`, `${colorSpace}(0% 0 0)`);
+        test_valid_value(`color`, `${colorSpace}(from color(display-p3 0 0 0) l a b / alpha)`, `${colorSpace}(0 0 0)`);
 
         // Testing replacement with 0.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) 0% 0 0)`, `${colorSpace}(0% 0 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) 0% 0 0 / 0)`, `${colorSpace}(0% 0 0 / 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) 0% a b / alpha)`, `${colorSpace}(0% 20 50)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l 0 b / alpha)`, `${colorSpace}(25% 0 50)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a 0 / alpha)`, `${colorSpace}(25% 20 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a b / 0)`, `${colorSpace}(25% 20 50 / 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) 0% a b / alpha)`, `${colorSpace}(0% 20 50 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l 0 b / alpha)`, `${colorSpace}(25% 0 50 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a 0 / alpha)`, `${colorSpace}(25% 20 0 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a b / 0)`, `${colorSpace}(25% 20 50 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) 0 0 0)`, `${colorSpace}(0 0 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) 0 0 0 / 0)`, `${colorSpace}(0 0 0 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) 0 a b / alpha)`, `${colorSpace}(0 20 50)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l 0 b / alpha)`, `${colorSpace}(25 0 50)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a 0 / alpha)`, `${colorSpace}(25 20 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b / 0)`, `${colorSpace}(25 20 50 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) 0 a b / alpha)`, `${colorSpace}(0 20 50 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l 0 b / alpha)`, `${colorSpace}(25 0 50 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a 0 / alpha)`, `${colorSpace}(25 20 0 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a b / 0)`, `${colorSpace}(25 20 50 / 0)`);
 
         // Testing replacement with a constant.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) 35% a b / alpha)`, `${colorSpace}(35% 20 50)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l 35 b / alpha)`, `${colorSpace}(25% 35 50)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a 35 / alpha)`, `${colorSpace}(25% 20 35)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a b / .35)`, `${colorSpace}(25% 20 50 / 0.35)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) 35% a b / alpha)`, `${colorSpace}(35% 20 50 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l 35 b / alpha)`, `${colorSpace}(25% 35 50 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a 35 / alpha)`, `${colorSpace}(25% 20 35 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a b / .35)`, `${colorSpace}(25% 20 50 / 0.35)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 200% 300 400 / 500)`, `${colorSpace}(200% 300 400)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) -200% -300 -400 / -500)`, `${colorSpace}(0% -300 -400 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) 35 a b / alpha)`, `${colorSpace}(35 20 50)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l 35 b / alpha)`, `${colorSpace}(25 35 50)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a 35 / alpha)`, `${colorSpace}(25 20 35)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b / .35)`, `${colorSpace}(25 20 50 / 0.35)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) 35 a b / alpha)`, `${colorSpace}(35 20 50 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l 35 b / alpha)`, `${colorSpace}(25 35 50 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a 35 / alpha)`, `${colorSpace}(25 20 35 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a b / .35)`, `${colorSpace}(25 20 50 / 0.35)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 200 300 400 / 500)`, `${colorSpace}(200 300 400)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) -200 -300 -400 / -500)`, `${colorSpace}(0 -300 -400 / 0)`);
 
         // Testing valid permutation (types match).
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l b a)`, `${colorSpace}(25% 50 20)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a a / a)`, `${colorSpace}(25% 20 20)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l b a)`, `${colorSpace}(25% 50 20)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a a / a)`, `${colorSpace}(25% 20 20)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l b a)`, `${colorSpace}(25 50 20)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a a / a)`, `${colorSpace}(25 20 20)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l b a)`, `${colorSpace}(25 50 20)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a a / a)`, `${colorSpace}(25 20 20)`);
 
         // Testing with calc().
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) calc(l) calc(a) calc(b))`, `${colorSpace}(25% 20 50)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) calc(l) calc(a) calc(b) / calc(alpha))`, `${colorSpace}(25% 20 50 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) calc(l) calc(a) calc(b))`, `${colorSpace}(25 20 50)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) calc(l) calc(a) calc(b) / calc(alpha))`, `${colorSpace}(25 20 50 / 0.4)`);
 
         // Testing with 'none'.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) none none none)`, `${colorSpace}(none none none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) none none none / none)`, `${colorSpace}(none none none / none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a none)`, `${colorSpace}(25% 20 none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a none / alpha)`, `${colorSpace}(25% 20 none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50) l a b / none)`, `${colorSpace}(25% 20 50 / none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a none / alpha)`, `${colorSpace}(25% 20 none / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / 40%) l a b / none)`, `${colorSpace}(25% 20 50 / none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) none none none)`, `${colorSpace}(none none none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) none none none / none)`, `${colorSpace}(none none none / none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a none)`, `${colorSpace}(25 20 none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a none / alpha)`, `${colorSpace}(25 20 none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b / none)`, `${colorSpace}(25 20 50 / none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a none / alpha)`, `${colorSpace}(25 20 none / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a b / none)`, `${colorSpace}(25 20 50 / none)`);
         // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(none none none) l a b)`, `${colorSpace}(0% 0 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(none none none / none) l a b / alpha)`, `${colorSpace}(0% 0 0 / 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% none 50) l a b)`, `${colorSpace}(25% 0 50)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25% 20 50 / none) l a b / alpha)`, `${colorSpace}(25% 20 50 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(none none none) l a b)`, `${colorSpace}(0 0 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(none none none / none) l a b / alpha)`, `${colorSpace}(0 0 0 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 none 50) l a b)`, `${colorSpace}(25 0 50)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / none) l a b / alpha)`, `${colorSpace}(25 20 50 / 0)`);
     }
+
+    // lab and oklab tests that require different results due to percent scaling differences.
+    test_valid_value(`color`, `lab(from lab(.7 45 30) alpha b a / l)`, `lab(100 30 45 / 0.7)`);
+    test_valid_value(`color`, `lab(from lab(.7 45 30) alpha a b / alpha)`, `lab(100 45 30)`);
+    test_valid_value(`color`, `lab(from lab(.7 45 30) alpha a a / alpha)`, `lab(100 45 45)`);
+    test_valid_value(`color`, `lab(from lab(.7 45 30 / 40%) alpha b a / l)`, `lab(40 30 45 / 0.7)`);
+    test_valid_value(`color`, `lab(from lab(.7 45 30 / 40%) alpha a b / alpha)`, `lab(40 45 30 / 0.4)`);
+    test_valid_value(`color`, `lab(from lab(.7 45 30 / 40%) alpha a a / alpha)`, `lab(40 45 45 / 0.4)`);
+
+    test_valid_value(`color`, `oklab(from oklab(.7 45 30) alpha b a / l)`, `oklab(1 30 45 / 0.7)`);
+    test_valid_value(`color`, `oklab(from oklab(.7 45 30) alpha a b / alpha)`, `oklab(1 45 30)`);
+    test_valid_value(`color`, `oklab(from oklab(.7 45 30) alpha a a / alpha)`, `oklab(1 45 45)`);
+    test_valid_value(`color`, `oklab(from oklab(.7 45 30 / 40%) alpha b a / l)`, `oklab(0.4 30 45 / 0.7)`);
+    test_valid_value(`color`, `oklab(from oklab(.7 45 30 / 40%) alpha a b / alpha)`, `oklab(0.4 45 30 / 0.4)`);
+    test_valid_value(`color`, `oklab(from oklab(.7 45 30 / 40%) alpha a a / alpha)`, `oklab(0.4 45 45 / 0.4)`);
 
     for (const colorSpace of [ "lch", "oklch" ]) {
         const rectangularForm = colorSpace == "lch" ? "lab" : "oklab";
 
         // Testing no modifications.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c h)`, `${colorSpace}(70% 45 30)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c h / alpha)`, `${colorSpace}(70% 45 30)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c h / alpha)`, `${colorSpace}(70% 45 30 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(200% 300 400 / 500%) l c h / alpha)`, `${colorSpace}(200% 300 40)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(-200% -300 -400 / -500%) l c h / alpha)`, `${colorSpace}(0% 0 320 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h)`, `${colorSpace}(0.7 45 30)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h / alpha)`, `${colorSpace}(0.7 45 30)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c h / alpha)`, `${colorSpace}(0.7 45 30 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(200 300 400 / 500%) l c h / alpha)`, `${colorSpace}(200 300 40)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(-200 -300 -400 / -500%) l c h / alpha)`, `${colorSpace}(0 0 320 / 0)`);
 
         // Test nesting relative colors.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(from ${colorSpace}(70% 45 30) l c h) l c h)`, `${colorSpace}(70% 45 30)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(from ${colorSpace}(0.7 45 30) l c h) l c h)`, `${colorSpace}(0.7 45 30)`);
 
         // Testing non-sRGB origin colors (no gamut mapping will happen since the destination is not a bounded RGB color space).
-        test_valid_value(`color`, `${colorSpace}(from color(display-p3 0 0 0) l c h / alpha)`, `${colorSpace}(0% 0 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${rectangularForm}(70% 45 30) l c h / alpha)`, `${colorSpace}(70% 54.08327 33.690067)`);
+        test_valid_value(`color`, `${colorSpace}(from color(display-p3 0 0 0) l c h / alpha)`, `${colorSpace}(0 0 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${rectangularForm}(0.7 45 30) l c h / alpha)`, `${colorSpace}(0.7 54.08327 33.690067)`);
 
         // Testing replacement with 0.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) 0% 0 0)`, `${colorSpace}(0% 0 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) 0% 0 0deg)`, `${colorSpace}(0% 0 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) 0% 0 0 / 0)`, `${colorSpace}(0% 0 0 / 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) 0% 0 0deg / 0)`, `${colorSpace}(0% 0 0 / 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) 0% c h / alpha)`, `${colorSpace}(0% 45 30)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l 0 h / alpha)`, `${colorSpace}(70% 0 30)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c 0 / alpha)`, `${colorSpace}(70% 45 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c 0deg / alpha)`, `${colorSpace}(70% 45 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c h / 0)`, `${colorSpace}(70% 45 30 / 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 0% c h / alpha)`, `${colorSpace}(0% 45 30 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l 0 h / alpha)`, `${colorSpace}(70% 0 30 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c 0 / alpha)`, `${colorSpace}(70% 45 0 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c 0deg / alpha)`, `${colorSpace}(70% 45 0 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c h / 0)`, `${colorSpace}(70% 45 30 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 0 0)`, `${colorSpace}(0 0 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 0 0deg)`, `${colorSpace}(0 0 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 0 0 / 0)`, `${colorSpace}(0 0 0 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 0 0deg / 0)`, `${colorSpace}(0 0 0 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 c h / alpha)`, `${colorSpace}(0 45 30)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l 0 h / alpha)`, `${colorSpace}(0.7 0 30)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c 0 / alpha)`, `${colorSpace}(0.7 45 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c 0deg / alpha)`, `${colorSpace}(0.7 45 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h / 0)`, `${colorSpace}(0.7 45 30 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 0 c h / alpha)`, `${colorSpace}(0 45 30 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l 0 h / alpha)`, `${colorSpace}(0.7 0 30 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c 0 / alpha)`, `${colorSpace}(0.7 45 0 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c 0deg / alpha)`, `${colorSpace}(0.7 45 0 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c h / 0)`, `${colorSpace}(0.7 45 30 / 0)`);
 
         // Testing replacement with a constant.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) 25% c h / alpha)`, `${colorSpace}(25% 45 30)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l 25 h / alpha)`, `${colorSpace}(70% 25 30)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c 25 / alpha)`, `${colorSpace}(70% 45 25)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c 25deg / alpha)`, `${colorSpace}(70% 45 25)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c h / .25)`, `${colorSpace}(70% 45 30 / 0.25)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 25% c h / alpha)`, `${colorSpace}(25% 45 30 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l 25 h / alpha)`, `${colorSpace}(70% 25 30 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c 25 / alpha)`, `${colorSpace}(70% 45 25 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c 25deg / alpha)`, `${colorSpace}(70% 45 25 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c h / .25)`, `${colorSpace}(70% 45 30 / 0.25)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 200% 300 400 / 500)`, `${colorSpace}(200% 300 40)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) -200% -300 -400 / -500)`, `${colorSpace}(0% 0 320 / 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 50% 120 400deg / 500)`, `${colorSpace}(50% 120 40)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) 50% 120 -400deg / -500)`, `${colorSpace}(50% 120 320 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 25 c h / alpha)`, `${colorSpace}(25 45 30)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l 25 h / alpha)`, `${colorSpace}(0.7 25 30)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c 25 / alpha)`, `${colorSpace}(0.7 45 25)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c 25deg / alpha)`, `${colorSpace}(0.7 45 25)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h / .25)`, `${colorSpace}(0.7 45 30 / 0.25)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 25 c h / alpha)`, `${colorSpace}(25 45 30 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l 25 h / alpha)`, `${colorSpace}(0.7 25 30 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c 25 / alpha)`, `${colorSpace}(0.7 45 25 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c 25deg / alpha)`, `${colorSpace}(0.7 45 25 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c h / .25)`, `${colorSpace}(0.7 45 30 / 0.25)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 200 300 400 / 500)`, `${colorSpace}(200 300 40)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) -200 -300 -400 / -500)`, `${colorSpace}(0 0 320 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 50 120 400deg / 500)`, `${colorSpace}(50 120 40)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 50 120 -400deg / -500)`, `${colorSpace}(50 120 320 / 0)`);
 
         // Testing valid permutation (types match).
         // NOTE: 'c' is a vaild hue, as hue is <angle>|<number>.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) alpha c h / l)`, `${colorSpace}(100% 45 30 / 0.7)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c c / alpha)`, `${colorSpace}(70% 45 45)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) alpha c h / alpha)`, `${colorSpace}(100% 45 30)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) alpha c c / alpha)`, `${colorSpace}(100% 45 45)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) alpha c h / l)`, `${colorSpace}(40% 45 30 / 0.7)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c c / alpha)`, `${colorSpace}(70% 45 45 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) alpha c h / alpha)`, `${colorSpace}(40% 45 30 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) alpha c c / alpha)`, `${colorSpace}(40% 45 45 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(.7 45 30) l c c / alpha)`, `${colorSpace}(0.7 45 45)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(.7 45 30 / 40%) l c c / alpha)`, `${colorSpace}(0.7 45 45 / 0.4)`);
 
         // Testing with calc().
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) calc(l) calc(c) calc(h))`, `${colorSpace}(70% 45 30)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) calc(l) calc(c) calc(h) / calc(alpha))`, `${colorSpace}(70% 45 30 / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) calc(l) calc(c) calc(h))`, `${colorSpace}(0.7 45 30)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) calc(l) calc(c) calc(h) / calc(alpha))`, `${colorSpace}(0.7 45 30 / 0.4)`);
 
         // Testing with 'none'.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) none none none)`,                                   `${colorSpace}(none none none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) none none none / none)`,                            `${colorSpace}(none none none / none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c none)`,                                         `${colorSpace}(70% 45 none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c none / alpha)`,                                 `${colorSpace}(70% 45 none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30) l c h / none)`,                                     `${colorSpace}(70% 45 30 / none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c none / alpha)`,                           `${colorSpace}(70% 45 none / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / 40%) l c h / none)`,                               `${colorSpace}(70% 45 30 / none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) none none none)`,                                   `${colorSpace}(none none none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) none none none / none)`,                            `${colorSpace}(none none none / none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c none)`,                                         `${colorSpace}(0.7 45 none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c none / alpha)`,                                 `${colorSpace}(0.7 45 none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h / none)`,                                     `${colorSpace}(0.7 45 30 / none)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c none / alpha)`,                           `${colorSpace}(0.7 45 none / 0.4)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c h / none)`,                               `${colorSpace}(0.7 45 30 / none)`);
         // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(none none none) l c h)`,                                       `${colorSpace}(0% 0 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(none none none / none) l c h / alpha)`,                        `${colorSpace}(0% 0 0 / 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% none 30) l c h)`,                                          `${colorSpace}(70% 0 30)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(70% 45 30 / none) l c h / alpha)`,                             `${colorSpace}(70% 45 30 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(none none none) l c h)`,                                       `${colorSpace}(0 0 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(none none none / none) l c h / alpha)`,                        `${colorSpace}(0 0 0 / 0)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 none 30) l c h)`,                                          `${colorSpace}(0.7 0 30)`);
+        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / none) l c h / alpha)`,                             `${colorSpace}(0.7 45 30 / 0)`);
     }
 
-    for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb" ]) {
+    // lch and oklch tests that require different results due to percent scaling differences.
+    test_valid_value(`color`, `lch(from lch(.7 45 30) alpha c h / l)`, `lch(100 45 30 / 0.7)`);
+    test_valid_value(`color`, `lch(from lch(.7 45 30) alpha c h / alpha)`, `lch(100 45 30)`);
+    test_valid_value(`color`, `lch(from lch(.7 45 30) alpha c c / alpha)`, `lch(100 45 45)`);
+    test_valid_value(`color`, `lch(from lch(.7 45 30 / 40%) alpha c h / l)`, `lch(40 45 30 / 0.7)`);
+    test_valid_value(`color`, `lch(from lch(.7 45 30 / 40%) alpha c h / alpha)`, `lch(40 45 30 / 0.4)`);
+    test_valid_value(`color`, `lch(from lch(.7 45 30 / 40%) alpha c c / alpha)`, `lch(40 45 45 / 0.4)`);
+
+    test_valid_value(`color`, `oklch(from oklch(.7 45 30) alpha c h / l)`, `oklch(1 45 30 / 0.7)`);
+    test_valid_value(`color`, `oklch(from oklch(.7 45 30) alpha c h / alpha)`, `oklch(1 45 30)`);
+    test_valid_value(`color`, `oklch(from oklch(.7 45 30) alpha c c / alpha)`, `oklch(1 45 45)`);
+    test_valid_value(`color`, `oklch(from oklch(.7 45 30 / 40%) alpha c h / l)`, `oklch(0.4 45 30 / 0.7)`);
+    test_valid_value(`color`, `oklch(from oklch(.7 45 30 / 40%) alpha c h / alpha)`, `oklch(0.4 45 30 / 0.4)`);
+    test_valid_value(`color`, `oklch(from oklch(.7 45 30 / 40%) alpha c c / alpha)`, `oklch(0.4 45 45 / 0.4)`);
+
+
+    for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb", "display-p3" ]) {
         // Testing no modifications.
         test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b)`,                              `color(${colorSpace} 0.7 0.5 0.3)`);
         test_valid_value(`color`, `color(from color(${colorSpace} 0.7 0.5 0.3) ${colorSpace} r g b / alpha)`,                      `color(${colorSpace} 0.7 0.5 0.3)`);
@@ -605,7 +630,7 @@
     test_valid_value(`color`, `lab(from var(--mycolor) l 0 0)`);
 
     // Example 18.
-    test_valid_value(`color`, `lch(from peru calc(l * 0.8) c h)`, `lch(49.80138% 54.003296 63.680317)`);
+    test_valid_value(`color`, `lch(from peru calc(l * 0.8) c h)`, `lch(49.80138 54.003296 63.680317)`);
 
     // Example 19.
     test_valid_value(`color`, `LCH(from var(--accent) l c calc(h + 180deg))`);


### PR DESCRIPTION
lab()/oklab()/lch()/oklch() now serialize to a numeric value rather than a percentage. As such, many of the parsing and computed value tests needed to be updated for the change.

Upstreaming from WebKit: https://commits.webkit.org/254741@main