### PR TITLE
Test Resource State Pseudo-classes

### DIFF
--- a/css/selectors/media/media-loading-state.html
+++ b/css/selectors/media/media-loading-state.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta name="timeout" content="long" />
 <title>Media Loading State: the :buffering and :stalled pseudo-classes</title>
 <link
   rel="help"
@@ -24,23 +25,42 @@
       await new Promise((r) => {
         video.addEventListener("stalled", r, { once: true });
         video.src = `/media/counting.mp4?pipe=trickle(100:d1:r2)&random=${Math.random()}`;
-        video.play();
       });
-
+      const promise = video.play();
       assert_equals(
         document.querySelector("video:stalled"),
         video,
         "video is stalled"
       );
+      video.pause();
+      // Wait for the video to abort trying to play
+      try {
+        await promise;
+      } catch (err) {}
     }, "Test :stalled pseudo-classes");
 
     promise_test(async (t) => {
       const video = document.querySelector("video");
+      await new Promise((r) => {
+        video.addEventListener("stalled", r, { once: true });
+        video.src = `/media/counting.mp4?pipe=trickle(100:d1:r2)&random=${Math.random()}`;
+      });
+      video.currentTime = 10;
+      const promise = video.play();
       assert_equals(
         document.querySelector("video:buffering"),
         video,
         "video is buffering"
       );
+      video.pause();
+      // Wait for the video to abort trying to play
+      try {
+        await promise;
+      } catch (err) {}
     }, "Test :buffering pseudo-classes");
+
+    onunhandledrejection = async (event) => {
+      window.xxx = event;
+    };
   </script>
 </body>

--- a/css/selectors/media/media-loading-state.html
+++ b/css/selectors/media/media-loading-state.html
@@ -18,8 +18,6 @@
         }
       }
     }, "Test :pseudo-class syntax is supported without throwing a SyntaxError");
-    // Unfortunately, we can't test the volume-locked state because it's not
-    // possible to lock the volume of a video element with JS.
     promise_test(async (t) => {
       const video = document.querySelector("video");
       await new Promise((r) => {

--- a/css/selectors/media/media-loading-state.html
+++ b/css/selectors/media/media-loading-state.html
@@ -18,6 +18,7 @@
         }
       }
     }, "Test :pseudo-class syntax is supported without throwing a SyntaxError");
+
     promise_test(async (t) => {
       const video = document.querySelector("video");
       await new Promise((r) => {

--- a/css/selectors/media/media-loading-state.html
+++ b/css/selectors/media/media-loading-state.html
@@ -2,7 +2,7 @@
 <title>Media Loading State: the :buffering and :stalled pseudo-classes</title>
 <link
   rel="help"
-  href="https://w3c.github.io/csswg-drafts/selectors/#sound-state"
+  href="https://w3c.github.io/csswg-drafts/selectors/#media-loading-state"
 />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/css/selectors/media/media-loading-state.html
+++ b/css/selectors/media/media-loading-state.html
@@ -32,7 +32,7 @@
         video,
         "video is stalled"
       );
-      video.pause();
+      video.src = "";
       // Wait for the video to abort trying to play
       try {
         await promise;
@@ -52,15 +52,11 @@
         video,
         "video is buffering"
       );
-      video.pause();
+      video.src = "";
       // Wait for the video to abort trying to play
       try {
         await promise;
       } catch (err) {}
     }, "Test :buffering pseudo-classes");
-
-    onunhandledrejection = async (event) => {
-      window.xxx = event;
-    };
   </script>
 </body>

--- a/css/selectors/media/media-loading-state.html
+++ b/css/selectors/media/media-loading-state.html
@@ -18,7 +18,8 @@
         }
       }
     }, "Test :pseudo-class syntax is supported without throwing a SyntaxError");
-
+    // Unfortunately, we can't test the volume-locked state because it's not
+    // possible to lock the volume of a video element with JS.
     promise_test(async (t) => {
       const video = document.querySelector("video");
       await new Promise((r) => {

--- a/css/selectors/media/media-loading-state.html
+++ b/css/selectors/media/media-loading-state.html
@@ -37,7 +37,7 @@
       try {
         await promise;
       } catch (err) {}
-    }, "Test :stalled pseudo-classes");
+    }, "Test :stalled pseudo-class");
 
     promise_test(async (t) => {
       const video = document.querySelector("video");
@@ -57,6 +57,6 @@
       try {
         await promise;
       } catch (err) {}
-    }, "Test :buffering pseudo-classes");
+    }, "Test :buffering pseudo-class");
   </script>
 </body>

