### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=250387

### DIFF
--- a/css/css-transforms/animation/rotate-animation-on-svg-ref.html
+++ b/css/css-transforms/animation/rotate-animation-on-svg-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Animating the "rotate" property on an SVG element</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+
+<style>
+
+svg {
+    width: 400px;
+    height: 400px;
+}
+
+rect {
+    width: 100px;
+    height: 100px;
+    transform-origin: 100px 100px;
+    rotate: 180deg;
+}
+
+</style>
+</head>
+<body>
+<svg><rect></rect></svg>
+</body>
+</html>

--- a/css/css-transforms/animation/rotate-animation-on-svg.html
+++ b/css/css-transforms/animation/rotate-animation-on-svg.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>Animating the "rotate" property on an SVG element</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+<link rel="match" href="rotate-animation-on-svg-ref.html">
+
+<style>
+
+@keyframes rotate-animation {
+    from { rotate: 0; }
+    to   { rotate: 180deg; }
+}
+
+svg {
+    width: 400px;
+    height: 400px;
+    overflow: visible;
+}
+
+rect {
+    width: 100px;
+    height: 100px;
+    transform-origin: 100px 100px;
+    animation: rotate-animation 1ms linear forwards;
+}
+
+</style>
+</head>
+<body>
+<svg><rect></rect></svg>
+
+<script>
+
+(async function() {
+    await Promise.all(document.getAnimations().map(animation => animation.finished));
+    document.documentElement.classList.remove("reftest-wait");
+})();
+
+</script>
+</body>
+</html>

--- a/css/css-transforms/animation/scale-animation-on-svg-ref.html
+++ b/css/css-transforms/animation/scale-animation-on-svg-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Animating the "scale" property on an SVG element</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+
+<style>
+
+svg {
+    width: 400px;
+    height: 400px;
+}
+
+rect {
+    width: 100px;
+    height: 100px;
+    transform-origin: top left;
+    scale: 2;
+}
+
+</style>
+</head>
+<body>
+<svg><rect></rect></svg>
+</body>
+</html>

--- a/css/css-transforms/animation/scale-animation-on-svg.html
+++ b/css/css-transforms/animation/scale-animation-on-svg.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>Animating the "scale" property on an SVG element</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+<link rel="match" href="scale-animation-on-svg-ref.html">
+
+<style>
+
+@keyframes scale-animation {
+    from { scale: 1; }
+    to   { scale: 2; }
+}
+
+svg {
+    width: 400px;
+    height: 400px;
+}
+
+rect {
+    width: 100px;
+    height: 100px;
+    transform-origin: top left;
+    animation: scale-animation 1ms linear forwards;
+}
+
+</style>
+</head>
+<body>
+<svg><rect></rect></svg>
+
+<script>
+
+(async function() {
+    await Promise.all(document.getAnimations().map(animation => animation.finished));
+    document.documentElement.classList.remove("reftest-wait");
+})();
+
+</script>
+</body>
+</html>

--- a/css/css-transforms/animation/translate-animation-on-svg-ref.html
+++ b/css/css-transforms/animation/translate-animation-on-svg-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Animating the "translate" property on an SVG element</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+
+<style>
+
+svg {
+    width: 400px;
+    height: 400px;
+}
+
+rect {
+    width: 200px;
+    height: 200px;
+    transform-origin: top left;
+    translate: 100px 100px;
+}
+
+</style>
+</head>
+<body>
+<svg><rect></rect></svg>
+</body>
+</html>

--- a/css/css-transforms/animation/translate-animation-on-svg.html
+++ b/css/css-transforms/animation/translate-animation-on-svg.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>Animating the "translate" property on an SVG element</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+<link rel="match" href="translate-animation-on-svg-ref.html">
+
+<style>
+
+@keyframes translate-animation {
+    from { translate: 0 0; }
+    to   { translate: 100px 100px; }
+}
+
+svg {
+    width: 400px;
+    height: 400px;
+}
+
+rect {
+    width: 100px;
+    height: 100px;
+    transform-origin: top left;
+    animation: translate-animation 1ms linear forwards;
+}
+
+</style>
+</head>
+<body>
+<svg><rect></rect></svg>
+
+<script>
+
+(async function() {
+    await Promise.all(document.getAnimations().map(animation => animation.finished));
+    document.documentElement.classList.remove("reftest-wait");
+})();
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [Using `rotate: x` and `transform: rotate(x)` yields different behavior with SVG](https://bugs.webkit.org/show_bug.cgi?id=250387)