### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=243562

### DIFF
--- a/css/css-animations/KeyframeEffect-getKeyframes.tentative.html
+++ b/css/css-animations/KeyframeEffect-getKeyframes.tentative.html
@@ -698,7 +698,7 @@ test(t => {
     { offset: 0, computedOffset: 0, easing: "ease", composite: "auto",
       backgroundSize: "auto" },
     { offset: 1, computedOffset: 1, easing: "ease", composite: "auto",
-      backgroundSize: "50%, 6px, contain" },
+      backgroundSize: "50% auto, 6px auto, contain" },
   ];
 
   for (let i = 0; i < frames.length; i++) {
@@ -708,7 +708,7 @@ test(t => {
   // Test inheriting a background-size value
 
   expected[0].backgroundSize = div.style.backgroundSize =
-    "30px, 40%, auto";
+    "30px auto, 40% auto, auto";
   frames = getKeyframes(div);
 
   for (let i = 0; i < frames.length; i++) {

--- a/css/css-backgrounds/background-size-001.html
+++ b/css/css-backgrounds/background-size-001.html
@@ -39,43 +39,43 @@
         document.getElementById("test").style.backgroundSize = "0px";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "0px", "background-size supporting value");
+                "0px auto", "background-size supporting value");
         }, "background-size_length_zero");
 
         document.getElementById("test").style.backgroundSize = "-0px";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "0px", "background-size supporting value");
+                "0px auto", "background-size supporting value");
         }, "background-size_length_negative_zero");
 
         document.getElementById("test").style.backgroundSize = "+0px";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "0px", "background-size supporting value");
+                "0px auto", "background-size supporting value");
         }, "background-size_length_positive_zero");
 
         document.getElementById("test").style.backgroundSize = "15px";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "15px", "background-size supporting value");
+                "15px auto", "background-size supporting value");
         }, "background-size_length_normal");
 
         document.getElementById("test").style.backgroundSize = "0%";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "0%", "background-size supporting value");
+                "0% auto", "background-size supporting value");
         }, "background-size_percentage_min");
 
         document.getElementById("test").style.backgroundSize = "50%";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "50%", "background-size supporting value");
+                "50% auto", "background-size supporting value");
         }, "background-size_percentage_normal");
 
         document.getElementById("test").style.backgroundSize = "100%";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "100%", "background-size supporting value");
+                "100% auto", "background-size supporting value");
         }, "background-size_percentage_max");
 
         document.getElementById("test").style.backgroundSize = "auto auto";
@@ -99,7 +99,7 @@
         document.getElementById("test").style.backgroundSize = "15px auto";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "15px", "background-size supporting value");
+                "15px auto", "background-size supporting value");
         }, "background-size_length_auto");
 
         document.getElementById("test").style.backgroundSize = "15px 15px";
@@ -117,7 +117,7 @@
         document.getElementById("test").style.backgroundSize = "50% auto";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "50%", "background-size supporting value");
+                "50% auto", "background-size supporting value");
         }, "background-size_percentage_auto");
 
         document.getElementById("test").style.backgroundSize = "50% 15px";

--- a/css/css-backgrounds/parsing/background-size-computed.html
+++ b/css/css-backgrounds/parsing/background-size-computed.html
@@ -17,8 +17,8 @@
 <body>
 <div id="target"></div>
 <script>
-test_computed_value("background-size", "1px", "1px");
-test_computed_value("background-size", "1px auto", "1px");
+test_computed_value("background-size", "1px", "1px auto");
+test_computed_value("background-size", "1px auto", "1px auto");
 test_computed_value("background-size", "2% 3%");
 test_computed_value("background-size", "auto");
 test_computed_value("background-size", "auto auto", "auto");

--- a/quirks/unitless-length/excluded-properties-002.html
+++ b/quirks/unitless-length/excluded-properties-002.html
@@ -35,6 +35,7 @@ for (let property of properties) {
     target.style[property] = '1234';
     assert_not_equals(target.style[property], '1234');
     assert_not_equals(target.style[property], '1234px');
+    assert_not_equals(target.style[property], '1234px auto');
   }, 'Property ' + property + ' does not support quirky length');
 }
 </script>


### PR DESCRIPTION
Update tests to reflect two-value serialization for background-size.