### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=252470

### DIFF
--- a/css/css-transitions/parsing/transition-invalid.html
+++ b/css/css-transitions/parsing/transition-invalid.html
@@ -19,6 +19,9 @@ test_invalid_value("transition", "-1s -2s");
 test_invalid_value("transition", "steps(1) steps(2)");
 
 test_invalid_value("transition", "none top");
+
+test_invalid_value("transition", "initial 1s");
+
 </script>
 </body>
 </html>

--- a/css/css-transitions/parsing/transition-valid.html
+++ b/css/css-transitions/parsing/transition-valid.html
@@ -22,6 +22,11 @@ test_valid_value("transition", "top", ["top", "top 0s ease 0s"]);
 test_valid_value("transition", "1s -3s cubic-bezier(0, -2, 1, 3) top", "top 1s cubic-bezier(0, -2, 1, 3) -3s");
 test_valid_value("transition", "1s -3s, cubic-bezier(0, -2, 1, 3) top", ["1s -3s, top cubic-bezier(0, -2, 1, 3)", "all 1s ease -3s, top 0s cubic-bezier(0, -2, 1, 3) 0s"]);
 
+test_valid_value("transition", "all", ["all", "all 0s ease 0s"]);
+test_valid_value("transition", "all 1s", ["1s", "all 1s ease 0s"]);
+
+test_valid_value("transition", "initial", "initial");
+
 // TODO: Add test with a single negative time.
 // TODO: Add test with a single timing-function keyword.
 </script>


### PR DESCRIPTION
WebKit export from bug: [\[css-transitions\] add WPT coverage for `transition: all` and `transition: initial`](https://bugs.webkit.org/show_bug.cgi?id=252470)