### PR TITLE
Fix promise rejection chaining in canvas tests

### DIFF
--- a/html/canvas/offscreen/compositing/2d.composite.canvas.clear.html
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.clear.html
@@ -32,14 +32,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'clear';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.clear.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.clear.worker.js
@@ -28,14 +28,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'clear';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.copy.html
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.copy.html
@@ -32,14 +32,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'copy';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 255,255,0,191, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.copy.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.copy.worker.js
@@ -28,14 +28,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'copy';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 255,255,0,191, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.destination-atop.html
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.destination-atop.html
@@ -32,14 +32,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'destination-atop';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 128,255,128,191, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.destination-atop.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.destination-atop.worker.js
@@ -28,14 +28,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'destination-atop';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 128,255,128,191, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.destination-in.html
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.destination-in.html
@@ -32,14 +32,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'destination-in';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 0,255,255,96, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.destination-in.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.destination-in.worker.js
@@ -28,14 +28,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'destination-in';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 0,255,255,96, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.destination-out.html
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.destination-out.html
@@ -32,14 +32,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'destination-out';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 0,255,255,32, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.destination-out.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.destination-out.worker.js
@@ -28,14 +28,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'destination-out';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 0,255,255,32, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.destination-over.html
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.destination-over.html
@@ -32,14 +32,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'destination-over';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 109,255,146,223, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.destination-over.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.destination-over.worker.js
@@ -28,14 +28,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'destination-over';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 109,255,146,223, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.lighter.html
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.lighter.html
@@ -32,14 +32,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'lighter';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 191,255,128,255, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.lighter.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.lighter.worker.js
@@ -28,14 +28,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'lighter';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 191,255,128,255, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.source-atop.html
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.source-atop.html
@@ -32,14 +32,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'source-atop';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 191,255,64,128, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.source-atop.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.source-atop.worker.js
@@ -28,14 +28,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'source-atop';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 191,255,64,128, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.source-in.html
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.source-in.html
@@ -32,14 +32,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'source-in';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 255,255,0,96, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.source-in.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.source-in.worker.js
@@ -28,14 +28,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'source-in';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 255,255,0,96, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.source-out.html
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.source-out.html
@@ -32,14 +32,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'source-out';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 255,255,0,96, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.source-out.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.source-out.worker.js
@@ -28,14 +28,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'source-out';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 255,255,0,96, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.source-over.html
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.source-over.html
@@ -32,14 +32,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'source-over';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 219,255,36,223, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.source-over.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.source-over.worker.js
@@ -28,14 +28,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'source-over';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 219,255,36,223, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.xor.html
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.xor.html
@@ -32,14 +32,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'xor';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 191,255,64,128, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.canvas.xor.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.canvas.xor.worker.js
@@ -28,14 +28,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx2.drawImage(bitmap, 0, 0);
           ctx.fillStyle = 'rgba(0, 255, 255, 0.5)';
           ctx.fillRect(0, 0, 100, 50);
           ctx.globalCompositeOperation = 'xor';
           ctx.drawImage(offscreenCanvas2, 0, 0);
           _assertPixelApprox(canvas, 50,25, 191,255,64,128, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.image.clear.html
+++ b/html/canvas/offscreen/compositing/2d.composite.image.clear.html
@@ -33,10 +33,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.image.clear.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.image.clear.worker.js
@@ -29,10 +29,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.image.copy.html
+++ b/html/canvas/offscreen/compositing/2d.composite.image.copy.html
@@ -33,10 +33,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 255,255,0,191, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.image.copy.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.image.copy.worker.js
@@ -29,10 +29,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 255,255,0,191, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.image.destination-atop.html
+++ b/html/canvas/offscreen/compositing/2d.composite.image.destination-atop.html
@@ -33,10 +33,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 128,255,128,191, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.image.destination-atop.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.image.destination-atop.worker.js
@@ -29,10 +29,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 128,255,128,191, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.image.destination-in.html
+++ b/html/canvas/offscreen/compositing/2d.composite.image.destination-in.html
@@ -33,10 +33,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 0,255,255,96, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.image.destination-in.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.image.destination-in.worker.js
@@ -29,10 +29,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 0,255,255,96, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.image.destination-out.html
+++ b/html/canvas/offscreen/compositing/2d.composite.image.destination-out.html
@@ -33,10 +33,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 0,255,255,32, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.image.destination-out.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.image.destination-out.worker.js
@@ -29,10 +29,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 0,255,255,32, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.image.destination-over.html
+++ b/html/canvas/offscreen/compositing/2d.composite.image.destination-over.html
@@ -33,10 +33,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 109,255,146,223, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.image.destination-over.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.image.destination-over.worker.js
@@ -29,10 +29,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 109,255,146,223, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.image.lighter.html
+++ b/html/canvas/offscreen/compositing/2d.composite.image.lighter.html
@@ -33,10 +33,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 191,255,128,255, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.image.lighter.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.image.lighter.worker.js
@@ -29,10 +29,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 191,255,128,255, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.image.source-atop.html
+++ b/html/canvas/offscreen/compositing/2d.composite.image.source-atop.html
@@ -33,10 +33,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 191,255,64,128, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.image.source-atop.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.image.source-atop.worker.js
@@ -29,10 +29,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 191,255,64,128, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.image.source-in.html
+++ b/html/canvas/offscreen/compositing/2d.composite.image.source-in.html
@@ -33,10 +33,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 255,255,0,96, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.image.source-in.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.image.source-in.worker.js
@@ -29,10 +29,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 255,255,0,96, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.image.source-out.html
+++ b/html/canvas/offscreen/compositing/2d.composite.image.source-out.html
@@ -33,10 +33,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 255,255,0,96, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.image.source-out.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.image.source-out.worker.js
@@ -29,10 +29,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 255,255,0,96, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.image.source-over.html
+++ b/html/canvas/offscreen/compositing/2d.composite.image.source-over.html
@@ -33,10 +33,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 219,255,36,223, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.image.source-over.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.image.source-over.worker.js
@@ -29,10 +29,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 219,255,36,223, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.image.xor.html
+++ b/html/canvas/offscreen/compositing/2d.composite.image.xor.html
@@ -33,10 +33,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 191,255,64,128, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.image.xor.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.image.xor.worker.js
@@ -29,10 +29,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0);
           _assertPixelApprox(canvas, 50,25, 191,255,64,128, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.image.copy.html
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.image.copy.html
@@ -33,11 +33,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 40, 40, 10, 10, 40, 50, 10, 10);
           _assertPixelApprox(canvas, 15,15, 0,0,0,0, 5);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.image.copy.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.image.copy.worker.js
