### PR TITLE
[css-color] Unwrap lab/oklab and lch/oklch for-loops

### DIFF
--- a/css/css-color/parsing/color-computed-color-mix-function.html
+++ b/css/css-color/parsing/color-computed-color-mix-function.html
@@ -157,104 +157,200 @@
     test_computed_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / 0.5))`, canonicalize(`hwb(75deg 20% 30% / 0.5)`));
     test_computed_value(`color`, `color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / none))`, canonicalize(`hwb(75deg 20% 30% / none)`));
 
-    for (const colorSpace of [ "lch", "oklch" ]) {
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), ${colorSpace}(50 60 70deg))`, `${colorSpace}(30 40 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 25%, ${colorSpace}(50 60 70deg))`, `${colorSpace}(40 50 60)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10 20 30deg), ${colorSpace}(50 60 70deg))`, `${colorSpace}(40 50 60)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), 25% ${colorSpace}(50 60 70deg))`, `${colorSpace}(20 30 40)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), ${colorSpace}(50 60 70deg) 25%)`, `${colorSpace}(20 30 40)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 25%, ${colorSpace}(50 60 70deg) 75%)`, `${colorSpace}(40 50 60)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 30%, ${colorSpace}(50 60 70deg) 90%)`, `${colorSpace}(40 50 60)`); // Scale down > 100% sum.
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 12.5%, ${colorSpace}(50 60 70deg) 37.5%)`, `${colorSpace}(40 50 60 / 0.5)`); // Scale up < 100% sum, causes alpha multiplication.
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 0%, ${colorSpace}(50 60 70deg))`, `${colorSpace}(50 60 70)`);
+    // lch()
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg), lch(50 60 70deg))`, `lch(30 40 50)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg) 25%, lch(50 60 70deg))`, `lch(40 50 60)`);
+    test_computed_value(`color`, `color-mix(in lch, 25% lch(10 20 30deg), lch(50 60 70deg))`, `lch(40 50 60)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg), 25% lch(50 60 70deg))`, `lch(20 30 40)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg), lch(50 60 70deg) 25%)`, `lch(20 30 40)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg) 25%, lch(50 60 70deg) 75%)`, `lch(40 50 60)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg) 30%, lch(50 60 70deg) 90%)`, `lch(40 50 60)`); // Scale down > 100% sum.
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg) 12.5%, lch(50 60 70deg) 37.5%)`, `lch(40 50 60 / 0.5)`); // Scale up < 100% sum, causes alpha multiplication.
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg) 0%, lch(50 60 70deg))`, `lch(50 60 70)`);
 
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4), ${colorSpace}(50 60 70deg / .8))`, `${colorSpace}(36.666664 46.666664 50 / 0.6)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 25%, ${colorSpace}(50 60 70deg / .8))`, `${colorSpace}(44.285713 54.285717 60 / 0.7)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10 20 30deg / .4), ${colorSpace}(50 60 70deg / .8))`, `${colorSpace}(44.285713 54.285717 60 / 0.7)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4), 25% ${colorSpace}(50 60 70deg / .8))`, `${colorSpace}(26 36 40 / 0.5)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4), ${colorSpace}(50 60 70deg / .8) 25%)`, `${colorSpace}(26 36 40 / 0.5)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 25%, ${colorSpace}(50 60 70deg / .8) 75%)`, `${colorSpace}(44.285713 54.285717 60 / 0.7)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 30%, ${colorSpace}(50 60 70deg / .8) 90%)`, `${colorSpace}(44.285713 54.285717 60 / 0.7)`); // Scale down > 100% sum.
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 12.5%, ${colorSpace}(50 60 70deg / .8) 37.5%)`, `${colorSpace}(44.285713 54.285717 60 / 0.35)`); // Scale up < 100% sum, causes alpha multiplication.
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 0%, ${colorSpace}(50 60 70deg / .8))`, `${colorSpace}(50 60 70 / 0.8)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg / .4), lch(50 60 70deg / .8))`, `lch(36.666664 46.666664 50 / 0.6)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg / .4) 25%, lch(50 60 70deg / .8))`, `lch(44.285713 54.285717 60 / 0.7)`);
+    test_computed_value(`color`, `color-mix(in lch, 25% lch(10 20 30deg / .4), lch(50 60 70deg / .8))`, `lch(44.285713 54.285717 60 / 0.7)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg / .4), 25% lch(50 60 70deg / .8))`, `lch(26 36 40 / 0.5)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg / .4), lch(50 60 70deg / .8) 25%)`, `lch(26 36 40 / 0.5)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg / .4) 25%, lch(50 60 70deg / .8) 75%)`, `lch(44.285713 54.285717 60 / 0.7)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg / .4) 30%, lch(50 60 70deg / .8) 90%)`, `lch(44.285713 54.285717 60 / 0.7)`); // Scale down > 100% sum.
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg / .4) 12.5%, lch(50 60 70deg / .8) 37.5%)`, `lch(44.285713 54.285717 60 / 0.35)`); // Scale up < 100% sum, causes alpha multiplication.
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg / .4) 0%, lch(50 60 70deg / .8))`, `lch(50 60 70 / 0.8)`);
 
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `${colorSpace}(100 0 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `${colorSpace}(100 0 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `${colorSpace}(100 0 10)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `${colorSpace}(100 0 10)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `${colorSpace}(100 0 350)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `${colorSpace}(100 0 350)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(100 0 40deg), lch(100 0 60deg))`, `lch(100 0 50)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(100 0 60deg), lch(100 0 40deg))`, `lch(100 0 50)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(100 0 50deg), lch(100 0 330deg))`, `lch(100 0 10)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(100 0 330deg), lch(100 0 50deg))`, `lch(100 0 10)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(100 0 20deg), lch(100 0 320deg))`, `lch(100 0 350)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(100 0 320deg), lch(100 0 20deg))`, `lch(100 0 350)`);
 
-        test_computed_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `${colorSpace}(100 0 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `${colorSpace}(100 0 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `${colorSpace}(100 0 10)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `${colorSpace}(100 0 10)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `${colorSpace}(100 0 350)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `${colorSpace}(100 0 350)`);
+    test_computed_value(`color`, `color-mix(in lch shorter hue, lch(100 0 40deg), lch(100 0 60deg))`, `lch(100 0 50)`);
+    test_computed_value(`color`, `color-mix(in lch shorter hue, lch(100 0 60deg), lch(100 0 40deg))`, `lch(100 0 50)`);
+    test_computed_value(`color`, `color-mix(in lch shorter hue, lch(100 0 50deg), lch(100 0 330deg))`, `lch(100 0 10)`);
+    test_computed_value(`color`, `color-mix(in lch shorter hue, lch(100 0 330deg), lch(100 0 50deg))`, `lch(100 0 10)`);
+    test_computed_value(`color`, `color-mix(in lch shorter hue, lch(100 0 20deg), lch(100 0 320deg))`, `lch(100 0 350)`);
+    test_computed_value(`color`, `color-mix(in lch shorter hue, lch(100 0 320deg), lch(100 0 20deg))`, `lch(100 0 350)`);
 
-        test_computed_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `${colorSpace}(100 0 230)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `${colorSpace}(100 0 230)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `${colorSpace}(100 0 190)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `${colorSpace}(100 0 190)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `${colorSpace}(100 0 170)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `${colorSpace}(100 0 170)`);
+    test_computed_value(`color`, `color-mix(in lch longer hue, lch(100 0 40deg), lch(100 0 60deg))`, `lch(100 0 230)`);
+    test_computed_value(`color`, `color-mix(in lch longer hue, lch(100 0 60deg), lch(100 0 40deg))`, `lch(100 0 230)`);
+    test_computed_value(`color`, `color-mix(in lch longer hue, lch(100 0 50deg), lch(100 0 330deg))`, `lch(100 0 190)`);
+    test_computed_value(`color`, `color-mix(in lch longer hue, lch(100 0 330deg), lch(100 0 50deg))`, `lch(100 0 190)`);
+    test_computed_value(`color`, `color-mix(in lch longer hue, lch(100 0 20deg), lch(100 0 320deg))`, `lch(100 0 170)`);
+    test_computed_value(`color`, `color-mix(in lch longer hue, lch(100 0 320deg), lch(100 0 20deg))`, `lch(100 0 170)`);
 
-        test_computed_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `${colorSpace}(100 0 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `${colorSpace}(100 0 230)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `${colorSpace}(100 0 190)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `${colorSpace}(100 0 10)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `${colorSpace}(100 0 170)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `${colorSpace}(100 0 350)`);
+    test_computed_value(`color`, `color-mix(in lch increasing hue, lch(100 0 40deg), lch(100 0 60deg))`, `lch(100 0 50)`);
+    test_computed_value(`color`, `color-mix(in lch increasing hue, lch(100 0 60deg), lch(100 0 40deg))`, `lch(100 0 230)`);
+    test_computed_value(`color`, `color-mix(in lch increasing hue, lch(100 0 50deg), lch(100 0 330deg))`, `lch(100 0 190)`);
+    test_computed_value(`color`, `color-mix(in lch increasing hue, lch(100 0 330deg), lch(100 0 50deg))`, `lch(100 0 10)`);
+    test_computed_value(`color`, `color-mix(in lch increasing hue, lch(100 0 20deg), lch(100 0 320deg))`, `lch(100 0 170)`);
+    test_computed_value(`color`, `color-mix(in lch increasing hue, lch(100 0 320deg), lch(100 0 20deg))`, `lch(100 0 350)`);
 
-        test_computed_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `${colorSpace}(100 0 230)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `${colorSpace}(100 0 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `${colorSpace}(100 0 10)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `${colorSpace}(100 0 190)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `${colorSpace}(100 0 350)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `${colorSpace}(100 0 170)`);
+    test_computed_value(`color`, `color-mix(in lch decreasing hue, lch(100 0 40deg), lch(100 0 60deg))`, `lch(100 0 230)`);
+    test_computed_value(`color`, `color-mix(in lch decreasing hue, lch(100 0 60deg), lch(100 0 40deg))`, `lch(100 0 50)`);
+    test_computed_value(`color`, `color-mix(in lch decreasing hue, lch(100 0 50deg), lch(100 0 330deg))`, `lch(100 0 10)`);
+    test_computed_value(`color`, `color-mix(in lch decreasing hue, lch(100 0 330deg), lch(100 0 50deg))`, `lch(100 0 190)`);
+    test_computed_value(`color`, `color-mix(in lch decreasing hue, lch(100 0 20deg), lch(100 0 320deg))`, `lch(100 0 350)`);
+    test_computed_value(`color`, `color-mix(in lch decreasing hue, lch(100 0 320deg), lch(100 0 20deg))`, `lch(100 0 170)`);
 
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(none none none))`, `${colorSpace}(none none none)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(50 60 70deg))`, `${colorSpace}(50 60 70)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), ${colorSpace}(none none none))`, `${colorSpace}(10 20 30)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 none), ${colorSpace}(50 60 70deg))`, `${colorSpace}(30 40 70)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), ${colorSpace}(50 60 none))`, `${colorSpace}(30 40 30)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none 20 30deg), ${colorSpace}(50 none 70deg))`, `${colorSpace}(50 20 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / none), ${colorSpace}(50 60 70deg))`, `${colorSpace}(30 40 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / none), ${colorSpace}(50 60 70deg / 0.5))`, `${colorSpace}(30 40 50 / 0.5)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / none), ${colorSpace}(50 60 70deg / none))`, `${colorSpace}(30 40 50 / none)`);
-    }
+    test_computed_value(`color`, `color-mix(in lch, lch(none none none), lch(none none none))`, `lch(none none none)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(none none none), lch(50 60 70deg))`, `lch(50 60 70)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg), lch(none none none))`, `lch(10 20 30)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 none), lch(50 60 70deg))`, `lch(30 40 70)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg), lch(50 60 none))`, `lch(30 40 30)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(none 20 30deg), lch(50 none 70deg))`, `lch(50 20 50)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg / none), lch(50 60 70deg))`, `lch(30 40 50)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg / none), lch(50 60 70deg / 0.5))`, `lch(30 40 50 / 0.5)`);
+    test_computed_value(`color`, `color-mix(in lch, lch(10 20 30deg / none), lch(50 60 70deg / none))`, `lch(30 40 50 / none)`);
 
-    for (const colorSpace of [ "lab", "oklab" ]) {
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 70))`, `${colorSpace}(30 40 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 25%, ${colorSpace}(50 60 70))`, `${colorSpace}(40 50 60)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10 20 30), ${colorSpace}(50 60 70))`, `${colorSpace}(40 50 60)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), 25% ${colorSpace}(50 60 70))`, `${colorSpace}(20 30 40)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 70) 25%)`, `${colorSpace}(20 30 40)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 25%, ${colorSpace}(50 60 70) 75%)`, `${colorSpace}(40 50 60)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 30%, ${colorSpace}(50 60 70) 90%)`, `${colorSpace}(40 50 60)`); // Scale down > 100% sum.
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 12.5%, ${colorSpace}(50 60 70) 37.5%)`, `${colorSpace}(40 50 60 / 0.5)`); // Scale up < 100% sum, causes alpha multiplication.
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 0%, ${colorSpace}(50 60 70))`, `${colorSpace}(50 60 70)`);
+    // oklch()
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg), oklch(50 60 70deg))`, `oklch(30 40 50)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg) 25%, oklch(50 60 70deg))`, `oklch(40 50 60)`);
+    test_computed_value(`color`, `color-mix(in oklch, 25% oklch(10 20 30deg), oklch(50 60 70deg))`, `oklch(40 50 60)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg), 25% oklch(50 60 70deg))`, `oklch(20 30 40)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg), oklch(50 60 70deg) 25%)`, `oklch(20 30 40)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg) 25%, oklch(50 60 70deg) 75%)`, `oklch(40 50 60)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg) 30%, oklch(50 60 70deg) 90%)`, `oklch(40 50 60)`); // Scale down > 100% sum.
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg) 12.5%, oklch(50 60 70deg) 37.5%)`, `oklch(40 50 60 / 0.5)`); // Scale up < 100% sum, causes alpha multiplication.
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg) 0%, oklch(50 60 70deg))`, `oklch(50 60 70)`);
 
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4), ${colorSpace}(50 60 70 / .8))`, `${colorSpace}(36.666664 46.666664 56.666664 / 0.6)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 25%, ${colorSpace}(50 60 70 / .8))`, `${colorSpace}(44.285713 54.285717 64.28571 / 0.7)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10 20 30 / .4), ${colorSpace}(50 60 70 / .8))`, `${colorSpace}(44.285713 54.285717 64.28571 / 0.7)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4), 25% ${colorSpace}(50 60 70 / .8))`, `${colorSpace}(26 36 46 / 0.5)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4), ${colorSpace}(50 60 70 / .8) 25%)`, `${colorSpace}(26 36 46 / 0.5)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 25%, ${colorSpace}(50 60 70 / .8) 75%)`, `${colorSpace}(44.285713 54.285717 64.28571 / 0.7)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 30%, ${colorSpace}(50 60 70 / .8) 90%)`, `${colorSpace}(44.285713 54.285717 64.28571 / 0.7)`); // Scale down > 100% sum.
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 12.5%, ${colorSpace}(50 60 70 / .8) 37.5%)`, `${colorSpace}(44.285713 54.285717 64.28571 / 0.35)`); // Scale up < 100% sum, causes alpha multiplication.
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 0%, ${colorSpace}(50 60 70 / .8))`, `${colorSpace}(50 60 70 / 0.8)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / .4), oklch(50 60 70deg / .8))`, `oklch(36.666664 46.666664 50 / 0.6)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / .4) 25%, oklch(50 60 70deg / .8))`, `oklch(44.285713 54.285717 60 / 0.7)`);
+    test_computed_value(`color`, `color-mix(in oklch, 25% oklch(10 20 30deg / .4), oklch(50 60 70deg / .8))`, `oklch(44.285713 54.285717 60 / 0.7)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / .4), 25% oklch(50 60 70deg / .8))`, `oklch(26 36 40 / 0.5)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / .4), oklch(50 60 70deg / .8) 25%)`, `oklch(26 36 40 / 0.5)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / .4) 25%, oklch(50 60 70deg / .8) 75%)`, `oklch(44.285713 54.285717 60 / 0.7)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / .4) 30%, oklch(50 60 70deg / .8) 90%)`, `oklch(44.285713 54.285717 60 / 0.7)`); // Scale down > 100% sum.
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / .4) 12.5%, oklch(50 60 70deg / .8) 37.5%)`, `oklch(44.285713 54.285717 60 / 0.35)`); // Scale up < 100% sum, causes alpha multiplication.
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / .4) 0%, oklch(50 60 70deg / .8))`, `oklch(50 60 70 / 0.8)`);
 
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(none none none))`, `${colorSpace}(none none none)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(50 60 70))`, `${colorSpace}(50 60 70)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(none none none))`, `${colorSpace}(10 20 30)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 none), ${colorSpace}(50 60 70))`, `${colorSpace}(30 40 70)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 none))`, `${colorSpace}(30 40 30)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none 20 30), ${colorSpace}(50 none 70))`, `${colorSpace}(50 20 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / none), ${colorSpace}(50 60 70))`, `${colorSpace}(30 40 50)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / none), ${colorSpace}(50 60 70 / 0.5))`, `${colorSpace}(30 40 50 / 0.5)`);
-        test_computed_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / none), ${colorSpace}(50 60 70 / none))`, `${colorSpace}(30 40 50 / none)`);
-    }
+    test_computed_value(`color`, `color-mix(in oklch, oklch(100 0 40deg), oklch(100 0 60deg))`, `oklch(100 0 50)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(100 0 60deg), oklch(100 0 40deg))`, `oklch(100 0 50)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(100 0 50deg), oklch(100 0 330deg))`, `oklch(100 0 10)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(100 0 330deg), oklch(100 0 50deg))`, `oklch(100 0 10)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(100 0 20deg), oklch(100 0 320deg))`, `oklch(100 0 350)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(100 0 320deg), oklch(100 0 20deg))`, `oklch(100 0 350)`);
+
+    test_computed_value(`color`, `color-mix(in oklch shorter hue, oklch(100 0 40deg), oklch(100 0 60deg))`, `oklch(100 0 50)`);
+    test_computed_value(`color`, `color-mix(in oklch shorter hue, oklch(100 0 60deg), oklch(100 0 40deg))`, `oklch(100 0 50)`);
+    test_computed_value(`color`, `color-mix(in oklch shorter hue, oklch(100 0 50deg), oklch(100 0 330deg))`, `oklch(100 0 10)`);
+    test_computed_value(`color`, `color-mix(in oklch shorter hue, oklch(100 0 330deg), oklch(100 0 50deg))`, `oklch(100 0 10)`);
+    test_computed_value(`color`, `color-mix(in oklch shorter hue, oklch(100 0 20deg), oklch(100 0 320deg))`, `oklch(100 0 350)`);
+    test_computed_value(`color`, `color-mix(in oklch shorter hue, oklch(100 0 320deg), oklch(100 0 20deg))`, `oklch(100 0 350)`);
+
+    test_computed_value(`color`, `color-mix(in oklch longer hue, oklch(100 0 40deg), oklch(100 0 60deg))`, `oklch(100 0 230)`);
+    test_computed_value(`color`, `color-mix(in oklch longer hue, oklch(100 0 60deg), oklch(100 0 40deg))`, `oklch(100 0 230)`);
+    test_computed_value(`color`, `color-mix(in oklch longer hue, oklch(100 0 50deg), oklch(100 0 330deg))`, `oklch(100 0 190)`);
+    test_computed_value(`color`, `color-mix(in oklch longer hue, oklch(100 0 330deg), oklch(100 0 50deg))`, `oklch(100 0 190)`);
+    test_computed_value(`color`, `color-mix(in oklch longer hue, oklch(100 0 20deg), oklch(100 0 320deg))`, `oklch(100 0 170)`);
+    test_computed_value(`color`, `color-mix(in oklch longer hue, oklch(100 0 320deg), oklch(100 0 20deg))`, `oklch(100 0 170)`);
+
+    test_computed_value(`color`, `color-mix(in oklch increasing hue, oklch(100 0 40deg), oklch(100 0 60deg))`, `oklch(100 0 50)`);
+    test_computed_value(`color`, `color-mix(in oklch increasing hue, oklch(100 0 60deg), oklch(100 0 40deg))`, `oklch(100 0 230)`);
+    test_computed_value(`color`, `color-mix(in oklch increasing hue, oklch(100 0 50deg), oklch(100 0 330deg))`, `oklch(100 0 190)`);
+    test_computed_value(`color`, `color-mix(in oklch increasing hue, oklch(100 0 330deg), oklch(100 0 50deg))`, `oklch(100 0 10)`);
+    test_computed_value(`color`, `color-mix(in oklch increasing hue, oklch(100 0 20deg), oklch(100 0 320deg))`, `oklch(100 0 170)`);
+    test_computed_value(`color`, `color-mix(in oklch increasing hue, oklch(100 0 320deg), oklch(100 0 20deg))`, `oklch(100 0 350)`);
+
+    test_computed_value(`color`, `color-mix(in oklch decreasing hue, oklch(100 0 40deg), oklch(100 0 60deg))`, `oklch(100 0 230)`);
+    test_computed_value(`color`, `color-mix(in oklch decreasing hue, oklch(100 0 60deg), oklch(100 0 40deg))`, `oklch(100 0 50)`);
+    test_computed_value(`color`, `color-mix(in oklch decreasing hue, oklch(100 0 50deg), oklch(100 0 330deg))`, `oklch(100 0 10)`);
+    test_computed_value(`color`, `color-mix(in oklch decreasing hue, oklch(100 0 330deg), oklch(100 0 50deg))`, `oklch(100 0 190)`);
+    test_computed_value(`color`, `color-mix(in oklch decreasing hue, oklch(100 0 20deg), oklch(100 0 320deg))`, `oklch(100 0 350)`);
+    test_computed_value(`color`, `color-mix(in oklch decreasing hue, oklch(100 0 320deg), oklch(100 0 20deg))`, `oklch(100 0 170)`);
+
+    test_computed_value(`color`, `color-mix(in oklch, oklch(none none none), oklch(none none none))`, `oklch(none none none)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(none none none), oklch(50 60 70deg))`, `oklch(50 60 70)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg), oklch(none none none))`, `oklch(10 20 30)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 none), oklch(50 60 70deg))`, `oklch(30 40 70)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg), oklch(50 60 none))`, `oklch(30 40 30)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(none 20 30deg), oklch(50 none 70deg))`, `oklch(50 20 50)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / none), oklch(50 60 70deg))`, `oklch(30 40 50)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / none), oklch(50 60 70deg / 0.5))`, `oklch(30 40 50 / 0.5)`);
+    test_computed_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / none), oklch(50 60 70deg / none))`, `oklch(30 40 50 / none)`);
+
+    // lab()
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30), lab(50 60 70))`, `lab(30 40 50)`);
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30) 25%, lab(50 60 70))`, `lab(40 50 60)`);
+    test_computed_value(`color`, `color-mix(in lab, 25% lab(10 20 30), lab(50 60 70))`, `lab(40 50 60)`);
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30), 25% lab(50 60 70))`, `lab(20 30 40)`);
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30), lab(50 60 70) 25%)`, `lab(20 30 40)`);
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30) 25%, lab(50 60 70) 75%)`, `lab(40 50 60)`);
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30) 30%, lab(50 60 70) 90%)`, `lab(40 50 60)`); // Scale down > 100% sum.
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30) 12.5%, lab(50 60 70) 37.5%)`, `lab(40 50 60 / 0.5)`); // Scale up < 100% sum, causes alpha multiplication.
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30) 0%, lab(50 60 70))`, `lab(50 60 70)`);
+
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30 / .4), lab(50 60 70 / .8))`, `lab(36.666664 46.666664 56.666664 / 0.6)`);
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30 / .4) 25%, lab(50 60 70 / .8))`, `lab(44.285713 54.285717 64.28571 / 0.7)`);
+    test_computed_value(`color`, `color-mix(in lab, 25% lab(10 20 30 / .4), lab(50 60 70 / .8))`, `lab(44.285713 54.285717 64.28571 / 0.7)`);
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30 / .4), 25% lab(50 60 70 / .8))`, `lab(26 36 46 / 0.5)`);
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30 / .4), lab(50 60 70 / .8) 25%)`, `lab(26 36 46 / 0.5)`);
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30 / .4) 25%, lab(50 60 70 / .8) 75%)`, `lab(44.285713 54.285717 64.28571 / 0.7)`);
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30 / .4) 30%, lab(50 60 70 / .8) 90%)`, `lab(44.285713 54.285717 64.28571 / 0.7)`); // Scale down > 100% sum.
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30 / .4) 12.5%, lab(50 60 70 / .8) 37.5%)`, `lab(44.285713 54.285717 64.28571 / 0.35)`); // Scale up < 100% sum, causes alpha multiplication.
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30 / .4) 0%, lab(50 60 70 / .8))`, `lab(50 60 70 / 0.8)`);
+
+    test_computed_value(`color`, `color-mix(in lab, lab(none none none), lab(none none none))`, `lab(none none none)`);
+    test_computed_value(`color`, `color-mix(in lab, lab(none none none), lab(50 60 70))`, `lab(50 60 70)`);
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30), lab(none none none))`, `lab(10 20 30)`);
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 none), lab(50 60 70))`, `lab(30 40 70)`);
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30), lab(50 60 none))`, `lab(30 40 30)`);
+    test_computed_value(`color`, `color-mix(in lab, lab(none 20 30), lab(50 none 70))`, `lab(50 20 50)`);
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30 / none), lab(50 60 70))`, `lab(30 40 50)`);
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30 / none), lab(50 60 70 / 0.5))`, `lab(30 40 50 / 0.5)`);
+    test_computed_value(`color`, `color-mix(in lab, lab(10 20 30 / none), lab(50 60 70 / none))`, `lab(30 40 50 / none)`);
+
+    // oklab()
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30), oklab(50 60 70))`, `oklab(30 40 50)`);
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30) 25%, oklab(50 60 70))`, `oklab(40 50 60)`);
+    test_computed_value(`color`, `color-mix(in oklab, 25% oklab(10 20 30), oklab(50 60 70))`, `oklab(40 50 60)`);
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30), 25% oklab(50 60 70))`, `oklab(20 30 40)`);
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30), oklab(50 60 70) 25%)`, `oklab(20 30 40)`);
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30) 25%, oklab(50 60 70) 75%)`, `oklab(40 50 60)`);
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30) 30%, oklab(50 60 70) 90%)`, `oklab(40 50 60)`); // Scale down > 100% sum.
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30) 12.5%, oklab(50 60 70) 37.5%)`, `oklab(40 50 60 / 0.5)`); // Scale up < 100% sum, causes alpha multiplication.
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30) 0%, oklab(50 60 70))`, `oklab(50 60 70)`);
+
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30 / .4), oklab(50 60 70 / .8))`, `oklab(36.666664 46.666664 56.666664 / 0.6)`);
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30 / .4) 25%, oklab(50 60 70 / .8))`, `oklab(44.285713 54.285717 64.28571 / 0.7)`);
+    test_computed_value(`color`, `color-mix(in oklab, 25% oklab(10 20 30 / .4), oklab(50 60 70 / .8))`, `oklab(44.285713 54.285717 64.28571 / 0.7)`);
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30 / .4), 25% oklab(50 60 70 / .8))`, `oklab(26 36 46 / 0.5)`);
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30 / .4), oklab(50 60 70 / .8) 25%)`, `oklab(26 36 46 / 0.5)`);
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30 / .4) 25%, oklab(50 60 70 / .8) 75%)`, `oklab(44.285713 54.285717 64.28571 / 0.7)`);
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30 / .4) 30%, oklab(50 60 70 / .8) 90%)`, `oklab(44.285713 54.285717 64.28571 / 0.7)`); // Scale down > 100% sum.
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30 / .4) 12.5%, oklab(50 60 70 / .8) 37.5%)`, `oklab(44.285713 54.285717 64.28571 / 0.35)`); // Scale up < 100% sum, causes alpha multiplication.
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30 / .4) 0%, oklab(50 60 70 / .8))`, `oklab(50 60 70 / 0.8)`);
+
+    test_computed_value(`color`, `color-mix(in oklab, oklab(none none none), oklab(none none none))`, `oklab(none none none)`);
+    test_computed_value(`color`, `color-mix(in oklab, oklab(none none none), oklab(50 60 70))`, `oklab(50 60 70)`);
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30), oklab(none none none))`, `oklab(10 20 30)`);
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 none), oklab(50 60 70))`, `oklab(30 40 70)`);
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30), oklab(50 60 none))`, `oklab(30 40 30)`);
+    test_computed_value(`color`, `color-mix(in oklab, oklab(none 20 30), oklab(50 none 70))`, `oklab(50 20 50)`);
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30 / none), oklab(50 60 70))`, `oklab(30 40 50)`);
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30 / none), oklab(50 60 70 / 0.5))`, `oklab(30 40 50 / 0.5)`);
+    test_computed_value(`color`, `color-mix(in oklab, oklab(10 20 30 / none), oklab(50 60 70 / none))`, `oklab(30 40 50 / none)`);
+
 
     for (const colorSpace of [ "srgb", "srgb-linear", "xyz", "xyz-d50", "xyz-d65" ]) {
         const resultColorSpace = colorSpace == "xyz" ? "xyz-d65" : colorSpace;

--- a/css/css-color/parsing/color-computed-lab.html
+++ b/css/css-color/parsing/color-computed-lab.html
@@ -22,67 +22,118 @@
   }
 </style>
 <script>
-for (const colorSpace of [ "lab", "oklab" ]) {
-    test_computed_value("color", `${colorSpace}(0 0 0)`, `${colorSpace}(0 0 0)`);
-    test_computed_value("color", `${colorSpace}(0 0 0 / 1)`, `${colorSpace}(0 0 0)`);
-    test_computed_value("color", `${colorSpace}(0 0 0 / 0.5)`, `${colorSpace}(0 0 0 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(20 0 10/0.5)`, `${colorSpace}(20 0 10 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(20 0 10/50%)`, `${colorSpace}(20 0 10 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(400 0 10/50%)`, `${colorSpace}(400 0 10 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(50 -160 160)`, `${colorSpace}(50 -160 160)`);
-    test_computed_value("color", `${colorSpace}(50 -200 200)`, `${colorSpace}(50 -200 200)`);
-    test_computed_value("color", `${colorSpace}(0 0 0 / -10%)`, `${colorSpace}(0 0 0 / 0)`);
-    test_computed_value("color", `${colorSpace}(0 0 0 / 110%)`, `${colorSpace}(0 0 0)`);
-    test_computed_value("color", `${colorSpace}(0 0 0 / 300%)`, `${colorSpace}(0 0 0)`);
-    test_computed_value("color", `${colorSpace}(-40 0 0)`, `${colorSpace}(0 0 0)`);
-    test_computed_value("color", `${colorSpace}(50 -20 0)`, `${colorSpace}(50 -20 0)`);
-    test_computed_value("color", `${colorSpace}(50 0 -20)`, `${colorSpace}(50 0 -20)`);
-    test_computed_value("color", `${colorSpace}(calc(50 * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))`, `${colorSpace}(150 -0.5 1.5 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(calc(-50 * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))`, `${colorSpace}(0 1.5 -1.5 / 0)`);
 
-    test_computed_value("color", `${colorSpace}(none none none / none)`, `${colorSpace}(none none none / none)`);
-    test_computed_value("color", `${colorSpace}(none none none)`, `${colorSpace}(none none none)`);
-    test_computed_value("color", `${colorSpace}(20 none none / none)`, `${colorSpace}(20 none none / none)`);
-    test_computed_value("color", `${colorSpace}(none none none / 0.5)`, `${colorSpace}(none none none / 0.5)`);
-    test_computed_value("color", `${colorSpace}(0 0 0 / none)`, `${colorSpace}(0 0 0 / none)`);
-}
+// lab()
+test_computed_value("color", "lab(0 0 0)", "lab(0 0 0)");
+test_computed_value("color", "lab(0 0 0 / 1)", "lab(0 0 0)");
+test_computed_value("color", "lab(0 0 0 / 0.5)", "lab(0 0 0 / 0.5)");
+test_computed_value("color", "lab(20 0 10/0.5)", "lab(20 0 10 / 0.5)");
+test_computed_value("color", "lab(20 0 10/50%)", "lab(20 0 10 / 0.5)");
+test_computed_value("color", "lab(400 0 10/50%)", "lab(400 0 10 / 0.5)");
+test_computed_value("color", "lab(50 -160 160)", "lab(50 -160 160)");
+test_computed_value("color", "lab(50 -200 200)", "lab(50 -200 200)");
+test_computed_value("color", "lab(0 0 0 / -10%)", "lab(0 0 0 / 0)");
+test_computed_value("color", "lab(0 0 0 / 110%)", "lab(0 0 0)");
+test_computed_value("color", "lab(0 0 0 / 300%)", "lab(0 0 0)");
+test_computed_value("color", "lab(-40 0 0)", "lab(0 0 0)");
+test_computed_value("color", "lab(50 -20 0)", "lab(50 -20 0)");
+test_computed_value("color", "lab(50 0 -20)", "lab(50 0 -20)");
+test_computed_value("color", "lab(calc(50 * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))", "lab(150 -0.5 1.5 / 0.5)");
+test_computed_value("color", "lab(calc(-50 * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))", "lab(0 1.5 -1.5 / 0)");
+
+test_computed_value("color", "lab(none none none / none)", "lab(none none none / none)");
+test_computed_value("color", "lab(none none none)", "lab(none none none)");
+test_computed_value("color", "lab(20 none none / none)", "lab(20 none none / none)");
+test_computed_value("color", "lab(none none none / 0.5)", "lab(none none none / 0.5)");
+test_computed_value("color", "lab(0 0 0 / none)", "lab(0 0 0 / none)");
+
+// oklab()
+test_computed_value("color", "oklab(0 0 0)", "oklab(0 0 0)");
+test_computed_value("color", "oklab(0 0 0 / 1)", "oklab(0 0 0)");
+test_computed_value("color", "oklab(0 0 0 / 0.5)", "oklab(0 0 0 / 0.5)");
+test_computed_value("color", "oklab(20 0 10/0.5)", "oklab(20 0 10 / 0.5)");
+test_computed_value("color", "oklab(20 0 10/50%)", "oklab(20 0 10 / 0.5)");
+test_computed_value("color", "oklab(400 0 10/50%)", "oklab(400 0 10 / 0.5)");
+test_computed_value("color", "oklab(50 -160 160)", "oklab(50 -160 160)");
+test_computed_value("color", "oklab(50 -200 200)", "oklab(50 -200 200)");
+test_computed_value("color", "oklab(0 0 0 / -10%)", "oklab(0 0 0 / 0)");
+test_computed_value("color", "oklab(0 0 0 / 110%)", "oklab(0 0 0)");
+test_computed_value("color", "oklab(0 0 0 / 300%)", "oklab(0 0 0)");
+test_computed_value("color", "oklab(-40 0 0)", "oklab(0 0 0)");
+test_computed_value("color", "oklab(50 -20 0)", "oklab(50 -20 0)");
+test_computed_value("color", "oklab(50 0 -20)", "oklab(50 0 -20)");
+test_computed_value("color", "oklab(calc(50 * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))", "oklab(150 -0.5 1.5 / 0.5)");
+test_computed_value("color", "oklab(calc(-50 * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))", "oklab(0 1.5 -1.5 / 0)");
+
+test_computed_value("color", "oklab(none none none / none)", "oklab(none none none / none)");
+test_computed_value("color", "oklab(none none none)", "oklab(none none none)");
+test_computed_value("color", "oklab(20 none none / none)", "oklab(20 none none / none)");
+test_computed_value("color", "oklab(none none none / 0.5)", "oklab(none none none / 0.5)");
+test_computed_value("color", "oklab(0 0 0 / none)", "oklab(0 0 0 / none)");
 
 // These tests validate that lab lightness range is 0-100 and oklab lightness range is 0.0-1.0.
-test_computed_value("color", `lab(20% 0 10/0.5)`, `lab(20 0 10 / 0.5)`);
-test_computed_value("color", `oklab(20% 0 10/0.5)`, `oklab(0.2 0 10 / 0.5)`);
+test_computed_value("color", "lab(20% 0 10/0.5)", "lab(20 0 10 / 0.5)");
+test_computed_value("color", "oklab(20% 0 10/0.5)", "oklab(0.2 0 10 / 0.5)");
 
