### PR TITLE
docs: fix wrong python version

### DIFF
--- a/docs/running-tests/from-local-system.md
+++ b/docs/running-tests/from-local-system.md
@@ -33,7 +33,7 @@ installed for the user only:
 
 ```bash
 python -m ensurepip --user
-export PATH="$PATH:$HOME/Library/Python/2.7/bin"
+export PATH="$PATH:$( python3 -m site --user-base )/bin"
 pip install --user virtualenv
 ```
 


### PR DESCRIPTION
The path is set for Python 2.7, but wpt uses Python 3. 