### PR TITLE
Update Safari expectations for STP 164

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/actions/actionsWithKeyPressed.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/actionsWithKeyPressed.html.ini
@@ -1,3 +1,0 @@
-[actionsWithKeyPressed.html]
-  expected:
-    if product == "safari": ERROR


### PR DESCRIPTION
The regression in STP 163 was fixed in STP 164, so flip this back.

(c.f. 21b3d11 from #38613)