### PR TITLE
popover-hide-crash.html hangs in WebKit

### DIFF
--- a/html/semantics/popovers/popover-hide-crash.html
+++ b/html/semantics/popovers/popover-hide-crash.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class='reftest-wait'>
+<html>
 <meta charset='utf-8' />
 <title>Popover hide crash test</title>
 <link rel='author' href="mailto:cathiechen@iglaia.com">


### PR DESCRIPTION
popover-hide-crash.html hangs in WebKit because the reftest-wait class was never removed, do this at the end of the script.