### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=258447

### DIFF
--- a/css/css-counter-styles/cjk-earthly-branch/css3-counter-styles-202-ref.html
+++ b/css/css-counter-styles/cjk-earthly-branch/css3-counter-styles-202-ref.html
@@ -5,38 +5,37 @@
 <title>cjk-earthly-branch, 13+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name="assert" content="list-style-type: cjk-earthly-branch produces numbers after 12 per the spec.">
+<meta name="assert" content="list-style-type: cjk-earthly-branch falls back to cjk-decimal after 12 per the spec.">
 <style type='text/css'>
-ol li { list-style-type: cjk-earthly-branch;  }
 /* the following CSS is not part of the test */
 .test { font-size: 25px; }
-ol { margin: 0; padding-left: 8em; line-height: 100%;}
+ol { margin: 0; padding-left: 8em; }
 </style>
 </head>
 <body>
 <p class="instructions">Test passes if the two columns are the same, IGNORING the suffix.</p>
-<div class="test">
-<ol start="13"><div><bdi dir=ltr>13、</bdi>13</div></ol>
-<ol start="14"><div><bdi dir=ltr>14、</bdi>14</div></ol>
-<ol start="77"><div><bdi dir=ltr>77、</bdi>77</div></ol>
-<ol start="80"><div><bdi dir=ltr>80、</bdi>80</div></ol>
-<ol start="99"><div><bdi dir=ltr>99、</bdi>99</div></ol>
-<ol start="100"><div><bdi dir=ltr>100、</bdi>100</div></ol>
-<ol start="101"><div><bdi dir=ltr>101、</bdi>101</div></ol>
-<ol start="222"><div><bdi dir=ltr>222、</bdi>222</div></ol>
-<ol start="540"><div><bdi dir=ltr>540、</bdi>540</div></ol>
-<ol start="999"><div><bdi dir=ltr>999、</bdi>999</div></ol>
-<ol start="1000"><div><bdi dir=ltr>1000、</bdi>1000</div></ol>
-<ol start="1005"><div><bdi dir=ltr>1005、</bdi>1005</div></ol>
-<ol start="1060"><div><bdi dir=ltr>1060、</bdi>1060</div></ol>
-<ol start="1065"><div><bdi dir=ltr>1065、</bdi>1065</div></ol>
-<ol start="1800"><div><bdi dir=ltr>1800、</bdi>1800</div></ol>
-<ol start="1860"><div><bdi dir=ltr>1860、</bdi>1860</div></ol>
-<ol start="5865"><div><bdi dir=ltr>5865、</bdi>5865</div></ol>
-<ol start="7005"><div><bdi dir=ltr>7005、</bdi>7005</div></ol>
-<ol start="7800"><div><bdi dir=ltr>7800、</bdi>7800</div></ol>
-<ol start="7864"><div><bdi dir=ltr>7864、</bdi>7864</div></ol>
-<ol start="9999"><div><bdi dir=ltr>9999、</bdi>9999</div></ol>
+<div class='test'>
+<ol start="13"><div><bdi>一三、</bdi>一三</div></ol>
+<ol start="14"><div><bdi>一四、</bdi>一四</div></ol>
+<ol start="77"><div><bdi>七七、</bdi>七七</div></ol>
+<ol start="80"><div><bdi>八〇、</bdi>八〇</div></ol>
+<ol start="99"><div><bdi>九九、</bdi>九九</div></ol>
+<ol start="100"><div><bdi>一〇〇、</bdi>一〇〇</div></ol>
+<ol start="101"><div><bdi>一〇一、</bdi>一〇一</div></ol>
+<ol start="222"><div><bdi>二二二、</bdi>二二二</div></ol>
+<ol start="540"><div><bdi>五四〇、</bdi>五四〇</div></ol>
+<ol start="999"><div><bdi>九九九、</bdi>九九九</div></ol>
+<ol start="1000"><div><bdi>一〇〇〇、</bdi>一〇〇〇</div></ol>
+<ol start="1005"><div><bdi>一〇〇五、</bdi>一〇〇五</div></ol>
+<ol start="1060"><div><bdi>一〇六〇、</bdi>一〇六〇</div></ol>
+<ol start="1065"><div><bdi>一〇六五、</bdi>一〇六五</div></ol>
+<ol start="1800"><div><bdi>一八〇〇、</bdi>一八〇〇</div></ol>
+<ol start="1860"><div><bdi>一八六〇、</bdi>一八六〇</div></ol>
+<ol start="5865"><div><bdi>五八六五、</bdi>五八六五</div></ol>
+<ol start="7005"><div><bdi>七〇〇五、</bdi>七〇〇五</div></ol>
+<ol start="7800"><div><bdi>七八〇〇、</bdi>七八〇〇</div></ol>
+<ol start="7864"><div><bdi>七八六四、</bdi>七八六四</div></ol>
+<ol start="9999"><div><bdi>九九九九、</bdi>九九九九</div></ol>
 </div>
 <!--Notes:
 You will need an appropriate font to run this test.

