### PR TITLE
Make preload links fire `onerror` event on network error

### DIFF
--- a/preload/onerror-event.html
+++ b/preload/onerror-event.html
@@ -16,18 +16,18 @@
     var gibberishFailed = false;
     var fetchFailed = false;
 </script>
-<link rel=preload href="non-existent/dummy.js" as=script onerror="scriptFailed = true;">
-<link rel=preload href="non-existent/dummy.css" as=style onerror="styleFailed = true;">
-<link rel=preload href="non-existent/square.png" as=image onerror="imageFailed = true;">
-<link rel=preload href="non-existent/Ahem.ttf" as=font crossorigin onerror="fontFailed = true;">
-<link rel=preload href="non-existent/test.mp4" as=video onerror="videoFailed = true;">
-<link rel=preload href="non-existent/test.oga" as=audio onerror="audioFailed = true;">
-<link rel=preload href="non-existent/security/captions.vtt" as=track onerror="trackFailed = true;">
-<link rel=preload href="non-existent/dummy.xml?fetch" as=fetch onerror="fetchFailed = true;">
-<link rel=preload href="non-existent/dummy.xml?foo" as=foobarxmlthing onerror="assert_unreached('invalid as value should not fire error event')">
-<link rel=preload href="non-existent/dummy.xml?empty" onerror="assert_unreached('empty as value should not fire error event')">
-<link rel=preload href="non-existent/dummy.xml?media" as=style media=print onerror="assert_unreached('non-matching media should not fire error event')">
-<link rel=preload href="non-existent/dummy.xml?media" as=style type='text/html' onerror="assert_unreached('invalid mime type should not fire error event')">
+<link rel=preload href="http://invalid/dummy.js" as=script onerror="scriptFailed = true;">
+<link rel=preload href="http://invalid/dummy.css" as=style onerror="styleFailed = true;">
+<link rel=preload href="http://invalid/square.png" as=image onerror="imageFailed = true;">
+<link rel=preload href="http://invalid/Ahem.ttf" as=font crossorigin onerror="fontFailed = true;">
+<link rel=preload href="http://invalid/test.mp4" as=video onerror="videoFailed = true;">
+<link rel=preload href="http://invalid/test.oga" as=audio onerror="audioFailed = true;">
+<link rel=preload href="http://invalid/security/captions.vtt" as=track onerror="trackFailed = true;">
+<link rel=preload href="http://invalid/dummy.xml?fetch" as=fetch onerror="fetchFailed = true;">
+<link rel=preload href="http://invalid/dummy.xml?foo" as=foobarxmlthing onerror="assert_unreached('invalid as value should not fire error event')">
+<link rel=preload href="http://invalid/dummy.xml?empty" onerror="assert_unreached('empty as value should not fire error event')">
+<link rel=preload href="http://invalid/dummy.xml?media" as=style media=print onerror="assert_unreached('non-matching media should not fire error event')">
+<link rel=preload href="http://invalid/dummy.xml?media" as=style type='text/html' onerror="assert_unreached('invalid mime type should not fire error event')">
 <body>
 <script>
     setup({single_test: true});


### PR DESCRIPTION
According to whatwg/html#1142 we expect `onerror` event of `<link rel=preload>` to be fired only on network errors and not on `404`.