-for (const colorSpace of [ "lch", "oklch" ]) {
-    test_computed_value("color", `${colorSpace}(0 0 0deg)`, `${colorSpace}(0 0 0)`);
-    test_computed_value("color", `${colorSpace}(0 0 0deg / 1)`, `${colorSpace}(0 0 0)`);
-    test_computed_value("color", `${colorSpace}(0 0 0deg / 0.5)`, `${colorSpace}(0 0 0 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(100 230 0deg / 0.5)`, `${colorSpace}(100 230 0 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(20 50 20deg/0.5)`, `${colorSpace}(20 50 20 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(20 50 20deg/50%)`, `${colorSpace}(20 50 20 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(10 20 20deg / -10%)`, `${colorSpace}(10 20 20 / 0)`);
-    test_computed_value("color", `${colorSpace}(10 20 20deg / 110%)`, `${colorSpace}(10 20 20)`);
-    test_computed_value("color", `${colorSpace}(10 20 1.28rad)`, `${colorSpace}(10 20 73.3386)`);
-    test_computed_value("color", `${colorSpace}(10 20 380deg)`, `${colorSpace}(10 20 20)`);
-    test_computed_value("color", `${colorSpace}(10 20 -340deg)`, `${colorSpace}(10 20 20)`);
-    test_computed_value("color", `${colorSpace}(10 20 740deg)`, `${colorSpace}(10 20 20)`);
-    test_computed_value("color", `${colorSpace}(10 20 -700deg)`, `${colorSpace}(10 20 20)`);
-    test_computed_value("color", `${colorSpace}(-40 0 0)`, `${colorSpace}(0 0 0)`);
-    test_computed_value("color", `${colorSpace}(20 -20 0)`, `${colorSpace}(20 0 0)`);
-    test_computed_value("color", `${colorSpace}(0 0 0 / 0.5)`, `${colorSpace}(0 0 0 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(10 20 20 / 110%)`, `${colorSpace}(10 20 20)`);
-    test_computed_value("color", `${colorSpace}(10 20 -700)`, `${colorSpace}(10 20 20)`);
-    test_computed_value("color", `${colorSpace}(calc(50 * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))`, `${colorSpace}(150 0 40 / 0.5)`);
-    test_computed_value("color", `${colorSpace}(calc(-50 * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))`, `${colorSpace}(0 1.5 320 / 0)`);
+// lch()
+test_computed_value("color", "lch(0 0 0deg)", "lch(0 0 0)");
+test_computed_value("color", "lch(0 0 0deg / 1)", "lch(0 0 0)");
+test_computed_value("color", "lch(0 0 0deg / 0.5)", "lch(0 0 0 / 0.5)");
+test_computed_value("color", "lch(100 230 0deg / 0.5)", "lch(100 230 0 / 0.5)");
+test_computed_value("color", "lch(20 50 20deg/0.5)", "lch(20 50 20 / 0.5)");
+test_computed_value("color", "lch(20 50 20deg/50%)", "lch(20 50 20 / 0.5)");
+test_computed_value("color", "lch(10 20 20deg / -10%)", "lch(10 20 20 / 0)");
+test_computed_value("color", "lch(10 20 20deg / 110%)", "lch(10 20 20)");
+test_computed_value("color", "lch(10 20 1.28rad)", "lch(10 20 73.3386)");
+test_computed_value("color", "lch(10 20 380deg)", "lch(10 20 20)");
+test_computed_value("color", "lch(10 20 -340deg)", "lch(10 20 20)");
+test_computed_value("color", "lch(10 20 740deg)", "lch(10 20 20)");
+test_computed_value("color", "lch(10 20 -700deg)", "lch(10 20 20)");
+test_computed_value("color", "lch(-40 0 0)", "lch(0 0 0)");
+test_computed_value("color", "lch(20 -20 0)", "lch(20 0 0)");
+test_computed_value("color", "lch(0 0 0 / 0.5)", "lch(0 0 0 / 0.5)");
+test_computed_value("color", "lch(10 20 20 / 110%)", "lch(10 20 20)");
+test_computed_value("color", "lch(10 20 -700)", "lch(10 20 20)");
+test_computed_value("color", "lch(calc(50 * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))", "lch(150 0 40 / 0.5)");
+test_computed_value("color", "lch(calc(-50 * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))", "lch(0 1.5 320 / 0)");
 
-    test_computed_value("color", `${colorSpace}(none none none / none)`, `${colorSpace}(none none none / none)`);
-    test_computed_value("color", `${colorSpace}(none none none)`, `${colorSpace}(none none none)`);
-    test_computed_value("color", `${colorSpace}(20 none none / none)`, `${colorSpace}(20 none none / none)`);
-    test_computed_value("color", `${colorSpace}(none none none / 0.5)`, `${colorSpace}(none none none / 0.5)`);
-    test_computed_value("color", `${colorSpace}(0 0 0 / none)`, `${colorSpace}(0 0 0 / none)`);
-}
+test_computed_value("color", "lch(none none none / none)", "lch(none none none / none)");
+test_computed_value("color", "lch(none none none)", "lch(none none none)");
+test_computed_value("color", "lch(20 none none / none)", "lch(20 none none / none)");
+test_computed_value("color", "lch(none none none / 0.5)", "lch(none none none / 0.5)");
+test_computed_value("color", "lch(0 0 0 / none)", "lch(0 0 0 / none)");
+
+// oklch()
+test_computed_value("color", "oklch(0 0 0deg)", "oklch(0 0 0)");
+test_computed_value("color", "oklch(0 0 0deg / 1)", "oklch(0 0 0)");
+test_computed_value("color", "oklch(0 0 0deg / 0.5)", "oklch(0 0 0 / 0.5)");
+test_computed_value("color", "oklch(100 230 0deg / 0.5)", "oklch(100 230 0 / 0.5)");
+test_computed_value("color", "oklch(20 50 20deg/0.5)", "oklch(20 50 20 / 0.5)");
+test_computed_value("color", "oklch(20 50 20deg/50%)", "oklch(20 50 20 / 0.5)");
+test_computed_value("color", "oklch(10 20 20deg / -10%)", "oklch(10 20 20 / 0)");
+test_computed_value("color", "oklch(10 20 20deg / 110%)", "oklch(10 20 20)");
+test_computed_value("color", "oklch(10 20 1.28rad)", "oklch(10 20 73.3386)");
+test_computed_value("color", "oklch(10 20 380deg)", "oklch(10 20 20)");
+test_computed_value("color", "oklch(10 20 -340deg)", "oklch(10 20 20)");
+test_computed_value("color", "oklch(10 20 740deg)", "oklch(10 20 20)");
+test_computed_value("color", "oklch(10 20 -700deg)", "oklch(10 20 20)");
+test_computed_value("color", "oklch(-40 0 0)", "oklch(0 0 0)");
+test_computed_value("color", "oklch(20 -20 0)", "oklch(20 0 0)");
+test_computed_value("color", "oklch(0 0 0 / 0.5)", "oklch(0 0 0 / 0.5)");
+test_computed_value("color", "oklch(10 20 20 / 110%)", "oklch(10 20 20)");
+test_computed_value("color", "oklch(10 20 -700)", "oklch(10 20 20)");
+test_computed_value("color", "oklch(calc(50 * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))", "oklch(150 0 40 / 0.5)");
+test_computed_value("color", "oklch(calc(-50 * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))", "oklch(0 1.5 320 / 0)");
+
+test_computed_value("color", "oklch(none none none / none)", "oklch(none none none / none)");
+test_computed_value("color", "oklch(none none none)", "oklch(none none none)");
+test_computed_value("color", "oklch(20 none none / none)", "oklch(20 none none / none)");
+test_computed_value("color", "oklch(none none none / 0.5)", "oklch(none none none / 0.5)");
+test_computed_value("color", "oklch(0 0 0 / none)", "oklch(0 0 0 / none)");
 
 // These tests validate that lch lightness range is 0-100 and oklch lightness range is 0.0-1.0.
-test_computed_value("color", `lch(20% 0 10/0.5)`, `lch(20 0 10 / 0.5)`);
-test_computed_value("color", `oklch(20% 0 10/0.5)`, `oklch(0.2 0 10 / 0.5)`);
+test_computed_value("color", "lch(20% 0 10/0.5)", "lch(20 0 10 / 0.5)");
+test_computed_value("color", "oklch(20% 0 10/0.5)", "oklch(0.2 0 10 / 0.5)");
 </script>
 </body>
 </html>

--- a/css/css-color/parsing/color-computed-relative-color.html
+++ b/css/css-color/parsing/color-computed-relative-color.html
@@ -291,68 +291,132 @@
   test_computed_value(`color`, `hwb(from hwb(120deg 20% 50% / none) h w b / alpha)`,             `rgba(51, 128, 51, 0)`);
   test_computed_value(`color`, `hwb(from hwb(none 20% 50% / .5) h w b / alpha)`,                 `rgba(128, 51, 51, 0.5)`);
 
-  for (const colorSpace of [ "lab", "oklab" ]) {
-      // Testing no modifications.
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b)`, `${colorSpace}(25 20 50)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b / alpha)`, `${colorSpace}(25 20 50)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a b / alpha)`, `${colorSpace}(25 20 50 / 0.4)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(200 300 400 / 500%) l a b / alpha)`, `${colorSpace}(200 300 400)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(-200 -300 -400 / -500%) l a b / alpha)`, `${colorSpace}(0 -300 -400 / 0)`);
+  // lab()
 
-      // Test nesting relative colors.
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(from ${colorSpace}(25 20 50) l a b) l a b)`, `${colorSpace}(25 20 50)`);
+  // Testing no modifications.
+  test_computed_value(`color`, `lab(from lab(25 20 50) l a b)`, `lab(25 20 50)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50) l a b / alpha)`, `lab(25 20 50)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50 / 40%) l a b / alpha)`, `lab(25 20 50 / 0.4)`);
+  test_computed_value(`color`, `lab(from lab(200 300 400 / 500%) l a b / alpha)`, `lab(200 300 400)`);
+  test_computed_value(`color`, `lab(from lab(-200 -300 -400 / -500%) l a b / alpha)`, `lab(0 -300 -400 / 0)`);
 
-      // Testing non-${colorSpace} origin to see conversion.
-      test_computed_value(`color`, `${colorSpace}(from color(display-p3 0 0 0) l a b / alpha)`, `${colorSpace}(0 0 0)`);
+  // Test nesting relative colors.
+  test_computed_value(`color`, `lab(from lab(from lab(25 20 50) l a b) l a b)`, `lab(25 20 50)`);
 
-      // Testing replacement with 0.
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) 0 0 0)`, `${colorSpace}(0 0 0)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) 0 0 0 / 0)`, `${colorSpace}(0 0 0 / 0)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) 0 a b / alpha)`, `${colorSpace}(0 20 50)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l 0 b / alpha)`, `${colorSpace}(25 0 50)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a 0 / alpha)`, `${colorSpace}(25 20 0)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b / 0)`, `${colorSpace}(25 20 50 / 0)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) 0 a b / alpha)`, `${colorSpace}(0 20 50 / 0.4)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l 0 b / alpha)`, `${colorSpace}(25 0 50 / 0.4)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a 0 / alpha)`, `${colorSpace}(25 20 0 / 0.4)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a b / 0)`, `${colorSpace}(25 20 50 / 0)`);
+  // Testing non-lab origin to see conversion.
+  test_computed_value(`color`, `lab(from color(display-p3 0 0 0) l a b / alpha)`, `lab(0 0 0)`);
 
-      // Testing replacement with a constant.
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) 35 a b / alpha)`, `${colorSpace}(35 20 50)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l 35 b / alpha)`, `${colorSpace}(25 35 50)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a 35 / alpha)`, `${colorSpace}(25 20 35)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b / .35)`, `${colorSpace}(25 20 50 / 0.35)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) 35 a b / alpha)`, `${colorSpace}(35 20 50 / 0.4)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l 35 b / alpha)`, `${colorSpace}(25 35 50 / 0.4)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a 35 / alpha)`, `${colorSpace}(25 20 35 / 0.4)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a b / .35)`, `${colorSpace}(25 20 50 / 0.35)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 200 300 400 / 500)`, `${colorSpace}(200 300 400)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) -200 -300 -400 / -500)`, `${colorSpace}(0 -300 -400 / 0)`);
+  // Testing replacement with 0.
+  test_computed_value(`color`, `lab(from lab(25 20 50) 0 0 0)`, `lab(0 0 0)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50) 0 0 0 / 0)`, `lab(0 0 0 / 0)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50) 0 a b / alpha)`, `lab(0 20 50)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50) l 0 b / alpha)`, `lab(25 0 50)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50) l a 0 / alpha)`, `lab(25 20 0)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50) l a b / 0)`, `lab(25 20 50 / 0)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50 / 40%) 0 a b / alpha)`, `lab(0 20 50 / 0.4)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50 / 40%) l 0 b / alpha)`, `lab(25 0 50 / 0.4)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50 / 40%) l a 0 / alpha)`, `lab(25 20 0 / 0.4)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50 / 40%) l a b / 0)`, `lab(25 20 50 / 0)`);
 
-      // Testing valid permutation (types match).
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l b a)`, `${colorSpace}(25 50 20)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a a / a)`, `${colorSpace}(25 20 20)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l b a)`, `${colorSpace}(25 50 20)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a a / a)`, `${colorSpace}(25 20 20)`);
+  // Testing replacement with a constant.
+  test_computed_value(`color`, `lab(from lab(25 20 50) 35 a b / alpha)`, `lab(35 20 50)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50) l 35 b / alpha)`, `lab(25 35 50)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50) l a 35 / alpha)`, `lab(25 20 35)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50) l a b / .35)`, `lab(25 20 50 / 0.35)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50 / 40%) 35 a b / alpha)`, `lab(35 20 50 / 0.4)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50 / 40%) l 35 b / alpha)`, `lab(25 35 50 / 0.4)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50 / 40%) l a 35 / alpha)`, `lab(25 20 35 / 0.4)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50 / 40%) l a b / .35)`, `lab(25 20 50 / 0.35)`);
+  test_computed_value(`color`, `lab(from lab(0.7 45 30 / 40%) 200 300 400 / 500)`, `lab(200 300 400)`);
+  test_computed_value(`color`, `lab(from lab(0.7 45 30 / 40%) -200 -300 -400 / -500)`, `lab(0 -300 -400 / 0)`);
 
-      // Testing with calc().
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) calc(l) calc(a) calc(b))`, `${colorSpace}(25 20 50)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) calc(l) calc(a) calc(b) / calc(alpha))`, `${colorSpace}(25 20 50 / 0.4)`);
+  // Testing valid permutation (types match).
+  test_computed_value(`color`, `lab(from lab(25 20 50) l b a)`, `lab(25 50 20)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50) l a a / a)`, `lab(25 20 20)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50 / 40%) l b a)`, `lab(25 50 20)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50 / 40%) l a a / a)`, `lab(25 20 20)`);
 
-      // Testing with 'none'.
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) none none none)`, `${colorSpace}(none none none)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) none none none / none)`, `${colorSpace}(none none none / none)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a none)`, `${colorSpace}(25 20 none)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a none / alpha)`, `${colorSpace}(25 20 none)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b / none)`, `${colorSpace}(25 20 50 / none)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a none / alpha)`, `${colorSpace}(25 20 none / 0.4)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a b / none)`, `${colorSpace}(25 20 50 / none)`);
-      // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(none none none) l a b)`, `${colorSpace}(0 0 0)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(none none none / none) l a b / alpha)`, `${colorSpace}(0 0 0 / 0)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 none 50) l a b)`, `${colorSpace}(25 0 50)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / none) l a b / alpha)`, `${colorSpace}(25 20 50 / 0)`);
-  }
+  // Testing with calc().
+  test_computed_value(`color`, `lab(from lab(25 20 50) calc(l) calc(a) calc(b))`, `lab(25 20 50)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50 / 40%) calc(l) calc(a) calc(b) / calc(alpha))`, `lab(25 20 50 / 0.4)`);
+
+  // Testing with 'none'.
+  test_computed_value(`color`, `lab(from lab(25 20 50) none none none)`, `lab(none none none)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50) none none none / none)`, `lab(none none none / none)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50) l a none)`, `lab(25 20 none)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50) l a none / alpha)`, `lab(25 20 none)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50) l a b / none)`, `lab(25 20 50 / none)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50 / 40%) l a none / alpha)`, `lab(25 20 none / 0.4)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50 / 40%) l a b / none)`, `lab(25 20 50 / none)`);
+  // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+  test_computed_value(`color`, `lab(from lab(none none none) l a b)`, `lab(0 0 0)`);
+  test_computed_value(`color`, `lab(from lab(none none none / none) l a b / alpha)`, `lab(0 0 0 / 0)`);
+  test_computed_value(`color`, `lab(from lab(25 none 50) l a b)`, `lab(25 0 50)`);
+  test_computed_value(`color`, `lab(from lab(25 20 50 / none) l a b / alpha)`, `lab(25 20 50 / 0)`);
+
+  // oklab()
+
+  // Testing no modifications.
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) l a b)`, `oklab(25 20 50)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) l a b / alpha)`, `oklab(25 20 50)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50 / 40%) l a b / alpha)`, `oklab(25 20 50 / 0.4)`);
+  test_computed_value(`color`, `oklab(from oklab(200 300 400 / 500%) l a b / alpha)`, `oklab(200 300 400)`);
+  test_computed_value(`color`, `oklab(from oklab(-200 -300 -400 / -500%) l a b / alpha)`, `oklab(0 -300 -400 / 0)`);
+
+  // Test nesting relative colors.
+  test_computed_value(`color`, `oklab(from oklab(from oklab(25 20 50) l a b) l a b)`, `oklab(25 20 50)`);
+
+  // Testing non-oklab origin to see conversion.
+  test_computed_value(`color`, `oklab(from color(display-p3 0 0 0) l a b / alpha)`, `oklab(0 0 0)`);
+
+  // Testing replacement with 0.
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) 0 0 0)`, `oklab(0 0 0)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) 0 0 0 / 0)`, `oklab(0 0 0 / 0)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) 0 a b / alpha)`, `oklab(0 20 50)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) l 0 b / alpha)`, `oklab(25 0 50)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) l a 0 / alpha)`, `oklab(25 20 0)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) l a b / 0)`, `oklab(25 20 50 / 0)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50 / 40%) 0 a b / alpha)`, `oklab(0 20 50 / 0.4)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50 / 40%) l 0 b / alpha)`, `oklab(25 0 50 / 0.4)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50 / 40%) l a 0 / alpha)`, `oklab(25 20 0 / 0.4)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50 / 40%) l a b / 0)`, `oklab(25 20 50 / 0)`);
+
+  // Testing replacement with a constant.
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) 35 a b / alpha)`, `oklab(35 20 50)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) l 35 b / alpha)`, `oklab(25 35 50)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) l a 35 / alpha)`, `oklab(25 20 35)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) l a b / .35)`, `oklab(25 20 50 / 0.35)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50 / 40%) 35 a b / alpha)`, `oklab(35 20 50 / 0.4)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50 / 40%) l 35 b / alpha)`, `oklab(25 35 50 / 0.4)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50 / 40%) l a 35 / alpha)`, `oklab(25 20 35 / 0.4)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50 / 40%) l a b / .35)`, `oklab(25 20 50 / 0.35)`);
+  test_computed_value(`color`, `oklab(from oklab(0.7 45 30 / 40%) 200 300 400 / 500)`, `oklab(200 300 400)`);
+  test_computed_value(`color`, `oklab(from oklab(0.7 45 30 / 40%) -200 -300 -400 / -500)`, `oklab(0 -300 -400 / 0)`);
+
+  // Testing valid permutation (types match).
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) l b a)`, `oklab(25 50 20)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) l a a / a)`, `oklab(25 20 20)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50 / 40%) l b a)`, `oklab(25 50 20)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50 / 40%) l a a / a)`, `oklab(25 20 20)`);
+
+  // Testing with calc().
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) calc(l) calc(a) calc(b))`, `oklab(25 20 50)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50 / 40%) calc(l) calc(a) calc(b) / calc(alpha))`, `oklab(25 20 50 / 0.4)`);
+
+  // Testing with 'none'.
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) none none none)`, `oklab(none none none)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) none none none / none)`, `oklab(none none none / none)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) l a none)`, `oklab(25 20 none)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) l a none / alpha)`, `oklab(25 20 none)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50) l a b / none)`, `oklab(25 20 50 / none)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50 / 40%) l a none / alpha)`, `oklab(25 20 none / 0.4)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50 / 40%) l a b / none)`, `oklab(25 20 50 / none)`);
+  // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+  test_computed_value(`color`, `oklab(from oklab(none none none) l a b)`, `oklab(0 0 0)`);
+  test_computed_value(`color`, `oklab(from oklab(none none none / none) l a b / alpha)`, `oklab(0 0 0 / 0)`);
+  test_computed_value(`color`, `oklab(from oklab(25 none 50) l a b)`, `oklab(25 0 50)`);
+  test_computed_value(`color`, `oklab(from oklab(25 20 50 / none) l a b / alpha)`, `oklab(25 20 50 / 0)`);
+
 
   // lab and oklab tests that require different results due to percent scaling differences.
   test_computed_value(`color`, `lab(from lab(.7 45 30) alpha b a / l)`, `lab(100 30 45 / 0.7)`);
