### PR TITLE
Fix content-visibility-035.html on WebKit iOS

### DIFF
--- a/css/css-contain/content-visibility/content-visibility-035.html
+++ b/css/css-contain/content-visibility/content-visibility-035.html
@@ -10,7 +10,7 @@
 <body style="margin: 0">
 
 <div id="host">
-  <input id="slotted" type="text">
+  <input id="slotted" type="button">
 </div>
 
 <script src="/resources/testharness.js"></script>


### PR DESCRIPTION
On WebKit iOS text inputs have some adjustments to padding/border, so use buttons which don't have these adjustments yet still can get focused.