### PR TITLE
[css-backgrounds] Created a reference file for order-of-images.htm

### DIFF
--- a/css/css-backgrounds/order-of-images.htm
+++ b/css/css-backgrounds/order-of-images.htm
@@ -1,9 +1,10 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>CSS Test: Order of images</title>
+        <title>CSS Backgrounds Test: Order of multiple overlapping background images</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-image" />
+        <link rel="match" href="reference/order-of-images-ref.html" />
         <meta name="assert" content="Background images are listed in order, with the first image being rendered on top of all the other images, and so on." />
         <style type="text/css">
             div

--- a/css/css-backgrounds/reference/order-of-images-ref.html
+++ b/css/css-backgrounds/reference/order-of-images-ref.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest Reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      height: 100px;
+      position: relative;
+      width: 100px;
+    }
+
+  div#outer-black
+    {
+      background-color: black;
+      left: 90px;
+      top: 90px;
+    }
+
+  div#middle-orange
+    {
+      background-color: orange;
+      bottom: 30px;
+      right: 30px;
+    }
+
+  div#inner-blue
+    {
+      background-color: blue;
+      bottom: 30px;
+      right: 30px;
+    }
+  </style>
+
+  <p>Test passes if a blue box overlaps an orange box, which overlaps a black box.
+
+  <div id="outer-black">
+
+    <div id="middle-orange">
+
+      <div id="inner-blue"></div>
+
+    </div>
+
+  </div>


### PR DESCRIPTION
At my website:

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/order-of-images-ref-GT.html

I tweaked the title text of the test

http://wpt.live/css/css-backgrounds/order-of-images.htm

and added a blank line at EOF