### PR TITLE
Layout 2020: Properly handle negative margins in floats

### DIFF
--- a/css/CSS2/floats/negative-block-margin-pushing-float-out-of-block-formatting-context-ref.html
+++ b/css/CSS2/floats/negative-block-margin-pushing-float-out-of-block-formatting-context-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com" />
+<meta name="assert" content="When a floating box has a negative margin negative enough that it pushes the float past the top of the block formatting context, it should render properly."/>
+
+<body>
+<div style="width: 50px; height: 50px; background: green;"></div>
+</body>

--- a/css/CSS2/floats/negative-block-margin-pushing-float-out-of-block-formatting-context.html
+++ b/css/CSS2/floats/negative-block-margin-pushing-float-out-of-block-formatting-context.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com" />
+<link rel="help" href="https://drafts.csswg.org/css2/#float-position"/>
+<meta name="assert" content="When a floating box has a negative margin negative enough that it pushes the float past the top of the block formatting context, it should render properly."/>
+<link rel="match" href="negative-block-margin-pushing-float-out-of-block-formatting-context-ref.html"/>
+
+<body>
+<div style="height: 100px;"></div>
+<div style="position: absolute;">
+    <div style="float: left; width: 50px; height: 50px; margin-top: -100px; background: green;"></div>
+</div>
+</body>


### PR DESCRIPTION
If a float has negative block margins, it should be pushed upward, but shouldn't affect the positioning of any floats that came before it. It should lower the ceiling though when it still has some non-negative block contribution. In order to implement this behavior, we should only place the float considering its non-negative block length contribution. If the float is pushed up completely past it's "natural" position, it should be placed like a float with zero block size.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#29859