### PR TITLE
Test priority of blob.type and headers content-type for blob()

### DIFF
--- a/fetch/api/body/mime-type.any.js
+++ b/fetch/api/body/mime-type.any.js
@@ -38,3 +38,90 @@
     assert_equals(blob.type, newMIMEType);
   }, `${bodyContainer.constructor.name}: setting missing Content-Type`);
 });
+
+[
+  () => new Request("about:blank", { method: "POST" }),
+  () => new Response(),
+].forEach(bodyContainerCreator => {
+  const bodyContainer = bodyContainerCreator();
+  promise_test(async t => {
+    const blob = await bodyContainer.blob();
+    assert_equals(blob.type, "");
+  }, `${bodyContainer.constructor.name}: MIME type for Blob from empty body`);
+});
+
+[
+  () => new Request("about:blank", { method: "POST", headers: [["Content-Type", "Mytext/Plain"]] }),
+  () => new Response("", { headers: [["Content-Type", "Mytext/Plain"]] })
+].forEach(bodyContainerCreator => {
+  const bodyContainer = bodyContainerCreator();
+  promise_test(async t => {
+    const blob = await bodyContainer.blob();
+    assert_equals(blob.type, 'mytext/plain');
+  }, `${bodyContainer.constructor.name}: MIME type for Blob from empty body with Content-Type`);
+});
+
+[
+  () => new Request("about:blank", { body: new Blob([""]), method: "POST" }),
+  () => new Response(new Blob([""]))
+].forEach(bodyContainerCreator => {
+  const bodyContainer = bodyContainerCreator();
+  promise_test(async t => {
+    const blob = await bodyContainer.blob();
+    assert_equals(blob.type, "");
+    assert_equals(bodyContainer.headers.get("Content-Type"), null);
+  }, `${bodyContainer.constructor.name}: MIME type for Blob`);
+});
+
+[
+  () => new Request("about:blank", { body: new Blob([""], { type: "Text/Plain" }), method: "POST" }),
+  () => new Response(new Blob([""], { type: "Text/Plain" }))
+].forEach(bodyContainerCreator => {
+  const bodyContainer = bodyContainerCreator();
+  promise_test(async t => {
+    const blob = await bodyContainer.blob();
+    assert_equals(blob.type, "text/plain");
+    assert_equals(bodyContainer.headers.get("Content-Type"), "text/plain");
+  }, `${bodyContainer.constructor.name}: MIME type for Blob with non-empty type`);
+});
+
+[
+  () => new Request("about:blank", { method: "POST", body: new Blob([""], { type: "Text/Plain" }), headers: [["Content-Type", "Text/Html"]] }),
+  () => new Response(new Blob([""], { type: "Text/Plain" }, { headers: [["Content-Type", "Text/Html"]] }))
+].forEach(bodyContainerCreator => {
+  const bodyContainer = bodyContainerCreator();
+  const cloned = bodyContainer.clone();
+  promise_test(async t => {
+    const blobs = [await bodyContainer.blob(), await cloned.blob()];
+    assert_equals(blobs[0].type, "text/html");
+    assert_equals(blobs[1].type, "text/html");
+    assert_equals(bodyContainer.headers.get("Content-Type"), "Text/Html");
+    assert_equals(cloned.headers.get("Content-Type"), "Text/Html");
+  }, `${bodyContainer.constructor.name}: Extract a MIME type with clone`);
+});
+
+[
+  () => new Request("about:blank", { body: new Blob([], { type: "text/plain" }), method: "POST", headers: [["Content-Type", "text/html"]] }),
+  () => new Response(new Blob([], { type: "text/plain" }), { headers: [["Content-Type", "text/html"]] }),
+].forEach(bodyContainerCreator => {
+  const bodyContainer = bodyContainerCreator();
+  promise_test(async t => {
+    assert_equals(bodyContainer.headers.get("Content-Type"), "text/html");
+    const blob = await bodyContainer.blob();
+    assert_equals(blob.type, "text/html");
+  }, `${bodyContainer.constructor.name}: Content-Type in headers wins Blob"s type`);
+});
+
+[
+  () => new Request("about:blank", { body: new Blob([], { type: "text/plain" }), method: "POST" }),
+  () => new Response(new Blob([], { type: "text/plain" })),
+].forEach(bodyContainerCreator => {
+  const bodyContainer = bodyContainerCreator();
+  promise_test(async t => {
+    assert_equals(bodyContainer.headers.get("Content-Type"), "text/plain");
+    const newMIMEType = "text/html";
+    bodyContainer.headers.set("Content-Type", newMIMEType);
+    const blob = await bodyContainer.blob();
+    assert_equals(blob.type, newMIMEType);
+  }, `${bodyContainer.constructor.name}: setting missing Content-Type in headers and it wins Blob"s type`);
+});


### PR DESCRIPTION
This would add the tests for https://github.com/whatwg/fetch/issues/1630. They are basically moved from [Chromium](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/http/tests/fetch/script-tests/request.js;l=1021-1032;drc=05c5ed4e58b4cc7d50d0018f7b4d2cdc17211389) and [WebKit](https://github.com/WebKit/WebKit/blob/512db9a6900b400f9ce93e90e6e178fa74fef03e/LayoutTests/http/wpt/fetch/fetch-as-blob.js#L62-L73) but changed a bit to test both request and response.

(but I wonder maybe it's worth also adding [another 3 tests in the webkit test](https://github.com/WebKit/WebKit/blob/512db9a6900b400f9ce93e90e6e178fa74fef03e/LayoutTests/http/wpt/fetch/fetch-as-blob.js#L26-L60) in this PR?)