### PR TITLE
[css-values] rewrite tests that check against `180deg`

### DIFF
--- a/css/css-values/acos-asin-atan-atan2-computed.html
+++ b/css/css-values/acos-asin-atan-atan2-computed.html
@@ -37,7 +37,7 @@ test_math_used('calc(atan(tan(0.7853975rad ) ))', '45deg', {type:'angle', approx
 test_math_used('calc(atan(tan(3.14159 / 4 + 1 - 1) ))', '45deg', {type:'angle', approx:0.1});
 test_math_used('calc(asin(sin(0.25turn)) )', '90deg', {type:'angle', approx:0.1});
 test_math_used('calc(atan2(0,1))', '0deg', {type:'angle', approx:0.1});
-test_math_used('calc(atan2(0,-1))', '-180deg', {type:'angle', approx:0.1});
+test_math_used('calc(atan2(0,-1) / 4)', '45deg', {type:'angle', approx:0.1}); // atan2(0,-1) equals 180deg, result is divided to avoid ambiguity with -180deg
 test_math_used('calc(atan2(1,-1))', '135deg', {type:'angle', approx:0.1});
 test_math_used('calc(atan2(-1,1))', '-45deg', {type:'angle', approx:0.1});
 

--- a/css/css-values/minmax-angle-computed.html
+++ b/css/css-values/minmax-angle-computed.html
@@ -46,14 +46,14 @@ test_angle_equals('min(270deg, max(0.25turn, 3.14rad))', '3.14rad');
 test_angle_equals('max(0.25turn, min(270deg, 3.14rad))', '3.14rad');
 
 // General calculations
-test_angle_equals('calc(min(90deg, 1.58rad) + 0.25turn)', '180deg');
+test_angle_equals('calc(min(90deg, 1.58rad) + 0.125turn)', '135deg');
 test_angle_equals('calc(min(90deg, 1.58rad) - 0.125turn)', '45deg');
-test_angle_equals('calc(min(90deg, 1.58rad) * 2', '180deg');
+test_angle_equals('calc(min(90deg, 1.58rad) * 1.5', '135deg');
 test_angle_equals('calc(min(90deg, 1.58rad) / 2', '45deg');
-test_angle_equals('calc(max(90deg, 1.56rad) + 0.25turn)', '180deg');
+test_angle_equals('calc(max(90deg, 1.56rad) + 0.125turn', '135deg');
 test_angle_equals('calc(max(90deg, 1.56rad) - 0.125turn)', '45deg');
-test_angle_equals('calc(max(90deg, 1.56rad) * 2', '180deg');
+test_angle_equals('calc(max(90deg, 1.56rad) * 1.5', '135deg');
 test_angle_equals('calc(max(90deg, 1.56rad) / 2', '45deg');
-test_angle_equals('calc(min(90deg, 1.58rad) + max(0.25turn, 99grad))', '180deg');
+test_angle_equals('calc(min(90deg, 1.58rad) + max(0.125turn, 49grad))', '135deg');
 test_angle_equals('calc(min(90deg, 1.58rad) - max(0.25turn, 99grad))', '0deg');
 </script>


### PR DESCRIPTION
Checking against `180deg` doesn't validate the sign of the outcome.
In these tests `180deg` is equivalent to `-180deg`.

But `180deg / 4` is not the same as `-180deg / 4`.
Always using something other than `180` makes sure that the sign of the result is correctly tested.