### PR TITLE
fix(fetch): add missing duplex option

### DIFF
--- a/fetch/api/abort/general.any.js
+++ b/fetch/api/abort/general.any.js
@@ -519,6 +519,7 @@ promise_test(async t => {
   const fetchPromise = fetch('../resources/empty.txt', {
     body, signal,
     method: 'POST',
+    duplex: 'half',
     headers: {
       'Content-Type': 'text/plain'
     }


### PR DESCRIPTION
Adds missing `duplex: 'half'` option which caused test to reject with a TypeError rather than a DOMException.