### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=250037

### DIFF
--- a/html/semantics/forms/the-button-element/button-willvalidate-readonly-attribute.html
+++ b/html/semantics/forms/the-button-element/button-willvalidate-readonly-attribute.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<meta charset="utf-8">
+<title>Button element with "readonly" attribute shouldn't be barred from constraint validation</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<button id="implicitSubmitButton" readonly>1</button>
+<button id="explicitSubmitButton" readonly type="submit">2</button>
+<script>
+  test(() => {
+    assert_true(implicitSubmitButton.willValidate);
+    assert_true(explicitSubmitButton.willValidate);
+  });
+</script>

--- a/html/semantics/forms/the-select-element/select-willvalidate-readonly-attribute.html
+++ b/html/semantics/forms/the-select-element/select-willvalidate-readonly-attribute.html
@@ -1,0 +1,24 @@
+<!DOCTYPE HTML>
+<meta charset="utf-8">
+<title>Select element with "readonly" attribute shouldn't be barred from constraint validation</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<select id="singleSelect" readonly>
+  <option>1
+  <option>2
+</select>
+
+<select id="multiSelect" readonly multiple>
+  <option>a
+  <option>b
+  <option>c
+  <option>d
+</select>
+
+<script>
+  test(() => {
+    assert_true(singleSelect.willValidate);
+    assert_true(multiSelect.willValidate);
+  });
+</script>


### PR DESCRIPTION
This upstream reviewed test ensures that `<button>` and `<select>` elements with "readonly" attribute are not barred from constraint validation.