### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=256171

### DIFF
--- a/css/css-color/color-mix-currentcolor-003-ref.html
+++ b/css/css-color/color-mix-currentcolor-003-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: currentColor is inherited correctly in color-mix()</title>
+<style>
+div {
+    color: color-mix(in srgb, green 50%, white);
+}
+</style>
+<div>
+    <div>This text should be pale green</div>
+</div>

--- a/css/css-color/color-mix-currentcolor-003.html
+++ b/css/css-color/color-mix-currentcolor-003.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="match" href="color-mix-currentcolor-003-ref.html">
+<title>currentColor is inherited correctly in color-mix()</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-5/#color-mix">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<style>
+body {
+    color: green;
+}
+div {
+    color: color-mix(in srgb, currentColor 50%, white);
+}
+div > div {
+    color: inherit;
+}
+</style>
+<div>
+    <div>This text should be pale green</div>
+</div>


### PR DESCRIPTION
WebKit export from bug: [REGRESSION(259145@main): Crash when using 'currentcolor' with color-mix() in color property](https://bugs.webkit.org/show_bug.cgi?id=256171)