### PR TITLE
webdriver: remove typing.Literal from inline.py

### DIFF
--- a/webdriver/tests/support/inline.py
+++ b/webdriver/tests/support/inline.py
@@ -1,6 +1,6 @@
 """Helpers for inlining extracts of documents in tests."""
 
-from typing import Literal, Optional
+from typing import Optional
 from urllib.parse import urlencode
 
 
@@ -26,10 +26,13 @@ MIME_TYPES = {
 }
 
 
-def build_inline(build_url, src,
-                 doctype: Literal["html", "xhtml", "xml"] = "html",
-                 mime: Optional[str] = None, charset: Optional[str] = None,
-                 parameters = None, **kwargs):
+def build_inline(build_url,
+                 src,
+                 doctype="html",
+                 mime: Optional[str] = None,
+                 charset: Optional[str] = None,
+                 parameters=None,
+                 **kwargs):
     if mime is None:
         mime = MIME_TYPES[doctype]
     if charset is None:


### PR DESCRIPTION
It is only available from python 3.8 upwards
(https://peps.python.org/pep-0586/), but the CI still uses python 3.7