### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=252158

### DIFF
--- a/css/css-transitions/support/properties.js
+++ b/css/css-transitions/support/properties.js
@@ -259,7 +259,6 @@ var unspecified_properties = {
     'box-shadow': ['box-shadow'],
     'font-size-adjust': ['number'],
     'font-stretch': ['font-stretch'],
-    'marker-offset': ['length'],
     'text-decoration-color': ['color'],
     'column-count': ['integer'],
     'column-gap': ['length'],
@@ -269,10 +268,6 @@ var unspecified_properties = {
     'transform': ['transform'],
     'transform-origin': ['horizontal'],
     'zoom': ['number'],
-    'outline-radius-topleft': ['length', 'percentage'],
-    'outline-radius-topright': ['length', 'percentage'],
-    'outline-radius-bottomright': ['length', 'percentage'],
-    'outline-radius-bottomleft': ['length', 'percentage'],
     'display': ['display'],
     'position': ['position'],
     'object-view-box': ['object-view-box']


### PR DESCRIPTION
WebKit export from bug: [\[css-transitions\] remove tests for outline-radius and marker-offset](https://bugs.webkit.org/show_bug.cgi?id=252158)