### PR TITLE
Revert "Update WebDriver keys"

### DIFF
--- a/webdriver/tests/support/keys.py
+++ b/webdriver/tests/support/keys.py
@@ -244,7 +244,7 @@ ALL_EVENTS = OrderedDict(
         )),
         ("EQUALS", OrderedDict(
             [
-                ("code", "NumpadEqual"),
+                ("code", ""),
                 ("ctrl", False),
                 ("key", "="),
                 ("location", 0),
@@ -442,7 +442,7 @@ ALL_EVENTS = OrderedDict(
         )),
         ("META", OrderedDict(
             [
-                ("code", "MetaLeft"),
+                ("code", "OSLeft"),
                 ("ctrl", False),
                 ("key", "Meta"),
                 ("location", 1),
@@ -607,7 +607,7 @@ ALL_EVENTS = OrderedDict(
         )),
         ("PAUSE", OrderedDict(
             [
-                ("code", "Pause"),
+                ("code", ""),
                 ("ctrl", False),
                 ("key", "Pause"),
                 ("location", 0),
@@ -750,7 +750,7 @@ ALL_EVENTS = OrderedDict(
         )),
         ("R_META", OrderedDict(
             [
-                ("code", "MetaRight"),
+                ("code", "OSRight"),
                 ("ctrl", False),
                 ("key", "Meta"),
                 ("location", 2),


### PR DESCRIPTION
Reverts web-platform-tests/wpt#40122

This was merged without the spec change being reviewed. Given that there still seem to be concerns around the changes proposed, and a lack of clarity about whether it matches implementations, we should revert until we have clear agreement.