### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=250506

### DIFF
--- a/css/css-properties-values-api/at-property-typedom.html
+++ b/css/css-properties-values-api/at-property-typedom.html
@@ -12,7 +12,7 @@ test(() => {
     // Before registering the property, ${name} should reify as a
     // a token sequence.
     assert_equals(div.computedStyleMap().get(name).constructor.name, 'CSSUnparsedValue');
-    assert_equals(div.computedStyleMap().get(name).toString(), ' 100px');
+    assert_equals(div.computedStyleMap().get(name).toString(), '100px');
 
     with_at_property({
       name: name,
@@ -29,7 +29,7 @@ test(() => {
     // After @property is removed, the computed value is once again a token
     // sequence.
     assert_equals(div.computedStyleMap().get(name).constructor.name, 'CSSUnparsedValue');
-    assert_equals(div.computedStyleMap().get(name).toString(), ' 100px');
+    assert_equals(div.computedStyleMap().get(name).toString(), '100px');
   });
 }, 'Properties declared with @property reify correctly');
 

--- a/css/css-properties-values-api/var-reference-registered-properties.html
+++ b/css/css-properties-values-api/var-reference-registered-properties.html
@@ -141,7 +141,7 @@ test(function(){
     let universal = generate_property('*');
     element.style = `font-size: 10px; ${length}: 10em; ${universal}: var(${length})`;
     let computedStyle = getComputedStyle(element);
-    assert_equals(computedStyle.getPropertyValue(universal), ' 100px');
+    assert_equals(computedStyle.getPropertyValue(universal), '100px');
     element.style = '';
 }, 'Values are absolutized when substituting into properties with universal syntax');
 

--- a/css/css-variables/variable-definition.html
+++ b/css/css-variables/variable-definition.html
@@ -34,13 +34,13 @@
         { varName:"-var4" ,    expectedValue:"",        style:"-var4:value3",               testName:"parsing multiple dashes with one dash at start of variable"},
         { varName:"--var",     expectedValue:"value",  style:"--var: value",               testName:" leading white space (single space)"},
         { varName:"--var",     expectedValue:"value1 value2", style:"--var:value1 value2",  testName:" middle white space (single space)"},
-        { varName:"--var",     expectedValue:"value ",  style:"--var:value ",               testName:" trailing white space (single space)"},
+        { varName:"--var",     expectedValue:"value",  style:"--var:value ",               testName:" trailing white space (single space)"},
         { varName:"--var",     expectedValue:"value", style:"--var:  value",              testName:" leading white space (double space) 2"},
-        { varName:"--var",     expectedValue:"value1  value2", style:"--var:value1  value2",testName:" middle white space (double space) 2"},
-        { varName:"--var",     expectedValue:"value  ", style:"--var:value  ",              testName:" trailing white space (double space) 2"},
-        { varName:"--var",     expectedValue:"value1 ",  style:"--var:value1 !important;", testName:"!important"},
+        { varName:"--var",     expectedValue:"value1 value2", style:"--var:value1  value2",testName:" middle white space (double space) 2"},
+        { varName:"--var",     expectedValue:"value", style:"--var:value  ",              testName:" trailing white space (double space) 2"},
+        { varName:"--var",     expectedValue:"value1",  style:"--var:value1 !important;", testName:"!important"},
         { varName:"--var",     expectedValue:"value1",  style:"--var:value1!important;--var:value2;", testName:"!important 2"},
-        { varName:"--var",     expectedValue:"value1 ", style:"--var:value1 !important;--var:value2;", testName:"!important (with space)"}
+        { varName:"--var",     expectedValue:"value1", style:"--var:value1 !important;--var:value2;", testName:"!important (with space)"}
     ];
 
     templates.forEach(function (template) {


### PR DESCRIPTION
WebKit export from bug: [Update whitespace expectations for custom properties to match CSS Syntax Level 3 in some WPTs](https://bugs.webkit.org/show_bug.cgi?id=250506)