### PR TITLE
fix(window_state_context.js): prevent restoring if already minimized.

### DIFF
--- a/page-visibility/resources/window_state_context.js
+++ b/page-visibility/resources/window_state_context.js
@@ -2,12 +2,13 @@ function window_state_context(t) {
     let rect = null;
     let state = "restored";
     t.add_cleanup(async () => {
-        if (state === "minimized")
-            await restore();
+        if (state === "minimized") await restore();
     });
     async function restore() {
-        state = "restored";
+        if (state !== "minimized") return;
+        state = "restoring";
         await test_driver.set_window_rect(rect);
+        state = "restored";
     }
 
     async function minimize() {

--- a/page-visibility/resources/window_state_context.js
+++ b/page-visibility/resources/window_state_context.js
@@ -2,7 +2,7 @@ function window_state_context(t) {
     let rect = null;
     let state = "restored";
     t.add_cleanup(async () => {
-        if (state === "minimized") await restore();
+      if (state === "minimized") await restore();
     });
     async function restore() {
         if (state !== "minimized") return;
@@ -17,22 +17,25 @@ function window_state_context(t) {
     }
 
     function visibilityEventPromise() {
-      return new Promise(resolve => new PerformanceObserver(
-        (entries, observer) => { observer.disconnect(); resolve(); }).observe(
-          {type: "visibility-state"}))
+      return new Promise((resolve) =>
+          new PerformanceObserver((entries, observer) => {
+              observer.disconnect();
+              resolve();
+          }).observe({ type: "visibility-state" })
+      );
     }
 
     async function minimizeAndWait() {
       const promise = visibilityEventPromise();
       await Promise.all([minimize(), promise]);
-      await new Promise(resolve => t.step_timeout(resolve, 0));
+      await new Promise((resolve) => t.step_timeout(resolve, 0));
     }
 
     async function restoreAndWait() {
       const promise = visibilityEventPromise();
       await Promise.all([restore(), promise]);
-      await new Promise(resolve => t.step_timeout(resolve, 0));
+      await new Promise((resolve) => t.step_timeout(resolve, 0));
     }
 
-    return {minimize, restore, minimizeAndWait, restoreAndWait};
+  return { minimize, restore, minimizeAndWait, restoreAndWait };
 }

--- a/page-visibility/resources/window_state_context.js
+++ b/page-visibility/resources/window_state_context.js
@@ -37,5 +37,5 @@ function window_state_context(t) {
       await new Promise((resolve) => t.step_timeout(resolve, 0));
     }
 
-  return { minimize, restore, minimizeAndWait, restoreAndWait };
+    return { minimize, restore, minimizeAndWait, restoreAndWait };
 }

--- a/page-visibility/resources/window_state_context.js
+++ b/page-visibility/resources/window_state_context.js
@@ -1,41 +1,45 @@
 function window_state_context(t) {
-    let rect = null;
-    let state = "restored";
-    t.add_cleanup(async () => {
-      if (state === "minimized") await restore();
-    });
-    async function restore() {
-        if (state !== "minimized") return;
-        state = "restoring";
-        await test_driver.set_window_rect(rect);
-        state = "restored";
+  let rect = null;
+  let state = "restored";
+  t.add_cleanup(async () => {
+    if (state === "minimized") {
+      await restore();
     }
-
-    async function minimize() {
-        state = "minimized";
-        rect = await test_driver.minimize_window();
+  });
+  async function restore() {
+    if (state !== "minimized") {
+      return;
     }
+    state = "restoring";
+    await test_driver.set_window_rect(rect);
+    state = "restored";
+  }
 
-    function visibilityEventPromise() {
-      return new Promise((resolve) =>
-          new PerformanceObserver((entries, observer) => {
-              observer.disconnect();
-              resolve();
-          }).observe({ type: "visibility-state" })
-      );
-    }
+  async function minimize() {
+    state = "minimized";
+    rect = await test_driver.minimize_window();
+  }
 
-    async function minimizeAndWait() {
-      const promise = visibilityEventPromise();
-      await Promise.all([minimize(), promise]);
-      await new Promise((resolve) => t.step_timeout(resolve, 0));
-    }
+  function visibilityEventPromise() {
+    return new Promise((resolve) =>
+      new PerformanceObserver((entries, observer) => {
+        observer.disconnect();
+        resolve();
+      }).observe({ type: "visibility-state" })
+    );
+  }
 
-    async function restoreAndWait() {
-      const promise = visibilityEventPromise();
-      await Promise.all([restore(), promise]);
-      await new Promise((resolve) => t.step_timeout(resolve, 0));
-    }
+  async function minimizeAndWait() {
+    const promise = visibilityEventPromise();
+    await Promise.all([minimize(), promise]);
+    await new Promise((resolve) => t.step_timeout(resolve, 0));
+  }
 
-    return { minimize, restore, minimizeAndWait, restoreAndWait };
+  async function restoreAndWait() {
+    const promise = visibilityEventPromise();
+    await Promise.all([restore(), promise]);
+    await new Promise((resolve) => t.step_timeout(resolve, 0));
+  }
+
+  return { minimize, restore, minimizeAndWait, restoreAndWait };
 }


### PR DESCRIPTION
Line 8 in particular fixed some tests that were accidentally restoring multiple times. 

The rest is just style fixes. 