### PR TITLE
text-box-trim: add ex test

### DIFF
--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-003-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-003-ref.html
@@ -3,11 +3,10 @@
 <meta description="Verify that an ex trimmed text has a height of 1ex" />
 
 <link rel="help" href="https://drafts.csswg.org/css-inline-3/#leading-trim">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 
 <style>
 div {
-  display: flex;
+  display: inline-flex;
   font-size: 72px;
   /* the text will not be at the same position as the test,
      but the height of the inline box should be the same */

--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-003-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-003-ref.html
@@ -8,20 +8,18 @@
 div {
   display: inline-flex;
   font-size: 72px;
-  /* the text will not be at the same position as the test,
-     but the height of the inline box should be the same */
+  /* hide the text as this test is about the box height */
   color: transparent;
 }
 
 span {
-  border: 1px solid blue;
-  display: inline-block;
-  /* limit theight to 1ex height using text-box-trim */
+  outline: 1px solid blue;
+  /* limit the height to 1ex height using overflow */
   overflow: hidden;
   height: 1ex;
 }
 </style>
 
 <div>
-  <span>e</span>
+  <span>test</span>
 </div>

--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-003-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-003-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>Tests boxes are trimmed at text-over/text-under baselines</title>
+<meta description="Verify that an ex trimmed text has a height of 1ex" />
+
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#leading-trim">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<style>
+div {
+  display: flex;
+  font-size: 72px;
+  /* the text will not be at the same position as the test,
+     but the height of the inline box should be the same */
+  color: transparent;
+}
+
+span {
+  border: 1px solid blue;
+  display: inline-block;
+  /* limit theight to 1ex height using text-box-trim */
+  overflow: hidden;
+  height: 1ex;
+}
+</style>
+
+<div>
+  <span>e</span>
+</div>

--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-003.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-003.html
@@ -8,14 +8,12 @@
 div {
   display: inline-flex;
   font-size: 72px;
-  /* the text will not be at the same position as the reference,
-     but the height of the inline box should be the same */
+  /* hide the text as this test is about the box height */
   color: transparent;
 }
 
 span {
-  border: 1px solid blue;
-  display: inline-block;
+  outline: 1px solid blue;
   line-height: 3;
   /* limit theight to 1ex height using text-box-trim */
   text-box-trim: both;
@@ -24,5 +22,5 @@ span {
 </style>
 
 <div>
-  <span>e</span>
+  <span>test</span>
 </div>

--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-003.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-003.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>Tests boxes are trimmed at text-over/text-under baselines</title>
+<meta description="Verify that an ex trimmed text has a height of 1ex" />
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#leading-trim">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="match" href="text-box-trim-half-leading-inline-box-001-ref.html">
+
+<style>
+div {
+  display: flex;
+  font-size: 72px;
+  /* the text will not be at the same position as the reference,
+     but the height of the inline box should be the same */
+  color: transparent;
+}
+
+span {
+  border: 1px solid blue;
+  display: inline-block;
+  line-height: 3;
+  /* limit theight to 1ex height using text-box-trim */
+  text-box-trim: both;
+  text-box-edge: ex alphabetic;
+}
+</style>
+
+<div>
+  <span>e</span>
+</div>

--- a/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-003.html
+++ b/css/css-inline/text-box-trim/text-box-trim-half-leading-inline-box-003.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <title>Tests boxes are trimmed at text-over/text-under baselines</title>
 <meta description="Verify that an ex trimmed text has a height of 1ex" />
+<link rel="match" href="text-box-trim-half-leading-inline-box-003-ref.html">
 <link rel="help" href="https://drafts.csswg.org/css-inline-3/#leading-trim">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<link rel="match" href="text-box-trim-half-leading-inline-box-001-ref.html">
 
 <style>
 div {
-  display: flex;
+  display: inline-flex;
   font-size: 72px;
   /* the text will not be at the same position as the reference,
      but the height of the inline box should be the same */


### PR DESCRIPTION
This PR creates a new test which compares rendered borders of two elements.

- a span with text-box-trim (`ex`):

```css
  outline: 1px solid blue;
  text-box-trim: both;
  text-box-edge: ex alphabetic
```

- a span with overflow hidden (`height: 1ex`)

```
  outline: 1px solid blue;
  overflow: hidden;
  height: 1ex;
```

Preview (Safari / Chrome / Firefox):

![preview_tests](https://github.com/web-platform-tests/wpt/assets/4113649/afdca607-5aa8-410e-9a7f-2f997ae4f0a4)

Right now the test fails in:

- Firefox [Firefox Issue 1816038 - [css-inline-3] Implement `text-box-trim` (formerly leading-trim)](https://bugzilla.mozilla.org/show_bug.cgi?id=1816038)
- Chrome Canary [Chromium Issue 1411581 - Implement `text-box-trim` property](https://bugs.chromium.org/p/chromium/issues/detail?id=1411581)

