### PR TITLE
Fix  #37272 request headers list

### DIFF
--- a/tools/wptserve/wptserve/request.py
+++ b/tools/wptserve/wptserve/request.py
@@ -385,15 +385,13 @@ class RequestHeaders(Dict[bytes, List[bytes]]):
         for header in items.keys():
             key = isomorphic_encode(header).lower()
             # get all headers with the same name
-            values = items.getallmatchingheaders(header)
+            values = items.get_all(header)
             if len(values) > 1:
                 # collect the multiple variations of the current header
                 multiples = []
-                # loop through the values from getallmatchingheaders
+                # loop through the values from get_all
                 for value in values:
-                    # getallmatchingheaders returns raw header lines, so
-                    # split to get name, value
-                    multiples.append(isomorphic_encode(value).split(b':', 1)[1].strip())
+                    multiples.append(isomorphic_encode(value))
                 headers = multiples
             else:
                 headers = [isomorphic_encode(items[header])]

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -667,6 +667,9 @@ class H2Headers(Dict[bytes, bytes]):
     # TODO This does not seem relevant for H2 headers, so using a dummy function for now
     def getallmatchingheaders(self, header):
         return ['dummy function']
+    
+    def get_all(self, header):
+        return ['dummy function']
 
 
 class H2HandlerCopy:


### PR DESCRIPTION
Fix for #37272 
The `getallmatchingheaders()` function is broken in python 3 (https://github.com/python/cpython/issues/49303).
This PR replaces the function with the working `get_all` function.