### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=258803

### DIFF
--- a/webcodecs/videoFrame-construction.window.js
+++ b/webcodecs/videoFrame-construction.window.js
@@ -9,11 +9,15 @@ promise_test(async t => {
 }, 'Test that timestamp is required when constructing VideoFrame from HTMLImageElement');
 
 promise_test(async t => {
-    let svgImageElement = document.createElementNS('http://www.w3.org/2000/svg','image');
-    let loadPromise = new Promise(r => svgImageElement.onload = r);
+    const svgDocument = document.createElementNS('http://www.w3.org/2000/svg','svg');
+    document.body.appendChild(svgDocument);
+    const svgImageElement = document.createElementNS('http://www.w3.org/2000/svg','image');
+    svgDocument.appendChild(svgImageElement);
+    const loadPromise = new Promise(r => svgImageElement.onload = r);
     svgImageElement.setAttributeNS('http://www.w3.org/1999/xlink','href','data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==');
     await loadPromise;
     verifyTimestampRequiredToConstructFrame(svgImageElement);
+    document.body.removeChild(svgDocument);
 }, 'Test that timestamp is required when constructing VideoFrame from SVGImageElement');
 
 promise_test(async t => {


### PR DESCRIPTION
WebKit export from bug: [Update LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.window.js to work around Safari SVG specificites](https://bugs.webkit.org/show_bug.cgi?id=258803)