### PR TITLE
Stop assuming iframes are mouse-focusable in inert-iframe-hittest.html

### DIFF
--- a/inert/inert-iframe-hittest.html
+++ b/inert/inert-iframe-hittest.html
@@ -11,7 +11,7 @@
 <script src="/resources/testdriver-actions.js"></script>
 
 <div id="wrapper" style="width: min-content">
-  <iframe id="iframe" inert></iframe>
+  <iframe id="iframe" inert tabindex="0"></iframe>
 </div>
 
 <script>


### PR DESCRIPTION
This test assumes iframes are mouse-focusable, which isn't true on all platforms for WebKit (this test passes fully on WebKitGTK, but fails on Safari).

Use tabindex=0 to ensure the iframe is actually mouse-focusable.