### PR TITLE
Include Ahem in mask-text-001.svg and reference

### DIFF
--- a/css/css-masking/mask-svg-content/mask-text-001.svg
+++ b/css/css-masking/mask-svg-content/mask-text-001.svg
@@ -6,6 +6,7 @@
 	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#svg-masks"/>
 	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#MaskElement"/>
 	<html:link rel="match" href="reference/mask-text-001-ref.svg"/>
+	<html:link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 	<metadata class="flags">svg</metadata>
 	<desc class="assert">The masked target elements get scaled with negative
 	factors. Check if that influences masking. You should see 4 green

--- a/css/css-masking/mask-svg-content/reference/mask-text-001-ref.svg
+++ b/css/css-masking/mask-svg-content/reference/mask-text-001-ref.svg
@@ -3,6 +3,7 @@
 <g id="testmeta">
 	<title>CSS Masking: Reftest reference</title>
 	<html:link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com"/>
+	<html:link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 	<metadata class="flags">svg</metadata>
 </g>
 <text fill="#000" font-family="Ahem" font-size="12px" transform="rotate(90 50 50)" x="50" y="50">foobar</text>


### PR DESCRIPTION
Ahem currently loads in Firefox & Chrome as system font, but not in Safari.

This test references Ahem, but never includes the stylesheet.