### PR TITLE
Webkit export of https://bugs.webkit.org/show_bug.cgi?id=247167

### DIFF
--- a/css/css-typed-om/resources/testhelper.js
+++ b/css/css-typed-om/resources/testhelper.js
@@ -31,6 +31,9 @@ function assert_color_channel_approx_equals(a, b) {
         assert_approx_equals(a[i].value, b[i].value, epsilonForUnitType(a.unit));
       }
       break;
+    case 'CSSKeywordValue':
+      assert_equals(a.value, b.value);
+      break;
     default:
       assert_equals(a.unit, b.unit);
       assert_approx_equals(a.value, b.value, epsilonForUnitType(a.unit));

--- a/css/css-typed-om/stylevalue-subclasses/cssHSL.html
+++ b/css/css-typed-om/stylevalue-subclasses/cssHSL.html
@@ -8,35 +8,38 @@
 <script>
 'use strict';
 
+const gUndefinedKeyword = new CSSKeywordValue("undefined");
+
 const gValidHueInputs = [
-  {hue: CSS.deg(180), desc: 'degrees'},
-  {hue: CSS.rad(1), desc: 'radians'},
-  {hue: CSS.grad(81), desc: 'gradians'},
+  {hue: 180, desc: "a number", expected: CSS.deg(180)},
+  {hue: CSS.deg(180), desc: 'degrees', expected: CSS.deg(180)},
+  {hue: CSS.rad(1), desc: 'radians', expected: CSS.rad(1)},
+  {hue: CSS.grad(81), desc: 'gradians', expected: CSS.grad(81)},
+  {hue: undefined, desc: "undefined", expected: gUndefinedKeyword},
 ];
 
 const gInvalidHueInputs = [
-  {hue: 180, desc: "a number"},
   {hue: CSS.px(1), desc: "css pixels"},
-  {hue: undefined, desc: "undefined"},
+  {hue: CSS.em(1), desc: "css em"},
 ]
 
