### PR TITLE
Remove Firefox TIMEOUT expectation for context.any.worker-module.html.

### DIFF
--- a/infrastructure/metadata/infrastructure/server/context.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/context.any.js.ini
@@ -1,7 +1,3 @@
-[context.any.worker-module.html]
-  expected:
-    if product == "firefox": [TIMEOUT, OK] # https://bugzilla.mozilla.org/show_bug.cgi?id=1247687
-
 [context.any.sharedworker-module.html]
   expected:
     if product == "firefox": TIMEOUT # https://bugzilla.mozilla.org/show_bug.cgi?id=1247687


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1247687 was fixed a few days
ago, and pull requests triggering infrastructure tests have been failing on
Firefox lately with an unexpected-OK error:

    /infrastructure/server/context.any.worker-module.html
      UNEXPECTED-OK /infrastructure/server/context.any.worker-module.html

(see #37686 for example)

Remove the TIMEOUT expectation, as the test does seem to be passing ever
since the Gecko patches landed, as evidenced by the timeline in
https://wpt.fyi/results/infrastructure/server/context.any.worker-module.html?label=master&label=experimental&aligned
