### PR TITLE
use get_title() in ShellTestEnvironment.prototype.next_default_test_name

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -494,7 +494,7 @@
     ShellTestEnvironment.prototype.next_default_test_name = function() {
         var suffix = this.name_counter > 0 ? " " + this.name_counter : "";
         this.name_counter++;
-        return "Untitled" + suffix;
+        return get_title() + suffix;
     };
 
     ShellTestEnvironment.prototype.on_new_harness_properties = function() {};


### PR DESCRIPTION
This would allow the proprietary Node.js runner to get correct titles for default test name tests.