### PR TITLE
Don't check for interactability with testdriver.send_keys

### DIFF
--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -296,12 +296,6 @@
                                         inline: "nearest"});
             }
 
-            var pointerInteractablePaintTree = getPointerInteractablePaintTree(element);
-            if (pointerInteractablePaintTree.length === 0 ||
-                !element.contains(pointerInteractablePaintTree[0])) {
-                return Promise.reject(new Error("element send_keys intercepted error"));
-            }
-
             return window.test_driver_internal.send_keys(element, keys);
         },
 


### PR DESCRIPTION
This doesn't make sense; we can still send keys to an element that's got e.g. zero width, but it won't appear in elementsFromPoint. It also doesn't match the checks that WebDriver does as part of its send keys algorithm.