### PR TITLE
Fix networkState_during_loadstart video sub-test.

### DIFF
--- a/html/semantics/embedded-content/media-elements/networkState_during_loadstart.html
+++ b/html/semantics/embedded-content/media-elements/networkState_during_loadstart.html
@@ -30,7 +30,7 @@ var tv = async_test("videoElement.networkState should be NETWORK_LOADING during 
 var v = document.getElementById("v");
 v.addEventListener("loadstart", function() {
   tv.step(function() {
-   assert_equals(a.networkState,
+   assert_equals(v.networkState,
    v.NETWORK_LOADING);
   });
   tv.done();


### PR DESCRIPTION
networkState_during_loadstart video sub-test now uses the video element rather than the audio element from the audio sub-test.