### PR TITLE
Remove oneRealm arg from set_permission

### DIFF
--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -206,15 +206,13 @@ _Note: these special-key codepoints are not necessarily what you would expect. F
 
 ### set_permission
 
-Usage: `test_driver.set_permission(descriptor, state, one_realm=false, context=null)`
+Usage: `test_driver.set_permission(descriptor, state, context=null)`
  * _descriptor_: a
    [PermissionDescriptor](https://w3c.github.io/permissions/#dictdef-permissiondescriptor)
    or derived object
  * _state_: a
    [PermissionState](https://w3c.github.io/permissions/#enumdef-permissionstate)
    value
- * _one_realm_: a boolean that indicates whether the permission settings
-   apply to only one realm
  * context: a WindowProxy for the browsing context in which to perform the call
 
 This function causes permission requests and queries for the status of a
@@ -226,5 +224,5 @@ Example:
 
 ``` js
 await test_driver.set_permission({ name: "background-fetch" }, "denied");
-await test_driver.set_permission({ name: "push", userVisibleOnly: true }, "granted", true);
+await test_driver.set_permission({ name: "push", userVisibleOnly: true }, "granted");
 ```

--- a/generic-sensor/generic-sensor-permission.https.html
+++ b/generic-sensor/generic-sensor-permission.https.html
@@ -13,7 +13,7 @@
 for (const entry of ['accelerometer', 'gyroscope',
     'magnetometer', 'ambient-light-sensor']) {
   promise_test(async t => {
-    await test_driver.set_permission({ name: entry }, 'denied', false);
+    await test_driver.set_permission({ name: entry }, 'denied');
 
     const status = await navigator.permissions.query({ name: entry });
     assert_class_string(status, "PermissionStatus");
@@ -21,7 +21,7 @@ for (const entry of ['accelerometer', 'gyroscope',
   }, `Deny ${entry} permission should work.`);
 
   promise_test(async t => {
-    await test_driver.set_permission({ name: entry }, 'granted', false);
+    await test_driver.set_permission({ name: entry }, 'granted');
 
     const status = await navigator.permissions.query({ name: entry });
     assert_class_string(status, "PermissionStatus");

--- a/geolocation-API/disabled-by-permissions-policy.https.sub.html
+++ b/geolocation-API/disabled-by-permissions-policy.https.sub.html
@@ -17,8 +17,7 @@
     promise_test(async (t) => {
       await test_driver.set_permission(
         { name: "geolocation" },
-        "granted",
-        false
+        "granted"
       );
 
       const posError = await new Promise((resolve, reject) => {

--- a/idle-detection/basics.tentative.https.window.js
+++ b/idle-detection/basics.tentative.https.window.js
@@ -5,7 +5,7 @@
 'use strict';
 
 promise_setup(async t => {
-  await test_driver.set_permission({name: 'idle-detection'}, 'granted', false);
+  await test_driver.set_permission({name: 'idle-detection'}, 'granted');
 })
 
 promise_test(async t => {

--- a/idle-detection/idle-detection-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub.html
+++ b/idle-detection/idle-detection-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub.html
@@ -21,7 +21,7 @@ const cross_origin_worker_frame_src = base_src + sub +
   relative_worker_frame_path;
 
 promise_setup(async () => {
-  await test_driver.set_permission({ name: 'idle-detection' }, 'granted', false);
+  await test_driver.set_permission({ name: 'idle-detection' }, 'granted');
 });
 
 promise_test(async t => {

--- a/idle-detection/idle-detection-allowed-by-permissions-policy-attribute.https.sub.html
+++ b/idle-detection/idle-detection-allowed-by-permissions-policy-attribute.https.sub.html
@@ -17,7 +17,7 @@ const cross_origin_src = sub + same_origin_src;
 const cross_origin_worker_frame_src = sub + same_origin_worker_frame_src;
 
 promise_setup(async () => {
-  await test_driver.set_permission({ name: 'idle-detection' }, 'granted', false);
+  await test_driver.set_permission({ name: 'idle-detection' }, 'granted');
 });
 
 promise_test(async t => {

--- a/idle-detection/idle-detection-allowed-by-permissions-policy.https.sub.html
+++ b/idle-detection/idle-detection-allowed-by-permissions-policy.https.sub.html
@@ -17,7 +17,7 @@ const cross_origin_src = sub + same_origin_src;
 const cross_origin_worker_frame_src = sub + same_origin_worker_frame_src;
 
 promise_setup(async () => {
-  await test_driver.set_permission({ name: 'idle-detection' }, 'granted', false);
+  await test_driver.set_permission({ name: 'idle-detection' }, 'granted');
 });
 
 promise_test(async t => {

--- a/idle-detection/idle-detection-default-permissions-policy.https.sub.html
+++ b/idle-detection/idle-detection-default-permissions-policy.https.sub.html
@@ -14,7 +14,7 @@ const cross_origin_src = 'https://{{domains[www]}}:{{ports[https][0]}}' +
   same_origin_src;
 
 promise_setup(async () => {
-  await test_driver.set_permission({ name: 'idle-detection' }, 'granted', false);
+  await test_driver.set_permission({ name: 'idle-detection' }, 'granted');
 });
 
 promise_test(async t => {

--- a/idle-detection/idle-permission.tentative.https.window.js
+++ b/idle-detection/idle-permission.tentative.https.window.js
@@ -3,14 +3,14 @@
 'use strict';
 
 promise_test(async t => {
-  await test_driver.set_permission({name: 'idle-detection'}, 'denied', false);
+  await test_driver.set_permission({name: 'idle-detection'}, 'denied');
 
   let detector = new IdleDetector();
   await promise_rejects_dom(t, 'NotAllowedError', detector.start());
 }, 'Denying idle-detection permission should block access.');
 
 promise_test(async t => {
-  await test_driver.set_permission({name: 'idle-detection'}, 'granted', false);
+  await test_driver.set_permission({name: 'idle-detection'}, 'granted');
 
   let detector = new IdleDetector();
   await detector.start();
@@ -24,7 +24,7 @@ promise_test(async t => {
 }, 'Granting idle-detection permission should allow access.');
 
 promise_test(async t => {
-  await test_driver.set_permission({name: 'idle-detection'}, 'prompt', false);
+  await test_driver.set_permission({name: 'idle-detection'}, 'prompt');
 
   await promise_rejects_dom(t, 'NotAllowedError', IdleDetector.requestPermission());
 

--- a/idle-detection/idlharness-worker.https.window.js
+++ b/idle-detection/idlharness-worker.https.window.js
@@ -4,7 +4,7 @@
 'use strict';
 
 promise_test(async t => {
-  await test_driver.set_permission({name: 'idle-detection'}, 'granted', false);
+  await test_driver.set_permission({name: 'idle-detection'}, 'granted');
 
   await fetch_tests_from_worker(new Worker('resources/idlharness-worker.js'));
 }, 'Run idlharness tests in a worker.');

--- a/idle-detection/idlharness.https.window.js
+++ b/idle-detection/idlharness.https.window.js
@@ -11,7 +11,7 @@ idl_test(
     ['idle-detection'],
     ['dom', 'html'],
     async (idl_array, t) => {
-      await test_driver.set_permission({ name: 'idle-detection' }, 'granted', false);
+      await test_driver.set_permission({ name: 'idle-detection' }, 'granted');
 
       self.idle = new IdleDetector();
       let watcher = new EventWatcher(t, self.idle, ["change"]);

--- a/idle-detection/interceptor.https.html
+++ b/idle-detection/interceptor.https.html
@@ -11,7 +11,7 @@
 'use strict';
 
 promise_setup(async t => {
-  await test_driver.set_permission({ name: 'idle-detection' }, 'granted', false);
+  await test_driver.set_permission({ name: 'idle-detection' }, 'granted');
   if (isChromiumBased) {
     await loadChromiumResources();
   }

--- a/infrastructure/metadata/infrastructure/testdriver/set_permission.https.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/set_permission.https.html.ini
@@ -1,8 +1,8 @@
 [set_permission.https.html]
-  [Grant Permission for one realm]
+  [Grant Permission]
     expected:
       if product != "chrome": FAIL
 
-  [Deny Permission, omit one realm]
+  [Deny Permission]
     expected:
       if product != "chrome": FAIL

--- a/infrastructure/testdriver/set_permission.https.html
+++ b/infrastructure/testdriver/set_permission.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <title>TestDriver set_permission method</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -7,11 +7,17 @@
 <script src="/resources/testdriver-vendor.js"></script>
 
 <script>
-promise_test(t => {
-  return test_driver.set_permission({name: "ambient-light-sensor"}, "granted", true);
-}, "Grant Permission for one realm");
+    const descriptor = { name: "geolocation" };
 
-promise_test(t => {
-  return test_driver.set_permission({name: "push", userVisibleOnly: true}, "denied");
-}, "Deny Permission, omit one realm");
+    promise_test(async (t) => {
+        await test_driver.set_permission(descriptor, "granted");
+        permission = await navigator.permissions.query(descriptor);
+        assert_equals(permission.state, "granted");
+    }, "Grant Permission");
+
+    promise_test(async (t) => {
+        await test_driver.set_permission(descriptor, "denied");
+        permission = await navigator.permissions.query(descriptor);
+        assert_equals(permission.state, "denied");
+    }, "Deny Permission");
 </script>

--- a/mediacapture-image/MediaStreamTrack-applyConstraints-getSettings.https.html
+++ b/mediacapture-image/MediaStreamTrack-applyConstraints-getSettings.https.html
@@ -11,7 +11,7 @@
 
 image_capture_test(async t => {
   await test_driver.set_permission({name: 'camera', panTiltZoom: true},
-        'granted', false);
+        'granted');
 
   const constraints = { advanced : [{ whiteBalanceMode : 'single-shot',
                                       exposureMode     : 'manual',
@@ -96,7 +96,7 @@ image_capture_test(async t => {
 
 image_capture_test(async t => {
   await test_driver.set_permission({name: 'camera', panTiltZoom: true},
-      'denied', false);
+      'denied');
 
   let stream = await navigator.mediaDevices.getUserMedia({video: true});
   let videoTrack = stream.getVideoTracks()[0];

--- a/mediacapture-image/MediaStreamTrack-applyConstraints-reject.https.html
+++ b/mediacapture-image/MediaStreamTrack-applyConstraints-reject.https.html
@@ -11,7 +11,7 @@
 var makePromiseTest = function(getConstraint) {
   image_capture_test(async (t, imageCaptureTest) => {
     await test_driver.set_permission({name: 'camera', panTiltZoom: true},
-        'granted', false);
+        'granted');
 
     imageCaptureTest.mockImageCapture().state().supportsTorch = false;
 

--- a/mediacapture-image/MediaStreamTrack-applyConstraints.https.html
+++ b/mediacapture-image/MediaStreamTrack-applyConstraints.https.html
@@ -13,7 +13,7 @@ const meteringModeNames = ['none', 'manual', 'single-shot', 'continuous'];
 
 image_capture_test(async (t, imageCaptureTest) => {
   await test_driver.set_permission({name: 'camera', panTiltZoom: true},
-        'granted', false);
+        'granted');
 
   const constraints = { advanced : [{ whiteBalanceMode : 'single-shot',
                                       exposureMode     : 'manual',

--- a/mediacapture-image/MediaStreamTrack-clone.https.html
+++ b/mediacapture-image/MediaStreamTrack-clone.https.html
@@ -11,7 +11,7 @@
 // original, with a mock Mojo service implementation.
 image_capture_test(async (t, imageCaptureTest) => {
   await test_driver.set_permission({name: 'camera', panTiltZoom: true},
-        'granted', false);
+        'granted');
 
   const constraints = { advanced : [{ whiteBalanceMode : 'single-shot',
                                       exposureMode     : 'manual',
@@ -126,7 +126,7 @@ image_capture_test(async (t, imageCaptureTest) => {
 // when cloning a MediaStreamTrack.
 image_capture_test(async (t, imageCaptureTest) => {
   await test_driver.set_permission({name: 'camera', panTiltZoom: true},
-        'granted', false);
+        'granted');
 
   let stream = await navigator.mediaDevices.getUserMedia({video: true});
   let originalVideoTrack = stream.getVideoTracks()[0];
@@ -199,7 +199,7 @@ image_capture_test(async (t, imageCaptureTest) => {
 // when cloning a MediaStreamTrack.
 image_capture_test(async (t, imageCaptureTest) => {
   await test_driver.set_permission({name: 'camera', panTiltZoom: true},
-      'granted', false);
+      'granted');
 
   let stream = await navigator.mediaDevices.getUserMedia({video: true});
   let originalVideoTrack = stream.getVideoTracks()[0];

--- a/mediacapture-image/MediaStreamTrack-getCapabilities.https.html
+++ b/mediacapture-image/MediaStreamTrack-getCapabilities.https.html
@@ -16,7 +16,7 @@ function makeImageCaptureTest(hasPanTiltZoomPermissionGranted) {
   image_capture_test(async (t, imageCaptureTest) => {
     const ptzPermission = hasPanTiltZoomPermissionGranted ? 'granted' : 'denied';
     await test_driver.set_permission({name: 'camera', panTiltZoom: true},
-        ptzPermission, false);
+        ptzPermission);
 
     let mockCapabilities = imageCaptureTest.mockImageCapture().state();
 

--- a/mediacapture-image/MediaStreamTrack-getConstraints.https.html
+++ b/mediacapture-image/MediaStreamTrack-getConstraints.https.html
@@ -32,7 +32,7 @@ const constraints = { whiteBalanceMode     : "single-shot",
 function makePromiseTest(constraint) {
   image_capture_test(async function(t) {
     await test_driver.set_permission({name: 'camera', panTiltZoom: true},
-        'granted', false);
+        'granted');
 
     let stream = await navigator.mediaDevices.getUserMedia({video: true});
     let videoTrack = stream.getVideoTracks()[0];

--- a/mediacapture-image/MediaStreamTrack-getSettings.https.html
+++ b/mediacapture-image/MediaStreamTrack-getSettings.https.html
@@ -17,7 +17,7 @@ function makeImageCaptureTest(hasPanTiltZoomPermissionGranted) {
   image_capture_test(async (t, imageCaptureTest) => {
     const ptzPermission = hasPanTiltZoomPermissionGranted ? 'granted' : 'denied';
     await test_driver.set_permission({name: 'camera', panTiltZoom: true},
-        ptzPermission, false);
+        ptzPermission);
 
     let mockSettings = imageCaptureTest.mockImageCapture().state();
 

--- a/mediacapture-streams/permission-helper.js
+++ b/mediacapture-streams/permission-helper.js
@@ -4,7 +4,7 @@
 async function setMediaPermission(status="granted", scope=["camera", "microphone"]) {
   try {
     for (let s of scope) {
-      await test_driver.set_permission({ name: s }, status, true);
+      await test_driver.set_permission({ name: s }, status);
     }
   } catch (e) {
     const noSetPermissionSupport = typeof e === "string" && e.match(/set_permission not implemented/);

--- a/permissions-policy/resources/permissions-policy-geolocation.html
+++ b/permissions-policy/resources/permissions-policy-geolocation.html
@@ -7,8 +7,7 @@
     test_driver.set_test_context(window.parent);
     await test_driver.set_permission(
       { name: "geolocation" },
-      "granted",
-      false
+      "granted"
     );
     let enabled = true;
     try {

--- a/permissions-policy/resources/permissions-policy-screen-wakelock.html
+++ b/permissions-policy/resources/permissions-policy-screen-wakelock.html
@@ -6,7 +6,7 @@
 Promise.resolve().then(async () => {
   try {
     await test_driver.set_permission(
-        { name: 'screen-wake-lock' }, 'granted', false);
+        { name: 'screen-wake-lock' }, 'granted');
 
     const wakeLock = await navigator.wakeLock.request("screen");
     await wakeLock.release();

--- a/resources/chromium/generic_sensor_mocks.js
+++ b/resources/chromium/generic_sensor_mocks.js
@@ -490,7 +490,7 @@ self.GenericSensorTest = (() => {
         for (const entry
                  of ['accelerometer', 'gyroscope', 'magnetometer',
                      'ambient-light-sensor']) {
-          await test_driver.set_permission({name: entry}, 'granted', false);
+          await test_driver.set_permission({name: entry}, 'granted');
         }
       }
 

--- a/resources/chromium/nfc-mock.js
+++ b/resources/chromium/nfc-mock.js
@@ -410,7 +410,7 @@ self.WebNFCTest = (() => {
         throw new Error('Call reset() before initialize().');
 
       // Grant nfc permissions for Chromium testdriver.
-      await test_driver.set_permission({ name: 'nfc' }, 'granted', false);
+      await test_driver.set_permission({ name: 'nfc' }, 'granted');
 
       if (testInternal.mockNFC == null) {
         testInternal.mockNFC = new MockNFC();

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -398,24 +398,22 @@
          *
          * @example
          * await test_driver.set_permission({ name: "background-fetch" }, "denied");
-         * await test_driver.set_permission({ name: "push", userVisibleOnly: true }, "granted", true);
+         * await test_driver.set_permission({ name: "push", userVisibleOnly: true }, "granted");
          *
-         * @param {Object} descriptor - a `PermissionDescriptor
-         *                              <https://w3c.github.io/permissions/#dictdef-permissiondescriptor>`_
-         *                              object
+         * @param {PermissionDescriptor} descriptor - a `PermissionDescriptor
+         *                              <https://w3c.github.io/permissions/#dom-permissiondescriptor>`_
+         *                              dictionary.
          * @param {String} state - the state of the permission
-         * @param {boolean} one_realm - Optional. Whether the permission applies to only one realm
          * @param {WindowProxy} context - Browsing context in which
          *                                to run the call, or null for the current
          *                                browsing context.
          * @returns {Promise} fulfilled after the permission is set, or rejected if setting the
          *                    permission fails
          */
-        set_permission: function(descriptor, state, one_realm=false, context=null) {
+        set_permission: function(descriptor, state, context=null) {
             let permission_params = {
               descriptor,
               state,
-              oneRealm: one_realm,
             };
             return window.test_driver_internal.set_permission(permission_params, context);
         },

--- a/screen-details/screen_enumeration_permission.https.window.js
+++ b/screen-details/screen_enumeration_permission.https.window.js
@@ -4,7 +4,7 @@
 "use strict";
 
 promise_test(async t => {
-  await test_driver.set_permission({ name: "window-placement" }, "denied", false);
+  await test_driver.set_permission({ name: "window-placement" }, "denied");
 
   const status = await navigator.permissions.query({ name:"window-placement" });
   assert_class_string(status, "PermissionStatus");
@@ -12,7 +12,7 @@ promise_test(async t => {
 }, "Deny window management permission should work.");
 
 promise_test(async t => {
-  await test_driver.set_permission({ name: "window-placement" }, "granted", false);
+  await test_driver.set_permission({ name: "window-placement" }, "granted");
 
   const status = await navigator.permissions.query({ name: "window-placement" });
   assert_class_string(status, "PermissionStatus");

--- a/speculation-rules/prerender/restriction-background-sync.tentative.https.html
+++ b/speculation-rules/prerender/restriction-background-sync.tentative.https.html
@@ -30,8 +30,7 @@ promise_test(async t => {
   // periodicSync.register() waits until the permission is granted, which
   // is deferred during prerendering so the test would trivially pass without
   // the permission.
-  await test_driver.set_permission({name: 'periodic-background-sync'}, 'granted',
-                                    location.origin, location.origin);
+  await test_driver.set_permission({name: 'periodic-background-sync'}, 'granted');
 
   // Install the service worker first to test periodicSync.register in the
   // prerendering page.

--- a/speculation-rules/prerender/restriction-midi-sysex.https.html
+++ b/speculation-rules/prerender/restriction-midi-sysex.https.html
@@ -21,7 +21,7 @@ promise_test(async t => {
   // is deferred during prerendering so the test would trivially pass without
   // the permission.
   await test_driver.set_permission(
-      {name: 'midi', sysex: true}, 'granted', true);
+      {name: 'midi', sysex: true}, 'granted');
 
   const gotMessage = new Promise(resolve => {
     bc.addEventListener('message', e => {

--- a/speculation-rules/prerender/restriction-midi.https.html
+++ b/speculation-rules/prerender/restriction-midi.https.html
@@ -21,7 +21,7 @@ promise_test(async t => {
   // is deferred during prerendering so the test would trivially pass without
   // the permission.
   await test_driver.set_permission(
-      {name: 'midi', sysex: false}, 'granted', true);
+      {name: 'midi', sysex: false}, 'granted');
 
   const gotMessage = new Promise(resolve => {
     bc.addEventListener('message', e => {

--- a/speculation-rules/prerender/restriction-notification.https.html
+++ b/speculation-rules/prerender/restriction-notification.https.html
@@ -25,7 +25,7 @@ promise_test(async t => {
 
   await test_driver.set_permission({
     name: 'notifications'
-  }, 'granted', true);
+  }, 'granted');
   const gotMessage = new Promise(resolve => {
     bc.addEventListener('message', e => {
       resolve(e.data);
@@ -48,7 +48,7 @@ promise_test(async t => {
 
   await test_driver.set_permission({
     name: 'notifications'
-  }, 'granted', true);
+  }, 'granted');
   const gotMessage = new Promise(resolve => {
     bc.addEventListener('message', e => {
       resolve(e.data);

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -143,9 +143,8 @@ class SetPermissionAction:
         descriptor = permission_params["descriptor"]
         name = descriptor["name"]
         state = permission_params["state"]
-        one_realm = permission_params.get("oneRealm", False)
-        self.logger.debug("Setting permission %s to %s, oneRealm=%s" % (name, state, one_realm))
-        self.protocol.set_permission.set_permission(descriptor, state, one_realm)
+        self.logger.debug("Setting permission %s to %s" % (name, state))
+        self.protocol.set_permission.set_permission(descriptor, state)
 
 class AddVirtualAuthenticatorAction:
     name = "add_virtual_authenticator"

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -611,13 +611,11 @@ class MarionetteSetPermissionProtocolPart(SetPermissionProtocolPart):
     def setup(self):
         self.marionette = self.parent.marionette
 
-    def set_permission(self, descriptor, state, one_realm):
+    def set_permission(self, descriptor, state):
         body = {
             "descriptor": descriptor,
             "state": state,
         }
-        if one_realm is not None:
-            body["oneRealm"] = one_realm
         try:
             self.marionette._send_message("WebDriver:SetPermission", body)
         except errors.UnsupportedOperationException:

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -290,13 +290,11 @@ class WebDriverSetPermissionProtocolPart(SetPermissionProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
 
-    def set_permission(self, descriptor, state, one_realm):
+    def set_permission(self, descriptor, state):
         permission_params_dict = {
             "descriptor": descriptor,
             "state": state,
         }
-        if one_realm is not None:
-            permission_params_dict["oneRealm"] = one_realm
         self.webdriver.send_session_command("POST", "permissions", permission_params_dict)
 
 

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -374,12 +374,11 @@ class SetPermissionProtocolPart(ProtocolPart):
     name = "set_permission"
 
     @abstractmethod
-    def set_permission(self, descriptor, state, one_realm=False):
+    def set_permission(self, descriptor, state):
         """Set permission state.
 
         :param descriptor: A PermissionDescriptor object.
-        :param state: The state to set the permission to.
-        :param one_realm: Whether to set the permission for only one realm."""
+        :param state: The state to set the permission to."""
         pass
 
 

--- a/web-nfc/NDEFReader_make-read-only.https.window.js
+++ b/web-nfc/NDEFReader_make-read-only.https.window.js
@@ -8,7 +8,7 @@
 const invalid_signals = ['string', 123, {}, true, Symbol(), () => {}, self];
 
 nfc_test(async t => {
-  await test_driver.set_permission({name: 'nfc'}, 'denied', false);
+  await test_driver.set_permission({name: 'nfc'}, 'denied');
   const ndef = new NDEFReader();
   await promise_rejects_dom(t, 'NotAllowedError', ndef.makeReadOnly());
 }, 'NDEFReader.makeReadOnly should fail if user permission is not granted.');

--- a/web-nfc/NDEFReader_scan.https.html
+++ b/web-nfc/NDEFReader_scan.https.html
@@ -36,7 +36,7 @@ nfc_test(async t => {
 }, "Test that NDEFReader.scan rejects if signal is not an AbortSignal.");
 
 nfc_test(async t => {
-  await test_driver.set_permission({ name: 'nfc' }, 'denied', false);
+  await test_driver.set_permission({ name: 'nfc' }, 'denied');
   const ndef = new NDEFReader();
   await promise_rejects_dom(t, 'NotAllowedError', ndef.scan());
 }, "NDEFReader.scan should fail if user permission is not granted.");

--- a/web-nfc/NDEFReader_write.https.html
+++ b/web-nfc/NDEFReader_write.https.html
@@ -145,7 +145,7 @@ nfc_test(async t => {
  invalid records.");
 
 nfc_test(async t => {
-  await test_driver.set_permission({ name: 'nfc' }, 'denied', false);
+  await test_driver.set_permission({ name: 'nfc' }, 'denied');
   const ndef = new NDEFReader();
   await promise_rejects_dom(t, 'NotAllowedError', ndef.write(test_text_data));
 }, 'NDEFReader.write should fail if user permission is not granted.');

--- a/web-nfc/nfc_permission.https.window.js
+++ b/web-nfc/nfc_permission.https.window.js
@@ -4,7 +4,7 @@
 'use strict';
 
 promise_test(async t => {
-  await test_driver.set_permission({name: 'nfc'}, 'denied', false);
+  await test_driver.set_permission({name: 'nfc'}, 'denied');
 
   const status = await navigator.permissions.query({name: 'nfc'});
   assert_class_string(status, 'PermissionStatus');
@@ -12,7 +12,7 @@ promise_test(async t => {
 }, 'Deny nfc permission should work.');
 
 promise_test(async t => {
-  await test_driver.set_permission({name: 'nfc'}, 'granted', false);
+  await test_driver.set_permission({name: 'nfc'}, 'granted');
 
   const status = await navigator.permissions.query({name: 'nfc'});
   assert_class_string(status, 'PermissionStatus');


### PR DESCRIPTION
The use of realm and "oneRealm" are being removed from the Permission spec. 
https://github.com/w3c/permissions/pull/397

And related discussion:
https://github.com/w3c/permissions/issues/387