### PR TITLE
Add tests for new CSP behavior for resource hints (prefetch)

### DIFF
--- a/content-security-policy/resource-hints/prefetch-allowed-by-any-directive.sub.html
+++ b/content-security-policy/resource-hints/prefetch-allowed-by-any-directive.sub.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+  <html>
+  <head>
+    <script src='/resources/testharness.js'></script>
+    <script src='/resources/testharnessreport.js'></script>
+    <script src='/common/utils.js'></script>
+    <script src='/common/get-host-info.sub.js'></script>
+    <script src='/content-security-policy/support/testharness-helper.js'></script>
+    <script src='/content-security-policy/support/prefetch-helper.js'></script>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'unsafe-inline'; img-src 'http://{{domains[www2]}}:{{ports[http][0]}}'">
+    <script>
+      const {OTHER_ORIGIN, REMOTE_ORIGIN} = get_host_info();
+      promise_test(async t => {
+        assert_true(await try_to_prefetch("/common/dummy.xml", t));
+      }, 'Prefetch should succeed when restricted by default-src but allowed by other directive');
+      promise_test(async t => {
+        assert_false(await try_to_prefetch(new URL("/common/dummy.xml", REMOTE_ORIGIN).toString(), t));
+      }, 'Prefetch should fail when restricted by default-src and different origin allowed by other directive');
+      promise_test(async t => {
+        assert_true(await try_to_prefetch(new URL("/common/dummy.xml", OTHER_ORIGIN).toString(), t));
+      }, 'Prefetch should succeed when restricted by default-src but origin allowed by other directive');
+    </script>
+  </head>
+  <body>
+  </body>
+  </html>

--- a/content-security-policy/resource-hints/prefetch-allowed-by-default.html
+++ b/content-security-policy/resource-hints/prefetch-allowed-by-default.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+  <html>
+  <head>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline'">
+    <script src='/resources/testharness.js'></script>
+    <script src='/resources/testharnessreport.js'></script>
+    <script src='/common/utils.js'></script>
+    <script src='/content-security-policy/support/testharness-helper.js'></script>
+    <script src='/content-security-policy/support/prefetch-helper.js'></script>
+    <script>
+      promise_test(async t => {
+        assert_true(await try_to_prefetch("/common/dummy.xml", t));
+      }, 'Prefetch should fail when allowed by default-src');
+    </script>
+  </head>
+  <body>
+  </body>
+  </html>

--- a/content-security-policy/resource-hints/prefetch-allowed-no-default.html
+++ b/content-security-policy/resource-hints/prefetch-allowed-no-default.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+  <html>
+  <head>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline' img-src 'self' 'unsafe-inline' connect-src 'self' 'unsafe-inline' object-src 'self' 'unsafe-inline' font-src 'self' 'unsafe-inline' child-src 'self' 'unsafe-inline'">
+    <script src='/resources/testharness.js'></script>
+    <script src='/resources/testharnessreport.js'></script>
+    <script src='/common/utils.js'></script>
+    <script src='/content-security-policy/support/testharness-helper.js'></script>
+    <script src='/content-security-policy/support/prefetch-helper.js'></script>
+    <script>
+      promise_test(async t => {
+        assert_true(await try_to_prefetch("/common/dummy.xml", t));
+      }, 'Prefetch should succeed when there is no default-src');
+    </script>
+  </head>
+  <body>
+  </body>
+  </html>

--- a/content-security-policy/resource-hints/prefetch-blocked-by-default.html
+++ b/content-security-policy/resource-hints/prefetch-blocked-by-default.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+  <html>
+  <head>
+    <script src='/resources/testharness.js'></script>
+    <script src='/resources/testharnessreport.js'></script>
+    <script src='/common/utils.js'></script>
+    <script src='/content-security-policy/support/testharness-helper.js'></script>
+    <script src='/content-security-policy/support/prefetch-helper.js'></script>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'">
+    <script>
+      promise_test(async t => {
+        assert_false(await try_to_prefetch("/common/dummy.xml", t));
+      }, 'Prefetch should fail when restricted by default-src');
+    </script>
+  </head>
+  <body>
+  </body>
+  </html>

--- a/content-security-policy/resource-hints/prefetch-no-csp.html
+++ b/content-security-policy/resource-hints/prefetch-no-csp.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src='/resources/testharness.js'></script>
+  <script src='/resources/testharnessreport.js'></script>
+  <script src='/common/utils.js'></script>
+  <script src='/content-security-policy/support/testharness-helper.js'></script>
+  <script src='/content-security-policy/support/prefetch-helper.js'></script>
+  <script>
+    promise_test(async t => {
+      assert_true(await try_to_prefetch("/common/dummy.xml", t));
+    }, 'Prefetch succeeds when no CSP');
+  </script>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
Instead of relying on `prefetch-src`, we rely on the least restrictive directive in the policy.

Tests https://github.com/w3c/webappsec-csp/pull/582