### PR TITLE
Revert "Fix WPT testcases that do not properly account for counter-st…

### DIFF
--- a/css/css-counter-styles/counter-style-at-rule/descriptor-prefix-ref.html
+++ b/css/css-counter-styles/counter-style-at-rule/descriptor-prefix-ref.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <meta charset="UTF-8">
-<title>CSS Reference: descriptor prefix</title>
+<title>CSS Reference: symbols function, invalid</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org/">
 <link rel="stylesheet" href="support/ref-common.css">
 <!-- ol -->
-<div>-2.&nbsp;</div>
-<div>-1.&nbsp;</div>
-<div>0.&nbsp;</div>
+<div>Appendix -2.&nbsp;</div>
+<div>Appendix -1.&nbsp;</div>
+<div>Appendix 0.&nbsp;</div>
 <div>Appendix I.&nbsp;</div>
 <div>Appendix II.&nbsp;</div>
 <!-- section -->

--- a/css/css-counter-styles/counter-style-at-rule/descriptor-prefix.html
+++ b/css/css-counter-styles/counter-style-at-rule/descriptor-prefix.html
@@ -7,8 +7,6 @@
 <link rel="stylesheet" href="support/test-common.css">
 <style type="text/css">
   @counter-style a {
-    /* Note that upper-roman has a range of (1, 3999), so negative or zero values
-       will use the fallback style. */
     system: extends upper-roman;
     prefix: "Appendix ";
   }

--- a/css/css-counter-styles/counter-style-at-rule/system-additive-ref.html
+++ b/css/css-counter-styles/counter-style-at-rule/system-additive-ref.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <meta charset="UTF-8">
-<title>CSS Reference: system additive</title>
+<title>CSS Reference: symbols function, invalid</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org/">
 <link rel="stylesheet" href="support/ref-common.css">
 <!-- list-style-type: a -->
-<div>-2.&nbsp;</div>
-<div>-1.&nbsp;</div>
-<div>0.&nbsp;</div>
+<div>-2</div>
+<div>-1</div>
+<div>0</div>
 <div>&#x2680;</div>
 <div>&#x2681;</div>
 <div>&#x2682;</div>
@@ -22,8 +22,8 @@
   document.write(Array(61).join('&#x2685;'));
 </script></div>
 <!-- list-style-type: b -->
-<div>-2.&nbsp;</div>
-<div>-1.&nbsp;</div>
+<div>-2</div>
+<div>-1</div>
 <div>&#x2637;</div>
 <div>&#x2636;</div>
 <div>&#x2635;</div>

