### PR TITLE
Make user activation tests less racy

### DIFF
--- a/html/user-activation/activation-trigger-keyboard-enter.html
+++ b/html/user-activation/activation-trigger-keyboard-enter.html
@@ -8,14 +8,15 @@
   <script src="/resources/testdriver-vendor.js"></script>
   <script src="resources/utils.js"></script>
 </head>
-<body>
+<body onload="runTests()">
   <h1>Test for keyboard activation trigger for ENTER key</h1>
   <p>Tests user activation from a ENTER keyboard event.</p>
   <input type="text" autofocus />
   <ol id="instructions">
     <li>Press ENTER key.
   </ol>
-  <script defer>
+  <script>
+  function runTests() {
     promise_test(async () => {
         const ENTER_KEY = '\uE007';
 
@@ -40,6 +41,7 @@
         assert_false(consumed,
                      "ENTER keyup should have no activation after keydown consumption");
     }, "Activation through ENTER keyboard event");
+  }
   </script>
 </body>
 </html>

--- a/html/user-activation/activation-trigger-keyboard-enter.html
+++ b/html/user-activation/activation-trigger-keyboard-enter.html
@@ -15,14 +15,15 @@
   <ol id="instructions">
     <li>Press ENTER key.
   </ol>
-  <script>
+  <script defer>
     promise_test(async () => {
         const ENTER_KEY = '\uE007';
-        test_driver.send_keys(document.body, ENTER_KEY);
 
         let keydown_event = getEvent('keydown');
         let keypress_event = getEvent('keypress');
         let keyup_event = getEvent('keyup');
+
+        await test_driver.send_keys(document.body, ENTER_KEY);
 
         await keydown_event;
         let consumed = await consumeTransientActivation();

--- a/html/user-activation/activation-trigger-keyboard-escape.html
+++ b/html/user-activation/activation-trigger-keyboard-escape.html
@@ -8,14 +8,15 @@
   <script src="/resources/testdriver-vendor.js"></script>
   <script src="resources/utils.js"></script>
 </head>
-<body>
+<body onload="runTests()">
   <h1>Test for keyboard activation trigger for ESCAPE key</h1>
   <p>Tests missing user activation from a ESCAPE keyboard event.</p>
   <input type="text" autofocus />
   <ol id="instructions">
     <li>Press ESCAPE key.
   </ol>
-  <script defer>
+  <script>
+  function runTests() {
     promise_test(async () => {
         const ESCAPE_KEY = '\uE00C';
 
@@ -34,6 +35,7 @@
         assert_false(consumed,
                      "ESCAPE keyup should have no activation after keydown consumption");
     }, "Activation through ESCAPE keyboard event");
+  }
   </script>
 </body>
 </html>

--- a/html/user-activation/activation-trigger-keyboard-escape.html
+++ b/html/user-activation/activation-trigger-keyboard-escape.html
@@ -15,13 +15,14 @@
   <ol id="instructions">
     <li>Press ESCAPE key.
   </ol>
-  <script>
+  <script defer>
     promise_test(async () => {
         const ESCAPE_KEY = '\uE00C';
-        test_driver.send_keys(document.body, ESCAPE_KEY);
 
         let keydown_event = getEvent('keydown');
         let keyup_event = getEvent('keyup');
+
+        await test_driver.send_keys(document.body, ESCAPE_KEY);
 
         await keydown_event;
         let consumed = await consumeTransientActivation();

--- a/html/user-activation/activation-trigger-mouse-left.html
+++ b/html/user-activation/activation-trigger-mouse-left.html
@@ -14,13 +14,14 @@
   <ol id="instructions">
     <li>Click anywhere in the document.
   </ol>
-  <script>
+  <script defer>
     promise_test(async () => {
-        test_driver.click(document.body);
 
         let mousedown_event = getEvent('mousedown');
         let mouseup_event = getEvent('mouseup');
         let click_event = getEvent('click');
+
+        await test_driver.click(document.body);
 
         await mousedown_event;
         let consumed = await consumeTransientActivation();

--- a/html/user-activation/activation-trigger-mouse-left.html
+++ b/html/user-activation/activation-trigger-mouse-left.html
@@ -8,13 +8,14 @@
   <script src="/resources/testdriver-vendor.js"></script>
   <script src="resources/utils.js"></script>
 </head>
-<body>
+<body onload="runTests()">
   <h1>Test for click activation trigger</h1>
   <p>Tests user activation from a mouse click.</p>
   <ol id="instructions">
     <li>Click anywhere in the document.
   </ol>
-  <script defer>
+  <script>
+  function runTests() {
     promise_test(async () => {
 
         let mousedown_event = getEvent('mousedown');
@@ -38,6 +39,7 @@
         assert_false(consumed,
                      "click should have no activation after mousedown consumption");
     }, "Activation through left-click mouse event");
+  }
   </script>
 </body>
 </html>

--- a/html/user-activation/activation-trigger-mouse-right.html
+++ b/html/user-activation/activation-trigger-mouse-right.html
@@ -15,7 +15,7 @@
   <ol id="instructions">
     <li>Right-click anywhere in the document.
   </ol>
-  <script>
+  <script defer>
     promise_test(async () => {
         var actions = new test_driver.Actions();
         actions.pointerMove(0, 0, {origin: document.body})

--- a/html/user-activation/activation-trigger-mouse-right.html
+++ b/html/user-activation/activation-trigger-mouse-right.html
@@ -9,13 +9,14 @@
   <script src="/resources/testdriver-vendor.js"></script>
   <script src="resources/utils.js"></script>
 </head>
-<body>
+<body onload="runTests()">
   <h1>Test for right-click activation trigger</h1>
   <p>Tests user activation from a mouse right-click.</p>
   <ol id="instructions">
     <li>Right-click anywhere in the document.
   </ol>
-  <script defer>
+  <script>
+  function runTests() {
     promise_test(async () => {
         var actions = new test_driver.Actions();
         actions.pointerMove(0, 0, {origin: document.body})
@@ -53,6 +54,7 @@
         assert_false(consumed,
                      "contextmenu should have no activation after mousedown consumption");
     }, "Activation through right-click mouse event");
+  }
   </script>
 </body>
 </html>

--- a/html/user-activation/activation-trigger-pointerevent.html
+++ b/html/user-activation/activation-trigger-pointerevent.html
@@ -18,7 +18,7 @@
   <ol id="instructions">
     <li>Click anywhere in the document.
   </ol>
-  <script>
+  <script defer>
     let pointer_type = location.search.substring(1);
 
     promise_test(async () => {

--- a/html/user-activation/activation-trigger-pointerevent.html
+++ b/html/user-activation/activation-trigger-pointerevent.html
@@ -12,13 +12,14 @@
   <script src="/resources/testdriver-vendor.js"></script>
   <script src="resources/utils.js"></script>
 </head>
-<body>
+<body onload="runTests()">
   <h1>Test for pointerevent click activation trigger</h1>
   <p>Tests user activation from a pointer click.</p>
   <ol id="instructions">
     <li>Click anywhere in the document.
   </ol>
-  <script defer>
+  <script>
+  function runTests() {
     let pointer_type = location.search.substring(1);
 
     promise_test(async () => {
@@ -57,6 +58,7 @@
                          pointer_type + " click should have no activation after pointerup consumption");
         }
     }, "Activation through " + pointer_type + " pointerevent click");
+  }
   </script>
 </body>
 </html>

--- a/html/user-activation/consumption-sameorigin.html
+++ b/html/user-activation/consumption-sameorigin.html
@@ -18,7 +18,7 @@
     let num_children_to_load = 3;
     let num_children_to_report = 3;
 
-    function finishLoadPhase() {
+    async function finishLoadPhase() {
         assert_equals(num_children_to_load, 0);
 
         test(() => {
@@ -26,7 +26,7 @@
             assert_false(navigator.userActivation.hasBeenActive);
         }, "Parent frame initial state");
 
-        test_driver.click(document.getElementById("child-so"));
+        await test_driver.click(document.getElementById("child-so"));
     }
 
     function finishReportPhase() {
@@ -40,7 +40,7 @@
         consumption_test.done();
     }
 
-    window.addEventListener("message", event => {
+    window.addEventListener("message", async event => {
         var msg = JSON.parse(event.data);
 
         if (msg.type == 'child-one-loaded') {
@@ -84,7 +84,7 @@
         // Phase switching.
         if (msg.type.endsWith("-loaded")) {
             if (--num_children_to_load == 0)
-                finishLoadPhase();
+                await finishLoadPhase();
         } else if (msg.type.endsWith("-report")) {
             if (--num_children_to_report == 0)
                 finishReportPhase();

--- a/html/user-activation/message-event-activation-api-iframe-cross-origin.sub.tentative.html
+++ b/html/user-activation/message-event-activation-api-iframe-cross-origin.sub.tentative.html
@@ -17,7 +17,7 @@
   </ol>
   <iframe id="child" width="200" height="200">
   </iframe>
-  <script defer>
+  <script>
     async_test(function(t) {
       var child = document.getElementById("child");
       child.src = "http://{{domains[www]}}:{{ports[http][0]}}/html/user-activation/resources/child-message-event-api.html";

--- a/html/user-activation/message-event-activation-api-iframe-cross-origin.sub.tentative.html
+++ b/html/user-activation/message-event-activation-api-iframe-cross-origin.sub.tentative.html
@@ -15,12 +15,12 @@
   <ol id="instructions">
     <li>Click inside the red area.
   </ol>
-  <iframe id="child" width="200" height="200"
-          src="http://{{domains[www]}}:{{ports[http][0]}}/html/user-activation/resources/child-message-event-api.html">
+  <iframe id="child" width="200" height="200">
   </iframe>
-  <script>
+  <script defer>
     async_test(function(t) {
       var child = document.getElementById("child");
+      child.src = "http://{{domains[www]}}:{{ports[http][0]}}/html/user-activation/resources/child-message-event-api.html";
       assert_false(navigator.userActivation.isActive);
       assert_false(navigator.userActivation.hasBeenActive);
       window.addEventListener("message", t.step_func(event => {

--- a/html/user-activation/navigation-state-reset-crossorigin.sub.html
+++ b/html/user-activation/navigation-state-reset-crossorigin.sub.html
@@ -13,12 +13,12 @@
   <ol id="instructions">
     <li>Click inside the yellow area.
   </ol>
-  <iframe id="child" width="200" height="50"
-          src="http://{{domains[www1]}}:{{ports[http][0]}}/html/user-activation/resources/child-one.html">
+  <iframe id="child" width="200" height="50">
   </iframe>
   <script>
     async_test(function(t) {
       var child = document.getElementById("child");
+      child.src = "http://{{domains[www1]}}:{{ports[http][0]}}/html/user-activation/resources/child-one.html";
       window.addEventListener("message", t.step_func(event => {
           var msg = JSON.parse(event.data);
           if (msg.type == 'child-one-loaded') {

--- a/html/user-activation/navigation-state-reset-sameorigin.html
+++ b/html/user-activation/navigation-state-reset-sameorigin.html
@@ -12,13 +12,13 @@
   <ol id="instructions">
     <li>Click inside the yellow area.
   </ol>
-  <iframe id="child" width="200" height="50"
-          src="resources/child-one.html">
+  <iframe id="child" width="200" height="50">
   </iframe>
   <script>
     async_test(function(t) {
       var child = document.getElementById("child");
-      window.addEventListener("message", t.step_func(event => {
+      child.src = "resources/child-one.html";
+      window.addEventListener("message", t.step_func(async event => {
           var msg = JSON.parse(event.data);
           if (msg.type == 'child-one-loaded') {
               assert_false(navigator.userActivation.isActive);
@@ -26,7 +26,7 @@
               assert_false(msg.isActive);
               assert_false(msg.hasBeenActive);
 
-              test_driver.click(child);
+              await test_driver.click(child);
           } else if (msg.type == 'child-one-clicked') {
               assert_true(navigator.userActivation.isActive);
               assert_true(navigator.userActivation.hasBeenActive);

--- a/html/user-activation/user-activation-interface.html
+++ b/html/user-activation/user-activation-interface.html
@@ -13,7 +13,7 @@
   <ol id="instructions">
     <li>Click anywhere in the document.
   </ol>
-  <script>
+  <script defer>
     promise_test(async () => {
         assert_true(!!navigator.userActivation, "This test requires navigator.userActivation API");
 

--- a/html/user-activation/user-activation-interface.html
+++ b/html/user-activation/user-activation-interface.html
@@ -7,13 +7,14 @@
   <script src="/resources/testdriver-vendor.js"></script>
   <script src="resources/utils.js"></script>
 </head>
-<body>
+<body onload="runTests()">
   <h1>Basic test for navigator.userActivation interface</h1>
   <p>Tests that navigator.userActivation shows user activation states.</p>
   <ol id="instructions">
     <li>Click anywhere in the document.
   </ol>
-  <script defer>
+  <script>
+  function runTests() {
     promise_test(async () => {
         assert_true(!!navigator.userActivation, "This test requires navigator.userActivation API");
 
@@ -25,6 +26,7 @@
         assert_true(navigator.userActivation.hasBeenActive, "Has sticky activation after click");
         assert_true(navigator.userActivation.isActive, "Has transient activation after click");
     }, "navigator.userActivation shows correct states before/after a click");
+  }
   </script>
 </body>
 </html>


### PR DESCRIPTION
A lot of tests try to touch the body too soon, leading to hangs/failures. Adding `defer` defers the scripts until after parsing is done. 

Other tests are missing `await` in various places, making them look sync which can be confusing.  