### PR TITLE
Add relevant spec links from new accessibility test files

### DIFF
--- a/accname/name/comp_embedded_control.html
+++ b/accname/name/comp_embedded_control.html
@@ -11,6 +11,8 @@
 </head>
 <body>
 
+<p>Tests the <a href="https://w3c.github.io/accname/#comp_embedded_control">#comp_embedded_control</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
+
 <label>
   <input type="checkbox" data-expectedlabel="Flash the screen 3 times" data-testname="checkbox label with embedded textfield" class="ex">
   Flash the screen

--- a/accname/name/comp_hidden_not_referenced.html
+++ b/accname/name/comp_hidden_not_referenced.html
@@ -11,6 +11,8 @@
 </head>
 <body>
 
+<p>Tests the <a href="https://w3c.github.io/accname/#comp_hidden_not_referenced">#comp_hidden_not_referenced</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
+
 <h2 class="ex" data-expectedlabel="heading label" data-testname="heading with interior hidden node">
   heading
   <span hidden>bogus</span>

--- a/accname/name/comp_host_language_label.html
+++ b/accname/name/comp_host_language_label.html
@@ -11,6 +11,8 @@
 </head>
 <body>
 
+<p>Tests the <a href="https://w3c.github.io/accname/#comp_host_language_label">#comp_host_language_label</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
+
 <label for="t">label</label>
 <input id="t" data-expectedlabel="label" data-testname="host language: label[for] input[type=text]" class="ex">
 <!-- Todo: test all remaining input types with label[for] -->

--- a/accname/name/comp_label.html
+++ b/accname/name/comp_label.html
@@ -11,6 +11,8 @@
 </head>
 <body>
 
+<p>Tests the <a href="https://w3c.github.io/accname/#comp_label">#comp_label</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
+
 <div aria-label="label" data-expectedlabel="label" data-testname="label valid on group" role="group" class="ex">x</div>
 
 <!-- Todo: test all remaining cases of https://w3c.github.io/accname/#comp_label -->

--- a/accname/name/comp_labelledby.html
+++ b/accname/name/comp_labelledby.html
@@ -11,6 +11,8 @@
 </head>
 <body>
 
+<p>Tests the <a href="https://w3c.github.io/accname/#comp_labelledby">#comp_labelledby</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
+
 <div role="group" aria-labelledby="h" class="ex" data-expectedlabel="div group label" data-testname="div group explicitly labelledby heading">
   <h2 id="h">div group label</h2>
   <p>text inside div group</p>

--- a/accname/name/comp_name_from_content.html
+++ b/accname/name/comp_name_from_content.html
@@ -11,6 +11,8 @@
 </head>
 <body>
 
+<p>Tests the <a href="https://w3c.github.io/accname/#comp_name_from_content">#comp_name_from_content</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
+
 <h1 data-expectedlabel="label" data-testname="heading name from content" class="ex">label</h1>
 
 <!--

--- a/accname/name/comp_text_node.html
+++ b/accname/name/comp_text_node.html
@@ -11,6 +11,8 @@
 </head>
 <body>
 
+<p>Tests the <a href="https://w3c.github.io/accname/#comp_text_node">#comp_text_node</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
+
 <!-- I'm not certain whether #comp_text_node requires a lot of testing outside of the #comp_name_from_content contexts, -->
 <!-- but I did think of one example where text node versus comment node may make a difference when joining text nodes with a space vs innerText. -->
 

--- a/accname/name/comp_tooltip.html
+++ b/accname/name/comp_tooltip.html
@@ -11,6 +11,8 @@
 </head>
 <body>
 
+  <p>Tests the <a href="https://w3c.github.io/accname/#comp_tooltip">#comp_tooltip</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
+
 <a href="#" title="label" data-expectedlabel="label" data-testname="link label from tooltip" class="ex"><img src="#" alt=""></a>
 
 <!-- Todo: test all remaining cases of https://w3c.github.io/accname/#comp_tooltip -->

--- a/accname/name/shadowdom/basic.html
+++ b/accname/name/shadowdom/basic.html
@@ -6,6 +6,8 @@
 <script src="/resources/testdriver-actions.js"></script>
 <script src="/wai-aria/scripts/aria-utils.js"></script>
 
+ <p>Tests the basic shadow DOM portions of the AccName <em>Name Computation</em> algorithm, coming in <a href="https://github.com/w3c/accname/pull/167">ARIA #167</a>.</p>
+
 <label id="label1">
   <div id="host1"></div>
 </label>

--- a/accname/name/shadowdom/slot.html
+++ b/accname/name/shadowdom/slot.html
@@ -6,6 +6,8 @@
 <script src="/resources/testdriver-actions.js"></script>
 <script src="/wai-aria/scripts/aria-utils.js"></script>
 
+ <p>Tests the shadow DOM slots portions of the AccName <em>Name Computation</em> algorithm, coming in <a href="https://github.com/w3c/accname/pull/167">ARIA #167</a>.</p>
+
 <label id="label1">
   <div id="host1">slotted</div>
 </label>

--- a/graphics-aria/graphics-roles.html
+++ b/graphics-aria/graphics-roles.html
@@ -10,6 +10,8 @@
 </head>
 <body>
 
+<p>Tests the concrete roles defined in the <a href="https://www.w3.org/TR/graphics-aria-1.0/#role_definitions">ARIA Graphics Module</a> role definitions.</p>
+
 <div role="graphics-document" data-expectedrole="graphics-document" class="ex">x</div>
 <div role="graphics-object" data-expectedrole="graphics-object" class="ex">x</div>
 <div role="graphics-symbol" data-expectedrole="graphics-symbol" class="ex">x</div>

