### PR TITLE
[mypy] Replace typing.Text with str

### DIFF
--- a/tools/ci/tc/github_checks_output.py
+++ b/tools/ci/tc/github_checks_output.py
@@ -1,7 +1,7 @@
 MYPY = False
 if MYPY:
     # MYPY is set to True when run under Mypy.
-    from typing import Optional, Text
+    from typing import Optional
 
 
 class GitHubChecksOutputter:
@@ -14,11 +14,11 @@ class GitHubChecksOutputter:
     https://docs.taskcluster.net/docs/reference/integrations/github/checks#custom-text-output-in-checks
     """
     def __init__(self, path):
-        # type: (Text) -> None
+        # type: (str) -> None
         self.path = path
 
     def output(self, line):
-        # type: (Text) -> None
+        # type: (str) -> None
         with open(self.path, mode="a") as f:
             f.write(line)
             f.write("\n")
@@ -28,7 +28,7 @@ __outputter = None
 
 
 def get_gh_checks_outputter(filepath):
-    # type: (Optional[Text]) -> Optional[GitHubChecksOutputter]
+    # type: (Optional[str]) -> Optional[GitHubChecksOutputter]
     """Return the outputter for GitHub Checks output, if enabled.
 
     :param filepath: The filepath to write GitHub Check output information to,

--- a/tools/lint/fnmatch.py
+++ b/tools/lint/fnmatch.py
@@ -6,21 +6,20 @@ if MYPY:
     # MYPY is set to True when run under Mypy.
     from typing import Iterable
     from typing import List
-    from typing import Text
 
 
 __all__ = ["fnmatch", "fnmatchcase", "filter", "translate"]
 
 
 def fnmatch(name, pat):
-    # type: (Text, Text) -> bool
+    # type: (str, str) -> bool
     name = os.path.normcase(name)
     pat = os.path.normcase(pat)
     return fnmatchcase(name, pat)
 
 
 def fnmatchcase(name, pat):
-    # type: (Text, Text) -> bool
+    # type: (str, str) -> bool
     if '?' not in pat and '[' not in pat:
         wildcards = pat.count("*")
         if wildcards == 0:
@@ -33,7 +32,7 @@ def fnmatchcase(name, pat):
 
 
 def filter(names, pat):
-    # type: (Iterable[Text], Text) -> List[Text]
+    # type: (Iterable[str], str) -> List[str]
     return [n for n in names if fnmatch(n, pat)]
 
 

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -35,7 +35,6 @@ if MYPY:
     from typing import Optional
     from typing import Sequence
     from typing import Set
-    from typing import Text
     from typing import Tuple
     from typing import Type
     from typing import TypeVar
@@ -99,7 +98,7 @@ you could add the following line to the lint.ignore file.
 
 
 def all_filesystem_paths(repo_root, subdir=None):
-    # type: (Text, Optional[Text]) -> Iterable[Text]
+    # type: (str, Optional[str]) -> Iterable[str]
     path_filter = PathFilter(repo_root.encode("utf8"),
                              extras=[b".git/"])
     if subdir:
@@ -117,7 +116,7 @@ def all_filesystem_paths(repo_root, subdir=None):
 
 
 def _all_files_equal(paths):
-    # type: (Iterable[Text]) -> bool
+    # type: (Iterable[str]) -> bool
     """
     Checks all the paths are files that are byte-for-byte identical
 
@@ -156,21 +155,21 @@ def _all_files_equal(paths):
 
 
 def check_path_length(repo_root, path):
-    # type: (Text, Text) -> List[rules.Error]
+    # type: (str, str) -> List[rules.Error]
     if len(path) + 1 > 150:
         return [rules.PathLength.error(path, (path, len(path) + 1))]
     return []
 
 
 def check_file_type(repo_root, path):
-    # type: (Text, Text) -> List[rules.Error]
+    # type: (str, str) -> List[rules.Error]
     if os.path.islink(path):
         return [rules.FileType.error(path, (path, "symlink"))]
     return []
 
 
 def check_worker_collision(repo_root, path):
-    # type: (Text, Text) -> List[rules.Error]
+    # type: (str, str) -> List[rules.Error]
     endings = [(".any.html", ".any.js"),
                (".any.worker.html", ".any.js"),
                (".worker.html", ".worker.js")]
@@ -181,7 +180,7 @@ def check_worker_collision(repo_root, path):
 
 
 def check_gitignore_file(repo_root, path):
-    # type: (Text, Text) -> List[rules.Error]
+    # type: (str, str) -> List[rules.Error]
     if not path.endswith(".gitignore"):
         return []
 
@@ -201,14 +200,14 @@ def check_gitignore_file(repo_root, path):
 
 
 def check_mojom_js(repo_root, path):
-    # type: (Text, Text) -> List[rules.Error]
+    # type: (str, str) -> List[rules.Error]
     if path.endswith(".mojom.js"):
         return [rules.MojomJSFile.error(path)]
     return []
 
 
 def check_ahem_copy(repo_root, path):
-    # type: (Text, Text) -> List[rules.Error]
+    # type: (str, str) -> List[rules.Error]
     lpath = path.lower()
     if "ahem" in lpath and lpath.endswith(".ttf"):
         return [rules.AhemCopy.error(path)]
@@ -216,7 +215,7 @@ def check_ahem_copy(repo_root, path):
 
 
 def check_tentative_directories(repo_root, path):
-    # type: (Text, Text) -> List[rules.Error]
+    # type: (str, str) -> List[rules.Error]
     path_parts = path.split(os.path.sep)
     for directory in path_parts[:-1]:
         if "tentative" in directory and directory != "tentative":
@@ -225,7 +224,7 @@ def check_tentative_directories(repo_root, path):
 
 
 def check_git_ignore(repo_root, paths):
-    # type: (Text, List[Text]) -> List[rules.Error]
+    # type: (str, List[str]) -> List[rules.Error]
     errors = []
 
     with tempfile.TemporaryFile('w+', newline='') as f:
@@ -255,7 +254,7 @@ w3c_dev_re = re.compile(r"https?\:\/\/dev\.w3c?\.org\/[^/?#]+\/([^/?#]+)")
 
 
 def check_css_globally_unique(repo_root, paths):
-    # type: (Text, List[Text]) -> List[rules.Error]
+    # type: (str, List[str]) -> List[rules.Error]
     """
     Checks that CSS filenames are sufficiently unique
 
@@ -273,9 +272,9 @@ def check_css_globally_unique(repo_root, paths):
     :returns: a list of errors found in ``paths``
 
     """
-    test_files = defaultdict(set)  # type: Dict[Text, Set[Text]]
-    ref_files = defaultdict(set)  # type: Dict[Text, Set[Text]]
-    support_files = defaultdict(set)  # type: Dict[Text, Set[Text]]
+    test_files = defaultdict(set)  # type: Dict[str, Set[str]]
+    ref_files = defaultdict(set)  # type: Dict[str, Set[str]]
+    support_files = defaultdict(set)  # type: Dict[str, Set[str]]
 
     for path in paths:
         if os.name == "nt":
@@ -304,7 +303,7 @@ def check_css_globally_unique(repo_root, paths):
         elif source_file.name_is_reference:
             ref_files[source_file.name].add(path)
         else:
-            test_name = source_file.name  # type: Text
+            test_name = source_file.name  # type: str
             test_name = test_name.replace('-manual', '')
             test_files[test_name].add(path)
 
@@ -314,7 +313,7 @@ def check_css_globally_unique(repo_root, paths):
         if len(colliding) > 1:
             if not _all_files_equal([os.path.join(repo_root, x) for x in colliding]):
                 # Only compute by_spec if there are prima-facie collisions because of cost
-                by_spec = defaultdict(set)  # type: Dict[Text, Set[Text]]
+                by_spec = defaultdict(set)  # type: Dict[str, Set[str]]
                 for path in colliding:
                     source_file = SourceFile(repo_root, path, "/")
                     for link in source_file.spec_links:
@@ -348,7 +347,7 @@ def check_css_globally_unique(repo_root, paths):
 
 
 def check_unique_testharness_basenames(repo_root, paths):
-    # type: (Text, List[Text]) -> List[rules.Error]
+    # type: (str, List[str]) -> List[rules.Error]
     """
     Checks that all testharness files have unique basename paths.
 
