### PR TITLE
[SPC] Add test for SPC authentication in a hidden document

### DIFF
--- a/secure-payment-confirmation/authentication-disallowed-when-hidden.https.html
+++ b/secure-payment-confirmation/authentication-disallowed-when-hidden.https.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test for the 'secure-payment-confirmation' payment method authentication - accepted case</title>
+<link rel="help" href="https://w3c.github.io/secure-payment-confirmation#sctn-authentication">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<!-- For minimize() -->
+<script src="/page-visibility/resources/window_state_context.js"></script>
+<script src="utils.sub.js"></script>
+<script>
+'use strict';
+
+promise_test(async t => {
+  const {minimize, restore} = window_state_context(t);
+
+  const authenticator = await window.test_driver.add_virtual_authenticator(
+      AUTHENTICATOR_OPTS);
+  t.add_cleanup(() => {
+    return window.test_driver.remove_virtual_authenticator(authenticator);
+  });
+
+  await window.test_driver.set_spc_transaction_mode("autoAccept");
+  t.add_cleanup(() => {
+    return window.test_driver.set_spc_transaction_mode("none");
+  });
+
+  const credential = await createCredential();
+
+  const challenge = 'server challenge';
+  const payeeOrigin = 'https://merchant.com';
+  const displayName = 'Troycard ***1234';
+  const request = new PaymentRequest([{
+    supportedMethods: 'secure-payment-confirmation',
+    data: {
+      credentialIds: [credential.rawId],
+      challenge: Uint8Array.from(challenge, c => c.charCodeAt(0)),
+      payeeOrigin,
+      rpId: window.location.hostname,
+      timeout: 60000,
+      instrument: {
+        displayName,
+        icon: ICON_URL,
+      },
+    }
+  }], PAYMENT_DETAILS);
+
+  // Before we trigger the Payment Request, minimize the window. This should
+  // cause the show() call to be rejected.
+  await minimize();
+  assert_equals(document.hidden, true);
+
+  await test_driver.bless('user activation');
+  return promise_rejects_dom(t, "AbortError", request.show());
+}, 'SPC authentication cannot be triggered from a hidden context');
+</script>


### PR DESCRIPTION
See https://github.com/w3c/secure-payment-confirmation/pull/238