### PR TITLE
fix(WebCryptoAPI): remove unhandled rejections

### DIFF
--- a/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits.js
+++ b/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits.js
@@ -183,6 +183,8 @@ function define_tests() {
                                           false, ["deriveBits", "deriveKey"])
                           .then(function(key) {
                               privateKeys[algorithmName] = key;
+                            }, function (err) {
+                              privateKeys[algorithmName] = null;
                           });
           promises.push(operation);
       });
@@ -192,6 +194,8 @@ function define_tests() {
                                           false, ["deriveKey"])
                           .then(function(key) {
                               noDeriveBitsKeys[algorithmName] = key;
+                            }, function (err) {
+                              noDeriveBitsKeys[algorithmName] = null;
                           });
           promises.push(operation);
       });
@@ -201,6 +205,8 @@ function define_tests() {
                                           false, [])
                           .then(function(key) {
                               publicKeys[algorithmName] = key;
+                            }, function (err) {
+                              publicKeys[algorithmName] = null;
                           });
           promises.push(operation);
       });

--- a/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits.js
+++ b/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits.js
@@ -150,7 +150,7 @@ function define_tests() {
           promise_test(function(test) {
               return subtle.generateKey({name: "AES-CBC", length: 128}, true, ["encrypt", "decrypt"])
               .then(function(secretKey) {
-                  subtle.deriveBits({name: algorithmName, public: secretKey}, privateKeys[algorithmName], 8 * sizes[algorithmName])
+                  return subtle.deriveBits({name: algorithmName, public: secretKey}, privateKeys[algorithmName], 8 * sizes[algorithmName])
                   .then(function(derivation) {
                       assert_unreached("deriveBits succeeded but should have failed with InvalidAccessError");
                   }, function(err) {

--- a/WebCryptoAPI/derive_bits_keys/cfrg_curves_keys.js
+++ b/WebCryptoAPI/derive_bits_keys/cfrg_curves_keys.js
@@ -151,6 +151,8 @@ function define_tests() {
                                           false, ["deriveBits", "deriveKey"])
                           .then(function(key) {
                               privateKeys[algorithmName] = key;
+                          }, function (err) {
+                            privateKeys[algorithmName] = null;
                           });
           promises.push(operation);
       });
@@ -160,6 +162,8 @@ function define_tests() {
                                           false, ["deriveBits"])
                           .then(function(key) {
                               noDeriveKeyKeys[algorithmName] = key;
+                          }, function (err) {
+                            noDeriveKeyKeys[algorithmName] = null;
                           });
           promises.push(operation);
       });
@@ -169,6 +173,8 @@ function define_tests() {
                                           false, [])
                           .then(function(key) {
                               publicKeys[algorithmName] = key;
+                          }, function (err) {
+                            publicKeys[algorithmName] = null;
                           });
           promises.push(operation);
       });

--- a/WebCryptoAPI/derive_bits_keys/cfrg_curves_keys.js
+++ b/WebCryptoAPI/derive_bits_keys/cfrg_curves_keys.js
@@ -127,7 +127,7 @@ function define_tests() {
           promise_test(function(test) {
               return subtle.generateKey({name: "HMAC", hash: "SHA-256", length: 256}, true, ["sign", "verify"])
               .then(function(secretKey) {
-                  subtle.deriveKey({name: algorithmName, public: secretKey}, privateKeys[algorithmName], {name: "AES-CBC", length: 256}, true, ["sign", "verify"])
+                  return subtle.deriveKey({name: algorithmName, public: secretKey}, privateKeys[algorithmName], {name: "AES-CBC", length: 256}, true, ["sign", "verify"])
                   .then(function(key) {return crypto.subtle.exportKey("raw", key);})
                   .then(function(exportedKey) {
                       assert_unreached("deriveKey succeeded but should have failed with InvalidAccessError");

--- a/WebCryptoAPI/derive_bits_keys/ecdh_bits.js
+++ b/WebCryptoAPI/derive_bits_keys/ecdh_bits.js
@@ -199,6 +199,8 @@ function define_tests() {
                                             false, ["deriveBits", "deriveKey"])
                             .then(function(key) {
                                 privateKeys[namedCurve] = key;
+                            }, function (err) {
+                                privateKeys[namedCurve] = null;
                             });
             promises.push(operation);
         });
@@ -208,6 +210,8 @@ function define_tests() {
                                             false, ["deriveKey"])
                             .then(function(key) {
                                 noDeriveBitsKeys[namedCurve] = key;
+                            }, function (err) {
+                                noDeriveBitsKeys[namedCurve] = null;
                             });
             promises.push(operation);
         });
@@ -217,6 +221,8 @@ function define_tests() {
                                             false, [])
                             .then(function(key) {
                                 publicKeys[namedCurve] = key;
+                            }, function (err) {
+                                publicKeys[namedCurve] = null;
                             });
             promises.push(operation);
         });
@@ -224,6 +230,8 @@ function define_tests() {
             var operation = subtle.generateKey({name: "ECDSA", namedCurve: namedCurve}, false, ["sign", "verify"])
                             .then(function(keyPair) {
                                 ecdsaKeyPairs[namedCurve] = keyPair;
+                            }, function (err) {
+                                ecdsaKeyPairs[namedCurve] = null;
                             });
             promises.push(operation);
         });

--- a/WebCryptoAPI/derive_bits_keys/ecdh_bits.js
+++ b/WebCryptoAPI/derive_bits_keys/ecdh_bits.js
@@ -165,7 +165,7 @@ function define_tests() {
             promise_test(function(test) {
                 return subtle.generateKey({name: "AES-CBC", length: 128}, true, ["encrypt", "decrypt"])
                 .then(function(secretKey) {
-                    subtle.deriveBits({name: "ECDH", public: secretKey}, privateKeys[namedCurve], 8 * sizes[namedCurve])
+                    return subtle.deriveBits({name: "ECDH", public: secretKey}, privateKeys[namedCurve], 8 * sizes[namedCurve])
                     .then(function(derivation) {
                         assert_unreached("deriveBits succeeded but should have failed with InvalidAccessError");
                     }, function(err) {

--- a/WebCryptoAPI/derive_bits_keys/ecdh_keys.js
+++ b/WebCryptoAPI/derive_bits_keys/ecdh_keys.js
@@ -143,7 +143,7 @@ function define_tests() {
             promise_test(function(test) {
                 return subtle.generateKey({name: "HMAC", hash: "SHA-256", length: 256}, true, ["sign", "verify"])
                 .then(function(secretKey) {
-                    subtle.deriveKey({name: "ECDH", public: secretKey}, privateKeys[namedCurve], {name: "AES-CBC", length: 256}, true, ["sign", "verify"])
+                    return subtle.deriveKey({name: "ECDH", public: secretKey}, privateKeys[namedCurve], {name: "AES-CBC", length: 256}, true, ["sign", "verify"])
                     .then(function(key) {return crypto.subtle.exportKey("raw", key);})
                     .then(function(exportedKey) {
                         assert_unreached("deriveKey succeeded but should have failed with InvalidAccessError");

--- a/WebCryptoAPI/derive_bits_keys/ecdh_keys.js
+++ b/WebCryptoAPI/derive_bits_keys/ecdh_keys.js
@@ -168,6 +168,8 @@ function define_tests() {
                                             false, ["deriveBits", "deriveKey"])
                             .then(function(key) {
                                 privateKeys[namedCurve] = key;
+                            }, function (err) {
+                                privateKeys[namedCurve] = null;
                             });
             promises.push(operation);
         });
@@ -177,6 +179,8 @@ function define_tests() {
                                             false, ["deriveBits"])
                             .then(function(key) {
                                 noDeriveKeyKeys[namedCurve] = key;
+                            }, function (err) {
+                                noDeriveKeyKeys[namedCurve] = null;
                             });
             promises.push(operation);
         });
@@ -186,6 +190,8 @@ function define_tests() {
                                             false, [])
                             .then(function(key) {
                                 publicKeys[namedCurve] = key;
+                            }, function (err) {
+                                publicKeys[namedCurve] = null;
                             });
             promises.push(operation);
         });
@@ -193,6 +199,8 @@ function define_tests() {
             var operation = subtle.generateKey({name: "ECDSA", namedCurve: namedCurve}, false, ["sign", "verify"])
                             .then(function(keyPair) {
                                 ecdsaKeyPairs[namedCurve] = keyPair;
+                            }, function (err) {
+                                ecdsaKeyPairs[namedCurve] = null;
                             });
             promises.push(operation);
         });


### PR DESCRIPTION
This change 

- removes possible unhandled rejections (caused Deno's wpt runner to abort)
- allows CFRG and ECDH suites to run even when not all algorithms are supported (by handling import/generate key rejection)