### PR TITLE
Retry failed Safari Run tests tasks

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -500,6 +500,7 @@ jobs:
       export SYSTEM_VERSION_COMPAT=0
       ./wpt run --no-manifest-update --no-restart-on-unexpected --no-fail-on-unexpected --this-chunk=$(System.JobPositionInPhase) --total-chunks=$(System.TotalJobsInPhase) --chunk-type hash --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_$(System.JobPositionInPhase).json --log-wptscreenshot $(Build.ArtifactStagingDirectory)/wpt_screenshot_$(System.JobPositionInPhase).txt --log-mach - --log-mach-level info --channel stable --kill-safari safari
     displayName: 'Run tests'
+    retryCountOnTaskFailure: 2
   - task: PublishBuildArtifacts@1
     displayName: 'Publish results'
     inputs:
@@ -540,6 +541,7 @@ jobs:
       export SYSTEM_VERSION_COMPAT=0
       ./wpt run --no-manifest-update --no-restart-on-unexpected --no-fail-on-unexpected --this-chunk=$(System.JobPositionInPhase) --total-chunks=$(System.TotalJobsInPhase) --chunk-type hash --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_$(System.JobPositionInPhase).json --log-wptscreenshot $(Build.ArtifactStagingDirectory)/wpt_screenshot_$(System.JobPositionInPhase).txt --log-mach - --log-mach-level info --channel preview --kill-safari safari
     displayName: 'Run tests'
+    retryCountOnTaskFailure: 2
   - task: PublishBuildArtifacts@1
     displayName: 'Publish results'
     inputs:


### PR DESCRIPTION
Failures here block getting results on wpt.fyi, which in turn blocks Interop updates. The problems seem to be on the Azure infrastructure side, so it's possible that just retrying in the case of failure will be enough.