### PR TITLE
Simplify canvas tests to avoid harness errors

### DIFF
--- a/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.svg.html
+++ b/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.svg.html
@@ -15,21 +15,11 @@ promise_test(async t => {
   var canvas = new OffscreenCanvas(100, 50);
   var ctx = canvas.getContext('2d');
 
-  var promise = new Promise(function(resolve, reject) {
-    var xhr = new XMLHttpRequest();
-    xhr.open("GET", '/images/green.svg');
-    xhr.responseType = 'blob';
-    xhr.send();
-    xhr.onload = function() {
-      resolve(xhr.response);
-    };
-  });
-  promise.then(function(response) {
-    createImageBitmap(response).then(bitmap => {
-      ctx.drawImage(bitmap, 0, 0);
-      _assertPixelApprox(canvas, 50,25, 0,255,0,255, 2);
-    });
-  });
+  const response = await fetch('/images/green.svg');
+  const blob = await response.blob();
+  const bitmap = await createImageBitmap(blob);
+  ctx.drawImage(bitmap, 0, 0);
+  _assertPixelApprox(canvas, 50,25, 0,255,0,255, 2);
 
 }, "drawImage() of an SVG image");
 </script>

--- a/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.svg.worker.js
+++ b/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.svg.worker.js
@@ -11,21 +11,11 @@ promise_test(async t => {
   var canvas = new OffscreenCanvas(100, 50);
   var ctx = canvas.getContext('2d');
 
-  var promise = new Promise(function(resolve, reject) {
-    var xhr = new XMLHttpRequest();
-    xhr.open("GET", '/images/green.svg');
-    xhr.responseType = 'blob';
-    xhr.send();
-    xhr.onload = function() {
-      resolve(xhr.response);
-    };
-  });
-  promise.then(function(response) {
-    createImageBitmap(response).then(bitmap => {
-      ctx.drawImage(bitmap, 0, 0);
-      _assertPixelApprox(canvas, 50,25, 0,255,0,255, 2);
-    });
-  });
+  const response = await fetch('/images/green.svg');
+  const blob = await response.blob();
+  const bitmap = await createImageBitmap(blob);
+  ctx.drawImage(bitmap, 0, 0);
+  _assertPixelApprox(canvas, 50,25, 0,255,0,255, 2);
   t.done();
 }, "drawImage() of an SVG image");
 done();

--- a/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.zerosource.image.html
+++ b/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.zerosource.image.html
@@ -17,21 +17,11 @@ promise_test(async t => {
 
   ctx.fillStyle = '#0f0';
   ctx.fillRect(0, 0, 100, 50);
-  var promise = new Promise(function(resolve, reject) {
-    var xhr = new XMLHttpRequest();
-    xhr.open("GET", '/images/red-zerowidth.svg');
-    xhr.responseType = 'blob';
-    xhr.send();
-    xhr.onload = function() {
-      resolve(xhr.response);
-    };
-  });
-  promise.then(function(response) {
-    createImageBitmap(response).then(bitmap => {
-      ctx.drawImage(bitmap, 0, 0, 100, 50);
-      _assertPixel(canvas, 50,25, 0,255,0,255);
-    });
-  });
+  const response = await fetch('/images/red-zerowidth.svg');
+  const blob = await response.blob();
+  const bitmap = await createImageBitmap(blob);
+  ctx.drawImage(bitmap, 0, 0, 100, 50);
+  _assertPixel(canvas, 50,25, 0,255,0,255);
 
 }, "drawImage with zero-sized source rectangle from image draws nothing without exception");
 </script>

--- a/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.zerosource.image.worker.js
+++ b/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.zerosource.image.worker.js
@@ -13,21 +13,11 @@ promise_test(async t => {
 
   ctx.fillStyle = '#0f0';
   ctx.fillRect(0, 0, 100, 50);
-  var promise = new Promise(function(resolve, reject) {
-    var xhr = new XMLHttpRequest();
-    xhr.open("GET", '/images/red-zerowidth.svg');
-    xhr.responseType = 'blob';
-    xhr.send();
-    xhr.onload = function() {
-      resolve(xhr.response);
-    };
-  });
-  promise.then(function(response) {
-    createImageBitmap(response).then(bitmap => {
-      ctx.drawImage(bitmap, 0, 0, 100, 50);
-      _assertPixel(canvas, 50,25, 0,255,0,255);
-    });
-  });
+  const response = await fetch('/images/red-zerowidth.svg');
+  const blob = await response.blob();
+  const bitmap = await createImageBitmap(blob);
+  ctx.drawImage(bitmap, 0, 0, 100, 50);
+  _assertPixel(canvas, 50,25, 0,255,0,255);
   t.done();
 }, "drawImage with zero-sized source rectangle from image draws nothing without exception");
 done();

--- a/html/canvas/tools/yaml-new/drawing-images-to-the-canvas.yaml
+++ b/html/canvas/tools/yaml-new/drawing-images-to-the-canvas.yaml
@@ -428,21 +428,11 @@
   code: |
     ctx.fillStyle = '#0f0';
     ctx.fillRect(0, 0, 100, 50);
-    var promise = new Promise(function(resolve, reject) {
-      var xhr = new XMLHttpRequest();
-      xhr.open("GET", '/images/red-zerowidth.svg');
-      xhr.responseType = 'blob';
-      xhr.send();
-      xhr.onload = function() {
-        resolve(xhr.response);
-      };
-    });
-    promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
-        ctx.drawImage(bitmap, 0, 0, 100, 50);
-        _assertPixel(canvas, 50,25, 0,255,0,255);
-      });
-    });
+    const response = await fetch('/images/red-zerowidth.svg');
+    const blob = await response.blob();
+    const bitmap = await createImageBitmap(blob);
+    ctx.drawImage(bitmap, 0, 0, 100, 50);
+    _assertPixel(canvas, 50,25, 0,255,0,255);
   expected: green
 
 - name: 2d.drawImage.negativesource
@@ -574,21 +564,11 @@
   test_type: promise
   canvasType: ['OffscreenCanvas', 'Worker']
   code: |
-    var promise = new Promise(function(resolve, reject) {
-      var xhr = new XMLHttpRequest();
-      xhr.open("GET", '/images/green.svg');
-      xhr.responseType = 'blob';
-      xhr.send();
-      xhr.onload = function() {
-        resolve(xhr.response);
-      };
-    });
-    promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
-        ctx.drawImage(bitmap, 0, 0);
-        _assertPixelApprox(canvas, 50,25, 0,255,0,255, 2);
-      });
-    });
+    const response = await fetch('/images/green.svg');
+    const blob = await response.blob();
+    const bitmap = await createImageBitmap(blob);
+    ctx.drawImage(bitmap, 0, 0);
+    _assertPixelApprox(canvas, 50,25, 0,255,0,255, 2);
   expected: green
 
 - name: 2d.drawImage.animated.poster


### PR DESCRIPTION
Example harness error:
https://wpt.fyi/results/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.svg.html?run_id=5175029174632448&run_id=5141664660717568&run_id=6215011616161792

The problem appears to be that the createImageBitmap() call is rejected,
but that promise isn't connected to the test in any way.
