### PR TITLE
Set custom default timeouts for WebDriver classic session

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -644,6 +644,7 @@ class WdspecExecutor(TestExecutor):
         session_config = {"host": self.browser.host,
                           "port": self.browser.port,
                           "capabilities": self.capabilities,
+                          "timeout_multiplier": self.timeout_multiplier,
                           "webdriver": {
                               "binary": self.webdriver_binary,
                               "args": self.webdriver_args

--- a/webdriver/tests/get_timeouts/get.py
+++ b/webdriver/tests/get_timeouts/get.py
@@ -23,15 +23,6 @@ def test_get_timeouts(session):
     assert isinstance(value["pageLoad"], int)
 
 
-def test_get_default_timeouts(session):
-    response = get_timeouts(session)
-
-    assert_success(response)
-    assert response.body["value"]["script"] == 30000
-    assert response.body["value"]["implicit"] == 0
-    assert response.body["value"]["pageLoad"] == 300000
-
-
 def test_get_new_timeouts(session):
     session.timeouts.script = 60
     session.timeouts.implicit = 1

--- a/webdriver/tests/support/fixtures.py
+++ b/webdriver/tests/support/fixtures.py
@@ -14,11 +14,12 @@ from tests.support.inline import build_inline
 from tests.support.http_request import HTTPRequest
 
 
+SCRIPT_TIMEOUT = 1
+PAGE_LOAD_TIMEOUT = 3
+IMPLICIT_WAIT_TIMEOUT = 0
+
 # The webdriver session can outlive a pytest session
 _current_session = None
-
-
-_custom_session = False
 
 
 def pytest_configure(config):
@@ -63,6 +64,7 @@ def full_configuration():
     host - WebDriver server host.
     port -  WebDriver server port.
     capabilites - Capabilites passed when creating the WebDriver session
+    timeout_multiplier - Multiplier for timeout values
     webdriver - Dict with keys `binary`: path to webdriver binary, and
                 `args`: Additional command line arguments passed to the webdriver
                 binary. This doesn't include all the required arguments e.g. the
@@ -136,6 +138,12 @@ async def session(capabilities, configuration):
     if _current_session.capabilities.get("setWindowRect"):
         _current_session.window.size = defaults.WINDOW_SIZE
         _current_session.window.position = defaults.WINDOW_POSITION
+
+    # Set default timeouts
+    multiplier = configuration["timeout_multiplier"]
+    _current_session.timeouts.implicit = IMPLICIT_WAIT_TIMEOUT * multiplier
+    _current_session.timeouts.page_load = PAGE_LOAD_TIMEOUT * multiplier
+    _current_session.timeouts.script = SCRIPT_TIMEOUT * multiplier
 
     yield _current_session
 


### PR DESCRIPTION
The default wdspec timeout for a complete file is set to 25s. Having a `page_load` timeout of 300s and a `script` timeout of 30s here doesn't make sense. As such I propose to use custom values for our wdspec tests which load pages from a local server anyway and that shouldn't take longer than around 3s.

To incorporate slow running builds we will also use the timeout multiplier to account for that.