### PR TITLE
User activation: refactor to support WebKit infrastructure

### DIFF
--- a/html/user-activation/activation-trigger-keyboard-enter.html
+++ b/html/user-activation/activation-trigger-keyboard-enter.html
@@ -8,7 +8,7 @@
   <script src="/resources/testdriver-vendor.js"></script>
   <script src="resources/utils.js"></script>
 </head>
-<body>
+<body onload="runTests()">
   <h1>Test for keyboard activation trigger for ENTER key</h1>
   <p>Tests user activation from a ENTER keyboard event.</p>
   <input type="text" autofocus />
@@ -16,13 +16,15 @@
     <li>Press ENTER key.
   </ol>
   <script>
+  function runTests() {
     promise_test(async () => {
         const ENTER_KEY = '\uE007';
-        test_driver.send_keys(document.body, ENTER_KEY);
 
         let keydown_event = getEvent('keydown');
         let keypress_event = getEvent('keypress');
         let keyup_event = getEvent('keyup');
+
+        await test_driver.send_keys(document.body, ENTER_KEY);
 
         await keydown_event;
         let consumed = await consumeTransientActivation();
@@ -39,6 +41,7 @@
         assert_false(consumed,
                      "ENTER keyup should have no activation after keydown consumption");
     }, "Activation through ENTER keyboard event");
+  }
   </script>
 </body>
 </html>

--- a/html/user-activation/activation-trigger-keyboard-escape.html
+++ b/html/user-activation/activation-trigger-keyboard-escape.html
@@ -8,7 +8,7 @@
   <script src="/resources/testdriver-vendor.js"></script>
   <script src="resources/utils.js"></script>
 </head>
-<body>
+<body onload="runTests()">
   <h1>Test for keyboard activation trigger for ESCAPE key</h1>
   <p>Tests missing user activation from a ESCAPE keyboard event.</p>
   <input type="text" autofocus />
@@ -16,12 +16,14 @@
     <li>Press ESCAPE key.
   </ol>
   <script>
+  function runTests() {
     promise_test(async () => {
         const ESCAPE_KEY = '\uE00C';
-        test_driver.send_keys(document.body, ESCAPE_KEY);
 
         let keydown_event = getEvent('keydown');
         let keyup_event = getEvent('keyup');
+
+        await test_driver.send_keys(document.body, ESCAPE_KEY);
 
         await keydown_event;
         let consumed = await consumeTransientActivation();
@@ -33,6 +35,7 @@
         assert_false(consumed,
                      "ESCAPE keyup should have no activation after keydown consumption");
     }, "Activation through ESCAPE keyboard event");
+  }
   </script>
 </body>
 </html>

--- a/html/user-activation/activation-trigger-mouse-left.html
+++ b/html/user-activation/activation-trigger-mouse-left.html
@@ -8,19 +8,21 @@
   <script src="/resources/testdriver-vendor.js"></script>
   <script src="resources/utils.js"></script>
 </head>
-<body>
+<body onload="runTests()">
   <h1>Test for click activation trigger</h1>
   <p>Tests user activation from a mouse click.</p>
   <ol id="instructions">
     <li>Click anywhere in the document.
   </ol>
   <script>
+  function runTests() {
     promise_test(async () => {
-        test_driver.click(document.body);
 
         let mousedown_event = getEvent('mousedown');
         let mouseup_event = getEvent('mouseup');
         let click_event = getEvent('click');
+
+        await test_driver.click(document.body);
 
         await mousedown_event;
         let consumed = await consumeTransientActivation();
@@ -37,6 +39,7 @@
         assert_false(consumed,
                      "click should have no activation after mousedown consumption");
     }, "Activation through left-click mouse event");
+  }
   </script>
 </body>
 </html>

--- a/html/user-activation/activation-trigger-mouse-right.html
+++ b/html/user-activation/activation-trigger-mouse-right.html
@@ -9,13 +9,14 @@
   <script src="/resources/testdriver-vendor.js"></script>
   <script src="resources/utils.js"></script>
 </head>
-<body>
+<body onload="runTests()">
   <h1>Test for right-click activation trigger</h1>
   <p>Tests user activation from a mouse right-click.</p>
   <ol id="instructions">
     <li>Right-click anywhere in the document.
   </ol>
   <script>
+  function runTests() {
     promise_test(async () => {
         var actions = new test_driver.Actions();
         actions.pointerMove(0, 0, {origin: document.body})
@@ -53,6 +54,7 @@
         assert_false(consumed,
                      "contextmenu should have no activation after mousedown consumption");
     }, "Activation through right-click mouse event");
+  }
   </script>
 </body>
 </html>

