### PR TITLE
Add missing test around cache-mode in fetch

### DIFF
--- a/fetch/http-cache/cache-mode.any.js
+++ b/fetch/http-cache/cache-mode.any.js
@@ -5,7 +5,19 @@
 // META: script=/common/get-host-info.sub.js
 // META: script=http-cache.js
 
+// 4.6. HTTP-network-or-cache fetch
+// https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
 var tests = [
+  // 15. If httpRequest's cache mode is "default"
+  // and httpRequest's header list contains
+  // `If-Modified-Since`, `If-None-Match`, `If-Unmodified-Since`, `If-Match`, or `If-Range`,
+  // then set httpRequest's cache mode to "no-store".
+  // TODO:
+
+  // 16. If httpRequest's cache mode is "no-cache",
+  //     httpRequest's prevent no-cache cache-control header modification flag is unset,
+  //     and httpRequest's header list does not contain `Cache-Control`,
+  //     then append (`Cache-Control`, `max-age=0`) to httpRequest's header list.
   {
     name: "Fetch sends Cache-Control: max-age=0 when cache mode is no-cache",
     requests: [
@@ -25,6 +37,12 @@ var tests = [
       }
     ]
   },
+
+  // 17. If httpRequest's cache mode is "no-store" or "reload", then:
+  //    1. If httpRequest's header list does not contain `Pragma`,
+  //       then append (`Pragma`, `no-cache`) to httpRequest's header list.
+  //    2. If httpRequest's header list does not contain `Cache-Control`,
+  //        then append (`Cache-Control`, `no-cache`) to httpRequest's header list.
   {
     name: "Fetch sends Cache-Control: no-cache and Pragma: no-cache when cache mode is no-store",
     requests: [
@@ -57,5 +75,7 @@ var tests = [
       }
     ]
   }
+
+  // TODO: "reload"
 ];
 run_tests(tests);

