### PR TITLE
Support virtual test suites in Wptrunner

### DIFF
--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -128,7 +128,7 @@ class URLManifestItem(ManifestItem):
                        set(parse_qs(parsed_url.query).get("wpt_flags", [])))
 
     def virtual_test(self,
-                     full_prefix  # type: Text
+                     full_prefix
                      ):
         # type: (Text) -> URLManifestItem
         # derive a virtual test from URLManifestItem
@@ -260,7 +260,7 @@ class RefTest(URLManifestItem):
             self.references = references
 
     def virtual_test(self,
-                     full_prefix  # type: Text
+                     full_prefix
                      ):
         # type: (Text) -> RefTest
         # derive a virtual reftest from a reftest

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -123,7 +123,10 @@ class URLManifestItem(ManifestItem):
         self._flags = (set(parsed_url.path.rsplit("/", 1)[1].split(".")[1:-1]) |
                        set(parse_qs(parsed_url.query).get("wpt_flags", [])))
 
-    def virtual_test(self, full_prefix):
+    def virtual_test(self,
+                     full_prefix  # type: Text
+                     ):
+        # type: (...) -> URLManifestItem
         # derive a virtual test from ManifestItem
         virtual_url = full_prefix[:-1] + self.url
         return type(self)(self._tests_root,
@@ -252,7 +255,10 @@ class RefTest(URLManifestItem):
         else:
             self.references = references
 
-    def virtual_test(self, full_prefix):
+    def virtual_test(self,
+                     full_prefix  # type: Text
+                     ):
+        # type: (...) -> URLManifestItem
         # derive a virtual reftest from ManifestItem
         virtual_url = full_prefix[:-1] + self.url
         virtual_references = []

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -123,6 +123,15 @@ class URLManifestItem(ManifestItem):
         self._flags = (set(parsed_url.path.rsplit("/", 1)[1].split(".")[1:-1]) |
                        set(parse_qs(parsed_url.query).get("wpt_flags", [])))
 
+    def virtual_test(self, full_prefix):
+        # derive a virtual test from ManifestItem
+        virtual_url = full_prefix[:-1] + self.url
+        return type(self)(self._tests_root,
+                          self.path,
+                          '/',
+                          virtual_url,
+                          **self._extras)
+
     @property
     def id(self):
         # type: () -> Text
@@ -242,6 +251,20 @@ class RefTest(URLManifestItem):
             self.references = []  # type: List[Tuple[Text, Text]]
         else:
             self.references = references
+
+    def virtual_test(self, full_prefix):
+        # derive a virtual reftest from ManifestItem
+        virtual_url = full_prefix[:-1] + self.url
+        virtual_references = []
+        for ref_url, ref_type in self.references:
+            virtual_references.append(('/' + full_prefix[:-1] + ref_url,
+                                       ref_type))
+        return type(self)(self._tests_root,
+                          self.path,
+                          '/',
+                          virtual_url,
+                          virtual_references,
+                          **self._extras)
 
     @property
     def timeout(self):

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -130,8 +130,8 @@ class URLManifestItem(ManifestItem):
     def virtual_test(self,
                      full_prefix  # type: Text
                      ):
-        # type: (Text) -> ManifestItem
-        # derive a virtual test from ManifestItem
+        # type: (Text) -> URLManifestItem
+        # derive a virtual test from URLManifestItem
         virtual_url = full_prefix[:-1] + self.url
         return type(self)(self._tests_root,
                           self.path,
@@ -262,8 +262,8 @@ class RefTest(URLManifestItem):
     def virtual_test(self,
                      full_prefix  # type: Text
                      ):
-        # type: (Text) -> ManifestItem
-        # derive a virtual reftest from ManifestItem
+        # type: (Text) -> RefTest
+        # derive a virtual reftest from a reftest
         virtual_url = full_prefix[:-1] + self.url
         virtual_references = []
         for ref_url, ref_type in self.references:

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -49,6 +49,10 @@ class ManifestItem(metaclass=ManifestItemMeta):
         self._tests_root = tests_root
         self.path = path
 
+    def virtual_test(self, full_prefix):
+        # type: (Text) -> ManifestItem
+        pass
+
     @abstractproperty
     def id(self):
         # type: () -> Text
@@ -126,7 +130,7 @@ class URLManifestItem(ManifestItem):
     def virtual_test(self,
                      full_prefix  # type: Text
                      ):
-        # type: (...) -> URLManifestItem
+        # type: (Text) -> ManifestItem
         # derive a virtual test from ManifestItem
         virtual_url = full_prefix[:-1] + self.url
         return type(self)(self._tests_root,
@@ -258,7 +262,7 @@ class RefTest(URLManifestItem):
     def virtual_test(self,
                      full_prefix  # type: Text
                      ):
-        # type: (...) -> URLManifestItem
+        # type: (Text) -> ManifestItem
         # derive a virtual reftest from ManifestItem
         virtual_url = full_prefix[:-1] + self.url
         virtual_references = []

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -157,6 +157,7 @@ class Manifest:
                     yield from tests
 
     def load_virtual_tests(self, full_prefixes_by_base):
+        # type: (Dict[Text, List[Text]]) -> None
         types_to_load = list(item_classes.keys() - ["support"])
         virtual_data = defaultdict(dict)
         for item_type, rel_path, tests in self.itertypes(*types_to_load):

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -1,7 +1,6 @@
 import os
 import sys
 from atomicwrites import atomic_write
-from collections import defaultdict
 from copy import deepcopy
 from multiprocessing import Pool, cpu_count
 
@@ -160,7 +159,7 @@ class Manifest:
     def load_virtual_tests(self, full_prefixes_by_base):
         # type: (Dict[Text, List[Text]]) -> None
         types_to_load = list(item_classes.keys() - ["support"])
-        virtual_data = defaultdict(dict)  # type: ManifestData
+        virtual_data = ManifestData(self)  # type: ManifestData
         for item_type, rel_path, tests in self.itertypes(*types_to_load):
             # base is either a test or  directory and should end with '/'.
             # base comes from virtual config and always use '/' as separator

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -31,6 +31,7 @@ if MYPY:
     from typing import IO
     from typing import Iterator
     from typing import Iterable
+    from typing import List
     from typing import Optional
     from typing import Set
     from typing import Text
@@ -159,7 +160,7 @@ class Manifest:
     def load_virtual_tests(self, full_prefixes_by_base):
         # type: (Dict[Text, List[Text]]) -> None
         types_to_load = list(item_classes.keys() - ["support"])
-        virtual_data = defaultdict(dict)
+        virtual_data = defaultdict(dict)  # type: ManifestData
         for item_type, rel_path, tests in self.itertypes(*types_to_load):
             # base is either a test or  directory and should end with '/'.
             # base comes from virtual config and always use '/' as separator

--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -112,6 +112,18 @@ class Browser:
         """
         return {}
 
+    def additional_args(self, test):
+        """Set of additional arguments used for a specific launch of a browser
+        """
+        return set()
+
+    def update_for_additional_args(self, executor_kwargs, additional_args):
+        """Update executor_kwargs with additional command line arguments.
+
+        Do nothing by default
+        """
+        return executor_kwargs
+
     @abstractmethod
     def start(self, group_metadata, **kwargs):
         """Launch the browser object and get it into a state where is is ready to run tests"""

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import copy
 
 from . import chrome_spki_certs
 from .base import WebDriverBrowser, require_arg
@@ -155,3 +156,16 @@ class ChromeBrowser(WebDriverBrowser):
                 cmd_arg("port", str(self.port)),
                 cmd_arg("url-base", self.base_path),
                 cmd_arg("enable-chrome-logs")] + self.webdriver_args
+
+    def additional_args(self, test):
+        return set(test.environment.get("args", []))
+
+    def update_for_additional_args(self, executor_kwargs, additional_args):
+        if not additional_args:
+            return executor_kwargs
+        kwargs = copy.deepcopy(executor_kwargs)
+        capabilities = kwargs.setdefault("capabilities", {})
+        chrome_options = capabilities.setdefault("goog:chromeOptions", {})
+        args = chrome_options.setdefault("args", [])
+        args.extend(additional_args)
+        return kwargs

--- a/tools/wptrunner/wptrunner/metadata.py
+++ b/tools/wptrunner/wptrunner/metadata.py
@@ -286,7 +286,7 @@ def unpack_result(data):
 
 
 def load_test_data(test_paths):
-    manifest_loader = testloader.ManifestLoader(test_paths, False)
+    manifest_loader = testloader.ManifestLoader(test_paths)
     manifests = manifest_loader.load()
 
     id_test_map = {}

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -235,7 +235,9 @@ class TagFilter:
 
 
 class ManifestLoader:
-    def __init__(self, test_paths, virtual_configs, force_manifest_update=False, manifest_download=False,
+    def __init__(self, test_paths, virtual_configs=[],
+                 force_manifest_update=False,
+                 manifest_download=False,
                  types=None):
         do_delayed_imports()
         self.test_paths = test_paths

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -235,13 +235,13 @@ class TagFilter:
 
 
 class ManifestLoader:
-    def __init__(self, test_paths, virtual_configs=[],
+    def __init__(self, test_paths, virtual_configs=None,
                  force_manifest_update=False,
                  manifest_download=False,
                  types=None):
         do_delayed_imports()
         self.test_paths = test_paths
-        self.virtual_configs = virtual_configs
+        self.virtual_configs = [] if virtual_configs is None else virtual_configs
         self.force_manifest_update = force_manifest_update
         self.manifest_download = manifest_download
         self.types = types
@@ -287,7 +287,7 @@ class TestLoader:
                  test_manifests,
                  test_types,
                  run_info,
-                 virtual_configs,
+                 virtual_configs=None,
                  manifest_filters=None,
                  chunk_type="none",
                  total_chunks=1,
@@ -329,7 +329,7 @@ class TestLoader:
 
         self.directory_manifests = {}
 
-        self.virtual_configs = virtual_configs
+        virtual_configs = [] if virtual_configs is None else virtual_configs
         self.args_by_full_prefix = {vc.full_prefix: vc.args for vc in virtual_configs}
 
         self._load_tests()

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -150,6 +150,8 @@ scheme host and port.""")
                                       help="Path to manifest listing tests to include")
     test_selection_group.add_argument("--test-groups", dest="test_groups_file", type=abs_path,
                                       help="Path to json file containing a mapping {group_name: [test_ids]}")
+    test_selection_group.add_argument("--virtual-configs", type=abs_path,
+                                      help="Path to virtual test suite configurations file.")
     test_selection_group.add_argument("--skip-timeout", action="store_true",
                                       help="Skip tests that are expected to time out")
     test_selection_group.add_argument("--skip-implementation-status",

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -60,8 +60,13 @@ def get_loader(test_paths, product, debug=None, run_info_extras=None, chunker_kw
                                     extras=run_info_extras,
                                     device_serials=kwargs.get("device_serial"),
                                     adb_binary=kwargs.get("adb_binary"))
+    virtual_configs = []
+    if kwargs["virtual_configs"]:
+        virtual_configs = testloader.read_virtual_configs(kwargs["virtual_configs"])
 
-    test_manifests = testloader.ManifestLoader(test_paths, force_manifest_update=kwargs["manifest_update"],
+    test_manifests = testloader.ManifestLoader(test_paths,
+                                               virtual_configs,
+                                               force_manifest_update=kwargs["manifest_update"],
                                                manifest_download=kwargs["manifest_download"]).load()
 
     manifest_filters = []
@@ -85,6 +90,7 @@ def get_loader(test_paths, product, debug=None, run_info_extras=None, chunker_kw
     test_loader = testloader.TestLoader(test_manifests,
                                         kwargs["test_types"],
                                         run_info,
+                                        virtual_configs,
                                         manifest_filters=manifest_filters,
                                         chunk_type=kwargs["chunk_type"],
                                         total_chunks=kwargs["total_chunks"],

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -239,6 +239,10 @@ class Test:
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def update_args(self, args):
+        assert self.environment.get("args") is None, "Attempt to overwrite args"
+        self.environment["args"] = args
+
     def update_metadata(self, metadata=None):
         if metadata is None:
             metadata = {}

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -118,6 +118,18 @@ class RequestRewriter:
                                 rewrite the request.
         """
         split_url = urlsplit(request_handler.path)
+        if split_url.path.startswith("/virtual/"):
+            # A hardcoded rule to remove /virtual/prefix
+            new_path = '/' + '/'.join(split_url.path.split('/')[3:])
+            new_url = list(split_url)
+            new_url[2] = new_path
+            new_url = urlunsplit(new_url)
+            request_handler.path = new_url
+            # We allow custom rewrites after strip full virtual prefix.
+            # This does not seem to be critical now as there is only
+            # one rewrite rule for /resources/WebIDLParser.js.
+            split_url = urlsplit(request_handler.path)
+
         if split_url.path in self.rules:
             methods, destination = self.rules[split_url.path]
             if "*" in methods or request_handler.command in methods:


### PR DESCRIPTION
This is an illustrative implementation for virtual test support in
wptrunner.
    
When a virtual configuration file is passed in through command line,
Wptrunner will load the virtual tests and their metadata after that of
the real tests. Virtual tests will have their own ids in the form:
virtual/prefix/.../some.html. Wpt server will strip 'virtual/prefix/'
and route the rest part of the id as usual.
    
Virtual metadata will be sitting at the corresponding place under
virtual/prefix/. If there is a separate wpt directory, for example,
/wpt_internal/ which is mapped to /wpt_internal/, the metadata for those
tests will be put under /wpt_internal/virtual/prefix/, while test ids
will be in the form: virtual/prefix/wpt_internal/.../some.html.
    
The corresponding RFC is RFC 110. In addition to the parameters listed
there, we now supports two additional parameters:
platforms: It is a list with possible values from 'Win', 'Mac' or
'Linux'.
expires: It can be either 'never' or some dates from future. The virtual
tests won't be run once they are expired.