### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=251596

### DIFF
--- a/css/css-properties-values-api/at-property-animation.html
+++ b/css/css-properties-values-api/at-property-animation.html
@@ -339,6 +339,61 @@ test_with_at_property({
 }, 'Registered properties referencing animated properties update correctly.');
 
 test_with_at_property({
+  syntax: '"<length>"',
+  inherits: false,
+  initialValue: '0px'
+}, (name) => {
+  with_style_node(`
+    @keyframes test {
+      from { ${name}: inherit; }
+      to { ${name}: 300px; }
+    }
+    #outer {
+      ${name}: 100px;
+    }
+    #div {
+      animation: test 100s -50s linear paused;
+    }
+  `, () => {
+    assert_equals(getComputedStyle(div).getPropertyValue(name), '200px');
+
+    outer.style.setProperty(name, '200px');
+    assert_equals(getComputedStyle(div).getPropertyValue(name), '250px');
+
+    outer.style.setProperty(name, '0px');
+    assert_equals(getComputedStyle(div).getPropertyValue(name), '150px');
+
+    outer.style.removeProperty(name);
+  });
+}, 'CSS animation setting "inherit" for a custom property on a keyframe is responsive to changing that custom property on the parent.');
+
+test_with_at_property({
+  syntax: '"<length>"',
+  inherits: false,
+  initialValue: '0px'
+}, (name) => {
+  with_style_node(`
+    #outer {
+      ${name}: 100px;
+    }
+  `, () => {
+    const animation = div.animate({ [name]: ["inherit", "300px"]}, 1000);
+    animation.currentTime = 500;
+    animation.pause();
+
+    assert_equals(getComputedStyle(div).getPropertyValue(name), '200px');
+
+    outer.style.setProperty(name, '200px');
+    assert_equals(getComputedStyle(div).getPropertyValue(name), '250px');
+
+    outer.style.setProperty(name, '0px');
+    assert_equals(getComputedStyle(div).getPropertyValue(name), '150px');
+
+    outer.style.removeProperty(name);
+  });
+}, 'JS-originated animation setting "inherit" for a custom property on a keyframe is responsive to changing that custom property on the parent.');
+
+test_with_at_property({
   syntax: '"<color>"',
   inherits: false,
   initialValue: 'black'


### PR DESCRIPTION
WebKit export from bug: [\[web-animations\] keyframes should be recomputed when a parent element changes value for a custom property set to "inherit"](https://bugs.webkit.org/show_bug.cgi?id=251596)