### PR TITLE
Fix Servo runner for wdspec tests.

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/servo.py
+++ b/tools/wptrunner/wptrunner/browsers/servo.py
@@ -93,19 +93,20 @@ class ServoBrowser(NullBrowser):
 
 class ServoWdspecBrowser(WebDriverBrowser):
     # TODO: could share an implemenation with servodriver.py, perhaps
-    def __init__(self, logger, binary="servo", webdriver_args=None,
-                 binary_args=None, host="127.0.0.1", env=None, port=None):
+    def __init__(self, logger, binary="servo", webdriver_binary="servo",
+                 binary_args=None, webdriver_args=None, env=None, port=None,
+                 **kwargs):
 
         env = os.environ.copy() if env is None else env
         env["RUST_BACKTRACE"] = "1"
 
         super().__init__(logger,
-                         binary,
-                         None,
+                         binary=binary,
+                         webdriver_binary=webdriver_binary,
                          webdriver_args=webdriver_args,
-                         host=host,
                          port=port,
-                         env=env)
+                         env=env,
+                         **kwargs)
         self.binary_args = binary_args
 
     def make_command(self):


### PR DESCRIPTION
* The Servo test runner for `test-type=wdspec` was failing due to the the class [ServoWdspecBrowser()](url) beeing initialized with unknown arguments See: https://github.com/web-platform-tests/wpt/runs/10514706333

* Fix it by accepting `**kwargs` and passing them to the superclass.

* Also define a default value for `webdriver_binary` which is needed to avoid an assertion in the main class. In any case the servo runner doesn't use this parameter, but `self.binary` in the the `make_command()` function.

//CC @jgraham @gsnedders @jdm