### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=257397

### DIFF
--- a/xhr/send-authentication-basic-cors-not-enabled.htm
+++ b/xhr/send-authentication-basic-cors-not-enabled.htm
@@ -5,6 +5,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/utils.js"></script>
+    <script src="/common/get-host-info.sub.js"></script>
     <link rel="help" href="https://xhr.spec.whatwg.org/#the-open()-method" data-tested-assertations="following::ol[1]/li[9]/ol[1]/li[1] following::ol[1]/li[9]/ol[1]/li[2]" />
     <link rel="help" href="https://xhr.spec.whatwg.org/#the-send()-method" data-tested-assertations="following::code[contains(@title,'http-authorization')]/.." />
   </head>
@@ -13,10 +14,10 @@
     <script>
       test(function() {
         var client = new XMLHttpRequest(),
-          urlstart = 'www1.'+location.host + location.pathname.replace(/\/[^\/]*$/, '/')
+          urlstart = get_host_info().REMOTE_ORIGIN + location.pathname.replace(/\/[^\/]*$/, '/')
         client.withCredentials = true
         user = token()
-        client.open("GET", location.protocol+'//'+urlstart + "resources/auth10/auth.py", false, user, 'pass')
+        client.open("GET", urlstart + "resources/auth10/auth.py", false, user, 'pass')
         client.setRequestHeader("x-user", user)
         assert_throws_dom("NetworkError", function(){ client.send(null) })
         assert_equals(client.responseText, '')

--- a/xhr/send-authentication-cors-basic-setrequestheader.htm
+++ b/xhr/send-authentication-cors-basic-setrequestheader.htm
@@ -5,15 +5,16 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/utils.js"></script>
+    <script src="/common/get-host-info.sub.js"></script>
   </head>
   <body>
     <div id="log"></div>
     <script>
       async_test(test => {
         var client = new XMLHttpRequest(),
-            urlstart = location.host + location.pathname.replace(/\/[^\/]*$/, '/'),
+            urlstart = get_host_info().REMOTE_ORIGIN + location.pathname.replace(/\/[^\/]*$/, '/'),
             user = token()
-        client.open("GET", location.protocol+'//www1.'+urlstart + "resources/auth2/corsenabled.py", false)
+        client.open("GET", urlstart + "resources/auth2/corsenabled.py", false)
         client.withCredentials = true
         client.setRequestHeader("x-user", user)
         client.setRequestHeader("x-pass", 'pass')

--- a/xhr/send-authentication-cors-setrequestheader-no-cred.htm
+++ b/xhr/send-authentication-cors-setrequestheader-no-cred.htm
@@ -5,6 +5,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/utils.js"></script>
+    <script src="/common/get-host-info.sub.js"></script>
     <!-- These spec references do not make much sense simply because the spec doesn't say very much about this.. -->
     <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method" data-tested-assertations="following::ol[1]/li[6]" />
     <link rel="help" href="https://xhr.spec.whatwg.org/#the-send()-method" data-tested-assertations="following::code[contains(@title,'http-authorization')]/.." />
@@ -16,9 +17,9 @@
       var test = async_test(desc)
       test.step(function() {
         var client = new XMLHttpRequest(),
-            urlstart = location.host + location.pathname.replace(/\/[^\/]*$/, '/'),
+            urlstart = get_host_info().REMOTE_ORIGIN + location.pathname.replace(/\/[^\/]*$/, '/'),
             user = token()
-        client.open("GET", location.protocol + "//www1." + urlstart + "resources/" + pathsuffix, false)
+        client.open("GET", urlstart + "resources/" + pathsuffix, false)
         client.setRequestHeader("x-user", user)
         client.setRequestHeader("x-pass", 'pass')
         client.setRequestHeader("Authorization", "Basic " + btoa(user + ":pass"))

--- a/xhr/send-network-error-sync-events.sub.htm
+++ b/xhr/send-network-error-sync-events.sub.htm
@@ -17,7 +17,7 @@
         {
             var xhr = new XMLHttpRequest();
 
-            xhr.open("POST", "http://nonexistent.{{host}}:{{ports[http][0]}}", false);
+            xhr.open("POST", "http://{{host}}:1", false); // Bad port.
 
             assert_throws_dom("NetworkError", function()
             {


### PR DESCRIPTION
Use get-host-info.sub.js to make the tests work with the WebKit test infrastructure.