### PR TITLE
Make import-maps iframe tests deterministic

### DIFF
--- a/import-maps/import-maps-base-url.sub.html
+++ b/import-maps/import-maps-base-url.sub.html
@@ -17,17 +17,22 @@ const importMap = `
 }
 `;
 
-window.addEventListener("load", () => {
-  testStaticImport(importMap, baseURL, "bare/bare", "log:bare");
-  testDynamicImport(importMap, baseURL, "bare/bare", "log:bare", "module");
-  testDynamicImport(importMap, baseURL, "bare/bare", "log:bare",
-      "text/javascript");
+promise_setup(function () {
+  return new Promise((resolve) => {
+    window.addEventListener("load", async () => {
+      await testStaticImport(importMap, baseURL, "bare/bare", "log:bare");
+      await testDynamicImport(importMap, baseURL, "bare/bare", "log:bare", "module");
+      await testDynamicImport(importMap, baseURL, "bare/bare", "log:bare", "text/javascript");
 
-  testStaticImportInjectBase(importMap, baseURL, "bare/bare", "log:bare");
-  testDynamicImportInjectBase(importMap, baseURL, "bare/bare", "log:bare", "module");
-  testDynamicImportInjectBase(importMap, baseURL, "bare/bare", "log:bare",
-      "text/javascript");
-});
+      await testStaticImportInjectBase(importMap, baseURL, "bare/bare", "log:bare");
+      await testDynamicImportInjectBase(importMap, baseURL, "bare/bare", "log:bare", "module");
+      await testDynamicImportInjectBase(importMap, baseURL, "bare/bare", "log:bare", "text/javascript");
+      done();
+      resolve();
+    });
+  });
+}, { explicit_done: true });
+
 
 </script>
 <body>

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -3822,7 +3822,9 @@
             return;
         }
 
-        this.pending_remotes.push(this.create_remote_window(remote));
+        var remoteContext = this.create_remote_window(remote);
+        this.pending_remotes.push(remoteContext);
+        return remoteContext.done;
     };
 
     /**
@@ -3837,7 +3839,7 @@
      * @param {Window} window - The window to fetch tests from.
      */
     function fetch_tests_from_window(window) {
-        tests.fetch_tests_from_window(window);
+        return tests.fetch_tests_from_window(window);
     }
     expose(fetch_tests_from_window, 'fetch_tests_from_window');
 


### PR DESCRIPTION
We found that import-maps' iframe tests are relying on particular order of script execution in iframes. This patch makes them serialized and deterministic order by the following three changes.

1. Align fetch_tests_from_window to fetch_tests_from_worker so that it can return a promise from RemoteContext.
2. Use async / await in import-maps' doTests helper function to serialize iframe tests. And use promise_setup to collect all tests from iframes asynchronously.
3. Apply (2)'s change to import-maps/import-maps-base-url.sub.html too.