### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=252312

### DIFF
--- a/css/css-properties-values-api/animation/custom-property-transition-property-all.html
+++ b/css/css-properties-values-api/animation/custom-property-transition-property-all.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<length>",
+  from: "100px",
+  to: "200px",
+  expected: "150px",
+  transitionProperty: "all"
+}, 'A custom property can yield a CSS Transition with transition-property: all');
+
+</script>

--- a/css/css-properties-values-api/resources/utils.js
+++ b/css/css-properties-values-api/resources/utils.js
@@ -183,6 +183,8 @@ function transition_test(options, description) {
   promise_test(async () => {
     const customProperty = generate_name();
 
+    options.transitionProperty ??= customProperty;
+
     CSS.registerProperty({
       name: customProperty,
       syntax: options.syntax,
@@ -199,7 +201,7 @@ function transition_test(options, description) {
       });
     });
 
-    target.style.transition = `${customProperty} 1s -500ms linear`;
+    target.style.transition = `${options.transitionProperty} 1s -500ms linear`;
     target.style.setProperty(customProperty, options.to);
 
     const animations = target.getAnimations();


### PR DESCRIPTION
WebKit export from bug: [\[css-transitions\] `transition-property: all` does not apply to custom properties](https://bugs.webkit.org/show_bug.cgi?id=252312)