### PR TITLE
Ignore urllib3's warnings when run on LibreSSL

### DIFF
--- a/tools/pytest.ini
+++ b/tools/pytest.ini
@@ -10,6 +10,8 @@ filterwarnings =
     # ignore importlib changes which six is unlikely to ever adopt
     ignore:_SixMetaPathImporter.exec_module\(\) not found; falling back to load_module\(\):ImportWarning
     ignore:_SixMetaPathImporter.find_spec\(\) not found; falling back to find_module\(\):ImportWarning
+    # ignore urllib3's warning when not using OpenSSL
+    ignore:.*currently the 'ssl' module is compiled with.*::urllib3
     # ignore mozinfo deprecation warnings
     ignore:distutils Version classes are deprecated\. Use packaging\.version instead\.:DeprecationWarning:mozinfo
     # ingore mozinfo's dependency on distro


### PR DESCRIPTION
This allows tests to run against the Xcode-provided Python 3, where the ssl module is linked against LibreSSL.