### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=248424

### DIFF
--- a/fetch/stale-while-revalidate/revalidate-not-blocked-by-csp.html
+++ b/fetch/stale-while-revalidate/revalidate-not-blocked-by-csp.html
@@ -54,12 +54,14 @@ promise_test(async t => {
   // Query the server again and again. At some point it must have received the
   // revalidation request. We poll, because we don't know when the revalidation
   // will occur.
+  let query = false;
   while(true) {
     await new Promise(r => step_timeout(r, 25));
-    let response = await fetch(image_src + "&query");
+    let response = await fetch(`${image_src}${query ? "&query" : ""}`);
     let count = response.headers.get("Count");
     if (count == "2")
       break;
+    query ^= true;
   }
 }, "Request revalidation aren't blocked by CSP");
 


### PR DESCRIPTION
WebKit export from bug: [imported/w3c/web-platform-tests/fetch/stale-while-revalidate/revalidate-not-blocked-by-csp.html times out](https://bugs.webkit.org/show_bug.cgi?id=248424)