### PR TITLE
docs: Fix testdriver docs, merge duplicated API documentation.

### DIFF
--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -94,7 +94,7 @@ the global scope.
 
 ```
 
-### Seure Payment Confirmation ###
+### Secure Payment Confirmation ###
 ```eval_rst
 .. js:autofunction:: test_driver.set_spc_transaction_mode
 ```
@@ -158,9 +158,9 @@ The requirement to have a handle to the test window does mean it's
 currently not possible to write tests where such handles can't be
 obtained e.g. in the case of `rel=noopener`.
 
-## Actions ##
+### Actions ###
 
-### Markup ###
+#### Markup ####
 
 To use the [Actions](#Actions) API `testdriver-actions.js` must be
 included in the document, in addition to `testdriver.js`:
@@ -169,7 +169,7 @@ included in the document, in addition to `testdriver.js`:
 <script src="/resources/testdriver-actions.js"></script>
 ```
 
-### API ###
+#### API ####
 
 ```eval_rst
 .. js:autoclass:: Actions
@@ -177,7 +177,7 @@ included in the document, in addition to `testdriver.js`:
 ```
 
 
-### Using in other browsing contexts ###
+#### Using in other browsing contexts ####
 
 For the actions API, the context can be set using the `setContext`
 method on the builder:
@@ -194,53 +194,3 @@ Note that if an action uses an element reference, the context will be
 derived from that element, and must match any explicitly set
 context. Using elements in multiple contexts in a single action chain
 is not supported.
-
-### send_keys
-
-Usage: `test_driver.send_keys(element, keys)`
- * _element_: a DOM Element object
- * _keys_: string to send to the element
-
-This function causes the string _keys_ to be sent to the target
-element (an `Element` object), potentially scrolling the document to
-make it possible to send keys. It returns a promise that resolves
-after the keys have been sent, or rejects if the keys cannot be sent
-to the element.
-
-This works with elements in other frames/windows as long as they are
-same-origin with the test, and the test does not depend on the
-window.name property remaining unset on the target window.
-
-Note that if the element that the keys need to be sent to does not have
-a unique ID, the document must not have any DOM mutations made
-between the function being called and the promise settling.
-
-To send special keys, one must send the respective key's codepoint. Since this uses the WebDriver protocol, you can find a [list for code points to special keys in the spec](https://w3c.github.io/webdriver/#keyboard-actions).
-For example, to send the tab key you would send "\uE004".
-
-_Note: these special-key codepoints are not necessarily what you would expect. For example, <kbd>Esc</kbd> is the invalid Unicode character `\uE00C`, not the `\u001B` Escape character from ASCII._
-
-[activation]: https://html.spec.whatwg.org/multipage/interaction.html#activation
-
-### set_permission
-
-Usage: `test_driver.set_permission(descriptor, state, context=null)`
- * _descriptor_: a
-   [PermissionDescriptor](https://w3c.github.io/permissions/#dictdef-permissiondescriptor)
-   or derived object
- * _state_: a
-   [PermissionState](https://w3c.github.io/permissions/#enumdef-permissionstate)
-   value
- * context: a WindowProxy for the browsing context in which to perform the call
-
-This function causes permission requests and queries for the status of a
-certain permission type (e.g. "push", or "background-fetch") to always
-return _state_. It returns a promise that resolves after the permission has
-been set to be overridden with _state_.
-
-Example:
-
-``` js
-await test_driver.set_permission({ name: "background-fetch" }, "denied");
-await test_driver.set_permission({ name: "push", userVisibleOnly: true }, "granted");
-```

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -262,7 +262,9 @@
          * occurs.
          *
          * If ``element`` is from a different browsing context, the
-         * command will be run in that context.
+         * command will be run in that context. The test must not depend
+         * on the ``window.name`` property being unset on the target
+         * window.
          *
          * To send special keys, send the respective key's codepoint,
          * as defined by `WebDriver
@@ -417,8 +419,9 @@
         /**
          * Sets the state of a permission
          *
-         * This function simulates a user setting a permission into a
-         * particular state.
+         * This function causes permission requests and queries for the status
+         * of a certain permission type (e.g. "push", or "background-fetch") to
+         * always return ``state``.
          *
          * Matches the `Set Permission
          * <https://w3c.github.io/permissions/#set-permission-command>`_
@@ -430,8 +433,10 @@
          *
          * @param {PermissionDescriptor} descriptor - a `PermissionDescriptor
          *                              <https://w3c.github.io/permissions/#dom-permissiondescriptor>`_
-         *                              dictionary.
-         * @param {String} state - the state of the permission
+         *                              or derived object.
+         * @param {PermissionState} state - a `PermissionState
+         *                          <https://w3c.github.io/permissions/#dom-permissionstate>`_
+         *                          value.
          * @param {WindowProxy} context - Browsing context in which
          *                                to run the call, or null for the current
          *                                browsing context.


### PR DESCRIPTION
- Fix a typo in one of the subsection names.
- Add an indentation level to the Actions section, it should be under "API". It had also caused everything else coming after it to be under the wrong section.
- Remove the documentation for set_permission() and send_keys() that came after the Actions section. These functions were already documented earlier in the Permissions and User Interaction subsections, respectively, with the contents coming from testdriver.js itself. Some bits and pieces from the testdriver.md documentation was added to the testdriver.js jsdocs.