### PR TITLE
followup to #38653

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -4754,7 +4754,7 @@
         if ('META_TITLE' in global_scope && META_TITLE) {
             return META_TITLE;
         }
-        if ('location' in global_scope && location.pathname) {
+        if ('location' in global_scope && 'pathname' in location) {
             return location.pathname.substring(location.pathname.lastIndexOf('/') + 1, location.pathname.indexOf('.'));
         }
         return "Untitled";

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -4754,7 +4754,7 @@
         if ('META_TITLE' in global_scope && META_TITLE) {
             return META_TITLE;
         }
-        if ('location' in global_scope) {
+        if ('location' in global_scope && location.pathname) {
             return location.pathname.substring(location.pathname.lastIndexOf('/') + 1, location.pathname.indexOf('.'));
         }
         return "Untitled";


### PR DESCRIPTION
@Ms2ger this is a followup to #38653

While the change is beneficial I didn't account for our runners on non-nightly release lines sometimes not having pathname on the global location.