### PR TITLE
Address flakiness issue in permissions/permissions-cg.https.html

### DIFF
--- a/permissions/permissions-cg.https.html
+++ b/permissions/permissions-cg.https.html
@@ -7,20 +7,44 @@
 <script src="/resources/testdriver-vendor.js"></script>
 
 <script>
+async function garbageCollect() {
+  if (typeof TestUtils !== 'undefined' && TestUtils.gc) {
+    await TestUtils.gc();
+  } else if (self.gc) {
+    await self.gc();
+  } else if (self.GCController) {
+    // Present in some WebKit development environments
+    await GCController.collect();
+  } else {
+    var gcRec = function (n) {
+      if (n < 1)
+        return {};
+      var temp = {i: "ab" + i + (i / 100000)};
+      temp += "foo";
+      gcRec(n-1);
+    };
+    for (var i = 0; i < 1000; i++)
+      gcRec(10);
+  }
+}
+
 promise_test(async () => {
   const { state: initialState } = await navigator.permissions.query({
     name: "geolocation",
   });
 
   const pass = new Promise(async (resolve) => {
-    const status = await navigator.permissions.query({
+    let status = await navigator.permissions.query({
       name: "geolocation",
     });
     status.addEventListener("change", resolve, { once: true });
-  });
 
-  // Will cause change event to be dispatched.
-  await test_driver.set_permission({ name: "geolocation" }, "granted");
+    status = null;
+    await garbageCollect();
+
+    // Will cause change event to be dispatched.
+    test_driver.set_permission({ name: "geolocation" }, "granted");
+  });
 
   // Wait for the change event to be dispatched.
   await pass;

--- a/permissions/permissions-cg.https.html
+++ b/permissions/permissions-cg.https.html
@@ -38,7 +38,7 @@ promise_test(async () => {
     await garbageCollect();
 
     // Will cause change event to be dispatched.
-    test_driver.set_permission({ name: "geolocation" }, "granted");
+    await test_driver.set_permission({ name: "geolocation" }, "granted");
   });
 
   // Wait for the change event to be dispatched.

--- a/permissions/permissions-cg.https.html
+++ b/permissions/permissions-cg.https.html
@@ -7,24 +7,19 @@
 <script src="/resources/testdriver-vendor.js"></script>
 
 <script>
-async function garbageCollect() {
-  if (typeof TestUtils !== 'undefined' && TestUtils.gc) {
-    await TestUtils.gc();
-  } else if (self.gc) {
-    await self.gc();
-  } else if (self.GCController) {
-    // Present in some WebKit development environments
-    await GCController.collect();
-  } else {
-    var gcRec = function (n) {
-      if (n < 1)
-        return {};
-      var temp = {i: "ab" + i + (i / 100000)};
-      temp += "foo";
-      gcRec(n-1);
-    };
-    for (var i = 0; i < 1000; i++)
-      gcRec(10);
+function garbageCollect() {
+  if (self.TestUtils?.gc) return TestUtils.gc();
+  if (self.gc) return self.gc();
+  // Present in some WebKit development environments
+  if (self.GCController) return GCController.collect();
+
+  for (var i = 0; i < 1000; i++) gcRec(10);
+
+  function gcRec(n) {
+    if (n < 1) return {};
+    let temp = { i: "ab" + i + i / 100000 };
+    temp += "foo";
+    gcRec(n - 1);
   }
 }
 


### PR DESCRIPTION
Make sure the PermissionStatus object gets constructed and its `change` event listener gets registered *BEFORE* we update the permission state. Previously, the order wasn't guaranteed and this would lead to flakiness because the `change` would get fired before the event listener got added.

Also trigger garbage collection explicitly to make it more likely to trigger GC bugs, given that this is what the test intends to cover.

This is a merge from https://github.com/WebKit/WebKit/pull/6358.