### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=249838

### DIFF
--- a/css/css-text/parsing/text-group-align-invalid.html
+++ b/css/css-text/parsing/text-group-align-invalid.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Text Module Test: parsing text-group-align with invalid values</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#text-group-align-property">
+<meta name="assert" content="text-group-align supports only the grammar 'none | start | end | left | right | center'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("text-group-align", "auto");
+test_invalid_value("text-group-align", "match-parent");
+test_invalid_value("text-group-align", "justify");
+test_invalid_value("text-group-align", "wrap");
+test_invalid_value("text-group-align", "left right");
+test_invalid_value("text-group-align", "center start");
+test_invalid_value("text-group-align", "end start");
+test_invalid_value("text-group-align", "none center");
+test_invalid_value("text-group-align", "start center");
+test_invalid_value("text-group-align", "right center");
+test_invalid_value("text-group-align", "5px");
+</script>
+</body>
+</html>

--- a/css/css-text/parsing/text-group-align-valid.html
+++ b/css/css-text/parsing/text-group-align-valid.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Text Module Test: parsing text-group-align with valid values</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#text-group-align-property">
+<meta name="assert" content="text-group-align supports the full grammar 'none | start | end | left | right | center'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("text-group-align", "none");
+test_valid_value("text-group-align", "start");
+test_valid_value("text-group-align", "end");
+test_valid_value("text-group-align", "left");
+test_valid_value("text-group-align", "right");
+test_valid_value("text-group-align", "center");
+test_valid_value("text-group-align", "initial");
+test_valid_value("text-group-align", "inherit");
+test_valid_value("text-group-align", "unset");
+test_valid_value("text-group-align", "revert");
+test_valid_value("text-group-align", "revert-layer");
+</script>
+</body>
+</html>

--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -1293,6 +1293,12 @@ const gCSSProperties2 = {
       { type: 'discrete', options: [ [ 'circle', 'open dot' ] ] }
     ]
   },
+  'text-group-align': {
+    // https://drafts.csswg.org/css-text-4/#propdef-text-group-align
+    types: [
+      { type: 'discrete', options: [ [ 'none', 'center' ] ] }
+    ]
+  },
   'text-indent': {
     // https://drafts.csswg.org/css-text-3/#propdef-text-indent
     types: [


### PR DESCRIPTION
WebKit export from bug: [\[text-group-align\] Parse CSS property behind preference](https://bugs.webkit.org/show_bug.cgi?id=249838)