### PR TITLE
Add mojo js support to wpt runner for AndroidWebView

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -506,6 +506,11 @@ class AndroidWebview(ChromeAndroidBase):
     name = "android_webview"
     browser_cls = browser.AndroidWebview
 
+    def setup_kwargs(self, kwargs):
+        if kwargs["mojojs_path"]:
+            kwargs["enable_mojojs"] = True
+            logger.info("--mojojs-path is provided, enabling MojoJS")
+
 
 class Opera(BrowserSetup):
     name = "opera"


### PR DESCRIPTION
We need this capability in order to use the gen directory for Android WebView. I have tested this with run_wpt_tests.py with AndroidWebView with Chromium against a new WPT that makes sense of /gen/.