### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=249399

### DIFF
--- a/css/css-properties-values-api/animation/custom-property-transition-angle.html
+++ b/css/css-properties-values-api/animation/custom-property-transition-angle.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<angle>",
+  from: "100deg",
+  to: "200deg",
+  expected: "150deg"
+}, 'A custom property of type <angle> can yield a CSS Transition');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-transition-color.html
+++ b/css/css-properties-values-api/animation/custom-property-transition-color.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<color>",
+  from: "rgb(100, 100, 100)",
+  to: "rgb(200, 200, 200)",
+  expected: "rgb(150, 150, 150)"
+}, 'A custom property of type <color> can yield a CSS Transition');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-transition-custom-ident.html
+++ b/css/css-properties-values-api/animation/custom-property-transition-custom-ident.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+no_transition_test({
+  syntax: "<custom-ident>",
+  from: "from",
+  to: "to",
+}, 'A custom property of type <custom-ident> cannot yield a CSS Transition');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-transition-image.html
+++ b/css/css-properties-values-api/animation/custom-property-transition-image.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+no_transition_test({
+  syntax: "<image>",
+  from: 'url("https://example.com/from")',
+  to: 'url("https://example.com/to")',
+}, 'A custom property of type <image> cannot yield a CSS Transition');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-transition-inherited-used-by-standard-property.html
+++ b/css/css-properties-values-api/animation/custom-property-transition-inherited-used-by-standard-property.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="container">
+    <div id="target"></div>
+</div>
+<script>
+
+test(() => {
+  const customProperty = "--my-length";
+
+  CSS.registerProperty({
+    name: customProperty,
+    syntax: "<length>",
+    inherits: true,
+    initialValue: "100px"
+  });
+
+  target.style.marginLeft = `var(${customProperty})`;
+  assert_equals(getComputedStyle(target).marginLeft, "100px");
+  assert_equals(getComputedStyle(target).getPropertyValue(customProperty), "100px");
+
+  container.style.transition = `${customProperty} 1s -500ms linear`;
+  container.style.setProperty(customProperty, "200px");
+
+  assert_equals(getComputedStyle(target).marginLeft, "150px");
+}, "Running a transition an inherited CSS variable is reflected on a standard property using that variable as a value");
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-transition-integer.html
+++ b/css/css-properties-values-api/animation/custom-property-transition-integer.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<integer>",
+  from: "100",
+  to: "200",
+  expected: "150"
+}, 'A custom property of type <integer> can yield a CSS Transition');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-transition-length-percentage.html
+++ b/css/css-properties-values-api/animation/custom-property-transition-length-percentage.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<length-percentage>",
+  from: "100px",
+  to: "100%",
+  expected: "calc(50% + 50px)"
+}, 'A custom property of type <length-percentage> can yield a CSS Transition');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-transition-length.html
+++ b/css/css-properties-values-api/animation/custom-property-transition-length.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<length>",
+  from: "100px",
+  to: "200px",
+  expected: "150px"
+}, 'A custom property of type <length> can yield a CSS Transition');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-transition-mismatched-list.html
+++ b/css/css-properties-values-api/animation/custom-property-transition-mismatched-list.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+no_transition_test({
+  syntax: "<angle>#",
+  from: '100deg, 200deg',
+  to: '300deg',
+}, 'A custom property of type <angle># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<angle>+",
+  from: '100deg 200deg',
+  to: '300deg',
+}, 'A custom property of type <angle>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<color>#",
+  from: 'rgb(100, 100, 100), rgb(150, 150, 150)',
+  to: 'rgb(200, 200, 200)',
+}, 'A custom property of type <color># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<color>+",
+  from: 'rgb(100, 100, 100) rgb(150, 150, 150)',
+  to: 'rgb(200, 200, 200)',
+}, 'A custom property of type <color>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<custom-ident>#",
+  from: 'foo, bar',
+  to: 'baz',
+}, 'A custom property of type <custom-ident># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<custom-ident>+",
+  from: 'foo bar',
+  to: 'baz',
+}, 'A custom property of type <custom-ident>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<image>#",
+  from: 'url("https://example.com/foo"), url("https://example.com/bar")',
+  to: 'url("https://example.com/to")',
+}, 'A custom property of type <image># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<image>+",
+  from: 'url("https://example.com/foo") url("https://example.com/bar")',
+  to: 'url("https://example.com/to")',
+}, 'A custom property of type <image>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<integer>#",
+  from: '100, 200',
+  to: '300',
+}, 'A custom property of type <integer># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<integer>+",
+  from: '100 200',
+  to: '300',
+}, 'A custom property of type <integer>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<length-percentage>#",
+  from: '100px, 200px',
+  to: '300%',
+}, 'A custom property of type <length-percentage># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<length-percentage>+",
+  from: '100px 200px',
+  to: '300%',
+}, 'A custom property of type <length-percentage>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<length>#",
+  from: '100px, 200px',
+  to: '300px',
+}, 'A custom property of type <length># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<length>+",
+  from: '100px 200px',
+  to: '300px',
+}, 'A custom property of type <length>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<number>#",
+  from: '100, 200',
+  to: '300',
+}, 'A custom property of type <number># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<number>+",
+  from: '100 200',
+  to: '300',
+}, 'A custom property of type <number>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<percentage>#",
+  from: '100%, 200%',
+  to: '300%',
+}, 'A custom property of type <percentage># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<percentage>+",
+  from: '100% 200%',
+  to: '300%',
+}, 'A custom property of type <percentage>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<resolution>#",
+  from: '100dppx, 200dppx',
+  to: '300dppx',
+}, 'A custom property of type <resolution># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<resolution>+",
+  from: '100dppx 200dppx',
+  to: '300dppx',
+}, 'A custom property of type <resolution>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<time>#",
+  from: '100s, 200s',
+  to: '300s',
+}, 'A custom property of type <time># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<time>+",
+  from: '100s 200s',
+  to: '300s',
+}, 'A custom property of type <time>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<url>#",
+  from: 'url("https://example.com/foo"), url("https://example.com/bar")',
+  to: 'url("https://example.com/to")',
+}, 'A custom property of type <url># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<url>+",
+  from: 'url("https://example.com/foo") url("https://example.com/bar")',
+  to: 'url("https://example.com/to")',
+}, 'A custom property of type <url>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-transition-non-inherited-used-by-standard-property.html
+++ b/css/css-properties-values-api/animation/custom-property-transition-non-inherited-used-by-standard-property.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+test(() => {
+  const customProperty = "--my-length";
+
+  CSS.registerProperty({
+    name: customProperty,
+    syntax: "<length>",
+    inherits: false,
+    initialValue: "100px"
+  });
+
+  target.style.marginLeft = `var(${customProperty})`;
+  assert_equals(getComputedStyle(target).marginLeft, "100px");
+
+  target.style.transition = `${customProperty} 1s -500ms linear`;
+  target.style.setProperty(customProperty, "200px");
+
+  assert_equals(getComputedStyle(target).marginLeft, "150px");
+}, "Running a transition a non-inherited CSS variable is reflected on a standard property using that variable as a value");
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-transition-number.html
+++ b/css/css-properties-values-api/animation/custom-property-transition-number.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<number>",
+  from: "100",
+  to: "200",
+  expected: "150"
+}, 'A custom property of type <number> can yield a CSS Transition');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-transition-percentage.html
+++ b/css/css-properties-values-api/animation/custom-property-transition-percentage.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<percentage>",
+  from: "100%",
+  to: "200%",
+  expected: "150%"
+}, 'A custom property of type <percentage> can yield a CSS Transition');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-transition-resolution.html
+++ b/css/css-properties-values-api/animation/custom-property-transition-resolution.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<resolution>",
+  from: "100dppx",
+  to: "200dppx",
+  expected: "150dppx"
+}, 'A custom property of type <resolution> can yield a CSS Transition');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-transition-time.html
+++ b/css/css-properties-values-api/animation/custom-property-transition-time.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<time>",
+  from: "100s",
+  to: "200s",
+  expected: "150s"
+}, 'A custom property of type <time> can yield a CSS Transition');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-transition-transform-function.html
+++ b/css/css-properties-values-api/animation/custom-property-transition-transform-function.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<transform-function>",
+  from: "translateX(100px)",
+  to: "translateX(200px)",
+  expected: "translateX(150px)"
+}, 'A custom property of type <transform-function> can yield a CSS Transition');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-transition-transform-list.html
+++ b/css/css-properties-values-api/animation/custom-property-transition-transform-list.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<transform-list>",
+  from: "translateX(100px) scale(2)",
+  to: "translateX(200px) scale(4)",
+  expected: "translateX(150px) scale(3)"
+}, 'A custom property of type <transform-list> can yield a CSS Transition');
+
+</script>

