### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=252102

### DIFF
--- a/html/semantics/popovers/popover-attribute-basic.html
+++ b/html/semantics/popovers/popover-attribute-basic.html
@@ -106,11 +106,11 @@ window.onload = () => {
     // be invisible. Otherwise, it should be visible.
     const expectVisible = !nonPopover.hasAttribute('popover');
     assertPopoverVisibility(nonPopover, /*isPopover*/false, expectVisible, 'A non-popover should start out visible');
-    assert_throws_dom("NotSupportedError",() => nonPopover.showPopover(),'Calling showPopover on a non-popover should throw NotSupportedError');
+    assert_throws_dom("InvalidStateError",() => nonPopover.showPopover(),'Calling showPopover on a non-popover should throw InvalidStateError');
     assertPopoverVisibility(nonPopover, /*isPopover*/false, expectVisible, 'Calling showPopover on a non-popover should leave it visible');
-    assert_throws_dom("NotSupportedError",() => nonPopover.hidePopover(),'Calling hidePopover on a non-popover should throw NotSupportedError');
+    assert_throws_dom("InvalidStateError",() => nonPopover.hidePopover(),'Calling hidePopover on a non-popover should throw InvalidStateError');
     assertPopoverVisibility(nonPopover, /*isPopover*/false, expectVisible, 'Calling hidePopover on a non-popover should leave it visible');
-    assert_throws_dom("NotSupportedError",() => nonPopover.togglePopover(),'Calling togglePopover on a non-popover should throw NotSupportedError');
+    assert_throws_dom("InvalidStateError",() => nonPopover.togglePopover(),'Calling togglePopover on a non-popover should throw InvalidStateError');
     assertPopoverVisibility(nonPopover, /*isPopover*/false, expectVisible, 'Calling togglePopover on a non-popover should leave it visible');
   }
 


### PR DESCRIPTION
The spec says to use InvalidStateError not NotSupportedError for popovers.