### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=251141

### DIFF
--- a/css/css-properties-values-api/at-property.html
+++ b/css/css-properties-values-api/at-property.html
@@ -148,6 +148,11 @@ test_not_applied('gandalf', 'grey', false);
 test_not_applied('<color>', 'notacolor', false);
 test_not_applied('<length>', '10em', false);
 
+test_not_applied('<transform-function>', 'translateX(1em)', false);
+test_not_applied('<transform-function>', 'translateY(1lh)', false);
+test_not_applied('<transform-list>', 'rotate(10deg) translateX(1em)', false);
+test_not_applied('<transform-list>', 'rotate(10deg) translateY(1lh)', false);
+
 // Inheritance
 
 test_with_at_property({


### PR DESCRIPTION
WebKit export from bug: [\[@property\] Check for computational dependencies in transform functions](https://bugs.webkit.org/show_bug.cgi?id=251141)