### PR TITLE
Remove step_timeout workaround when waiting for scroll coordinates to update

### DIFF
--- a/css/css-scroll-snap/scroll-margin-visibility-check.html
+++ b/css/css-scroll-snap/scroll-margin-visibility-check.html
@@ -35,7 +35,7 @@ let target = document.getElementById("target");
 promise_test(async function() {
   scroller.scrollTo(0, 0);
   await new Promise(resolve => {
-      scroller.addEventListener("scroll", resolve);
+      scroller.addEventListener("scroll", resolve, { once: true });
       document.getElementById("target").focus();
   });
   assert_true(scroller.scrollTop > 0, "Visibility check should not account for margin");

--- a/css/css-scroll-snap/scroll-margin-visibility-check.html
+++ b/css/css-scroll-snap/scroll-margin-visibility-check.html
@@ -35,7 +35,7 @@ let target = document.getElementById("target");
 promise_test(async function() {
   scroller.scrollTo(0, 0);
   await new Promise(resolve => {
-      scroller.addEventListener("scroll", () => step_timeout(resolve, 0));
+      scroller.addEventListener("scroll", resolve);
       document.getElementById("target").focus();
   });
   assert_true(scroller.scrollTop > 0, "Visibility check should not account for margin");

--- a/css/css-scroll-snap/scroll-target-margin-005.html
+++ b/css/css-scroll-snap/scroll-target-margin-005.html
@@ -25,7 +25,7 @@
 promise_test(async function() {
    document.scrollingElement.scrollTo(0, 20000);
    await new Promise(resolve => {
-     document.addEventListener("scroll", resolve);
+     document.addEventListener("scroll", resolve, { once: true });
      document.getElementById("target").focus();
    });
   // Should be around 4900 (5000 - 200px of margin). Give some leeway to account for line height / borders / input padding / etc.

--- a/css/css-scroll-snap/scroll-target-margin-005.html
+++ b/css/css-scroll-snap/scroll-target-margin-005.html
@@ -25,7 +25,7 @@
 promise_test(async function() {
    document.scrollingElement.scrollTo(0, 20000);
    await new Promise(resolve => {
-     document.addEventListener("scroll", () => step_timeout(resolve, 0));
+     document.addEventListener("scroll", resolve);
      document.getElementById("target").focus();
    });
   // Should be around 4900 (5000 - 200px of margin). Give some leeway to account for line height / borders / input padding / etc.

--- a/html/semantics/interactive-elements/the-dialog-element/focus-after-close.html
+++ b/html/semantics/interactive-elements/the-dialog-element/focus-after-close.html
@@ -167,7 +167,7 @@ async function test_move_focus_dont_scroll_viewport(showModal) {
   document.body.appendChild(outViewPortButton);
 
   await new Promise(resolve => {
-    document.addEventListener("scroll", resolve);
+    document.addEventListener("scroll", resolve, { once: true });
     outViewPortButton.focus();
   });
 

--- a/html/semantics/interactive-elements/the-dialog-element/focus-after-close.html
+++ b/html/semantics/interactive-elements/the-dialog-element/focus-after-close.html
@@ -167,7 +167,7 @@ async function test_move_focus_dont_scroll_viewport(showModal) {
   document.body.appendChild(outViewPortButton);
 
   await new Promise(resolve => {
-    document.addEventListener("scroll", () => step_timeout(resolve, 0));
+    document.addEventListener("scroll", resolve);
     outViewPortButton.focus();
   });
 


### PR DESCRIPTION
The pattern `addEventListener("scroll", () => step_timeout(resolve, 0))` was used for waiting for scroll coordinates to update after a scroll was performed as the result of a `focus()` call. `step_timeout(resolve, 0)` was notably needed because WebKit had a bug where the scroll coordinates (e.g. `scrollTop`) wouldn't update at the time the `scroll` event was emitted.

However that bug looks fixed in recent WebKit builds, so this workaround can be removed, and we can use the following instead:

`addEventListener("scroll", resolve, { once: true })`

