### PR TITLE
URL: fix invalid IPv6 test

### DIFF
--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -967,17 +967,7 @@
   {
     "input": "http://[::127.0.0.1.]",
     "base": "http://example.org/foo/bar",
-    "href": "http://[::7f00:1]/",
-    "origin": "http://[::7f00:1]",
-    "protocol": "http:",
-    "username": "",
-    "password": "",
-    "host": "[::7f00:1]",
-    "hostname": "[::7f00:1]",
-    "port": "",
-    "pathname": "/",
-    "search": "",
-    "hash": ""
+    "failure": true
   },
   {
     "input": "http://[0:0:0:0:0:0:13.1.68.3]",


### PR DESCRIPTION
This test was introduced in the https://github.com/web-platform-tests/wpt/pull/38484

The result of test with input `"http://[::127.0.0.1.]"` must be failure, as IPv6 parser returns failure in the 6.5.5.2.2. step when `numbersSeen` becomes equal to `4`.

See: https://url.spec.whatwg.org/#concept-ipv6-parser