### PR TITLE
Modify fuzziness of white-space-intrinsic-size tests to pass on iOS

### DIFF
--- a/css/css-text/white-space/white-space-intrinsic-size-017.html
+++ b/css/css-text/white-space/white-space-intrinsic-size-017.html
@@ -12,7 +12,7 @@
   <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 
-  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-3958">
+  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
   <meta content="When 'white-space' is 'pre-wrap', preserved white spaces at the beginning and at the end of the line affect the intrinsic max-content size." name="assert">
 
   <style>

--- a/css/css-text/white-space/white-space-intrinsic-size-018.html
+++ b/css/css-text/white-space/white-space-intrinsic-size-018.html
@@ -12,7 +12,7 @@
   <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 
-  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-3958">
+  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
   <meta content="When 'white-space' is 'pre', preserved white spaces at the beginning and at the end of the line affect the intrinsic max-content size." name="assert">
 
   <style>


### PR DESCRIPTION
Increase the maximum pixel difference for white-space-intrinsic-size tests so that they pass on iOS.