### PR TITLE
Remove undefined subtest from offset-path-interpolation-005.html

### DIFF
--- a/css/motion/animation/offset-path-interpolation-005.html
+++ b/css/motion/animation/offset-path-interpolation-005.html
@@ -128,12 +128,10 @@
         from: 'ray(-10deg farthest-corner)',
         to: 'ray(-50deg farthest-corner at 100% 100%)'
       }, [
-        {at: -1, expect: 'ray(30deg farthest-corner at 0% 0%)'},
-        {at: 0, expect: 'ray(-10deg farthest-corner)'},
-        {at: 0.125, expect: 'ray(-15deg farthest-corner at 56.25% 56.25%)'},
-        {at: 0.875, expect: 'ray(-45deg farthest-corner at 93.75% 93.75%)'},
+        // TODO: Test intermediate values as well, once the expected behavior
+        // is clear in the spec. Right now it's a bit unclear whether or how to
+        // interpolate to/from the initial 'auto' value.
         {at: 1, expect: 'ray(-50deg farthest-corner at 100% 100%)'},
-        {at: 2, expect: 'ray(-90deg farthest-corner at 150% 150%)'},
       ]);
 
       // No interpolation between different sizes and/or different containment and/or coord-boxes.


### PR DESCRIPTION
This addresses https://github.com/web-platform-tests/interop/issues/367

As discussed there, the interpolation behavior isn't well-defined for offset-path's default position when a position isn't provided; and the behavior that the test was expecting (using 50% 50% for interpolation) doesn't actually seem to be correct.

In this patch, I'm preserving a nerfed version of the subtest, keeping only the "at: 1" value where the correct value is unambiguous (matching the "to" value). This gives some small amount of test coverage for this situation, without encoding expectations about whether or how interpolation would proceed.