### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=249390

### DIFF
--- a/css/css-properties-values-api/animation/custom-property-animation-custom-ident.html
+++ b/css/css-properties-values-api/animation/custom-property-animation-custom-ident.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+discrete_animation_test("<custom-ident>", "from", "to");
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-animation-image.html
+++ b/css/css-properties-values-api/animation/custom-property-animation-image.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+discrete_animation_test("<image>", 'url("https://example.com/from")', 'url("https://example.com/to")');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-animation-url.html
+++ b/css/css-properties-values-api/animation/custom-property-animation-url.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+discrete_animation_test("<url>", 'url("https://example.com/from")', 'url("https://example.com/to")');
+
+</script>

--- a/css/css-properties-values-api/resources/utils.js
+++ b/css/css-properties-values-api/resources/utils.js
@@ -147,3 +147,34 @@ function animation_test(property, values, description) {
     assert_equals(getComputedStyle(target).getPropertyValue(name), values.expected);
   }, description);
 };
+
+function discrete_animation_test(syntax, fromValue, toValue) {
+  test(() => {
+    const name = generate_name();
+
+    CSS.registerProperty({
+      name,
+      syntax,
+      inherits: false,
+      initialValue: fromValue
+    });
+
+    const duration = 1000;
+    const keyframes = [];
+    keyframes[name] = toValue;
+    const animation = target.animate(keyframes, duration);
+    animation.pause();
+
+    const checkAtProgress = (progress, expected) => {
+      animation.currentTime = duration * 0.25;
+      assert_equals(getComputedStyle(target).getPropertyValue(name), fromValue, `The correct value is used at progress = ${progress}`);
+    };
+
+    checkAtProgress(0, fromValue);
+    checkAtProgress(0.25, fromValue);
+    checkAtProgress(0.49, fromValue);
+    checkAtProgress(0.5, toValue);
+    checkAtProgress(0.75, toValue);
+    checkAtProgress(1, toValue);
+  }, `Animating a custom property of type ${syntax} is discrete`);
+}


### PR DESCRIPTION
WebKit export from bug: [\[web-animations\] add tests for custom properties discrete interpolation](https://bugs.webkit.org/show_bug.cgi?id=249390)