### PR TITLE
Set all_loaded flag synchronously

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -91,8 +91,8 @@
         }
 
         on_event(window, 'load', function() {
+          this_obj.all_loaded = true;
           setTimeout(() => {
-            this_obj.all_loaded = true;
             if (tests.all_done()) {
               tests.complete();
             }


### PR DESCRIPTION
This should fix the case where done() is called in the load handler, but still allows new tests to be defined inside the handler in the case that you don't explicitly call done()