### PR TITLE
Fix shadow-dom/focus-navigation/focus-navigation-slots-in-slot.html for Safari

### DIFF
--- a/shadow-dom/focus-navigation/focus-navigation-slots-in-slot.html
+++ b/shadow-dom/focus-navigation/focus-navigation-slots-in-slot.html
@@ -8,38 +8,38 @@
 <script src="resources/focus-utils.js"></script>
 <p>Tests for moving focus by pressing tab key across nodes in slot scope.<br>
 
-<button id="b1">outside</button>
+<div id="b1" tabindex="0">outside</div>
 <div id='host'>
   <template data-mode='open'>
     <slot></slot>
   </template>
   <slot>
-    <button id="1A">single nested slot</button>
-    <button id="1B">single nested slot</button>
+    <div id="1A" tabindex="0">single nested slot</div>
+    <div id="1B" tabindex="0">single nested slot</div>
   </slot>
   <slot>
-    <button id="1C">single nested slot</button>
+    <div id="1C" tabindex="0">single nested slot</div>
   </slot>
   <slot>
     <slot>
-      <button id="2A">double nested slot</button>
-      <button id="2B">double nested slot</button>
+      <div id="2A" tabindex="0">double nested slot</div>
+      <div id="2B" tabindex="0">double nested slot</div>
     </slot>
   </slot>
   <slot>
-    <button id="3A">single nested slot</button>
+    <div id="3A" tabindex="0">single nested slot</div>
     <slot>
-      <button id="3B">double nested slot</button>
+      <div id="3B" tabindex="0">double nested slot</div>
       <slot>
-        <button id="3C">Triple nested slot</button>
-        <button id="3D">Triple nested slot</button>
+        <div id="3C" tabindex="0">Triple nested slot</div>
+        <div id="3D" tabindex="0">Triple nested slot</div>
       </slot>
-      <button id="3E">double nested slot</button>
+      <div id="3E" tabindex="0">double nested slot</div>
     </slot>
-    <button id="3F">single nested slot</button>
+    <div id="3F" tabindex="0">single nested slot</div>
   </slot>
 </div>
-<button id="b2">outside</button>
+<div id="b2" tabindex="0">outside</div>
 
 <script>
 'use strict';


### PR DESCRIPTION
This test was erroneously assuming that buttons are focusable. This is not true by default in Safari so use a div with tabindex instead.