### PR TITLE
Make TestUsingH2Server.teardown_method close the client

### DIFF
--- a/tools/wptserve/tests/functional/base.py
+++ b/tools/wptserve/tests/functional/base.py
@@ -95,6 +95,7 @@ class TestUsingH2Server:
                                    http2=True, verify=False)
 
     def teardown_method(self, test_method):
+        self.client.close()
         self.server.stop()
 
 


### PR DESCRIPTION
Without this, we end up with a lot of H2 server threads stuck in `ssl.recv` constantly waiting for more data from the client.