### PR TITLE
[wptrunner] Remove obsolete testharness `supports_eager_pageload=False` workaround

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/actions/wheelScroll.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/wheelScroll.html.ini
@@ -1,3 +1,3 @@
 [wheelScroll.html]
   expected:
-    if product == "epiphany" or product == "safari": ERROR
+    if product == "epiphany": ERROR

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -49,7 +49,6 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     executor_kwargs = base_executor_kwargs(test_type, test_environment, run_info_data,
                                            **kwargs)
     executor_kwargs["close_after_done"] = True
-    executor_kwargs["supports_eager_pageload"] = False
     executor_kwargs["sanitizer_enabled"] = sanitizer_enabled
 
     capabilities = {
@@ -65,9 +64,6 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
             "w3c": True
         }
     }
-
-    if test_type == "testharness":
-        capabilities["pageLoadStrategy"] = "none"
 
     chrome_options = capabilities["goog:chromeOptions"]
     if kwargs["binary"] is not None:

--- a/tools/wptrunner/wptrunner/browsers/edgechromium.py
+++ b/tools/wptrunner/wptrunner/browsers/edgechromium.py
@@ -39,7 +39,6 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
                                            run_info_data,
                                            **kwargs)
     executor_kwargs["close_after_done"] = True
-    executor_kwargs["supports_eager_pageload"] = False
 
     capabilities = {
         "ms:edgeOptions": {
@@ -55,9 +54,6 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
             "w3c": True
         }
     }
-
-    if test_type == "testharness":
-        capabilities["pageLoadStrategy"] = "none"
 
     for (kwarg, capability) in [("binary", "binary"), ("binary_args", "args")]:
         if kwargs[kwarg] is not None:

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -205,6 +205,7 @@ class SeleniumCookiesProtocolPart(CookiesProtocolPart):
         except exceptions.NoSuchCookieException:
             return None
 
+
 class SeleniumWindowProtocolPart(WindowProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
@@ -217,6 +218,7 @@ class SeleniumWindowProtocolPart(WindowProtocolPart):
     def set_rect(self, rect):
         self.logger.info("Setting window rect")
         self.webdriver.window.rect = rect
+
 
 class SeleniumSendKeysProtocolPart(SendKeysProtocolPart):
     def setup(self):
@@ -333,7 +335,7 @@ class SeleniumTestharnessExecutor(TestharnessExecutor):
 
     def __init__(self, logger, browser, server_config, timeout_multiplier=1,
                  close_after_done=True, capabilities=None, debug_info=None,
-                 supports_eager_pageload=True, **kwargs):
+                 **kwargs):
         """Selenium-based executor for testharness.js tests"""
         TestharnessExecutor.__init__(self, logger, browser, server_config,
                                      timeout_multiplier=timeout_multiplier,
@@ -343,7 +345,6 @@ class SeleniumTestharnessExecutor(TestharnessExecutor):
             self.script_resume = f.read()
         self.close_after_done = close_after_done
         self.window_id = str(uuid.uuid4())
-        self.supports_eager_pageload = supports_eager_pageload
 
     def is_alive(self):
         return self.protocol.is_alive()
@@ -381,9 +382,6 @@ class SeleniumTestharnessExecutor(TestharnessExecutor):
 
         protocol.base.load(url)
 
-        if not self.supports_eager_pageload:
-            self.wait_for_load(protocol)
-
         handler = CallbackHandler(self.logger, protocol, test_window)
         while True:
             result = protocol.base.execute_script(
@@ -392,29 +390,6 @@ class SeleniumTestharnessExecutor(TestharnessExecutor):
             if done:
                 break
         return rv
-
-    def wait_for_load(self, protocol):
-        # pageLoadStrategy=eager doesn't work in Chrome so try to emulate in user script
-        loaded = False
-        seen_error = False
-        while not loaded:
-            try:
-                loaded = protocol.base.execute_script("""
-var callback = arguments[arguments.length - 1];
-if (location.href === "about:blank") {
-  callback(false);
-} else if (document.readyState !== "loading") {
-  callback(true);
-} else {
-  document.addEventListener("readystatechange", () => {if (document.readyState !== "loading") {callback(true)}});
-}""", asynchronous=True)
-            except Exception:
-                # We can get an error here if the script runs in the initial about:blank
-                # document before it has navigated, with the driver returning an error
-                # indicating that the document was unloaded
-                if seen_error:
-                    raise
-                seen_error = True
 
 
 class SeleniumRefTestExecutor(RefTestExecutor):

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -226,6 +226,7 @@ class WebDriverCookiesProtocolPart(CookiesProtocolPart):
         except error.NoSuchCookieException:
             return None
 
+
 class WebDriverWindowProtocolPart(WindowProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
@@ -237,6 +238,7 @@ class WebDriverWindowProtocolPart(WindowProtocolPart):
     def set_rect(self, rect):
         self.logger.info("Restoring")
         self.webdriver.window.rect = rect
+
 
 class WebDriverSendKeysProtocolPart(SendKeysProtocolPart):
     def setup(self):
@@ -466,8 +468,7 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
 
     def __init__(self, logger, browser, server_config, timeout_multiplier=1,
                  close_after_done=True, capabilities=None, debug_info=None,
-                 supports_eager_pageload=True, cleanup_after_test=True,
-                 **kwargs):
+                 cleanup_after_test=True, **kwargs):
         """WebDriver-based executor for testharness.js tests"""
         TestharnessExecutor.__init__(self, logger, browser, server_config,
                                      timeout_multiplier=timeout_multiplier,
@@ -480,7 +481,6 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
 
         self.close_after_done = close_after_done
         self.window_id = str(uuid.uuid4())
-        self.supports_eager_pageload = supports_eager_pageload
         self.cleanup_after_test = cleanup_after_test
 
     def is_alive(self):
@@ -525,9 +525,6 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
         handler = WebDriverCallbackHandler(self.logger, protocol, test_window)
         protocol.webdriver.url = url
 
-        if not self.supports_eager_pageload:
-            self.wait_for_load(protocol)
-
         while True:
             result = protocol.base.execute_script(
                 self.script_resume % format_map, asynchronous=True)
@@ -557,29 +554,6 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
             protocol.testharness.close_old_windows()
 
         return rv
-
-    def wait_for_load(self, protocol):
-        # pageLoadStrategy=eager doesn't work in Chrome so try to emulate in user script
-        loaded = False
-        seen_error = False
-        while not loaded:
-            try:
-                loaded = protocol.base.execute_script("""
-var callback = arguments[arguments.length - 1];
-if (location.href === "about:blank") {
-  callback(false);
-} else if (document.readyState !== "loading") {
-  callback(true);
-} else {
-  document.addEventListener("readystatechange", () => {if (document.readyState !== "loading") {callback(true)}});
-}""", asynchronous=True)
-            except error.JavascriptErrorException:
-                # We can get an error here if the script runs in the initial about:blank
-                # document before it has navigated, with the driver returning an error
-                # indicating that the document was unloaded
-                if seen_error:
-                    raise
-                seen_error = True
 
 
 class WebDriverRefTestExecutor(RefTestExecutor):


### PR DESCRIPTION
`chromedriver` support for eager pageloads shipped in M77: https://chromedriver.storage.googleapis.com/77.0.3865.10/notes.txt

This change removes a workaround in wptrunner's WebDriver testharness
executor for Chromium-based browser (`chrome` and `edgechromium`) that
formerly lacked `pageLoadStrategy: eager` support.

See Also: crrev.com/c/1241213/5/chrome/test/chromedriver/capabilities.cc#202