### PR TITLE
[wptrunner] Remove metadata key to suppress subtests

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -613,16 +613,10 @@ class TestRunnerManager(threading.Thread):
         # Write the result of each subtest
         file_result, test_results = results
         subtest_unexpected = False
-        expect_any_subtest_status = test.expect_any_subtest_status()
-        if expect_any_subtest_status:
-            self.logger.debug("Ignoring subtest statuses for test %s" % test.id)
         for result in test_results:
             if test.disabled(result.name):
                 continue
-            if expect_any_subtest_status:
-                expected = result.status
-            else:
-                expected = test.expected(result.name)
+            expected = test.expected(result.name)
             known_intermittent = test.known_intermittent(result.name)
             is_unexpected = expected != result.status and result.status not in known_intermittent
 

--- a/tools/wptrunner/wptrunner/tests/test_wpttest.py
+++ b/tools/wptrunner/wptrunner/tests/test_wpttest.py
@@ -71,11 +71,6 @@ test_6 = b"""\
   expected: [OK, FAIL]
 """
 
-test_7 = b"""\
-[7.html]
-  blink_expect_any_subtest_status: yep
-"""
-
 test_fuzzy = b"""\
 [fuzzy.html]
   fuzzy: fuzzy-ref.html:1;200
@@ -205,12 +200,6 @@ def test_known_intermittent():
     test_obj = make_test_object(test_6, "a/6.html", 6, ("test", "a", 7), None, False)
     assert test_obj.expected() == "OK"
     assert test_obj.known_intermittent() == ["FAIL"]
-
-
-def test_expect_any_subtest_status():
-    test_obj = make_test_object(test_7, "a/7.html", 7, ("test", "a", 8), None, False)
-    assert test_obj.expected() == "OK"
-    assert test_obj.expect_any_subtest_status() is True
 
 
 def test_metadata_fuzzy():

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -437,17 +437,6 @@ class Test:
         except KeyError:
             return []
 
-    def expect_any_subtest_status(self):
-        metadata = self._get_metadata()
-        if metadata is None:
-            return False
-        try:
-            # This key is used by the Blink CI to ignore subtest statuses
-            metadata.get("blink_expect_any_subtest_status")
-            return True
-        except KeyError:
-            return False
-
     def __repr__(self):
         return f"<{self.__module__}.{self.__class__.__name__} {self.id}>"
 


### PR DESCRIPTION
In Chromium, WPT metadata was previously automatically generated from a Chromium-specific expectations format that only recorded test-level statuses. The way wptrunner in Chromium dealt with non-PASS subtests was to suppress any with the `blink_expect_any_subtest_status` key. This hack is no longer needed after Chromium adopts checked-in WPT metadata.