### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=224483

### DIFF
--- a/css/css-text-decor/invalidation/text-decoration-thickness-ref.html
+++ b/css/css-text-decor/invalidation/text-decoration-thickness-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+    <meta charset="utf-8">
+    <title>text-decoration-thickness invalidation reference</title>
+    <style>
+        :link {
+            text-decoration: underline;
+            text-decoration-thickness: 3px;
+        }
+    </style>
+    <div style="font-size: 28px;">
+        <a href="#" id="link">Hover over this link, and check if the text-decoration-thickness increases.</a>
+    </div>
+</html>

--- a/css/css-text-decor/invalidation/text-decoration-thickness.html
+++ b/css/css-text-decor/invalidation/text-decoration-thickness.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+    <meta charset="utf-8">
+    <title>text-decoration-thickness invalidation</title>
+    <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+    <link rel="help" href="https://drafts.csswg.org/selectors/#the-hover-pseudo">
+    <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#text-decoration-thickness-property">
+    <link rel="match" href="text-decoration-thickness-ref.html">
+    <style>
+        :link {
+            text-decoration: underline;
+            text-decoration-thickness: 1px;
+        }
+        :link:hover {
+            text-decoration-thickness: 3px;
+        }
+    </style>
+    <div style="font-size: 28px;">
+        <a href="#" id="link">Hover over this link, and check if the text-decoration-thickness increases.</a>
+    </div>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-actions.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <script>
+        window.addEventListener("load", async () => {
+            // Hover the link
+            await new test_driver.Actions().pointerMove(0, 0, { origin: link }).send();
+
+            document.documentElement.classList.remove("reftest-wait");
+        });
+    </script>
+</html>


### PR DESCRIPTION
WebKit export from bug: [text-decoration-thickness property doesn't always trigger repaint when changed](https://bugs.webkit.org/show_bug.cgi?id=224483)