### PR TITLE
Correct <input pattern> test

### DIFF
--- a/html/semantics/forms/the-input-element/pattern_attribute.html
+++ b/html/semantics/forms/the-input-element/pattern_attribute.html
@@ -1,34 +1,26 @@
 <!DOCTYPE html>
-<html>
+<title>pattern attribute</title>
+<meta name=viewport content="width=device-width">
+<link rel="author" title="Fabrice Clari" href="mailto:f.clari@inno-group.com">
+<link rel="author" title="Dimitri Bocquet" href="mailto:Dimitri.Bocquet@mosquito-fp7.eu">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#attr-input-pattern">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<h1><code>pattern</code> attribute</h1>
+<div style="display: none">
+  <input pattern="[a-z]{3}" value="abcd" title="three letters max">
+</div>
+<div id="log"></div>
+<script>
+  test(function() {
+    const input = document.querySelector("input");
 
-  <head>
-    <title>Pattern Attribute</title>
-    <meta name=viewport content="width=device-width, maximum-scale=1.0, user-scalable=no" />
-    <link rel="author" title="Fabrice Clari" href="mailto:f.clari@inno-group.com">
-    <link rel="author" title="Dimitri Bocquet" href="mailto:Dimitri.Bocquet@mosquito-fp7.eu">
-    <link rel="help" href="https://html.spec.whatwg.org/multipage/#attr-input-pattern">
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-  </head>
+    assert_idl_attribute(input, "pattern");
+    assert_equals(input.pattern, "[a-z]{3}");
 
-  <body>
+    assert_inherits(input, "validity");
+    assert_false(input.validity.valid);
 
-
-      <h1>Pattern Attribute</h1>
-      <div style="display: none">
-      <input pattern="[a-z]{3}" value="abcd" title="three letters max"/>
-    </div>
-
-    <div id="log">
-    </div>
-
-  <script type="text/javascript">
-
-
-    test(function() {assert_equals(document.getElementsByTagName("input")[0].getAttribute("pattern"), "[a-z]{3}")}, "pattern attribute support on input element");
-
-  </script>
-
-  </body>
-
-</html>
+    assert_true(input.matches(":invalid"));
+  }, "pattern attribute support on input element");
+</script>


### PR DESCRIPTION
Previously, this test wasn’t testing anything useful — it would “pass” just the same for any invalid or unsupported attribute (e.g. `pattern-lolwat-idontexist`) in any browser.

This patch fixes that by testing `.pattern` instead of `.getAttribute('pattern')`, and adds some more `<input pattern>` tests.