### PR TITLE
Add missing test for css @supports pseudo elements

### DIFF
--- a/css/css-conditional/at-supports-047.html
+++ b/css/css-conditional/at-supports-047.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+	<head>
+		<title>CSS Test (Conditional Rules): In @supports, pseudo elements can be parsed successfully</title>
+		<link rel="author" title="Jan Nicklas" href="https://twitter.com/jantimon">
+		<link rel="help" href="http://www.w3.org/TR/css3-conditional/#at-supports">
+		<link rel="match" href="at-supports-001-ref.html">
+		<style>
+			div {
+				background:red;
+				height:100px;
+				width:100px;
+			}
+			@supports selector(input::placeholder) {
+				div { background-color:green; }
+			}
+		</style>
+	</head>
+	<body>
+		<p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+		<div></div>
+	</body>
+</html>


### PR DESCRIPTION
This pr adds an additional test for css conditions:

```css
@supports selector(input::placeholder) { }
```

Current Results:

Chrome:
<img width="378" alt="Window" src="https://user-images.githubusercontent.com/4113649/195277929-f31bcc14-2f67-4016-830c-f6ddc6f5bebf.png">

Firefox:
<img width="410" alt="Window" src="https://user-images.githubusercontent.com/4113649/195278016-414ec6af-20bb-480d-a149-008f11a0ea0c.png">

Safari TP:
<img width="383" alt="Window" src="https://user-images.githubusercontent.com/4113649/195278127-ffcb6fcd-89eb-4ad8-9310-bc1d200217c1.png">

Safari Bug: https://bugs.webkit.org/show_bug.cgi?id=241847