-for (const {hue, desc} of gValidHueInputs) {
+for (const {hue, desc, expected} of gValidHueInputs) {
   test(() => {
     const result = new CSSHSL(hue, 0.5, 0.5);
-    assert_color_channel_approx_equals(result.h, hue);
+    assert_color_channel_approx_equals(result.h, expected);
   }, `Constructing a CSSHSL with ${desc} for the hue works as intended.`);
 
   test(() => {
     const result = new CSSHSL(CSS.deg(0), 0.5, 0.5);
     result.h = hue;
-    assert_color_channel_approx_equals(result.h, hue);
+    assert_color_channel_approx_equals(result.h, expected);
   }, `CSSHSL.h can be updated with a ${desc}.`);
 }
 
 for (const {hue, desc} of gInvalidHueInputs) {
   test(() => {
-    assert_throws_js(TypeError, () => new CSSHSL(hue, 0, 0));
-  }, `Constructing a CSSHSL with ${desc} for hue throws a type error.`);
+    assert_throws_dom("SyntaxError", () => new CSSHSL(hue, 0, 0));
+  }, `Constructing a CSSHSL with ${desc} for hue throws a SyntaxError.`);
 }
 
 test(() => {
@@ -56,16 +59,16 @@ test(() => {
 }, 'CSSHSL can be constructed from four numbers.');
 
 test(() => {
-  assert_throws_js(TypeError, () => new CSSHSL(CSS.deg(0), CSS.number(1), 0, 0));
-  assert_throws_js(TypeError, () => new CSSHSL(CSS.deg(0), 0, CSS.number(1), 0));
-  assert_throws_js(TypeError, () => new CSSHSL(CSS.deg(0), 0, 0, CSS.number(1)));
+  assert_throws_dom("SyntaxError", () => new CSSHSL(CSS.deg(0), CSS.number(1), 0, 0));
+  assert_throws_dom("SyntaxError", () => new CSSHSL(CSS.deg(0), 0, CSS.number(1), 0));
+  assert_throws_dom("SyntaxError", () => new CSSHSL(CSS.deg(0), 0, 0, CSS.number(1)));
 }, `Constructing a CSSHSL with CSS.number for s, l or alpha throws a TypeError`);
 
 for (const attr of ['s', 'l', 'alpha']) {
   test(() => {
     const result = new CSSHSL(CSS.deg(0), 0, 0);
-    assert_throws_js(TypeError, () => result[attr] = CSS.number(1));
-  }, `Updating a CSSHSL with CSS.number for ${attr} throws a TypeError`);
+    assert_throws_dom("SyntaxError", () => result[attr] = CSS.number(1));
+  }, `Updating a CSSHSL with CSS.number for ${attr} throws a SyntaxError`);
 
   test(() => {
     const result = new CSSHSL(CSS.deg(0), 0, 0);

--- a/css/css-typed-om/stylevalue-subclasses/cssHWB.html
+++ b/css/css-typed-om/stylevalue-subclasses/cssHWB.html
@@ -14,10 +14,13 @@ const gValidHueInputs = [
   {hue: CSS.grad(81), desc: 'gradians'},
 ];
 
-const gInvalidHueInputs = [
+const gInvalidHueInputsNotNumericValue = [
   {hue: 180, desc: "a number"},
-  {hue: CSS.px(1), desc: "css pixels"},
   {hue: undefined, desc: "undefined"},
+]
+
+const gInvalidHueInputsNumericValue = [
+  {hue: CSS.px(1), desc: "css pixels"},
 ]
 
 for (const {hue, desc} of gValidHueInputs) {
@@ -33,10 +36,16 @@ for (const {hue, desc} of gValidHueInputs) {
   }, `CSSHWB.h can be updated with a ${desc}.`);
 }
 
-for (const {hue, desc} of gInvalidHueInputs) {
+for (const {hue, desc} of gInvalidHueInputsNotNumericValue) {
   test(() => {
     assert_throws_js(TypeError, () => new CSSHWB(hue, 0, 0));
-  }, `Constructing a CSSHWB with ${desc} for hue throws a type error.`);
+  }, `Constructing a CSSHWB with ${desc} for hue throws a TypeError.`);
+}
+
+for (const {hue, desc} of gInvalidHueInputsNumericValue) {
+  test(() => {
+    assert_throws_dom("SyntaxError", () => new CSSHWB(hue, 0, 0));
+  }, `Constructing a CSSHWB with ${desc} for hue throws a SyntaxError.`);
 }
 
 test(() => {
@@ -56,16 +65,16 @@ test(() => {
 }, 'CSSHWB can be constructed from four numbers.');
 
 test(() => {
-  assert_throws_js(TypeError, () => new CSSHWB(CSS.deg(0), CSS.number(1), 0, 0));
-  assert_throws_js(TypeError, () => new CSSHWB(CSS.deg(0), 0, CSS.number(1), 0));
-  assert_throws_js(TypeError, () => new CSSHWB(CSS.deg(0), 0, 0, CSS.number(1)));
-}, `Constructing a CSSHWB with CSS.number for s, l or alpha throws a TypeError`);
+  assert_throws_dom("SyntaxError", () => new CSSHWB(CSS.deg(0), CSS.number(1), 0, 0));
+  assert_throws_dom("SyntaxError", () => new CSSHWB(CSS.deg(0), 0, CSS.number(1), 0));
+  assert_throws_dom("SyntaxError", () => new CSSHWB(CSS.deg(0), 0, 0, CSS.number(1)));
+}, `Constructing a CSSHWB with CSS.number for s, l or alpha throws a SyntaxError`);
 
 for (const attr of ['w', 'b', 'alpha']) {
   test(() => {
     const result = new CSSHWB(CSS.deg(0), 0, 0);
-    assert_throws_js(TypeError, () => result[attr] = CSS.number(1));
-  }, `Updating a CSSHWB with CSS.number for ${attr} throws a TypeError`);
+    assert_throws_dom("SyntaxError", () => result[attr] = CSS.number(1));
+  }, `Updating a CSSHWB with CSS.number for ${attr} throws a SyntaxError`);
 
   test(() => {
     const result = new CSSHWB(CSS.deg(0), 0, 0);

--- a/css/css-typed-om/stylevalue-subclasses/cssLCH.html
+++ b/css/css-typed-om/stylevalue-subclasses/cssLCH.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSLCH tests</title>
+<link rel="help" href="https://drafts.css-houdini.org/css-typed-om-1/#csshwb">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/testhelper.js"></script>
+<script>
+'use strict';
+
+const gValidLightnessInputs = [
+  {lightness: CSS.percent(50), desc: 'percent', expected: CSS.percent(50)},
+  {lightness: 0.5, desc: 'number', expected: CSS.percent(50)},
+];
+
+const gInvalidLightnessInputs = [
+  {lightness: CSS.px(1), desc: "css pixels"},
+  {lightness: CSS.deg(180), desc: "degrees"},
+]
+
+for (const {lightness, desc, expected} of gValidLightnessInputs) {
+  test(() => {
+    const result = new CSSLCH(lightness, 0.5, 0.5);
+    assert_color_channel_approx_equals(result.l, expected);
+  }, `Constructing a CSSLCH with ${desc} for the lightness works as intended.`);
+
+  test(() => {
+    const result = new CSSLCH(CSS.percent(0), 0.5, 0.5);
+    result.l = lightness;
+    assert_color_channel_approx_equals(result.l, expected);
+  }, `CSSLCH.l can be updated with a ${desc}.`);
+}
+
+for (const {lightness, desc} of gInvalidLightnessInputs) {
+  test(() => {
+    assert_throws_dom("SyntaxError", () => new CSSLCH(lightness, 0, 0));
+  }, `Constructing a CSSLCH with ${desc} for lightness throws a SyntaxError.`);
+}
+
+test(() => {
+  const result = new CSSLCH(CSS.percent(27), 0.7, 8);
+  assert_color_channel_approx_equals(result.l, CSS.percent(27));
+  assert_color_channel_approx_equals(result.c, CSS.percent(70));
+  assert_color_channel_approx_equals(result.h, CSS.deg(8));
+  assert_color_channel_approx_equals(result.alpha, CSS.percent(100));
+}, 'CSSLCH can be constructed from three numbers and will get an alpha of 100%.');
+
+test(() => {
+  const result = new CSSLCH(0.2, 0.7, CSS.rad(8), CSS.percent(0.4));
+  assert_color_channel_approx_equals(result.l, CSS.percent(20));
+  assert_color_channel_approx_equals(result.c, CSS.percent(70));
+  assert_color_channel_approx_equals(result.h, CSS.rad(8));
+  assert_color_channel_approx_equals(result.alpha, CSS.percent(0.4));
+}, 'CSSLCH can be constructed from four numbers.');
+
+test(() => {
+  assert_throws_dom("SyntaxError", () => new CSSLCH(CSS.number(1), 0, 0, 0));
+  assert_throws_dom("SyntaxError", () => new CSSLCH(0, CSS.number(1), 0, 0));
+  assert_throws_dom("SyntaxError", () => new CSSLCH(0, 0, CSS.number(1), 0));
+  assert_throws_dom("SyntaxError", () => new CSSLCH(0, 0, 0, CSS.number(1)));
+}, `Constructing a CSSLCH with CSS.number for l, c, h or alpha throws a SyntaxError`);
+
+for (const attr of ['l', 'c', 'alpha']) {
+  test(() => {
+    const result = new CSSLCH(CSS.percent(0), 0, 0);
+    assert_throws_dom("SyntaxError", () => result[attr] = CSS.number(1));
+  }, `Updating a CSSLCH with CSS.number for ${attr} throws a SyntaxError`);
+
+  test(() => {
+    const result = new CSSLCH(CSS.percent(0), 0, 0);
+    result[attr] = 0.5;
+    assert_color_channel_approx_equals(result[attr], CSS.percent(50));
+  }, 'CSSLCH.' + attr + ' can be updated to a number.');
+
+  test(() => {
+    const result = new CSSLCH(CSS.percent(0), 0, 0);
+    result[attr] = CSS.percent(50);
+    assert_color_channel_approx_equals(result[attr], CSS.percent(50));
+  }, 'CSSLCH.' + attr + ' can be updated with a CSS percent.');
+}
+</script>

--- a/css/css-typed-om/stylevalue-subclasses/cssLab.html
+++ b/css/css-typed-om/stylevalue-subclasses/cssLab.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSLab tests</title>
+<link rel="help" href="https://drafts.css-houdini.org/css-typed-om-1/#csshwb">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/testhelper.js"></script>
+<script>
+'use strict';
+
+const gValidLightnessInputs = [
+  {lightness: CSS.percent(50), desc: 'percent', expected: CSS.percent(50)},
+  {lightness: 0.5, desc: 'number', expected: CSS.percent(50)},
+];
+
+const gInvalidLightnessInputs = [
+  {lightness: CSS.px(1), desc: "css pixels"},
+  {lightness: CSS.deg(180), desc: "degrees"},
+]
+
+for (const {lightness, desc, expected} of gValidLightnessInputs) {
+  test(() => {
+    const result = new CSSLab(lightness, 0.5, 0.5);
+    assert_color_channel_approx_equals(result.l, expected);
+  }, `Constructing a CSSLab with ${desc} for the lightness works as intended.`);
+
+  test(() => {
+    const result = new CSSLab(CSS.percent(0), 0.5, 0.5);
+    result.l = lightness;
+    assert_color_channel_approx_equals(result.l, expected);
+  }, `CSSLab.l can be updated with a ${desc}.`);
+}
+
+for (const {lightness, desc} of gInvalidLightnessInputs) {
+  test(() => {
+    assert_throws_dom("SyntaxError", () => new CSSLab(lightness, 0, 0));
+  }, `Constructing a CSSLab with ${desc} for lightness throws a SyntaxError.`);
+}
+
+test(() => {
+  const result = new CSSLab(CSS.percent(27), 7, CSS.number(8));
+  assert_color_channel_approx_equals(result.l, CSS.percent(27));
+  assert_color_channel_approx_equals(result.a, CSS.number(7));
+  assert_color_channel_approx_equals(result.b, CSS.number(8));
+  assert_color_channel_approx_equals(result.alpha, CSS.percent(100));
+}, 'CSSLab can be constructed from three numbers and will get an alpha of 100%.');
+
+test(() => {
+  const result = new CSSLab(0.2, 7, CSS.number(8), CSS.percent(0.4));
+  assert_color_channel_approx_equals(result.l, CSS.percent(20));
+  assert_color_channel_approx_equals(result.a, CSS.number(7));
+  assert_color_channel_approx_equals(result.b, CSS.number(8));
+  assert_color_channel_approx_equals(result.alpha, CSS.percent(0.4));
+}, 'CSSLab can be constructed from four numbers.');
+
+test(() => {
+  assert_throws_dom("SyntaxError", () => new CSSLab(CSS.number(1), 0, 0, 0));
+  assert_throws_dom("SyntaxError", () => new CSSLab(0, 0, 0, CSS.number(1)));
+}, `Constructing a CSSLab with CSS.number for l or alpha throws a SyntaxError`);
+
+for (const attr of ['l', 'alpha']) {
+  test(() => {
+    const result = new CSSLab(CSS.percent(0), 0, 0);
+    assert_throws_dom("SyntaxError", () => result[attr] = CSS.number(1));
+  }, `Updating a CSSLab with CSS.number for ${attr} throws a SyntaxError`);
+
+  test(() => {
+    const result = new CSSLab(CSS.percent(0), 0, 0);
+    result[attr] = 0.5;
+    assert_color_channel_approx_equals(result[attr], CSS.percent(50));
+  }, 'CSSLab.' + attr + ' can be updated to a number.');
+
+  test(() => {
+    const result = new CSSLab(CSS.percent(0), 0, 0);
+    result[attr] = CSS.percent(50);
+    assert_color_channel_approx_equals(result[attr], CSS.percent(50));
+  }, 'CSSLab.' + attr + ' can be updated with a CSS percent.');
+}
+</script>

--- a/css/css-typed-om/stylevalue-subclasses/cssOKLCH.html
+++ b/css/css-typed-om/stylevalue-subclasses/cssOKLCH.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSOKLCH tests</title>
+<link rel="help" href="https://drafts.css-houdini.org/css-typed-om-1/#csshwb">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/testhelper.js"></script>
+<script>
+'use strict';
+
+const gValidLightnessInputs = [
+  {lightness: CSS.percent(50), desc: 'percent', expected: CSS.percent(50)},
+  {lightness: 0.5, desc: 'number', expected: CSS.percent(50)},
+];
+
+const gInvalidLightnessInputs = [
+  {lightness: CSS.px(1), desc: "css pixels"},
+  {lightness: CSS.deg(180), desc: "degrees"},
+]
+
+for (const {lightness, desc, expected} of gValidLightnessInputs) {
+  test(() => {
+    const result = new CSSOKLCH(lightness, 0.5, 0.5);
+    assert_color_channel_approx_equals(result.l, expected);
+  }, `Constructing a CSSOKLCH with ${desc} for the lightness works as intended.`);
+
+  test(() => {
+    const result = new CSSOKLCH(CSS.percent(0), 0.5, 0.5);
+    result.l = lightness;
+    assert_color_channel_approx_equals(result.l, expected);
+  }, `CSSOKLCH.l can be updated with a ${desc}.`);
+}
+
+for (const {lightness, desc} of gInvalidLightnessInputs) {
+  test(() => {
+    assert_throws_dom("SyntaxError", () => new CSSOKLCH(lightness, 0, 0));
+  }, `Constructing a CSSOKLCH with ${desc} for lightness throws a SyntaxError.`);
+}
+
+test(() => {
+  const result = new CSSOKLCH(CSS.percent(27), 0.7, 8);
+  assert_color_channel_approx_equals(result.l, CSS.percent(27));
+  assert_color_channel_approx_equals(result.c, CSS.percent(70));
+  assert_color_channel_approx_equals(result.h, CSS.deg(8));
+  assert_color_channel_approx_equals(result.alpha, CSS.percent(100));
+}, 'CSSOKLCH can be constructed from three numbers and will get an alpha of 100%.');
+
+test(() => {
+  const result = new CSSOKLCH(0.2, 0.7, CSS.rad(8), CSS.percent(0.4));
+  assert_color_channel_approx_equals(result.l, CSS.percent(20));
+  assert_color_channel_approx_equals(result.c, CSS.percent(70));
+  assert_color_channel_approx_equals(result.h, CSS.rad(8));
+  assert_color_channel_approx_equals(result.alpha, CSS.percent(0.4));
+}, 'CSSOKLCH can be constructed from four numbers.');
+
+test(() => {
+  assert_throws_dom("SyntaxError", () => new CSSOKLCH(CSS.number(1), 0, 0, 0));
+  assert_throws_dom("SyntaxError", () => new CSSOKLCH(0, CSS.number(1), 0, 0));
+  assert_throws_dom("SyntaxError", () => new CSSOKLCH(0, 0, CSS.number(1), 0));
+  assert_throws_dom("SyntaxError", () => new CSSOKLCH(0, 0, 0, CSS.number(1)));
+}, `Constructing a CSSOKLCH with CSS.number for l, c, h or alpha throws a SyntaxError`);
+
+for (const attr of ['l', 'c', 'alpha']) {
+  test(() => {
+    const result = new CSSOKLCH(CSS.percent(0), 0, 0);
+    assert_throws_dom("SyntaxError", () => result[attr] = CSS.number(1));
+  }, `Updating a CSSOKLCH with CSS.number for ${attr} throws a SyntaxError`);
+
+  test(() => {
+    const result = new CSSOKLCH(CSS.percent(0), 0, 0);
+    result[attr] = 0.5;
+    assert_color_channel_approx_equals(result[attr], CSS.percent(50));
+  }, 'CSSOKLCH.' + attr + ' can be updated to a number.');
+
+  test(() => {
+    const result = new CSSOKLCH(CSS.percent(0), 0, 0);
+    result[attr] = CSS.percent(50);
+    assert_color_channel_approx_equals(result[attr], CSS.percent(50));
+  }, 'CSSOKLCH.' + attr + ' can be updated with a CSS percent.');
+}
+</script>

--- a/css/css-typed-om/stylevalue-subclasses/cssOKLab.html
+++ b/css/css-typed-om/stylevalue-subclasses/cssOKLab.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSOKLab tests</title>
+<link rel="help" href="https://drafts.css-houdini.org/css-typed-om-1/#csshwb">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/testhelper.js"></script>
+<script>
+'use strict';
+
+const gValidLightnessInputs = [
+  {lightness: CSS.percent(50), desc: 'percent', expected: CSS.percent(50)},
+  {lightness: 0.5, desc: 'number', expected: CSS.percent(50)},
+];
+
+const gInvalidLightnessInputs = [
+  {lightness: CSS.px(1), desc: "css pixels"},
+  {lightness: CSS.deg(180), desc: "degrees"},
+]
+
+for (const {lightness, desc, expected} of gValidLightnessInputs) {
+  test(() => {
+    const result = new CSSOKLab(lightness, 0.5, 0.5);
+    assert_color_channel_approx_equals(result.l, expected);
+  }, `Constructing a CSSOKLab with ${desc} for the lightness works as intended.`);
+
+  test(() => {
+    const result = new CSSOKLab(CSS.percent(0), 0.5, 0.5);
+    result.l = lightness;
+    assert_color_channel_approx_equals(result.l, expected);
+  }, `CSSOKLab.l can be updated with a ${desc}.`);
+}
+
+for (const {lightness, desc} of gInvalidLightnessInputs) {
+  test(() => {
+    assert_throws_dom("SyntaxError", () => new CSSOKLab(lightness, 0, 0));
+  }, `Constructing a CSSOKLab with ${desc} for lightness throws a SyntaxError.`);
+}
+
+test(() => {
+  const result = new CSSOKLab(CSS.percent(27), 7, CSS.number(8));
+  assert_color_channel_approx_equals(result.l, CSS.percent(27));
+  assert_color_channel_approx_equals(result.a, CSS.number(7));
+  assert_color_channel_approx_equals(result.b, CSS.number(8));
+  assert_color_channel_approx_equals(result.alpha, CSS.percent(100));
+}, 'CSSOKLab can be constructed from three numbers and will get an alpha of 100%.');
+
+test(() => {
+  const result = new CSSOKLab(0.2, 7, CSS.number(8), CSS.percent(0.4));
+  assert_color_channel_approx_equals(result.l, CSS.percent(20));
+  assert_color_channel_approx_equals(result.a, CSS.number(7));
+  assert_color_channel_approx_equals(result.b, CSS.number(8));
+  assert_color_channel_approx_equals(result.alpha, CSS.percent(0.4));
+}, 'CSSOKLab can be constructed from four numbers.');
+
+test(() => {
+  assert_throws_dom("SyntaxError", () => new CSSOKLab(CSS.number(1), 0, 0, 0));
+  assert_throws_dom("SyntaxError", () => new CSSOKLab(0, 0, 0, CSS.number(1)));
+}, `Constructing a CSSOKLab with CSS.number for l or alpha throws a SyntaxError`);
+
+for (const attr of ['l', 'alpha']) {
+  test(() => {
+    const result = new CSSOKLab(CSS.percent(0), 0, 0);
+    assert_throws_dom("SyntaxError", () => result[attr] = CSS.number(1));
+  }, `Updating a CSSOKLab with CSS.number for ${attr} throws a SyntaxError`);
+
+  test(() => {
+    const result = new CSSOKLab(CSS.percent(0), 0, 0);
+    result[attr] = 0.5;
+    assert_color_channel_approx_equals(result[attr], CSS.percent(50));
+  }, 'CSSOKLab.' + attr + ' can be updated to a number.');
+
+  test(() => {
+    const result = new CSSOKLab(CSS.percent(0), 0, 0);
+    result[attr] = CSS.percent(50);
+    assert_color_channel_approx_equals(result[attr], CSS.percent(50));
+  }, 'CSSOKLab.' + attr + ' can be updated with a CSS percent.');
+}
+</script>


### PR DESCRIPTION
Merge https://github.com/WebKit/WebKit/pull/5888 from WebKit to add test coverage for cssLCH, cssLab, cssOKLCH and cssOKLab. Also update the tests for cssHSL and cssHWB to match the latest CSS-Typed-OM specification.