### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=249582

### DIFF
--- a/css/css-typed-om/the-stylepropertymap/properties/animation-duration.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/animation-duration.html
@@ -13,7 +13,10 @@
 'use strict';
 
 runListValuedPropertyTests('animation-duration', [
-  { syntax: '<time>' },
+  {
+    syntax: '<time>',
+    specified: assert_is_equal_with_range_handling
+  },
 ]);
 
 </script>

--- a/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count.html
@@ -15,7 +15,10 @@
 
 runListValuedPropertyTests('animation-iteration-count', [
   { syntax: 'infinite' },
-  { syntax: '<number>' },
+  {
+    syntax: '<number>',
+    specified: assert_is_equal_with_range_handling
+  },
 ]);
 
 </script>

--- a/css/css-typed-om/the-stylepropertymap/properties/background-size.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/background-size.html
@@ -14,8 +14,14 @@
 'use strict';
 
 runListValuedPropertyTests('background-size', [
-  { syntax: '<length>' },
-  { syntax: '<percentage>' },
+  {
+    syntax: '<length>',
+    specified: assert_is_equal_with_range_handling
+  },
+  {
+    syntax: '<percentage>',
+    specified: assert_is_equal_with_range_handling
+  },
   { syntax: 'auto' },
   { syntax: 'cover' },
   { syntax: 'contain' },

--- a/css/css-typed-om/the-stylepropertymap/properties/border-image-outset.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/border-image-outset.html
@@ -18,10 +18,12 @@ runPropertyTests('border-image-outset', [
   // Typed OM level 1.
   {
     syntax: '<length>',
+    specified: assert_is_equal_with_range_handling,
     computed: (_, result) => assert_is_unsupported(result)
   },
   {
     syntax: '<number>',
+    specified: assert_is_equal_with_range_handling,
     computed: (_, result) => assert_is_unsupported(result)
   },
 ]);

--- a/css/css-typed-om/the-stylepropertymap/properties/border-image-slice.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/border-image-slice.html
@@ -18,10 +18,12 @@ runPropertyTests('border-image-slice', [
   // Typed OM level 1.
   {
     syntax: '<number>',
+    specified: assert_is_equal_with_range_handling,
     computed: (_, result) => assert_is_unsupported(result)
   },
   {
     syntax: '<percentage>',
+    specified: assert_is_equal_with_range_handling,
     computed: (_, result) => assert_is_unsupported(result)
   },
 ]);

--- a/css/css-typed-om/the-stylepropertymap/properties/border-image-width.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/border-image-width.html
@@ -18,14 +18,17 @@ runPropertyTests('border-image-width', [
   // Typed OM level 1.
   {
     syntax: '<length>',
+    specified: assert_is_equal_with_range_handling,
     computed: (_, result) => assert_is_unsupported(result)
   },
   {
     syntax: '<percentage>',
+    specified: assert_is_equal_with_range_handling,
     computed: (_, result) => assert_is_unsupported(result)
   },
   {
     syntax: '<number>',
+    specified: assert_is_equal_with_range_handling,
     computed: (_, result) => assert_is_unsupported(result)
   },
   {

--- a/css/css-typed-om/the-stylepropertymap/properties/border-radius.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/border-radius.html
@@ -19,10 +19,12 @@ for (const suffix of ['top-left', 'top-right', 'bottom-left', 'bottom-right']) {
   runPropertyTests('border-' + suffix + '-radius', [
     {
       syntax: '<length>',
+      specified: assert_is_equal_with_range_handling,
       computed: (_, result) => assert_is_unsupported(result)
     },
     {
       syntax: '<percentage>',
+      specified: assert_is_equal_with_range_handling,
       computed: (_, result) => assert_is_unsupported(result)
     },
   ]);

--- a/css/css-typed-om/the-stylepropertymap/properties/font-weight.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/font-weight.html
@@ -38,7 +38,7 @@ runPropertyTests('font-weight', [
     syntax: '<number>',
     specified: (input, result) => {
       if (input instanceof CSSUnitValue &&
-          (input.value < 0 || input.value > 1000))
+          (input.value < 1 || input.value > 1000))
         assert_style_value_equals(result, new CSSMathSum(input));
       else
         assert_style_value_equals(result, input);

--- a/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows.html
@@ -20,8 +20,14 @@ for (const suffix of ['columns', 'rows']) {
     { syntax: 'min-content' },
     { syntax: 'max-content' },
     { syntax: 'auto' },
-    { syntax: '<length>' },
-    { syntax: '<percentage>' },
+    {
+      syntax: '<length>',
+      specified: assert_is_equal_with_range_handling
+    },
+    {
+      syntax: '<percentage>',
+      specified: assert_is_equal_with_range_handling
+    },
     { syntax: '<flex>' },
   ]);
 

--- a/css/css-typed-om/the-stylepropertymap/properties/logical.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/logical.html
@@ -19,14 +19,34 @@ const logical = {
   corners: ['start-start', 'start-end', 'end-start', 'end-end'],
 };
 
-for (const prefix of ['margin-', 'inset-', 'padding-']) {
-  for (const side of [...logical.sides, ...logical.axes]) {
-    runPropertyTests(prefix + side, [
-      // TODO: Test 'auto'
-      { syntax: '<percentage>' },
-      { syntax: '<length>' },
-    ]);
-  }
+for (const side of [...logical.sides, ...logical.axes]) {
+  runPropertyTests('margin-' + side, [
+    // TODO: Test 'auto'
+    { syntax: '<percentage>' },
+    { syntax: '<length>' }
+  ]);
+}
+
+for (const side of [...logical.sides, ...logical.axes]) {
+  runPropertyTests('padding-' + side, [
+    // TODO: Test 'auto'
+    {
+      syntax: '<percentage>',
+      specified: assert_is_equal_with_range_handling
+    },
+    {
+      syntax: '<length>',
+      specified: assert_is_equal_with_range_handling
+    },
+  ]);
+}
+
+for (const side of [...logical.sides, ...logical.axes]) {
+  runPropertyTests('inset-' + side, [
+    // TODO: Test 'auto'
+    { syntax: '<percentage>' },
+    { syntax: '<length>' }
+  ]);
 }
 
 // BORDERS
@@ -42,7 +62,10 @@ for (const side of [...logical.sides, ...logical.axes]) {
     { syntax: 'thin' },
     { syntax: 'medium' },
     { syntax: 'thick' },
-    { syntax: '<length>' },
+    {
+      syntax: '<length>',
+      specified: assert_is_equal_with_range_handling
+    },
   ]);
 
   runPropertyTests(`border-${side}-color`, [
@@ -59,8 +82,14 @@ for (const side of [...logical.sides, ...logical.axes]) {
 // border radius
 for (const side of logical.corners) {
   runPropertyTests(`border-${side}-radius`, [
-    { syntax: '<percentage>' },
-    { syntax: '<length>' },
+    {
+      syntax: '<percentage>',
+      specified: assert_is_equal_with_range_handling
+    },
+    {
+      syntax: '<length>',
+      specified: assert_is_equal_with_range_handling
+    },
   ]);
 }
 </script>

--- a/css/css-typed-om/the-stylepropertymap/properties/scroll-padding.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/scroll-padding.html
@@ -15,15 +15,27 @@
 
 for (const suffix of ['top', 'left', 'right', 'bottom']) {
   runPropertyTests('scroll-padding-' + suffix, [
-    { syntax: '<percentage>' },
-    { syntax: '<length>' },
+    {
+      syntax: '<percentage>',
+      specified: assert_is_equal_with_range_handling
+    },
+    {
+      syntax: '<length>',
+      specified: assert_is_equal_with_range_handling
+    },
   ]);
 }
 
 for (const suffix of ['inline-start', 'block-start', 'inline-end', 'block-end']) {
   runPropertyTests('scroll-padding-' + suffix, [
-    { syntax: '<percentage>' },
-    { syntax: '<length>' },
+    {
+      syntax: '<percentage>',
+      specified: assert_is_equal_with_range_handling
+    },
+    {
+      syntax: '<length>',
+      specified: assert_is_equal_with_range_handling
+    },
   ]);
 }
 

--- a/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit.html
@@ -14,7 +14,10 @@
 'use strict';
 
 runPropertyTests('stroke-miterlimit', [
-  { syntax: '<number>' },
+  {
+    syntax: '<number>',
+    specified: assert_is_equal_with_range_handling
+  },
 ]);
 
 </script>


### PR DESCRIPTION
Update CSS-Typed-OM tests to more consistently add range checks for properties
not allowing negative values:

- animation-duration
https://w3c.github.io/csswg-drafts/css-animations/#animation-duration

- animation-iteration-count
https://w3c.github.io/csswg-drafts/css-animations/#animation-iteration-count
https://w3c.github.io/csswg-drafts/css-animations/#typedef-single-animation-iteration-count

- background-size
https://w3c.github.io/csswg-drafts/css-backgrounds/#the-background-size
https://w3c.github.io/csswg-drafts/css-backgrounds/#typedef-bg-size

- border-image-outset
https://w3c.github.io/csswg-drafts/css-backgrounds/#the-border-image-outset

- border-image-slice
https://w3c.github.io/csswg-drafts/css-backgrounds/#border-image-slice

- border-image-width
https://w3c.github.io/csswg-drafts/css-backgrounds/#border-image-width

- border-top-left-radius, border-top-right-radius, border-bottom-right-radius, border-bottom-left-radius
https://w3c.github.io/csswg-drafts/css-backgrounds/#border-radius

- font-weight
https://w3c.github.io/csswg-drafts/css-fonts/#font-weight-prop
https://w3c.github.io/csswg-drafts/css-fonts/#font-weight-absolute-values

- grid-auto-columns, grid-auto-rows
https://w3c.github.io/csswg-drafts/css-grid/#auto-tracks
https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-size
https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-breadth

- padding-block-start, padding-block-end, padding-inline-start, padding-inline-end
https://w3c.github.io/csswg-drafts/css-logical/#padding-properties
https://w3c.github.io/csswg-drafts/css-box-4/#propdef-padding-top

- border-block-start-width, border-block-end-width, border-inline-start-width, border-inline-end-width
https://w3c.github.io/csswg-drafts/css-logical/#border-width
https://w3c.github.io/csswg-drafts/css-backgrounds-3/#propdef-border-top-width
https://w3c.github.io/csswg-drafts/css-backgrounds-3/#typedef-line-width

- scroll-padding-top, scroll-padding-right, scroll-padding-bottom, scroll-padding-left
https://w3c.github.io/csswg-drafts/css-scroll-snap/#padding-longhands-physical

- scroll-padding-inline-start, scroll-padding-block-start, scroll-padding-inline-end, scroll-padding-block-end
https://w3c.github.io/csswg-drafts/css-scroll-snap/#padding-longhands-logical

- stroke-miterlimit
https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty