### PR TITLE
[css-nesting] nesting selector : basic test

### DIFF
--- a/css/css-nesting/nesting-selector-ref.html
+++ b/css/css-nesting/nesting-selector-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>Nesting selector</title>
+<link rel="author" title="Romain Menke" href="mailto:romainmenke@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-nesting-1/#selectordef-">
+<style>
+  .test {
+    background-color: green;
+    width: 100px;
+    height: 100px;
+    display: grid;
+  }
+
+  body *+* {
+    margin-top: 8px;
+  }
+
+</style>
+
+<body>
+  <p>Tests pass if <strong>block is green</strong></p>
+  <div class="test"></div>
+</body>

--- a/css/css-nesting/nesting-selector.html
+++ b/css/css-nesting/nesting-selector.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<title>Nesting selector</title>
+<link rel="author" title="Romain Menke" href="mailto:romainmenke@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-nesting-1/#selectordef-">
+<link rel="match" href="nesting-selector-ref.html">
+<style>
+  .test {
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    display: grid;
+  }
+
+  & .test1 {
+    background-color: green;
+  }
+
+  body .test1 {
+    /* ":scope" has higher specificity than "body" */
+    background-color: red;
+  }
+
+  body *+* {
+    margin-top: 8px;
+  }
+
+</style>
+
+<body>
+  <p>Tests pass if <strong>block is green</strong></p>
+  <div class="test test1"></div>
+</body>


### PR DESCRIPTION
The css nesting specification was updated recently and `&` is not meaningful outside of nested contexts.

> When used in the selector of a nested style rule, the nesting selector represents the elements matched by the parent rule. When used in any other context, it represents the same elements as :scope in that context (unless otherwise defined).

specification : https://drafts.csswg.org/css-nesting-1/#selectordef-

example : 

```
<style>
& {}
</style>
```

This change adds a minimal test for `&` at the root. 