### PR TITLE
Add option to support Chrome's custom BiDi Mapper path

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -132,6 +132,10 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
         chrome_options["args"].append(
             f"--origin-to-force-quic-on=web-platform.test:{webtranport_h3_port[0]}")
 
+    # Handle custom BiDi Mapper path.
+    if (kwargs["bidi_mapper_path"]):
+        capabilities["goog:chromeOptions"]["bidiMapperPath"] = kwargs["bidi_mapper_path"]
+
     executor_kwargs["capabilities"] = capabilities
 
     return executor_kwargs

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -349,6 +349,7 @@ scheme host and port.""")
     chrome_group.add_argument("--mojojs-path",
                              help="Path to mojojs gen/ directory. If it is not specified, `wpt run` "
                              "will download and extract mojojs.zip into _venv2/mojojs/gen.")
+    chrome_group.add_argument("--bidi-mapper-path", help="Path to custom BiDi-CDP Mapper.")
     chrome_group.add_argument("--enable-swiftshader", action="store_true", default=False,
                              help="Enable SwiftShader for CPU-based 3D graphics. This can be used "
                              "in environments with no hardware GPU available.")


### PR DESCRIPTION
To provide flexibility in BiDi testing, we want to be able to run WPT tests on a ChromeDriver instance with a custom BiDi-CDP Mapper. This argument is intended to provide such a possibility.

* This change uses the ChromeDriver capability introduced in [Add ability to run ChromeDriver with a custom BiDi Mapper (I14c2851f) · Gerrit Code Review](https://crrev.com/c/4114081).
* Required for [ChromeDriver Classic + BiDi WPT runner · Issue #348 · GoogleChromeLabs/chromium-bidi](https://github.com/GoogleChromeLabs/chromium-bidi/issues/348).