### PR TITLE
Remove duplicated restore calls

### DIFF
--- a/screen-orientation/hidden_document.html
+++ b/screen-orientation/hidden_document.html
@@ -14,7 +14,6 @@
 
   promise_test(async (t) => {
     const { minimize, restore } = window_state_context(t);
-    t.add_cleanup(restore);
 
     await minimize();
 
@@ -24,7 +23,6 @@
 
   promise_test(async (t) => {
     const { minimize, restore } = window_state_context(t);
-    t.add_cleanup(restore);
 
     await minimize();
 
@@ -34,7 +32,6 @@
 
   promise_test(async (t) => {
     const { minimize, restore } = window_state_context(t);
-    t.add_cleanup(restore);
     t.add_cleanup(makeCleanup());
     await screen.orientation.lock(getOppositeOrientation());
 
@@ -46,7 +43,6 @@
 
   promise_test(async (t) => {
     const { minimize, restore } = window_state_context(t);
-    t.add_cleanup(restore);
     t.add_cleanup(makeCleanup());
     await screen.orientation.lock(getOppositeOrientation());
 

--- a/screen-orientation/resources/orientation-utils.js
+++ b/screen-orientation/resources/orientation-utils.js
@@ -38,7 +38,9 @@ export function makeCleanup(
 ) {
   return async () => {
     if (initialOrientation) {
-      await screen.orientation.lock(initialOrientation);
+      try {
+        await screen.orientation.lock(initialOrientation);
+      } catch {}
     }
     screen.orientation.unlock();
     requestAnimationFrame(async () => {


### PR DESCRIPTION
Calling `window_state_context()` sets that `restore()` is added as cleanup function. So it is unnecessary to set `restore()` as cleanup function again.

Also, until `minimize()` is called, rect is null, so this test will call `set_window_rect()` with null parameter. It doesn't support on Gecko [*1].

*1 https://searchfox.org/mozilla-central/rev/9563aef5a0aeaedc73f363172a93b2f10e289c2e/testing/marionette/client/marionette_driver/marionette.py#1358-1375