--- a/css/css-properties-values-api/animation/custom-property-transition-url.html
+++ b/css/css-properties-values-api/animation/custom-property-transition-url.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+no_transition_test({
+  syntax: "<url>",
+  from: 'url("https://example.com/from")',
+  to: 'url("https://example.com/to")',
+}, 'A custom property of type <url> cannot yield a CSS Transition');
+
+</script>

--- a/css/css-properties-values-api/resources/utils.js
+++ b/css/css-properties-values-api/resources/utils.js
@@ -178,3 +178,60 @@ function discrete_animation_test(syntax, fromValue, toValue, description) {
     checkAtProgress(1, toValue);
   }, description || `Animating a custom property of type ${syntax} is discrete`);
 }
+
+function transition_test(options, description) {
+  promise_test(async () => {
+    const customProperty = generate_name();
+
+    CSS.registerProperty({
+      name: customProperty,
+      syntax: options.syntax,
+      inherits: false,
+      initialValue: options.from
+    });
+
+    assert_equals(getComputedStyle(target).getPropertyValue(customProperty), options.from, "Element has the expected initial value");
+
+    const transitionEventPromise = new Promise(resolve => {
+      target.addEventListener("transitionrun", event => {
+          assert_equals(event.propertyName, customProperty, "TransitionEvent has the expected property name");
+          resolve();
+      });
+    });
+
+    target.style.transition = `${customProperty} 1s -500ms linear`;
+    target.style.setProperty(customProperty, options.to);
+
+    const animations = target.getAnimations();
+    assert_equals(animations.length, 1, "A single animation is running");
+
+    const transition = animations[0];
+    assert_class_string(transition, "CSSTransition", "A CSSTransition is running");
+
+    transition.pause();
+    assert_equals(getComputedStyle(target).getPropertyValue(customProperty), options.expected, "Element has the expected animated value");
+
+    await transitionEventPromise;
+  }, description);
+}
+
+function no_transition_test(options, description) {
+  test(() => {
+    const customProperty = generate_name();
+
+    CSS.registerProperty({
+      name: customProperty,
+      syntax: options.syntax,
+      inherits: false,
+      initialValue: options.from
+    });
+
+    assert_equals(getComputedStyle(target).getPropertyValue(customProperty), options.from, "Element has the expected initial value");
+
+    target.style.transition = `${customProperty} 1s -500ms linear`;
+    target.style.setProperty(customProperty, options.to);
+
+    assert_equals(target.getAnimations().length, 0, "No animation was created");
+    assert_equals(getComputedStyle(target).getPropertyValue(customProperty), options.to, "Element has the expected final value");
+  }, description);
+};


### PR DESCRIPTION
WebKit export from bug: [\[css-transitions\] support transitions of custom properties](https://bugs.webkit.org/show_bug.cgi?id=249399)