### PR TITLE
Web share: refactor disabled-by-permissions-policy-cross-origin

### DIFF
--- a/web-share/disabled-by-permissions-policy-cross-origin.https.sub.html
+++ b/web-share/disabled-by-permissions-policy-cross-origin.https.sub.html
@@ -47,6 +47,7 @@
     }
 
     promise_test(async (t) => {
+      assert_true("share" in navigator, "navigator.share exists");
       const iframe = await loadIframe(t, crossOriginSrc);
       const iframeWindow = iframe.contentWindow;
       iframeWindow.postMessage({ action: "share", data: shareData }, "*");
@@ -56,6 +57,7 @@
     }, "share() is disabled by default 'self' by permissions policy for cross-origin iframes");
 
     promise_test(async (t) => {
+      assert_true("share" in navigator, "navigator.share exists");
       const iframe = await loadIframe(t, crossOriginSrc, "web-share=()");
       const iframeWindow = iframe.contentWindow;
       iframeWindow.postMessage({ action: "share", data: shareData }, "*");
@@ -65,6 +67,7 @@
     }, "share() is disabled explicitly by permissions policy for cross-origin iframe");
 
     promise_test(async (t) => {
+      assert_true("share" in navigator, "navigator.share exists");
       const iframe = await loadIframe(t, crossOriginSrc, "web-share=(self)");
       const iframeWindow = iframe.contentWindow;
       iframeWindow.postMessage({ action: "share", data: shareData }, "*");
@@ -74,6 +77,7 @@
     }, "share() not allowed, as only allowed to share with self");
 
     promise_test(async (t) => {
+      assert_true("share" in navigator, "navigator.share exists");
       const iframe = await loadIframe(t, crossOriginSrc);
       const iframeWindow = iframe.contentWindow;
       iframeWindow.postMessage({ action: "canShare", data: shareData }, "*");
@@ -82,6 +86,7 @@
     }, "canShare() not allowed to share by default permissions policy cross-origin");
 
     promise_test(async (t) => {
+      assert_true("share" in navigator, "navigator.share exists");
       const iframe = await loadIframe(
         t,
         crossOriginSrc,
@@ -100,6 +105,7 @@
     }, "canShare() is allowed by permissions policy to share cross-origin on a particular origin");
 
     promise_test(async (t) => {
+      assert_true("share" in navigator, "navigator.share exists");
       const iframe = await loadIframe(t, sameOriginPath, "web-share=(self)");
       iframe.contentWindow.postMessage(
         { action: "canShare", data: shareData },

--- a/web-share/disabled-by-permissions-policy-cross-origin.https.sub.html
+++ b/web-share/disabled-by-permissions-policy-cross-origin.https.sub.html
@@ -47,7 +47,7 @@
     }
 
     promise_test(async (t) => {
-      assert_true("share" in navigator, "navigator.share exists");
+      assert_true("share" in navigator, "navigator.share is exposed");
       const iframe = await loadIframe(t, crossOriginSrc);
       const iframeWindow = iframe.contentWindow;
       iframeWindow.postMessage({ action: "share", data: shareData }, "*");
@@ -57,7 +57,7 @@
     }, "share() is disabled by default 'self' by permissions policy for cross-origin iframes");
 
     promise_test(async (t) => {
-      assert_true("share" in navigator, "navigator.share exists");
+      assert_true("share" in navigator, "navigator.share is exposed");
       const iframe = await loadIframe(t, crossOriginSrc, "web-share=()");
       const iframeWindow = iframe.contentWindow;
       iframeWindow.postMessage({ action: "share", data: shareData }, "*");
@@ -67,7 +67,7 @@
     }, "share() is disabled explicitly by permissions policy for cross-origin iframe");
 
     promise_test(async (t) => {
-      assert_true("share" in navigator, "navigator.share exists");
+      assert_true("share" in navigator, "navigator.share is exposed");
       const iframe = await loadIframe(t, crossOriginSrc, "web-share=(self)");
       const iframeWindow = iframe.contentWindow;
       iframeWindow.postMessage({ action: "share", data: shareData }, "*");
@@ -77,7 +77,7 @@
     }, "share() not allowed, as only allowed to share with self");
 
     promise_test(async (t) => {
-      assert_true("share" in navigator, "navigator.share exists");
+      assert_true("canShare" in navigator, "navigator.canShare is exposed");
       const iframe = await loadIframe(t, crossOriginSrc);
       const iframeWindow = iframe.contentWindow;
       iframeWindow.postMessage({ action: "canShare", data: shareData }, "*");
@@ -86,7 +86,7 @@
     }, "canShare() not allowed to share by default permissions policy cross-origin");
 
     promise_test(async (t) => {
-      assert_true("share" in navigator, "navigator.share exists");
+      assert_true("canShare" in navigator, "navigator.canShare is exposed");
       const iframe = await loadIframe(
         t,
         crossOriginSrc,
@@ -105,7 +105,7 @@
     }, "canShare() is allowed by permissions policy to share cross-origin on a particular origin");
 
     promise_test(async (t) => {
-      assert_true("share" in navigator, "navigator.share exists");
+      assert_true("canShare" in navigator, "navigator.canShare is exposed");
       const iframe = await loadIframe(t, sameOriginPath, "web-share=(self)");
       iframe.contentWindow.postMessage(
         { action: "canShare", data: shareData },

--- a/web-share/disabled-by-permissions-policy-cross-origin.https.sub.html
+++ b/web-share/disabled-by-permissions-policy-cross-origin.https.sub.html
@@ -11,7 +11,16 @@
     <script src="/resources/testharnessreport.js"></script>
   </head>
   <body></body>
-  <script defer>
+  <script>
+    const crossOrigin = "https://{{hosts[alt][]}}:{{ports[https][0]}}";
+    const sameOriginPath = "/web-share/resources/post-message.html";
+    const crossOriginSrc = `${crossOrigin}${sameOriginPath}`;
+    const shareData = {
+      title: "WebShare Test",
+      text: "This is a test of the Web Share API",
+      url: "https://example.com/",
+    };
+
     function waitForMessage(message) {
       return new Promise((resolve) => {
         window.addEventListener("message", function listener(event) {
@@ -22,55 +31,86 @@
       });
     }
 
-    async function loadCrossOriginFrame() {
+    async function loadIframe(t, src, allowList) {
       const iframe = document.createElement("iframe");
-      iframe.src =
-        "https://{{hosts[][www]}}:{{ports[https][0]}}/web-share/resources/post-message.html";
-      document.body.appendChild(iframe);
+      if (allowList !== null) iframe.allow = allowList;
+      t.add_cleanup(() => {
+        iframe.remove();
+      });
+      await new Promise((resolve) => {
+        iframe.src = src;
+        document.body.appendChild(iframe);
+        iframe.onload = resolve;
+      });
       await waitForMessage("loaded");
       return iframe;
     }
 
-    function makeCleanup(iframe) {
-      return () => {
-        iframe.remove();
-      };
-    }
-
-    const shareData = {
-      title: "WebShare Test",
-      text: "This is a test of the Web Share API",
-      url: "https://example.com/",
-    };
-
     promise_test(async (t) => {
-      const iframe = await loadCrossOriginFrame();
-      t.add_cleanup(makeCleanup(iframe));
+      const iframe = await loadIframe(t, crossOriginSrc);
       const iframeWindow = iframe.contentWindow;
       iframeWindow.postMessage({ action: "share", data: shareData }, "*");
       const data = await waitForMessage("share");
       assert_equals(data.result, "error");
       assert_equals(data.error, "NotAllowedError");
-    }, "share() is disabled by permissions policy cross-origin");
+    }, "share() is disabled by default 'self' by permissions policy for cross-origin iframes");
 
     promise_test(async (t) => {
-      const iframe = await loadCrossOriginFrame();
-      t.add_cleanup(makeCleanup(iframe));
+      const iframe = await loadIframe(t, crossOriginSrc, "web-share=()");
+      const iframeWindow = iframe.contentWindow;
+      iframeWindow.postMessage({ action: "share", data: shareData }, "*");
+      const data = await waitForMessage("share");
+      assert_equals(data.result, "error");
+      assert_equals(data.error, "NotAllowedError");
+    }, "share() is disabled explicitly by permissions policy for cross-origin iframe");
+
+    promise_test(async (t) => {
+      const iframe = await loadIframe(t, crossOriginSrc, "web-share=(self)");
+      const iframeWindow = iframe.contentWindow;
+      iframeWindow.postMessage({ action: "share", data: shareData }, "*");
+      const data = await waitForMessage("share");
+      assert_equals(data.result, "error");
+      assert_equals(data.error, "NotAllowedError");
+    }, "share() not allowed, as only allowed to share with self");
+
+    promise_test(async (t) => {
+      const iframe = await loadIframe(t, crossOriginSrc);
       const iframeWindow = iframe.contentWindow;
       iframeWindow.postMessage({ action: "canShare", data: shareData }, "*");
       const data = await waitForMessage("canShare");
       assert_equals(data.result, false, "Expected false, as it can't share.");
-    }, "canShare() returns false when not allowed by permissions policy cross-origin");
+    }, "canShare() not allowed to share by default permissions policy cross-origin");
 
     promise_test(async (t) => {
-      const iframe = await loadCrossOriginFrame();
-      t.add_cleanup(makeCleanup(iframe));
+      const iframe = await loadIframe(
+        t,
+        crossOriginSrc,
+        `web-share=("${crossOrigin}")`
+      );
       iframe.contentWindow.postMessage(
         { action: "canShare", data: shareData },
         "*"
       );
       const data = await waitForMessage("canShare");
-      assert_equals(data.result, true, "Expected true, is it can now share.");
-    }, "canShare() returns false when not allowed by permissions policy cross-origin with empty data");
+      assert_equals(
+        data.result,
+        true,
+        `Expected true, is it can now share on ${origin}.`
+      );
+    }, "canShare() is allowed by permissions policy to share cross-origin on a particular origin");
+
+    promise_test(async (t) => {
+      const iframe = await loadIframe(t, sameOriginPath, "web-share=(self)");
+      iframe.contentWindow.postMessage(
+        { action: "canShare", data: shareData },
+        "*"
+      );
+      const data = await waitForMessage("canShare");
+      assert_equals(
+        data.result,
+        true,
+        "Expected true, at it can share with self."
+      );
+    }, "canShare() with self");
   </script>
 </html>


### PR DESCRIPTION
Small refactor while updating Webkit. 

WebKit's infrastructure only supports ""https://{{hosts[alt][]}}:{{ports[https][0]}}", so needed to change it... it has no effect on the test however. 