### PR TITLE
WebCryptoAPI: assert that CryptoKey instances have the expected Symbol.toStringTag

### DIFF
--- a/WebCryptoAPI/util/helpers.js
+++ b/WebCryptoAPI/util/helpers.js
@@ -160,6 +160,7 @@ function assert_goodCryptoKey(key, algorithm, extractable, usages, kind) {
         assert_in_array(usage, correctUsages, "Has " + usage + " usage");
     });
     assert_equals(key.usages.length, usageCount, "usages property is correct");
+    assert_equals(Object.prototype.toString.call(key), '[object CryptoKey]', "has the expected Symbol.toStringTag");
 }
 
 

--- a/WebCryptoAPI/util/helpers.js
+++ b/WebCryptoAPI/util/helpers.js
@@ -160,7 +160,7 @@ function assert_goodCryptoKey(key, algorithm, extractable, usages, kind) {
         assert_in_array(usage, correctUsages, "Has " + usage + " usage");
     });
     assert_equals(key.usages.length, usageCount, "usages property is correct");
-    assert_equals(Object.prototype.toString.call(key), '[object CryptoKey]', "has the expected Symbol.toStringTag");
+    assert_equals(key[Symbol.toStringTag], 'CryptoKey', "has the expected Symbol.toStringTag");
 }
 
 


### PR DESCRIPTION
We've recently come across user's expectation that the Node.js implementation would have the same `Symbol.toStringTag` as browsers do for object type detection.

Refs: #37710
Refs: https://github.com/nodejs/node/issues/45987

Having this WPT in place would have told us as implementers early that something we've missed is possibly already relied upon in the javascript ecosystem.