@@ -29,11 +29,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 40, 40, 10, 10, 40, 50, 10, 10);
           _assertPixelApprox(canvas, 15,15, 0,0,0,0, 5);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.image.destination-atop.html
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.image.destination-atop.html
@@ -33,11 +33,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 40, 40, 10, 10, 40, 50, 10, 10);
           _assertPixelApprox(canvas, 15,15, 0,0,0,0, 5);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.image.destination-atop.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.image.destination-atop.worker.js
@@ -29,11 +29,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 40, 40, 10, 10, 40, 50, 10, 10);
           _assertPixelApprox(canvas, 15,15, 0,0,0,0, 5);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.image.destination-in.html
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.image.destination-in.html
@@ -33,11 +33,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 40, 40, 10, 10, 40, 50, 10, 10);
           _assertPixelApprox(canvas, 15,15, 0,0,0,0, 5);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.image.destination-in.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.image.destination-in.worker.js
@@ -29,11 +29,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 40, 40, 10, 10, 40, 50, 10, 10);
           _assertPixelApprox(canvas, 15,15, 0,0,0,0, 5);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.image.source-in.html
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.image.source-in.html
@@ -33,11 +33,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 40, 40, 10, 10, 40, 50, 10, 10);
           _assertPixelApprox(canvas, 15,15, 0,0,0,0, 5);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.image.source-in.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.image.source-in.worker.js
@@ -29,11 +29,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 40, 40, 10, 10, 40, 50, 10, 10);
           _assertPixelApprox(canvas, 15,15, 0,0,0,0, 5);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.image.source-out.html
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.image.source-out.html
@@ -33,11 +33,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 40, 40, 10, 10, 40, 50, 10, 10);
           _assertPixelApprox(canvas, 15,15, 0,0,0,0, 5);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.image.source-out.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.image.source-out.worker.js
