### PR TITLE
URL: add coverage for IPv6 with percent-encoding

### DIFF
--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -3964,6 +3964,16 @@
     "base": "http://other.com/",
     "failure": true
   },
+  {
+    "input": "http://[::%31]",
+    "base": "http://other.com/",
+    "failure": true
+  },
+  {
+    "input": "http://%5B::1]",
+    "base": "http://other.com/",
+    "failure": true
+  },
   "Misc Unicode",
   {
     "input": "http://foo:💩@example.com/bar",


### PR DESCRIPTION
This fails in Chrome. I suspect it's not needed to file a dedicated bug as presumably URL work will be tracked more generally as part of Interop 2023.

cc @ricea 