@@ -369,78 +433,147 @@
   test_computed_value(`color`, `oklab(from oklab(.7 45 30 / 40%) alpha a b / alpha)`, `oklab(0.4 45 30 / 0.4)`);
   test_computed_value(`color`, `oklab(from oklab(.7 45 30 / 40%) alpha a a / alpha)`, `oklab(0.4 45 45 / 0.4)`);
 
-  for (const colorSpace of [ "lch", "oklch" ]) {
-      const rectangularForm = colorSpace == "lch" ? "lab" : "oklab";
+  // lch()
 
-      // Testing no modifications.
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h)`, `${colorSpace}(0.7 45 30)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h / alpha)`, `${colorSpace}(0.7 45 30)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c h / alpha)`, `${colorSpace}(0.7 45 30 / 0.4)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(200 300 400 / 500%) l c h / alpha)`, `${colorSpace}(200 300 40)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(-200 -300 -400 / -500%) l c h / alpha)`, `${colorSpace}(0 0 320 / 0)`);
+  // Testing no modifications.
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) l c h)`, `lch(0.7 45 30)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) l c h / alpha)`, `lch(0.7 45 30)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / 40%) l c h / alpha)`, `lch(0.7 45 30 / 0.4)`);
+  test_computed_value(`color`, `lch(from lch(200 300 400 / 500%) l c h / alpha)`, `lch(200 300 40)`);
+  test_computed_value(`color`, `lch(from lch(-200 -300 -400 / -500%) l c h / alpha)`, `lch(0 0 320 / 0)`);
 
-      // Test nesting relative colors.
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(from ${colorSpace}(0.7 45 30) l c h) l c h)`, `${colorSpace}(0.7 45 30)`);
+  // Test nesting relative colors.
+  test_computed_value(`color`, `lch(from lch(from lch(0.7 45 30) l c h) l c h)`, `lch(0.7 45 30)`);
 
-      // Testing non-sRGB origin colors (no gamut mapping will happen since the destination is not a bounded RGB color space).
-      test_computed_value(`color`, `${colorSpace}(from color(display-p3 0 0 0) l c h / alpha)`, `${colorSpace}(0 0 0)`);
-      test_computed_value(`color`, `${colorSpace}(from ${rectangularForm}(0.7 45 30) l c h / alpha)`, `${colorSpace}(0.7 54.08327 33.690067)`);
+  // Testing non-sRGB origin colors (no gamut mapping will happen since the destination is not a bounded RGB color space).
+  test_computed_value(`color`, `lch(from color(display-p3 0 0 0) l c h / alpha)`, `lch(0 0 0)`);
+  test_computed_value(`color`, `lch(from lab(0.7 45 30) l c h / alpha)`, `lch(0.7 54.08327 33.690067)`);
 
-      // Testing replacement with 0.
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 0 0)`, `${colorSpace}(0 0 0)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 0 0deg)`, `${colorSpace}(0 0 0)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 0 0 / 0)`, `${colorSpace}(0 0 0 / 0)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 0 0deg / 0)`, `${colorSpace}(0 0 0 / 0)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 c h / alpha)`, `${colorSpace}(0 45 30)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l 0 h / alpha)`, `${colorSpace}(0.7 0 30)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c 0 / alpha)`, `${colorSpace}(0.7 45 0)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c 0deg / alpha)`, `${colorSpace}(0.7 45 0)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h / 0)`, `${colorSpace}(0.7 45 30 / 0)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 0 c h / alpha)`, `${colorSpace}(0 45 30 / 0.4)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l 0 h / alpha)`, `${colorSpace}(0.7 0 30 / 0.4)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c 0 / alpha)`, `${colorSpace}(0.7 45 0 / 0.4)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c 0deg / alpha)`, `${colorSpace}(0.7 45 0 / 0.4)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c h / 0)`, `${colorSpace}(0.7 45 30 / 0)`);
+  // Testing replacement with 0.
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) 0 0 0)`, `lch(0 0 0)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) 0 0 0deg)`, `lch(0 0 0)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) 0 0 0 / 0)`, `lch(0 0 0 / 0)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) 0 0 0deg / 0)`, `lch(0 0 0 / 0)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) 0 c h / alpha)`, `lch(0 45 30)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) l 0 h / alpha)`, `lch(0.7 0 30)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) l c 0 / alpha)`, `lch(0.7 45 0)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) l c 0deg / alpha)`, `lch(0.7 45 0)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) l c h / 0)`, `lch(0.7 45 30 / 0)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / 40%) 0 c h / alpha)`, `lch(0 45 30 / 0.4)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / 40%) l 0 h / alpha)`, `lch(0.7 0 30 / 0.4)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / 40%) l c 0 / alpha)`, `lch(0.7 45 0 / 0.4)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / 40%) l c 0deg / alpha)`, `lch(0.7 45 0 / 0.4)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / 40%) l c h / 0)`, `lch(0.7 45 30 / 0)`);
 
-      // Testing replacement with a constant.
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 25 c h / alpha)`, `${colorSpace}(25 45 30)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l 25 h / alpha)`, `${colorSpace}(0.7 25 30)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c 25 / alpha)`, `${colorSpace}(0.7 45 25)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c 25deg / alpha)`, `${colorSpace}(0.7 45 25)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h / .25)`, `${colorSpace}(0.7 45 30 / 0.25)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 25 c h / alpha)`, `${colorSpace}(25 45 30 / 0.4)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l 25 h / alpha)`, `${colorSpace}(0.7 25 30 / 0.4)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c 25 / alpha)`, `${colorSpace}(0.7 45 25 / 0.4)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c 25deg / alpha)`, `${colorSpace}(0.7 45 25 / 0.4)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c h / .25)`, `${colorSpace}(0.7 45 30 / 0.25)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 200 300 400 / 500)`, `${colorSpace}(200 300 40)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) -200 -300 -400 / -500)`, `${colorSpace}(0 0 320 / 0)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 50 120 400deg / 500)`, `${colorSpace}(50 120 40)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 50 120 -400deg / -500)`, `${colorSpace}(50 120 320 / 0)`);
+  // Testing replacement with a constant.
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) 25 c h / alpha)`, `lch(25 45 30)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) l 25 h / alpha)`, `lch(0.7 25 30)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) l c 25 / alpha)`, `lch(0.7 45 25)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) l c 25deg / alpha)`, `lch(0.7 45 25)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) l c h / .25)`, `lch(0.7 45 30 / 0.25)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / 40%) 25 c h / alpha)`, `lch(25 45 30 / 0.4)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / 40%) l 25 h / alpha)`, `lch(0.7 25 30 / 0.4)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / 40%) l c 25 / alpha)`, `lch(0.7 45 25 / 0.4)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / 40%) l c 25deg / alpha)`, `lch(0.7 45 25 / 0.4)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / 40%) l c h / .25)`, `lch(0.7 45 30 / 0.25)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / 40%) 200 300 400 / 500)`, `lch(200 300 40)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / 40%) -200 -300 -400 / -500)`, `lch(0 0 320 / 0)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / 40%) 50 120 400deg / 500)`, `lch(50 120 40)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / 40%) 50 120 -400deg / -500)`, `lch(50 120 320 / 0)`);
 
-      // Testing valid permutation (types match).
-      // NOTE: 'c' is a vaild hue, as hue is <angle>|<number>.
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(.7 45 30) l c c / alpha)`, `${colorSpace}(0.7 45 45)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(.7 45 30 / 40%) l c c / alpha)`, `${colorSpace}(0.7 45 45 / 0.4)`);
+  // Testing valid permutation (types match).
+  // NOTE: 'c' is a vaild hue, as hue is <angle>|<number>.
+  test_computed_value(`color`, `lch(from lch(.7 45 30) l c c / alpha)`, `lch(0.7 45 45)`);
+  test_computed_value(`color`, `lch(from lch(.7 45 30 / 40%) l c c / alpha)`, `lch(0.7 45 45 / 0.4)`);
 
-      // Testing with calc().
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) calc(l) calc(c) calc(h))`, `${colorSpace}(0.7 45 30)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) calc(l) calc(c) calc(h) / calc(alpha))`, `${colorSpace}(0.7 45 30 / 0.4)`);
+  // Testing with calc().
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) calc(l) calc(c) calc(h))`, `lch(0.7 45 30)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / 40%) calc(l) calc(c) calc(h) / calc(alpha))`, `lch(0.7 45 30 / 0.4)`);
 
-      // Testing with 'none'.
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) none none none)`,                                   `${colorSpace}(none none none)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) none none none / none)`,                            `${colorSpace}(none none none / none)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c none)`,                                         `${colorSpace}(0.7 45 none)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c none / alpha)`,                                 `${colorSpace}(0.7 45 none)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h / none)`,                                     `${colorSpace}(0.7 45 30 / none)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c none / alpha)`,                           `${colorSpace}(0.7 45 none / 0.4)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c h / none)`,                               `${colorSpace}(0.7 45 30 / none)`);
-      // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(none none none) l c h)`,                                       `${colorSpace}(0 0 0)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(none none none / none) l c h / alpha)`,                        `${colorSpace}(0 0 0 / 0)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 none 30) l c h)`,                                          `${colorSpace}(0.7 0 30)`);
-      test_computed_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / none) l c h / alpha)`,                             `${colorSpace}(0.7 45 30 / 0)`);
-  }
+  // Testing with 'none'.
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) none none none)`,                                   `lch(none none none)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) none none none / none)`,                            `lch(none none none / none)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) l c none)`,                                         `lch(0.7 45 none)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) l c none / alpha)`,                                 `lch(0.7 45 none)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30) l c h / none)`,                                     `lch(0.7 45 30 / none)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / 40%) l c none / alpha)`,                           `lch(0.7 45 none / 0.4)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / 40%) l c h / none)`,                               `lch(0.7 45 30 / none)`);
+  // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+  test_computed_value(`color`, `lch(from lch(none none none) l c h)`,                                       `lch(0 0 0)`);
+  test_computed_value(`color`, `lch(from lch(none none none / none) l c h / alpha)`,                        `lch(0 0 0 / 0)`);
+  test_computed_value(`color`, `lch(from lch(0.7 none 30) l c h)`,                                          `lch(0.7 0 30)`);
+  test_computed_value(`color`, `lch(from lch(0.7 45 30 / none) l c h / alpha)`,                             `lch(0.7 45 30 / 0)`);
+
+  // oklch()
+
+  // Testing no modifications.
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) l c h)`, `oklch(0.7 45 30)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) l c h / alpha)`, `oklch(0.7 45 30)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l c h / alpha)`, `oklch(0.7 45 30 / 0.4)`);
+  test_computed_value(`color`, `oklch(from oklch(200 300 400 / 500%) l c h / alpha)`, `oklch(200 300 40)`);
+  test_computed_value(`color`, `oklch(from oklch(-200 -300 -400 / -500%) l c h / alpha)`, `oklch(0 0 320 / 0)`);
+
+  // Test nesting relative colors.
+  test_computed_value(`color`, `oklch(from oklch(from oklch(0.7 45 30) l c h) l c h)`, `oklch(0.7 45 30)`);
+
+  // Testing non-sRGB origin colors (no gamut mapping will happen since the destination is not a bounded RGB color space).
+  test_computed_value(`color`, `oklch(from color(display-p3 0 0 0) l c h / alpha)`, `oklch(0 0 0)`);
+  test_computed_value(`color`, `oklch(from oklab(0.7 45 30) l c h / alpha)`, `oklch(0.7 54.08327 33.690067)`);
+
+  // Testing replacement with 0.
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) 0 0 0)`, `oklch(0 0 0)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) 0 0 0deg)`, `oklch(0 0 0)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) 0 0 0 / 0)`, `oklch(0 0 0 / 0)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) 0 0 0deg / 0)`, `oklch(0 0 0 / 0)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) 0 c h / alpha)`, `oklch(0 45 30)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) l 0 h / alpha)`, `oklch(0.7 0 30)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) l c 0 / alpha)`, `oklch(0.7 45 0)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) l c 0deg / alpha)`, `oklch(0.7 45 0)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) l c h / 0)`, `oklch(0.7 45 30 / 0)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) 0 c h / alpha)`, `oklch(0 45 30 / 0.4)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l 0 h / alpha)`, `oklch(0.7 0 30 / 0.4)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l c 0 / alpha)`, `oklch(0.7 45 0 / 0.4)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l c 0deg / alpha)`, `oklch(0.7 45 0 / 0.4)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l c h / 0)`, `oklch(0.7 45 30 / 0)`);
+
+  // Testing replacement with a constant.
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) 25 c h / alpha)`, `oklch(25 45 30)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) l 25 h / alpha)`, `oklch(0.7 25 30)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) l c 25 / alpha)`, `oklch(0.7 45 25)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) l c 25deg / alpha)`, `oklch(0.7 45 25)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) l c h / .25)`, `oklch(0.7 45 30 / 0.25)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) 25 c h / alpha)`, `oklch(25 45 30 / 0.4)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l 25 h / alpha)`, `oklch(0.7 25 30 / 0.4)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l c 25 / alpha)`, `oklch(0.7 45 25 / 0.4)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l c 25deg / alpha)`, `oklch(0.7 45 25 / 0.4)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l c h / .25)`, `oklch(0.7 45 30 / 0.25)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) 200 300 400 / 500)`, `oklch(200 300 40)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) -200 -300 -400 / -500)`, `oklch(0 0 320 / 0)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) 50 120 400deg / 500)`, `oklch(50 120 40)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) 50 120 -400deg / -500)`, `oklch(50 120 320 / 0)`);
+
+  // Testing valid permutation (types match).
+  // NOTE: 'c' is a vaild hue, as hue is <angle>|<number>.
+  test_computed_value(`color`, `oklch(from oklch(.7 45 30) l c c / alpha)`, `oklch(0.7 45 45)`);
+  test_computed_value(`color`, `oklch(from oklch(.7 45 30 / 40%) l c c / alpha)`, `oklch(0.7 45 45 / 0.4)`);
+
+  // Testing with calc().
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) calc(l) calc(c) calc(h))`, `oklch(0.7 45 30)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) calc(l) calc(c) calc(h) / calc(alpha))`, `oklch(0.7 45 30 / 0.4)`);
+
+  // Testing with 'none'.
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) none none none)`,                                   `oklch(none none none)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) none none none / none)`,                            `oklch(none none none / none)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) l c none)`,                                         `oklch(0.7 45 none)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) l c none / alpha)`,                                 `oklch(0.7 45 none)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30) l c h / none)`,                                     `oklch(0.7 45 30 / none)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l c none / alpha)`,                           `oklch(0.7 45 none / 0.4)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l c h / none)`,                               `oklch(0.7 45 30 / none)`);
+  // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+  test_computed_value(`color`, `oklch(from oklch(none none none) l c h)`,                                       `oklch(0 0 0)`);
+  test_computed_value(`color`, `oklch(from oklch(none none none / none) l c h / alpha)`,                        `oklch(0 0 0 / 0)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 none 30) l c h)`,                                          `oklch(0.7 0 30)`);
+  test_computed_value(`color`, `oklch(from oklch(0.7 45 30 / none) l c h / alpha)`,                             `oklch(0.7 45 30 / 0)`);
 
   // lch and oklch tests that require different results due to percent scaling differences.
   test_computed_value(`color`, `lch(from lch(.7 45 30) alpha c h / l)`, `lch(100 45 30 / 0.7)`);

--- a/css/css-color/parsing/color-valid-color-mix-function.html
+++ b/css/css-color/parsing/color-valid-color-mix-function.html
@@ -175,104 +175,199 @@
     test_valid_value(`color`, `color-mix(in hwb, oklch(100 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hwb, oklch(100 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`);
     test_valid_value(`color`, `color-mix(in hwb, oklch(0 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hwb, oklch(0 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`);
 
-    for (const colorSpace of [ "lch", "oklch" ]) {
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), ${colorSpace}(50 60 70deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 70))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 25%, ${colorSpace}(50 60 70deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 25%, ${colorSpace}(50 60 70))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10 20 30deg), ${colorSpace}(50 60 70deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 25%, ${colorSpace}(50 60 70))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), 25% ${colorSpace}(50 60 70deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 70) 25%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), ${colorSpace}(50 60 70deg) 25%)`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 70) 25%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 25%, ${colorSpace}(50 60 70deg) 75%)`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 25%, ${colorSpace}(50 60 70) 75%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 30%, ${colorSpace}(50 60 70deg) 90%)`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 30%, ${colorSpace}(50 60 70) 90%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 12.5%, ${colorSpace}(50 60 70deg) 37.5%)`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 12.5%, ${colorSpace}(50 60 70) 37.5%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg) 0%, ${colorSpace}(50 60 70deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 0%, ${colorSpace}(50 60 70))`);
+    // lch()
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg), lch(50 60 70deg))`, `color-mix(in lch, lch(10 20 30), lch(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg) 25%, lch(50 60 70deg))`, `color-mix(in lch, lch(10 20 30) 25%, lch(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in lch, 25% lch(10 20 30deg), lch(50 60 70deg))`, `color-mix(in lch, lch(10 20 30) 25%, lch(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg), 25% lch(50 60 70deg))`, `color-mix(in lch, lch(10 20 30), lch(50 60 70) 25%)`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg), lch(50 60 70deg) 25%)`, `color-mix(in lch, lch(10 20 30), lch(50 60 70) 25%)`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg) 25%, lch(50 60 70deg) 75%)`, `color-mix(in lch, lch(10 20 30) 25%, lch(50 60 70) 75%)`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg) 30%, lch(50 60 70deg) 90%)`, `color-mix(in lch, lch(10 20 30) 30%, lch(50 60 70) 90%)`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg) 12.5%, lch(50 60 70deg) 37.5%)`, `color-mix(in lch, lch(10 20 30) 12.5%, lch(50 60 70) 37.5%)`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg) 0%, lch(50 60 70deg))`, `color-mix(in lch, lch(10 20 30) 0%, lch(50 60 70))`);
 
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4), ${colorSpace}(50 60 70deg / .8))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / 0.4), ${colorSpace}(50 60 70 / 0.8))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 25%, ${colorSpace}(50 60 70deg / .8))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / 0.4) 25%, ${colorSpace}(50 60 70 / 0.8))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10 20 30deg / .4), ${colorSpace}(50 60 70deg / .8))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / 0.4) 25%, ${colorSpace}(50 60 70 / 0.8))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4), 25% ${colorSpace}(50 60 70deg / .8))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / 0.4), ${colorSpace}(50 60 70 / 0.8) 25%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4), ${colorSpace}(50 60 70deg / .8) 25%)`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / 0.4), ${colorSpace}(50 60 70 / 0.8) 25%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 25%, ${colorSpace}(50 60 70deg / .8) 75%)`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / 0.4) 25%, ${colorSpace}(50 60 70 / 0.8) 75%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 30%, ${colorSpace}(50 60 70deg / .8) 90%)`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / 0.4) 30%, ${colorSpace}(50 60 70 / 0.8) 90%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 12.5%, ${colorSpace}(50 60 70deg / .8) 37.5%)`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / 0.4) 12.5%, ${colorSpace}(50 60 70 / 0.8) 37.5%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / .4) 0%, ${colorSpace}(50 60 70deg / .8))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / 0.4) 0%, ${colorSpace}(50 60 70 / 0.8))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg / .4), lch(50 60 70deg / .8))`, `color-mix(in lch, lch(10 20 30 / 0.4), lch(50 60 70 / 0.8))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg / .4) 25%, lch(50 60 70deg / .8))`, `color-mix(in lch, lch(10 20 30 / 0.4) 25%, lch(50 60 70 / 0.8))`);
+    test_valid_value(`color`, `color-mix(in lch, 25% lch(10 20 30deg / .4), lch(50 60 70deg / .8))`, `color-mix(in lch, lch(10 20 30 / 0.4) 25%, lch(50 60 70 / 0.8))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg / .4), 25% lch(50 60 70deg / .8))`, `color-mix(in lch, lch(10 20 30 / 0.4), lch(50 60 70 / 0.8) 25%)`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg / .4), lch(50 60 70deg / .8) 25%)`, `color-mix(in lch, lch(10 20 30 / 0.4), lch(50 60 70 / 0.8) 25%)`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg / .4) 25%, lch(50 60 70deg / .8) 75%)`, `color-mix(in lch, lch(10 20 30 / 0.4) 25%, lch(50 60 70 / 0.8) 75%)`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg / .4) 30%, lch(50 60 70deg / .8) 90%)`, `color-mix(in lch, lch(10 20 30 / 0.4) 30%, lch(50 60 70 / 0.8) 90%)`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg / .4) 12.5%, lch(50 60 70deg / .8) 37.5%)`, `color-mix(in lch, lch(10 20 30 / 0.4) 12.5%, lch(50 60 70 / 0.8) 37.5%)`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg / .4) 0%, lch(50 60 70deg / .8))`, `color-mix(in lch, lch(10 20 30 / 0.4) 0%, lch(50 60 70 / 0.8))`);
 
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 40), ${colorSpace}(100 0 60))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 60), ${colorSpace}(100 0 40))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 50), ${colorSpace}(100 0 330))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 330), ${colorSpace}(100 0 50))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 20), ${colorSpace}(100 0 320))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 320), ${colorSpace}(100 0 20))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(100 0 40deg), lch(100 0 60deg))`, `color-mix(in lch, lch(100 0 40), lch(100 0 60))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(100 0 60deg), lch(100 0 40deg))`, `color-mix(in lch, lch(100 0 60), lch(100 0 40))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(100 0 50deg), lch(100 0 330deg))`, `color-mix(in lch, lch(100 0 50), lch(100 0 330))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(100 0 330deg), lch(100 0 50deg))`, `color-mix(in lch, lch(100 0 330), lch(100 0 50))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(100 0 20deg), lch(100 0 320deg))`, `color-mix(in lch, lch(100 0 20), lch(100 0 320))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(100 0 320deg), lch(100 0 20deg))`, `color-mix(in lch, lch(100 0 320), lch(100 0 20))`);
 
-      test_valid_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 40), ${colorSpace}(100 0 60))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 60), ${colorSpace}(100 0 40))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 50), ${colorSpace}(100 0 330))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 330), ${colorSpace}(100 0 50))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 20), ${colorSpace}(100 0 320))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} shorter hue, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(100 0 320), ${colorSpace}(100 0 20))`);
+    test_valid_value(`color`, `color-mix(in lch shorter hue, lch(100 0 40deg), lch(100 0 60deg))`, `color-mix(in lch, lch(100 0 40), lch(100 0 60))`);
+    test_valid_value(`color`, `color-mix(in lch shorter hue, lch(100 0 60deg), lch(100 0 40deg))`, `color-mix(in lch, lch(100 0 60), lch(100 0 40))`);
+    test_valid_value(`color`, `color-mix(in lch shorter hue, lch(100 0 50deg), lch(100 0 330deg))`, `color-mix(in lch, lch(100 0 50), lch(100 0 330))`);
+    test_valid_value(`color`, `color-mix(in lch shorter hue, lch(100 0 330deg), lch(100 0 50deg))`, `color-mix(in lch, lch(100 0 330), lch(100 0 50))`);
+    test_valid_value(`color`, `color-mix(in lch shorter hue, lch(100 0 20deg), lch(100 0 320deg))`, `color-mix(in lch, lch(100 0 20), lch(100 0 320))`);
+    test_valid_value(`color`, `color-mix(in lch shorter hue, lch(100 0 320deg), lch(100 0 20deg))`, `color-mix(in lch, lch(100 0 320), lch(100 0 20))`);
 
