### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=252656

### DIFF
--- a/css/css-masking/animations/mask-image-interpolation.html
+++ b/css/css-masking/animations/mask-image-interpolation.html
@@ -28,102 +28,53 @@
 <body>
 <script>
 // neutral
-test_interpolation({
+test_no_interpolation({
   property: 'mask-image',
   from: neutralKeyframe,
   to: 'url(../resources/green-20.png)',
-}, [
-  {at: -0.3, expect: 'url(../resources/stripes-20.png)'},
-  {at: 0, expect: 'url(../resources/stripes-20.png)'},
-  {at: 0.3, expect: 'url(../resources/stripes-20.png)'},
-  {at: 0.6, expect: 'url(../resources/green-20.png)'},
-  {at: 1, expect: 'url(../resources/green-20.png)'},
-  {at: 1.5, expect: 'url(../resources/green-20.png)'},
-]);
+});
 
 // initial
-test_interpolation({
+test_no_interpolation({
   property: 'mask-image',
   from: 'initial',
   to: 'url(../resources/green-20.png)',
-}, [
-  {at: -0.3, expect: 'none'},
-  {at: 0, expect: 'none'},
-  {at: 0.3, expect: 'none'},
-  {at: 0.6, expect: 'url(../resources/green-20.png)'},
-  {at: 1, expect: 'url(../resources/green-20.png)'},
-  {at: 1.5, expect: 'url(../resources/green-20.png)'},
-]);
+});
 
 // inherit
-test_interpolation({
+test_no_interpolation({
   property: 'mask-image',
   from: 'inherit',
   to: 'url(../resources/green-20.png)',
-}, [
-  {at: -0.3, expect: 'url(../resources/blue-20.png)'},
-  {at: 0, expect: 'url(../resources/blue-20.png)'},
-  {at: 0.3, expect: 'url(../resources/blue-20.png)'},
-  {at: 0.6, expect: 'url(../resources/green-20.png)'},
-  {at: 1, expect: 'url(../resources/green-20.png)'},
-  {at: 1.5, expect: 'url(../resources/green-20.png)'},
-]);
+});
 
 // unset
-test_interpolation({
+test_no_interpolation({
   property: 'mask-image',
   from: 'unset',
   to: 'url(../resources/stripes-20.png)',
-}, [
-  {at: -0.3, expect: 'none'},
-  {at: 0, expect: 'none'},
-  {at: 0.3, expect: 'none'},
-  {at: 0.6, expect: 'url(../resources/stripes-20.png)'},
-  {at: 1, expect: 'url(../resources/stripes-20.png)'},
-  {at: 1.5, expect: 'url(../resources/stripes-20.png)'},
-]);
+});
 
 // Image to image
-test_interpolation({
+test_no_interpolation({
   property: 'mask-image',
   from: 'url(../resources/stripes-20.png)',
   to: 'url(../resources/blue-20.png)',
-}, [
-  {at: -0.3, expect: 'url(../resources/stripes-20.png)'},
-  {at: 0, expect: 'url(../resources/stripes-20.png)'},
-  {at: 0.3, expect: 'url(../resources/stripes-20.png)'},
-  {at: 0.6, expect: 'url(../resources/blue-20.png)'},
-  {at: 1, expect: 'url(../resources/blue-20.png)'},
-  {at: 1.5, expect: 'url(../resources/blue-20.png)'},
-]);
+});
 
 //Image to gradient
-test_interpolation({
+test_no_interpolation({
   property: 'mask-image',
   from: 'url(../resources/stripes-20.png)',
   to: 'linear-gradient(45deg, blue, transparent)'
-}, [
-  {at: -0.3, expect: 'url(../resources/stripes-20.png)'},
-  {at: 0, expect: 'url(../resources/stripes-20.png)'},
-  {at: 0.3, expect: 'url(../resources/stripes-20.png)'},
-  {at: 0.6, expect: 'linear-gradient(45deg, blue, transparent)'},
-  {at: 1, expect: 'linear-gradient(45deg, blue, transparent)'},
-  {at: 1.5, expect: 'linear-gradient(45deg, blue, transparent)'},
-]);
+});
 
 // Keyword to image
-test_interpolation({
+test_no_interpolation({
   property: 'mask-image',
   from: 'none',
   to: 'url(../resources/green-20.png)',
-}, [
-  {at: -0.3, expect: 'none'},
-  {at: 0, expect: 'none'},
-  {at: 0.3, expect: 'none'},
-  {at: 0.6, expect: 'url(../resources/green-20.png)'},
-  {at: 1, expect: 'url(../resources/green-20.png)'},
-  {at: 1.5, expect: 'url(../resources/green-20.png)'},
-]);
+});
 
 // Multiple to multiple
 var fromA = 'url(../resources/stripes-20.png)';
@@ -132,49 +83,28 @@ var toA = 'url(../resources/blue-20.png)';
 var toB = 'url(../resources/stripes-20.png)';
 var from = fromA + ', ' + fromB;
 var to = toA + ', ' + toB;
-test_interpolation({
+test_no_interpolation({
   property: 'mask-image',
   from: from,
   to: to,
-}, [
-  {at: -0.3, expect: from},
-  {at: 0, expect: from},
-  {at: 0.3, expect: from},
-  {at: 0.6, expect: to},
-  {at: 1, expect: to},
-  {at: 1.5, expect: to},
-]);
+});
 
 // Single to multiple
 from = 'url(../resources/blue-20.png)';
 toA = 'url(../resources/stripes-20.png)';
 toB = 'url(../resources/blue-20.png)';
 to = toA + ', ' + toB;
-test_interpolation({
+test_no_interpolation({
   property: 'mask-image',
   from: from,
   to: to,
-}, [
-  {at: -0.3, expect: from},
-  {at: 0, expect: from},
-  {at: 0.3, expect: from},
-  {at: 0.6, expect: to},
-  {at: 1, expect: to},
-  {at: 1.5, expect: to},
-]);
+});
 
 // Multiple mismatched types
-test_interpolation({
+test_no_interpolation({
   property: 'mask-image',
   from: 'url(../resources/blue-20.png), none',
   to: 'url(../resources/stripes-20.png), url(../resources/blue-20.png)',
-}, [
-  {at: -0.3, expect: from},
-  {at: 0, expect: from},
-  {at: 0.3, expect: from},
-  {at: 0.6, expect: to},
-  {at: 1, expect: to},
-  {at: 1.5, expect: to},
-]);
+});
 </script>
 </body>


### PR DESCRIPTION
WebKit export from bug: [\[web-animations\] mask-image should support discrete animation](https://bugs.webkit.org/show_bug.cgi?id=252656)