### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=253713

### DIFF
--- a/css/css-box/margin-trim/computed-margin-values/flexbox-column-block-end.html
+++ b/css/css-box/margin-trim/computed-margin-values/flexbox-column-block-end.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="block-end trimmed margins should be reflected in computed style">
+<style>
+flexbox {
+    display: flex;
+    flex-direction: column;
+    width: min-content;
+    margin-trim: block-end;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-block-end: 10px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('flexbox > item')">
+<div id="target">
+<flexbox>
+    <item data-expected-margin-bottom="10" data-offset-y="8"></item>
+    <item data-expected-margin-bottom="0" data-offset-y="68"></item>
+</flexbox>
+</div>
+</body>
+</html>

--- a/css/css-box/margin-trim/computed-margin-values/flexbox-column-multi-line-block-end.html
+++ b/css/css-box/margin-trim/computed-margin-values/flexbox-column-multi-line-block-end.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="block-end trimmed margins should be reflected in computed style">
+<style>
+flexbox {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    width: 100px;
+    height: 110px;
+    margin-trim: block-end;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-block-end: 10px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('flexbox > item')">
+<div id="target">
+<flexbox>
+    <item data-offset-y="8" data-expected-margin-bottom="10"></item>
+    <item data-offset-y="68" data-expected-margin-bottom="0"></item>
+    <item data-offset-y="8" data-expected-margin-bottom="10"></item>
+    <item data-offset-y="68" data-expected-margin-top="0"></item>
+</flexbox>
+</div>
+</body>
+</html>

--- a/css/css-box/margin-trim/computed-margin-values/flexbox-column-multi-line-block.html
+++ b/css/css-box/margin-trim/computed-margin-values/flexbox-column-multi-line-block.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="both trimmed block margins should be reflected in computed style">
+<style>
+flexbox {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    width: 100px;
+    height: 120px;
+    margin-trim: block;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-block: 10px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('flexbox > item')">
+<div id="target">
+<flexbox>
+    <item data-offset-y="8" data-expected-margin-top="0" data-expected-margin-bottom="10"></item>
+    <item data-offset-y="78" data-expected-margin-top="10" data-expected-margin-bottom="0" ></item>
+    <item data-offset-y="8" data-expected-margin-top="0" data-expected-margin-bottom="10"></item>
+    <item data-offset-y="78" data-expected-margin-top="10" data-expected-margin-bottom="0"></item>
+</flexbox>
+</div>
+</body>
+</html>

--- a/css/css-box/margin-trim/computed-margin-values/flexbox-row-block-end.html
+++ b/css/css-box/margin-trim/computed-margin-values/flexbox-row-block-end.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="block-end trimmed margins should be reflected in computed style">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    margin-trim: block-end;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline: 10px;
+}
+item:nth-child(1) {
+    margin-block-end: 10px;
+}
+item:nth-child(2) {
+    margin-block-end: -10px;
+}
+item:nth-child(3) {
+    margin-block-end: 30%;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('flexbox > item')">
+<div id="target">
+<flexbox>
+    <item data-expected-margin-bottom="0"></item>
+    <item data-expected-margin-bottom="0"></item>
+    <item data-expected-margin-bottom="0"></item>
+</flexbox>
+</div>
+</body>
+</html>

--- a/css/css-box/margin-trim/computed-margin-values/flexbox-row-block.html
+++ b/css/css-box/margin-trim/computed-margin-values/flexbox-row-block.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="both trimmed block margins should be reflected in computed style">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    margin-trim: block;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline: 10px;
+}
+item:nth-child(1) {
+    margin-block: 10px;
+}
+item:nth-child(2) {
+    margin-block: -10px;
+}
+item:nth-child(3) {
+    margin-block: 30%;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('flexbox > item')">
+<div id="target">
+<flexbox>
+    <item data-expected-margin-top="0" data-expected-margin-bottom="0" data-offset-y="8"></item>
+    <item data-expected-margin-top="0" data-expected-margin-bottom="0" data-offset-y="8"></item>
+    <item data-expected-margin-top="0" data-expected-margin-bottom="0" data-offset-y="8"></item>
+</flexbox>
+</div>
+</body>
+</html>

--- a/css/css-box/margin-trim/computed-margin-values/flexbox-row-multi-line-block-end.html
+++ b/css/css-box/margin-trim/computed-margin-values/flexbox-row-multi-line-block-end.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="block-end trimmed margins should be reflected in computed style">
+<style>
+flexbox {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100px;
+    margin-trim: block-end;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-block-end: 10px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('flexbox > item')">
+<div id="target">
+<flexbox>
+    <item data-offset-y="8" data-expected-margin-bottom="10"></item>
+    <item data-offset-y="8" data-expected-margin-bottom="10"></item>
+    <item data-offset-y="68" data-expected-margin-bottom="0"></item>
+    <item data-offset-y="68" data-expected-margin-bottom="0"></item>
+</flexbox>
+</div>
+</body>
+</html>

--- a/css/css-box/margin-trim/computed-margin-values/flexbox-row-multi-line-block.html
+++ b/css/css-box/margin-trim/computed-margin-values/flexbox-row-multi-line-block.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="both trimmed block margins should be reflected in computed style">
+<style>
+flexbox {
+    display: flex;
+    width: 100px;
+    flex-wrap: wrap;
+    margin-trim: block;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-block: 10px;
+}
+
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('flexbox > item')">
+<div id="target">
+<flexbox>
+    <item data-expected-margin-top="0" data-expected-margin-bottom="10" data-offset-y="8"></item>
+    <item data-expected-margin-top="0" data-expected-margin-bottom="10" data-offset-y="8"></item>
+    <item data-expected-margin-top="10" data-expected-margin-bottom="0" data-offset-y="78"></item>
+    <item data-expected-margin-top="10" data-expected-margin-bottom="0" data-offset-y="78"></item>
+</flexbox>
+</div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[margin-trim\] Trimmed block-end margins for flex items should be reflected in computed style](https://bugs.webkit.org/show_bug.cgi?id=253713)