@@ -383,8 +382,8 @@ def check_unique_testharness_basenames(repo_root, paths):
 
 
 def check_unique_case_insensitive_paths(repo_root, paths):
-    # type: (Text, List[Text]) -> List[rules.Error]
-    seen = {}  # type: Dict[Text, Text]
+    # type: (str, List[str]) -> List[rules.Error]
+    seen = {}  # type: Dict[str, str]
     errors = []
     for path in paths:
         lower_path = path.lower()
@@ -397,7 +396,7 @@ def check_unique_case_insensitive_paths(repo_root, paths):
 
 
 def parse_ignorelist(f):
-    # type: (IO[Text]) -> Tuple[Ignorelist, Set[Text]]
+    # type: (IO[str]) -> Tuple[Ignorelist, Set[str]]
     """
     Parse the ignorelist file given by `f`, and return the parsed structure.
 
@@ -406,7 +405,7 @@ def parse_ignorelist(f):
     """
 
     data = defaultdict(lambda:defaultdict(set))  # type: Ignorelist
-    skipped_files = set()  # type: Set[Text]
+    skipped_files = set()  # type: Set[str]
 
     for line in f:
         line = line.strip()
@@ -478,7 +477,7 @@ regexps = [item() for item in  # type: ignore
 
 
 def check_regexp_line(repo_root, path, f):
-    # type: (Text, Text, IO[bytes]) -> List[rules.Error]
+    # type: (str, str, IO[bytes]) -> List[rules.Error]
     errors = []  # type: List[rules.Error]
 
     applicable_regexps = [regexp for regexp in regexps if regexp.applies(path)]
@@ -492,7 +491,7 @@ def check_regexp_line(repo_root, path, f):
 
 
 def check_parsed(repo_root, path, f):
-    # type: (Text, Text, IO[bytes]) -> List[rules.Error]
+    # type: (str, str, IO[bytes]) -> List[rules.Error]
     source_file = SourceFile(repo_root, path, "/", contents=f.read())
 
     errors = []  # type: List[rules.Error]
@@ -561,7 +560,7 @@ def check_parsed(repo_root, path, f):
         if timeout_value != "long":
             errors.append(rules.InvalidTimeout.error(path, (timeout_value,)))
 
-    required_elements = []  # type: List[Text]
+    required_elements = []  # type: List[str]
 
     testharnessreport_nodes = []  # type: List[ElementTree.Element]
     if source_file.testharness_nodes:
@@ -642,7 +641,7 @@ def check_parsed(repo_root, path, f):
         src = element.attrib["src"]
 
         def incorrect_path(script, src):
-            # type: (Text, Text) -> bool
+            # type: (str, str) -> bool
             return (script == src or
                 ("/%s" % script in src and src != "/resources/%s" % script))
 
@@ -698,7 +697,7 @@ class OpenModeCheck(ASTCheck):
 ast_checkers = [item() for item in [OpenModeCheck]]
 
 def check_python_ast(repo_root, path, f):
-    # type: (Text, Text, IO[bytes]) -> List[rules.Error]
+    # type: (str, str, IO[bytes]) -> List[rules.Error]
     if not path.endswith(".py"):
         return []
 
@@ -729,7 +728,7 @@ def check_global_metadata(value):
 
 
 def check_script_metadata(repo_root, path, f):
-    # type: (Text, Text, IO[bytes]) -> List[rules.Error]
+    # type: (str, str, IO[bytes]) -> List[rules.Error]
     if path.endswith((".worker.js", ".any.js")):
         meta_re = js_meta_re
         broken_metadata = broken_js_metadata
@@ -780,7 +779,7 @@ ahem_stylesheet_re = re.compile(br"\/fonts\/ahem\.css|support\/ahem.css",
 
 
 def check_ahem_system_font(repo_root, path, f):
-    # type: (Text, Text, IO[bytes]) -> List[rules.Error]
+    # type: (str, str, IO[bytes]) -> List[rules.Error]
     if not path.endswith((".html", ".htm", ".xht", ".xhtml")):
         return []
     contents = f.read()
@@ -791,7 +790,7 @@ def check_ahem_system_font(repo_root, path, f):
 
 
 def check_path(repo_root, path):
-    # type: (Text, Text) -> List[rules.Error]
+    # type: (str, str) -> List[rules.Error]
     """
     Runs lints that check the file path.
 
@@ -807,7 +806,7 @@ def check_path(repo_root, path):
 
 
 def check_all_paths(repo_root, paths):
-    # type: (Text, List[Text]) -> List[rules.Error]
+    # type: (str, List[str]) -> List[rules.Error]
     """
     Runs lints that check all paths globally.
 
@@ -823,7 +822,7 @@ def check_all_paths(repo_root, paths):
 
 
 def check_file_contents(repo_root, path, f=None):
-    # type: (Text, Text, Optional[IO[bytes]]) -> List[rules.Error]
+    # type: (str, str, Optional[IO[bytes]]) -> List[rules.Error]
     """
     Runs lints that check the file contents.
 
@@ -843,7 +842,7 @@ def check_file_contents(repo_root, path, f=None):
 
 
 def check_file_contents_apply(args):
-    # type: (Tuple[Text, Text]) -> List[rules.Error]
+    # type: (Tuple[str, str]) -> List[rules.Error]
     return check_file_contents(*args)
 
 
@@ -903,7 +902,7 @@ def output_errors_github_checks(outputter, errors, first_reported):
 
 
 def output_error_count(error_count):
-    # type: (Dict[Text, int]) -> None
+    # type: (Dict[str, int]) -> None
     if not error_count:
         return
 
@@ -918,14 +917,14 @@ def output_error_count(error_count):
 
 
 def changed_files(wpt_root):
-    # type: (Text) -> List[Text]
+    # type: (str) -> List[str]
     revish = testfiles.get_revish(revish=None)
     changed, _ = testfiles.files_changed(revish, None, include_uncommitted=True, include_new=True)
     return [os.path.relpath(item, wpt_root) for item in changed]
 
 
 def lint_paths(kwargs, wpt_root):
-    # type: (Dict[Text, Any], Text) -> List[Text]
+    # type: (Dict[str, Any], str) -> List[str]
     if kwargs.get("paths"):
         paths = []
         for path in kwargs.get("paths", []):
@@ -1019,8 +1018,8 @@ MIN_FILES_FOR_PARALLEL = 80
 
 
 def lint(repo_root, paths, output_format, ignore_glob=None, github_checks_outputter=None, jobs=0):
-    # type: (Text, List[Text], Text, Optional[List[Text]], Optional[GitHubChecksOutputter], int) -> int
-    error_count = defaultdict(int)  # type: Dict[Text, int]
+    # type: (str, List[str], str, Optional[List[str]], Optional[GitHubChecksOutputter], int) -> int
+    error_count = defaultdict(int)  # type: Dict[str, int]
     last = None
 
     if jobs == 0:
@@ -1042,7 +1041,7 @@ def lint(repo_root, paths, output_format, ignore_glob=None, github_checks_output
                      "normal": output_errors_text}[output_format]
 
     def process_errors(errors):
-        # type: (List[rules.Error]) -> Optional[Tuple[Text, Text]]
+        # type: (List[rules.Error]) -> Optional[Tuple[str, str]]
         """
         Filters and prints the errors, and updates the ``error_count`` object.
 

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -6,31 +6,31 @@ import re
 MYPY = False
 if MYPY:
     # MYPY is set to True when run under Mypy.
-    from typing import Any, List, Match, Optional, Pattern, Text, Tuple, cast
+    from typing import Any, List, Match, Optional, Pattern, Tuple, cast
     Error = Tuple[str, str, str, Optional[int]]
 
 
 def collapse(text):
-    # type: (Text) -> Text
+    # type: (str) -> str
     return inspect.cleandoc(str(text)).replace("\n", " ")
 
 
 class Rule(metaclass=abc.ABCMeta):
     @abc.abstractproperty
     def name(self):
-        # type: () -> Text
+        # type: () -> str
         pass
 
     @abc.abstractproperty
     def description(self):
-        # type: () -> Text
+        # type: () -> str
         pass
 
-    to_fix = None  # type: Optional[Text]
+    to_fix = None  # type: Optional[str]
 
     @classmethod
     def error(cls, path, context=(), line_no=None):
-        # type: (Text, Tuple[Any, ...], Optional[int]) -> Error
+        # type: (str, Tuple[Any, ...], Optional[int]) -> Error
         if MYPY:
             name = cast(str, cls.name)
             description = cast(str, cls.description)
@@ -379,22 +379,22 @@ class Regexp(metaclass=abc.ABCMeta):
 
     @abc.abstractproperty
     def name(self):
-        # type: () -> Text
+        # type: () -> str
         pass
 
     @abc.abstractproperty
     def description(self):
-        # type: () -> Text
+        # type: () -> str
         pass
 
-    file_extensions = None  # type: Optional[List[Text]]
+    file_extensions = None  # type: Optional[List[str]]
 
     def __init__(self):
         # type: () -> None
         self._re = re.compile(self.pattern)  # type: Pattern[bytes]
 
     def applies(self, path):
-        # type: (Text) -> bool
+        # type: (str) -> bool
         return (self.file_extensions is None or
                 os.path.splitext(path)[1] in self.file_extensions)
 

--- a/tools/manifest/XMLParser.py
+++ b/tools/manifest/XMLParser.py
@@ -11,7 +11,6 @@ if MYPY:
     from typing import Dict
     from typing import List
     from typing import Optional
-    from typing import Text
     from typing import Union
 
 _catalog = join(dirname(__file__), "catalog")
@@ -23,9 +22,9 @@ def _wrap_error(e):
     err.position = e.lineno, e.offset
     raise err
 
-_names = {}  # type: Dict[Text, Text]
+_names = {}  # type: Dict[str, str]
 def _fixname(key):
-    # type: (Text) -> Text
+    # type: (str) -> str
     try:
         name = _names[key]
     except KeyError:
@@ -49,7 +48,7 @@ class XMLParser:
     Python does, rather than just those supported by expat.
     """
     def __init__(self, encoding=None):
-        # type: (Optional[Text]) -> None
+        # type: (Optional[str]) -> None
         self._parser = expat.ParserCreate(encoding, "}")
         self._target = etree.TreeBuilder()
         # parser settings
@@ -65,33 +64,33 @@ class XMLParser:
         self._parser.SkippedEntityHandler = self._skipped  # type: ignore
         # used for our horrible re-encoding hack
         self._fed_data = []  # type: Optional[List[bytes]]
-        self._read_encoding = None  # type: Optional[Text]
+        self._read_encoding = None  # type: Optional[str]
 
     def _xml_decl(self, version, encoding, standalone):
-        # type: (Text, Optional[Text], int) -> None
+        # type: (str, Optional[str], int) -> None
         self._read_encoding = encoding
 
     def _start(self, tag, attrib_in):
-        # type: (Text, List[str]) -> etree.Element
+        # type: (str, List[str]) -> etree.Element
         assert isinstance(tag, str)
         self._fed_data = None
         tag = _fixname(tag)
-        attrib = OrderedDict()  # type: Dict[Union[bytes, Text], Union[bytes, Text]]
+        attrib = OrderedDict()  # type: Dict[Union[bytes, str], Union[bytes, str]]
         if attrib_in:
             for i in range(0, len(attrib_in), 2):
                 attrib[_fixname(attrib_in[i])] = attrib_in[i+1]
         return self._target.start(tag, attrib)
 
     def _data(self, text):
-        # type: (Text) -> None
+        # type: (str) -> None
         self._target.data(text)
 
     def _end(self, tag):
-        # type: (Text) -> etree.Element
+        # type: (str) -> etree.Element
         return self._target.end(_fixname(tag))
 
     def _external(self, context, base, system_id, public_id):
-        # type: (Text, Optional[Text], Optional[Text], Optional[Text]) -> bool
+        # type: (str, Optional[str], Optional[str], Optional[str]) -> bool
         if public_id in {
                 "-//W3C//DTD XHTML 1.0 Transitional//EN",
                 "-//W3C//DTD XHTML 1.1//EN",
@@ -113,7 +112,7 @@ class XMLParser:
         return True
 
     def _skipped(self, name, is_parameter_entity):
-        # type: (Text, bool) -> None
+        # type: (str, bool) -> None
         err = expat.error("undefined entity %s: line %d, column %d" %
                           (name, self._parser.ErrorLineNumber,
                            self._parser.ErrorColumnNumber))

--- a/tools/manifest/download.py
+++ b/tools/manifest/download.py
@@ -23,7 +23,6 @@ if MYPY:
     from typing import Callable
     from typing import List
     from typing import Optional
-    from typing import Text
 
 here = os.path.dirname(__file__)
 
@@ -32,12 +31,12 @@ logger = log.get_logger()
 
 
 def abs_path(path):
-    # type: (Text) -> Text
+    # type: (str) -> str
     return os.path.abspath(os.path.expanduser(path))
 
 
 def should_download(manifest_path, rebuild_time=timedelta(days=5)):
-    # type: (Text, timedelta) -> bool
+    # type: (str, timedelta) -> bool
     if not os.path.exists(manifest_path):
         return True
     mtime = datetime.fromtimestamp(os.path.getmtime(manifest_path))
@@ -48,9 +47,9 @@ def should_download(manifest_path, rebuild_time=timedelta(days=5)):
 
 
 def merge_pr_tags(repo_root, max_count=50):
-    # type: (Text, int) -> List[Text]
+    # type: (str, int) -> List[str]
     gitfunc = git(repo_root)
-    tags = []  # type: List[Text]
+    tags = []  # type: List[str]
     if gitfunc is None:
         return tags
     for line in gitfunc("log", "--format=%D", "--max-count=%s" % max_count).split("\n"):
@@ -61,7 +60,7 @@ def merge_pr_tags(repo_root, max_count=50):
 
 
 def score_name(name):
-    # type: (Text) -> Optional[int]
+    # type: (str) -> Optional[int]
     """Score how much we like each filename, lower wins, None rejects"""
 
     # Accept both ways of naming the manifest asset, even though
@@ -77,7 +76,7 @@ def score_name(name):
 
 
 def github_url(tags):
-    # type: (List[Text]) -> Optional[List[Text]]
+    # type: (List[str]) -> Optional[List[str]]
     for tag in tags:
         url = "https://api.github.com/repos/web-platform-tests/wpt/releases/tags/%s" % tag
         try:
@@ -108,9 +107,9 @@ def github_url(tags):
 
 
 def download_manifest(
-        manifest_path,  # type: Text
-        tags_func,  # type: Callable[[], List[Text]]
-        url_func,  # type: Callable[[List[Text]], Optional[List[Text]]]
+        manifest_path,  # type: str
+        tags_func,  # type: Callable[[], List[str]]
+        url_func,  # type: Callable[[List[str]], Optional[List[str]]]
         force=False  # type: bool
 ):
     # type: (...) -> bool
@@ -192,7 +191,7 @@ def create_parser():
 
 
 def download_from_github(path, tests_root, force=False):
-    # type: (Text, Text, bool) -> bool
+    # type: (str, str, bool) -> bool
     return download_manifest(path, lambda: merge_pr_tags(tests_root), github_url,
                              force=force)
 

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -8,7 +8,7 @@ from .utils import to_os_path
 MYPY = False
 if MYPY:
     # MYPY is set to True when run under Mypy.
-    from typing import Any, Dict, Hashable, List, Optional, Sequence, Text, Tuple, Type, Union, cast
+    from typing import Any, Dict, Hashable, List, Optional, Sequence, Tuple, Type, Union, cast
     from .manifest import Manifest
     Fuzzy = Dict[Optional[Tuple[str, str, str]], List[int]]
     PageRanges = Dict[str, List[int]]
@@ -45,13 +45,13 @@ class ManifestItem(metaclass=ManifestItemMeta):
     __slots__ = ("_tests_root", "path")
 
     def __init__(self, tests_root, path):
-        # type: (Text, Text) -> None
+        # type: (str, str) -> None
         self._tests_root = tests_root
         self.path = path
 
     @abstractproperty
     def id(self):
-        # type: () -> Text
+        # type: () -> str
         """The test's id (usually its url)"""
         pass
 
@@ -63,7 +63,7 @@ class ManifestItem(metaclass=ManifestItemMeta):
 
     @property
     def path_parts(self):
-        # type: () -> Tuple[Text, ...]
+        # type: () -> Tuple[str, ...]
         return tuple(self.path.split(os.path.sep))
 
     def key(self):
@@ -92,7 +92,7 @@ class ManifestItem(metaclass=ManifestItemMeta):
     @classmethod
     def from_json(cls,
                   manifest,  # type: Manifest
-                  path,  # type: Text
+                  path,  # type: str
                   obj  # type: Any
                   ):
         # type: (...) -> ManifestItem
@@ -106,10 +106,10 @@ class URLManifestItem(ManifestItem):
     __slots__ = ("url_base", "_url", "_extras", "_flags")
 
     def __init__(self,
-                 tests_root,  # type: Text
-                 path,  # type: Text
-                 url_base,  # type: Text
-                 url,  # type: Optional[Text]
+                 tests_root,  # type: str
+                 path,  # type: str
+                 url_base,  # type: str
+                 url,  # type: Optional[str]
                  **extras  # type: Any
                  ):
         # type: (...) -> None
@@ -125,12 +125,12 @@ class URLManifestItem(ManifestItem):
 
     @property
     def id(self):
-        # type: () -> Text
+        # type: () -> str
         return self.url
 
     @property
     def url(self):
-        # type: () -> Text
+        # type: () -> str
         rel_url = self._url or self.path.replace(os.path.sep, "/")
         # we can outperform urljoin, because we know we just have path relative URLs
         if self.url_base == "/":
@@ -155,16 +155,16 @@ class URLManifestItem(ManifestItem):
         return "www" in self._flags
 
     def to_json(self):
-        # type: () -> Tuple[Optional[Text], Dict[Any, Any]]
+        # type: () -> Tuple[Optional[str], Dict[Any, Any]]
         rel_url = None if self._url == self.path.replace(os.path.sep, "/") else self._url
-        rv = (rel_url, {})  # type: Tuple[Optional[Text], Dict[Any, Any]]
+        rv = (rel_url, {})  # type: Tuple[Optional[str], Dict[Any, Any]]
         return rv
 
     @classmethod
     def from_json(cls,
                   manifest,  # type: Manifest
-                  path,  # type: Text
-                  obj  # type: Tuple[Text, Dict[Any, Any]]
+                  path,  # type: str
+                  obj  # type: Tuple[str, Dict[Any, Any]]
                   ):
         # type: (...) -> URLManifestItem
         path = to_os_path(path)
@@ -185,31 +185,31 @@ class TestharnessTest(URLManifestItem):
 
     @property
     def timeout(self):
-        # type: () -> Optional[Text]
+        # type: () -> Optional[str]
         return self._extras.get("timeout")
 
     @property
     def pac(self):
-        # type: () -> Optional[Text]
+        # type: () -> Optional[str]
         return self._extras.get("pac")
 
     @property
     def testdriver(self):
-        # type: () -> Optional[Text]
+        # type: () -> Optional[str]
         return self._extras.get("testdriver")
 
     @property
     def jsshell(self):
-        # type: () -> Optional[Text]
+        # type: () -> Optional[str]
         return self._extras.get("jsshell")
 
     @property
     def script_metadata(self):
-        # type: () -> Optional[List[Tuple[Text, Text]]]
+        # type: () -> Optional[List[Tuple[str, str]]]
         return self._extras.get("script_metadata")
 
     def to_json(self):
-        # type: () -> Tuple[Optional[Text], Dict[Text, Any]]
+        # type: () -> Tuple[Optional[str], Dict[str, Any]]
         rv = super().to_json()
         if self.timeout is not None:
             rv[-1]["timeout"] = self.timeout
@@ -230,56 +230,56 @@ class RefTest(URLManifestItem):
     item_type = "reftest"
 
     def __init__(self,
-                 tests_root,  # type: Text
-                 path,  # type: Text
-                 url_base,  # type: Text
-                 url,  # type: Optional[Text]
-                 references=None,  # type: Optional[List[Tuple[Text, Text]]]
+                 tests_root,  # type: str
+                 path,  # type: str
+                 url_base,  # type: str
+                 url,  # type: Optional[str]
+                 references=None,  # type: Optional[List[Tuple[str, str]]]
                  **extras  # type: Any
                  ):
         super().__init__(tests_root, path, url_base, url, **extras)
         if references is None:
-            self.references = []  # type: List[Tuple[Text, Text]]
+            self.references = []  # type: List[Tuple[str, str]]
         else:
             self.references = references
 
     @property
     def timeout(self):
-        # type: () -> Optional[Text]
+        # type: () -> Optional[str]
         return self._extras.get("timeout")
 
     @property
     def viewport_size(self):
-        # type: () -> Optional[Text]
+        # type: () -> Optional[str]
         return self._extras.get("viewport_size")
 
     @property
     def dpi(self):
-        # type: () -> Optional[Text]
+        # type: () -> Optional[str]
         return self._extras.get("dpi")
 
     @property
     def fuzzy(self):
         # type: () -> Fuzzy
-        fuzzy = self._extras.get("fuzzy", {})  # type: Union[Fuzzy, List[Tuple[Optional[Sequence[Text]], List[int]]]]
+        fuzzy = self._extras.get("fuzzy", {})  # type: Union[Fuzzy, List[Tuple[Optional[Sequence[str]], List[int]]]]
         if not isinstance(fuzzy, list):
             return fuzzy
 
         rv = {}  # type: Fuzzy
-        for k, v in fuzzy:  # type: Tuple[Optional[Sequence[Text]], List[int]]
+        for k, v in fuzzy:  # type: Tuple[Optional[Sequence[str]], List[int]]
             if k is None:
-                key = None  # type: Optional[Tuple[Text, Text, Text]]
+                key = None  # type: Optional[Tuple[str, str, str]]
             else:
-                # mypy types this as Tuple[Text, ...]
+                # mypy types this as Tuple[str, ...]
                 assert len(k) == 3
                 key = tuple(k)  # type: ignore
             rv[key] = v
         return rv
 
     def to_json(self):  # type: ignore
-        # type: () -> Tuple[Optional[Text], List[Tuple[Text, Text]], Dict[Text, Any]]
+        # type: () -> Tuple[Optional[str], List[Tuple[str, str]], Dict[str, Any]]
         rel_url = None if self._url == self.path else self._url
-        rv = (rel_url, self.references, {})  # type: Tuple[Optional[Text], List[Tuple[Text, Text]], Dict[Text, Any]]
+        rv = (rel_url, self.references, {})  # type: Tuple[Optional[str], List[Tuple[str, str]], Dict[str, Any]]
         extras = rv[-1]
         if self.timeout is not None:
             extras["timeout"] = self.timeout
@@ -294,8 +294,8 @@ class RefTest(URLManifestItem):
     @classmethod
     def from_json(cls,  # type: ignore
                   manifest,  # type: Manifest
-                  path,  # type: Text
-                  obj  # type: Tuple[Text, List[Tuple[Text, Text]], Dict[Any, Any]]
+                  path,  # type: str
+                  obj  # type: Tuple[str, List[Tuple[str, str]], Dict[Any, Any]]
                   ):
         # type: (...) -> RefTest
         tests_root = manifest.tests_root
@@ -352,7 +352,7 @@ class CrashTest(URLManifestItem):
 
     @property
     def timeout(self):
-        # type: () -> Optional[Text]
+        # type: () -> Optional[str]
         return None
 
 
@@ -363,11 +363,11 @@ class WebDriverSpecTest(URLManifestItem):
 
     @property
     def timeout(self):
-        # type: () -> Optional[Text]
+        # type: () -> Optional[str]
         return self._extras.get("timeout")
 
     def to_json(self):
-        # type: () -> Tuple[Optional[Text], Dict[Text, Any]]
+        # type: () -> Tuple[Optional[str], Dict[str, Any]]
         rv = super().to_json()
         if self.timeout is not None:
             rv[-1]["timeout"] = self.timeout
@@ -381,5 +381,5 @@ class SupportFile(ManifestItem):
 
     @property
     def id(self):
-        # type: () -> Text
+        # type: () -> str
         return self.path

--- a/tools/manifest/jsonlib.py
+++ b/tools/manifest/jsonlib.py
@@ -5,7 +5,7 @@ import json
 MYPY = False
 if MYPY:
     # MYPY is set to True when run under Mypy.
-    from typing import Any, AnyStr, Callable, Dict, IO, Text
+    from typing import Any, AnyStr, Callable, Dict, IO
 
 
 __all__ = ["load", "dump_local", "dump_local", "dump_dist", "dumps_dist"]
@@ -79,12 +79,12 @@ else:
 
 if has_ujson:
     def dumps_local(obj):
-        # type: (Any) -> Text
+        # type: (Any) -> str
         return ujson.dumps(obj, **_ujson_dump_local_kwargs)
 
 else:
     def dumps_local(obj):
-        # type: (Any) -> Text
+        # type: (Any) -> str
         return json.dumps(obj, **_json_dump_local_kwargs)
 
 
@@ -127,7 +127,7 @@ if has_ujson:
         fp.write(_ujson_fixup(ujson.dumps(obj, **_ujson_dump_dist_kwargs)))
 
     def dumps_dist(obj):
-        # type: (Any) -> Text
+        # type: (Any) -> str
         return _ujson_fixup(ujson.dumps(obj, **_ujson_dump_dist_kwargs))
 else:
     def dump_dist(obj, fp):
@@ -135,5 +135,5 @@ else:
         json.dump(obj, fp, **_json_dump_dist_kwargs)
 
     def dumps_dist(obj):
-        # type: (Any) -> Text
+        # type: (Any) -> str
         return json.dumps(obj, **_json_dump_dist_kwargs)

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -19,7 +19,6 @@ if MYPY:
     from typing import Optional
     from typing import Pattern
     from typing import Set
-    from typing import Text
     from typing import Tuple
     from typing import Union
     from typing import cast
@@ -50,11 +49,11 @@ python_meta_re = re.compile(br"#\s*META:\s*(\w*)=(.*)$")
 
 reference_file_re = re.compile(r'(^|[\-_])(not)?ref[0-9]*([\-_]|$)')
 
-space_chars = "".join(html5lib.constants.spaceCharacters)  # type: Text
+space_chars = "".join(html5lib.constants.spaceCharacters)  # type: str
 
 
 def replace_end(s, old, new):
-    # type: (Text, Text, Text) -> Text
+    # type: (str, str, str) -> str
     """
     Given a string `s` that ends with `old`, replace that occurrence of `old`
     with `new`.
@@ -64,7 +63,7 @@ def replace_end(s, old, new):
 
 
 def read_script_metadata(f, regexp):
-    # type: (BinaryIO, Pattern[bytes]) -> Iterable[Tuple[Text, Text]]
+    # type: (BinaryIO, Pattern[bytes]) -> Iterable[Tuple[str, str]]
     """
     Yields any metadata (pairs of strings) from the file-like object `f`,
     as specified according to a supplied regexp.
@@ -93,11 +92,11 @@ _any_variants = {
     "worker-module": {},
     "shadowrealm": {},
     "jsshell": {"suffix": ".any.js"},
-}  # type: Dict[Text, Dict[Text, Any]]
+}  # type: Dict[str, Dict[str, Any]]
 
 
 def get_any_variants(item):
-    # type: (Text) -> Set[Text]
+    # type: (str) -> Set[str]
     """
     Returns a set of variants (strings) defined by the given keyword.
     """
@@ -111,7 +110,7 @@ def get_any_variants(item):
 
 
 def get_default_any_variants():
-    # type: () -> Set[Text]
+    # type: () -> Set[str]
     """
     Returns a set of variants (strings) that will be used by default.
     """
@@ -119,7 +118,7 @@ def get_default_any_variants():
 
 
 def parse_variants(value):
-    # type: (Text) -> Set[Text]
+    # type: (str) -> Set[str]
     """
     Returns a set of variants (strings) defined by a comma-separated value.
     """
@@ -136,7 +135,7 @@ def parse_variants(value):
 
 
 def global_suffixes(value):
-    # type: (Text) -> Set[Tuple[Text, bool]]
+    # type: (str) -> Set[Tuple[str, bool]]
     """
     Yields tuples of the relevant filename suffix (a string) and whether the
     variant is intended to run in a JS shell, for the variants defined by the
@@ -156,7 +155,7 @@ def global_suffixes(value):
 
 
 def global_variant_url(url, suffix):
-    # type: (Text, Text) -> Text
+    # type: (str, str) -> str
     """
     Returns a url created from the given url and suffix (all strings).
     """
@@ -193,7 +192,7 @@ def _parse_xml(f):
 class SourceFile:
     parsers = {"html":_parse_html,
                "xhtml":_parse_xml,
-               "svg":_parse_xml}  # type: Dict[Text, Callable[[BinaryIO], ElementTree.Element]]
+               "svg":_parse_xml}  # type: Dict[str, Callable[[BinaryIO], ElementTree.Element]]
 
     root_dir_non_test = {"common"}
 
@@ -203,10 +202,10 @@ class SourceFile:
 
     dir_path_non_test = {("css21", "archive"),
                          ("css", "CSS2", "archive"),
-                         ("css", "common")}  # type: Set[Tuple[Text, ...]]
+                         ("css", "common")}  # type: Set[Tuple[str, ...]]
 
     def __init__(self, tests_root, rel_path, url_base, hash=None, contents=None):
-        # type: (Text, Text, Text, Optional[Text], Optional[bytes]) -> None
+        # type: (str, str, str, Optional[str], Optional[bytes]) -> None
         """Object representing a file in a source tree.
 
         :param tests_root: Path to the root of the source tree
@@ -229,17 +228,17 @@ class SourceFile:
 
         meta_flags = name.split(".")[1:]
 
-        self.tests_root = tests_root  # type: Text
-        self.rel_path = rel_path  # type: Text
-        self.dir_path = dir_path  # type: Text
-        self.filename = filename  # type: Text
-        self.name = name  # type: Text
-        self.ext = ext  # type: Text
-        self.type_flag = type_flag  # type: Optional[Text]
-        self.meta_flags = meta_flags  # type: Union[List[bytes], List[Text]]
+        self.tests_root = tests_root  # type: str
+        self.rel_path = rel_path  # type: str
+        self.dir_path = dir_path  # type: str
+        self.filename = filename  # type: str
+        self.name = name  # type: str
+        self.ext = ext  # type: str
+        self.type_flag = type_flag  # type: Optional[str]
+        self.meta_flags = meta_flags  # type: Union[List[bytes], List[str]]
         self.url_base = url_base
         self.contents = contents
-        self.items_cache = None  # type: Optional[Tuple[Text, List[ManifestItem]]]
+        self.items_cache = None  # type: Optional[Tuple[str, List[ManifestItem]]]
         self._hash = hash
 
     def __getstate__(self):
@@ -254,7 +253,7 @@ class SourceFile:
         return rv
 
     def name_prefix(self, prefix):
-        # type: (Text) -> bool
+        # type: (str) -> bool
         """Check if the filename starts with a given prefix
 
         :param prefix: The prefix to check"""
@@ -283,28 +282,28 @@ class SourceFile:
 
     @cached_property
     def rel_path_parts(self):
-        # type: () -> Tuple[Text, ...]
+        # type: () -> Tuple[str, ...]
         return tuple(self.rel_path.split(os.path.sep))
 
     @cached_property
     def path(self):
-        # type: () -> Text
+        # type: () -> str
         return os.path.join(self.tests_root, self.rel_path)
 
     @cached_property
     def rel_url(self):
-        # type: () -> Text
+        # type: () -> str
         assert not os.path.isabs(self.rel_path), self.rel_path
         return self.rel_path.replace(os.sep, "/")
 
     @cached_property
     def url(self):
-        # type: () -> Text
+        # type: () -> str
         return urljoin(self.url_base, self.rel_url)
 
     @cached_property
     def hash(self):
-        # type: () -> Text
+        # type: () -> str
         if not self._hash:
             with self.open() as f:
                 content = f.read()
@@ -434,7 +433,7 @@ class SourceFile:
 
     @property
     def markup_type(self):
-        # type: () -> Optional[Text]
+        # type: () -> Optional[str]
         """Return the type of markup contained in a file, based on its extension,
         or None if it doesn't contain markup"""
         ext = self.ext
@@ -487,7 +486,7 @@ class SourceFile:
 
     @cached_property
     def script_metadata(self):
-        # type: () -> Optional[List[Tuple[Text, Text]]]
+        # type: () -> Optional[List[Tuple[str, str]]]
         if self.name_is_worker or self.name_is_multi_global or self.name_is_window:
             regexp = js_meta_re
         elif self.name_is_webdriver:
@@ -500,7 +499,7 @@ class SourceFile:
 
     @cached_property
     def timeout(self):
-        # type: () -> Optional[Text]
+        # type: () -> Optional[str]
         """The timeout of a test or reference file. "long" if the file has an extended timeout
         or None otherwise"""
         if self.script_metadata:
@@ -511,7 +510,7 @@ class SourceFile:
             return None
 
         if self.timeout_nodes:
-            timeout_str = self.timeout_nodes[0].attrib.get("content", None)  # type: Optional[Text]
+            timeout_str = self.timeout_nodes[0].attrib.get("content", None)  # type: Optional[str]
             if timeout_str and timeout_str.lower() == "long":
                 return "long"
 
@@ -519,7 +518,7 @@ class SourceFile:
 
     @cached_property
     def pac(self):
-        # type: () -> Optional[Text]
+        # type: () -> Optional[str]
         """The PAC (proxy config) of a test or reference file. A URL or null"""
         if self.script_metadata:
             for (meta, content) in self.script_metadata:
@@ -544,7 +543,7 @@ class SourceFile:
 
     @cached_property
     def viewport_size(self):
-        # type: () -> Optional[Text]
+        # type: () -> Optional[str]
         """The viewport size of a test or reference file"""
         if self.root is None:
             return None
@@ -564,7 +563,7 @@ class SourceFile:
 
     @cached_property
     def dpi(self):
-        # type: () -> Optional[Text]
+        # type: () -> Optional[str]
         """The device pixel ratio of a test or reference file"""
         if self.root is None:
             return None
@@ -575,17 +574,17 @@ class SourceFile:
         return self.dpi_nodes[0].attrib.get("content", None)
 
     def parse_ref_keyed_meta(self, node):
-        # type: (ElementTree.Element) -> Tuple[Optional[Tuple[Text, Text, Text]], Text]
-        item = node.attrib.get("content", "")  # type: Text
+        # type: (ElementTree.Element) -> Tuple[Optional[Tuple[str, str, str]], str]
+        item = node.attrib.get("content", "")  # type: str
 
         parts = item.rsplit(":", 1)
         if len(parts) == 1:
-            key = None  # type: Optional[Tuple[Text, Text, Text]]
+            key = None  # type: Optional[Tuple[str, str, str]]
             value = parts[0]
         else:
             key_part = urljoin(self.url, parts[0])
             reftype = None
-            for ref in self.references:  # type: Tuple[Text, Text]
+            for ref in self.references:  # type: Tuple[str, str]
                 if ref[0] == key_part:
                     reftype = ref[1]
                     break
@@ -608,8 +607,8 @@ class SourceFile:
 
     @cached_property
     def fuzzy(self):
-        # type: () -> Dict[Optional[Tuple[Text, Text, Text]], List[List[int]]]
-        rv = {}  # type: Dict[Optional[Tuple[Text, Text, Text]], List[List[int]]]
+        # type: () -> Dict[Optional[Tuple[str, str, str]], List[List[int]]]
+        rv = {}  # type: Dict[Optional[Tuple[str, str, str]], List[List[int]]]
         if self.root is None:
             return rv
 
@@ -623,10 +622,10 @@ class SourceFile:
             ranges = value.split(";")
             if len(ranges) != 2:
                 raise ValueError("Malformed fuzzy value %s" % value)
-            arg_values = {}  # type: Dict[Text, List[int]]
+            arg_values = {}  # type: Dict[str, List[int]]
             positional_args = deque()  # type: Deque[List[int]]
-            for range_str_value in ranges:  # type: Text
-                name = None  # type: Optional[Text]
+            for range_str_value in ranges:  # type: str
+                name = None  # type: Optional[str]
                 if "=" in range_str_value:
                     name, range_str_value = (part.strip()
                                              for part in range_str_value.split("=", 1))
@@ -668,10 +667,10 @@ class SourceFile:
 
     @cached_property
     def page_ranges(self):
-        # type: () -> Dict[Text, List[List[Optional[int]]]]
+        # type: () -> Dict[str, List[List[Optional[int]]]]
         """List of ElementTree Elements corresponding to nodes in a test that
         specify print-reftest page ranges"""
-        rv = {}  # type: Dict[Text, List[List[Optional[int]]]]
+        rv = {}  # type: Dict[str, List[List[Optional[int]]]]
         for node in self.page_ranges_nodes:
             key_data, value = self.parse_ref_keyed_meta(node)
             # Just key by url
@@ -727,8 +726,8 @@ class SourceFile:
 
     @cached_property
     def test_variants(self):
-        # type: () -> List[Text]
-        rv = []  # type: List[Text]
+        # type: () -> List[str]
+        rv = []  # type: List[str]
         if self.ext == ".js":
             script_metadata = self.script_metadata
             assert script_metadata is not None
@@ -738,7 +737,7 @@ class SourceFile:
         else:
             for element in self.variant_nodes:
                 if "content" in element.attrib:
-                    variant = element.attrib["content"]  # type: Text
+                    variant = element.attrib["content"]  # type: str
                     rv.append(variant)
 
         for variant in rv:
@@ -785,10 +784,10 @@ class SourceFile:
 
     @cached_property
     def references(self):
-        # type: () -> List[Tuple[Text, Text]]
+        # type: () -> List[Tuple[str, str]]
         """List of (ref_url, relation) tuples for any reftest references specified in
         the file"""
-        rv = []  # type: List[Tuple[Text, Text]]
+        rv = []  # type: List[Tuple[str, str]]
         rel_map = {"match": "==", "mismatch": "!="}
         for item in self.reftest_nodes:
             if "href" in item.attrib:
@@ -815,9 +814,9 @@ class SourceFile:
 
     @cached_property
     def css_flags(self):
-        # type: () -> Set[Text]
+        # type: () -> Set[str]
         """Set of flags specified in the file"""
-        rv = set()  # type: Set[Text]
+        rv = set()  # type: Set[str]
         for item in self.css_flag_nodes:
             if "content" in item.attrib:
                 for flag in item.attrib["content"].split():
@@ -845,9 +844,9 @@ class SourceFile:
 
     @cached_property
     def spec_links(self):
-        # type: () -> Set[Text]
+        # type: () -> Set[str]
         """Set of spec links specified in the file"""
-        rv = set()  # type: Set[Text]
+        rv = set()  # type: Set[str]
         for item in self.spec_link_nodes:
             if "href" in item.attrib:
                 rv.add(item.attrib["href"].strip(space_chars))
@@ -865,7 +864,7 @@ class SourceFile:
 
     @property
     def type(self):
-        # type: () -> Text
+        # type: () -> str
         possible_types = self.possible_types
         if len(possible_types) == 1:
             return possible_types.pop()
@@ -875,7 +874,7 @@ class SourceFile:
 
     @property
     def possible_types(self):
-        # type: () -> Set[Text]
+        # type: () -> Set[str]
         """Determines the set of possible types without reading the file"""
 
         if self.items_cache:
@@ -929,7 +928,7 @@ class SourceFile:
                 SupportFile.item_type}
 
     def manifest_items(self):