--- a/html/user-activation/activation-trigger-pointerevent.html
+++ b/html/user-activation/activation-trigger-pointerevent.html
@@ -12,13 +12,14 @@
   <script src="/resources/testdriver-vendor.js"></script>
   <script src="resources/utils.js"></script>
 </head>
-<body>
+<body onload="runTests()">
   <h1>Test for pointerevent click activation trigger</h1>
   <p>Tests user activation from a pointer click.</p>
   <ol id="instructions">
     <li>Click anywhere in the document.
   </ol>
   <script>
+  function runTests() {
     let pointer_type = location.search.substring(1);
 
     promise_test(async () => {
@@ -57,6 +58,7 @@
                          pointer_type + " click should have no activation after pointerup consumption");
         }
     }, "Activation through " + pointer_type + " pointerevent click");
+  }
   </script>
 </body>
 </html>

--- a/html/user-activation/consumption-crossorigin.sub.html
+++ b/html/user-activation/consumption-crossorigin.sub.html
@@ -44,6 +44,10 @@
     }
 
     window.addEventListener("message", event => {
+
+        // Test driver can send messages too...
+        if (typeof event.data !== "string") return;
+
         var msg = JSON.parse(event.data);
 
         if (msg.type == 'child-one-loaded') {
@@ -65,8 +69,8 @@
             test_driver.click(document.getElementById("child-xo"));
         } else if (msg.type == 'child-one-report') {
             test(() => {
-                assert_false(msg.isActive);
-                assert_true(msg.hasBeenActive);
+                assert_false(msg.isActive, "Child1 frame isActive");
+                assert_true(msg.hasBeenActive, "Child1 frame hasBeenActive");
             }, "Child1 frame final state");
         } else if (msg.type == 'child-crossorigin-report') {
             // This msg was triggered by a user click followed by a window.open().
@@ -81,8 +85,8 @@
             frames[1].frames[0].postMessage(ask_report, "*");
         } else if (msg.type == 'child-two-report') {
             test(() => {
-                assert_false(msg.isActive);
-                assert_false(msg.hasBeenActive);
+                assert_false(msg.isActive, "isActive");
+                assert_false(msg.hasBeenActive, "hasBeenActive");
             }, "Grand child frame final state");
         }
 
@@ -95,20 +99,27 @@
                 finishReportPhase();
         }
     });
+    async function createIframes() {
+        const child1 = document.createElement("iframe");
+        child1.src = "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/user-activation/resources/child-one.html";
+        child1.id = "child1";
+        await new Promise((resolve) => {
+            child1.onload = resolve;
+            document.body.appendChild(child1);
+        });
+        const childXO = document.createElement("iframe");
+        childXO.id = "child-xo";
+        childXO.src = "http://{{hosts[alt][]}}:{{ports[http][1]}}/html/user-activation/resources/consumption-crossorigin-child.sub.html";
+        document.body.appendChild(childXO);
+    }
   </script>
 </head>
-<body>
+<body onload="createIframes()">
   <h1>User activation consumption across cross-origin frame boundary</h1>
   <p>Tests that user activation consumption resets the transient states in all cross-origin frames.</p>
   <ol id="instructions">
     <li>Click anywhere on the yellow area.
     <li>Click anywhere on the green area (child frame).
   </ol>
-  <iframe id="child1" width="300px" height="40px"
-          src="http://{{domains[www1]}}:{{ports[http][0]}}/html/user-activation/resources/child-one.html">
-  </iframe>
-  <iframe id="child-xo" width="300px" height="140px"
-          src="http://{{domains[www2]}}:{{ports[http][0]}}/html/user-activation/resources/consumption-crossorigin-child.sub.html">
-  </iframe>
 </body>
 </html>

--- a/html/user-activation/consumption-sameorigin.html
+++ b/html/user-activation/consumption-sameorigin.html
@@ -26,7 +26,7 @@
             assert_false(navigator.userActivation.hasBeenActive);
         }, "Parent frame initial state");
 
-        test_driver.click(document.getElementById("child-so"));
+        return test_driver.click(document.getElementById("child-so"));
     }
 
     function finishReportPhase() {
@@ -40,7 +40,10 @@
         consumption_test.done();
     }
 
