### PR TITLE
[wptrunner] Add `--enable-sanitizer` to run all tests as crashtests

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -6,18 +6,20 @@ from .base import NullBrowser  # noqa: F401
 from .base import get_timeout_multiplier   # noqa: F401
 from .base import cmd_arg
 from ..executors import executor_kwargs as base_executor_kwargs
-from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
-                                           WebDriverRefTestExecutor,  # noqa: F401
-                                           WebDriverCrashtestExecutor)  # noqa: F401
+from ..executors.executorwebdriver import WebDriverCrashtestExecutor  # noqa: F401
 from ..executors.base import WdspecExecutor  # noqa: F401
-from ..executors.executorchrome import ChromeDriverPrintRefTestExecutor  # noqa: F401
+from ..executors.executorchrome import (  # noqa: F401
+    ChromeDriverPrintRefTestExecutor,
+    ChromeDriverRefTestExecutor,
+    ChromeDriverTestharnessExecutor,
+)
 
 
 __wptrunner__ = {"product": "chrome",
                  "check_args": "check_args",
                  "browser": "ChromeBrowser",
-                 "executor": {"testharness": "WebDriverTestharnessExecutor",
-                              "reftest": "WebDriverRefTestExecutor",
+                 "executor": {"testharness": "ChromeDriverTestharnessExecutor",
+                              "reftest": "ChromeDriverRefTestExecutor",
                               "print-reftest": "ChromeDriverPrintRefTestExecutor",
                               "wdspec": "WdspecExecutor",
                               "crashtest": "WebDriverCrashtestExecutor"},
@@ -27,6 +29,7 @@ __wptrunner__ = {"product": "chrome",
                  "env_options": "env_options",
                  "update_properties": "update_properties",
                  "timeout_multiplier": "get_timeout_multiplier",}
+
 
 def check_args(**kwargs):
     require_arg(kwargs, "webdriver_binary")
@@ -40,10 +43,14 @@ def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
 
 def executor_kwargs(logger, test_type, test_environment, run_info_data,
                     **kwargs):
+    sanitizer_enabled = kwargs.get("sanitizer_enabled")
+    if sanitizer_enabled:
+        test_type = "crashtest"
     executor_kwargs = base_executor_kwargs(test_type, test_environment, run_info_data,
                                            **kwargs)
     executor_kwargs["close_after_done"] = True
     executor_kwargs["supports_eager_pageload"] = False
+    executor_kwargs["sanitizer_enabled"] = sanitizer_enabled
 
     capabilities = {
         "goog:chromeOptions": {

--- a/tools/wptrunner/wptrunner/browsers/content_shell.py
+++ b/tools/wptrunner/wptrunner/browsers/content_shell.py
@@ -63,8 +63,12 @@ def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
 
 def executor_kwargs(logger, test_type, test_environment, run_info_data,
                     **kwargs):
+    sanitizer_enabled = kwargs.get("sanitizer_enabled")
+    if sanitizer_enabled:
+        test_type = "crashtest"
     executor_kwargs = base_executor_kwargs(test_type, test_environment, run_info_data,
                                            **kwargs)
+    executor_kwargs["sanitizer_enabled"] = sanitizer_enabled
     return executor_kwargs
 
 

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -7,7 +7,6 @@ from urllib.parse import urljoin
 
 from .base import (
     CrashtestExecutor,
-    TestExecutor,
     TestharnessExecutor,
     get_pages,
 )
@@ -23,9 +22,9 @@ from .protocol import PrintProtocolPart
 here = os.path.dirname(__file__)
 
 
-def make_sanitizer_mixin(crashtest_executor_cls: Type[CrashtestExecutor]):
+def make_sanitizer_mixin(crashtest_executor_cls: Type[CrashtestExecutor]):  # type: ignore[no-untyped-def]
     class SanitizerMixin:
-        def __new__(cls, logger, browser, **kwargs) -> Type[TestExecutor]:
+        def __new__(cls, logger, browser, **kwargs):
             # Overriding `__new__` is the least worst way we can force tests to run
             # as crashtests at runtime while still supporting:
             #   * Class attributes (e.g., `extra_timeout`)
@@ -58,11 +57,11 @@ def make_sanitizer_mixin(crashtest_executor_cls: Type[CrashtestExecutor]):
 _SanitizerMixin = make_sanitizer_mixin(WebDriverCrashtestExecutor)
 
 
-class ChromeDriverRefTestExecutor(WebDriverRefTestExecutor, _SanitizerMixin):
+class ChromeDriverRefTestExecutor(WebDriverRefTestExecutor, _SanitizerMixin):  # type: ignore
     pass
 
 
-class ChromeDriverTestharnessExecutor(WebDriverTestharnessExecutor, _SanitizerMixin):
+class ChromeDriverTestharnessExecutor(WebDriverTestharnessExecutor, _SanitizerMixin):  # type: ignore
     pass
 
 

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -2,14 +2,68 @@
 
 import os
 import traceback
-
+from typing import Type
 from urllib.parse import urljoin
 
-from .base import get_pages
-from .executorwebdriver import WebDriverProtocol, WebDriverRefTestExecutor, WebDriverRun
+from .base import (
+    CrashtestExecutor,
+    TestExecutor,
+    TestharnessExecutor,
+    get_pages,
+)
+from .executorwebdriver import (
+    WebDriverCrashtestExecutor,
+    WebDriverProtocol,
+    WebDriverRefTestExecutor,
+    WebDriverRun,
+    WebDriverTestharnessExecutor,
+)
 from .protocol import PrintProtocolPart
 
 here = os.path.dirname(__file__)
+
+
+def make_sanitizer_mixin(crashtest_executor_cls: Type[CrashtestExecutor]):
+    class SanitizerMixin:
+        def __new__(cls, logger, browser, **kwargs) -> Type[TestExecutor]:
+            # Overriding `__new__` is the least worst way we can force tests to run
+            # as crashtests at runtime while still supporting:
+            #   * Class attributes (e.g., `extra_timeout`)
+            #   * Pickleability for `multiprocessing` transport
+            #   * The `__wptrunner__` product interface
+            #
+            # These requirements rule out approaches with `functools.partial(...)`
+            # or global variables.
+            if kwargs.get("sanitizer_enabled"):
+                executor = crashtest_executor_cls(logger, browser, **kwargs)
+
+                def convert_from_crashtest_result(test, result):
+                    if issubclass(cls, TestharnessExecutor):
+                        status = result["status"]
+                        if status == "PASS":
+                            status = "OK"
+                        harness_result = test.result_cls(status, result["message"])
+                        # Don't report subtests.
+                        return harness_result, []
+                    # `crashtest` statuses are a subset of `(print-)reftest`
+                    # ones, so no extra conversion necessary.
+                    return cls.convert_result(executor, test, result)
+
+                executor.convert_result = convert_from_crashtest_result
+                return executor
+            return super().__new__(cls)
+    return SanitizerMixin
+
+
+_SanitizerMixin = make_sanitizer_mixin(WebDriverCrashtestExecutor)
+
+
+class ChromeDriverRefTestExecutor(WebDriverRefTestExecutor, _SanitizerMixin):
+    pass
+
+
+class ChromeDriverTestharnessExecutor(WebDriverTestharnessExecutor, _SanitizerMixin):
+    pass
 
 
 class ChromeDriverPrintProtocolPart(PrintProtocolPart):
@@ -67,7 +121,7 @@ class ChromeDriverProtocol(WebDriverProtocol):
     implements = WebDriverProtocol.implements + [ChromeDriverPrintProtocolPart]
 
 
-class ChromeDriverPrintRefTestExecutor(WebDriverRefTestExecutor):
+class ChromeDriverPrintRefTestExecutor(ChromeDriverRefTestExecutor):
     protocol_cls = ChromeDriverProtocol
 
     def setup(self, runner):

--- a/tools/wptrunner/wptrunner/executors/executorcontentshell.py
+++ b/tools/wptrunner/wptrunner/executors/executorcontentshell.py
@@ -207,7 +207,7 @@ class ContentShellCrashtestExecutor(CrashtestExecutor):
 _SanitizerMixin = make_sanitizer_mixin(ContentShellCrashtestExecutor)
 
 
-class ContentShellRefTestExecutor(RefTestExecutor, _SanitizerMixin):
+class ContentShellRefTestExecutor(RefTestExecutor, _SanitizerMixin):  # type: ignore
     def __init__(self, logger, browser, server_config, timeout_multiplier=1, screenshot_cache=None,
             debug_info=None, reftest_screenshot="unexpected", **kwargs):
         super().__init__(logger, browser, server_config, timeout_multiplier, screenshot_cache,
@@ -253,7 +253,7 @@ class ContentShellPrintRefTestExecutor(ContentShellRefTestExecutor):
     is_print = True
 
 
-class ContentShellTestharnessExecutor(TestharnessExecutor, _SanitizerMixin):
+class ContentShellTestharnessExecutor(TestharnessExecutor, _SanitizerMixin):  # type: ignore
     def __init__(self, logger, browser, server_config, timeout_multiplier=1, debug_info=None,
             **kwargs):
         super().__init__(logger, browser, server_config, timeout_multiplier, debug_info, **kwargs)

--- a/tools/wptrunner/wptrunner/executors/executorcontentshell.py
+++ b/tools/wptrunner/wptrunner/executors/executorcontentshell.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 
 from .base import RefTestExecutor, RefTestImplementation, CrashtestExecutor, TestharnessExecutor
+from .executorchrome import make_sanitizer_mixin
 from .protocol import Protocol, ProtocolPart
 from time import time
 from queue import Empty
@@ -188,7 +189,25 @@ def _convert_exception(test, exception, errors):
     raise exception
 
 
-class ContentShellRefTestExecutor(RefTestExecutor):
+class ContentShellCrashtestExecutor(CrashtestExecutor):
+    def __init__(self, logger, browser, server_config, timeout_multiplier=1, debug_info=None,
+            **kwargs):
+        super().__init__(logger, browser, server_config, timeout_multiplier, debug_info, **kwargs)
+        self.protocol = ContentShellProtocol(self, browser)
+
+    def do_test(self, test):
+        try:
+            _ = self.protocol.content_shell_test.do_test(self.test_url(test), test.timeout * self.timeout_multiplier)
+            self.protocol.content_shell_errors.read_errors()
+            return self.convert_result(test, {"status": "PASS", "message": None})
+        except BaseException as exception:
+            return _convert_exception(test, exception, self.protocol.content_shell_errors.read_errors())
+
+
+_SanitizerMixin = make_sanitizer_mixin(ContentShellCrashtestExecutor)
+
+
+class ContentShellRefTestExecutor(RefTestExecutor, _SanitizerMixin):
     def __init__(self, logger, browser, server_config, timeout_multiplier=1, screenshot_cache=None,
             debug_info=None, reftest_screenshot="unexpected", **kwargs):
         super().__init__(logger, browser, server_config, timeout_multiplier, screenshot_cache,
@@ -234,22 +253,7 @@ class ContentShellPrintRefTestExecutor(ContentShellRefTestExecutor):
     is_print = True
 
 
-class ContentShellCrashtestExecutor(CrashtestExecutor):
-    def __init__(self, logger, browser, server_config, timeout_multiplier=1, debug_info=None,
-            **kwargs):
-        super().__init__(logger, browser, server_config, timeout_multiplier, debug_info, **kwargs)
-        self.protocol = ContentShellProtocol(self, browser)
-
-    def do_test(self, test):
-        try:
-            _ = self.protocol.content_shell_test.do_test(self.test_url(test), test.timeout * self.timeout_multiplier)
-            self.protocol.content_shell_errors.read_errors()
-            return self.convert_result(test, {"status": "PASS", "message": None})
-        except BaseException as exception:
-            return _convert_exception(test, exception, self.protocol.content_shell_errors.read_errors())
-
-
-class ContentShellTestharnessExecutor(TestharnessExecutor):
+class ContentShellTestharnessExecutor(TestharnessExecutor, _SanitizerMixin):
     def __init__(self, logger, browser, server_config, timeout_multiplier=1, debug_info=None,
             **kwargs):
         super().__init__(logger, browser, server_config, timeout_multiplier, debug_info, **kwargs)

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -362,6 +362,11 @@ scheme host and port.""")
     chrome_group.add_argument("--no-enable-experimental", action="store_false", dest="enable_experimental",
                               help="Do not enable --enable-experimental-web-platform-features flag "
                               "on experimental channels")
+    chrome_group.add_argument(
+        "--enable-sanitizer",
+        action="store_true",
+        dest="sanitizer_enabled",
+        help="Only alert on sanitizer-related errors and crashes.")
 
     sauce_group = parser.add_argument_group("Sauce Labs-specific")
     sauce_group.add_argument("--sauce-browser", dest="sauce_browser",


### PR DESCRIPTION
Chromium's `run_web_tests.py` has an [`--enable-sanitizer` flag](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/tools/blinkpy/web_tests/controllers/single_test_runner.py;l=111-113;drc=2e06a18bfbbf569054f422a7c358c5920a5fd5c5;bpv=0;bpt=0) to run all tests as crash tests. Chromium CI enables this flag for sanitized builds of `chrome`/`content_shell` to reduce noise from functional test failures, which are redundant with those from nonsanitized builds.

In [crrev.com/c/4099689](crrev.com/c/4099689), this flag was added to the Chromium wptrunner results processor, but this could lead to an inconsistent exit code (nonzero, but no test failures). This change promotes the flag to a Chrome-specific native wptrunner flag to actually run tests as crashtests, since result reporting and evaluating test runs is a core harness responsibility.

Fixes [crbug.com/1427892](crbug.com/1427892)