### PR TITLE
Make content-visibility-080.html output visible

### DIFF
--- a/css/css-contain/content-visibility/content-visibility-080.html
+++ b/css/css-contain/content-visibility/content-visibility-080.html
@@ -19,7 +19,8 @@
 </style>
 
 <script>
-test(() => {
+test((t) => {
+  t.add_cleanup(() => { document.getElementsByTagName('style')[0].remove(); });
   const range = document.caretRangeFromPoint();
   assert_not_equals(range, null, "range exists");
   assert_equals(range.startContainer, html, "startContainer is html");


### PR DESCRIPTION
We want to test content-visibility hidden effect on caretRangeFromPoint so we have to enable that. However applying this on the html element also hides any text being output including asserts. So make sure to undo the content-visibility in order to have readable output.