### PR TITLE
Mark multiTouch test as failing in Chrome.

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPointsSimultaneousMove.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPointsSimultaneousMove.html.ini
@@ -1,0 +1,4 @@
+[multiTouchPointsSimultaneousMove.html]
+  [TestDriver actions: two touch points with both moving]
+    expected:
+      if product == "chrome": [PASS, FAIL]


### PR DESCRIPTION
This is required to unblock infrastructure tests