### PR TITLE
[wptrunner] Support headful debugging of `content_shell`

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/content_shell.py
+++ b/tools/wptrunner/wptrunner/browsers/content_shell.py
@@ -53,6 +53,9 @@ def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
         args.append(
             f"--origin-to-force-quic-on=web-platform.test:{webtranport_h3_port[0]}")
 
+    if not kwargs["headless"]:
+        args.append("--disable-headless-mode")
+
     # These flags are specific to content_shell - they activate web test protocol mode.
     args.append("--run-web-tests")
     args.append("-")


### PR DESCRIPTION
* Translate `wpt run --no-headless` to `content_shell --disable-headless-mode` (`content_shell --run-web-tests` is headless by default).
* Implement `ContentShellProtocol.base.wait()` so that `wpt run --pause-after-test` pauses until the browser exits (i.e., the window is interactively closed).

Bug: crbug.com/1440021