### PR TITLE
Fix text-decoration for block containers in layout-2020

### DIFF
--- a/css/css-text-decor/reference/text-decoration-propagation-04-ref.html
+++ b/css/css-text-decor/reference/text-decoration-propagation-04-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>CSS Test reference: text-decoration propagation</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com" />
+<link rel="help" href="https://www.w3.org/TR/css-text-decor-3/#line-decoration">
+<style>
+div { margin: 1em 0 }
+</style>
+<div style="text-decoration: underline">
+  lorem
+</div>
+<div style="text-decoration: underline overline">
+  ipsum
+</div>
+<div style="text-decoration: underline">
+  dolor
+</div>
+<div style="text-decoration: underline overline">
+  sit
+</div>
+<div style="text-decoration: underline overline line-through">
+  amet
+</div>
+<div style="text-decoration: underline overline">
+  consectetur
+</div>
+<div style="text-decoration: underline">
+  adipiscing
+</div>

--- a/css/css-text-decor/text-decoration-propagation-04.html
+++ b/css/css-text-decor/text-decoration-propagation-04.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>CSS Test: text-decoration propagation</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com" />
+<link rel="help" href="https://www.w3.org/TR/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://github.com/servo/servo/issues/29654">
+<link rel="match" href="reference/text-decoration-propagation-04-ref.html">
+<style>
+div { margin: 1em 0 }
+</style>
+<div style="text-decoration: underline">
+  lorem
+  <div style="text-decoration: overline">
+    ipsum
+  </div>
+  dolor
+  <div style="text-decoration: overline">
+    sit
+    <div style="text-decoration: line-through">
+      amet
+    </div>
+    consectetur
+  </div>
+  adipiscing
+</span>


### PR DESCRIPTION
It was only applied to the 1st inline formatting context of a block container. Other IFCs were created with the Default trait, implying TextDecorationLine::NONE.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#29655