### PR TITLE
Fix timeout in WebKit for lock-sandboxed-iframe.html

### DIFF
--- a/screen-orientation/resources/sandboxed-iframe-locking.html
+++ b/screen-orientation/resources/sandboxed-iframe-locking.html
@@ -20,7 +20,12 @@ test_driver.bless("request full screen", async () => {
   }
 
   screen.orientation.unlock();
-  await document.exitFullscreen();
+  try {
+    await document.exitFullscreen();
+  } catch (error) {
+    data.result = "errored";
+    data.name = error.name;
+  }
 
   parent.window.postMessage(data, "*");
 });


### PR DESCRIPTION
Fix timeout in WebKit for lock-sandboxed-iframe.html by adding a try / catch around the exitFullscreen() call, in case the promise gets rejected.