### PR TITLE
Properly position absolutes with static insets that are children of floats

### DIFF
--- a/css/CSS2/floats/float-with-absolutely-positioned-child-with-static-inset-ref.html
+++ b/css/CSS2/floats/float-with-absolutely-positioned-child-with-static-inset-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<link rel="author" title="Martin Robinson" href="mrobinson@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css2/visuren.html#float-position">
+<meta name="assert" content="An absolutely positioned child of a float with a static inset should be positioned the same as a non-positioned child of that float." />
+
+<style>
+#float {
+    float: right;
+    width: 250px;
+}
+
+#abs-child {
+    background: green;
+    width: 100px;
+    height: 100px;
+}
+
+#abs-grandchild {
+    background: darkgreen;
+    width: 50px;
+    height: 50px;
+}
+</style>
+
+<body>
+    <div id="float">
+        <div id="abs-child">
+            <div id="abs-grandchild"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/css/CSS2/floats/float-with-absolutely-positioned-child-with-static-inset.html
+++ b/css/CSS2/floats/float-with-absolutely-positioned-child-with-static-inset.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<link rel="author" title="Martin Robinson" href="mrobinson@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css2/visuren.html#float-position">
+<link rel="match" href="float-with-absolutely-positioned-child-with-static-inset-ref.html">
+<meta name="assert" content="An absolutely positioned child of a float with a static inset should be positioned the same as a non-positioned child of that float." />
+
+<style>
+#float {
+    float: right;
+    width: 250px;
+}
+
+#abs-child {
+    background: green;
+    position: absolute;
+    width: 100px;
+    height: 100px;
+}
+
+#abs-grandchild {
+    background: darkgreen;
+    position: absolute;
+    width: 50px;
+    height: 50px;
+}
+</style>
+
+<body>
+    <div id="float">
+        <div id="abs-child">
+            <div id="abs-grandchild"></div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Previously, final float positions were calculated when their parents
were positioned. This prevented proper positioning of absolute children
of floats with static insets, because they accumulate offsets as they
are hoisted up the tree.

This change moves the final float positioning to
`PlacementState::place_fragment` for the float itself so that it happens
before any insets are updated for hoisted descendants. In addition to
simplifying the code, this makes it a bit more efficient. Finally,
floats are taken into account when updating static insets of hoisted
boxes.

Fixes #<!-- nolink -->29826.

Reviewed in servo/servo#29899