### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=251351

### DIFF
--- a/css/css-properties-values-api/animation/custom-property-animation-list-type-mismatch.html
+++ b/css/css-properties-values-api/animation/custom-property-animation-list-type-mismatch.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<number>+ | <transform-list>",
+  inherits: false,
+  initialValue: "translateX(100px)"
+}, {
+  keyframes: ["200"],
+  expected: "200"
+}, 'Animating a custom property allowing multiple list types with two mismatching types');
+
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[web-animations\] animating two custom property list values with mismatching types should use a discrete animation](https://bugs.webkit.org/show_bug.cgi?id=251351)