### PR TITLE
bidi: remove tlsEnd from network.FetchTimingInfo

### DIFF
--- a/webdriver/tests/bidi/network/__init__.py
+++ b/webdriver/tests/bidi/network/__init__.py
@@ -45,7 +45,6 @@ def assert_timing_info(timing_info):
             "connectStart": any_int,
             "connectEnd": any_int,
             "tlsStart": any_int,
-            "tlsEnd": any_int,
             "requestStart": any_int,
             "responseStart": any_int,
             "responseEnd": any_int,


### PR DESCRIPTION
tlsEnd never made it to the spec:
https://w3c.github.io/webdriver-bidi/#type-network-FetchTimingInfo

c.f. https://github.com/w3c/webdriver-bidi/pull/204:

> tlsEnd: float this should be the same as connectEnd

As it is a redundant param anyway, remove it from WPT.