### PR TITLE
Add PerformanceEntry dependency for HTML idlharness.js tests

### DIFF
--- a/html/dom/idlharness.https.html
+++ b/html/dom/idlharness.https.html
@@ -38,7 +38,7 @@ const waitForLoad = new Promise(resolve => { addEventListener('load', resolve); 
 
 idl_test(
   ['html'],
-  ['wai-aria', 'SVG', 'cssom', 'touch-events', 'uievents', 'dom', 'xhr', 'FileAPI', 'mediacapture-streams'],
+  ['wai-aria', 'SVG', 'cssom', 'touch-events', 'uievents', 'dom', 'xhr', 'FileAPI', 'mediacapture-streams', 'performance-timeline'],
   async idlArray => {
     self.documentWithHandlers = new Document();
     const handler = function(e) {};

--- a/html/dom/idlharness.worker.js
+++ b/html/dom/idlharness.worker.js
@@ -5,7 +5,7 @@ importScripts("/resources/WebIDLParser.js", "/resources/idlharness.js");
 
 idl_test(
   ["html"],
-  ["wai-aria", "dom", "cssom", "touch-events", "uievents"],
+  ["wai-aria", "dom", "cssom", "touch-events", "uievents", "performance-timeline"],
   idlArray => {
     idlArray.add_untested_idls('typedef Window WindowProxy;');
     idlArray.add_objects({


### PR DESCRIPTION
Needed for https://github.com/web-platform-tests/wpt/pull/39623.
