### PR TITLE
Create ./wpt spec script

### DIFF
--- a/tools/manifest/commands.json
+++ b/tools/manifest/commands.json
@@ -19,5 +19,12 @@
     "parser": "create_parser",
     "help": "Print test paths given a set of test ids",
     "virtualenv": false
+  },
+  "spec": {
+    "path": "spec.py",
+    "script": "run",
+    "parser": "create_parser",
+    "help": "Update the SPEC_MANIFEST.json file",
+    "virtualenv": false
   }
 }

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -340,3 +340,37 @@ class SupportFile(ManifestItem):
     @property
     def id(self) -> Text:
         return self.path
+
+
+class SpecItem(ManifestItem):
+    __slots__ = ("specs")
+
+    item_type = "spec"
+
+    def __init__(self,
+                 tests_root: Text,
+                 path: Text,
+                 specs: List[Text]
+                 ) -> None:
+        super().__init__(tests_root, path)
+        self.specs = specs
+
+    @property
+    def id(self) -> Text:
+        return self.path
+
+    def to_json(self) -> Tuple[Optional[Text], Dict[Text, Any]]:
+        rv: Tuple[Optional[Text], Dict[Any, Any]] = (None, {})
+        for i in range(len(self.specs)):
+            spec_key = "spec_link" + str(i+1)
+            rv[-1][spec_key] = self.specs[i]
+        return rv
+
+    @classmethod
+    def from_json(cls,  # type: ignore
+                  manifest: "Manifest",
+                  path: Text,
+                  obj: Any
+                  ) -> "ManifestItem":
+        """Not properly implemented and is not used."""
+        return cls("/", "", [])

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -362,7 +362,7 @@ class SpecItem(ManifestItem):
     def to_json(self) -> Tuple[Optional[Text], Dict[Text, Any]]:
         rv: Tuple[Optional[Text], Dict[Any, Any]] = (None, {})
         for i in range(len(self.specs)):
-            spec_key = "spec_link" + str(i+1)
+            spec_key = f"spec_link{i+1}"
             rv[-1][spec_key] = self.specs[i]
         return rv
 

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -367,7 +367,7 @@ class SpecItem(ManifestItem):
         return rv
 
     @classmethod
