### PR TITLE
[css-text] line-break-normal-015a should apply LB22

### DIFF
--- a/css/css-text/line-break/line-break-normal-015a.xht
+++ b/css/css-text/line-break/line-break-normal-015a.xht
@@ -50,7 +50,7 @@
 				<span>サンプルサンプル文<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル文<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプルサンプル<br />文<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -59,7 +59,7 @@
 				<span>サンプルサンプル文<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル文<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプルサンプル<br />文<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/line-break-strict-015a.xht
+++ b/css/css-text/line-break/line-break-strict-015a.xht
@@ -50,7 +50,7 @@
 				<span>サンプルサンプル文<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル文<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプルサンプル<br />文<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -59,7 +59,7 @@
 				<span>サンプルサンプル文<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル文<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプルサンプル<br />文<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-normal-015a-ref.xht
+++ b/css/css-text/line-break/reference/line-break-normal-015a-ref.xht
@@ -41,19 +41,19 @@
 		<div class="wrapper">
 			<!-- inseparable characters TWO DOT LEADER -->
 			<p class="control" lang="ja">
-				<span>サンプルサンプル文<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプルサンプル<br />文<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル文<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプルサンプル<br />文<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
 			<!-- inseparable characters HORIZONTAL ELLIPSIS -->
 			<p class="control" lang="ja">
-				<span>サンプルサンプル文<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプルサンプル<br />文<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル文<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプルサンプル<br />文<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-strict-015a-ref.xht
+++ b/css/css-text/line-break/reference/line-break-strict-015a-ref.xht
@@ -41,19 +41,19 @@
 		<div class="wrapper">
 			<!-- inseparable characters TWO DOT LEADER -->
 			<p class="control" lang="ja">
-				<span>サンプルサンプル文<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプルサンプル<br />文<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル文<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプルサンプル<br />文<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
 			<!-- inseparable characters HORIZONTAL ELLIPSIS -->
 			<p class="control" lang="ja">
-				<span>サンプルサンプル文<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプルサンプル<br />文<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル文<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプルサンプル<br />文<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>


### PR DESCRIPTION
`line-break-normal-015a` doesn't match with UAX14.  (`文`) ID (`‥`) (U+0x2025, IN)  will apply [LB22](https://unicode.org/reports/tr14/#LB22) rule.

> LB22 Do not break before ellipses.
> `× IN`

So between ID and IN isn't break opportunity.