### PR TITLE
Handle '/' in url query string or fragment

### DIFF
--- a/tools/wpt/tests/test_update_expectations.py
+++ b/tools/wpt/tests/test_update_expectations.py
@@ -7,6 +7,7 @@ import pytest
 
 from tools.wpt import wpt
 from tools.wptrunner.wptrunner import manifestexpected
+from tools.wptrunner.wptrunner.manifestupdate import get_test_name
 from localpaths import repo_root
 
 @pytest.fixture
@@ -118,11 +119,11 @@ def test_update(tmp_path, metadata_file):
                                                      run_info_firefox)
     # Default expected isn't stored
     with pytest.raises(KeyError):
-        assert firefox_expected.get_test(test_id.rpartition('/')[-1]).get("expected")
-    assert firefox_expected.get_test(test_id.rpartition('/')[-1]).get_subtest(subtest_name).expected == "FAIL"
+        assert firefox_expected.get_test(get_test_name(test_id)).get("expected")
+    assert firefox_expected.get_test(get_test_name(test_id)).get_subtest(subtest_name).expected == "FAIL"
 
     chrome_expected = manifestexpected.get_manifest(metadata_path,
                                                     test_path,
                                                     run_info_chrome)
-    assert chrome_expected.get_test(test_id.rpartition('/')[-1]).expected == "ERROR"
-    assert chrome_expected.get_test(test_id.rpartition('/')[-1]).get_subtest(subtest_name).expected == "NOTRUN"
+    assert chrome_expected.get_test(get_test_name(test_id)).expected == "ERROR"
+    assert chrome_expected.get_test(get_test_name(test_id)).get_subtest(subtest_name).expected == "NOTRUN"

--- a/tools/wptrunner/wptrunner/manifestupdate.py
+++ b/tools/wptrunner/wptrunner/manifestupdate.py
@@ -60,7 +60,7 @@ def data_cls_getter(output_node, visited_node):
     else:
         raise ValueError
 
-def get_test_name(test_id)
+def get_test_name(test_id):
     # test name is base name of test path + query string + frament
     return test_id[len(urlsplit(test_id).path.rsplit("/", 1)[0]) + 1:]
 

--- a/tools/wptrunner/wptrunner/manifestupdate.py
+++ b/tools/wptrunner/wptrunner/manifestupdate.py
@@ -60,6 +60,10 @@ def data_cls_getter(output_node, visited_node):
     else:
         raise ValueError
 
+def get_test_name(test_id)
+    # test name is base name of test path + query string + frament
+    return test_id[len(urlsplit(test_id).path.rsplit("/", 1)[0]) + 1:]
+
 
 class UpdateProperties:
     def __init__(self, manifest, **kwargs):
@@ -218,7 +222,7 @@ class TestNode(ManifestItem):
 
         :param test_type: The type of the test
         :param test_id: The id of the test"""
-        name = test_id[len(urlsplit(test_id).path.rsplit("/", 1)[0]) + 1:]
+        name = get_test_name(test_id)
         node = DataNode(name)
         self = cls(node)
 

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -11,6 +11,7 @@ from collections import defaultdict, deque, namedtuple
 
 from . import manifestinclude
 from . import manifestexpected
+from . import manifestupdate
 from . import mpcontext
 from . import wpttest
 from mozlog import structured
@@ -267,7 +268,7 @@ class TestLoader:
     def get_test(self, manifest_file, manifest_test, inherit_metadata, test_metadata):
         if test_metadata is not None:
             inherit_metadata.append(test_metadata)
-            test_metadata = test_metadata.get_test(manifest_test.id.rpartition('/')[-1])
+            test_metadata = test_metadata.get_test(manifestupdate.get_test_name(manifest_test.id))
 
         return wpttest.from_manifest(manifest_file, manifest_test, inherit_metadata, test_metadata)
 

--- a/tools/wptrunner/wptrunner/tests/test_wpttest.py
+++ b/tools/wptrunner/wptrunner/tests/test_wpttest.py
@@ -7,7 +7,7 @@ from manifest import manifest as wptmanifest
 from manifest.item import TestharnessTest, RefTest
 from manifest.utils import to_os_path
 from . test_update import tree_and_sourcefile_mocks
-from .. import manifestexpected, wpttest
+from .. import manifestexpected, manifestupdate, wpttest
 
 
 dir_ini_0 = b"""\
@@ -111,7 +111,8 @@ def make_test_object(test_name,
                                                     test_path=test_path)
 
     test = next(iter(tests[index][2])) if iterate else tests[index][2].pop()
-    return wpttest.from_manifest(tests, test, inherit_metadata, test_metadata.get_test(test.id.rpartition('/')[-1]))
+    return wpttest.from_manifest(tests, test, inherit_metadata,
+                                 test_metadata.get_test(manifestupdate.get_test_name(test.id)))
 
 
 def test_run_info():
@@ -224,7 +225,8 @@ def test_metadata_fuzzy():
                                                     test_path="a/fuzzy.html")
 
     test = next(manifest.iterpath(to_os_path("a/fuzzy.html")))
-    test_obj = wpttest.from_manifest(manifest, test, [], test_metadata.get_test(test.id.rpartition('/')[-1]))
+    test_obj = wpttest.from_manifest(manifest, test, [],
+                                     test_metadata.get_test(manifestupdate.get_test_name(test.id)))
 
     assert test_obj.fuzzy == {('/a/fuzzy.html', '/a/fuzzy-ref.html', '=='): [[2, 3], [10, 15]]}
     assert test_obj.fuzzy_override == {'/a/fuzzy-ref.html': ((1, 1), (200, 200))}


### PR DESCRIPTION
Previously we used rpartition to get the test name for test id. This will break if there is '/' in query string or fragment. Follow how this is done previously to correctly handle such case.