### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=250453

### DIFF
--- a/html/semantics/forms/the-textarea-element/textarea-validity-valueMissing-inside-datalist.html
+++ b/html/semantics/forms/the-textarea-element/textarea-validity-valueMissing-inside-datalist.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>textarea element with "required" attribute and empty value is considered "suffering from being missing" even if inside datalist element</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element:suffering-from-being-missing">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<datalist>
+  <textarea required></textarea>
+</datalist>
+
+<script>
+test(() => {
+  const textarea = document.querySelector("textarea");
+
+  assert_true(textarea.validity.valueMissing);
+  assert_false(textarea.validity.valid);
+});
+</script>


### PR DESCRIPTION
This WebKit-reviewed test ensures that `<textarea>` element's [suffering from being missing](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-being-missing) validity state is conditional on it being [mutable](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-mutable) rather than a being candidate for constraint validation.