### PR TITLE
Fix transform-translate-background-{001,002}.html ref

### DIFF
--- a/css/css-transforms/transform-translate-background-001-ref.html
+++ b/css/css-transforms/transform-translate-background-001-ref.html
@@ -6,6 +6,8 @@
 <style>
   html {
     background: green;
+    /* Match scrollbar change caused by translateY transformation */
+    margin-top: -250vh;
   }
 </style>
 <div style="height: 400vh;"></div>


### PR DESCRIPTION
The spec says transforms should only be ignored for the background-image, so the scrollbar change caused by the transform should still be reflected. Use a negative margin-top to do that.

Fixes #36454