### PR TITLE
Add the first test for basic text-box-trim functionality

### DIFF
--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-001-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-001-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>Reference for trimming inline boxes</title>
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#leading-trim">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<style>
+div {
+  border: 1px solid orange;
+  font-size: 20px;
+  line-height: 1;
+}
+
+span {
+  border: 1px solid blue;
+  font-family: Ahem;
+  font-size: 20px;
+  line-height: 1;
+  text-box-trim: both;
+}
+</style>
+
+<div>
+  <span>Test</span>
+</div>

--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-001.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-001.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>Tests inline boxes are trimmed at text-over/text-under baselines</title>
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#leading-trim">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="match" href="text-box-trim-half-leading-inline-box-001-ref.html">
+
+<style>
+div {
+  border: 1px solid orange;
+  font-size: 20px;
+  line-height: 1;
+}
+
+span {
+  border: 1px solid blue;
+  font-family: Ahem;
+  font-size: 20px;
+  line-height: 3;
+  text-box-trim: both;
+}
+</style>
+
+<div>
+  <span>Test</span>
+</div>


### PR DESCRIPTION
This PR adds the first functionality test for the text-box-trim property, to test the following points:

[1] The `text-box-edge` would be treated as "text" even if we do not specify a non-leading value. 
> For [inline boxes](https://w3c.github.io/csswg-drafts/css-display-4/#inline-box): trims the [block-start](https://w3c.github.io/csswg-drafts/css-writing-modes-4/#block-start) side of the box to match its [content edge](https://w3c.github.io/csswg-drafts/css-box-4/#content-edge) to the metric specified by [text-box-edge](https://drafts.csswg.org/css-inline-3/#propdef-text-box-edge) (treating [leading](https://drafts.csswg.org/css-inline-3/#valdef-text-box-edge-leading) as [text](https://drafts.csswg.org/css-inline-3/#valdef-text-box-edge-text)).

[2] Use the text's text-over/text-under baseline to generate the content box
> Use the [text-over baseline](https://drafts.csswg.org/css-inline-3/#text-over-baseline)/[text-under baseline](https://drafts.csswg.org/css-inline-3/#text-under-baseline).

[3] Since `text-box-edge` is not "leading" && this is not a root inline box(span does not create a root inline box), we do not need to perform half-leading here.
> if [text-box-edge](https://drafts.csswg.org/css-inline-3/#propdef-text-box-edge) is not [leading](https://drafts.csswg.org/css-inline-3/#valdef-text-box-edge-leading) and this is not the [root inline box](https://drafts.csswg.org/css-inline-3/#root-inline-box), if the [half-leading](https://drafts.csswg.org/css-inline-3/#half-leading) is positive, treat it as zero.

[1] https://drafts.csswg.org/css-inline-3/#valdef-text-box-trim-start
[2] https://drafts.csswg.org/css-inline-3/#valdef-text-box-edge-text
[3] https://drafts.csswg.org/css-inline-3/#inline-height
 

preview:
https://github.com/Clqsin45/wpt/blob/demosets/linc-demo/text-box-trim/text-box-trim-basic-preview-v0.png