### PR TITLE
Fix content-visibility-068.html on WebKit

### DIFF
--- a/css/css-contain/content-visibility/content-visibility-068.html
+++ b/css/css-contain/content-visibility/content-visibility-068.html
@@ -48,7 +48,7 @@ async_test((t) => {
     });
 
     focusable.focus();
-    requestAnimationFrame(step2);
+    step_timeout(step2, 0);
   }
   // After focusing the subtree, the container should be somewhere closer than
   // 3000px (scrolled into view) and the height should be 10px, since it no


### PR DESCRIPTION
In WebKit the focus() will schedule an async scroll, so use a timeout to make sure the scroll has been performed before moving on to the next subtest.