### PR TITLE
Simplify chained-setTimeout.html

### DIFF
--- a/html/user-activation/chained-setTimeout.html
+++ b/html/user-activation/chained-setTimeout.html
@@ -1,63 +1,34 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
-  <script src="/resources/testdriver.js"></script>
-  <script src="/resources/testdriver-vendor.js"></script>
-  <script>
-    let chained_timeout_test = async_test("Chained setTimeout test");
+  <head>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <script>
+        function runTest() {
+            promise_test(async (t) => {
+                const { userActivation } = navigator;
+                assert_false(userActivation.isActive, "isActive must be false");
+                assert_false(userActivation.hasBeenActive, "userActivation must be false");
 
-    const max_call_depth = 3;
-    const delay_ms = 10;
+                await test_driver.click(document.body);
 
-    function testInitialStates(depth) {
-        assert_true(1 <= depth && depth <= max_call_depth);
-
-        chained_timeout_test.step_timeout(() => {
-            let test_name = "Call-depth=" + depth + ": initial activation states are false";
-            test(() => {
-                assert_false(navigator.userActivation.isActive);
-                assert_false(navigator.userActivation.hasBeenActive);
-            }, test_name);
-
-            if (depth < max_call_depth)
-                testInitialStates(depth+1);
-            else
-                test_driver.click(document.body);
-        }, delay_ms);
-    }
-
-    function testFinalStates(depth) {
-        assert_true(1 <= depth && depth <= max_call_depth);
-
-        chained_timeout_test.step_timeout(() => {
-            let test_name = "Call-depth=" + depth + ": after-click activation states are true";
-            test(() => {
-                assert_true(navigator.userActivation.isActive);
-                assert_true(navigator.userActivation.hasBeenActive);
-            }, test_name);
-
-            if (depth < max_call_depth)
-                testFinalStates(depth+1);
-            else
-                chained_timeout_test.done();
-        }, delay_ms)
-    }
-
-    function run() {
-        window.addEventListener("click", event => {
-            testFinalStates(1);
-        });
-
-        testInitialStates(1);
-    }
-  </script>
-</head>
-<body onload="run()">
-  <h1>User activation state in chained setTimeout calls</h1>
-  <p>Tests that user activation state is visible in arbitrary call depth of setTimeout.</p>
-  <ol id="instructions">
-    <li>Click anywhere in the document.
-  </ol></body>
+                for (let depth = 1; depth <= 3; depth++) {
+                    await new Promise((resolve) => {
+                        t.step_timeout(resolve, 10);
+                    });
+                    assert_true(userActivation.isActive, "isActive must be true");
+                    assert_true(userActivation.hasBeenActive, "hasBeenActive must be true");
+                }
+            }, "Chained setTimeout test");
+        }
+    </script>
+    <body onload="runTest()">
+    <h1>User activation state in chained setTimeout calls</h1>
+    <p>
+      Tests that user activation state is visible in arbitrary call depth of
+      setTimeout.
+    </p>
+  </body>
 </html>


### PR DESCRIPTION
I rewrote the test to make it more simple and better capture the intent.

It continues to check that transient activation remains active for at least 30ms. However, I removed the initial timeouts as they didn't make sense to check *before* the click actually happens.

I still don't fully agree with this test though. WebKit does set the transient activation to 5 seconds, so this should generally work. However, it still risks being flaky (if testing infrastructure is not able to deliver the timeouts in a timely manner). 