### PR TITLE
[CSS2] ‘{min,max}-{width,height}’ and percentages in descendants

### DIFF
--- a/css/CSS2/positioning/absolute-non-replaced-max-001-ref.html
+++ b/css/CSS2/positioning/absolute-non-replaced-max-001-ref.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
+<p>Test passes if there is a green square containing a smaller black square below.
+<div style="width: 2em; height: 2em; background: green;">
+    <div style="width: 1em; height: 1em; background: black;"></div>
+</div>

--- a/css/CSS2/positioning/absolute-non-replaced-max-001.html
+++ b/css/CSS2/positioning/absolute-non-replaced-max-001.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: ‘max-width’ and ‘max-height’ affect percentage sizes in descendants</title>
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css2/#min-max-widths">
+<link rel="help" href="https://drafts.csswg.org/css2/#min-max-heights">
+<link rel="match" href="absolute-non-replaced-max-001-ref.html">
+<meta name="assert" value="This test verifies that when the used ‘width’ and ‘height’ are affected by ‘max-width’ and ‘max-height’, the descendants are laid out with a containing block of the new size, so any percentage sizes are resolved against that new size.">
+<p>Test passes if there is a green square containing a smaller black square below.
+<div style="position: absolute; width: 4em; height: 4em; max-width: 2em; max-height: 2em; background: green;">
+    <div style="width: 50%; height: 50%; background: black;"></div>
+</div>

--- a/css/CSS2/positioning/absolute-non-replaced-min-001.html
+++ b/css/CSS2/positioning/absolute-non-replaced-min-001.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: ‘min-width’ and ‘min-height’ affect percentage sizes in descendants</title>
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css2/#min-max-widths">
+<link rel="help" href="https://drafts.csswg.org/css2/#min-max-heights">
+<link rel="match" href="absolute-non-replaced-min-max-001-ref.html">
+<meta name="assert" value="This test verifies that when the used ‘width’ and ‘height’ are affected by ‘min-width’ and ‘min-height’, the descendants are laid out with a containing block of the new size, so any percentage sizes are resolved against that new size.">
+<p>Test passes if there is a green square below.
+<div style="position: absolute; width: 0; height: 0; min-width: 1em; min-height: 1em; background: black;">
+    <div style="width: 100%; height: 100%; background: green;"></div>
+</div>

--- a/css/CSS2/positioning/absolute-non-replaced-min-max-001-ref.html
+++ b/css/CSS2/positioning/absolute-non-replaced-min-max-001-ref.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
+<p>Test passes if there is a green square below.
+<div style="width: 1em; height: 1em; background: green;"></div>

--- a/css/CSS2/positioning/absolute-non-replaced-min-max-001.html
+++ b/css/CSS2/positioning/absolute-non-replaced-min-max-001.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: ‘min-width’ and ‘min-height’ take precedence over ‘max-width’ and ‘max-height’ when contradictory</title>
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css2/#min-max-widths">
+<link rel="help" href="https://drafts.csswg.org/css2/#min-max-heights">
+<link rel="match" href="absolute-non-replaced-min-max-001-ref.html">
+<meta name="assert" value="This test verifies that when ‘min-width’ is greater than ‘max-width’, or ‘min-height’ is greater than ‘max-height’, the minimums take precedence, because the steps that recalculate sizes and margins for the minimums (step 3) come after the steps for the maximums (step 2).">
+<p>Test passes if there is a green square below.
+<div style="position: absolute; width: 0; height: 0; min-width: 1em; min-height: 1em; max-width: 0; max-height: 0; background: green;"></div>


### PR DESCRIPTION
This patch is a manual export of the new tests added by servo/servo#29594, which assert that ‘min-width’ takes precedence over ‘max-width’, ‘min-height’ takes precedence over ‘max-height’, and all of these properties affect the size of the containing block that descendant percentages are resolved against.