### PR TITLE
Except where impractical, set Connection: Close with close_connection

### DIFF
--- a/cors/resources/expose-headers.py
+++ b/cors/resources/expose-headers.py
@@ -2,6 +2,7 @@ def main(request, response):
     response.add_required_headers = False
     output =  b"HTTP/1.1 221 ALL YOUR BASE BELONG TO H1\r\n"
     output += b"Access-Control-Allow-Origin: *\r\n"
+    output += b"Connection: close\r\n"
     output += b"BB-8: hey\r\n"
     output += b"Content-Language: mkay\r\n"
     output += request.GET.first(b"expose") + b"\r\n"

--- a/fetch/content-length/resources/content-length.py
+++ b/fetch/content-length/resources/content-length.py
@@ -2,6 +2,7 @@ def main(request, response):
     response.add_required_headers = False
     output =  b"HTTP/1.1 200 OK\r\n"
     output += b"Content-Type: text/plain;charset=UTF-8\r\n"
+    output += b"Connection: close\r\n"
     output += request.GET.first(b"length") + b"\r\n"
     output += b"\r\n"
     output += b"Fact: this is really forty-two bytes long."

--- a/fetch/content-type/resources/content-type.py
+++ b/fetch/content-type/resources/content-type.py
@@ -11,6 +11,7 @@ def main(request, response):
         for value in values:
             output += b"Content-Type: " + value + b"\r\n"
     output += b"Content-Length: " + isomorphic_encode(str(len(content))) + b"\r\n"
+    output += b"Connection: close\r\n"
     output += b"\r\n"
     output += content
     response.writer.write(output)

--- a/fetch/metadata/resources/record-header.py
+++ b/fetch/metadata/resources/record-header.py
@@ -18,6 +18,7 @@ def main(request, response):
   ## Handle the header retrieval request ##
   if b'retrieve' in request.GET:
     response.writer.write_status(200)
+    response.writer.write_header(b"Connection", b"close")
     response.writer.end_headers()
     try:
       header_value = request.server.stash.take(testId)

--- a/fetch/nosniff/resources/nosniff.py
+++ b/fetch/nosniff/resources/nosniff.py
@@ -2,6 +2,7 @@ def main(request, response):
     response.add_required_headers = False
     output =  b"HTTP/1.1 220 YOU HAVE NO POWER HERE\r\n"
     output += b"Content-Length: 22\r\n"
+    output += b"Connection: close\r\n"
     output += b"Content-Type: x/x\r\n"
     output += request.GET.first(b"nosniff") + b"\r\n"
     output += b"\r\n"

--- a/resource-timing/resources/resource-timing-content-length.py
+++ b/resource-timing/resources/resource-timing-content-length.py
@@ -5,6 +5,7 @@ def main(request, response):
 
     output =  b"HTTP/1.1 200 OK\r\n"
     output += b"Content-Type: text/plain;charset=UTF-8\r\n"
+    output += b"Connection: close\r\n"
     if length == b"auto" :
         output += b"Content-Length:"
         output += "{0}".format(len(content)).encode("ascii")

--- a/xhr/resources/bad-chunk-encoding.py
+++ b/xhr/resources/bad-chunk-encoding.py
@@ -7,6 +7,7 @@ def main(request, response):
     response.headers.set(b"Transfer-Encoding", b"chunked")
     response.headers.set(b"Content-Type", b"text/plain")
     response.headers.set(b"X-Content-Type-Options", b"nosniff")
+    response.headers.set(b"Connection", b"close")
     response.close_connection = True
     response.write_status_headers()
     time.sleep(delay)

--- a/xhr/resources/echo-content-type.py
+++ b/xhr/resources/echo-content-type.py
@@ -1,5 +1,6 @@
 def main(request, response):
     response.headers.set(b"Content-Type", b"text/plain")
+    response.headers.set(b"Connection", b"close")
     response.status = 200
     response.content = request.headers.get(b"Content-Type")
     response.close_connection = True

--- a/xhr/resources/echo-headers.py
+++ b/xhr/resources/echo-headers.py
@@ -1,6 +1,7 @@
 def main(request, response):
     response.writer.write_status(200)
     response.writer.write_header(b"Content-Type", b"text/plain")
+    response.writer.write_header(b"Connection", b"close")
     response.writer.end_headers()
     response.writer.write(str(request.raw_headers))
     response.close_connection = True


### PR DESCRIPTION
Because of the unexpected close, CFNetwork sometimes runs into a retry limit trying to find a working connection. Given we SHOULD be closing gracefully, and these tests are not attempting to test abrupt closure, it makes sense to just change these tests.

The files not changed here are:

tools/wptserve/wptserve/server.py
tools/wptserve/wptserve/handlers.py
tools/wptserve/wptserve/response.py
fetch/h1-parsing/resources/status-code.py
fetch/h1-parsing/resources/message.py

See also https://github.com/web-platform-tests/wpt/pull/38091.