### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=245100

### DIFF
--- a/css/css-scroll-snap/scroll-margin-visibility-check.html
+++ b/css/css-scroll-snap/scroll-margin-visibility-check.html
@@ -19,7 +19,7 @@ body { margin: 0 }
   height: 100px;
   background-color: blue;
   scroll-margin: 100px;
-  margin-left: 450px;
+  margin-left: 510px;
 }
 </style>
 
@@ -32,9 +32,12 @@ body { margin: 0 }
 <script>
 let scroller = document.getElementById("scroller");
 let target = document.getElementById("target");
-test(t => {
+promise_test(async function() {
   scroller.scrollTo(0, 0);
-  target.focus();
+  await new Promise(resolve => {
+      scroller.addEventListener("scroll", () => step_timeout(resolve, 0));
+      document.getElementById("target").focus();
+  });
   assert_true(scroller.scrollTop > 0, "Visibility check should not account for margin");
   assert_true(scroller.scrollLeft > 0, "Visibility check should not account for margin");
 });


### PR DESCRIPTION
[css-scroll-snap] focus should not take into account scroll margin for visibility check https://commits.webkit.org/254732@main

Author is @nmoucht.