### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=258809

### DIFF
--- a/webcodecs/videoFrame-canvasImageSource.html
+++ b/webcodecs/videoFrame-canvasImageSource.html
@@ -61,7 +61,21 @@ async_test(t => {
     frame.close();
     t.done();
   }));
-  video.src = 'four-colors.mp4';
+
+  const mediaConfig = {
+    type: 'file',
+    video: {
+      contentType: 'video/mp4; codecs="av01.0.04M.08"',
+      width: 320,
+      height: 240,
+      bitrate: 1000000,
+      framerate: '30'
+    }
+  };
+  navigator.mediaCapabilities.decodingInfo(mediaConfig).then(t.step_func(result => {
+    assert_implements_optional(result.supported, "AV.1 file streaming unsupported");
+    video.src = 'four-colors.mp4';
+  }));
 }, '<video> and VideoFrame constructed VideoFrame');
 
 test(t => {


### PR DESCRIPTION
WebKit export from bug: [WPT webcodecs/videoFrame-canvasImageSource.html is failing a test due to AV1 usage](https://bugs.webkit.org/show_bug.cgi?id=258809)