### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=241617

### DIFF
--- a/css/css-highlight-api/Highlight-setlike-tampered-Set-prototype.html
+++ b/css/css-highlight-api/Highlight-setlike-tampered-Set-prototype.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<title>Highlight is a setlike interface that works as expected even if Set.prototype is tampered</title>
+<link rel="help" href="https://drafts.csswg.org/css-highlight-api-1/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+"use strict";
+
+function tamperSetPrototype() {
+  delete Set.prototype.size;
+
+  Set.prototype.entries = null;
+  Set.prototype.forEach = undefined;
+  Set.prototype.has = "foo";
+  Set.prototype.keys = 0;
+  Set.prototype.values = Symbol();
+  Set.prototype[Symbol.iterator] = 1;
+  Set.prototype.add = true;
+  Set.prototype.clear = "";
+  Set.prototype.delete = -1.5;
+
+  Object.freeze(Set.prototype);
+}
+
+test(() => {
+  tamperSetPrototype();
+
+  const staticRange = new StaticRange({startContainer: document.body, endContainer: document.body, startOffset: 0, endOffset: 0});
+  const highlight = new Highlight(staticRange);
+
+  assert_equals(highlight.size, 1);
+  assert_true(highlight.has(staticRange));
+  assert_equals([...highlight.entries()][0][0], staticRange);
+
+  highlight.clear();
+  assert_equals(highlight.size, 0);
+
+  highlight.add(staticRange);
+  assert_equals(highlight.size, 1);
+
+  highlight.delete(staticRange);
+  assert_equals(highlight.size, 0);
+  assert_false(highlight.has(staticRange));
+
+  highlight.add(staticRange);
+  assert_equals([...highlight.keys()][0], staticRange);
+  assert_equals([...highlight.values()][0], staticRange);
+
+  let callbackCalled = false;
+  highlight.forEach(() => { callbackCalled = true; });
+  assert_true(callbackCalled);
+}, "Highlight is a setlike interface that works as expected even if Set.prototype is tampered.");
+</script>

--- a/css/css-highlight-api/HighlightRegistry-maplike-tampered-Map-prototype.html
+++ b/css/css-highlight-api/HighlightRegistry-maplike-tampered-Map-prototype.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<title>HighlightRegistry is a maplike interface that works as expected even if Map.prototype is tampered</title>
+<link rel="help" href="https://drafts.csswg.org/css-highlight-api-1/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+"use strict";
+
+function tamperMapPrototype() {
+  delete Map.prototype.size;
+
+  Map.prototype.entries = null;
+  Map.prototype.forEach = undefined;
+  Map.prototype.get = "foo";
+  Map.prototype.has = 0;
+  Map.prototype.keys = Symbol();
+  Map.prototype.values = 1;
+  Map.prototype[Symbol.iterator] = true;
+  Map.prototype.clear = false;
+  Map.prototype.delete = "";
+  Map.prototype.set = 3.14;
+
+  Object.freeze(Map.prototype);
+}
+
+test(() => {
+  tamperMapPrototype();
+
+  const highlight = new Highlight(new StaticRange({startContainer: document.body, endContainer: document.body, startOffset: 0, endOffset: 0}));
+  const highlightRegister = new HighlightRegister();
+
+  assert_equals(highlightRegister.size, 0);
+  highlightRegister.set("foo", highlight);
+  assert_equals(highlightRegister.size, 1);
+
+  assert_true(highlightRegister.has("foo"));
+  assert_equals([...highlightRegister.entries()][0][0], "foo");
+
+  highlightRegister.clear();
+  assert_equals(highlightRegister.size, 0);
+  assert_equals(highlightRegister.get("foo"), undefined);
+
+  highlightRegister.set("bar", highlight);
+  assert_equals(highlightRegister.get("bar"), highlight);
+  assert_equals([...highlightRegister][0][1], highlight);
+
+  highlightRegister.delete("bar");
+  assert_equals(highlightRegister.size, 0);
+  assert_false(highlightRegister.has("bar"));
+
+  highlightRegister.set("baz", highlight);
+  assert_equals([...highlightRegister.keys()][0], "baz");
+  assert_equals([...highlightRegister.values()][0], highlight);
+
+  let callbackCalled = false;
+  highlightRegister.forEach(() => { callbackCalled = true; });
+  assert_true(callbackCalled);
+}, "HighlightRegistry is a maplike interface that works as expected even if Map.prototype is tampered.");
+</script>


### PR DESCRIPTION
This upstream reviewed tests ensure that tampered `Map.prototype` / `Set.prototype` don't affect `maplike<>` / `setlike<>` declarations.