### PR TITLE
Throw an error if webdriver action fails

### DIFF
--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -150,7 +150,7 @@
                 resolve(result);
             };
             const on_failure = data => {
-                reject(`${data.status}: ${data.message}`);
+                reject(new Error(`WebDriver action failed with '${data.status}' status (check stdout for the WebDriver error stack)`));
             };
             pending.set(cmd_id, [on_success, on_failure]);
         });


### PR DESCRIPTION
Promise reject should always go with an Error object because unhandled promise throws the given value.

If webdriver action fails, then it prints stack in terminal and all the wpt testsuite has is {status:error} object with no context. The given data has no |message| field either so the promise is rejected with 'error: undefined' string which makes a very misterious error. Throwing a real error with a good message gives a stack and a hint how to debug the failure.

Original Mozilla request: https://phabricator.services.mozilla.com/D178969