-      test_valid_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 40), ${colorSpace}(100 0 60))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 60), ${colorSpace}(100 0 40))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 50), ${colorSpace}(100 0 330))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 330), ${colorSpace}(100 0 50))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 20), ${colorSpace}(100 0 320))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `color-mix(in ${colorSpace} longer hue, ${colorSpace}(100 0 320), ${colorSpace}(100 0 20))`);
+    test_valid_value(`color`, `color-mix(in lch longer hue, lch(100 0 40deg), lch(100 0 60deg))`, `color-mix(in lch longer hue, lch(100 0 40), lch(100 0 60))`);
+    test_valid_value(`color`, `color-mix(in lch longer hue, lch(100 0 60deg), lch(100 0 40deg))`, `color-mix(in lch longer hue, lch(100 0 60), lch(100 0 40))`);
+    test_valid_value(`color`, `color-mix(in lch longer hue, lch(100 0 50deg), lch(100 0 330deg))`, `color-mix(in lch longer hue, lch(100 0 50), lch(100 0 330))`);
+    test_valid_value(`color`, `color-mix(in lch longer hue, lch(100 0 330deg), lch(100 0 50deg))`, `color-mix(in lch longer hue, lch(100 0 330), lch(100 0 50))`);
+    test_valid_value(`color`, `color-mix(in lch longer hue, lch(100 0 20deg), lch(100 0 320deg))`, `color-mix(in lch longer hue, lch(100 0 20), lch(100 0 320))`);
+    test_valid_value(`color`, `color-mix(in lch longer hue, lch(100 0 320deg), lch(100 0 20deg))`, `color-mix(in lch longer hue, lch(100 0 320), lch(100 0 20))`);
 
-      test_valid_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 40), ${colorSpace}(100 0 60))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 60), ${colorSpace}(100 0 40))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 50), ${colorSpace}(100 0 330))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 330), ${colorSpace}(100 0 50))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 20), ${colorSpace}(100 0 320))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `color-mix(in ${colorSpace} increasing hue, ${colorSpace}(100 0 320), ${colorSpace}(100 0 20))`);
+    test_valid_value(`color`, `color-mix(in lch increasing hue, lch(100 0 40deg), lch(100 0 60deg))`, `color-mix(in lch increasing hue, lch(100 0 40), lch(100 0 60))`);
+    test_valid_value(`color`, `color-mix(in lch increasing hue, lch(100 0 60deg), lch(100 0 40deg))`, `color-mix(in lch increasing hue, lch(100 0 60), lch(100 0 40))`);
+    test_valid_value(`color`, `color-mix(in lch increasing hue, lch(100 0 50deg), lch(100 0 330deg))`, `color-mix(in lch increasing hue, lch(100 0 50), lch(100 0 330))`);
+    test_valid_value(`color`, `color-mix(in lch increasing hue, lch(100 0 330deg), lch(100 0 50deg))`, `color-mix(in lch increasing hue, lch(100 0 330), lch(100 0 50))`);
+    test_valid_value(`color`, `color-mix(in lch increasing hue, lch(100 0 20deg), lch(100 0 320deg))`, `color-mix(in lch increasing hue, lch(100 0 20), lch(100 0 320))`);
+    test_valid_value(`color`, `color-mix(in lch increasing hue, lch(100 0 320deg), lch(100 0 20deg))`, `color-mix(in lch increasing hue, lch(100 0 320), lch(100 0 20))`);
 
-      test_valid_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 40deg), ${colorSpace}(100 0 60deg))`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 40), ${colorSpace}(100 0 60))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 60deg), ${colorSpace}(100 0 40deg))`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 60), ${colorSpace}(100 0 40))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 50deg), ${colorSpace}(100 0 330deg))`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 50), ${colorSpace}(100 0 330))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 330deg), ${colorSpace}(100 0 50deg))`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 330), ${colorSpace}(100 0 50))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 20deg), ${colorSpace}(100 0 320deg))`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 20), ${colorSpace}(100 0 320))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 320deg), ${colorSpace}(100 0 20deg))`, `color-mix(in ${colorSpace} decreasing hue, ${colorSpace}(100 0 320), ${colorSpace}(100 0 20))`);
+    test_valid_value(`color`, `color-mix(in lch decreasing hue, lch(100 0 40deg), lch(100 0 60deg))`, `color-mix(in lch decreasing hue, lch(100 0 40), lch(100 0 60))`);
+    test_valid_value(`color`, `color-mix(in lch decreasing hue, lch(100 0 60deg), lch(100 0 40deg))`, `color-mix(in lch decreasing hue, lch(100 0 60), lch(100 0 40))`);
+    test_valid_value(`color`, `color-mix(in lch decreasing hue, lch(100 0 50deg), lch(100 0 330deg))`, `color-mix(in lch decreasing hue, lch(100 0 50), lch(100 0 330))`);
+    test_valid_value(`color`, `color-mix(in lch decreasing hue, lch(100 0 330deg), lch(100 0 50deg))`, `color-mix(in lch decreasing hue, lch(100 0 330), lch(100 0 50))`);
+    test_valid_value(`color`, `color-mix(in lch decreasing hue, lch(100 0 20deg), lch(100 0 320deg))`, `color-mix(in lch decreasing hue, lch(100 0 20), lch(100 0 320))`);
+    test_valid_value(`color`, `color-mix(in lch decreasing hue, lch(100 0 320deg), lch(100 0 20deg))`, `color-mix(in lch decreasing hue, lch(100 0 320), lch(100 0 20))`);
 
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(none none none))`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(none none none))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(50 60 70deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(50 60 70))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), ${colorSpace}(none none none))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(none none none))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 none), ${colorSpace}(50 60 70deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 none), ${colorSpace}(50 60 70))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg), ${colorSpace}(50 60 none))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 none))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none 20 30deg), ${colorSpace}(50 none 70deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(none 20 30), ${colorSpace}(50 none 70))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / none), ${colorSpace}(50 60 70deg))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / none), ${colorSpace}(50 60 70))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / none), ${colorSpace}(50 60 70deg / 0.5))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / none), ${colorSpace}(50 60 70 / 0.5))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30deg / none), ${colorSpace}(50 60 70deg / none))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / none), ${colorSpace}(50 60 70 / none))`);
-    }
+    test_valid_value(`color`, `color-mix(in lch, lch(none none none), lch(none none none))`, `color-mix(in lch, lch(none none none), lch(none none none))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(none none none), lch(50 60 70deg))`, `color-mix(in lch, lch(none none none), lch(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg), lch(none none none))`, `color-mix(in lch, lch(10 20 30), lch(none none none))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 none), lch(50 60 70deg))`, `color-mix(in lch, lch(10 20 none), lch(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg), lch(50 60 none))`, `color-mix(in lch, lch(10 20 30), lch(50 60 none))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(none 20 30deg), lch(50 none 70deg))`, `color-mix(in lch, lch(none 20 30), lch(50 none 70))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg / none), lch(50 60 70deg))`, `color-mix(in lch, lch(10 20 30 / none), lch(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg / none), lch(50 60 70deg / 0.5))`, `color-mix(in lch, lch(10 20 30 / none), lch(50 60 70 / 0.5))`);
+    test_valid_value(`color`, `color-mix(in lch, lch(10 20 30deg / none), lch(50 60 70deg / none))`, `color-mix(in lch, lch(10 20 30 / none), lch(50 60 70 / none))`);
 
