### PR TITLE
Ensure scripty type for local URLs in importScripts

### DIFF
--- a/workers/importscripts_mime.any.js
+++ b/workers/importscripts_mime.any.js
@@ -40,13 +40,13 @@ let test_cases = [
   ["TEXT/HTML", false],
 ];
 
-for (var test_case of test_cases) {
+for (const [mimeType, isScriptType] of test_cases) {
   test(t => {
-    let import_url = "/workers/support/imported_script.py?mime=" + test_case[0];
-    if (test_case[1]) {
+    let import_url = "/workers/support/imported_script.py?mime=" + mimeType;
+    if (isScriptType) {
       assert_equals(undefined, importScripts(import_url));
     } else {
       assert_throws_dom("NetworkError", _ => { importScripts(import_url) })
     }
-  }, "importScripts() requires scripty MIME types: " + test_case[0] + " is " + (test_case[1] ? "allowed" : "blocked") + ".");
+  }, "importScripts() requires scripty MIME types: " + mimeType + " is " + (isScriptType ? "allowed" : "blocked") + ".");
 }

--- a/workers/importscripts_mime_local.any.js
+++ b/workers/importscripts_mime_local.any.js
@@ -1,8 +1,6 @@
-// META: global=worker
+// META: global=dedicatedworker,sharedworker
 //
 // Tests for https://github.com/whatwg/html/issues/8869
-// Targeting Workers only because ServiceWorkers don't
-// have access to URL.createObjectURL
 
 importScripts("/resources/testharness.js");
 

--- a/workers/importscripts_mime_local.worker.js
+++ b/workers/importscripts_mime_local.worker.js
@@ -1,0 +1,68 @@
+// META: global=worker
+//
+// Tests for https://github.com/whatwg/html/issues/8869
+// Targeting Workers only because ServiceWorkers don't
+// have access to URL.createObjectURL
+
+importScripts("/resources/testharness.js");
+
+let test_cases = [
+  // Supported mimetypes:
+  ["text/javascript", true],
+  ["application/javascript", true],
+  ["text/ecmascript", true],
+
+  // Blocked mimetpyes:
+  ["image/png", false],
+  ["text/csv", false],
+  ["video/mpeg", false],
+
+  // Legacy mimetypes:
+  ["text/html", false],
+  ["text/plain", false],
+  ["application/xml", false],
+  ["application/octet-stream", false],
+
+  // Potato mimetypes:
+  ["text/potato", false],
+  ["potato/text", false],
+  ["aaa/aaa", false],
+  ["zzz/zzz", false],
+
+  // Parameterized mime types:
+  ["text/javascript; charset=utf-8", true],
+  ["text/javascript;charset=utf-8", true],
+  ["text/javascript;bla;bla", true],
+  ["text/csv; charset=utf-8", false],
+  ["text/csv;charset=utf-8", false],
+  ["text/csv;bla;bla", false],
+
+  // Funky capitalization:
+  ["Text/html", false],
+  ["text/Html", false],
+  ["TeXt/HtMl", false],
+  ["TEXT/HTML", false],
+];
+
+for (var test_case of test_cases) {
+  test(t => {
+    let import_url = `data:${ test_case[0] },`;
+    if (test_case[1]) {
+      assert_equals(undefined, importScripts(import_url));
+    } else {
+      assert_throws_dom("NetworkError", _ => { importScripts(import_url) })
+    }
+  }, "importScripts() requires scripty MIME types for data: URLs: " + test_case[0] + " is " + (test_case[1] ? "allowed" : "blocked") + ".");
+}
+
+for (var test_case of test_cases) {
+  test(t => {
+    let import_url = URL.createObjectURL(new Blob([""], { type: test_case[0] }));
+    if (test_case[1]) {
+      assert_equals(undefined, importScripts(import_url));
+    } else {
+      assert_throws_dom("NetworkError", _ => { importScripts(import_url) })
+    }
+  }, "importScripts() requires scripty MIME types for blob: URLs: " + test_case[0] + " is " + (test_case[1] ? "allowed" : "blocked") + ".");
+}
+done();

--- a/workers/importscripts_mime_local.worker.js
+++ b/workers/importscripts_mime_local.worker.js
@@ -44,25 +44,25 @@ let test_cases = [
   ["TEXT/HTML", false],
 ];
 
-for (var test_case of test_cases) {
+for (const [mimeType, isScriptType] of test_cases) {
   test(t => {
-    let import_url = `data:${ test_case[0] },`;
-    if (test_case[1]) {
+    let import_url = `data:${ mimeType },`;
+    if (isScriptType) {
       assert_equals(undefined, importScripts(import_url));
     } else {
       assert_throws_dom("NetworkError", _ => { importScripts(import_url) })
     }
-  }, "importScripts() requires scripty MIME types for data: URLs: " + test_case[0] + " is " + (test_case[1] ? "allowed" : "blocked") + ".");
+  }, "importScripts() requires scripty MIME types for data: URLs: " + mimeType + " is " + (isScriptType ? "allowed" : "blocked") + ".");
 }
 
-for (var test_case of test_cases) {
+for (const [mimeType, isScriptType] of test_cases) {
   test(t => {
-    let import_url = URL.createObjectURL(new Blob([""], { type: test_case[0] }));
-    if (test_case[1]) {
+    let import_url = URL.createObjectURL(new Blob([""], { type: mimeType }));
+    if (isScriptType) {
       assert_equals(undefined, importScripts(import_url));
     } else {
       assert_throws_dom("NetworkError", _ => { importScripts(import_url) })
     }
-  }, "importScripts() requires scripty MIME types for blob: URLs: " + test_case[0] + " is " + (test_case[1] ? "allowed" : "blocked") + ".");
+  }, "importScripts() requires scripty MIME types for blob: URLs: " + mimeType + " is " + (isScriptType ? "allowed" : "blocked") + ".");
 }
 done();


### PR DESCRIPTION
See https://github.com/whatwg/html/issues/8869.

Based on https://github.com/web-platform-tests/wpt/blob/master/workers/importscripts_mime.any.js which tests for "external" URLs.

This currently expects the specced behavior, i.e local URLs should also enforce strict MIME types. This fails in both Firefox and Chrome and passes in Safari.  
Note that in its initial form it doesn't use `.any.` because I couldn't find a way to exclude only ServiceWorkers (which don't have access to `createObjectURL`). It also doesn't test for `filesystem:` protocol because I'm not quite sure what's the status of this, and how to write a test for it...

cc @annevk @mikewest 