### PR TITLE
remove disabled tests from total count

### DIFF
--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -205,9 +205,7 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
         executor_cls = test_implementation.executor_cls
 
         for test in test_loader.disabled_tests[test_type]:
-            logger.test_start(test.id)
-            logger.test_end(test.id, status="SKIP")
-            test_status.skipped += 1
+            logger.warning(test.id + " SKIP/DISABLED")
 
         if test_type == "testharness":
             tests_to_run[test_type] = []

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -163,6 +163,7 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
     tests_by_type = defaultdict(list)
     for test_type in test_loader.test_types:
         tests_by_type[test_type].extend(test_loader.tests[test_type])
+        tests_by_type[test_type].extend(test_loader.disabled_tests[test_type])
 
     try:
         test_groups = test_source_cls.tests_by_group(
@@ -205,7 +206,9 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
         executor_cls = test_implementation.executor_cls
 
         for test in test_loader.disabled_tests[test_type]:
-            logger.warning(test.id + " SKIP/DISABLED")
+            logger.test_start(test.id)
+            logger.test_end(test.id, status="SKIP")
+            test_status.skipped += 1
 
         if test_type == "testharness":
             tests_to_run[test_type] = []


### PR DESCRIPTION
Right now there is a discrepancy between count at start of the test run and at the end.
This is due to disabled tests being added to total count.
Just log disabled tests and ignore these rather than adding to total.

Tested in CL:
https://chromium-review.googlesource.com/c/chromium/src/+/4215272

Bug:
https://bugs.chromium.org/p/chromium/issues/detail?id=1409939