### PR TITLE
[text-box-trim] nested elements

### DIFF
--- a/css/css-inline/text-box-trim/text-box-trim-nesting-001-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-nesting-001-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<title>Tests nested boxes are trimmed at text-over/text-under baselines</title>
+<meta description="Verify that a nested ex trimmed text has a height of 1ex" />
+
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#leading-trim">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<style>
+div {
+  display: inline-flex;
+  font-size: 72px;
+  /* 
+     for browser which don't support text-box-trim the text will not be at the same position 
+     as the reference, but the height of the inline box should be the same 
+  */
+  color: transparent;
+  border-top: 2px solid orange;
+}
+
+span {
+  border: 1px solid blue;
+  display: inline-block;
+  /* limit theight to 1ex height using text-box-trim */
+  overflow: hidden;
+  height: 1ex;
+}
+</style>
+
+<div>
+  <span>e</span>
+</div>

--- a/css/css-inline/text-box-trim/text-box-trim-nesting-001-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-nesting-001-ref.html
@@ -3,7 +3,6 @@
 <meta description="Verify that a nested ex trimmed text has a height of 1ex" />
 
 <link rel="help" href="https://drafts.csswg.org/css-inline-3/#leading-trim">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 
 <style>
 div {
@@ -18,14 +17,15 @@ div {
 }
 
 span {
-  border: 1px solid blue;
-  display: inline-block;
-  /* limit theight to 1ex height using text-box-trim */
+  outline: 1px solid blue;
+  /* limit the height to 1ex using overflow */
   overflow: hidden;
-  height: 1ex;
+  max-height: 1ex;
 }
 </style>
 
 <div>
-  <span>e</span>
+  <section>
+    <span>test</span>
+  </section>
 </div>

--- a/css/css-inline/text-box-trim/text-box-trim-nesting-001-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-nesting-001-ref.html
@@ -9,9 +9,9 @@
 div {
   display: inline-flex;
   font-size: 72px;
-  /* 
-     for browser which don't support text-box-trim the text will not be at the same position 
-     as the reference, but the height of the inline box should be the same 
+  /*
+     for browser which don't support text-box-trim the text will not be at the same position
+     as the reference, but the height of the inline box should be the same
   */
   color: transparent;
   border-top: 2px solid orange;

--- a/css/css-inline/text-box-trim/text-box-trim-nesting-001-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-nesting-001-ref.html
@@ -8,12 +8,9 @@
 div {
   display: inline-flex;
   font-size: 72px;
-  /*
-     for browser which don't support text-box-trim the text will not be at the same position
-     as the reference, but the height of the inline box should be the same
-  */
-  color: transparent;
   border-top: 2px solid orange;
+  /* hide the text as this test is about the box height */
+  color: transparent;
 }
 
 span {
@@ -25,7 +22,7 @@ span {
 </style>
 
 <div>
-  <section>
+  <section>a
     <span>test</span>
   </section>
 </div>

--- a/css/css-inline/text-box-trim/text-box-trim-nesting-001.html
+++ b/css/css-inline/text-box-trim/text-box-trim-nesting-001.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<title>Tests nested boxes are trimmed at text-over/text-under baselines</title>
+<meta description="Verify that a nested ex trimmed text has a height of 1ex" />
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#leading-trim">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="match" href="text-box-trim-nesting-001-ref.html">
+
+<style>
+div {
+  display: inline-flex;
+  font-size: 72px;
+  /* 
+     for browser which don't support text-box-trim the text will not be at the same position 
+     as the reference, but the height of the inline box should be the same 
+  */
+  color: transparent;
+  border-top: 2px solid orange;
+}
+
+section {
+  /* limit theight to 1ex height using text-box-trim */
+  text-box-trim: both;
+  text-box-edge: ex alphabetic;
+}
+
+span {
+  border: 1px solid blue;
+  display: inline-block;
+  line-height: 3;
+  /* limit theight to 1ex height using text-box-trim */
+  text-box-trim: both;
+  text-box-edge: ex alphabetic;
+}
+</style>
+
+<div>
+  <section>
+    <span>e</span>
+  </section>
+</div>

--- a/css/css-inline/text-box-trim/text-box-trim-nesting-001.html
+++ b/css/css-inline/text-box-trim/text-box-trim-nesting-001.html
@@ -2,7 +2,6 @@
 <title>Tests nested boxes are trimmed at text-over/text-under baselines</title>
 <meta description="Verify that a nested ex trimmed text has a height of 1ex" />
 <link rel="help" href="https://drafts.csswg.org/css-inline-3/#leading-trim">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <link rel="match" href="text-box-trim-nesting-001-ref.html">
 
 <style>
@@ -18,16 +17,13 @@ div {
 }
 
 section {
-  /* limit theight to 1ex height using text-box-trim */
   text-box-trim: both;
   text-box-edge: ex alphabetic;
 }
 
 span {
-  border: 1px solid blue;
-  display: inline-block;
-  line-height: 3;
-  /* limit theight to 1ex height using text-box-trim */
+  outline: 1px solid blue;
+  /* limit the height to 1ex using overflow */
   text-box-trim: both;
   text-box-edge: ex alphabetic;
 }
@@ -35,6 +31,6 @@ span {
 
 <div>
   <section>
-    <span>e</span>
+    <span>test</span>
   </section>
 </div>

--- a/css/css-inline/text-box-trim/text-box-trim-nesting-001.html
+++ b/css/css-inline/text-box-trim/text-box-trim-nesting-001.html
@@ -8,12 +8,9 @@
 div {
   display: inline-flex;
   font-size: 72px;
-  /*
-     for browser which don't support text-box-trim the text will not be at the same position
-     as the reference, but the height of the inline box should be the same
-  */
-  color: transparent;
   border-top: 2px solid orange;
+  /* hide the text as this test is about the box height */
+  color: transparent;
 }
 
 section {
@@ -30,7 +27,7 @@ span {
 </style>
 
 <div>
-  <section>
+  <section>a
     <span>test</span>
   </section>
 </div>

--- a/css/css-inline/text-box-trim/text-box-trim-nesting-001.html
+++ b/css/css-inline/text-box-trim/text-box-trim-nesting-001.html
@@ -9,9 +9,9 @@
 div {
   display: inline-flex;
   font-size: 72px;
-  /* 
-     for browser which don't support text-box-trim the text will not be at the same position 
-     as the reference, but the height of the inline box should be the same 
+  /*
+     for browser which don't support text-box-trim the text will not be at the same position
+     as the reference, but the height of the inline box should be the same
   */
   color: transparent;
   border-top: 2px solid orange;


### PR DESCRIPTION
Tests nested text-box-trim elements

```css
section {
  text-box-trim: both;
  text-box-edge: ex alphabetic;
}

span {
  text-box-trim: both;
  text-box-edge: ex alphabetic;
}
```

```html
<section><span>test</span></section>
```

![test-preview](https://github.com/web-platform-tests/wpt/assets/4113649/35379e6f-cc32-42d0-ac68-ec66619603d6)

Right now the test fails in:

- Safari Tech Preview [Webkit Issue 252161 - [leading-trim] nested elements shift text upwards](https://bugs.webkit.org/show_bug.cgi?id=252161)
- Firefox [Firefox Issue 1816038 - [css-inline-3] Implement `text-box-trim` (formerly leading-trim)](https://bugzilla.mozilla.org/show_bug.cgi?id=1816038)
- Chrome Canary [Chromium Issue 1411581 - Implement `text-box-trim` property](https://bugs.chromium.org/p/chromium/issues/detail?id=1411581)

