### PR TITLE
Do not launch more processes than the test groups we have

### DIFF
--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -432,8 +432,7 @@ class GroupedSource(TestSource):
             test_queue.put(item)
 
         # Do not launch more workers than the number of groups
-        print(f'#1 groups = f{len(groups)}, kwargs = {kwargs["processes"]}')
-        processes = min(len(groups), kwargs["processes"])
+        processes = max(1, min(len(groups), kwargs["processes"]))
         cls.add_sentinal(test_queue, processes)
         return test_queue, processes
 
@@ -473,8 +472,7 @@ class SingleTestSource(TestSource):
                     num_of_groups += 1
 
         # Do not launch more workers than the number of groups
-        print(f'#2 groups = f{num_of_groups}, kwargs = {kwargs["processes"]}')
-        processes = min(num_of_groups, kwargs["processes"])
+        processes = max(1, min(num_of_groups, kwargs["processes"]))
         cls.add_sentinal(test_queue, processes)
         return test_queue, processes
 
@@ -528,8 +526,7 @@ class GroupFileTestSource(TestSource):
                 num_of_groups += 1
 
         # Do not launch more workers than the number of groups
-        print(f'#3 groups = f{num_of_groups}, kwargs = {kwargs["processes"]}')
-        processes = min(num_of_groups, kwargs["processes"])
+        processes = max(1, min(num_of_groups, kwargs["processes"]))
         cls.add_sentinal(test_queue, processes)
         return test_queue, processes
 

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -404,6 +404,13 @@ class TestSource:
         for _ in range(num_of_workers):
             test_queue.put(TestGroup(None, None, None))
 
+    @classmethod
+    def process_count(cls, requested_processes, num_test_groups):
+        """Get the number of processes to use.
+
+        This must always be at least one, but otherwise not more than the number of test groups"""
+        return max(1, min(requested_processes, num_test_groups))
+
 
 class GroupedSource(TestSource):
     @classmethod
@@ -431,8 +438,7 @@ class GroupedSource(TestSource):
         for item in groups:
             test_queue.put(item)
 
-        # Do not launch more workers than the number of groups
-        processes = max(1, min(len(groups), kwargs["processes"]))
+        processes = cls.process_count(kwargs["processes"], len(groups))
         cls.add_sentinal(test_queue, processes)
         return test_queue, processes
 
@@ -454,7 +460,7 @@ class SingleTestSource(TestSource):
     def make_queue(cls, tests_by_type, **kwargs):
         mp = mpcontext.get_context()
         test_queue = mp.Queue()
-        num_of_groups = 0
+        num_test_groups = 0
         for test_type, tests in tests_by_type.items():
             processes = kwargs["processes"]
             queues = [deque([]) for _ in range(processes)]
@@ -469,10 +475,9 @@ class SingleTestSource(TestSource):
             for item in zip(queues, itertools.repeat(test_type), metadatas):
                 if len(item[0]) > 0:
                     test_queue.put(TestGroup(*item))
-                    num_of_groups += 1
+                    num_test_groups += 1
 
-        # Do not launch more workers than the number of groups
-        processes = max(1, min(num_of_groups, kwargs["processes"]))
+        processes = cls.process_count(kwargs["processes"], num_test_groups)
         cls.add_sentinal(test_queue, processes)
         return test_queue, processes
 
@@ -505,7 +510,7 @@ class GroupFileTestSource(TestSource):
     def make_queue(cls, tests_by_type, **kwargs):
         mp = mpcontext.get_context()
         test_queue = mp.Queue()
