### PR TITLE
CSSMatrixTransformComponent should be CSSMatrixComponent

### DIFF
--- a/css/css-typed-om/CSSMatrixComponent-DOMMatrix-mutable.html
+++ b/css/css-typed-om/CSSMatrixComponent-DOMMatrix-mutable.html
@@ -8,7 +8,7 @@
   <div id="log"></div>
   <script>
     test(function() {
-      var component = new CSSMatrixTransformComponent(new DOMMatrix());
+      var component = new CSSMatrixComponent(new DOMMatrix());
       assert_equals(component.matrix.m11, 1, 'DOMMatrix expected to be initialized to identity');
       component.matrix.m11 = 2;
       assert_equals(component.matrix.m11, 2, 'modification of m11 component of DOMMatrix expected to succeed');


### PR DESCRIPTION
This is most likely a typo as the spec doesn't discuss a `CSSMatrixTransformComponent` but instead a `CSSMatrixComponent`.