### PR TITLE
Add tabindex to popover buttons

### DIFF
--- a/html/semantics/popovers/popover-focus-2.html
+++ b/html/semantics/popovers/popover-focus-2.html
@@ -11,23 +11,23 @@
 <script src="resources/popover-utils.js"></script>
 
 <div id=fixup>
-  <button id=button1>Button1</button>
+  <button id=button1 tabindex="0">Button1</button>
   <div popover id=popover1 style="top:100px">
-    <button id=inside_popover1>Inside1</button>
-    <button id=invoker2 popovertarget=popover2>Nested Invoker 2</button>
-    <button id=inside_popover2>Inside2</button>
+    <button id=inside_popover1 tabindex="0">Inside1</button>
+    <button id=invoker2 popovertarget=popover2 tabindex="0">Nested Invoker 2</button>
+    <button id=inside_popover2 tabindex="0">Inside2</button>
   </div>
-  <button id=button2>Button2</button>
-  <button popovertarget=popover1 id=invoker1>Invoker1</button>
-  <button id=button3>Button3</button>
+  <button id=button2 tabindex="0">Button2</button>
+  <button popovertarget=popover1 id=invoker1 tabindex="0">Invoker1</button>
+  <button id=button3 tabindex="0">Button3</button>
   <div popover id=popover2 style="top:200px">
-    <button id=inside_popover3>Inside3</button>
-    <button id=invoker3 popovertarget=popover3>Nested Invoker 3</button>
+    <button id=inside_popover3 tabindex="0">Inside3</button>
+    <button id=invoker3 popovertarget=popover3 tabindex="0">Nested Invoker 3</button>
   </div>
   <div popover id=popover3 style="top:300px">
     Non-focusable popover
   </div>
-  <button id=button4>Button4</button>
+  <button id=button4 tabindex="0">Button4</button>
 </div>
 <style>
   #fixup [popover] {
@@ -90,11 +90,11 @@ promise_test(async t => {
 }, "Popover focus navigation");
 </script>
 
-<button id=circular0 popovertarget=popover4>Invoker</button>
+<button id=circular0 popovertarget=popover4 tabindex="0">Invoker</button>
 <div id=popover4 popover>
-  <button id=circular1 autofocus popovertarget=popover4 popovertargetaction=hide></button>
-  <button id=circular2 popovertarget=popover4 popovertargetaction=show></button>
-  <button id=circular3 popovertarget=popover4></button>
+  <button id=circular1 autofocus popovertarget=popover4 popovertargetaction=hide tabindex="0"></button>
+  <button id=circular2 popovertarget=popover4 popovertargetaction=show tabindex="0"></button>
+  <button id=circular3 popovertarget=popover4 tabindex="0"></button>
 </div>
 <button id=circular4>after</button>
 <script>
