### PR TITLE
HTML-AAM should map <i> computedrole to emphasis

### DIFF
--- a/html-aam/roles.html
+++ b/html-aam/roles.html
@@ -98,7 +98,7 @@
 <hgroup data-testname="el-hgroup" data-expectedrole="group" class="ex"><h1>x</h1></hgroup>
 <hr data-testname="el-hr" data-expectedrole="separator" class="ex">
 <!-- todo: html -->
-<i data-testname="el-i" data-expectedrole="generic" class="ex">x</i>
+<i data-testname="el-i" data-expectedrole="emphasis" class="ex">x</i>
 <!-- todo: iframe -->
 <img src="#" alt="x" data-testname="el-img" data-expectedrole="image" class="ex">
 


### PR DESCRIPTION
Resolves https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/39