### PR TITLE
[image-set] Add tests for negative and zero resolutions.

### DIFF
--- a/css/css-images/image-set/image-set-negative-resolution-rendering-3.html
+++ b/css/css-images/image-set/image-set-negative-resolution-rendering-3.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>Image set negative resolution rendering</title>
+<link rel="help" href="https://drafts.csswg.org/css-images-4/#image-set-notation">
+<link rel="match" href="/css/reference/blank.html">
+<meta name="assert" content="image-set rendering with negative resolution">
+<style>
+  #test {
+    background-image: url("/images/red.png");
+    background-image: image-set(url("/images/red.png") calc(-1 * 1x));
+    width: 100px;
+    height: 100px;
+  }
+</style>
+<div id="test"></div>

--- a/css/css-images/image-set/image-set-parsing.html
+++ b/css/css-images/image-set/image-set-parsing.html
@@ -159,6 +159,14 @@ function test_non_positive_resolutions_parsing() {
     'background-image',
     'image-set(url("example.png") 0dpcm)'
   );
+  test_valid_value_variants(
+    'background-image',
+    'image-set(url("example.png") calc(-1 * 1x))'
+  );
+  test_valid_value_variants(
+    'background-image',
+    'image-set(url("example.png") calc(1x + -1x))'
+  );
 
   test_invalid_value_variants(
     'background-image',

--- a/css/css-images/image-set/image-set-zero-resolution-rendering-2.html
+++ b/css/css-images/image-set/image-set-zero-resolution-rendering-2.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-images-4/#image-set-notation">
+<link rel="match" href="/css/reference/blank.html">
+<meta name="assert" content="image-set rendering with zero resolution">
+<style>
+#test {
+    background-image: url("/images/red.png");
+    background-image: image-set(url("/images/red.png") calc(0dppx * -1));
+    width: 100px;
+    height: 100px;
+}
+</style>
+<div id="test"></div>
+

--- a/css/css-images/image-set/image-set-zero-resolution-rendering.html
+++ b/css/css-images/image-set/image-set-zero-resolution-rendering.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-images-4/#image-set-notation">
+<link rel="match" href="/css/reference/blank.html">
+<meta name="assert" content="image-set rendering with zero resolution">
+<style>
+#test {
+    background-image: url("/images/red.png");
+    background-image: image-set(url("/images/red.png") 0x);
+    width: 100px;
+    height: 100px;
+}
+</style>
+<div id="test"></div>
+


### PR DESCRIPTION
calc() with negative resolution is supposed to clamp to zero. Zero resolutions are supposed to be `<invalid-image>`s from the css images level 4 spec. This adds parsing and rendering test cases for those situations.