### PR TITLE
Add help link to PNG cICP test

### DIFF
--- a/png/cicp-chunk.html
+++ b/png/cicp-chunk.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <title>PNG test: cICP chunk</title>
+<link rel="help" href="https://w3c.github.io/PNG-spec/#cICP-chunk">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/html/canvas/resources/canvas-tests.js"></script>


### PR DESCRIPTION
Currently, there is no help link for the PNG cICP test.

This commit adds a link to help people understand the context of the test.