### PR TITLE
Update 6 years old README on fetch/http-cache

### DIFF
--- a/fetch/http-cache/README.md
+++ b/fetch/http-cache/README.md
@@ -13,7 +13,7 @@ A few notes:
   race the cache with a network request.
 
 * Likewise, some tests might fail because there is a separate document-level
-  cache that's ill-defined; see [this
+  cache that's not well defined; see [this
   issue](https://github.com/whatwg/fetch/issues/354).
 
 * [Partial content tests](partial.any.js) (a.k.a. Range requests) are not specified

--- a/fetch/http-cache/README.md
+++ b/fetch/http-cache/README.md
@@ -20,9 +20,6 @@ A few notes:
 * Some browser caches will behave differently when reloading /
   shift-reloading, despite the `cache mode` staying the same.
 
-* At the moment, Edge doesn't appear to using HTTP caching in conjunction
-  with Fetch at all.
-
 
 ## Test Format
 

--- a/fetch/http-cache/README.md
+++ b/fetch/http-cache/README.md
@@ -16,7 +16,7 @@ A few notes:
   cache that's ill-defined; see [this
   issue](https://github.com/whatwg/fetch/issues/354).
 
-* [Partial content tests](partial.html) (a.k.a. Range requests) are not specified
+* [Partial content tests](partial.any.js) (a.k.a. Range requests) are not specified
   in Fetch; tests are included here for interest only.
 
 * Some browser caches will behave differently when reloading /

--- a/fetch/http-cache/README.md
+++ b/fetch/http-cache/README.md
@@ -22,8 +22,8 @@ A few notes:
 * Some browser caches will behave differently when reloading /
   shift-reloading, despite the `cache mode` staying the same.
 
-* [cache-tests.fyi](https://cache-tests.fyi/) is yet another test suites of http caching
-  which also includes Server/CDN implementation.
+* [cache-tests.fyi](https://cache-tests.fyi/) is another test suite of HTTP caching
+  which also caters to server/CDN implementations.
 
 ## Test Format
 

--- a/fetch/http-cache/README.md
+++ b/fetch/http-cache/README.md
@@ -6,7 +6,7 @@ lens of Fetch.
 
 A few notes:
 
-* By its nature, [caching is an entirely optional](
+* By its nature, [caching is entirely optional](
   https://www.rfc-editor.org/rfc/rfc9111.html#section-2-2);
   some tests expecting a response to be
   cached might fail because the client chose not to cache it, or chose to

--- a/fetch/http-cache/README.md
+++ b/fetch/http-cache/README.md
@@ -1,12 +1,14 @@
 ## HTTP Caching Tests
 
 These tests cover HTTP-specified behaviours for caches, primarily from
-[RFC7234](http://httpwg.org/specs/rfc7234.html), but as seen through the
+[RFC9111](https://www.rfc-editor.org/rfc/rfc9111.html), but as seen through the
 lens of Fetch.
 
 A few notes:
 
-* By its nature, caching is optional; some tests expecting a response to be
+* By its nature, [caching is an entirely optional](
+  https://www.rfc-editor.org/rfc/rfc9111.html#section-2-2);
+  some tests expecting a response to be
   cached might fail because the client chose not to cache it, or chose to
   race the cache with a network request.
 

--- a/fetch/http-cache/README.md
+++ b/fetch/http-cache/README.md
@@ -22,6 +22,8 @@ A few notes:
 * Some browser caches will behave differently when reloading /
   shift-reloading, despite the `cache mode` staying the same.
 
+* [cache-tests.fyi](https://cache-tests.fyi/) is yet another test suites of http caching
+  which also includes Server/CDN implementation.
 
 ## Test Format
 


### PR DESCRIPTION
- edge is now based on chromium
- new RFC9111 obsoletes RFC7234
- Fix renamed link 