### PR TITLE
Fix tests requiring non-standard MouseEvent.toElement/fromElement

### DIFF
--- a/pointerevents/pointerevent_support.js
+++ b/pointerevents/pointerevent_support.js
@@ -71,37 +71,6 @@ function check_PointerEvent(event, testNamePrefix) {
     "boolean": function (v) { return typeof v === "boolean" },
     "object": function (v) { return typeof v === "object" }
   };
-  [
-    ["long", "pointerId"],
-    ["float", "width"],
-    ["float", "height"],
-    ["float", "pressure"],
-    ["long", "tiltX"],
-    ["long", "tiltY"],
-    ["string", "pointerType"],
-    ["boolean", "isPrimary"],
-    ["long", "detail", 0],
-    ["object", "fromElement"],
-    ["object", "toElement"],
-    ["boolean", "isTrusted"],
-    ["boolean", "composed"],
-    ["boolean", "bubbles"]
-  ].forEach(function (attr) {
-    var type = attr[0];
-    var name = attr[1];
-
-    test(function () {
-      // Existence check.
-      assert_true(name in event, "attribute exists");
-
-      // Readonly check.
-      assert_readonly(event.type, name, "attribute is readonly");
-
-      // Type check.
-      assert_true(idl_type_check[type](event[name]),
-        "attribute type " + type + " (JS type was " + typeof event[name] + ")");
-    }, pointerTestName + "." + name + " conforms to WebIDL");
-  });
 
   // Check values for inherited attributes.
   // https://w3c.github.io/pointerevents/#attributes-and-default-actions

--- a/pointerevents/pointerevent_support.js
+++ b/pointerevents/pointerevent_support.js
@@ -75,9 +75,11 @@ function check_PointerEvent(event, testNamePrefix) {
   // Check values for inherited attributes.
   // https://w3c.github.io/pointerevents/#attributes-and-default-actions
   test(function () {
+    assert_implements_optional("fromElement" in event);
     assert_equals(event.fromElement, null);
   }, pointerTestName + ".fromElement value is null");
   test(function () {
+    assert_implements_optional("toElement" in event);
     assert_equals(event.toElement, null);
   }, pointerTestName + ".toElement value is null");
   test(function () {


### PR DESCRIPTION
See https://github.com/web-platform-tests/interop/issues/308. See the commit messages for more detail about each change.

cc @EdgarChen @flackr 