### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=244943

### DIFF
--- a/html/capability-delegation/delegate-fullscreen-request-subframe-cross-origin.https.sub.tentative.html
+++ b/html/capability-delegation/delegate-fullscreen-request-subframe-cross-origin.https.sub.tentative.html
@@ -4,6 +4,7 @@
      https://github.com/WICG/capability-delegation/issues/10
 -->
 <title>Capability Delegation of Fullscreen Requests: Subframe Cross-Origin</title>
+<script src="/common/get-host-info.sub.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
@@ -20,14 +21,15 @@
   See wpt/html/user-activation/propagation*.html for frame tree user activation visibility tests.
 </div>
 
-<iframe allow="fullscreen" width="300px" height="50px"
-        src="https://{{hosts[alt][www]}}:{{ports[https][0]}}/html/capability-delegation/resources/delegate-fullscreen-request-recipient.html">
+<iframe allow="fullscreen" width="300px" height="50px">
 </iframe>
 
 <script>
+  const origin = get_host_info().HTTPS_REMOTE_ORIGIN;
+  document.querySelector("iframe").src = origin + "/html/capability-delegation/resources/delegate-fullscreen-request-recipient.html";
+
   function testCrossOriginSubframeFullscreenDelegation(capability, activate, expectation) {
       const message = {"type": "make-fullscreen-request"};
-      const origin = "https://{{hosts[alt][www]}}:{{ports[https][0]}}";
       const expectationType = expectation ? "succeeds" : "fails";
       const delegationType = capability ? "with delegation" : "without delegation";
       const activationType = activate ? "with user activation" : "with no user activation";


### PR DESCRIPTION
Update delegate-fullscreen-request-subframe-cross-origin.https.sub.tentative.html to use get-host-info.sub.js

Update test to rely on get-host-info.sub.js to get a remote origin, instead of hard-coding "https://{{hosts[alt][www]}}:{{ports[https][0]}}" so that it can run with the WebKit test infrastructure where custom WPT localhost domains are not supported.

This is a merge of WebKit's https://github.com/WebKit/WebKit/pull/6572.