### PR TITLE
Add verbose debug routes to RoutesBuilder

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -573,6 +573,7 @@ class RoutesBuilder:
             ("*", "/.well-known/attribution-reporting/debug/report-event-attribution", handlers.PythonScriptHandler),
             ("*", "/.well-known/attribution-reporting/report-aggregate-attribution", handlers.PythonScriptHandler),
             ("*", "/.well-known/attribution-reporting/debug/report-aggregate-attribution", handlers.PythonScriptHandler),
+            ("*", "/.well-known/attribution-reporting/debug/verbose", handlers.PythonScriptHandler),
             ("*", "/.well-known/web-identity", handlers.PythonScriptHandler),
             ("*", "*.py", handlers.PythonScriptHandler),
             ("GET", "*", handlers.FileHandler)


### PR DESCRIPTION
Attribution Reporting API supports collecting verbose debug reports. Adding verbose debug reports routes as a well-known route to the RoutesBuilder so that the WPT server can receive and return debug reports.

https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#optional-verbose-debugging-reports