### PR TITLE
Fix invalid HTML: /> syntax on non-void elements

### DIFF
--- a/accessibility/crashtests/map-update-crash.html
+++ b/accessibility/crashtests/map-update-crash.html
@@ -7,7 +7,7 @@ This test passes if it does not crash.
 <img  usemap="#map2">
 <map id=map name="map2">
     <command id=command>
-        <article id=article ></article>
+        <article id=article></article>
     </command>
 </map>
 <script>

--- a/client-hints/sandbox/resources/iframe-with-embedded-popup-expect-no-hints.html
+++ b/client-hints/sandbox/resources/iframe-with-embedded-popup-expect-no-hints.html
@@ -7,6 +7,6 @@
   });
 
 </script>
-<iframe src="embedded-popup-expect-no-hints.html" />
+<iframe src="embedded-popup-expect-no-hints.html"></iframe>
 </body>
 </html>

--- a/content-security-policy/font-src/font-match-allowed.sub.html
+++ b/content-security-policy/font-src/font-match-allowed.sub.html
@@ -7,7 +7,7 @@
   <script src='/resources/testharnessreport.js'></script>
 </head>
 <body>
-  <div id="log"/>
+  <div id="log"></div>
   <script>
     async_test(function(t) {
       document.addEventListener("securitypolicyviolation", t.unreached_func("Loading allowed fonts should not trigger a violation."));

--- a/content-security-policy/font-src/font-mismatch-blocked.sub.html
+++ b/content-security-policy/font-src/font-mismatch-blocked.sub.html
@@ -7,7 +7,7 @@
   <script src='/resources/testharnessreport.js'></script>
 </head>
 <body>
-  <div id="log"/>
+  <div id="log"></div>
   <script>
     async_test(function(t) {
       var link = document.createElement('link');

--- a/content-security-policy/font-src/font-none-blocked.sub.html
+++ b/content-security-policy/font-src/font-none-blocked.sub.html
@@ -7,7 +7,7 @@
   <script src='/resources/testharnessreport.js'></script>
 </head>
 <body>
-  <div id="log"/>
+  <div id="log"></div>
   <script>
     async_test(function(t) {
       var link = document.createElement('link');

--- a/content-security-policy/font-src/font-self-allowed.html
+++ b/content-security-policy/font-src/font-self-allowed.html
@@ -7,7 +7,7 @@
   <script src='/resources/testharnessreport.js'></script>
 </head>
 <body>
-  <div id="log"/>
+  <div id="log"></div>
   <script>
     async_test(function(t) {
       document.addEventListener("securitypolicyviolation", t.unreached_func("Loading allowed fonts should not trigger a violation."));

--- a/content-security-policy/font-src/font-stylesheet-font-blocked.sub.html
+++ b/content-security-policy/font-src/font-stylesheet-font-blocked.sub.html
@@ -7,7 +7,7 @@
   <script src='/resources/testharnessreport.js'></script>
 </head>
 <body>
-  <div id="log"/>
+  <div id="log"></div>
   <script>
     async_test(function(t) {
       var link = document.createElement('link');

--- a/content-security-policy/img-src/img-src-4_1.sub.html
+++ b/content-security-policy/img-src/img-src-4_1.sub.html
@@ -7,7 +7,7 @@
     <script src='/resources/testharnessreport.js'></script>
 </head>
 <body>
-    <div id='log'/>
+    <div id='log'></div>
 
     <script>
       async_test(function(t) {

--- a/content-security-policy/img-src/img-src-full-host-wildcard-blocked.sub.html
+++ b/content-security-policy/img-src/img-src-full-host-wildcard-blocked.sub.html
@@ -7,7 +7,7 @@
     <script src='/resources/testharnessreport.js'></script>
 </head>
 <body>
-    <div id='log'/>
+    <div id='log'></div>
 
     <script>
       var t1 = async_test("img src does not match full host and wildcard csp directive");

--- a/content-security-policy/img-src/img-src-host-partial-wildcard-allowed.sub.html
+++ b/content-security-policy/img-src/img-src-host-partial-wildcard-allowed.sub.html
@@ -7,7 +7,7 @@
     <script src='/resources/testharnessreport.js'></script>
 </head>
 <body>
-    <div id='log'/>
+    <div id='log'></div>
 
     <script>
       var t1 = async_test("img src matches correctly partial wildcard host csp directive");

--- a/content-security-policy/img-src/img-src-none-blocks.html
+++ b/content-security-policy/img-src/img-src-none-blocks.html
@@ -7,7 +7,7 @@
     <script src='/resources/testharnessreport.js'></script>
 </head>
 <body>
-    <div id='log'/>
+    <div id='log'></div>
 
     <script>
       var t1 = async_test("img-src with 'none' source should not match");

--- a/content-security-policy/img-src/img-src-port-wildcard-allowed.sub.html
+++ b/content-security-policy/img-src/img-src-port-wildcard-allowed.sub.html
@@ -7,7 +7,7 @@
     <script src='/resources/testharnessreport.js'></script>
 </head>
 <body>
-    <div id='log'/>
+    <div id='log'></div>
 
     <script>
       var t1 = async_test("img-src with wildcard port should match any port");

--- a/content-security-policy/img-src/img-src-wildcard-allowed.html
+++ b/content-security-policy/img-src/img-src-wildcard-allowed.html
@@ -7,7 +7,7 @@
     <script src='/resources/testharnessreport.js'></script>
 </head>
 <body>
-    <div id='log'/>
+    <div id='log'></div>
 
     <script>
       var t1 = async_test("img-src with wildcard should match all");

--- a/content-security-policy/navigation/javascript-url-navigation-inherits-csp.html
+++ b/content-security-policy/navigation/javascript-url-navigation-inherits-csp.html
@@ -3,7 +3,7 @@
 <script src="/resources/testharnessreport.js"></script>
 
 <script>
-  var window_url = encodeURIComponent("javascript:'<iframe src=/content-security-policy/support/fail.js />'");
+  var window_url = encodeURIComponent("javascript:'<iframe src=/content-security-policy/support/fail.js></iframe>'");
   var report_cookie_name = encodeURIComponent("javascript-url-navigation-inherits-csp");
   window.open("support/test_csp_self_window.sub.html?window_url=" + window_url + "&report_cookie_name=" + report_cookie_name);
   setTimeout(function() {

--- a/content-security-policy/reporting/report-uri-from-child-frame.html
+++ b/content-security-policy/reporting/report-uri-from-child-frame.html
@@ -18,6 +18,6 @@
         }
       }
     </script>
-    <iframe src="support/generate-csp-report.html"/>
+    <iframe src="support/generate-csp-report.html"></iframe>
 </body>
 </html>

--- a/css/css-animations/cancel-animation-shadow-slot-invalidation.html
+++ b/css/css-animations/cancel-animation-shadow-slot-invalidation.html
@@ -18,7 +18,7 @@
 <div id="dirty" class="none">PASS</div>
 <script>
   const root = host.attachShadow({mode:"open"});
-  root.innerHTML = "<slot />";
+  root.innerHTML = "<slot></slot>";
   requestAnimationFrame(() => {
     root.firstChild.name = "skip-slot";
     dirty.className = "";

--- a/css/css-backgrounds/background-clip-content-box.html
+++ b/css/css-backgrounds/background-clip-content-box.html
@@ -24,7 +24,7 @@
         background-color:red;
        }
     </style>
-   <head/>
+  </head>
  <body>
   <p>
    "Test passes if the background color is limited to the content only and border is blue dotted without red."

--- a/css/css-backgrounds/reference/reference.html
+++ b/css/css-backgrounds/reference/reference.html
@@ -32,7 +32,7 @@
        }
 
     </style>
-   <head/>
+  </head>
  <body>
   <p>
    "Test passes if the border is blue dotted without red."

--- a/css/css-cascade/scope-deep.html
+++ b/css/css-cascade/scope-deep.html
@@ -22,7 +22,7 @@ function createStyleSheet(length, i) {
   `.trim();
 }
 
-// <div class=s0><div class=s1>...<span/>...</div></div>
+// <div class=s0><div class=s1>...<span></span>...</div></div>
 function createElementChain(length, i) {
   if (length < 1)
     throw 'Invalid length';

--- a/css/css-display/display-contents-slot-attach-whitespace.html
+++ b/css/css-display/display-contents-slot-attach-whitespace.html
@@ -7,5 +7,5 @@
 <div id="host"><span>two</span> <span>words</span></div>
 <script>
   host.offsetTop;
-  host.attachShadow({mode:"open"}).innerHTML = "<slot />";
+  host.attachShadow({mode:"open"}).innerHTML = "<slot></slot>";
 </script>

--- a/css/css-masking/mask-image/mask-image-5-ref.html
+++ b/css/css-masking/mask-image/mask-image-5-ref.html
@@ -14,6 +14,6 @@
     </style>
   </head>
   <body>
-    <div/>
+    <div></div>
   </body>
 </html>

--- a/css/css-masking/mask-image/mask-image-5.html
+++ b/css/css-masking/mask-image/mask-image-5.html
@@ -21,6 +21,6 @@
     </style>
   </head>
   <body>
-    <div class="mask-by-data-url"/>
+    <div class="mask-by-data-url"></div>
   </body>
 </html>

--- a/css/css-scoping/keyframes-004.html
+++ b/css/css-scoping/keyframes-004.html
@@ -19,7 +19,7 @@
           animation: myanim 10s infinite;
         }
       </style>
-      <slot />
+      <slot></slot>
     `;
 
     assert_equals(document.getElementById('in-document').getAnimations().length, 1);

--- a/css/css-scoping/shadow-cascade-order-001.html
+++ b/css/css-scoping/shadow-cascade-order-001.html
@@ -294,15 +294,15 @@ testCascadingOrder('closed');
 //     <style>::slotted(my-item) { color: blue; }</style>
 //     <div>
 //       <:shadow>
-//         <slot></slot>
+//         <slot/>
 //       </:shadow>
-//       <slot></slot>
+//       <slot/>
 //     </div>
 //   </:shadow>
 //   <my-item style="color: green;">
 //     <:shadow>
 //       <style>:host { color: yellow; }</style>
-//       <slot></slot>
+//       <slot/>
 //     </:shadow>
 //     ITEM
 //   </my-item>

--- a/css/css-scoping/shadow-cascade-order-001.html
+++ b/css/css-scoping/shadow-cascade-order-001.html
@@ -22,12 +22,12 @@
 // <my-list>
 //   <:shadow>
 //     <style>::slotted(my-item) { color: blue; }</style>
-//     <slot/>
+//     <slot></slot>
 //   </:shadow>
 //   <my-item style="color: green;">
 //     <:shadow>
 //       <style>:host { color: yellow; }</style>
-//       <slot/>
+//       <slot></slot>
 //     </:shadow>
 //     ITEM
 //   </my-item>
@@ -294,15 +294,15 @@ testCascadingOrder('closed');
 //     <style>::slotted(my-item) { color: blue; }</style>
 //     <div>
 //       <:shadow>
-//         <slot/>
+//         <slot></slot>
 //       </:shadow>
-//       <slot/>
+//       <slot></slot>
 //     </div>
 //   </:shadow>
 //   <my-item style="color: green;">
 //     <:shadow>
 //       <style>:host { color: yellow; }</style>
-//       <slot/>
+//       <slot></slot>
 //     </:shadow>
 //     ITEM
 //   </my-item>

--- a/css/css-scoping/slotted-with-pseudo-element.html
+++ b/css/css-scoping/slotted-with-pseudo-element.html
@@ -14,7 +14,7 @@
 <script>
   function attachShadowWithSlottedStyle(host, styleString) {
     var root = host.attachShadow({mode:"open"});
-    root.innerHTML = "<style>"+styleString+"</style><slot/>";
+    root.innerHTML = "<style>"+styleString+"</style><slot></slot>";
   }
 
   attachShadowWithSlottedStyle(host1, "::slotted(span)::before { content: 'PASS' }");

--- a/css/selectors/modal-pseudo-class.html
+++ b/css/selectors/modal-pseudo-class.html
@@ -11,7 +11,7 @@
 
 <dialog id="dialog">Just another dialog.</dialog>
 <div id="container">
-  <button id="btn"/>
+  <button id="btn"></button>
 </div>
 
 <script>

--- a/element-timing/background-image-multiple-elements.html
+++ b/element-timing/background-image-multiple-elements.html
@@ -82,7 +82,7 @@ body {
 <div width=200 height=100 id="div2" class="my_div" elementtiming="et2">
   Sample text inside div.
 </div>
-<div id="div3"/>
+<div id="div3"></div>
   I am a div that should not be observed!
 </div>
 </body>

--- a/element-timing/background-image-multiple-elements.html
+++ b/element-timing/background-image-multiple-elements.html
@@ -82,7 +82,7 @@ body {
 <div width=200 height=100 id="div2" class="my_div" elementtiming="et2">
   Sample text inside div.
 </div>
-<div id="div3"></div>
+<div id="div3">
   I am a div that should not be observed!
 </div>
 </body>

--- a/element-timing/image-rect-iframe.html
+++ b/element-timing/image-rect-iframe.html
@@ -29,5 +29,5 @@ body {
     });
   }, 'Element Timing entry in iframe has coordinates relative to the iframe.');
 </script>
-<iframe src="resources/iframe-with-square-sends-entry.html"/>
+<iframe src="resources/iframe-with-square-sends-entry.html"></iframe>
 </body>

--- a/element-timing/observe-video-poster.html
+++ b/element-timing/observe-video-poster.html
@@ -29,4 +29,4 @@ body {
   margin: 0;
 }
 </style>
-<video elementtiming='my_poster' id='the_poster' src='/media/test.mp4' poster='resources/circle.svg'/>
+<video elementtiming='my_poster' id='the_poster' src='/media/test.mp4' poster='resources/circle.svg'></video>

--- a/html/canvas/element/manual/unclosed-canvas-4.htm
+++ b/html/canvas/element/manual/unclosed-canvas-4.htm
@@ -12,6 +12,6 @@
         The canvas is never closed, and the rest of the body ends up inside it.
         There's nothing special about div; we get the same results with other types of elements.
         The fact that the canvas tag uses XML self-closing syntax has no effect.</p>
-        <canvas></canvas></div>This text should NOT be visible if JavaScript is enabled.
+        <canvas/></div>This text should NOT be visible if JavaScript is enabled.
     </body>
 </html>

--- a/html/canvas/element/manual/unclosed-canvas-4.htm
+++ b/html/canvas/element/manual/unclosed-canvas-4.htm
@@ -12,6 +12,6 @@
         The canvas is never closed, and the rest of the body ends up inside it.
         There's nothing special about div; we get the same results with other types of elements.
         The fact that the canvas tag uses XML self-closing syntax has no effect.</p>
-        <canvas/></div>This text should NOT be visible if JavaScript is enabled.
+        <canvas></canvas></div>This text should NOT be visible if JavaScript is enabled.
     </body>
 </html>

--- a/html/editing/dnd/canvas/002.html
+++ b/html/editing/dnd/canvas/002.html
@@ -31,7 +31,7 @@ function start(event)
 </script>
 </head>
 <body onload="paint('gray')">
-<div draggable="true" ondragstart="start(event)"/>
+<div draggable="true" ondragstart="start(event)"></div>
 <p>Drag green box above to the gray canvas below. Canvas should turn green when you drop green box on it.</p>
 <p>
   <canvas width="100" height="100" ondragenter="event.preventDefault()" ondragover="return false">Canvas</canvas>

--- a/html/editing/dnd/canvas/005.html
+++ b/html/editing/dnd/canvas/005.html
@@ -24,7 +24,7 @@ function start(event)
 </script>
 </head>
 <body>
-<div draggable="true" ondragstart="start(event)"/>
+<div draggable="true" ondragstart="start(event)"></div>
 <p>Drag green box above to the gray canvas below. Canvas should turn green when you drop green box on it.</p>
 <p><iframe src="helper-drop-here-canvas.xhtml">Canvas</iframe></p>
 <script>

--- a/html/rendering/replaced-elements/embedded-content/video-controls-vertical-writing-mode-ref.html
+++ b/html/rendering/replaced-elements/embedded-content/video-controls-vertical-writing-mode-ref.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <div>
-  <video controls />
+  <video controls></video>
 </div>

--- a/html/rendering/replaced-elements/embedded-content/video-controls-vertical-writing-mode.html
+++ b/html/rendering/replaced-elements/embedded-content/video-controls-vertical-writing-mode.html
@@ -4,5 +4,5 @@
 <link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#embedded-content-rendering-rules" />
 <link rel="match" href="video-controls-vertical-writing-mode-ref.html" />
 <div style="writing-mode:vertical-lr">
-  <video controls />
+  <video controls></video>
 </div>

--- a/html/semantics/scripting-1/the-script-element/async_009.htm
+++ b/html/semantics/scripting-1/the-script-element/async_009.htm
@@ -12,7 +12,7 @@
         var t = async_test("Document.write() silently fails from an Async script");
 
         var log = t.step_func(function() {
-          document.write("<span id='writtenText'/>");
+          document.write("<span id='writtenText'></span>");
           assert_equals(null, document.getElementById('writtenText'));
           t.done();
         });

--- a/html/syntax/parsing/template/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-body-context.html
+++ b/html/syntax/parsing/template/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-body-context.html
@@ -112,13 +112,13 @@ var parameters = [
      doc, 'thead', '<col id="col3" width="150"/>', 'col3', 'COL'],
 
     ['Clearing stack back to a table body context. Test <colgroup> in <tbody>',
-     doc, 'tbody', '<colgroup id="colgroup1" width="150"/>', 'colgroup1', 'COLGROUP'],
+     doc, 'tbody', '<colgroup id="colgroup1" width="150"></colgroup>', 'colgroup1', 'COLGROUP'],
 
     ['Clearing stack back to a table body context. Test <colgroup> in <tfoot>',
-     doc, 'tfoot', '<colgroup id="colgroup2" width="150"/>', 'colgroup2', 'COLGROUP'],
+     doc, 'tfoot', '<colgroup id="colgroup2" width="150"></colgroup>', 'colgroup2', 'COLGROUP'],
 
     ['Clearing stack back to a table body context. Test <colgroup> in <thead>',
-     doc, 'thead', '<colgroup id="colgroup3" width="150"/>', 'colgroup3', 'COLGROUP'],
+     doc, 'thead', '<colgroup id="colgroup3" width="150"></colgroup>', 'colgroup3', 'COLGROUP'],
 
     ['Clearing stack back to a table body context. Test <tbody> in <tbody>',
      doc, 'tbody', '<tbody id="tbody1"></tbody>', 'tbody1', 'TBODY', 1],

--- a/html/syntax/parsing/template/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-context.html
+++ b/html/syntax/parsing/template/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-context.html
@@ -62,7 +62,7 @@ var parameters = [
      doc, '<caption id="caption1">Table caption</caption>', 'caption1', 'CAPTION'],
 
     ['Clearing stack back to a table context. Test <colgroup>',
-     doc, '<colgroup id="colgroup1" width="100%"/>', 'colgroup1', 'COLGROUP'],
+     doc, '<colgroup id="colgroup1" width="100%"></colgroup>', 'colgroup1', 'COLGROUP'],
 
     ['Clearing stack back to a table context. Test <tbody>',
      doc, '<tbody id="tbody1"></tbody>', 'tbody1', 'TBODY', 1],

--- a/largest-contentful-paint/video-poster.html
+++ b/largest-contentful-paint/video-poster.html
@@ -22,4 +22,4 @@ async_test(function (t) {
   observer.observe({type: 'largest-contentful-paint', buffered: true});
 }, "Able to observe a video's poster image.");
 </script>
-<video id='the_poster' src='/media/test.mp4' poster='/images/blue.png'/>
+<video id='the_poster' src='/media/test.mp4' poster='/images/blue.png'></video>

--- a/mediacapture-image/ImageCapture-grabFrame.html
+++ b/mediacapture-image/ImageCapture-grabFrame.html
@@ -2,8 +2,8 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<canvas id='canvas0' width=10 height=10/>
-<canvas id='canvas1' width=10 height=10/>
+<canvas id='canvas0' width=10 height=10></canvas>
+<canvas id='canvas1' width=10 height=10></canvas>
 </body>
 <script>
 

--- a/mediacapture-image/MediaStreamTrack-applyConstraints-fast.html
+++ b/mediacapture-image/MediaStreamTrack-applyConstraints-fast.html
@@ -2,7 +2,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<canvas id='canvas' width=10 height=10/>
+<canvas id='canvas' width=10 height=10></canvas>
 </body>
 <script>
 

--- a/mediacapture-image/MediaStreamTrack-getCapabilities-fast.html
+++ b/mediacapture-image/MediaStreamTrack-getCapabilities-fast.html
@@ -2,7 +2,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<canvas id='canvas' width=10 height=10/>
+<canvas id='canvas' width=10 height=10></canvas>
 </body>
 <script>
 

--- a/mediacapture-image/MediaStreamTrack-getSettings-fast.html
+++ b/mediacapture-image/MediaStreamTrack-getSettings-fast.html
@@ -2,7 +2,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<canvas id='canvas' width=10 height=10/>
+<canvas id='canvas' width=10 height=10></canvas>
 </body>
 <script>
 

--- a/mediacapture-image/detached-HTMLCanvasElement.html
+++ b/mediacapture-image/detached-HTMLCanvasElement.html
@@ -6,7 +6,7 @@
 
 async_test(t => {
   let iframe = document.createElement('iframe');
-  let html = "<canvas id='canvas' width=10 height=10 />";
+  let html = "<canvas id='canvas' width=10 height=10></canvas>";
   iframe.srcdoc = html;
   iframe.onload = t.step_func_done(() => {
     // This detaches the frame while retaining a reference to an

--- a/mediacapture-image/getPhotoCapabilities.html
+++ b/mediacapture-image/getPhotoCapabilities.html
@@ -3,7 +3,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mediacapture-image/resources/imagecapture-helpers.js"></script>
 <body>
-<canvas id='canvas' width=10 height=10/>
+<canvas id='canvas' width=10 height=10></canvas>
 </body>
 <script>
 

--- a/mediacapture-image/getPhotoSettings.html
+++ b/mediacapture-image/getPhotoSettings.html
@@ -3,7 +3,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mediacapture-image/resources/imagecapture-helpers.js"></script>
 <body>
-<canvas id='canvas' width=10 height=10/>
+<canvas id='canvas' width=10 height=10></canvas>
 </body>
 <script>
 

--- a/mediacapture-image/takePhoto-reject.html
+++ b/mediacapture-image/takePhoto-reject.html
@@ -3,7 +3,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mediacapture-image/resources/imagecapture-helpers.js"></script>
 <body>
-<canvas id='canvas' width=10 height=10/>
+<canvas id='canvas' width=10 height=10></canvas>
 </body>
 <script>
 

--- a/mediacapture-image/takePhoto-with-PhotoSettings.html
+++ b/mediacapture-image/takePhoto-with-PhotoSettings.html
@@ -3,7 +3,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mediacapture-image/resources/imagecapture-helpers.js"></script>
 <body>
-<canvas id='canvas' width=10 height=10/>
+<canvas id='canvas' width=10 height=10></canvas>
 </body>
 <script>
 

--- a/mediacapture-image/takePhoto.html
+++ b/mediacapture-image/takePhoto.html
@@ -3,7 +3,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mediacapture-image/resources/imagecapture-helpers.js"></script>
 <body>
-<canvas id='canvas' width=10 height=10/>
+<canvas id='canvas' width=10 height=10></canvas>
 </body>
 <script>
 

--- a/mediacapture-record/MediaRecorder-peerconnection.https.html
+++ b/mediacapture-record/MediaRecorder-peerconnection.https.html
@@ -15,7 +15,7 @@
 </head>
 
 <body>
-  <video id="remote" autoplay width="240" />
+  <video id="remote" autoplay width="240"></video>
   <script>
 
 promise_setup(async () => {

--- a/mediacapture-record/passthrough/MediaRecorder-passthrough.https.html
+++ b/mediacapture-record/passthrough/MediaRecorder-passthrough.https.html
@@ -14,7 +14,7 @@
 </head>
 
 <body>
-  <video id="remote" autoplay width="240" />
+  <video id="remote" autoplay width="240"></video>
   <script>
 
 [{kind: "video", audio: false, codecPreference: "VP8", codecRegex: /.*vp8.*/},

--- a/pointerevents/pointerevent_touch-action-rotated-divs_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-rotated-divs_touch-manual.html
@@ -87,6 +87,6 @@
     </ol>
     <div id="target"></div>
     <input type="button" id="btnDone" value="Done" />
-    <div id="log" />
+    <div id="log"></div>
   </body>
 </html>

--- a/shadow-dom/declarative/declarative-with-disabled-shadow.tentative.html
+++ b/shadow-dom/declarative/declarative-with-disabled-shadow.tentative.html
@@ -16,7 +16,7 @@ customElements.define('shadow-disabled',ShadowDisabledElement);
 </script>
 
 <shadow-disabled>
-  <template shadowrootmode="open"><span id=inside/></template>
+  <template shadowrootmode="open"><span id=inside></span></template>
 </shadow-disabled>
 
 <script>

--- a/shadow-dom/focus-navigation/focus-reverse-unassignable-slot.html
+++ b/shadow-dom/focus-navigation/focus-reverse-unassignable-slot.html
@@ -13,7 +13,7 @@
 
 <div>
   <template shadowrootmode=open>
-    <slot />
+    <slot></slot>
   </template>
   <slot>
     <input id=input1>

--- a/trusted-types/TrustedTypePolicyFactory-getAttributeType-namespace.tentative.html
+++ b/trusted-types/TrustedTypePolicyFactory-getAttributeType-namespace.tentative.html
@@ -12,7 +12,7 @@ const parser = new DOMParser();
     '<!doctype html><html><head><script src="./foo.js"><'+'/script></head></html>',
     'text/html'),
   parser.parseFromString(
-    '<html xmlns="http://www.w3.org/1999/xhtml"><head><script src="./foo.js"></script></head></html>',
+    '<html xmlns="http://www.w3.org/1999/xhtml"><head><script src="./foo.js" /></head></html>',
     'application/xhtml+xml'),
   parser.parseFromString(
   '<xml xmlns:html="http://www.w3.org/1999/xhtml"><html:script src="./foo.js" /></xml>',

--- a/trusted-types/TrustedTypePolicyFactory-getAttributeType-namespace.tentative.html
+++ b/trusted-types/TrustedTypePolicyFactory-getAttributeType-namespace.tentative.html
@@ -12,7 +12,7 @@ const parser = new DOMParser();
     '<!doctype html><html><head><script src="./foo.js"><'+'/script></head></html>',
     'text/html'),
   parser.parseFromString(
-    '<html xmlns="http://www.w3.org/1999/xhtml"><head><script src="./foo.js" /></head></html>',
+    '<html xmlns="http://www.w3.org/1999/xhtml"><head><script src="./foo.js"></script></head></html>',
     'application/xhtml+xml'),
   parser.parseFromString(
   '<xml xmlns:html="http://www.w3.org/1999/xhtml"><html:script src="./foo.js" /></xml>',

--- a/video-rvfc/request-video-frame-callback-during-xr-session.https.html
+++ b/video-rvfc/request-video-frame-callback-during-xr-session.https.html
@@ -2,7 +2,7 @@
 <html>
 <title>Test that video.rVFC callbacks started during an XRSession work.</title>
 <body>
-    <canvas/>
+    <canvas></canvas>
 </body>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/video-rvfc/request-video-frame-callback-webrtc.https.html
+++ b/video-rvfc/request-video-frame-callback-webrtc.https.html
@@ -9,7 +9,7 @@
   <div id="log"></div>
   <div>
     <video id="local-view" muted autoplay="autoplay"></video>
-    <video id="remote-view" muted autoplay="autoplay"/>
+    <video id="remote-view" muted autoplay="autoplay"></video>
     </video>
   </div>
 

--- a/video-rvfc/request-video-frame-callback-webrtc.https.html
+++ b/video-rvfc/request-video-frame-callback-webrtc.https.html
@@ -10,7 +10,6 @@
   <div>
     <video id="local-view" muted autoplay="autoplay"></video>
     <video id="remote-view" muted autoplay="autoplay"></video>
-    </video>
   </div>
 
   <!-- These files are in place when executing on W3C. -->

--- a/webrtc/simplecall-no-ssrcs.https.html
+++ b/webrtc/simplecall-no-ssrcs.https.html
@@ -9,7 +9,7 @@
   <div id="log"></div>
   <div>
     <video id="local-view" muted autoplay="autoplay"></video>
-    <video id="remote-view" muted autoplay="autoplay"/>
+    <video id="remote-view" muted autoplay="autoplay"></video>
     </video>
   </div>
 

--- a/webrtc/simplecall-no-ssrcs.https.html
+++ b/webrtc/simplecall-no-ssrcs.https.html
@@ -10,7 +10,6 @@
   <div>
     <video id="local-view" muted autoplay="autoplay"></video>
     <video id="remote-view" muted autoplay="autoplay"></video>
-    </video>
   </div>
 
   <!-- These files are in place when executing on W3C. -->

--- a/webrtc/simplecall.https.html
+++ b/webrtc/simplecall.https.html
@@ -9,7 +9,7 @@
   <div id="log"></div>
   <div>
     <video id="local-view" muted autoplay="autoplay"></video>
-    <video id="remote-view" muted autoplay="autoplay"/>
+    <video id="remote-view" muted autoplay="autoplay"></video>
     </video>
   </div>
 

--- a/webrtc/simplecall.https.html
+++ b/webrtc/simplecall.https.html
@@ -10,7 +10,6 @@
   <div>
     <video id="local-view" muted autoplay="autoplay"></video>
     <video id="remote-view" muted autoplay="autoplay"></video>
-    </video>
   </div>
 
   <!-- These files are in place when executing on W3C. -->

--- a/webxr/webxr_permissions_policy.https.html
+++ b/webxr/webxr_permissions_policy.https.html
@@ -3,7 +3,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/webxr_util.js"></script>
 <script src="resources/webxr_test_constants.js"></script>
-<canvas />
+<canvas></canvas>
 
 <script>
 xr_promise_test(


### PR DESCRIPTION
In VSCode, I searched for

```
<(a|abbr|article|audio|b|bdi|bdo|blockquote|body|button|canvas|caption|cite|code|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|fieldset|figcaption|figure|footer|form|h[1-6]|head|header|html|i|iframe|ins|kbd|label|legend|li|main|map|mark|menu|meter|nav|noscript|object|ol|optgroup|option|output|p|picture|pre|progress|q|rp|rt|ruby|s|samp|script|search|section|select|slot|small|span|strong|style|sub|summary|sup|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|u|ul|var|video)(\s+[^>]+)?\s*/>
```
and replaced with
```
<$1$2></$1>
```
(with some manual fixups)

Files to include: `*.html, *.htm`
Files to exclude: `dom/nodes/, domparsing/, quirks/, conformance-checkers/, acid/` (these are testing XML parsing, except Acid3 which has pseudo-markup in comments)