### PR TITLE
Update tools/webtransport/META.yml

### DIFF
--- a/tools/webtransport/META.yml
+++ b/tools/webtransport/META.yml
@@ -1,3 +1,3 @@
 suggested_reviewers:
   - bashi
-  - yutakahirano
+  - nidhijaju


### PR DESCRIPTION
yutakahirano no longer works on WebTransport. nidhijaju is an editor of W3C WebTransport API.