@@ -29,11 +29,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 40, 40, 10, 10, 40, 50, 10, 10);
           _assertPixelApprox(canvas, 15,15, 0,0,0,0, 5);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.copy.html
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.copy.html
@@ -33,11 +33,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.fillStyle = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillRect(0, 50, 100, 50);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.copy.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.copy.worker.js
@@ -29,11 +29,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.fillStyle = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillRect(0, 50, 100, 50);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-atop.html
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-atop.html
@@ -33,11 +33,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.fillStyle = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillRect(0, 50, 100, 50);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-atop.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-atop.worker.js
@@ -29,11 +29,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.fillStyle = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillRect(0, 50, 100, 50);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-in.html
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-in.html
@@ -33,11 +33,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.fillStyle = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillRect(0, 50, 100, 50);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-in.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-in.worker.js
@@ -29,11 +29,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.fillStyle = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillRect(0, 50, 100, 50);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-in.html
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-in.html
@@ -33,11 +33,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.fillStyle = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillRect(0, 50, 100, 50);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-in.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-in.worker.js
@@ -29,11 +29,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.fillStyle = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillRect(0, 50, 100, 50);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-out.html
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-out.html
@@ -33,11 +33,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.fillStyle = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillRect(0, 50, 100, 50);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-out.worker.js
+++ b/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-out.worker.js
@@ -29,11 +29,11 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.fillStyle = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillRect(0, 50, 100, 50);
           _assertPixelApprox(canvas, 50,25, 0,0,0,0, 5);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.image.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.image.html
@@ -32,7 +32,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
@@ -40,7 +40,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.image.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.image.worker.js
@@ -28,7 +28,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
@@ -36,7 +36,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.crosscanvas.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.crosscanvas.html
@@ -30,7 +30,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var offscreenCanvas2 = new OffscreenCanvas(100, 50);
           var pattern = offscreenCanvas2.getContext('2d').createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = '#f00';
@@ -38,7 +38,7 @@ t.step(function() {
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
           _assertPixel(canvas, 50,25, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.crosscanvas.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.crosscanvas.worker.js
@@ -26,7 +26,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var offscreenCanvas2 = new OffscreenCanvas(100, 50);
           var pattern = offscreenCanvas2.getContext('2d').createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = '#f00';
@@ -34,7 +34,7 @@ t.step(function() {
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
           _assertPixel(canvas, 50,25, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.basic.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.basic.html
@@ -32,7 +32,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
@@ -40,7 +40,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.basic.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.basic.worker.js
@@ -28,7 +28,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
@@ -36,7 +36,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord1.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord1.html
@@ -34,7 +34,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.translate(50, 0);
@@ -43,7 +43,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord1.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord1.worker.js
@@ -30,7 +30,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.translate(50, 0);
@@ -39,7 +39,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord2.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord2.html
@@ -30,7 +30,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 50, 50);
@@ -43,7 +43,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord2.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord2.worker.js
@@ -26,7 +26,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 50, 50);
@@ -39,7 +39,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord3.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord3.html
@@ -32,7 +32,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.translate(50, 25);
@@ -43,7 +43,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord3.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord3.worker.js
@@ -28,7 +28,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.translate(50, 25);
@@ -39,7 +39,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.outside.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.outside.html
@@ -32,7 +32,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = '#0f0';
           ctx.fillRect(0, 0, 100, 50);
@@ -45,7 +45,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.outside.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.outside.worker.js
@@ -28,7 +28,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = '#0f0';
           ctx.fillRect(0, 0, 100, 50);
@@ -41,7 +41,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.orientation.image.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.orientation.image.html
@@ -32,7 +32,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.save();
@@ -45,7 +45,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.orientation.image.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.orientation.image.worker.js
@@ -28,7 +28,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.save();
@@ -41,7 +41,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.basic.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.basic.html
@@ -32,7 +32,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
@@ -40,7 +40,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.basic.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.basic.worker.js
@@ -28,7 +28,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
@@ -36,7 +36,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord1.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord1.html
@@ -32,7 +32,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.translate(-128, -78);
@@ -41,7 +41,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord1.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord1.worker.js
@@ -28,7 +28,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.translate(-128, -78);
@@ -37,7 +37,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord2.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord2.html
@@ -30,7 +30,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
@@ -38,7 +38,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord2.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord2.worker.js
@@ -26,7 +26,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
@@ -34,7 +34,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord3.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord3.html
@@ -30,7 +30,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
@@ -40,7 +40,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord3.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord3.worker.js
@@ -26,7 +26,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
@@ -36,7 +36,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.outside.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.outside.html
@@ -32,7 +32,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.translate(50, 25);
@@ -41,7 +41,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.outside.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.outside.worker.js
@@ -28,7 +28,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'no-repeat');
           ctx.fillStyle = pattern;
           ctx.translate(50, 25);
@@ -37,7 +37,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.basic.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.basic.html
@@ -34,7 +34,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat-x');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
@@ -42,7 +42,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.basic.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.basic.worker.js
@@ -30,7 +30,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat-x');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
@@ -38,7 +38,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.coord1.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.coord1.html
@@ -32,7 +32,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat-x');
           ctx.fillStyle = pattern;
           ctx.translate(0, 16);
@@ -45,7 +45,7 @@ t.step(function() {
           _assertPixel(canvas, 98,25, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.coord1.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.coord1.worker.js
@@ -28,7 +28,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat-x');
           ctx.fillStyle = pattern;
           ctx.translate(0, 16);
@@ -41,7 +41,7 @@ t.step(function() {
           _assertPixel(canvas, 98,25, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.outside.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.outside.html
@@ -32,7 +32,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat-x');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
@@ -42,7 +42,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.outside.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.outside.worker.js
@@ -28,7 +28,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat-x');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
@@ -38,7 +38,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.basic.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.basic.html
@@ -34,7 +34,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat-y');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
@@ -42,7 +42,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.basic.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.basic.worker.js
@@ -30,7 +30,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat-y');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
@@ -38,7 +38,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.coord1.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.coord1.html
@@ -32,7 +32,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat-y');
           ctx.fillStyle = pattern;
           ctx.translate(48, 0);
@@ -45,7 +45,7 @@ t.step(function() {
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 50,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.coord1.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.coord1.worker.js
@@ -28,7 +28,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat-y');
           ctx.fillStyle = pattern;
           ctx.translate(48, 0);
@@ -41,7 +41,7 @@ t.step(function() {
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 50,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.outside.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.outside.html
@@ -32,7 +32,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat-y');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
@@ -42,7 +42,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.outside.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.outside.worker.js
@@ -28,7 +28,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat-y');
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 100, 50);
@@ -38,7 +38,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.repeat.empty.html
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.repeat.empty.html
@@ -32,7 +32,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, "");
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 200, 50);
@@ -40,7 +40,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.repeat.empty.worker.js
+++ b/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.repeat.empty.worker.js
@@ -28,7 +28,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, "");
           ctx.fillStyle = pattern;
           ctx.fillRect(0, 0, 200, 50);
@@ -36,7 +36,7 @@ t.step(function() {
           _assertPixel(canvas, 98,1, 0,255,0,255);
           _assertPixel(canvas, 1,48, 0,255,0,255);
           _assertPixel(canvas, 98,48, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/shadows/2d.shadow.image.alpha.html
+++ b/html/canvas/offscreen/shadows/2d.shadow.image.alpha.html
@@ -34,10 +34,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, -50);
           _assertPixelApprox(canvas, 50,25, 127,0,127,255, 2);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/shadows/2d.shadow.image.alpha.worker.js
+++ b/html/canvas/offscreen/shadows/2d.shadow.image.alpha.worker.js
@@ -30,10 +30,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, -50);
           _assertPixelApprox(canvas, 50,25, 127,0,127,255, 2);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/shadows/2d.shadow.image.basic.html
+++ b/html/canvas/offscreen/shadows/2d.shadow.image.basic.html
@@ -34,10 +34,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, -50);
           _assertPixel(canvas, 50,25, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/shadows/2d.shadow.image.basic.worker.js
+++ b/html/canvas/offscreen/shadows/2d.shadow.image.basic.worker.js
@@ -30,10 +30,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, -50);
           _assertPixel(canvas, 50,25, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/shadows/2d.shadow.image.scale.html
+++ b/html/canvas/offscreen/shadows/2d.shadow.image.scale.html
@@ -34,12 +34,12 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0, 100, 50, -10, -50, 240, 50);
           _assertPixelApprox(canvas, 25,25, 0,255,0,255, 2);
           _assertPixelApprox(canvas, 50,25, 0,255,0,255, 2);
           _assertPixelApprox(canvas, 75,25, 0,255,0,255, 2);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/shadows/2d.shadow.image.scale.worker.js
+++ b/html/canvas/offscreen/shadows/2d.shadow.image.scale.worker.js
@@ -30,12 +30,12 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, 0, 100, 50, -10, -50, 240, 50);
           _assertPixelApprox(canvas, 25,25, 0,255,0,255, 2);
           _assertPixelApprox(canvas, 50,25, 0,255,0,255, 2);
           _assertPixelApprox(canvas, 75,25, 0,255,0,255, 2);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/shadows/2d.shadow.image.section.html
+++ b/html/canvas/offscreen/shadows/2d.shadow.image.section.html
@@ -34,12 +34,12 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 50, 0, 50, 50, 0, -50, 50, 50);
           _assertPixelApprox(canvas, 25,25, 0,255,0,255, 2);
           _assertPixelApprox(canvas, 50,25, 0,255,0,255, 2);
           _assertPixelApprox(canvas, 75,25, 0,255,0,255, 2);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/shadows/2d.shadow.image.section.worker.js
+++ b/html/canvas/offscreen/shadows/2d.shadow.image.section.worker.js
@@ -30,12 +30,12 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 50, 0, 50, 50, 0, -50, 50, 50);
           _assertPixelApprox(canvas, 25,25, 0,255,0,255, 2);
           _assertPixelApprox(canvas, 50,25, 0,255,0,255, 2);
           _assertPixelApprox(canvas, 75,25, 0,255,0,255, 2);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/shadows/2d.shadow.image.transparent.1.html
+++ b/html/canvas/offscreen/shadows/2d.shadow.image.transparent.1.html
@@ -34,10 +34,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, -50);
           _assertPixel(canvas, 50,25, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/shadows/2d.shadow.image.transparent.1.worker.js
+++ b/html/canvas/offscreen/shadows/2d.shadow.image.transparent.1.worker.js
@@ -30,10 +30,10 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 0, -50);
           _assertPixel(canvas, 50,25, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/shadows/2d.shadow.image.transparent.2.html
+++ b/html/canvas/offscreen/shadows/2d.shadow.image.transparent.2.html
@@ -36,14 +36,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 50, -50);
           ctx.shadowColor = '#f00';
           ctx.drawImage(bitmap, -50, -50);
           _assertPixel(canvas, 25,25, 0,255,0,255);
           _assertPixel(canvas, 50,25, 0,255,0,255);
           _assertPixel(canvas, 75,25, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/shadows/2d.shadow.image.transparent.2.worker.js
+++ b/html/canvas/offscreen/shadows/2d.shadow.image.transparent.2.worker.js
@@ -32,14 +32,14 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           ctx.drawImage(bitmap, 50, -50);
           ctx.shadowColor = '#f00';
           ctx.drawImage(bitmap, -50, -50);
           _assertPixel(canvas, 25,25, 0,255,0,255);
           _assertPixel(canvas, 50,25, 0,255,0,255);
           _assertPixel(canvas, 75,25, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/shadows/2d.shadow.pattern.alpha.html
+++ b/html/canvas/offscreen/shadows/2d.shadow.pattern.alpha.html
@@ -30,7 +30,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat');
           ctx.fillStyle = '#f00';
           ctx.fillRect(0, 0, 100, 50);
@@ -38,7 +38,7 @@ t.step(function() {
           ctx.shadowColor = '#00f';
           ctx.fillStyle = pattern;
           ctx.fillRect(0, -50, 100, 50);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/shadows/2d.shadow.pattern.alpha.worker.js
+++ b/html/canvas/offscreen/shadows/2d.shadow.pattern.alpha.worker.js
@@ -26,7 +26,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat');
           ctx.fillStyle = '#f00';
           ctx.fillRect(0, 0, 100, 50);
@@ -34,7 +34,7 @@ t.step(function() {
           ctx.shadowColor = '#00f';
           ctx.fillStyle = pattern;
           ctx.fillRect(0, -50, 100, 50);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/shadows/2d.shadow.pattern.basic.html
+++ b/html/canvas/offscreen/shadows/2d.shadow.pattern.basic.html
@@ -30,7 +30,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat');
           ctx.fillStyle = '#f00';
           ctx.fillRect(0, 0, 100, 50);
@@ -38,7 +38,7 @@ t.step(function() {
           ctx.shadowOffsetY = 50;
           ctx.fillStyle = pattern;
           ctx.fillRect(0, -50, 100, 50);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/shadows/2d.shadow.pattern.basic.worker.js
+++ b/html/canvas/offscreen/shadows/2d.shadow.pattern.basic.worker.js
@@ -26,7 +26,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat');
           ctx.fillStyle = '#f00';
           ctx.fillRect(0, 0, 100, 50);
@@ -34,7 +34,7 @@ t.step(function() {
           ctx.shadowOffsetY = 50;
           ctx.fillStyle = pattern;
           ctx.fillRect(0, -50, 100, 50);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.1.html
+++ b/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.1.html
@@ -30,7 +30,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat');
           ctx.fillStyle = '#0f0';
           ctx.fillRect(0, 0, 100, 50);
@@ -38,7 +38,7 @@ t.step(function() {
           ctx.shadowOffsetY = 50;
           ctx.fillStyle = pattern;
           ctx.fillRect(0, -50, 100, 50);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.1.worker.js
+++ b/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.1.worker.js
@@ -26,7 +26,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat');
           ctx.fillStyle = '#0f0';
           ctx.fillRect(0, 0, 100, 50);
@@ -34,7 +34,7 @@ t.step(function() {
           ctx.shadowOffsetY = 50;
           ctx.fillStyle = pattern;
           ctx.fillRect(0, -50, 100, 50);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.2.html
+++ b/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.2.html
@@ -30,7 +30,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat');
           ctx.fillStyle = '#f00';
           ctx.fillRect(0, 0, 50, 50);
@@ -43,7 +43,7 @@ t.step(function() {
           _assertPixel(canvas, 25,25, 0,255,0,255);
           _assertPixel(canvas, 50,25, 0,255,0,255);
           _assertPixel(canvas, 75,25, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 
 });

--- a/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.2.worker.js
+++ b/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.2.worker.js
@@ -26,7 +26,7 @@ t.step(function() {
       };
   });
   promise.then(function(response) {
-      createImageBitmap(response).then(bitmap => {
+      return createImageBitmap(response).then(bitmap => {
           var pattern = ctx.createPattern(bitmap, 'repeat');
           ctx.fillStyle = '#f00';
           ctx.fillRect(0, 0, 50, 50);
@@ -39,7 +39,7 @@ t.step(function() {
           _assertPixel(canvas, 25,25, 0,255,0,255);
           _assertPixel(canvas, 50,25, 0,255,0,255);
           _assertPixel(canvas, 75,25, 0,255,0,255);
-      }, t_fail);
+      });
   }).then(t_pass, t_fail);
 });
 done();

--- a/html/canvas/tools/yaml/offscreen/fill-and-stroke-styles.yaml
+++ b/html/canvas/tools/yaml/offscreen/fill-and-stroke-styles.yaml
@@ -900,7 +900,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'no-repeat');
             ctx.fillStyle = pattern;
             ctx.fillRect(0, 0, 100, 50);
@@ -908,7 +908,7 @@
             @assert pixel 98,1 == 0,255,0,255;
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.basic.canvas
@@ -996,7 +996,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, "");
             ctx.fillStyle = pattern;
             ctx.fillRect(0, 0, 200, 50);
@@ -1004,7 +1004,7 @@
             @assert pixel 98,1 == 0,255,0,255;
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.repeat.null
@@ -1087,7 +1087,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var offscreenCanvas2 = new OffscreenCanvas(100, 50);
             var pattern = offscreenCanvas2.getContext('2d').createPattern(bitmap, 'no-repeat');
             ctx.fillStyle = '#f00';
@@ -1095,7 +1095,7 @@
             ctx.fillStyle = pattern;
             ctx.fillRect(0, 0, 100, 50);
             @assert pixel 50,25 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.paint.norepeat.basic
@@ -1112,7 +1112,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'no-repeat');
             ctx.fillStyle = pattern;
             ctx.fillRect(0, 0, 100, 50);
@@ -1120,7 +1120,7 @@
             @assert pixel 98,1 == 0,255,0,255;
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.paint.norepeat.outside
@@ -1137,7 +1137,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'no-repeat');
             ctx.fillStyle = '#0f0';
             ctx.fillRect(0, 0, 100, 50);
@@ -1150,7 +1150,7 @@
             @assert pixel 98,1 == 0,255,0,255;
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.paint.norepeat.coord1
@@ -1169,7 +1169,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'no-repeat');
             ctx.fillStyle = pattern;
             ctx.translate(50, 0);
@@ -1178,7 +1178,7 @@
             @assert pixel 98,1 == 0,255,0,255;
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.paint.norepeat.coord2
@@ -1193,7 +1193,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'no-repeat');
             ctx.fillStyle = pattern;
             ctx.fillRect(0, 0, 50, 50);
@@ -1206,7 +1206,7 @@
             @assert pixel 98,1 == 0,255,0,255;
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.paint.norepeat.coord3
@@ -1223,7 +1223,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'no-repeat');
             ctx.fillStyle = pattern;
             ctx.translate(50, 25);
@@ -1234,7 +1234,7 @@
             @assert pixel 98,1 == 0,255,0,255;
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.paint.repeat.basic
@@ -1251,7 +1251,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'no-repeat');
             ctx.fillStyle = pattern;
             ctx.fillRect(0, 0, 100, 50);
@@ -1259,7 +1259,7 @@
             @assert pixel 98,1 == 0,255,0,255;
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.paint.repeat.outside
@@ -1276,7 +1276,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'no-repeat');
             ctx.fillStyle = pattern;
             ctx.translate(50, 25);
@@ -1285,7 +1285,7 @@
             @assert pixel 98,1 == 0,255,0,255;
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.paint.repeat.coord1
@@ -1302,7 +1302,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'no-repeat');
             ctx.fillStyle = pattern;
             ctx.translate(-128, -78);
@@ -1311,7 +1311,7 @@
             @assert pixel 98,1 == 0,255,0,255;
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.paint.repeat.coord2
@@ -1326,7 +1326,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'no-repeat');
             ctx.fillStyle = pattern;
             ctx.fillRect(0, 0, 100, 50);
@@ -1334,7 +1334,7 @@
             @assert pixel 98,1 == 0,255,0,255;
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.paint.repeat.coord3
@@ -1349,7 +1349,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'no-repeat');
             ctx.fillStyle = pattern;
             ctx.fillRect(0, 0, 100, 50);
@@ -1359,7 +1359,7 @@
             @assert pixel 98,1 == 0,255,0,255;
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.paint.repeatx.basic
@@ -1378,7 +1378,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'repeat-x');
             ctx.fillStyle = pattern;
             ctx.fillRect(0, 0, 100, 50);
@@ -1386,7 +1386,7 @@
             @assert pixel 98,1 == 0,255,0,255;
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.paint.repeatx.outside
@@ -1403,7 +1403,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'repeat-x');
             ctx.fillStyle = pattern;
             ctx.fillRect(0, 0, 100, 50);
@@ -1413,7 +1413,7 @@
             @assert pixel 98,1 == 0,255,0,255;
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.paint.repeatx.coord1
@@ -1430,7 +1430,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'repeat-x');
             ctx.fillStyle = pattern;
             ctx.translate(0, 16);
@@ -1443,7 +1443,7 @@
             @assert pixel 98,25 == 0,255,0,255;
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.paint.repeaty.basic
@@ -1462,7 +1462,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'repeat-y');
             ctx.fillStyle = pattern;
             ctx.fillRect(0, 0, 100, 50);
@@ -1470,7 +1470,7 @@
             @assert pixel 98,1 == 0,255,0,255;
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.paint.repeaty.outside
@@ -1487,7 +1487,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'repeat-y');
             ctx.fillStyle = pattern;
             ctx.fillRect(0, 0, 100, 50);
@@ -1497,7 +1497,7 @@
             @assert pixel 98,1 == 0,255,0,255;
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.paint.repeaty.coord1
@@ -1516,7 +1516,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'repeat-y');
             ctx.fillStyle = pattern;
             ctx.translate(48, 0);
@@ -1529,7 +1529,7 @@
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 50,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.paint.orientation.image
@@ -1547,7 +1547,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'no-repeat');
             ctx.fillStyle = pattern;
             ctx.save();
@@ -1560,7 +1560,7 @@
             @assert pixel 98,1 == 0,255,0,255;
             @assert pixel 1,48 == 0,255,0,255;
             @assert pixel 98,48 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.pattern.paint.orientation.canvas

--- a/html/canvas/tools/yaml/offscreen/meta.yaml
+++ b/html/canvas/tools/yaml/offscreen/meta.yaml
@@ -149,10 +149,10 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             ctx.drawImage(bitmap, 0, 0);
             @assert pixel 50,25 ==~ %s +/- 5;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
     """ % (dest, op, to_test(expected)),
             } )
@@ -176,14 +176,14 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             ctx2.drawImage(bitmap, 0, 0);
             ctx.fillStyle = 'rgba%s';
             ctx.fillRect(0, 0, 100, 50);
             ctx.globalCompositeOperation = '%s';
             ctx.drawImage(offscreenCanvas2, 0, 0);
             @assert pixel 50,25 ==~ %s +/- 5;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
     """ % (dest, op, to_test(expected)),
             } )
@@ -232,11 +232,11 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             ctx.drawImage(bitmap, 40, 40, 10, 10, 40, 50, 10, 10);
             @assert pixel 15,15 ==~ %s +/- 5;
             @assert pixel 50,25 ==~ %s +/- 5;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
     """ % (dest, op, to_test(expected0), to_test(expected0)),
             } )
@@ -281,11 +281,11 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             ctx.fillStyle = ctx.createPattern(bitmap, 'no-repeat');
             ctx.fillRect(0, 50, 100, 50);
             @assert pixel 50,25 ==~ %s +/- 5;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
     """ % (dest, op, to_test(expected0)),
             } )

--- a/html/canvas/tools/yaml/offscreen/shadows.yaml
+++ b/html/canvas/tools/yaml/offscreen/shadows.yaml
@@ -439,10 +439,10 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             ctx.drawImage(bitmap, 0, -50);
             @assert pixel 50,25 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.shadow.image.transparent.1
@@ -464,10 +464,10 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             ctx.drawImage(bitmap, 0, -50);
             @assert pixel 50,25 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.shadow.image.transparent.2
@@ -491,14 +491,14 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             ctx.drawImage(bitmap, 50, -50);
             ctx.shadowColor = '#f00';
             ctx.drawImage(bitmap, -50, -50);
             @assert pixel 25,25 == 0,255,0,255;
             @assert pixel 50,25 == 0,255,0,255;
             @assert pixel 75,25 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.shadow.image.alpha
@@ -520,10 +520,10 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             ctx.drawImage(bitmap, 0, -50);
             @assert pixel 50,25 ==~ 127,0,127,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.shadow.image.section
@@ -545,12 +545,12 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             ctx.drawImage(bitmap, 50, 0, 50, 50, 0, -50, 50, 50);
             @assert pixel 25,25 ==~ 0,255,0,255;
             @assert pixel 50,25 ==~ 0,255,0,255;
             @assert pixel 75,25 ==~ 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.shadow.image.scale
@@ -572,12 +572,12 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             ctx.drawImage(bitmap, 0, 0, 100, 50, -10, -50, 240, 50);
             @assert pixel 25,25 ==~ 0,255,0,255;
             @assert pixel 50,25 ==~ 0,255,0,255;
             @assert pixel 75,25 ==~ 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.shadow.canvas.basic
@@ -659,7 +659,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'repeat');
             ctx.fillStyle = '#f00';
             ctx.fillRect(0, 0, 100, 50);
@@ -667,7 +667,7 @@
             ctx.shadowOffsetY = 50;
             ctx.fillStyle = pattern;
             ctx.fillRect(0, -50, 100, 50);
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.shadow.pattern.transparent.1
@@ -686,7 +686,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'repeat');
             ctx.fillStyle = '#0f0';
             ctx.fillRect(0, 0, 100, 50);
@@ -694,7 +694,7 @@
             ctx.shadowOffsetY = 50;
             ctx.fillStyle = pattern;
             ctx.fillRect(0, -50, 100, 50);
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.shadow.pattern.transparent.2
@@ -712,7 +712,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'repeat');
             ctx.fillStyle = '#f00';
             ctx.fillRect(0, 0, 50, 50);
@@ -725,7 +725,7 @@
             @assert pixel 25,25 == 0,255,0,255;
             @assert pixel 50,25 == 0,255,0,255;
             @assert pixel 75,25 == 0,255,0,255;
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.shadow.pattern.alpha
@@ -743,7 +743,7 @@
         };
     });
     promise.then(function(response) {
-        createImageBitmap(response).then(bitmap => {
+        return createImageBitmap(response).then(bitmap => {
             var pattern = ctx.createPattern(bitmap, 'repeat');
             ctx.fillStyle = '#f00';
             ctx.fillRect(0, 0, 100, 50);
@@ -751,7 +751,7 @@
             ctx.shadowColor = '#00f';
             ctx.fillStyle = pattern;
             ctx.fillRect(0, -50, 100, 50);
-        }, t_fail);
+        });
     }).then(t_pass, t_fail);
 
 - name: 2d.shadow.gradient.basic


### PR DESCRIPTION
The problem with these tests was that a failed assert in the innermost function would not end up failing the test. That's because of the difference between these two patterns:

```js
promise.then(causeError, handleError);
```

```js
promise.then(causeError).catch(handleError);
```

The former will result in an unhandled promise rejection, as the `handleError` callback is only invoked if the outermost `promise` is rejected, not if the promise resolution callback (`causeError`) rejects.

Fix this by simply chaining up to the the outer promise in these tests, where errors are handled with `.then(t_pass, t_fail)`.