### PR TITLE
[wptrunner] Content shell driver uses stdlib `subprocess`

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/actions/wheelScroll.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/wheelScroll.html.ini
@@ -1,3 +1,3 @@
 [wheelScroll.html]
   expected:
-    if product == "epiphany": ERROR
+    if product == "epiphany" or product == "safari": ERROR


### PR DESCRIPTION
Per the [`mozprocess` docs](https://searchfox.org/mozilla-central/diff/3c0bcb202c7573129ce8af7f8bcfffa2389a2bc9/testing/mozbase/mozprocess/mozprocess/processhandler.py#9-10), use `subprocess` instead of `mozprocess`. This cleans up

```
File "C:\b\s\w\ir\.task_template_vpython_cache\vpython\store\python_venv-jmti3st0nsnsdqnkri9ptk6dpk\contents\lib\site-packages\mozprocess\processhandler.py", line 714, in _custom_wait
  raise OSError(
OSError: IO Completion Port failed to signal process shutdown
```

errors currently seen in [the log](https://chromium-swarm.appspot.com/task?id=61d187705a9fc610). All tests still run expectedly with [this](https://ci.chromium.org/ui/p/chromium/builders/try/linux-wpt-content-shell-fyi-rel/1570/overview) [change](https://ci.chromium.org/ui/p/chromium/builders/try/win10-wpt-content-shell-fyi-rel/1259/overview).