### PR TITLE
Remove serialization of font shorthand property when font-palette is set to non initial value

### DIFF
--- a/css/css-fonts/font-palette-vs-shorthand.html
+++ b/css/css-fonts/font-palette-vs-shorthand.html
@@ -47,7 +47,6 @@ test(function() {
     let testElem = document.getElementById("a");
     let computed = window.getComputedStyle(testElem);
     assert_equals(computed.fontPalette, "dark");
-    assert_equals(computed.font, "");
     assert_equals(computed.fontFamily, "colr");
     assert_equals(computed.fontSize, "50px");
 });
@@ -68,7 +67,6 @@ test(function() {
     let testElem = document.getElementById("c");
     let computed = window.getComputedStyle(testElem);
     assert_equals(computed.fontPalette, "dark");
-    assert_equals(computed.font, "");
 });
 
 test(function() {


### PR DESCRIPTION
Currently in spec for [font shorthand](https://drafts.csswg.org/css-fonts/#font-prop) and [font-palette](https://drafts.csswg.org/css-fonts/#propdef-font-palette) properties there is no specification if the font shorthand property should be serialized or not if font-palette is set to non initial value. Suggesting to remove this assertions from the test and raise a spec issue to clarify it in spec.