### PR TITLE
Refine gitignore rule for submissions subdirectory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,4 @@ scratch
 /webaudio/idl/*
 
 # w3c-test.org PR-branch mirroring
-submissions/
+/submissions/


### PR DESCRIPTION
When running the WPT lints over the WPT import in Servo, we get a lot of gitignore hits on the tests in `uievents/legacy-domevents-tests/submissions/`. I'm not sure what changed in the past 1.5 years since we last synced that made this be reported, but it seems like the current ignore rule is overly broad.