### PR TITLE
Scrollend will not fire when no scrolling occurs

### DIFF
--- a/dom/events/scrolling/scrollend-event-fired-to-element-with-overscroll-behavior.html
+++ b/dom/events/scrolling/scrollend-event-fired-to-element-with-overscroll-behavior.html
@@ -81,12 +81,20 @@ function runTest() {
         'on target.');
     assert_equals(target_div.scrollLeft, 0);
 
-    // Scroll up on target div and wait for the element with overscroll-y to get
-    // scrollend event.
+    let touchEndPromise = new Promise((resolve) => {
+      target_div.addEventListener("touchend", resolve);
+    });
     await touchScrollInTarget(300, target_div, 'up');
-    await waitFor(() => { return vertical_scrollend_arrived; },
-        'Expected element did not receive scrollend event after scroll up on ' +
-        'target.');
+
+    // The scrollend event should never be fired before the gesture has completed.
+    await touchEndPromise;
+
+    // Ensure we wait at least a tick after the touch end.
+    await waitForCompositorCommit();
+
+    // We should not trigger a scrollend event for a scroll that did not change
+    // the scroll position.
+    assert_equals(vertical_scrollend_arrived, false);
     assert_equals(target_div.scrollTop, 0);
   }, 'Tests that the last element in the cut scroll chain gets scrollend ' +
      'event when no element scrolls by touch.');


### PR DESCRIPTION
If the scroll position does not change, no scrollend event is fired following a scroll. Update the scrollend tests to reflect this.

Related to: https://github.com/w3c/csswg-drafts/issues/7927