### PR TITLE
Use boxes instead of text in t425-hsla-basic-a.xht

### DIFF
--- a/css/css-color/t425-hsla-basic-a-ref.html
+++ b/css/css-color/t425-hsla-basic-a-ref.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Reference</title>
 <style>
-    div { width: 600px; height: 30px; background-color: #66FF66; }
+    div { width: 600px; height: 30px; margin-bottom: 10px; background-color: #66FF66; }
 </style>
 <body>
     <div></div>

--- a/css/css-color/t425-hsla-basic-a-ref.html
+++ b/css/css-color/t425-hsla-basic-a-ref.html
@@ -5,7 +5,7 @@
     div { width: 600px; height: 30px; margin-bottom: 10px; background-color: #66FF66; }
 </style>
 <body>
-    <p>The two boxes render the same color on screen.</p>
+    <p>Test passes if the two boxes below are the same color.</p>
     <div></div>
     <div></div>
 </body>

--- a/css/css-color/t425-hsla-basic-a-ref.html
+++ b/css/css-color/t425-hsla-basic-a-ref.html
@@ -2,9 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Reference</title>
 <style>
-    #one { color: #66FF66; }
+    div { width: 600px; height: 30px; color: #66FF66; }
 </style>
 <body>
-    <p id="one">This text should be light green (the same color as the line below).</p>
-    <p id="one">This text should be light green (the same color as the line above).</p>
+    <div></div>
+    <div></div>
 </body>

--- a/css/css-color/t425-hsla-basic-a-ref.html
+++ b/css/css-color/t425-hsla-basic-a-ref.html
@@ -5,6 +5,7 @@
     div { width: 600px; height: 30px; margin-bottom: 10px; background-color: #66FF66; }
 </style>
 <body>
+    <p>The two boxes render the same color on screen.</p>
     <div></div>
     <div></div>
 </body>

--- a/css/css-color/t425-hsla-basic-a-ref.html
+++ b/css/css-color/t425-hsla-basic-a-ref.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Reference</title>
 <style>
-    div { width: 600px; height: 30px; color: #66FF66; }
+    div { width: 600px; height: 30px; background-color: #66FF66; }
 </style>
 <body>
     <div></div>

--- a/css/css-color/t425-hsla-basic-a.xht
+++ b/css/css-color/t425-hsla-basic-a.xht
@@ -9,12 +9,13 @@
 		<meta name="assert" content="Test basic functioning of hsla() colors." />
 		<style type="text/css"><![CDATA[
 		html, body { background: white; }
-		#one { color: hsla(120, 100%, 70%, 1.0); }
-		#two { color: hsla(120, 100%, 50%, 0.6); }
+		div { width: 600px; height: 30px; }
+		#one { background-color: hsla(120, 100%, 70%, 1.0); }
+		#two { background-color: hsla(120, 100%, 50%, 0.6); }
 		]]></style>
 	</head>
 	<body>
-		<p id="one">This text should be light green (the same color as the line below).</p>
-		<p id="two">This text should be light green (the same color as the line above).</p>
+		<div id="one">This text should be light green (the same color as the line below).</div>
+		<div id="two">This text should be light green (the same color as the line above).</div>
 	</body>
 </html>

--- a/css/css-color/t425-hsla-basic-a.xht
+++ b/css/css-color/t425-hsla-basic-a.xht
@@ -15,7 +15,7 @@
 		]]></style>
 	</head>
 	<body>
-		<div id="one">This text should be light green (the same color as the line below).</div>
-		<div id="two">This text should be light green (the same color as the line above).</div>
+		<div id="one"></div>
+		<div id="two"></div>
 	</body>
 </html>

--- a/css/css-color/t425-hsla-basic-a.xht
+++ b/css/css-color/t425-hsla-basic-a.xht
@@ -15,6 +15,7 @@
 		]]></style>
 	</head>
 	<body>
+		<p>The two boxes render the same color on screen.</p>
 		<div id="one"></div>
 		<div id="two"></div>
 	</body>

--- a/css/css-color/t425-hsla-basic-a.xht
+++ b/css/css-color/t425-hsla-basic-a.xht
@@ -15,7 +15,7 @@
 		]]></style>
 	</head>
 	<body>
-		<p>The two boxes render the same color on screen.</p>
+		<p>Test passes if the two boxes below are the same color.</p>
 		<div id="one"></div>
 		<div id="two"></div>
 	</body>

--- a/css/css-color/t425-hsla-basic-a.xht
+++ b/css/css-color/t425-hsla-basic-a.xht
@@ -9,7 +9,7 @@
 		<meta name="assert" content="Test basic functioning of hsla() colors." />
 		<style type="text/css"><![CDATA[
 		html, body { background: white; }
-		div { width: 600px; height: 30px; }
+		div { width: 600px; height: 30px; margin-bottom: 10px; }
 		#one { background-color: hsla(120, 100%, 70%, 1.0); }
 		#two { background-color: hsla(120, 100%, 50%, 0.6); }
 		]]></style>


### PR DESCRIPTION
The main purpose of this test is to test the basic functioning of hsla colors, however it is affected by anti-aliasing issues in WebKit that are secondary to what the test is testing. By using boxes, this anti-aliasing issue can be avoided.