### PR TITLE
[image-set] Fix expectation of image-set with calc().

### DIFF
--- a/css/css-images/image-set/image-set-parsing.html
+++ b/css/css-images/image-set/image-set-parsing.html
@@ -161,11 +161,13 @@ function test_non_positive_resolutions_parsing() {
   );
   test_valid_value_variants(
     'background-image',
-    'image-set(url("example.png") calc(-1 * 1x))'
+    'image-set(url("example.png") calc(-1 * 1x))',
+    'image-set(url("example.png") calc(-1dppx))',
   );
   test_valid_value_variants(
     'background-image',
-    'image-set(url("example.png") calc(1x + -1x))'
+    'image-set(url("example.png") calc(1x + -1x))',
+    'image-set(url("example.png") calc(0dppx))',
   );
 
   test_invalid_value_variants(


### PR DESCRIPTION
This fixes some of the tests introduced in
ba004353155163b0c356b753394e50d2dd6f0b87.

Resolutions like any other calc()-supporting dimensions are specified to simplify as much as possible, and serialize to the canonical units.

This is what css-values-4 specifies, and there are other tests in this file which already have that expectation.