### PR TITLE
[wptmanifest] Allow atoms in a group block

### DIFF
--- a/tools/wptrunner/wptrunner/wptmanifest/parser.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/parser.py
@@ -599,6 +599,8 @@ class Parser:
             self.expression_values()
             if self.token[0] == token_types.string:
                 self.value()
+            elif self.token[0] == token_types.atom:
+                self.atom()
             elif self.token[0] == token_types.list_start:
                 self.consume()
                 self.list_value()

--- a/tools/wptrunner/wptrunner/wptmanifest/tests/test_serializer.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/tests/test_serializer.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 
+import textwrap
 import unittest
 
 from .. import parser, serializer
@@ -145,6 +146,15 @@ class TokenizerTest(unittest.TestCase):
         self.compare(br"""key: \]
         """, """key: ]
 """)
+
+    def test_atom_as_default(self):
+        self.compare(
+            textwrap.dedent(
+                """\
+                key:
+                  if a == 1: @True
+                  @False
+                """).encode())
 
     def test_escape_0(self):
         self.compare(br"""k\t\:y: \a\b\f\n\r\t\v""",


### PR DESCRIPTION
This change fixes an unintuitive parse failure that occurs from writing something like:
```
disabled:
  @False
```

Whereas this parses OK:
```
disabled: @False
```