### PR TITLE
Extract customized builtin test cases out of custom-elements/HTMLElement-constructor.html

### DIFF
--- a/custom-elements/HTMLElement-constructor-customized-bulitins.html
+++ b/custom-elements/HTMLElement-constructor-customized-bulitins.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: HTMLElement must allow subclassing</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="HTMLElement must allow subclassing">
+<link rel="help" href="https://html.spec.whatwg.org/#html-element-constructors">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+test(function() {
+    class SomeCustomElement extends HTMLElement {};
+    var getCount = 0;
+    var countingProxy = new Proxy(SomeCustomElement, {
+        get: function(target, prop, receiver) {
+            if (prop == "prototype") {
+                ++getCount;
+            }
+            return Reflect.get(target, prop, receiver);
+        }
+    });
+    customElements.define("failure-counting-element-1", countingProxy,
+                          { extends: "button" });
+    // define() gets the prototype of the constructor it's passed, so
+    // reset the counter.
+    getCount = 0;
+    assert_throws_js(TypeError,
+                     function () { new countingProxy() },
+                     "Should not be able to construct an HTMLElement named 'button'");
+    assert_equals(getCount, 0, "Should never have gotten .prototype");
+}, 'HTMLElement constructor must not get .prototype until it finishes its extends sanity checks, calling proxy constructor directly');
+
+test(function() {
+    class SomeCustomElement extends HTMLElement {};
+    var getCount = 0;
+    var countingProxy = new Proxy(SomeCustomElement, {
+        get: function(target, prop, receiver) {
+            if (prop == "prototype") {
+                ++getCount;
+            }
+            return Reflect.get(target, prop, receiver);
+        }
+    });
+    customElements.define("failure-counting-element-2", countingProxy,
+                          { extends: "button" });
+    // define() gets the prototype of the constructor it's passed, so
+    // reset the counter.
+    getCount = 0;
+    assert_throws_js(TypeError,
+                     function () { Reflect.construct(HTMLElement, [], countingProxy) },
+                     "Should not be able to construct an HTMLElement named 'button'");
+    assert_equals(getCount, 0, "Should never have gotten .prototype");
+}, 'HTMLElement constructor must not get .prototype until it finishes its extends sanity checks, calling via Reflect');
+
+</script>
+</body>
+</html>
+

--- a/custom-elements/HTMLElement-constructor.html
+++ b/custom-elements/HTMLElement-constructor.html
@@ -195,47 +195,6 @@ test(function() {
             return Reflect.get(target, prop, receiver);
         }
     });
-    customElements.define("failure-counting-element-2", countingProxy,
-                          { extends: "button" });
-    // define() gets the prototype of the constructor it's passed, so
-    // reset the counter.
-    getCount = 0;
-    assert_throws_js(TypeError,
-                     function () { Reflect.construct(HTMLElement, [], countingProxy) },
-                     "Should not be able to construct an HTMLElement named 'button'");
-    assert_equals(getCount, 0, "Should never have gotten .prototype");
-}, 'HTMLElement constructor must not get .prototype until it finishes its extends sanity checks, calling via Reflect');
-
-test(function() {
-    class SomeCustomElement extends HTMLElement {};
-    var getCount = 0;
-    var countingProxy = new Proxy(SomeCustomElement, {
-        get: function(target, prop, receiver) {
-            if (prop == "prototype") {
-                ++getCount;
-            }
-            return Reflect.get(target, prop, receiver);
-        }
-    });
-
-    // Purposefully don't register it.
-    assert_throws_js(TypeError,
-                     function () { new countingProxy() },
-                     "Should not be able to construct an HTMLElement named 'button'");
-    assert_equals(getCount, 0, "Should never have gotten .prototype");
-}, 'HTMLElement constructor must not get .prototype until it finishes its registration sanity checks, calling proxy constructor directly');
-
-test(function() {
-    class SomeCustomElement extends HTMLElement {};
-    var getCount = 0;
-    var countingProxy = new Proxy(SomeCustomElement, {
-        get: function(target, prop, receiver) {
-            if (prop == "prototype") {
-                ++getCount;
-            }
-            return Reflect.get(target, prop, receiver);
-        }
-    });
 
     // Purposefully don't register it.
     assert_throws_js(TypeError,


### PR DESCRIPTION
Split custom-elements/HTMLElement-constructor.html into two files one testing autonomous and another testing customized builtins for better tracking.