### PR TITLE
test element with size 0x0 should be notified

### DIFF
--- a/resize-observer/notify.html
+++ b/resize-observer/notify.html
@@ -342,7 +342,7 @@ function test10() {
 
 function test11() {
   let t = createAndAppendElement("div");
-  t.style.width = "0px";
+  t.style.display = "none";
 
   let helper = new ResizeTestHelper(
     "test11: element sized 0x0 should be notified",

--- a/resize-observer/notify.html
+++ b/resize-observer/notify.html
@@ -340,6 +340,28 @@ function test10() {
   return helper.start();
 }
 
+function test11() {
+  let t = createAndAppendElement("div");
+  t.style.width = "0px";
+
+  let helper = new ResizeTestHelper(
+    "test11: element sized 0x0 should be notified",
+    [
+      {
+        setup: observer => {
+          observer.observe(t);
+        },
+        notify: entries => {
+          assert_equals(entries.length, 1, "1 pending notification");
+          assert_equals(entries[0].target, t, "target is t");
+          assert_equals(entries[0].contentRect.width, 0, "target width");
+          assert_equals(entries[0].contentRect.height, 0, "target height");
+        }
+      }
+    ]);
+  return helper.start(() => t.remove());
+}
+
 let guard;
 test(_ => {
   assert_own_property(window, "ResizeObserver");

--- a/resize-observer/notify.html
+++ b/resize-observer/notify.html
@@ -379,6 +379,7 @@ test0()
   .then(() => { return test8(); })
   .then(() => { return test9(); })
   .then(() => { return test10(); })
+  .then(() => { return test11(); })
   .then(() => { guard.done(); });
 
 </script>


### PR DESCRIPTION
Added a case to test "When first observing an element with ResizeObserver, lastReportedSize gets initialized with a -1 x -1 size", so element with size 0x0 should be notified
https://github.com/w3c/csswg-drafts/issues/3664