### PR TITLE
Make the CPython bug 102126 workaround cover 3.10.10 and 3.11.2

### DIFF
--- a/tools/manifest/tests/test_manifest.py
+++ b/tools/manifest/tests/test_manifest.py
@@ -121,8 +121,8 @@ def manifest_tree(draw):
     return output
 
 
-@pytest.mark.skipif(sys.version_info.major == 3 and sys.version_info.minor == 10,
-                    reason="Deadlock on shutdown with Python 3.10")
+@pytest.mark.skipif(sys.version_info[:3] in ((3, 10, 10), (3, 11, 2)),
+                    reason="https://github.com/python/cpython/issues/102126")
 @h.given(manifest_tree())
 # FIXME: Workaround for https://github.com/web-platform-tests/wpt/issues/22758
 @h.settings(suppress_health_check=(h.HealthCheck.too_slow,))
@@ -142,8 +142,8 @@ def test_manifest_to_json(s):
     assert loaded.to_json() == json_str
 
 
-@pytest.mark.skipif(sys.version_info.major == 3 and sys.version_info.minor == 10,
-                    reason="Deadlock on shutdown with Python 3.10")
+@pytest.mark.skipif(sys.version_info[:3] in ((3, 10, 10), (3, 11, 2)),
+                    reason="https://github.com/python/cpython/issues/102126")
 @h.given(manifest_tree())
 # FIXME: Workaround for https://github.com/web-platform-tests/wpt/issues/22758
 @h.settings(suppress_health_check=(h.HealthCheck.too_slow,))


### PR DESCRIPTION
While the underlying CPython bug is vastly older, it only began to occur in our usage in these recent releases. As such, we can be very specific in what we skip the tests on.

This also unblocks running tests on CPython 3.11.2.

Fixes #39337.