### PR TITLE
Use better assertions for computedrole

### DIFF
--- a/webdriver/tests/get_computed_role/get.py
+++ b/webdriver/tests/get_computed_role/get.py
@@ -77,7 +77,7 @@ def test_stale_element_reference(session, stale_element, as_frame):
 
 
 @pytest.mark.parametrize("html,tag,expected", [
-    ("<main>foo</main>", "main", "main"),
+    ("<nav>foo</nav>", "nav", "navigation"),
     ("<input role=searchbox>", "input", "searchbox"),
     ("<img role=button tabindex=0>", "img", "button")])
 def test_computed_roles(session, inline, html, tag, expected):

--- a/webdriver/tests/get_computed_role/get.py
+++ b/webdriver/tests/get_computed_role/get.py
@@ -77,7 +77,7 @@ def test_stale_element_reference(session, stale_element, as_frame):
 
 
 @pytest.mark.parametrize("html,tag,expected", [
-    ("<nav>foo</nav>", "nav", "navigation"),
+    ("<article>foo</article>", "article", "article"),
     ("<input role=searchbox>", "input", "searchbox"),
     ("<img role=button tabindex=0>", "img", "button")])
 def test_computed_roles(session, inline, html, tag, expected):

--- a/webdriver/tests/get_computed_role/get.py
+++ b/webdriver/tests/get_computed_role/get.py
@@ -77,9 +77,9 @@ def test_stale_element_reference(session, stale_element, as_frame):
 
 
 @pytest.mark.parametrize("html,tag,expected", [
-    ("<li role=menuitem>foo", "li", "menuitem"),
+    ("<main>foo</main>", "main", "main"),
     ("<input role=searchbox>", "input", "searchbox"),
-    ("<img role=presentation>", "img", "presentation")])
+    ("<img role=button tabindex=0>", "img", "button")])
 def test_computed_roles(session, inline, html, tag, expected):
     session.url = inline(html)
     element = session.find.css(tag, all=False)


### PR DESCRIPTION
Resolves #39118

Replaces two invalid computedrole assertions which relied on an orphaned menuitem and a previously unspecified but now incorrect role synonym. 

All three of the updated computedrole tests pass in WebKit and Chromium ( and Gecko soon), and this test effectively exercises the webdriver computedrole getter. Other disputed or erroneous tests that were removed here will be handled in /html-aam and /wai-aria/role

More detail in #39118