### PR TITLE
[css-color-4] fix incorrect copy/paste from #39137

### DIFF
--- a/css/css-color/parsing/color-computed-color-function.html
+++ b/css/css-color/parsing/color-computed-color-function.html
@@ -47,8 +47,8 @@ for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophot
     test_computed_value("color", `color(${colorSpace} none none none / 0.5)`, `color(${colorSpace} none none none / 0.5)`);
     test_computed_value("color", `color(${colorSpace} 0 0 0 / none)`, `color(${colorSpace} 0 0 0 / none)`);
 
-    test_computed_value("color", `color(${colorSpace} calc(NaN) 0 0 / none)`, `color(${colorSpace} 0 0 0)`);
-    test_computed_value("color", `color(${colorSpace} calc(0 / 0) 0 0 / none)`, `color(${colorSpace} 0 0 0)`);
+    test_computed_value("color", `color(${colorSpace} calc(NaN) 0 0)`, `color(${colorSpace} 0 0 0)`);
+    test_computed_value("color", `color(${colorSpace} calc(0 / 0) 0 0)`, `color(${colorSpace} 0 0 0)`);
 }
 
 for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
@@ -76,8 +76,8 @@ for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
     test_computed_value("color", `color(${colorSpace} none none none / 0.5)`, `color(${resultColorSpace} none none none / 0.5)`);
     test_computed_value("color", `color(${colorSpace} 0 0 0 / none)`, `color(${resultColorSpace} 0 0 0 / none)`);
 
-    test_computed_value("color", `color(${colorSpace} calc(NaN) 0 0 / none)`, `color(${resultColorSpace} 0 0 0)`);
-    test_computed_value("color", `color(${colorSpace} calc(0 / 0) 0 0 / none)`, `color(${resultColorSpace} 0 0 0)`);
+    test_computed_value("color", `color(${colorSpace} calc(NaN) 0 0)`, `color(${resultColorSpace} 0 0 0)`);
+    test_computed_value("color", `color(${colorSpace} calc(0 / 0) 0 0)`, `color(${resultColorSpace} 0 0 0)`);
 }
 
 // Opaque sRGB in color()

--- a/css/css-color/parsing/color-valid-color-function.html
+++ b/css/css-color/parsing/color-valid-color-function.html
@@ -44,8 +44,8 @@ for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophot
 
     test_valid_value("color", `color(${colorSpace} 0 calc(infinity) 0)`, `color(${colorSpace} 0 calc(infinity) 0)`);
     test_valid_value("color", `color(${colorSpace} 0 calc(-infinity) 0)`, `color(${colorSpace} 0 calc(-infinity) 0)`);
-    test_valid_value("color", `color(${colorSpace} calc(NaN) 0 0 / none)`, `color(${colorSpace} calc(NaN) 0 0)`);
-    test_valid_value("color", `color(${colorSpace} calc(0 / 0) 0 0 / none)`, `color(${colorSpace} calc(NaN) 0 0)`);
+    test_valid_value("color", `color(${colorSpace} calc(NaN) 0 0)`, `color(${colorSpace} calc(NaN) 0 0)`);
+    test_valid_value("color", `color(${colorSpace} calc(0 / 0) 0 0)`, `color(${colorSpace} calc(NaN) 0 0)`);
 }
 
 for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
@@ -75,8 +75,8 @@ for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
 
     test_valid_value("color", `color(${colorSpace} 0 calc(infinity) 0)`, `color(${colorSpace} 0 calc(infinity) 0)`);
     test_valid_value("color", `color(${colorSpace} 0 calc(-infinity) 0)`, `color(${colorSpace} 0 calc(-infinity) 0)`);
-    test_valid_value("color", `color(${colorSpace} calc(NaN) 0 0 / none)`, `color(${colorSpace} calc(NaN) 0 0)`);
-    test_valid_value("color", `color(${colorSpace} calc(0 / 0) 0 0 / none)`, `color(${colorSpace} calc(NaN) 0 0)`);
+    test_valid_value("color", `color(${colorSpace} calc(NaN) 0 0)`, `color(${colorSpace} calc(NaN) 0 0)`);
+    test_valid_value("color", `color(${colorSpace} calc(0 / 0) 0 0)`, `color(${colorSpace} calc(NaN) 0 0)`);
 }
 </script>
 </body>


### PR DESCRIPTION
see : https://github.com/web-platform-tests/wpt/pull/39137

The `none` alpha component was accidental.