### PR TITLE
Implement consume_user_activation() web driver components

### DIFF
--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -88,6 +88,11 @@ the global scope.
 .. js:autofunction:: test_driver.bless
 ```
 
+### User Activation ###
+```eval_rst
+.. js:autofunction:: test_driver.consume_user_activation
+```
+
 ### Window State ###
 ```eval_rst
 .. js:autofunction:: test_driver.minimize_window

--- a/html/user-activation/resources/utils.js
+++ b/html/user-activation/resources/utils.js
@@ -17,19 +17,12 @@ function getEvent(eventType) {
 }
 
 
-// Returns a Promise which is resolved with a "true" iff transient activation
-// was available and successfully consumed.
-//
-// This function relies on Fullscreen API to check/consume user activation
-// state.
+// Returns a Promise resolved with true iff transient activation was present and consumed.
 async function consumeTransientActivation() {
-  try {
-    await document.body.requestFullscreen();
-    await document.exitFullscreen();
-    return true;
-  } catch(e) {
+  if (!navigator.userActivation.isActive)
     return false;
-  }
+  await test_driver.consume_user_activation();
+  return !navigator.userActivation.isActive;
 }
 
 // Returns a `Promise` that gets resolved when `window` receives a "message"

--- a/html/user-activation/resources/utils.js
+++ b/html/user-activation/resources/utils.js
@@ -19,10 +19,7 @@ function getEvent(eventType) {
 
 // Returns a Promise resolved with true iff transient activation was present and consumed.
 async function consumeTransientActivation() {
-  if (!navigator.userActivation.isActive)
-    return false;
-  await test_driver.consume_user_activation();
-  return !navigator.userActivation.isActive;
+  return await test_driver.consume_user_activation();
 }
 
 // Returns a `Promise` that gets resolved when `window` receives a "message"

--- a/html/user-activation/resources/utils.js
+++ b/html/user-activation/resources/utils.js
@@ -19,7 +19,21 @@ function getEvent(eventType) {
 
 // Returns a Promise resolved with true iff transient activation was present and consumed.
 async function consumeTransientActivation() {
-  return await test_driver.consume_user_activation();
+  try {
+    return await test_driver.consume_user_activation();
+  } catch (e) {
+    // Fall back to the Fullscreen API for browsers that don't implement the
+    // consume-user-activation automation command yet: requesting fullscreen
+    // requires and consumes transient activation, so it succeeds iff activation
+    // was present.
+    try {
+      await document.body.requestFullscreen();
+      await document.exitFullscreen();
+      return true;
+    } catch (e2) {
+      return false;
+    }
+  }
 }
 
 // Returns a `Promise` that gets resolved when `window` receives a "message"

--- a/infrastructure/metadata/infrastructure/testdriver/consume_user_activation.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/consume_user_activation.html.ini
@@ -1,0 +1,6 @@
+[consume_user_activation.html]
+  [Nothing to consume]
+    expected: FAIL
+
+  [Consume transient activation]
+    expected: FAIL

--- a/infrastructure/testdriver/consume_user_activation.html
+++ b/infrastructure/testdriver/consume_user_activation.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>TestDriver consume_user_activation method</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<script>
+    promise_test(async (t) => {
+        await test_driver.bless("consume user activation");
+        assert_true(navigator.userActivation.isActive);
+        const consumed = await test_driver.consume_user_activation();
+        assert_true(consumed);
+        assert_false(navigator.userActivation.isActive);
+    }, "Consume transient activation");
+
+    promise_test(async (t) => {
+        assert_false(navigator.userActivation.isActive);
+        const consumed = await test_driver.consume_user_activation();
+        assert_false(consumed);
+    }, "Nothing to consume");
+</script>

--- a/infrastructure/testdriver/consume_user_activation.html
+++ b/infrastructure/testdriver/consume_user_activation.html
@@ -7,6 +7,16 @@
 <script src="/resources/testdriver-vendor.js"></script>
 
 <script>
+    // "Nothing to consume" runs first: it needs a fresh document with no transient
+    // activation, before the bless() in the next test grants any. (Order-independence
+    // guards against activation from an earlier test bleeding in — the CI failure mode
+    // seen when consume_user_activation is unimplemented and its promise rejects.)
+    promise_test(async (t) => {
+        assert_false(navigator.userActivation.isActive);
+        const consumed = await test_driver.consume_user_activation();
+        assert_false(consumed);
+    }, "Nothing to consume");
+
     promise_test(async (t) => {
         await test_driver.bless("consume user activation");
         assert_true(navigator.userActivation.isActive);
@@ -14,10 +24,4 @@
         assert_true(consumed);
         assert_false(navigator.userActivation.isActive);
     }, "Consume transient activation");
-
-    promise_test(async (t) => {
-        assert_false(navigator.userActivation.isActive);
-        const consumed = await test_driver.consume_user_activation();
-        assert_false(consumed);
-    }, "Nothing to consume");
 </script>

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -2191,6 +2191,31 @@
         },
 
         /**
+         * Consumes user activation in the given context.
+         *
+         * Matches the `consume-user-activation
+         * <https://html.spec.whatwg.org/#user-activation-user-agent-automation>`_
+         * WebDriver extension command, which consumes the context's active
+         * window's transient user activation and reports whether activation
+         * was present to consume.
+         *
+         * @example
+         * await test_driver.consume_user_activation();
+         * await test_driver.consume_user_activation(iframe.contentWindow);
+         *
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         * @returns {Promise<boolean>} Fulfilled with true if transient
+         *                    activation was present and consumed; otherwise
+         *                    false. Rejected in case the WebDriver command
+         *                    errors out.
+         */
+        consume_user_activation: function(context=null) {
+            return window.test_driver_internal.consume_user_activation(context);
+        },
+
+        /**
          * Runs the `bounce tracking timer algorithm
          * <https://privacycg.github.io/nav-tracking-mitigations/#bounce-tracking-timer>`_,
          * which removes all hosts from the stateful bounce tracking map, without
@@ -2741,6 +2766,10 @@
 
         async clear_device_posture(context=null) {
             throw new Error("clear_device_posture() is not implemented by testdriver-vendor.js");
+        },
+
+        async consume_user_activation(context=null) {
+            throw new Error("consume_user_activation() is not implemented by testdriver-vendor.js");
         },
 
         async run_bounce_tracking_mitigations(context=null) {

--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -407,6 +407,9 @@ class BrowserWindow:
     def fullscreen(self):
         return self.session.send_session_command("POST", "window/fullscreen")
 
+    def consume_user_activation(self):
+        return self.session.send_session_command("POST", "window/consume-user-activation")
+
 
 class Find:
     def __init__(self, session):

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -515,6 +515,16 @@ class ClearDevicePostureAction:
     def __call__(self, payload):
         return self.protocol.device_posture.clear_device_posture()
 
+class ConsumeUserActivationAction:
+    name = "consume_user_activation"
+
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        return self.protocol.consume_user_activation.consume_user_activation()
+
 class RunBounceTrackingMitigationsAction:
     name = "run_bounce_tracking_mitigations"
 
@@ -659,6 +669,7 @@ actions = [ClickAction,
            GetVirtualSensorInformationAction,
            SetDevicePostureAction,
            ClearDevicePostureAction,
+           ConsumeUserActivationAction,
            RunBounceTrackingMitigationsAction,
            CreateVirtualPressureSourceAction,
            UpdateVirtualPressureSourceAction,

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -32,6 +32,7 @@ from .protocol import (AccessibilityProtocolPart,
                        CoverageProtocolPart,
                        DebugProtocolPart,
                        DevicePostureProtocolPart,
+                       ConsumeUserActivationProtocolPart,
                        DisplayFeaturesProtocolPart,
                        GenerateTestReportProtocolPart,
                        GlobalPrivacyControlProtocolPart,
@@ -786,6 +787,14 @@ class MarionetteDevicePostureProtocolPart(DevicePostureProtocolPart):
         raise NotImplementedError("clear_device_posture not yet implemented")
 
 
+class MarionetteConsumeUserActivationProtocolPart(ConsumeUserActivationProtocolPart):
+    def setup(self):
+        self.marionette = self.parent.marionette
+
+    def consume_user_activation(self):
+        raise NotImplementedError("consume_user_activation not yet implemented")
+
+
 class MarionetteVirtualPressureSourceProtocolPart(VirtualPressureSourceProtocolPart):
     def setup(self):
         self.marionette = self.parent.marionette
@@ -851,6 +860,7 @@ class MarionetteProtocol(Protocol):
                   MarionetteAccessibilityProtocolPart,
                   MarionetteVirtualSensorProtocolPart,
                   MarionetteDevicePostureProtocolPart,
+                  MarionetteConsumeUserActivationProtocolPart,
                   MarionetteVirtualPressureSourceProtocolPart,
                   MarionetteDisplayFeaturesProtocolPart,
                   MarionetteWebExtensionsProtocolPart]

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -46,6 +46,7 @@ from .protocol import (BaseProtocolPart,
                        BidiPermissionsProtocolPart,
                        BidiScriptProtocolPart,
                        DevicePostureProtocolPart,
+                       ConsumeUserActivationProtocolPart,
                        StorageProtocolPart,
                        VirtualPressureSourceProtocolPart,
                        ProtectedAudienceProtocolPart,
@@ -971,6 +972,14 @@ class WebDriverDevicePostureProtocolPart(DevicePostureProtocolPart):
         return self.webdriver.send_session_command("DELETE", "deviceposture")
 
 
+class WebDriverConsumeUserActivationProtocolPart(ConsumeUserActivationProtocolPart):
+    def setup(self):
+        self.webdriver = self.parent.webdriver
+
+    def consume_user_activation(self):
+        return self.webdriver.send_session_command("POST", "window/consume-user-activation")
+
+
 class WebDriverBidiDigitalCredentialsProtocolPart(DigitalCredentialsProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
@@ -1085,6 +1094,7 @@ class WebDriverProtocol(Protocol):
                   WebDriverDebugProtocolPart,
                   WebDriverVirtualSensorPart,
                   WebDriverDevicePostureProtocolPart,
+                  WebDriverConsumeUserActivationProtocolPart,
                   WebDriverStorageProtocolPart,
                   WebDriverVirtualPressureSourceProtocolPart,
                   WebDriverProtectedAudienceProtocolPart,

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -977,7 +977,7 @@ class WebDriverConsumeUserActivationProtocolPart(ConsumeUserActivationProtocolPa
         self.webdriver = self.parent.webdriver
 
     def consume_user_activation(self):
-        return self.webdriver.send_session_command("POST", "window/consume-user-activation")
+        return self.webdriver.window.consume_user_activation()
 
 
 class WebDriverBidiDigitalCredentialsProtocolPart(DigitalCredentialsProtocolPart):

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -1294,6 +1294,16 @@ class DevicePostureProtocolPart(ProtocolPart):
     def clear_device_posture(self):
         pass
 
+class ConsumeUserActivationProtocolPart(ProtocolPart):
+    """Protocol part for consuming user activation"""
+    __metaclass__ = ABCMeta
+
+    name = "consume_user_activation"
+
+    @abstractmethod
+    def consume_user_activation(self):
+        pass
+
 class VirtualPressureSourceProtocolPart(ProtocolPart):
     """Protocol part for Virtual Pressure Source"""
     __metaclass__ = ABCMeta

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -686,6 +686,10 @@
         return create_context_action("clear_device_posture", context, {});
     };
 
+    window.test_driver_internal.consume_user_activation = function(context=null) {
+        return create_context_action("consume_user_activation", context, {});
+    };
+
     window.test_driver_internal.run_bounce_tracking_mitigations = function (context = null) {
         return create_context_action("run_bounce_tracking_mitigations", context, {});
     };

--- a/webdriver/tests/classic/consume_user_activation/consume.py
+++ b/webdriver/tests/classic/consume_user_activation/consume.py
@@ -1,0 +1,53 @@
+from tests.support.classic.asserts import assert_error, assert_success
+
+
+def consume_user_activation(session):
+    return session.transport.send(
+        "POST", "session/{session_id}/window/consume-user-activation".format(
+            **vars(session)))
+
+
+def is_active(session):
+    return session.execute_script(
+        "return navigator.userActivation.isActive")
+
+
+def test_no_top_browsing_context(session, closed_window):
+    response = consume_user_activation(session)
+    assert_error(response, "no such window")
+
+
+def test_no_browsing_context(session, closed_frame):
+    response = consume_user_activation(session)
+    assert_success(response)
+
+
+def test_response_payload(session, inline):
+    session.url = inline("<p>foo")
+
+    response = consume_user_activation(session)
+    value = assert_success(response)
+    assert isinstance(value, bool)
+
+
+def test_nothing_to_consume(session, inline):
+    session.url = inline("<p>foo")
+    assert is_active(session) is False
+
+    response = consume_user_activation(session)
+    assert_success(response, False)
+
+    assert is_active(session) is False
+
+
+def test_consume_transient_activation(session, inline):
+    session.url = inline("<button>click</button>")
+    assert is_active(session) is False
+
+    session.find.css("button", all=False).click()
+    assert is_active(session) is True
+
+    response = consume_user_activation(session)
+    assert_success(response, True)
+
+    assert is_active(session) is False


### PR DESCRIPTION
Matches the [consume-user-activation](https://html.spec.whatwg.org/#user-activation-user-agent-automation) WebDriver command, which corresponds to these steps in HTML: https://html.spec.whatwg.org/#consume-user-activation