### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=252672

### DIFF
--- a/css/css-rhythm/block-step-size-0-disables-rounding.html
+++ b/css/css-rhythm/block-step-size-0-disables-rounding.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="Specifying 0 for block-step-size should not change the size of the box">
+<style>
+div {
+    inline-size: 100px;
+    block-size: 50px;
+    background-color: green;
+}
+div:first-child {
+    block-step-size: 0px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div></div>
+<div></div>
+</head>
+</html>

--- a/css/css-rhythm/block-step-size-adjustment-block-replaced-element-round-up-ref.html
+++ b/css/css-rhythm/block-step-size-adjustment-block-replaced-element-round-up-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<meta name="assert" content="Replaced element with display block should add margins according to block-step-size">
+<style>
+div {
+    inline-size: 60px;
+    block-size: 60px;
+    background-color: green;
+}
+img {
+    display: block;
+    margin-block: 45px;
+}
+</style>
+</head>
+<body>
+<img src="/css/support/60x60-green.png">
+<div></div>
+</body>
+</html>

--- a/css/css-rhythm/block-step-size-adjustment-block-replaced-element-round-up.html
+++ b/css/css-rhythm/block-step-size-adjustment-block-replaced-element-round-up.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="block-step-size-adjustment-block-replaced-element-round-up-ref.html">
+<meta name="assert" content="Replaced element with display block should add margins according to block-step-size">
+<style>
+div {
+    inline-size: 60px;
+    block-size: 60px;
+    background-color: green;
+}
+img {
+    display: block;
+    block-step-size: 150px;
+}
+</style>
+</head>
+<body>
+<img src="/css/support/60x60-green.png">
+<div></div>
+</body>
+</html>

--- a/css/css-rhythm/block-step-size-adjustment-round-up-ref.html
+++ b/css/css-rhythm/block-step-size-adjustment-round-up-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="block-step-size-adjustment-round-up-ref.html">
+<meta name="assert" content="Item's margin box block size gets rounded up to the nearested multiple of block-step-size">
+<style>
+div {
+    inline-size: 50px;
+    block-size: 50px;
+    background-color: green;
+}
+div:first-child {
+    margin-block: 10px;
+}
+</style>
+</head>
+<body>
+<div></div>
+<div></div>
+</body>
+</html>

--- a/css/css-rhythm/block-step-size-adjustment-round-up-relative-unit-ref.html
+++ b/css/css-rhythm/block-step-size-adjustment-round-up-relative-unit-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<meta name="assert" content="Item's margin box block size gets rounded up to the nearested multiple of block-step-size using font relative unit">
+<style>
+div {
+    inline-size: 50px;
+    block-size: 50px;
+    background-color: green;
+}
+div:first-child {
+    margin-block: 10px;
+}
+</style>
+</head>
+<body>
+<div></div>
+<div></div>
+</body>
+</html>

--- a/css/css-rhythm/block-step-size-adjustment-round-up-relative-unit.html
+++ b/css/css-rhythm/block-step-size-adjustment-round-up-relative-unit.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="block-step-size-adjustment-round-up-relative-unit-ref.html">
+<meta name="assert" content="Item's margin box block size gets rounded up to the nearested multiple of block-step-size using font relative unit">
+<style>
+div {
+    inline-size: 50px;
+    block-size: 50px;
+    font-size: 10px;
+    background-color: green;
+}
+div:first-child {
+    block-step-size: 7em;
+}
+</style>
+</head>
+<body>
+<div></div>
+<div></div>
+</body>
+</html>

--- a/css/css-rhythm/block-step-size-adjustment-round-up-vert-lr-ref.html
+++ b/css/css-rhythm/block-step-size-adjustment-round-up-vert-lr-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="block-step-size-adjustment-round-up-ref.html">
+<meta name="assert" content="Item's margin box block size gets rounded up to the nearested multiple of block-step-size in vertical-lr writing mode">
+<style>
+body {
+    writing-mode: vertical-lr; 
+}
+div {
+    inline-size: 50px;
+    block-size: 50px;
+    background-color: green;
+}
+div:first-child {
+    margin-block: 10px;
+}
+</style>
+</head>
+<body>
+<div></div>
+<div></div>
+</body>
+</html>

--- a/css/css-rhythm/block-step-size-adjustment-round-up-vert-lr.html
+++ b/css/css-rhythm/block-step-size-adjustment-round-up-vert-lr.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="block-step-size-adjustment-round-up-vert-lr-ref.html">
+<meta name="assert" content="Item's margin box block size gets rounded up to the nearested multiple of block-step-size in vertical-lr writing mode">
+<style>
+body {
+    writing-mode: vertical-lr;
+}
+div {
+    inline-size: 50px;
+    block-size: 50px;
+    background-color: green;
+}
+div:first-child {
+    block-step-size: 35px;
+}
+</style>
+</head>
+<body>
+<div></div>
+<div></div>
+</body>
+</html>

--- a/css/css-rhythm/block-step-size-adjustment-round-up.html
+++ b/css/css-rhythm/block-step-size-adjustment-round-up.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="block-step-size-adjustment-round-up-ref.html">
+<meta name="assert" content="Item's margin box block size gets rounded up to the nearested multiple of block-step-size">
+<style>
+div {
+    inline-size: 50px;
+    block-size: 50px;
+    background-color: green;
+}
+div:first-child {
+    block-step-size: 35px;
+}
+</style>
+</head>
+<body>
+<div></div>
+<div></div>
+</body>
+</html>

--- a/css/css-rhythm/block-step-size-larger-than-item-margin-box-round-up-ref.html
+++ b/css/css-rhythm/block-step-size-larger-than-item-margin-box-round-up-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<meta name="assert" content="Element's margin box size should just get set to the specified block-step-size if it is smaller"><style>
+div {
+    inline-size: 50px;
+    block-size: 50px;
+    background-color: green;
+}
+div:first-child {
+    margin-block: 25px;
+}
+</style>
+</head>
+<body>
+    <div></div>
+    <div></div>
+</body>
+</html>

--- a/css/css-rhythm/block-step-size-larger-than-item-margin-box-round-up.html
+++ b/css/css-rhythm/block-step-size-larger-than-item-margin-box-round-up.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="block-step-size-larger-than-item-margin-box-ref.html">
+<meta name="assert" content="Element's margin box size should just get set to the specified block-step-size if it is smaller">
+<style>
+div {
+    inline-size: 50px;
+    block-size: 50px;
+    background-color: green;
+    block-step-size: 100px;
+
+}
+</style>
+</head>
+<body>
+    <div></div>
+    <div></div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[rhythmic-sizing\] Add half of block-step-size (rounded up) space to each block margin for non-orthogonal in flow block level elements with no margin collapsing](https://bugs.webkit.org/show_bug.cgi?id=252672)