### PR TITLE
Make font-variant-position-02 and font-variant-position-03 reftests

### DIFF
--- a/css/css-fonts/font-variant-position-02-ref.html
+++ b/css/css-fonts/font-variant-position-02-ref.html
@@ -15,9 +15,10 @@
   }
 </style>
 <body>
-<p>Test passes if the three lines below are identical, with one checkmark (✓) followed by one cross (✗)</p>
+<p>Test passes if the three lines below are identical, with two checkmarks (✓);
+  if the first line has a checkmark followed by two normally sized crosses, the test fails. </p>
 <section class="test">
-	<p class="ref">AB</p>
-	<p class="ref">AB</p>
-	<p class="ref">AB</p>
+	<p class="ref">AA</p>
+	<p class="ref">AA</p>
+	<p class="ref">AA</p>
 </section>

--- a/css/css-fonts/font-variant-position-02.html
+++ b/css/css-fonts/font-variant-position-02.html
@@ -5,6 +5,7 @@
 <link rel="author" title="Chris Lilley" href="chris@w3.org">
 <link rel="help" href="https://www.w3.org/TR/css-fonts-3/#font-variant-position-prop">
 <link rel="help" href="https://www.w3.org/TR/css-fonts-3/#font-feature-settings-prop">
+<link rel="match" href="font-variant-position-02-ref.html">
 <meta name="assert" content="Enables display of subscript variants (OpenType feature: subs).">
 <style>
   @font-face {
@@ -24,11 +25,10 @@
   }
 </style>
 <body>
-<p>Test passes if the second and third lines below are identical, with two checkmarks (✓) followed by one cross (✗); and
-  also, if the first line is <em>either</em> identical to the other two, <em>or</em> has one checkmark followed by two <b>subscript</b> crosses.
-  If the first line has a checkmark followed by two normally sized crosses, the test fails.  </p>
+<p>Test passes if the three lines below are identical, with two checkmarks (✓);
+  if the first line has a checkmark followed by two normally sized crosses, the test fails. </p>
 <section class="test">
-  <p>A<span class="high">HI</span></p>
-  <p>A<span class="low">HI</span></p>
-	<p class="ref">AAB</p>
+  <p>A<span class="high">H</span></p>
+  <p>A<span class="low">H</span></p>
+	<p class="ref">AA</p>
 </section>

--- a/css/css-fonts/font-variant-position-03-ref.html
+++ b/css/css-fonts/font-variant-position-03-ref.html
@@ -15,11 +15,10 @@
   }
 </style>
 <body>
-<p>Test passes if the three lines below are identical, with one cross (✗) followed by one checkmark (✓)  </p>
-<!-- Identical? If the UA is allowed to simulate subscripts and superscripts then the first line will use smaller glyphs than the second and third. Maybe "similar" and point out size doesn't matter on this test?  -->
-
+  <p>Test passes if the three lines below are identical, with two checkmarks (✓);
+    if the first line has a checkmark followed by two normally sized crosses, the test fails. </p>
 <section class="test">
-	<p class="ref">BA</p>
-	<p class="ref">BA</p>
-	<p class="ref">BA</p>
+	<p class="ref">AA</p>
+	<p class="ref">AA</p>
+	<p class="ref">AA</p>
 </section>

--- a/css/css-fonts/font-variant-position-03.html
+++ b/css/css-fonts/font-variant-position-03.html
@@ -5,6 +5,7 @@
 <link rel="author" title="Chris Lilley" href="chris@w3.org">
 <link rel="help" href="https://www.w3.org/TR/css-fonts-3/#font-variant-position-prop">
 <link rel="help" href="https://www.w3.org/TR/css-fonts-3/#font-feature-settings-prop">
+<link rel="match" href="font-variant-position-03-ref.html">
 <meta name="assert" content="Enables display of subscript variants (OpenType feature: subs).">
 <style>
   @font-face {
@@ -24,12 +25,10 @@
   }
 </style>
 <body>
-<p>Test passes if the second and third lines below are identical, with two crosses (✗) followed by one checkmark (✓); and
-  also, if the first line is <em>either</em> identical to the other two, <em>or</em> has one  cross followed by two <b>superscript</b> crosses.
-  If the first line has three normally sized crosses, the test fails.</p>
-
+  <p>Test passes if the three lines below are identical, with two checkmarks (✓);
+    if the first line has a checkmark followed by two normally sized crosses, the test fails. </p>
 <section class="test">
-  <p>B<span class="high">HI</span></p>
-  <p>B<span class="low">HI</span></p>
-	<p class="ref">BBA</p>
+  <p>A<span class="high">I</span></p>
+  <p>A<span class="low">I</span></p>
+	<p class="ref">AA</p>
 </section>


### PR DESCRIPTION
Currently there are no reftest in wpt that checks `font-variant-position ` property set to `sub` and `super`, therefore added reftest links for `font-variant-position-02` and `font-variant-position-03` test which checks `sub` and `super` keywords respectively. 

Currently Chrome and Safari don't support synthesizing of subscript and superscript glyphs, but Firefox does. Therefore also removed glyphs that are synthesized in above mentioned tests, since tests with synthesizing looks different in different browsers.