### PR TITLE
CORS mode fetch with POST should always send the origin

### DIFF
--- a/fetch/origin/assorted.window.js
+++ b/fetch/origin/assorted.window.js
@@ -194,7 +194,7 @@ function referrerPolicyTestString(referrerPolicy, method, destination) {
     promise_test(fetchReferrerPolicy(testObj.policy,
                                      destination.name,
                                      "cors",
-                                     (destination.name == "same-origin") ? destination.expectedOrigin : origins.HTTP_ORIGIN,
+                                     origins.HTTP_ORIGIN,
                                      "POST"),
                  referrerPolicyTestString(testObj.policy, "POST",
                                           destination.name + " fetch cors mode"));


### PR DESCRIPTION
See https://github.com/whatwg/fetch/pull/1463