### PR TITLE
Run macOS jobs on Azure Pipelines using macOS 13

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
   displayName: 'affected tests: Safari Technology Preview'
   condition: eq(variables['Build.Reason'], 'PullRequest')
   pool:
-    vmImage: 'macOS-12'
+    vmImage: 'macOS-13'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -51,7 +51,7 @@ jobs:
   displayName: 'affected tests without changes: Safari Technology Preview'
   condition: eq(variables['Build.Reason'], 'PullRequest')
   pool:
-    vmImage: 'macOS-12'
+    vmImage: 'macOS-13'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -93,7 +93,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_infrastructure']
   pool:
-    vmImage: 'macOS-12'
+    vmImage: 'macOS-13'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -139,7 +139,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.tools_unittest']
   pool:
-    vmImage: 'macOS-12'
+    vmImage: 'macOS-13'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -155,7 +155,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.tools_unittest']
   pool:
-    vmImage: 'macOS-12'
+    vmImage: 'macOS-13'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -171,7 +171,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_unittest']
   pool:
-    vmImage: 'macOS-12'
+    vmImage: 'macOS-13'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -187,7 +187,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_unittest']
   pool:
-    vmImage: 'macOS-12'
+    vmImage: 'macOS-13'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -203,7 +203,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wpt_integration']
   pool:
-    vmImage: 'macOS-12'
+    vmImage: 'macOS-13'
   steps:
   # full checkout required
   - task: UsePythonVersion@0
@@ -223,7 +223,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wpt_integration']
   pool:
-    vmImage: 'macOS-12'
+    vmImage: 'macOS-13'
   steps:
   # full checkout required
   - task: UsePythonVersion@0
@@ -478,7 +478,7 @@ jobs:
     parallel: 8 # chosen to make runtime ~2h
   timeoutInMinutes: 180
   pool:
-    vmImage: 'macOS-12'
+    vmImage: 'macOS-13'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -520,7 +520,7 @@ jobs:
     parallel: 8 # chosen to make runtime ~2h
   timeoutInMinutes: 180
   pool:
-    vmImage: 'macOS-12'
+    vmImage: 'macOS-13'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -559,7 +559,7 @@ jobs:
     parallel: 8 # chosen to make runtime ~2h
   timeoutInMinutes: 180
   pool:
-    vmImage: 'macOS-12'
+    vmImage: 'macOS-13'
   steps:
   - task: UsePythonVersion@0
     inputs:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -104,6 +104,7 @@ jobs:
       packages: virtualenv
   - template: tools/ci/azure/install_fonts.yml
   - template: tools/ci/azure/install_certs.yml
+  - template: tools/ci/azure/color_profile.yml
   - template: tools/ci/azure/install_chrome.yml
   - template: tools/ci/azure/install_firefox.yml
   - template: tools/ci/azure/install_safari.yml
@@ -487,6 +488,7 @@ jobs:
     parameters:
       packages: virtualenv
   - template: tools/ci/azure/install_certs.yml
+  - template: tools/ci/azure/color_profile.yml
   - template: tools/ci/azure/install_safari.yml
     parameters:
       channel: stable
@@ -528,6 +530,7 @@ jobs:
     parameters:
       packages: virtualenv
   - template: tools/ci/azure/install_certs.yml
+  - template: tools/ci/azure/color_profile.yml
   - template: tools/ci/azure/install_safari.yml
   - template: tools/ci/azure/update_hosts.yml
   - template: tools/ci/azure/update_manifest.yml
@@ -566,6 +569,7 @@ jobs:
     parameters:
       packages: virtualenv
   - template: tools/ci/azure/install_certs.yml
+  - template: tools/ci/azure/color_profile.yml
   - template: tools/ci/azure/update_hosts.yml
   - template: tools/ci/azure/update_manifest.yml
   - script: |

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -7,3 +7,8 @@ infrastructure is operating correctly:
  * The tests in server/ are designed to test the WPT server configuration
 
  * The tests in expected-fail/ should all fail.
+
+To update the expectations stored in metadata/, you want to use the `wpt`
+tool with an invocation such as `./wpt update-expectations --metadata
+infrastructure/metadata --manifest MANIFEST.json [wptreport.json]` with one
+or more wptreport.json files.

--- a/infrastructure/metadata/infrastructure/testdriver/file_upload.sub.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/file_upload.sub.html.ini
@@ -1,4 +1,6 @@
 [file_upload.sub.html]
+  expected:
+    if product == "safari": TIMEOUT
   [File upload using testdriver]
     expected:
-      if product == "epiphany" or product == "webkit": FAIL
+      if (product == "epiphany") or (product == "webkit"): FAIL

