### PR TITLE
Account that send_keys throws different exceptions in inert test

### DIFF
--- a/inert/inert-node-is-uneditable.html
+++ b/inert/inert-node-is-uneditable.html
@@ -18,7 +18,7 @@ var notEditable = document.querySelector('#not-editable');
 var editable = document.querySelector('#editable');
 
 function sendKey(key) {
-    return test_driver.Actions()
+    return new test_driver.Actions()
         .keyDown(key)
         .keyUp(key)
         .send();

--- a/inert/inert-node-is-uneditable.html
+++ b/inert/inert-node-is-uneditable.html
@@ -20,11 +20,7 @@ promise_test(async function() {
     notEditable.focus();
     var oldValue = notEditable.textContent;
     assert_equals(oldValue, "I'm not editable.");
-    await promise_rejects_js(
-        this,
-        Error,
-        test_driver.send_keys(notEditable, 'a'),
-        "send_keys should reject for non-interactive elements");
+    await test_driver.send_keys(notEditable, 'a');
     assert_equals(notEditable.textContent, oldValue);
 }, "Can't edit inert contenteditable");
 

--- a/inert/inert-node-is-uneditable.html
+++ b/inert/inert-node-is-uneditable.html
@@ -7,6 +7,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-actions.js"></script>
     <script src="/resources/testdriver-vendor.js"></script>
   </head>
 <body>

--- a/inert/inert-node-is-uneditable.html
+++ b/inert/inert-node-is-uneditable.html
@@ -16,11 +16,18 @@
 var notEditable = document.querySelector('#not-editable');
 var editable = document.querySelector('#editable');
 
+function sendKey(key) {
+    return test_driver.Actions()
+        .keyDown(key)
+        .keyUp(key)
+        .send();
+}
+
 promise_test(async function() {
     notEditable.focus();
     var oldValue = notEditable.textContent;
     assert_equals(oldValue, "I'm not editable.");
-    await test_driver.send_keys(notEditable, 'a');
+    await sendKey('a');
     assert_equals(notEditable.textContent, oldValue);
 }, "Can't edit inert contenteditable");
 
@@ -28,7 +35,7 @@ promise_test(async () => {
     editable.focus();
     var oldValue = editable.textContent;
     assert_equals(oldValue, "I'm editable.");
-    await test_driver.send_keys(editable, 'a');
+    await sendKey('a');
     assert_not_equals(editable.textContent, oldValue);
 }, "Can edit non-inert contenteditable");
 


### PR DESCRIPTION
#40774 made it so send_keys no longer throws in non-interactive nodes, however it still throws for a different reason. Use test_driver actions and stop checking that an exception is thrown. The value assert below is enough to check that the field is not editable.