### PR TITLE
Show complete server URL when starting server

### DIFF
--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -841,7 +841,8 @@ class WebTestHttpd:
         :param block: True to run the server on the current thread, blocking,
                       False to run on a separate thread."""
         http_type = "http2" if self.http2 else "https" if self.use_ssl else "http"
-        self.logger.info(f"Starting {http_type} server on {self.host}:{self.port}")
+        http_scheme = "https" if self.use_ssl else "http"
+        self.logger.info(f"Starting {http_type} server on {http_scheme}://{self.host}:{self.port}")
         self.started = True
         self.server_thread = threading.Thread(target=self.httpd.serve_forever)
         self.server_thread.setDaemon(True)  # don't hang on exit


### PR DESCRIPTION
This allows server URLs to be clickable in terminals like iTerm2. (otherwise it requires copy/paste and then having to manually add the scheme in the browser, which get old kinda quickly).

![Screenshot 2022-10-17 at 11 23 29 pm](https://user-images.githubusercontent.com/870154/196176115-4f9683cf-8831-457d-9bbd-5efaa20219a5.png)

