### PR TITLE
WebCryptoAPI: test that Secure Curves have no namedCurve

### DIFF
--- a/WebCryptoAPI/util/helpers.js
+++ b/WebCryptoAPI/util/helpers.js
@@ -131,7 +131,7 @@ function assert_goodCryptoKey(key, algorithm, extractable, usages, kind) {
     }
 
     if (/^(?:Ed|X)(?:25519|448)$/.test(key.algorithm.name)) {
-        assert_false('namedCurve' in key.algorithm, "Does not have a namedCurve property")
+        assert_false('namedCurve' in key.algorithm, "Does not have a namedCurve property");
     }
 
     // usages is expected to be provided for a key pair, but we are checking

--- a/WebCryptoAPI/util/helpers.js
+++ b/WebCryptoAPI/util/helpers.js
@@ -130,6 +130,10 @@ function assert_goodCryptoKey(key, algorithm, extractable, usages, kind) {
         assert_equals(key.algorithm.hash.name.toUpperCase(), algorithm.hash.toUpperCase(), "Correct hash function");
     }
 
+    if (/^(?:Ed|X)(?:25519|448)$/.test(key.algorithm.name)) {
+        assert_false('namedCurve' in key.algorithm, "Does not have a namedCurve property")
+    }
+
     // usages is expected to be provided for a key pair, but we are checking
     // only a single key. The publicKey and privateKey portions of a key pair
     // recognize only some of the usages appropriate for a key pair.


### PR DESCRIPTION
Tests that https://wicg.github.io/webcrypto-secure-curves/ do not have a namedCurve property. Adding this because whilst tracking implementations I've come across this more than once.