### PR TITLE
Use Ahem in t422-rgba-a0.6-a.xht and t32-opacity-basic-0.6-a.xht

### DIFF
--- a/css/css-color/t32-opacity-basic-0.6-a-ref.html
+++ b/css/css-color/t32-opacity-basic-0.6-a-ref.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
-  .test { color: rgb(102, 102, 102); }
+    .test { font-family: Ahem; color: rgb(102, 102, 102); }
 </style>
 <body>
+    <p>The test passes if the two lines below look identical:</p>
     <p class="test">This text should be the same color as the line below.</p>
     <p class="test">This text should be the same color as the line above.</p>
 </body>

--- a/css/css-color/t32-opacity-basic-0.6-a.xht
+++ b/css/css-color/t32-opacity-basic-0.6-a.xht
@@ -7,15 +7,17 @@
 		<link rel="help" href="http://www.w3.org/TR/css3-color/#transparency" />
 		<link rel="help" href="http://www.w3.org/TR/css3-color/#rgb-color" />
 		<link rel="match" href="t32-opacity-basic-0.6-a-ref.html" />
+		<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 		<meta name="assert" content="Opacity of 0.6 makes box partially opaque.  Colors are in sRGB color space (may test)." />
 		<style type="text/css"><![CDATA[
 			html, body { background: white; color: black; }
-			p { color: black; }
+			#one, #two { font-family: Ahem; }
 			#one { color: rgb(102, 102, 102); }
 			#two { opacity: 0.6; }
 		]]></style>
 	</head>
 	<body>
+		<p>The test passes if the two lines below look identical:</p>
 		<p id="one">This text should be the same color as the line below.</p>
 		<p id="two">This text should be the same color as the line above.</p>
 	</body>

--- a/css/css-color/t422-rgba-a0.6-a.xht
+++ b/css/css-color/t422-rgba-a0.6-a.xht
@@ -7,15 +7,17 @@
 		<link rel="help" href="http://www.w3.org/TR/css3-color/#rgba-color" />
 		<link rel="help" href="http://www.w3.org/TR/css3-color/#rgb-color" />
 		<link rel="match" href="t32-opacity-basic-0.6-a-ref.html" />
+		<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 		<meta name="assert" content="Opacity of 0.6 makes text partially opaque.  Colors are in sRGB color space (may test)." />
 		<style type="text/css"><![CDATA[
 			html, body { background: white; color: black; }
-			p { color: black; }
+			#one, #two { font-family: Ahem; }
 			#one { color: rgb(102, 102, 102); }
 			#two { color: rgba(0, 0, 0, 0.6); }
 		]]></style>
 	</head>
 	<body>
+		<p>The test passes if the two lines below look identical:</p>
 		<p id="one">This text should be the same color as the line below.</p>
 		<p id="two">This text should be the same color as the line above.</p>
 	</body>


### PR DESCRIPTION
These tests are about alpha colors and opacity, however they are affected by anti-aliasing issues in WebKit that are secondary. By using Ahem, anti-aliasing issues can be avoided.