### PR TITLE
Fix shadow-dom/focus-navigation/focus-nested-slots.html for Safari

### DIFF
--- a/shadow-dom/focus-navigation/focus-nested-slots.html
+++ b/shadow-dom/focus-navigation/focus-nested-slots.html
@@ -10,42 +10,42 @@
 <script src="resources/shadow-dom.js"></script>
 <script src="resources/focus-utils.js"></script>
 
-<button id=button1>one</button>
+<div id=div1 tabindex=0>one</div>
 <span>
   <template shadowroot=open>
     <slot name=myslot></slot>
   </template>
   <slot slot=myslot>
-    <button id=button2>two</button>
-    <button id=button3>three</button>
-    <button id=button4>four</button>
+    <div id=div2 tabindex=0>two</div>
+    <div id=div3 tabindex=0>three</div>
+    <div id=div4 tabindex=0>four</div>
   </slot>
 </span>
-<button id=button5>five</button>
+<div id=div5 tabindex=0>five</div>
 
 <script>
 
 promise_test(async () => {
   convertDeclarativeTemplatesToShadowRootsWithin(document);
-  button1.focus();
-  assert_equals(document.activeElement, button1);
+  div1.focus();
+  assert_equals(document.activeElement, div1);
 
   await navigateFocusForward();
-  assert_equals(document.activeElement, button2);
+  assert_equals(document.activeElement, div2);
   await navigateFocusForward();
-  assert_equals(document.activeElement, button3);
+  assert_equals(document.activeElement, div3);
   await navigateFocusForward();
-  assert_equals(document.activeElement, button4);
+  assert_equals(document.activeElement, div4);
   await navigateFocusForward();
-  assert_equals(document.activeElement, button5);
+  assert_equals(document.activeElement, div5);
   await navigateFocusBackward();
-  assert_equals(document.activeElement, button4);
+  assert_equals(document.activeElement, div4);
   await navigateFocusBackward();
-  assert_equals(document.activeElement, button3);
+  assert_equals(document.activeElement, div3);
   await navigateFocusBackward();
-  assert_equals(document.activeElement, button2);
+  assert_equals(document.activeElement, div2);
   await navigateFocusBackward();
-  assert_equals(document.activeElement, button1);
+  assert_equals(document.activeElement, div1);
 }, `Verifies that focus order goes in flat tree order with buttons inside nested slots which have a mixture of assigned and unassigned states.`);
 
 </script>


### PR DESCRIPTION
This test was erroneously assuming buttons are focusable. Use a div with tabindex instead since this is not the case in Safari.