### PR TITLE
Remove allowpaymentrequest permission policy tests

### DIFF
--- a/feature-policy/resources/featurepolicy.js
+++ b/feature-policy/resources/featurepolicy.js
@@ -24,8 +24,8 @@ function assert_feature_policy_supported() {
 //      feature (https://wicg.github.io/feature-policy/#features).
 //      See examples at:
 //      https://github.com/WICG/feature-policy/blob/master/features.md
-//    allow_attribute: Optional argument, only used for testing fullscreen:
-//      "allowfullscreen"
+//    allow_attribute: Optional argument, only used for testing fullscreen
+//      by passing "allowfullscreen".
 function test_feature_availability(
     feature_description, test, src, expect_feature_available, feature_name,
     allow_attribute) {

--- a/permissions-policy/payment-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub.html
+++ b/permissions-policy/payment-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub.html
@@ -24,16 +24,5 @@
         expect_feature_unavailable_default, 'payment');
   }, header + ' disallows cross-origin navigation in an iframe.');
 
-  async_test(t => {
-    test_feature_availability(
-        'PaymentRequest()', t, same_origin_src,
-        expect_feature_available_default, 'payment', 'allowpaymentrequest');
-  }, header + ' allowpaymentrequest=true allows same-origin navigation in an iframe.');
-
-  async_test(t => {
-    test_feature_availability(
-        'PaymentRequest()', t, cross_origin_src,
-        expect_feature_unavailable_default, 'payment', 'allowpaymentrequest');
-  }, header + ' allowpaymentrequest=true disallows cross-origin navigation in an iframe.');
   </script>
 </body>

--- a/permissions-policy/payment-default-permissions-policy.https.sub.html
+++ b/permissions-policy/payment-default-permissions-policy.https.sub.html
@@ -31,17 +31,5 @@
     test_feature_availability('PaymentRequest()', t, cross_origin_src,
         expect_feature_unavailable_default);
   }, header + ' disallows cross-origin iframes.');
-
-  async_test(t => {
-    test_feature_availability(
-        'PaymentRequest()', t, same_origin_src,
-        expect_feature_available_default, undefined, 'allowpaymentrequest');
-  }, header + ' allowpaymentrequest=true allows same-origin iframes.');
-
-  async_test(t => {
-    test_feature_availability(
-        'PaymentRequest()', t, cross_origin_src,
-        expect_feature_available_default, undefined, 'allowpaymentrequest');
-  }, header + ' allowpaymentrequest=true allows cross-origin iframes.');
   </script>
 </body>

--- a/permissions-policy/payment-disabled-by-permissions-policy.https.sub.html
+++ b/permissions-policy/payment-disabled-by-permissions-policy.https.sub.html
@@ -29,17 +29,5 @@
     test_feature_availability('PaymentRequest()', t, cross_origin_src,
         expect_feature_unavailable_default,);
   }, header + ' disallows cross-origin iframes.');
-
-  async_test(t => {
-    test_feature_availability(
-        'PaymentRequest()', t, same_origin_src,
-        expect_feature_unavailable_default, undefined, 'allowpaymentrequest');
-  }, header + ' allowpaymentrequest=true disallows same-origin iframes.');
-
-  async_test(t => {
-    test_feature_availability(
-        'PaymentRequest()', t, cross_origin_src,
-        expect_feature_unavailable_default, undefined, 'allowpaymentrequest');
-  }, header + ' allowpaymentrequest=true disallows cross-origin iframes.');
   </script>
 </body>

--- a/permissions-policy/resources/permissions-policy.js
+++ b/permissions-policy/resources/permissions-policy.js
@@ -24,8 +24,8 @@ function assert_permissions_policy_supported() {
 //      feature (https://w3c.github.io/webappsec-permissions-policy/#features).
 //      See examples at:
 //      https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md
-//    allow_attribute: Optional argument, only used for testing fullscreen or
-//      payment: either "allowfullscreen" or "allowpaymentrequest" is passed.
+//    allow_attribute: Optional argument, only used for testing fullscreen
+//      by passing "allowfullscreen".
 //    is_promise_test: Optional argument, true if this call should return a
 //    promise. Used by test_feature_availability_with_post_message_result()
 function test_feature_availability(


### PR DESCRIPTION
These should have been removed as part of:
https://github.com/whatwg/html/pull/5915

But were somehow missed. 