### PR TITLE
Test text-box-trim property with padding margin

### DIFF
--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-002-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-002-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>Reference for not trimming block-boxes at their first/last formatted lines if the FCL has non-zero padding. </title>
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#leading-trim">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<style>
+.div-parent {
+  outline: 1px solid orange;
+  font-family: Ahem;
+  font-size: 20px;
+  line-height: 2;
+}
+</style>
+
+<div class ="div-parent"">
+  <div id="d1"></div>
+  <div id="d2" style="padding: 2px">Testline1<br>Testline2<br>Testline3</div>
+</div>

--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-002-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-002-ref.html
@@ -12,7 +12,7 @@
 }
 </style>
 
-<div class ="div-parent"">
+<div class ="div-parent">
   <div id="d1"></div>
   <div id="d2" style="padding: 2px">Testline1<br>Testline2<br>Testline3</div>
 </div>

--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-002.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-002.html
@@ -14,7 +14,7 @@
 }
 </style>
 
-<div class ="div-parent"">
+<div class ="div-parent">
   <div id="d1"></div>
   <div id="d2" style="padding: 2px">Testline1<br>Testline2<br>Testline3</div>
 </div>

--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-002.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-002.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Tests half-leading should not be applied if the first/last formatted line has non-zero padding.</title>
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#leading-trim">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="match" href="text-box-trim-half-leading-block-box-002-ref.html">
+
+<style>
+.div-parent {
+  outline: 1px solid orange;
+  font-family: Ahem;
+  font-size: 20px;
+  line-height: 2;
+  text-box-trim: both;
+}
+</style>
+
+<div class ="div-parent"">
+  <div id="d1"></div>
+  <div id="d2" style="padding: 2px">Testline1<br>Testline2<br>Testline3</div>
+</div>

--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-003-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-003-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>Tests the first formatted line is not affected by its parent if there is intervening non-zero padding. </title>
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#leading-trim">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<style>
+.div-parent {
+  outline: 1px solid orange;
+  font-family: Ahem;
+  font-size: 20px;
+  line-height: 1;
+}
+</style>
+
+<div class ="div-parent"">
+  <div id="d1" style="padding: 2px"></div>
+  <div id="d2"><br>Testline1<br><br><br>Testline2<br><br><br>Testline3</div>
+</div>

--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-003-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-003-ref.html
@@ -12,7 +12,7 @@
 }
 </style>
 
-<div class ="div-parent"">
+<div class ="div-parent">
   <div id="d1" style="padding: 2px"></div>
   <div id="d2"><br>Testline1<br><br><br>Testline2<br><br><br>Testline3</div>
 </div>

--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-003.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-003.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Tests the first formatted line is not affected by its parent if there is intervening non-zero padding. </title>
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#leading-trim">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="match" href="text-box-trim-half-leading-block-box-003-ref.html">
+
+<style>
+.div-parent {
+  outline: 1px solid orange;
+  font-family: Ahem;
+  font-size: 20px;
+  line-height: 3;
+  text-box-trim: both;
+}
+</style>
+
+<div class ="div-parent"">
+  <div id="d1" style="padding: 2px"></div>
+  <div id="d2">Testline1<br>Testline2<br>Testline3</div>
+</div>

--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-003.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-block-box-003.html
@@ -14,7 +14,7 @@
 }
 </style>
 
-<div class ="div-parent"">
+<div class ="div-parent">
   <div id="d1" style="padding: 2px"></div>
   <div id="d2">Testline1<br>Testline2<br>Testline3</div>
 </div>


### PR DESCRIPTION
This PR is a follow-up of #39706, adding two tests for multiline text with padding to ensure:
1. If there is intervening non-zero padding, do not trim the first/last formatted line.

Following the specification of:
[1] For [block containers](https://drafts.csswg.org/css-display-4/#block-container): trim the [block-start](https://drafts.csswg.org/css-writing-modes-4/#block-start) side of the [first formatted line](https://drafts.csswg.org/css-pseudo-4/#first-formatted-line) to the corresponding [text-box-edge](http://w3c.github.io/csswg-drafts/css-inline-3/#propdef-text-box-edge) metric of its [root inline box](http://w3c.github.io/csswg-drafts/css-inline-3/#root-inline-box). If there is no such line, or **if there is intervening non-zero padding or borders**, there is no effect.

w3c/csswg-drafts#5237 explains why we should not apply this property to descendant line boxes with non-zero padding/margin/.. 

Doc:
[test case of CSS text-box-trim property](https://docs.google.com/document/d/1eT0xEOrfVI3RhZ6goJLW1yOWHXLBq2tzAYrHe3NIiO8/edit#bookmark=id.6gn6wxezyf5y)