### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=255736

### DIFF
--- a/css/css-box/margin-trim/computed-margin-values/block-container-block-end-nested-child.html
+++ b/css/css-box/margin-trim/computed-margin-values/block-container-block-end-nested-child.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="">
+<meta name="assert" content="">
+<style>
+container {
+    display: block;
+    inline-size: min-content;
+    margin-trim: block-end;
+}
+item {
+    display: block;
+    background-color: green;
+    inline-size: 50px;
+    block-size: 10px;
+    margin-block-end: 10px;
+}
+.border {
+    border: 1px solid black;
+}
+.collapsed {
+    block-size: 0px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('item')">
+    <div id="target">
+        <container>
+            <item data-expected-margin-bottom="10"></item>
+            <item data-expected-margin-bottom="0" style="block-size: auto;">
+                <div><item data-expected-margin-bottom="10"></item></div>
+                <div>
+                    <item data-expected-margin-bottom="0" style="block-size: auto;">
+                        <div><item data-expected-margin-bottom="0"></item></div>
+                    </item>
+                    <item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item>
+                </div>
+                <item class="collapsed" data-expected-margin-bottom="0">
+                    <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                </item>
+            </item>
+            <item class="collapsed" data-expected-margin-bottom="0">
+                <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+            </item>
+        </container>
+    </div>
+</body>
+</html>

--- a/css/css-box/margin-trim/computed-margin-values/block-container-block-end-with-self-collapsing-children.html
+++ b/css/css-box/margin-trim/computed-margin-values/block-container-block-end-with-self-collapsing-children.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="">
+<meta name="assert" content="">
+<style>
+container {
+    display: block;
+    inline-size: min-content;
+    margin-trim: block-end;
+}
+item {
+    display: block;
+    background-color: green;
+    inline-size: 50px;
+    block-size: 50px;
+    margin-block-end: 10px;
+}
+.collapsed {
+    block-size: 0px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('item')">
+    <div id="target">
+        <container>
+            <item data-expected-margin-bottom="10"></item>
+            <item data-expected-margin-bottom="0"></item>
+            <item class="collapsed" data-expected-margin-bottom="0">
+                <div><item class="collapsed" data-expected-margin-bottom="0">
+                    <div><item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item></div>
+                </item></div>
+                <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+            </item>
+            <item class="collapsed" data-expected-margin-bottom="0">
+                <div><item class="collapsed" data-expected-margin-bottom="0">
+                    <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    <div><item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item></div>
+                    <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                </item></div>
+                <div><item class="collapsed" data-expected-margin-bottom="0">
+                    <div><item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item></div>
+                </item></div>
+            </item>
+            <item class="collapsed" data-expected-margin-bottom="0"></item>
+        </container>
+    </div>
+</body>
+</html>

--- a/css/css-box/margin-trim/computed-margin-values/block-container-block-end.html
+++ b/css/css-box/margin-trim/computed-margin-values/block-container-block-end.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="">
+<meta name="assert" content="">
+<style>
+container {
+    display: block;
+    inline-size: min-content;
+    margin-trim: block-end;
+}
+item {
+    display: block;
+    background-color: green;
+    inline-size: 50px;
+    block-size: 50px;
+    margin-block-end: 10px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('item')">
+    <div id="target">
+        <container>
+            <item data-expected-margin-bottom="0"></item>
+        </container>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[margin-trim\]\[block layout\] self-collapsing children at block-end don't have nested content trimmed](https://bugs.webkit.org/show_bug.cgi?id=255736)