### PR TITLE
test out of [0,255] rgb

### DIFF
--- a/css/css-color/parsing/color-valid-rgb.html
+++ b/css/css-color/parsing/color-valid-rgb.html
@@ -28,6 +28,18 @@ test_valid_value("color", "rgba(none none none / .5)", "rgba(0, 0, 0, 0.5)");
 test_valid_value("color", "rgba(20% none none)", "rgb(51, 0, 0)");
 test_valid_value("color", "rgba(20% none none / none)", "rgba(51, 0, 0, 0)");
 test_valid_value("color", "rgba(none none none / 50%)", "rgba(0, 0, 0, 0.5)");
+test_valid_value("color", "rgb(-2 3 4)", "rgb(0, 3, 4)");
+test_valid_value("color", "rgb(-20% 20% 40%)", "rgb(0, 51, 102)");
+test_valid_value("color", "rgb(257 30 40)", "rgb(255, 30, 40)");
+test_valid_value("color", "rgb(250% 20% 40%)", "rgb(255, 51, 102)");
+test_valid_value("color", "rgba(-2 3 4)", "rgb(0, 3, 4)");
+test_valid_value("color", "rgba(-20% 20% 40%)", "rgb(0, 51, 102)");
+test_valid_value("color", "rgba(257 30 40)", "rgb(255, 30, 40)");
+test_valid_value("color", "rgba(250% 20% 40%)", "rgb(255, 51, 102)");
+test_valid_value("color", "rgba(-2 3 4 / .5)", "rgba(0, 3, 4, 0.5)");
+test_valid_value("color", "rgba(-20% 20% 40% / 50%)", "rgba(0, 51, 102, 0.5)");
+test_valid_value("color", "rgba(257 30 40 / 50%)", "rgba(255, 30, 40, 0.5)");
+test_valid_value("color", "rgba(250% 20% 40% / .5)", "rgba(255, 51, 102, 0.5)");
 </script>
 </body>
 </html>


### PR DESCRIPTION
`rgb()` and `rgba()` with component values out of the 0,255 or 0%,100% range were untested for modern syntax CSS Color 4; only tested for legacy syntax CSS Color-3 with color-valid.html.

