### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=97239

### DIFF
--- a/css/css-align/baseline-rules/inline-table-inline-block-baseline-ref.html
+++ b/css/css-align/baseline-rules/inline-table-inline-block-baseline-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
+<title>CSS Box Alignment Test: inline-block and inline-table baselines</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#baseline-export">
+<style>
+.container {
+    border: solid 1px black;
+}
+.block {
+    display: inline-block;
+    background: aqua;
+}
+.table {
+    display: inline-table;
+    font-size: 40px;
+    background: tan;
+}
+.margin {
+    margin-block-start: 50px;
+}
+</style>
+<body>
+<div class="container">
+<div class="margin">
+    <div class="block">aaa</div>
+    <table class="table" cellspacing="0" cellpadding="0"><td>bbb</table>
+</div>
+</div>
+
+</body>
+</html>

--- a/css/css-align/baseline-rules/inline-table-inline-block-baseline-vert-rl-ref.html
+++ b/css/css-align/baseline-rules/inline-table-inline-block-baseline-vert-rl-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
+<title>CSS Box Alignment Test: inline-block and inline-table baseline synthesis</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#baseline-export">
+<style>
+.container {
+    border: solid 1px black;
+    writing-mode: vertical-rl;
+}
+.block {
+    display: inline-block;
+    background: aqua;
+}
+.table {
+    display: inline-table;
+    font-size: 40px;
+    background: tan;
+}
+.margin {
+    margin-block-start: 50px;
+}
+</style>
+<body>
+<div class="container">
+<div class="margin">
+    <div class="block">aaa</div>
+    <table class="table" cellspacing="0" cellpadding="0"><td>bbb</table>
+</div>
+</div>
+</body>
+</html>

--- a/css/css-align/baseline-rules/inline-table-inline-block-baseline-vert-rl.html
+++ b/css/css-align/baseline-rules/inline-table-inline-block-baseline-vert-rl.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
+<title>CSS Box Alignment Test: inline-block and inline-table baseline synthesis</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#baseline-export">
+<link rel="match" href="inline-table-inline-block-baseline-vert-rl-ref.html">
+<style>
+.container {
+    border: solid 1px black;
+    writing-mode: vertical-rl;
+}
+.block {
+    display: inline-block;
+    background: aqua;
+}
+.table {
+    display: inline-table;
+    font-size: 40px;
+    background: tan;
+    margin-block-start: 50px;
+}
+</style>
+<body>
+<div class="container">
+    <div class="block">aaa</div>
+    <table class="table" cellspacing="0" cellpadding="0"><td>bbb</table>
+</div>
+</body>
+</html>

--- a/css/css-align/baseline-rules/inline-table-inline-block-baseline.html
+++ b/css/css-align/baseline-rules/inline-table-inline-block-baseline.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
+<title>CSS Box Alignment Test: inline-block and inline-table baselines</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#baseline-export">
+<link rel="match" href="inline-table-inline-block-baseline-ref.html">
+<style>
+.container {
+    border: solid 1px black;
+}
+.block {
+    display: inline-block;
+    background: aqua;
+}
+.table {
+    display: inline-table;
+    font-size: 40px;
+    background: tan;
+    margin-block-start: 50px;
+}
+</style>
+<body>
+<div class="container">
+    <div class="block">aaa</div>
+    <table class="table" cellspacing="0" cellpadding="0"><td>bbb</table>
+</div>
+</body>
+</html>


### PR DESCRIPTION
These tests implicitly test the baseline alignment of inline-block and inline-table elements. In the initial writing mode (horizontal-tb), the baseline of the inline-block element is the baseline of the text and the table is the bottom of the content edge.

In the vert-rl case, the baselines will need to be syntheized.

https://www.w3.org/TR/css-align-3/#baseline-export