### PR TITLE
Update version detection for Edge binaries

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1431,7 +1431,7 @@ class EdgeChromium(Browser):
         except (subprocess.CalledProcessError, OSError) as e:
             self.logger.warning(f"Failed to call {binary}: {e}")
             return None
-        m = re.match(r"Microsoft Edge (.*) ", version_string)
+        m = re.match(r"Microsoft Edge ([0-9][0-9.]*)", version_string)
         if not m:
             self.logger.warning(f"Failed to extract version from: {version_string}")
             return None
@@ -1449,7 +1449,7 @@ class EdgeChromium(Browser):
         except (subprocess.CalledProcessError, OSError) as e:
             self.logger.warning(f"Failed to call {webdriver_binary}: {e}")
             return None
-        m = re.match(r"MSEdgeDriver ([0-9][0-9.]*)", version_string)
+        m = re.match(r"Microsoft Edge WebDriver ([0-9][0-9.]*)", version_string)
         if not m:
             self.logger.warning(f"Failed to extract version from: {version_string}")
             return None

--- a/tools/wpt/tests/test_browser.py
+++ b/tools/wpt/tests/test_browser.py
@@ -64,15 +64,15 @@ def test_edgechromium_webdriver_version(mocked_call):
     webdriver_binary = '/usr/bin/edgedriver'
 
     # Working cases.
-    mocked_call.return_value = 'MSEdgeDriver 84.0.4147.30'
+    mocked_call.return_value = 'Microsoft Edge WebDriver 84.0.4147.30'
     assert edge.webdriver_version(webdriver_binary) == '84.0.4147.30'
-    mocked_call.return_value = 'MSEdgeDriver 87.0.1 (abcd1234-refs/branch-heads/4147@{#310})'
+    mocked_call.return_value = 'Microsoft Edge WebDriver 87.0.1 (abcd1234-refs/branch-heads/4147@{#310})'
     assert edge.webdriver_version(webdriver_binary) == '87.0.1'
 
     # Various invalid version strings
     mocked_call.return_value = 'Edge 84.0.4147.30 (dev)'
     assert edge.webdriver_version(webdriver_binary) is None
-    mocked_call.return_value = 'MSEdgeDriver New 84.0.4147.30'
+    mocked_call.return_value = 'Microsoft Edge WebDriver New 84.0.4147.30'
     assert edge.webdriver_version(webdriver_binary) is None
     mocked_call.return_value = ''
     assert edge.webdriver_version(webdriver_binary) is None


### PR DESCRIPTION
Addresses #36042

Update the version detection for Edge browser and driver binaries. On macOS or Linux, the version is extracted from the command line output using a regex. Edge insider channels include the channel name (e.g. "Dev", "Canary") after the version string. This updates the regex to match only the version string and ignore the rest. The driver regex has also been updated to match the more recent "Microsoft Edge WebDriver" branding which is used on all channels now.