### PR TITLE
Test javascript: URL-created document properties

### DIFF
--- a/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-load-as-html.xhtml
+++ b/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-load-as-html.xhtml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="windows-1250"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="../resources/helpers.js"></script>
+  <meta charset="windows-1250"/>
+  <title>javascript: URL navigation to a string must create a HTML document using the correct properties</title>
+</head>
+<body>
+  <!--
+    This document is XHTML and windows-1250 so that we can test the resulting javascript: URL document is not.
+    The same for the window we open.
+  -->
+  <script><![CDATA[
+  promise_test(async (t) => {
+    const w = await openWindow("resources/xhtml-and-non-utf-8.xhtml", t);
+
+    w.location.href = `javascript:'a string<script>
+      opener.postMessage({
+        compatMode: document.compatMode,
+        contentType: document.contentType,
+        characterSet: document.characterSet,
+        doctypeIsNull: document.doctype === null
+      }, "*");
+    <` + `/script>'`;
+
+    const results = await waitForMessage(w);
+
+    assert_equals(results.compatMode, "BackCompat");
+    assert_equals(results.contentType, "text/html");
+    assert_equals(results.characterSet, "UTF-8");
+    assert_equals(results.doctypeIsNull, true);
+  });
+  ]]></script>
+</body>
+</html>

--- a/html/browsers/browsing-the-web/navigating-across-documents/resources/xhtml-and-non-utf-8.xhtml
+++ b/html/browsers/browsing-the-web/navigating-across-documents/resources/xhtml-and-non-utf-8.xhtml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="windows-1250"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="windows-1250"/>
+  <title>A test document used when you need something very non-default</title>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
They need to be UTF-8, text/html, and quirks mode, even if the previous page was not and their navigation initiator was not.