--- a/css/selectors/media/media-loading-state.html
+++ b/css/selectors/media/media-loading-state.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<title>Media Loading State: the :buffering and :stalled pseudo-classes</title>
+<link
+  rel="help"
+  href="https://w3c.github.io/csswg-drafts/selectors/#sound-state"
+/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+  <video width="300" height="300" muted loop controls></video>
+  <script type="module">
+    test((t) => {
+      for (const pseudo of [":buffering", ":stalled"]) {
+        try {
+          document.querySelector(`.not-a-thing${pseudo}`);
+        } catch (e) {
+          assert_unreached(`${pseudo} is not supported`);
+        }
+      }
+    }, "Test :pseudo-class syntax is supported without throwing a SyntaxError");
+
+    promise_test(async (t) => {
+      const video = document.querySelector("video");
+      await new Promise((r) => {
+        video.addEventListener("stalled", r, { once: true });
+        video.src = `/media/counting.mp4?pipe=trickle(100:d1:r2)&random=${Math.random()}`;
+        video.play();
+      });
+
+      assert_equals(
+        document.querySelector("video:stalled"),
+        video,
+        "video is stalled"
+      );
+    }, "Test :stalled pseudo-classes");
+
+    promise_test(async (t) => {
+      const video = document.querySelector("video");
+      assert_equals(
+        document.querySelector("video:buffering"),
+        video,
+        "video is buffering"
+      );
+    }, "Test :buffering pseudo-classes");
+  </script>
+</body>

--- a/css/selectors/media/media-playback-state.html
+++ b/css/selectors/media/media-playback-state.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<title>
+  Media Playback State: the :playing, :paused, and :seeking pseudo-classes
+</title>
+<link
+  rel="help"
+  href="https://w3c.github.io/csswg-drafts/selectors/#video-state"
+/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+  <video width="300" height="300" muted loop></video>
+  <script>
+    test((t) => {
+      for (const pseudo of [":playing", ":paused", ":seeking"]) {
+        try {
+          document.querySelector(`.not-a-thing${pseudo}`);
+        } catch (e) {
+          assert_unreached(`${pseudo} is not supported`);
+        }
+      }
+    }, "Test :pseudo-class syntax is supported without throwing a SyntaxError");
+
+    promise_test(async (t) => {
+      const video = document.querySelector("video");
+      await new Promise((r) => {
+        video.addEventListener("canplay", r, { once: true });
+        video.src = "/media/counting.mp4";
+      });
+      video.muted = true; // allows us to play the video
+      assert_true(video.muted, "video is muted");
+      assert_true(video.paused, "video is paused");
+      await new Promise((r) => {
+        video.addEventListener("playing", r, { once: true });
+        video.play();
+      });
+      assert_false(video.paused, "video is playing");
+      assert_equals(document.querySelector("video:playing"), video);
+      assert_equals(document.querySelector("video:not(:playing)"), null);
+      assert_equals(document.querySelector("video:paused"), null);
+      assert_equals(document.querySelector("video:not(:paused)"), video);
+    }, "Test :playing pseudo-classes");
+
+    promise_test(async (t) => {
+      const video = document.querySelector("video");
+      await new Promise((r) => {
+        video.addEventListener("canplay", r, { once: true });
+        video.src = "/media/counting.mp4";
+      });
+      assert_equals(video.paused, true);
+      assert_equals(document.querySelector("video:playing"), null);
+      assert_equals(document.querySelector("video:not(:playing)"), video);
+      assert_equals(document.querySelector("video:paused"), video);
+      assert_equals(document.querySelector("video:not(:paused)"), null);
+    }, "Test :paused pseudo-classes");
+
+    promise_test(async (t) => {
+      const video = document.querySelector("video");
+      await new Promise((r) => {
+        video.addEventListener("canplay", r, { once: true });
+        video.src = "/media/counting.mp4";
+      });
+      assert_equals(document.querySelector("video:seeking"), null);
+      assert_equals(document.querySelector("video:not(:seeking)"), video);
+      await new Promise((r) => {
+        video.addEventListener("seeking", r, { once: true });
+        video.currentTime = 10;
+      });
+      assert_equals(document.querySelector("video:seeking"), video);
+      assert_equals(document.querySelector("video:not(:seeking)"), null);
+    }, "Test :seeking pseudo-class");
+  </script>
+</body>

--- a/css/selectors/media/sound-state.html
+++ b/css/selectors/media/sound-state.html
@@ -38,6 +38,5 @@
       assert_equals(document.querySelector("video:muted"), video);
       assert_equals(document.querySelector("video:not(:muted)"), null);
     }, "Test :muted pseudo-classes");
