### PR TITLE
Stop failing inert-computed-style.html when `user-select: auto` isn't supported

### DIFF
--- a/inert/inert-computed-style.html
+++ b/inert/inert-computed-style.html
@@ -40,10 +40,12 @@
       "auto",
       "inert node doesn't change pointer-events computed value",
     );
-    assert_equals(
-      getComputedStyle(inert).userSelect,
-      "auto",
-      "inert node doesn't change user-select computed value",
-    );
+    if (CSS.supports("user-select: auto")) {
+      assert_equals(
+        getComputedStyle(inert).userSelect,
+        "auto",
+        "inert node doesn't change user-select computed value",
+      );
+    }
   });
 </script>

--- a/inert/inert-computed-style.html
+++ b/inert/inert-computed-style.html
@@ -15,11 +15,11 @@
     left: 0;
     background-color: blue;
   }
-  #non-inert {
+  #nonInert {
     background-color: red;
   }
 </style>
-<div id="non-inert"></div>
+<div id="nonInert"></div>
 <div id="inert"></div>
 <script>
   test(function() {
@@ -32,20 +32,18 @@
     inert.inert = true;
     assert_equals(
       document.elementFromPoint(50, 50),
-      document.getElementById("non-inert"),
+      nonInert,
       "inert node is transparent to events (as pointer-events: none)",
     );
     assert_equals(
       getComputedStyle(inert).pointerEvents,
-      "auto",
+      getComputedStyle(nonInert).pointerEvents,
       "inert node doesn't change pointer-events computed value",
     );
-    if (CSS.supports("user-select: auto")) {
-      assert_equals(
-        getComputedStyle(inert).userSelect,
-        "auto",
-        "inert node doesn't change user-select computed value",
-      );
-    }
+    assert_equals(
+      getComputedStyle(inert).userSelect,
+      getComputedStyle(nonInert).userSelect,
+      "inert node doesn't change user-select computed value",
+    );
   });
 </script>


### PR DESCRIPTION
WebKit currently does not support unprefixed `user-select`, and nor does it support the `auto` value.