### PR TITLE
[wptrunner] Enable print-reftests for content shell

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/content_shell.py
+++ b/tools/wptrunner/wptrunner/browsers/content_shell.py
@@ -10,17 +10,23 @@ from . import chrome_spki_certs
 from .base import Browser, ExecutorBrowser
 from .base import get_timeout_multiplier   # noqa: F401
 from ..executors import executor_kwargs as base_executor_kwargs
-from ..executors.executorcontentshell import (ContentShellRefTestExecutor,  # noqa: F401
-                                              ContentShellCrashtestExecutor,  # noqa: F401
-                                              ContentShellTestharnessExecutor)  # noqa: F401
+from ..executors.executorcontentshell import (  # noqa: F401
+    ContentShellCrashtestExecutor,
+    ContentShellPrintRefTestExecutor,
+    ContentShellRefTestExecutor,
+    ContentShellTestharnessExecutor,
+)
 
 
 __wptrunner__ = {"product": "content_shell",
                  "check_args": "check_args",
                  "browser": "ContentShellBrowser",
-                 "executor": {"reftest": "ContentShellRefTestExecutor",
+                 "executor": {
                      "crashtest": "ContentShellCrashtestExecutor",
-                     "testharness": "ContentShellTestharnessExecutor"},
+                     "print-reftest": "ContentShellPrintRefTestExecutor",
+                     "reftest": "ContentShellRefTestExecutor",
+                     "testharness": "ContentShellTestharnessExecutor",
+                 },
                  "browser_kwargs": "browser_kwargs",
                  "executor_kwargs": "executor_kwargs",
                  "env_extras": "env_extras",


### PR DESCRIPTION
This is done by passing the `'print` specifier over stdin.

Tested with:
```shell
xvfb-run wpt run ... infrastructure/reftest/*-print.html \
    --metadata=infrastructure/metadata
```

All except `reftest_mismatch_page_margins-print.html` should pass (`@page` for changing dimensions/margins [does not currently work](https://bugs.chromium.org/p/chromium/issues/detail?id=1090628#c32), apparently).