### PR TITLE
Do not include test path in test metadata

### DIFF
--- a/tools/wpt/tests/test_update_expectations.py
+++ b/tools/wpt/tests/test_update_expectations.py
@@ -118,11 +118,11 @@ def test_update(tmp_path, metadata_file):
                                                      run_info_firefox)
     # Default expected isn't stored
     with pytest.raises(KeyError):
-        assert firefox_expected.get_test(test_id.split('/')[-1]).get("expected")
-    assert firefox_expected.get_test(test_id.split('/')[-1]).get_subtest(subtest_name).expected == "FAIL"
+        assert firefox_expected.get_test(test_id.rpartition('/')[-1]).get("expected")
+    assert firefox_expected.get_test(test_id.rpartition('/')[-1]).get_subtest(subtest_name).expected == "FAIL"
 
     chrome_expected = manifestexpected.get_manifest(metadata_path,
                                                     test_path,
                                                     run_info_chrome)
-    assert chrome_expected.get_test(test_id.split('/')[-1]).expected == "ERROR"
-    assert chrome_expected.get_test(test_id.split('/')[-1]).get_subtest(subtest_name).expected == "NOTRUN"
+    assert chrome_expected.get_test(test_id.rpartition('/')[-1]).expected == "ERROR"
+    assert chrome_expected.get_test(test_id.rpartition('/')[-1]).get_subtest(subtest_name).expected == "NOTRUN"

--- a/tools/wpt/tests/test_update_expectations.py
+++ b/tools/wpt/tests/test_update_expectations.py
@@ -118,11 +118,11 @@ def test_update(tmp_path, metadata_file):
                                                      run_info_firefox)
     # Default expected isn't stored
     with pytest.raises(KeyError):
-        assert firefox_expected.get_test(test_id).get("expected")
-    assert firefox_expected.get_test(test_id).get_subtest(subtest_name).expected == "FAIL"
+        assert firefox_expected.get_test(test_id.split('/')[-1]).get("expected")
+    assert firefox_expected.get_test(test_id.split('/')[-1]).get_subtest(subtest_name).expected == "FAIL"
 
     chrome_expected = manifestexpected.get_manifest(metadata_path,
                                                     test_path,
                                                     run_info_chrome)
-    assert chrome_expected.get_test(test_id).expected == "ERROR"
-    assert chrome_expected.get_test(test_id).get_subtest(subtest_name).expected == "NOTRUN"
+    assert chrome_expected.get_test(test_id.split('/')[-1]).expected == "ERROR"
+    assert chrome_expected.get_test(test_id.split('/')[-1]).get_subtest(subtest_name).expected == "NOTRUN"

--- a/tools/wpt/tests/test_update_expectations.py
+++ b/tools/wpt/tests/test_update_expectations.py
@@ -115,7 +115,6 @@ def test_update(tmp_path, metadata_file):
 
     firefox_expected = manifestexpected.get_manifest(metadata_path,
                                                      test_path,
-                                                     "/",
                                                      run_info_firefox)
     # Default expected isn't stored
     with pytest.raises(KeyError):
@@ -124,7 +123,6 @@ def test_update(tmp_path, metadata_file):
 
     chrome_expected = manifestexpected.get_manifest(metadata_path,
                                                     test_path,
-                                                    "/",
                                                     run_info_chrome)
     assert chrome_expected.get_test(test_id).expected == "ERROR"
     assert chrome_expected.get_test(test_id).get_subtest(subtest_name).expected == "NOTRUN"

--- a/tools/wptrunner/wptrunner/manifestexpected.py
+++ b/tools/wptrunner/wptrunner/manifestexpected.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 
 from collections import deque
-from urllib.parse import urljoin
 
 from .wptmanifest.backends import static
 from .wptmanifest.backends.base import ManifestItem
@@ -221,15 +220,13 @@ def fuzzy_prop(node):
 
 
 class ExpectedManifest(ManifestItem):
