### PR TITLE
WebCryptoAPI: 256 tagLength is out of WebIDL octet range

### DIFF
--- a/WebCryptoAPI/encrypt_decrypt/aes_gcm_vectors.js
+++ b/WebCryptoAPI/encrypt_decrypt/aes_gcm_vectors.js
@@ -246,7 +246,7 @@ function getTestVectors() {
     var failing = [];
     keyLengths.forEach(function(keyLength) {
         // First, make some tests for bad tag lengths
-        [24, 48, 72, 95, 129, 256].forEach(function(badTagLength) {
+        [24, 48, 72, 95, 129].forEach(function(badTagLength) {
             failing.push({
                 name: "AES-GCM " + keyLength.toString() + "-bit key, illegal tag length " + badTagLength.toString() + "-bits",
                 keyBuffer: keyBytes[keyLength],


### PR DESCRIPTION
Because `tagLength` is defined as `[EnforceRange] octet tagLength;` 256 is out of range for an `octet` and the WebIDL behaviour is to throw a TypeError because of EnforceRange, this test checks for OperationError from https://w3c.github.io/webcrypto/#aes-gcm-operations 1.4.otherwise.

Removing 256 from the list so that it only contains invalid values from within the `octet` allowed range.

wpt.fyi current results agree

<img width="1215" alt="image" src="https://user-images.githubusercontent.com/241506/212528475-4a7cf132-ca33-47d9-be6b-59fe8e6a9cc7.png">
