### PR TITLE
WebKitGTK: run the tests in the CI (TaskCluster) with 4 parallel jobs

### DIFF
--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -26,7 +26,9 @@ def get_browser_args(product, channel):
             args.extend(["--install-browser", "--install-webdriver"])
         return args
     if product == "webkitgtk_minibrowser":
-        return ["--install-browser"]
+        # Using 4 parallel jobs gives 4x speed-up even on a 1-core machine and doesn't cause extra timeouts.
+        # See: https://github.com/web-platform-tests/wpt/issues/38723#issuecomment-1470938179
+        return ["--install-browser", "--processes=4"]
     return []
 
 


### PR DESCRIPTION
WebKitGTK tests have started to timeout on the CI again. The issue is caused because there is a 2-3 hour maximum time allowed for each test chunk to run and we are hitting the time limit.

In the past we tried to fix this by raisin this timeout or the number of chunks.
See commits: ac16b46831 and 6f7c2fd96f and a218d10eb9

This time instead of rising the time limit or the number of chunks let's try to run the tests in parallel. Using 4 jobs gives 4x speed-up even on a machine that only has 1 core because we avoid waiting serially for tests that are slow or timeout. For more details see:
https://github.com/web-platform-tests/wpt/issues/38723#issuecomment-1470938179

Fixes: #38723

/cc @jgraham 