### PR TITLE
Allow zero on <table> height, <tr> height, and <col> width 

### DIFF
--- a/html/rendering/dimension-attributes.html
+++ b/html/rendering/dimension-attributes.html
@@ -137,17 +137,10 @@ const tests = [
   [ newElem("img"), "height", "height", true ],
   [ newElem("td"), "width", "width", false ],
   [ newElem("td"), "height", "height", false ],
-  // https://github.com/whatwg/html/issues/4715 tracks the fact that for
-  // <table width> and <table height> the "0 is valid" boolean should probably
-  // be true.
   [ newElem("table"), "width", "width", false ],
-  [ newElem("table"), "height", "height", false ],
-  // https://github.com/whatwg/html/issues/4716 tracks the fact that for the
-  // <tr height> case that "0 is valid" boolean should probably be true.
-  [ newElem("tr"), "height", "height", false ],
-  // https://github.com/whatwg/html/issues/4717 tracks the fact that for the
-  // <col width> case that "0 is valid" boolean should probably be true.
-  [ newElem("col"), "width", "width", false ],
+  [ newElem("table"), "height", "height", true ],
+  [ newElem("tr"), "height", "height", true ],
+  [ newElem("col"), "width", "width", true ],
   [ newElem("embed"), "hspace", "marginLeft", true ],
   [ newElem("embed"), "hspace", "marginRight", true ],
   [ newElem("embed"), "vspace", "marginTop", true ],


### PR DESCRIPTION
As discussed in https://github.com/whatwg/html/issues/4715, this pull request aligns the dimension attribute tests with the current behavior in Chromium, Safari, and Firefox. Now these tests should pass in all browsers.

As an aside, I didn't change the `<hr> width` behavior as [requested here](https://github.com/whatwg/html/issues/4715#issuecomment-1547434842). This is because I found failures regardless of whether `<hr>` allowed or didn't allow zero on the `width`, so I decided to just leave it as is.