### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=258078

### DIFF
--- a/html/semantics/selectors/pseudo-classes/disabled.html
+++ b/html/semantics/selectors/pseudo-classes/disabled.html
@@ -26,6 +26,7 @@
 </select>
 <textarea id=textarea1>textarea1</textarea>
 <textarea disabled id=textarea2>textarea2</textarea>
+<fieldset id=fieldset1></fieldset>
 <fieldset disabled id=fieldset2>
   <legend><input type=checkbox id=club></legend>
   <p><label>Name on card: <input id=clubname required></label></p>
@@ -39,21 +40,21 @@
 <progress disabled></progress>
 
 <script>
-  testSelectorIdsMatch(":disabled", ["button2", "input2", "select2", "optgroup2", "option2", "textarea2", "clubname", "clubnum"], "':disabled' should match only disabled elements");
+  testSelectorIdsMatch(":disabled", ["button2", "input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should match only disabled elements");
 
   document.getElementById("button2").removeAttribute("disabled");
-  testSelectorIdsMatch(":disabled", ["input2", "select2", "optgroup2", "option2", "textarea2", "clubname", "clubnum"], "':disabled' should not match elements whose disabled attribute has been removed");
+  testSelectorIdsMatch(":disabled", ["input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should not match elements whose disabled attribute has been removed");
 
   document.getElementById("button1").setAttribute("disabled", "disabled");
-  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "clubname", "clubnum"], "':disabled' should also match elements whose disabled attribute has been set");
+  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should also match elements whose disabled attribute has been set");
 
   document.getElementById("button1").setAttribute("disabled", "disabled");
-  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "clubname", "clubnum"], "':disabled' should also match elements whose disabled attribute has been set twice");
+  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should also match elements whose disabled attribute has been set twice");
 
   document.getElementById("input2").setAttribute("type", "submit"); // change input type to submit
-  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "clubname", "clubnum"], "':disabled' should also match disabled elements whose type has changed");
+  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should also match disabled elements whose type has changed");
 
   var input = document.createElement("input");
   input.setAttribute("disabled", "disabled");
-  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "clubname", "clubnum"], "':disabled' should not match elements not in the document");
+  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should not match elements not in the document");
 </script>

--- a/html/semantics/selectors/pseudo-classes/enabled.html
+++ b/html/semantics/selectors/pseudo-classes/enabled.html
@@ -36,6 +36,7 @@
  </menu>
 </form>
 <fieldset id=fieldset1></fieldset>
+<fieldset disabled id=fieldset2></fieldset>
 
 <script>
   testSelectorIdsMatch(":enabled", ["button1", "input1", "select1", "optgroup1", "option1", "textarea1", "submitbutton", "fieldset1"], "':enabled' elements that are not disabled");


### PR DESCRIPTION
Revert recent changes to `:enabled` / `:disabled` CSS selector tests for fieldset. Those changes were not actually correct. See https://github.com/whatwg/html/issues/5886#issuecomment-1582410112 for more information.