### PR TITLE
Use relative path for PNG test

### DIFF
--- a/png/cicp-chunk.html
+++ b/png/cicp-chunk.html
@@ -35,5 +35,5 @@ img.onload = () => {
     assert_approx_equals(pixel[3], pixel_expected[3], epsilon);
   }, {colorSpace: "display-p3"});
 };
-img.src = "/images/cicp.png";
+img.src = "./images/cicp.png";
 </script>


### PR DESCRIPTION
Currently, the PNG cICP test has an image path like "/images/...". Really, this should have been a relative path.

This commit updates the image path to be relative.