-    for (const colorSpace of [ "lab", "oklab" ]) {
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 70))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 70))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 25%, ${colorSpace}(50 60 70))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 25%, ${colorSpace}(50 60 70))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10 20 30), ${colorSpace}(50 60 70))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 25%, ${colorSpace}(50 60 70))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), 25% ${colorSpace}(50 60 70))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 70) 25%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 70) 25%)`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 70) 25%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 25%, ${colorSpace}(50 60 70) 75%)`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 25%, ${colorSpace}(50 60 70) 75%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 30%, ${colorSpace}(50 60 70) 90%)`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 30%, ${colorSpace}(50 60 70) 90%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 12.5%, ${colorSpace}(50 60 70) 37.5%)`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 12.5%, ${colorSpace}(50 60 70) 37.5%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 0%, ${colorSpace}(50 60 70))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30) 0%, ${colorSpace}(50 60 70))`);
+    // oklch()
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg), oklch(50 60 70deg))`, `color-mix(in oklch, oklch(10 20 30), oklch(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg) 25%, oklch(50 60 70deg))`, `color-mix(in oklch, oklch(10 20 30) 25%, oklch(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in oklch, 25% oklch(10 20 30deg), oklch(50 60 70deg))`, `color-mix(in oklch, oklch(10 20 30) 25%, oklch(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg), 25% oklch(50 60 70deg))`, `color-mix(in oklch, oklch(10 20 30), oklch(50 60 70) 25%)`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg), oklch(50 60 70deg) 25%)`, `color-mix(in oklch, oklch(10 20 30), oklch(50 60 70) 25%)`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg) 25%, oklch(50 60 70deg) 75%)`, `color-mix(in oklch, oklch(10 20 30) 25%, oklch(50 60 70) 75%)`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg) 30%, oklch(50 60 70deg) 90%)`, `color-mix(in oklch, oklch(10 20 30) 30%, oklch(50 60 70) 90%)`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg) 12.5%, oklch(50 60 70deg) 37.5%)`, `color-mix(in oklch, oklch(10 20 30) 12.5%, oklch(50 60 70) 37.5%)`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg) 0%, oklch(50 60 70deg))`, `color-mix(in oklch, oklch(10 20 30) 0%, oklch(50 60 70))`);
 
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4), ${colorSpace}(50 60 70 / .8))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / 0.4), ${colorSpace}(50 60 70 / 0.8))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 25%, ${colorSpace}(50 60 70 / .8))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / 0.4) 25%, ${colorSpace}(50 60 70 / 0.8))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, 25% ${colorSpace}(10 20 30 / .4), ${colorSpace}(50 60 70 / .8))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / 0.4) 25%, ${colorSpace}(50 60 70 / 0.8))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4), 25% ${colorSpace}(50 60 70 / .8))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / 0.4), ${colorSpace}(50 60 70 / 0.8) 25%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4), ${colorSpace}(50 60 70 / .8) 25%)`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / 0.4), ${colorSpace}(50 60 70 / 0.8) 25%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 25%, ${colorSpace}(50 60 70 / .8) 75%)`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / 0.4) 25%, ${colorSpace}(50 60 70 / 0.8) 75%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 30%, ${colorSpace}(50 60 70 / .8) 90%)`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / 0.4) 30%, ${colorSpace}(50 60 70 / 0.8) 90%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 12.5%, ${colorSpace}(50 60 70 / .8) 37.5%)`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / 0.4) 12.5%, ${colorSpace}(50 60 70 / 0.8) 37.5%)`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / .4) 0%, ${colorSpace}(50 60 70 / .8))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / 0.4) 0%, ${colorSpace}(50 60 70 / 0.8))`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / .4), oklch(50 60 70deg / .8))`, `color-mix(in oklch, oklch(10 20 30 / 0.4), oklch(50 60 70 / 0.8))`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / .4) 25%, oklch(50 60 70deg / .8))`, `color-mix(in oklch, oklch(10 20 30 / 0.4) 25%, oklch(50 60 70 / 0.8))`);
+    test_valid_value(`color`, `color-mix(in oklch, 25% oklch(10 20 30deg / .4), oklch(50 60 70deg / .8))`, `color-mix(in oklch, oklch(10 20 30 / 0.4) 25%, oklch(50 60 70 / 0.8))`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / .4), 25% oklch(50 60 70deg / .8))`, `color-mix(in oklch, oklch(10 20 30 / 0.4), oklch(50 60 70 / 0.8) 25%)`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / .4), oklch(50 60 70deg / .8) 25%)`, `color-mix(in oklch, oklch(10 20 30 / 0.4), oklch(50 60 70 / 0.8) 25%)`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / .4) 25%, oklch(50 60 70deg / .8) 75%)`, `color-mix(in oklch, oklch(10 20 30 / 0.4) 25%, oklch(50 60 70 / 0.8) 75%)`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / .4) 30%, oklch(50 60 70deg / .8) 90%)`, `color-mix(in oklch, oklch(10 20 30 / 0.4) 30%, oklch(50 60 70 / 0.8) 90%)`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / .4) 12.5%, oklch(50 60 70deg / .8) 37.5%)`, `color-mix(in oklch, oklch(10 20 30 / 0.4) 12.5%, oklch(50 60 70 / 0.8) 37.5%)`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / .4) 0%, oklch(50 60 70deg / .8))`, `color-mix(in oklch, oklch(10 20 30 / 0.4) 0%, oklch(50 60 70 / 0.8))`);
 
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(none none none))`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(none none none))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(50 60 70))`, `color-mix(in ${colorSpace}, ${colorSpace}(none none none), ${colorSpace}(50 60 70))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(none none none))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(none none none))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 none), ${colorSpace}(50 60 70))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 none), ${colorSpace}(50 60 70))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 none))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30), ${colorSpace}(50 60 none))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(none 20 30), ${colorSpace}(50 none 70))`, `color-mix(in ${colorSpace}, ${colorSpace}(none 20 30), ${colorSpace}(50 none 70))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / none), ${colorSpace}(50 60 70))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / none), ${colorSpace}(50 60 70))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / none), ${colorSpace}(50 60 70 / 0.5))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / none), ${colorSpace}(50 60 70 / 0.5))`);
-      test_valid_value(`color`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / none), ${colorSpace}(50 60 70 / none))`, `color-mix(in ${colorSpace}, ${colorSpace}(10 20 30 / none), ${colorSpace}(50 60 70 / none))`);
-    }
+    test_valid_value(`color`, `color-mix(in oklch, oklch(100 0 40deg), oklch(100 0 60deg))`, `color-mix(in oklch, oklch(100 0 40), oklch(100 0 60))`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(100 0 60deg), oklch(100 0 40deg))`, `color-mix(in oklch, oklch(100 0 60), oklch(100 0 40))`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(100 0 50deg), oklch(100 0 330deg))`, `color-mix(in oklch, oklch(100 0 50), oklch(100 0 330))`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(100 0 330deg), oklch(100 0 50deg))`, `color-mix(in oklch, oklch(100 0 330), oklch(100 0 50))`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(100 0 20deg), oklch(100 0 320deg))`, `color-mix(in oklch, oklch(100 0 20), oklch(100 0 320))`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(100 0 320deg), oklch(100 0 20deg))`, `color-mix(in oklch, oklch(100 0 320), oklch(100 0 20))`);
+
+    test_valid_value(`color`, `color-mix(in oklch shorter hue, oklch(100 0 40deg), oklch(100 0 60deg))`, `color-mix(in oklch, oklch(100 0 40), oklch(100 0 60))`);
+    test_valid_value(`color`, `color-mix(in oklch shorter hue, oklch(100 0 60deg), oklch(100 0 40deg))`, `color-mix(in oklch, oklch(100 0 60), oklch(100 0 40))`);
+    test_valid_value(`color`, `color-mix(in oklch shorter hue, oklch(100 0 50deg), oklch(100 0 330deg))`, `color-mix(in oklch, oklch(100 0 50), oklch(100 0 330))`);
+    test_valid_value(`color`, `color-mix(in oklch shorter hue, oklch(100 0 330deg), oklch(100 0 50deg))`, `color-mix(in oklch, oklch(100 0 330), oklch(100 0 50))`);
+    test_valid_value(`color`, `color-mix(in oklch shorter hue, oklch(100 0 20deg), oklch(100 0 320deg))`, `color-mix(in oklch, oklch(100 0 20), oklch(100 0 320))`);
+    test_valid_value(`color`, `color-mix(in oklch shorter hue, oklch(100 0 320deg), oklch(100 0 20deg))`, `color-mix(in oklch, oklch(100 0 320), oklch(100 0 20))`);
+
+    test_valid_value(`color`, `color-mix(in oklch longer hue, oklch(100 0 40deg), oklch(100 0 60deg))`, `color-mix(in oklch longer hue, oklch(100 0 40), oklch(100 0 60))`);
+    test_valid_value(`color`, `color-mix(in oklch longer hue, oklch(100 0 60deg), oklch(100 0 40deg))`, `color-mix(in oklch longer hue, oklch(100 0 60), oklch(100 0 40))`);
+    test_valid_value(`color`, `color-mix(in oklch longer hue, oklch(100 0 50deg), oklch(100 0 330deg))`, `color-mix(in oklch longer hue, oklch(100 0 50), oklch(100 0 330))`);
+    test_valid_value(`color`, `color-mix(in oklch longer hue, oklch(100 0 330deg), oklch(100 0 50deg))`, `color-mix(in oklch longer hue, oklch(100 0 330), oklch(100 0 50))`);
+    test_valid_value(`color`, `color-mix(in oklch longer hue, oklch(100 0 20deg), oklch(100 0 320deg))`, `color-mix(in oklch longer hue, oklch(100 0 20), oklch(100 0 320))`);
+    test_valid_value(`color`, `color-mix(in oklch longer hue, oklch(100 0 320deg), oklch(100 0 20deg))`, `color-mix(in oklch longer hue, oklch(100 0 320), oklch(100 0 20))`);
+
+    test_valid_value(`color`, `color-mix(in oklch increasing hue, oklch(100 0 40deg), oklch(100 0 60deg))`, `color-mix(in oklch increasing hue, oklch(100 0 40), oklch(100 0 60))`);
+    test_valid_value(`color`, `color-mix(in oklch increasing hue, oklch(100 0 60deg), oklch(100 0 40deg))`, `color-mix(in oklch increasing hue, oklch(100 0 60), oklch(100 0 40))`);
+    test_valid_value(`color`, `color-mix(in oklch increasing hue, oklch(100 0 50deg), oklch(100 0 330deg))`, `color-mix(in oklch increasing hue, oklch(100 0 50), oklch(100 0 330))`);
+    test_valid_value(`color`, `color-mix(in oklch increasing hue, oklch(100 0 330deg), oklch(100 0 50deg))`, `color-mix(in oklch increasing hue, oklch(100 0 330), oklch(100 0 50))`);
+    test_valid_value(`color`, `color-mix(in oklch increasing hue, oklch(100 0 20deg), oklch(100 0 320deg))`, `color-mix(in oklch increasing hue, oklch(100 0 20), oklch(100 0 320))`);
+    test_valid_value(`color`, `color-mix(in oklch increasing hue, oklch(100 0 320deg), oklch(100 0 20deg))`, `color-mix(in oklch increasing hue, oklch(100 0 320), oklch(100 0 20))`);
+
+    test_valid_value(`color`, `color-mix(in oklch decreasing hue, oklch(100 0 40deg), oklch(100 0 60deg))`, `color-mix(in oklch decreasing hue, oklch(100 0 40), oklch(100 0 60))`);
+    test_valid_value(`color`, `color-mix(in oklch decreasing hue, oklch(100 0 60deg), oklch(100 0 40deg))`, `color-mix(in oklch decreasing hue, oklch(100 0 60), oklch(100 0 40))`);
+    test_valid_value(`color`, `color-mix(in oklch decreasing hue, oklch(100 0 50deg), oklch(100 0 330deg))`, `color-mix(in oklch decreasing hue, oklch(100 0 50), oklch(100 0 330))`);
+    test_valid_value(`color`, `color-mix(in oklch decreasing hue, oklch(100 0 330deg), oklch(100 0 50deg))`, `color-mix(in oklch decreasing hue, oklch(100 0 330), oklch(100 0 50))`);
+    test_valid_value(`color`, `color-mix(in oklch decreasing hue, oklch(100 0 20deg), oklch(100 0 320deg))`, `color-mix(in oklch decreasing hue, oklch(100 0 20), oklch(100 0 320))`);
+    test_valid_value(`color`, `color-mix(in oklch decreasing hue, oklch(100 0 320deg), oklch(100 0 20deg))`, `color-mix(in oklch decreasing hue, oklch(100 0 320), oklch(100 0 20))`);
+
+    test_valid_value(`color`, `color-mix(in oklch, oklch(none none none), oklch(none none none))`, `color-mix(in oklch, oklch(none none none), oklch(none none none))`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(none none none), oklch(50 60 70deg))`, `color-mix(in oklch, oklch(none none none), oklch(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg), oklch(none none none))`, `color-mix(in oklch, oklch(10 20 30), oklch(none none none))`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 none), oklch(50 60 70deg))`, `color-mix(in oklch, oklch(10 20 none), oklch(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg), oklch(50 60 none))`, `color-mix(in oklch, oklch(10 20 30), oklch(50 60 none))`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(none 20 30deg), oklch(50 none 70deg))`, `color-mix(in oklch, oklch(none 20 30), oklch(50 none 70))`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / none), oklch(50 60 70deg))`, `color-mix(in oklch, oklch(10 20 30 / none), oklch(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / none), oklch(50 60 70deg / 0.5))`, `color-mix(in oklch, oklch(10 20 30 / none), oklch(50 60 70 / 0.5))`);
+    test_valid_value(`color`, `color-mix(in oklch, oklch(10 20 30deg / none), oklch(50 60 70deg / none))`, `color-mix(in oklch, oklch(10 20 30 / none), oklch(50 60 70 / none))`);
+
+    // lab()
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30), lab(50 60 70))`, `color-mix(in lab, lab(10 20 30), lab(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30) 25%, lab(50 60 70))`, `color-mix(in lab, lab(10 20 30) 25%, lab(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in lab, 25% lab(10 20 30), lab(50 60 70))`, `color-mix(in lab, lab(10 20 30) 25%, lab(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30), 25% lab(50 60 70))`, `color-mix(in lab, lab(10 20 30), lab(50 60 70) 25%)`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30), lab(50 60 70) 25%)`, `color-mix(in lab, lab(10 20 30), lab(50 60 70) 25%)`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30) 25%, lab(50 60 70) 75%)`, `color-mix(in lab, lab(10 20 30) 25%, lab(50 60 70) 75%)`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30) 30%, lab(50 60 70) 90%)`, `color-mix(in lab, lab(10 20 30) 30%, lab(50 60 70) 90%)`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30) 12.5%, lab(50 60 70) 37.5%)`, `color-mix(in lab, lab(10 20 30) 12.5%, lab(50 60 70) 37.5%)`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30) 0%, lab(50 60 70))`, `color-mix(in lab, lab(10 20 30) 0%, lab(50 60 70))`);
+
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30 / .4), lab(50 60 70 / .8))`, `color-mix(in lab, lab(10 20 30 / 0.4), lab(50 60 70 / 0.8))`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30 / .4) 25%, lab(50 60 70 / .8))`, `color-mix(in lab, lab(10 20 30 / 0.4) 25%, lab(50 60 70 / 0.8))`);
+    test_valid_value(`color`, `color-mix(in lab, 25% lab(10 20 30 / .4), lab(50 60 70 / .8))`, `color-mix(in lab, lab(10 20 30 / 0.4) 25%, lab(50 60 70 / 0.8))`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30 / .4), 25% lab(50 60 70 / .8))`, `color-mix(in lab, lab(10 20 30 / 0.4), lab(50 60 70 / 0.8) 25%)`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30 / .4), lab(50 60 70 / .8) 25%)`, `color-mix(in lab, lab(10 20 30 / 0.4), lab(50 60 70 / 0.8) 25%)`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30 / .4) 25%, lab(50 60 70 / .8) 75%)`, `color-mix(in lab, lab(10 20 30 / 0.4) 25%, lab(50 60 70 / 0.8) 75%)`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30 / .4) 30%, lab(50 60 70 / .8) 90%)`, `color-mix(in lab, lab(10 20 30 / 0.4) 30%, lab(50 60 70 / 0.8) 90%)`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30 / .4) 12.5%, lab(50 60 70 / .8) 37.5%)`, `color-mix(in lab, lab(10 20 30 / 0.4) 12.5%, lab(50 60 70 / 0.8) 37.5%)`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30 / .4) 0%, lab(50 60 70 / .8))`, `color-mix(in lab, lab(10 20 30 / 0.4) 0%, lab(50 60 70 / 0.8))`);
+
+    test_valid_value(`color`, `color-mix(in lab, lab(none none none), lab(none none none))`, `color-mix(in lab, lab(none none none), lab(none none none))`);
+    test_valid_value(`color`, `color-mix(in lab, lab(none none none), lab(50 60 70))`, `color-mix(in lab, lab(none none none), lab(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30), lab(none none none))`, `color-mix(in lab, lab(10 20 30), lab(none none none))`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 none), lab(50 60 70))`, `color-mix(in lab, lab(10 20 none), lab(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30), lab(50 60 none))`, `color-mix(in lab, lab(10 20 30), lab(50 60 none))`);
+    test_valid_value(`color`, `color-mix(in lab, lab(none 20 30), lab(50 none 70))`, `color-mix(in lab, lab(none 20 30), lab(50 none 70))`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30 / none), lab(50 60 70))`, `color-mix(in lab, lab(10 20 30 / none), lab(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30 / none), lab(50 60 70 / 0.5))`, `color-mix(in lab, lab(10 20 30 / none), lab(50 60 70 / 0.5))`);
+    test_valid_value(`color`, `color-mix(in lab, lab(10 20 30 / none), lab(50 60 70 / none))`, `color-mix(in lab, lab(10 20 30 / none), lab(50 60 70 / none))`);
+
+    // oklab()
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30), oklab(50 60 70))`, `color-mix(in oklab, oklab(10 20 30), oklab(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30) 25%, oklab(50 60 70))`, `color-mix(in oklab, oklab(10 20 30) 25%, oklab(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in oklab, 25% oklab(10 20 30), oklab(50 60 70))`, `color-mix(in oklab, oklab(10 20 30) 25%, oklab(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30), 25% oklab(50 60 70))`, `color-mix(in oklab, oklab(10 20 30), oklab(50 60 70) 25%)`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30), oklab(50 60 70) 25%)`, `color-mix(in oklab, oklab(10 20 30), oklab(50 60 70) 25%)`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30) 25%, oklab(50 60 70) 75%)`, `color-mix(in oklab, oklab(10 20 30) 25%, oklab(50 60 70) 75%)`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30) 30%, oklab(50 60 70) 90%)`, `color-mix(in oklab, oklab(10 20 30) 30%, oklab(50 60 70) 90%)`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30) 12.5%, oklab(50 60 70) 37.5%)`, `color-mix(in oklab, oklab(10 20 30) 12.5%, oklab(50 60 70) 37.5%)`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30) 0%, oklab(50 60 70))`, `color-mix(in oklab, oklab(10 20 30) 0%, oklab(50 60 70))`);
+
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30 / .4), oklab(50 60 70 / .8))`, `color-mix(in oklab, oklab(10 20 30 / 0.4), oklab(50 60 70 / 0.8))`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30 / .4) 25%, oklab(50 60 70 / .8))`, `color-mix(in oklab, oklab(10 20 30 / 0.4) 25%, oklab(50 60 70 / 0.8))`);
+    test_valid_value(`color`, `color-mix(in oklab, 25% oklab(10 20 30 / .4), oklab(50 60 70 / .8))`, `color-mix(in oklab, oklab(10 20 30 / 0.4) 25%, oklab(50 60 70 / 0.8))`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30 / .4), 25% oklab(50 60 70 / .8))`, `color-mix(in oklab, oklab(10 20 30 / 0.4), oklab(50 60 70 / 0.8) 25%)`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30 / .4), oklab(50 60 70 / .8) 25%)`, `color-mix(in oklab, oklab(10 20 30 / 0.4), oklab(50 60 70 / 0.8) 25%)`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30 / .4) 25%, oklab(50 60 70 / .8) 75%)`, `color-mix(in oklab, oklab(10 20 30 / 0.4) 25%, oklab(50 60 70 / 0.8) 75%)`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30 / .4) 30%, oklab(50 60 70 / .8) 90%)`, `color-mix(in oklab, oklab(10 20 30 / 0.4) 30%, oklab(50 60 70 / 0.8) 90%)`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30 / .4) 12.5%, oklab(50 60 70 / .8) 37.5%)`, `color-mix(in oklab, oklab(10 20 30 / 0.4) 12.5%, oklab(50 60 70 / 0.8) 37.5%)`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30 / .4) 0%, oklab(50 60 70 / .8))`, `color-mix(in oklab, oklab(10 20 30 / 0.4) 0%, oklab(50 60 70 / 0.8))`);
+
+    test_valid_value(`color`, `color-mix(in oklab, oklab(none none none), oklab(none none none))`, `color-mix(in oklab, oklab(none none none), oklab(none none none))`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(none none none), oklab(50 60 70))`, `color-mix(in oklab, oklab(none none none), oklab(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30), oklab(none none none))`, `color-mix(in oklab, oklab(10 20 30), oklab(none none none))`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 none), oklab(50 60 70))`, `color-mix(in oklab, oklab(10 20 none), oklab(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30), oklab(50 60 none))`, `color-mix(in oklab, oklab(10 20 30), oklab(50 60 none))`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(none 20 30), oklab(50 none 70))`, `color-mix(in oklab, oklab(none 20 30), oklab(50 none 70))`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30 / none), oklab(50 60 70))`, `color-mix(in oklab, oklab(10 20 30 / none), oklab(50 60 70))`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30 / none), oklab(50 60 70 / 0.5))`, `color-mix(in oklab, oklab(10 20 30 / none), oklab(50 60 70 / 0.5))`);
+    test_valid_value(`color`, `color-mix(in oklab, oklab(10 20 30 / none), oklab(50 60 70 / none))`, `color-mix(in oklab, oklab(10 20 30 / none), oklab(50 60 70 / none))`);
 
     for (const colorSpace of [ "srgb", "srgb-linear", "xyz", "xyz-d50", "xyz-d65" ]) {
         const resultColorSpace = colorSpace == "xyz" ? "xyz-d65" : colorSpace;

--- a/css/css-color/parsing/color-valid-lab.html
+++ b/css/css-color/parsing/color-valid-lab.html
@@ -14,59 +14,110 @@
 </head>
 <body>
 <script>
-for (const colorSpace of [ "lab", "oklab" ]) {
-    test_valid_value("color", `${colorSpace}(0 0 0)`, `${colorSpace}(0 0 0)`);
-    test_valid_value("color", `${colorSpace}(0 0 0 / 1)`, `${colorSpace}(0 0 0)`);
-    test_valid_value("color", `${colorSpace}(0 0 0 / 0.5)`, `${colorSpace}(0 0 0 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(20 0 10/0.5)`, `${colorSpace}(20 0 10 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(20 0 10/50%)`, `${colorSpace}(20 0 10 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(400 0 10/50%)`, `${colorSpace}(400 0 10 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(50 -160 160)`, `${colorSpace}(50 -160 160)`);
-    test_valid_value("color", `${colorSpace}(50 -200 200)`, `${colorSpace}(50 -200 200)`);
-    test_valid_value("color", `${colorSpace}(0 0 0 / -10%)`, `${colorSpace}(0 0 0 / 0)`);
-    test_valid_value("color", `${colorSpace}(0 0 0 / 110%)`, `${colorSpace}(0 0 0)`);
-    test_valid_value("color", `${colorSpace}(0 0 0 / 300%)`, `${colorSpace}(0 0 0)`);
-    test_valid_value("color", `${colorSpace}(-40 0 0)`, `${colorSpace}(0 0 0)`);
-    test_valid_value("color", `${colorSpace}(50 -20 0)`, `${colorSpace}(50 -20 0)`);
-    test_valid_value("color", `${colorSpace}(50 0 -20)`, `${colorSpace}(50 0 -20)`);
-    test_valid_value("color", `${colorSpace}(calc(50 * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))`, `${colorSpace}(150 -0.5 1.5 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(calc(-50 * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))`, `${colorSpace}(0 1.5 -1.5 / 0)`);
 
-    test_valid_value("color", `${colorSpace}(none none none / none)`, `${colorSpace}(none none none / none)`);
-    test_valid_value("color", `${colorSpace}(none none none)`, `${colorSpace}(none none none)`);
-    test_valid_value("color", `${colorSpace}(20 none none / none)`, `${colorSpace}(20 none none / none)`);
-    test_valid_value("color", `${colorSpace}(none none none / 0.5)`, `${colorSpace}(none none none / 0.5)`);
-    test_valid_value("color", `${colorSpace}(0 0 0 / none)`, `${colorSpace}(0 0 0 / none)`);
-}
+// lab()
+test_valid_value("color", "lab(0 0 0)", "lab(0 0 0)");
+test_valid_value("color", "lab(0 0 0 / 1)", "lab(0 0 0)");
+test_valid_value("color", "lab(0 0 0 / 0.5)", "lab(0 0 0 / 0.5)");
+test_valid_value("color", "lab(20 0 10/0.5)", "lab(20 0 10 / 0.5)");
+test_valid_value("color", "lab(20 0 10/50%)", "lab(20 0 10 / 0.5)");
+test_valid_value("color", "lab(400 0 10/50%)", "lab(400 0 10 / 0.5)");
+test_valid_value("color", "lab(50 -160 160)", "lab(50 -160 160)");
+test_valid_value("color", "lab(50 -200 200)", "lab(50 -200 200)");
+test_valid_value("color", "lab(0 0 0 / -10%)", "lab(0 0 0 / 0)");
+test_valid_value("color", "lab(0 0 0 / 110%)", "lab(0 0 0)");
+test_valid_value("color", "lab(0 0 0 / 300%)", "lab(0 0 0)");
+test_valid_value("color", "lab(-40 0 0)", "lab(0 0 0)");
+test_valid_value("color", "lab(50 -20 0)", "lab(50 -20 0)");
+test_valid_value("color", "lab(50 0 -20)", "lab(50 0 -20)");
+test_valid_value("color", "lab(calc(50 * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))", "lab(150 -0.5 1.5 / 0.5)");
+test_valid_value("color", "lab(calc(-50 * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))", "lab(0 1.5 -1.5 / 0)");
 
-for (const colorSpace of [ "lch", "oklch" ]) {
-    test_valid_value("color", `${colorSpace}(0 0 0deg)`, `${colorSpace}(0 0 0)`);
-    test_valid_value("color", `${colorSpace}(0 0 0deg / 1)`, `${colorSpace}(0 0 0)`);
-    test_valid_value("color", `${colorSpace}(0 0 0deg / 0.5)`, `${colorSpace}(0 0 0 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(100 230 0deg / 0.5)`, `${colorSpace}(100 230 0 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(20 50 20deg/0.5)`, `${colorSpace}(20 50 20 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(20 50 20deg/50%)`, `${colorSpace}(20 50 20 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(10 20 20deg / -10%)`, `${colorSpace}(10 20 20 / 0)`);
-    test_valid_value("color", `${colorSpace}(10 20 20deg / 110%)`, `${colorSpace}(10 20 20)`);
-    test_valid_value("color", `${colorSpace}(10 20 1.28rad)`, `${colorSpace}(10 20 73.3386)`);
-    test_valid_value("color", `${colorSpace}(10 20 380deg)`, `${colorSpace}(10 20 20)`);
-    test_valid_value("color", `${colorSpace}(10 20 -340deg)`, `${colorSpace}(10 20 20)`);
-    test_valid_value("color", `${colorSpace}(10 20 740deg)`, `${colorSpace}(10 20 20)`);
-    test_valid_value("color", `${colorSpace}(10 20 -700deg)`, `${colorSpace}(10 20 20)`);
-    test_valid_value("color", `${colorSpace}(-40 0 0)`, `${colorSpace}(0 0 0)`);
-    test_valid_value("color", `${colorSpace}(20 -20 0)`, `${colorSpace}(20 0 0)`);
-    test_valid_value("color", `${colorSpace}(0 0 0 / 0.5)`, `${colorSpace}(0 0 0 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(10 20 20 / 110%)`, `${colorSpace}(10 20 20)`);
-    test_valid_value("color", `${colorSpace}(10 20 -700)`, `${colorSpace}(10 20 20)`);
-    test_valid_value("color", `${colorSpace}(calc(50 * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))`, `${colorSpace}(150 0 40 / 0.5)`);
-    test_valid_value("color", `${colorSpace}(calc(-50 * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))`, `${colorSpace}(0 1.5 320 / 0)`);
+test_valid_value("color", "lab(none none none / none)", "lab(none none none / none)");
+test_valid_value("color", "lab(none none none)", "lab(none none none)");
+test_valid_value("color", "lab(20 none none / none)", "lab(20 none none / none)");
+test_valid_value("color", "lab(none none none / 0.5)", "lab(none none none / 0.5)");
+test_valid_value("color", "lab(0 0 0 / none)", "lab(0 0 0 / none)");
 
-    test_valid_value("color", `${colorSpace}(none none none / none)`, `${colorSpace}(none none none / none)`);
-    test_valid_value("color", `${colorSpace}(none none none)`, `${colorSpace}(none none none)`);
-    test_valid_value("color", `${colorSpace}(20 none none / none)`, `${colorSpace}(20 none none / none)`);
-    test_valid_value("color", `${colorSpace}(none none none / 0.5)`, `${colorSpace}(none none none / 0.5)`);
-    test_valid_value("color", `${colorSpace}(0 0 0 / none)`, `${colorSpace}(0 0 0 / none)`);
-}
+// oklab()
+test_valid_value("color", "oklab(0 0 0)", "oklab(0 0 0)");
+test_valid_value("color", "oklab(0 0 0 / 1)", "oklab(0 0 0)");
+test_valid_value("color", "oklab(0 0 0 / 0.5)", "oklab(0 0 0 / 0.5)");
+test_valid_value("color", "oklab(20 0 10/0.5)", "oklab(20 0 10 / 0.5)");
+test_valid_value("color", "oklab(20 0 10/50%)", "oklab(20 0 10 / 0.5)");
+test_valid_value("color", "oklab(400 0 10/50%)", "oklab(400 0 10 / 0.5)");
+test_valid_value("color", "oklab(50 -160 160)", "oklab(50 -160 160)");
+test_valid_value("color", "oklab(50 -200 200)", "oklab(50 -200 200)");
+test_valid_value("color", "oklab(0 0 0 / -10%)", "oklab(0 0 0 / 0)");
+test_valid_value("color", "oklab(0 0 0 / 110%)", "oklab(0 0 0)");
+test_valid_value("color", "oklab(0 0 0 / 300%)", "oklab(0 0 0)");
+test_valid_value("color", "oklab(-40 0 0)", "oklab(0 0 0)");
+test_valid_value("color", "oklab(50 -20 0)", "oklab(50 -20 0)");
+test_valid_value("color", "oklab(50 0 -20)", "oklab(50 0 -20)");
+test_valid_value("color", "oklab(calc(50 * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))", "oklab(150 -0.5 1.5 / 0.5)");
+test_valid_value("color", "oklab(calc(-50 * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))", "oklab(0 1.5 -1.5 / 0)");
+
+test_valid_value("color", "oklab(none none none / none)", "oklab(none none none / none)");
+test_valid_value("color", "oklab(none none none)", "oklab(none none none)");
+test_valid_value("color", "oklab(20 none none / none)", "oklab(20 none none / none)");
+test_valid_value("color", "oklab(none none none / 0.5)", "oklab(none none none / 0.5)");
+test_valid_value("color", "oklab(0 0 0 / none)", "oklab(0 0 0 / none)");
+
+// lch()
+test_valid_value("color", "lch(0 0 0deg)", "lch(0 0 0)");
+test_valid_value("color", "lch(0 0 0deg / 1)", "lch(0 0 0)");
+test_valid_value("color", "lch(0 0 0deg / 0.5)", "lch(0 0 0 / 0.5)");
+test_valid_value("color", "lch(100 230 0deg / 0.5)", "lch(100 230 0 / 0.5)");
+test_valid_value("color", "lch(20 50 20deg/0.5)", "lch(20 50 20 / 0.5)");
+test_valid_value("color", "lch(20 50 20deg/50%)", "lch(20 50 20 / 0.5)");
+test_valid_value("color", "lch(10 20 20deg / -10%)", "lch(10 20 20 / 0)");
+test_valid_value("color", "lch(10 20 20deg / 110%)", "lch(10 20 20)");
+test_valid_value("color", "lch(10 20 1.28rad)", "lch(10 20 73.3386)");
+test_valid_value("color", "lch(10 20 380deg)", "lch(10 20 20)");
+test_valid_value("color", "lch(10 20 -340deg)", "lch(10 20 20)");
+test_valid_value("color", "lch(10 20 740deg)", "lch(10 20 20)");
+test_valid_value("color", "lch(10 20 -700deg)", "lch(10 20 20)");
+test_valid_value("color", "lch(-40 0 0)", "lch(0 0 0)");
+test_valid_value("color", "lch(20 -20 0)", "lch(20 0 0)");
+test_valid_value("color", "lch(0 0 0 / 0.5)", "lch(0 0 0 / 0.5)");
+test_valid_value("color", "lch(10 20 20 / 110%)", "lch(10 20 20)");
+test_valid_value("color", "lch(10 20 -700)", "lch(10 20 20)");
+test_valid_value("color", "lch(calc(50 * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))", "lch(150 0 40 / 0.5)");
+test_valid_value("color", "lch(calc(-50 * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))", "lch(0 1.5 320 / 0)");
+
+test_valid_value("color", "lch(none none none / none)", "lch(none none none / none)");
+test_valid_value("color", "lch(none none none)", "lch(none none none)");
+test_valid_value("color", "lch(20 none none / none)", "lch(20 none none / none)");
+test_valid_value("color", "lch(none none none / 0.5)", "lch(none none none / 0.5)");
+test_valid_value("color", "lch(0 0 0 / none)", "lch(0 0 0 / none)");
+
+// oklch()
+test_valid_value("color", "oklch(0 0 0deg)", "oklch(0 0 0)");
+test_valid_value("color", "oklch(0 0 0deg / 1)", "oklch(0 0 0)");
+test_valid_value("color", "oklch(0 0 0deg / 0.5)", "oklch(0 0 0 / 0.5)");
+test_valid_value("color", "oklch(100 230 0deg / 0.5)", "oklch(100 230 0 / 0.5)");
+test_valid_value("color", "oklch(20 50 20deg/0.5)", "oklch(20 50 20 / 0.5)");
+test_valid_value("color", "oklch(20 50 20deg/50%)", "oklch(20 50 20 / 0.5)");
+test_valid_value("color", "oklch(10 20 20deg / -10%)", "oklch(10 20 20 / 0)");
+test_valid_value("color", "oklch(10 20 20deg / 110%)", "oklch(10 20 20)");
+test_valid_value("color", "oklch(10 20 1.28rad)", "oklch(10 20 73.3386)");
+test_valid_value("color", "oklch(10 20 380deg)", "oklch(10 20 20)");
+test_valid_value("color", "oklch(10 20 -340deg)", "oklch(10 20 20)");
+test_valid_value("color", "oklch(10 20 740deg)", "oklch(10 20 20)");
+test_valid_value("color", "oklch(10 20 -700deg)", "oklch(10 20 20)");
+test_valid_value("color", "oklch(-40 0 0)", "oklch(0 0 0)");
+test_valid_value("color", "oklch(20 -20 0)", "oklch(20 0 0)");
+test_valid_value("color", "oklch(0 0 0 / 0.5)", "oklch(0 0 0 / 0.5)");
+test_valid_value("color", "oklch(10 20 20 / 110%)", "oklch(10 20 20)");
+test_valid_value("color", "oklch(10 20 -700)", "oklch(10 20 20)");
+test_valid_value("color", "oklch(calc(50 * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))", "oklch(150 0 40 / 0.5)");
+test_valid_value("color", "oklch(calc(-50 * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))", "oklch(0 1.5 320 / 0)");
+
+test_valid_value("color", "oklch(none none none / none)", "oklch(none none none / none)");
+test_valid_value("color", "oklch(none none none)", "oklch(none none none)");
+test_valid_value("color", "oklch(20 none none / none)", "oklch(20 none none / none)");
+test_valid_value("color", "oklch(none none none / 0.5)", "oklch(none none none / 0.5)");
+test_valid_value("color", "oklch(0 0 0 / none)", "oklch(0 0 0 / none)");
 </script>
 </body>
 </html>

--- a/css/css-color/parsing/color-valid-relative-color.html
+++ b/css/css-color/parsing/color-valid-relative-color.html
@@ -290,68 +290,131 @@
     test_valid_value(`color`, `hwb(from hwb(120deg 20% 50% / none) h w b / alpha)`,             `rgba(51, 128, 51, 0)`);
     test_valid_value(`color`, `hwb(from hwb(none 20% 50% / .5) h w b / alpha)`,                 `rgba(128, 51, 51, 0.5)`);
 
-    for (const colorSpace of [ "lab", "oklab" ]) {
-        // Testing no modifications.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b)`, `${colorSpace}(25 20 50)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b / alpha)`, `${colorSpace}(25 20 50)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a b / alpha)`, `${colorSpace}(25 20 50 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(200 300 400 / 500%) l a b / alpha)`, `${colorSpace}(200 300 400)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(-200 -300 -400 / -500%) l a b / alpha)`, `${colorSpace}(0 -300 -400 / 0)`);
+    // lab()
 
-        // Test nesting relative colors.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(from ${colorSpace}(25 20 50) l a b) l a b)`, `${colorSpace}(25 20 50)`);
+    // Testing no modifications.
+    test_valid_value(`color`, `lab(from lab(25 20 50) l a b)`, `lab(25 20 50)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50) l a b / alpha)`, `lab(25 20 50)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50 / 40%) l a b / alpha)`, `lab(25 20 50 / 0.4)`);
+    test_valid_value(`color`, `lab(from lab(200 300 400 / 500%) l a b / alpha)`, `lab(200 300 400)`);
+    test_valid_value(`color`, `lab(from lab(-200 -300 -400 / -500%) l a b / alpha)`, `lab(0 -300 -400 / 0)`);
 
-        // Testing non-${colorSpace} origin to see conversion.
-        test_valid_value(`color`, `${colorSpace}(from color(display-p3 0 0 0) l a b / alpha)`, `${colorSpace}(0 0 0)`);
+    // Test nesting relative colors.
+    test_valid_value(`color`, `lab(from lab(from lab(25 20 50) l a b) l a b)`, `lab(25 20 50)`);
 
-        // Testing replacement with 0.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) 0 0 0)`, `${colorSpace}(0 0 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) 0 0 0 / 0)`, `${colorSpace}(0 0 0 / 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) 0 a b / alpha)`, `${colorSpace}(0 20 50)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l 0 b / alpha)`, `${colorSpace}(25 0 50)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a 0 / alpha)`, `${colorSpace}(25 20 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b / 0)`, `${colorSpace}(25 20 50 / 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) 0 a b / alpha)`, `${colorSpace}(0 20 50 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l 0 b / alpha)`, `${colorSpace}(25 0 50 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a 0 / alpha)`, `${colorSpace}(25 20 0 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a b / 0)`, `${colorSpace}(25 20 50 / 0)`);
+    // Testing non-lab origin to see conversion.
+    test_valid_value(`color`, `lab(from color(display-p3 0 0 0) l a b / alpha)`, `lab(0 0 0)`);
 
-        // Testing replacement with a constant.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) 35 a b / alpha)`, `${colorSpace}(35 20 50)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l 35 b / alpha)`, `${colorSpace}(25 35 50)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a 35 / alpha)`, `${colorSpace}(25 20 35)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b / .35)`, `${colorSpace}(25 20 50 / 0.35)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) 35 a b / alpha)`, `${colorSpace}(35 20 50 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l 35 b / alpha)`, `${colorSpace}(25 35 50 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a 35 / alpha)`, `${colorSpace}(25 20 35 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a b / .35)`, `${colorSpace}(25 20 50 / 0.35)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 200 300 400 / 500)`, `${colorSpace}(200 300 400)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) -200 -300 -400 / -500)`, `${colorSpace}(0 -300 -400 / 0)`);
+    // Testing replacement with 0.
+    test_valid_value(`color`, `lab(from lab(25 20 50) 0 0 0)`, `lab(0 0 0)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50) 0 0 0 / 0)`, `lab(0 0 0 / 0)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50) 0 a b / alpha)`, `lab(0 20 50)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50) l 0 b / alpha)`, `lab(25 0 50)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50) l a 0 / alpha)`, `lab(25 20 0)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50) l a b / 0)`, `lab(25 20 50 / 0)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50 / 40%) 0 a b / alpha)`, `lab(0 20 50 / 0.4)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50 / 40%) l 0 b / alpha)`, `lab(25 0 50 / 0.4)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50 / 40%) l a 0 / alpha)`, `lab(25 20 0 / 0.4)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50 / 40%) l a b / 0)`, `lab(25 20 50 / 0)`);
 
-        // Testing valid permutation (types match).
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l b a)`, `${colorSpace}(25 50 20)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a a / a)`, `${colorSpace}(25 20 20)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l b a)`, `${colorSpace}(25 50 20)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a a / a)`, `${colorSpace}(25 20 20)`);
+    // Testing replacement with a constant.
+    test_valid_value(`color`, `lab(from lab(25 20 50) 35 a b / alpha)`, `lab(35 20 50)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50) l 35 b / alpha)`, `lab(25 35 50)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50) l a 35 / alpha)`, `lab(25 20 35)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50) l a b / .35)`, `lab(25 20 50 / 0.35)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50 / 40%) 35 a b / alpha)`, `lab(35 20 50 / 0.4)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50 / 40%) l 35 b / alpha)`, `lab(25 35 50 / 0.4)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50 / 40%) l a 35 / alpha)`, `lab(25 20 35 / 0.4)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50 / 40%) l a b / .35)`, `lab(25 20 50 / 0.35)`);
+    test_valid_value(`color`, `lab(from lab(0.7 45 30 / 40%) 200 300 400 / 500)`, `lab(200 300 400)`);
+    test_valid_value(`color`, `lab(from lab(0.7 45 30 / 40%) -200 -300 -400 / -500)`, `lab(0 -300 -400 / 0)`);
 
-        // Testing with calc().
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) calc(l) calc(a) calc(b))`, `${colorSpace}(25 20 50)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) calc(l) calc(a) calc(b) / calc(alpha))`, `${colorSpace}(25 20 50 / 0.4)`);
+    // Testing valid permutation (types match).
+    test_valid_value(`color`, `lab(from lab(25 20 50) l b a)`, `lab(25 50 20)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50) l a a / a)`, `lab(25 20 20)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50 / 40%) l b a)`, `lab(25 50 20)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50 / 40%) l a a / a)`, `lab(25 20 20)`);
 
