### PR TITLE
createImageBitmap: Add Blob as sources for tests of 'options: Orientation: none' 

### DIFF
--- a/html/canvas/element/manual/imagebitmap/createImageBitmap-exif-orientation_none.html
+++ b/html/canvas/element/manual/imagebitmap/createImageBitmap-exif-orientation_none.html
@@ -61,7 +61,7 @@ function runImageBitmapTest(promise, orientation, sourceType) {
 for (let orientation of [1, 2, 3, 4, 5, 6, 7, 8]) {
     const imageSrc = `resources/squares_${orientation}.jpg`;
 
-    runImageBitmapTest(loadImage(imageSrc), orientation, 'HTMLImage');
+    runImageBitmapTest(loadImage(imageSrc), orientation, 'HTMLImageElement');
     runImageBitmapTest(fetch(imageSrc).then(response => response.blob()), orientation, 'Blob');
 }
 

--- a/html/canvas/element/manual/imagebitmap/createImageBitmap-exif-orientation_none.html
+++ b/html/canvas/element/manual/imagebitmap/createImageBitmap-exif-orientation_none.html
@@ -30,7 +30,7 @@ function checkColors(ctx, w, h, is_verticle, expectedColors) {
     }
 }
 
-for (let orientation of [1, 2, 3, 4, 5, 6, 7, 8]) {
+function runImageBitmapTest(promise, orientation, sourceType) {
     async_test(function(t) {
         const canvas = document.createElement("canvas");
         canvas.width = 160;
@@ -38,7 +38,7 @@ for (let orientation of [1, 2, 3, 4, 5, 6, 7, 8]) {
         document.body.append(canvas);
 
         const ctx = canvas.getContext("2d");
-        loadImage(`resources/squares_${orientation}.jpg`)
+        promise
             .then((image) => createImageBitmap(image, { imageOrientation: "none" }))
             .then(t.step_func_done(function(imageBitmap) {
                 ctx.drawImage(imageBitmap, 0, 0, 160, 320);
@@ -55,7 +55,14 @@ for (let orientation of [1, 2, 3, 4, 5, 6, 7, 8]) {
                     [3, 1, 255, 128, 128, 255],
                 ]);
             }));
-    }, `createImageBitmap with Orientation ${orientation}`);
+    }, `createImageBitmap with source ${sourceType} and Orientation ${orientation}`);
+}
+
+for (let orientation of [1, 2, 3, 4, 5, 6, 7, 8]) {
+    const imageSrc = `resources/squares_${orientation}.jpg`;
+
+    runImageBitmapTest(loadImage(imageSrc), orientation, 'HTMLImage');
+    runImageBitmapTest(fetch(imageSrc).then(response => response.blob()), orientation, 'Blob');
 }
 
 </script>


### PR DESCRIPTION
The current test only checks the use of HTMLImage as a source of images with EXIF data.

Add tests for using image files loaded as Blobs (eg via fetch()) as a source.

(Firefox has a seperate code paths for these two source types)