### PR TITLE
Revert "URL: ensure surrogates end up as U+FFFD"

### DIFF
--- a/url/resources/percent-encoding.json
+++ b/url/resources/percent-encoding.json
@@ -44,13 +44,5 @@
     "output": {
       "utf-8": "%C3%A1|"
     }
-  },
-  "Surrogate!",
-  {
-    "input": "\ud800",
-    "output": {
-      "utf-8": "%EF%BF%BD",
-      "windows-1252": "%26%2365533%3B"
-    }
   }
 ]


### PR DESCRIPTION
Reverts #37250 as percent-encoding.py is not equipped to test surrogates. The only decent coverage for this is still in html/infrastructure/urls/resolving-urls/query-encoding.