### PR TITLE
Support the --reftest-screenshot command line argument in the Servo reftest executor

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -180,16 +180,18 @@ class ServoRefTestExecutor(ProcessTestExecutor):
 
     def __init__(self, logger, browser, server_config, binary=None, timeout_multiplier=1,
                  screenshot_cache=None, debug_info=None, pause_after_test=False,
-                 **kwargs):
+                 reftest_screenshot="unexpected", **kwargs):
         ProcessTestExecutor.__init__(self,
                                      logger,
                                      browser,
                                      server_config,
                                      timeout_multiplier=timeout_multiplier,
-                                     debug_info=debug_info)
+                                     debug_info=debug_info,
+                                     reftest_screenshot=reftest_screenshot)
 
         self.protocol = ConnectionlessProtocol(self, browser)
         self.screenshot_cache = screenshot_cache
+        self.reftest_screenshot = reftest_screenshot
         self.implementation = RefTestImplementation(self)
         self.tempdir = tempfile.mkdtemp()
         self.hosts_path = write_hosts_file(server_config)


### PR DESCRIPTION
Commit 7f6659f8e4 added a reftest-screenshot parameter that is passed to the browser reftest executor, but it didn't implemented it for the Servo reftest executor.

So this was causing errors when trying to run the tests with Servo. Add the missing implementation for setting reftest-screenshot on the Servo reftest executor.

Servo runs on wpt.fyi were stopped due to this on https://github.com/web-platform-tests/wpt/issues/36326
I'm going to propose to re-enable the runs after this fix lands

//cc @jgraham @gsnedders 