### PR TITLE
[fetch] Test that `User-Agent` is not a forbidden request header

### DIFF
--- a/fetch/api/request/request-headers.any.js
+++ b/fetch/api/request/request-headers.any.js
@@ -9,6 +9,7 @@ var validRequestHeaders = [
   ["sec", "OK"],
   ["secb", "OK"],
   ["Set-Cookie2", "OK"],
+  ["User-Agent", "OK"],
 ];
 var invalidRequestHeaders = [
   ["Accept-Charset", "KO"],


### PR DESCRIPTION
`User-Agent` used to be a forbidden request header until it was removed in whatwg/fetch#37. However, this removal was never tested in WPT, and Chrome still treats it as forbidden. This change adds that test.
