### PR TITLE
Screen orientation: don't assume -primary/secondary are supported

### DIFF
--- a/screen-orientation/active-lock.html
+++ b/screen-orientation/active-lock.html
@@ -14,7 +14,7 @@
     document.body.appendChild(fragment);
     const { type: preType } = screen.orientation;
     const isPortrait = preType.startsWith("portrait");
-    const newType = `${isPortrait ? "landscape" : "portrait"}-primary`;
+    const newType = `${isPortrait ? "landscape" : "portrait"}`;
     const p = screen.orientation.lock(newType);
     screen.orientation.onchange = t.unreached_func(
       "change event must not fire"

--- a/screen-orientation/lock-basic.html
+++ b/screen-orientation/lock-basic.html
@@ -90,10 +90,10 @@ promise_test(async t => {
   });
   const preType = screen.orientation.type;
   const isPortrait = preType.includes("portrait");
-  const newType = `${ isPortrait ? "landscape" : "portrait" }-primary`;
+  const newType = `${ isPortrait ? "landscape" : "portrait" }`;
   const p = screen.orientation.lock(newType);
   assert_equals(screen.orientation.type, preType, "Must not change orientation until next spin of event loop");
   await p;
-  assert_equals(screen.orientation.type, newType);
+  assert_true(screen.orientation.type.startsWith(newType), `Expected type to start with ${newType}`);
 }, "Test that screen.orientation.lock() is actually async");
 </script>

