### PR TITLE
core-aam: update role-description prohibited test case to match webkit's implementation

### DIFF
--- a/core-aam/generic_roledescription_prohibited-manual.html
+++ b/core-aam/generic_roledescription_prohibited-manual.html
@@ -61,7 +61,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for generic with a roledescription.</p>
-  <p role="generic" id="test" aria-roledescription="foo">content</p>
+  <div role="generic" id="test" aria-roledescription="foo">content</div>
   <div id="manualMode"></div>
   <div id="log"></div>
   <div id="ATTAmessages"></div>


### PR DESCRIPTION
webkit only prohibit's aria-roledescription on elements with implicit generic mapping (div and span): https://bugs.webkit.org/show_bug.cgi?id=174248

