### PR TITLE
Stop assuming iframes are mouse-focusable in inert-iframe-hittest.html

### DIFF
--- a/inert/inert-iframe-hittest.html
+++ b/inert/inert-iframe-hittest.html
@@ -93,7 +93,6 @@ promise_test(async function() {
       "wrapper got enter and over events");
   }
 
-  assert_true(target.matches(":focus"), "target is focused");
   assert_true(target.matches(":active"), "target is active");
   assert_true(target.matches(":hover"), "target is hovered");
   assert_true(wrapper.matches(":hover"), "wrapper is hovered");


### PR DESCRIPTION
This test assumes iframes are mouse-focusable, which isn't true on all platforms for WebKit (this test passes fully on WebKitGTK, but fails on Safari).