### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=252238

### DIFF
--- a/css/css-fonts/parsing/font-variation-settings-computed.html
+++ b/css/css-fonts/parsing/font-variation-settings-computed.html
@@ -23,6 +23,12 @@ test_computed_value('font-variation-settings', '"wght" 700, "wght" 500', '"wght"
 test_computed_value('font-variation-settings', '"wght" 700, "XHGT" 0.7',
     ['"wght" 700, "XHGT" 0.7', '"XHGT" 0.7, "wght" 700']);
 
+test_computed_value('font-variation-settings', '"wght" 100, "wdth" 200', '"wdth" 200, "wght" 100',
+    "values should be sorted alphabetically by tag.");
+
+test_computed_value('font-variation-settings', '"wght" 100, "wdth" 200, "wght" 300, "wdth" 400', '"wdth" 400, "wght" 300',
+    "duplicate values should be removed, keeping the rightmost occurrence, and sorted alphabetically by tag.");
+
 test_computed_value('font-variation-settings', '"XHGT" calc(0.4 + 0.3)', '"XHGT" 0.7');
 </script>
 </body>


### PR DESCRIPTION
WebKit export from bug: [\[css-fonts\] font-feature-settings and font-variation-settings should sort their tags alphabetically](https://bugs.webkit.org/show_bug.cgi?id=252238)