@@ -107,9 +107,9 @@ promise_test(async t => {
 </script>
 
 <div id=focus-return1>
-  <button popovertarget=focus-return1-p popovertargetaction=show>Show popover</button>
+  <button popovertarget=focus-return1-p popovertargetaction=show tabindex="0">Show popover</button>
   <div popover id=focus-return1-p>
-    <button popovertarget=focus-return1-p popovertargetaction=hide autofocus>Hide popover</button>
+    <button popovertarget=focus-return1-p popovertargetaction=hide autofocus tabindex="0">Hide popover</button>
   </div>
 </div>
 <script>
@@ -129,8 +129,8 @@ promise_test(async t => {
 </script>
 
 <div id=focus-return2>
-  <button popovertarget=focus-return2-p>Toggle popover</button>
-  <div popover id=focus-return2-p>Popover with <button>focusable element</button></div>
+  <button popovertarget=focus-return2-p tabindex="0">Toggle popover</button>
+  <div popover id=focus-return2-p>Popover with <button tabindex="0">focusable element</button></div>
   <span tabindex=0>Other focusable element</span>
 </div>
 <script>

--- a/html/semantics/popovers/popover-focus.html
+++ b/html/semantics/popovers/popover-focus.html
@@ -13,7 +13,7 @@
 
 <div popover data-test='default behavior - popover is not focused' data-no-focus>
   <p>This is a popover</p>
-  <button>first button</button>
+  <button tabindex="0">first button</button>
 </div>
 
 <div popover data-test='autofocus popover' autofocus tabindex=-1 class=should-be-focused>
@@ -24,29 +24,29 @@
 
 <div popover data-test='autofocus popover with button' autofocus tabindex=-1 class=should-be-focused>
   <p>This is a popover</p>
-  <button>button</button>
+  <button tabindex="0">button</button>
 </div>
 
 <div popover data-test='autofocus child'>
   <p>This is a popover</p>
-  <button autofocus class=should-be-focused>autofocus button</button>
+  <button autofocus class=should-be-focused tabindex="0">autofocus button</button>
 </div>
 
 <div popover data-test='autofocus on tabindex=0 element'>
   <p autofocus tabindex=0 class=should-be-focused>This is a popover with autofocus on a tabindex=0 element</p>
-  <button>button</button>
+  <button tabindex="0">button</button>
 </div>
 
 <div popover data-test='autofocus multiple children'>
   <p>This is a popover</p>
-  <button autofocus class=should-be-focused>autofocus button</button>
-  <button autofocus>second autofocus button</button>
+  <button autofocus class=should-be-focused tabindex="0">autofocus button</button>
+  <button autofocus tabindex="0">second autofocus button</button>
 </div>
 
 <div popover autofocus tabindex=-1 data-test='autofocus popover and multiple autofocus children' class=should-be-focused>
   <p>This is a popover</p>
-  <button autofocus>autofocus button</button>
-  <button autofocus>second autofocus button</button>
+  <button autofocus tabindex="0">autofocus button</button>
+  <button autofocus tabindex="0">second autofocus button</button>
 </div>
 
 <style>
@@ -71,11 +71,13 @@
       button.remove();
     });
     popover.id = popoverId;
+    button.setAttribute('tabindex', '0');
     button.setAttribute('popovertarget', popoverId);
     return button;
   }
   function addPriorFocus(t) {
     const priorFocus = document.createElement('button');
+    priorFocus.setAttribute("tabindex", "0");
     priorFocus.id = 'priorFocus';
     document.body.appendChild(priorFocus);
     t.add_cleanup(() => priorFocus.remove());
@@ -218,6 +220,7 @@
 
       // Same thing, but the button is unrelated (no popovertarget)
       button = document.createElement('button');
+      button.setAttribute("tabindex", "0");
       document.body.appendChild(button);
       priorFocus.focus();
       popover.showPopover();

--- a/html/semantics/popovers/popover-light-dismiss.html
+++ b/html/semantics/popovers/popover-light-dismiss.html
@@ -13,7 +13,7 @@
 
 <button id=b1t popovertarget='p1'>Popover 1</button>
 <button id=b1s popovertarget='p1' popovertargetaction=show>Popover 1</button>
-<button id=p1anchor>Popover1 anchor (no action)</button>
+<button id=p1anchor  tabindex="0">Popover1 anchor (no action)</button>
 <span id=outside>Outside all popovers</span>
 <div popover id=p1 anchor=p1anchor>
   <span id=inside1>Inside popover 1</span>
@@ -23,7 +23,7 @@
 <div popover id=p2 anchor=b2>
   <span id=inside2>Inside popover 2</span>
 </div>
-<button id=after_p1>Next control after popover1</button>
+<button id=after_p1 tabindex="0">Next control after popover1</button>
 <style>
   #p1 {top: 50px;}
   #p2 {top: 120px;}
@@ -332,7 +332,7 @@
 
 <my-element id="myElement">
   <template shadowrootmode="open">
-    <button id=b7 onclick='showPopover7()'>Popover7</button>
+    <button id=b7 onclick='showPopover7()' tabindex="0">Popover7</button>
     <div popover id=p7 anchor=b7 style="top: 100px;">
       <p>Popover content.</p>
       <input id="inside7" type="text" placeholder="some text">
@@ -364,10 +364,10 @@
 </script>
 
 <div popover id=p8 anchor=p8anchor>
-  <button>Button</button>
+  <button tabindex="0">Button</button>
   <span id=inside8after>Inside popover 8 after button</span>
 </div>
-<button id=p8anchor>Popover8 anchor (no action)</button>
+<button id=p8anchor tabindex="0">Popover8 anchor (no action)</button>
 <script>
   promise_test(async () => {
     const popover8 = document.querySelector('#p8');
@@ -398,7 +398,7 @@
 <div popover id=convoluted_p3 anchor=convoluted_anchor>Popover 3
   <button popovertarget=convoluted_p4>Open Popover 4</button>
 </div>
-<button onclick="convoluted_p1.showPopover()">Open convoluted popover</button>
+<button onclick="convoluted_p1.showPopover()" tabindex="0">Open convoluted popover</button>
 <style>
   #convoluted_p1 {top:50px;}
   #convoluted_p2 {top:150px;}
@@ -565,7 +565,7 @@ promise_test(async () => {
 
 <div id=p19 popover>Popover 19</div>
 <div id=p20 popover>Popover 20</div>
-<button id=example2>Example 2</button>
+<button id=example2 tabindex="0">Example 2</button>
 
 <script>
 promise_test(async () => {

--- a/html/semantics/popovers/popover-not-keyboard-focusable.html
+++ b/html/semantics/popovers/popover-not-keyboard-focusable.html
@@ -10,11 +10,11 @@
 <script src="/resources/testdriver-actions.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 
-<button id=firstfocus>Button 1</button>
+<button id=firstfocus tabindex="0">Button 1</button>
 <div popover>
   <p>This is a popover without a focusable element</p>
 </div>
-<button id=secondfocus>Button 2</button>
+<button id=secondfocus tabindex="0">Button 2</button>
 
 <script>
 promise_test(async () => {
@@ -34,6 +34,7 @@ promise_test(async () => {
 
   // Add a focusable button to the popover and make sure we can focus that
   const button = document.createElement('button');
+  button.setAttribute("tabindex", "0");
   popover.appendChild(button);
   b1.focus();
   popover.showPopover();


### PR DESCRIPTION
Add tabindex to popover buttons in order to make them focusable on macOS and pass these tests.