### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=251590

### DIFF
--- a/css/css-properties-values-api/registered-properties-inheritance.html
+++ b/css/css-properties-values-api/registered-properties-inheritance.html
@@ -59,6 +59,13 @@ test(function(){
 }, "Explicitly inheriting from a parent with no value results in initial value.");
 
 test(function(){
+    CSS.registerProperty({name: '--initial-length-3', syntax: '<length>', initialValue: '0px', inherits: false});
+    outer.style = '--initial-length-3: 100px';
+    inner.style = '--initial-length-3: inherit';
+    assert_equals(getComputedStyle(inner).getPropertyValue('--initial-length-3'), '100px');
+}, "Explicitly inheriting from a parent with a value results in that value.");
+
+test(function(){
     CSS.registerProperty({name: '--inherited-length-4', syntax: '<length>', initialValue: '0px', inherits: true});
     outer.style = '--inherited-length-4: 42px';
     inner.style = '--inherited-length-4: var(--undefined)';


### PR DESCRIPTION
WebKit export from bug: [\[css-properties-values-api\] non-inherited custom property fails to inherit from parent when "inherit" is set](https://bugs.webkit.org/show_bug.cgi?id=251590)