### PR TITLE
Convert html/semantics/forms/the-input-element/email-set-value.html to a ref test.

### DIFF
--- a/html/semantics/forms/the-input-element/email-set-value-ref.html
+++ b/html/semantics/forms/the-input-element/email-set-value-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<title>Input Email setValue</title>
+<input type="text" value=" foo@bar   ">
+<input type="text" value="foo@bar">
+<script>document.querySelectorAll('input')[1].focus();</script>

--- a/html/semantics/forms/the-input-element/email-set-value.html
+++ b/html/semantics/forms/the-input-element/email-set-value.html
@@ -1,30 +1,26 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
 <title>Input Email setValue</title>
 <link rel="author" href="mailto:atotic@chromium.org">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#e-mail-state-(type=email)">
 <link rel="help" href="https://crbug.com/423785">
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
+<link rel="match" href="email-set-value-ref.html">
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-actions.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 
 <input type="email">
+<input type="email">
 
 <script>
-promise_test(async () => {
-  let input = document.querySelector("input");
+(async function () {
+  let inputs = document.querySelectorAll("input");
   let unsanitized = ' foo@bar   ';
   let sanitized = unsanitized.trim();
-  await test_driver.send_keys(input, unsanitized);
-  input.select();
-  assert_equals(input.value, sanitized, "value is sanitized");
-  assert_equals(window.getSelection().toString(), unsanitized,
-    "visible value is unsanitized");
-  input.value = sanitized;
-  input.select();
-  assert_equals(window.getSelection().toString(), sanitized,
-    "visible value is sanitized after setValue(sanitized)");
-},
-"setValue(sanitizedValue) is reflected in visible text field content");
+  await test_driver.send_keys(inputs[0], unsanitized);
+  await test_driver.send_keys(inputs[1], unsanitized);
+  inputs[1].value = sanitized;
+  inputs[1].select();
+  document.documentElement.className = '';
+})();
 </script>


### PR DESCRIPTION
Fixes the issue 37214 by converting this test to a ref test. getSelection().toString() returning the visible text of input element is a non-standard Blink/WebKit behavior and should not be relied upon by the test.