### PR TITLE
typo: navigation -> nav

### DIFF
--- a/wai-aria/role/fallback-roles.html
+++ b/wai-aria/role/fallback-roles.html
@@ -13,8 +13,8 @@
 
   <p>Verifies Fallback Roles from <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a></p>
 
-  <navigation role="region group" data-testname="fallback role w/ region with no label" data-expectedrole="group" class="ex">x</nav>
-  <navigation role="region group" data-testname="fallback role w/ region with label" aria-label="x" data-expectedrole="region" class="ex">x</nav>
+  <nav role="region group" data-testname="fallback role w/ region with no label" data-expectedrole="group" class="ex">x</nav>
+  <nav role="region group" data-testname="fallback role w/ region with label" aria-label="x" data-expectedrole="region" class="ex">x</nav>
 
 <!-- todo: additional fallback roles:
 


### PR DESCRIPTION
Typo was causing failures due to an element continuation.