### PR TITLE
[CSSOM] Serialization of CSSKeyframesRule.cssText shouldn't escape id…

### DIFF
--- a/css/cssom/CSSKeyframesRule.html
+++ b/css/cssom/CSSKeyframesRule.html
@@ -63,11 +63,11 @@
 
         empty.name = "initial";
         assert_equals(empty.name, "initial", "CSSKeyframesRule name setter, CSS-wide keyword");
-        assert_equals(empty.cssText.replace(/\s/g, ""), "@keyframes\"initial\"{}", "CSSKeyframesRule cssText attribute with CSS-wide keyword name");
+        assert_equals(empty.cssText.replace(/\s/g, ""), "@keyframesinitial{}", "CSSKeyframesRule cssText attribute with CSS-wide keyword name");
 
         empty.name = "none";
         assert_equals(empty.name, "none", "CSSKeyframesRule name setter, 'none'");
-        assert_equals(empty.cssText.replace(/\s/g, ""), "@keyframes\"none\"{}", "CSSKeyframesRule cssText attribute with 'none' name");
+        assert_equals(empty.cssText.replace(/\s/g, ""), "@keyframesnone{}", "CSSKeyframesRule cssText attribute with 'none' name");
     });
     </script>
 </head>


### PR DESCRIPTION
…entifiers

According to https://www.w3.org/TR/cssom-1/#css-rules the `name` value of a CSSKeyframesRule should be output as an identifier, following https://www.w3.org/TR/cssom-1/#serialize-an-identifier This means that the value should not be escaped or surrounded by quotes.

Update the test to follow this rule.

This causes Blink and WebKit to pass the test, but causes Gecko to fail it.