### PR TITLE
retrieve viewport dimension right before taking screenshot

### DIFF
--- a/webdriver/tests/bidi/browsing_context/capture_screenshot/capture_screenshot.py
+++ b/webdriver/tests/bidi/browsing_context/capture_screenshot/capture_screenshot.py
@@ -6,12 +6,11 @@ from . import viewport_dimensions
 
 
 @pytest.mark.asyncio
-async def test_capture(bidi_session, url, top_context, inline, compare_png_bidi):
-    expected_size = await viewport_dimensions(bidi_session, top_context)
-
+async def test_capture(bidi_session, top_context, inline, compare_png_bidi):
     await bidi_session.browsing_context.navigate(
         context=top_context["context"], url="about:blank", wait="complete"
     )
+    expected_size = await viewport_dimensions(bidi_session, top_context)
     reference_data = await bidi_session.browsing_context.capture_screenshot(
         context=top_context["context"])
     assert png_dimensions(reference_data) == expected_size

--- a/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py
+++ b/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py
@@ -12,16 +12,16 @@ from . import viewport_dimensions
 
 @pytest.mark.asyncio
 async def test_iframe(bidi_session, top_context, inline, iframe):
-    viewport_size = await viewport_dimensions(bidi_session, top_context)
-
     iframe_content = f"{INNER_IFRAME_STYLE}{DEFAULT_CONTENT}"
     url = inline(f"{OUTER_IFRAME_STYLE}{iframe(iframe_content)}")
+
     await bidi_session.browsing_context.navigate(context=top_context["context"],
                                                  url=url,
                                                  wait="complete")
+    expected_size = await viewport_dimensions(bidi_session, top_context)
     reference_data = await bidi_session.browsing_context.capture_screenshot(
         context=top_context["context"])
-    assert png_dimensions(reference_data) == viewport_size
+    assert png_dimensions(reference_data) == expected_size
 
     all_contexts = await bidi_session.browsing_context.get_tree(root=top_context["context"])
     frame_context = all_contexts[0]["children"][0]
@@ -34,13 +34,12 @@ async def test_iframe(bidi_session, top_context, inline, iframe):
 @pytest.mark.parametrize("domain", ["", "alt"], ids=["same_origin", "cross_origin"])
 @pytest.mark.asyncio
 async def test_context_origin(bidi_session, top_context, inline, iframe, compare_png_bidi, domain):
-    expected_size = await viewport_dimensions(bidi_session, top_context)
-
     initial_url = inline(f"{REFERENCE_STYLE}{REFERENCE_CONTENT}")
+
     await bidi_session.browsing_context.navigate(context=top_context["context"],
                                                  url=initial_url,
                                                  wait="complete")
-
+    expected_size = await viewport_dimensions(bidi_session, top_context)
     reference_data = await bidi_session.browsing_context.capture_screenshot(
         context=top_context["context"])
     assert png_dimensions(reference_data) == expected_size


### PR DESCRIPTION
Retrieve viewport dimension right before taking screenshot

From a WPT test perspective, this is a no-op.

However, it unblocks our (Chromium) headful tests.

The tests pass today, but they fail in CI (github actions), and only
there (c.f.
https://github.com/GoogleChromeLabs/chromium-bidi/commit/4b7bdf396a474670385216545acefac86783bb0a),
as the expected image height is different from the reference image.

If we delay retrieving the expected dimensions only when we actually
need them, then the tests pass in CI.