### PR TITLE
WebCryptoAPI: test secret/private importKey empty usages rejections

### DIFF
--- a/WebCryptoAPI/generateKey/failures.js
+++ b/WebCryptoAPI/generateKey/failures.js
@@ -204,7 +204,7 @@ function run_test(algorithmNames) {
     });
 
 
-    // The last thing that should be checked is an empty usages (for secret keys).
+    // The last thing that should be checked is empty usages (disallowed for secret and private keys).
     testVectors.forEach(function(vector) {
         var name = vector.name;
 

--- a/WebCryptoAPI/import_export/ec_importKey.https.any.js
+++ b/WebCryptoAPI/import_export/ec_importKey.https.any.js
@@ -85,14 +85,13 @@
                 });
 
                 // Next, test private keys
-                allValidUsages(vector.privateUsages, []).forEach(function(usages) {
-                    ['pkcs8', 'jwk'].forEach(function(format) {
-                        var algorithm = {name: vector.name, namedCurve: curve};
-                        var data = keyData[curve];
-
+                ['pkcs8', 'jwk'].forEach(function(format) {
+                    var algorithm = {name: vector.name, namedCurve: curve};
+                    var data = keyData[curve];
+                    allValidUsages(vector.privateUsages, []).forEach(function(usages) {
                         testFormat(format, algorithm, data, curve, usages, extractable);
-                        testEmptyUsages(format, algorithm, data, curve, extractable);
                     });
+                    testEmptyUsages(format, algorithm, data, curve, extractable);
                 });
             });
 

--- a/WebCryptoAPI/import_export/ec_importKey.https.any.js
+++ b/WebCryptoAPI/import_export/ec_importKey.https.any.js
@@ -91,6 +91,7 @@
                         var data = keyData[curve];
 
                         testFormat(format, algorithm, data, curve, usages, extractable);
+                        testEmptyUsages(format, algorithm, data, curve, extractable);
                     });
                 });
             });
@@ -134,6 +135,21 @@
                 }
             });
         }, "Good parameters: " + keySize.toString() + " bits " + parameterString(format, compressed, keyData, algorithm, extractable, usages));
+    }
+
+    // Test importKey with a given key format and other parameters but with empty usages.
+    // Should fail with SyntaxError
+    function testEmptyUsages(format, algorithm, data, keySize, extractable) {
+        const keyData = data[format];
+        const usages = [];
+        promise_test(function(test) {
+            return subtle.importKey(format, keyData, algorithm, extractable, usages).
+            then(function(key) {
+                assert_unreached("importKey succeeded but should have failed with SyntaxError");
+            }, function(err) {
+                assert_equals(err.name, "SyntaxError", "Should throw correct error, not " + err.name + ": " + err.message);
+            });
+        }, "Empty Usages: " + keySize.toString() + " bits " + parameterString(format, false, keyData, algorithm, extractable, usages));
     }
 
 

--- a/WebCryptoAPI/import_export/okp_importKey_failures.js
+++ b/WebCryptoAPI/import_export/okp_importKey_failures.js
@@ -132,6 +132,19 @@ function run_test(algorithmNames) {
         });
     });
 
+    // Algorithms normalize okay, but usages bad (empty).
+    // Should fail due to SyntaxError
+    testVectors.forEach(function(vector) {
+        var name = vector.name;
+        validKeyData.filter((test) => test.format === 'pkcs8' || (test.format === 'jwk' && test.data.d)).forEach(function(test) {
+            allAlgorithmSpecifiersFor(name).forEach(function(algorithm) {
+                [true, false].forEach(function(extractable) {
+                    testError(test.format, algorithm, test.data, name, [/* Empty usages */], extractable, "SyntaxError", "Empty usages");
+                });
+            });
+        });
+    });
+
     // Algorithms normalize okay, usages ok. The length of the key must thouw a DataError exception.
     testVectors.forEach(function(vector) {
         var name = vector.name;

--- a/WebCryptoAPI/import_export/rsa_importKey.https.any.js
+++ b/WebCryptoAPI/import_export/rsa_importKey.https.any.js
@@ -92,14 +92,13 @@
                     });
 
                     // Next, test private keys
-                    allValidUsages(vector.privateUsages, []).forEach(function(usages) {
-                        ['pkcs8', 'jwk'].forEach(function(format) {
-                            var algorithm = {name: vector.name, hash: hash};
-                            var data = keyData[size];
-
+                    ['pkcs8', 'jwk'].forEach(function(format) {
+                        var algorithm = {name: vector.name, hash: hash};
+                        var data = keyData[size];
+                        allValidUsages(vector.privateUsages, []).forEach(function(usages) {
                             testFormat(format, algorithm, data, size, usages, extractable);
-                            testEmptyUsages(format, algorithm, data, size, extractable);
                         });
+                        testEmptyUsages(format, algorithm, data, size, extractable);
                     });
                 });
             });

