### PR TITLE
Implement downloading WebKitTestRunner in `wpt`

### DIFF
--- a/tools/wpt/install.py
+++ b/tools/wpt/install.py
@@ -13,7 +13,8 @@ latest_channels = {
     'edgechromium': 'dev',
     'safari': 'preview',
     'servo': 'nightly',
-    'webkitgtk_minibrowser': 'nightly'
+    'webkitgtk_minibrowser': 'nightly',
+    'wktr': 'main',
 }
 
 channel_by_name = {
@@ -44,7 +45,7 @@ def get_parser():
     parser = argparse.ArgumentParser(
         parents=[channel_args],
         description="Install a given browser or webdriver frontend.")
-    parser.add_argument('browser', choices=['firefox', 'chrome', 'chromium', 'servo', 'safari'],
+    parser.add_argument('browser', choices=['firefox', 'chrome', 'chromium', 'servo', 'safari', 'wktr'],
                         help='name of web browser product')
     parser.add_argument('component', choices=['browser', 'webdriver'],
                         help='name of component')
@@ -107,7 +108,12 @@ def install(name, component, destination, channel="nightly", logger=None, downlo
 
     method = prefix + suffix
 
-    browser_cls = getattr(browser, name.title())
+    if name == "wktr":
+        canonical_name = "WebKitTestRunner"
+    else:
+        canonical_name = name.title()
+
+    browser_cls = getattr(browser, canonical_name)
     logger.info('Now installing %s %s...', name, component)
     kwargs = {}
     if download_only and rename:

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -691,10 +691,16 @@ class WebKitTestRunner(BrowserSetup):
     browser_cls = browser.WebKitTestRunner
 
     def install(self, channel=None):
-        raise NotImplementedError
+        if self.prompt_install(self.name):
+            return self.browser.install(self.venv.path, channel=channel)
 
     def setup_kwargs(self, kwargs):
-        pass
+        if kwargs["binary"] is None:
+            binary = self.browser.find_binary(self.venv.path, channel=kwargs["browser_channel"])
+
+            if binary is None:
+                raise WptrunError("Unable to find binary in PATH")
+            kwargs["binary"] = binary
 
 
 class WebKitGTKMiniBrowser(BrowserSetup):


### PR DESCRIPTION
~This is currently on top of #39033, but the last commit here is \~basically correct.~

This copies over `download_url` from #39033, but is otherwise unrelated to that PR now. This suffices for `./wpt run --log-mach - --install-browser --manifest MANIFEST.json --metadata infrastructure/metadata wktr infrastructure`.