### PR TITLE
Refactor viewport helpers

### DIFF
--- a/webdriver/tests/bidi/__init__.py
+++ b/webdriver/tests/bidi/__init__.py
@@ -80,6 +80,7 @@ async def create_console_api_message(bidi_session, context, text):
     )
     return text
 
+
 def remote_mapping_to_dict(js_object):
     obj = {}
     for key, value in js_object:

--- a/webdriver/tests/bidi/__init__.py
+++ b/webdriver/tests/bidi/__init__.py
@@ -88,6 +88,7 @@ def remote_mapping_to_dict(js_object):
 
     return obj
 
+
 async def get_viewport_dimensions(bidi_session, context):
     expression = """
         ({

--- a/webdriver/tests/bidi/__init__.py
+++ b/webdriver/tests/bidi/__init__.py
@@ -79,3 +79,25 @@ async def create_console_api_message(bidi_session, context, text):
         target=ContextTarget(context["context"]),
     )
     return text
+
+def remote_mapping_to_dict(js_object):
+    obj = {}
+    for key, value in js_object:
+        obj[key] = value["value"]
+
+    return obj
+
+async def get_viewport_dimensions(bidi_session, context):
+    expression = """
+        ({
+          height: window.innerHeight || document.documentElement.clientHeight,
+          width: window.innerWidth || document.documentElement.clientWidth,
+        });
+    """
+    result = await bidi_session.script.evaluate(
+        expression=expression,
+        target=ContextTarget(context["context"]),
+        await_promise=False,
+    )
+
+    return remote_mapping_to_dict(result["value"])

--- a/webdriver/tests/bidi/__init__.py
+++ b/webdriver/tests/bidi/__init__.py
@@ -81,12 +81,20 @@ async def create_console_api_message(bidi_session, context, text):
     return text
 
 
-def remote_mapping_to_dict(js_object):
-    obj = {}
-    for key, value in js_object:
-        obj[key] = value["value"]
+async def get_device_pixel_ratio(bidi_session, context):
+    """Get the DPR of the context.
 
-    return obj
+    :param bidi_session: BiDiSession
+    :param context: Browsing context ID
+    :returns: (int) devicePixelRatio.
+    """
+    result = await bidi_session.script.call_function(
+        function_declaration="""() => {
+        return Math.floor(window.devicePixelRatio);
+    }""",
+        target=ContextTarget(context["context"]),
+        await_promise=False)
+    return result["value"]
 
 
 async def get_viewport_dimensions(bidi_session, context):
@@ -103,3 +111,11 @@ async def get_viewport_dimensions(bidi_session, context):
     )
 
     return remote_mapping_to_dict(result["value"])
+
+
+def remote_mapping_to_dict(js_object):
+    obj = {}
+    for key, value in js_object:
+        obj[key] = value["value"]
+
+    return obj

--- a/webdriver/tests/bidi/browsing_context/capture_screenshot/__init__.py
+++ b/webdriver/tests/bidi/browsing_context/capture_screenshot/__init__.py
@@ -1,8 +1,9 @@
 from webdriver.bidi.modules.script import ContextTarget
 
-from ... import get_viewport_dimensions
+from ... import get_device_pixel_ratio, get_viewport_dimensions
 
-async def physical_viewport_dimensions(bidi_session, context):
+
+async def get_physical_viewport_dimensions(bidi_session, context):
     """Get the physical dimensions of the context's viewport.
 
     :param bidi_session: BiDiSession
@@ -10,20 +11,5 @@ async def physical_viewport_dimensions(bidi_session, context):
     :returns: Tuple of (int, int) containing viewport width, viewport height.
     """
     viewport = await get_viewport_dimensions(bidi_session, context)
-    dpr = await device_pixel_ratio(bidi_session, context)
+    dpr = await get_device_pixel_ratio(bidi_session, context)
     return (viewport["width"] * dpr, viewport["height"] * dpr)
-
-async def device_pixel_ratio(bidi_session, context):
-    """Get the DPR of the context.
-
-    :param bidi_session: BiDiSession
-    :param context: Browsing context ID
-    :returns: (int) devicePixelRatio.
-    """
-    result = await bidi_session.script.call_function(
-        function_declaration="""() => {
-        return Math.floor(window.devicePixelRatio);
-    }""",
-        target=ContextTarget(context["context"]),
-        await_promise=False)
-    return result["value"]

--- a/webdriver/tests/bidi/browsing_context/capture_screenshot/__init__.py
+++ b/webdriver/tests/bidi/browsing_context/capture_screenshot/__init__.py
@@ -1,22 +1,29 @@
 from webdriver.bidi.modules.script import ContextTarget
 
+from ... import get_viewport_dimensions
 
-async def viewport_dimensions(bidi_session, context):
-    """Get the dimensions of the context's viewport.
+async def physical_viewport_dimensions(bidi_session, context):
+    """Get the physical dimensions of the context's viewport.
 
     :param bidi_session: BiDiSession
     :param context: Browsing context ID
     :returns: Tuple of (int, int) containing viewport width, viewport height.
     """
