### PR TITLE
CSS variables tests should require trimming values

### DIFF
--- a/css/css-typed-om/the-stylepropertymap/computed/computed.tentative.html
+++ b/css/css-typed-om/the-stylepropertymap/computed/computed.tentative.html
@@ -35,7 +35,7 @@ test(() => {
 
 test(() => {
   const result = styleMap.get('--foo');
-  assert_style_value_equals(result, new CSSUnparsedValue([' auto']));
+  assert_style_value_equals(result, new CSSUnparsedValue(['auto']));
 }, 'Computed StylePropertyMap contains custom property declarations in style rules');
 
 test(() => {
@@ -45,7 +45,7 @@ test(() => {
 
 test(() => {
   const result = styleMap.get('--bar');
-  assert_style_value_equals(result, new CSSUnparsedValue([' 5']));
+  assert_style_value_equals(result, new CSSUnparsedValue(['5']));
 }, 'Computed StylePropertyMap contains custom property declarations in inline rules');
 
 test(() => {

--- a/css/css-typed-om/the-stylepropertymap/computed/get.html
+++ b/css/css-typed-om/the-stylepropertymap/computed/get.html
@@ -24,7 +24,7 @@ test(t => {
 test(t => {
   const styleMap = createComputedStyleMap(t, '--foo: auto; --bar: 10px');
   assert_style_value_equals(styleMap.get('--foo'),
-      new CSSUnparsedValue([' auto']));
+      new CSSUnparsedValue(['auto']));
 }, 'Getting a valid custom property from computed style returns the ' +
    'correct entry');
 

--- a/css/css-typed-om/the-stylepropertymap/computed/getAll.tentative.html
+++ b/css/css-typed-om/the-stylepropertymap/computed/getAll.tentative.html
@@ -31,7 +31,7 @@ test(t => {
 
 test(t => {
   const styleMap = createComputedStyleMap(t, '--foo: auto; --bar: 10px');
-  assert_style_value_array_equals(styleMap.getAll('--foo'), [new CSSUnparsedValue([' auto'])]);
+  assert_style_value_array_equals(styleMap.getAll('--foo'), [new CSSUnparsedValue(['auto'])]);
 }, 'Calling StylePropertyMap.getAll with a valid custom property returns a single element list with the correct entry');
 
 test(t => {

--- a/css/css-typed-om/the-stylepropertymap/computed/iterable.tentative.html
+++ b/css/css-typed-om/the-stylepropertymap/computed/iterable.tentative.html
@@ -41,9 +41,9 @@ test(t => {
 
 test(t => {
   const styleMap = createComputedStyleMap(t, '--A: A; --C: C; color: red; --B: B;');
-  assert_style_value_array_equals(findInStyleMap(styleMap, '--A'), [new CSSUnparsedValue([' A'])]);
-  assert_style_value_array_equals(findInStyleMap(styleMap, '--B'), [new CSSUnparsedValue([' B'])]);
-  assert_style_value_array_equals(findInStyleMap(styleMap, '--C'), [new CSSUnparsedValue([' C'])]);
+  assert_style_value_array_equals(findInStyleMap(styleMap, '--A'), [new CSSUnparsedValue(['A'])]);
+  assert_style_value_array_equals(findInStyleMap(styleMap, '--B'), [new CSSUnparsedValue(['B'])]);
+  assert_style_value_array_equals(findInStyleMap(styleMap, '--C'), [new CSSUnparsedValue(['C'])]);
 }, 'StylePropertyMap iterator returns custom properties with the correct CSSStyleValue');
 
 test(t => {

--- a/css/css-typed-om/the-stylepropertymap/declared/declared.tentative.html
+++ b/css/css-typed-om/the-stylepropertymap/declared/declared.tentative.html
@@ -45,7 +45,7 @@ test(() => {
 }, 'Declared StylePropertyMap does not contain inline styles');
 
 test(() => {
-  assert_style_value_equals(styleMap.get('--foo'), new CSSUnparsedValue([' auto']));
+  assert_style_value_equals(styleMap.get('--foo'), new CSSUnparsedValue(['auto']));
 }, 'Declared StylePropertyMap contains custom property declarations');
 
 test(() => {

--- a/css/css-typed-om/the-stylepropertymap/declared/get.html
+++ b/css/css-typed-om/the-stylepropertymap/declared/get.html
@@ -29,7 +29,7 @@ test(t => {
 test(t => {
   const styleMap = createDeclaredStyleMap(t, '--foo: auto; --bar: 10px');
   assert_style_value_equals(styleMap.get('--foo'),
-      new CSSUnparsedValue([' auto']));
+      new CSSUnparsedValue(['auto']));
 }, 'Getting a valid custom property from CSS rule returns the ' +
    'correct entry');
 

--- a/css/css-typed-om/the-stylepropertymap/declared/getAll.tentative.html
+++ b/css/css-typed-om/the-stylepropertymap/declared/getAll.tentative.html
@@ -36,7 +36,7 @@ test(t => {
 
 test(t => {
   const styleMap = createDeclaredStyleMap(t, '--foo: auto; --bar: 10px');
-  assert_style_value_array_equals(styleMap.getAll('--foo'), [new CSSUnparsedValue([' auto'])]);
+  assert_style_value_array_equals(styleMap.getAll('--foo'), [new CSSUnparsedValue(['auto'])]);
 }, 'Calling StylePropertyMap.getAll with a valid custom property returns a single element list with the correct entry');
 
 test(t => {

--- a/css/css-typed-om/the-stylepropertymap/declared/iterable.tentative.html
+++ b/css/css-typed-om/the-stylepropertymap/declared/iterable.tentative.html
@@ -42,9 +42,9 @@ test(t => {
   const keys = [...styleMap.keys()], values = [...styleMap.values()];
 
   assert_array_equals(keys, ['--A', '--B', '--C']);
-  assert_style_value_array_equals(values[0], [new CSSUnparsedValue([' A'])]);
-  assert_style_value_array_equals(values[1], [new CSSUnparsedValue([' B'])]);
-  assert_style_value_array_equals(values[2], [new CSSUnparsedValue([' C'])]);
+  assert_style_value_array_equals(values[0], [new CSSUnparsedValue(['A'])]);
+  assert_style_value_array_equals(values[1], [new CSSUnparsedValue(['B'])]);
+  assert_style_value_array_equals(values[2], [new CSSUnparsedValue(['C'])]);
 }, 'StylePropertyMap iterator returns custom properties with the correct CSSStyleValue');
 
 </script>

--- a/css/css-typed-om/the-stylepropertymap/inline/get.html
+++ b/css/css-typed-om/the-stylepropertymap/inline/get.html
@@ -29,7 +29,7 @@ test(t => {
 test(t => {
   const styleMap = createInlineStyleMap(t, '--foo: auto; --bar: 10px');
   assert_style_value_equals(styleMap.get('--foo'),
-      new CSSUnparsedValue([' auto']));
+      new CSSUnparsedValue(['auto']));
 }, 'Getting a valid custom property from inline style returns the ' +
    'correct entry');
 

--- a/css/css-typed-om/the-stylepropertymap/inline/getAll.tentative.html
+++ b/css/css-typed-om/the-stylepropertymap/inline/getAll.tentative.html
@@ -36,7 +36,7 @@ test(t => {
 
 test(t => {
   const styleMap = createInlineStyleMap(t, '--foo: auto; --bar: 10px');
-  assert_style_value_array_equals(styleMap.getAll('--foo'), [new CSSUnparsedValue([' auto'])]);
+  assert_style_value_array_equals(styleMap.getAll('--foo'), [new CSSUnparsedValue(['auto'])]);
 }, 'Calling StylePropertyMap.getAll with a valid custom property returns a single element list with the correct entry');
 
 test(t => {

--- a/css/css-typed-om/the-stylepropertymap/inline/iterable.tentative.html
+++ b/css/css-typed-om/the-stylepropertymap/inline/iterable.tentative.html
@@ -42,9 +42,9 @@ test(t => {
   const keys = [...styleMap.keys()], values = [...styleMap.values()];
 
   assert_array_equals(keys, ['--A', '--B', '--C']);
-  assert_style_value_array_equals(values[0], [new CSSUnparsedValue([' A'])]);
-  assert_style_value_array_equals(values[1], [new CSSUnparsedValue([' B'])]);
-  assert_style_value_array_equals(values[2], [new CSSUnparsedValue([' C'])]);
+  assert_style_value_array_equals(values[0], [new CSSUnparsedValue(['A'])]);
+  assert_style_value_array_equals(values[1], [new CSSUnparsedValue(['B'])]);
+  assert_style_value_array_equals(values[2], [new CSSUnparsedValue(['C'])]);
 }, 'StylePropertyMap iterator returns custom properties with the correct CSSStyleValue');
 
 </script>


### PR DESCRIPTION
There was a spec change a few years ago requiring spaces around CSS declaration's value to be trimmed: w3c/csswg-drafts#1986. The discussion leading to this spec change: w3c/csswg-drafts#774.

This closes issue #34880.