### PR TITLE
Corrected background-size-001 test

### DIFF
--- a/css/css-backgrounds/background-size-001.html
+++ b/css/css-backgrounds/background-size-001.html
@@ -39,43 +39,43 @@
         document.getElementById("test").style.backgroundSize = "0px";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "0px auto", "background-size supporting value");
+                "0px", "background-size supporting value");
         }, "background-size_length_zero");
 
         document.getElementById("test").style.backgroundSize = "-0px";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "0px auto", "background-size supporting value");
+                "0px", "background-size supporting value");
         }, "background-size_length_negative_zero");
 
         document.getElementById("test").style.backgroundSize = "+0px";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "0px auto", "background-size supporting value");
+                "0px", "background-size supporting value");
         }, "background-size_length_positive_zero");
 
         document.getElementById("test").style.backgroundSize = "15px";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "15px auto", "background-size supporting value");
+                "15px", "background-size supporting value");
         }, "background-size_length_normal");
 
         document.getElementById("test").style.backgroundSize = "0%";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "0% auto", "background-size supporting value");
+                "0%", "background-size supporting value");
         }, "background-size_percentage_min");
 
         document.getElementById("test").style.backgroundSize = "50%";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "50% auto", "background-size supporting value");
+                "50%", "background-size supporting value");
         }, "background-size_percentage_normal");
 
         document.getElementById("test").style.backgroundSize = "100%";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "100% auto", "background-size supporting value");
+                "100%", "background-size supporting value");
         }, "background-size_percentage_max");
 
         document.getElementById("test").style.backgroundSize = "auto auto";
@@ -99,7 +99,7 @@
         document.getElementById("test").style.backgroundSize = "15px auto";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "15px auto", "background-size supporting value");
+                "15px", "background-size supporting value");
         }, "background-size_length_auto");
 
         document.getElementById("test").style.backgroundSize = "15px 15px";
@@ -117,7 +117,7 @@
         document.getElementById("test").style.backgroundSize = "50% auto";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "50% auto", "background-size supporting value");
+                "50%", "background-size supporting value");
         }, "background-size_percentage_auto");
 
         document.getElementById("test").style.backgroundSize = "50% 15px";


### PR DESCRIPTION
"background-size can take a single value that defaults to auto, so it should serialize out [when using `getComputedStyle()`] without the auto (if it's the second value)" - fantasai , from [Pull Request 38352](https://github.com/web-platform-tests/wpt/pull/38352#issuecomment-1424945272)

The correction to background-size-001.html test in here does just that, exactly that.