### PR TITLE
[css-backgrounds] Added clip-text-multi-line-002 test and its reference

### DIFF
--- a/css/css-backgrounds/background-clip/clip-text-multi-line-002-ref.html
+++ b/css/css-backgrounds/background-clip/clip-text-multi-line-002-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS test reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="stylesheet" href="/fonts/ahem.css">
+
+  <style>
+  div
+    {
+      color: green;
+      font-size: 30px;
+      font-family: Ahem;
+      line-height: 1.5;
+    }
+  </style>
+
+ </head>
+
+ <body>
+
+  <p>Test passes if there are 2 green stripes and if the top stripe is half the width of the bottom stripe.
+
+  <div>12345<br>1234567890</div>

--- a/css/css-backgrounds/background-clip/clip-text-multi-line-002.html
+++ b/css/css-backgrounds/background-clip/clip-text-multi-line-002.html
@@ -17,6 +17,7 @@
   -->
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="author" href="mailto:mmaxfield@apple.com" title="Myles C. Maxfield">
   <link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#valdef-background-clip-text">
   <link rel="match" href="clip-text-multi-line-002-ref.html">
   <link rel="stylesheet" href="/fonts/ahem.css">

--- a/css/css-backgrounds/background-clip/clip-text-multi-line-002.html
+++ b/css/css-backgrounds/background-clip/clip-text-multi-line-002.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Backgrounds Test: 'background-clip: text' and painting of multi-line text</title>
+
+  <!--
+
+  Inspired by
+
+  http://wpt.live/css/css-backgrounds/background-clip/clip-text-multi-line.html
+
+  For more info, see
+
+  https://github.com/web-platform-tests/wpt/pull/30812#issuecomment-1314514987
+
+  -->
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#valdef-background-clip-text">
+  <link rel="match" href="clip-text-multi-line-002-ref.html">
+  <link rel="stylesheet" href="/fonts/ahem.css">
+
+  <style>
+  div
+    {
+      background-clip: text;
+      background-color: red;
+      background-image: linear-gradient(green, green);
+      color: transparent;
+      font-family: Ahem;
+      font-size: 30px;
+      line-height: 1.5;
+    }
+  </style>
+
+ </head>
+
+ <body>
+
+  <p>Test passes if there are 2 green stripes and if the top stripe is half the width of the bottom stripe.
+
+  <div>12345<br>1234567890</div>


### PR DESCRIPTION
This test spun from [a comment I made in Issue 30812](https://github.com/web-platform-tests/wpt/pull/30812#issuecomment-1314514987) . This test is an optimized, clearer test and it does not rely on the `fill-color` property.

At my website:
http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/clip-text-multi-line-002.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/clip-text-multi-line-002-ref.html