### PR TITLE
Remove "acceptInsecureCerts" capabilities marker which is no longer required.

### DIFF
--- a/webdriver/tests/bidi/session/new/connect.py
+++ b/webdriver/tests/bidi/session/new/connect.py
@@ -23,7 +23,6 @@ async def test_bidi_session_send(bidi_session, send_blocking_command):
 # bidi session following a bidi session with a different capabilities
 # to test session recreation
 @pytest.mark.asyncio
-@pytest.mark.capabilities({"acceptInsecureCerts": True})
 async def test_bidi_session_with_different_capability(bidi_session,
                                                       send_blocking_command):
     await send_blocking_command("session.status", {})

--- a/webdriver/tests/classic/back/back.py
+++ b/webdriver/tests/classic/back/back.py
@@ -33,9 +33,6 @@ def test_no_browsing_history(session):
     assert_success(response)
 
 
-# Capability needed as long as no valid certificate is available:
-#   https://github.com/web-platform-tests/wpt/issues/28847
-@pytest.mark.capabilities({"acceptInsecureCerts": True})
 @pytest.mark.parametrize("protocol,parameters", [
     ("http", ""),
     ("https", ""),

--- a/webdriver/tests/classic/element_click/navigate.py
+++ b/webdriver/tests/classic/element_click/navigate.py
@@ -165,9 +165,6 @@ def test_link_from_nested_context_with_target(session, inline, iframe, target):
     wait.until(lambda s: s.find.css("#foo"))
 
 
-# Capability needed as long as no valid certificate is available:
-#   https://github.com/web-platform-tests/wpt/issues/28847
-@pytest.mark.capabilities({"acceptInsecureCerts": True})
 def test_link_cross_origin(session, inline, url):
     base_path = ("/webdriver/tests/support/html/subframe.html" +
                  "?pipe=header(Cross-Origin-Opener-Policy,same-origin)")

--- a/webdriver/tests/classic/forward/forward.py
+++ b/webdriver/tests/classic/forward/forward.py
@@ -61,9 +61,6 @@ def test_no_browsing_history(session, inline):
     assert element.property("id") == "foo"
 
 
-# Capability needed as long as no valid certificate is available:
-#   https://github.com/web-platform-tests/wpt/issues/28847
-@pytest.mark.capabilities({"acceptInsecureCerts": True})
 @pytest.mark.parametrize("protocol,parameters", [
     ("http", ""),
     ("https", ""),

--- a/webdriver/tests/classic/get_named_cookie/get.py
+++ b/webdriver/tests/classic/get_named_cookie/get.py
@@ -122,7 +122,6 @@ def test_duplicated_cookie(session, url, server_config, inline):
 
 
 @pytest.mark.parametrize("same_site", ["None", "Lax", "Strict"])
-@pytest.mark.capabilities({"acceptInsecureCerts": True})
 def test_get_cookie_with_same_site_flag(session, url, same_site):
     session.url = url("/common/blank.html", protocol="https")
     clear_all_cookies(session)

--- a/webdriver/tests/classic/get_window_handle/get.py
+++ b/webdriver/tests/classic/get_window_handle/get.py
@@ -23,9 +23,6 @@ def test_basic(session):
     assert_success(response, session.window_handle)
 
 
-# Capability needed as long as no valid certificate is available:
-#   https://github.com/web-platform-tests/wpt/issues/28847
-@pytest.mark.capabilities({"acceptInsecureCerts": True})
 def test_navigation_with_coop_headers(session, url):
     base_path = ("/webdriver/tests/support/html/subframe.html" +
                  "?pipe=header(Cross-Origin-Opener-Policy,same-origin)")

--- a/webdriver/tests/classic/permissions/set.py
+++ b/webdriver/tests/classic/permissions/set.py
@@ -29,7 +29,6 @@ def query(session, name):
     { "descriptor": [ { "name": "geolocation" } ], "state": "granted" },
     [ { "descriptor": { "name": "geolocation" }, "state": "granted" } ],
 ])
-@pytest.mark.capabilities({"acceptInsecureCerts": True})
 def test_invalid_parameters(session, url, parameters):
     session.url = url("/common/blank.html", protocol="https")
     response = session.transport.send(
@@ -53,7 +52,6 @@ def test_non_secure_context(session, url, state):
     assert_error(response, "invalid argument")
 
 @pytest.mark.parametrize("state", ["granted", "denied", "prompt"])
-@pytest.mark.capabilities({"acceptInsecureCerts": True})
 def test_set_to_state(session, url, state):
     session.url = url("/common/blank.html", protocol="https")
     parameters = { "descriptor": { "name": "geolocation" }, "state": state }

--- a/webdriver/tests/classic/refresh/refresh.py
+++ b/webdriver/tests/classic/refresh/refresh.py
@@ -39,9 +39,6 @@ def test_no_browsing_context(session, closed_frame, inline):
     assert session.find.css("#foo", all=False)
 
 
-# Capability needed as long as no valid certificate is available:
-#   https://github.com/web-platform-tests/wpt/issues/28847
-@pytest.mark.capabilities({"acceptInsecureCerts": True})
 @pytest.mark.parametrize("protocol,parameters", [
     ("http", ""),
     ("https", ""),


### PR DESCRIPTION
Pushing this patch that I would like to land via https://bugzilla.mozilla.org/show_bug.cgi?id=1839123 here so that we can get test results for Chrome and Safari.