### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=249770

### DIFF
--- a/css/css-properties-values-api/at-property-animation.html
+++ b/css/css-properties-values-api/at-property-animation.html
@@ -258,7 +258,7 @@ test_with_at_property({
 test(() => {
   let name = generate_name();
   with_style_node(`div { ${name}: 100px; transition: ${name} steps(2, start) 100s; }`, () => {
-    assert_equals(getComputedStyle(div).getPropertyValue(name), ' 100px');
+    assert_equals(getComputedStyle(div).getPropertyValue(name), '100px');
 
     let style1 = document.createElement('style');
     style1.textContent = `
@@ -287,7 +287,7 @@ test(() => {
       // (making the computed value a token sequence again). We should snap
       // to the new token sequence.
       style1.remove();
-      assert_equals(getComputedStyle(div).getPropertyValue(name), ' 400px');
+      assert_equals(getComputedStyle(div).getPropertyValue(name), '400px');
     } finally {
       style1.remove();
       style2.remove();

--- a/css/css-properties-values-api/at-property-cssom.html
+++ b/css/css-properties-values-api/at-property-cssom.html
@@ -180,18 +180,18 @@ test_inherits('--initial-value-only', false);
 
 // CSSPropertyRule.initialValue
 
-test_initial_value('--valid', ' red');
-test_initial_value('--valid-reverse', ' 0px');
+test_initial_value('--valid', 'red');
+test_initial_value('--valid-reverse', '0px');
 test_initial_value('--valid-universal', null);
-test_initial_value('--valid-whitespace', ' red, blue');
-test_initial_value('--vALId', ' red');
+test_initial_value('--valid-whitespace', 'red, blue');
+test_initial_value('--vALId', 'red');
 
 test_initial_value('--no-descriptors', null);
-test_initial_value('--no-syntax', ' red');
-test_initial_value('--no-inherits', ' red');
+test_initial_value('--no-syntax', 'red');
+test_initial_value('--no-inherits', 'red');
 test_initial_value('--no-initial-value', null);
 test_initial_value('--syntax-only', null);
 test_initial_value('--inherits-only', null);
-test_initial_value('--initial-value-only', ' red');
+test_initial_value('--initial-value-only', 'red');
 
 </script>

--- a/css/css-properties-values-api/at-property-shadow.html
+++ b/css/css-properties-values-api/at-property-shadow.html
@@ -38,9 +38,9 @@ test(() => {
   root.append(template.content.cloneNode(true));
   let inside = root.querySelector('#inside');
   assert_equals(getComputedStyle(outside).getPropertyValue('--x'), '2px');
-  assert_equals(getComputedStyle(outside).getPropertyValue('--y'), ' calc(1px + 1px)');
+  assert_equals(getComputedStyle(outside).getPropertyValue('--y'), 'calc(1px + 1px)');
   assert_equals(getComputedStyle(inside).getPropertyValue('--x'), '2px');
-  assert_equals(getComputedStyle(inside).getPropertyValue('--y'), ' calc(1px + 1px)');
+  assert_equals(getComputedStyle(inside).getPropertyValue('--y'), 'calc(1px + 1px)');
 }, '@property rules in shadow trees should have no effect');
 
 </script>

--- a/css/css-properties-values-api/determine-registration.html
+++ b/css/css-properties-values-api/determine-registration.html
@@ -101,7 +101,7 @@ test(() => {
 
   with_style_node(`div { ${name}: calc(1px + 1px); }`, () => {
     // ${name} should be a token sequence at this point.
-    assert_equals(getComputedStyle(div).getPropertyValue(name), ' calc(1px + 1px)');
+    assert_equals(getComputedStyle(div).getPropertyValue(name), 'calc(1px + 1px)');
 
     with_at_property({
       name: name,
@@ -114,7 +114,7 @@ test(() => {
     });
 
     // ${name} should be a token sequence again.
-    assert_equals(getComputedStyle(div).getPropertyValue(name), ' calc(1px + 1px)');
+    assert_equals(getComputedStyle(div).getPropertyValue(name), 'calc(1px + 1px)');
   });
 }, 'Computed value becomes token sequence when @property is removed');
 
@@ -122,7 +122,7 @@ test(() => {
   let name = generate_name();
 
   with_style_node(`#outer { ${name}: 10px; }`, () => {
-    assert_equals(getComputedStyle(div).getPropertyValue(name), ' 10px');
+    assert_equals(getComputedStyle(div).getPropertyValue(name), '10px');
 
     with_at_property({
       name: name,
@@ -134,7 +134,7 @@ test(() => {
       assert_equals(getComputedStyle(div).getPropertyValue(name), '0px');
     });
 
-    assert_equals(getComputedStyle(div).getPropertyValue(name), ' 10px');
+    assert_equals(getComputedStyle(div).getPropertyValue(name), '10px');
   });
 }, 'Inherited status is reflected in computed styles when @property is removed');
 

--- a/css/css-properties-values-api/registered-property-cssom.html
+++ b/css/css-properties-values-api/registered-property-cssom.html
@@ -25,8 +25,8 @@ var sheetStyle = document.styleSheets[0].cssRules[0].style;
 
 test(function() {
   // Nothing registered yet, whatever you specify works
-  assert_equals(computedStyle.getPropertyValue('--length'), ' 10px');
-  assert_equals(computedStyle.getPropertyValue('--color'), ' red');
+  assert_equals(computedStyle.getPropertyValue('--length'), '10px');
+  assert_equals(computedStyle.getPropertyValue('--color'), 'red');
 
   inlineStyle.setProperty('--length', '5');
   inlineStyle.setProperty('--color', 'hello');

--- a/css/css-properties-values-api/var-reference-registered-properties.html
+++ b/css/css-properties-values-api/var-reference-registered-properties.html
@@ -54,9 +54,9 @@ test(function() {
     assert_equals(computedStyle.getPropertyValue('--registered-length-5'), '70px');
     assert_equals(computedStyle.getPropertyValue('--registered-length-6'), '80px');
     assert_equals(computedStyle.getPropertyValue('--registered-length-7'), '123px');
-    assert_equals(computedStyle.getPropertyValue('--length-1'), ' 20px');
-    assert_equals(computedStyle.getPropertyValue('--length-2'), ' 10px');
-    assert_equals(computedStyle.getPropertyValue('--length-3'), ' calc(123px + 123px)');
+    assert_equals(computedStyle.getPropertyValue('--length-1'), '20px');
+    assert_equals(computedStyle.getPropertyValue('--length-2'), '10px');
+    assert_equals(computedStyle.getPropertyValue('--length-3'), 'calc(123px + 123px)');
     assert_equals(computedStyle.getPropertyValue('--registered-length-invalid'), '15px');
 
     assert_equals(computedStyle.getPropertyValue('--registered-token-stream-1'), '');


### PR DESCRIPTION
WebKit export from bug: [\[@property\] Whitespaces around initial-value should be trimmed](https://bugs.webkit.org/show_bug.cgi?id=249770)