### PR TITLE
Fix typo of window_state_context.js's path

### DIFF
--- a/screen-orientation/hidden_document.html
+++ b/screen-orientation/hidden_document.html
@@ -8,7 +8,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script src="/screen-visibility/resources/window_state_context.js"></script>
+<script src="/page-visibility/resources/window_state_context.js"></script>
 <script src="/screen-orientation/resources/orientation_.js"></script>
 <script>
   promise_test(async (t) => {


### PR DESCRIPTION
I think that window_state_context.js path by https://github.com/web-platform-tests/wpt/pull/36734 is incorrect.