### PR TITLE
add single dot host test

### DIFF
--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -3917,6 +3917,22 @@
     "search": "",
     "hash": ""
   },
+  "Non-special domains with empty labels",
+  {
+    "input": "h://.",
+    "base": "about:blank",
+    "href": "h://.",
+    "origin": "h://.",
+    "protocol": "h:",
+    "username": "",
+    "password": "",
+    "host": ".",
+    "hostname": ".",
+    "port": "",
+    "pathname": "",
+    "search": "",
+    "hash": ""
+  },
   "Broken IPv6",
   {
     "input": "http://[www.google.com]/",


### PR DESCRIPTION
I suspect Chrome and Firefox are not following the standard when the host is a single-byte `.` character and its non-special URL.

non-special:
https://jsdom.github.io/whatwg-url/#url=aDovLy4=&base=YWJvdXQ6Ymxhbms=

special:
https://jsdom.github.io/whatwg-url/#url=aHR0cDovLy4=&base=YWJvdXQ6Ymxhbms=

Related to https://github.com/jsdom/whatwg-url/pull/82, https://github.com/jsdom/whatwg-url/pull/245

By following https://url.spec.whatwg.org/# I think standard and implementation in [this](https://github.com/jsdom/whatwg-url/) repository is correct and `.` should be returned.

This repository currently only has special test case.
https://github.com/web-platform-tests/wpt/blob/2a64dae4641fbd61bd4257df460e188f425b492e/url/resources/urltestdata.json#L3889-L3919

This PR adds test case for non-special URL.
