### PR TITLE
mime type values should not be casted to lowercase

### DIFF
--- a/FileAPI/file/File-constructor.any.js
+++ b/FileAPI/file/File-constructor.any.js
@@ -92,7 +92,7 @@ if (globalThis.document !== undefined) {
 // testing the third argument
 [
   {type: 'text/plain', expected: 'text/plain'},
-  {type: 'text/plain;charset=UTF-8', expected: 'text/plain;charset=utf-8'},
+  {type: 'text/plain;charset=UTF-8', expected: 'text/plain;charset=UTF-8'},
   {type: 'TEXT/PLAIN', expected: 'text/plain'},
   {type: '𝓽𝓮𝔁𝓽/𝔭𝔩𝔞𝔦𝔫', expected: ''},
   {type: 'ascii/nonprintable\u001F', expected: ''},


### PR DESCRIPTION
see: 
- https://github.com/whatwg/html/issues/6251
- https://github.com/w3c/FileAPI/issues/43