### PR TITLE
Add test for referrer in module imports

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/module-import-referrer.html
+++ b/html/semantics/scripting-1/the-script-element/module/module-import-referrer.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Referrer for module imports</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script type="module">
+
+import { referrerExternalStatic, referrerExternalDynamic } from "./module-import-referrer.js";
+
+// "name" parameter is necessary for bypassing the module map.
+import { referrer as referrerInlineStatic } from "./resources/referrer-checker.py?name=internal-static"
+const { referrer: referrerInlineDynamic } = await import("./resources/referrer-checker.py?name=internal-dynamic");
+
+const scriptURL = new URL("module-import-referrer.js", location.href)
+
+test(t => {
+  assert_equals(
+    referrerInlineStatic, location.href,
+      "Referrer should be the document URL");
+}, "Static imports from inline modules in the HTML document");
+
+test(t => {
+  assert_equals(
+    referrerInlineDynamic, location.href,
+      "Referrer should be the document URL");
+}, "Dynamic imports from inline modules in the HTML document");
+
+test(t => {
+  assert_equals(
+    referrerExternalStatic, scriptURL.href,
+      "Referrer should be the importer module URL");
+}, "Static imports from external modules");
+
+test(t => {
+  assert_equals(
+    referrerExternalDynamic, location.href,
+      "Referrer should be the document URL");
+}, "Dynamic imports from external modules");
+
+</script>
+</body>
+</html>

--- a/html/semantics/scripting-1/the-script-element/module/module-import-referrer.html
+++ b/html/semantics/scripting-1/the-script-element/module/module-import-referrer.html
@@ -36,7 +36,7 @@ test(t => {
 
 test(t => {
   assert_equals(
-    referrerExternalDynamic, location.href,
+    referrerExternalDynamic, scriptURL.href,
       "Referrer should be the document URL");
 }, "Dynamic imports from external modules");
 

--- a/html/semantics/scripting-1/the-script-element/module/module-import-referrer.html
+++ b/html/semantics/scripting-1/the-script-element/module/module-import-referrer.html
@@ -4,6 +4,7 @@
 <title>Referrer for module imports</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script>setup({ explicit_done: true })</script>
 </head>
 <body>
 <script type="module">
@@ -39,6 +40,8 @@ test(t => {
     referrerExternalDynamic, scriptURL.href,
       "Referrer should be the document URL");
 }, "Dynamic imports from external modules");
+
+done();
 
 </script>
 </body>

--- a/html/semantics/scripting-1/the-script-element/module/module-import-referrer.js
+++ b/html/semantics/scripting-1/the-script-element/module/module-import-referrer.js
@@ -1,0 +1,2 @@
+export { referrer as referrerExternalStatic } from "./resources/referrer-checker.py?name=external-static"
+export const { referrer: referrerExternalDynamic } = await import("./resources/referrer-checker.py?name=external-dynamic");


### PR DESCRIPTION
This PR adds tests for the `referrer` used by fetches of modules imported using `import` statements and dynamic `import()`.

The first commit adds tests for the currently specified behavior, while the second commit updates it to match the behavior proposed in https://github.com/whatwg/html/issues/3744 to align static and dynamic imports.

From my manual tests, Firefox implements the new behavior while Webkit and Chromium implement the current behavior.

There is something wrong with the tests, because Chrome and Safari only run the first one, but I cannot figure out why. If I delete the first test, then they only run the second one (that becomes first).