### PR TITLE
Add AVIF MIME type

### DIFF
--- a/tools/wptserve/wptserve/constants.py
+++ b/tools/wptserve/wptserve/constants.py
@@ -11,6 +11,7 @@ content_types = utils.invert_dict({
     "audio/ogg": ["oga"],
     "audio/webm": ["weba"],
     "audio/x-wav": ["wav"],
+    "image/avif": ["avif"],
     "image/bmp": ["bmp"],
     "image/gif": ["gif"],
     "image/jpeg": ["jpg", "jpeg"],


### PR DESCRIPTION
Prior to this patch, e.g. http://wpt.live/images/animated-avif.avif is served with `Content-Type: application/octet-stream`, causing a forced download in any browser when navigated to directly. This patch fixes it by using the proper MIME type for any `*.avif` files.