### PR TITLE
[Reporting API] generateTestReport sends to endpoint

### DIFF
--- a/reporting/generateTestReport-honors-endpoint.https.sub.html
+++ b/reporting/generateTestReport-honors-endpoint.https.sub.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html>
+<head>
+  <title>Test that the reporting-api generate_test_report feature honors endpoints</title>
+  <link rel="author" title="Brent Fulgham" href="bfulgham@apple.com">
+  <script src='/resources/testharness.js'></script>
+  <script src='/resources/testharnessreport.js'></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src='resources/report-helper.js'></script>
+</head>
+<body>
+  <script>
+    const base_url = `${location.protocol}//${location.host}`;
+    const endpoint = `${base_url}/reporting/resources/report.py`;
+    const id = '41534b09-65b2-498a-9fd3-104281ed63ce';
+
+    function checkReportIsValid(reports, type, url) {
+      for (const report of reports) {
+        if (report.type !== type) continue;
+        if (report.url.endsWith("reporting/generateTestReport-honors-endpoint.https.sub.html"))
+          return true;
+      }
+      assert_unreached(`A report of ${type} from ${url} was not found.`);
+    }
+
+    async_test(function(test) {
+      var observer = new ReportingObserver(function(reports) {
+        test.step(function() {
+          assert_equals(reports.length, 1);
+          // Ensure that the contents of the report are valid.
+          assert_equals(reports[0].type, "test");
+          assert_true(reports[0].url.endsWith("reporting/generateTestReport-honors-endpoint.https.sub.html"));
+          assert_equals(reports[0].body.message, "Test message.");
+        });
+        test.done();
+      });
+      observer.observe();
+
+      // This should result in a "test" type report being generated and observed.
+      test_driver.generate_test_report("Test message.")
+        .catch(test.unreached_func('generate test report failed'));
+    }, "Generate Test Report");
+
+    promise_test(async t => {
+      const reports = await pollReports(endpoint, id);
+      checkReportIsValid(reports, 'test', location.href);
+    }, "Reporting-Endpoints target received the test report.");
+</script>
+</body>
+</html>

--- a/reporting/generateTestReport-honors-endpoint.https.sub.html.sub.headers
+++ b/reporting/generateTestReport-honors-endpoint.https.sub.html.sub.headers
@@ -1,0 +1,1 @@
+Reporting-Endpoints: default="https://{{host}}:{{ports[https][0]}}/reporting/resources/report.py?reportID=41534b09-65b2-498a-9fd3-104281ed63ce"


### PR DESCRIPTION
[Reporting API] Test reports should go "Reporting-Endpoints" Endpoints
This PR adds a new test that violation reports generated by the 'generateTestReport' function are sent to the endpoint specified in the "Reporting-Endpoints" header.

Webkit export of https://bugs.webkit.org/show_bug.cgi?id=244907
