### PR TITLE
Fix pytest failure at upstream CI

### DIFF
--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -12,9 +12,10 @@ deps =
 
 changedir =
   mypy: {toxinidir}/..
+  !flake8-!mypy: {toxinidir}
 
 commands =
-  !flake8-!mypy: pytest --cov=tools --cov-report=term {posargs}
+  !flake8-!mypy: pytest --cov=. --cov-report=term {posargs}
   flake8: flake8 --append-config={toxinidir}/flake8.ini {posargs}
   mypy: mypy --config-file={toxinidir}/mypy.ini tools/
 


### PR DESCRIPTION
Previously tools/unitest was failing on PR 37364. The error is that pytest_plugins is used in infrastructure/webdriver/tests/conftest.py. This file is not in the tools folder, and even though we only intended to collect test coverage for files under tools, pytest is scanning all the files in wpt repo, and failed to collect tests due to the above error.

The error itself probably is due to a recent upgrade to pytest.

Updated tox.ini to set current working directory to tools, before staring pytest.