### PR TITLE
dom, domxpath: Update lookupNamespaceURI() and createNSResolver()

### DIFF
--- a/dom/nodes/Node-lookupNamespaceURI.html
+++ b/dom/nodes/Node-lookupNamespaceURI.html
@@ -26,6 +26,7 @@ var frag = document.createDocumentFragment();
 lookupNamespaceURI(frag, null, null, 'DocumentFragment should have null namespace, prefix null');
 lookupNamespaceURI(frag, '', null, 'DocumentFragment should have null namespace, prefix ""');
 lookupNamespaceURI(frag, 'foo', null, 'DocumentFragment should have null namespace, prefix "foo"');
+lookupNamespaceURI(frag, 'xml', null, 'DocumentFragment should have null namespace, prefix "xml"');
 lookupNamespaceURI(frag, 'xmlns', null, 'DocumentFragment should have null namespace, prefix "xmlns"');
 isDefaultNamespace(frag, null, true, 'DocumentFragment is in default namespace, prefix null');
 isDefaultNamespace(frag, '', true, 'DocumentFragment is in default namespace, prefix ""');
@@ -36,6 +37,7 @@ var docType = document.doctype;
 lookupNamespaceURI(docType, null, null, 'DocumentType should have null namespace, prefix null');
 lookupNamespaceURI(docType, '', null, 'DocumentType should have null namespace, prefix ""');
 lookupNamespaceURI(docType, 'foo', null, 'DocumentType should have null namespace, prefix "foo"');
+lookupNamespaceURI(docType, 'xml', null, 'DocumentType should have null namespace, prefix "xml"');
 lookupNamespaceURI(docType, 'xmlns', null, 'DocumentType should have null namespace, prefix "xmlns"');
 isDefaultNamespace(docType, null, true, 'DocumentType is in default namespace, prefix null');
 isDefaultNamespace(docType, '', true, 'DocumentType is in default namespace, prefix ""');
