### PR TITLE
WebCryptoAPI: re-use assert_goodCryptoKey in import tests

### DIFF
--- a/WebCryptoAPI/generateKey/successes.js
+++ b/WebCryptoAPI/generateKey/successes.js
@@ -64,7 +64,7 @@ function run_test(algorithmNames, slowTest) {
             .then(function(result) {
                 if (resultType === "CryptoKeyPair") {
                     assert_goodCryptoKey(result.privateKey, algorithm, extractable, usages, "private");
-                    assert_goodCryptoKey(result.publicKey, algorithm, extractable, usages, "public");
+                    assert_goodCryptoKey(result.publicKey, algorithm, true, usages, "public");
                 } else {
                     assert_goodCryptoKey(result, algorithm, extractable, usages, "secret");
                 }

--- a/WebCryptoAPI/import_export/ec_importKey.https.any.js
+++ b/WebCryptoAPI/import_export/ec_importKey.https.any.js
@@ -1,5 +1,6 @@
 // META: title=WebCryptoAPI: importKey() for EC keys
 // META: timeout=long
+// META: script=../util/helpers.js
 
 // Test importKey and exportKey for EC algorithms. Only "happy paths" are
 // currently tested - those where the operation should succeed.
@@ -110,6 +111,7 @@
             return subtle.importKey(format, keyData, algorithm, extractable, usages).
             then(function(key) {
                 assert_equals(key.constructor, CryptoKey, "Imported a CryptoKey object");
+                assert_goodCryptoKey(key, algorithm, extractable, usages, (format === 'pkcs8' || (format === 'jwk' && keyData.d)) ? 'private' : 'public');
                 if (!extractable) {
                     return;
                 }

--- a/WebCryptoAPI/import_export/okp_importKey.https.any.js
+++ b/WebCryptoAPI/import_export/okp_importKey.https.any.js
@@ -1,5 +1,6 @@
 // META: title=WebCryptoAPI: importKey() for OKP keys
 // META: timeout=long
+// META: script=../util/helpers.js
 
 // Test importKey and exportKey for OKP algorithms. Only "happy paths" are
 // currently tested - those where the operation should succeed.
@@ -104,6 +105,7 @@
             return subtle.importKey(format, keyData[format], algorithm, extractable, usages).
             then(function(key) {
                 assert_equals(key.constructor, CryptoKey, "Imported a CryptoKey object");
+                assert_goodCryptoKey(key, algorithm, extractable, usages, (format === 'pkcs8' || (format === 'jwk' && keyData[format].d)) ? 'private' : 'public');
                 if (!extractable) {
                     return;
                 }

--- a/WebCryptoAPI/import_export/rsa_importKey.https.any.js
+++ b/WebCryptoAPI/import_export/rsa_importKey.https.any.js
@@ -1,5 +1,6 @@
 // META: title=WebCryptoAPI: importKey() for RSA keys
 // META: timeout=long
+// META: script=../util/helpers.js
 
 // Test importKey and exportKey for RSA algorithms. Only "happy paths" are
 // currently tested - those where the operation should succeed.
@@ -113,6 +114,7 @@
             return subtle.importKey(format, keyData[format], algorithm, extractable, usages).
             then(function(key) {
                 assert_equals(key.constructor, CryptoKey, "Imported a CryptoKey object");
+                assert_goodCryptoKey(key, algorithm, extractable, usages, (format === 'pkcs8' || (format === 'jwk' && keyData[format].d)) ? 'private' : 'public');
                 if (!extractable) {
                     return;
                 }

--- a/WebCryptoAPI/import_export/symmetric_importKey.https.any.js
+++ b/WebCryptoAPI/import_export/symmetric_importKey.https.any.js
@@ -1,5 +1,6 @@
 // META: title=WebCryptoAPI: importKey() for symmetric keys
 // META: timeout=long
+// META: script=../util/helpers.js
 
 // Test importKey and exportKey for non-PKC algorithms. Only "happy paths" are
 // currently tested - those where the operation should succeed.
@@ -57,6 +58,10 @@
         });
     });
 
+    function hasLength(algorithm) {
+        return algorithm.name === 'HMAC' || algorithm.name.startsWith('AES')
+    }
+
     // Test importKey with a given key format and other parameters. If
     // extrable is true, export the key and verify that it matches the input.
     function testFormat(format, algorithm, keyData, keySize, usages, extractable) {
@@ -64,6 +69,7 @@
             return subtle.importKey(format, keyData, algorithm, extractable, usages).
             then(function(key) {
                 assert_equals(key.constructor, CryptoKey, "Imported a CryptoKey object");
+                assert_goodCryptoKey(key, hasLength(key.algorithm) ? { length: keySize, ...algorithm } : algorithm, extractable, usages, 'secret');
                 if (!extractable) {
                     return;
                 }

--- a/WebCryptoAPI/import_export/symmetric_importKey.https.any.js
+++ b/WebCryptoAPI/import_export/symmetric_importKey.https.any.js
@@ -59,7 +59,7 @@
     });
 
     function hasLength(algorithm) {
-        return algorithm.name === 'HMAC' || algorithm.name.startsWith('AES')
+        return algorithm.name === 'HMAC' || algorithm.name.startsWith('AES');
     }
 
     // Test importKey with a given key format and other parameters. If

--- a/WebCryptoAPI/util/helpers.js
+++ b/WebCryptoAPI/util/helpers.js
@@ -19,7 +19,7 @@ var registeredAlgorithmNames = [
     "SHA-256",
     "SHA-384",
     "SHA-512",
-    "HKDF-CTR",
+    "HKDF",
     "PBKDF2",
     "Ed25519",
     "Ed448",
@@ -104,9 +104,6 @@ function assert_goodCryptoKey(key, algorithm, extractable, usages, kind) {
 
     assert_equals(key.constructor, CryptoKey, "Is a CryptoKey");
     assert_equals(key.type, kind, "Is a " + kind + " key");
-    if (key.type === "public") {
-        extractable = true; // public keys are always extractable
-    }
     assert_equals(key.extractable, extractable, "Extractability is correct");
 
     assert_equals(key.algorithm.name, registeredAlgorithmName, "Correct algorithm name");


### PR DESCRIPTION
Adds assert for successful imports.