### PR TITLE
A named properties object returns named properties from OwnPropertyKeys.

### DIFF
--- a/webidl/ecmascript-binding/window-named-properties-object.html
+++ b/webidl/ecmascript-binding/window-named-properties-object.html
@@ -223,7 +223,7 @@ test(t => {
         forInKeys.push(key);
 
     assert_array_equals(forInKeys, Object.keys(w.EventTarget.prototype));
-    assert_array_equals(Object.getOwnPropertyNames(wp), []);
+    assert_array_equals(Object.getOwnPropertyNames(wp), ["a", "b"]);
     assert_array_equals(Reflect.ownKeys(wp), [Symbol.toStringTag]);
 }, "[[OwnPropertyKeys]]");
 

--- a/webidl/ecmascript-binding/window-named-properties-object.html
+++ b/webidl/ecmascript-binding/window-named-properties-object.html
@@ -224,7 +224,7 @@ test(t => {
 
     assert_array_equals(forInKeys, Object.keys(w.EventTarget.prototype));
     assert_array_equals(Object.getOwnPropertyNames(wp), ["a", "b"]);
-    assert_array_equals(Reflect.ownKeys(wp), [Symbol.toStringTag]);
+    assert_array_equals(Reflect.ownKeys(wp), ["a", "b", Symbol.toStringTag]);
 }, "[[OwnPropertyKeys]]");
 
 function createWindowProperties(t) {


### PR DESCRIPTION
A Window's named properties object doesn't have a custom `[OwnPropertyKeys]` (see https://webidl.spec.whatwg.org/#named-properties-object), so it uses [`OrdinaryOwnPropertyKeys`](https://tc39.es/ecma262/#sec-ordinaryownpropertykeys) which simply adds all property keys. So `[OwnPropertyKeys]` on a named properties object returns all named properties and `@@toStringTag`. `Object.getOwnPropertyNames` then filters out the strings, leaving the named properties.