### PR TITLE
Role Changes to Support section 9.1 of ARIA spec

### DIFF
--- a/wai-aria/role/abstract-roles.html
+++ b/wai-aria/role/abstract-roles.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+<head>
+  <title>Abstract Role Verification Tests</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+
+<p>Verifies <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a></p>
+  <nav role="command" data-testname="command role" data-expectedrole="navigation" class="ex">x</nav>
+  <nav role="composite" data-testname="composite role" data-expectedrole="navigation" class="ex">x</nav>
+  <nav role="input" data-testname="input role" data-expectedrole="navigation" class="ex">x</nav>
+  <nav role="landmark" data-testname="landmark role" data-expectedrole="navigation" class="ex">x</nav>
+  <nav role="range" data-testname="range role" data-expectedrole="navigation" class="ex">x</nav>
+  <nav role="roletype" data-testname="roletype role" data-expectedrole="navigation" class="ex">x</nav>
+  <nav role="section" data-testname="section role" data-expectedrole="navigation" class="ex">x</nav>
+  <nav role="sectionhead" data-testname="sectionhead role" data-expectedrole="navigation" class="ex">x</nav>
+  <nav role="select" data-testname="select role" data-expectedrole="navigation" class="ex">x</nav>
+  <nav role="structure" data-testname="structure role" data-expectedrole="navigation" class="ex">x</nav>
+  <nav role="widget" data-testname="widget role" data-expectedrole="navigation" class="ex">x</nav>
+  <nav role="window" data-testname="window role" data-expectedrole="navigation" class="ex">x</nav>
+
+
+<script>
+AriaUtils.verifyRolesBySelector(".ex");
+</script>
+
+</body>
+</html>

--- a/wai-aria/role/basic.html
+++ b/wai-aria/role/basic.html
@@ -7,9 +7,7 @@
 
 <div id='d' style='height: 100px; width: 100px' role="group" aria-label="test label"></div>
 <h1 id="h">test heading</h1>
