### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=252206

### DIFF
--- a/css/css-rhythm/parsing/block-step-insert-computed.html
+++ b/css/css-rhythm/parsing/block-step-insert-computed.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-insert computed values</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-insert">
+<meta name="assert" content="Checking computed values for block-step-insert">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+    #target {
+      font-size: 40px;
+    }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+    test_computed_value("block-step-insert", "margin");
+    test_computed_value("block-step-insert", "padding");
+</script>
+</body>
+</html>

--- a/css/css-rhythm/parsing/block-step-insert-invalid.html
+++ b/css/css-rhythm/parsing/block-step-insert-invalid.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-insert invalid values</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-insert">
+<meta name="assert" content="Invalid values for block-step-insert should not be parsed">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+    #target {
+      font-size: 40px;
+    }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+    test_invalid_value("block-step-insert", "auto");
+    test_invalid_value("block-step-insert", "-1px");
+    test_invalid_value("block-step-insert", "min-content");
+    test_invalid_value("block-step-insert", "10%");
+    test_invalid_value("block-step-insert", "20");
+    test_invalid_value("block-step-insert", "none");
+    test_invalid_value("block-step-insert", "border-box");
+    test_invalid_value('block-step-insert', "margin-box");
+    test_invalid_value("block-step-insert", "margin padding");
+    test_invalid_value("block-step-insert", "padding margin");
+</script>
+</body>
+</html>

--- a/css/css-rhythm/parsing/block-step-insert-valid.html
+++ b/css/css-rhythm/parsing/block-step-insert-valid.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-insert valid values</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-insert">
+<meta name="assert" content="Parsing valid values for block-step-insert property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+    #target {
+      font-size: 40px;
+    }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+    test_valid_value("block-step-insert", "margin");
+    test_valid_value("block-step-insert", "padding");
+</script>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[rhythmic-sizing\] Add block-step-insert to CSS parser](https://bugs.webkit.org/show_bug.cgi?id=252206)