### PR TITLE
Add tests for the `browsingContext.fragmentNavigated` event

### DIFF
--- a/webdriver/tests/bidi/browsing_context/fragment_navigated/fragment_navigated.py
+++ b/webdriver/tests/bidi/browsing_context/fragment_navigated/fragment_navigated.py
@@ -13,7 +13,11 @@ EMPTY_PAGE = "/webdriver/tests/bidi/support/empty.html"
 FRAGMENT_NAVIGATED_EVENT = "browsingContext.fragmentNavigated"
 
 
-async def test_unsubscribe(bidi_session, inline, top_context):
+async def test_unsubscribe(bidi_session, url, top_context):
+    await bidi_session.browsing_context.navigate(
+        context=top_context["context"], url=url(EMPTY_PAGE), wait="complete"
+    )
+
     await bidi_session.session.subscribe(events=[FRAGMENT_NAVIGATED_EVENT])
     await bidi_session.session.unsubscribe(events=[FRAGMENT_NAVIGATED_EVENT])
 
@@ -27,12 +31,10 @@ async def test_unsubscribe(bidi_session, inline, top_context):
         FRAGMENT_NAVIGATED_EVENT, on_event
     )
 
-    url = inline("<div>foo</div>")
-
     # When navigation reaches complete state,
     # we should have received a browsingContext.fragmentNavigated event
     await bidi_session.browsing_context.navigate(
-        context=top_context["context"], url=url, wait="complete"
+        context=top_context["context"], url=url(EMPTY_PAGE + '#foo'), wait="complete"
     )
 
     assert len(events) == 0
@@ -40,25 +42,33 @@ async def test_unsubscribe(bidi_session, inline, top_context):
     remove_listener()
 
 
-async def test_subscribe(bidi_session, subscribe_events, inline, new_tab, wait_for_event):
+async def test_subscribe(bidi_session, subscribe_events, url, new_tab, wait_for_event):
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"], url=url(EMPTY_PAGE), wait="complete"
+    )
+
     await subscribe_events(events=[FRAGMENT_NAVIGATED_EVENT])
 
     on_entry = wait_for_event(FRAGMENT_NAVIGATED_EVENT)
-    url = inline("<div>foo</div>")
-    await bidi_session.browsing_context.navigate(context=new_tab["context"], url=url)
+    target_url = url(EMPTY_PAGE + '#foo')
+    await bidi_session.browsing_context.navigate(context=new_tab["context"], url=target_url, wait="complete")
     event = await on_entry
 
-    assert_navigation_info(event, {"context": new_tab["context"], "url": url})
+    assert_navigation_info(event, {"context": new_tab["context"], "url": target_url})
 
 
-async def test_timestamp(bidi_session, current_time, subscribe_events, inline, new_tab, wait_for_event):
+async def test_timestamp(bidi_session, current_time, subscribe_events, url, new_tab, wait_for_event):
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"], url=url(EMPTY_PAGE), wait="complete"
+    )
+
     await subscribe_events(events=[FRAGMENT_NAVIGATED_EVENT])
 
     time_start = await current_time()
 
     on_entry = wait_for_event(FRAGMENT_NAVIGATED_EVENT)
-    url = inline("<div>foo</div>")
-    await bidi_session.browsing_context.navigate(context=new_tab["context"], url=url)
+    target_url = url(EMPTY_PAGE + '#foo')
+    await bidi_session.browsing_context.navigate(context=new_tab["context"], url=target_url, wait="complete")
     event = await on_entry
 
     time_end = await current_time()
@@ -69,75 +79,47 @@ async def test_timestamp(bidi_session, current_time, subscribe_events, inline, n
     )
 
 
