### PR TITLE
Add test for CustomElementRegistry getName interface

### DIFF
--- a/custom-elements/CustomElementRegistry.html
+++ b/custom-elements/CustomElementRegistry.html
@@ -624,16 +624,27 @@ test(function () {
 }, 'customElements.get return the constructor of the entry with the given name when there is a matching entry.');
 
 test(function () {
-  assert_equals(customElements.getName(class extends HTMLElement {}), undefined);
-}, 'customElements.getName must return undefined when the registry does not contain an entry with the given constructor');
+  assert_equals(customElements.getName(class extends HTMLElement {}), null);
+}, 'customElements.getName must return null when the registry does not contain an entry with the given constructor');
 
 test(function () {
-    class ExistingCustomElement extends HTMLElement {};
-    assert_equals(customElements.getName(ExistingCustomElement), undefined);
-    customElements.define('existing-custom-element', ExistingCustomElement);
-    assert_equals(customElements.get(ExistingCustomElement), 'existing-custom-element');
-}, 'customElements.getName returns the name of the entry with the given constructor when there is a matching entry.');
+  assert_equals(customElements.getName(undefined), null);
+}, 'customElements.getName must return null when called with undefined');
 
+test(function () {
+  assert_equals(customElements.getName(null), null);
+}, 'customElements.getName must return null when called with null');
+
+test(function () {
+  assert_equals(customElements.getName(''), null);
+}, 'customElements.getName must return null when called with a string');
+
+test(function () {
+    class OtherExistingCustomElement extends HTMLElement {};
+    assert_equals(customElements.getName(OtherExistingCustomElement), null);
+    customElements.define('other-existing-custom-element', OtherExistingCustomElement);
+    assert_equals(customElements.getName(OtherExistingCustomElement), 'other-existing-custom-element');
+}, 'customElements.getName returns the name of the entry with the given constructor when there is a matching entry.');
 
 test(function () {
     assert_true(customElements.whenDefined('some-name') instanceof Promise);

--- a/custom-elements/CustomElementRegistry.html
+++ b/custom-elements/CustomElementRegistry.html
@@ -624,6 +624,18 @@ test(function () {
 }, 'customElements.get return the constructor of the entry with the given name when there is a matching entry.');
 
 test(function () {
+  assert_equals(customElements.getName(class extends HTMLElement {}), undefined);
+}, 'customElements.getName must return undefined when the registry does not contain an entry with the given constructor');
+
+test(function () {
+    class ExistingCustomElement extends HTMLElement {};
+    assert_equals(customElements.getName(ExistingCustomElement), undefined);
+    customElements.define('existing-custom-element', ExistingCustomElement);
+    assert_equals(customElements.get(ExistingCustomElement), 'existing-custom-element');
+}, 'customElements.getName returns the name of the entry with the given constructor when there is a matching entry.');
+
+
+test(function () {
     assert_true(customElements.whenDefined('some-name') instanceof Promise);
 }, 'customElements.whenDefined must return a promise for a valid custom element name');
 


### PR DESCRIPTION
In CustomElements v0 you could use the `.name` field to get the defined tag name, but CustomElements v1 does not offer such a field. `localName` can be used within an instance but this prohibits use in, for example, static methods.

This was discussed in the WCCG F2F, tracked in
https://github.com/WICG/webcomponents/issues/566. The conclusion of the F2F was to write up a spec change and WPT tests.