-    window.addEventListener("message", event => {
+    window.addEventListener("message", async event => {
+        // Test driver can send messages too...
+        if (typeof event.data !== "string") return;
+
         var msg = JSON.parse(event.data);
 
         if (msg.type == 'child-one-loaded') {
@@ -84,25 +87,32 @@
         // Phase switching.
         if (msg.type.endsWith("-loaded")) {
             if (--num_children_to_load == 0)
-                finishLoadPhase();
+                await finishLoadPhase();
         } else if (msg.type.endsWith("-report")) {
             if (--num_children_to_report == 0)
                 finishReportPhase();
         }
     });
+    async function createIframes() {
+        const child1 = document.createElement("iframe");
+        child1.src = "resources/child-one.html";
+        child1.id = "child1";
+        await new Promise((resolve) => {
+            child1.onload = resolve;
+            document.body.appendChild(child1);
+        });
+        const childSO = document.createElement("iframe");
+        childSO.id = "child-so";
+        childSO.src = "resources/consumption-sameorigin-child.html";
+        document.body.appendChild(childSO);
+    }
   </script>
 </head>
-<body>
+<body onload="createIframes()" >
   <h1>User activation consumption across same-origin frame boundary</h1>
   <p>Tests that user activation consumption resets the transient states in all same-origin frames.</p>
   <ol id="instructions">
     <li>Click anywhere on the green area (child frame).
   </ol>
-  <iframe id="child1" width="300px" height="40px"
-          src="resources/child-one.html">
-  </iframe>
-  <iframe id="child-so" width="300px" height="140px"
-          src="resources/consumption-sameorigin-child.html">
-  </iframe>
 </body>
 </html>

--- a/html/user-activation/detached-iframe.html
+++ b/html/user-activation/detached-iframe.html
@@ -42,6 +42,6 @@
       assert_equals(iframe.contentWindow, null, "No more global");
       assert_true(userActivation.isActive, "isActive");
       assert_true(userActivation.hasBeenActive, "hasBeenActive");
-    }, "navigator.userActivation retains state even if browsing context is destroyed");
+    }, "navigator.userActivation retains state even if global is removed");
   </script>
 </html>

--- a/html/user-activation/message-event-activation-api-iframe-cross-origin.sub.tentative.html
+++ b/html/user-activation/message-event-activation-api-iframe-cross-origin.sub.tentative.html
@@ -15,12 +15,12 @@
   <ol id="instructions">
     <li>Click inside the red area.
   </ol>