-
   </script>
 </body>

--- a/css/selectors/media/sound-state.html
+++ b/css/selectors/media/sound-state.html
@@ -39,14 +39,5 @@
       assert_equals(document.querySelector("video:not(:muted)"), null);
     }, "Test :muted pseudo-classes");
 
-    promise_test(async (t) => {
-      // Unfortunately, we can't test the volume-locked state because it's not
-      // possible to lock the volume of a video element with JS.
-      assert_equals(
-        document.querySelector("video:volume-locked"),
-        null,
-        "must know :volume-locked"
-      );
-    }, "Test :volume-locked pseudo-classes");
   </script>
 </body>

--- a/css/selectors/media/sound-state.html
+++ b/css/selectors/media/sound-state.html
@@ -9,6 +9,9 @@
 <body>
   <video width="300" height="300" muted loop></video>
   <script type="module">
+    // Unfortunately, we can't test the volume-locked state because it's not
+    // possible to lock the volume of a video element with JS.
+    
     test((t) => {
       for (const pseudo of [":muted", ":volume-locked"]) {
         try {

--- a/css/selectors/media/sound-state.html
+++ b/css/selectors/media/sound-state.html
@@ -11,7 +11,7 @@
   <script type="module">
     // Unfortunately, we can't test the volume-locked state because it's not
     // possible to lock the volume of a video element with JS.
-    
+
     test((t) => {
       for (const pseudo of [":muted", ":volume-locked"]) {
         try {

--- a/css/selectors/media/sound-state.html
+++ b/css/selectors/media/sound-state.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<title>Sound State: the :muted and :volume-locked pseudo-classes</title>
+<link
+  rel="help"
+  href="https://w3c.github.io/csswg-drafts/selectors/#sound-state"
+/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+  <video width="300" height="300" muted loop></video>
+  <script type="module">
+    test((t) => {
+      for (const pseudo of [":muted", ":volume-locked"]) {
+        try {
+          document.querySelector(`.not-a-thing${pseudo}`);
+        } catch (e) {
+          assert_unreached(`${pseudo} is not supported`);
+        }
+      }
+    }, "Test :pseudo-class syntax is supported without throwing a SyntaxError");
+
+    promise_test(async (t) => {
+      assert_equals(
+        document.querySelector("video:muted"),
+        null,
+        "must know :muted"
+      );
+      const video = document.querySelector("video");
+      await new Promise((r) => {
+        video.addEventListener("canplay", r, { once: true });
+        video.src = "/media/counting.mp4";
+      });
+      video.muted = false;
+      assert_false(video.muted, "video is unmuted");
+      assert_equals(document.querySelector("video:muted"), null);
+      assert_equals(document.querySelector("video:not(:muted)"), video);
+      video.muted = true;
+      assert_equals(document.querySelector("video:muted"), video);
+      assert_equals(document.querySelector("video:not(:muted)"), null);
+    }, "Test :muted pseudo-classes");
+
+    promise_test(async (t) => {
+      // Unfortunately, we can't test the volume-locked state because it's not
+      // possible to lock the volume of a video element with JS.
+      assert_equals(
+        document.querySelector("video:volume-locked"),
+        null,
+        "must know :volume-locked"
+      );
+    }, "Test :volume-locked pseudo-classes");
+  </script>
+</body>

--- a/css/selectors/media/sound-state.html
+++ b/css/selectors/media/sound-state.html
@@ -7,7 +7,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-  <video width="300" height="300" muted loop></video>
+  <video width="300" height="300" loop></video>
   <script type="module">
     // Unfortunately, we can't test the volume-locked state because it's not
     // possible to lock the volume of a video element with JS.
@@ -40,6 +40,6 @@
       video.muted = true;
       assert_equals(document.querySelector("video:muted"), video);
       assert_equals(document.querySelector("video:not(:muted)"), null);
-    }, "Test :muted pseudo-classes");
+    }, "Test :muted pseudo-class");
   </script>
 </body>


### PR DESCRIPTION
Tests for https://github.com/web-platform-tests/interop/issues/224

Ported over from WebKit's internal tests. 

I'm a bit unsure if the `:buffering` and `:stalled` will be flaky (shouldn't be 🤞🙏)... HTML spec says video should stall after ~3 seconds, which indeed it does. Regardless, wee might want someone with media experience to check them? 
 
I'll run them a few thousand times on WebKit to see if they are ok. 
