### PR TITLE
orientation.unlock doesn't return promise

### DIFF
--- a/screen-orientation/hidden_document.html
+++ b/screen-orientation/hidden_document.html
@@ -9,8 +9,9 @@
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="/page-visibility/resources/window_state_context.js"></script>
-<script src="/screen-orientation/resources/orientation_.js"></script>
-<script>
+<script type="module">
+  import { makeCleanup, getOppositeOrientation } from "./resources/orientation-utils.js";
+
   promise_test(async (t) => {
     const { minimize, restore } = window_state_context(t);
     t.add_cleanup(restore);
@@ -28,25 +29,26 @@
     await minimize();
 
     assert_equals(document.visibilityState, "hidden", "Document must be hidden");
-    await promise_rejects_dom(t, "SecurityError", screen.orientation.unlock() );
+    assert_throws_dom("SecurityError", () => screen.orientation.unlock());
   }, "hidden documents must reject went trying to call unlock");
 
   promise_test(async (t) => {
     const { minimize, restore } = window_state_context(t);
     t.add_cleanup(restore);
-    t.add_cleanup(make_cleanup());
+    t.add_cleanup(makeCleanup());
     await screen.orientation.lock(getOppositeOrientation());
 
     await minimize();
 
     assert_equals(document.visibilityState, "hidden", "Document must be hidden");
-    await promise_rejects_dom(t, "SecurityError", screen.orientation.unlock() );
+    assert_throws_dom("SecurityError", () => screen.orientation.unlock());
   }, "hidden documents must not unlock the screen orientation");
 
   promise_test(async (t) => {
     const { minimize, restore } = window_state_context(t);
     t.add_cleanup(restore);
-    t.add_cleanup(make_cleanup());
+    t.add_cleanup(makeCleanup());
+
     await screen.orientation.lock(getOppositeOrientation());
 
     await minimize();
@@ -59,6 +61,6 @@
 
     assert_equals(document.visibilityState, "visible");
     await screen.orientation.lock(getOppositeOrientation());
-    await screen.orientation.unlock();
+    screen.orientation.unlock();
   }, "Once maximized, a minimized window can lock or unlock the screen orientation again");
 </script>

--- a/screen-orientation/hidden_document.html
+++ b/screen-orientation/hidden_document.html
@@ -48,7 +48,6 @@
     const { minimize, restore } = window_state_context(t);
     t.add_cleanup(restore);
     t.add_cleanup(makeCleanup());
-
     await screen.orientation.lock(getOppositeOrientation());
 
     await minimize();


### PR DESCRIPTION
`hidden_document.html` uses `promise_rejects_dom` for `orientation.unlock`, but it doesn't return promise. So we should use `assert_throws_dom` instead.

Also, since this test has some issues, this fix includes it
- We don't have `screen-orientation/resources/orientation_.js`
- Import orientation-utils.js to use `getOppositeOrientation`
- Typo fix of `make_cleanup`.