### PR TITLE
Retry unexpected tests inside run_test_iteration

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -704,7 +704,7 @@ class TestRunnerManager(threading.Thread):
         # PASS (for reftest), and all unexpected results for subtests (if any) are
         # unexpected pass.
         is_unexpected_pass = ((is_unexpected or subtest_unexpected) and
-                              status in ["OK", "PASS"]  and subtest_all_unexpected_pass)
+                              status in ["OK", "PASS"] and subtest_all_unexpected_pass)
         if is_unexpected_pass:
             self.unexpected_pass_tests.add(test.id)
 

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -665,7 +665,6 @@ class TestRunnerManager(threading.Thread):
                 if result.status != "PASS" and not is_expected_notrun:
                     # Any result against an expected "NOTRUN" should be treated
                     # as unexpected pass.
-                if result.status != "PASS":
                     subtest_all_pass_or_expected = False
 
             self.logger.test_status(test.id,

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -711,7 +711,6 @@ class TestRunnerManager(threading.Thread):
         if is_unexpected_pass:
             self.unexpected_pass_tests.add(test.id)
 
-
         if "assertion_count" in file_result.extra:
             assertion_count = file_result.extra["assertion_count"]
             if assertion_count is not None and assertion_count > 0:

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -333,9 +333,8 @@ class TestRunnerManager(threading.Thread):
         self.logger = None
 
         self.test_count = 0
-        self.unexpected_count = 0
-        self.unexpected_pass_count = 0
         self.unexpected_tests = set()
+        self.unexpected_pass_tests = set()
 
         # This may not really be what we want
         self.daemon = True
@@ -651,6 +650,7 @@ class TestRunnerManager(threading.Thread):
         # Write the result of each subtest
         file_result, test_results = results
         subtest_unexpected = False
+        subtest_all_unexpected_pass = True
         for result in test_results:
             if test.disabled(result.name):
                 continue
@@ -659,13 +659,10 @@ class TestRunnerManager(threading.Thread):
             is_unexpected = expected != result.status and result.status not in known_intermittent
 
             if is_unexpected:
-                self.unexpected_count += 1
-                self.logger.debug("Unexpected count in this thread %i" % self.unexpected_count)
                 subtest_unexpected = True
 
-            is_unexpected_pass = is_unexpected and result.status == "PASS"
-            if is_unexpected_pass:
-                self.unexpected_pass_count += 1
+                if result.status != "PASS":
+                    subtest_all_unexpected_pass = False
 
             self.logger.test_status(test.id,
                                     result.name,
@@ -698,16 +695,19 @@ class TestRunnerManager(threading.Thread):
 
         self.test_count += 1
         is_unexpected = expected != status and status not in known_intermittent
-        if is_unexpected:
-            self.unexpected_count += 1
-            self.logger.debug("Unexpected count in this thread %i" % self.unexpected_count)
-
-        is_unexpected_pass = is_unexpected and status == "OK"
-        if is_unexpected_pass:
-            self.unexpected_pass_count += 1
 
         if is_unexpected or subtest_unexpected:
             self.unexpected_tests.add(test.id)
+
+        # A result is unexpected pass if the test or any subtest run
+        # unexpectedly, and the overall status is OK (for test harness test), or
+        # PASS (for reftest), and all unexpected results for subtests (if any) are
+        # unexpected pass.
+        is_unexpected_pass = ((is_unexpected or subtest_unexpected) and
+                              status in ["OK", "PASS"]  and subtest_all_unexpected_pass)
+        if is_unexpected_pass:
+            self.unexpected_pass_tests.add(test.id)
+
 
         if "assertion_count" in file_result.extra:
             assertion_count = file_result.extra["assertion_count"]
@@ -975,11 +975,8 @@ class ManagerGroup:
     def test_count(self):
         return sum(manager.test_count for manager in self.pool)
 
-    def unexpected_count(self):
-        return sum(manager.unexpected_count for manager in self.pool)
-
-    def unexpected_pass_count(self):
-        return sum(manager.unexpected_pass_count for manager in self.pool)
-
     def unexpected_tests(self):
         return set().union(*(manager.unexpected_tests for manager in self.pool))
+
+    def unexpected_pass_tests(self):
+        return set().union(*(manager.unexpected_pass_tests for manager in self.pool))

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -657,10 +657,14 @@ class TestRunnerManager(threading.Thread):
             expected = test.expected(result.name)
             known_intermittent = test.known_intermittent(result.name)
             is_unexpected = expected != result.status and result.status not in known_intermittent
+            is_expected_notrun = (expected == "NOTRUN" or "NOTRUN" in known_intermittent)
 
             if is_unexpected:
                 subtest_unexpected = True
 
+                if result.status != "PASS" and not is_expected_notrun:
+                    # Any result against an expected "NOTRUN" should be treated
+                    # as unexpected pass.
                 if result.status != "PASS":
                     subtest_all_pass_or_expected = False
 

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -650,7 +650,7 @@ class TestRunnerManager(threading.Thread):
         # Write the result of each subtest
         file_result, test_results = results
         subtest_unexpected = False
-        subtest_all_unexpected_pass = True
+        subtest_all_pass_or_expected = True
         for result in test_results:
             if test.disabled(result.name):
                 continue
@@ -662,7 +662,7 @@ class TestRunnerManager(threading.Thread):
                 subtest_unexpected = True
 
                 if result.status != "PASS":
-                    subtest_all_unexpected_pass = False
+                    subtest_all_pass_or_expected = False
 
             self.logger.test_status(test.id,
                                     result.name,
@@ -704,7 +704,7 @@ class TestRunnerManager(threading.Thread):
         # PASS (for reftest), and all unexpected results for subtests (if any) are
         # unexpected pass.
         is_unexpected_pass = ((is_unexpected or subtest_unexpected) and
-                              status in ["OK", "PASS"] and subtest_all_unexpected_pass)
+                              status in ["OK", "PASS"] and subtest_all_pass_or_expected)
         if is_unexpected_pass:
             self.unexpected_pass_tests.add(test.id)
 

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -184,9 +184,9 @@ scheme host and port.""")
     debugging_group.add_argument("--repeat-until-unexpected", action="store_true", default=None,
                                  help="Run tests in a loop until one returns an unexpected result")
     debugging_group.add_argument('--retry-unexpected', type=int, default=0,
-                                 help=('Maximum number of times to retry unexpectedly failed tests.'
-                                       'A test is retried until it gets one of the expected status or pass,'
-                                       'Or until it exhausts the maximum number of retries.'))
+                                 help=('Maximum number of times to retry unexpected tests. '
+                                       'A test is retried until it gets one of the expected status, '
+                                       'or until it exhausts the maximum number of retries.'))
     debugging_group.add_argument('--pause-after-test', action="store_true", default=None,
                                  help="Halt the test runner after each test (this happens by default if only a single test is run)")
     debugging_group.add_argument('--no-pause-after-test', dest="pause_after_test", action="store_false",

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -184,11 +184,9 @@ scheme host and port.""")
     debugging_group.add_argument("--repeat-until-unexpected", action="store_true", default=None,
                                  help="Run tests in a loop until one returns an unexpected result")
     debugging_group.add_argument('--retry-unexpected', type=int, default=0,
-                                 help=('Maximum number of times to retry '
-                                       'each test that consistently runs '
-                                       'unexpectedly in the initial repeat '
-                                       'loop. A retried test takes any '
-                                       'expected status as its final result.'))
+                                 help=('Maximum number of times to retry unexpectedly failed tests.'
+                                       'A test is retried until it gets one of the expected status or pass,'
+                                       'Or until it exhausts the maximum number of retries.'))
     debugging_group.add_argument('--pause-after-test', action="store_true", default=None,
                                  help="Halt the test runner after each test (this happens by default if only a single test is run)")
     debugging_group.add_argument('--no-pause-after-test', dest="pause_after_test", action="store_false",

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -170,7 +170,7 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
         logger.critical("Loading tests failed")
         return False
 
-    logger.suite_start(test_groups,
+    logger.suite_start(tests_by_type,
                        name='web-platform-test',
                        run_info=run_info,
                        extra={"run_by_dir": run_test_kwargs["run_by_dir"]})
@@ -237,6 +237,12 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
                 tests_to_run[test_type] = [test for test in tests
                                            if test.id in unexpected_fail_tests]
 
+            logger.suite_end()
+            logger.suite_start(tests_to_run,
+                               name='web-platform-test',
+                               run_info=run_info,
+                               extra={"run_by_dir": run_test_kwargs["run_by_dir"]})
+
         with ManagerGroup("web-platform-tests",
                           run_test_kwargs["processes"],
                           test_source_cls,
@@ -263,6 +269,8 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
 
     test_status.unexpected += len(unexpected_tests)
     test_status.unexpected_pass += len(unexpected_pass_tests)
+
+    logger.suite_end()
 
     return True
 
@@ -436,7 +444,6 @@ def run_tests(config, test_paths, product, **kwargs):
                 recording.set(["after-end"])
                 logger.info(f"Got {test_status.unexpected} unexpected results, "
                     f"with {test_status.unexpected_pass} unexpected passes")
-                logger.suite_end()
 
                 # Note this iteration's runtime
                 iteration_runtime = datetime.now() - iteration_start

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -227,7 +227,10 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
     retry_counts = run_test_kwargs["retry_unexpected"]
     for i in range(retry_counts + 1):
         if i > 0:
-            unexpected_fail_tests = unexpected_tests - unexpected_pass_tests
+            if not run_test_kwargs["fail_on_unexpected_pass"]:
+                unexpected_fail_tests = unexpected_tests - unexpected_pass_tests
+            else:
+                unexpected_fail_tests = unexpected_tests
             if len(unexpected_fail_tests) == 0:
                 break
             for test_type, tests in tests_to_run.items():

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -229,7 +229,7 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
         if i > 0:
             unexpected_fail_tests = unexpected_tests - unexpected_pass_tests
             if len(unexpected_fail_tests) == 0:
-                break;
+                break
             for test_type, tests in tests_to_run.items():
                 tests_to_run[test_type] = [test for test in tests
                                            if test.id in unexpected_fail_tests]


### PR DESCRIPTION
Fixed what test should be identified as unexpected pass, and made a change to not retry unexpectedly passed tests when no-fail-on-unexpected-pass presents.