### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=197963

### DIFF
--- a/custom-elements/form-associated/ElementInternals-labels.html
+++ b/custom-elements/form-associated/ElementInternals-labels.html
@@ -40,6 +40,10 @@ test(() => {
   container.innerHTML = '<my-control></my-control>';
   control = container.querySelector('my-control');
   assert_array_equals(control.i.labels, []);
+
+  container.innerHTML = '<label><x-foo></x-foo></label>';
+  label = container.querySelector('label');
+  assert_equals(label.control, null);
 }, 'LABEL association');
 
 test(() => {

--- a/custom-elements/form-associated/ElementInternals-validation.html
+++ b/custom-elements/form-associated/ElementInternals-validation.html
@@ -85,6 +85,20 @@ test(() => {
   assert_false(controls[4].i.willValidate, 'in disabled fieldset');
 }, 'willValidate after upgrade');
 
+test(t => {
+  const control = document.createElement('will-be-defined-2');
+
+  customElements.define('will-be-defined-2', class extends HTMLElement {
+    static get formAssociated() { return true; }
+  });
+
+  container.append(control);
+  t.add_cleanup(() => { container.innerHTML = ''; });
+
+  const i = control.attachInternals();
+  assert_true(i.willValidate);
+}, 'willValidate after upgrade (document.createElement)');
+
 test(() => {
   const element = new NotFormAssociatedElement();
   assert_throws_dom('NotSupportedError', () => element.i.willValidate);


### PR DESCRIPTION
A few WebKit-reviewed form-associated custom-elements test cases that were failing at some point during the implementation.