### PR TITLE
[css-text] Add a few introductory word-break:auto tests

### DIFF
--- a/css/css-text/word-break/reference/word-break-auto-ref-000.html
+++ b/css/css-text/word-break/reference/word-break-auto-ref-000.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref"><span>明日</span></div>
+<div class="ref"><span>明日</span></div>
+</body>
+</html>

--- a/css/css-text/word-break/reference/word-break-auto-ref-001.html
+++ b/css/css-text/word-break/reference/word-break-auto-ref-001.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref"><span>携帯</span></div>
+<div class="ref"><span>携帯</span></div>
+</body>
+</html>

--- a/css/css-text/word-break/reference/word-break-auto-ref-002.html
+++ b/css/css-text/word-break/reference/word-break-auto-ref-002.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref"><span>キラ</span></div>
+<div class="ref"><span>キラ</span></div>
+</body>
+</html>

--- a/css/css-text/word-break/reference/word-break-auto-ref-003.html
+++ b/css/css-text/word-break/reference/word-break-auto-ref-003.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref"><span>베트남에서</span></div>
+<div class="ref"><span>베트남에서</span></div>
+</body>
+</html>

--- a/css/css-text/word-break/reference/word-break-auto-ref-004.html
+++ b/css/css-text/word-break/reference/word-break-auto-ref-004.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref"><span>회전교차로에서</span></div>
+<div class="ref"><span>회전교차로에서</span></div>
+</body>
+</html>

--- a/css/css-text/word-break/reference/word-break-auto-ref-005.html
+++ b/css/css-text/word-break/reference/word-break-auto-ref-005.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref"><span>Pro를</span></div>
+<div class="ref"><span>Pro를</span></div>
+</body>
+</html>

--- a/css/css-text/word-break/word-break-auto-000.html
+++ b/css/css-text/word-break/word-break-auto-000.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<meta name="assert" content="word-break: auto keeps phrases together.">
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-auto-ref-000.html'>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: auto; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test"><div id="testdiv"><span id="testspan">明日</span></div></div>
+<div class="ref"><span>明日</span></div>
+</body>
+</html>

--- a/css/css-text/word-break/word-break-auto-001.html
+++ b/css/css-text/word-break/word-break-auto-001.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<meta name="assert" content="word-break: auto keeps phrases together.">
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-auto-ref-001.html'>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: auto; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test"><div id="testdiv"><span id="testspan">携帯</span></div></div>
+<div class="ref"><span>携帯</span></div>
+</body>
+</html>

--- a/css/css-text/word-break/word-break-auto-002.html
+++ b/css/css-text/word-break/word-break-auto-002.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<meta name="assert" content="word-break: auto keeps phrases together.">
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-auto-ref-002.html'>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: auto; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test"><div id="testdiv"><span id="testspan">キラ</span></div></div>
+<div class="ref"><span>キラ</span></div>
+</body>
+</html>

--- a/css/css-text/word-break/word-break-auto-003.html
+++ b/css/css-text/word-break/word-break-auto-003.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<meta name="assert" content="word-break: auto keeps phrases together.">
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-auto-ref-003.html'>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: auto; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test"><div id="testdiv"><span id="testspan">베트남에서</span></div></div>
+<div class="ref"><span>베트남에서</span></div>
+</body>
+</html>

--- a/css/css-text/word-break/word-break-auto-004.html
+++ b/css/css-text/word-break/word-break-auto-004.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<meta name="assert" content="word-break: auto keeps phrases together.">
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-auto-ref-004.html'>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: auto; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test"><div id="testdiv"><span id="testspan">회전교차로에서</span></div></div>
+<div class="ref"><span>회전교차로에서</span></div>
+</body>
+</html>

--- a/css/css-text/word-break/word-break-auto-005.html
+++ b/css/css-text/word-break/word-break-auto-005.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<meta name="assert" content="word-break: auto keeps phrases together.">
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-auto-ref-005.html'>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: auto; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test"><div id="testdiv"><span id="testspan">Pro를</span></div></div>
+<div class="ref"><span>Pro를</span></div>
+</body>
+</html>


### PR DESCRIPTION
This adds a few tests for word-break: auto. A few things to note here:

1. The definition of phrase/word based line breaking is intentionally fuzzy. Different implementations, with different linguistic analysis and dictionaries, should be able to pass these tests. Therefore, they are intentionally not very rigorous - they just represent a baseline of support.
2. Because of the above, there ideally wouldn't actually be many tests for this value. WPT shouldn't overspecify support. This patch adds 6 tests; there can certainly be more added, but we should intentionally not be comprehensive here.

I've verified that these tests pass both on CFStringTokenizer and on ICU.