### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=246278

### DIFF
--- a/webcodecs/videoDecoder-codec-specific.https.any.js
+++ b/webcodecs/videoDecoder-codec-specific.https.any.js
@@ -351,6 +351,7 @@ promise_test(async t => {
 
   let errors = 0;
   callbacks.error = e => errors++;
+  callbacks.output = frame => { frame.close(); };
 
   const decoder = createVideoDecoder(t, callbacks);
   decoder.configure(CONFIG);
@@ -490,6 +491,7 @@ promise_test(async t => {
 
 promise_test(async t => {
   const callbacks = {};
+  callbacks.output = frame => { frame.close(); };
   const decoder = createVideoDecoder(t, callbacks);
 
   // No decodes yet.


### PR DESCRIPTION
WebKit export from bug: [Rebaseline(255215@main): \[ macOS arm64 \] 2X imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any(Layout tests) are constant failures](https://bugs.webkit.org/show_bug.cgi?id=246278)