### PR TITLE
Handle min/max sizes in non-replaced positioned boxes

### DIFF
--- a/css/CSS2/positioning/absolute-non-replaced-max-001-ref.html
+++ b/css/CSS2/positioning/absolute-non-replaced-max-001-ref.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
+<p>Test passes if there is a green square containing a smaller black square below.
+<div style="width: 2em; height: 2em; background: green;">
+    <div style="width: 1em; height: 1em; background: black;"></div>
+</div>

--- a/css/CSS2/positioning/absolute-non-replaced-max-001.html
+++ b/css/CSS2/positioning/absolute-non-replaced-max-001.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: ‘max-width’ and ‘max-height’ affect percentage sizes in descendants</title>
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css2/#min-max-widths">
+<link rel="help" href="https://drafts.csswg.org/css2/#min-max-heights">
+<link rel="match" href="absolute-non-replaced-max-001-ref.html">
+<meta name="assert" value="This test verifies that when the used ‘width’ and ‘height’ are affected by ‘max-width’ and ‘max-height’, the descendants are laid out with a containing block of the new size, so any percentage sizes are resolved against that new size.">
+<p>Test passes if there is a green square containing a smaller black square below.
+<div style="position: absolute; width: 4em; height: 4em; max-width: 2em; max-height: 2em; background: green;">
+    <div style="width: 50%; height: 50%; background: black;"></div>
+</div>

--- a/css/CSS2/positioning/absolute-non-replaced-min-001.html
+++ b/css/CSS2/positioning/absolute-non-replaced-min-001.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: ‘min-width’ and ‘min-height’ affect percentage sizes in descendants</title>
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css2/#min-max-widths">
+<link rel="help" href="https://drafts.csswg.org/css2/#min-max-heights">
+<link rel="match" href="absolute-non-replaced-min-max-001-ref.html">
+<meta name="assert" value="This test verifies that when the used ‘width’ and ‘height’ are affected by ‘min-width’ and ‘min-height’, the descendants are laid out with a containing block of the new size, so any percentage sizes are resolved against that new size.">
+<p>Test passes if there is a green square below.
+<div style="position: absolute; width: 0; height: 0; min-width: 1em; min-height: 1em; background: black;">
+    <div style="width: 100%; height: 100%; background: green;"></div>
+</div>

--- a/css/CSS2/positioning/absolute-non-replaced-min-max-001-ref.html
+++ b/css/CSS2/positioning/absolute-non-replaced-min-max-001-ref.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
+<p>Test passes if there is a green square below.
+<div style="width: 1em; height: 1em; background: green;"></div>

--- a/css/CSS2/positioning/absolute-non-replaced-min-max-001.html
+++ b/css/CSS2/positioning/absolute-non-replaced-min-max-001.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: ‘min-width’ and ‘min-height’ take precedence over ‘max-width’ and ‘max-height’ when contradictory</title>
+<link rel="author" name="Delan Azabani" href="mailto:dazabani@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css2/#min-max-widths">
+<link rel="help" href="https://drafts.csswg.org/css2/#min-max-heights">
+<link rel="match" href="absolute-non-replaced-min-max-001-ref.html">
+<meta name="assert" value="This test verifies that when ‘min-width’ is greater than ‘max-width’, or ‘min-height’ is greater than ‘max-height’, the minimums take precedence, because the steps that recalculate sizes and margins for the minimums (step 3) come after the steps for the maximums (step 2).">
+<p>Test passes if there is a green square below.
+<div style="position: absolute; width: 0; height: 0; min-width: 1em; min-height: 1em; max-width: 0; max-height: 0; background: green;"></div>


### PR DESCRIPTION
This patch makes HoistedAbsolutelyPositionedBox handle min/max sizes in the non-replaced case, per CSS2 [#min-max-widths](https://drafts.csswg.org/css2/#min-max-widths) and [#min-max-heights](https://drafts.csswg.org/css2/#min-max-heights). No changes are made to the replaced case.

3 new tests:

* /css/CSS2/positioning/absolute-non-replaced-max-001.html (fails under layout 2013)
* /css/CSS2/positioning/absolute-non-replaced-min-001.html (fails under layout 2013)
* /css/CSS2/positioning/absolute-non-replaced-min-max-001.html (passes under layout 2013)

13 tests now pass:

* [/css/CSS2/positioning/absolute-non-replaced-max-height-002.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-max-height-002.xht)
* [/css/CSS2/positioning/absolute-non-replaced-max-height-003.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-max-height-003.xht)
* [/css/CSS2/positioning/absolute-non-replaced-max-height-007.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-max-height-007.xht)
* [/css/CSS2/positioning/absolute-non-replaced-max-height-008.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-max-height-008.xht)
* [/css/CSS2/positioning/absolute-non-replaced-max-height-009.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-max-height-009.xht)
* [/css/CSS2/positioning/absolute-non-replaced-max-height-011.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-max-height-011.xht)
* [/css/CSS2/positioning/absolute-non-replaced-width-025.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-width-025.xht)
* [/css/CSS2/positioning/absolute-non-replaced-width-026.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-width-026.xht)
* [/css/CSS2/positioning/abspos-change-in-inline-block.html](https://wpt.live/css/CSS2/positioning/abspos-change-in-inline-block.html)
* [/css/CSS2/positioning/abspos-width-change-inline-container-001.html](https://wpt.live/css/CSS2/positioning/abspos-width-change-inline-container-001.html)
* [/css/CSS2/positioning/detach-abspos-before-layout.html](https://wpt.live/css/CSS2/positioning/detach-abspos-before-layout.html)
* [/css/CSS2/positioning/relpos-percentage-left-in-scrollable-2.html](https://wpt.live/css/CSS2/positioning/relpos-percentage-left-in-scrollable-2.html)
* [/css/CSS2/positioning/relpos-percentage-left-in-scrollable.html](https://wpt.live/css/CSS2/positioning/relpos-percentage-left-in-scrollable.html)

11 tests would now pass if `<br>` was inserted between the two `<img>` tags in the reference (#29591):

* [/css/CSS2/positioning/absolute-non-replaced-height-003.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-height-003.xht)
* [/css/CSS2/positioning/absolute-non-replaced-height-004.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-height-004.xht)
* [/css/CSS2/positioning/absolute-non-replaced-height-005.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-height-005.xht)
* [/css/CSS2/positioning/absolute-non-replaced-height-010.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-height-010.xht)
* [/css/CSS2/positioning/absolute-non-replaced-height-011.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-height-011.xht)
* [/css/CSS2/positioning/absolute-non-replaced-height-012.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-height-012.xht)
* [/css/CSS2/positioning/absolute-non-replaced-max-height-004.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-max-height-004.xht)
* [/css/CSS2/positioning/absolute-non-replaced-max-height-005.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-max-height-005.xht)
* [/css/CSS2/positioning/absolute-non-replaced-max-height-006.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-max-height-006.xht)
* [/css/CSS2/positioning/absolute-non-replaced-max-height-010.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-max-height-010.xht)
* [/css/CSS2/positioning/absolute-non-replaced-max-height-012.xht](https://wpt.live/css/CSS2/positioning/absolute-non-replaced-max-height-012.xht)

1 test continues to fail, but the expectation was out of date:

* [/css/CSS2/positioning/relpos-percentage-top-in-scrollable.html](https://wpt.live/css/CSS2/positioning/relpos-percentage-top-in-scrollable.html)

Reviewed in servo/servo#29594