### PR TITLE
Revert "webusb: Feature-Policy is now Permissions-Policy"

### DIFF
--- a/webusb/usb-allowed-by-feature-policy.https.sub.html.headers
+++ b/webusb/usb-allowed-by-feature-policy.https.sub.html.headers
@@ -1,1 +1,1 @@
-Permissions-Policy: usb=*
+Feature-Policy: usb *

--- a/webusb/usb-disabled-by-feature-policy.https.sub.html.headers
+++ b/webusb/usb-disabled-by-feature-policy.https.sub.html.headers
@@ -1,1 +1,1 @@
-Permissions-Policy: usb=()
+Feature-Policy: usb 'none'


### PR DESCRIPTION
Reverts web-platform-tests/wpt#37107

See https://crbug.com/1393121. https://crrev.com/c/4049072 cannot be applied as a patch to web-platform-tests/wpt because the patch is trying to delete the old `Feature-Policy: ...` lines that no longer match. We need to revert web-platform-tests/wpt#37107 to remove the conflict for the exporter.