### PR TITLE
Move some tests from toascii.json to urltestdata.json

### DIFF
--- a/url/resources/setters_tests.json
+++ b/url/resources/setters_tests.json
@@ -1061,6 +1061,42 @@
                 "host": "",
                 "hostname": ""
             }
+        },
+        {
+            "href": "https://example.com/",
+            "new_value": "a%C2%ADb",
+            "expected": {
+                "href": "https://ab/",
+                "host": "ab",
+                "hostname": "ab"
+            }
+        },
+        {
+            "href": "https://example.com/",
+            "new_value": "\u00AD",
+            "expected": {
+                "href": "https://example.com/",
+                "host": "example.com",
+                "hostname": "example.com"
+            }
+        },
+        {
+            "href": "https://example.com/",
+            "new_value": "%C2%AD",
+            "expected": {
+                "href": "https://example.com/",
+                "host": "example.com",
+                "hostname": "example.com"
+            }
+        },
+        {
+            "href": "https://example.com/",
+            "new_value": "xn--",
+            "expected": {
+                "href": "https://example.com/",
+                "host": "example.com",
+                "hostname": "example.com"
+            }
         }
     ],
     "hostname": [
@@ -1435,6 +1471,42 @@
                 "href": "sc:///",
                 "host": "",
                 "hostname": ""
+            }
+        },
+        {
+            "href": "https://example.com/",
+            "new_value": "a%C2%ADb",
+            "expected": {
+                "href": "https://ab/",
+                "host": "ab",
+                "hostname": "ab"
+            }
+        },
+        {
+            "href": "https://example.com/",
+            "new_value": "\u00AD",
+            "expected": {
+                "href": "https://example.com/",
+                "host": "example.com",
+                "hostname": "example.com"
+            }
+        },
+        {
+            "href": "https://example.com/",
+            "new_value": "%C2%AD",
+            "expected": {
+                "href": "https://example.com/",
+                "host": "example.com",
+                "hostname": "example.com"
+            }
+        },
+        {
+            "href": "https://example.com/",
+            "new_value": "xn--",
+            "expected": {
+                "href": "https://example.com/",
+                "host": "example.com",
+                "hostname": "example.com"
             }
         }
     ],

--- a/url/resources/toascii.json
+++ b/url/resources/toascii.json
@@ -161,23 +161,6 @@
     "output": "ab"
   },
   {
-    "input": "a%C2%ADb",
-    "output": "ab"
-  },
-  {
-    "comment": "Empty host after domain to ASCII",
-    "input": "\u00AD",
-    "output": null
-  },
-  {
-    "input": "%C2%AD",
-    "output": null
-  },
-  {
-    "input": "xn--",
-    "output": null
-  },
-  {
     "comment": "Interesting UseSTD3ASCIIRules=false cases",
     "input": "≠",
     "output": "xn--1ch"

--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -8892,5 +8892,33 @@
     "protocol": "https:",
     "search": "",
     "username": ""
+  },
+  {
+    "input": "https://a%C2%ADb/",
+    "base": "about:blank",
+    "hash": "",
+    "host": "ab",
+    "hostname": "ab",
+    "href": "https://ab/",
+    "origin": "https://ab",
+    "password": "",
+    "pathname": "/",
+    "port": "",
+    "protocol": "https:",
+    "search": "",
+    "username": ""
+  },
+  {
+    "comment": "Empty host after domain to ASCII",
+    "input": "https://\u00AD/",
+    "failure": true
+  },
+  {
+    "input": "https://%C2%AD/",
+    "failure": true
+  },
+  {
+    "input": "https://xn--/",
+    "failure": true
   }
 ]

--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -8911,14 +8911,17 @@
   {
     "comment": "Empty host after domain to ASCII",
     "input": "https://\u00AD/",
+    "base": "about:blank",
     "failure": true
   },
   {
     "input": "https://%C2%AD/",
+    "base": "about:blank",
     "failure": true
   },
   {
     "input": "https://xn--/",
+    "base": "about:blank",
     "failure": true
   }
 ]


### PR DESCRIPTION
These were introduced in e9a106175a02a192a7239f42a94235fbe0f0c7a3. However, these are not tests of the Unicode ToASCII algorithm. They are tests of the extra step introduced in https://github.com/whatwg/url/commit/cceb4356cca233b6dfdaabd888263157b2204e44 to the URL Standard.

Keep toascii.json focused on testing the ToASCII algorithm, so that software which implements it can use that file.

/cc @rmisev