### PR TITLE
Enable back runs of Servo (start with weekly instead of daily for now)

### DIFF
--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -218,6 +218,7 @@ tasks:
                 browser: servo
                 channel: nightly
               use:
+                - trigger-weekly
                 - trigger-push
           do:
             - ${vars.browser}-${vars.channel}-${vars.suite}:


### PR DESCRIPTION
The servo reftest executor was fixed in 112c0145a2 (#37610) so let's enable back again the daily runs of servo on the WPT CI.

This reverts commit a633361f58 "Fix #36326: stop daily runs of Servo"

//CC @jgraham @gsnedders @jdm 