### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=250936

### DIFF
--- a/html/semantics/selectors/pseudo-classes/valid-invalid-fieldset-disconnected.html
+++ b/html/semantics/selectors/pseudo-classes/valid-invalid-fieldset-disconnected.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:valid, :invalid) on disconnected fieldset element</title>
+<link rel=help href="https://html.spec.whatwg.org/multipage/semantics-other.html#selector-valid">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<fieldset id=fieldset1>
+  <input id=input1>
+</fieldset>
+
+<fieldset id=fieldset2>
+  <select id=select1 required multiple>
+    <option>foo
+  </select>
+</fieldset>
+
+<script>
+test(() => {
+  const fieldset = document.querySelector("#fieldset1");
+  const input = document.querySelector("#input1");
+
+  assert_true(fieldset.matches(":valid"));
+  assert_false(fieldset.matches(":invalid"));
+
+  fieldset.remove();
+  input.setCustomValidity("foo");
+
+  assert_false(fieldset.matches(":valid"));
+  assert_true(fieldset.matches(":invalid"));
+
+  input.setCustomValidity("");
+
+  assert_true(fieldset.matches(":valid"));
+  assert_false(fieldset.matches(":invalid"));
+}, "<input> element becomes invalid inside disconnected <fieldset>");
+
+test(() => {
+  const fieldset = document.querySelector("#fieldset2");
+  const select = document.querySelector("#select1");
+
+  assert_false(fieldset.matches(":valid"));
+  assert_true(fieldset.matches(":invalid"));
+
+  fieldset.remove();
+  select.required = false;
+
+  assert_true(fieldset.matches(":valid"));
+  assert_false(fieldset.matches(":invalid"));
+
+  select.required = true;
+  select.firstElementChild.selected = true;
+
+  assert_true(fieldset.matches(":valid"));
+  assert_false(fieldset.matches(":invalid"));
+}, "<select> element becomes valid inside disconnected <fieldset>");
+</script>


### PR DESCRIPTION
This WebKit-reviewed test ensure that form controls in disconnected subtrees update validity status of their `<fieldset>` ancestors.