### PR TITLE
Remove children from shadow root when it's not required

### DIFF
--- a/webdriver/tests/bidi/script/call_function/result_node.py
+++ b/webdriver/tests/bidi/script/call_function/result_node.py
@@ -464,17 +464,6 @@ async def test_doctype_node(
                 "sharedId": any_string,
                 "value": {
                     "childNodeCount": 1,
-                    "children": [{
-                        "type": "node",
-                        "sharedId": any_string,
-                        "value": {
-                            "attributes": {"id": "in-shadow-dom"},
-                            "childNodeCount": 1,
-                            "localName": "div",
-                            "namespaceURI": "http://www.w3.org/1999/xhtml",
-                            "nodeType": 1
-                        }
-                    }],
                     "nodeType": 11
                 }
             }

--- a/webdriver/tests/bidi/script/evaluate/result_node.py
+++ b/webdriver/tests/bidi/script/evaluate/result_node.py
@@ -452,17 +452,6 @@ async def test_doctype_node(bidi_session, get_test_page, top_context, expression
                 "sharedId": any_string,
                 "value": {
                     "childNodeCount": 1,
-                    "children": [{
-                        "type": "node",
-                        "sharedId": any_string,
-                        "value": {
-                            "attributes": {"id": "in-shadow-dom"},
-                            "childNodeCount": 1,
-                            "localName": "div",
-                            "namespaceURI": "http://www.w3.org/1999/xhtml",
-                            "nodeType": 1
-                        }
-                    }],
                     "nodeType": 11
                 }
             }


### PR DESCRIPTION
Children should not be provided in the value, as long as the node implements `shadowRoot` and `includeShadowTree` is not set in `serializationOptions` which defaults it to `none`. So it falls into condition the following condition: "...if value implements ShadowRoot and serialization options["includeShadowTree"] is "none"...".