### PR TITLE
Expect `<video> autoplay` to pass in Safari

### DIFF
--- a/infrastructure/metadata/infrastructure/assumptions/allowed-to-play.html.ini
+++ b/infrastructure/metadata/infrastructure/assumptions/allowed-to-play.html.ini
@@ -7,3 +7,7 @@
   [<audio> autoplay]
     expected:
       if product == "safari": FAIL # https://bugs.webkit.org/show_bug.cgi?id=190775
+
+  [<video> autoplay]
+    expected:
+      if product == "safari": PASS


### PR DESCRIPTION
This subtest inherited a stale test-level `ERROR` expectation.