--- a/css/css-counter-styles/cjk-earthly-branch/css3-counter-styles-202.html
+++ b/css/css-counter-styles/cjk-earthly-branch/css3-counter-styles-202.html
@@ -6,38 +6,38 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel='match' href='css3-counter-styles-202-ref.html'>
-<meta name="assert" content="list-style-type: cjk-earthly-branch produces numbers after 12 per the spec.">
+<meta name="assert" content="list-style-type: cjk-earthly-branch fall back to cjk-decimal after 12 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: cjk-earthly-branch;  }
 /* the following CSS is not part of the test */
 .test { font-size: 25px; }
-ol { margin: 0; padding-left: 8em; list-style-position: inside; line-height: 100%;}
+ol { margin: 0; padding-left: 8em; list-style-position: inside;}
 </style>
 </head>
 <body>
 <p class="instructions">Test passes if the two columns are the same, IGNORING the suffix.</p>
 <div class="test">
-<ol start="13"><li title="13">13</li></ol>
-<ol start="14"><li title="14">14</li></ol>
-<ol start="77"><li title="77">77</li></ol>
-<ol start="80"><li title="80">80</li></ol>
-<ol start="99"><li title="99">99</li></ol>
-<ol start="100"><li title="100">100</li></ol>
-<ol start="101"><li title="101">101</li></ol>
-<ol start="222"><li title="222">222</li></ol>
-<ol start="540"><li title="540">540</li></ol>
-<ol start="999"><li title="999">999</li></ol>
-<ol start="1000"><li title="1000">1000</li></ol>
-<ol start="1005"><li title="1005">1005</li></ol>
-<ol start="1060"><li title="1060">1060</li></ol>
-<ol start="1065"><li title="1065">1065</li></ol>
-<ol start="1800"><li title="1800">1800</li></ol>
-<ol start="1860"><li title="1860">1860</li></ol>
-<ol start="5865"><li title="5865">5865</li></ol>
-<ol start="7005"><li title="7005">7005</li></ol>
-<ol start="7800"><li title="7800">7800</li></ol>
-<ol start="7864"><li title="7864">7864</li></ol>
-<ol start="9999"><li title="9999">9999</li></ol>
+<ol start="13"><li title="13">一三</li></ol>
+<ol start="14"><li title="14">一四</li></ol>
+<ol start="77"><li title="77">七七</li></ol>
+<ol start="80"><li title="80">八〇</li></ol>
+<ol start="99"><li title="99">九九</li></ol>
+<ol start="100"><li title="100">一〇〇</li></ol>
+<ol start="101"><li title="101">一〇一</li></ol>
+<ol start="222"><li title="222">二二二</li></ol>
+<ol start="540"><li title="540">五四〇</li></ol>
+<ol start="999"><li title="999">九九九</li></ol>
+<ol start="1000"><li title="1000">一〇〇〇</li></ol>
+<ol start="1005"><li title="1005">一〇〇五</li></ol>
+<ol start="1060"><li title="1060">一〇六〇</li></ol>
+<ol start="1065"><li title="1065">一〇六五</li></ol>
+<ol start="1800"><li title="1800">一八〇〇</li></ol>
+<ol start="1860"><li title="1860">一八六〇</li></ol>
+<ol start="5865"><li title="5865">五八六五</li></ol>
+<ol start="7005"><li title="7005">七〇〇五</li></ol>
+<ol start="7800"><li title="7800">七八〇〇</li></ol>
+<ol start="7864"><li title="7864">七八六四</li></ol>
+<ol start="9999"><li title="9999">九九九九</li></ol>
 </div>
 <!--Notes:
 You will need an appropriate font to run this test.

--- a/css/css-counter-styles/cjk-heavenly-stem/css3-counter-styles-205-ref.html
+++ b/css/css-counter-styles/cjk-heavenly-stem/css3-counter-styles-205-ref.html
@@ -5,39 +5,38 @@
 <title>cjk-heavenly-stem, 10+</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
