### PR TITLE
Remove duplicate color(srgb) invalid value test

### DIFF
--- a/css/css-color/parsing/color-invalid-color-function.html
+++ b/css/css-color/parsing/color-invalid-color-function.html
@@ -50,9 +50,8 @@ test_invalid_value("color", "color()");  // Empty
 test_invalid_value("color", "color(banana 1 1 1)");  // Bad color space
 test_invalid_value("color", "color(displayp3 1 1 1)");  // Bad Display P3 color space
 test_invalid_value("color", "color(1 1 1)");  // No color space
-test_invalid_value("color", "color(srgb 1 1)", "color(srgb 1 1 0)");  // One missing component
-test_invalid_value("color", "color(srgb 1)", "color(srgb 1 0 0)");  // Two missing components
-test_invalid_value("color", "color(srgb)", "color(srgb 0 0 0)");  // All components missing
+test_invalid_value("color", "color(srgb 1 1)");  // One missing component
+test_invalid_value("color", "color(srgb 1)");  // Two missing components
 
 test_invalid_value("color", "color(srgb 1 1 1 1)");  // Too many parameters
 test_invalid_value("color", "color(srgb 1 1 1 1 1)");  // Way too many parameters


### PR DESCRIPTION
This is causing a harness error due to the same subtest name, which was
introduced by two PRs landing on the same day:
https://github.com/web-platform-tests/wpt/pull/38203
https://github.com/web-platform-tests/wpt/pull/38258

Also remove the 3rd argument to test_invalid_value() since it only takes
2 arguments.