--- a/css/css-counter-styles/counter-style-at-rule/system-additive.html
+++ b/css/css-counter-styles/counter-style-at-rule/system-additive.html
@@ -7,13 +7,11 @@
 <link rel="stylesheet" href="support/test-common.css">
 <style type="text/css">
   @counter-style a {
-    /* Negative and zero values cannot be represented, and will use fallback style (decimal). */
     system: additive;
     additive-symbols: 6 \2685, 5 \2684, 4 \2683, 3 \2682, 2 \2681, 1 \2680;
     suffix: "";
   }
   @counter-style b {
-    /* Negative values cannot be represented, and will use fallback style (decimal). */
     system: additive;
     additive-symbols: 7 \2630, 6 \2631, 5 \2632, 4 \2633, 3 \2634, 2 \2635, 1 \2636, 0 \2637;
     suffix: "";

--- a/css/css-counter-styles/counter-style-at-rule/system-alphabetic-ref.html
+++ b/css/css-counter-styles/counter-style-at-rule/system-alphabetic-ref.html
@@ -3,9 +3,9 @@
 <title>CSS Reference: symbols function, invalid</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org/">
 <link rel="stylesheet" href="support/ref-common.css">
-<div>-2.&nbsp;</div>
-<div>-1.&nbsp;</div>
-<div>0.&nbsp;</div>
+<div>-2</div>
+<div>-1</div>
+<div>0</div>
 <div>&#x26AA;</div>
 <div>&#x26AB;</div>
 <div>&#x26AA;&#x26AA;</div>

--- a/css/css-counter-styles/counter-style-at-rule/system-alphabetic.html
+++ b/css/css-counter-styles/counter-style-at-rule/system-alphabetic.html
@@ -7,8 +7,6 @@
 <link rel="stylesheet" href="support/test-common.css">
 <style type="text/css">
   @counter-style a {
-    /* alphabetic has a range that starts from 1, so negative/zero values will
-       fall back to decimal */
     system: alphabetic;
     symbols: \26AA  \26AB;
     suffix: '';

--- a/css/css-counter-styles/counter-style-at-rule/system-extends-ref.html
+++ b/css/css-counter-styles/counter-style-at-rule/system-extends-ref.html
@@ -4,24 +4,24 @@
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org/">
 <link rel="stylesheet" href="support/ref-common.css">
 <!-- list-style-type: a -->
-<div>-2.&nbsp;</div>
-<div>-1.&nbsp;</div>
-<div>0.&nbsp;</div>
+<div>Chapter -2.&nbsp;</div>
+<div>Chapter -1.&nbsp;</div>
+<div>Chapter 0.&nbsp;</div>
 <div>Chapter I.&nbsp;</div>
 <div>Chapter II.&nbsp;</div>
 <div>Chapter III.&nbsp;</div>
 <div>Chapter IV.&nbsp;</div>
 <div>Chapter V.&nbsp;</div>
-<div>6.&nbsp;</div>
-<div>7.&nbsp;</div>
+<div>Chapter 6.&nbsp;</div>
+<div>Chapter 7.&nbsp;</div>
 <!-- list-style-type: b -->
-<div>-2.&nbsp;</div>
-<div>-1.&nbsp;</div>
-<div>0.&nbsp;</div>
+<div>Section -2.&nbsp;</div>
+<div>Section -1.&nbsp;</div>
+<div>Section 0.&nbsp;</div>
 <div>Section I.&nbsp;</div>
 <div>Section II.&nbsp;</div>
 <div>Section III.&nbsp;</div>
 <div>Section IV.&nbsp;</div>
 <div>Section V.&nbsp;</div>
 <div>Section VI.&nbsp;</div>
-<div>7.&nbsp;</div>
+<div>Section 7.&nbsp;</div>

--- a/css/css-counter-styles/counter-style-at-rule/system-extends.html
+++ b/css/css-counter-styles/counter-style-at-rule/system-extends.html
@@ -7,13 +7,11 @@
 <link rel="stylesheet" href="support/test-common.css">
 <style type="text/css">
   @counter-style a {
-    /* Values outside the range will fall back to decimal (and hence have no prefix) */
     system: extends upper-roman;
     prefix: "Chapter ";
     range: 1 5;
   }
   @counter-style b {
-    /* Values outside the range will fall back to decimal (and hence have no prefix) */
     system: extends a;
     prefix: "Section ";
     range: 1 6;

--- a/css/css-counter-styles/counter-style-at-rule/system-symbolic-ref.html
+++ b/css/css-counter-styles/counter-style-at-rule/system-symbolic-ref.html
@@ -4,9 +4,9 @@
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org/">
 <link rel="stylesheet" href="support/ref-common.css">
 <!-- list-style-type: a -->
-<div>-2.&nbsp;</div>
-<div>-1.&nbsp;</div>
-<div>0.&nbsp;</div>
+<div>-2</div>
+<div>-1</div>
+<div>0</div>
 <div>*</div>
 <div>&#x2051;</div>
 <div>&#x2020;</div>

--- a/css/css-counter-styles/counter-style-at-rule/system-symbolic.html
+++ b/css/css-counter-styles/counter-style-at-rule/system-symbolic.html
@@ -8,8 +8,6 @@
 <style type="text/css">
   @counter-style a {
     /* system: symbolic; */
-    /* symbolic does not support negative or zero values, so they will fall back
-       to decimal */
     symbols: '*' \2051  \2020  \2021;
     suffix: '';
   }


### PR DESCRIPTION
…yle fallback behavior of prefix/suffix descriptors."

This reverts commit 90a953f4c4f0235160e96c8dd27d4a5e7638511d.

Reverting this change since it doesn't conform to the specification: https://www.w3.org/TR/css-counter-styles-3/#counter-styles

> Note: prefix and suffix don’t play a part in this algorithm. This is intentional; the prefix and suffix aren’t part of the string returned by the counter() or counters() functions. Instead, the prefix and suffix are added by the algorithm that constructs the value of the content property for the ::marker pseudo-element. This also implies that the prefix and suffix always come from the specified counter-style, even if the actual representation is constructed by a fallback style.

An issue was opened at https://github.com/w3c/csswg-drafts/issues/8619 Until we have a resolution for that I propose we revert to what spec determines. If resolution outdates this current change, then we can undo the reversion.