-    # TODO: url_base is not used and should be removed
-    def __init__(self, node, test_path, url_base):
+    def __init__(self, node, test_path):
         """Object representing all the tests in a particular manifest
 
         :param name: Name of the AST Node associated with this object.
                      Should always be None since this should always be associated with
                      the root node of the AST.
         :param test_path: Path of the test file associated with this manifest.
-        :param url_base: Base url for serving the tests in this manifest
         """
         name = node.data
         if name is not None:
@@ -239,7 +236,6 @@ class ExpectedManifest(ManifestItem):
         ManifestItem.__init__(self, node)
         self.child_map = {}
         self.test_path = test_path
-        self.url_base = url_base
 
     def append(self, child):
         """Add a test to the manifest"""
@@ -406,7 +402,7 @@ class TestNode(ManifestItem):
 
     @property
     def id(self):
-        return urljoin(self.parent.url, self.name)
+        return self.name
 
     @property
     def disabled(self):
@@ -512,8 +508,7 @@ def get_manifest(metadata_root, test_path, url_base, run_info):
             return static.compile(f,
                                   run_info,
                                   data_cls_getter=data_cls_getter,
-                                  test_path=test_path,
-                                  url_base=url_base)
+                                  test_path=test_path)
     except OSError:
         return None
 

--- a/tools/wptrunner/wptrunner/manifestexpected.py
+++ b/tools/wptrunner/wptrunner/manifestexpected.py
@@ -510,8 +510,7 @@ def get_manifest(metadata_root, test_path, url_base, run_info):
             return static.compile(f,
                                   run_info,
                                   data_cls_getter=data_cls_getter,
-                                  test_path=test_path,
-                                  url_base=url_base)
+                                  test_path=test_path)
     except OSError:
         return None
 

--- a/tools/wptrunner/wptrunner/manifestexpected.py
+++ b/tools/wptrunner/wptrunner/manifestexpected.py
@@ -260,11 +260,6 @@ class ExpectedManifest(ManifestItem):
         return self.child_map.get(test_id)
 
     @property
-    def url(self):
-        return urljoin(self.url_base,
-                       "/".join(self.test_path.split(os.path.sep)))
-
-    @property
     def disabled(self):
         return bool_prop("disabled", self)
 

--- a/tools/wptrunner/wptrunner/manifestexpected.py
+++ b/tools/wptrunner/wptrunner/manifestexpected.py
@@ -492,13 +492,12 @@ class SubtestNode(TestNode):
         return True
 
 
-def get_manifest(metadata_root, test_path, url_base, run_info):
+def get_manifest(metadata_root, test_path, run_info):
     """Get the ExpectedManifest for a particular test path, or None if there is no
     metadata stored for that test path.
 
     :param metadata_root: Absolute path to the root of the metadata directory
     :param test_path: Path to the test(s) relative to the test root
-    :param url_base: Base url for serving the tests in this manifest
     :param run_info: Dictionary of properties of the test run for which the expectation
                      values should be computed.
     """

--- a/tools/wptrunner/wptrunner/manifestexpected.py
+++ b/tools/wptrunner/wptrunner/manifestexpected.py
@@ -1,6 +1,5 @@
 # mypy: allow-untyped-defs
 
-import os
 from collections import deque
 from urllib.parse import urljoin
 
@@ -222,7 +221,7 @@ def fuzzy_prop(node):
 
 
 class ExpectedManifest(ManifestItem):
-    def __init__(self, node, test_path, url_base):
+    def __init__(self, node, test_path):
         """Object representing all the tests in a particular manifest
 
         :param name: Name of the AST Node associated with this object.
@@ -236,12 +235,9 @@ class ExpectedManifest(ManifestItem):
             raise ValueError("ExpectedManifest should represent the root node")
         if test_path is None:
             raise ValueError("ExpectedManifest requires a test path")
-        if url_base is None:
-            raise ValueError("ExpectedManifest requires a base url")
         ManifestItem.__init__(self, node)
         self.child_map = {}
         self.test_path = test_path
-        self.url_base = url_base
 
     def append(self, child):
         """Add a test to the manifest"""

--- a/tools/wptrunner/wptrunner/manifestexpected.py
+++ b/tools/wptrunner/wptrunner/manifestexpected.py
@@ -221,7 +221,8 @@ def fuzzy_prop(node):
 
 
 class ExpectedManifest(ManifestItem):
-    def __init__(self, node, test_path):
+    # TODO: url_base is not used and should be removed
+    def __init__(self, node, test_path, url_base):
         """Object representing all the tests in a particular manifest
 
         :param name: Name of the AST Node associated with this object.
