### PR TITLE
[FedCM] Use --fake-ui-for-fedcm flag

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -83,6 +83,8 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     # Allow WebRTC tests to call getUserMedia and getDisplayMedia.
     chrome_options["args"].append("--use-fake-device-for-media-stream")
     chrome_options["args"].append("--use-fake-ui-for-media-stream")
+    # Use a fake UI for FedCM to allow testing it.
+    chrome_options["args"].append("--use-fake-ui-for-fedcm")
     # Shorten delay for Reporting <https://w3c.github.io/reporting/>.
     chrome_options["args"].append("--short-reporting-delay")
     # Point all .test domains to localhost for Chrome

--- a/tools/wptrunner/wptrunner/browsers/edgechromium.py
+++ b/tools/wptrunner/wptrunner/browsers/edgechromium.py
@@ -65,6 +65,7 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
         if "--headless" not in capabilities["ms:edgeOptions"]["args"]:
             capabilities["ms:edgeOptions"]["args"].append("--headless")
         capabilities["ms:edgeOptions"]["args"].append("--use-fake-device-for-media-stream")
+        capabilities["ms:edgeOptions"]["args"].append("--use-fake-ui-for-fedcm")
 
     if kwargs["enable_experimental"]:
         capabilities["ms:edgeOptions"]["args"].append("--enable-experimental-web-platform-features")


### PR DESCRIPTION
FedCM tests currently rely on the fake UI that Chrome's testrunner uses; also pass the flag here.