### PR TITLE
[wptrunner] Allow expectation inheritance from `__dir__.ini`

### DIFF
--- a/tools/wptrunner/wptrunner/manifestexpected.py
+++ b/tools/wptrunner/wptrunner/manifestexpected.py
@@ -53,7 +53,8 @@ def list_prop(name, node):
             return [list_prop]
         return list(list_prop)
     except KeyError:
-        return []
+        # Return `None` instead of `[]` to signal the list was not found.
+        return None
 
 
 def str_prop(name, node):
@@ -120,6 +121,16 @@ def leak_threshold(node):
     except KeyError:
         pass
     return rv
+
+
+def expected_prop(node):
+    statuses = list_prop("expected", node)
+    return statuses[0] if statuses else None
+
+
+def known_intermittent_prop(node):
+    statuses = list_prop("expected", node)
+    return statuses[1:] if statuses is not None else None
 
 
 def fuzzy_prop(node):
@@ -318,11 +329,11 @@ class ExpectedManifest(ManifestItem):
 
     @property
     def expected(self):
-        return list_prop("expected", self)[0]
+        return expected_prop(self)
 
     @property
     def known_intermittent(self):
-        return list_prop("expected", self)[1:]
+        return known_intermittent_prop(self)
 
     @property
     def implementation_status(self):
@@ -381,6 +392,14 @@ class DirectoryManifest(ManifestItem):
     @property
     def fuzzy(self):
         return fuzzy_prop(self)
+
+    @property
+    def expected(self):
+        return expected_prop(self)
+
+    @property
+    def known_intermittent(self):
+        return known_intermittent_prop(self)
 
     @property
     def implementation_status(self):
@@ -469,11 +488,11 @@ class TestNode(ManifestItem):
 
     @property
     def expected(self):
-        return list_prop("expected", self)[0]
+        return expected_prop(self)
 
     @property
     def known_intermittent(self):
-        return list_prop("expected", self)[1:]
+        return known_intermittent_prop(self)
 
     @property
     def implementation_status(self):

--- a/tools/wptrunner/wptrunner/tests/test_wpttest.py
+++ b/tools/wptrunner/wptrunner/tests/test_wpttest.py
@@ -12,6 +12,7 @@ from .. import manifestexpected, wpttest
 
 dir_ini_0 = b"""\
 prefs: [a:b]
+expected: [TIMEOUT, OK]
 """
 
 dir_ini_1 = b"""\
@@ -19,6 +20,7 @@ prefs: [@Reset, b:c]
 max-asserts: 2
 min-asserts: 1
 tags: [b, c]
+expected: CRASH
 """
 
 dir_ini_2 = b"""\
@@ -136,6 +138,8 @@ def test_metadata_inherit():
 
     test_obj = make_test_object(test_0, "a/0.html", 0, items, inherit_metadata, True)
 
+    assert test_obj.expected() == "CRASH"
+    assert test_obj.known_intermittent() == []
     assert test_obj.max_assertion_count == 3
     assert test_obj.min_assertion_count == 1
     assert test_obj.prefs == {"b": "c", "c": "d"}

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -398,21 +398,11 @@ class Test:
             default = self.result_cls.default_expected
         else:
             default = self.subtest_result_cls.default_expected
-
-        metadata = self._get_metadata(subtest)
-        if metadata is None:
-            return default
-
-        try:
-            expected = metadata.get("expected")
-            if isinstance(expected, str):
+        for meta in self.itermeta(subtest):
+            expected = meta.expected
+            if expected is not None:
                 return expected
-            elif isinstance(expected, list):
-                return expected[0]
-            elif expected is None:
-                return default
-        except KeyError:
-            return default
+        return default
 
     def implementation_status(self):
         implementation_status = None
@@ -425,17 +415,11 @@ class Test:
         return "implementing"
 
     def known_intermittent(self, subtest=None):
-        metadata = self._get_metadata(subtest)
-        if metadata is None:
-            return []
-
-        try:
-            expected = metadata.get("expected")
-            if isinstance(expected, list):
-                return expected[1:]
-            return []
-        except KeyError:
-            return []
+        for meta in self.itermeta(subtest):
+            known_intermittent = meta.known_intermittent
+            if known_intermittent is not None:
+                return known_intermittent
+        return []
 
     def __repr__(self):
         return f"<{self.__module__}.{self.__class__.__name__} {self.id}>"


### PR DESCRIPTION
[1] seems to imply a test without per-test metadata can inherit the `expected` key of an ancestor `__dir__.ini`, but this does not actually work currently. This change applies the metadata search the other properties use to `expected` and `known_intermittent`. Special care was taken to ensure `expected` and `known_intermittent` are retrieved from the same key-value node.

One use case for a directory-wide expectation is to suppress failures that share a common cause (e.g., flag-enabled functionality). This avoids the need to create per-test metadata files with repeated contents that are not ergonomic to update.

[1]: https://web-platform-tests.org/tools/wptrunner/docs/expectation.html#directory-metadata