### PR TITLE
WebDriver BiDi: update serialization tests

### DIFF
--- a/webdriver/tests/bidi/script/call_function/result.py
+++ b/webdriver/tests/bidi/script/call_function/result.py
@@ -57,7 +57,10 @@ async def test_primitive_values(bidi_session, top_context, await_promise, expres
                             "flags": "g",
                         },
                     },
-                    {"type": "array"},
+                    {
+                        "type": "array",
+                        "value": [{"type": "number", "value": 1}],
+                    },
                 ],
             },
         ),
@@ -66,7 +69,10 @@ async def test_primitive_values(bidi_session, top_context, await_promise, expres
             {
                 "type": "object",
                 "value": [
-                    ["foo", {"type": "object"}],
+                    ["foo", {
+                        "type": "object",
+                        "value": [["bar", {"type": "string", "value": "baz"}]]
+                    }],
                     ["qux", {"type": "string", "value": "quux"}],
                 ],
             },
@@ -97,7 +103,10 @@ async def test_primitive_values(bidi_session, top_context, await_promise, expres
                         {"type": "boolean", "value": True},
                         {"type": "boolean", "value": False},
                     ],
-                    ["baz", {"type": "array"}],
+                    ["baz", {
+                        "type": "array",
+                        "value": [{"type": "number", "value": 1}]
+                    }],
                 ],
             },
         ),
@@ -109,8 +118,17 @@ async def test_primitive_values(bidi_session, top_context, await_promise, expres
                     {"type": "number", "value": 1},
                     {"type": "string", "value": "foo"},
                     {"type": "boolean", "value": True},
-                    {"type": "array"},
-                    {"type": "map"},
+                    {
+                        "type": "array",
+                        "value": [{"type": "number", "value": 1}]
+                    },
+                    {
+                        "type": "map",
+                        "value": [[
+                            {"type": "number", "value": 1},
+                            {"type": "number", "value": 2}
+                        ]]
+                    },
                 ],
             },
         ),

--- a/webdriver/tests/bidi/script/evaluate/result.py
+++ b/webdriver/tests/bidi/script/evaluate/result.py
@@ -51,7 +51,10 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
                             "flags": "g",
                         },
                     },
-                    {"type": "array"},
+                    {
+                        "type": "array",
+                        "value": [{"type": "number", "value": 1}],
+                    },
                 ],
             },
         ),
@@ -60,7 +63,10 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
             {
                 "type": "object",
                 "value": [
-                    ["foo", {"type": "object"}],
+                    ["foo", {
+                        "type": "object",
+                        "value": [["bar", {"type": "string", "value": "baz"}]]
+                    }],
                     ["qux", {"type": "string", "value": "quux"}],
                 ],
             },
@@ -100,9 +106,12 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
                         {"type": "boolean", "value": True},
                         {"type": "boolean", "value": False},
                     ],
-                    ["baz", {"type": "array"}],
-                ],
-            },
+                    ["baz", {
+                        "type": "array",
+                        "value": [{"type": "number", "value": 1}]
+                    }]
+                ]
+            }
         ),
         (
             "new Set([1, 'foo', true, [1], new Map([[1,2]])])",
@@ -112,10 +121,19 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
                     {"type": "number", "value": 1},
                     {"type": "string", "value": "foo"},
                     {"type": "boolean", "value": True},
-                    {"type": "array"},
-                    {"type": "map"},
-                ],
-            },
+                    {
+                        "type": "array",
+                        "value": [{"type": "number", "value": 1}]
+                    },
+                    {
+                        "type": "map",
+                        "value": [[
+                            {"type": "number", "value": 1},
+                            {"type": "number", "value": 2}
+                        ]]
+                    }
+                ]
+            }
         ),
         ("new WeakMap()", {"type": "weakmap", },),
         ("new WeakSet()", {"type": "weakset", },),


### PR DESCRIPTION
Adjust to the default serialization options with full-depth JS objects serialization (`maxObjectDepth: null`).