### PR TITLE
[wpt-lint] Handle `FileNotFoundError` when `git` is not found

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -1134,7 +1134,7 @@ file_lints = [check_regexp_line, check_parsed, check_python_ast, check_script_me
 try:
     subprocess.check_output(["git", "--version"])
     all_paths_lints += [check_git_ignore]
-except subprocess.CalledProcessError:
+except (subprocess.CalledProcessError, FileNotFoundError):
     print('No git present; skipping .gitignore lint.')
 
 if __name__ == "__main__":


### PR DESCRIPTION
`tools.lint.lint` is unimportable when `git` does not exist in the `PATH`:

```
  ...
  File "C:\b\s\w\ir\third_party\wpt_tools\wpt\tools\lint\__init__.py", line 1, in <module>
    from . import lint  # noqa: F401
  File "C:\b\s\w\ir\third_party\wpt_tools\wpt\tools\lint\lint.py", line 1135, in <module>
    subprocess.check_output(["git", "--version"])
  ...
  File "C:\b\s\w\ir\.task_template_vpython_cache\vpython\store\cpython-e6tenrlsesftvg6k08ajgkk7b4\contents\bin\Lib\subprocess.py", line 1311, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
FileNotFoundError: [WinError 2] The system cannot find the file specified
```