### PR TITLE
URL: fix invalid test

### DIFF
--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -3922,7 +3922,7 @@
     "input": "h://.",
     "base": "about:blank",
     "href": "h://.",
-    "origin": "h://.",
+    "origin": "null",
     "protocol": "h:",
     "username": "",
     "password": "",


### PR DESCRIPTION
According to https://url.spec.whatwg.org/#origin non-special URL has opaque origin, which is serialized as "null".