### PR TITLE
Removed the customized builtin test case from custom-elements/HTMLElement-constructor.html

### DIFF
--- a/custom-elements/HTMLElement-constructor.html
+++ b/custom-elements/HTMLElement-constructor.html
@@ -173,28 +173,6 @@ test(function() {
             return Reflect.get(target, prop, receiver);
         }
     });
-    customElements.define("failure-counting-element-1", countingProxy,
-                          { extends: "button" });
-    // define() gets the prototype of the constructor it's passed, so
-    // reset the counter.
-    getCount = 0;
-    assert_throws_js(TypeError,
-                     function () { new countingProxy() },
-                     "Should not be able to construct an HTMLElement named 'button'");
-    assert_equals(getCount, 0, "Should never have gotten .prototype");
-}, 'HTMLElement constructor must not get .prototype until it finishes its extends sanity checks, calling proxy constructor directly');
-
-test(function() {
-    class SomeCustomElement extends HTMLElement {};
-    var getCount = 0;
-    var countingProxy = new Proxy(SomeCustomElement, {
-        get: function(target, prop, receiver) {
-            if (prop == "prototype") {
-                ++getCount;
-            }
-            return Reflect.get(target, prop, receiver);
-        }
-    });
 
     // Purposefully don't register it.
     assert_throws_js(TypeError,


### PR DESCRIPTION
The test case is redundant with custom-elements/HTMLElement-constructor-customized-bulitins.html