### PR TITLE
Fix browsingContext.create tests to be spec compliant

### DIFF
--- a/webdriver/tests/bidi/log/entry_added/event_buffer.py
+++ b/webdriver/tests/bidi/log/entry_added/event_buffer.py
@@ -81,9 +81,10 @@ async def test_console_log_cached_message_after_refresh(
 
     # Log a message, refresh, log another message and subscribe
     expected_text_1 = await create_log(bidi_session, new_tab, log_type, "cached_message_1")
-    await bidi_session.browsing_context.navigate(
-        context=new_tab["context"], url=new_tab["url"], wait="complete"
-    )
+    context = new_tab["context"]
+    await bidi_session.browsing_context.navigate(context=context,
+                                                 url='about:blank',
+                                                 wait="complete")
     expected_text_2 = await create_log(bidi_session, new_tab, log_type, "cached_message_2")
 
     await subscribe_events(events=["log.entryAdded"])

--- a/webdriver/tests/bidi/log/entry_added/subscription.py
+++ b/webdriver/tests/bidi/log/entry_added/subscription.py
@@ -63,9 +63,10 @@ async def test_subscribe_unsubscribe(bidi_session, new_tab, wait_for_event, log_
     assert len(events) == 0
 
     # Refresh to create a new context
-    await bidi_session.browsing_context.navigate(
-        context=new_tab["context"], url=new_tab["url"], wait="complete"
-    )
+    context = new_tab["context"]
+    await bidi_session.browsing_context.navigate(context=context,
+                                                 url='about:blank',
+                                                 wait="complete")
 
     # Check we still don't receive ConsoleLogEntry events from the new context
     expected_text_1 = await create_log(bidi_session, new_tab, log_type, "text_1")
@@ -76,9 +77,10 @@ async def test_subscribe_unsubscribe(bidi_session, new_tab, wait_for_event, log_
 
     # Refresh to create a new context. Note that we refresh to avoid getting
     # cached events from the log event buffer.
-    await bidi_session.browsing_context.navigate(
-        context=new_tab["context"], url=new_tab["url"], wait="complete"
-    )
+    context = new_tab["context"]
+    await bidi_session.browsing_context.navigate(context=context,
+                                                 url='about:blank',
+                                                 wait="complete")
 
     # Check that if we subscribe again, we can receive events
     await bidi_session.session.subscribe(events=["log.entryAdded"])

--- a/webdriver/tests/bidi/session/subscribe/invalid.py
+++ b/webdriver/tests/bidi/session/subscribe/invalid.py
@@ -148,7 +148,10 @@ async def test_subscribe_to_closed_tab(bidi_session, send_blocking_command):
 
     # Try to subscribe to the closed context
     with pytest.raises(NoSuchFrameException):
-        response = await send_blocking_command(
+        await send_blocking_command(
             "session.subscribe",
-            {"events": ["log.entryAdded"], "contexts": [new_tab["context"]]},
+            {
+                "events": ["log.entryAdded"],
+                "contexts": [new_tab["context"]]
+            },
         )


### PR DESCRIPTION
CreateResult returns only {context: BrowsingContext}, however some WPT tests are accessing a non-existent "url" key from it.

Spec: https://w3c.github.io/webdriver-bidi/#command-browsingContext-create