### PR TITLE
Fix image-set-computed.sub.html to allow for multiple precisions

### DIFF
--- a/css/css-images/image-set/image-set-computed.sub.html
+++ b/css/css-images/image-set/image-set-computed.sub.html
@@ -40,7 +40,7 @@ function test_calculated_resolution_units() {
     "image-set(url('http://{{host}}/example.png') calc(37dpcm + 0.79532dpcm))",
     [
       'image-set(url("http://{{host}}/example.png") 1dppx)',
-      'image-set(url("http://web-platform.test/example.png") 1.000001dppx)'
+      'image-set(url("http://{{host}}/example.png") 1.000001dppx)'
     ]
   );
 }

--- a/css/css-images/image-set/image-set-computed.sub.html
+++ b/css/css-images/image-set/image-set-computed.sub.html
@@ -38,7 +38,10 @@ function test_calculated_resolution_units() {
   test_computed_value_variants(
     'background-image',
     "image-set(url('http://{{host}}/example.png') calc(37dpcm + 0.79532dpcm))",
-    'image-set(url("http://{{host}}/example.png") 1dppx)'
+    [
+      'image-set(url("http://{{host}}/example.png") 1dppx)',
+      'image-set(url("http://web-platform.test/example.png") 1.000001dppx)'
+    ]
   );
 }
 


### PR DESCRIPTION
WebKit serializes with more floating point precision than other engines which makes the subtest fail there. Since precision is implementation-defined, both are acceptable.

https://drafts.csswg.org/css-values/#numeric-types
> The precision and supported range of numeric values in CSS is implementation-defined, and can vary based on the property or other context a value is used in. However, within the CSS specifications, infinite precision and range is assumed. When a value cannot be explicitly supported due to range/precision limitations, it must be converted to the closest value supported by the implementation, but how the implementation defines "closest" is implementation-defined as well.