### PR TITLE
[webtransport_h3_server] Don't use aioquic's SETTINGS validation

### DIFF
--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -15,8 +15,8 @@ from typing import Any, Dict, List, Optional, Tuple
 from aioquic.buffer import Buffer  # type: ignore
 from aioquic.asyncio import QuicConnectionProtocol, serve  # type: ignore
 from aioquic.asyncio.client import connect  # type: ignore
-from aioquic.h3.connection import H3_ALPN, FrameType, H3Connection, ProtocolError  # type: ignore
-from aioquic.h3.events import H3Event, HeadersReceived, WebTransportStreamDataReceived, DatagramReceived, DataReceived, SettingsError  # type: ignore
+from aioquic.h3.connection import H3_ALPN, FrameType, H3Connection, ProtocolError, SettingsError  # type: ignore
+from aioquic.h3.events import H3Event, HeadersReceived, WebTransportStreamDataReceived, DatagramReceived, DataReceived  # type: ignore
 from aioquic.quic.configuration import QuicConfiguration  # type: ignore
 from aioquic.quic.connection import logger as quic_connection_logger  # type: ignore
 from aioquic.quic.connection import stream_is_unidirectional

--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -16,7 +16,7 @@ from aioquic.buffer import Buffer  # type: ignore
 from aioquic.asyncio import QuicConnectionProtocol, serve  # type: ignore
 from aioquic.asyncio.client import connect  # type: ignore
 from aioquic.h3.connection import H3_ALPN, FrameType, H3Connection, ProtocolError  # type: ignore
-from aioquic.h3.events import H3Event, HeadersReceived, WebTransportStreamDataReceived, DatagramReceived, DataReceived  # type: ignore
+from aioquic.h3.events import H3Event, HeadersReceived, WebTransportStreamDataReceived, DatagramReceived, DataReceived, SettingsError  # type: ignore
 from aioquic.quic.configuration import QuicConfiguration  # type: ignore
 from aioquic.quic.connection import logger as quic_connection_logger  # type: ignore
 from aioquic.quic.connection import stream_is_unidirectional
@@ -65,11 +65,17 @@ class H3ConnectionWithDatagram(H3Connection):
         self._datagram_setting: Optional[H3DatagramSetting] = None
 
     def _validate_settings(self, settings: Dict[int, int]) -> None:
-        super()._validate_settings(settings)
+        # aioquic doesn't recognize the RFC version of HTTP Datagrams yet.
+        # Intentionally don't call `super()._validate_settings(settings)` since
+        # it raises a SettingsError when only the RFC version is negotiated.
         if settings.get(H3DatagramSetting.RFC) == 1:
             self._datagram_setting = H3DatagramSetting.RFC
         elif settings.get(H3DatagramSetting.DRAFT04) == 1:
             self._datagram_setting = H3DatagramSetting.DRAFT04
+
+        if self._datagram_setting is None:
+            raise SettingsError("HTTP Datagrams support required")
+
 
     def _get_local_settings(self) -> Dict[int, int]:
         settings = super()._get_local_settings()


### PR DESCRIPTION
The current aioquic doesn't recognize the RFC version of HTTP Datagrams, but it requires an old draft version of HTTP Datagrams settings parameter. Don't use aioquic's validation to work around this interop issue.