### PR TITLE
Notifications: test that silent defaults to null

### DIFF
--- a/notifications/constructor-basic.https.html
+++ b/notifications/constructor-basic.https.html
@@ -13,4 +13,34 @@ test(function() {
         notification.close()
     }
 }, "Called the notification constructor with one argument.")
+
+test(() => {
+    assert_equals(
+        new Notification("a").silent,
+        null,
+        "Expected null by default"
+    );
+}, "Constructing a notification without a NotificationOptions defaults to null.");
+
+test(() => {
+    for (const silent of [null, undefined]) {
+        assert_equals(
+            new Notification("a", { silent }).silent,
+            null,
+            `Expected silent to be null when initialized with ${silent}.`
+        );
+    }
+    for (const silent of [true, 1, 100, {}, [], "a string"]) {
+        assert_true(
+            new Notification("a", { silent }).silent,
+            `Expected silent to be true when initialized with ${silent}.`
+        );
+    }
+    for (const silent of [false, 0, "", NaN]) {
+        assert_false(
+            new Notification("a", { silent }).silent,
+            `Expected silent to be false when initialized with ${silent}.`
+        );
+    }
+}, "constructing a notification with a NotificationOptions dictionary correctly sets and reflects the silent attribute.");
 </script>


### PR DESCRIPTION
Tests for https://github.com/whatwg/notifications/pull/194 

Manual export of WebKit bug https://bugs.webkit.org/show_bug.cgi?id=256828

These were already reviewed upstream. 
