### PR TITLE
Correct stale element errors for cross-origin navigations

### DIFF
--- a/webdriver/tests/back/back.py
+++ b/webdriver/tests/back/back.py
@@ -164,6 +164,6 @@ def test_cross_origin(session, url):
 
     assert session.url == first_page
 
-    with pytest.raises(error.NoSuchElementException):
+    with pytest.raises(error.StaleElementReferenceException):
         elem.click()
     elem = session.find.css("#delete", all=False)

--- a/webdriver/tests/element_click/navigate.py
+++ b/webdriver/tests/element_click/navigate.py
@@ -1,6 +1,5 @@
 import pytest
-
-from webdriver.error import NoSuchElementException
+from webdriver import error
 
 from tests.support.asserts import assert_success
 from tests.support.helpers import wait_for_new_handle
@@ -121,7 +120,7 @@ def test_link_from_toplevel_context_with_target(session, inline, target):
     wait = Poll(
         session,
         timeout=5,
-        ignored_exceptions=NoSuchElementException,
+        ignored_exceptions=error.NoSuchElementException,
         message="Expected element has not been found")
     wait.until(lambda s: s.find.css("#foo"))
 
@@ -160,7 +159,7 @@ def test_link_from_nested_context_with_target(session, inline, iframe, target):
     wait = Poll(
         session,
         timeout=5,
-        ignored_exceptions=NoSuchElementException,
+        ignored_exceptions=error.NoSuchElementException,
         message="Expected element has not been found")
     wait.until(lambda s: s.find.css("#foo"))
 
@@ -180,6 +179,8 @@ def test_link_cross_origin(session, inline, url):
     assert_success(response)
 
     assert session.url == target_page
+    with pytest.raises(error.StaleElementReferenceException):
+        link.click()
 
     session.find.css("#delete", all=False)
 

--- a/webdriver/tests/forward/forward.py
+++ b/webdriver/tests/forward/forward.py
@@ -190,6 +190,6 @@ def test_cross_origin(session, url):
 
     assert session.url == second_page
 
-    with pytest.raises(error.NoSuchElementException):
+    with pytest.raises(error.StaleElementReferenceException):
         elem.click()
     elem = session.find.css("#delete", all=False)

--- a/webdriver/tests/navigate_to/navigate.py
+++ b/webdriver/tests/navigate_to/navigate.py
@@ -74,7 +74,7 @@ def test_cross_origin(session, inline, url):
     assert_success(response)
 
     assert session.url == second_page
-    with pytest.raises(error.NoSuchElementException):
+    with pytest.raises(error.StaleElementReferenceException):
         elem.click()
 
     session.find.css("#delete", all=False)


### PR DESCRIPTION
[I inappropriately modified the navigation tests](https://github.com/web-platform-tests/wpt/pull/37717) for cross-origin to return a `no such element` error while per spec it should be a `stale element reference` error. This PR corrects the expectation of those tests and will make sure that Chrome, Edge, and Safari tests will pass again.

It will fail for Firefox and I'm going to work on this via https://bugzilla.mozilla.org/show_bug.cgi?id=1822466.