### PR TITLE
Make trailing-space-and-text-alignment-*.html tests pass on iOS

### DIFF
--- a/css/css-text/white-space/support/trailing-space-and-text-alignment.css
+++ b/css/css-text/white-space/support/trailing-space-and-text-alignment.css
@@ -1,0 +1,24 @@
+textarea {
+    /* Reset user-agent style */
+    margin: initial;
+    padding: initial;
+    border: initial;
+    border-radius: initial;
+    outline: initial;
+    resize: initial;
+    overflow-wrap: initial;
+
+    height: 100px;
+    font: 40px/1 Ahem;
+    border: 1px solid black;
+    overflow-y: hidden;
+    overflow-x: auto;
+
+    /* testing */
+    width: 3ch;
+}
+.left { text-align: left; }
+.center { text-align: center; }
+.right { text-align: right; }
+.start { text-align: start; }
+.end { text-align: end; }

--- a/css/css-text/white-space/trailing-space-and-text-alignment-001.html
+++ b/css/css-text/white-space/trailing-space-and-text-alignment-001.html
@@ -9,32 +9,12 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-normal">
 <link rel="match" href="reference/trailing-space-and-text-alignment-001-ref.html">
 <meta name="assert" content="preserved trailing spaces under 'white-space: normal' hang and shouldn't cause overflow and activate the horizontal scrollbar.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="stylesheet" href="support/trailing-space-and-text-alignment.css">
 <style>