--- a/screen-orientation/lock-sandboxed-iframe.html
+++ b/screen-orientation/lock-sandboxed-iframe.html
@@ -35,8 +35,8 @@ promise_test(async t => {
 }, "Test without 'allow-orientation-lock' sandboxing directive");
 
 promise_test(async t => {
-  const disallowedIframe = document.getElementById("allowedIframe");
-  disallowedIframe.src = "resources/sandboxed-iframe-locking.html";
+  const allowedIframe = document.getElementById("allowedIframe");
+  allowedIframe.src = "resources/sandboxed-iframe-locking.html";
 
   const message = await wait_result();
 

--- a/screen-orientation/onchange-event-subframe.html
+++ b/screen-orientation/onchange-event-subframe.html
@@ -24,10 +24,8 @@
       return document.documentElement.requestFullscreen();
     });
     let orientations = [
-      "portrait-primary",
-      "portrait-secondary",
-      "landscape-primary",
-      "landscape-secondary",
+      "portrait",
+      "landscape",
     ];
     if (screen.orientation.type.includes("portrait")) {
       orientations = orientations.reverse();
@@ -37,9 +35,8 @@
     for (const orientation of orientations) {
       await screen.orientation.lock(orientation);
       const message = await messageWatcher.wait_for("message");
-      assert_equals(
-        message.data,
-        orientation,
+      assert_true(
+        message.data.startsWith(orientation),
         "subframe receives orientation change event"
       );
     }

--- a/screen-orientation/onchange-event.html
+++ b/screen-orientation/onchange-event.html
@@ -9,11 +9,12 @@ promise_test(async t => {
     try {
       await document.exitFullscreen();
     } catch (e) {}
+    screen.orientation.unlock();
   });
   await test_driver.bless("request full screen", () => {
     return document.documentElement.requestFullscreen();
   });
-  const type = screen.orientation.type;
+  const type = screen.orientation.type.startsWith("portrait") ? "landscape" : "portrait";
   screen.orientation.onchange = t.unreached_func("change event should not be fired");
   await screen.orientation.lock(type);
   assert_equals(screen.orientation.type, type);
@@ -30,21 +31,21 @@ promise_test(async t => {
     return document.documentElement.requestFullscreen();
   });
   let orientations = [
-    'portrait-primary',
-    'portrait-secondary',
-    'landscape-primary',
-    'landscape-secondary'
+    'portrait',
+    'landscape',
   ];
-  if (screen.orientation.type.includes('portrait')) {
+  if (screen.orientation.type.startsWith('portrait')) {
     orientations = orientations.reverse();
   }
   const orientationWatcher = new EventWatcher(t, screen.orientation, 'change');
 
   for (const orientation of orientations) {
     // change event is fired before resolving promise by lock.
-    const promise = screen.orientation.lock(orientation);
-    await orientationWatcher.wait_for('change');
-    await promise;
+    const result = await Promise.race([
+      screen.orientation.lock(orientation),
+      orientationWatcher.wait_for('change'),
+    ]);
+    assert_equals(result instanceof Event, "The event must be fired first.");
     assert_equals(screen.orientation.type, orientation);
   }
 }, "Test that orientationchange event is fired when the orientation changes.");

--- a/screen-orientation/orientation-reading.html
+++ b/screen-orientation/orientation-reading.html
@@ -31,7 +31,12 @@ promise_test(async t => {
   await test_driver.bless("request full screen", () => {
     return document.documentElement.requestFullscreen();
   });
-  await screen.orientation.lock("portrait-primary");
+  try {
+    await screen.orientation.lock("portrait-primary");
+  } catch (err) {
+    // implementation might not support locking to portrait-primary
+    return;
+  }
   const orientations =
     screen.orientation.angle === 0
       ? {
@@ -44,20 +49,35 @@ promise_test(async t => {
           primaryOrientation2: "portrait-primary",
           secondaryOrientation2: "portrait-secondary",
         };
-  await screen.orientation.lock(orientations.secondaryOrientation1);
+  try {
+    await screen.orientation.lock(orientations.secondaryOrientation1);
+  } catch (err) {
+    // implementation might not support locking to this orientation
+    return;
+  }
   assert_equals(
     screen.orientation.angle,
     180,
     "Secondary orientation 1 angle must be 180"
   );
-  await screen.orientation.lock(orientations.primaryOrientation2);
+  try {
+    await screen.orientation.lock(orientations.primaryOrientation2);
+  } catch (err) {
+    // implementation might not support locking to this orientation
+    return;
+  }
   assert_true(
     screen.orientation.angle == 90 || screen.orientation.angle == 270,
     "Primary orientation 2 angle must be either 90 or 270"
   );
   const primaryOrientation2Angle = screen.orientation.angle;
   const secondaryOrientation2Angle = primaryOrientation2Angle === 90 ? 270 : 90;
-  await screen.orientation.lock(orientations.secondaryOrientation2);
+  try {
+    await screen.orientation.lock(orientations.secondaryOrientation2);
+  } catch (err) {
+    // implementation might not support locking to this orientation
+    return;
+  }
   assert_equals(
     screen.orientation.angle,
     secondaryOrientation2Angle,
@@ -97,8 +117,8 @@ promise_test(async t => {
   const orientationWatcher = new EventWatcher(t, orientation, "change");
 
   const newOrientationType =
-    orientationType.includes("portrait") ? "landscape-primary" :
-                                           "portrait-primary";
+    orientationType.includes("portrait") ? "landscape" :
+                                           "portrait";
   const promise = orientation.lock(newOrientationType);
 
   // change event is fired before resolving promise by lock.

--- a/screen-orientation/resources/iframe-listen-orientation-change.html
+++ b/screen-orientation/resources/iframe-listen-orientation-change.html
@@ -1,5 +1,9 @@
 <script>
-window.screen.orientation.addEventListener('change', () => {
-  parent.window.postMessage(screen.orientation.type, "*");
-});
+  try {
+    window.screen?.orientation.addEventListener("change", () => {
+      parent.window.postMessage(screen.orientation.type, "*");
+    });
+  } catch (err) {
+    parent.window.postMessage(err.message, "*");
+  }
 </script>

--- a/screen-orientation/resources/iframe-listen-orientation-change.html
+++ b/screen-orientation/resources/iframe-listen-orientation-change.html
@@ -1,6 +1,6 @@
 <script>
   try {
-    window.screen?.orientation.addEventListener("change", () => {
+    window.screen.orientation.addEventListener("change", () => {
       parent.window.postMessage(screen.orientation.type, "*");
     });
   } catch (err) {

--- a/screen-orientation/resources/sandboxed-iframe-locking.html
+++ b/screen-orientation/resources/sandboxed-iframe-locking.html
@@ -5,17 +5,17 @@
 test_driver.set_test_context(parent);
 
 // At first, run simple unlock test without lock.
-screen.orientation.unlock();
+screen.orientation?.unlock();
 
 test_driver.bless("request full screen", async () => {
-  await document.documentElement.requestFullscreen();
 
   let msg = "";
   try {
-    await screen.orientation.lock("portrait-primary")
+    await document.documentElement.requestFullscreen();
+    await screen.orientation.lock("portrait")
     msg = screen.orientation.type;
   } catch (error) {
-    msg = error.name;
+    msg = `error: ${error.name} ${error.message}`;
   }
 
   try {


### PR DESCRIPTION
Fixed a potential timeout in "lock-sandboxed-iframe.html". 

Not all implementations support every type of lock. 