### PR TITLE
Env variables should be strings

### DIFF
--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -111,7 +111,7 @@ components:
   tox-python3_6:
     env:
       TOXENV: py36
-      PY_COLORS: 0
+      PY_COLORS: "0"
     install:
       - python3.6
       - python3.6-distutils
@@ -120,7 +120,7 @@ components:
   tox-python3_10:
     env:
       TOXENV: py310
-      PY_COLORS: 0
+      PY_COLORS: "0"
     install:
       - python3.10
       - python3.10-distutils


### PR DESCRIPTION
Soon schemas would be strict about task payload and would not allow non-string env variables
