### PR TITLE
structuredClone(): fix WPT cases to test transferables with the { transfer: [ list of transferables ] } second parameter

### DIFF
--- a/html/webappapis/structured-clone/structured-clone-battery-of-tests-with-transferables.js
+++ b/html/webappapis/structured-clone/structured-clone-battery-of-tests-with-transferables.js
@@ -2,7 +2,7 @@ structuredCloneBatteryOfTests.push({
   description: 'ArrayBuffer',
   async f(runner) {
     const buffer = new Uint8Array([1]).buffer;
-    const copy = await runner.structuredClone(buffer, [buffer]);
+    const copy = await runner.structuredClone(buffer, { transfer: [buffer] });
     assert_equals(buffer.byteLength, 0);
     assert_equals(copy.byteLength, 1);
   }
@@ -12,7 +12,7 @@ structuredCloneBatteryOfTests.push({
   description: 'MessagePort',
   async f(runner) {
     const {port1, port2} = new MessageChannel();
-    const copy = await runner.structuredClone(port2, [port2]);
+    const copy = await runner.structuredClone(port2, { transfer: [port2] });
     const msg = new Promise(resolve => port1.onmessage = resolve);
     copy.postMessage('ohai');
     assert_equals((await msg).data, 'ohai');
@@ -25,11 +25,11 @@ structuredCloneBatteryOfTests.push({
   description: 'A detached ArrayBuffer cannot be transferred',
   async f(runner, t) {
     const buffer = new ArrayBuffer();
-    await runner.structuredClone(buffer, [buffer]);
+    await runner.structuredClone(buffer, { transfer: [buffer] });
     await promise_rejects_dom(
       t,
       "DataCloneError",
-      runner.structuredClone(buffer, [buffer])
+      runner.structuredClone(buffer, { transfer: [buffer] })
     );
   }
 });
@@ -38,11 +38,11 @@ structuredCloneBatteryOfTests.push({
   description: 'A detached platform object cannot be transferred',
   async f(runner, t) {
     const {port1} = new MessageChannel();
-    await runner.structuredClone(port1, [port1]);
+    await runner.structuredClone(port1, { transfer: [port1] });
     await promise_rejects_dom(
       t,
       "DataCloneError",
-      runner.structuredClone(port1, [port1])
+      runner.structuredClone(port1, { transfer: [port1] })
     );
   }
 });
@@ -54,7 +54,7 @@ structuredCloneBatteryOfTests.push({
     await promise_rejects_dom(
       t,
       "DataCloneError",
-      runner.structuredClone(blob, [blob])
+      runner.structuredClone(blob, { transfer: [blob] })
     );
   }
 });
@@ -66,7 +66,7 @@ structuredCloneBatteryOfTests.push({
     const messagePortInterface = globalThis.MessagePort;
     delete globalThis.MessagePort;
     try {
-      const transfer = await runner.structuredClone(port1, [port1]);
+      const transfer = await runner.structuredClone(port1, { transfer: [port1] });
       assert_true(transfer instanceof messagePortInterface);
     } finally {
       globalThis.MessagePort = messagePortInterface;
@@ -82,7 +82,7 @@ structuredCloneBatteryOfTests.push({
     // Make sure that ReadableStream is transferable before we test its subclasses.
     try {
       const stream = new ReadableStream();
-      await runner.structuredClone(stream, [stream]);
+      await runner.structuredClone(stream, { transfer: [stream] });
     } catch(err) {
       if (err instanceof DOMException && err.code === DOMException.DATA_CLONE_ERR) {
         throw new OptionalFeatureUnsupportedError("ReadableStream isn't transferable");
@@ -93,7 +93,7 @@ structuredCloneBatteryOfTests.push({
 
     class ReadableStreamSubclass extends ReadableStream {}
     const original = new ReadableStreamSubclass();
-    const transfer = await runner.structuredClone(original, [original]);
+    const transfer = await runner.structuredClone(original, { transfer: [original] });
     assert_equals(Object.getPrototypeOf(transfer), ReadableStream.prototype);
   }
 });

--- a/html/webappapis/structured-clone/structured-clone-battery-of-tests.js
+++ b/html/webappapis/structured-clone/structured-clone-battery-of-tests.js
@@ -1,6 +1,6 @@
 /* This file is mostly a remix of @zcorpan’s web worker test suite */
 
-structuredCloneBatteryOfTests = [];
+const structuredCloneBatteryOfTests = [];
 
 function check(description, input, callback, requiresDocument = false) {
   structuredCloneBatteryOfTests.push({


### PR DESCRIPTION
In the `structuredClone` algorithm, the second parameter passed should be
```js
{
  transfer: [ obj1, obj2 ] // list of transferables
}
```
rather than just an array.

This behavior is specified in <https://html.spec.whatwg.org/#dom-structuredclone> and implemented by Chrome, Firefox, and Node.js.