### PR TITLE
Update infrastructure metadata for `webtransport-h3.https.sub.any.js`

### DIFF
--- a/infrastructure/metadata/infrastructure/server/webtransport-h3.https.sub.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/webtransport-h3.https.sub.any.js.ini
@@ -1,28 +1,30 @@
 [webtransport-h3.https.sub.any.html]
-  [WebTransport server should be running and should handle a bidirectional stream]
-    expected:
-      if product == "chrome": PASS
-      FAIL
-
-[webtransport-h3.https.sub.any.window.html]
+  disabled:
+    if product == "firefox": times out
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
       if product == "chrome": PASS
       FAIL
 
 [webtransport-h3.https.sub.any.worker.html]
+  disabled:
+    if product == "firefox": times out
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
       if product == "chrome": PASS
       FAIL
 
 [webtransport-h3.https.sub.any.sharedworker.html]
+  disabled:
+    if product == "firefox": times out
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
       if product == "chrome": PASS
       FAIL
 
 [webtransport-h3.https.sub.any.serviceworker.html]
+  disabled:
+    if product == "firefox": times out
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
       if product == "chrome": PASS


### PR DESCRIPTION
These tests are timing out on Firefox macOS and blocking unrelated PRs (e.g., #39196, #39201, #39227):

```
/infrastructure/server/webtransport-h3.https.sub.any.serviceworker.html
  TIMEOUT WebTransport server should be running and should handle a bidirectional stream - Test timed out
  TIMEOUT /infrastructure/server/webtransport-h3.https.sub.any.serviceworker.html
/infrastructure/server/webtransport-h3.https.sub.any.worker.html
  TIMEOUT WebTransport server should be running and should handle a bidirectional stream - Test timed out
  TIMEOUT /infrastructure/server/webtransport-h3.https.sub.any.worker.html
/infrastructure/server/webtransport-h3.https.sub.any.sharedworker.html
  TIMEOUT WebTransport server should be running and should handle a bidirectional stream - Test timed out
  TIMEOUT /infrastructure/server/webtransport-h3.https.sub.any.sharedworker.html
/infrastructure/server/webtransport-h3.https.sub.any.html
  TIMEOUT WebTransport server should be running and should handle a bidirectional stream - Test timed out
  TIMEOUT /infrastructure/server/webtransport-h3.https.sub.any.html
```

Disable them for now. Also, remove the `.any.window.html` section, which is redundant with `.any.html`.