### PR TITLE
[html] Interactions between indexed and named access on the Window object

### DIFF
--- a/html/browsers/the-window-object/window-indexed-access-vs-named-access.html
+++ b/html/browsers/the-window-object/window-indexed-access-vs-named-access.html
@@ -7,7 +7,8 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=0></div>
-<div id=3></div>
+<div id=4></div>
+<iframe name=3></iframe>
 <iframe name=2></iframe>
 <iframe name=1></iframe>
 <script>
@@ -23,27 +24,35 @@ test(function() {
     assert_equals(window["1"], iframes[1].contentWindow);
 }, "WindowProxy: document-tree child navigable with index 1 (indexed access)");
 test(function() {
-    assert_equals(window[2], iframes[0].contentWindow);
-    assert_equals(window["2"], iframes[0].contentWindow);
-}, "WindowProxy: document-tree child navigable with target name 2 (named access)");
+    assert_equals(window[2], iframes[2].contentWindow);
+    assert_equals(window["2"], iframes[2].contentWindow);
+}, "WindowProxy: document-tree child navigable with index 2 (indexed access)");
 test(function() {
-    assert_equals(window[3], divs[1]);
-    assert_equals(window["3"], divs[1]);
-}, "WindowProxy: element with id 3 (named access)");
+    assert_equals(window[3], iframes[0].contentWindow);
+    assert_equals(window["3"], iframes[0].contentWindow);
+}, "WindowProxy: document-tree child navigable with target name 3 (named access)");
+test(function() {
+    assert_equals(window[4], divs[1]);
+    assert_equals(window["4"], divs[1]);
+}, "WindowProxy: element with id 4 (named access)");
 test(function() {
     assert_equals(wp[0], divs[0]);
     assert_equals(wp["0"], divs[0]);
 }, "Window prototype: element with id 0 (named access)");
 test(function() {
-    assert_equals(wp[1], iframes[1].contentWindow);
-    assert_equals(wp["1"], iframes[1].contentWindow);
+    assert_equals(wp[1], iframes[2].contentWindow);
+    assert_equals(wp["1"], iframes[2].contentWindow);
 }, "Window prototype: document-tree child navigable with target name 1 (named access)");
 test(function() {
-    assert_equals(wp[2], iframes[0].contentWindow);
-    assert_equals(wp["2"], iframes[0].contentWindow);
+    assert_equals(wp[2], iframes[1].contentWindow);
+    assert_equals(wp["2"], iframes[1].contentWindow);
 }, "Window prototype: document-tree child navigable with target name 2 (named access)");
 test(function() {
-    assert_equals(wp[3], divs[1]);
-    assert_equals(wp["3"], divs[1]);
-}, "Window prototype: element with id 3 (named access)");
+    assert_equals(wp[3], iframes[0].contentWindow);
+    assert_equals(wp["3"], iframes[0].contentWindow);
+}, "Window prototype: document-tree child navigable with target name 3 (named access)");
+test(function() {
+    assert_equals(wp[4], divs[1]);
+    assert_equals(wp["4"], divs[1]);
+}, "Window prototype: element with id 4 (named access)");
 </script>

--- a/html/browsers/the-window-object/window-indexed-access-vs-named-access.html
+++ b/html/browsers/the-window-object/window-indexed-access-vs-named-access.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Interactions between indexed and named access on the Window object</title>
+<link rel="author" title="Delan Azabani" href="dazabani@igalia.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#accessing-other-browsing-contexts">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#named-access-on-the-window-object">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=0></div>
+<div id=3></div>
+<iframe name=2></iframe>
+<iframe name=1></iframe>
+<script>
+const divs = document.querySelectorAll("div");
+const iframes = document.querySelectorAll("iframe");
+const wp = Object.getPrototypeOf(window);
+test(function() {
+    assert_equals(window[0], iframes[0].contentWindow);
+    assert_equals(window["0"], iframes[0].contentWindow);
+}, "WindowProxy: document-tree child navigable with index 0 (indexed access)");
+test(function() {
+    assert_equals(window[1], iframes[1].contentWindow);
+    assert_equals(window["1"], iframes[1].contentWindow);
+}, "WindowProxy: document-tree child navigable with index 1 (indexed access)");
+test(function() {
+    assert_equals(window[2], iframes[0].contentWindow);
+    assert_equals(window["2"], iframes[0].contentWindow);
+}, "WindowProxy: document-tree child navigable with target name 2 (named access)");
+test(function() {
+    assert_equals(window[3], divs[1]);
+    assert_equals(window["3"], divs[1]);
+}, "WindowProxy: element with id 3 (named access)");
+test(function() {
+    assert_equals(wp[0], divs[0]);
+    assert_equals(wp["0"], divs[0]);
+}, "Window prototype: element with id 0 (named access)");
+test(function() {
+    assert_equals(wp[1], iframes[1].contentWindow);
+    assert_equals(wp["1"], iframes[1].contentWindow);
+}, "Window prototype: document-tree child navigable with target name 1 (named access)");
+test(function() {
+    assert_equals(wp[2], iframes[0].contentWindow);
+    assert_equals(wp["2"], iframes[0].contentWindow);
+}, "Window prototype: document-tree child navigable with target name 2 (named access)");
+test(function() {
+    assert_equals(wp[3], divs[1]);
+    assert_equals(wp["3"], divs[1]);
+}, "Window prototype: element with id 3 (named access)");
+</script>


### PR DESCRIPTION
This patch is a manual export of the new test added by servo/servo#29396, which asserts that indexed access on the Window object shadows named access, since the former is on WindowProxy and the latter is on the Window named properties object.