### PR TITLE
XML: comment and PI in doctype internal subset

### DIFF
--- a/css/cssom/xml-stylesheet-pi-in-doctype.xhtml
+++ b/css/cssom/xml-stylesheet-pi-in-doctype.xhtml
@@ -1,0 +1,20 @@
+<!DOCTYPE html [<?xml-stylesheet href="data:text/css,html{z-index: 1}"?>]>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>xml-stylesheet processing instruction in doctype internal subset</title>
+    <link rel="help" href="https://www.w3.org/TR/2004/REC-xml-infoset-20040204/#infoitem.pi"/>
+    <!-- "[parent] The document, element, or document type declaration information item
+    which contains this information item in its [children] property. " -->
+    <link rel="help" href="https://w3c.github.io/csswg-drafts/cssom/#prolog"/>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      promise_test(async () => {
+        await new Promise(resolve => window.onload = resolve);
+        assert_equals(getComputedStyle(document.documentElement).zIndex, "auto");
+      });
+    </script>
+  </body>
+</html>

--- a/css/cssom/xml-stylesheet-pi-in-doctype.xhtml
+++ b/css/cssom/xml-stylesheet-pi-in-doctype.xhtml
@@ -2,9 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>xml-stylesheet processing instruction in doctype internal subset</title>
-    <link rel="help" href="https://www.w3.org/TR/2004/REC-xml-infoset-20040204/#infoitem.pi"/>
-    <!-- "[parent] The document, element, or document type declaration information item
-    which contains this information item in its [children] property. " -->
     <link rel="help" href="https://w3c.github.io/csswg-drafts/cssom/#prolog"/>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>

--- a/dom/nodes/Comment-in-doctype.xhtml
+++ b/dom/nodes/Comment-in-doctype.xhtml
@@ -1,0 +1,18 @@
+<!DOCTYPE html [<!--x-->]><html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>XML: Comment in doctype internal subset</title>
+    <link rel="help" href="https://www.w3.org/TR/2004/REC-xml-infoset-20040204/#infoitem.comment"/>
+    <!-- "There is a comment information item for each XML comment in the original document,
+    except for those appearing in the DTD (which are not represented)." -->
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      test(() => {
+        assert_equals(document.documentElement.previousSibling, document.firstChild);
+        assert_equals(document.firstChild.nodeType, Node.DOCUMENT_TYPE_NODE);
+      });
+    </script>
+  </body>
+</html>

--- a/dom/nodes/Comment-in-doctype.xhtml
+++ b/dom/nodes/Comment-in-doctype.xhtml
@@ -1,9 +1,6 @@
 <!DOCTYPE html [<!--x-->]><html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>XML: Comment in doctype internal subset</title>
-    <link rel="help" href="https://www.w3.org/TR/2004/REC-xml-infoset-20040204/#infoitem.comment"/>
-    <!-- "There is a comment information item for each XML comment in the original document,
-    except for those appearing in the DTD (which are not represented)." -->
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
   </head>

--- a/dom/nodes/ProcessingInstruction-in-doctype.xhtml
+++ b/dom/nodes/ProcessingInstruction-in-doctype.xhtml
@@ -1,9 +1,6 @@
 <!DOCTYPE html [<?x y?>]><html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>XML: Processing instruction in doctype internal subset</title>
-    <link rel="help" href="https://www.w3.org/TR/2004/REC-xml-infoset-20040204/#infoitem.pi"/>
-    <!-- "[parent] The document, element, or document type declaration information item
-    which contains this information item in its [children] property. " -->
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
   </head>

--- a/dom/nodes/ProcessingInstruction-in-doctype.xhtml
+++ b/dom/nodes/ProcessingInstruction-in-doctype.xhtml
@@ -1,0 +1,18 @@
+<!DOCTYPE html [<?x y?>]><html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>XML: Processing instruction in doctype internal subset</title>
+    <link rel="help" href="https://www.w3.org/TR/2004/REC-xml-infoset-20040204/#infoitem.pi"/>
+    <!-- "[parent] The document, element, or document type declaration information item
+    which contains this information item in its [children] property. " -->
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      test(() => {
+        assert_equals(document.documentElement.previousSibling, document.firstChild);
+        assert_equals(document.firstChild.nodeType, Node.DOCUMENT_TYPE_NODE);
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Per the XML Information Set spec, comments in the doctype are not represented and PIs are children of the doctype. The DOM does not allow children of DocumentType nodes. Therefore, in the DOM, they should not be represented.