### PR TITLE
css mediaqueries : add tests for negated conditions

### DIFF
--- a/css/mediaqueries/negation-001.html
+++ b/css/mediaqueries/negation-001.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+	<head>
+		<title>Test: support for negated conditions in Media Queries</title>
+		<link rel="author" title="Romain Menke" href="https://github.com/romainmenke">
+		<link rel="help" href="https://www.w3.org/TR/mediaqueries-4/#media-conditions">
+		<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+		<meta name="assert" content="Test passes if negated conditions are correctly evaluated.">
+		<style>
+			div {
+				background-color: red;
+				height: 20px;
+				width: 100px;
+			}
+			@media not print {
+				.test1 { background: green; }
+			}
+			@media not (monochrome) {
+				.test2 { background: green; }
+			}
+			@media (not (monochrome)) {
+				.test3 { background: green; }
+			}
+			@media not (not (color)) {
+				.test4 { background: green; }
+			}
+			@media not ((unknown) or (monochrome)) {
+				.test5 { background: green; }
+			}
+	</style>
+	</head>
+	<body>
+		<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+		<div class="test1"></div>
+		<div class="test2"></div>
+		<div class="test3"></div>
+		<div class="test4"></div>
+		<div class="test5"></div>
+	</body>
+</html>

--- a/css/mediaqueries/negation-002.html
+++ b/css/mediaqueries/negation-002.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+	<head>
+		<title>Test: It is invalid to mix "and" and "or" and "not" at the same level of a media query.</title>
+		<link rel="author" title="Romain Menke" href="https://github.com/romainmenke">
+		<link rel="help" href="https://www.w3.org/TR/mediaqueries-4/#media-conditions">
+		<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+		<meta name="assert" content="Test passes if invalid combinations with 'not' do not apply.">
+		<style>
+			div {
+				background-color: red;
+				height: 25px;
+				width: 100px;
+			}
+
+			@media ((color) and (color)) {
+				/* Only green when the browser supports the general syntax */
+				div {
+					background-color: green;
+				}
+			}
+
+			@media (not (monochrome) and (color)) {
+				.test1 { background: red; }
+			}
+			@media (not (monochrome) or (color)) {
+				.test2 { background: red; }
+			}
+			@media ((color) and not (monochrome)) {
+				.test3 { background: red; }
+			}
+			@media ((color) or not (monochrome)) {
+				.test4 { background: red; }
+			}
+	</style>
+	</head>
+	<body>
+		<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+		<div class="test1"></div>
+		<div class="test2"></div>
+		<div class="test3"></div>
+		<div class="test4"></div>
+	</body>
+</html>


### PR DESCRIPTION
In `mediaqueries-3` only `not screen and ...` was supported.
In `mediaqueries-4` the `not` keyword can be used before `<media-in-parens>`.

Blink :
- succeeds

Gecko :
- single failure on `@media not ((unknown) or (monochrome)) {}`

WebKit :
- fails
- WebKit doesn't support the syntax yet.
- https://bugs.webkit.org/show_bug.cgi?id=200842
