### PR TITLE
Workaround WebKit differences with load events & document.open

### DIFF
--- a/import-maps/data-driven/resources/test-helper.js
+++ b/import-maps/data-driven/resources/test-helper.js
@@ -19,10 +19,10 @@ function createTestIframe(importMap, importMapBaseURL) {
       iframe.src = 'data:text/html;base64,' + btoa(testHTML);
     } else {
       iframe.src = '/common/blank.html';
-      iframe.onload = () => {
+      iframe.addEventListener('load', () => {
         iframe.contentDocument.write(testHTML);
         iframe.contentDocument.close();
-      };
+      }, {once: true});
     }
     document.body.appendChild(iframe);
   });


### PR DESCRIPTION
This is with regards to https://bugs.webkit.org/show_bug.cgi?id=245719 which is incidental in these tests, and almost certainly covered by existing tests.