### PR TITLE
Avoid markers in counter-styles-at-rule tests in the same line

### DIFF
--- a/css/css-counter-styles/counter-style-at-rule/support/ref-common.css
+++ b/css/css-counter-styles/counter-style-at-rule/support/ref-common.css
@@ -5,7 +5,6 @@ body {
 div, p {
   padding: 0; margin: 0;
   line-height: 150%;
-  float: left;
 }
 p {
   padding-right: .5em;

--- a/css/css-counter-styles/counter-style-at-rule/support/test-common.css
+++ b/css/css-counter-styles/counter-style-at-rule/support/test-common.css
@@ -10,7 +10,6 @@ ol, ul {
   list-style-position: inside;
 }
 li, p {
-  float: left;
   padding: 0;
 }
 p {


### PR DESCRIPTION
At the counter-styles at-rule tests, the markers in the tests, and the divs in the related references are forced to be in the same line by 'float: left' in the common style for the files.

This causes some fuzziness in WebKit tests due to subpixel differences on how the engine renders text in divs and markers in list-items.

I'd like to remove float: left from the files to avoid adding fuzziness tolerance in all these tests.