### PR TITLE
Adjust log level `warning` to `warn` to match the WebDriver BiDi spec

### DIFF
--- a/webdriver/tests/bidi/log/entry_added/console.py
+++ b/webdriver/tests/bidi/log/entry_added/console.py
@@ -47,7 +47,7 @@ async def test_text_with_argument_variation(
         ("log", "info"),
         ("table", "info"),
         ("trace", "debug"),
-        ("warn", "warning"),
+        ("warn", "warn"),
     ],
 )
 async def test_level(


### PR DESCRIPTION
Adjust WPT tests to the spec proposal: https://github.com/w3c/webdriver-bidi/pull/259