### PR TITLE
Fix hint related test in popover attribute subtest

### DIFF
--- a/html/semantics/popovers/popover-attribute-basic.html
+++ b/html/semantics/popovers/popover-attribute-basic.html
@@ -160,8 +160,8 @@ window.onload = () => {
       assert_false(popover.matches(':open'));
       popover.showPopover();
       assert_true(popover.matches(':open'));
-      popover.setAttribute('popover','manual');
     }
+    popover.setAttribute('popover','manual');
     assert_false(popover.matches(':open'));
     popover.showPopover();
     assert_true(popover.matches(':open'));


### PR DESCRIPTION
If popover hint are not enabled on a platform the subtest makes a wrong assumption, fix this.