### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=249590

### DIFF
--- a/css/css-typed-om/the-stylepropertymap/properties/flood-opacity.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/flood-opacity.html
@@ -13,7 +13,7 @@
 <script>
 'use strict';
 
-function assert_is_equal_with_clamping(input, result) {
+function assert_is_equal_with_clamping_number(input, result) {
   const number = input.to('number');
 
   if (number.value < 0)
@@ -24,11 +24,27 @@ function assert_is_equal_with_clamping(input, result) {
     assert_style_value_equals(result, input);
 }
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const number = input.to('percent');
+  const value = number.value / 100.;
+
+  if (value < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'number'));
+  else if (value > 1)
+    assert_style_value_equals(result, new CSSUnitValue(1, 'number'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(value, 'number'));
+}
+
 runPropertyTests('flood-opacity', [
   {
     syntax: '<number>',
-    computed: assert_is_equal_with_clamping
+    computed: assert_is_equal_with_clamping_number
   },
+  {
+    syntax: '<percentage>',
+    computed: assert_is_equal_with_clamping_percentage
+  }
 ]);
 
 </script>


### PR DESCRIPTION
Fix css/css-typed-om/the-stylepropertymap/properties/flood-opacity.html to match the latest specification:
- https://drafts.fxtf.org/filter-effects/#FloodOpacityProperty
- https://drafts.csswg.org/css-color-5/#typedef-alpha-value

The specification allows percentages.