### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=252536

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/modal-dialog-backdrop-opacity-ref.html
+++ b/html/semantics/interactive-elements/the-dialog-element/modal-dialog-backdrop-opacity-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<link rel="stylesheet" href="resources/dialog.css">
+<style>
+.backdrop {
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+
+    background-color: green;
+    opacity: 0.5;
+}
+</style>
+<body>
+<div class="backdrop"></div>
+<div class="pseudodialog">Test passes if you see a green backdrop at half opacity.</div>
+</body>
+</html>

--- a/html/semantics/interactive-elements/the-dialog-element/modal-dialog-backdrop-opacity.html
+++ b/html/semantics/interactive-elements/the-dialog-element/modal-dialog-backdrop-opacity.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="match" href="modal-dialog-backdrop-opacity-ref.html">
+<link rel="help" href="https://fullscreen.spec.whatwg.org/#user-agent-level-style-sheet-defaults">
+<style>
+dialog::backdrop {
+    background-color: rgb(0, 128, 0);
+    opacity: 0.5;
+}
+</style>
+<body>
+<dialog>Test passes if you see a green backdrop at half opacity.</dialog>
+<script>
+document.querySelector('dialog').showModal();
+</script>
+</body>


### PR DESCRIPTION
WebKit export from bug: [REGRESSION(257538@main): CSS opacity doesn't work on dialog::backdrop](https://bugs.webkit.org/show_bug.cgi?id=252536)