### PR TITLE
Each subtest must assert_implements_optional

### DIFF
--- a/webcodecs/videoDecoder-codec-specific.https.any.js
+++ b/webcodecs/videoDecoder-codec-specific.https.any.js
@@ -133,6 +133,22 @@ function view(buffer, {offset, size}) {
   return new Uint8Array(buffer, offset, size);
 }
 
+async function checkImplements() {
+  // Don't run any tests if the codec is not supported.
+  assert_equals("function", typeof VideoDecoder.isConfigSupported);
+  let supported = false;
+  try {
+    // TODO(sandersd): To properly support H.264 in AVC format, this should
+    // include the `description`. For now this test assumes that H.264 Annex B
+    // support is the same as H.264 AVC support.
+    const support =
+        await VideoDecoder.isConfigSupported({codec: CONFIG.codec});
+    supported = support.supported;
+  } catch (e) {
+  }
+  assert_implements_optional(supported, CONFIG.codec + ' unsupported');
+}
+
 let CONFIG = null;
 let CHUNK_DATA = null;
 let CHUNKS = null;
@@ -144,20 +160,6 @@ promise_setup(async () => {
     '?h264_avc': H264_AVC_DATA,
     '?h264_annexb': H264_ANNEXB_DATA
   }[location.search];
-
-  // Don't run any tests if the codec is not supported.
-  assert_equals("function", typeof VideoDecoder.isConfigSupported);
-  let supported = false;
-  try {
-    // TODO(sandersd): To properly support H.264 in AVC format, this should
-    // include the `description`. For now this test assumes that H.264 Annex B
-    // support is the same as H.264 AVC support.
-    const support =
-        await VideoDecoder.isConfigSupported({codec: data.config.codec});
-    supported = support.supported;
-  } catch (e) {
-  }
-  assert_implements_optional(supported, data.config.codec + ' unsupported');
 
   // Fetch the media data and prepare buffers.
   const response = await fetch(data.src);
@@ -176,11 +178,13 @@ promise_setup(async () => {
 });
 
 promise_test(async t => {
+  await checkImplements();
   const support = await VideoDecoder.isConfigSupported(CONFIG);
   assert_true(support.supported, 'supported');
 }, 'Test isConfigSupported()');
 
 promise_test(async t => {
+  await checkImplements();
   // TODO(sandersd): Create a 1080p `description` for H.264 in AVC format.
   // This version is testing only the H.264 Annex B path.
   const config = {
@@ -196,6 +200,7 @@ promise_test(async t => {
 }, 'Test isConfigSupported() with 1080p crop');
 
 promise_test(async t => {
+  await checkImplements();
   // Define a valid config that includes a hypothetical `futureConfigFeature`,
   // which is not yet recognized by the User Agent.
   const config = {
@@ -233,6 +238,7 @@ promise_test(async t => {
 }, 'Test that isConfigSupported() returns a parsed configuration');
 
 promise_test(async t => {
+  await checkImplements();
   async function test(t, config, description) {
     await promise_rejects_js(
         t, TypeError, VideoDecoder.isConfigSupported(config), description);
@@ -247,12 +253,14 @@ promise_test(async t => {
 }, 'Test invalid configs');
 
 promise_test(async t => {
+  await checkImplements();
   const decoder = createVideoDecoder(t);
   decoder.configure(CONFIG);
   assert_equals(decoder.state, 'configured', 'state');
 }, 'Test configure()');
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
   const decoder = createVideoDecoder(t, callbacks);
   decoder.configure(CONFIG);
@@ -271,6 +279,7 @@ promise_test(async t => {
 }, 'Decode a key frame');
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
   const decoder = createVideoDecoder(t, callbacks);
   decoder.configure(CONFIG);
@@ -281,6 +290,7 @@ promise_test(async t => {
 }, 'Decode a non key frame first fails');
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
   const decoder = createVideoDecoder(t, callbacks);
   decoder.configure(CONFIG);
@@ -323,6 +333,7 @@ promise_test(async t => {
 }, 'Verify reset() suppresses outputs');
 
 promise_test(async t => {
+  await checkImplements();
   const decoder = createVideoDecoder(t);
   assert_equals(decoder.state, 'unconfigured');
 
@@ -334,6 +345,7 @@ promise_test(async t => {
 }, 'Test unconfigured VideoDecoder operations');
 
 promise_test(async t => {
+  await checkImplements();
   const decoder = createVideoDecoder(t);
   decoder.close();
   assert_equals(decoder.state, 'closed');
@@ -347,6 +359,7 @@ promise_test(async t => {
 }, 'Test closed VideoDecoder operations');
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
 
   let errors = 0;
@@ -367,6 +380,7 @@ promise_test(async t => {
 
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
 
   let errors = 0;
@@ -391,6 +405,7 @@ promise_test(async t => {
 }, 'Decode corrupt frame');
 
 promise_test(async t => {
+  await checkImplements();
   const decoder = createVideoDecoder(t);
 
   decoder.configure(CONFIG);
@@ -406,6 +421,7 @@ promise_test(async t => {
 }, 'Close while decoding corrupt frame');
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
   const decoder = createVideoDecoder(t, callbacks);
 
@@ -427,6 +443,7 @@ promise_test(async t => {
 }, 'Test decoding after flush');
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
   const decoder = createVideoDecoder(t, callbacks);
 
@@ -446,6 +463,7 @@ promise_test(async t => {
 }, 'Test decoding a with negative timestamp');
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
   const decoder = createVideoDecoder(t, callbacks);
 
@@ -473,6 +491,7 @@ promise_test(async t => {
 }, 'Test reset during flush');
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
   const decoder = createVideoDecoder(t, callbacks);
 
@@ -490,6 +509,7 @@ promise_test(async t => {
 
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
   callbacks.output = frame => { frame.close(); };
   const decoder = createVideoDecoder(t, callbacks);


### PR DESCRIPTION
Currently, this test assumes that calling this assert in promise_setup suffices to make every subtest resolve as PRECONDITION_FAILED, but this isn't the case: there is no logic that propogates this from the setup to each test.