### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=247390

### DIFF
--- a/service-workers/service-worker/update-import-scripts.https.html
+++ b/service-workers/service-worker/update-import-scripts.https.html
@@ -123,5 +123,13 @@ promise_test(async t => {
   assert_active_only(registration, expected_url);
 }, 'update() should find an update in an imported script but update() should ' +
    'result in failure due to missing the other imported script.');
+
+promise_test(async t => {
+  const [registration, expected_url] = await prepare_ready_normal_worker(
+    t, 'import-scripts-cross-origin-worker.sub.js');
+  t.add_cleanup(() => registration.unregister());
+  await registration.update();
+  assert_installing_and_active(registration, expected_url);
+}, 'update() should work with cross-origin importScripts.');
 </script>
 </body>


### PR DESCRIPTION
WebKit export from bug: [\[Service Workers\] Add WPT coverage for calling update() on a ServiceWorkerRegistration with cross-origin importScripts](https://bugs.webkit.org/show_bug.cgi?id=247390)