### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=250566

### DIFF
--- a/css/css-fonts/parsing/font-face-src-format.html
+++ b/css/css-fonts/parsing/font-face-src-format.html
@@ -13,6 +13,12 @@
     { src: 'url("foo.ttf"), url("bar.ttf")', valid: true },
     // Empty format() is not valid
     { src: 'url("foo.ttf") format()', valid: false },
+    // Garbage data instead of format() is not valid
+    { src: 'url("foo.ttf") dummy()', valid: false },
+    // Garbage data following valid format() is not valid
+    { src: 'url("foo.ttf") format("woff") dummy()', valid: false },
+    // Garbage data preceding valid format() is not valid
+    { src: 'url("foo.ttf") dummy() format("woff")', valid: false },
     // Quoted strings in format()
     { src: 'url("foo.ttf") format("collection")', valid: true },
     { src: 'url("foo.ttf") format("opentype")', valid: true },

--- a/css/css-fonts/parsing/font-face-src-local.html
+++ b/css/css-fonts/parsing/font-face-src-local.html
@@ -8,6 +8,10 @@
 <script>
   const sheet = testStyle.sheet;
   tests = [
+    // Gargbage data following valid local() is not valid
+    { src:'local(A) dummy()', valid:false},
+    // Gargbage data preceding valid local() is not valid
+    { src:'dummy() local(A)', valid:false},
     // Unquoted collapsing space
     { src:'local(  A  )', valid:true },
     { src:'local(A B)', valid:true },


### PR DESCRIPTION
WebKit export from bug: [Improve wpt font-face-src coverage for garbage data](https://bugs.webkit.org/show_bug.cgi?id=250566)