-<meta name="assert" content="list-style-type: cjk-heavenly-stem produces numbers after 9 per the spec.">
+<meta name="assert" content="list-style-type: cjk-heavenly-stem falls back to cjk-decimal after 10 per the spec.">
 <style type='text/css'>
-ol li { list-style-type: cjk-heavenly-stem;  }
 /* the following CSS is not part of the test */
 .test { font-size: 25px; }
-ol { margin: 0; padding-left: 8em; line-height: 100%;}
+ol { margin: 0; padding-left: 8em;}
 </style>
 </head>
 <body>
 <p class="instructions">Test passes if the two columns are the same, IGNORING the suffix.</p>
 <div class="test">
-<ol start="11"><div><bdi dir=ltr>11、</bdi>11</div></ol>
-<ol start="12"><div><bdi dir=ltr>12、</bdi>12</div></ol>
-<ol start="43"><div><bdi dir=ltr>43、</bdi>43</div></ol>
-<ol start="77"><div><bdi dir=ltr>77、</bdi>77</div></ol>
-<ol start="80"><div><bdi dir=ltr>80、</bdi>80</div></ol>
-<ol start="99"><div><bdi dir=ltr>99、</bdi>99</div></ol>
-<ol start="100"><div><bdi dir=ltr>100、</bdi>100</div></ol>
-<ol start="101"><div><bdi dir=ltr>101、</bdi>101</div></ol>
-<ol start="222"><div><bdi dir=ltr>222、</bdi>222</div></ol>
-<ol start="540"><div><bdi dir=ltr>540、</bdi>540</div></ol>
-<ol start="999"><div><bdi dir=ltr>999、</bdi>999</div></ol>
-<ol start="1000"><div><bdi dir=ltr>1000、</bdi>1000</div></ol>
-<ol start="1005"><div><bdi dir=ltr>1005、</bdi>1005</div></ol>
-<ol start="1060"><div><bdi dir=ltr>1060、</bdi>1060</div></ol>
-<ol start="1065"><div><bdi dir=ltr>1065、</bdi>1065</div></ol>
-<ol start="1800"><div><bdi dir=ltr>1800、</bdi>1800</div></ol>
-<ol start="1860"><div><bdi dir=ltr>1860、</bdi>1860</div></ol>
-<ol start="5865"><div><bdi dir=ltr>5865、</bdi>5865</div></ol>
-<ol start="7005"><div><bdi dir=ltr>7005、</bdi>7005</div></ol>
-<ol start="7800"><div><bdi dir=ltr>7800、</bdi>7800</div></ol>
-<ol start="7864"><div><bdi dir=ltr>7864、</bdi>7864</div></ol>
-<ol start="9999"><div><bdi dir=ltr>9999、</bdi>9999</div></ol>
+<ol start="11"><div><bdi>一一、</bdi>一一</div></ol>
+<ol start="12"><div><bdi>一二、</bdi>一二</div></ol>
+<ol start="43"><div><bdi>四三、</bdi>四三</div></ol>
+<ol start="77"><div><bdi>七七、</bdi>七七</div></ol>
+<ol start="80"><div><bdi>八〇、</bdi>八〇</div></ol>
+<ol start="99"><div><bdi>九九、</bdi>九九</div></ol>
+<ol start="100"><div><bdi>一〇〇、</bdi>一〇〇</div></ol>
+<ol start="101"><div><bdi>一〇一、</bdi>一〇一</div></ol>
+<ol start="222"><div><bdi>二二二、</bdi>二二二</div></ol>
+<ol start="540"><div><bdi>五四〇、</bdi>五四〇</div></ol>
+<ol start="999"><div><bdi>九九九、</bdi>九九九</div></ol>
+<ol start="1000"><div><bdi>一〇〇〇、</bdi>一〇〇〇</div></ol>
+<ol start="1005"><div><bdi>一〇〇五、</bdi>一〇〇五</div></ol>
+<ol start="1060"><div><bdi>一〇六〇、</bdi>一〇六〇</div></ol>
+<ol start="1065"><div><bdi>一〇六五、</bdi>一〇六五</div></ol>
+<ol start="1800"><div><bdi>一八〇〇、</bdi>一八〇〇</div></ol>
+<ol start="1860"><div><bdi>一八六〇、</bdi>一八六〇</div></ol>
+<ol start="5865"><div><bdi>五八六五、</bdi>五八六五</div></ol>
+<ol start="7005"><div><bdi>七〇〇五、</bdi>七〇〇五</div></ol>
+<ol start="7800"><div><bdi>七八〇〇、</bdi>七八〇〇</div></ol>
+<ol start="7864"><div><bdi>七八六四、</bdi>七八六四</div></ol>
+<ol start="9999"><div><bdi>九九九九、</bdi>九九九九</div></ol>
 </div>
 <!--Notes:
 You will need an appropriate font to run this test.

