### PR TITLE
Ignore exceptions on setter of `orientation.type` and `orientation.angle`

### DIFF
--- a/screen-orientation/orientation-reading.html
+++ b/screen-orientation/orientation-reading.html
@@ -90,8 +90,16 @@ test(() => {
   const type = screen.orientation.type;
   const angle = screen.orientation.angle;
 
-  screen.orientation.type = "foo";
-  screen.orientation.angle = 42;
+  try {
+    screen.orientation.type = "foo";
+  } catch (err) {
+    // implementation might throw an exception due to readonly
+  }
+  try {
+    screen.orientation.angle = 42;
+  } catch (err) {
+    // implementation might throw an exception due to readonly
+  }
 
   assert_equals(screen.orientation.type, type);
   assert_equals(screen.orientation.angle, angle);


### PR DESCRIPTION
`orientation-reading.html` has a test that type and angle are read only.  But WebIDL's readonly may throw an exception for setter. So we should ignore the exception for setter.