### PR TITLE
[css-values] Improved calc-serialization-002.html according to comments in Issue 3741

### DIFF
--- a/css/css-values/calc-serialization-002.html
+++ b/css/css-values/calc-serialization-002.html
@@ -85,8 +85,15 @@
 
     verifySerialization("calc(4vmin + 0pt + 3pc)", "calc(48px + 4vmin)", "testing calc(4vmin + 0pt + 3pc)");
 
-    verifySerialization("calc(4vmin + 0pt)", "calc(4vmin)", "testing calc(4vmin + 0pt)");
+    verifySerialization("calc(4vmin + 0pt)", "calc(0px + 4vmin)", "testing calc(4vmin + 0pt)");
 
+  /*
+
+  More info on the calc(4vmin + 0pt) sub-test:
+  https://github.com/web-platform-tests/wpt/pull/38245#issuecomment-1464215777
+  Date: March 10th 2023
+
+  */
 
   /* 6 Substractions */
 

--- a/css/css-values/calc-serialization-002.html
+++ b/css/css-values/calc-serialization-002.html
@@ -2,13 +2,13 @@
 
   <meta charset="UTF-8">
 
-  <title>CSS Values and Units: serialization of calc() specified values: 17 arithmetical operations (complex)</title>
+  <title>CSS Values and Units: serialization of calc() specified values: 19 arithmetical operations (complex)</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-values-4/#calc-serialize">
 
   <meta content="" name="flags">
-  <meta content="This test verifies how 17 arithmetical operations of mixed length units in calc() specified values are serialized. Absolute length units (cm, in, mm, pc, pt, q, px), font-relative length units (ex, em, rem), viewport-percentage length units (vh, vmax, vmin, vw) and percentage units are tested. 12 additions, 4 substractions and 1 division are tested." name="assert">
+  <meta content="This test verifies how 19 arithmetical operations of mixed length units in calc() specified values are serialized. Absolute length units (cm, in, mm, pc, pt, q, px), font-relative length units (ex, em, rem), viewport-percentage length units (vh, vmax, vmin, vw) and percentage units are tested. 12 additions, 6 substractions and 1 division are tested." name="assert">
 
   <!--
 
@@ -59,7 +59,7 @@
 
   */
 
-  /* Additions */
+  /* 12 Additions */
 
     verifySerialization("calc(1vh + 2px + 3%)", "calc(3% + 2px + 1vh)", "testing calc(1vh + 2px + 3%)");
 
@@ -87,13 +87,13 @@
 
     verifySerialization("calc(4vmin + 0pt)", "calc(4vmin)", "testing calc(4vmin + 0pt)");
 
+
+  /* 6 Substractions */
+
+
     verifySerialization("calc(100% - 100% + 1em)", "calc(0% + 1em)", "testing calc(100% - 100% + 1em)");
 
     verifySerialization("calc(100% + 1em - 100%)", "calc(0% + 1em)", "testing calc(100% + 1em - 100%)");
-
-
-  /* Substractions */
-
 
     verifySerialization("calc(1vh - 7px)", "calc(-7px + 1vh)", "testing calc(1vh - 7px)");
 
@@ -114,7 +114,7 @@
     verifySerialization("calc(1vmin - 14%)", "calc(-14% + 1vmin)", "testing calc(1vmin - 14%)");
 
 
-  /* Multiplication and division */
+  /* 1 Multiplication and division */
 
 
     verifySerialization("calc(4 * 3px + 4pc / 8)", "calc(20px)", "testing calc(4 * 3px + 4pc / 8)");

--- a/css/css-values/calc-serialization-002.html
+++ b/css/css-values/calc-serialization-002.html
@@ -2,13 +2,20 @@
 
   <meta charset="UTF-8">
 
-  <title>CSS Values and Units: calc() serialization of a summation (complex)</title>
+  <title>CSS Values and Units: serialization of calc() specified values: 17 arithmetical operations (complex)</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
-  <link rel="help" href="https://www.w3.org/TR/css-values-4/#compat">
   <link rel="help" href="https://www.w3.org/TR/css-values-4/#calc-serialize">
 
-  <meta content="This test verifies how 11 summations of mixed length units are serialized. Absolute length units, relative length units, font-relative length units, viewport-percentage length units and percentage units are tested." name="assert">
+  <meta content="" name="flags">
+  <meta content="This test verifies how 17 arithmetical operations of mixed length units in calc() specified values are serialized. Absolute length units (cm, in, mm, pc, pt, q, px), font-relative length units (ex, em, rem), viewport-percentage length units (vh, vmax, vmin, vw) and percentage units are tested. 12 additions, 4 substractions and 1 division are tested." name="assert">
+
+  <!--
+
+  Issue 1050968: CSS calc and other math function serialization doesn't follow the spec
+  https://bugs.chromium.org/p/chromium/issues/detail?id=1050968
+
+  -->
 
   <script src="/resources/testharness.js"></script>
 
