### PR TITLE
Add fuzzy data for border-image-repeat-space-10.html

### DIFF
--- a/css/css-backgrounds/border-image-repeat-space-10.html
+++ b/css/css-backgrounds/border-image-repeat-space-10.html
@@ -4,6 +4,7 @@
 <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
 <link rel="help" href="https://www.w3.org/TR/css3-background/#the-border-image-repeat">
 <link rel="match" href="border-image-repeat-space-10-ref.html">
+<meta name="fuzzy" content="maxDifference=0-80;totalPixels=0-1472">
 <meta name="assert" content="Check that 'border-image-repeat:space' renders as expected by comparing to something not using 'border-image-repeat:space'.">
 
 <style>


### PR DESCRIPTION
* Chrome has 1472 total pixels differing because of a small hardly visible shift between the test & the ref.
* Safari is mostly anti-aliasing.

Also, `maxDifference=80` ensures the differences remain small color-wise.