### PR TITLE
Fix size-adjust usage in css-fonts tests

### DIFF
--- a/css/css-fonts/font-size-adjust-012.html
+++ b/css/css-fonts/font-size-adjust-012.html
@@ -19,7 +19,7 @@
             --secondary-font: 'ahem-ex-250';
         }
         .adjusted {
-            font-size-adjust: 0.5;
+            font-size-adjust: 50%;
         }
         .test {
             font-family: var(--primary-font), var(--secondary-font);

--- a/css/css-fonts/size-adjust-02-ref.html
+++ b/css/css-fonts/size-adjust-02-ref.html
@@ -12,7 +12,7 @@
 div {
   font-size: 40px;
   line-height: 100px;
-  font-size-adjust: 0.5;
+  font-size-adjust: 50%;
 }
 
 .reference {

--- a/css/css-fonts/size-adjust-02.html
+++ b/css/css-fonts/size-adjust-02.html
@@ -23,7 +23,7 @@
 div {
   font-size: 40px;
   line-height: 100px;
-  font-size-adjust: 0.5;
+  font-size-adjust: 50%;
 }
 
 .reference {

--- a/css/css-fonts/system-ui-ar-notref.html
+++ b/css/css-fonts/system-ui-ar-notref.html
@@ -8,7 +8,7 @@
   font-family: noto-naskh;
   src: url(/fonts/noto/NotoNaskhArabic-regular.woff2),
        url(/fonts/noto/NotoNaskhArabic-regular.ttf);
-  size-adjust: 0.5; /* cause mismatch even if system-ui maps to Noto Naskh */
+  size-adjust: 50%; /* cause mismatch even if system-ui maps to Noto Naskh */
 }
 p {
   font-family: Ahem, noto-naskh, serif;

--- a/css/css-fonts/system-ui-ar.html
+++ b/css/css-fonts/system-ui-ar.html
@@ -11,7 +11,7 @@
   font-family: noto-naskh;
   src: url(/fonts/noto/NotoNaskhArabic-regular.woff2),
        url(/fonts/noto/NotoNaskhArabic-regular.ttf);
-  size-adjust: 0.5; /* cause mismatch even if system-ui maps to Noto Naskh */
+  size-adjust: 50%; /* cause mismatch even if system-ui maps to Noto Naskh */
 }
 p {
   font-family: Ahem, system-ui, noto-naskh, serif;

--- a/css/css-fonts/system-ui-ja-notref.html
+++ b/css/css-fonts/system-ui-ja-notref.html
@@ -7,7 +7,7 @@
 @font-face {
   font-family: mplus;
   src: url(/fonts/mplus-1p-regular.woff);
-  size-adjust: 0.5; /* cause mismatch even if system-ui maps to M+ */
+  size-adjust: 50%; /* cause mismatch even if system-ui maps to M+ */
 }
 p {
   font-family: Ahem, mplus, serif;

--- a/css/css-fonts/system-ui-ja-vs-zh.html
+++ b/css/css-fonts/system-ui-ja-vs-zh.html
@@ -10,7 +10,7 @@
 @font-face {
   font-family: mplus;
   src: url(/fonts/mplus-1p-regular.woff);
-  size-adjust: 0.5; /* cause mismatch even if system-ui maps to M+ */
+  size-adjust: 50%; /* cause mismatch even if system-ui maps to M+ */
 }
 p {
   font-family: Ahem, system-ui, mplus, serif;

--- a/css/css-fonts/system-ui-ja.html
+++ b/css/css-fonts/system-ui-ja.html
@@ -10,7 +10,7 @@
 @font-face {
   font-family: mplus;
   src: url(/fonts/mplus-1p-regular.woff);
-  size-adjust: 0.5; /* cause mismatch even if system-ui maps to M+ */
+  size-adjust: 50%; /* cause mismatch even if system-ui maps to M+ */
 }
 p {
   font-family: Ahem, system-ui, mplus, serif;

--- a/css/css-fonts/system-ui-ur-notref.html
+++ b/css/css-fonts/system-ui-ur-notref.html
@@ -8,7 +8,7 @@
   font-family: noto-naskh;
   src: url(/fonts/noto/NotoNaskhArabic-regular.woff2),
        url(/fonts/noto/NotoNaskhArabic-regular.ttf);
-  size-adjust: 0.5; /* cause mismatch even if system-ui maps to Noto Naskh */
+  size-adjust: 50%; /* cause mismatch even if system-ui maps to Noto Naskh */
 }
 p {
   font-family: Ahem, noto-naskh, serif;

--- a/css/css-fonts/system-ui-ur-vs-ar.html
+++ b/css/css-fonts/system-ui-ur-vs-ar.html
@@ -11,7 +11,7 @@
   font-family: noto-naskh;
   src: url(/fonts/noto/NotoNaskhArabic-regular.woff2),
        url(/fonts/noto/NotoNaskhArabic-regular.ttf);
-  size-adjust: 0.5; /* cause mismatch even if system-ui maps to Noto Naskh */
+  size-adjust: 50%; /* cause mismatch even if system-ui maps to Noto Naskh */
 }
 p {
   font-family: Ahem, system-ui, noto-naskh, serif;

--- a/css/css-fonts/system-ui-ur.html
+++ b/css/css-fonts/system-ui-ur.html
@@ -11,7 +11,7 @@
   font-family: noto-naskh;
   src: url(/fonts/noto/NotoNaskhArabic-regular.woff2),
        url(/fonts/noto/NotoNaskhArabic-regular.ttf);
-  size-adjust: 0.5; /* cause mismatch even if system-ui maps to Noto Naskh */
+  size-adjust: 50%; /* cause mismatch even if system-ui maps to Noto Naskh */
 }
 p {
   font-family: Ahem, system-ui, noto-naskh, serif;

--- a/css/css-fonts/system-ui-zh-notref.html
+++ b/css/css-fonts/system-ui-zh-notref.html
@@ -7,7 +7,7 @@
 @font-face {
   font-family: mplus;
   src: url(/fonts/mplus-1p-regular.woff);
-  size-adjust: 0.5; /* cause mismatch even if system-ui maps to M+ */
+  size-adjust: 50%; /* cause mismatch even if system-ui maps to M+ */
 }
 p {
   font-family: Ahem, mplus, serif;

--- a/css/css-fonts/system-ui-zh.html
+++ b/css/css-fonts/system-ui-zh.html
@@ -10,7 +10,7 @@
 @font-face {
   font-family: mplus;
   src: url(/fonts/mplus-1p-regular.woff);
-  size-adjust: 0.5; /* cause mismatch even if system-ui maps to M+ */
+  size-adjust: 50%; /* cause mismatch even if system-ui maps to M+ */
 }
 p {
   font-family: Ahem, system-ui, mplus, serif;


### PR DESCRIPTION
The `size-adjust` descriptor accepts a percentage, not a number.

Fixes #35543