@@ -38,25 +45,21 @@
   /*
 
   "
-  Sort the terms in the following order:
 
-    The number, if present
+  If nodes contains a number, remove it from nodes and append it to ret.
 
-    The percentage, if present
+  If nodes contains a percentage, remove it from nodes and append it to ret.
 
-    The dimensions, ordered by their units ASCII case-insensitive alphabetically
+  If nodes contains any dimensions, remove them from nodes, sort them by their units, ordered ASCII case-insensitively, and append them to ret.
+
+  If nodes still contains any items, append them to ret in the same order.
+
   "
-  https://www.w3.org/TR/css-values-4/#math-function-serialize-a-summation
-
-  cm  centimeters  1cm = 96px/2.54
-  mm  millimeters  1mm = 1/10th of 1cm
-  Q   quarter-millimeters  1Q = 1/40th of 1cm
-  in  inches  1in = 2.54cm = 96px
-  pc  picas  1pc = 1/6th of 1in
-  pt  points  1pt = 1/72th of 1in
-  px  pixels  1px = 1/96th of 1in
+  https://www.w3.org/TR/css-values-4/#calc-serialize
 
   */
+
+  /* Additions */
 
     verifySerialization("calc(1vh + 2px + 3%)", "calc(3% + 2px + 1vh)", "testing calc(1vh + 2px + 3%)");
 
@@ -64,27 +67,61 @@
 
     verifySerialization("calc(5px + 6em + 1vh)", "calc(6em + 5px + 1vh)", "testing calc(5px + 6em + 1vh)");
 
-    verifySerialization("calc(1vh - 7px)", "calc(-7px + 1vh)", "testing calc(1vh - 7px)");
-
     verifySerialization("calc(-8px + 9em + 1vh)", "calc(9em - 8px + 1vh)", "testing calc(-8px + 9em + 1vh)");
 
     verifySerialization("calc(1pc + 1in + 1vh + 10%)", "calc(10% + 112px + 1vh)", "testing calc(1pc + 1in + 1vh + 10%)");
-
- /* verifySerialization(specified_value, serialization_expected, description)  */
 
     verifySerialization("calc(25.4q + 1vh + 12%)", "calc(12% + 24px + 1vh)", "testing calc(25.4q + 1vh + 12%)");
 
     verifySerialization("calc(1em + 1.27cm + 13% + 3em)", "calc(13% + 4em + 48px)", "testing calc(1em + 1.27cm + 13% + 3em)");
 
-    verifySerialization("calc(1vmin - 14%)", "calc(-14% + 1vmin)", "testing calc(1vmin - 14%)");
+ /* verifySerialization(specified_value, serialization_expected, description)  */
 
     verifySerialization("calc(15vw + 16vmin - 17vh)", "calc(-17vh + 16vmin + 15vw)", "testing calc(15vw + 16vmin - 17vh)");
 
-    verifySerialization("calc(-80px + 25.4mm)", "calc(16px)", "testing calc(-80px + 25.4mm)");
+    verifySerialization("calc(9pt + calc(9rem + 10px))", "calc(22px + 9rem)", "testing calc(9pt + calc(9rem + 10px))");
+
+    verifySerialization("calc(5pt + 5em + 4pt + 3em)", "calc(8em + 12px)", "testing calc(5pt + 5em + 4pt + 3em)");
+
+    verifySerialization("calc(4vmin + 0pt + 3pc)", "calc(48px + 4vmin)", "testing calc(4vmin + 0pt + 3pc)");
+
+    verifySerialization("calc(4vmin + 0pt)", "calc(4vmin)", "testing calc(4vmin + 0pt)");
+
+    verifySerialization("calc(100% - 100% + 1em)", "calc(0% + 1em)", "testing calc(100% - 100% + 1em)");
+
+    verifySerialization("calc(100% + 1em - 100%)", "calc(0% + 1em)", "testing calc(100% + 1em - 100%)");
+
+
+  /* Substractions */
+
+
+    verifySerialization("calc(1vh - 7px)", "calc(-7px + 1vh)", "testing calc(1vh - 7px)");
+
+    verifySerialization("calc(5ex - 9ex)", "calc(-4ex)", "testing calc(5ex - 9ex)");
 
     /*
-    This calc(-80px + 25.4mm) test is on purpose last. We want the
-    div#target to occupy 16px and to not cause document box height
+
+    An out-of-range value inside calc() is not syntactically invalid.
+    Inside a calc() function, the resulting summation value can be
+    out of range and can be serialized.
+
+    */
+
+    verifySerialization("calc(-80px + 25.4mm)", "calc(16px)", "testing calc(-80px + 25.4mm)");
+
+ /* verifySerialization(specified_value, serialization_expected, description)  */
+
+    verifySerialization("calc(1vmin - 14%)", "calc(-14% + 1vmin)", "testing calc(1vmin - 14%)");
+
+
+  /* Multiplication and division */
+
+
+    verifySerialization("calc(4 * 3px + 4pc / 8)", "calc(20px)", "testing calc(4 * 3px + 4pc / 8)");
+
+    /*
+    This calc(4 * 3px + 4pc / 8) test is on purpose last. We want the
+    div#target to occupy 20px and to not cause document box height
     to be unneedlessly tall.
     */
 


### PR DESCRIPTION
This is a follow-up to [Pull Request 16168](https://github.com/web-platform-tests/wpt/pull/16168). We also discussed this test in [Issue 3741](https://github.com/w3c/csswg-drafts/issues/3741).

Test at my website:

http://www.gtalbot.org/BrowserBugsSection/CSS3Values/calc-serialization-002-new.html

The only small doubt I have is why 
Firefox 102.7.0 ESR and Epiphany
3.38.2 (using WebKitGTK 2.38.3) 
both serialize

`calc(4vmin + 0pt)`

as

`calc(0px + 4vmin)`

and not as

`calc(4vmin)`