### PR TITLE
Clean log buffer in tests

### DIFF
--- a/webdriver/tests/bidi/log/entry_added/event_buffer.py
+++ b/webdriver/tests/bidi/log/entry_added/event_buffer.py
@@ -10,6 +10,10 @@ from . import assert_base_entry, create_log
 async def test_console_log_cached_messages(
     bidi_session, wait_for_event, log_type, new_tab
 ):
+    # Clear events buffer.
+    await bidi_session.session.subscribe(events=["log.entryAdded"])
+    await bidi_session.session.unsubscribe(events=["log.entryAdded"])
+
     # Log a message before subscribing
     expected_text = await create_log(bidi_session, new_tab, log_type, "cached_message")
 
@@ -63,6 +67,10 @@ async def test_console_log_cached_messages(
 async def test_console_log_cached_message_after_refresh(
     bidi_session, subscribe_events, new_tab, log_type
 ):
+    # Clear events buffer.
+    await bidi_session.session.subscribe(events=["log.entryAdded"])
+    await bidi_session.session.unsubscribe(events=["log.entryAdded"])
+
     # Track all received log.entryAdded events in the events array
     events = []
 


### PR DESCRIPTION
The log buffer has to be cleaned before each test to avoid artefacts in case of new session created per test.