### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=253716

### DIFF
--- a/css/css-box/margin-trim/computed-margin-values/grid-block-start.html
+++ b/css/css-box/margin-trim/computed-margin-values/grid-block-start.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-grid">
+<meta name="assert" content="Grid items with trimmed block start margins should be reflected in computed style">
+<style>
+grid {
+    display: grid;
+    width: min-content;
+    border: 1px solid black;
+    grid-template-columns: auto auto;
+    margin-trim: block-start;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.locked-location {
+    grid-row: 1;
+    grid-column: 2;
+}
+item:nth-child(1) {
+    margin-block-start: 50%;
+}
+item:nth-child(2) {
+    margin-block-start: -30px;
+}
+item:nth-child(3) {
+    margin-block-start: 10px;
+}
+item:nth-child(4) {
+    margin-block-start: 10px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('grid > item')">
+    <div id="target">
+    <grid>
+        <item class="locked-location" data-expected-margin-top="0"></item>
+        <item data-expected-margin-top="0"></item>
+        <item data-expected-margin-top="10"></item>
+        <item data-expected-margin-top="10"></item>
+    </grid>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[margin-trim\] Trimmed block-start margins for grid items should be reflected in computed style](https://bugs.webkit.org/show_bug.cgi?id=253716)