--- a/fetch/http-cache/cache-mode.any.js
+++ b/fetch/http-cache/cache-mode.any.js
@@ -12,7 +12,194 @@ var tests = [
   // and httpRequest's header list contains
   // `If-Modified-Since`, `If-None-Match`, `If-Unmodified-Since`, `If-Match`, or `If-Range`,
   // then set httpRequest's cache mode to "no-store".
-  // TODO:
+
+  /// If-Modified-Since
+  {
+    name: "Fetch sends Cache-Control: no-cache and Pragma: no-cache when cache mode is default and header list contains If-Modified-Since",
+    requests: [
+      {
+        cache: "default",
+        request_headers: [['if-modified-since', 'Tue, 22 Feb 2022 22:22:22 GMT']],
+        expected_request_headers: [
+          ['cache-control', 'no-cache'],
+          ['pragma', 'no-cache']
+        ]
+      }
+    ]
+  },
+  {
+    name: "Fetch doesn't touch Cache-Control when cache mode is default, header list contains If-Modified-Since and Cache-Control is already present",
+    requests: [
+      {
+        cache: "default",
+        request_headers: [
+          ['if-modified-since', 'Tue, 22 Feb 2022 22:22:22 GMT'],
+          ['cache-control', 'foo']
+        ],
+        expected_request_headers: [
+          ['cache-control', 'foo']
+          ['pragma', 'no-cache']
+        ]
+      }
+    ]
+  },
+  {
+    name: "Fetch doesn't touch Cache-Control when cache mode is default, header list contains If-Modified-Since and Pragma is already present",
+    requests: [
+      {
+        cache: "default",
+        request_headers: [
+          ['if-modified-since', 'Tue, 22 Feb 2022 22:22:22 GMT'],
+          ['pragma', 'foo']
+        ],
+        expected_request_headers: [
+          ['cache-control', 'no-cache']
+          ['pragma', 'foo']
+        ]
+      }
+    ]
+  },
+
+  /// If-Unmodified-Since
+  {
+    name: "Fetch sends Cache-Control: no-cache and Pragma: no-cache when cache mode is default and header list contains If-Unmodified-Since",
+    requests: [
+      {
+        cache: "default",
+        request_headers: [['if-unmodified-since', 'Tue, 22 Feb 2022 22:22:22 GMT']],
+        expected_request_headers: [
+          ['cache-control', 'no-cache'],
+          ['pragma', 'no-cache']
+        ]
+      }
+    ]
+  },
+  {
+    name: "Fetch doesn't touch Cache-Control when cache mode is default, header list contains If-Unmodified-Since and Cache-Control is already present",
+    requests: [
+      {
+        cache: "default",
+        request_headers: [
+          ['if-unmodified-since', 'Tue, 22 Feb 2022 22:22:22 GMT'],
+          ['cache-control', 'foo']
+        ],
+        expected_request_headers: [
+          ['cache-control', 'foo']
+          ['pragma', 'no-cache']
+        ]
+      }
+    ]
+  },
+  {
+    name: "Fetch doesn't touch Cache-Control when cache mode is default, header list contains If-Unmodified-Since and Pragma is already present",
+    requests: [
+      {
+        cache: "default",
+        request_headers: [
+          ['if-unmodified-since', 'Tue, 22 Feb 2022 22:22:22 GMT'],
+          ['pragma', 'foo']
+        ],
+        expected_request_headers: [
+          ['cache-control', 'no-cache']
+          ['pragma', 'foo']
+        ]
+      }
+    ]
+  },
+
+  /// If-Match
+  {
+    name: "Fetch sends Cache-Control: no-cache and Pragma: no-cache when cache mode is default and header list contains If-Match",
+    requests: [
+      {
+        cache: "default",
+        request_headers: [['if-match', 'foo']],
+        expected_request_headers: [
+          ['cache-control', 'no-cache'],
+          ['pragma', 'no-cache']
+        ]
+      }
+    ]
+  },
+  {
+    name: "Fetch doesn't touch Cache-Control when cache mode is default, header list contains If-Match and Cache-Control is already present",
+    requests: [
+      {
+        cache: "default",
+        request_headers: [
+          ['if-match', 'foo'],
+          ['cache-control', 'foo']
+        ],
+        expected_request_headers: [
+          ['cache-control', 'foo']
+          ['pragma', 'no-cache']
+        ]
+      }
+    ]
+  },
+  {
+    name: "Fetch doesn't touch Cache-Control when cache mode is default, header list contains If-Match and Pragma is already present",
+    requests: [
+      {
+        cache: "default",
+        request_headers: [
+          ['if-match', 'foo'],
+          ['pragma', 'foo']
+        ],
+        expected_request_headers: [
+          ['cache-control', 'no-cache']
+          ['pragma', 'foo']
+        ]
+      }
+    ]
+  },
+
+  /// If-Range
+  {
+    name: "Fetch sends Cache-Control: no-cache and Pragma: no-cache when cache mode is default and header list contains If-Range",
+    requests: [
+      {
+        cache: "default",
+        request_headers: [['if-range', 'foo']],
+        expected_request_headers: [
+          ['cache-control', 'no-cache'],
+          ['pragma', 'no-cache']
+        ]
+      }
+    ]
+  },
+  {
+    name: "Fetch doesn't touch Cache-Control when cache mode is default, header list contains If-Range and Cache-Control is already present",
+    requests: [
+      {
+        cache: "default",
+        request_headers: [
+          ['if-range', 'foo'],
+          ['cache-control', 'foo']
+        ],
+        expected_request_headers: [
+          ['cache-control', 'foo']
+          ['pragma', 'no-cache']
+        ]
+      }
+    ]
+  },
+  {
+    name: "Fetch doesn't touch Cache-Control when cache mode is default, header list contains If-Range and Pragma is already present",
+    requests: [
+      {
+        cache: "default",
+        request_headers: [
+          ['if-range', 'foo'],
+          ['pragma', 'foo']
+        ],
+        expected_request_headers: [
+          ['cache-control', 'no-cache']
+          ['pragma', 'foo']
+        ]
+      }
+    ]
+  },
 
   // 16. If httpRequest's cache mode is "no-cache",
   //     httpRequest's prevent no-cache cache-control header modification flag is unset,

--- a/fetch/http-cache/cache-mode.any.js
+++ b/fetch/http-cache/cache-mode.any.js
@@ -43,6 +43,8 @@ var tests = [
   //       then append (`Pragma`, `no-cache`) to httpRequest's header list.
   //    2. If httpRequest's header list does not contain `Cache-Control`,
   //        then append (`Cache-Control`, `no-cache`) to httpRequest's header list.
+
+  // mode: "no-store"
   {
     name: "Fetch sends Cache-Control: no-cache and Pragma: no-cache when cache mode is no-store",
     requests: [
@@ -74,8 +76,40 @@ var tests = [
         expected_request_headers: [['pragma', 'foo']]
       }
     ]
-  }
+  },
 
-  // TODO: "reload"
+  // mode: "reload"
+  {
+    name: "Fetch sends Cache-Control: no-cache and Pragma: no-cache when cache mode is reload",
+    requests: [
+      {
+        cache: "reload",
+        expected_request_headers: [
+          ['cache-control', 'no-cache'],
+          ['pragma', 'no-cache']
+        ]
+      }
+    ]
+  },
+  {
+    name: "Fetch doesn't touch Cache-Control when cache mode is reload and Cache-Control is already present",
+    requests: [
+      {
+        cache: "reload",
+        request_headers: [['cache-control', 'foo']],
+        expected_request_headers: [['cache-control', 'foo']]
+      }
+    ]
+  },
+  {
+    name: "Fetch doesn't touch Pragma when cache mode is reload and Pragma is already present",
+    requests: [
+      {
+        cache: "reload",
+        request_headers: [['pragma', 'foo']],
+        expected_request_headers: [['pragma', 'foo']]
+      }
+    ]
+  }
 ];
 run_tests(tests);


### PR DESCRIPTION
http-cache/cache-mode.any.js has some test around cache-mode, but some missing test can be found in spec.

- https://fetch.spec.whatwg.org/#http-network-or-cache-fetch

This PR adding them into test case.

note:
- Adding spec in comment to show what should be covered in test case
- I didn't change any style, but I feeling it's chance to fix them because change has significant amout.
- cache-mode defalt test can be parameterised, but I left them in copy-pasting style. Let me know if it better to use parameterised function.