### PR TITLE
URL: correct location.href failure tests

### DIFF
--- a/url/failure.html
+++ b/url/failure.html
@@ -43,7 +43,7 @@ function runTests(testData) {
       self.test(t => {
         const frame = document.body.appendChild(document.createElement("iframe"));
         t.add_cleanup(() => frame.remove());
-        assert_throws_dom("SyntaxError", () => frame.contentWindow.location = test.input, frame.contentWindow);
+        assert_throws_dom("SyntaxError", frame.contentWindow.DOMException, () => frame.contentWindow.location = test.input);
       }, "Location's href: " + name);
 
       self.test(() => {

--- a/url/failure.html
+++ b/url/failure.html
@@ -5,7 +5,6 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <div id=log></div>
-<iframe></iframe>
 <script>
 promise_test(() => fetch("resources/urltestdata.json").then(res => res.json()).then(runTests), "Loading data…")
 
@@ -41,9 +40,11 @@ function runTests(testData) {
         assert_throws_js(TypeError, () => self.navigator.sendBeacon(test.input))
       }, "sendBeacon(): " + name)
 
-      self.test(() => {
-        assert_throws_js(self[0].TypeError, () => self[0].location = test.input)
-      }, "Location's href: " + name)
+      self.test(t => {
+        const frame = document.body.appendChild(document.createElement("iframe"));
+        t.add_cleanup(() => frame.remove());
+        assert_throws_dom("SyntaxError", () => frame.contentWindow.location = test.input, frame.contentWindow);
+      }, "Location's href: " + name);
 
       self.test(() => {
         assert_throws_dom("SyntaxError", () => self.open(test.input).close())


### PR DESCRIPTION
Tests depended on results of prior tests and the tested exception was incorrect per the HTML Standard.

---

Firefox and Safari did throw a `TypeError` (correct global seemingly). Chrome threw a "`SyntaxError`", but wrong global. Good times.