+    viewport = await get_viewport_dimensions(bidi_session, context)
+    dpr = await device_pixel_ratio(bidi_session, context)
+    return (viewport["width"] * dpr, viewport["height"] * dpr)
+
+async def device_pixel_ratio(bidi_session, context):
+    """Get the DPR of the context.
+
+    :param bidi_session: BiDiSession
+    :param context: Browsing context ID
+    :returns: (int) devicePixelRatio.
+    """
     result = await bidi_session.script.call_function(
         function_declaration="""() => {
-        const {devicePixelRatio, innerHeight, innerWidth} = window;
-
-        return [
-          Math.floor(innerWidth * devicePixelRatio),
-          Math.floor(innerHeight * devicePixelRatio)
-        ];
+        return Math.floor(window.devicePixelRatio);
     }""",
         target=ContextTarget(context["context"]),
         await_promise=False)
-    return tuple(item["value"] for item in result["value"])
+    return result["value"]

--- a/webdriver/tests/bidi/browsing_context/capture_screenshot/capture_screenshot.py
+++ b/webdriver/tests/bidi/browsing_context/capture_screenshot/capture_screenshot.py
@@ -2,12 +2,12 @@ import pytest
 
 from tests.support.image import png_dimensions
 
-from . import viewport_dimensions
+from . import physical_viewport_dimensions
 
 
 @pytest.mark.asyncio
