### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=256611

### DIFF
--- a/css/css-grid/masonry/tentative/masonry-columns-item-containing-block-is-grid-content-width.html
+++ b/css/css-grid/masonry/tentative/masonry-columns-item-containing-block-is-grid-content-width.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-3/#containing-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Svg should use grid's content logical width for its containing block size and get sized to 100px x 100px">
+<style>
+grid {
+    display: grid;
+    grid-template-columns:masonry;
+    grid-template-rows: auto;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<grid>
+    <svg width="100" height="100" viewBox="0 0 1 1" style="width: 100%; max-width: 100px; background: green;"></svg>
+</grid>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[css-grid\]\[masonry\] Images with percentage width in masonry columns grid not rendering](https://bugs.webkit.org/show_bug.cgi?id=256611)