### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=249601

### DIFF
--- a/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows.html
@@ -16,6 +16,18 @@
 for (const suffix of ['columns', 'rows']) {
   runPropertyTests(`grid-template-${suffix}`, [
     { syntax: 'none' },
+    {
+      syntax: '<length>',
+      specified: assert_is_equal_with_range_handling
+    },
+    {
+      syntax: '<percentage>',
+      specified: assert_is_equal_with_range_handling
+    },
+    {
+      syntax: '<flex>',
+      specified: assert_is_equal_with_range_handling
+    }
   ]);
 
   runUnsupportedPropertyTests(`grid-template-${suffix}`, [

--- a/css/css-typed-om/the-stylepropertymap/properties/resources/testsuite.js
+++ b/css/css-typed-om/the-stylepropertymap/properties/resources/testsuite.js
@@ -193,12 +193,17 @@ const gTestSyntaxExamples = {
         description: "one fraction",
         input: new CSSUnitValue(1, 'fr')
       },
+      // TODO(https://github.com/w3c/css-houdini-drafts/issues/734):
+      // Add calc tests involving 'fr' when that is spec'd in CSS.
+    ],
+  },
+  '<negative-flex>': {
+    description: 'a flexible length',
+    examples: [
       {
         description: "negative fraction",
         input: new CSSUnitValue(-3.14, 'fr')
       },
-      // TODO(https://github.com/w3c/css-houdini-drafts/issues/734):
-      // Add calc tests involving 'fr' when that is spec'd in CSS.
     ],
   },
   '<number>': {


### PR DESCRIPTION
I updated the grid-template-columns-rows.html WPT test to allow <length>,
<percentage> and <flex>, as per the specification:
- https://w3c.github.io/csswg-drafts/css-grid/#auto-tracks
- https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-size
- https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-breadth