-        num_of_groups = 0
+        num_test_groups = 0
 
         for test_type, tests in tests_by_type.items():
             tests_by_group = cls.tests_by_group({test_type: tests},
@@ -523,10 +528,9 @@ class GroupFileTestSource(TestSource):
                     test.update_metadata(group_metadata)
 
                 test_queue.put(TestGroup(group, test_type, group_metadata))
-                num_of_groups += 1
+                num_test_groups += 1
 
-        # Do not launch more workers than the number of groups
-        processes = max(1, min(num_of_groups, kwargs["processes"]))
+        processes = cls.process_count(kwargs["processes"], num_test_groups)
         cls.add_sentinal(test_queue, processes)
         return test_queue, processes
 

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -432,6 +432,7 @@ class GroupedSource(TestSource):
             test_queue.put(item)
 
         # Do not launch more workers than the number of groups
+        print(f'#1 groups = f{len(groups)}, kwargs = {kwargs["processes"]}')
         processes = min(len(groups), kwargs["processes"])
         cls.add_sentinal(test_queue, processes)
         return test_queue, processes
@@ -472,6 +473,7 @@ class SingleTestSource(TestSource):
                     num_of_groups += 1
 
         # Do not launch more workers than the number of groups
+        print(f'#2 groups = f{num_of_groups}, kwargs = {kwargs["processes"]}')
         processes = min(num_of_groups, kwargs["processes"])
         cls.add_sentinal(test_queue, processes)
         return test_queue, processes
@@ -526,6 +528,7 @@ class GroupFileTestSource(TestSource):
                 num_of_groups += 1
 
         # Do not launch more workers than the number of groups
+        print(f'#3 groups = f{num_of_groups}, kwargs = {kwargs["processes"]}')
         processes = min(num_of_groups, kwargs["processes"])
         cls.add_sentinal(test_queue, processes)
         return test_queue, processes

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -889,19 +889,19 @@ class TestRunnerManager(threading.Thread):
 
 
 def make_test_queue(tests, test_source_cls, **test_source_kwargs):
-    queue = test_source_cls.make_queue(tests, **test_source_kwargs)
+    queue, num_of_workers = test_source_cls.make_queue(tests, **test_source_kwargs)
 
     # There is a race condition that means sometimes we continue
     # before the tests have been written to the underlying pipe.
     # Polling the pipe for data here avoids that
     queue._reader.poll(10)
     assert not queue.empty()
-    return queue
+    return queue, num_of_workers
 
 
 class ManagerGroup:
     """Main thread object that owns all the TestRunnerManager threads."""
-    def __init__(self, suite_name, size, test_source_cls, test_source_kwargs,
+    def __init__(self, suite_name, test_source_cls, test_source_kwargs,
                  test_implementation_by_type,
                  rerun=1,
                  pause_after_test=False,
@@ -912,7 +912,6 @@ class ManagerGroup:
                  restart_on_new_group=True,
                  recording=None):
         self.suite_name = suite_name
-        self.size = size
         self.test_source_cls = test_source_cls
         self.test_source_kwargs = test_source_kwargs
         self.test_implementation_by_type = test_implementation_by_type
@@ -940,11 +939,11 @@ class ManagerGroup:
 
     def run(self, tests):
         """Start all managers in the group"""
-        self.logger.debug("Using %i processes" % self.size)
 
-        test_queue = make_test_queue(tests, self.test_source_cls, **self.test_source_kwargs)
+        test_queue, size = make_test_queue(tests, self.test_source_cls, **self.test_source_kwargs)
+        self.logger.info("Using %i child processes" % size)
 
-        for idx in range(self.size):
+        for idx in range(size):
             manager = TestRunnerManager(self.suite_name,
                                         idx,
                                         test_queue,

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 
 import argparse
+import multiprocessing
 import os
 import sys
 from collections import OrderedDict
@@ -13,6 +14,14 @@ from .formatters import chromium, wptreport, wptscreenshot
 
 def abs_path(path):
     return os.path.abspath(os.path.expanduser(path))
+
+
+def cpu_count():
+    cpu_count = multiprocessing.cpu_count()
+    if sys.platform == 'win32':
+        # Use no more than 56 cores on Windows or Python3 may hang.
+        cpu_count = min(cpu_count, 56)
+    return cpu_count
 
 
 def url_or_path(path):
@@ -581,7 +590,7 @@ def check_args(kwargs):
             sys.exit(1)
 
     if kwargs["processes"] is None:
-        kwargs["processes"] = 1
+        kwargs["processes"] = cpu_count()
 
     if kwargs["debugger"] is not None:
         import mozdebug

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 
 import argparse
-import multiprocessing
 import os
 import sys
 from collections import OrderedDict
@@ -14,14 +13,6 @@ from .formatters import chromium, wptreport, wptscreenshot
 
 def abs_path(path):
     return os.path.abspath(os.path.expanduser(path))
-
-
-def cpu_count():
-    cpu_count = multiprocessing.cpu_count()
-    if sys.platform == 'win32':
-        # Use no more than 56 cores on Windows or Python3 may hang.
-        cpu_count = min(cpu_count, 56)
-    return cpu_count
 
 
 def url_or_path(path):
@@ -590,7 +581,7 @@ def check_args(kwargs):
             sys.exit(1)
 
     if kwargs["processes"] is None:
-        kwargs["processes"] = cpu_count()
+        kwargs["processes"] = 1
 
     if kwargs["debugger"] is not None:
         import mozdebug

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -252,7 +252,6 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
                                extra={"run_by_dir": run_test_kwargs["run_by_dir"]})
 
         with ManagerGroup("web-platform-tests",
-                          run_test_kwargs["processes"],
                           test_source_cls,
                           test_source_kwargs,
                           test_implementation_by_type,
@@ -374,8 +373,6 @@ def run_tests(config, test_paths, product, **kwargs):
                                            chunker_kwargs=chunker_kwargs,
                                            test_groups=test_groups,
                                            **kwargs)
-
-        logger.info("Using %i client processes" % kwargs["processes"])
 
         test_status = TestStatus()
         repeat = kwargs["repeat"]


### PR DESCRIPTION
so that we don't launch workers then find no works to do.