### PR TITLE
Test that History is associated with Document, not Window

### DIFF
--- a/common/object-association.js
+++ b/common/object-association.js
@@ -25,19 +25,11 @@ function runTests(propertyName, equalityOrInequalityAsserter, mustOrMustNotRepla
     const frame = iframe.contentWindow;
 
     const before = frame[propertyName];
-    assert_true(before !== undefined && before !== null, `window.${propertyName} must be implemented`);
+    assert_implements(before, `window.${propertyName} must be implemented`);
 
-    // Note: cannot use step_func_done for this because it might be called twice, per the below comment.
-    iframe.onload = t.step_func(() => {
-      if (frame.location.href === "about:blank") {
-        // Browsers are not reliable on whether about:blank fires the load event; see
-        // https://github.com/whatwg/html/issues/490
-        return;
-      }
-
+    iframe.onload = t.step_func_done(() => {
       const after = frame[propertyName];
       equalityOrInequalityAsserter(after, before);
-      t.done();
     });
 
     iframe.src = "/common/blank.html";
@@ -50,7 +42,7 @@ function runTests(propertyName, equalityOrInequalityAsserter, mustOrMustNotRepla
     const frame = iframe.contentWindow;
 
     const before = frame[propertyName];
-    assert_true(before !== undefined && before !== null, `window.${propertyName} must be implemented`);
+    assert_implements(before, `window.${propertyName} must be implemented`);
 
     iframe.remove();
 
@@ -66,7 +58,7 @@ function runTests(propertyName, equalityOrInequalityAsserter, mustOrMustNotRepla
     iframe.onload = t.step_func_done(() => {
       const frame = iframe.contentWindow;
       const before = frame[propertyName];
-      assert_true(before !== undefined && before !== null, `window.${propertyName} must be implemented`);
+      assert_implements(before, `window.${propertyName} must be implemented`);
 
       frame.document.open();
 

--- a/html/browsers/history/the-history-interface/history-associated-with-document.window.js
+++ b/html/browsers/history/the-history-interface/history-associated-with-document.window.js
@@ -1,0 +1,6 @@
+// META: title=the History object must be associated with the Document object, not the Window object
+// META: script=/common/object-association.js
+
+// See https://github.com/whatwg/html/issues/2566.
+
+testIsPerDocument("history");


### PR DESCRIPTION
This is done by expanding the object-association.js helper and using it.

See https://github.com/whatwg/html/issues/2566.