### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=253883

### DIFF
--- a/media-source/mediasource-buffered.html
+++ b/media-source/mediasource-buffered.html
@@ -228,6 +228,17 @@
                     test.done();
                 });
             }, "Get buffered range after removing sourcebuffer.");
+
+            mediasource_test(function(test, mediaElement, mediaSource)
+            {
+                mediaElement.pause();
+                mediaElement.addEventListener("error", test.unreached_func("Unexpected event 'error'"));
+                mediaElement.addEventListener("ended", test.step_func_done());
+
+                var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_ONLY_TYPE);
+                assert_equals(mediaSource.sourceBuffers[0].buffered , mediaSource.sourceBuffers[0].buffered);
+                test.done();
+            }, "buffered return the same object over multiple calls.");
         </script>
     </body>
 </html>


### PR DESCRIPTION
Per spec, https://w3c.github.io/media-source/#dom-sourcebuffer-buffered

Step 5,
```
5. If intersection ranges does not contain the exact same range information as the current value of this attribute, then update the current value of this attribute to intersection ranges.
6. Return the current value of this attribute.
```

The current value of this attribute should only be modified if it has changed.

Origin of change in the spec was https://www.w3.org/Bugs/Public/show_bug.cgi?id=27790