### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=249396

### DIFF
--- a/css/css-properties-values-api/animation/custom-property-animation-inherited-used-by-standard-property.html
+++ b/css/css-properties-values-api/animation/custom-property-animation-inherited-used-by-standard-property.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="container">
+    <div id="target"></div>
+</div>
+<script>
+
+test(() => {
+  CSS.registerProperty({
+    name: "--my-length",
+    syntax: "<length>",
+    inherits: true,
+    initialValue: "0px"
+  });
+
+  target.style.marginLeft = "var(--my-length)";
+
+  const duration = 1000;
+  const animation = container.animate({ "--my-length": "100px" }, duration);
+  animation.pause();
+  animation.currentTime = duration / 4;
+
+  assert_equals(getComputedStyle(target).marginLeft, "25px");
+}, "Animating an inherited CSS variable on a parent is reflected on a standard property using that variable as a value on a child");
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-animation-non-inherited-used-by-standard-property.html
+++ b/css/css-properties-values-api/animation/custom-property-animation-non-inherited-used-by-standard-property.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+test(() => {
+  CSS.registerProperty({
+    name: "--my-length",
+    syntax: "<length>",
+    inherits: false,
+    initialValue: "0px"
+  });
+
+  target.style.marginLeft = "var(--my-length)";
+
+  const duration = 1000;
+  const animation = target.animate({ "--my-length": "100px" }, duration);
+  animation.pause();
+  animation.currentTime = duration / 4;
+
+  assert_equals(getComputedStyle(target).marginLeft, "25px");
+}, "Animating a non-inherited CSS variable is reflected on a standard property using that variable as a value");
+
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[web-animations\] add tests to see that an animated CSS variable is accounted for when used in standard properties](https://bugs.webkit.org/show_bug.cgi?id=249396)