### PR TITLE
[wptrunner] Dedup content shell command line args

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/content_shell.py
+++ b/tools/wptrunner/wptrunner/browsers/content_shell.py
@@ -40,7 +40,7 @@ def check_args(**kwargs):
 
 
 def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
-    args = kwargs["binary_args"]
+    args = list(kwargs["binary_args"])
 
     args.append("--ignore-certificate-errors-spki-list=%s" %
         ','.join(chrome_spki_certs.IGNORE_CERTIFICATE_ERRORS_SPKI_LIST))


### PR DESCRIPTION
Return a copy of the binary args list in `content_shell.browser_kwargs` instead of mutating the original so that the same args are not added multiple times.