--- a/tools/ci/azure/affected_tests.yml
+++ b/tools/ci/azure/affected_tests.yml
@@ -14,6 +14,7 @@ steps:
   parameters:
     packages: virtualenv
 - template: install_certs.yml
+- template: color_profile.yml
 - template: install_safari.yml
 - template: update_hosts.yml
 - template: update_manifest.yml

--- a/tools/ci/azure/color_profile.yml
+++ b/tools/ci/azure/color_profile.yml
@@ -1,0 +1,5 @@
+steps:
+- script: |
+    ./wpt macos-color-profile
+  displayName: 'Set display color profile'
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))

--- a/tools/ci/commands.json
+++ b/tools/ci/commands.json
@@ -13,6 +13,15 @@
     "help": "Output a hosts file to stdout",
     "virtualenv": false
   },
+  "macos-color-profile": {
+    "path": "macos_color_profile.py",
+    "script": "run",
+    "help": "Change the macOS color profile to sRGB",
+    "virtualenv": true,
+    "requirements": [
+      "requirements_macos_color_profile.txt"
+    ]
+  },
   "regen-certs": {
     "path": "regen_certs.py",
     "script": "run",

--- a/tools/ci/macos_color_profile.py
+++ b/tools/ci/macos_color_profile.py
@@ -1,0 +1,43 @@
+from typing import Any
+
+from Cocoa import NSURL
+from ColorSync import (
+    CGDisplayCreateUUIDFromDisplayID,
+    ColorSyncDeviceSetCustomProfiles,
+    kColorSyncDeviceDefaultProfileID,
+    kColorSyncDisplayDeviceClass,
+)
+from Quartz import (
+    CGGetOnlineDisplayList,
+    kCGErrorSuccess,
+)
+
+
+def set_all_displays(profile_url: NSURL) -> bool:
+    max_displays = 10
+
+    (err, display_ids, display_count) = CGGetOnlineDisplayList(max_displays, None, None)
+    if err != kCGErrorSuccess:
+        raise ValueError(err)
+
+    display_uuids = [CGDisplayCreateUUIDFromDisplayID(d) for d in display_ids]
+
+    for display_uuid in display_uuids:
+        profile_info = {kColorSyncDeviceDefaultProfileID: profile_url}
+
+        success = ColorSyncDeviceSetCustomProfiles(
+            kColorSyncDisplayDeviceClass,
+            display_uuid,
+            profile_info,
+        )
+        if not success:
+            raise Exception(f"failed to set profile on {display_uuid}")
+
+    return True
+
+
+def run(venv: Any, **kwargs: Any) -> None:
+    srgb_profile_url = NSURL.fileURLWithPath_(
+        "/System/Library/ColorSync/Profiles/sRGB Profile.icc"
+    )
+    set_all_displays(srgb_profile_url)

--- a/tools/ci/requirements_macos_color_profile.txt
+++ b/tools/ci/requirements_macos_color_profile.txt
@@ -1,0 +1,4 @@
+pyobjc-core==9.1.1
+pyobjc-framework-Cocoa==9.1.1
+pyobjc-framework-ColorSync==9.1.1
+pyobjc-framework-Quartz==9.1.1

--- a/tools/mypy.ini
+++ b/tools/mypy.ini
@@ -27,6 +27,15 @@ show_error_codes = True
 
 # Ignore missing or untyped libraries.
 
+[mypy-Cocoa.*]
+ignore_missing_imports = True
+
+[mypy-ColorSync.*]
+ignore_missing_imports = True
+
+[mypy-Quartz.*]
+ignore_missing_imports = True
+
 [mypy-github.*]
 ignore_missing_imports = True
 

--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -132,7 +132,14 @@ def create_complete_parser():
     for command in commands:
         props = commands[command]
 
-        venv.install_requirements(*props.get("requirements", []))
+        try:
+            venv.install_requirements(*props.get("requirements", []))
+        except Exception:
+            logging.warning(
+                f"Unable to install requirements ({props['requirements']!r}) for command {command}"
+            )
+            continue
+
 
         subparser = import_command('wpt', command, props)[1]
         if not subparser:


### PR DESCRIPTION
While this doesn't appear to have been announced anywhere, it has once again silently launched at the same time as GitHub Actions gained availability. There seems to be little downside to just doing this now, so let's do it.

https://dev.azure.com/web-platform-tests/wpt/_build/results?buildId=99408&view=results is a STP run, https://dev.azure.com/web-platform-tests/wpt/_build/results?buildId=99411&view=results is a Safari (stable) run.

(These differ only in commit message, not in content.)