### PR TITLE
Improve logging of changed paths in TC decision task

### DIFF
--- a/tools/ci/tc/decision.py
+++ b/tools/ci/tc/decision.py
@@ -72,7 +72,7 @@ def get_run_jobs(event):
                          else event["after"])
     logger.info("Looking for changes in range %s" % revish)
     paths = jobs.get_paths(revish=revish)
-    logger.info("Found changes in paths:%s" % "\n".join(paths))
+    logger.info("Found changes in paths:\n * %s" % "\n * ".join(paths))
     path_jobs = jobs.get_jobs(paths)
     all_jobs = path_jobs | get_extra_jobs(event)
     logger.info("Including jobs:\n * %s" % "\n * ".join(all_jobs))


### PR DESCRIPTION
Sample of the output before this:

```
Found changes in paths:content-security-policy/style-src/inline-style-allowed-while-cloning-objects.sub.html
infrastructure/expected-fail/window-onload-test.html
css/cssom-view/negativeMargins.html
html/browsers/the-windowproxy-exotic-object/windowproxy-prototype-setting-goes-cross-origin-domain.sub.html
infrastructure/README.md
```

It should now be a bullet list instead, like the lists logged before and
after this.
