### PR TITLE
Update metadata for `webtransport-h3.https.sub.any.js`

### DIFF
--- a/infrastructure/metadata/infrastructure/server/webtransport-h3.https.sub.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/webtransport-h3.https.sub.any.js.ini
@@ -1,29 +1,23 @@
 [webtransport-h3.https.sub.any.html]
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
-      if product == "chrome": PASS
-      FAIL
-
-[webtransport-h3.https.sub.any.window.html]
-  [WebTransport server should be running and should handle a bidirectional stream]
-    expected:
-      if product == "chrome": PASS
+      if product == "chrome" and os != "mac": PASS
       FAIL
 
 [webtransport-h3.https.sub.any.worker.html]
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
-      if product == "chrome": PASS
+      if product == "chrome" and os != "mac": PASS
       FAIL
 
 [webtransport-h3.https.sub.any.sharedworker.html]
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
-      if product == "chrome": PASS
+      if product == "chrome" and os != "mac": PASS
       FAIL
 
 [webtransport-h3.https.sub.any.serviceworker.html]
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
-      if product == "chrome": PASS
+      if product == "chrome" and os != "mac": PASS
       FAIL


### PR DESCRIPTION
For now, expect a failure for "chrome" (#36504) to unblock unrelated changes.

Also, drive-by removal of a `.any.window.html` scope that doesn't exist.