### PR TITLE
[wptrunner] Fix test ID reported in `testharnessreport-content-shell.js`

### DIFF
--- a/tools/wptrunner/wptrunner/testharnessreport-content-shell.js
+++ b/tools/wptrunner/wptrunner/testharnessreport-content-shell.js
@@ -1,6 +1,4 @@
 var props = {output:%(output)d, debug: %(debug)s};
-var start_loc = document.createElement('a');
-start_loc.href = location.href;
 setup(props);
 
 testRunner.dumpAsText();
@@ -9,7 +7,7 @@ testRunner.setPopupBlockingEnabled(false);
 testRunner.setDumpJavaScriptDialogs(false);
 
 add_completion_callback(function (tests, harness_status) {
-    var id = decodeURIComponent(start_loc.pathname) + decodeURIComponent(start_loc.search) + decodeURIComponent(start_loc.hash);
+    var id = decodeURIComponent(location.pathname) + decodeURIComponent(location.search) + decodeURIComponent(location.hash);
     var result_string = JSON.stringify([
         id,
         harness_status.status,


### PR DESCRIPTION
Currently, the `content_shell` reporter uses `HTMLAnchorElement` to parse `location.href` to derive the test ID, which is plumbed through `content_shell`'s internal `testRunner` API and into the wptrunner driver.

For an unknown reason, the URL parts of the `HTMLAnchorElement` can be `undefined`, leading to crbug.com/1418753. It's not clear if there's a good reason why we use `<a>` for parsing the URL eagerly, other than copying other `testharnessreport-*.js`. Indeed, `servodriver` just uses `window.location.*` [1] directly on completion, which also seems to fix the linked crbug.

[1]: https://developer.mozilla.org/en-US/docs/Web/API/Location