### PR TITLE
Update Safari testdriver expectation

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/file_upload.sub.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/file_upload.sub.html.ini
@@ -1,6 +1,6 @@
 [file_upload.sub.html]
   expected:
-    if product == "safari": TIMEOUT
+    if product == "safari": [OK, TIMEOUT]
   [File upload using testdriver]
     expected:
       if (product == "epiphany") or (product == "webkit"): FAIL


### PR DESCRIPTION
Sometimes the test doesn't time out:
  https://dev.azure.com/web-platform-tests/wpt/_build/results?buildId=100834&view=results
  https://dev.azure.com/web-platform-tests/wpt/_build/results?buildId=100902&view=results