### PR TITLE
Update metadata for infrastructure tests

### DIFF
--- a/infrastructure/metadata/infrastructure/server/context.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/context.any.js.ini
@@ -1,6 +1,6 @@
 [context.any.worker-module.html]
   expected:
-    if product == "firefox": TIMEOUT # https://bugzilla.mozilla.org/show_bug.cgi?id=1247687
+    if product == "firefox": [TIMEOUT, OK] # https://bugzilla.mozilla.org/show_bug.cgi?id=1247687
 
 [context.any.sharedworker-module.html]
   expected:

--- a/infrastructure/metadata/infrastructure/server/context.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/context.any.js.ini
@@ -1,7 +1,3 @@
-[context.any.worker-module.html]
-  expected:
-    if product == "firefox": [TIMEOUT, OK] # https://bugzilla.mozilla.org/show_bug.cgi?id=1247687
-
 [context.any.sharedworker-module.html]
   expected:
     if product == "firefox": TIMEOUT # https://bugzilla.mozilla.org/show_bug.cgi?id=1247687

--- a/infrastructure/metadata/infrastructure/server/context.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/context.any.js.ini
@@ -1,3 +1,7 @@
+[context.any.worker-module.html]
+  expected:
+    if product == "firefox": [TIMEOUT, OK] # https://bugzilla.mozilla.org/show_bug.cgi?id=1247687
+    
 [context.any.sharedworker-module.html]
   expected:
     if product == "firefox": TIMEOUT # https://bugzilla.mozilla.org/show_bug.cgi?id=1247687

--- a/infrastructure/metadata/infrastructure/server/context.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/context.any.js.ini
@@ -1,7 +1,7 @@
 [context.any.worker-module.html]
   expected:
     if product == "firefox": [TIMEOUT, OK] # https://bugzilla.mozilla.org/show_bug.cgi?id=1247687
-    
+
 [context.any.sharedworker-module.html]
   expected:
     if product == "firefox": TIMEOUT # https://bugzilla.mozilla.org/show_bug.cgi?id=1247687


### PR DESCRIPTION
One unexpected OK caused "infrastructure/ tests: macOS" task to fail. Update metadata to suppress such failures.