--- a/css/css-counter-styles/cjk-heavenly-stem/css3-counter-styles-205.html
+++ b/css/css-counter-styles/cjk-heavenly-stem/css3-counter-styles-205.html
@@ -6,39 +6,39 @@
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css-counter-styles-3/#simple-numeric'>
 <link rel='match' href='css3-counter-styles-205-ref.html'>
-<meta name="assert" content="list-style-type: cjk-heavenly-stem produces numbers after 9 per the spec.">
+<meta name="assert" content="list-style-type: cjk-heavenly-stem falls back to cjk-decimal after 10 per the spec.">
 <style type='text/css'>
 ol li { list-style-type: cjk-heavenly-stem;  }
 /* the following CSS is not part of the test */
 .test { font-size: 25px; }
-ol { margin: 0; padding-left: 8em; list-style-position: inside; line-height: 100%; }
+ol { margin: 0; padding-left: 8em; list-style-position: inside;}
 </style>
 </head>
 <body>
 <p class="instructions">Test passes if the two columns are the same, IGNORING the suffix.</p>
 <div class="test">
-<ol start="11"><li title="11">11</li></ol>
-<ol start="12"><li title="12">12</li></ol>
-<ol start="43"><li title="43">43</li></ol>
-<ol start="77"><li title="77">77</li></ol>
-<ol start="80"><li title="80">80</li></ol>
-<ol start="99"><li title="99">99</li></ol>
-<ol start="100"><li title="100">100</li></ol>
-<ol start="101"><li title="101">101</li></ol>
-<ol start="222"><li title="222">222</li></ol>
-<ol start="540"><li title="540">540</li></ol>
-<ol start="999"><li title="999">999</li></ol>
-<ol start="1000"><li title="1000">1000</li></ol>
-<ol start="1005"><li title="1005">1005</li></ol>
-<ol start="1060"><li title="1060">1060</li></ol>
-<ol start="1065"><li title="1065">1065</li></ol>
-<ol start="1800"><li title="1800">1800</li></ol>
-<ol start="1860"><li title="1860">1860</li></ol>
-<ol start="5865"><li title="5865">5865</li></ol>
-<ol start="7005"><li title="7005">7005</li></ol>
-<ol start="7800"><li title="7800">7800</li></ol>
-<ol start="7864"><li title="7864">7864</li></ol>
-<ol start="9999"><li title="9999">9999</li></ol>
+<ol start="11"><li title="11">一一</li></ol>
+<ol start="12"><li title="12">一二</li></ol>
+<ol start="43"><li title="43">四三</li></ol>
+<ol start="77"><li title="77">七七</li></ol>
+<ol start="80"><li title="80">八〇</li></ol>
+<ol start="99"><li title="99">九九</li></ol>
+<ol start="100"><li title="100">一〇〇</li></ol>
+<ol start="101"><li title="101">一〇一</li></ol>
+<ol start="222"><li title="222">二二二</li></ol>
+<ol start="540"><li title="540">五四〇</li></ol>
+<ol start="999"><li title="999">九九九</li></ol>
+<ol start="1000"><li title="1000">一〇〇〇</li></ol>
+<ol start="1005"><li title="1005">一〇〇五</li></ol>
+<ol start="1060"><li title="1060">一〇六〇</li></ol>
+<ol start="1065"><li title="1065">一〇六五</li></ol>
+<ol start="1800"><li title="1800">一八〇〇</li></ol>
+<ol start="1860"><li title="1860">一八六〇</li></ol>
+<ol start="5865"><li title="5865">五八六五</li></ol>
+<ol start="7005"><li title="7005">七〇〇五</li></ol>
+<ol start="7800"><li title="7800">七八〇〇</li></ol>
+<ol start="7864"><li title="7864">七八六四</li></ol>
+<ol start="9999"><li title="9999">九九九九</li></ol>
 </div>
 <!--Notes:
 You will need an appropriate font to run this test.


### PR DESCRIPTION
WebKit export from bug: [\[css-counter-styles-3\] cjk-earthly-branch and cjk-heavenly-stem should fallback to cjk-decimal](https://bugs.webkit.org/show_bug.cgi?id=258447)