### PR TITLE
update eof for windows

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorcontentshell.py
+++ b/tools/wptrunner/wptrunner/executors/executorcontentshell.py
@@ -95,8 +95,8 @@ class ContentShellTestPart(ProtocolPart):
                 result += line[:-len(self.eof_marker)]
                 break
             elif line.endswith('#EOF\r\n'):
-                result += line
-                result += 'Got a CRLF-terminated #EOF - this is a driver bug.'
+                result += line[:-len('#EOF\r\n')]
+                self.logger.warning('Got a CRLF-terminated #EOF - this is a driver bug.')
                 break
 
             result += line

--- a/tools/wptrunner/wptrunner/executors/executorcontentshell.py
+++ b/tools/wptrunner/wptrunner/executors/executorcontentshell.py
@@ -44,7 +44,7 @@ class ContentShellTestPart(ProtocolPart):
     name = "content_shell_test"
     eof_marker = "#EOF" + linesep  # Marker sent by content_shell after blocks.
 
-    if sys.platform.startswith('win'):
+    if sys.platform == "win32":
         eof_marker = (b'#EOF\n').decode()
 
     def __init__(self, parent):

--- a/tools/wptrunner/wptrunner/executors/executorcontentshell.py
+++ b/tools/wptrunner/wptrunner/executors/executorcontentshell.py
@@ -7,6 +7,7 @@ from queue import Empty
 from base64 import b64encode
 from os import linesep
 import json
+import sys
 
 
 class CrashError(BaseException):
@@ -42,6 +43,9 @@ class ContentShellTestPart(ProtocolPart):
     """
     name = "content_shell_test"
     eof_marker = "#EOF" + linesep  # Marker sent by content_shell after blocks.
+
+    if sys.platform.startswith('win'):
+        eof_marker = (b'#EOF\n').decode()
 
     def __init__(self, parent):
         super().__init__(parent)

--- a/tools/wptrunner/wptrunner/executors/executorcontentshell.py
+++ b/tools/wptrunner/wptrunner/executors/executorcontentshell.py
@@ -5,9 +5,7 @@ from .protocol import Protocol, ProtocolPart
 from time import time
 from queue import Empty
 from base64 import b64encode
-from os import linesep
 import json
-import sys
 
 
 class CrashError(BaseException):
@@ -42,10 +40,7 @@ class ContentShellTestPart(ProtocolPart):
     https://chromium.googlesource.com/chromium/src.git/+/HEAD/content/web_test/browser/test_info_extractor.h
     """
     name = "content_shell_test"
-    eof_marker = "#EOF" + linesep  # Marker sent by content_shell after blocks.
-
-    if sys.platform == "win32":
-        eof_marker = '#EOF\n'
+    eof_marker = '#EOF\n'  # Marker sent by content_shell after blocks.
 
     def __init__(self, parent):
         super().__init__(parent)
@@ -71,7 +66,7 @@ class ContentShellTestPart(ProtocolPart):
     def _send_command(self, command):
         """Sends a single `command`, i.e. a URL to open, to content_shell.
         """
-        self.stdin_queue.put((command + linesep).encode("utf-8"))
+        self.stdin_queue.put((command + "\n").encode("utf-8"))
 
     def _read_block(self, deadline=None):
         """Tries to read a single block of content from stdout before the `deadline`.

--- a/tools/wptrunner/wptrunner/executors/executorcontentshell.py
+++ b/tools/wptrunner/wptrunner/executors/executorcontentshell.py
@@ -45,7 +45,7 @@ class ContentShellTestPart(ProtocolPart):
     eof_marker = "#EOF" + linesep  # Marker sent by content_shell after blocks.
 
     if sys.platform == "win32":
-        eof_marker = (b'#EOF\n').decode()
+        eof_marker = '#EOF\n'
 
     def __init__(self, parent):
         super().__init__(parent)
@@ -98,6 +98,10 @@ class ContentShellTestPart(ProtocolPart):
 
             if line.endswith(self.eof_marker):
                 result += line[:-len(self.eof_marker)]
+                break
+            elif line.endswith('#EOF\r\n'):
+                result += line
+                result += 'Got a CRLF-terminated #EOF - this is a driver bug.'
                 break
 
             result += line


### PR DESCRIPTION
On windows it's not correctly matching the EOF that's received from content_shell.
In this change we update to use the correct format to end the process correctly. 