### PR TITLE
Update Safari prefs on Azure Pipelines

### DIFF
--- a/tools/ci/azure/install_safari.yml
+++ b/tools/ci/azure/install_safari.yml
@@ -16,7 +16,10 @@ steps:
       # https://github.com/web-platform-tests/wpt/issues/21751
       mkdir -p ~/Library/WebDriver/
       cp tools/ci/azure/com.apple.SafariTechnologyPreview.plist ~/Library/WebDriver/
-      defaults write com.apple.SafariTechnologyPreview WebKitJavaScriptCanOpenWindowsAutomatically 1
+      defaults write com.apple.SafariTechnologyPreview WebKitPreferences.requiresUserGestureForAudioPlayback 1
+      defaults write com.apple.SafariTechnologyPreview WebKitPreferences.requiresUserGestureForMediaPlayback 1
+      defaults write com.apple.SafariTechnologyPreview WebKitPreferences.requiresUserGestureForVideoPlayback 1
+      defaults write com.apple.SafariTechnologyPreview WebKitPreferences.javaScriptCanOpenWindowsAutomatically 1
       defaults write com.apple.SafariTechnologyPreview ExperimentalServerTimingEnabled 1
     displayName: 'Install Safari Technology Preview'
 - ${{ if eq(parameters.channel, 'stable') }}:
@@ -25,5 +28,8 @@ steps:
       export SYSTEM_VERSION_COMPAT=0
       sudo softwareupdate --install $( softwareupdate -l | grep -o '\* Label: \(Safari.*\)' | sed -e 's/* Label: //' )
       sudo safaridriver --enable
-      defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically 1
+      defaults write com.apple.Safari WebKitPreferences.requiresUserGestureForAudioPlayback 1
+      defaults write com.apple.Safari WebKitPreferences.requiresUserGestureForMediaPlayback 1
+      defaults write com.apple.Safari WebKitPreferences.requiresUserGestureForVideoPlayback 1
+      defaults write com.apple.Safari WebKitPreferences.javaScriptCanOpenWindowsAutomatically 1
     displayName: 'Configure Safari'

--- a/tools/ci/azure/install_safari.yml
+++ b/tools/ci/azure/install_safari.yml
@@ -16,11 +16,10 @@ steps:
       # https://github.com/web-platform-tests/wpt/issues/21751
       mkdir -p ~/Library/WebDriver/
       cp tools/ci/azure/com.apple.SafariTechnologyPreview.plist ~/Library/WebDriver/
-      defaults write com.apple.SafariTechnologyPreview WebKitPreferences.requiresUserGestureForAudioPlayback 1
-      defaults write com.apple.SafariTechnologyPreview WebKitPreferences.requiresUserGestureForMediaPlayback 1
-      defaults write com.apple.SafariTechnologyPreview WebKitPreferences.requiresUserGestureForVideoPlayback 1
+      defaults write com.apple.SafariTechnologyPreview WebKitPreferences.requiresUserGestureForAudioPlayback 0
+      defaults write com.apple.SafariTechnologyPreview WebKitPreferences.requiresUserGestureForMediaPlayback 0
+      defaults write com.apple.SafariTechnologyPreview WebKitPreferences.requiresUserGestureForVideoPlayback 0
       defaults write com.apple.SafariTechnologyPreview WebKitPreferences.javaScriptCanOpenWindowsAutomatically 1
-      defaults write com.apple.SafariTechnologyPreview ExperimentalServerTimingEnabled 1
     displayName: 'Install Safari Technology Preview'
 - ${{ if eq(parameters.channel, 'stable') }}:
   - script: |
@@ -28,8 +27,8 @@ steps:
       export SYSTEM_VERSION_COMPAT=0
       sudo softwareupdate --install $( softwareupdate -l | grep -o '\* Label: \(Safari.*\)' | sed -e 's/* Label: //' )
       sudo safaridriver --enable
-      defaults write com.apple.Safari WebKitPreferences.requiresUserGestureForAudioPlayback 1
-      defaults write com.apple.Safari WebKitPreferences.requiresUserGestureForMediaPlayback 1
-      defaults write com.apple.Safari WebKitPreferences.requiresUserGestureForVideoPlayback 1
+      defaults write com.apple.Safari WebKitPreferences.requiresUserGestureForAudioPlayback 0
+      defaults write com.apple.Safari WebKitPreferences.requiresUserGestureForMediaPlayback 0
+      defaults write com.apple.Safari WebKitPreferences.requiresUserGestureForVideoPlayback 0
       defaults write com.apple.Safari WebKitPreferences.javaScriptCanOpenWindowsAutomatically 1
     displayName: 'Configure Safari'


### PR DESCRIPTION
This is a very old commit. IIRC it didn't work as intended. But look at this now I'm wondering why they're all `1` given the name of the prefs?