### PR TITLE
Align enumerate-device check with spec

### DIFF
--- a/mediacapture-streams/MediaDevices-enumerateDevices-persistent-permission.https.html
+++ b/mediacapture-streams/MediaDevices-enumerateDevices-persistent-permission.https.html
@@ -18,8 +18,8 @@
     // the page loaded below hasn't had capture enabled
     // so enumerateDevices should not list detailed info yet
     const iframe = document.createElement("iframe");
-    iframe.setAttribute("allow", "camera 'src';microphone 'src'");
-    iframe.src = "/mediacapture-streams/iframe-enumerate.html";
+    iframe.setAttribute("allow", "microphone;camera");
+    iframe.src = "/mediacapture-streams/iframe-enumerate-nogum.html";
     document.body.appendChild(iframe);
     const loadWatcher = new EventWatcher(t, iframe, ['load']);
     await loadWatcher.wait_for('load');

--- a/mediacapture-streams/iframe-enumerate-nogum.html
+++ b/mediacapture-streams/iframe-enumerate-nogum.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<script src="message-enumerateddevices-nogum.js"></script>

--- a/mediacapture-streams/message-enumerateddevices-nogum.js
+++ b/mediacapture-streams/message-enumerateddevices-nogum.js
@@ -1,0 +1,6 @@
+onmessage = async e => {
+  const devices = await navigator.mediaDevices.enumerateDevices();
+  e.source.postMessage({
+    devices: devices.map(d => d.toJSON())
+  }, '*');
+}


### PR DESCRIPTION
enumerateDevices() return devices who have previously captured in the document, so to get a mostly-empty list of devices, the iframe document must not have successfully called getUserMedia