### PR TITLE
[webaudio] Add test for defaultValue property of an AudioParam

### DIFF
--- a/webaudio/the-audio-api/the-audioparam-interface/audioparam-default-value.html
+++ b/webaudio/the-audio-api/the-audioparam-interface/audioparam-default-value.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>
+      audioparam-default-value.html
+    </title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/webaudio/resources/audit.js"></script>
+  </head>
+  <body>
+    <script id="layout-test-code">
+      const audit = Audit.createTaskRunner();
+
+      audit.define('test', function(task, should) {
+        const context = new OfflineAudioContext(1, 1, 44100);
+        const defaultValue = -1;
+        const gainNode = new GainNode(context, { gain: defaultValue });
+
+        should(gainNode.gain.defaultValue, "AudioParam's defaultValue").beEqualTo(defaultValue);
+
+        task.done();
+      });
+
+      audit.run();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a test for the `defaultValue` property of an `AudioParam`. This test currently only passes in Safari.

https://webaudio.github.io/web-audio-api/#dom-audioparam-defaultvalue

Please let me know if there is anything that should be changed.