-        # type: () -> Tuple[Text, List[ManifestItem]]
+        # type: () -> Tuple[str, List[ManifestItem]]
         """List of manifest items corresponding to the file. There is typically one
         per test, but in the case of reftests a node may have corresponding manifest
         items without being a test itself."""
@@ -944,7 +943,7 @@ class SourceFile:
                 SupportFile(
                     self.tests_root,
                     self.rel_path
-                )]  # type: Tuple[Text, List[ManifestItem]]
+                )]  # type: Tuple[str, List[ManifestItem]]
 
         elif self.name_is_manual:
             rv = ManualTest.item_type, [

--- a/tools/manifest/testpaths.py
+++ b/tools/manifest/testpaths.py
@@ -13,7 +13,6 @@ if MYPY:
     from typing import Dict
     from typing import Iterable
     from typing import List
-    from typing import Text
 
 wpt_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
 
@@ -56,9 +55,9 @@ def create_parser():
 
 
 def get_path_id_map(src_root, tests_root, manifest_file, test_ids):
-    # type: (Text, Text, Manifest, Iterable[Text]) -> Dict[Text, List[Text]]
+    # type: (str, str, Manifest, Iterable[str]) -> Dict[str, List[str]]
     test_ids = set(test_ids)
-    path_id_map = defaultdict(list)  # type: Dict[Text, List[Text]]
+    path_id_map = defaultdict(list)  # type: Dict[str, List[str]]
 
     compute_rel_path = src_root != tests_root
 
@@ -75,7 +74,7 @@ def get_path_id_map(src_root, tests_root, manifest_file, test_ids):
 
 
 def get_paths(**kwargs):
-    # type: (**Any) -> Dict[Text, List[Text]]
+    # type: (**Any) -> Dict[str, List[str]]
     tests_root = kwargs["tests_root"]
     assert tests_root is not None
     path = kwargs["path"]
@@ -96,7 +95,7 @@ def get_paths(**kwargs):
 
 
 def write_output(path_id_map, as_json):
-    # type: (Dict[Text, List[Text]], bool) -> None
+    # type: (Dict[str, List[str]], bool) -> None
     if as_json:
         print(json.dumps(path_id_map))
     else:

--- a/tools/manifest/typedata.py
+++ b/tools/manifest/typedata.py
@@ -10,7 +10,6 @@ if MYPY:
     from typing import List
     from typing import Optional
     from typing import Set
-    from typing import Text
     from typing import Tuple
     from typing import Type
     from typing import Union
@@ -43,13 +42,13 @@ class TypeData(TypeDataType):
         over the class."""
         self._manifest = m
         self._type_cls = type_cls  # type: Type[item.ManifestItem]
-        self._json_data = {}  # type: Dict[Text, Any]
-        self._data = {}  # type: Dict[Text, Any]
-        self._hashes = {}  # type: Dict[Tuple[Text, ...], Text]
+        self._json_data = {}  # type: Dict[str, Any]
+        self._data = {}  # type: Dict[str, Any]
+        self._hashes = {}  # type: Dict[Tuple[str, ...], str]
         self.hashes = PathHash(self)
 
     def _delete_node(self, data, key):
-        # type: (Dict[Text, Any], Tuple[Text, ...]) -> None
+        # type: (Dict[str, Any], Tuple[str, ...]) -> None
         """delete a path from a Dict data with a given key"""
         path = []
         node = data
@@ -68,8 +67,8 @@ class TypeData(TypeDataType):
                 break
 
     def __getitem__(self, key):
-        # type: (Tuple[Text, ...]) -> Set[item.ManifestItem]
-        node = self._data  # type: Union[Dict[Text, Any], Set[item.ManifestItem], List[Any]]
+        # type: (Tuple[str, ...]) -> Set[item.ManifestItem]
+        node = self._data  # type: Union[Dict[str, Any], Set[item.ManifestItem], List[Any]]
         for pathseg in key:
             if isinstance(node, dict) and pathseg in node:
                 node = node[pathseg]
@@ -118,7 +117,7 @@ class TypeData(TypeDataType):
         return data
 
     def __setitem__(self, key, value):
-        # type: (Tuple[Text, ...], Set[item.ManifestItem]) -> None
+        # type: (Tuple[str, ...], Set[item.ManifestItem]) -> None
         try:
             self._delete_node(self._json_data, key)
         except KeyError:
@@ -132,7 +131,7 @@ class TypeData(TypeDataType):
         node[key[-1]] = value
 
     def __delitem__(self, key):
-        # type: (Tuple[Text, ...]) -> None
+        # type: (Tuple[str, ...]) -> None
         try:
             self._delete_node(self._data, key)
         except KeyError:
@@ -144,11 +143,11 @@ class TypeData(TypeDataType):
                 pass
 
     def __iter__(self):
-        # type: () -> Iterator[Tuple[Text, ...]]
+        # type: () -> Iterator[Tuple[str, ...]]
         """Iterator over keys in the TypeData in codepoint order"""
-        data_node = self._data  # type: Optional[Union[Dict[Text, Any], Set[item.ManifestItem]]]
-        json_node = self._json_data  # type: Optional[Union[Dict[Text, Any], List[Any]]]
-        path = tuple()  # type: Tuple[Text, ...]
+        data_node = self._data  # type: Optional[Union[Dict[str, Any], Set[item.ManifestItem]]]
+        json_node = self._json_data  # type: Optional[Union[Dict[str, Any], List[Any]]]
+        path = tuple()  # type: Tuple[str, ...]
         stack = [(data_node, json_node, path)]
         while stack:
             data_node, json_node, path = stack.pop()
@@ -159,7 +158,7 @@ class TypeData(TypeDataType):
                 assert data_node is None or isinstance(data_node, dict)
                 assert json_node is None or isinstance(json_node, dict)
 
-                keys = set()  # type: Set[Text]
+                keys = set()  # type: Set[str]
                 if data_node is not None:
                     keys |= set(iter(data_node))
                 if json_node is not None:
@@ -174,7 +173,7 @@ class TypeData(TypeDataType):
         # type: () -> int
         count = 0
 
-        stack = [self._data]  # type: List[Union[Dict[Text, Any], Set[item.ManifestItem]]]
+        stack = [self._data]  # type: List[Union[Dict[str, Any], Set[item.ManifestItem]]]
         while stack:
             v = stack.pop()
             if isinstance(v, set):
@@ -182,7 +181,7 @@ class TypeData(TypeDataType):
             else:
                 stack.extend(v.values())
 
-        json_stack = [self._json_data]  # type: List[Union[Dict[Text, Any], List[Any]]]
+        json_stack = [self._json_data]  # type: List[Union[Dict[str, Any], List[Any]]]
         while json_stack:
             json_v = json_stack.pop()
             if isinstance(json_v, list):
@@ -230,7 +229,7 @@ class TypeData(TypeDataType):
         self._hashes.clear()
 
     def set_json(self, json_data):
-        # type: (Dict[Text, Any]) -> None
+        # type: (Dict[str, Any]) -> None
         """Provide the object with a raw JSON blob
 
         Note that this object graph is assumed to be owned by the TypeData
@@ -243,7 +242,7 @@ class TypeData(TypeDataType):
         self._json_data = json_data
 
     def to_json(self):
-        # type: () -> Dict[Text, Any]
+        # type: () -> Dict[str, Any]
         """Convert the current data to JSON
 
         Note that the returned object may contain references to the internal
@@ -262,7 +261,7 @@ class TypeData(TypeDataType):
             else:
                 return element
 
-        stack = [(self._data, json_rv, tuple())]  # type: List[Tuple[Dict[Text, Any], Dict[Text, Any], Tuple[Text, ...]]]
+        stack = [(self._data, json_rv, tuple())]  # type: List[Tuple[Dict[str, Any], Dict[str, Any], Tuple[str, ...]]]
         while stack:
             data_node, json_node, par_full_key = stack.pop()
             for k, v in data_node.items():
@@ -284,7 +283,7 @@ class PathHash(PathHashType):
         self._data = data
 
     def __getitem__(self, k):
-        # type: (Tuple[Text, ...]) -> Text
+        # type: (Tuple[str, ...]) -> str
         if k not in self._data:
             raise KeyError
 
@@ -304,7 +303,7 @@ class PathHash(PathHashType):
         raise KeyError
 
     def __setitem__(self, k, v):
-        # type: (Tuple[Text, ...], Text) -> None
+        # type: (Tuple[str, ...], str) -> None
         if k not in self._data:
             raise KeyError
 
@@ -324,11 +323,11 @@ class PathHash(PathHashType):
         self._data._hashes[k] = v
 
     def __delitem__(self, k):
-        # type: (Tuple[Text, ...]) -> None
+        # type: (Tuple[str, ...]) -> None
         raise ValueError("keys here must match underlying data")
 
     def __iter__(self):
-        # type: () -> Iterator[Tuple[Text, ...]]
+        # type: () -> Iterator[Tuple[str, ...]]
         return iter(self._data)
 
     def __len__(self):

--- a/tools/manifest/utils.py
+++ b/tools/manifest/utils.py
@@ -5,7 +5,6 @@ import sys
 MYPY = False
 if MYPY:
     # MYPY is set to True when run under Mypy.
-    from typing import Text
     from typing import Callable
     from typing import Any
     from typing import Generic
@@ -20,7 +19,7 @@ else:
 
 
 def rel_path_to_url(rel_path, url_base="/"):
-    # type: (Text, Text) -> Text
+    # type: (str, str) -> str
     assert not os.path.isabs(rel_path), rel_path
     if url_base[0] != "/":
         url_base = "/" + url_base
@@ -30,7 +29,7 @@ def rel_path_to_url(rel_path, url_base="/"):
 
 
 def from_os_path(path):
-    # type: (Text) -> Text
+    # type: (str) -> str
     assert os.path.sep == "/" or sys.platform == "win32"
     if "/" == os.path.sep:
         rv = path
@@ -42,7 +41,7 @@ def from_os_path(path):
 
 
 def to_os_path(path):
-    # type: (Text) -> Text
+    # type: (str) -> str
     assert os.path.sep == "/" or sys.platform == "win32"
     if "\\" in path:
         raise ValueError("normalised path contains \\")
@@ -52,9 +51,9 @@ def to_os_path(path):
 
 
 def git(path):
-    # type: (Text) -> Optional[Callable[..., Text]]
+    # type: (str) -> Optional[Callable[..., str]]
     def gitfunc(cmd, *args):
-        # type: (Text, *Text) -> Text
+        # type: (str, *str) -> str
         full_cmd = ["git", cmd] + list(args)
         try:
             return subprocess.check_output(full_cmd, cwd=path, stderr=subprocess.STDOUT).decode('utf8')

--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -32,7 +32,6 @@ if MYPY:
     from typing import Pattern
     from typing import Sequence
     from typing import Set
-    from typing import Text
     from typing import Tuple
 
 DEFAULT_IGNORE_RULERS = ("resources/testharness*", "resources/testdriver*")
@@ -49,7 +48,7 @@ def display_branch_point():
 
 
 def branch_point():
-    # type: () -> Optional[Text]
+    # type: () -> Optional[str]
     git = get_git_cmd(wpt_root)
     if git is None:
         raise Exception("git not found")
@@ -62,7 +61,7 @@ def branch_point():
         # This is a PR, so the base branch is in GITHUB_BRANCH
         base_branch = os.environ.get("GITHUB_BRANCH")
         assert base_branch, "GITHUB_BRANCH environment variable is defined"
-        branch_point = git("merge-base", "HEAD", base_branch)  # type: Optional[Text]
+        branch_point = git("merge-base", "HEAD", base_branch)  # type: Optional[str]
     else:
         # Otherwise we aren't on a PR, so we try to find commits that are only in the
         # current branch c.f.
@@ -87,7 +86,7 @@ def branch_point():
                                                 cmd,
                                                 commits_bytes)
 
-        commit_parents = OrderedDict()  # type: Dict[Text, List[Text]]
+        commit_parents = OrderedDict()  # type: Dict[str, List[str]]
         commits = commits_bytes.decode("ascii")
         if commits:
             for line in commits.split("\n"):
@@ -134,7 +133,7 @@ def branch_point():
 
 
 def compile_ignore_rule(rule):
-    # type: (Text) -> Pattern[Text]
+    # type: (str) -> Pattern[str]
     rule = rule.replace(os.path.sep, "/")
     parts = rule.split("/")
     re_parts = []
@@ -149,7 +148,7 @@ def compile_ignore_rule(rule):
 
 
 def repo_files_changed(revish, include_uncommitted=False, include_new=False):
-    # type: (Text, bool, bool) -> Set[Text]
+    # type: (str, bool, bool) -> Set[str]
     git = get_git_cmd(wpt_root)
     if git is None:
         raise Exception("git not found")
@@ -187,7 +186,7 @@ def repo_files_changed(revish, include_uncommitted=False, include_new=False):
 
 
 def exclude_ignored(files, ignore_rules):
-    # type: (Iterable[Text], Optional[Sequence[Text]]) -> Tuple[List[Text], List[Text]]
+    # type: (Iterable[str], Optional[Sequence[str]]) -> Tuple[List[str], List[str]]
     if ignore_rules is None:
         ignore_rules = DEFAULT_IGNORE_RULERS
     compiled_ignore_rules = [compile_ignore_rule(item) for item in set(ignore_rules)]
@@ -207,12 +206,12 @@ def exclude_ignored(files, ignore_rules):
     return changed, ignored
 
 
-def files_changed(revish,  # type: Text
-                  ignore_rules=None,  # type: Optional[Sequence[Text]]
+def files_changed(revish,  # type: str
+                  ignore_rules=None,  # type: Optional[Sequence[str]]
                   include_uncommitted=False,  # type: bool
                   include_new=False  # type: bool
                   ):
-    # type: (...) -> Tuple[List[Text], List[Text]]
+    # type: (...) -> Tuple[List[str], List[str]]
     """Find files changed in certain revisions.
 
     The function passes `revish` directly to `git diff`, so `revish` can have a
@@ -229,26 +228,26 @@ def files_changed(revish,  # type: Text
 
 
 def _in_repo_root(full_path):
-    # type: (Text) -> bool
+    # type: (str) -> bool
     rel_path = os.path.relpath(full_path, wpt_root)
     path_components = rel_path.split(os.sep)
     return len(path_components) < 2
 
 
 def load_manifest(manifest_path=None, manifest_update=True):
-    # type: (Optional[Text], bool) -> manifest.Manifest
+    # type: (Optional[str], bool) -> manifest.Manifest
     if manifest_path is None:
         manifest_path = os.path.join(wpt_root, "MANIFEST.json")
     return manifest.load_and_update(wpt_root, manifest_path, "/",
                                     update=manifest_update)
 
 
-def affected_testfiles(files_changed,  # type: Iterable[Text]
-                       skip_dirs=None,  # type: Optional[Set[Text]]
-                       manifest_path=None,  # type: Optional[Text]
+def affected_testfiles(files_changed,  # type: Iterable[str]
+                       skip_dirs=None,  # type: Optional[Set[str]]
+                       manifest_path=None,  # type: Optional[str]
                        manifest_update=True  # type: bool
                        ):
-    # type: (...) -> Tuple[Set[Text], Set[Text]]
+    # type: (...) -> Tuple[Set[str], Set[str]]
     """Determine and return list of test files that reference changed files."""
     if skip_dirs is None:
         skip_dirs = {"conformance-checkers", "docs", "tools"}
@@ -277,7 +276,7 @@ def affected_testfiles(files_changed,  # type: Iterable[Text]
     tests_changed = {item for item in files_changed if item in test_files}
 
     nontest_changed_paths = set()
-    rewrites = {"/resources/webidl2/lib/webidl2.js": "/resources/WebIDLParser.js"}  # type: Dict[Text, Text]
+    rewrites = {"/resources/webidl2/lib/webidl2.js": "/resources/WebIDLParser.js"}  # type: Dict[str, str]
     for full_path in nontests_changed:
         rel_path = os.path.relpath(full_path, wpt_root)
         path_components = rel_path.split(os.sep)
@@ -294,7 +293,7 @@ def affected_testfiles(files_changed,  # type: Iterable[Text]
                                 for interface in interfaces_changed]
 
     def affected_by_wdspec(test):
-        # type: (Text) -> bool
+        # type: (str) -> bool
         affected = False
         if test in wdspec_test_files:
             for support_full_path, _ in nontest_changed_paths:
@@ -310,7 +309,7 @@ def affected_testfiles(files_changed,  # type: Iterable[Text]
         return affected
 
     def affected_by_interfaces(file_contents):
-        # type: (Text) -> bool
+        # type: (str) -> bool
         if len(interfaces_changed_names) > 0:
             if 'idlharness.js' in file_contents:
                 for interface in interfaces_changed_names:
@@ -337,7 +336,7 @@ def affected_testfiles(files_changed,  # type: Iterable[Text]
             with open(test_full_path, "rb") as fh:
                 raw_file_contents = fh.read()  # type: bytes
                 if raw_file_contents.startswith(b"\xfe\xff"):
-                    file_contents = raw_file_contents.decode("utf-16be", "replace")  # type: Text
+                    file_contents = raw_file_contents.decode("utf-16be", "replace")  # type: str
                 elif raw_file_contents.startswith(b"\xff\xfe"):
                     file_contents = raw_file_contents.decode("utf-16le", "replace")
                 else:
@@ -387,7 +386,7 @@ def get_parser_affected():
 
 
 def get_revish(**kwargs):
-    # type: (**Any) -> Text
+    # type: (**Any) -> str
     revish = kwargs.get("revish")
     if revish is None:
         revish = "%s..HEAD" % branch_point()


### PR DESCRIPTION
This was relevant when we supported Python 2, but is now just an alias
for `str`. `str` is already used in many places, so this makes it
consistent.