@@ -44,23 +46,25 @@ isDefaultNamespace(docType, 'xmlns', false, 'DocumentType is in default namespac
 
 var fooElem = document.createElementNS('fooNamespace', 'prefix:elem');
 fooElem.setAttribute('bar', 'value');
-
+const XMLNS_NS = 'http://www.w3.org/2000/xmlns/';
+const XML_NS =  'http://www.w3.org/XML/1998/namespace';
 lookupNamespaceURI(fooElem, null, null, 'Element should have null namespace, prefix null');
 lookupNamespaceURI(fooElem, '', null, 'Element should have null namespace, prefix ""');
 lookupNamespaceURI(fooElem, 'fooNamespace', null, 'Element should not have namespace matching prefix with namespaceURI value');
-lookupNamespaceURI(fooElem, 'xmlns', null, 'Element should not have XMLNS namespace');
+lookupNamespaceURI(fooElem, 'xml', XML_NS, 'Element should have XML namespace');
+lookupNamespaceURI(fooElem, 'xmlns', XMLNS_NS, 'Element should have XMLNS namespace');
 lookupNamespaceURI(fooElem, 'prefix', 'fooNamespace', 'Element has namespace URI matching prefix');
 isDefaultNamespace(fooElem, null, true, 'Empty namespace is not default, prefix null');
 isDefaultNamespace(fooElem, '', true, 'Empty namespace is not default, prefix ""');
 isDefaultNamespace(fooElem, 'fooNamespace', false, 'fooNamespace is not default');
-isDefaultNamespace(fooElem, 'http://www.w3.org/2000/xmlns/', false, 'xmlns namespace is not default');
+isDefaultNamespace(fooElem, XMLNS_NS, false, 'xmlns namespace is not default');
 
-fooElem.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:bar', 'barURI');
-fooElem.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns', 'bazURI');
+fooElem.setAttributeNS(XMLNS_NS, 'xmlns:bar', 'barURI');
+fooElem.setAttributeNS(XMLNS_NS, 'xmlns', 'bazURI');
 
 lookupNamespaceURI(fooElem, null, 'bazURI', 'Element should have baz namespace, prefix null');
 lookupNamespaceURI(fooElem, '', 'bazURI', 'Element should have baz namespace, prefix ""');
-lookupNamespaceURI(fooElem, 'xmlns', null, 'Element does not has namespace with xlmns prefix');
+lookupNamespaceURI(fooElem, 'xmlns', XMLNS_NS, 'Element should have namespace with xmlns prefix');
 lookupNamespaceURI(fooElem, 'bar', 'barURI', 'Element has bar namespace');
 
 isDefaultNamespace(fooElem, null, false, 'Empty namespace is not default on fooElem, prefix null');
@@ -79,7 +83,7 @@ lookupNamespaceURI(comment, 'bar', 'barURI', 'Comment should inherit bar namespa
 isDefaultNamespace(comment, null, false, 'For comment, empty namespace is not default, prefix null');
 isDefaultNamespace(comment, '', false, 'For comment, empty namespace is not default, prefix ""');
 isDefaultNamespace(comment, 'fooNamespace', false, 'For comment, fooNamespace is not default');
-isDefaultNamespace(comment, 'http://www.w3.org/2000/xmlns/', false, 'For comment, xmlns namespace is not default');
+isDefaultNamespace(comment, XMLNS_NS, false, 'For comment, xmlns namespace is not default');
 isDefaultNamespace(comment, 'barURI', false, 'For comment, inherited bar namespace is not default');
 isDefaultNamespace(comment, 'bazURI', true, 'For comment, inherited baz namespace is default');
 
@@ -88,19 +92,19 @@ fooElem.appendChild(fooChild);
 
 lookupNamespaceURI(fooChild, null, 'childNamespace', 'Child element should inherit baz namespace');
 lookupNamespaceURI(fooChild, '', 'childNamespace', 'Child element should have null namespace');
-lookupNamespaceURI(fooChild, 'xmlns', null, 'Child element should not have XMLNS namespace');
+lookupNamespaceURI(fooChild, 'xmlns', XMLNS_NS, 'Child element should have XMLNS namespace');
 lookupNamespaceURI(fooChild, 'prefix', 'fooNamespace', 'Child element has namespace URI matching prefix');
 
 isDefaultNamespace(fooChild, null, false, 'Empty namespace is not default for child, prefix null');
 isDefaultNamespace(fooChild, '', false, 'Empty namespace is not default for child, prefix ""');
 isDefaultNamespace(fooChild, 'fooNamespace', false, 'fooNamespace is not default for child');
-isDefaultNamespace(fooChild, 'http://www.w3.org/2000/xmlns/', false, 'xmlns namespace is not default for child');
+isDefaultNamespace(fooChild, XMLNS_NS, false, 'xmlns namespace is not default for child');
 isDefaultNamespace(fooChild, 'barURI', false, 'bar namespace is not default for child');
 isDefaultNamespace(fooChild, 'bazURI', false, 'baz namespace is default for child');
 isDefaultNamespace(fooChild, 'childNamespace', true, 'childNamespace is default for child');
 
-document.documentElement.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:bar', 'barURI');
-document.documentElement.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns', 'bazURI');
+document.documentElement.setAttributeNS(XMLNS_NS, 'xmlns:bar', 'barURI');
+document.documentElement.setAttributeNS(XMLNS_NS, 'xmlns', 'bazURI');
 
 lookupNamespaceURI(document, null, 'http://www.w3.org/1999/xhtml', 'Document should have xhtml namespace, prefix null');
 lookupNamespaceURI(document, '', 'http://www.w3.org/1999/xhtml', 'Document should have xhtml namespace, prefix ""');
@@ -110,10 +114,21 @@ lookupNamespaceURI(document, 'bar', 'barURI', 'Document has bar namespace');
 isDefaultNamespace(document, null, false, 'For document, empty namespace is not default, prefix null');
 isDefaultNamespace(document, '', false, 'For document, empty namespace is not default, prefix ""');
 isDefaultNamespace(document, 'fooNamespace', false, 'For document, fooNamespace is not default');
-isDefaultNamespace(document, 'http://www.w3.org/2000/xmlns/', false, 'For document, xmlns namespace is not default');
+isDefaultNamespace(document, XMLNS_NS, false, 'For document, xmlns namespace is not default');
 isDefaultNamespace(document, 'barURI', false, 'For document, bar namespace is not default');
 isDefaultNamespace(document, 'bazURI', false, 'For document, baz namespace is not default');
 isDefaultNamespace(document, 'http://www.w3.org/1999/xhtml', true, 'For document, xhtml namespace is default');
+
+const doc = new Document();
+lookupNamespaceURI(doc, 'xml', null, 'Document without documentElement has no namespace URI matching "xml"');
+lookupNamespaceURI(doc, 'xmlns', null, 'Document without documentElement has no namespace URI matching "xmlns"');
+
+const attr = document.createAttribute('foo');
+lookupNamespaceURI(attr, 'xml', null, 'Disconnected Attr has no namespace URI matching "xml"');
+lookupNamespaceURI(attr, 'xmlns', null, 'Disconnected Attr has no namespace URI matching "xmlns"');
+document.body.setAttributeNode(attr);
+lookupNamespaceURI(attr, 'xml', XML_NS, 'Connected Attr has namespace URI matching "xml"');
+lookupNamespaceURI(attr, 'xmlns', XMLNS_NS, 'Connected Attr no namespace URI matching "xmlns"');
 
 var comment = document.createComment('comment');
 document.appendChild(comment);

--- a/domxpath/xpathevaluatorbase-creatensresolver.html
+++ b/domxpath/xpathevaluatorbase-creatensresolver.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<body>
+<script>
+[document, new XPathEvaluator()].forEach(evaluator => {
+  test(() => {
+    assert_equals(evaluator.createNSResolver(document), document, 'Document');
+    const fragment = document.createDocumentFragment();
+    assert_equals(evaluator.createNSResolver(fragment), fragment,
+                  'DocumentFragment');
+    assert_equals(evaluator.createNSResolver(document.doctype),
+                  document.doctype, 'DocumentType');
+    assert_equals(evaluator.createNSResolver(document.body), document.body,
+                  'Element');
+    assert_equals(evaluator.createNSResolver(document.body.firstChild),
+                  document.body.firstChild, 'Text');
+    const attr = document.createAttribute('foo');
+    assert_equals(evaluator.createNSResolver(attr), attr, 'Attr');
+  }, `createNSResolver() should return the specified node as is. (${evaluator.constructor.name})`);
+
+  function createAndLookup(evaluator, node) {
+    return evaluator.createNSResolver(node).lookupNamespaceURI('xml');
+  }
+
+  test(() => {
+    assert_equals(createAndLookup(evaluator, new Document()), null, 'Document');
+    assert_equals(createAndLookup(evaluator, new DocumentFragment()), null,
+                  'DocumentFragment');
+    assert_equals(createAndLookup(evaluator, document.doctype), null,
+                  'DocumentType');
+    assert_equals(createAndLookup(evaluator, document.createElement('body')),
+                  'http://www.w3.org/XML/1998/namespace', 'Element');
+    assert_equals(createAndLookup(evaluator, document.createTextNode('foo')),
+                  null, 'Text');
+    assert_equals(createAndLookup(evaluator, document.createAttribute('bar')),
+                  null, 'Attr');
+  }, `createNSResolver() resultant object should not add support of 'xml' prefix. (${evaluator.constructor.name})`);
+});
+</script>
+</body>


### PR DESCRIPTION
for https://github.com/whatwg/dom/pull/1165.

lookupNamespaceURI():
  Element should handle "xml" and "xmlns" by default.

createNSResolver():
  It should return the argument as is, and should not add "xml" prefix support.