-        // Testing with 'none'.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) none none none)`, `${colorSpace}(none none none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) none none none / none)`, `${colorSpace}(none none none / none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a none)`, `${colorSpace}(25 20 none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a none / alpha)`, `${colorSpace}(25 20 none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50) l a b / none)`, `${colorSpace}(25 20 50 / none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a none / alpha)`, `${colorSpace}(25 20 none / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / 40%) l a b / none)`, `${colorSpace}(25 20 50 / none)`);
-        // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(none none none) l a b)`, `${colorSpace}(0 0 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(none none none / none) l a b / alpha)`, `${colorSpace}(0 0 0 / 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 none 50) l a b)`, `${colorSpace}(25 0 50)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(25 20 50 / none) l a b / alpha)`, `${colorSpace}(25 20 50 / 0)`);
-    }
+    // Testing with calc().
+    test_valid_value(`color`, `lab(from lab(25 20 50) calc(l) calc(a) calc(b))`, `lab(25 20 50)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50 / 40%) calc(l) calc(a) calc(b) / calc(alpha))`, `lab(25 20 50 / 0.4)`);
+
+    // Testing with 'none'.
+    test_valid_value(`color`, `lab(from lab(25 20 50) none none none)`, `lab(none none none)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50) none none none / none)`, `lab(none none none / none)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50) l a none)`, `lab(25 20 none)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50) l a none / alpha)`, `lab(25 20 none)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50) l a b / none)`, `lab(25 20 50 / none)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50 / 40%) l a none / alpha)`, `lab(25 20 none / 0.4)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50 / 40%) l a b / none)`, `lab(25 20 50 / none)`);
+    // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+    test_valid_value(`color`, `lab(from lab(none none none) l a b)`, `lab(0 0 0)`);
+    test_valid_value(`color`, `lab(from lab(none none none / none) l a b / alpha)`, `lab(0 0 0 / 0)`);
+    test_valid_value(`color`, `lab(from lab(25 none 50) l a b)`, `lab(25 0 50)`);
+    test_valid_value(`color`, `lab(from lab(25 20 50 / none) l a b / alpha)`, `lab(25 20 50 / 0)`);
+
+    // oklab()
+
+    // Testing no modifications.
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) l a b)`, `oklab(25 20 50)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) l a b / alpha)`, `oklab(25 20 50)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50 / 40%) l a b / alpha)`, `oklab(25 20 50 / 0.4)`);
+    test_valid_value(`color`, `oklab(from oklab(200 300 400 / 500%) l a b / alpha)`, `oklab(200 300 400)`);
+    test_valid_value(`color`, `oklab(from oklab(-200 -300 -400 / -500%) l a b / alpha)`, `oklab(0 -300 -400 / 0)`);
+
+    // Test nesting relative colors.
+    test_valid_value(`color`, `oklab(from oklab(from oklab(25 20 50) l a b) l a b)`, `oklab(25 20 50)`);
+
+    // Testing non-oklab origin to see conversion.
+    test_valid_value(`color`, `oklab(from color(display-p3 0 0 0) l a b / alpha)`, `oklab(0 0 0)`);
+
+    // Testing replacement with 0.
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) 0 0 0)`, `oklab(0 0 0)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) 0 0 0 / 0)`, `oklab(0 0 0 / 0)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) 0 a b / alpha)`, `oklab(0 20 50)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) l 0 b / alpha)`, `oklab(25 0 50)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) l a 0 / alpha)`, `oklab(25 20 0)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) l a b / 0)`, `oklab(25 20 50 / 0)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50 / 40%) 0 a b / alpha)`, `oklab(0 20 50 / 0.4)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50 / 40%) l 0 b / alpha)`, `oklab(25 0 50 / 0.4)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50 / 40%) l a 0 / alpha)`, `oklab(25 20 0 / 0.4)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50 / 40%) l a b / 0)`, `oklab(25 20 50 / 0)`);
+
+    // Testing replacement with a constant.
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) 35 a b / alpha)`, `oklab(35 20 50)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) l 35 b / alpha)`, `oklab(25 35 50)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) l a 35 / alpha)`, `oklab(25 20 35)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) l a b / .35)`, `oklab(25 20 50 / 0.35)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50 / 40%) 35 a b / alpha)`, `oklab(35 20 50 / 0.4)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50 / 40%) l 35 b / alpha)`, `oklab(25 35 50 / 0.4)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50 / 40%) l a 35 / alpha)`, `oklab(25 20 35 / 0.4)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50 / 40%) l a b / .35)`, `oklab(25 20 50 / 0.35)`);
+    test_valid_value(`color`, `oklab(from oklab(0.7 45 30 / 40%) 200 300 400 / 500)`, `oklab(200 300 400)`);
+    test_valid_value(`color`, `oklab(from oklab(0.7 45 30 / 40%) -200 -300 -400 / -500)`, `oklab(0 -300 -400 / 0)`);
+
+    // Testing valid permutation (types match).
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) l b a)`, `oklab(25 50 20)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) l a a / a)`, `oklab(25 20 20)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50 / 40%) l b a)`, `oklab(25 50 20)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50 / 40%) l a a / a)`, `oklab(25 20 20)`);
+
+    // Testing with calc().
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) calc(l) calc(a) calc(b))`, `oklab(25 20 50)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50 / 40%) calc(l) calc(a) calc(b) / calc(alpha))`, `oklab(25 20 50 / 0.4)`);
+
+    // Testing with 'none'.
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) none none none)`, `oklab(none none none)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) none none none / none)`, `oklab(none none none / none)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) l a none)`, `oklab(25 20 none)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) l a none / alpha)`, `oklab(25 20 none)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50) l a b / none)`, `oklab(25 20 50 / none)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50 / 40%) l a none / alpha)`, `oklab(25 20 none / 0.4)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50 / 40%) l a b / none)`, `oklab(25 20 50 / none)`);
+    // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+    test_valid_value(`color`, `oklab(from oklab(none none none) l a b)`, `oklab(0 0 0)`);
+    test_valid_value(`color`, `oklab(from oklab(none none none / none) l a b / alpha)`, `oklab(0 0 0 / 0)`);
+    test_valid_value(`color`, `oklab(from oklab(25 none 50) l a b)`, `oklab(25 0 50)`);
+    test_valid_value(`color`, `oklab(from oklab(25 20 50 / none) l a b / alpha)`, `oklab(25 20 50 / 0)`);
 
     // lab and oklab tests that require different results due to percent scaling differences.
     test_valid_value(`color`, `lab(from lab(.7 45 30) alpha b a / l)`, `lab(100 30 45 / 0.7)`);
