### PR TITLE
Regenerate 2d.filter.canvasFilterObject.componentTransfer.identity.tentative.html

### DIFF
--- a/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.identity.tentative.html
+++ b/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.identity.tentative.html
@@ -42,3 +42,4 @@ for (const color of inputColors) {
 
 });
 </script>
+


### PR DESCRIPTION
This should make the "update-built" CI check pass again.

PR #36401 ("Batch-remove unused arguments in _assertPixel and _assertPixelApprox") seems to have accidentally removed an extra empty line that's added by the test generation scripts.