-    def from_json(cls,  # type: ignore
+    def from_json(cls,
                   manifest: "Manifest",
                   path: Text,
                   obj: Any

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -53,7 +53,7 @@ item_classes: Dict[Text, Type[ManifestItem]] = {"testharness": TestharnessTest,
                                                 "support": SupportFile}
 
 
-def compute_manifest_items(source_file: SourceFile) -> Tuple[Tuple[Text, ...], Text, Set[ManifestItem], Text]:
+def compute_manifest_items(source_file: SourceFile) -> Optional[Tuple[Tuple[Text, ...], Text, Set[ManifestItem], Text]]:
     rel_path_parts = source_file.rel_path_parts
     new_type, manifest_items = source_file.manifest_items()
     file_hash = source_file.hash
@@ -227,9 +227,9 @@ class Manifest:
             chunksize = max(1, len(to_update) // 10000)
             logger.debug("Doing a multiprocessed update. CPU count: %s, "
                 "processes: %s, chunksize: %s" % (cpu_count(), processes, chunksize))
-            results: Iterator[Tuple[Tuple[Text, ...],
+            results: Iterator[Optional[Tuple[Tuple[Text, ...],
                                     Text,
-                                    Set[ManifestItem], Text]] = pool.imap_unordered(
+                                    Set[ManifestItem], Text]]] = pool.imap_unordered(
                                         update_func,
                                         to_update,
                                         chunksize=chunksize)

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -414,7 +414,7 @@ def load_and_update(tests_root: Text,
             try:
                 tree = vcs.get_tree(tests_root, manifest, manifest_path, cache_root,
                                     working_copy, rebuild)
-                changed = manifest.update(tree, parallel, True)
+                changed = manifest.update(tree, parallel)
                 break
             except InvalidCacheError:
                 logger.warning("Manifest cache was invalid, doing a complete rebuild")

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -4,7 +4,7 @@ from atomicwrites import atomic_write
 from copy import deepcopy
 from logging import Logger
 from multiprocessing import Pool, cpu_count
-from typing import (Any, Container, Dict, IO, Iterator, Iterable, Optional, Set, Text, Tuple, Type,
+from typing import (Any, Callable, Container, Dict, IO, Iterator, Iterable, Optional, Set, Text, Tuple, Type,
                     Union)
 
 from . import jsonlib
@@ -140,7 +140,8 @@ class Manifest:
                 if path[:tpath_len] == tpath:
                     yield from tests
 
-    def update(self, tree: Iterable[Tuple[Text, Optional[Text], bool]], parallel: bool = True, is_spec: bool = False) -> bool:
+    def update(self, tree: Iterable[Tuple[Text, Optional[Text], bool]], parallel: bool = True,
+               update_func: Callable[..., Any] = compute_manifest_items) -> bool:
         """Update the manifest given an iterable of items that make up the updated manifest.
 
         The iterable must either generate tuples of the form (SourceFile, True) for paths
@@ -201,10 +202,6 @@ class Manifest:
         if to_update:
             logger.debug("Computing manifest update for %s items" % len(to_update))
             changed = True
-
-        update_func = compute_manifest_items
-        if is_spec:
-            update_func = compute_manifest_spec_items
 
         # 25 items was derived experimentally (2020-01) to be approximately the
         # point at which it is quicker to create a Pool and parallelize update.

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -22,6 +22,7 @@ from .item import (ConformanceCheckerTest,
                    ManualTest,
                    PrintRefTest,
                    RefTest,
+                   SpecItem,
                    SupportFile,
                    TestharnessTest,
                    VisualTest,
@@ -1057,4 +1058,16 @@ class SourceFile:
                     del self.__dict__[prop]
             del self.__dict__["__cached_properties__"]
 
+        return rv
+
+    def manifest_spec_items(self) -> Optional[Tuple[Text, List[ManifestItem]]]:
+        specs = list(self.spec_links)
+        if not specs:
+            return None
+        rv: Tuple[Text, List[ManifestItem]] = (SpecItem.item_type, [
+            SpecItem(
+                self.tests_root,
+                self.rel_path,
+                specs
+            )])
         return rv

--- a/tools/manifest/spec.py
+++ b/tools/manifest/spec.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+import argparse
+import os
+from typing import Any, Optional, Text
+
+from . import vcs
+from .manifest import InvalidCacheError, Manifest, write
+from .log import get_logger, enable_debug_logging
+
+
+here = os.path.dirname(__file__)
+
+wpt_root = os.path.abspath(os.path.join(here, os.pardir, os.pardir))
+
+logger = get_logger()
+
+
+def update_spec(tests_root: Text,
+                manifest_path: Text,
+                url_base: Text,
+                cache_root: Optional[Text] = None,
+                working_copy: bool = True,
+                parallel: bool = True
+                ) -> Manifest:
+
+    manifest = Manifest(tests_root, url_base)
+
+    logger.info("Updating SPEC_MANIFEST")
+    for retry in range(2):
+        try:
+            tree = vcs.get_tree(tests_root, manifest, manifest_path, cache_root,
+                                working_copy, True)
+            changed = manifest.update(tree, parallel, True)
+            break
+        except InvalidCacheError:
+            logger.warning("Manifest cache was invalid, doing a complete rebuild")
+    else:
+        # If we didn't break there was an error
+        raise
+
+    if changed:
+        write(manifest, manifest_path)
+    tree.dump_caches()
+
+    return manifest
+
+
+def update_from_cli(**kwargs: Any) -> None:
+    tests_root = kwargs["tests_root"]
+    path = kwargs["path"]
+    assert tests_root is not None
+
+    update_spec(tests_root,
+                path,
+                kwargs["url_base"],
+                cache_root=kwargs["cache_root"],
+                parallel=kwargs["parallel"])
+
+
+def abs_path(path: str) -> str:
+    return os.path.abspath(os.path.expanduser(path))
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-v", "--verbose", dest="verbose", action="store_true", default=False,
+        help="Turn on verbose logging")
+    parser.add_argument(
+        "-p", "--path", type=abs_path, help="Path to manifest file.")
+    parser.add_argument(
+        "--tests-root", type=abs_path, default=wpt_root, help="Path to root of tests.")
+    parser.add_argument(
+        "--url-base", action="store", default="/",
+        help="Base url to use as the mount point for tests in this manifest.")
+    parser.add_argument(
+        "--cache-root", action="store", default=os.path.join(wpt_root, ".wptcache"),
+        help="Path in which to store any caches (default <tests_root>/.wptcache/)")
+    parser.add_argument(
+        "--no-parallel", dest="parallel", action="store_false", default=True,
+        help="Do not parallelize building the manifest")
+    return parser
+
+
+def run(*args: Any, **kwargs: Any) -> None:
+    if kwargs["path"] is None:
+        kwargs["path"] = os.path.join(kwargs["tests_root"], "SPEC_MANIFEST.json")
+    if kwargs["verbose"]:
+        enable_debug_logging()
+    update_from_cli(**kwargs)

--- a/tools/manifest/spec.py
+++ b/tools/manifest/spec.py
@@ -31,7 +31,7 @@ def update_spec(tests_root: Text,
                             working_copy, True)
         changed = manifest.update(tree, parallel, compute_manifest_spec_items)
     except InvalidCacheError:
-        logger.warning("Manifest cache in spec.py was invalid.")
+        logger.error("Manifest cache in spec.py was invalid.")
         return
 
     if changed:

--- a/tools/manifest/tests/test_manifest.py
+++ b/tools/manifest/tests/test_manifest.py
@@ -323,7 +323,7 @@ def test_manifest_spec_to_json():
 
     tree, sourcefile_mock = tree_and_sourcefile_mocks([(s, None, True)])
     with mock.patch("tools.manifest.manifest.SourceFile", side_effect=sourcefile_mock):
-        assert m.update(tree, True, True) is True
+        assert m.update(tree, True, manifest.compute_manifest_spec_items) is True
 
     assert m.to_json() == {
         'version': 8,

--- a/tools/manifest/tests/test_manifest.py
+++ b/tools/manifest/tests/test_manifest.py
@@ -308,3 +308,30 @@ def test_update_from_json_modified():
         'url_base': '/',
         'version': 8
     }
+
+def test_manifest_spec_to_json():
+    m = manifest.Manifest("")
+
+    path = "a" + os.path.sep + "b"
+    hash = "0"*40
+    rel_path_parts = tuple(path.split(os.path.sep))
+    s = mock.Mock(rel_path=path,
+                  rel_path_parts=rel_path_parts,
+                  hash=hash)
+    spec = item.SpecItem("/foobar", path, ["specA"])
+    s.manifest_spec_items = mock.Mock(return_value=(item.SpecItem.item_type, [spec]))
+
+    tree, sourcefile_mock = tree_and_sourcefile_mocks([(s, None, True)])
+    with mock.patch("tools.manifest.manifest.SourceFile", side_effect=sourcefile_mock):
+        assert m.update(tree, True, True) is True
+
+    assert m.to_json() == {
+        'version': 8,
+        'url_base': '/',
+        'items': {
+            'spec': {'a': {'b': [
+                '0000000000000000000000000000000000000000',
+                (None, {'spec_link1': 'specA'})
+            ]}},
+        }
+    }


### PR DESCRIPTION
[#1489](https://github.com/web-platform-tests/wpt.fyi/issues/1489). Create ./wpt spec script to extract spec information. This change does not affect the existing MANIFEST build behaviour.

The SPEC_MANIFEST.json format conforms to [the standard manifest format](https://github.com/web-platform-tests/wpt.fyi/tree/main/api#apimanifest), e.g.
```
{
 "items": {
  "spec": {
   "crashtests": {
    "bdo-table-cell.html": [
     "ae12541f8d8cb97248a7a7f3a3683f753aa96377",
     [
      null,
      {
       "spec_link1": "https://crbug.com/1314808"
      }
     ]
    ]
   }
  }
 },
 "url_base": "/",
 "version": 8
}
```
where {} stores spec information, spec_link1, spec_link2...

See more comments from the draft PR #40392

### Note
`from_json` is created for a mypy issue on CI.  TODO: Maybe it should be properly implemented to test read from SPEC_MANIFEST.json

SPEC_MANIFEST.json should be released weekly, similar to MANIFEST.json