-  <iframe id="child" width="200" height="200"
-          src="http://{{domains[www]}}:{{ports[http][0]}}/html/user-activation/resources/child-message-event-api.html">
+  <iframe id="child" width="200" height="200">
   </iframe>
   <script>
     async_test(function(t) {
       var child = document.getElementById("child");
+      child.src = "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/user-activation/resources/child-message-event-api.html";
       assert_false(navigator.userActivation.isActive);
       assert_false(navigator.userActivation.hasBeenActive);
       window.addEventListener("message", t.step_func(event => {

--- a/html/user-activation/navigation-state-reset-crossorigin.sub.html
+++ b/html/user-activation/navigation-state-reset-crossorigin.sub.html
@@ -13,13 +13,16 @@
   <ol id="instructions">
     <li>Click inside the yellow area.
   </ol>
-  <iframe id="child" width="200" height="50"
-          src="http://{{domains[www1]}}:{{ports[http][0]}}/html/user-activation/resources/child-one.html">
+  <iframe id="child" width="200" height="50">
   </iframe>
   <script>
     async_test(function(t) {
       var child = document.getElementById("child");
+      child.src = "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/user-activation/resources/child-one.html";
       window.addEventListener("message", t.step_func(event => {
+          // Test driver can send messages too...
+          if (typeof event.data !== "string") return;
+
           var msg = JSON.parse(event.data);
           if (msg.type == 'child-one-loaded') {
               assert_false(navigator.userActivation.isActive);
@@ -34,7 +37,7 @@
               assert_true(msg.isActive);
               assert_true(msg.hasBeenActive);
 
-              child.src = "http://{{domains[www2]}}:{{ports[http][0]}}/html/user-activation/resources/child-two.html";
+              child.src = "http://{{hosts[alt][]}}:{{ports[http][1]}}/html/user-activation/resources/child-two.html";
           } else if (msg.type == 'child-two-loaded') {
               assert_true(navigator.userActivation.isActive);
               assert_true(navigator.userActivation.hasBeenActive);

--- a/html/user-activation/navigation-state-reset-sameorigin.html
+++ b/html/user-activation/navigation-state-reset-sameorigin.html
@@ -1,49 +1,62 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
-  <script src="/resources/testdriver.js"></script>
-  <script src="/resources/testdriver-vendor.js"></script>
-</head>
-<body>
-  <h1>Post-navigation activation state in child</h1>
-  <p>Tests that navigating a same-origin child frame resets its activation states.</p>
-  <ol id="instructions">
-    <li>Click inside the yellow area.
-  </ol>
-  <iframe id="child" width="200" height="50"
-          src="resources/child-one.html">
-  </iframe>
-  <script>
-    async_test(function(t) {
-      var child = document.getElementById("child");
-      window.addEventListener("message", t.step_func(event => {
-          var msg = JSON.parse(event.data);
-          if (msg.type == 'child-one-loaded') {
-              assert_false(navigator.userActivation.isActive);
-              assert_false(navigator.userActivation.hasBeenActive);
-              assert_false(msg.isActive);
-              assert_false(msg.hasBeenActive);
+  <head>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+  </head>
+  <body>
+    <h1>Post-navigation activation state in child</h1>
+    <p>
+      Tests that navigating a same-origin child frame resets its activation
+      states.
+    </p>
+    <ol id="instructions">
+      <li>Click inside the yellow area.</li>
+    </ol>
 
-              test_driver.click(child);
-          } else if (msg.type == 'child-one-clicked') {
-              assert_true(navigator.userActivation.isActive);
-              assert_true(navigator.userActivation.hasBeenActive);
-              assert_true(msg.isActive);
-              assert_true(msg.hasBeenActive);
+    <iframe id="child" width="200" height="50"> </iframe>
+    <script>
+      function message(type) {
+        return new Promise((resolve) => {
+          window.addEventListener("message", function listener(event) {
+            const data = JSON.parse(event.data);
+            if (data.type === type) {
+              window.removeEventListener("message", listener);
+              resolve(data);
+            }
+          });
+        });
+      }
+      promise_test(async (t) => {
+        var child = document.getElementById("child");
+        child.src = "./resources/child-one.html";
+        const unclickeData = await message("child-one-loaded");
+        assert_false(navigator.userActivation.isActive);
+        assert_false(navigator.userActivation.hasBeenActive);
+        assert_false(unclickeData.isActive);
+        assert_false(unclickeData.hasBeenActive);
 
-              child.src = "resources/child-two.html";
-          } else if (msg.type == 'child-two-loaded') {
-              assert_true(navigator.userActivation.isActive);
-              assert_true(navigator.userActivation.hasBeenActive);
-              assert_false(msg.isActive);
-              assert_false(msg.hasBeenActive);
+        const [, child1Data] = await Promise.all([
+          test_driver.click(child),
+          message("child-one-clicked"),
+        ]);
 
-              t.done();
-          }
-      }));
-    }, "Post-navigation state reset.");
-  </script>
-</body>
+        assert_true(navigator.userActivation.isActive);
+        assert_true(navigator.userActivation.hasBeenActive);
+        assert_true(child1Data.isActive);
+        assert_true(child1Data.hasBeenActive);
+
+        child.src = "./resources/child-two.html";
+
+        const child2Data = await message("child-two-loaded");
+
+        assert_true(navigator.userActivation.isActive);
+        assert_true(navigator.userActivation.hasBeenActive);
+        assert_false(child2Data.isActive);
+        assert_false(child2Data.hasBeenActive);
+      }, "Post-navigation state reset.");
+    </script>
+  </body>
 </html>

--- a/html/user-activation/propagation-crossorigin.sub.html
+++ b/html/user-activation/propagation-crossorigin.sub.html
@@ -43,6 +43,9 @@
     }
 
     window.addEventListener("message", event => {
+        // Test driver can send messages too...
+        if (typeof event.data !== "string") return;
+
         var msg = JSON.parse(event.data);
 
         if (msg.type == 'child-one-loaded') {
@@ -92,19 +95,27 @@
                 finishReportPhase();
         }
     });
+    async function createIframes() {
+        const child1 = document.createElement("iframe");
+        child1.src = "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/user-activation/resources/child-one.html";
+        child1.id = "child1";
+        document.body.appendChild(child1);
+        await new Promise((resolve) => {
+            child1.onload = resolve;
+            document.body.appendChild(child1);
+        });
+        const childXO = document.createElement("iframe");
+        childXO.id = "child-xo";
+        childXO.src = "http://{{hosts[alt][]}}:{{ports[http][1]}}/html/user-activation/resources/propagation-crossorigin-child.sub.html";
+        document.body.appendChild(childXO);
+    }
   </script>
 </head>
-<body>
+<body onload="createIframes()">
   <h1>User activation propagation across cross-origin frame boundary</h1>
   <p>Tests that user activation does not propagate across cross-origin frame boundary.</p>
   <ol id="instructions">
     <li>Click anywhere on the green area (child frame).
   </ol>
-  <iframe id="child1" width="300px" height="40px"
-          src="http://{{domains[www1]}}:{{ports[http][0]}}/html/user-activation/resources/child-one.html">
-  </iframe>
-  <iframe id="child-xo" width="300px" height="140px"
-          src="http://{{domains[www2]}}:{{ports[http][0]}}/html/user-activation/resources/propagation-crossorigin-child.sub.html">
-  </iframe>
 </body>
 </html>

--- a/html/user-activation/propagation-sameorigin.html
+++ b/html/user-activation/propagation-sameorigin.html
@@ -41,6 +41,9 @@
     }
 
     window.addEventListener("message", event => {
+        // Test driver can send messages too...
+        if (typeof event.data !== "string") return;
+
         var msg = JSON.parse(event.data);
 
         if (msg.type == 'child-one-loaded') {
@@ -90,19 +93,26 @@
                 finishReportPhase();
         }
     });
+    async function createIframes() {
+        const child1 = document.createElement("iframe");
+        child1.src = "resources/child-one.html";
+        child1.id = "child1";
+        await new Promise((resolve) => {
+            child1.onload = resolve;
+            document.body.appendChild(child1);
+        });
+        const childSO = document.createElement("iframe");
+        childSO.id = "child-so";
+        childSO.src = "resources/propagation-sameorigin-child.html";
+        document.body.appendChild(childSO);
+    }
   </script>
 </head>
-<body>
+<body onload="createIframes()">
   <h1>User activation propagation across same-origin frame boundary</h1>
   <p>Tests that user activation propagates across same-origin frame boundary.</p>
   <ol id="instructions">
     <li>Click anywhere on the green area (child frame).
   </ol>
-  <iframe id="child1" width="300px" height="40px"
-          src="resources/child-one.html">
-  </iframe>
-  <iframe id="child-so" width="300px" height="140px"
-          src="resources/propagation-sameorigin-child.html">
-  </iframe>
 </body>
 </html>

--- a/html/user-activation/resources/consumption-crossorigin-child.sub.html
+++ b/html/user-activation/resources/consumption-crossorigin-child.sub.html
@@ -23,7 +23,7 @@
   <!-- The midpoint of this frame should be outside the grandchild frame. -->
   <div style="height: 75px;">Cross-origin child frame</div>
   <iframe id="child2" width="270px" height="30px"
-          src="http://{{domains[www]}}:{{ports[http][0]}}/html/user-activation/resources/child-two.html">
+          src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/user-activation/resources/child-two.html">
   </iframe>
 </body>
 </html>

--- a/html/user-activation/resources/propagation-crossorigin-child.sub.html
+++ b/html/user-activation/resources/propagation-crossorigin-child.sub.html
@@ -21,7 +21,7 @@
   <!-- The midpoint of this frame should be outside the grandchild frame. -->
   <div style="height: 75px;">Cross-origin child frame</div>
   <iframe id="child2" width="270px" height="30px"
-          src="http://{{domains[www]}}:{{ports[http][0]}}/html/user-activation/resources/child-two.html">
+          src="http://{{hosts[alt][]}}:{{ports[http][0]}}/html/user-activation/resources/child-two.html">
   </iframe>
 </body>
 </html>

--- a/html/user-activation/user-activation-interface.html
+++ b/html/user-activation/user-activation-interface.html
@@ -7,13 +7,14 @@
   <script src="/resources/testdriver-vendor.js"></script>
   <script src="resources/utils.js"></script>
 </head>
-<body>
+<body onload="runTests()">
   <h1>Basic test for navigator.userActivation interface</h1>
   <p>Tests that navigator.userActivation shows user activation states.</p>
   <ol id="instructions">
     <li>Click anywhere in the document.
   </ol>
   <script>
+  function runTests() {
     promise_test(async () => {
         assert_true(!!navigator.userActivation, "This test requires navigator.userActivation API");
 
@@ -25,6 +26,7 @@
         assert_true(navigator.userActivation.hasBeenActive, "Has sticky activation after click");
         assert_true(navigator.userActivation.isActive, "Has transient activation after click");
     }, "navigator.userActivation shows correct states before/after a click");
+  }
   </script>
 </body>
 </html>


### PR DESCRIPTION
Test to better support WebKit's infrastructure. 

In particular, WebKit doesn't know about: 

 * `domains[www1]` and so on, so those are changed to `{{hosts[alt][]}}` and a different port. 
 * Some of the tests are missing `await`. 
 * Some tests would run before the `body` was ready.  

Reviewed-on: https://github.com/WebKit/WebKit/pull/4841
Reviewed-by: @youennf 

