### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=251936

### DIFF
--- a/fetch/api/request/request-headers.any.js
+++ b/fetch/api/request/request-headers.any.js
@@ -59,6 +59,7 @@ var invalidRequestNoCorsHeaders = [
   ["proxya", "KO"],
   ["sec", "KO"],
   ["secb", "KO"],
+  ["Empty-Value", ""],
 ];
 
 validRequestHeaders.forEach(function(header) {


### PR DESCRIPTION
This adds a test that Headers objects with the `"request-no-cors"` guard don't accept empty header values for non-safelisted header names.