### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=251578

### DIFF
--- a/css/css-animations/responsive/column-width-001.html
+++ b/css/css-animations/responsive/column-width-001.html
@@ -61,7 +61,7 @@ test(() => {
   const second = document.getElementById('second');
   assert_equals(getComputedStyle(second).columnWidth, '30px');
   second.style.fontSize = '90px';
-  assert_equals(getComputedStyle(second).columnWidth, '0px');
+  assert_equals(getComputedStyle(second).columnWidth, '20px');
 }, 'column-width clamps to 0px');
 
 test(() => {


### PR DESCRIPTION
WebKit export from bug: [\[css-animations\] css/css-animations/responsive/column-width-001.html makes incorrect assumption about clamping](https://bugs.webkit.org/show_bug.cgi?id=251578)