### PR TITLE
register a timeout in AbortSignal.any test

### DIFF
--- a/dom/abort/resources/abort-signal-any-tests.js
+++ b/dom/abort/resources/abort-signal-any-tests.js
@@ -130,7 +130,7 @@ function abortSignalAnyTests(signalInterface, controllerInterface) {
 
     const combinedSignal = signalInterface.any([controller.signal, timeoutSignal]);
 
-    const ref = setTimeout(assert_unreached, 10);
+    const ref = step_timeout(assert_unreached, 10);
     combinedSignal.onabort = t.step_func_done(() => {
       assert_true(combinedSignal.aborted);
       assert_true(combinedSignal.reason instanceof DOMException,

--- a/dom/abort/resources/abort-signal-any-tests.js
+++ b/dom/abort/resources/abort-signal-any-tests.js
@@ -130,12 +130,14 @@ function abortSignalAnyTests(signalInterface, controllerInterface) {
 
     const combinedSignal = signalInterface.any([controller.signal, timeoutSignal]);
 
+    const ref = setTimeout(assert_unreached, 10);
     combinedSignal.onabort = t.step_func_done(() => {
       assert_true(combinedSignal.aborted);
       assert_true(combinedSignal.reason instanceof DOMException,
           "combinedSignal.reason is a DOMException");
       assert_equals(combinedSignal.reason.name, "TimeoutError",
           "combinedSignal.reason is a TimeoutError");
+      clearTimeout(ref);
     });
   }, `${desc} works with signals returned by AbortSignal.timeout() ${suffix}`);
 


### PR DESCRIPTION
Refs:  https://github.com/nodejs/node/pull/47821#issuecomment-1536646998

Because of the (i assume) weak references this test causes the Node.js worker that executes the suite to exit before this one runs to completion.

This change makes it so that a timeout is registered that should never be reached whilst still testing the combinedSignal behaviours when triggered by AbortSignal.timeout whilst keeping our test execution worker alive.