### PR TITLE
[image-set] Don't expect an image to render if there are no supported types in the image-set

### DIFF
--- a/css/css-images/image-set/image-set-type-unsupported-rendering-2.html
+++ b/css/css-images/image-set/image-set-type-unsupported-rendering-2.html
@@ -3,7 +3,7 @@
 <link rel="author" title="Noam Rosenthal" href="mailto:noam@webkit.org">
 <link rel="author" title="Traian Captan" href="mailto:tcaptan@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-images-4/#image-set-notation">
-<link rel="match" href="reference/image-set-rendering-ref.html">
+<link rel="match" href="/css/reference/blank.html">
 <meta name="assert" content="image-set rendering with all unsupported types">
 <!--
 Spec definition:
@@ -16,9 +16,6 @@ If all the values in the image set are of an unsupported type,
 the set should be empty.
 
 "This has no effect on the validity of the image-set() function"
-
-https://github.com/w3c/csswg-drafts/issues/8266 to define what the result
-should be here, maybe an alternative would be to not render an image at all.
 -->
 <style>
   #test {

--- a/css/css-images/image-set/image-set-type-unsupported-rendering.html
+++ b/css/css-images/image-set/image-set-type-unsupported-rendering.html
@@ -3,7 +3,7 @@
 <link rel="author" title="Noam Rosenthal" href="mailto:noam@webkit.org">
 <link rel="author" title="Traian Captan" href="mailto:tcaptan@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-images-4/#image-set-notation">
-<link rel="match" href="reference/image-set-rendering-ref.html">
+<link rel="match" href="/css/reference/blank.html">
 <meta name="assert" content="image-set rendering with unsupported type">
 <!--
 Spec definition:
@@ -12,10 +12,10 @@ Spec definition:
   First, remove any <image-set-option>s from the list that specify
   an unknown or unsupported MIME type in their type() value."
 
-"This has no effect on the validity of the image-set() function"
+If all the values in the image set are of an unsupported type,
+the set should be empty.
 
-https://github.com/w3c/csswg-drafts/issues/8266 to define what the result
-should be here, maybe an alternative would be to not render an image at all.
+"This has no effect on the validity of the image-set() function"
 -->
 <style>
   #test {


### PR DESCRIPTION

If the image-set does not contain any images with a supported MIME type the image set is valid but empty. In that case we shouldn't expect any image to render.

See https://github.com/w3c/csswg-drafts/issues/8266 for discussion.