### PR TITLE
[wptrunner] Allow test window reuse for Chrome

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -50,6 +50,7 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
                                            **kwargs)
     executor_kwargs["close_after_done"] = True
     executor_kwargs["sanitizer_enabled"] = sanitizer_enabled
+    executor_kwargs["reuse_window"] = kwargs.get("reuse_window", False)
 
     capabilities = {
         "goog:chromeOptions": {

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -70,6 +70,13 @@ class ChromeDriverTestharnessProtocolPart(WebDriverTestharnessProtocolPart):
 
     def setup(self):
         super().setup()
+        # Handle (an alphanumeric string) that may be set if window reuse is
+        # enabled. This state allows the protocol to distinguish the test
+        # window from other windows a test itself may create that the "Get
+        # Window Handles" command also returns.
+        #
+        # Because test window persistence is a Chrome-only feature, it's not
+        # exposed to the base WebDriver testharness executor.
         self.test_window = None
         self.reuse_window = self.parent.reuse_window
 

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -130,12 +130,7 @@ class ChromeDriverTestharnessProtocolPart(WebDriverTestharnessProtocolPart):
         # WindowProxy (not supported by Chrome currently).
         deadline = time.time() + timeout
         while time.time() < deadline:
-            handles = self.webdriver.handles
-            if len(handles) == 2:
-                self.test_window = next(iter(set(handles) - {parent}))
-            elif handles[0] == parent and len(handles) > 2:
-                # Hope the first one here is the test window
-                self.test_window = handles[1]
+            self.test_window = self._poll_handles_for_test_window(parent)
             if self.test_window is not None:
                 assert self.test_window != parent
                 return self.test_window

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -80,13 +80,6 @@ class ChromeDriverTestharnessProtocolPart(WebDriverTestharnessProtocolPart):
         self.test_window = None
         self.reuse_window = self.parent.reuse_window
 
-    def load_runner(self, url_protocol):
-        prev_runner_handle = self.runner_handle
-        super().load_runner(url_protocol)
-        if self.runner_handle != prev_runner_handle:
-            # Ensure the orphaned test window is closed.
-            self.close_test_window()
-
     def close_test_window(self):
         if self.test_window:
             self._close_window(self.test_window)

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -95,13 +95,6 @@ class ChromeDriverTestharnessProtocolPart(WebDriverTestharnessProtocolPart):
         self.webdriver.window_handle = self.runner_handle
         return self.runner_handle
 
-    def _close_window(self, window_handle):
-        try:
-            self.webdriver.window_handle = window_handle
-            self.webdriver.window.close()
-        except error.NoSuchWindowException:
-            pass
-
     def open_test_window(self, window_id):
         if self.test_window:
             # Try to reuse the existing test window by emulating the `about:blank`

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -154,12 +154,7 @@ class WebDriverTestharnessProtocolPart(TestharnessProtocolPart):
                 pass
 
             if test_window is None:
-                after = self.webdriver.handles
-                if len(after) == 2:
-                    test_window = next(iter(set(after) - {parent}))
-                elif after[0] == parent and len(after) > 2:
-                    # Hope the first one here is the test window
-                    test_window = after[1]
+                test_window = self._poll_handles_for_test_window(parent)
 
             if test_window is not None:
                 assert test_window != parent
@@ -168,6 +163,16 @@ class WebDriverTestharnessProtocolPart(TestharnessProtocolPart):
             time.sleep(0.1)
 
         raise Exception("unable to find test window")
+
+    def _poll_handles_for_test_window(self, parent):
+        test_window = None
+        after = self.webdriver.handles
+        if len(after) == 2:
+            test_window = next(iter(set(after) - {parent}))
+        elif after[0] == parent and len(after) > 2:
+            # Hope the first one here is the test window
+            test_window = after[1]
+        return test_window
 
     def test_window_loaded(self):
         """Wait until the page in the new window has been loaded.

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -119,13 +119,16 @@ class WebDriverTestharnessProtocolPart(TestharnessProtocolPart):
         self.webdriver.actions.release()
         handles = [item for item in self.webdriver.handles if item != self.runner_handle]
         for handle in handles:
-            try:
-                self.webdriver.window_handle = handle
-                self.webdriver.window.close()
-            except error.NoSuchWindowException:
-                pass
+            self._close_window(handle)
         self.webdriver.window_handle = self.runner_handle
         return self.runner_handle
+
+    def _close_window(self, window_handle):
+        try:
+            self.webdriver.window_handle = window_handle
+            self.webdriver.window.close()
+        except error.NoSuchWindowException:
+            pass
 
     def open_test_window(self, window_id):
         self.webdriver.execute_script(

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -127,6 +127,10 @@ class WebDriverTestharnessProtocolPart(TestharnessProtocolPart):
         self.webdriver.window_handle = self.runner_handle
         return self.runner_handle
 
+    def open_test_window(self, window_id):
+        self.webdriver.execute_script(
+            "window.open('about:blank', '%s', 'noopener')" % window_id)
+
     def get_test_window(self, window_id, parent, timeout=5):
         """Find the test window amongst all the open windows.
         This is assumed to be either the named window or the one after the parent in the list of
@@ -513,7 +517,7 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
         parent_window = protocol.testharness.close_old_windows()
 
         # Now start the test harness
-        protocol.base.execute_script("window.open('about:blank', '%s', 'noopener')" % self.window_id)
+        protocol.testharness.open_test_window(self.window_id)
         test_window = protocol.testharness.get_test_window(self.window_id,
                                                            parent_window,
                                                            timeout=5*self.timeout_multiplier)

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -367,6 +367,12 @@ scheme host and port.""")
         action="store_true",
         dest="sanitizer_enabled",
         help="Only alert on sanitizer-related errors and crashes.")
+    chrome_group.add_argument(
+        "--reuse-window",
+        action="store_true",
+        help=("Reuse a window across `testharness.js` tests where possible, "
+              "which can speed up testing. Also useful for ensuring that the "
+              "renderer process has a stable PID for a debugger to attach to."))
 
     sauce_group = parser.add_argument_group("Sauce Labs-specific")
     sauce_group.add_argument("--sauce-browser", dest="sauce_browser",


### PR DESCRIPTION
Currently, the base WebDriver testharness executor creates a new window (i.e., tab) for every test. For Chrome controlled via chromedriver, the overhead of creating the window and synchronously polling the remote end until the window's handle loads `about:blank` is substantial (~0.35s per test).

This change adds a Chrome-specific wptrunner flag `--reuse-window` to persist and reuse a test window so long as the runner window does not need to be reloaded. To emulate the creation of a new window, the executor navigates to `about:blank` and clears the navigation history via a Chrome DevTools Protocol call, which has a lower per-test overhead of ~0.07s.

Empirically, in aggregate, this reduces total shard runtime from 135+ min -> 120-125 min with no systemic increases in flakiness [1, 2].

`--reuse-window` is also useful for debugging the renderer process in multiple tests. When a test window is closed, the underlying renderer process is replaced, which breaks the connection to the debugger.

The existing behavior is preserved without `--reuse-window`.

[1]: With patch: https://ci.chromium.org/ui/p/chromium/builders/try/linux-wpt-fyi-rel/1877/overview
[2]: Without patch: https://ci.chromium.org/ui/p/chromium/builders/ci/linux-wpt-fyi-rel/41852/overview