### PR TITLE
The target using last remembered size could be sliced

### DIFF
--- a/css/css-sizing/contain-intrinsic-size/auto-010.html
+++ b/css/css-sizing/contain-intrinsic-size/auto-010.html
@@ -72,7 +72,8 @@ promise_test(async function() {
 
   await nextRendering();
   target.className = "cis-auto content-skip";
-  checkSizes([[50, 150]], "Using last remembered size");
+  assert_equals(target.clientWidth, 50, "Using last remembered size");
+  assert_equals(target.clientHeight, 150, "Using last remembered size");
 }, "Last remembered size supports multiple fragments");
 
 promise_test(async function() {
@@ -85,6 +86,7 @@ promise_test(async function() {
 
   await nextRendering();
   target.className = "cis-auto content-skip";
-  checkSizes([[50, 175]], "Using updated last remembered size");
+  assert_equals(target.clientWidth, 50, "Using updated last remembered size");
+  assert_equals(target.clientHeight, 175, "Using updated last remembered size");
 }, "Last remembered size is updated when 2nd fragment changes size");
 </script>

--- a/css/css-sizing/contain-intrinsic-size/auto-010.html
+++ b/css/css-sizing/contain-intrinsic-size/auto-010.html
@@ -60,6 +60,11 @@ function checkSizes(expectedSizes, msg) {
   }
 }
 
+function checkSize(expectedWidth, expectedHeight, msg) {
+  assert_equals(target.clientWidth, expectedWidth, msg + " - clientWidth");
+  assert_equals(target.clientHeight, expectedHeight, msg + " - clientHeight");
+}
+
 function nextRendering() {
   return new Promise(resolve => {
     requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
@@ -72,8 +77,7 @@ promise_test(async function() {
 
   await nextRendering();
   target.className = "cis-auto content-skip";
-  assert_equals(target.clientWidth, 50, "Using last remembered size");
-  assert_equals(target.clientHeight, 150, "Using last remembered size");
+  checkSize(50, 150, "Using last remembered size");
 }, "Last remembered size supports multiple fragments");
 
 promise_test(async function() {
@@ -86,7 +90,6 @@ promise_test(async function() {
 
   await nextRendering();
   target.className = "cis-auto content-skip";
-  assert_equals(target.clientWidth, 50, "Using updated last remembered size");
-  assert_equals(target.clientHeight, 175, "Using updated last remembered size");
+  checkSize(50, 175, "Using updated last remembered size");
 }, "Last remembered size is updated when 2nd fragment changes size");
 </script>


### PR DESCRIPTION
The target using last remembered size could be sliced, so we check clientWidth and clientHeight instead.