### PR TITLE
Add use-fake-ui-for-media-stream switch to chrome

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -76,8 +76,9 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
 
     # Allow audio autoplay without a user gesture.
     chrome_options["args"].append("--autoplay-policy=no-user-gesture-required")
-    # Allow WebRTC tests to call getUserMedia.
+    # Allow WebRTC tests to call getUserMedia and getDisplayMedia.
     chrome_options["args"].append("--use-fake-device-for-media-stream")
+    chrome_options["args"].append("--use-fake-ui-for-media-stream")
     # Shorten delay for Reporting <https://w3c.github.io/reporting/>.
     chrome_options["args"].append("--short-reporting-delay")
     # Point all .test domains to localhost for Chrome


### PR DESCRIPTION
This PR attempts to fix getDisplayMedia tests in Chrome.

See https://github.com/web-platform-tests/wpt/pull/36289