### PR TITLE
[WebCryptoAPI] add deriveBits nullable and optional length tests

### DIFF
--- a/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits.js
+++ b/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits.js
@@ -69,6 +69,26 @@ function define_tests() {
               });
           }, algorithmName + " with null length");
 
+          // undefined length
+          promise_test(function(test) {
+              return subtle.deriveBits({name: algorithmName, public: publicKeys[algorithmName]}, privateKeys[algorithmName], undefined)
+              .then(function(derivation) {
+                  assert_true(equalBuffers(derivation, derivations[algorithmName]), "Derived correct bits");
+              }, function(err) {
+                  assert_unreached("deriveBits failed with error " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " with undefined length");
+
+          // omitted length
+          promise_test(function(test) {
+              return subtle.deriveBits({name: algorithmName, public: publicKeys[algorithmName]}, privateKeys[algorithmName])
+              .then(function(derivation) {
+                  assert_true(equalBuffers(derivation, derivations[algorithmName]), "Derived correct bits");
+              }, function(err) {
+                  assert_unreached("deriveBits failed with error " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " with omitted length");
+
           // Shorter than entire derivation per algorithm
           promise_test(function(test) {
               return subtle.deriveBits({name: algorithmName, public: publicKeys[algorithmName]}, privateKeys[algorithmName], 8 * sizes[algorithmName] - 32)

--- a/WebCryptoAPI/derive_bits_keys/ecdh_bits.js
+++ b/WebCryptoAPI/derive_bits_keys/ecdh_bits.js
@@ -65,6 +65,26 @@ function define_tests() {
                 });
             }, namedCurve + " with null length");
 
+            // undefined length
+            promise_test(function(test) {
+                return subtle.deriveBits({name: "ECDH", public: publicKeys[namedCurve]}, privateKeys[namedCurve], undefined)
+                .then(function(derivation) {
+                    assert_true(equalBuffers(derivation, derivations[namedCurve]), "Derived correct bits");
+                }, function(err) {
+                    assert_unreached("deriveBits failed with error " + err.name + ": " + err.message);
+                });
+            }, namedCurve + " with undefined length");
+
+            // omitted length
+            promise_test(function(test) {
+                return subtle.deriveBits({name: "ECDH", public: publicKeys[namedCurve]}, privateKeys[namedCurve])
+                .then(function(derivation) {
+                    assert_true(equalBuffers(derivation, derivations[namedCurve]), "Derived correct bits");
+                }, function(err) {
+                    assert_unreached("deriveBits failed with error " + err.name + ": " + err.message);
+                });
+            }, namedCurve + " with omitted length");
+
             // Shorter than entire derivation per algorithm
             promise_test(function(test) {
                 return subtle.deriveBits({name: "ECDH", public: publicKeys[namedCurve]}, privateKeys[namedCurve], 8 * sizes[namedCurve] - 32)

--- a/WebCryptoAPI/derive_bits_keys/hkdf.js
+++ b/WebCryptoAPI/derive_bits_keys/hkdf.js
@@ -149,6 +149,26 @@ function define_tests() {
                             });
                         }, testName + " with null length");
 
+                        // length undefined (OperationError)
+                        subsetTest(promise_test, function(test) {
+                            return subtle.deriveBits(algorithm, baseKeys[derivedKeySize], undefined)
+                            .then(function(derivation) {
+                                assert_unreached("null length should have thrown an OperationError");
+                            }, function(err) {
+                                assert_equals(err.name, "OperationError", "deriveBits with undefined length correctly threw OperationError: " + err.message);
+                            });
+                        }, testName + " with undefined length");
+
+                        // length omitted (OperationError)
+                        subsetTest(promise_test, function(test) {
+                            return subtle.deriveBits(algorithm, baseKeys[derivedKeySize])
+                            .then(function(derivation) {
+                                assert_unreached("omitted length should have thrown an OperationError");
+                            }, function(err) {
+                                assert_equals(err.name, "OperationError", "deriveBits with omitted length correctly threw OperationError: " + err.message);
+                            });
+                        }, testName + " with omitted length");
+
                         // length not multiple of 8 (OperationError)
                         subsetTest(promise_test, function(test) {
                             return subtle.deriveBits(algorithm, baseKeys[derivedKeySize], 44)

--- a/WebCryptoAPI/derive_bits_keys/pbkdf2.js
+++ b/WebCryptoAPI/derive_bits_keys/pbkdf2.js
@@ -114,6 +114,26 @@ function define_tests() {
                             });
                         }, testName + " with null length");
 
+                        // length undefined (OperationError)
+                        subsetTest(promise_test, function(test) {
+                            return subtle.deriveBits({name: "PBKDF2", salt: salts[saltSize], hash: hashName, iterations: parseInt(iterations)}, baseKeys[passwordSize], undefined)
+                            .then(function(derivation) {
+                                assert_unreached("undefined length should have thrown an OperationError");
+                            }, function(err) {
+                                assert_equals(err.name, "OperationError", "deriveBits with undefined length correctly threw OperationError: " + err.message);
+                            });
+                        }, testName + " with undefined length");
+
+                        // length omitted (OperationError)
+                        subsetTest(promise_test, function(test) {
+                            return subtle.deriveBits({name: "PBKDF2", salt: salts[saltSize], hash: hashName, iterations: parseInt(iterations)}, baseKeys[passwordSize])
+                            .then(function(derivation) {
+                                assert_unreached("omitted length should have thrown an OperationError");
+                            }, function(err) {
+                                assert_equals(err.name, "OperationError", "deriveBits with omitted length correctly threw OperationError: " + err.message);
+                            });
+                        }, testName + " with omitted length");
+
                         // 0 length (OperationError)
                         subsetTest(promise_test, function(test) {
                             return subtle.deriveBits({name: "PBKDF2", salt: salts[saltSize], hash: hashName, iterations: parseInt(iterations)}, baseKeys[passwordSize], 0)

--- a/interfaces/WebCryptoAPI.idl
+++ b/interfaces/WebCryptoAPI.idl
@@ -68,7 +68,7 @@ interface SubtleCrypto {
                          sequence<KeyUsage> keyUsages );
   Promise<ArrayBuffer> deriveBits(AlgorithmIdentifier algorithm,
                           CryptoKey baseKey,
-                          unsigned long length);
+                          optional unsigned long? length = null);
 
   Promise<CryptoKey> importKey(KeyFormat format,
                          (BufferSource or JsonWebKey) keyData,


### PR DESCRIPTION
As per https://github.com/w3c/webcrypto/pull/345