### PR TITLE
pytest: use native assertions instead of `recursive_compare`

### DIFF
--- a/tools/requirements_pytest.txt
+++ b/tools/requirements_pytest.txt
@@ -1,3 +1,4 @@
+anys==0.2.1
 pytest==7.3.1
 pytest-cov==4.0.0
 hypothesis==6.72.4

--- a/webdriver/tests/bidi/log/entry_added/console.py
+++ b/webdriver/tests/bidi/log/entry_added/console.py
@@ -2,7 +2,7 @@ import pytest
 from webdriver.bidi.modules.script import ContextTarget
 
 from . import assert_console_entry, create_console_api_message_for_primitive_value
-from ... import any_string, int_interval, recursive_compare
+from ... import any_string, int_interval
 
 
 @pytest.mark.asyncio

--- a/webdriver/tests/bidi/script/call_function/arguments.py
+++ b/webdriver/tests/bidi/script/call_function/arguments.py
@@ -3,8 +3,6 @@ from tests.support.sync import AsyncPoll
 import webdriver.bidi.error as error
 from webdriver.bidi.modules.script import ContextTarget, SerializationOptions
 
-from ... import any_string, recursive_compare
-
 
 @pytest.mark.asyncio
 async def test_default_arguments(bidi_session, top_context):
@@ -13,10 +11,10 @@ async def test_default_arguments(bidi_session, top_context):
         await_promise=False,
         target=ContextTarget(top_context["context"]))
 
-    recursive_compare({
+    assert {
         "type": "array",
         "value": []
-    }, result)
+    } <= result
 
 
 @pytest.mark.asyncio
@@ -50,7 +48,7 @@ async def test_primitive_value(bidi_session, top_context, argument, expected):
         target=ContextTarget(top_context["context"]),
     )
 
-    recursive_compare(argument, result)
+    assert argument <= result
 
 
 @pytest.mark.asyncio
@@ -68,7 +66,7 @@ async def test_primitive_value_NaN(bidi_session, top_context):
         target=ContextTarget(top_context["context"]),
     )
 
-    recursive_compare(nan_remote_value, result)
+    assert nan_remote_value <= result
 
 
 @pytest.mark.asyncio
@@ -131,7 +129,7 @@ async def test_local_value(bidi_session, top_context, argument, expected_type):
         target=ContextTarget(top_context["context"]),
     )
 
-    recursive_compare(argument, result)
+    assert argument <= result
 
 
 @pytest.mark.asyncio
@@ -242,7 +240,7 @@ async def test_remote_reference_argument(
         target=ContextTarget(top_context["context"]),
     )
 
-    assert result == expected
+    assert expected <= result
 
 
 @pytest.mark.asyncio
@@ -285,7 +283,7 @@ async def test_remote_reference_deserialization(
         function_declaration=function_declaration,
         arguments=[value_fn(remote_value)],
     )
-    assert result == {"type": "boolean", "value": True}
+    assert result <= {"type": "boolean", "value": True}
 
     # Reload the page to cleanup the state
     await bidi_session.browsing_context.navigate(
@@ -339,7 +337,7 @@ async def test_remote_reference_node_argument(
         target=ContextTarget(top_context["context"]),
     )
 
-    assert result == {"type": "number", "value": expected_node_type}
+    assert result <= {"type": "number", "value": expected_node_type}
 
 
 @pytest.mark.asyncio
@@ -363,7 +361,7 @@ async def test_remote_reference_node_cdata(bidi_session, inline, top_context):
         target=ContextTarget(top_context["context"]),
     )
 
-    assert result == {"type": "number", "value": 4}
+    assert result <= {"type": "number", "value": 4}
 
 
 @pytest.mark.asyncio
