### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=246876

### DIFF
--- a/web-animations/timing-model/animations/setting-the-current-time-of-an-animation.html
+++ b/web-animations/timing-model/animations/setting-the-current-time-of-an-animation.html
@@ -48,10 +48,10 @@ promise_test(async t => {
 promise_test(async t => {
   const animation = createDiv(t).animate(null, 100 * MS_PER_SEC);
 
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.currentTime = CSSNumericValue.parse("30%");
   });
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.currentTime = CSSNumericValue.parse("30deg");
   });
 

--- a/web-animations/timing-model/animations/setting-the-start-time-of-an-animation.html
+++ b/web-animations/timing-model/animations/setting-the-start-time-of-an-animation.html
@@ -16,10 +16,10 @@ promise_test(async t => {
     new Animation(new KeyframeEffect(createDiv(t), null, 100 * MS_PER_SEC),
                   null);
 
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.startTime = CSSNumericValue.parse("30%");
   });
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.startTime = CSSNumericValue.parse("30deg");
   });
 


### PR DESCRIPTION
WebKit export from bug: [\[web-animations\] support CSSNumberish? values for Animation.startTime and Animation.currentTime setters](https://bugs.webkit.org/show_bug.cgi?id=246876)