### PR TITLE
Add a test for white-space: break-spaces

### DIFF
--- a/css/css-text/text-align/text-align-whitespace-ref.html
+++ b/css/css-text/text-align/text-align-whitespace-ref.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<style>
+.test {
+  display: block;
+  margin: 1em;
+  font-family: monospace;
+  width: 31ch;
+  border: 1px solid;
+  white-space: pre-wrap;
+  white-space: break-spaces;
+}
+</style>
+<code class="test">
+  style={{ lineHeight: <span>'100px'</span> }}</code>

--- a/css/css-text/text-align/text-align-whitespace.html
+++ b/css/css-text/text-align/text-align-whitespace.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<link rel="match" href="text-align-whitespace-ref.html">
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1261435">
+<style>
+.test {
+  display: block;
+  margin: 1em;
+  font-family: monospace;
+  width: 31ch;
+  border: 1px solid;
+  white-space: pre-wrap;
+  white-space: break-spaces;
+}
+</style>
+<code class="test">
+  style={{ lineHeight: '100px' }}</code>


### PR DESCRIPTION
This is based on a test in
https://bugs.chromium.org/p/chromium/issues/detail?id=1261435 and required for Interop 2023.