### PR TITLE
Use reference in the same directory for root-siblings.html

### DIFF
--- a/css/selectors/root-siblings.html
+++ b/css/selectors/root-siblings.html
@@ -3,14 +3,17 @@
 <title>CSS Test: Parsing check for * ~ :root error handling</title>
 <link rel="author" title="Microsoft" href="http://www.microsoft.com/">
 <link rel="help" href="https://drafts.csswg.org/selectors-3/#selector-syntax">
-<link rel="match" href="../CSS2/reference/ref-this-text-should-be-green.xht">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="* ~ :root should not match anything">
 <style>
-* ~ :root p {
-  color: red;
+* ~ :root div {
+  background-color: red;
 }
-p {
-  color: green;
+div {
+  width: 100px;
+  height: 100px;
+  background-color: green;
 }
 </style>
-<p>This text should be green.</p>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div></div>


### PR DESCRIPTION
Instead of using a reference from the CSS2 directory. Makes it easier to import into WebKit.