### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=253715

### DIFF
--- a/css/css-box/margin-trim/computed-margin-values/flexbox-column-inline-end.html
+++ b/css/css-box/margin-trim/computed-margin-values/flexbox-column-inline-end.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="trimmed inline-end margins should be reflected in computed style">
+<style>
+flexbox {
+    display: flex;
+    flex-direction: column;
+    width: min-content;
+    margin-trim: inline-end;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+item:nth-child(1) {
+    margin-inline-end: 10px;
+}
+item:nth-child(2) {
+    margin-inline-end: -10px;
+}
+item:nth-child(3) {
+    margin-inline-end: 30%;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('flexbox > item')">
+<div id="target">
+<flexbox>
+    <item data-expected-margin-right="0" data-offset-x="8"></item>
+    <item data-expected-margin-right="0" data-offset-x="8"></item>
+    <item data-expected-margin-right="0" data-offset-x="8"></item>
+</flexbox>
+</div>
+</body>
+</html>

--- a/css/css-box/margin-trim/computed-margin-values/flexbox-column-multi-line-inline-end.html
+++ b/css/css-box/margin-trim/computed-margin-values/flexbox-column-multi-line-inline-end.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="trimmed inline-end margins should be reflected in computed style">
+<style>
+flexbox {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    width: min-content;
+    height: 100px;
+    margin-trim: inline-end;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline-end: 10px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('flexbox > item')">
+<div id="target">
+<flexbox>
+    <item data-offset-x="8" data-expected-margin-right="10"></item>
+    <item data-offset-x="8" data-expected-margin-right="10"></item>
+    <item data-offset-x="68" data-expected-margin-right="0"></item>
+    <item data-offset-x="68" data-expected-margin-right="0"></item>
+</flexbox>
+</div>
+</body>
+</html>

--- a/css/css-box/margin-trim/computed-margin-values/flexbox-row-inline-end.html
+++ b/css/css-box/margin-trim/computed-margin-values/flexbox-row-inline-end.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="trimmed inline-end margins should be reflected in computed style">
+<style>
+flexbox {
+    display: flex;
+    margin-trim: inline-end;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline-end: 20px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('flexbox > item')">
+<div id="target">
+<flexbox>
+    <item data-expected-margin-right="20" data-offset-x="8"></item>
+    <item data-expected-margin-right="20" data-offset-x="78"></item>
+    <item data-expected-margin-right="0" data-offset-x="148"></item>
+</flexbox>
+</div>
+</body>
+</html>

--- a/css/css-box/margin-trim/computed-margin-values/flexbox-row-multi-line-inline-end.html
+++ b/css/css-box/margin-trim/computed-margin-values/flexbox-row-multi-line-inline-end.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="trimmed inline-end margins should be reflected in computed style">
+<style>
+flexbox {
+    display: flex;
+    width: 110px;
+    flex-wrap: wrap;
+    margin-trim: inline-end;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+item:nth-child(1) {
+    margin-inline-end: 10px;
+}
+item:nth-child(2) {
+    margin-inline-end: -10px;
+}
+item:nth-child(3) {
+    margin-inline-end: 10px;
+}
+item:nth-child(4) {
+    margin-inline-end: 50%;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('flexbox > item')">
+<div id="target">
+<flexbox>
+    <item data-expected-margin-right="10" data-offset-x="8"></item>
+    <item data-expected-margin-right="0" data-offset-x="68"></item>
+    <item data-expected-margin-right="10" data-offset-x="8"></item>
+    <item data-expected-margin-right="0" data-offset-x="68"></item>
+</flexbox>
+</div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[margin-trim\] Trimmed inline-end margins for flex items should be reflected in computed style](https://bugs.webkit.org/show_bug.cgi?id=253715)