--- a/WebCryptoAPI/import_export/rsa_importKey.https.any.js
+++ b/WebCryptoAPI/import_export/rsa_importKey.https.any.js
@@ -98,6 +98,7 @@
                             var data = keyData[size];
 
                             testFormat(format, algorithm, data, size, usages, extractable);
+                            testEmptyUsages(format, algorithm, data, size, extractable);
                         });
                     });
                 });
@@ -133,6 +134,20 @@
                 assert_unreached("Threw an unexpected error: " + err.toString());
             });
         }, "Good parameters: " + keySize.toString() + " bits " + parameterString(format, keyData[format], algorithm, extractable, usages));
+    }
+
+    // Test importKey with a given key format and other parameters but with empty usages.
+    // Should fail with SyntaxError
+    function testEmptyUsages(format, algorithm, keyData, keySize, extractable) {
+        const usages = [];
+        promise_test(function(test) {
+            return subtle.importKey(format, keyData[format], algorithm, extractable, usages).
+            then(function(key) {
+                assert_unreached("importKey succeeded but should have failed with SyntaxError");
+            }, function(err) {
+                assert_equals(err.name, "SyntaxError", "Should throw correct error, not " + err.name + ": " + err.message);
+            });
+        }, "Empty Usages: " + keySize.toString() + " bits " + parameterString(format, keyData, algorithm, extractable, usages));
     }
 
 

--- a/WebCryptoAPI/import_export/symmetric_importKey.https.any.js
+++ b/WebCryptoAPI/import_export/symmetric_importKey.https.any.js
@@ -41,18 +41,18 @@
         }
 
         rawKeyData.forEach(function(keyData) {
-            // Generate all combinations of valid usages for testing
-            allValidUsages(vector.legalUsages, []).forEach(function(usages) {
-                // Try each legal value of the extractable parameter
-                vector.extractable.forEach(function(extractable) {
-                    vector.formats.forEach(function(format) {
-                        var data = keyData;
-                        if (format === "jwk") {
-                            data = jwkData(keyData, algorithm);
-                        }
+            // Try each legal value of the extractable parameter
+            vector.extractable.forEach(function(extractable) {
+                vector.formats.forEach(function(format) {
+                    var data = keyData;
+                    if (format === "jwk") {
+                        data = jwkData(keyData, algorithm);
+                    }
+                    // Generate all combinations of valid usages for testing
+                    allValidUsages(vector.legalUsages, []).forEach(function(usages) {
                         testFormat(format, algorithm, data, keyData.length * 8, usages, extractable);
-                        testEmptyUsages(format, algorithm, data, keyData.length * 8, extractable);
                     });
+                    testEmptyUsages(format, algorithm, data, keyData.length * 8, extractable);
                 });
             });
 

--- a/WebCryptoAPI/import_export/symmetric_importKey.https.any.js
+++ b/WebCryptoAPI/import_export/symmetric_importKey.https.any.js
@@ -51,6 +51,7 @@
                             data = jwkData(keyData, algorithm);
                         }
                         testFormat(format, algorithm, data, keyData.length * 8, usages, extractable);
+                        testEmptyUsages(format, algorithm, data, keyData.length * 8, extractable);
                     });
                 });
             });
@@ -88,6 +89,20 @@
                 assert_unreached("Threw an unexpected error: " + err.toString());
             });
         }, "Good parameters: " + keySize.toString() + " bits " + parameterString(format, keyData, algorithm, extractable, usages));
+    }
+
+    // Test importKey with a given key format and other parameters but with empty usages.
+    // Should fail with SyntaxError
+    function testEmptyUsages(format, algorithm, keyData, keySize, extractable) {
+        const usages = [];
+        promise_test(function(test) {
+            return subtle.importKey(format, keyData, algorithm, extractable, usages).
+            then(function(key) {
+                assert_unreached("importKey succeeded but should have failed with SyntaxError");
+            }, function(err) {
+                assert_equals(err.name, "SyntaxError", "Should throw correct error, not " + err.name + ": " + err.message);
+            });
+        }, "Empty Usages: " + keySize.toString() + " bits " + parameterString(format, keyData, algorithm, extractable, usages));
     }
 
 


### PR DESCRIPTION
Adds importKey negative tests for empty usages as per [importKey steps](https://w3c.github.io/webcrypto/#SubtleCrypto-method-importKey:~:text=and%20usages.-,If%20the%20%5B%5Btype%5D%5D%20internal%20slot%20of%20result%20is%20%22secret%22%20or%20%22private%22%20and%20usages%20is%20empty%2C%20then%20throw%20a%20SyntaxError.,-Set%20the%20%5B%5Bextractable).