### PR TITLE
Always expect deg in CSS calc NaN unit tests

### DIFF
--- a/css/css-values/calc-infinity-nan-serialize-angle.html
+++ b/css/css-values/calc-infinity-nan-serialize-angle.html
@@ -14,9 +14,9 @@ function test_serialization(t,s, {prop="transform"}={}) {
 //TEST CASE                                            | EXPECTED
 var test_map = {
     "1deg * NaN"                                       :"calc(NaN * 1deg)",
-    "1rad * NaN"                                       :"calc(NaN * 1rad)",
-    "1turn * NaN"                                      :"calc(NaN * 1turn)",
-    "1grad * nan"                                      :"calc(NaN * 1grad)",
+    "1rad * NaN"                                       :"calc(NaN * 1deg)",
+    "1turn * NaN"                                      :"calc(NaN * 1deg)",
+    "1grad * nan"                                      :"calc(NaN * 1deg)",
     "1deg * infinity / infinity"                       :"calc(NaN * 1deg)",
     "1deg * 0 * infinity"                              :"calc(NaN * 1deg)",
     "1deg * (infinity + -infinity)"                    :"calc(NaN * 1deg)",


### PR DESCRIPTION
According to the spec: https://www.w3.org/TR/css-values-3/#compat
> When [serializing](https://www.w3.org/TR/cssom-1/#serializing-css-values) [computed values](https://www.w3.org/TR/css-cascade-5/#computed-value) [[CSSOM]](https://www.w3.org/TR/css-values-3/#biblio-cssom), compatible units (those related by a static multiplicative factor, like the 96:1 factor between [px](https://www.w3.org/TR/css-values-3/#px) and [in](https://www.w3.org/TR/css-values-3/#in), or the computed [font-size](https://www.w3.org/TR/css-fonts-4/#propdef-font-size) factor between [em](https://www.w3.org/TR/css-values-3/#em) and px) are converted into a single canonical unit.

But in [the tests for NaN with units (L17-19)](https://github.com/web-platform-tests/wpt/blob/master/css/css-values/calc-infinity-nan-serialize-angle.html#L17-L19), it is checked to be the same as the unit given, not the canonical unit (deg)? Safari would now pass, and Chrome would fail.

Solves #38821. This might be better as a downstream (Gecko) change, please let me know which would be best. (https://phabricator.services.mozilla.com/D171658)