### PR TITLE
Update metadata for http2-websocket.sub.h2.any.js

### DIFF
--- a/infrastructure/metadata/infrastructure/server/http2-websocket.sub.h2.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/http2-websocket.sub.h2.any.js.ini
@@ -3,7 +3,7 @@
     if product == "safari": TIMEOUT
   [WSS over h2]
     expected:
-      if product == "firefox" or product == "epiphany" or product == "webkit": FAIL
+      if product == "epiphany" or product == "webkit": FAIL
       if product == "safari": TIMEOUT
 
 
@@ -12,5 +12,5 @@
     if product == "safari": TIMEOUT
   [WSS over h2]
     expected:
-      if product == "firefox" or product == "epiphany" or product == "webkit": FAIL
+      if product == "epiphany" or product == "webkit": FAIL
       if product == "safari": TIMEOUT


### PR DESCRIPTION
PR 37496 is blocked due to an unexpected pass on this test. Update metadata to reflect the state of the art.