### PR TITLE
text-box-trim: Test multiline behavior

### DIFF
--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-001-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-001-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Reference for trimming block-boxes at their first/last formatted lines</title>
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#leading-trim">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="match" href="text-box-trim-half-leading-inline-box-001-ref.html">
+
+<style>
+.div-parent {
+  outline: 1px solid orange;
+  font-family: Ahem;
+  font-size: 20px;
+  line-height: 1;
+  text-box-trim: both;
+}
+</style>
+
+<div class ="div-parent"">
+  <div id="d1"></div>
+  <div id="d2">Testline1<br><br><br>Testline2<br><br><br>Testline3</div>
+</div>

--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-001.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-001.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Tests block boxes's edges are trimmed at text-over/text-under baselines of their first/last formatted lines</title>
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#leading-trim">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="match" href="text-box-trim-half-leading-inline-box-001-ref.html">
+
+<style>
+.div-parent {
+  outline: 1px solid orange;
+  font-family: Ahem;
+  font-size: 20px;
+  line-height: 3;
+  text-box-trim: both;
+}
+</style>
+
+<div class ="div-parent"">
+  <div id="d1"></div>
+  <div id="d2">Testline1<br>Testline2<br>Testline3</div>
+</div>

--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-002-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-002-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>Reference for trimming multi-line text in inline boxes</title>
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#leading-trim">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<style>
+div {
+  border: 1px solid orange;
+  font-size: 20px;
+  line-height: 1;
+}
+
+span {
+  border: 1px solid blue;
+  font-family: Ahem;
+  font-size: 20px;
+  line-height: 1;
+}
+</style>
+
+<div>
+  <span>Testline1<br><br><br>TestLine2<br><br><br>TestLine3</span>
+</div>

--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-002.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-002.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>Tests inline boxes with multi-line text are trimmed at text-over/text-under baselines</title>
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#leading-trim">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="match" href="text-box-trim-half-leading-inline-box-001-ref.html">
+
+<style>
+div {
+  border: 1px solid orange;
+  font-size: 20px;
+  line-height: 1;
+}
+
+span {
+  border: 1px solid blue;
+  font-family: Ahem;
+  font-size: 20px;
+  line-height: 3;
+  text-box-trim: both;
+}
+</style>
+
+<div>
+  <span>Testline1<br>TestLine2<br>TestLine3</span>
+</div>


### PR DESCRIPTION
This PR adds two tests for multiline text to ensure:
1. half-leading should be applied between lines.
2. should not be applied at the text-start/end side of the box.

Following the specification of:
[1] The text-box-edge would be treated as "text" even if we do not specify a non-leading value.
> For [inline boxes](https://w3c.github.io/csswg-drafts/css-display-4/#inline-box): trims the [block-start](https://w3c.github.io/csswg-drafts/css-writing-modes-4/#block-start) side of the box to match its [content edge](https://w3c.github.io/csswg-drafts/css-box-4/#content-edge) to the metric specified by [text-box-edge](http://w3c.github.io/csswg-drafts/css-inline-3/#propdef-text-box-edge) (treating [leading](http://w3c.github.io/csswg-drafts/css-inline-3/#valdef-text-box-edge-leading) as [text](http://w3c.github.io/csswg-drafts/css-inline-3/#valdef-text-box-edge-text)).

[2] For a block container, the first/last formatted line's block-start/end sides should be trimed.
[text-box-edge](http://w3c.github.io/csswg-drafts/css-inline-3/#propdef-text-box-edge) metric of its [root inline box](http://w3c.github.io/csswg-drafts/css-inline-3/#root-inline-box)
> For [block containers](https://w3c.github.io/csswg-drafts/css-display-4/#block-container): trim the [block-start](https://w3c.github.io/csswg-drafts/css-writing-modes-4/#block-start) side of the [first formatted line](https://w3c.github.io/csswg-drafts/css-pseudo-4/#first-formatted-line) to the corresponding [text-box-edge](http://w3c.github.io/csswg-drafts/css-inline-3/#propdef-text-box-edge) metric of its [root inline box](http://w3c.github.io/csswg-drafts/css-inline-3/#root-inline-box).

[3] and discussion thread of:
leading-trim only has an effect by itself in corner cases w3c/csswg-drafts#8473


Demo:
inline box:
https://github.com/Clqsin45/wpt/blob/demosets/linc-demo/text-box-trim/half-leading-002.png

block box:
https://github.com/Clqsin45/wpt/blob/demosets/linc-demo/text-box-trim/half-leading-block-001.png

Doc:
[test case of CSS text-box-trim property](https://docs.google.com/document/d/1eT0xEOrfVI3RhZ6goJLW1yOWHXLBq2tzAYrHe3NIiO8/edit#bookmark=id.nq6ip3dpilgw )