### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=253073

### DIFF
--- a/background-fetch/mixed-content-and-allowed-schemes.https.window.js
+++ b/background-fetch/mixed-content-and-allowed-schemes.https.window.js
@@ -30,22 +30,29 @@ backgroundFetchTest((t, bgFetch) => {
   return bgFetch.fetch(uniqueId(), 'http://localhost');
 }, 'localhost http: fetch should register ok');
 
+function testBgFetch(bgFetch, url)
+{
+  return bgFetch.fetch(uniqueId(), url).then(fetch => {
+    return fetch.match(url);
+  }).then(match => match.responseReady);
+}
+
 backgroundFetchTest((t, bgFetch) => {
   return promise_rejects_js(t, TypeError,
-                         bgFetch.fetch(uniqueId(), 'wss:127.0.0.1'));
+                         testBgFetch(bgFetch, 'wss:127.0.0.1'));
 }, 'wss: fetch should reject');
 
 backgroundFetchTest((t, bgFetch) => {
   return promise_rejects_js(t, TypeError,
-                         bgFetch.fetch(uniqueId(), 'file:///'));
+                         testBgFetch(bgFetch, 'file:///'));
 }, 'file: fetch should reject');
 
 backgroundFetchTest((t, bgFetch) => {
   return promise_rejects_js(t, TypeError,
-                         bgFetch.fetch(uniqueId(), 'data:text/plain,foo'));
+                         testBgFetch(bgFetch, 'data:text/plain,foo'));
 }, 'data: fetch should reject');
 
 backgroundFetchTest((t, bgFetch) => {
   return promise_rejects_js(t, TypeError,
-                         bgFetch.fetch(uniqueId(), 'foobar:bazqux'));
+                         testBgFetch(bgFetch, 'foobar:bazqux'));
 }, 'unknown scheme fetch should reject');

--- a/background-fetch/port-blocking.https.window.js
+++ b/background-fetch/port-blocking.https.window.js
@@ -28,8 +28,12 @@ backgroundFetchTest((t, bgFetch) => {
   return bgFetch.fetch(uniqueId(), 'https://example.com:8080');
 }, 'fetch to non-default non-bad port (8080) should register ok');
 
-backgroundFetchTest((t, bgFetch) => {
+backgroundFetchTest(async (t, bgFetch) => {
+  const promise = bgFetch.fetch(uniqueId(), 'https://example.com:587').then(fetch => {
+    return fetch.match('https://example.com:587');
+  }).then(record => record.responseReady);
+
   return promise_rejects_js(
       t, TypeError,
-      bgFetch.fetch(uniqueId(), 'https://example.com:587'));
+      promise);
 }, 'fetch to bad port (SMTP) should reject');


### PR DESCRIPTION
WebKit export from bug: [Restrict background fetch loads to HTTP family](https://bugs.webkit.org/show_bug.cgi?id=253073)