### PR TITLE
Reducing Vulnerabilities using Snyk tool 

### DIFF
--- a/css/tools/requirements.txt
+++ b/css/tools/requirements.txt
@@ -3,6 +3,6 @@
 Template-Python==0.1.post1
 html5lib==1.1
 lxml==4.9.1
-mercurial==4.6.1
+mercurial==4.9
 six==1.16.0
 webencodings==0.5.1

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:rolling
 
 # No interactive frontend during docker build
 ENV DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Upgraded mercurial from 4.6.1 to 4.9 (Check snyk reports)
Used ubuntu:rolling instead of ubuntu:20.04 to reduce vulnerabilities.