### PR TITLE
Fix BiDi serialization test

### DIFF
--- a/webdriver/tests/bidi/script/call_function/result.py
+++ b/webdriver/tests/bidi/script/call_function/result.py
@@ -66,10 +66,10 @@ async def test_primitive_values(bidi_session, top_context, await_promise, expres
             {
                 "type": "object",
                 "value": [
-                    ["foo", {"type": "object"}],
-                    ["qux", {"type": "string", "value": "quux"}],
                     ["1", {"type": "string", "value": "fred"}],
                     ["2", {"type": "string", "value": "thud"}],
+                    ["foo", {"type": "object"}],
+                    ["qux", {"type": "string", "value": "quux"}],
                 ],
             },
         ),

--- a/webdriver/tests/bidi/script/call_function/result.py
+++ b/webdriver/tests/bidi/script/call_function/result.py
@@ -62,22 +62,14 @@ async def test_primitive_values(bidi_session, top_context, await_promise, expres
             },
         ),
         (
-            "({'foo': {'bar': 'baz'}, 'qux': 'quux'})",
-            {
-                "type": "object",
-                "value": [
-                    ["foo", {"type": "object"}],
-                    ["qux", {"type": "string", "value": "quux"}],
-                ],
-            },
-        ),
-        (
-            "({1: 'fred', '2': 'thud'})",
+            "({'foo': {'bar': 'baz'}, 'qux': 'quux', 1: 'fred', '2': 'thud'})",
             {
                 "type": "object",
                 "value": [
                     ["1", {"type": "string", "value": "fred"}],
                     ["2", {"type": "string", "value": "thud"}],
+                    ["foo", {"type": "object"}],
+                    ["qux", {"type": "string", "value": "quux"}],
                 ],
             },
         ),

--- a/webdriver/tests/bidi/script/call_function/result.py
+++ b/webdriver/tests/bidi/script/call_function/result.py
@@ -62,12 +62,20 @@ async def test_primitive_values(bidi_session, top_context, await_promise, expres
             },
         ),
         (
-            "({'foo': {'bar': 'baz'}, 'qux': 'quux', 1: 'fred', '2': 'thud'})",
+            "({'foo': {'bar': 'baz'}, 'qux': 'quux'})",
             {
                 "type": "object",
                 "value": [
                     ["foo", {"type": "object"}],
                     ["qux", {"type": "string", "value": "quux"}],
+                ],
+            },
+        ),
+        (
+            "({1: 'fred', '2': 'thud'})",
+            {
+                "type": "object",
+                "value": [
                     ["1", {"type": "string", "value": "fred"}],
                     ["2", {"type": "string", "value": "thud"}],
                 ],

--- a/webdriver/tests/bidi/script/call_function/result.py
+++ b/webdriver/tests/bidi/script/call_function/result.py
@@ -62,20 +62,12 @@ async def test_primitive_values(bidi_session, top_context, await_promise, expres
             },
         ),
         (
-            "({'foo': {'bar': 'baz'}, 'qux': 'quux'})",
+            "({'foo': {'bar': 'baz'}, 'qux': 'quux', 1: 'fred', '2': 'thud'})",
             {
                 "type": "object",
                 "value": [
                     ["foo", {"type": "object"}],
                     ["qux", {"type": "string", "value": "quux"}],
-                ],
-            },
-        ),
-        (
-            "({1: 'fred', '2': 'thud'})",
-            {
-                "type": "object",
-                "value": [
                     ["1", {"type": "string", "value": "fred"}],
                     ["2", {"type": "string", "value": "thud"}],
                 ],

--- a/webdriver/tests/bidi/script/call_function/result.py
+++ b/webdriver/tests/bidi/script/call_function/result.py
@@ -62,14 +62,22 @@ async def test_primitive_values(bidi_session, top_context, await_promise, expres
             },
         ),
         (
-            "({'foo': {'bar': 'baz'}, 'qux': 'quux', 1: 'fred', '2': 'thud'})",
+            "({'foo': {'bar': 'baz'}, 'qux': 'quux'})",
+            {
+                "type": "object",
+                "value": [
+                    ["foo", {"type": "object"}],
+                    ["qux", {"type": "string", "value": "quux"}],
+                ],
+            },
+        ),
+        (
+            "({1: 'fred', '2': 'thud'})",
             {
                 "type": "object",
                 "value": [
                     ["1", {"type": "string", "value": "fred"}],
                     ["2", {"type": "string", "value": "thud"}],
-                    ["foo", {"type": "object"}],
-                    ["qux", {"type": "string", "value": "quux"}],
                 ],
             },
         ),

--- a/webdriver/tests/bidi/script/evaluate/result.py
+++ b/webdriver/tests/bidi/script/evaluate/result.py
@@ -60,10 +60,10 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
             {
                 "type": "object",
                 "value": [
-                    ["foo", {"type": "object"}],
-                    ["qux", {"type": "string", "value": "quux"}],
                     ["1", {"type": "string", "value": "fred"}],
                     ["2", {"type": "string", "value": "thud"}],
+                    ["foo", {"type": "object"}],
+                    ["qux", {"type": "string", "value": "quux"}],
                 ],
             },
         ),

--- a/webdriver/tests/bidi/script/evaluate/result.py
+++ b/webdriver/tests/bidi/script/evaluate/result.py
@@ -56,22 +56,14 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
             },
         ),
         (
-            "({'foo': {'bar': 'baz'}, 'qux': 'quux'})",
-            {
-                "type": "object",
-                "value": [
-                    ["foo", {"type": "object"}],
-                    ["qux", {"type": "string", "value": "quux"}],
-                ],
-            },
-        ),
-        (
-            "(1: 'fred', '2': 'thud'})",
+            "({'foo': {'bar': 'baz'}, 'qux': 'quux', 1: 'fred', '2': 'thud'})",
             {
                 "type": "object",
                 "value": [
                     ["1", {"type": "string", "value": "fred"}],
                     ["2", {"type": "string", "value": "thud"}],
+                    ["foo", {"type": "object"}],
+                    ["qux", {"type": "string", "value": "quux"}],
                 ],
             },
         ),

