### PR TITLE
[wdspec] browsingContext.print: fix rounding error in page.py test

### DIFF
--- a/tools/wptrunner/wptrunner/print_pdf_runner.html
+++ b/tools/wptrunner/wptrunner/print_pdf_runner.html
@@ -11,19 +11,19 @@ async function _render(pdfData) {
   let loadingTask = pdfjsLib.getDocument({data: atob(pdfData)});
   let pdf = await loadingTask.promise;
   let rendered = [];
-  for (let pageNumber=1; pageNumber<=pdf.numPages; pageNumber++) {
+  for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
     let page = await pdf.getPage(pageNumber);
-    var viewport = page.getViewport({scale: 96./72.});
+    const viewport = page.getViewport({ scale: 96. / 72. });
     // Prepare canvas using PDF page dimensions
-    var canvas = document.getElementsByTagName('canvas')[0];
-    var context = canvas.getContext('2d');
+    const canvas = document.getElementsByTagName('canvas')[0];
+    const context = canvas.getContext('2d');
     canvas.height = viewport.height;
     canvas.width = viewport.width;
 
     // Render PDF page into canvas context
-    var renderContext = {
+    const renderContext = {
       canvasContext: context,
-      viewport: viewport
+      viewport
     };
     await page.render(renderContext).promise;
     rendered.push(canvas.toDataURL());

--- a/webdriver/tests/support/fixtures_bidi.py
+++ b/webdriver/tests/support/fixtures_bidi.py
@@ -208,8 +208,8 @@ def assert_pdf_dimensions(render_pdf_to_png_bidi):
         png = await render_pdf_to_png_bidi(pdf)
         width, height = png_dimensions(png)
 
-        assert height in [floor(cm_to_px(expected_dimensions["height"])), round(cm_to_px(expected_dimensions["height"]))]
-        assert width in [floor(cm_to_px(expected_dimensions["width"])), round(cm_to_px(expected_dimensions["width"]))]
+        assert floor(cm_to_px(expected_dimensions["height"])) == height
+        assert floor(cm_to_px(expected_dimensions["width"])) == width
 
     return assert_pdf_dimensions
 

--- a/webdriver/tests/support/fixtures_bidi.py
+++ b/webdriver/tests/support/fixtures_bidi.py
@@ -1,3 +1,4 @@
+from math import floor
 import base64
 
 from tests.support.image import cm_to_px, png_dimensions, ImageDifference
@@ -207,8 +208,8 @@ def assert_pdf_dimensions(render_pdf_to_png_bidi):
         png = await render_pdf_to_png_bidi(pdf)
         width, height = png_dimensions(png)
 
-        assert (height - 1) <= cm_to_px(expected_dimensions["height"]) <= (height + 1)
-        assert (width - 1) <= cm_to_px(expected_dimensions["width"]) <= (width + 1)
+        assert floor(cm_to_px(expected_dimensions["height"])) == height
+        assert floor(cm_to_px(expected_dimensions["width"])) == width
 
     return assert_pdf_dimensions
 

--- a/webdriver/tests/support/fixtures_bidi.py
+++ b/webdriver/tests/support/fixtures_bidi.py
@@ -1,4 +1,3 @@
-from math import floor
 import base64
 
 from tests.support.image import cm_to_px, png_dimensions, ImageDifference
@@ -208,8 +207,8 @@ def assert_pdf_dimensions(render_pdf_to_png_bidi):
         png = await render_pdf_to_png_bidi(pdf)
         width, height = png_dimensions(png)
 
-        assert floor(cm_to_px(expected_dimensions["height"])) == height
-        assert floor(cm_to_px(expected_dimensions["width"])) == width
+        assert (height - 1) <= cm_to_px(expected_dimensions["height"]) <= (height + 1)
+        assert (width - 1) <= cm_to_px(expected_dimensions["width"]) <= (width + 1)
 
     return assert_pdf_dimensions
 

--- a/webdriver/tests/support/fixtures_bidi.py
+++ b/webdriver/tests/support/fixtures_bidi.py
@@ -207,8 +207,8 @@ def assert_pdf_dimensions(render_pdf_to_png_bidi):
         png = await render_pdf_to_png_bidi(pdf)
         width, height = png_dimensions(png)
 
-        assert cm_to_px(expected_dimensions["height"]) == height
-        assert cm_to_px(expected_dimensions["width"]) == width
+        assert (height - 1) <= cm_to_px(expected_dimensions["height"]) <= (height + 1)
+        assert (width - 1) <= cm_to_px(expected_dimensions["width"]) <= (width + 1)
 
     return assert_pdf_dimensions
 

--- a/webdriver/tests/support/fixtures_bidi.py
+++ b/webdriver/tests/support/fixtures_bidi.py
@@ -208,8 +208,8 @@ def assert_pdf_dimensions(render_pdf_to_png_bidi):
         png = await render_pdf_to_png_bidi(pdf)
         width, height = png_dimensions(png)
 
-        assert floor(cm_to_px(expected_dimensions["height"])) == height
-        assert floor(cm_to_px(expected_dimensions["width"])) == width
+        assert height in [floor(cm_to_px(expected_dimensions["height"])), round(cm_to_px(expected_dimensions["height"]))]
+        assert width in [floor(cm_to_px(expected_dimensions["width"])), round(cm_to_px(expected_dimensions["width"]))]
 
     return assert_pdf_dimensions
 

--- a/webdriver/tests/support/image.py
+++ b/webdriver/tests/support/image.py
@@ -8,7 +8,7 @@ inch_in_cm = 2.54
 
 
 def cm_to_px(cm):
-    return cm * PPI / inch_in_cm
+    return round(cm * PPI / inch_in_cm)
 
 
 def px_to_cm(px):

--- a/webdriver/tests/support/image.py
+++ b/webdriver/tests/support/image.py
@@ -8,7 +8,7 @@ inch_in_cm = 2.54
 
 
 def cm_to_px(cm):
-    return round(cm * PPI / inch_in_cm)
+    return cm * PPI / inch_in_cm
 
 
 def px_to_cm(px):


### PR DESCRIPTION
[pytest](https://github.com/web-platform-tests/wpt/blob/7a087d54be8b6c0ca0181a86dc1ff0b28461c383/webdriver/tests/support/image.py) uses:

    def cm_to_px(cm): return round(cm * 96 / 2.54)

[js](https://github.com/web-platform-tests/wpt/blob/7a087d54be8b6c0ca0181a86dc1ff0b28461c383/tools/wptrunner/wptrunner/print_pdf_runner.html) uses:

    const viewport = page.getViewport({ scale: 96. / 72. });
    ...
    canvas.height = viewport.height;
    canvas.width = viewport.width;

This produces a rounding error, even though the dimension is correct:

    >       assert cm_to_px(expected_dimensions["height"]) == height
    E       assert 454 == 453
    E         +454
    E         -453

The inconsistency of rounding in both ends becomes clear when we eliminate "round" in the pytest side:

    >       assert cm_to_px(expected_dimensions["height"]) == height
    E       assert 453.54330708661416 == 453
    E         +453.54330708661416
    E         -453

There are multiple ways to fix this issue.

Option #1: Use "floor" instead of "round" in pytest. This approach fixes some tests, but others still fail. I guess in some cases "round" is correct.

Option #2: Use a range in the assertion comparison, allowing a difference of up to +-1.0. This is what this PR does.

The comparison is performed in
[`assert_pdf_dimensions`](https://github.com/web-platform-tests/wpt/blob/b6107cc1ac8b9c2800b4c8e58af719b8e4d9b8db/webdriver/tests/support/fixtures_bidi.py#L210).

The problematic part is .96 / .72 which evaluates to 4/3 = 1.333333....