### PR TITLE
make logging messages use utf-8

### DIFF
--- a/tools/wptrunner/wptrunner/wptlogging.py
+++ b/tools/wptrunner/wptrunner/wptlogging.py
@@ -81,6 +81,7 @@ class QueueHandler(logging.Handler):
 
     def emit(self, record):
         msg = self.format(record)
+        msg = msg.encode("utf-8")
         data = {"action": "log",
                 "level": record.levelname,
                 "thread": record.threadName,


### PR DESCRIPTION
Attempt to fix the win10 builder with encoding issues.
In this CL we force all logged messages to have utf-8 encoding.

Bug:https://bugs.chromium.org/p/chromium/issues/detail?id=1371195