@@ -238,6 +239,7 @@ class ExpectedManifest(ManifestItem):
         ManifestItem.__init__(self, node)
         self.child_map = {}
         self.test_path = test_path
+        self.url_base = url_base
 
     def append(self, child):
         """Add a test to the manifest"""
@@ -510,7 +512,8 @@ def get_manifest(metadata_root, test_path, url_base, run_info):
             return static.compile(f,
                                   run_info,
                                   data_cls_getter=data_cls_getter,
-                                  test_path=test_path)
+                                  test_path=test_path,
+                                  url_base=url_base)
     except OSError:
         return None
 

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -267,7 +267,7 @@ class TestLoader:
     def get_test(self, manifest_file, manifest_test, inherit_metadata, test_metadata):
         if test_metadata is not None:
             inherit_metadata.append(test_metadata)
-            test_metadata = test_metadata.get_test(manifest_test.id)
+            test_metadata = test_metadata.get_test(manifest_test.id.split('/')[-1])
 
         return wpttest.from_manifest(manifest_file, manifest_test, inherit_metadata, test_metadata)
 
@@ -287,7 +287,7 @@ class TestLoader:
     def load_metadata(self, test_manifest, metadata_path, test_path):
         inherit_metadata = self.load_dir_metadata(test_manifest, metadata_path, test_path)
         test_metadata = manifestexpected.get_manifest(
-            metadata_path, test_path, test_manifest.url_base, self.run_info)
+            metadata_path, test_path, self.run_info)
         return inherit_metadata, test_metadata
 
     def iter_tests(self):

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -267,7 +267,7 @@ class TestLoader:
     def get_test(self, manifest_file, manifest_test, inherit_metadata, test_metadata):
         if test_metadata is not None:
             inherit_metadata.append(test_metadata)
-            test_metadata = test_metadata.get_test(manifest_test.id.split('/')[-1])
+            test_metadata = test_metadata.get_test(manifest_test.id.rpartition('/')[-1])
 
         return wpttest.from_manifest(manifest_file, manifest_test, inherit_metadata, test_metadata)
 

--- a/tools/wptrunner/wptrunner/tests/test_manifestexpected.py
+++ b/tools/wptrunner/wptrunner/tests/test_manifestexpected.py
@@ -31,6 +31,5 @@ def test_fuzzy(fuzzy, expected):
     manifest = manifestexpected.static.compile(f,
                                                {},
                                                data_cls_getter=manifestexpected.data_cls_getter,
-                                               test_path="test/test.html",
-                                               url_base="/")
+                                               test_path="test/test.html")
     assert manifest.get_test("/test/test.html").fuzzy == expected

--- a/tools/wptrunner/wptrunner/tests/test_manifestexpected.py
+++ b/tools/wptrunner/wptrunner/tests/test_manifestexpected.py
@@ -32,4 +32,4 @@ def test_fuzzy(fuzzy, expected):
                                                {},
                                                data_cls_getter=manifestexpected.data_cls_getter,
                                                test_path="test/test.html")
-    assert manifest.get_test("/test/test.html").fuzzy == expected
+    assert manifest.get_test("test.html").fuzzy == expected

--- a/tools/wptrunner/wptrunner/tests/test_wpttest.py
+++ b/tools/wptrunner/wptrunner/tests/test_wpttest.py
@@ -111,7 +111,7 @@ def make_test_object(test_name,
                                                     test_path=test_path)
 
     test = next(iter(tests[index][2])) if iterate else tests[index][2].pop()