-<p>Verifies <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a></p>
-<p role="foo" id="p">this is a paragraph</p>
-<span role="foo group" id="span">this is a span</span>
+
 <script>
 promise_test(async t => {
   const role = await test_driver.get_computed_role(document.getElementById('d'));
@@ -20,17 +18,5 @@ promise_test(async t => {
   const role = await test_driver.get_computed_role(document.getElementById('h'));
   assert_equals(role, "heading");
 }, "tests implicit role");
-
-
-promise_test(async t => {
-  const role = await test_driver.get_computed_role(document.getElementById('p'));
-  assert_equals(role, "paragraph");
-}, "tests unknown role");
-
-promise_test(async t => {
-  const role = await test_driver.get_computed_role(document.getElementById('span'));
-  assert_equals(role, "group");
-}, "tests fallback role");
-
 
 </script>

--- a/wai-aria/role/basic.html
+++ b/wai-aria/role/basic.html
@@ -7,17 +7,30 @@
 
 <div id='d' style='height: 100px; width: 100px' role="group" aria-label="test label"></div>
 <h1 id="h">test heading</h1>
+<p>Verifies <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a></p>
+<p role="foo" id="p">this is a paragraph</p>
+<span role="foo group" id="span">this is a span</span>
 <script>
-
 promise_test(async t => {
   const role = await test_driver.get_computed_role(document.getElementById('d'));
   assert_equals(role, "group");
 }, "tests explicit role");
 
-
 promise_test(async t => {
   const role = await test_driver.get_computed_role(document.getElementById('h'));
   assert_equals(role, "heading");
 }, "tests implicit role");
+
+
+promise_test(async t => {
+  const role = await test_driver.get_computed_role(document.getElementById('p'));
+  assert_equals(role, "paragraph");
+}, "tests unknown role");
+
+promise_test(async t => {
+  const role = await test_driver.get_computed_role(document.getElementById('span'));
+  assert_equals(role, "group");
+}, "tests fallback role");
+
 
 </script>

--- a/wai-aria/role/basic.html
+++ b/wai-aria/role/basic.html
@@ -7,7 +7,6 @@
 
 <div id='d' style='height: 100px; width: 100px' role="group" aria-label="test label"></div>
 <h1 id="h">test heading</h1>
-
 <script>
 promise_test(async t => {
   const role = await test_driver.get_computed_role(document.getElementById('d'));

--- a/wai-aria/role/basic.html
+++ b/wai-aria/role/basic.html
@@ -8,10 +8,12 @@
 <div id='d' style='height: 100px; width: 100px' role="group" aria-label="test label"></div>
 <h1 id="h">test heading</h1>
 <script>
+
 promise_test(async t => {
   const role = await test_driver.get_computed_role(document.getElementById('d'));
   assert_equals(role, "group");
 }, "tests explicit role");
+
 
 promise_test(async t => {
   const role = await test_driver.get_computed_role(document.getElementById('h'));

--- a/wai-aria/role/fallback-roles.html
+++ b/wai-aria/role/fallback-roles.html
@@ -16,14 +16,14 @@
   <navigation role="region group" data-testname="fallback role w/ region with no label" data-expectedrole="group" class="ex">x</nav>
   <navigation role="region group" data-testname="fallback role w/ region with label" aria-label="x" data-expectedrole="region" class="ex">x</nav>
 
-<!-- todo: additional fallback roles: 
+<!-- todo: additional fallback roles:
 
-- valid/valid "switch checkbox" 
+- valid/valid "switch checkbox"
 - valid/invalid "foo group"
-- unicode char tests with fallback 
-- whitespace tests with fallback 
 - unicode char tests with fallback
-- "invalid, punctuation, tests, link, button" 
+- whitespace tests with fallback
+- unicode char tests with fallback
+- "invalid, punctuation, tests, link, button"
 
 -->
 

--- a/wai-aria/role/fallback-roles.html
+++ b/wai-aria/role/fallback-roles.html
@@ -10,12 +10,12 @@
     <script src="/wai-aria/scripts/aria-utils.js"></script>
   </head>
   <body>
-  
+
   <p>Verifies Fallback Roles from <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a></p>
-  
+
   <navigation role="region group" data-testname="fallback role w/ region with no label" data-expectedrole="group" class="ex">x</nav>
   <navigation role="region group" data-testname="fallback role w/ region with label" aria-label="x" data-expectedrole="region" class="ex">x</nav>
-  
+
 <script>
 AriaUtils.verifyRolesBySelector(".ex");
 </script>

--- a/wai-aria/role/fallback-roles.html
+++ b/wai-aria/role/fallback-roles.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Fallback Role Verification Tests</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <script src="/resources/testdriver-actions.js"></script>
+    <script src="/wai-aria/scripts/aria-utils.js"></script>
+  </head>
+  <body>
+  
+  <p>Verifies Fallback Roles from <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a></p>
+  
+  <navigation role="region group" data-testname="fallback role w/ region with no label" data-expectedrole="group" class="ex">x</nav>
+  <navigation role="region group" data-testname="fallback role w/ region with label" aria-label="x" data-expectedrole="region" class="ex">x</nav>
+  
+<script>
+AriaUtils.verifyRolesBySelector(".ex");
+</script>
+
+</body>
+</html>

--- a/wai-aria/role/fallback-roles.html
+++ b/wai-aria/role/fallback-roles.html
@@ -16,6 +16,17 @@
   <navigation role="region group" data-testname="fallback role w/ region with no label" data-expectedrole="group" class="ex">x</nav>
   <navigation role="region group" data-testname="fallback role w/ region with label" aria-label="x" data-expectedrole="region" class="ex">x</nav>
 
+<!-- todo: additional fallback roles: 
+
+- valid/valid "switch checkbox" 
+- valid/invalid "foo group"
+- unicode char tests with fallback 
+- whitespace tests with fallback 
+- unicode char tests with fallback
+- "invalid, punctuation, tests, link, button" 
+
+-->
+
 <script>
 AriaUtils.verifyRolesBySelector(".ex");
 </script>

--- a/wai-aria/role/form-roles.html
+++ b/wai-aria/role/form-roles.html
@@ -1,0 +1,29 @@
+
+<!doctype html>
+<html>
+<head>
+  <title>Form Role Verification Tests</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<p>Verifies <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a></p>
+
+
+<!-- no label -->
+<nav role="form" data-testname="form without label" data-expectedrole="navigation" class="ex">x</nav>
+
+<!-- w/ label -->
+<nav role="form" data-testname="form with label" data-expectedrole="form" aria-label="x" class="ex">x</nav>
+
+<script>
+AriaUtils.verifyRolesBySelector(".ex");
+</script>
+
+</body>
+</html>

--- a/wai-aria/role/form-roles.html
+++ b/wai-aria/role/form-roles.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 
-<p>Verifies <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a></p>
+<p>Verifies <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a> and the <a href="https://w3c.github.io/aria/#form">form</a> role.</p>
 
 
 <!-- no label -->

--- a/wai-aria/role/invalid-roles.html
+++ b/wai-aria/role/invalid-roles.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-  <title>Form Role Verification Tests</title>
+  <title>Invalid Role Verification Tests</title>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/testdriver.js"></script>
@@ -11,14 +11,10 @@
 </head>
 <body>
 
-<p>Verifies <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a></p>
+<p>Verifies Invalid Roles from <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a></p>
 
-
-<!-- no label -->
-<nav role="form" data-testname="form without label" data-expectedrole="navigation" class="ex">x</nav>
-
-<!-- w/ label -->
-<nav role="form" data-testname="form with label" data-expectedrole="form" aria-label="x" class="ex">x</nav>
+<nav role="foo" data-testname="invalid role name foo" data-expectedrole="navigation" class="ex">x</nav>
+<nav role="foo bar" data-testname="multiple invalid role names" data-expectedrole="navigation" class="ex">x</nav>
 
 <script>
 AriaUtils.verifyRolesBySelector(".ex");

--- a/wai-aria/role/invalid-roles.html
+++ b/wai-aria/role/invalid-roles.html
@@ -16,6 +16,19 @@
 <nav role="foo" data-testname="invalid role name foo" data-expectedrole="navigation" class="ex">x</nav>
 <nav role="foo bar" data-testname="multiple invalid role names" data-expectedrole="navigation" class="ex">x</nav>
 
+<!-- todo: additional invalid roles: 
+
+- whitespace tests (including line breaks, tabs, zero-width space, braille space)
+- diacritics
+- joiners (e.g. like emoji variants use)
+- non-western chars
+- RTL strings (Hebrew & Arabic)
+- escaped chars, URL-encoded chars
+- backslash closing quote and other obvious hack attempts
+- etc.
+
+-->
+
 <script>
 AriaUtils.verifyRolesBySelector(".ex");
 </script>

--- a/wai-aria/role/invalid-roles.html
+++ b/wai-aria/role/invalid-roles.html
@@ -16,7 +16,7 @@
 <nav role="foo" data-testname="invalid role name foo" data-expectedrole="navigation" class="ex">x</nav>
 <nav role="foo bar" data-testname="multiple invalid role names" data-expectedrole="navigation" class="ex">x</nav>
 
-<!-- todo: additional invalid roles: 
+<!-- todo: additional invalid roles:
 
 - whitespace tests (including line breaks, tabs, zero-width space, braille space)
 - diacritics

--- a/wai-aria/role/roles.html
+++ b/wai-aria/role/roles.html
@@ -56,7 +56,7 @@ AriaUtils.assignAndVerifyRolesByRoleNames([
   "emphasis",
   "feed",
   "figure",
-  "form",
+  // form -> ./form-roles.html
   "generic",
   // graphics-* roles -> /graphics-aria
   // "grid" -> ./grid-roles.html


### PR DESCRIPTION
Closes https://github.com/w3c/aria/issues/1941
Closes https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/12

Related to https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/11
Related to https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/19

Adds tests to Support the prose in 
https://w3c.github.io/aria/#document-handling_author-errors_roles
