### PR TITLE
Publish Azure Pipelines results for macOS infrastructure jobs

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -111,20 +111,25 @@ jobs:
   - template: tools/ci/azure/update_manifest.yml
   - script: |
       set -eux -o pipefail
-      ./wpt run --yes --no-manifest-update --manifest MANIFEST.json --metadata infrastructure/metadata/ --log-mach - --log-mach-level info --channel dev chrome infrastructure/
+      ./wpt run --yes --no-manifest-update --manifest MANIFEST.json --metadata infrastructure/metadata/ --log-mach - --log-mach-level info --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_macos_chrome.json --channel dev chrome infrastructure/
     condition: succeededOrFailed()
     displayName: 'Run tests (Chrome Dev)'
   - script: |
       set -eux -o pipefail
-      ./wpt run --yes --no-manifest-update --manifest MANIFEST.json --metadata infrastructure/metadata/ --log-mach - --log-mach-level info --channel nightly firefox infrastructure/
+      ./wpt run --yes --no-manifest-update --manifest MANIFEST.json --metadata infrastructure/metadata/ --log-mach - --log-mach-level info --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_macos_firefox.json --channel nightly firefox infrastructure/
     condition: succeededOrFailed()
     displayName: 'Run tests (Firefox Nightly)'
   - script: |
       set -eux -o pipefail
       export SYSTEM_VERSION_COMPAT=0
-      ./wpt run --yes --no-manifest-update --manifest MANIFEST.json --metadata infrastructure/metadata/ --log-mach - --log-mach-level info --channel preview safari infrastructure/
+      ./wpt run --yes --no-manifest-update --manifest MANIFEST.json --metadata infrastructure/metadata/ --log-mach - --log-mach-level info  --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_macos_safari.json --channel preview safari infrastructure/
     condition: succeededOrFailed()
     displayName: 'Run tests (Safari Technology Preview)'
+  - task: PublishBuildArtifacts@1
+    condition: succeededOrFailed()
+    displayName: 'Publish results'
+    inputs:
+      artifactName: 'infrastructure-results'
   - template: tools/ci/azure/publish_logs.yml
   - template: tools/ci/azure/sysdiagnose.yml
 


### PR DESCRIPTION
This should make it easier to update the expectations without having to manually run the tests.

This is the Azure Pipelines part of #39388.