### PR TITLE
Add <input pattern> tests for RegExp `u` flag

### DIFF
--- a/html/semantics/forms/the-input-element/pattern_attribute.html
+++ b/html/semantics/forms/the-input-element/pattern_attribute.html
@@ -1,19 +1,23 @@
 <!DOCTYPE html>
+<meta charset="utf-8">
 <title>pattern attribute</title>
 <meta name=viewport content="width=device-width">
 <link rel="author" title="Fabrice Clari" href="mailto:f.clari@inno-group.com">
 <link rel="author" title="Dimitri Bocquet" href="mailto:Dimitri.Bocquet@mosquito-fp7.eu">
+<link rel="author" title="Mathias Bynens" href="https://mathiasbynens.be/">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#attr-input-pattern">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <h1><code>pattern</code> attribute</h1>
 <div style="display: none">
-  <input pattern="[a-z]{3}" value="abcd" title="three letters max">
+  <input pattern="[a-z]{3}" value="abcd" id="basic">
+  <input pattern="a.b" value="a&#x1D306;b" id="unicode-code-points">
+  <input pattern="\p{ASCII_Hex_Digit}+" value="c0ff33" id="unicode-property-escape">
 </div>
 <div id="log"></div>
 <script>
-  test(function() {
-    const input = document.querySelector("input");
+  test(() => {
+    const input = document.querySelector("#basic");
 
     assert_idl_attribute(input, "pattern");
     assert_equals(input.pattern, "[a-z]{3}");
@@ -22,5 +26,17 @@
     assert_false(input.validity.valid);
 
     assert_true(input.matches(":invalid"));
-  }, "pattern attribute support on input element");
+  }, "basic <input pattern> support");
+
+  test(() => {
+    const input = document.querySelector("#unicode-code-points");
+    assert_true(input.validity.valid);
+    assert_true(input.matches(":valid"));
+  }, "<input pattern> is Unicode code point-aware");
+
+  test(() => {
+    const input = document.querySelector("#unicode-property-escape");
+    assert_true(input.validity.valid);
+    assert_true(input.matches(":valid"));
+  }, "<input pattern> supports Unicode property escape syntax");
 </script>


### PR DESCRIPTION
This patch adds a test verifying that <input pattern> is Unicode code point-aware (rather than dealing with individual surrogate halves), and another test verifying that <input pattern> supports Unicode property escape syntax. These two pieces of functionality are part of the RegExp `u` flag in JavaScript.

References:
- https://www.w3.org/Bugs/Public/show_bug.cgi?id=26915
- https://github.com/whatwg/html/commit/0fa713879d902d8ada81d80aa458deaf0b284b4f