### PR TITLE
Switch from using AV1 to VP9 for the test trying to create a VideoFrame from a video element

### DIFF
--- a/webcodecs/videoFrame-construction.any.js
+++ b/webcodecs/videoFrame-construction.any.js
@@ -100,13 +100,17 @@ promise_test(async t => {
     return;
 
   let video = document.createElement('video');
-  video.src = 'av1.mp4';
+  video.src = 'vp9.mp4';
   video.autoplay = true;
   video.controls = false;
   video.muted = false;
   document.body.appendChild(video);
 
   const loadVideo = new Promise((resolve) => {
+    if (video.requestVideoFrameCallback) {
+      video.requestVideoFrameCallback(resolve);
+      return;
+    }
     video.onloadeddata = () => resolve();
   });
   await loadVideo;


### PR DESCRIPTION
This helps as VP9 is more widespread than AV1.
Also, we use requestVideoFrameCallback if available instead of onloadeddata as it is guaranteed there will be a VideoFrame with requestVideoFrameCallback.

I filed https://bugs.webkit.org/show_bug.cgi?id=258450, to dig up the difference of behaviour between Chrome and Safari 