### PR TITLE
wpt: print help when no arguments are provided

### DIFF
--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -80,6 +80,10 @@ def parse_args(argv, commands=load_commands()):
     for command, props in commands.items():
         subparsers.add_parser(command, help=props["help"], add_help=False)
 
+    if not argv:
+        parser.print_help()
+        return None, None
+
     args, extra = parser.parse_known_args(argv)
 
     return args, extra
@@ -188,6 +192,9 @@ def main(prog=None, argv=None):
     commands = load_commands()
 
     main_args, command_args = parse_args(argv, commands)
+
+    if not main_args:
+        return
 
     command = main_args.command
     props = commands[command]


### PR DESCRIPTION
When no arguments are provided to the `./wpt` command, print help.