### PR TITLE
Updated test_document_element_is_interactable for active element check

### DIFF
--- a/webdriver/tests/element_send_keys/interactability.py
+++ b/webdriver/tests/element_send_keys/interactability.py
@@ -44,7 +44,7 @@ def test_document_element_is_interactable(session, inline):
 
     response = element_send_keys(session, element, "foo")
     assert_success(response)
-    assert session.active_element == element
+    assert session.active_element in [element, body]
     assert result.property("value") == "foo"
 
 


### PR DESCRIPTION
Picked up from https://github.com/web-platform-tests/wpt/pull/17769:

> ChromeDriver was failing this test despite being W3C compliant in this regard. The reason Chrome's webdriver failed was due to Chrome's HTMLDocument not being focusable. In contrast, Firefox's webdriver passes this test because Firefox's HTMLDocument is focusable. According to the W3 spec (linked below), HTMLDocument need not be focusable (can be seen through the absence of the focus method). Therefore this test should be removed since it does not test spec-compliance.
> 
> W3 spec:
> https://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-1006298752
