### PR TITLE
Implement reftest variants

### DIFF
--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -1017,18 +1017,23 @@ class SourceFile:
                 ))
 
         elif self.content_is_ref_node:
-            rv = RefTest.item_type, [
-                RefTest(
+            rv = RefTest.item_type, []
+            for variant in self.test_variants:
+                url = self.rel_url + variant
+                rv[1].append(RefTest(
                     self.tests_root,
                     self.rel_path,
                     self.url_base,
-                    self.rel_url,
-                    references=self.references,
+                    url,
+                    references=[
+                        (ref[0] + variant, ref[1])
+                        for ref in self.references
+                    ],
                     timeout=self.timeout,
                     viewport_size=self.viewport_size,
                     dpi=self.dpi,
                     fuzzy=self.fuzzy
-                )]
+                ))
 
         elif self.content_is_css_visual and not self.name_is_reference:
             rv = VisualTest.item_type, [

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -526,6 +526,40 @@ def test_testharness_variant_invalid(variant):
         s.test_variants
 
 
+def test_reftest_variant():
+    content = (b"<meta name=variant content=\"?first\">" +
+               b"<meta name=variant content=\"?second\">" +
+               b"<link rel=\"match\" href=\"ref.html\">")
+
+    s = create("html/test.html", contents=content)
+    assert not s.name_is_non_test
+    assert not s.name_is_manual
+    assert not s.name_is_visual
+    assert not s.name_is_worker
+    assert not s.name_is_reference
+
+    item_type, items = s.manifest_items()
+    assert item_type == "reftest"
+
+    actual_tests = [
+        {"url": item.url, "refs": item.references}
+        for item in items
+    ]
+
+    expected_tests = [
+        {
+            "url": "/html/test.html?first",
+            "refs": [("/html/ref.html?first", "==")],
+        },
+        {
+            "url": "/html/test.html?second",
+            "refs": [("/html/ref.html?second", "==")],
+        },
+    ]
+
+    assert actual_tests == expected_tests
+
+
 @pytest.mark.parametrize("ext", ["htm", "html"])
 def test_relative_testharness(ext):
     content = b"<script src=../resources/testharness.js></script>"


### PR DESCRIPTION
Support variants for reftests via a variant meta tag.

Related to: https://github.com/web-platform-tests/rfcs/pull/149