### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=249510

### DIFF
--- a/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset.html
@@ -15,7 +15,11 @@
 
 runPropertyTests('stroke-dashoffset', [
   { syntax: '<length>' },
-  { syntax: '<percentage>' }
+  { syntax: '<percentage>' },
+  {
+    syntax: '<number>',
+    computed: (_, result) => assert_is_unit('px', result)
+  },
 ]);
 
 </script>

--- a/css/css-typed-om/the-stylepropertymap/properties/stroke-width.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/stroke-width.html
@@ -22,6 +22,11 @@ runListValuedPropertyTests('stroke-width', [
     syntax: '<percentage>',
     specified: assert_is_equal_with_range_handling
   },
+  {
+    syntax: '<number>',
+    specified: assert_is_equal_with_range_handling,
+    computed: (_, result) => assert_is_unit('px', result)
+  },
 ]);
 
 </script>

--- a/svg/painting/parsing/stroke-dashoffset-valid.svg
+++ b/svg/painting/parsing/stroke-dashoffset-valid.svg
@@ -13,10 +13,10 @@
   <h:script src="/css/support/parsing-testcommon.js"/>
   <script><![CDATA[
 
-test_valid_value("stroke-dashoffset", "0", "0px");
+test_valid_value("stroke-dashoffset", "0");
 test_valid_value("stroke-dashoffset", "10px");
 test_valid_value("stroke-dashoffset", "-20%");
-test_valid_value("stroke-dashoffset", "30", "30px");
+test_valid_value("stroke-dashoffset", "30");
 test_valid_value("stroke-dashoffset", "40Q", "40q");
 test_valid_value("stroke-dashoffset", "calc(2em + 3ex)");
 test_valid_value("stroke-dashoffset", "calc(3)");

--- a/svg/painting/parsing/stroke-width-valid.svg
+++ b/svg/painting/parsing/stroke-width-valid.svg
@@ -13,8 +13,8 @@
   <h:script src="/css/support/parsing-testcommon.js"/>
   <script><![CDATA[
 
-test_valid_value("stroke-width", "0", "0px");
-test_valid_value("stroke-width", "10", "10px");
+test_valid_value("stroke-width", "0");
+test_valid_value("stroke-width", "10");
 test_valid_value("stroke-width", "1px");
 test_valid_value("stroke-width", "calc(2em + 3ex)");
 test_valid_value("stroke-width", "4%");


### PR DESCRIPTION
Align a few stroke-width / stroke-dashoffset tests with the latest SVG2 specification:
- https://svgwg.org/svg2-draft/painting.html#StrokeWidth
- https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty