### PR TITLE
CORS: use proper subdomains in basic.htm

### DIFF
--- a/cors/basic.htm
+++ b/cors/basic.htm
@@ -43,12 +43,12 @@ function cors(desc, scheme, subdomain = "", port = location.port) {
 }
 
 cors("Same domain basic usage");
-cors("Cross domain basic usage", "http", "www1");
+cors("Cross domain basic usage", "http", "www1.");
 cors("Same domain different port", "http", undefined, PORT);
 
-cors("Cross domain different port", "http", "www1", PORT);
+cors("Cross domain different port", "http", "www1.", PORT);
 
-cors("Cross domain different protocol", "https", "www1", PORTS);
+cors("Cross domain different protocol", "https", "www1.", PORTS);
 
 cors("Same domain different protocol different port", "https", undefined, PORTS);
 


### PR DESCRIPTION
When this was refactored in f90659e93e0056d77b524c5fd8badf084b975c9a the dot was dropped. Chrome kept passing the tests however, presumably because the Chrome test runner doesn't care about the actual domains being used.