-async def test_capture(bidi_session, top_context, inline, compare_png_bidi):
-    expected_size = await viewport_dimensions(bidi_session, top_context)
+async def test_capture(bidi_session, url, top_context, inline, compare_png_bidi):
+    expected_size = await physical_viewport_dimensions(bidi_session, top_context)
 
     await bidi_session.browsing_context.navigate(
         context=top_context["context"], url="about:blank", wait="complete"

--- a/webdriver/tests/bidi/browsing_context/capture_screenshot/capture_screenshot.py
+++ b/webdriver/tests/bidi/browsing_context/capture_screenshot/capture_screenshot.py
@@ -2,12 +2,12 @@ import pytest
 
 from tests.support.image import png_dimensions
 
-from . import physical_viewport_dimensions
+from . import get_physical_viewport_dimensions
 
 
 @pytest.mark.asyncio
-async def test_capture(bidi_session, url, top_context, inline, compare_png_bidi):
-    expected_size = await physical_viewport_dimensions(bidi_session, top_context)
+async def test_capture(bidi_session, top_context, inline, compare_png_bidi):
+    expected_size = await get_physical_viewport_dimensions(bidi_session, top_context)
 
     await bidi_session.browsing_context.navigate(
         context=top_context["context"], url="about:blank", wait="complete"

--- a/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py
+++ b/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py
@@ -7,12 +7,12 @@ from tests.support.screenshot import (DEFAULT_CONTENT,
                                       OUTER_IFRAME_STYLE,
                                       INNER_IFRAME_STYLE)
 
-from . import physical_viewport_dimensions
+from . import get_physical_viewport_dimensions
 
 
 @pytest.mark.asyncio
 async def test_iframe(bidi_session, top_context, inline, iframe):
-    viewport_size = await physical_viewport_dimensions(bidi_session, top_context)
+    viewport_size = await get_physical_viewport_dimensions(bidi_session, top_context)
 
     iframe_content = f"{INNER_IFRAME_STYLE}{DEFAULT_CONTENT}"
     url = inline(f"{OUTER_IFRAME_STYLE}{iframe(iframe_content)}")
@@ -34,7 +34,7 @@ async def test_iframe(bidi_session, top_context, inline, iframe):
 @pytest.mark.parametrize("domain", ["", "alt"], ids=["same_origin", "cross_origin"])
 @pytest.mark.asyncio
 async def test_context_origin(bidi_session, top_context, inline, iframe, compare_png_bidi, domain):
-    expected_size = await physical_viewport_dimensions(bidi_session, top_context)
+    expected_size = await get_physical_viewport_dimensions(bidi_session, top_context)
 
     initial_url = inline(f"{REFERENCE_STYLE}{REFERENCE_CONTENT}")
     await bidi_session.browsing_context.navigate(context=top_context["context"],

--- a/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py
+++ b/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py
@@ -7,12 +7,12 @@ from tests.support.screenshot import (DEFAULT_CONTENT,
                                       OUTER_IFRAME_STYLE,
                                       INNER_IFRAME_STYLE)
 
-from . import viewport_dimensions
+from . import physical_viewport_dimensions
 
 
 @pytest.mark.asyncio
 async def test_iframe(bidi_session, top_context, inline, iframe):
-    viewport_size = await viewport_dimensions(bidi_session, top_context)
+    viewport_size = await physical_viewport_dimensions(bidi_session, top_context)
 
     iframe_content = f"{INNER_IFRAME_STYLE}{DEFAULT_CONTENT}"
     url = inline(f"{OUTER_IFRAME_STYLE}{iframe(iframe_content)}")
@@ -34,7 +34,7 @@ async def test_iframe(bidi_session, top_context, inline, iframe):
 @pytest.mark.parametrize("domain", ["", "alt"], ids=["same_origin", "cross_origin"])
 @pytest.mark.asyncio
 async def test_context_origin(bidi_session, top_context, inline, iframe, compare_png_bidi, domain):
-    expected_size = await viewport_dimensions(bidi_session, top_context)
+    expected_size = await physical_viewport_dimensions(bidi_session, top_context)
 
     initial_url = inline(f"{REFERENCE_STYLE}{REFERENCE_CONTENT}")
     await bidi_session.browsing_context.navigate(context=top_context["context"],

--- a/webdriver/tests/bidi/input/perform_actions/__init__.py
+++ b/webdriver/tests/bidi/input/perform_actions/__init__.py
@@ -1,4 +1,5 @@
 from webdriver.bidi.modules.script import ContextTarget
+
 from ... import get_viewport_dimensions, remote_mapping_to_dict
 
 async def get_inview_center_bidi(bidi_session, context, element):

--- a/webdriver/tests/bidi/input/perform_actions/__init__.py
+++ b/webdriver/tests/bidi/input/perform_actions/__init__.py
@@ -1,17 +1,9 @@
 from webdriver.bidi.modules.script import ContextTarget
-
-
-def remote_mapping_to_dict(js_object):
-    obj = {}
-    for key, value in js_object:
-        obj[key] = value["value"]
-
-    return obj
-
+from ... import get_viewport_dimensions, remote_mapping_to_dict
 
 async def get_inview_center_bidi(bidi_session, context, element):
     elem_rect = await get_element_rect(bidi_session, context=context, element=element)
-    viewport_rect = await get_viewport_rect(bidi_session, context=context)
+    viewport_rect = await get_viewport_dimensions(bidi_session, context=context)
 
     x = {
         "left": max(0, min(elem_rect["x"], elem_rect["x"] + elem_rect["width"])),
@@ -41,22 +33,6 @@ async def get_element_rect(bidi_session, context, element):
 el => el.getBoundingClientRect().toJSON()
 """,
         arguments=[element],
-        target=ContextTarget(context["context"]),
-        await_promise=False,
-    )
-
-    return remote_mapping_to_dict(result["value"])
-
-
-async def get_viewport_rect(bidi_session, context):
-    expression = """
-        ({
-          height: window.innerHeight || document.documentElement.clientHeight,
-          width: window.innerWidth || document.documentElement.clientWidth,
-        });
-    """
-    result = await bidi_session.script.evaluate(
-        expression=expression,
         target=ContextTarget(context["context"]),
         await_promise=False,
     )

--- a/webdriver/tests/bidi/input/perform_actions/pointer_origin.py
+++ b/webdriver/tests/bidi/input/perform_actions/pointer_origin.py
@@ -8,9 +8,7 @@ from tests.support.helpers import filter_dict
 
 from .. import get_events
 from . import (
-    get_element_rect,
     get_inview_center_bidi,
-    get_viewport_rect,
     remote_mapping_to_dict,
 )
 


### PR DESCRIPTION
Moved the viewport helpers used throughout the test BiDi tests to the top level in preparation for https://github.com/web-platform-tests/wpt/pull/40584