-    textarea {
-        /* Reset user-agent style */
-        margin: initial;
-        padding: initial;
-        border: initial;
-        outline: initial;
-        resize: initial;
-        overflow-wrap: initial;
-
-        height: 100px;
-        font: 40px/1 Ahem;
-        border: 1px solid black;
-        overflow-y: hidden;
-        overflow-x: auto;
-
-        /* testing */
-        width: 3ch;
-        white-space: normal;
+textarea {
+    white-space: normal;
 }
-.left { text-align: left; }
-.center { text-align: center; }
-.right { text-align: right; }
-.start { text-align: start; }
-.end { text-align: end; }
 </style>
 <textarea class="left">XXX   X</textarea>
 <textarea class="center">XXX   X</textarea>

--- a/css/css-text/white-space/trailing-space-and-text-alignment-002.html
+++ b/css/css-text/white-space/trailing-space-and-text-alignment-002.html
@@ -9,32 +9,12 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-pre">
 <link rel="match" href="reference/trailing-space-and-text-alignment-002-ref.html">
 <meta name="assert" content="preserved trailing spaces under 'white-space: pre' shouldn't hang and may cause overflow and activate the scrollbars.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="stylesheet" href="support/trailing-space-and-text-alignment.css">
 <style>
-    textarea {
-        /* Reset user-agent style */
-        margin: initial;
-        padding: initial;
-        border: initial;
-        outline: initial;
-        resize: initial;
-        overflow-wrap: initial;
-
-        height: 100px;
-        font: 40px/1 Ahem;
-        border: 1px solid black;
-        overflow-y: hidden;
-        overflow-x: auto;
-
-        /* testing */
-        width: 3ch;
-        white-space: pre;
-    }
-.left { text-align: left; }
-.center { text-align: center; }
-.right { text-align: right; }
-.start { text-align: start; }
-.end { text-align: end; }
+textarea {
+    white-space: pre;
+}
 </style>
 <textarea class="left">XXX &#10;X</textarea>
 <textarea class="center">XXX &#10;X</textarea>

--- a/css/css-text/white-space/trailing-space-and-text-alignment-003.html
+++ b/css/css-text/white-space/trailing-space-and-text-alignment-003.html
@@ -9,32 +9,12 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-pre-wrap">
 <link rel="match" href="reference/trailing-space-and-text-alignment-001-ref.html">
 <meta name="assert" content="preserved trailing spaces under 'white-space: pre-wrap' hang and shouldn't cause overflow and activate the horizontal scrollbar.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="stylesheet" href="support/trailing-space-and-text-alignment.css">
 <style>
-    textarea {
-        /* Reset user-agent style */
-        margin: initial;
-        padding: initial;
-        border: initial;
-        outline: initial;
-        resize: initial;
-        overflow-wrap: initial;
-
-        height: 100px;
-        font: 40px/1 Ahem;
-        border: 1px solid black;
-        overflow-y: hidden;
-        overflow-x: auto;
-
-        /* testing */
-        width: 3ch;
-        white-space: pre-wrap;
+textarea {
+    white-space: pre-wrap;
 }
-.left { text-align: left; }
-.center { text-align: center; }
-.right { text-align: right; }
-.start { text-align: start; }
-.end { text-align: end; }
 </style>
 <textarea class="left">XXX X</textarea>
 <textarea class="center">XXX X</textarea>

--- a/css/css-text/white-space/trailing-space-and-text-alignment-004.html
+++ b/css/css-text/white-space/trailing-space-and-text-alignment-004.html
@@ -9,32 +9,12 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-break-spaces">
 <link rel="match" href="reference/trailing-space-and-text-alignment-002-ref.html">
 <meta name="assert" content="preserved trailing spaces under 'white-space: break-spaces' shouldn't hang and may cause overflow and activate the horizontal scrollbar.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="stylesheet" href="support/trailing-space-and-text-alignment.css">
 <style>
-    textarea {
-        /* Reset user-agent style */
-        margin: initial;
-        padding: initial;
-        border: initial;
-        outline: initial;
-        resize: initial;
-        overflow-wrap: initial;
-
-        height: 100px;
-        font: 40px/1 Ahem;
-        border: 1px solid black;
-        overflow-y: hidden;
-        overflow-x: auto;
-
-        /* testing */
-        width: 3ch;
-        white-space: break-spaces;
+textarea {
+    white-space: break-spaces;
 }
-.left { text-align: left; }
-.center { text-align: center; }
-.right { text-align: right; }
-.start { text-align: start; }
-.end { text-align: end; }
 </style>
 <textarea class="left">XXX X</textarea>
 <textarea class="center">XXX X</textarea>

--- a/css/css-text/white-space/trailing-space-and-text-alignment-005.html
+++ b/css/css-text/white-space/trailing-space-and-text-alignment-005.html
@@ -9,32 +9,12 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-pre-line">
 <link rel="match" href="reference/trailing-space-and-text-alignment-001-ref.html">
 <meta name="assert" content="preserved trailing spaces under 'white-space: pre-line' hang and shouldn't cause overflow and activate the horizontal scrollbar.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="stylesheet" href="support/trailing-space-and-text-alignment.css">
 <style>
-    textarea {
-        /* Reset user-agent style */
-        margin: initial;
-        padding: initial;
-        border: initial;
-        outline: initial;
-        resize: initial;
-        overflow-wrap: initial;
-
-        height: 100px;
-        font: 40px/1 Ahem;
-        border: 1px solid black;
-        overflow-y: hidden;
-        overflow-x: auto;
-
-        /* testing */
-        width: 3ch;
-        white-space: pre-line;
+textarea {
+    white-space: pre-line;
 }
-.left { text-align: left; }
-.center { text-align: center; }
-.right { text-align: right; }
-.start { text-align: start; }
-.end { text-align: end; }
 </style>
 <textarea class="left">XXX   X</textarea>
 <textarea class="center">XXX   X</textarea>

--- a/css/css-text/white-space/trailing-space-and-text-alignment-rtl-001.html
+++ b/css/css-text/white-space/trailing-space-and-text-alignment-rtl-001.html
@@ -9,33 +9,13 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-normal">
 <link rel="match" href="reference/trailing-space-and-text-alignment-rtl-001-ref.html">
 <meta name="assert" content="preserved trailing spaces under 'white-space: normal' hang and shouldn't cause overflow and activate the horizontal scrollbar.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="stylesheet" href="support/trailing-space-and-text-alignment.css">
 <style>
-    textarea {
-        /* Reset user-agent style */
-        margin: initial;
-        padding: initial;
-        border: initial;
-        outline: initial;
-        resize: initial;
-        overflow-wrap: initial;
-
-        height: 100px;
-        font: 40px/1 Ahem;
-        border: 1px solid black;
-        overflow-y: hidden;
-        overflow-x: auto;
-
-        /* testing */
-        width: 3ch;
-        white-space: normal;
-        direction: rtl;
+textarea {
+    white-space: normal;
+    direction: rtl;
 }
-.left { text-align: left; }
-.center { text-align: center; }
-.right { text-align: right; }
-.start { text-align: start; }
-.end { text-align: end; }
 </style>
 <textarea class="left">XXX   X</textarea>
 <textarea class="center">XXX   X</textarea>

--- a/css/css-text/white-space/trailing-space-and-text-alignment-rtl-002.html
+++ b/css/css-text/white-space/trailing-space-and-text-alignment-rtl-002.html
@@ -9,33 +9,13 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-pre">
 <link rel="match" href="reference/trailing-space-and-text-alignment-rtl-002-ref.html">
 <meta name="assert" content="preserved trailing spaces under 'white-space: pre' shouldn't hang and may cause overflow and activate the scrollbars.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="stylesheet" href="support/trailing-space-and-text-alignment.css">
 <style>
-    textarea {
-        /* Reset user-agent style */
-        margin: initial;
-        padding: initial;
-        border: initial;
-        outline: initial;
-        resize: initial;
-        overflow-wrap: initial;
-
-        height: 100px;
-        font: 40px/1 Ahem;
-        border: 1px solid black;
-        overflow-y: hidden;
-        overflow-x: auto;
-
-        /* testing */
-        width: 3ch;
-        white-space: pre;
-        direction: rtl;
-    }
-.left { text-align: left; }
-.center { text-align: center; }
-.right { text-align: right; }
-.start { text-align: start; }
-.end { text-align: end; }
+textarea {
+    white-space: pre;
+    direction: rtl;
+}
 </style>
 <textarea class="left">XXX &#10;X</textarea>
 <textarea class="center">XXX &#10;X</textarea>

--- a/css/css-text/white-space/trailing-space-and-text-alignment-rtl-003.html
+++ b/css/css-text/white-space/trailing-space-and-text-alignment-rtl-003.html
@@ -9,33 +9,13 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-pre-wrap">
 <link rel="match" href="reference/trailing-space-and-text-alignment-rtl-001-ref.html">
 <meta name="assert" content="preserved trailing spaces under 'white-space: pre-wrap' hang and shouldn't cause overflow and activate the horizontal scrollbar.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="stylesheet" href="support/trailing-space-and-text-alignment.css">
 <style>
-    textarea {
-        /* Reset user-agent style */
-        margin: initial;
-        padding: initial;
-        border: initial;
-        outline: initial;
-        resize: initial;
-        overflow-wrap: initial;
-
-        height: 100px;
-        font: 40px/1 Ahem;
-        border: 1px solid black;
-        overflow-y: hidden;
-        overflow-x: auto;
-
-        /* testing */
-        width: 3ch;
-        white-space: pre-wrap;
-        direction: rtl;
+textarea {
+    white-space: pre-wrap;
+    direction: rtl;
 }
-.left { text-align: left; }
-.center { text-align: center; }
-.right { text-align: right; }
-.start { text-align: start; }
-.end { text-align: end; }
 </style>
 <textarea class="left">XXX X</textarea>
 <textarea class="center">XXX X</textarea>

--- a/css/css-text/white-space/trailing-space-and-text-alignment-rtl-004.html
+++ b/css/css-text/white-space/trailing-space-and-text-alignment-rtl-004.html
@@ -9,33 +9,13 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-break-spaces">
 <link rel="match" href="reference/trailing-space-and-text-alignment-rtl-005-ref.html">
 <meta name="assert" content="preserved trailing spaces under 'white-space: break-spaces' shouldn't hang and may cause overflow and activate the horizontal scrollbar.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="stylesheet" href="support/trailing-space-and-text-alignment.css">
 <style>
-    textarea {
-        /* Reset user-agent style */
-        margin: initial;
-        padding: initial;
-        border: initial;
-        outline: initial;
-        resize: initial;
-        overflow-wrap: initial;
-
-        height: 100px;
-        font: 40px/1 Ahem;
-        border: 1px solid black;
-        overflow-y: hidden;
-        overflow-x: auto;
-
-        /* testing */
-        width: 3ch;
-        white-space: break-spaces;
-        direction: rtl;
+textarea {
+    white-space: break-spaces;
+    direction: rtl;
 }
-.left { text-align: left; }
-.center { text-align: center; }
-.right { text-align: right; }
-.start { text-align: start; }
-.end { text-align: end; }
 </style>
 <textarea class="left">XXX X</textarea>
 <textarea class="center">XXX X</textarea>

--- a/css/css-text/white-space/trailing-space-and-text-alignment-rtl-005.html
+++ b/css/css-text/white-space/trailing-space-and-text-alignment-rtl-005.html
@@ -9,33 +9,13 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-pre-line">
 <link rel="match" href="reference/trailing-space-and-text-alignment-rtl-001-ref.html">
 <meta name="assert" content="preserved trailing spaces under 'white-space: pre-line' hang and shouldn't cause overflow and activate the horizontal scrollbar.">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="stylesheet" href="support/trailing-space-and-text-alignment.css">
 <style>
-    textarea {
-        /* Reset user-agent style */
-        margin: initial;
-        padding: initial;
-        border: initial;
-        outline: initial;
-        resize: initial;
-        overflow-wrap: initial;
-
-        height: 100px;
-        font: 40px/1 Ahem;
-        border: 1px solid black;
-        overflow-y: hidden;
-        overflow-x: auto;
-
-        /* testing */
-        width: 3ch;
-        white-space: pre-line;
-        direction: rtl;
+textarea {
+    white-space: pre-line;
+    direction: rtl;
 }
-.left { text-align: left; }
-.center { text-align: center; }
-.right { text-align: right; }
-.start { text-align: start; }
-.end { text-align: end; }
 </style>
 <textarea class="left">XXX   X</textarea>
 <textarea class="center">XXX   X</textarea>


### PR DESCRIPTION
Add border-radius: initial to reset the border-radius added by iOS UA styles. Also move common CSS to a separate file.