### PR TITLE
[wptrunner] Wait for TestRunnerManager threads to exit on interrupt

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -974,9 +974,7 @@ class ManagerGroup:
         deadline = None if timeout is None else time.time() + timeout
         for manager in self.pool:
             manager_timeout = None
-            if deadline is None:
-                manager_timeout = None
-            else:
+            if deadline is not None:
                 manager_timeout = max(0, deadline - time.time())
             manager.join(manager_timeout)
 

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -964,7 +964,7 @@ class ManagerGroup:
             self.pool.add(manager)
         self.wait()
 
-    def wait(self, timeout: Optional[float] = None):
+    def wait(self, timeout: Optional[float] = None) -> None:
         """Wait for all the managers in the group to finish.
 
         Arguments:

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -1,9 +1,11 @@
 # mypy: allow-untyped-defs
 
 import threading
+import time
 import traceback
 from queue import Empty
 from collections import namedtuple
+from typing import Optional
 
 from mozlog import structuredlog, capture
 
@@ -962,10 +964,21 @@ class ManagerGroup:
             self.pool.add(manager)
         self.wait()
 
-    def wait(self):
-        """Wait for all the managers in the group to finish"""
+    def wait(self, timeout: Optional[float] = None):
+        """Wait for all the managers in the group to finish.
+
+        Arguments:
+            timeout: Overall timeout (in seconds) for all threads to join. The
+                default value indicates an indefinite timeout.
+        """
+        deadline = None if timeout is None else time.time() + timeout
         for manager in self.pool:
-            manager.join()
+            manager_timeout = None
+            if deadline is None:
+                manager_timeout = None
+            else:
+                manager_timeout = max(0, deadline - time.time())
+            manager.join(manager_timeout)
 
     def stop(self):
         """Set the stop flag so that all managers in the group stop as soon

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -267,8 +267,11 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
                 handle_interrupt_signals()
                 manager_group.run(tests_to_run)
             except KeyboardInterrupt:
-                logger.critical("Main thread got signal")
+                logger.critical(
+                    "Main thread got signal; "
+                    "waiting for TestRunnerManager threads to exit.")
                 manager_group.stop()
+                manager_group.wait(timeout=10)
                 raise
 
             test_status.total_tests += manager_group.test_count()
@@ -277,10 +280,9 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
 
     test_status.unexpected += len(unexpected_tests)
     test_status.unexpected_pass += len(unexpected_pass_tests)
-
     logger.suite_end()
-
     return True
+
 
 def handle_interrupt_signals():
     def termination_handler(_signum, _unused_frame):


### PR DESCRIPTION
When wptrunner is interrupted, the manager group sets its stop flag but doesn't wait for the runner manager threads to acknowledge and join. Besides possible resource leakage, this can cause the threads to continue logging events after the main thread calls `shutdown()` on the `web-platform-tests` logger, which is not allowed.

In this change, the main thread waits for the threads to join with a timeout on an interrupt. The timeout needs to be long enough for the threads to cycle through their event loops one more time, but not so long as to appear unresponsive.