### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=251147

### DIFF
--- a/css/mediaqueries/match-media-parsing.html
+++ b/css/mediaqueries/match-media-parsing.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-syntax-3/#parse-comma-separated-list-of-component-values">
+<script type="text/javascript" src="/resources/testharness.js"></script>
+<script type="text/javascript" src="/resources/testharnessreport.js"></script>
+
+<script>
+function test_parsing(query, expected) {
+    test(() => {
+        const match = window.matchMedia(query);
+        assert_equals(match.media, expected)
+    }, "Test parsing '" + query + "' with matchMedia");
+}
+test_parsing("", "");
+test_parsing(" ", "");
+test_parsing("all", "all");
+test_parsing(" all", "all");
+test_parsing("   all   ", "all");
+test_parsing("all,all", "all, all");
+test_parsing(" all , all ", "all, all");
+test_parsing("(color)", "(color)");
+test_parsing("(color", "(color)");
+test_parsing(" (color)", "(color)");
+test_parsing(" ( color  )  ", "(color)");
+test_parsing(" ( color   ", "(color)");
+test_parsing("color)", "not all");
+test_parsing("  color)", "not all");
+test_parsing("  color ), ( color", "not all, (color)");
+test_parsing(" foo ", "foo");
+test_parsing(",", "not all, not all");
+test_parsing(" , ", "not all, not all");
+test_parsing(",,", "not all, not all, not all");
+test_parsing("  ,  ,  ", "not all, not all, not all");
+test_parsing(" foo,", "foo, not all");
+</script>


### PR DESCRIPTION
WebKit export from bug: [REGRESSION (257227@main): initial whitespace breaks the query in window.matchMedia()](https://bugs.webkit.org/show_bug.cgi?id=251147)