### PR TITLE
The height of <select> with attribute size 

### DIFF
--- a/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-009.html
+++ b/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-009.html
@@ -39,14 +39,16 @@ select {
 data-expected-client-width="55" data-expected-client-height="66"></select>
 <select multiple class="test cis-width"
 data-expected-client-width="55"></select>
-<select multiple size="1" class="test cis-width"
-data-expected-client-width="55"></select>
-<select multiple size="10" class="test cis-width"
-data-expected-client-width="55"></select>
 <select multiple class="test cis-height"
 data-expected-client-height="66"></select>
+
+<select multiple size="1" class="test cis-width"
+data-expected-client-width="55"></select>
 <select multiple size="1" class="test cis-height"
 data-expected-client-height="66"></select>
+
+<select multiple size="10" class="test cis-width"
+data-expected-client-width="55"></select>
 <select multiple size="10" class="test cis-height"
 data-expected-client-height="66"></select>
 

--- a/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-009.html
+++ b/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-009.html
@@ -54,7 +54,6 @@ data-expected-client-height="66"></select>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
 <script>
-
 const reference = document.getElementById("reference");
 const normalWidth = reference.clientWidth;
 for (let test of document.querySelectorAll(".test.cis-width")) {

--- a/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-009.html
+++ b/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-009.html
@@ -31,7 +31,9 @@ select {
 </style>
 
 <!-- To measure the size of an empty <select> without size containment -->
-<select id="reference" multiple size="1"></select>
+<select id="reference-size-1" multiple size="1"></select>
+<select id="reference-size-4" multiple></select>
+<select id="reference-size-10" multiple size="10"></select>
 
 <select multiple class="test cis-both"
 data-expected-client-width="55" data-expected-client-height="66"></select>
@@ -52,12 +54,11 @@ data-expected-client-height="66"></select>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
 <script>
-const reference = document.getElementById("reference");
-const rowHeight = reference.clientHeight;
-const normalWidth = reference.clientWidth;
+const normalWidth = document.getElementById("reference-size-1").clientWidth;
 for (let test of document.querySelectorAll(".test.cis-width")) {
-  const numRows = test.size || 4;
-  test.dataset.expectedClientHeight = rowHeight * numRows;
+  let idText = "reference-size-";
+  idText += test.size ? test.size : 4;
+  test.dataset.expectedClientHeight = document.getElementById(idText).clientHeight;
 }
 for (let test of document.querySelectorAll(".test.cis-height")) {
   test.dataset.expectedClientWidth = normalWidth;

--- a/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-009.html
+++ b/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-009.html
@@ -31,9 +31,7 @@ select {
 </style>
 
 <!-- To measure the size of an empty <select> without size containment -->
-<select id="reference-size-1" multiple size="1"></select>
-<select id="reference-size-4" multiple></select>
-<select id="reference-size-10" multiple size="10"></select>
+<select id="reference" multiple size="1"></select>
 
 <select multiple class="test cis-both"
 data-expected-client-width="55" data-expected-client-height="66"></select>
@@ -56,11 +54,11 @@ data-expected-client-height="66"></select>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
 <script>
-const normalWidth = document.getElementById("reference-size-1").clientWidth;
+let reference = document.getElementById("reference");
+const normalWidth = reference.clientWidth;
 for (let test of document.querySelectorAll(".test.cis-width")) {
-  let idText = "reference-size-";
-  idText += test.size ? test.size : 4;
-  test.dataset.expectedClientHeight = document.getElementById(idText).clientHeight;
+  reference.size = test.size ? test.size : 4;
+  test.dataset.expectedClientHeight = reference.clientHeight;
 }
 for (let test of document.querySelectorAll(".test.cis-height")) {
   test.dataset.expectedClientWidth = normalWidth;

--- a/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-009.html
+++ b/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-009.html
@@ -54,7 +54,7 @@ data-expected-client-height="66"></select>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
 <script>
-let reference = document.getElementById("reference");
+const reference = document.getElementById("reference");
 const normalWidth = reference.clientWidth;
 for (let test of document.querySelectorAll(".test.cis-width")) {
   reference.size = test.size || 4;

--- a/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-009.html
+++ b/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-009.html
@@ -54,6 +54,7 @@ data-expected-client-height="66"></select>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
 <script>
+
 const reference = document.getElementById("reference");
 const normalWidth = reference.clientWidth;
 for (let test of document.querySelectorAll(".test.cis-width")) {

--- a/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-009.html
+++ b/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-009.html
@@ -57,7 +57,7 @@ data-expected-client-height="66"></select>
 let reference = document.getElementById("reference");
 const normalWidth = reference.clientWidth;
 for (let test of document.querySelectorAll(".test.cis-width")) {
-  reference.size = test.size ? test.size : 4;
+  reference.size = test.size || 4;
   test.dataset.expectedClientHeight = reference.clientHeight;
 }
 for (let test of document.querySelectorAll(".test.cis-height")) {


### PR DESCRIPTION
In this case, we expect (clientHeight of `<select size=1>` * rowNumber) is the `clientHeight` of `<select size="rowNumber">`.
I'm not sure about it. Per[1]:
> The size attribute gives the number of options to show to the user
So the height of `<select>` should be large enough to display the options.
The options have border which is not included in `clientHeight`, so the number is not larger enough to reveal all of the options. See:

```
<select multiple size="10" class="test cis-width"
data-expected-client-width="55">
<option>1</option>
<option>1</option>
<option>1</option>
<option>1</option>
<option>1</option>
<option>1</option>
<option>1</option>
<option>1</option>
<option>1</option>
<option>10</option>
</select>
```

This patch make sure that the calculation difference of <select> with attribute size doesn't affect this test.

[1] https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-size