### PR TITLE
Modify tests to incorporate white-space longhands

### DIFF
--- a/css/css-cascade/all-prop-revert-layer.html
+++ b/css/css-cascade/all-prop-revert-layer.html
@@ -329,6 +329,7 @@
   text-transform: lowercase;
   text-underline-offset: 123px;
   text-underline-position: under;
+  text-wrap: nowrap;
   top: 123px;
   touch-action: none;
   transform: scale(-1);
@@ -345,7 +346,8 @@
   vector-effect: non-scaling-stroke;
   vertical-align: 123px;
   visibility: collapse;
-  white-space: pre;
+  white-space-collapse: preserve;
+  white-space-trim: discard-inner;
   widows: 123;
   width: 123px;
   will-change: height;

--- a/css/css-typed-om/the-stylepropertymap/properties/white-space.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/white-space.html
@@ -13,12 +13,35 @@
 <script>
 'use strict';
 
-runPropertyTests('white-space', [
-  { syntax: 'normal'},
-  { syntax: 'pre' },
-  { syntax: 'nowrap' },
-  { syntax: 'pre-wrap' },
-  { syntax: 'pre-line' },
+runPropertyTests('white-space-collapse', [
+  { syntax: 'collapse'},
+  { syntax: 'discard' },
+  { syntax: 'preserve' },
+  { syntax: 'preserve-breaks' },
+  { syntax: 'preserve-spaces' },
+  { syntax: 'break-spaces' },
 ]);
+
+runPropertyTests('text-wrap', [
+  { syntax: 'wrap'},
+  { syntax: 'nowrap' },
+  { syntax: 'balance' },
+  { syntax: 'stable' },
+  { syntax: 'pretty' },
+]);
+
+runPropertyTests('white-space-trim', [
+  { syntax: 'none'},
+  { syntax: 'discard-before' },
+  { syntax: 'discard-after' },
+  { syntax: 'discard-inner' },
+]);
+
+runUnsupportedPropertyTests('white-space-trim', [
+  'discard-before discard-after',
+  'discard-before discard-inner',
+  'discard-after discard-inner',
+  'discard-before discard-after discard-inner'
+])
 
 </script>


### PR DESCRIPTION
Modify tests so that they use white-space longhands {white-space-collapse, text-wrap, white-space-trim} instead of the white-space shorthand.