-    return wpttest.from_manifest(tests, test, inherit_metadata, test_metadata.get_test(test.id.split('/')[-1]))
+    return wpttest.from_manifest(tests, test, inherit_metadata, test_metadata.get_test(test.id.rpartition('/')[-1]))
 
 
 def test_run_info():
@@ -224,7 +224,7 @@ def test_metadata_fuzzy():
                                                     test_path="a/fuzzy.html")
 
     test = next(manifest.iterpath(to_os_path("a/fuzzy.html")))
-    test_obj = wpttest.from_manifest(manifest, test, [], test_metadata.get_test(test.id.split('/')[-1]))
+    test_obj = wpttest.from_manifest(manifest, test, [], test_metadata.get_test(test.id.rpartition('/')[-1]))
 
     assert test_obj.fuzzy == {('/a/fuzzy.html', '/a/fuzzy-ref.html', '=='): [[2, 3], [10, 15]]}
     assert test_obj.fuzzy_override == {'/a/fuzzy-ref.html': ((1, 1), (200, 200))}

--- a/tools/wptrunner/wptrunner/tests/test_wpttest.py
+++ b/tools/wptrunner/wptrunner/tests/test_wpttest.py
@@ -111,7 +111,7 @@ def make_test_object(test_name,
                                                     test_path=test_path)
 
     test = next(iter(tests[index][2])) if iterate else tests[index][2].pop()
-    return wpttest.from_manifest(tests, test, inherit_metadata, test_metadata.get_test(test.id))
+    return wpttest.from_manifest(tests, test, inherit_metadata, test_metadata.get_test(test.id.split('/')[-1]))
 
 
 def test_run_info():
@@ -224,7 +224,7 @@ def test_metadata_fuzzy():
                                                     test_path="a/fuzzy.html")
 
     test = next(manifest.iterpath(to_os_path("a/fuzzy.html")))
-    test_obj = wpttest.from_manifest(manifest, test, [], test_metadata.get_test(test.id))
+    test_obj = wpttest.from_manifest(manifest, test, [], test_metadata.get_test(test.id.split('/')[-1]))
 
     assert test_obj.fuzzy == {('/a/fuzzy.html', '/a/fuzzy-ref.html', '=='): [[2, 3], [10, 15]]}
     assert test_obj.fuzzy_override == {'/a/fuzzy-ref.html': ((1, 1), (200, 200))}

--- a/tools/wptrunner/wptrunner/tests/test_wpttest.py
+++ b/tools/wptrunner/wptrunner/tests/test_wpttest.py
@@ -108,8 +108,7 @@ def make_test_object(test_name,
     test_metadata = manifestexpected.static.compile(BytesIO(test_name),
                                                     condition,
                                                     data_cls_getter=manifestexpected.data_cls_getter,
-                                                    test_path=test_path,
-                                                    url_base="/")
+                                                    test_path=test_path)
 
     test = next(iter(tests[index][2])) if iterate else tests[index][2].pop()
     return wpttest.from_manifest(tests, test, inherit_metadata, test_metadata.get_test(test.id))
@@ -222,8 +221,7 @@ def test_metadata_fuzzy():
     test_metadata = manifestexpected.static.compile(BytesIO(test_fuzzy),
                                                     {},
                                                     data_cls_getter=manifestexpected.data_cls_getter,
-                                                    test_path="a/fuzzy.html",
-                                                    url_base="/")
+                                                    test_path="a/fuzzy.html")
 
     test = next(manifest.iterpath(to_os_path("a/fuzzy.html")))
     test_obj = wpttest.from_manifest(manifest, test, [], test_metadata.get_test(test.id))


### PR DESCRIPTION
ExpectedManifest maintains a dict to map test ids to their test metadata. This PR changed the key to only use the base name of the test ids.

To get test metadata for a test, we now need to find the metadata file at the corresponding path, then retrieve the test metadata use the base name of the test.