### PR TITLE
Screen orientation lock: remove bad 'hidden' tests

### DIFF
--- a/screen-orientation/hidden_document.html
+++ b/screen-orientation/hidden_document.html
@@ -25,7 +25,6 @@
 
   promise_test(async (t) => {
     const { minimize, restore } = window_state_context(t);
-    t.add_cleanup(restore);
 
     await minimize();
 

--- a/screen-orientation/hidden_document.html
+++ b/screen-orientation/hidden_document.html
@@ -14,48 +14,22 @@
 
   promise_test(async (t) => {
     const { minimize, restore } = window_state_context(t);
+    t.add_cleanup(restore);
 
     await minimize();
 
     assert_equals(document.visibilityState, "hidden", "Document must be hidden");
-    await promise_rejects_dom(t, "SecurityError", screen.orientation.lock("landscape") );
+    const opposite = getOppositeOrientation();
+    await promise_rejects_dom(t, "SecurityError", screen.orientation.lock(opposite) );
   }, "hidden documents must reject went trying to call lock or unlock");
 
   promise_test(async (t) => {
     const { minimize, restore } = window_state_context(t);
+    t.add_cleanup(restore);
 
     await minimize();
 
     assert_equals(document.visibilityState, "hidden", "Document must be hidden");
     assert_throws_dom("SecurityError", () => screen.orientation.unlock());
   }, "hidden documents must reject went trying to call unlock");
-
-  promise_test(async (t) => {
-    const { minimize, restore } = window_state_context(t);
-    t.add_cleanup(makeCleanup());
-    await screen.orientation.lock(getOppositeOrientation());
-
-    await minimize();
-
-    assert_equals(document.visibilityState, "hidden", "Document must be hidden");
-    assert_throws_dom("SecurityError", () => screen.orientation.unlock());
-  }, "hidden documents must not unlock the screen orientation");
-
-  promise_test(async (t) => {
-    const { minimize, restore } = window_state_context(t);
-    t.add_cleanup(makeCleanup());
-    await screen.orientation.lock(getOppositeOrientation());
-
-    await minimize();
-
-    assert_equals(document.visibilityState, "hidden");
-    await promise_rejects_dom(t, "SecurityError", screen.orientation.lock(getOppositeOrientation()));
-
-    // Maximize, now everything should work as expected.
-    await restore();
-
-    assert_equals(document.visibilityState, "visible");
-    await screen.orientation.lock(getOppositeOrientation());
-    screen.orientation.unlock();
-  }, "Once maximized, a minimized window can lock or unlock the screen orientation again");
 </script>

--- a/screen-orientation/hidden_document.html
+++ b/screen-orientation/hidden_document.html
@@ -14,7 +14,7 @@
 
   promise_test(async (t) => {
     const { minimize, restore } = window_state_context(t);
-    t.add_cleanup(restore);
+    t.add_cleanup(makeCleanup());
 
     await minimize();
 


### PR DESCRIPTION
As discussed in https://github.com/w3c/screen-orientation/pull/232