### PR TITLE
Update scrollbar-width-014.html to pass in Firefox

### DIFF
--- a/css/css-scrollbars/scrollbar-width-014.html
+++ b/css/css-scrollbars/scrollbar-width-014.html
@@ -15,6 +15,13 @@
     display: none;
   }
 
+  /* This is so that browsers that don't implement the WebKit prefix still pass the test */
+  @supports not selector(::-webkit-scrollbar) {
+    :root {
+      overflow: hidden;
+    }
+  }
+
   :root,
   body {
     margin: 0;


### PR DESCRIPTION
When I originally wrote this collection of scrollbar-width tests I wrote them in such a way that they'd pass in Firefox (using @supports). Unfortunately I missed this one.