### PR TITLE
ResizeObserver: Element with size 0x0 should be notified -- part 2

### DIFF
--- a/resize-observer/notify.html
+++ b/resize-observer/notify.html
@@ -345,7 +345,29 @@ function test11() {
   t.style.display = "none";
 
   let helper = new ResizeTestHelper(
-    "test11: element sized 0x0 should be notified",
+    "test11: display:none element should be notified",
+    [
+      {
+        setup: observer => {
+          observer.observe(t);
+        },
+        notify: entries => {
+          assert_equals(entries.length, 1, "1 pending notification");
+          assert_equals(entries[0].target, t, "target is t");
+          assert_equals(entries[0].contentRect.width, 0, "target width");
+          assert_equals(entries[0].contentRect.height, 0, "target height");
+        }
+      }
+    ]);
+  return helper.start(() => t.remove());
+}
+
+function test12() {
+  let t = createAndAppendElement("div");
+  t.style.width = "0px";
+
+  let helper = new ResizeTestHelper(
+    "test12: element sized 0x0 should be notified",
     [
       {
         setup: observer => {
@@ -380,6 +402,7 @@ test0()
   .then(() => { return test9(); })
   .then(() => { return test10(); })
   .then(() => { return test11(); })
+  .then(() => { return test12(); })
   .then(() => { guard.done(); });
 
 </script>


### PR DESCRIPTION
Followup of https://github.com/web-platform-tests/wpt/pull/38041
Added another case to test visible element with size 0x0.