### PR TITLE
add sigterm handling to wptrunner

### DIFF
--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -277,12 +277,12 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
     return True
 
 def handle_interrupt_signals():
-    def SigtermHandler(_signum, _unused_frame):
+    def termination_handler(_signum, _unused_frame):
         raise KeyboardInterrupt()
     if sys.platform == "win32":
-        signal.signal(signal.SIGBREAK, SigtermHandler)
+        signal.signal(signal.SIGBREAK, termination_handler)
     else:
-        signal.signal(signal.SIGTERM, SigtermHandler)
+        signal.signal(signal.SIGTERM, termination_handler)
 
 
 def evaluate_runs(test_status, run_test_kwargs):

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import signal
 import sys
 from collections import defaultdict
 from datetime import datetime, timedelta
@@ -257,6 +258,7 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
                           run_test_kwargs["restart_on_new_group"],
                           recording=recording) as manager_group:
             try:
+                handle_interrupt_signals()
                 manager_group.run(tests_to_run)
             except KeyboardInterrupt:
                 logger.critical("Main thread got signal")
@@ -273,6 +275,14 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
     logger.suite_end()
 
     return True
+
+def handle_interrupt_signals():
+    def SigtermHandler(_signum, _unused_frame):
+        raise KeyboardInterrupt()
+    if sys.platform == "win32":
+        signal.signal(signal.SIGBREAK, SigtermHandler)
+    else:
+        signal.signal(signal.SIGTERM, SigtermHandler)
 
 
 def evaluate_runs(test_status, run_test_kwargs):


### PR DESCRIPTION
Add sigterm signals for wpt runner to shut down gracefully.
Translate them to keyboardinterrupt so the process can properly go down the cleanup route.

tested in CL:
https://chromium-review.googlesource.com/c/chromium/src/+/4135543