### PR TITLE
Fix shadow-dom/focus-navigation/focus-navigation-web-component-input-type-radio.html for Safari

### DIFF
--- a/shadow-dom/focus-navigation/focus-navigation-web-component-radio.html
+++ b/shadow-dom/focus-navigation/focus-navigation-web-component-radio.html
@@ -8,7 +8,7 @@
 <script src="resources/focus-utils.js"></script>
 
 <template id="custom-radio">
-  <input type="radio">
+  <span aria-role="radio" tabindex="0">&#x1F518;</span>
   <slot></slot>
 </template>
 


### PR DESCRIPTION
This test was erroneously assuming that radio buttons are focusable. Use a span with ARIA role=radio and tabindex=0 instead as this is not the case in Safari.