### PR TITLE
[wptrunner] Add `id_hash` chunk type

### DIFF
--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 
+import abc
 import hashlib
 import itertools
 import json
@@ -8,6 +9,7 @@ from urllib.parse import urlsplit
 from abc import ABCMeta, abstractmethod
 from queue import Empty
 from collections import defaultdict, deque, namedtuple
+from typing import Any, cast
 
 from . import manifestinclude
 from . import manifestexpected
@@ -78,8 +80,8 @@ def update_include_for_groups(test_groups, include):
     return new_include
 
 
-class TestChunker:
-    def __init__(self, total_chunks, chunk_number, **kwargs):
+class TestChunker(abc.ABC):
+    def __init__(self, total_chunks: int, chunk_number: int, **kwargs: Any):
         self.total_chunks = total_chunks
         self.chunk_number = chunk_number
         assert self.chunk_number <= self.total_chunks
@@ -87,8 +89,9 @@ class TestChunker:
         assert self.logger
         self.kwargs = kwargs
 
+    @abstractmethod
     def __call__(self, manifest):
-        raise NotImplementedError
+        ...
 
 
 class Unchunked(TestChunker):
@@ -102,30 +105,50 @@ class Unchunked(TestChunker):
 
 class HashChunker(TestChunker):
     def __call__(self, manifest):
-        chunk_index = self.chunk_number - 1
         for test_type, test_path, tests in manifest:
-            h = int(hashlib.md5(test_path.encode()).hexdigest(), 16)
-            if h % self.total_chunks == chunk_index:
-                yield test_type, test_path, tests
+            tests_for_chunk = {
+                test for test in tests
+                if self._key_in_chunk(self.chunk_key(test_type, test_path, test))
+            }
+            if tests_for_chunk:
+                yield test_type, test_path, tests_for_chunk
+
+    def _key_in_chunk(self, key: str) -> bool:
+        chunk_index = self.chunk_number - 1
+        digest = hashlib.md5(key.encode()).hexdigest()
+        return int(digest, 16) % self.total_chunks == chunk_index
+
+    @abstractmethod
+    def chunk_key(self, test_type: str, test_path: str,
+                  test: wpttest.Test) -> str:
+        ...
 
 
-class DirectoryHashChunker(TestChunker):
+class PathHashChunker(HashChunker):
+    def chunk_key(self, test_type: str, test_path: str,
+                  test: wpttest.Test) -> str:
+        return test_path
+
+
+class IDHashChunker(HashChunker):
+    def chunk_key(self, test_type: str, test_path: str,
+                  test: wpttest.Test) -> str:
+        return cast(str, test.id)
+
+
+class DirectoryHashChunker(HashChunker):
     """Like HashChunker except the directory is hashed.
 
     This ensures that all tests in the same directory end up in the same
     chunk.
     """
-    def __call__(self, manifest):
-        chunk_index = self.chunk_number - 1
+    def chunk_key(self, test_type: str, test_path: str,
+                  test: wpttest.Test) -> str:
         depth = self.kwargs.get("depth")
-        for test_type, test_path, tests in manifest:
-            if depth:
-                hash_path = os.path.sep.join(os.path.dirname(test_path).split(os.path.sep, depth)[:depth])
-            else:
-                hash_path = os.path.dirname(test_path)
-            h = int(hashlib.md5(hash_path.encode()).hexdigest(), 16)
-            if h % self.total_chunks == chunk_index:
-                yield test_type, test_path, tests
+        if depth:
+            return os.path.sep.join(os.path.dirname(test_path).split(os.path.sep, depth)[:depth])
+        else:
+            return os.path.dirname(test_path)
 
 
 class TestFilter:
@@ -245,7 +268,8 @@ class TestLoader:
         if chunker_kwargs is None:
             chunker_kwargs = {}
         self.chunker = {"none": Unchunked,
-                        "hash": HashChunker,
+                        "hash": PathHashChunker,
+                        "id_hash": IDHashChunker,
                         "dir_hash": DirectoryHashChunker}[chunk_type](total_chunks,
                                                                       chunk_number,
                                                                       **chunker_kwargs)

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -280,7 +280,8 @@ scheme host and port.""")
                                 help="Total number of chunks to use")
     chunking_group.add_argument("--this-chunk", action="store", type=int, default=1,
                                 help="Chunk number to run")
-    chunking_group.add_argument("--chunk-type", action="store", choices=["none", "hash", "dir_hash"],
+    chunking_group.add_argument("--chunk-type", action="store",
+                                choices=["none", "hash", "id_hash", "dir_hash"],
                                 default=None, help="Chunking type to use")
 
     ssl_group = parser.add_argument_group("SSL/TLS")


### PR DESCRIPTION
Currently, `wpt run --chunk-type=hash` assigns tests to chunks using a hash of the test path. This scheme can sometimes unevenly distribute work when a slow test generates many variants or `.any.js` scopes, which are always bucketed into the same chunk. For CI systems that use chunking, uneven partitioning can contribute to greater long-pole times and longer overall builds.

This change introduces a new `id_hash` strategy that hashes by test ID for maximum uniformity.