### PR TITLE
URL: hash/search roundtripping with opaque paths

### DIFF
--- a/url/resources/setters_tests.json
+++ b/url/resources/setters_tests.json
@@ -1603,12 +1603,28 @@
     ],
     "pathname": [
         {
-            "comment": "Cannot-be-a-base don’t have a path",
+            "comment": "Opaque paths cannot be set",
             "href": "mailto:me@example.net",
             "new_value": "/foo",
             "expected": {
                 "href": "mailto:me@example.net",
                 "pathname": "me@example.net"
+            }
+        },
+        {
+            "href": "data:original",
+            "new_value": "new value",
+            "expected": {
+                "href": "data:original",
+                "pathname": "original"
+            }
+        },
+        {
+            "href": "sc:original",
+            "new_value": "new value",
+            "expected": {
+                "href": "sc:original",
+                "pathname": "original"
             }
         },
         {
@@ -1832,20 +1848,20 @@
             }
         },
         {
-            "comment": "Drop trailing spaces from trailing opaque paths",
-            "href": "data:nospace",
+            "comment": "Non-special URLs with non-opaque paths percent-encode U+0020",
+            "href": "data:/nospace",
             "new_value": "space ",
             "expected": {
-                "href": "data:space",
-                "pathname": "space"
+                "href": "data:/space%20",
+                "pathname": "/space%20"
             }
         },
         {
-            "href": "sc:nospace",
+            "href": "sc:/nospace",
             "new_value": "space ",
             "expected": {
-                "href": "sc:space",
-                "pathname": "space"
+                "href": "sc:/space%20",
+                "pathname": "/space%20"
             }
         }
     ],

--- a/url/resources/setters_tests.json
+++ b/url/resources/setters_tests.json
@@ -1830,6 +1830,23 @@
                 "href": "non-spec:/p",
                 "pathname": "/p"
             }
+        },
+        {
+            "comment": "Drop trailing spaces from trailing opaque paths",
+            "href": "data:nospace",
+            "new_value": "space ",
+            "expected": {
+                "href": "data:space",
+                "pathname": "space"
+            }
+        },
+        {
+            "href": "sc:nospace",
+            "new_value": "space ",
+            "expected": {
+                "href": "sc:space",
+                "pathname": "space"
+            }
         }
     ],
     "search": [
@@ -1913,6 +1930,42 @@
             "expected": {
                 "href": "http://example.net/?%c3%89t%C3%A9",
                 "search": "?%c3%89t%C3%A9"
+            }
+        },
+        {
+            "comment": "Drop trailing spaces from trailing opaque paths",
+            "href": "data:space ?query",
+            "new_value": "",
+            "expected": {
+                "href": "data:space",
+                "pathname": "space",
+                "search": ""
+            }
+        },
+        {
+            "href": "sc:space ?query",
+            "new_value": "",
+            "expected": {
+                "href": "sc:space",
+                "pathname": "space",
+                "search": ""
+            }
+        },
+        {
+            "comment": "Do not drop trailing spaces from non-trailing opaque paths",
+            "href": "data:space  ?query#fragment",
+            "new_value": "",
+            "expected": {
+                "href": "data:space  #fragment",
+                "search": ""
+            }
+        },
+        {
+            "href": "sc:space  ?query#fragment",
+            "new_value": "",
+            "expected": {
+                "href": "sc:space  #fragment",
+                "search": ""
             }
         }
     ],
@@ -2047,6 +2100,42 @@
             "expected": {
                 "href": "javascript:alert(1)#castle",
                 "hash": "#castle"
+            }
+        },
+        {
+            "comment": "Drop trailing spaces from trailing opaque paths",
+            "href": "data:space                                                                                                                                  #fragment",
+            "new_value": "",
+            "expected": {
+                "href": "data:space",
+                "pathname": "space",
+                "hash": ""
+            }
+        },
+        {
+            "href": "sc:space    #fragment",
+            "new_value": "",
+            "expected": {
+                "href": "sc:space",
+                "pathname": "space",
+                "hash": ""
+            }
+        },
+        {
+            "comment": "Do not drop trailing spaces from non-trailing opaque paths",
+            "href": "data:space  ?query#fragment",
+            "new_value": "",
+            "expected": {
+                "href": "data:space  ?query",
+                "hash": ""
+            }
+        },
+        {
+            "href": "sc:space  ?query#fragment",
+            "new_value": "",
+            "expected": {
+                "href": "sc:space  ?query",
+                "hash": ""
             }
         }
     ]

--- a/url/urlsearchparams-delete.any.js
+++ b/url/urlsearchparams-delete.any.js
@@ -43,3 +43,21 @@ test(function() {
     assert_equals(url.href, 'http://example.com/', 'url.href does not have ?');
     assert_equals(url.search, '', 'url.search does not have ?');
 }, 'Removing non-existent param removes ? from URL');
+
+test(() => {
+  const url = new URL('data:space    ?test');
+  assert_true(url.searchParams.has('test'));
+  url.searchParams.delete('test');
+  assert_false(url.searchParams.has('test'));
+  assert_equals(url.search, '');
+  assert_equals(url.pathname, 'space');
+  assert_equals(url.href, 'data:space');
+}, 'Changing the query of a URL with an opaque path can impact the path');
+
+test(() => {
+  const url = new URL('data:space    ?test#test');
+  url.searchParams.delete('test');
+  assert_equals(url.search, '');
+  assert_equals(url.pathname, 'space    ');
+  assert_equals(url.href, 'data:space    #test');
+}, 'Changing the query of a URL with an opaque path can impact the path if the URL has no fragment');


### PR DESCRIPTION
For https://github.com/whatwg/url/pull/728.