### PR TITLE
URL: fix setters tests

### DIFF
--- a/url/resources/setters_tests.json
+++ b/url/resources/setters_tests.json
@@ -273,7 +273,7 @@
         {
             "comment": "Tab and newline are stripped",
             "href": "http://test/",
-            "new_value": "h\u000A\u000Att\u0009ps",
+            "new_value": "h\u000D\u000Att\u0009ps",
             "expected": {
               "href": "https://test/",
               "protocol": "https:",
@@ -299,7 +299,7 @@
         },
         {
             "href": "http://test/",
-            "new_value": "https\u000D",
+            "new_value": "https\u000E",
             "expected": {
               "href": "http://test/",
               "protocol": "http:"

--- a/url/resources/setters_tests.json
+++ b/url/resources/setters_tests.json
@@ -281,6 +281,14 @@
             }
         },
         {
+            "href": "http://test/",
+            "new_value": "https\u000D",
+            "expected": {
+              "href": "https://test/",
+              "protocol": "https:"
+            }
+        },
+        {
             "comment": "Non-tab/newline C0 controls result in no-op",
             "href": "http://test/",
             "new_value": "https\u0000",


### PR DESCRIPTION
These tests were introduced in the https://github.com/web-platform-tests/wpt/pull/38032

According to the URL specification U+000D is a newline character and must be removed before further processing.