### PR TITLE
Changing the dir attribute of documentElement doesn't update a child element matching :dir pseudo class

### DIFF
--- a/css/selectors/dir-pseudo-update-document-element-ref.html
+++ b/css/selectors/dir-pseudo-update-document-element-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    float: left;
+    background-color: green;
+}
+
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/css/selectors/dir-pseudo-update-document-element.html
+++ b/css/selectors/dir-pseudo-update-document-element.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html dir="ltr">
+<head>
+<link rel="match" href="dir-pseudo-update-document-element-ref.html">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#the-dir-pseudo">
+<script>
+document.documentElement.setAttribute('dir', 'rtl');
+</script>
+<style>
+div {
+    width: 100px;
+    height: 100px;
+    float: left;
+}
+
+div:dir(rtl) {
+    background-color: green;
+}
+
+div:dir(ltr) {
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=257133

Export the test as WPT.