### PR TITLE
feat(streams): detach buffer using structuredClone

### DIFF
--- a/streams/readable-byte-streams/enqueue-with-detached-buffer.window.js
+++ b/streams/readable-byte-streams/enqueue-with-detached-buffer.window.js
@@ -5,7 +5,11 @@ promise_test(async t => {
     pull: t.step_func((controller) => {
       const buffer = controller.byobRequest.view.buffer;
       // Detach the buffer.
-      postMessage(buffer, '*', [buffer]);
+      if(typeof postMessage === 'function') {
+        postMessage(buffer, '*', [buffer]);
+      } else {
+        structuredClone(buffer, { transfer: [buffer] });
+      }
 
       // Try to enqueue with a new buffer.
       assert_throws_js(TypeError, () => controller.enqueue(new Uint8Array([42])));


### PR DESCRIPTION
This PR adds `structuredClone` as a fallback to detach an ArrayBuffer if `postMessage` is not defined, so the test can be used in Deno