### PR TITLE
Badging: test non-fully-active document

### DIFF
--- a/badging/non-fully-active.https.html
+++ b/badging/non-fully-active.https.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>Badging: attempting to badge non-fully active document</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body></body>
+<script>
+promise_test(async t => {
+  const iframe = document.createElement("iframe");
+  document.body.appendChild(iframe);
+  await new Promise(resolve => {
+    iframe.onload = resolve;
+    iframe.src = "about:blank";
+  });
+  const exceptionCtor = iframe.contentWindow.DOMException;
+  const {navigator: nav} = iframe.contentWindow;
+  iframe.remove();
+  return promise_rejects_dom(t, "InvalidStateError", exceptionCtor, nav.setAppBadge(1));
+}, "badging a non-fully active document should reject with InvalidStateError");
+</script>


### PR DESCRIPTION
Fully active check for "set the application badge", as defined in the first few steps of the algorithm: 
https://w3c.github.io/badging/#dfn-set-the-application-badge