### PR TITLE
Test navigator.credentials.preventSilentAccess()

### DIFF
--- a/credential-management/credentialscontainer-prevent-silent-access.https.html
+++ b/credential-management/credentialscontainer-prevent-silent-access.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>Credential Management API: preventSilentAccess().</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(function() {
+    return navigator.credentials.preventSilentAccess()
+        .then((result) => {
+            assert_equals(result, undefined);
+        });
+}, "navigator.credentials.preventSilentAccess() resolves with undefined.");
+</script>


### PR DESCRIPTION
This test checks that implementations of preventSilentAccess match the specification. Safari currently unconditionally throws a "NotSupportedError: Not implemented." despite implementing the function.