### PR TITLE
Add timeout to `fetch` function

### DIFF
--- a/webdriver/tests/bidi/network/conftest.py
+++ b/webdriver/tests/bidi/network/conftest.py
@@ -15,14 +15,14 @@ def fetch(bidi_session, top_context, configuration):
     """Perform a fetch from the page of the provided context, default to the
     top context.
     """
-    async def fetch(url, method="GET", headers=None, context=top_context, timeout=1000):
+    async def fetch(url, method="GET", headers=None, context=top_context, timeout_in_seconds=1):
         method_arg = f"method: '{method}',"
 
         headers_arg = ""
         if headers != None:
             headers_arg = f"headers: {json.dumps(headers)},"
 
-        timeout = timeout * configuration["timeout_multiplier"]
+        timeout_in_seconds = timeout_in_seconds * configuration["timeout_multiplier"]
 
         # Wait for fetch() to resolve a response and for response.text() to
         # resolve as well to make sure the request/response is completed when
@@ -30,7 +30,7 @@ def fetch(bidi_session, top_context, configuration):
         await bidi_session.script.evaluate(
             expression=f"""
                  const controller = new AbortController();
-                 setTimeout(() => controller.abort(), {timeout});
+                 setTimeout(() => controller.abort(), {timeout_in_seconds * 1000});
                  fetch("{url}", {{
                    {method_arg}
                    {headers_arg}

--- a/webdriver/tests/bidi/network/conftest.py
+++ b/webdriver/tests/bidi/network/conftest.py
@@ -15,7 +15,7 @@ def fetch(bidi_session, top_context):
     """Perform a fetch from the page of the provided context, default to the
     top context.
     """
-    async def fetch(url, method="GET", headers=None, context=top_context):
+    async def fetch(url, method="GET", headers=None, context=top_context, timeout=1000):
         method_arg = f"method: '{method}',"
 
         headers_arg = ""
@@ -27,9 +27,12 @@ def fetch(bidi_session, top_context):
         # the helper returns.
         await bidi_session.script.evaluate(
             expression=f"""
+                 const controller = new AbortController();
+                 setTimeout(() => controller.abort(), {timeout});
                  fetch("{url}", {{
                    {method_arg}
                    {headers_arg}
+                   signal: controller.signal
                  }}).then(response => response.text());""",
             target=ContextTarget(context["context"]),
             await_promise=True,

--- a/webdriver/tests/bidi/network/conftest.py
+++ b/webdriver/tests/bidi/network/conftest.py
@@ -11,7 +11,7 @@ PAGE_EMPTY_HTML = "/webdriver/tests/bidi/network/support/empty.html"
 
 
 @pytest.fixture
-def fetch(bidi_session, top_context):
+def fetch(bidi_session, top_context, configuration):
     """Perform a fetch from the page of the provided context, default to the
     top context.
     """
@@ -21,6 +21,8 @@ def fetch(bidi_session, top_context):
         headers_arg = ""
         if headers != None:
             headers_arg = f"headers: {json.dumps(headers)},"
+
+        timeout = timeout * configuration["timeout_multiplier"]
 
         # Wait for fetch() to resolve a response and for response.text() to
         # resolve as well to make sure the request/response is completed when


### PR DESCRIPTION
The default `fetch` timeout is 300 seconds, which makes relying on it the whole test file fail with `TIMEOUT`. This [masks](https://wpt.fyi/results/webdriver/tests/bidi/network/response_completed/response_completed.py?label=experimental&label=master&aligned) other issues with the network.
* Add `timeout` parameter to the `fetch` with default `1s`.