### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=249617

### DIFF
--- a/css/css-sizing/aspect-ratio/replaced-element-041.html
+++ b/css/css-sizing/aspect-ratio/replaced-element-041.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Replaced Element 041</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-sizing-4/#aspect-ratio-size-transfers">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html"/>
+<meta name="assert" content="Replaced element transferred max size should be floored by transferred min size" />
+<style>
+div {
+    width: 0px;
+}
+img {
+    min-width: 100px;
+    max-width: 100%;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 0px">
+<img src="/css/support/60x60-green.png">
+</div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [REGRESSION(257434@main): Crash in RenderReplaced::computeIntrinsicSizesConstrainedByTransferredMinMaxSizes on https://gitlab.com/gnutls/gnutls/](https://bugs.webkit.org/show_bug.cgi?id=249617)