### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=247507

### DIFF
--- a/css/css-sizing/aspect-ratio/replaced-element-039.html
+++ b/css/css-sizing/aspect-ratio/replaced-element-039.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>Replaced element honors transferred max-height</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#min-max-widths">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#min-max-heights">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
+<meta name="assert" content="SVG item with aspect ratio + intrinsic width + no intrinsic height honors transferred max-height." />
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' width='200'%3E%3Crect width='100%25' height='100%25' fill='green'/%3E%3C/svg%3E" style="max-height: 100px; flex: 0 0 auto; background: red;">

--- a/css/css-sizing/aspect-ratio/replaced-element-040.html
+++ b/css/css-sizing/aspect-ratio/replaced-element-040.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>Replaced element honors transferred max-width</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#min-max-widths">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#min-max-heights">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
+<meta name="assert" content="SVG item with aspect ratio + intrinsic height + no intrinsic width honors transferred max-width." />
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' height='200'%3E%3Crect width='100%25' height='100%25' fill='green'/%3E%3C/svg%3E" style="max-width: 100px; flex: 0 0 auto; background: red;">


### PR DESCRIPTION
WebKit export from bug: [Replaced elements with intrinsic ratio and missing size don't respect min-max constraints](https://bugs.webkit.org/show_bug.cgi?id=247507)