### PR TITLE
Fix URL encoding issue in json-module/valid-content-type.html

### DIFF
--- a/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.html
+++ b/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.html
@@ -29,11 +29,11 @@ import v from "../serve-with-content-type.py?fn=json-module/module.json&ct=appli
 check(t2, v);
 </script>
 <script type="module" onerror="t3.step(() => assert_unreached(event))">
-import v from "../serve-with-content-type.py?fn=json-module/module.json&ct=text/html+json" assert { type: "json"};
+import v from "../serve-with-content-type.py?fn=json-module/module.json&ct=text/html%2Bjson" assert { type: "json"};
 check(t3, v);
 </script>
 <script type="module" onerror="t4.step(() => assert_unreached(event))">
-import v from "../serve-with-content-type.py?fn=json-module/module.json&ct=image/svg+json" assert { type: "json"};
+import v from "../serve-with-content-type.py?fn=json-module/module.json&ct=image/svg%2Bjson" assert { type: "json"};
 check(t4, v);
 </script>
 <script type="module" onerror="t5.step(() => assert_unreached(event))">


### PR DESCRIPTION
The issue is that the plus sign will be treated as a space. Thus, when the value is read inside `serve-with-content-type.py` we get `text/html json` instead of the expected `text/html+json`.