### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=249366

### DIFF
--- a/css/css-box/inheritance.html
+++ b/css/css-box/inheritance.html
@@ -23,7 +23,7 @@ assert_not_inherited('margin-bottom', '0px', '10px');
 assert_not_inherited('margin-left', '0px', '10px');
 assert_not_inherited('margin-right', '0px', '10px');
 assert_not_inherited('margin-top', '0px', '10px');
-assert_not_inherited('margin-trim', 'none', 'all');
+assert_not_inherited('margin-trim', 'none', 'block');
 assert_not_inherited('padding-bottom', '0px', '10px');
 assert_not_inherited('padding-left', '0px', '10px');
 assert_not_inherited('padding-right', '0px', '10px');


### PR DESCRIPTION
WebKit export from bug: [Fix imported/w3c/web-platform-tests/css/css-box/inheritance.html for margin-trim](https://bugs.webkit.org/show_bug.cgi?id=249366)