### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=252358

### DIFF
--- a/css/css-rhythm/block-step-size-establishes-independent-formatting-context-list-item.html
+++ b/css/css-rhythm/block-step-size-establishes-independent-formatting-context-list-item.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="block-step-size values other than none on block level elements cause the box to establish an independent formatting context">
+<style>
+div {
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    float: left;
+}
+.block-step-size {
+    display: list-item;
+    list-style: none;
+    block-step-size: 1px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="floating"></div>
+<div class="block-step-size"></div>
+</body>
+</html>

--- a/css/css-rhythm/block-step-size-establishes-independent-formatting-context.html
+++ b/css/css-rhythm/block-step-size-establishes-independent-formatting-context.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="block-step-size values other than none on block level elements cause the box to establish an independent formatting context">
+<style>
+div {
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    float: left;
+}
+.block-step-size {
+    block-step-size: 1px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="floating"></div>
+<div class="block-step-size"></div>
+</body>
+</html>

--- a/css/css-rhythm/block-step-size-none-does-not-establish-indepdendent-formatting-context.html
+++ b/css/css-rhythm/block-step-size-none-does-not-establish-indepdendent-formatting-context.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="block-step-size none should not establish an independent formatting context for the box">
+<style>
+div {
+    width: 100px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    position: relative;
+    z-index: -1;
+    float: left;
+    background-color: red;
+}
+.block-step-size {
+    block-step-size: none;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class="floating"></div>
+<div class="block-step-size"></div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[rhythmic-sizing\] block-step-size values other than none should cause the box to establish an independent formatting context](https://bugs.webkit.org/show_bug.cgi?id=252358)