### PR TITLE
[webtransport] Check existence of Origin header

### DIFF
--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -118,11 +118,13 @@ class WebTransportH3Protocol(QuicConnectionProtocol):
 
             method = headers.get(b":method")
             protocol = headers.get(b":protocol")
-            if method == b"CONNECT" and protocol == b"webtransport":
+            origin = headers.get(b"origin")
+            # Accept any Origin but the client must send it.
+            if method == b"CONNECT" and protocol == b"webtransport" and origin:
                 self._session_stream_id = event.stream_id
                 self._handshake_webtransport(event, headers)
             else:
-                self._send_error_response(event.stream_id, 400)
+                self._send_error_response(event.stream_id, 404)
 
         if isinstance(event, DataReceived) and\
            self._session_stream_id == event.stream_id:

--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -124,7 +124,8 @@ class WebTransportH3Protocol(QuicConnectionProtocol):
                 self._session_stream_id = event.stream_id
                 self._handshake_webtransport(event, headers)
             else:
-                self._send_error_response(event.stream_id, 404)
+                status_code = 404 if origin else 403
+                self._send_error_response(event.stream_id, status_code)
 
         if isinstance(event, DataReceived) and\
            self._session_stream_id == event.stream_id:


### PR DESCRIPTION
The draft says clients must provide an Origin header [1].

[1] https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3-04#section-3.3