### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=249205

### DIFF
--- a/css/css-box/parsing/margin-trim-computed.html
+++ b/css/css-box/parsing/margin-trim-computed.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS margin-trim computed style</title>
+<link rel="help" href="https://www.w3.org/TR/css-box-4/#margin-trim">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="Test the computed values for margin-trim">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("margin-trim", "none");
+test_computed_value("margin-trim", "block");
+test_computed_value("margin-trim", "inline");
+test_computed_value("margin-trim", "block-start block-end", "block");
+test_computed_value("margin-trim", "inline-start inline-end", "inline");
+test_computed_value("margin-trim", "block-start");
+test_computed_value("margin-trim", "block-end");
+test_computed_value("margin-trim", "inline-start");
+test_computed_value("margin-trim", "inline-end");
+test_computed_value("margin-trim", "block-start inline-start");
+test_computed_value("margin-trim", "inline-start block-start", "block-start inline-start");
+test_computed_value("margin-trim", "inline-end block-start", "block-start inline-end");
+test_computed_value("margin-trim", "inline-end block-end", "block-end inline-end");
+test_computed_value("margin-trim", "block-start block-end inline-start", "block-start inline-start block-end");
+test_computed_value("margin-trim", "inline-start block-start inline-end block-end", "block-start inline-start block-end inline-end");
+test_computed_value("margin-trim", "inline-start inline-end block-start", "block-start inline-start inline-end");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/margin-trim.html
+++ b/css/css-box/parsing/margin-trim.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS margin-trim: property parsing</title>
+<link rel="help" href="https://www.w3.org/TR/css-box-4/#margin-trim">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="Test parsing for the margin-trim property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+// Individual values should get set
+test_valid_value("margin-trim", "none");
+test_valid_value("margin-trim", "block");
+test_valid_value("margin-trim", "inline");
+test_valid_value("margin-trim", "block-start");
+test_valid_value("margin-trim", "block-end");
+test_valid_value("margin-trim", "inline-start");
+test_valid_value("margin-trim", "inline-end");
+
+// Serialize values into either block or inline
+test_valid_value("margin-trim", "block-start block-end", "block");
+test_valid_value("margin-trim", "inline-start inline-end", "inline");
+test_valid_value("margin-trim", "block-end block-start", "block");
+test_valid_value("margin-trim", "inline-end inline-start", "inline");
+test_valid_value("margin-trim", "inline-start block-start");
+
+test_valid_value("margin-trim", "inline-end block-start block-end");
+test_valid_value("margin-trim", "block-start inline-start block-end inline-end");
+test_valid_value("margin-trim", "inline-end block-end inline-start block-start");
+
+test_invalid_value("margin-trim", "block inline");
+test_invalid_value("margin-trim", "block block");
+test_invalid_value("margin-trim", "inline inline");
+test_invalid_value("margin-trim", "block inline-start inline-end");
+test_invalid_value("margin-trim", "block block-start block-end");
+test_invalid_value("margin-trim", "block-start block-end block");
+test_invalid_value("margin-trim", "block 10px");
+test_invalid_value("margin-trim", "auto");
+test_invalid_value("margin-trim", "left");
+</script>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[margin-trim\] Add margin-trim to CSS parser](https://bugs.webkit.org/show_bug.cgi?id=249205)