### PR TITLE
fix(mimesniff): normalize input in isByteCompatible

### DIFF
--- a/mimesniff/mime-types/README.md
+++ b/mimesniff/mime-types/README.md
@@ -13,6 +13,11 @@ A wrapper for these JSON MIME type tests needs to take care that not all `input`
 
 ```js
 function isByteCompatible(str) {
+  // see https://fetch.spec.whatwg.org/#concept-header-value-normalize
+  if(/^[\u0009\u0020\u000A\u000D]+|[\u0009\u0020\u000A\u000D]+$/.test(str)) {
+    return "header-value-incompatible";
+  }
+
   for(let i = 0; i < str.length; i++) {
     const charCode = str.charCodeAt(i);
     // See https://fetch.spec.whatwg.org/#concept-header-value

--- a/mimesniff/mime-types/charset-parameter.window.js
+++ b/mimesniff/mime-types/charset-parameter.window.js
@@ -4,13 +4,18 @@ promise_test(() => {
 }, "Loading data…");
 
 function isByteCompatible(str) {
+  // see https://fetch.spec.whatwg.org/#concept-header-value-normalize
+  if(/^[\u0009\u0020\u000A\u000D]+|[\u0009\u0020\u000A\u000D]+$/.test(str)) {
+    return "header-value-incompatible";
+  }
+
   for(let i = 0; i < str.length; i++) {
     const charCode = str.charCodeAt(i);
     // See https://fetch.spec.whatwg.org/#concept-header-value
     if(charCode > 0xFF) {
       return "incompatible";
     } else if(charCode === 0x00 || charCode === 0x0A || charCode === 0x0D) {
-      return "header-value-incompatible";
+      return "header-value-error";
     }
   }
   return "compatible";

--- a/mimesniff/mime-types/parsing.any.js
+++ b/mimesniff/mime-types/parsing.any.js
@@ -8,6 +8,8 @@ promise_test(() => {
 }, "Loading data…");
 
 function isByteCompatible(str) {
+  // normalize https://fetch.spec.whatwg.org/#concept-header-value-normalize
+  str = str.replace(/^[\u0009\u0020\u000A\u000D]+|[\u0009\u0020\u000A\u000D]+$/g, '');
   for(let i = 0; i < str.length; i++) {
     const charCode = str.charCodeAt(i);
     // See https://fetch.spec.whatwg.org/#concept-header-value

--- a/mimesniff/mime-types/parsing.any.js
+++ b/mimesniff/mime-types/parsing.any.js
@@ -8,15 +8,18 @@ promise_test(() => {
 }, "Loading data…");
 
 function isByteCompatible(str) {
-  // normalize https://fetch.spec.whatwg.org/#concept-header-value-normalize
-  str = str.replace(/^[\u0009\u0020\u000A\u000D]+|[\u0009\u0020\u000A\u000D]+$/g, '');
+  // see https://fetch.spec.whatwg.org/#concept-header-value-normalize
+  if(/^[\u0009\u0020\u000A\u000D]+|[\u0009\u0020\u000A\u000D]+$/.test(str)) {
+    return "header-value-incompatible";
+  }
+
   for(let i = 0; i < str.length; i++) {
     const charCode = str.charCodeAt(i);
     // See https://fetch.spec.whatwg.org/#concept-header-value
     if(charCode > 0xFF) {
       return "incompatible";
     } else if(charCode === 0x00 || charCode === 0x0A || charCode === 0x0D) {
-      return "header-value-incompatible";
+      return "header-value-error";
     }
   }
   return "compatible";
@@ -35,7 +38,10 @@ function runTests(tests) {
 
     promise_test(() => {
       const compatibleNess = isByteCompatible(val.input);
-      if(compatibleNess === "incompatible" || compatibleNess === "header-value-incompatible") {
+
+      if(compatibleNess === "header-value-incompatible") {
+        return Promise.resolve();
+      } if(compatibleNess === "incompatible" || compatibleNess === "header-value-error") {
         assert_throws_js(TypeError, () => new Request("about:blank", { headers: [["Content-Type", val.input]] }));
         assert_throws_js(TypeError, () => new Response(null, { headers: [["Content-Type", val.input]] }));
         return Promise.resolve();

--- a/mimesniff/mime-types/parsing.any.js
+++ b/mimesniff/mime-types/parsing.any.js
@@ -36,12 +36,13 @@ function runTests(tests) {
       assert_equals(new File([], "noname", { type: val.input}).type, output, "File");
     }, val.input + " (Blob/File)");
 
-    promise_test(() => {
-      const compatibleNess = isByteCompatible(val.input);
+    const compatibleNess = isByteCompatible(val.input);
+    if(compatibleNess === "header-value-incompatible") {
+      return;
+    }
 
-      if(compatibleNess === "header-value-incompatible") {
-        return Promise.resolve();
-      } if(compatibleNess === "incompatible" || compatibleNess === "header-value-error") {
+    promise_test(() => {
+      if(compatibleNess === "incompatible" || compatibleNess === "header-value-error") {
         assert_throws_js(TypeError, () => new Request("about:blank", { headers: [["Content-Type", val.input]] }));
         assert_throws_js(TypeError, () => new Response(null, { headers: [["Content-Type", val.input]] }));
         return Promise.resolve();


### PR DESCRIPTION
This PR normalizes the header value before checking if it's invalid.

The test expects a `TypeError` for the following values
https://github.com/web-platform-tests/wpt/blob/5e9bb795bc7c57a07ee258f362e50c4014108530/mimesniff/mime-types/resources/generated-mime-types.json#L194-L201

While those values are invalid headers, AFAIK the spec states that the header value should be normalized. Currently, those values can be appended to a Headers object in all browsers I've tested, and they get normalized to `x/` and `/x`