### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=253717

### DIFF
--- a/css/css-box/margin-trim/computed-margin-values/grid-block-end-column-auto-flow.html
+++ b/css/css-box/margin-trim/computed-margin-values/grid-block-end-column-auto-flow.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css-box-4/#margin-trim-grid">
+<meta name="assert" content="Trimmed block-end margins for grid items should be reflected in computed style">
+</head>
+<style>
+grid {
+    display: grid;
+    width: min-content;
+    grid-auto-flow: column;
+    border: 1px solid black;
+    grid-template-rows: auto auto auto;
+    margin-trim: block-end;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    margin-block-end: 10px;
+}
+.span-four {
+    grid-row: span 4;
+}
+item:nth-child(1) {
+    grid-row: 1;
+    background-color: green;
+}
+item:nth-child(2) {
+    grid-row: 2;
+    background-color: blue;
+}
+item:nth-child(3) {
+    grid-row: 3;
+    background-color: purple;
+}
+item:nth-child(4) {
+    background-color:burlywood;
+}
+item:nth-child(5) {
+    background-color: grey;
+    grid-row: 4;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<body onload="checkLayout('grid > item')">
+    <div id="target">
+    <grid>
+        <item data-expected-margin-bottom="10"></item>
+        <item data-expected-margin-bottom="10"></item>
+        <item data-expected-margin-bottom="10"></item>
+        <item data-expected-margin-bottom="0" class="span-four"></item>
+        <item data-expected-margin-bottom="0"></item>
+    </grid>
+    </div>
+</body>
+</html>

--- a/css/css-box/margin-trim/computed-margin-values/grid-block-end-item-spans-multiple-rows.html
+++ b/css/css-box/margin-trim/computed-margin-values/grid-block-end-item-spans-multiple-rows.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title></title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css-box-4/#margin-trim-grid">
+<meta name="assert" content="item that spans into last row should have block-end margin trimmed">
+</head>
+<style>
+grid {
+    display: grid;
+    border: 1px solid black;
+    grid-template-columns: auto auto;
+    margin-trim: block-end;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    margin-bottom: 10px;
+}
+.row-two {
+    grid-row: 2;
+    background-color: green;
+}
+.span-two-rows {
+    grid-row: span 2;
+    background-color: blue;
+    height: 90px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<body onload="checkLayout('grid > item')">
+    <div id="target">
+    <grid>
+        <item data-expected-margin-bottom="0" class="span-two-rows"></item>
+        <item data-expected-margin-bottom="0" class="row-two"></item>
+    </grid>
+    </div>
+</body>
+</html>

--- a/css/css-box/margin-trim/computed-margin-values/grid-block-end-item-spans-multiple-rows.html
+++ b/css/css-box/margin-trim/computed-margin-values/grid-block-end-item-spans-multiple-rows.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title></title>
 <link rel="author" href="mailto:sammy.gill@apple.com">
 <link rel="help" href="https://w3c.github.io/csswg-drafts/css-box-4/#margin-trim-grid">
 <meta name="assert" content="item that spans into last row should have block-end margin trimmed">

--- a/css/css-box/margin-trim/computed-margin-values/grid-block-end.html
+++ b/css/css-box/margin-trim/computed-margin-values/grid-block-end.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title></title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css-box-4/#margin-trim-grid">
+<meta name="assert" content="Trimmed block-end margins for grid items should be reflected in computed style">
+</head>
+<style>
+grid {
+    display: grid;
+    width: min-content;
+    border: 1px solid black;
+    grid-template-columns: repeat(4, auto);
+    margin-trim: block-end;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    margin-bottom: 10px;
+}
+.locked-position {
+    grid-row: 2;
+    grid-column: 2;
+    margin-block-end: 50px;
+    background-color: magenta;
+}
+.span-three-columns {
+    grid-column: span 3;
+    background-color: purple;
+}
+.span-five-columns {
+    grid-column: span 5;
+}
+item:nth-child(1) {
+    background-color: green;
+}
+item:nth-child(4) {
+    background-color: blue;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<body onload="checkLayout('grid > item')">
+    <div id="target">
+    <grid>
+        <item class="span-five-columns" data-expected-margin-bottom="10"></item>
+        <item class="locked-position" data-expected-margin-bottom="50"></item>
+        <item class="span-three-columns" data-expected-margin-bottom="10"></item>
+        <item data-expected-margin-bottom="0"></item>
+    </grid>
+    </div>
+</body>
+</html>

--- a/css/css-box/margin-trim/computed-margin-values/grid-block-end.html
+++ b/css/css-box/margin-trim/computed-margin-values/grid-block-end.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title></title>
 <link rel="author" href="mailto:sammy.gill@apple.com">
 <link rel="help" href="https://w3c.github.io/csswg-drafts/css-box-4/#margin-trim-grid">
 <meta name="assert" content="Trimmed block-end margins for grid items should be reflected in computed style">


### PR DESCRIPTION
WebKit export from bug: [\[margin-trim\] Trimmed block-end margins for grid items should be reflected in computed style](https://bugs.webkit.org/show_bug.cgi?id=253717)