### PR TITLE
Update PDF `EOF` verification

### DIFF
--- a/webdriver/tests/support/pdf.py
+++ b/webdriver/tests/support/pdf.py
@@ -4,5 +4,5 @@ from base64 import decodebytes
 def assert_pdf(value):
     data = decodebytes(value.encode())
 
-    assert data.startswith(b"%PDF-"), "Decoded data starts with the PDF signature"
-    assert data.endswith(b"%%EOF\n") or data.endswith(b"%%EOF"), "Decoded data ends with the EOF flag"
+    assert data.startswith(b"%PDF-"), "Decoded data should start with the PDF signature"
+    assert data.endswith(b"%%EOF"), "Decoded data should end with the EOF flag"

--- a/webdriver/tests/support/pdf.py
+++ b/webdriver/tests/support/pdf.py
@@ -5,4 +5,4 @@ def assert_pdf(value):
     data = decodebytes(value.encode())
 
     assert data.startswith(b"%PDF-"), "Decoded data starts with the PDF signature"
-    assert data.endswith(b"%%EOF\n"), "Decoded data ends with the EOF flag"
+    assert data.endswith(b"%%EOF\n") or data.endswith(b"%%EOF"), "Decoded data ends with the EOF flag"

--- a/webdriver/tests/support/pdf.py
+++ b/webdriver/tests/support/pdf.py
@@ -5,4 +5,5 @@ def assert_pdf(value):
     data = decodebytes(value.encode())
 
     assert data.startswith(b"%PDF-"), "Decoded data should start with the PDF signature"
+    # TODO: removed `data.endswith(b"%%EOF")` after https://crbug.com/1430371 is fixed.
     assert data.endswith(b"%%EOF\n") or data.endswith(b"%%EOF"), "Decoded data should end with the EOF flag"

--- a/webdriver/tests/support/pdf.py
+++ b/webdriver/tests/support/pdf.py
@@ -5,4 +5,4 @@ def assert_pdf(value):
     data = decodebytes(value.encode())
 
     assert data.startswith(b"%PDF-"), "Decoded data should start with the PDF signature"
-    assert data.endswith(b"%%EOF"), "Decoded data should end with the EOF flag"
+    assert data.endswith(b"%%EOF\n") or data.endswith(b"%%EOF"), "Decoded data should end with the EOF flag"


### PR DESCRIPTION
PDF format should end with `EOF`, not `EOF\n`. As discussed with @whimboo, no need in tolerating `EOF\n`.