### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=252205

### DIFF
--- a/css/css-rhythm/parsing/block-step-size-computed.html
+++ b/css/css-rhythm/parsing/block-step-size-computed.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-size computed values</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<meta name="assert" content="Checking computed values for block-step-size">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+    #target {
+      font-size: 40px;
+    }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+    test_computed_value("block-step-size", "0px");
+    test_computed_value("block-step-size", "none");
+    test_computed_value("block-step-size", "100px");
+    test_computed_value("block-step-size", "2em", "80px");
+    test_computed_value("block-step-size", "calc(10px + 0.5em)", "30px");
+    test_computed_value("block-step-size", "calc(10px - 0.5em)", "0px");
+</script>
+</body>
+</html>

--- a/css/css-rhythm/parsing/block-step-size-invalid.html
+++ b/css/css-rhythm/parsing/block-step-size-invalid.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-size invalid values</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<meta name="assert" content="Invalid values for block-step-size should not be parsed">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+    #target {
+      font-size: 40px;
+    }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+    test_invalid_value("block-step-size", "auto");
+    test_invalid_value("block-step-size", "-1px");
+    test_invalid_value("block-step-size", "min-content");
+    test_invalid_value("block-step-size", "10%");
+    test_invalid_value("block-step-size", "20");
+</script>
+</body>
+</html>

--- a/css/css-rhythm/parsing/block-step-size-valid.html
+++ b/css/css-rhythm/parsing/block-step-size-valid.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-size valid values</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<meta name="assert" content="Parsing valid values for block-step-size properties">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+    #target {
+      font-size: 40px;
+    }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+    test_valid_value("block-step-size", "1px");
+    test_valid_value("block-step-size", "2em");
+    test_valid_value("block-step-size", "0", "0px");
+    test_valid_value("block-step-size", "none");
+    test_valid_value("block-step-size", "calc(2em + 3ex)");
+    test_valid_value("block-step-size", "1.2em");
+</script>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[rhythmic-sizing\] Add block-step-size to CSS parser](https://bugs.webkit.org/show_bug.cgi?id=252205)