### PR TITLE
WebTransport enabled in Firefox Nightly 113

### DIFF
--- a/infrastructure/metadata/infrastructure/server/webtransport-h3.https.sub.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/webtransport-h3.https.sub.any.js.ini
@@ -2,28 +2,33 @@
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
       if product == "chrome": PASS
+      if product == "firefox": [PASS, FAIL]
       FAIL
 
 [webtransport-h3.https.sub.any.window.html]
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
       if product == "chrome": PASS
+      if product == "firefox": [PASS, FAIL]
       FAIL
 
 [webtransport-h3.https.sub.any.worker.html]
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
       if product == "chrome": PASS
+      if product == "firefox": [PASS, FAIL]
       FAIL
 
 [webtransport-h3.https.sub.any.sharedworker.html]
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
       if product == "chrome": PASS
+      if product == "firefox": [PASS, FAIL]
       FAIL
 
 [webtransport-h3.https.sub.any.serviceworker.html]
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
       if product == "chrome": PASS
+      if product == "firefox": [PASS, FAIL]
       FAIL


### PR DESCRIPTION
Fixes https://github.com/web-platform-tests/wpt/issues/39309, I hope.

I wasn't sure how to handle this feature being in Nightly-only for now. Should I use
```
if product == "firefox": PASS
```
...or will this break testing of the release version?

So I went with
```
if product == "firefox": [PASS, FAIL]
```
...but I'm not sure if that works either. Input welcome.