### PR TITLE
Fixed CI failure of idlharness.js for unexposed overloaded functions.

### DIFF
--- a/interfaces/webnn.idl
+++ b/interfaces/webnn.idl
@@ -27,8 +27,13 @@ dictionary MLContextOptions {
 
 [SecureContext, Exposed=(Window, DedicatedWorker)]
 interface ML {
-  MLContext createContext(optional MLContextOptions options = {});
-  MLContext createContext(GPUDevice gpuDevice);
+  Promise<MLContext> createContext(optional MLContextOptions options = {});
+  Promise<MLContext> createContext(GPUDevice gpuDevice);
+
+  [Exposed=(DedicatedWorker)]
+  MLContext createContextSync(optional MLContextOptions options = {});
+  [Exposed=(DedicatedWorker)]
+  MLContext createContextSync(GPUDevice gpuDevice);
 };
 
 typedef record<DOMString, ArrayBufferView> MLNamedArrayBufferViews;
@@ -38,12 +43,12 @@ interface MLContext {};
 
 partial interface MLContext {
   [Exposed=(DedicatedWorker)]
-  undefined compute(
+  undefined computeSync(
       MLGraph graph, MLNamedArrayBufferViews inputs, MLNamedArrayBufferViews outputs);
 };
 
 partial interface MLContext {
-  Promise<undefined> computeAsync(
+  Promise<undefined> compute(
       MLGraph graph, MLNamedArrayBufferViews inputs, MLNamedArrayBufferViews outputs);
 };
 
@@ -103,12 +108,12 @@ interface MLGraphBuilder {
   // Create a single-value operand from the specified number of the specified type.
   MLOperand constant(double value, optional MLOperandType type = "float32");
 
+  // Compile the graph up to the specified output operands asynchronously.
+  Promise<MLGraph> build(MLNamedOperands outputs);
+
   // Compile the graph up to the specified output operands synchronously.
   [Exposed=(DedicatedWorker)]
-  MLGraph build(MLNamedOperands outputs);
-
-  // Compile the graph up to the specified output operands asynchronously.
-  Promise<MLGraph> buildAsync(MLNamedOperands outputs);
+  MLGraph buildSync(MLNamedOperands outputs);
 };
 
 dictionary MLBatchNormalizationOptions {

--- a/webnn/idlharness.https.any.js
+++ b/webnn/idlharness.https.any.js
@@ -35,25 +35,22 @@ idl_test(
       }
 
       for (const deviceType of DeviceTypeArray) {
-        const context = navigator.ml.createContext({deviceType});
-        // Per spec navigator.ml.createContext should return a MLContext, but
-        // in Chromium it returns a Promise<MLContext>. Fail the setup if this
-        // happens, since the tests wouldn't make sense.
-        if (context instanceof Promise) {
-          context.catch(() => {});
-          assert_unreached('navigator.ml.createContext returned a Promise');
+        if (isSync) {
+          self.context = navigator.ml.createContextSync({deviceType});
+        } else {
+          self.context = await navigator.ml.createContext({deviceType});
         }
-        self.context = context;
-        self.builder = new MLGraphBuilder(context);
+
+        self.builder = new MLGraphBuilder(self.context);
         self.input = builder.input('input', {type: 'float32', dimensions: [1, 1, 5, 5]});
         self.filter = builder.constant({type: 'float32', dimensions: [1, 1, 3, 3]}, new Float32Array(9).fill(1));
         self.relu = builder.relu();
         self.output = builder.conv2d(input, filter, {activation: relu, inputLayout: "nchw"});
 
         if (isSync) {
-          self.graph = builder.build({output});
+          self.graph = builder.buildSync({output});
         } else {
-          self.graph = await builder.buildAsync({output});
+          self.graph = await builder.build({output});
         }
       }
     }


### PR DESCRIPTION
This PR is to fix the CI failures of [wpt-chrome-dev-stability](https://github.com/web-platform-tests/wpt/pull/37222/checks?check_run_id=9764925588) and [wpt-firefox-nightly-stability](https://github.com/web-platform-tests/wpt/pull/37222/checks?check_run_id=9764925476) which reported following result in table

Test | Subtest | Results | Messages
-- | -- | -- | --
/webnn/idlharness.https.any.html | ML interface: member createContextSync | Duplicate subtest name |  
/webnn/idlharness.https.any.html | ML interface: navigator.ml must not have property "createContextSync" | Duplicate subtest name

by testing unexposed overloaded functions on https://github.com/web-platform-tests/wpt/pull/37222 and https://github.com/web-platform-tests/wpt/pull/36908

@jgraham @foolip PTAL, thanks.

