### PR TITLE
Run sysdiagnose at the end of Azure Pipelines jobs on macOS

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -126,6 +126,7 @@ jobs:
     condition: succeededOrFailed()
     displayName: 'Run tests (Safari Technology Preview)'
   - template: tools/ci/azure/publish_logs.yml
+  - template: tools/ci/azure/sysdiagnose.yml
 
 - job: tools_unittest_mac_py37
   displayName: 'tools/ unittests: macOS + Python 3.7'
@@ -378,6 +379,7 @@ jobs:
     inputs:
       artifactName: 'edge-stable-results'
   - template: tools/ci/azure/publish_logs.yml
+  - template: tools/ci/azure/sysdiagnose.yml
 - template: tools/ci/azure/fyi_hook.yml
   parameters:
     dependsOn: results_edge_stable
@@ -416,6 +418,7 @@ jobs:
     inputs:
       artifactName: 'edge-dev-results'
   - template: tools/ci/azure/publish_logs.yml
+  - template: tools/ci/azure/sysdiagnose.yml
 - template: tools/ci/azure/fyi_hook.yml
   parameters:
     dependsOn: results_edge_dev
@@ -453,6 +456,7 @@ jobs:
     inputs:
       artifactName: 'edge-canary-results'
   - template: tools/ci/azure/publish_logs.yml
+  - template: tools/ci/azure/sysdiagnose.yml
 - template: tools/ci/azure/fyi_hook.yml
   parameters:
     dependsOn: results_edge_canary
@@ -493,6 +497,7 @@ jobs:
     inputs:
       artifactName: 'safari-results'
   - template: tools/ci/azure/publish_logs.yml
+  - template: tools/ci/azure/sysdiagnose.yml
 - template: tools/ci/azure/fyi_hook.yml
   parameters:
     dependsOn: results_safari
@@ -531,6 +536,7 @@ jobs:
     inputs:
       artifactName: 'safari-preview-results'
   - template: tools/ci/azure/publish_logs.yml
+  - template: tools/ci/azure/sysdiagnose.yml
 - template: tools/ci/azure/fyi_hook.yml
   parameters:
     dependsOn: results_safari_preview

--- a/tools/ci/azure/sysdiagnose.yml
+++ b/tools/ci/azure/sysdiagnose.yml
@@ -1,0 +1,13 @@
+steps:
+- script: |
+    mkdir -p /Users/runner/sysdiagnose
+    # No UI, and no time sensitive, generated, or archived logs
+    sudo sysdiagnose -ub -PGR -f /Users/runner/sysdiagnose -A sysdiagnose_$(System.JobPositionInPhase)
+  displayName: 'Collect sysdiagnose'
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish sysdiagnose'
+  inputs:
+    pathtoPublish: /Users/runner/sysdiagnose/
+    artifactName: sysdiagnose
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))


### PR DESCRIPTION
This runs this with quite a lot of arguments, mostly to exclude the generated and/or time-sensitive logs, along with the larger log archive, for the sake of making this a sensible amount to store for each run.

Notably, this does include crash and spin logs, which have already proven useful to track down intermittent crashes on Azure Pipelines.