@@ -368,78 +431,147 @@
     test_valid_value(`color`, `oklab(from oklab(.7 45 30 / 40%) alpha a b / alpha)`, `oklab(0.4 45 30 / 0.4)`);
     test_valid_value(`color`, `oklab(from oklab(.7 45 30 / 40%) alpha a a / alpha)`, `oklab(0.4 45 45 / 0.4)`);
 
-    for (const colorSpace of [ "lch", "oklch" ]) {
-        const rectangularForm = colorSpace == "lch" ? "lab" : "oklab";
+    // lch()
 
-        // Testing no modifications.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h)`, `${colorSpace}(0.7 45 30)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h / alpha)`, `${colorSpace}(0.7 45 30)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c h / alpha)`, `${colorSpace}(0.7 45 30 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(200 300 400 / 500%) l c h / alpha)`, `${colorSpace}(200 300 40)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(-200 -300 -400 / -500%) l c h / alpha)`, `${colorSpace}(0 0 320 / 0)`);
+    // Testing no modifications.
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) l c h)`, `lch(0.7 45 30)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) l c h / alpha)`, `lch(0.7 45 30)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / 40%) l c h / alpha)`, `lch(0.7 45 30 / 0.4)`);
+    test_valid_value(`color`, `lch(from lch(200 300 400 / 500%) l c h / alpha)`, `lch(200 300 40)`);
+    test_valid_value(`color`, `lch(from lch(-200 -300 -400 / -500%) l c h / alpha)`, `lch(0 0 320 / 0)`);
 
-        // Test nesting relative colors.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(from ${colorSpace}(0.7 45 30) l c h) l c h)`, `${colorSpace}(0.7 45 30)`);
+    // Test nesting relative colors.
+    test_valid_value(`color`, `lch(from lch(from lch(0.7 45 30) l c h) l c h)`, `lch(0.7 45 30)`);
 
-        // Testing non-sRGB origin colors (no gamut mapping will happen since the destination is not a bounded RGB color space).
-        test_valid_value(`color`, `${colorSpace}(from color(display-p3 0 0 0) l c h / alpha)`, `${colorSpace}(0 0 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${rectangularForm}(0.7 45 30) l c h / alpha)`, `${colorSpace}(0.7 54.08327 33.690067)`);
+    // Testing non-sRGB origin colors (no gamut mapping will happen since the destination is not a bounded RGB color space).
+    test_valid_value(`color`, `lch(from color(display-p3 0 0 0) l c h / alpha)`, `lch(0 0 0)`);
+    test_valid_value(`color`, `lch(from lab(0.7 45 30) l c h / alpha)`, `lch(0.7 54.08327 33.690067)`);
 
-        // Testing replacement with 0.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 0 0)`, `${colorSpace}(0 0 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 0 0deg)`, `${colorSpace}(0 0 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 0 0 / 0)`, `${colorSpace}(0 0 0 / 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 0 0deg / 0)`, `${colorSpace}(0 0 0 / 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 0 c h / alpha)`, `${colorSpace}(0 45 30)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l 0 h / alpha)`, `${colorSpace}(0.7 0 30)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c 0 / alpha)`, `${colorSpace}(0.7 45 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c 0deg / alpha)`, `${colorSpace}(0.7 45 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h / 0)`, `${colorSpace}(0.7 45 30 / 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 0 c h / alpha)`, `${colorSpace}(0 45 30 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l 0 h / alpha)`, `${colorSpace}(0.7 0 30 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c 0 / alpha)`, `${colorSpace}(0.7 45 0 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c 0deg / alpha)`, `${colorSpace}(0.7 45 0 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c h / 0)`, `${colorSpace}(0.7 45 30 / 0)`);
+    // Testing replacement with 0.
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) 0 0 0)`, `lch(0 0 0)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) 0 0 0deg)`, `lch(0 0 0)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) 0 0 0 / 0)`, `lch(0 0 0 / 0)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) 0 0 0deg / 0)`, `lch(0 0 0 / 0)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) 0 c h / alpha)`, `lch(0 45 30)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) l 0 h / alpha)`, `lch(0.7 0 30)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) l c 0 / alpha)`, `lch(0.7 45 0)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) l c 0deg / alpha)`, `lch(0.7 45 0)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) l c h / 0)`, `lch(0.7 45 30 / 0)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / 40%) 0 c h / alpha)`, `lch(0 45 30 / 0.4)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / 40%) l 0 h / alpha)`, `lch(0.7 0 30 / 0.4)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / 40%) l c 0 / alpha)`, `lch(0.7 45 0 / 0.4)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / 40%) l c 0deg / alpha)`, `lch(0.7 45 0 / 0.4)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / 40%) l c h / 0)`, `lch(0.7 45 30 / 0)`);
 
-        // Testing replacement with a constant.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) 25 c h / alpha)`, `${colorSpace}(25 45 30)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l 25 h / alpha)`, `${colorSpace}(0.7 25 30)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c 25 / alpha)`, `${colorSpace}(0.7 45 25)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c 25deg / alpha)`, `${colorSpace}(0.7 45 25)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h / .25)`, `${colorSpace}(0.7 45 30 / 0.25)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 25 c h / alpha)`, `${colorSpace}(25 45 30 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l 25 h / alpha)`, `${colorSpace}(0.7 25 30 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c 25 / alpha)`, `${colorSpace}(0.7 45 25 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c 25deg / alpha)`, `${colorSpace}(0.7 45 25 / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c h / .25)`, `${colorSpace}(0.7 45 30 / 0.25)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 200 300 400 / 500)`, `${colorSpace}(200 300 40)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) -200 -300 -400 / -500)`, `${colorSpace}(0 0 320 / 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 50 120 400deg / 500)`, `${colorSpace}(50 120 40)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) 50 120 -400deg / -500)`, `${colorSpace}(50 120 320 / 0)`);
+    // Testing replacement with a constant.
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) 25 c h / alpha)`, `lch(25 45 30)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) l 25 h / alpha)`, `lch(0.7 25 30)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) l c 25 / alpha)`, `lch(0.7 45 25)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) l c 25deg / alpha)`, `lch(0.7 45 25)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) l c h / .25)`, `lch(0.7 45 30 / 0.25)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / 40%) 25 c h / alpha)`, `lch(25 45 30 / 0.4)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / 40%) l 25 h / alpha)`, `lch(0.7 25 30 / 0.4)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / 40%) l c 25 / alpha)`, `lch(0.7 45 25 / 0.4)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / 40%) l c 25deg / alpha)`, `lch(0.7 45 25 / 0.4)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / 40%) l c h / .25)`, `lch(0.7 45 30 / 0.25)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / 40%) 200 300 400 / 500)`, `lch(200 300 40)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / 40%) -200 -300 -400 / -500)`, `lch(0 0 320 / 0)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / 40%) 50 120 400deg / 500)`, `lch(50 120 40)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / 40%) 50 120 -400deg / -500)`, `lch(50 120 320 / 0)`);
 
-        // Testing valid permutation (types match).
-        // NOTE: 'c' is a vaild hue, as hue is <angle>|<number>.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(.7 45 30) l c c / alpha)`, `${colorSpace}(0.7 45 45)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(.7 45 30 / 40%) l c c / alpha)`, `${colorSpace}(0.7 45 45 / 0.4)`);
+    // Testing valid permutation (types match).
+    // NOTE: 'c' is a vaild hue, as hue is <angle>|<number>.
+    test_valid_value(`color`, `lch(from lch(.7 45 30) l c c / alpha)`, `lch(0.7 45 45)`);
+    test_valid_value(`color`, `lch(from lch(.7 45 30 / 40%) l c c / alpha)`, `lch(0.7 45 45 / 0.4)`);
 
-        // Testing with calc().
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) calc(l) calc(c) calc(h))`, `${colorSpace}(0.7 45 30)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) calc(l) calc(c) calc(h) / calc(alpha))`, `${colorSpace}(0.7 45 30 / 0.4)`);
+    // Testing with calc().
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) calc(l) calc(c) calc(h))`, `lch(0.7 45 30)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / 40%) calc(l) calc(c) calc(h) / calc(alpha))`, `lch(0.7 45 30 / 0.4)`);
 
-        // Testing with 'none'.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) none none none)`,                                   `${colorSpace}(none none none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) none none none / none)`,                            `${colorSpace}(none none none / none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c none)`,                                         `${colorSpace}(0.7 45 none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c none / alpha)`,                                 `${colorSpace}(0.7 45 none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30) l c h / none)`,                                     `${colorSpace}(0.7 45 30 / none)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c none / alpha)`,                           `${colorSpace}(0.7 45 none / 0.4)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / 40%) l c h / none)`,                               `${colorSpace}(0.7 45 30 / none)`);
-        // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(none none none) l c h)`,                                       `${colorSpace}(0 0 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(none none none / none) l c h / alpha)`,                        `${colorSpace}(0 0 0 / 0)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 none 30) l c h)`,                                          `${colorSpace}(0.7 0 30)`);
-        test_valid_value(`color`, `${colorSpace}(from ${colorSpace}(0.7 45 30 / none) l c h / alpha)`,                             `${colorSpace}(0.7 45 30 / 0)`);
-    }
+    // Testing with 'none'.
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) none none none)`,                                   `lch(none none none)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) none none none / none)`,                            `lch(none none none / none)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) l c none)`,                                         `lch(0.7 45 none)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) l c none / alpha)`,                                 `lch(0.7 45 none)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30) l c h / none)`,                                     `lch(0.7 45 30 / none)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / 40%) l c none / alpha)`,                           `lch(0.7 45 none / 0.4)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / 40%) l c h / none)`,                               `lch(0.7 45 30 / none)`);
+    // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+    test_valid_value(`color`, `lch(from lch(none none none) l c h)`,                                       `lch(0 0 0)`);
+    test_valid_value(`color`, `lch(from lch(none none none / none) l c h / alpha)`,                        `lch(0 0 0 / 0)`);
+    test_valid_value(`color`, `lch(from lch(0.7 none 30) l c h)`,                                          `lch(0.7 0 30)`);
+    test_valid_value(`color`, `lch(from lch(0.7 45 30 / none) l c h / alpha)`,                             `lch(0.7 45 30 / 0)`);
+
+    // oklch()
+
+    // Testing no modifications.
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) l c h)`, `oklch(0.7 45 30)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) l c h / alpha)`, `oklch(0.7 45 30)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l c h / alpha)`, `oklch(0.7 45 30 / 0.4)`);
+    test_valid_value(`color`, `oklch(from oklch(200 300 400 / 500%) l c h / alpha)`, `oklch(200 300 40)`);
+    test_valid_value(`color`, `oklch(from oklch(-200 -300 -400 / -500%) l c h / alpha)`, `oklch(0 0 320 / 0)`);
+
+    // Test nesting relative colors.
+    test_valid_value(`color`, `oklch(from oklch(from oklch(0.7 45 30) l c h) l c h)`, `oklch(0.7 45 30)`);
+
+    // Testing non-sRGB origin colors (no gamut mapping will happen since the destination is not a bounded RGB color space).
+    test_valid_value(`color`, `oklch(from color(display-p3 0 0 0) l c h / alpha)`, `oklch(0 0 0)`);
+    test_valid_value(`color`, `oklch(from oklab(0.7 45 30) l c h / alpha)`, `oklch(0.7 54.08327 33.690067)`);
+
+    // Testing replacement with 0.
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) 0 0 0)`, `oklch(0 0 0)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) 0 0 0deg)`, `oklch(0 0 0)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) 0 0 0 / 0)`, `oklch(0 0 0 / 0)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) 0 0 0deg / 0)`, `oklch(0 0 0 / 0)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) 0 c h / alpha)`, `oklch(0 45 30)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) l 0 h / alpha)`, `oklch(0.7 0 30)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) l c 0 / alpha)`, `oklch(0.7 45 0)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) l c 0deg / alpha)`, `oklch(0.7 45 0)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) l c h / 0)`, `oklch(0.7 45 30 / 0)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) 0 c h / alpha)`, `oklch(0 45 30 / 0.4)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l 0 h / alpha)`, `oklch(0.7 0 30 / 0.4)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l c 0 / alpha)`, `oklch(0.7 45 0 / 0.4)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l c 0deg / alpha)`, `oklch(0.7 45 0 / 0.4)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l c h / 0)`, `oklch(0.7 45 30 / 0)`);
+
+    // Testing replacement with a constant.
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) 25 c h / alpha)`, `oklch(25 45 30)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) l 25 h / alpha)`, `oklch(0.7 25 30)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) l c 25 / alpha)`, `oklch(0.7 45 25)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) l c 25deg / alpha)`, `oklch(0.7 45 25)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) l c h / .25)`, `oklch(0.7 45 30 / 0.25)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) 25 c h / alpha)`, `oklch(25 45 30 / 0.4)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l 25 h / alpha)`, `oklch(0.7 25 30 / 0.4)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l c 25 / alpha)`, `oklch(0.7 45 25 / 0.4)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l c 25deg / alpha)`, `oklch(0.7 45 25 / 0.4)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l c h / .25)`, `oklch(0.7 45 30 / 0.25)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) 200 300 400 / 500)`, `oklch(200 300 40)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) -200 -300 -400 / -500)`, `oklch(0 0 320 / 0)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) 50 120 400deg / 500)`, `oklch(50 120 40)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) 50 120 -400deg / -500)`, `oklch(50 120 320 / 0)`);
+
+    // Testing valid permutation (types match).
+    // NOTE: 'c' is a vaild hue, as hue is <angle>|<number>.
+    test_valid_value(`color`, `oklch(from oklch(.7 45 30) l c c / alpha)`, `oklch(0.7 45 45)`);
+    test_valid_value(`color`, `oklch(from oklch(.7 45 30 / 40%) l c c / alpha)`, `oklch(0.7 45 45 / 0.4)`);
+
+    // Testing with calc().
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) calc(l) calc(c) calc(h))`, `oklch(0.7 45 30)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) calc(l) calc(c) calc(h) / calc(alpha))`, `oklch(0.7 45 30 / 0.4)`);
+
+    // Testing with 'none'.
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) none none none)`,                                   `oklch(none none none)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) none none none / none)`,                            `oklch(none none none / none)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) l c none)`,                                         `oklch(0.7 45 none)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) l c none / alpha)`,                                 `oklch(0.7 45 none)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30) l c h / none)`,                                     `oklch(0.7 45 30 / none)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l c none / alpha)`,                           `oklch(0.7 45 none / 0.4)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / 40%) l c h / none)`,                               `oklch(0.7 45 30 / none)`);
+    // FIXME: Clarify with spec editors if 'none' should pass through to the constants.
+    test_valid_value(`color`, `oklch(from oklch(none none none) l c h)`,                                       `oklch(0 0 0)`);
+    test_valid_value(`color`, `oklch(from oklch(none none none / none) l c h / alpha)`,                        `oklch(0 0 0 / 0)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 none 30) l c h)`,                                          `oklch(0.7 0 30)`);
+    test_valid_value(`color`, `oklch(from oklch(0.7 45 30 / none) l c h / alpha)`,                             `oklch(0.7 45 30 / 0)`);
 
     // lch and oklch tests that require different results due to percent scaling differences.
     test_valid_value(`color`, `lch(from lch(.7 45 30) alpha c h / l)`, `lch(100 45 30 / 0.7)`);


### PR DESCRIPTION
In preparation for #39000, break for-loops apart into separate tests for `lab()` vs. `oklab()` and `lch()` vs. `oklch()`, since with clamping of L > 100% they generally won't be able to share input values due to one having a range of `[0-100]` and the other `[0-1]`. (This is strictly refactoring existing tests, no changed values.)