-async def test_iframe(bidi_session, subscribe_events, new_tab, test_page, test_page_same_origin_frame):
-    events = []
-
-    async def on_event(method, data):
-        # Filter out events for about:blank to avoid browser differences
-        if data["url"] != 'about:blank':
-            events.append(data)
-
-    remove_listener = bidi_session.add_event_listener(
-        FRAGMENT_NAVIGATED_EVENT, on_event
-    )
-    await subscribe_events(events=[FRAGMENT_NAVIGATED_EVENT])
-
-    await bidi_session.browsing_context.navigate(
-        context=new_tab["context"], url=test_page_same_origin_frame
-    )
-
-    wait = AsyncPoll(
-        bidi_session, message="Didn't receive browsingContext.fragmentNavigated for frames"
-    )
-    await wait.until(lambda _: len(events) >= 2)
-    assert len(events) == 2
-
-    contexts = await bidi_session.browsing_context.get_tree(root=new_tab["context"])
-
-    assert len(contexts) == 1
-    root_info = contexts[0]
-    assert len(root_info["children"]) == 1
-    child_info = root_info["children"][0]
-
-    # The ordering of fragmentNavigated events is not guaranteed between the
-    # root page and the iframe, find the appropriate events in the current list.
-    first_is_root = events[0]["context"] == root_info["context"]
-    root_event = events[0] if first_is_root else events[1]
-    child_event = events[1] if first_is_root else events[0]
-
-    assert_navigation_info(
-        root_event,
-        {"context": root_info["context"], "url": test_page_same_origin_frame}
-    )
-    assert_navigation_info(child_event, {"context": child_info["context"], "url": test_page})
-
-    remove_listener()
-
-
-async def test_cross_document(
+async def test_navigation_id(
     bidi_session, new_tab, url, subscribe_events, wait_for_event
 ):
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"], url=url(EMPTY_PAGE), wait="complete"
+    )
+
     await subscribe_events([FRAGMENT_NAVIGATED_EVENT])
 
     on_frame_navigated = wait_for_event(FRAGMENT_NAVIGATED_EVENT)
 
+    target_url = url(EMPTY_PAGE + '#foo');
     result = await bidi_session.browsing_context.navigate(
-        context=new_tab["context"], url=url(EMPTY_PAGE))
+        context=new_tab["context"], url=target_url)
 
     recursive_compare(
         {
             'context': new_tab["context"],
             'navigation': result["navigation"],
             'timestamp': any_int,
-            'url': url(EMPTY_PAGE)
+            'url': target_url
         },
         await on_frame_navigated,
     )
 
 
 @pytest.mark.parametrize(
+    "context_kind",
+    ["top-level", "iframe"],
+    ids=[
+        "in a top-level context",
+        "in an iframe context",
+    ]
+)
+@pytest.mark.parametrize(
     "navigation_kind",
     ["browsing_context.navigate", "script.call_function"],
+    ids=[
+        "navigation via browsing_context.navigate",
+        "navigation via script.call_function",
+    ]
 )
 @pytest.mark.parametrize(
     "hash_before, hash_after",
@@ -155,26 +137,45 @@ async def test_cross_document(
     ],
 )
 async def test_navigate_in_the_same_document(
-    bidi_session, new_tab, url, subscribe_events, wait_for_event, hash_before, hash_after, navigation_kind
+    bidi_session, new_tab, url, inline, subscribe_events, wait_for_event, hash_before, hash_after, navigation_kind, context_kind
 ):
-    await bidi_session.browsing_context.navigate(
-        context=new_tab["context"], url=url(EMPTY_PAGE + hash_before), wait="complete"
-    )
+    initial_url = url(EMPTY_PAGE + hash_before)
+    target_context = new_tab["context"]
+    if context_kind == 'top-level':
+      await bidi_session.browsing_context.navigate(
+          context=new_tab["context"], url=initial_url, wait="complete"
+      )
+    elif context_kind == 'iframe':
+      parent_url = inline(f"<iframe src='{initial_url}'></iframe>")
+      await bidi_session.browsing_context.navigate(
+          context=new_tab["context"], url=parent_url, wait="complete"
+      )
+      all_contexts = await bidi_session.browsing_context.get_tree()
+
+      # about:blank + a new tab are top-level contexts.
+      assert len(all_contexts) == 2
+      parent_info = all_contexts[1]
+      assert len(parent_info["children"]) == 1
+      child_info = parent_info["children"][0]
+      target_context = child_info["context"]
+    else:
+      raise Exception("Unknown context_kind")
 
     await subscribe_events([FRAGMENT_NAVIGATED_EVENT])
 
     on_frame_navigated = wait_for_event(FRAGMENT_NAVIGATED_EVENT)
 
