### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=111329

### DIFF
--- a/css/css-transitions/transition-important.html
+++ b/css/css-transitions/transition-important.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>CSS Transitions Test: !important property</title>
+<link rel="help" href="https://drafts.csswg.org/css-cascade-5/#cascade-sort">
+<script src="/resources/testharness.js" type="text/javascript"></script>
+<script src="/resources/testharnessreport.js" type="text/javascript"></script>
+<style>
+#target {
+    width: 200px;
+    height: 200px;
+    background-color: green;
+    transition: background-color 100s;
+}
+.red {
+    background-color: red !important;
+}
+</style>
+<div id="target"></div>
+<script>
+test(t => {
+    assert_equals(getComputedStyle(target).backgroundColor, "rgb(0, 128, 0)");
+    target.className = "red";
+    assert_equals(getComputedStyle(target).backgroundColor, "rgb(0, 128, 0)");
+}, "!important should not override transition");
+</script>


### PR DESCRIPTION
WebKit export from bug: [REGRESSION (258514@main): Transition of !important property fails to animate](https://bugs.webkit.org/show_bug.cgi?id=111329)