### PR TITLE
Add ReadMe to top-level wpt/accessibility dir

### DIFF
--- a/accessibility/ReadMe.md
+++ b/accessibility/ReadMe.md
@@ -1,6 +1,6 @@
-# ReadMe for /accessibility 
+# ReadMe for /accessibility
 
-This top-level `/accessibility` directory contains primarily (only?) general crash tests. 
+This top-level `/accessibility` directory contains primarily (only?) general crash tests.
 
 Accessibility specs are tested in top-level directories named after the particular spec. For example, see automated accessibility tests in:
 
@@ -9,6 +9,6 @@ Accessibility specs are tested in top-level directories named after the particul
 - `/accname`
 - etc.
 
-Primary reviewers for each of those specs can often be found in the META.yml file in each respective directory. Reach out directly or file related issues in each spec repo. 
+Primary reviewers for each of those specs can often be found in the META.yml file in each respective directory. Reach out directly or file related issues in each spec repo.
 
 Pull requests welcome. Thank you!

--- a/accessibility/ReadMe.md
+++ b/accessibility/ReadMe.md
@@ -9,6 +9,6 @@ Accessibility specs are tested in top-level directories named after the particul
 - `/accname`
 - etc.
 
-Primary reviewers for each of those specs can often be found in the META.yml file in each respective directory. Reach out directly or file related issues  in each spec repo. 
+Primary reviewers for each of those specs can often be found in the META.yml file in each respective directory. Reach out directly or file related issues in each spec repo. 
 
 Pull requests welcome. Thank you!

--- a/accessibility/ReadMe.md
+++ b/accessibility/ReadMe.md
@@ -1,0 +1,14 @@
+# ReadMe for /accessibility 
+
+This top-level `/accessibility` directory contains primarily (only?) general crash tests. 
+
+Accessibility specs are tested in top-level directories named after the particular spec. For example, see automated accessibility tests in:
+
+- `/wai-aria`
+- `/html-aam`
+- `/accname`
+- etc.
+
+Primary reviewers for each of those specs can often be found in the META.yml file in each respective directory. Reach out directly or file related issues  in each spec repo. 
+
+Pull requests welcome. Thank you!


### PR DESCRIPTION
Resolves https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/22

Adds ReadMe to /accessibility pointing contributors to related automated accessibility testing.