--- a/html-aam/roles.html
+++ b/html-aam/roles.html
@@ -11,7 +11,10 @@
 </head>
 <body>
 
-<!-- Most test names correspond to unique ID defined in the https://w3c.github.io/html-aam/ spec. -->
+
+<p>Tests the computedrole mappings defined in <a href="https://w3c.github.io/html-aam/">HTML-AAM</a>. Most test names correspond to unique ID defined in the spec.<p>
+
+<p>These should remain in alphabetical order, and include all HTML tagnames. If a tag is not tested here, include a pointer to the file where it is tested, such as: <code>&lt;!-- caption -&gt; ./table-roles.html --&gt;</code></p>
 
 <a href="#" data-testname="el-a" data-expectedrole="link" class="ex">x</a>
 <a data-testname="el-a-no-href" data-expectedrole="generic" class="ex">x</a>

--- a/html-aam/table-roles.html
+++ b/html-aam/table-roles.html
@@ -11,6 +11,8 @@
 </head>
 <body>
 
+<p>Tests the computedrole mappings for the table-related roles defined in <a href="https://w3c.github.io/html-aam/">HTML-AAM</a>. Most test names correspond to unique ID defined in the spec.<p>
+
 <table data-testname="el-table" data-expectedrole="table" class="ex">
   <caption data-testname="el-caption" data-expectedrole="caption" class="ex">caption</caption>
   <thead data-testname="el-thead" data-expectedrole="rowgroup" class="ex">

--- a/wai-aria/role/abstract-roles.html
+++ b/wai-aria/role/abstract-roles.html
@@ -12,7 +12,8 @@
 <body>
 
 
-<p>Verifies <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a></p>
+<p>Tests <a href="https://w3c.github.io/aria/#abstract_roles">Abstract Roles</a> and related <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a></p>
+
   <nav role="command" data-testname="command role" data-expectedrole="navigation" class="ex">x</nav>
   <nav role="composite" data-testname="composite role" data-expectedrole="navigation" class="ex">x</nav>
   <nav role="input" data-testname="input role" data-expectedrole="navigation" class="ex">x</nav>

--- a/wai-aria/role/fallback-roles.html
+++ b/wai-aria/role/fallback-roles.html
@@ -11,7 +11,7 @@
   </head>
   <body>
 
-  <p>Verifies Fallback Roles from <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a></p>
+  <p>Tests <a href="https://w3c.github.io/aria/#host_general_role">8.1 Role Attribute</a> role token list selection and <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a>.</p>
 
   <nav role="region group" data-testname="fallback role w/ region with no label" data-expectedrole="group" class="ex">x</nav>
   <nav role="region group" data-testname="fallback role w/ region with label" aria-label="x" data-expectedrole="region" class="ex">x</nav>
@@ -19,7 +19,7 @@
 <!-- todo: additional fallback roles:
 
 - valid/valid "switch checkbox"
-- valid/invalid "foo group"
+- invalid/valid "foo group"
 - unicode char tests with fallback
 - whitespace tests with fallback
 - unicode char tests with fallback

--- a/wai-aria/role/invalid-roles.html
+++ b/wai-aria/role/invalid-roles.html
@@ -20,7 +20,7 @@
 
 - whitespace tests (including line breaks, tabs, zero-width space, braille space)
 - diacritics
-- joiners (e.g. like emoji variants use)
+- zero-width joiners (e.g. ZWJ like emoji variants use)
 - non-western chars
 - RTL strings (Hebrew & Arabic)
 - escaped chars, URL-encoded chars

--- a/wai-aria/role/list-roles.html
+++ b/wai-aria/role/list-roles.html
@@ -11,6 +11,8 @@
 </head>
 <body>
 
+<p>Tests <a href="https://w3c.github.io/aria/#list">list</a> and related roles.</p>
+
 <div role="list" data-testname="first simple list" data-expectedrole="list" class="ex">
   <div role="listitem" data-testname="first simple listitem" data-expectedrole="listitem" class="ex">x</div>
   <div role="listitem" data-testname="last simple listitem" data-expectedrole="listitem" class="ex">x</div>

--- a/wai-aria/role/region-roles.html
+++ b/wai-aria/role/region-roles.html
@@ -11,6 +11,8 @@
 </head>
 <body>
 
+<p>Tests <a href="https://w3c.github.io/aria/#region">region</a> and related roles, as well as the "name from author" rule in <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a>.</p>
+
 <!-- no label -->
 <nav role="region" data-testname="region without label" data-expectedrole="navigation" class="ex">x</nav>
 

--- a/wai-aria/role/roles.html
+++ b/wai-aria/role/roles.html
@@ -10,6 +10,9 @@
   <script src="/wai-aria/scripts/aria-utils.js"></script>
 </head>
 <body>
+
+<p>Tests most <a href="https://w3c.github.io/aria/#role_definitions">ARIA role definitions</a>. See comments for more info.</p>
+
 <script>
 
 /*

--- a/wai-aria/role/synonym-roles.html
+++ b/wai-aria/role/synonym-roles.html
@@ -11,6 +11,8 @@
 </head>
 <body>
 
+<p>Tests synonym roles image/img and none/presentation via <a href="https://w3c.github.io/core-aam/#roleMappingComputedRole">Core-AAM Computed Role</a>.</p>
+
 <!-- spec resolution https://github.com/w3c/core-aam/issues/166 -->
 
 <div role="none" id="none" data-expectedrole="none" data-testname="none role == computedrole none" class="ex">x</div><!-- preferred -->


### PR DESCRIPTION
Closes https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/46

Add notes pointing each test file to the relevant portion of the spec it tests