+    target_url = url(EMPTY_PAGE + hash_after)
     if navigation_kind == "browsing_context.navigate":
       result = await bidi_session.browsing_context.navigate(
-          context=new_tab["context"], url=url(EMPTY_PAGE + hash_after))
+          context=target_context, url=target_url)
 
       recursive_compare(
           {
-              'context': new_tab["context"],
+              'context': target_context,
               'navigation': result["navigation"],
               'timestamp': any_int,
-              'url': url(EMPTY_PAGE + hash_after)
+              'url': target_url
           },
           await on_frame_navigated,
       )
@@ -185,26 +186,26 @@ async def test_navigate_in_the_same_document(
               document.location = url;
           }""",
           arguments=[
-              {"type": "string", "value": url(EMPTY_PAGE + hash_after)},
+              {"type": "string", "value": target_url},
           ],
           await_promise=False,
-          target=ContextTarget(new_tab["context"]),
+          target=ContextTarget(target_context),
       )
 
       recursive_compare(
           {
-              'context': new_tab["context"],
+              'context': target_context,
               'timestamp': any_int,
-              'url': url(EMPTY_PAGE + hash_after)
+              'url': target_url
           },
           await on_frame_navigated,
       )
     else:
-       raise Exception("Unknown navigation_kind")
+      raise Exception("Unknown navigation_kind")
 
 
 @pytest.mark.parametrize("type_hint", ["tab", "window"])
-async def test_new_context(bidi_session, subscribe_events, wait_for_event, type_hint):
+async def test_new_context(bidi_session, subscribe_events, type_hint):
     await subscribe_events(events=[FRAGMENT_NAVIGATED_EVENT])
 
     events = []
@@ -223,11 +224,8 @@ async def test_new_context(bidi_session, subscribe_events, wait_for_event, type_
     remove_listener()
 
 
-async def test_document_write(bidi_session, subscribe_events, top_context, wait_for_event):
+async def test_document_write(bidi_session, subscribe_events, top_context):
     await subscribe_events(events=[FRAGMENT_NAVIGATED_EVENT])
-
-    on_entry = wait_for_event(FRAGMENT_NAVIGATED_EVENT)
-
 
     events = []
 
@@ -249,12 +247,42 @@ async def test_document_write(bidi_session, subscribe_events, top_context, wait_
     remove_listener()
 
 
-async def test_page_with_base_tag(bidi_session, subscribe_events, inline, new_tab, wait_for_event):
+async def test_page_with_base_tag(bidi_session, subscribe_events, inline, new_tab):
     await subscribe_events(events=[FRAGMENT_NAVIGATED_EVENT])
 
-    on_entry = wait_for_event(FRAGMENT_NAVIGATED_EVENT)
+    events = []
+
+    async def on_event(method, data):
+        events.append(data)
+
+    remove_listener = bidi_session.add_event_listener(FRAGMENT_NAVIGATED_EVENT, on_event)
+
     url = inline("""<base href="/relative-path">""")
     await bidi_session.browsing_context.navigate(context=new_tab["context"], url=url)
-    event = await on_entry
 
-    assert_navigation_info(event, {"context": new_tab["context"], "url": url})
+    wait = AsyncPoll(bidi_session, timeout=0.5)
+    with pytest.raises(TimeoutException):
+        await wait.until(lambda _: len(events) > 0)
+
+    remove_listener()
+
+
+async def test_regular_navigation(bidi_session, subscribe_events, url, new_tab):
+    await bidi_session.browsing_context.navigate(context=new_tab["context"], url=url(EMPTY_PAGE), wait="complete")
+
+    await subscribe_events(events=[FRAGMENT_NAVIGATED_EVENT])
+
+    events = []
+
+    async def on_event(method, data):
+        events.append(data)
+
+    remove_listener = bidi_session.add_event_listener(FRAGMENT_NAVIGATED_EVENT, on_event)
+
+    await bidi_session.browsing_context.navigate(context=new_tab["context"], url=url(EMPTY_PAGE + '?foo'), wait="complete")
+
+    wait = AsyncPoll(bidi_session, timeout=0.5)
+    with pytest.raises(TimeoutException):
+        await wait.until(lambda _: len(events) > 0)
+
+    remove_listener()

--- a/webdriver/tests/bidi/browsing_context/fragment_navigated/fragment_navigated.py
+++ b/webdriver/tests/bidi/browsing_context/fragment_navigated/fragment_navigated.py
@@ -92,7 +92,7 @@ async def test_navigation_id(
 
     target_url = url(EMPTY_PAGE + '#foo');
     result = await bidi_session.browsing_context.navigate(
-        context=new_tab["context"], url=target_url)
+        context=new_tab["context"], url=target_url, wait="complete")
 
     recursive_compare(
         {
@@ -168,7 +168,7 @@ async def test_navigate_in_the_same_document(
     target_url = url(EMPTY_PAGE + hash_after)
     if navigation_kind == "browsing_context.navigate":
       result = await bidi_session.browsing_context.navigate(
-          context=target_context, url=target_url)
+          context=target_context, url=target_url, wait="complete")
 
       recursive_compare(
           {
@@ -258,7 +258,7 @@ async def test_page_with_base_tag(bidi_session, subscribe_events, inline, new_ta
     remove_listener = bidi_session.add_event_listener(FRAGMENT_NAVIGATED_EVENT, on_event)
 
     url = inline("""<base href="/relative-path">""")
-    await bidi_session.browsing_context.navigate(context=new_tab["context"], url=url)
+    await bidi_session.browsing_context.navigate(context=new_tab["context"], url=url, wait="complete")
 
     wait = AsyncPoll(bidi_session, timeout=0.5)
     with pytest.raises(TimeoutException):

--- a/webdriver/tests/bidi/browsing_context/fragment_navigated/fragment_navigated.py
+++ b/webdriver/tests/bidi/browsing_context/fragment_navigated/fragment_navigated.py
@@ -154,7 +154,7 @@ async def test_cross_document(
         "with hash to without hash",
     ],
 )
-async def test_history_api(
+async def test_navigate_in_the_same_document(
     bidi_session, new_tab, url, subscribe_events, wait_for_event, hash_before, hash_after, navigation_kind
 ):
     await bidi_session.browsing_context.navigate(

--- a/webdriver/tests/bidi/browsing_context/fragment_navigated/fragment_navigated.py
+++ b/webdriver/tests/bidi/browsing_context/fragment_navigated/fragment_navigated.py
@@ -8,7 +8,7 @@ from .. import assert_navigation_info
 
 pytestmark = pytest.mark.asyncio
 
-EMPTY_PAGE = "/webdriver/tests/bidi/browsing_context/navigate/support/empty.html"
+EMPTY_PAGE = "/webdriver/tests/bidi/support/empty.html"
 FRAGMENT_NAVIGATED_EVENT = "browsingContext.fragmentNavigated"
 
 

--- a/webdriver/tests/bidi/browsing_context/fragment_navigated/history_api.py
+++ b/webdriver/tests/bidi/browsing_context/fragment_navigated/history_api.py
@@ -1,0 +1,56 @@
+import pytest
+
+from webdriver.bidi.modules.script import ContextTarget
+
+from ... import any_int, recursive_compare
+
+pytestmark = pytest.mark.asyncio
+
+EMPTY_PAGE = "/webdriver/tests/bidi/support/empty.html"
+FRAGMENT_NAVIGATED_EVENT = "browsingContext.fragmentNavigated"
+
+
+@pytest.mark.parametrize(
+    "hash_before, hash_after",
+    [
+        ("", "#foo"),
+        ("#foo", "#bar"),
+        ("#foo", "#foo"),
+        ("#bar", ""),
+    ]
+)
+async def test_history_push_state(
+    bidi_session, new_tab, url, subscribe_events, wait_for_event, hash_before, hash_after
+):
+    target_context = new_tab["context"]
+
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"], url=url(EMPTY_PAGE + hash_before), wait="complete"
+    )
+
+    await subscribe_events([FRAGMENT_NAVIGATED_EVENT])
+
+    on_frame_navigated = wait_for_event(FRAGMENT_NAVIGATED_EVENT)
+
+    target_url = url(EMPTY_PAGE + hash_after)
+
+    await bidi_session.script.call_function(
+        raw_result=True,
+        function_declaration="""(url) => {
+            history.pushState(null, null, url);
+        }""",
+        arguments=[
+            {"type": "string", "value": target_url},
+        ],
+        await_promise=False,
+        target=ContextTarget(target_context),
+    )
+
+    recursive_compare(
+        {
+            'context': target_context,
+            'timestamp': any_int,
+            'url': target_url
+        },
+        await on_frame_navigated,
+    )

--- a/webdriver/tests/bidi/browsing_context/navigate/fragment_navigated.py
+++ b/webdriver/tests/bidi/browsing_context/navigate/fragment_navigated.py
@@ -1,0 +1,101 @@
+import pytest
+
+from tests.support.sync import AsyncPoll
+from webdriver.bidi.modules.script import ContextTarget
+
+from ... import any_int, any_string, recursive_compare
+
+pytestmark = pytest.mark.asyncio
+
+EMPTY_PAGE = "/webdriver/tests/bidi/browsing_context/navigate/support/empty.html"
+FRAGMENT_NAVIGATED_EVENT = "browsingContext.fragmentNavigated"
+
+
+async def test_fragment_navigated_new_document(
+    bidi_session, new_tab, url, subscribe_events, wait_for_event
+):
+    await subscribe_events([FRAGMENT_NAVIGATED_EVENT])
+
+    on_frame_navigated = wait_for_event(FRAGMENT_NAVIGATED_EVENT)
+
+    result = await bidi_session.browsing_context.navigate(
+        context=new_tab["context"], url=url(EMPTY_PAGE))
+
+    recursive_compare(
+        {
+            'context': new_tab["context"],
+            'navigation': result["navigation"],
+            'timestamp': any_int,
+            'url': url(EMPTY_PAGE)
+        },
+        await on_frame_navigated,
+    )
+
+
+@pytest.mark.parametrize(
+    "navigation_kind",
+    ["browsing_context.navigate", "script.call_function"],
+)
+@pytest.mark.parametrize(
+    "hash_before, hash_after",
+    [
+        ("", "#foo"),
+        ("#foo", "#bar"),
+        ("#foo", "#foo"),
+        ("#bar", ""),
+    ],
+    ids=[
+        "without hash to with hash",
+        "with different hashes",
+        "with identical hashes",
+        "with hash to without hash",
+    ],
+)
+async def test_fragment_navigated_same_document(
+    bidi_session, new_tab, url, subscribe_events, wait_for_event, hash_before, hash_after, navigation_kind
+):
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"], url=url(EMPTY_PAGE + hash_before), wait="complete"
+    )
+
+    await subscribe_events([FRAGMENT_NAVIGATED_EVENT])
+
+    on_frame_navigated = wait_for_event(FRAGMENT_NAVIGATED_EVENT)
+
+    if navigation_kind == "browsing_context.navigate":
+      result = await bidi_session.browsing_context.navigate(
+          context=new_tab["context"], url=url(EMPTY_PAGE + hash_after))
+
+      recursive_compare(
+          {
+              'context': new_tab["context"],
+              'navigation': result["navigation"],
+              'timestamp': any_int,
+              'url': url(EMPTY_PAGE + hash_after)
+          },
+          await on_frame_navigated,
+      )
+    elif navigation_kind == "script.call_function":
+      await bidi_session.script.call_function(
+          raw_result=True,
+          function_declaration="""(url) => {
+              history.pushState(null, null, url);
+          }""",
+          arguments=[
+              {"type": "string", "value": url(EMPTY_PAGE + hash_after)},
+          ],
+          await_promise=False,
+          target=ContextTarget(new_tab["context"]),
+      )
+
+      recursive_compare(
+          {
+              'context': new_tab["context"],
+              'navigation': None,
+              'timestamp': any_int,
+              'url': url(EMPTY_PAGE + hash_after)
+          },
+          await on_frame_navigated,
+      )
+    else:
+       raise Exception("Unknown navigation_kind")


### PR DESCRIPTION
- [x] `./wpt lint` passes
- [x] tests pass with chromium-bidi
- [x] history API navigations
- [x] regular navigation
- [x] test_subscribe
- [x] test_unsubscribe
- [x] test_timestamp
- [x] test with iframes
- [x] test with document.write
- [x] test with a base tag