### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=255023

### DIFF
--- a/css/css-grid/masonry/tentative/item-placement/masonry-rows-with-grid-width-changed-ref.html
+++ b/css/css-grid/masonry/tentative/item-placement/masonry-rows-with-grid-width-changed-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-3">
+<meta name="assert" content="When the width of the masonry grid changes, items are repositioned with correct offsets and are not overlapping">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+grid {
+    display: grid;
+    width: 1%;
+    grid-template-rows: masonry;
+    grid-template-columns: auto;
+    grid-gap: 10px;
+    font-family: Ahem;
+    font-size: 40px;
+}
+item {
+    background-color: grey;
+}
+</style>
+</head>
+<body>
+  <grid>
+    <item>Hello, world!</item>
+    <item>2</item>
+  </grid>
+</body>
+</html>

--- a/css/css-grid/masonry/tentative/item-placement/masonry-rows-with-grid-width-changed.html
+++ b/css/css-grid/masonry/tentative/item-placement/masonry-rows-with-grid-width-changed.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-3">
+<link rel="match" href="masonry-rows-with-grid-width-changed-ref.html">
+<meta name="assert" content="When the width of the masonry grid changes, items are repositioned with correct offsets and are not overlapping">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  grid {
+    display: grid;
+    grid-template-rows: masonry;
+    grid-template-columns: auto;
+    grid-gap: 10px;
+    font-family: Ahem;
+    font-size: 40px;
+  }
+  item {
+    background-color: grey;
+  }
+</style>
+</head>
+<body>
+  <grid>
+    <item>Hello, world!</item>
+    <item>2</item>
+  </grid>
+</body>
+<script>
+  // Make sure layout occurs and then mutate the style to retrigger it
+  document.body.offsetHeight;
+  document.querySelector("grid").style["width"] = "1%";
+</script>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[css-grid\] Masonry layout is not recalculated when grid contents change](https://bugs.webkit.org/show_bug.cgi?id=255023)