### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=249401

### DIFF
--- a/css/css-properties-values-api/animation/custom-property-animation-angle.html
+++ b/css/css-properties-values-api/animation/custom-property-animation-angle.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<angle>",
+  inherits: false,
+  initialValue: "0deg"
+}, {
+  keyframes: ["100deg", "200deg"],
+  expected: "150deg"
+}, 'Animating a custom property of type <angle>');
+
+animation_test({
+  syntax: "<angle>",
+  inherits: false,
+  initialValue: "100deg"
+}, {
+  keyframes: "200deg",
+  expected: "150deg"
+}, 'Animating a custom property of type <angle> with a single keyframe');
+
+animation_test({
+  syntax: "<angle>",
+  inherits: false,
+  initialValue: "100deg"
+}, {
+  composite: "add",
+  keyframes: ["200deg", "300deg"],
+  expected: "350deg"
+}, 'Animating a custom property of type <angle> with additivity');
+
+animation_test({
+  syntax: "<angle>",
+  inherits: false,
+  initialValue: "100deg"
+}, {
+  composite: "add",
+  keyframes: "300deg",
+  expected: "250deg"
+}, 'Animating a custom property of type <angle> with a single keyframe and additivity');
+
+animation_test({
+  syntax: "<angle>",
+  inherits: false,
+  initialValue: "100deg"
+}, {
+  iterationComposite: "accumulate",
+  keyframes: ["0deg", "100deg"],
+  expected: "250deg"
+}, 'Animating a custom property of type <angle> with iterationComposite');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-animation-integer.html
+++ b/css/css-properties-values-api/animation/custom-property-animation-integer.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<integer>",
+  inherits: false,
+  initialValue: 0
+}, {
+  keyframes: [100, 200],
+  expected: "150"
+}, 'Animating a custom property of type <integer>');
+
+animation_test({
+  syntax: "<integer>",
+  inherits: false,
+  initialValue: 100
+}, {
+  keyframes: 200,
+  expected: "150"
+}, 'Animating a custom property of type <integer> with a single keyframe');
+
+animation_test({
+  syntax: "<integer>",
+  inherits: false,
+  initialValue: 100
+}, {
+  composite: "add",
+  keyframes: [200, 300],
+  expected: "350"
+}, 'Animating a custom property of type <integer> with additivity');
+
+animation_test({
+  syntax: "<integer>",
+  inherits: false,
+  initialValue: 100
+}, {
+  composite: "add",
+  keyframes: 300,
+  expected: "250"
+}, 'Animating a custom property of type <integer> with a single keyframe and additivity');
+
+animation_test({
+  syntax: "<integer>",
+  inherits: false,
+  initialValue: 100
+}, {
+  iterationComposite: "accumulate",
+  keyframes: [0, 100],
+  expected: "250"
+}, 'Animating a custom property of type <integer> with iterationComposite');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-animation-number.html
+++ b/css/css-properties-values-api/animation/custom-property-animation-number.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<number>",
+  inherits: false,
+  initialValue: 0
+}, {
+  keyframes: [100, 200],
+  expected: "150"
+}, 'Animating a custom property of type <number>');
+
+animation_test({
+  syntax: "<number>",
+  inherits: false,
+  initialValue: 100
+}, {
+  keyframes: 200,
+  expected: "150"
+}, 'Animating a custom property of type <number> with a single keyframe');
+
+animation_test({
+  syntax: "<number>",
+  inherits: false,
+  initialValue: 100
+}, {
+  composite: "add",
+  keyframes: [200, 300],
+  expected: "350"
+}, 'Animating a custom property of type <number> with additivity');
+
+animation_test({
+  syntax: "<number>",
+  inherits: false,
+  initialValue: 100
+}, {
+  composite: "add",
+  keyframes: 300,
+  expected: "250"
+}, 'Animating a custom property of type <number> with a single keyframe and additivity');
+
+animation_test({
+  syntax: "<number>",
+  inherits: false,
+  initialValue: 100
+}, {
+  iterationComposite: "accumulate",
+  keyframes: [0, 100],
+  expected: "250"
+}, 'Animating a custom property of type <number> with iterationComposite');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-animation-percentage.html
+++ b/css/css-properties-values-api/animation/custom-property-animation-percentage.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<percentage>",
+  inherits: false,
+  initialValue: "0%"
+}, {
+  keyframes: ["100%", "200%"],
+  expected: "150%"
+}, 'Animating a custom property of type <percentage>');
+
+animation_test({
+  syntax: "<percentage>",
+  inherits: false,
+  initialValue: "100%"
+}, {
+  keyframes: "200%",
+  expected: "150%"
+}, 'Animating a custom property of type <percentage> with a single keyframe');
+
+animation_test({
+  syntax: "<percentage>",
+  inherits: false,
+  initialValue: "100%"
+}, {
+  composite: "add",
+  keyframes: ["200%", "300%"],
+  expected: "350%"
+}, 'Animating a custom property of type <percentage> with additivity');
+
+animation_test({
+  syntax: "<percentage>",
+  inherits: false,
+  initialValue: "100%"
+}, {
+  composite: "add",
+  keyframes: "300%",
+  expected: "250%"
+}, 'Animating a custom property of type <percentage> with a single keyframe and additivity');
+
+animation_test({
+  syntax: "<percentage>",
+  inherits: false,
+  initialValue: "100%"
+}, {
+  iterationComposite: "accumulate",
+  keyframes: ["0%", "100%"],
+  expected: "250%"
+}, 'Animating a custom property of type <percentage> with iterationComposite');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-animation-resolution.html
+++ b/css/css-properties-values-api/animation/custom-property-animation-resolution.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<resolution>",
+  inherits: false,
+  initialValue: "0dppx"
+}, {
+  keyframes: ["100dppx", "200dppx"],
+  expected: "150dppx"
+}, 'Animating a custom property of type <resolution>');
+
+animation_test({
+  syntax: "<resolution>",
+  inherits: false,
+  initialValue: "100dppx"
+}, {
+  keyframes: "200dppx",
+  expected: "150dppx"
+}, 'Animating a custom property of type <resolution> with a single keyframe');
+
+animation_test({
+  syntax: "<resolution>",
+  inherits: false,
+  initialValue: "100dppx"
+}, {
+  composite: "add",
+  keyframes: ["200dppx", "300dppx"],
+  expected: "350dppx"
+}, 'Animating a custom property of type <resolution> with additivity');
+
+animation_test({
+  syntax: "<resolution>",
+  inherits: false,
+  initialValue: "100dppx"
+}, {
+  composite: "add",
+  keyframes: "300dppx",
+  expected: "250dppx"
+}, 'Animating a custom property of type <resolution> with a single keyframe and additivity');
+
+animation_test({
+  syntax: "<resolution>",
+  inherits: false,
+  initialValue: "100dppx"
+}, {
+  iterationComposite: "accumulate",
+  keyframes: ["0dppx", "100dppx"],
+  expected: "250dppx"
+}, 'Animating a custom property of type <resolution> with iterationComposite');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-animation-time.html
+++ b/css/css-properties-values-api/animation/custom-property-animation-time.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<time>",
+  inherits: false,
+  initialValue: "0s"
+}, {
+  keyframes: ["100s", "200s"],
+  expected: "150s"
+}, 'Animating a custom property of type <time>');
+
+animation_test({
+  syntax: "<time>",
+  inherits: false,
+  initialValue: "100s"
+}, {
+  keyframes: "200s",
+  expected: "150s"
+}, 'Animating a custom property of type <time> with a single keyframe');
+
+animation_test({
+  syntax: "<time>",
+  inherits: false,
+  initialValue: "100s"
+}, {
+  composite: "add",
+  keyframes: ["200s", "300s"],
+  expected: "350s"
+}, 'Animating a custom property of type <time> with additivity');
+
+animation_test({
+  syntax: "<time>",
+  inherits: false,
+  initialValue: "100s"
+}, {
+  composite: "add",
+  keyframes: "300s",
+  expected: "250s"
+}, 'Animating a custom property of type <time> with a single keyframe and additivity');
+
+animation_test({
+  syntax: "<time>",
+  inherits: false,
+  initialValue: "100s"
+}, {
+  iterationComposite: "accumulate",
+  keyframes: ["0s", "100s"],
+  expected: "250s"
+}, 'Animating a custom property of type <time> with iterationComposite');
+
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[web-animations\] support interpolation of numeric custom properties](https://bugs.webkit.org/show_bug.cgi?id=249401)