### PR TITLE
Update metadata for context.any.sharedworker-module.html

### DIFF
--- a/infrastructure/metadata/infrastructure/server/context.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/context.any.js.ini
@@ -1,7 +1,3 @@
-[context.any.sharedworker-module.html]
-  expected:
-    if product == "firefox": TIMEOUT # https://bugzilla.mozilla.org/show_bug.cgi?id=1247687
-
 [context.any.serviceworker.html]
   [context]
     expected:


### PR DESCRIPTION
It's now passing as https://bugzilla.mozilla.org/show_bug.cgi?id=1247687
was fixed.
