### PR TITLE
[webnn] Update comments for WebNN concat op and reshape op

### DIFF
--- a/webnn/concat.https.any.js
+++ b/webnn/concat.https.any.js
@@ -8,7 +8,7 @@
 // https://webmachinelearning.github.io/webnn/#api-mlgraphbuilder-concat
 
 const buildConcat = (operationName, builder, resources) => {
-  // MLOperand concat(sequence<MLOperand> inputs, long axis);
+  // MLOperand concat(sequence<MLOperand> inputs, unsigned long axis);
   const namedOutputOperand = {};
   const inputOperands = [];
   for (let input of resources.inputs) {

--- a/webnn/reshape.https.any.js
+++ b/webnn/reshape.https.any.js
@@ -8,7 +8,7 @@
 // https://webmachinelearning.github.io/webnn/#api-mlgraphbuilder-reshape
 
 const buildReshape = (operationName, builder, resources) => {
-  // MLOperand reshape(MLOperand input, sequence<long> newShape);
+  // MLOperand reshape(MLOperand input, sequence<unsigned long?> newShape);
   const namedOutputOperand = {};
   const inputOperand = createSingleInputOperand(builder, resources);
   // invoke builder.reshape()


### PR DESCRIPTION
1. According to current WebNN API Spec of [**concat** operation](https://webmachinelearning.github.io/webnn/#api-mlgraphbuilder-concat) and [**reshape** operation](https://webmachinelearning.github.io/webnn/#api-mlgraphbuilder-reshape),  these previous comments are outdated, this pr is to update them to align with updated Spec. 
2. For conformance tests of **concat** operation , there's none existed tests with negative **aixs**, so there's no change for tests.
3. Last https://github.com/web-platform-tests/wpt/pull/38273 has already updated conformance tests of **reshape** operation, so there's no change this time.

@Honry @dontcallmedom PTAL, thanks.