--- a/webdriver/tests/bidi/script/evaluate/result.py
+++ b/webdriver/tests/bidi/script/evaluate/result.py
@@ -56,20 +56,12 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
             },
         ),
         (
-            "({'foo': {'bar': 'baz'}, 'qux': 'quux'})",
+            "({'foo': {'bar': 'baz'}, 'qux': 'quux', 1: 'fred', '2': 'thud'})",
             {
                 "type": "object",
                 "value": [
                     ["foo", {"type": "object"}],
                     ["qux", {"type": "string", "value": "quux"}],
-                ],
-            },
-        ),
-        (
-            "(1: 'fred', '2': 'thud'})",
-            {
-                "type": "object",
-                "value": [
                     ["1", {"type": "string", "value": "fred"}],
                     ["2", {"type": "string", "value": "thud"}],
                 ],

--- a/webdriver/tests/bidi/script/evaluate/result.py
+++ b/webdriver/tests/bidi/script/evaluate/result.py
@@ -56,14 +56,22 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
             },
         ),
         (
-            "({'foo': {'bar': 'baz'}, 'qux': 'quux', 1: 'fred', '2': 'thud'})",
+            "({'foo': {'bar': 'baz'}, 'qux': 'quux'})",
+            {
+                "type": "object",
+                "value": [
+                    ["foo", {"type": "object"}],
+                    ["qux", {"type": "string", "value": "quux"}],
+                ],
+            },
+        ),
+        (
+            "(1: 'fred', '2': 'thud'})",
             {
                 "type": "object",
                 "value": [
                     ["1", {"type": "string", "value": "fred"}],
                     ["2", {"type": "string", "value": "thud"}],
-                    ["foo", {"type": "object"}],
-                    ["qux", {"type": "string", "value": "quux"}],
                 ],
             },
         ),

--- a/webdriver/tests/bidi/script/evaluate/result.py
+++ b/webdriver/tests/bidi/script/evaluate/result.py
@@ -56,12 +56,20 @@ async def test_primitive_values(bidi_session, top_context, expression, expected)
             },
         ),
         (
-            "({'foo': {'bar': 'baz'}, 'qux': 'quux', 1: 'fred', '2': 'thud'})",
+            "({'foo': {'bar': 'baz'}, 'qux': 'quux'})",
             {
                 "type": "object",
                 "value": [
                     ["foo", {"type": "object"}],
                     ["qux", {"type": "string", "value": "quux"}],
+                ],
+            },
+        ),
+        (
+            "(1: 'fred', '2': 'thud'})",
+            {
+                "type": "object",
+                "value": [
                     ["1", {"type": "string", "value": "fred"}],
                     ["2", {"type": "string", "value": "thud"}],
                 ],


### PR DESCRIPTION
Align serialization test with the ECMAScript spec. Numbers should be followed by the strings.