### PR TITLE
Trigger layout explicitely in cleanup for auto-006.html

### DIFF
--- a/css/css-sizing/contain-intrinsic-size/auto-006.html
+++ b/css/css-sizing/contain-intrinsic-size/auto-006.html
@@ -76,6 +76,7 @@ function cleanup() {
   parent.className = "";
   target.className = "";
   contents.className = "";
+  checkSize(0, 0, "Sizing after cleanup");
 }
 
 promise_test(async function() {


### PR DESCRIPTION
In WebKit, it does not always trigger layout when JS changes CSS value.
In auto-006.html, the cases need to trigger layout in `cleanup()`, otherwise the previous last remembered size might affect the next case.
So add `checkSize` to trigger layout explicitly in `cleanup()`.