### PR TITLE
dont fail h3 connection immediately

### DIFF
--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -292,8 +292,7 @@ class TestEnvironment:
                 for port, server in servers:
                     if scheme == "webtransport-h3":
                         if not webtranport_h3_server_is_running(host, port, timeout=5.0):
-                            # TODO(bashi): Consider supporting retry.
-                            failed.append((host, port))
+                            pending.append((host, port))
                         continue
                     s = socket.socket()
                     s.settimeout(0.1)


### PR DESCRIPTION
Currently seeing a sporadic failure when attempting to connect to h3 server.
I found server is starting correctly, but unlike the other servers we aren't giving the full 30 seconds for the server to startup, we immediately fail the h3 server. 
So for this fix I am making the h3 server do what the other servers are doing and have it pending for 30 seconds and if it fails then it will timeout/send an error.