### PR TITLE
Add IDBIndex array keypath tests

### DIFF
--- a/IndexedDB/idbindex_keyPath.any.js
+++ b/IndexedDB/idbindex_keyPath.any.js
@@ -42,12 +42,11 @@ indexeddb_test(
     const index = store.index('index');
     const cursorReq = index.openCursor();
 
-    cursorReq.onsuccess = t.step_func((e) => {
+    cursorReq.onsuccess = t.step_func_done((e) => {
       const expectedKeyValue = [1];
-      const actualKeyValue = e.target.result.key.valueOf();
+      const actualKeyValue = e.target.result.key;
 
-      assert_array_equals(actualKeyValue, expectedKeyValue);
-      t.done();
+      assert_array_equals(actualKeyValue, expectedKeyValue, "An array keypath should yield an array key");
     });
   },
   `IDBIndex's keyPath array with a single value`);
@@ -65,12 +64,11 @@ indexeddb_test(
     const index = store.index('index');
     const cursorReq = index.openCursor();
 
-    cursorReq.onsuccess = t.step_func((e) => {
+    cursorReq.onsuccess = t.step_func_done((e) => {
       const expectedKeyValue = [1, 2];
-      const actualKeyValue = e.target.result.key.valueOf();
+      const actualKeyValue = e.target.result.key;
 
-      assert_array_equals(actualKeyValue, expectedKeyValue);
-      t.done();
+      assert_array_equals(actualKeyValue, expectedKeyValue, "An array keypath should yield an array key");
     });
   },
   `IDBIndex's keyPath array with multiple values`);

--- a/IndexedDB/idbindex_keyPath.any.js
+++ b/IndexedDB/idbindex_keyPath.any.js
@@ -1,4 +1,4 @@
-// META: title=IndexedDB: IDBIndex keyPath attribute - same object
+// META: title=IndexedDB: IDBIndex keyPath attribute
 // META: script=resources/support.js
 
 indexeddb_test(
@@ -28,3 +28,49 @@ indexeddb_test(
     t.done();
   },
   `IDBIndex's keyPath attribute returns the same object.`);
+
+  indexeddb_test(
+  (t, db) => {
+    const store = db.createObjectStore('store', {autoIncrement: true});
+    store.createIndex('index', ['a']);
+
+    store.add({a: 1, b: 2, c: 3})
+  },
+  (t, db) => {
+    const tx = db.transaction('store', 'readonly', {durability: 'relaxed'});
+    const store = tx.objectStore('store');
+    const index = store.index('index');
+    const cursorReq = index.openCursor();
+
+    cursorReq.onsuccess = t.step_func((e) => {
+      const expectedKeyValue = [1];
+      const actualKeyValue = e.target.result.key.valueOf();
+
+      assert_array_equals(actualKeyValue, expectedKeyValue);
+      t.done();
+    });
+  },
+  `IDBIndex's keyPath array with a single value`);
+
+  indexeddb_test(
+  (t, db) => {
+    const store = db.createObjectStore('store', {autoIncrement: true});
+    store.createIndex('index', ['a', 'b']);
+
+    store.add({a: 1, b: 2, c: 3})
+  },
+  (t, db) => {
+    const tx = db.transaction('store', 'readonly', {durability: 'relaxed'});
+    const store = tx.objectStore('store');
+    const index = store.index('index');
+    const cursorReq = index.openCursor();
+
+    cursorReq.onsuccess = t.step_func((e) => {
+      const expectedKeyValue = [1, 2];
+      const actualKeyValue = e.target.result.key.valueOf();
+
+      assert_array_equals(actualKeyValue, expectedKeyValue);
+      t.done();
+    });
+  },
+  `IDBIndex's keyPath array with multiple values`);

--- a/IndexedDB/keypath.htm
+++ b/IndexedDB/keypath.htm
@@ -135,6 +135,10 @@
         [ { name: "orange", type: { name: "fruit" }}, { name: "orange", type: { name: "telecom" }} ],
         [ ["orange", "fruit"], ["orange", "telecom" ] ]);
 
+    keypath(['type'],
+        [ { name: "orange", type: "fruit" }, { name: "cucumber", type: "vegetable" } ],
+        [ ["fruit"], ["vegetable"] ], "list with 1 field");
+
     loop_array = [];
     loop_array.push(loop_array);
     keypath(loop_array,


### PR DESCRIPTION
Adds WPT for validating IDBIndex array key path.

I wrote this to help surface a bug in the WebKit IDB implementation where single field array key paths (e.g. `['a']`) get incorrectly coerced to scalar keys. Reference: https://github.com/w3c/IndexedDB/issues/394

(I also added a case to `IndexedDB/keypath.htm` that tests single-key **_IDBObjectStore_** key paths. WebKit is behaving as expected there.)

