### PR TITLE
Get rid of ResourceWarnings produced by the tests

### DIFF
--- a/tools/wptserve/tests/functional/test_handlers.py
+++ b/tools/wptserve/tests/functional/test_handlers.py
@@ -137,6 +137,7 @@ class TestFunctionHandler(TestUsingServer):
             self.request(route[1])
 
         assert cm.value.code == 500
+        del cm
 
     def test_tuple_2_rv(self):
         @wptserve.handlers.handler
@@ -188,6 +189,7 @@ class TestFunctionHandler(TestUsingServer):
             self.request(route[1])
 
         assert cm.value.code == 500
+        del cm
 
     def test_none_rv(self):
         @wptserve.handlers.handler
@@ -278,18 +280,21 @@ class TestPythonHandler(TestUsingServer):
             self.request("/no_main.py")
 
         assert cm.value.code == 500
+        del cm
 
     def test_invalid(self):
         with pytest.raises(HTTPError) as cm:
             self.request("/invalid.py")
 
         assert cm.value.code == 500
+        del cm
 
     def test_missing(self):
         with pytest.raises(HTTPError) as cm:
             self.request("/missing.py")
 
         assert cm.value.code == 404
+        del cm
 
 
 class TestDirectoryHandler(TestUsingServer):

--- a/tools/wptserve/tests/functional/test_pipes.py
+++ b/tools/wptserve/tests/functional/test_pipes.py
@@ -52,17 +52,20 @@ class TestHeader(TestUsingServer):
 class TestSlice(TestUsingServer):
     def test_both_bounds(self):
         resp = self.request("/document.txt", query="pipe=slice(1,10)")
-        expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()
+        with open(os.path.join(doc_root, "document.txt"), 'rb') as f:
+            expected = f.read()
         self.assertEqual(resp.read(), expected[1:10])
 
     def test_no_upper(self):
         resp = self.request("/document.txt", query="pipe=slice(1)")
-        expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()
+        with open(os.path.join(doc_root, "document.txt"), 'rb') as f:
+            expected = f.read()
         self.assertEqual(resp.read(), expected[1:])
 
     def test_no_lower(self):
         resp = self.request("/document.txt", query="pipe=slice(null,10)")
-        expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()
+        with open(os.path.join(doc_root, "document.txt"), 'rb') as f:
+            expected = f.read()
         self.assertEqual(resp.read(), expected[:10])
 
 class TestSub(TestUsingServer):
@@ -147,7 +150,8 @@ class TestTrickle(TestUsingServer):
         t0 = time.time()
         resp = self.request("/document.txt", query="pipe=trickle(1:d2:5:d1:r2)")
         t1 = time.time()
-        expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()
+        with open(os.path.join(doc_root, "document.txt"), 'rb') as f:
+            expected = f.read()
         self.assertEqual(resp.read(), expected)
         self.assertGreater(6, t1-t0)
 

--- a/tools/wptserve/wptserve/request.py
+++ b/tools/wptserve/wptserve/request.py
@@ -60,6 +60,16 @@ class InputFile:
         else:
             self._buf = BytesIO()
 
+    def close(self):
+        self._buf.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
     @property
     def _buf_position(self):
         rv = self._buf.tell()
@@ -298,6 +308,16 @@ class Request:
         self._auth = None
 
         self.server = Server(self)
+
+    def close(self):
+        return self.raw_input.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
 
     def __repr__(self):
         return "<Request %s %s>" % (self.method, self.url)

--- a/tools/wptserve/wptserve/response.py
+++ b/tools/wptserve/wptserve/response.py
@@ -203,10 +203,14 @@ class Response:
         elif isinstance(self.content, str):
             yield self.content.encode(self.encoding)
         elif hasattr(self.content, "read"):
-            if read_file:
-                yield self.content.read()
-            else:
-                yield self.content
+            # Read the file in chunks rather than reading the whole file into
+            # memory at once. (See also ResponseWriter.file_chunk_size)
+            while True:
+                read = self.content.read(32 * 1024)
+                if len(read) == 0:
+                    break
+                yield read
+            self.content.close()
         else:
             for item in self.content:
                 if hasattr(item, "__call__"):

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -249,21 +249,21 @@ class BaseWebTestRequestHandler(http.server.BaseHTTPRequestHandler):
 
         self.server.rewriter.rewrite(self)
 
-        request = Request(self)
-        response = Response(self, request)
+        with Request(self) as request:
+            response = Response(self, request)
 
-        if request.method == "CONNECT":
-            self.handle_connect(response)
-            return
+            if request.method == "CONNECT":
+                self.handle_connect(response)
+                return
 
-        if not request_line_is_valid:
-            response.set_error(414)
-            response.write()
-            return
+            if not request_line_is_valid:
+                response.set_error(414)
+                response.write()
+                return
 
-        self.logger.debug(f"{request.method} {request.request_path}")
-        handler = self.server.router.get_handler(request)
-        self.finish_handling(request, response, handler)
+            self.logger.debug(f"{request.method} {request.request_path}")
+            handler = self.server.router.get_handler(request)
+            self.finish_handling(request, response, handler)
 
     def finish_handling(self, request, response, handler):
         # If the handler we used for the request had a non-default base path


### PR DESCRIPTION
This gets us to a point of being able to treat warnings as errors, and gets rid of all ResourceWarnings.