### PR TITLE
[Azure Pipelines] Don't install virtualenv

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -100,9 +100,6 @@ jobs:
     inputs:
       versionSpec: '3.10'
   - template: tools/ci/azure/checkout.yml
-  - template: tools/ci/azure/pip_install.yml
-    parameters:
-      packages: virtualenv
   - template: tools/ci/azure/install_fonts.yml
   - template: tools/ci/azure/install_certs.yml
   - template: tools/ci/azure/color_profile.yml
@@ -370,9 +367,6 @@ jobs:
       versionSpec: '3.10'
   - template: tools/ci/azure/system_info.yml
   - template: tools/ci/azure/checkout.yml
-  - template: tools/ci/azure/pip_install.yml
-    parameters:
-      packages: virtualenv
   - template: tools/ci/azure/install_certs.yml
   - template: tools/ci/azure/install_edge.yml
     parameters:
@@ -409,9 +403,6 @@ jobs:
       versionSpec: '3.10'
   - template: tools/ci/azure/system_info.yml
   - template: tools/ci/azure/checkout.yml
-  - template: tools/ci/azure/pip_install.yml
-    parameters:
-      packages: virtualenv
   - template: tools/ci/azure/install_certs.yml
   - template: tools/ci/azure/install_edge.yml
     parameters:
@@ -447,9 +438,6 @@ jobs:
     inputs:
       versionSpec: '3.10'
   - template: tools/ci/azure/checkout.yml
-  - template: tools/ci/azure/pip_install.yml
-    parameters:
-      packages: virtualenv
   - template: tools/ci/azure/install_certs.yml
   - template: tools/ci/azure/install_edge.yml
     parameters:
@@ -485,9 +473,6 @@ jobs:
     inputs:
       versionSpec: '3.10'
   - template: tools/ci/azure/checkout.yml
-  - template: tools/ci/azure/pip_install.yml
-    parameters:
-      packages: virtualenv
   - template: tools/ci/azure/install_certs.yml
   - template: tools/ci/azure/color_profile.yml
   - template: tools/ci/azure/install_safari.yml
@@ -527,9 +512,6 @@ jobs:
     inputs:
       versionSpec: '3.10'
   - template: tools/ci/azure/checkout.yml
-  - template: tools/ci/azure/pip_install.yml
-    parameters:
-      packages: virtualenv
   - template: tools/ci/azure/install_certs.yml
   - template: tools/ci/azure/color_profile.yml
   - template: tools/ci/azure/install_safari.yml
@@ -566,9 +548,6 @@ jobs:
     inputs:
       versionSpec: '3.10'
   - template: tools/ci/azure/checkout.yml
-  - template: tools/ci/azure/pip_install.yml
-    parameters:
-      packages: virtualenv
   - template: tools/ci/azure/install_certs.yml
   - template: tools/ci/azure/color_profile.yml
   - template: tools/ci/azure/update_hosts.yml

--- a/tools/ci/azure/affected_tests.yml
+++ b/tools/ci/azure/affected_tests.yml
@@ -10,9 +10,6 @@ steps:
       set -eux -o pipefail
       git checkout ${{ parameters.checkoutCommit }}
     displayName: 'Checkout ${{ parameters.checkoutCommit }}'
-- template: pip_install.yml
-  parameters:
-    packages: virtualenv
 - template: install_certs.yml
 - template: color_profile.yml
 - template: install_safari.yml


### PR DESCRIPTION
It ought to not be needed after https://github.com/web-platform-tests/wpt/pull/40130.