@@ -403,7 +401,7 @@ async def test_remote_reference_sharedId_precedence_over_handle(
             "(collection) => collection.item(0)",
             {
                 "type": "node",
-                "sharedId": any_string,
+                "sharedId": ANY_STR,
                 "value": {
                     "attributes": {},
                     "childNodeCount": 0,
@@ -419,7 +417,7 @@ async def test_remote_reference_sharedId_precedence_over_handle(
             "(nodeList) => nodeList.item(0)",
             {
                 "type": "node",
-                "sharedId": any_string,
+                "sharedId": ANY_STR,
                 "value": {
                     "attributes": {},
                     "childNodeCount": 0,

--- a/webdriver/tests/bidi/script/call_function/await_promise.py
+++ b/webdriver/tests/bidi/script/call_function/await_promise.py
@@ -1,9 +1,6 @@
 import pytest
 
-from webdriver.bidi.modules.script import ContextTarget, ScriptEvaluateResultException
-
-from ... import any_int, any_string, recursive_compare
-from .. import any_stack_trace
+from webdriver.bidi.modules.script import ContextTarget
 
 
 @pytest.mark.asyncio
@@ -25,9 +22,7 @@ async def test_await_promise_delayed(bidi_session, top_context, await_promise):
             "type": "string",
             "value": "SOME_DELAYED_RESULT"}
     else:
-        recursive_compare({
-            "type": "promise"},
-            result)
+        assert {"type": "promise"} <= result
 
 
 @pytest.mark.asyncio
@@ -43,6 +38,4 @@ async def test_await_promise_async_arrow(bidi_session, top_context, await_promis
             "type": "string",
             "value": "SOME_VALUE"}
     else:
-        recursive_compare({
-            "type": "promise"},
-            result)
+        assert {"type": "promise"} <= result

--- a/webdriver/tests/bidi/script/call_function/internal_id.py
+++ b/webdriver/tests/bidi/script/call_function/internal_id.py
@@ -1,7 +1,5 @@
 import pytest
 
-from ... import recursive_compare, any_string
-
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
@@ -49,7 +47,7 @@ async def test_remote_values_with_internal_id(
     # Make sure that the same duplicated objects have the same internal ids
     assert internalId1 == internalId2
 
-    recursive_compare(value, result_value)
+    assert value <= result_value
 
 
 @pytest.mark.asyncio

--- a/webdriver/tests/bidi/script/call_function/realm.py
+++ b/webdriver/tests/bidi/script/call_function/realm.py
@@ -1,7 +1,6 @@
 import pytest
 
 from webdriver.bidi.modules.script import RealmTarget
-from ... import recursive_compare
 
 
 @pytest.mark.asyncio
@@ -13,7 +12,7 @@ async def test_target_realm(bidi_session, default_realm):
         await_promise=True,
     )
 
-    recursive_compare({"realm": default_realm, "result": {"type": "undefined"}}, result)
+    assert {"realm": default_realm, "result": {"type": "undefined"}} <= result
 
     result = await bidi_session.script.call_function(
         raw_result=True,
@@ -22,9 +21,7 @@ async def test_target_realm(bidi_session, default_realm):
         await_promise=True,
     )
 
-    recursive_compare(
-        {"realm": default_realm, "result": {"type": "number", "value": 3}}, result
-    )
+    assert {"realm": default_realm, "result": {"type": "number", "value": 3}} <= result
 
 
 @pytest.mark.asyncio
@@ -56,9 +53,7 @@ async def test_different_target_realm(bidi_session):
         target=RealmTarget(first_tab_default_realm),
         await_promise=True,
     )
-    recursive_compare(
-        {"realm": first_tab_default_realm, "result": {"type": "number", "value": 3}}, top_context_result
-    )
+    assert {"realm": first_tab_default_realm, "result": {"type": "number", "value": 3}} <= top_context_result
 
     new_context_result = await bidi_session.script.call_function(
         raw_result=True,
@@ -66,6 +61,4 @@ async def test_different_target_realm(bidi_session):
         target=RealmTarget(second_tab_default_realm),
         await_promise=True,
     )
-    recursive_compare(
-        {"realm": second_tab_default_realm, "result": {"type": "number", "value": 5}}, new_context_result
-    )
+    assert {"realm": second_tab_default_realm, "result": {"type": "number", "value": 5}} <= new_context_result

--- a/webdriver/tests/bidi/script/call_function/strict_mode.py
+++ b/webdriver/tests/bidi/script/call_function/strict_mode.py
@@ -1,8 +1,7 @@
 import pytest
 
 from webdriver.bidi.modules.script import ContextTarget, ScriptEvaluateResultException
-from ... import any_int, any_string, recursive_compare
-from .. import any_stack_trace, specific_error_response
+from .. import specific_error_response
 
 
 @pytest.mark.asyncio
@@ -15,7 +14,7 @@ async def test_strict_mode(bidi_session, top_context):
             await_promise=False,
             target=ContextTarget(top_context["context"]),
         )
-    recursive_compare(specific_error_response({"type": "error"}), exception.value.result)
+    assert specific_error_response({"type": "error"}) <= exception.value.result
 
     # In non-strict mode, the command should succeed and global `SOME_VARIABLE` should be created.
     result = await bidi_session.script.call_function(

--- a/webdriver/tests/bidi/script/call_function/this.py
+++ b/webdriver/tests/bidi/script/call_function/this.py
@@ -20,7 +20,7 @@ async def test_this(bidi_session, top_context):
         await_promise=False,
         target=ContextTarget(top_context["context"]))
 
-    assert result == {
+    assert result <= {
         'type': 'number',
         'value': 42}
 
@@ -32,9 +32,9 @@ async def test_default_this(bidi_session, top_context):
         await_promise=False,
         target=ContextTarget(top_context["context"]))
 
-    recursive_compare({
+    assert {
         "type": 'window',
-    }, result)
+    } <= result
 
 
 @pytest.mark.asyncio
@@ -77,7 +77,7 @@ async def test_remote_value_deserialization(
         function_declaration=function_declaration,
         this=value_fn(remote_value),
     )
-    assert result == {"type": "boolean", "value": True}
+    assert result <= {"type": "boolean", "value": True}
 
     # Reload the page to cleanup the state
     await bidi_session.browsing_context.navigate(

--- a/webdriver/tests/bidi/script/evaluate/evaluate.py
+++ b/webdriver/tests/bidi/script/evaluate/evaluate.py
@@ -1,8 +1,6 @@
 import pytest
 from webdriver.bidi.modules.script import ContextTarget, RealmTarget
 
-from ... import recursive_compare
-
 
 @pytest.mark.asyncio
 async def test_eval(bidi_session, top_context):
@@ -11,7 +9,7 @@ async def test_eval(bidi_session, top_context):
         target=ContextTarget(top_context["context"]),
         await_promise=True)
 
-    assert result == {
+    assert result <= {
         "type": "number",
         "value": 3}
 
@@ -23,7 +21,7 @@ async def test_interact_with_dom(bidi_session, top_context):
         target=ContextTarget(top_context["context"]),
         await_promise=True)
 
-    assert result == {
+    assert result <= {
         "type": "string",
         "value": "window.location.href: about:blank"}
 
@@ -37,7 +35,7 @@ async def test_target_realm(bidi_session, default_realm):
         await_promise=True,
     )
 
-    recursive_compare({"realm": default_realm, "result": {"type": "number", "value": 3}}, result)
+    assert {"realm": default_realm, "result": {"type": "number", "value": 3}} <= result
 
     result = await bidi_session.script.evaluate(
         raw_result=True,
@@ -46,9 +44,7 @@ async def test_target_realm(bidi_session, default_realm):
         await_promise=True,
     )
 
-    recursive_compare(
-        {"realm": default_realm, "result": {"type": "number", "value": 3}}, result
-    )
+    assert {"realm": default_realm, "result": {"type": "number", "value": 3}} <= result
 
 
 @pytest.mark.asyncio
@@ -80,9 +76,7 @@ async def test_different_target_realm(bidi_session):
         target=RealmTarget(first_tab_default_realm),
         await_promise=True,
     )
-    recursive_compare(
-        {"realm": first_tab_default_realm, "result": {"type": "number", "value": 3}}, top_context_result
-    )
+    assert {"realm": first_tab_default_realm, "result": {"type": "number", "value": 3}} <= top_context_result
 
     new_context_result = await bidi_session.script.evaluate(
         raw_result=True,
@@ -90,6 +84,4 @@ async def test_different_target_realm(bidi_session):
         target=RealmTarget(second_tab_default_realm),
         await_promise=True,
     )
-    recursive_compare(
-        {"realm": second_tab_default_realm, "result": {"type": "number", "value": 5}}, new_context_result
-    )
+    assert {"realm": second_tab_default_realm, "result": {"type": "number", "value": 5}} <= new_context_result

--- a/webdriver/tests/bidi/script/get_realms/context.py
+++ b/webdriver/tests/bidi/script/get_realms/context.py
@@ -1,8 +1,7 @@
 import pytest
 
+from anys import AnyLE
 from webdriver.bidi.modules.script import ContextTarget
-
-from ... import recursive_compare
 
 
 @pytest.mark.asyncio
@@ -29,17 +28,14 @@ async def test_context(
 
     result = await bidi_session.script.get_realms(context=new_context["context"])
 
-    recursive_compare(
-        [
-            {
-                "context": new_context["context"],
-                "origin": test_origin,
-                "realm": new_context_result["realm"],
-                "type": "window",
-            },
-        ],
-        result,
-    )
+    assert [
+        AnyLE({
+            "context": new_context["context"],
+            "origin": test_origin,
+            "realm": new_context_result["realm"],
+            "type": "window",
+        }),
+    ] == result
 
     contexts = await bidi_session.browsing_context.get_tree(root=new_context["context"])
     assert len(contexts) == 1
@@ -57,14 +53,11 @@ async def test_context(
 
     result = await bidi_session.script.get_realms(context=frame_context)
 
-    recursive_compare(
-        [
-            {
-                "context": frame_context,
-                "origin": test_alt_origin,
-                "realm": frame_context_result["realm"],
-                "type": "window",
-            },
-        ],
-        result,
-    )
+    assert [
+        AnyLE({
+            "context": frame_context,
+            "origin": test_alt_origin,
+            "realm": frame_context_result["realm"],
+            "type": "window",
+        }),
+    ] == result

--- a/webdriver/tests/bidi/script/get_realms/get_realms.py
+++ b/webdriver/tests/bidi/script/get_realms/get_realms.py
@@ -1,8 +1,7 @@
 import pytest
 
+from anys import AnyLE, ANY_STR
 from webdriver.bidi.modules.script import ContextTarget
-
-from ... import any_string, recursive_compare
 
 PAGE_ABOUT_BLANK = "about:blank"
 
@@ -11,17 +10,14 @@ PAGE_ABOUT_BLANK = "about:blank"
 async def test_payload_types(bidi_session):
     result = await bidi_session.script.get_realms()
 
-    recursive_compare(
-        [
-            {
-                "context": any_string,
-                "origin": any_string,
-                "realm": any_string,
-                "type": any_string,
-            }
-        ],
-        result,
-    )
+    assert [
+        AnyLE({
+            "context": ANY_STR,
+            "origin": ANY_STR,
+            "realm": ANY_STR,
+            "type": ANY_STR,
+        })
+    ] == result
 
 
 @pytest.mark.asyncio
@@ -67,23 +63,20 @@ async def test_multiple_top_level_contexts(bidi_session, top_context, type_hint)
         await_promise=False,
     )
 
-    recursive_compare(
-        [
-            {
-                "context": top_context["context"],
-                "origin": "null",
-                "realm": top_context_result["realm"],
-                "type": "window",
-            },
-            {
-                "context": new_context["context"],
-                "origin": "null",
-                "realm": new_context_result["realm"],
-                "type": "window",
-            },
-        ],
-        result,
-    )
+    assert [
+        AnyLE({
+            "context": top_context["context"],
+            "origin": "null",
+            "realm": top_context_result["realm"],
+            "type": "window",
+        }),
+        AnyLE({
+            "context": new_context["context"],
+            "origin": "null",
+            "realm": new_context_result["realm"],
+            "type": "window",
+        }),
+    ] == result
 
 
 @pytest.mark.asyncio
@@ -124,23 +117,20 @@ async def test_iframes(
         await_promise=False,
     )
 
-    recursive_compare(
-        [
-            {
-                "context": top_context["context"],
-                "origin": test_origin,
-                "realm": top_context_result["realm"],
-                "type": "window",
-            },
-            {
-                "context": frame_context,
-                "origin": test_alt_origin,
-                "realm": frame_context_result["realm"],
-                "type": "window",
-            },
-        ],
-        result,
-    )
+    assert [
+        AnyLE({
+            "context": top_context["context"],
+            "origin": test_origin,
+            "realm": top_context_result["realm"],
+            "type": "window",
+        }),
+        AnyLE({
+            "context": frame_context,
+            "origin": test_alt_origin,
+            "realm": frame_context_result["realm"],
+            "type": "window",
+        }),
+    ] == result
 
     # Clean up origin
     await bidi_session.browsing_context.navigate(
@@ -165,17 +155,14 @@ async def test_origin(bidi_session, inline, top_context, test_origin):
         await_promise=False,
     )
 
-    recursive_compare(
-        [
-            {
-                "context": top_context["context"],
-                "origin": test_origin,
-                "realm": top_context_result["realm"],
-                "type": "window",
-            }
-        ],
-        result,
-    )
+    assert [
+        AnyLE({
+            "context": top_context["context"],
+            "origin": test_origin,
+            "realm": top_context_result["realm"],
+            "type": "window",
+        })
+    ] == result
 
     # Clean up origin
     await bidi_session.browsing_context.navigate(

--- a/webdriver/tests/bidi/script/get_realms/sandbox.py
+++ b/webdriver/tests/bidi/script/get_realms/sandbox.py
@@ -1,8 +1,7 @@
 import pytest
 
+from anys import AnyLE
 from webdriver.bidi.modules.script import ContextTarget
-
-from ... import recursive_compare
 
 PAGE_ABOUT_BLANK = "about:blank"
 
@@ -26,24 +25,21 @@ async def test_sandbox(bidi_session, top_context):
 
     result = await bidi_session.script.get_realms()
 
-    recursive_compare(
-        [
-            {
-                "context": top_context["context"],
-                "origin": "null",
-                "realm": evaluate_result["realm"],
-                "type": "window",
-            },
-            {
-                "context": top_context["context"],
-                "origin": "null",
-                "realm": evaluate_in_sandbox_result["realm"],
-                "sandbox": "sandbox",
-                "type": "window",
-            },
-        ],
-        result,
-    )
+    assert [
+        AnyLE({
+            "context": top_context["context"],
+            "origin": "null",
+            "realm": evaluate_result["realm"],
+            "type": "window",
+        }),
+        AnyLE({
+            "context": top_context["context"],
+            "origin": "null",
+            "realm": evaluate_in_sandbox_result["realm"],
+            "sandbox": "sandbox",
+            "type": "window",
+        }),
+    ] == result
 
     # Reload to clean up sandboxes
     await bidi_session.browsing_context.navigate(
@@ -75,24 +71,21 @@ async def test_origin(bidi_session, inline, top_context, test_origin):
 
     result = await bidi_session.script.get_realms()
 
-    recursive_compare(
-        [
-            {
-                "context": top_context["context"],
-                "origin": test_origin,
-                "realm": evaluate_result["realm"],
-                "type": "window",
-            },
-            {
-                "context": top_context["context"],
-                "origin": test_origin,
-                "realm": evaluate_in_sandbox_result["realm"],
-                "sandbox": "sandbox",
-                "type": "window",
-            },
-        ],
-        result,
-    )
+    assert [
+        AnyLE({
+            "context": top_context["context"],
+            "origin": test_origin,
+            "realm": evaluate_result["realm"],
+            "type": "window",
+        }),
+        AnyLE({
+            "context": top_context["context"],
+            "origin": test_origin,
+            "realm": evaluate_in_sandbox_result["realm"],
+            "sandbox": "sandbox",
+            "type": "window",
+        }),
+    ] == result
 
     # Reload to clean up sandboxes
     await bidi_session.browsing_context.navigate(
@@ -120,24 +113,21 @@ async def test_type(bidi_session, top_context):
     # Should be extended when more types are supported
     result = await bidi_session.script.get_realms(type="window")
 
-    recursive_compare(
-        [
-            {
-                "context": top_context["context"],
-                "origin": "null",
-                "realm": evaluate_result["realm"],
-                "type": "window",
-            },
-            {
-                "context": top_context["context"],
-                "origin": "null",
-                "realm": evaluate_in_sandbox_result["realm"],
-                "sandbox": "sandbox",
-                "type": "window",
-            },
-        ],
-        result,
-    )
+    assert [
+        AnyLE({
+            "context": top_context["context"],
+            "origin": "null",
+            "realm": evaluate_result["realm"],
+            "type": "window",
+        }),
+        AnyLE({
+            "context": top_context["context"],
+            "origin": "null",
+            "realm": evaluate_in_sandbox_result["realm"],
+            "sandbox": "sandbox",
+            "type": "window",
+        }),
+    ] == result
 
     # Reload to clean up sandboxes
     await bidi_session.browsing_context.navigate(
@@ -177,24 +167,21 @@ async def test_multiple_top_level_contexts(
     )
 
     result = await bidi_session.script.get_realms(context=new_context["context"])
-    recursive_compare(
-        [
-            {
-                "context": new_context["context"],
-                "origin": test_origin,
-                "realm": evaluate_result["realm"],
-                "type": "window",
-            },
-            {
-                "context": new_context["context"],
-                "origin": test_origin,
-                "realm": evaluate_in_sandbox_result["realm"],
-                "sandbox": "sandbox",
-                "type": "window",
-            },
-        ],
-        result,
-    )
+    assert [
+        AnyLE({
+            "context": new_context["context"],
+            "origin": test_origin,
+            "realm": evaluate_result["realm"],
+            "type": "window",
+        }),
+        AnyLE({
+            "context": new_context["context"],
+            "origin": test_origin,
+            "realm": evaluate_in_sandbox_result["realm"],
+            "sandbox": "sandbox",
+            "type": "window",
+        }),
+    ] == result
 
     contexts = await bidi_session.browsing_context.get_tree(root=new_context["context"])
     assert len(contexts) == 1
@@ -218,21 +205,18 @@ async def test_multiple_top_level_contexts(
     )
 
     result = await bidi_session.script.get_realms(context=frame_context)
-    recursive_compare(
-        [
-            {
-                "context": frame_context,
-                "origin": test_alt_origin,
-                "realm": evaluate_result["realm"],
-                "type": "window",
-            },
-            {
-                "context": frame_context,
-                "origin": test_alt_origin,
-                "realm": evaluate_in_sandbox_result["realm"],
-                "sandbox": "sandbox",
-                "type": "window",
-            },
-        ],
-        result,
-    )
+    assert [
+        AnyLE({
+            "context": frame_context,
+            "origin": test_alt_origin,
+            "realm": evaluate_result["realm"],
+            "type": "window",
+        }),
+        AnyLE({
+            "context": frame_context,
+            "origin": test_alt_origin,
+            "realm": evaluate_in_sandbox_result["realm"],
+            "sandbox": "sandbox",
+            "type": "window",
+        }),
+    ] == result

--- a/webdriver/tests/bidi/script/get_realms/type.py
+++ b/webdriver/tests/bidi/script/get_realms/type.py
@@ -1,8 +1,7 @@
 import pytest
 
+from anys import AnyLE
 from webdriver.bidi.modules.script import ContextTarget
-
-from ... import recursive_compare
 
 PAGE_ABOUT_BLANK = "about:blank"
 
@@ -21,14 +20,9 @@ async def test_type(bidi_session, top_context, type):
         await_promise=False,
     )
 
-    recursive_compare(
-        [
-            {
-                "context": top_context["context"],
-                "origin": "null",
-                "realm": top_context_result["realm"],
-                "type": type,
-            }
-        ],
-        result,
-    )
+    assert [AnyLE({
+        "context": top_context["context"],
+        "origin": "null",
+        "realm": top_context_result["realm"],
+        "type": type,
+    })] == result

--- a/webdriver/tests/bidi/session/subscribe/contexts.py
+++ b/webdriver/tests/bidi/session/subscribe/contexts.py
@@ -1,8 +1,7 @@
 import asyncio
-
 import pytest
 
-from ... import create_console_api_message, recursive_compare
+from ... import create_console_api_message
 
 
 # The basic use case of subscribing to all contexts for a single event
@@ -35,12 +34,9 @@ async def test_subscribe_to_one_context(
     await on_entry_added
 
     assert len(events) == 1
-    recursive_compare(
-        {
-            "text": expected_text,
-        },
-        events[0],
-    )
+    assert {
+        "text": expected_text,
+    } <= events[0]
 
     remove_listener()
 
@@ -67,12 +63,9 @@ async def test_subscribe_to_one_context_twice(
     await on_entry_added
 
     assert len(events) == 1
-    recursive_compare(
-        {
-            "text": expected_text,
-        },
-        events[0],
-    )
+    assert {
+        "text": expected_text,
+    } <= events[0]
 
     assert len(events) == 1
 
@@ -107,12 +100,9 @@ async def test_subscribe_to_one_context_and_then_to_all(
     await on_entry_added
 
     assert len(events) == 1
-    recursive_compare(
-        {
-            "text": expected_text,
-        },
-        events[0],
-    )
+    assert {
+        "text": expected_text,
+    } <= events[0]
 
     events = []
 
@@ -121,35 +111,26 @@ async def test_subscribe_to_one_context_and_then_to_all(
 
     # Check that we received the buffered event
     assert len(events) == 1
-    recursive_compare(
-        {
-            "text": buffered_event_expected_text,
-        },
-        events[0],
-    )
+    assert {
+        "text": buffered_event_expected_text,
+    } <= events[0]
 
     # Trigger again events in each context
     expected_text = await create_console_api_message(bidi_session, new_tab, "text3")
     await on_entry_added
 
     assert len(events) == 2
-    recursive_compare(
-        {
-            "text": expected_text,
-        },
-        events[1],
-    )
+    assert {
+        "text": expected_text,
+    } <= events[1]
 
     expected_text = await create_console_api_message(bidi_session, top_context, "text4")
     await on_entry_added
 
     assert len(events) == 3
-    recursive_compare(
-        {
-            "text": expected_text,
-        },
-        events[2],
-    )
+    assert {
+        "text": expected_text,
+    } <= events[2]
 
     remove_listener()
 

--- a/webdriver/tests/bidi/session/unsubscribe/contexts.py
+++ b/webdriver/tests/bidi/session/unsubscribe/contexts.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from ... import create_console_api_message, recursive_compare
+from ... import create_console_api_message
 
 
 # The basic use case of unsubscribing from all contexts for a single event
@@ -40,12 +40,9 @@ async def test_unsubscribe_from_one_context(
     await on_entry_added
 
     assert len(events) == 1
-    recursive_compare(
-        {
-            "text": expected_text,
-        },
-        events[0],
-    )
+    assert {
+        "text": expected_text,
+    } <= events[0]
 
     remove_listener()
     await bidi_session.session.unsubscribe(


### PR DESCRIPTION
Native assertions have better introspection upon test failure reporting
    
Furthermore, introduce `anys` library to provide matchers to native assertions.
    
Docs: https://pypi.org/project/anys/

## Status

- [x] use `<=` instead of `==`
- [x] add `anys` library
- [ ] convert remaining `any_*` to use `anys` library (Find all: `ack recursive_compare`)