### PR TITLE
[css-fonts] Update expected error in @font-face format test

### DIFF
--- a/css/css-fonts/format-specifiers-variations.html
+++ b/css/css-fonts/format-specifiers-variations.html
@@ -36,7 +36,7 @@ function runTestOnFormatSpecifiers(formats, expectFail) {
             if (!expectFail) {
                 return fontFace.load();
             } else {
-                return promise_rejects_dom(testDetails, "NetworkError", fontFace.load());
+                return promise_rejects_dom(testDetails, "SyntaxError", fontFace.load());
             }
         }, (expectFail ? "Do not load" : "Load") + " Ahem with format " + formats[i], {
             "format": formats[i]


### PR DESCRIPTION
From https://drafts.csswg.org/css-font-loading/#font-face-constructor:
  "If the source argument is a CSSOMString, parse it according to the
  grammar of the CSS src descriptor of the @font-face rule. If any of
  them fail to parse correctly, reject font face’s [[FontStatusPromise]]
  with a DOMException named "SyntaxError""

From https://www.w3.org/TR/css-fonts-4/#font-face-src-parsing
  "If there are no supported entries at the end of this process, the
  value for the src descriptor is a parse error.

This means, incorrect values for format (as the test generates them in the cases where expectFail = true) should be rejected early in parsing and be reported as a rejected promise of DOMException type Syntax error, not network error.