### PR TITLE
[wdspec] bidi: print: add tests for content area with less than 1x1 point

### DIFF
--- a/webdriver/tests/bidi/browsing_context/print/background.py
+++ b/webdriver/tests/bidi/browsing_context/print/background.py
@@ -2,7 +2,7 @@ import base64
 import pytest
 
 from tests.support.asserts import assert_pdf
-from tests.support.image import px_to_cm
+from tests.support.image import pt_to_cm
 
 pytestmark = pytest.mark.asyncio
 
@@ -46,8 +46,8 @@ async def test_background(
             "left": 0
         },
         page={
-            "width": px_to_cm(1),
-            "height": px_to_cm(1)
+            "width": pt_to_cm(1),
+            "height": pt_to_cm(1),
         },
     )
 

--- a/webdriver/tests/bidi/browsing_context/print/invalid.py
+++ b/webdriver/tests/bidi/browsing_context/print/invalid.py
@@ -124,24 +124,12 @@ async def test_params_page_invalid_type(bidi_session, top_context, page):
     [
         {"height": -1},
         {"width": -1},
-    ],
-)
-async def test_params_page_invalid_value(bidi_session, top_context, page):
-    with pytest.raises(error.InvalidArgumentException):
-        await bidi_session.browsing_context.print(
-            context=top_context["context"], page=page
-        )
-
-
-@pytest.mark.parametrize(
-    "page",
-    [
         {"height": 0.01},
         {"width": 0.01},
     ],
 )
-async def test_params_page_small_value(bidi_session, top_context, page):
-    with pytest.raises(error.UnsupportedOperationException):
+async def test_params_page_invalid_value(bidi_session, top_context, page):
+    with pytest.raises(error.InvalidArgumentException):
         await bidi_session.browsing_context.print(
             context=top_context["context"], page=page
         )

--- a/webdriver/tests/bidi/browsing_context/print/invalid.py
+++ b/webdriver/tests/bidi/browsing_context/print/invalid.py
@@ -134,6 +134,20 @@ async def test_params_page_invalid_value(bidi_session, top_context, page):
 
 
 @pytest.mark.parametrize(
+    "margin",
+    [
+        {"height": 0.01},
+        {"width": 0.01},
+    ],
+)
+async def test_params_page_small_value(bidi_session, top_context, page):
+    with pytest.raises(error.UnsupportedOperationException):
+        await bidi_session.browsing_context.print(
+            context=top_context["context"], page=page
+        )
+
+
+@pytest.mark.parametrize(
     "page_ranges",
     [
         False,

--- a/webdriver/tests/bidi/browsing_context/print/invalid.py
+++ b/webdriver/tests/bidi/browsing_context/print/invalid.py
@@ -124,8 +124,8 @@ async def test_params_page_invalid_type(bidi_session, top_context, page):
     [
         {"height": -1},
         {"width": -1},
-        {"height": 0.01},
-        {"width": 0.01},
+        {"height": 0.03},
+        {"width": 0.03},
     ],
 )
 async def test_params_page_invalid_value(bidi_session, top_context, page):

--- a/webdriver/tests/bidi/browsing_context/print/invalid.py
+++ b/webdriver/tests/bidi/browsing_context/print/invalid.py
@@ -134,7 +134,7 @@ async def test_params_page_invalid_value(bidi_session, top_context, page):
 
 
 @pytest.mark.parametrize(
-    "margin",
+    "page",
     [
         {"height": 0.01},
         {"width": 0.01},

--- a/webdriver/tests/bidi/browsing_context/print/margin.py
+++ b/webdriver/tests/bidi/browsing_context/print/margin.py
@@ -105,14 +105,19 @@ async def test_margin_same_as_page_dimension(
     await bidi_session.browsing_context.navigate(
         context=top_context["context"], url=page, wait="complete"
     )
-    print_value = await bidi_session.browsing_context.print(
-        context=top_context["context"],
-        shrink_to_fit=False,
-        margin=margin,
-    )
 
-    # Check that content is out of page dimensions.
-    await assert_pdf_content(print_value, [{"type": "string", "value": ""}])
+    try:
+        print_value = await bidi_session.browsing_context.print(
+            context=top_context["context"],
+            shrink_to_fit=False,
+            margin=margin,
+        )
+
+        # Check that content is out of page dimensions.
+        await assert_pdf_content(print_value, [{"type": "string", "value": ""}])
+    except Exception as e:
+        # Some implementations are not capable of producing an empty PDF.
+        assert e.args[0] == 'invalid print parameters: content area is empty'
 
 
 @pytest.mark.parametrize(

--- a/webdriver/tests/bidi/browsing_context/print/margin.py
+++ b/webdriver/tests/bidi/browsing_context/print/margin.py
@@ -119,7 +119,7 @@ async def test_margin_same_as_page_dimension(
         await assert_pdf_content(print_value, [{"type": "string", "value": ""}])
     except UnsupportedOperationException:
         # Empty content area: https://github.com/w3c/webdriver-bidi/issues/473
-        ...
+        pass
 
 
 @pytest.mark.parametrize(

--- a/webdriver/tests/bidi/browsing_context/print/margin.py
+++ b/webdriver/tests/bidi/browsing_context/print/margin.py
@@ -1,6 +1,8 @@
 # META: timeout=long
 import pytest
 
+from webdriver.bidi.error import UnsupportedOperationException
+
 pytestmark = pytest.mark.asyncio
 
 
@@ -115,9 +117,9 @@ async def test_margin_same_as_page_dimension(
 
         # Check that content is out of page dimensions.
         await assert_pdf_content(print_value, [{"type": "string", "value": ""}])
-    except Exception as e:
-        # Some implementations are not capable of producing an empty PDF.
-        assert e.args[0] == 'invalid print parameters: content area is empty'
+    except UnsupportedOperationException:
+        # Empty content area: https://github.com/w3c/webdriver-bidi/issues/473
+        ...
 
 
 @pytest.mark.parametrize(

--- a/webdriver/tests/bidi/browsing_context/print/margin.py
+++ b/webdriver/tests/bidi/browsing_context/print/margin.py
@@ -108,18 +108,13 @@ async def test_margin_same_as_page_dimension(
         context=top_context["context"], url=page, wait="complete"
     )
 
-    try:
-        print_value = await bidi_session.browsing_context.print(
+   # This yields and empty content area: https://github.com/w3c/webdriver-bidi/issues/473
+   with pytest.raises(UnsupportedOperationException):
+        await bidi_session.browsing_context.print(
             context=top_context["context"],
             shrink_to_fit=False,
             margin=margin,
         )
-
-        # Check that content is out of page dimensions.
-        await assert_pdf_content(print_value, [{"type": "string", "value": ""}])
-    except UnsupportedOperationException:
-        # Empty content area: https://github.com/w3c/webdriver-bidi/issues/473
-        pass
 
 
 @pytest.mark.parametrize(

--- a/webdriver/tests/bidi/browsing_context/print/margin.py
+++ b/webdriver/tests/bidi/browsing_context/print/margin.py
@@ -139,7 +139,6 @@ async def test_margin_minimum_page_size(
     bidi_session,
     top_context,
     inline,
-    assert_pdf_content,
     assert_pdf_dimensions,
     margin,
 ):
@@ -154,10 +153,13 @@ async def test_margin_minimum_page_size(
         margin=margin
     )
 
-    # Check that margins don't affect page dimensions and equal in this case defaults.
+    expected_width = 21.59 - (0.0 if ("top" in margin or "bottom" in margin) else inch_in_cm / inch_in_point)
+    expected_height = 27.94 - (0.0 if ("left" in margin or "right" in margin) else inch_in_cm / inch_in_point),
+
+    # Check that margins don't affect page dimensions and equal defaults.
     await assert_pdf_dimensions(value, {
-       "width": 21.59 - (0.0 if ("top" in margin or "bottom" in margin) else inch_in_cm / inch_in_point),
-       "height": 27.94 - (0.0 if ("left" in margin or "right" in margin) else inch_in_cm / inch_in_point),
+       "width": expected_width,
+       "height": expected_height,
     })
 
 

--- a/webdriver/tests/bidi/browsing_context/print/margin.py
+++ b/webdriver/tests/bidi/browsing_context/print/margin.py
@@ -1,4 +1,5 @@
 # META: timeout=long
+from math import ceil
 import pytest
 
 from webdriver.bidi.error import UnsupportedOperationException
@@ -109,8 +110,8 @@ async def test_margin_same_as_page_dimension(
         context=top_context["context"], url=page, wait="complete"
     )
 
-   # This yields and empty content area: https://github.com/w3c/webdriver-bidi/issues/473
-   with pytest.raises(UnsupportedOperationException):
+    # This yields and empty content area: https://github.com/w3c/webdriver-bidi/issues/473
+    with pytest.raises(UnsupportedOperationException):
         await bidi_session.browsing_context.print(
             context=top_context["context"],
             shrink_to_fit=False,
@@ -121,10 +122,10 @@ async def test_margin_same_as_page_dimension(
 @pytest.mark.parametrize(
     "margin",
     [
-        {"top": 27.94 - inch_in_cm / inch_in_point},
-        {"left": 21.59 - inch_in_cm / inch_in_point},
-        {"right": 21.59 - inch_in_cm / inch_in_point},
-        {"bottom": 27.94 - inch_in_cm / inch_in_point},
+        {"top": 27.94 - ceil(inch_in_cm / inch_in_point)},
+        {"left": 21.59 - ceil(inch_in_cm / inch_in_point)},
+        {"right": 21.59 - ceil(inch_in_cm / inch_in_point)},
+        {"bottom": 27.94 - ceil(inch_in_cm / inch_in_point)},
     ],
     ids=[
         "top",

--- a/webdriver/tests/bidi/browsing_context/print/margin.py
+++ b/webdriver/tests/bidi/browsing_context/print/margin.py
@@ -7,6 +7,9 @@ from tests.support.image import inch_in_cm, inch_in_point
 
 pytestmark = pytest.mark.asyncio
 
+DEFAULT_PAGE_HEIGHT = 27.94
+DEFAULT_PAGE_WIDTH = 21.59
+
 
 def get_content(css=""):
     return f"""
@@ -86,11 +89,16 @@ async def test_margin_default(
 @pytest.mark.parametrize(
     "margin",
     [
-        {"top": 27.94},
-        {"left": 21.59},
-        {"right": 21.59},
-        {"bottom": 27.94},
-        {"top": 27.94, "left": 21.59, "right": 21.59, "bottom": 27.94},
+        {"top": DEFAULT_PAGE_HEIGHT},
+        {"left": DEFAULT_PAGE_WIDTH},
+        {"right": DEFAULT_PAGE_WIDTH},
+        {"bottom": DEFAULT_PAGE_HEIGHT},
+        {
+            "top": DEFAULT_PAGE_HEIGHT,
+            "left": DEFAULT_PAGE_WIDTH,
+            "right": DEFAULT_PAGE_WIDTH,
+            "bottom": DEFAULT_PAGE_HEIGHT,
+        },
     ],
     ids=[
         "top",
@@ -123,10 +131,10 @@ async def test_margin_same_as_page_dimension(
 @pytest.mark.parametrize(
     "margin",
     [
-        {"top": 27.94 - ceil(inch_in_cm / inch_in_point)},
-        {"left": 21.59 - ceil(inch_in_cm / inch_in_point)},
-        {"right": 21.59 - ceil(inch_in_cm / inch_in_point)},
-        {"bottom": 27.94 - ceil(inch_in_cm / inch_in_point)},
+        {"top": DEFAULT_PAGE_HEIGHT - ceil(inch_in_cm / inch_in_point)},
+        {"left": DEFAULT_PAGE_WIDTH - ceil(inch_in_cm / inch_in_point)},
+        {"right": DEFAULT_PAGE_WIDTH - ceil(inch_in_cm / inch_in_point)},
+        {"bottom": DEFAULT_PAGE_HEIGHT - ceil(inch_in_cm / inch_in_point)},
     ],
     ids=[
         "top",
@@ -154,14 +162,14 @@ async def test_margin_minimum_page_size(
     )
 
     if "top" in margin or "bottom" in margin:
-        expected_width = 21.59
+        expected_width = DEFAULT_PAGE_WIDTH
     else:
-        expected_width = 21.59 - (inch_in_cm / inch_in_point)
+        expected_width = DEFAULT_PAGE_WIDTH - (inch_in_cm / inch_in_point)
 
     if "left" in margin or "right" in margin:
-        expected_height = 27.94
+        expected_height = DEFAULT_PAGE_HEIGHT
     else:
-        expected_height = 27.94 - (inch_in_cm / inch_in_point)
+        expected_height = DEFAULT_PAGE_HEIGHT - (inch_in_cm / inch_in_point)
 
     # Check that margins don't affect page dimensions and equal defaults.
     await assert_pdf_dimensions(value, {
@@ -199,5 +207,9 @@ async def test_margin_does_not_affect_page_size(
         margin=margin
     )
 
-    # Check that margins don't affect page dimensions and equal in this case defaults.
-    await assert_pdf_dimensions(value, {"width": 21.59, "height": 27.94})
+    # Check that margins don't affect page dimensions
+    # and equal in this case defaults.
+    await assert_pdf_dimensions(value, {
+        "width": DEFAULT_PAGE_WIDTH,
+        "height": DEFAULT_PAGE_HEIGHT,
+    })

--- a/webdriver/tests/bidi/browsing_context/print/margin.py
+++ b/webdriver/tests/bidi/browsing_context/print/margin.py
@@ -2,6 +2,7 @@
 import pytest
 
 from webdriver.bidi.error import UnsupportedOperationException
+from tests.support.image import inch_in_cm, inch_in_point
 
 pytestmark = pytest.mark.asyncio
 
@@ -27,22 +28,22 @@ def get_content(css=""):
     "margin, reference_css, css",
     [
         (
-            {"top": 2.54},
+            {"top": inch_in_cm},
             "margin-top: 1.54cm;",
             "",
         ),
         (
-            {"left": 2.54},
+            {"left": inch_in_cm},
             "margin-left: 1.54cm;",
             "",
         ),
         (
-            {"right": 2.54},
+            {"right": inch_in_cm},
             "margin-right: 1.54cm;",
             "",
         ),
         (
-            {"bottom": 2.54},
+            {"bottom": inch_in_cm},
             "height: 24.4cm;",
             "height: 26.94cm;",
         ),
@@ -120,10 +121,10 @@ async def test_margin_same_as_page_dimension(
 @pytest.mark.parametrize(
     "margin",
     [
-        {"top": 27.94 - 2.54 / 72},
-        {"left": 21.59 - 2.54 / 72},
-        {"right": 21.59 - 2.54 / 72},
-        {"bottom": 27.94 - 2.54 / 72},
+        {"top": 27.94 - inch_in_cm / inch_in_point},
+        {"left": 21.59 - inch_in_cm / inch_in_point},
+        {"right": 21.59 - inch_in_cm / inch_in_point},
+        {"bottom": 27.94 - inch_in_cm / inch_in_point},
     ],
     ids=[
         "top",
@@ -152,8 +153,8 @@ async def test_minimum_page_size_with_individual_margins(
 
     # Check that margins don't affect page dimensions and equal in this case defaults.
     await assert_pdf_dimensions(value, {
-       "width": 21.59 - (0.0 if ("top" in margin or "bottom" in margin) else 2.54 / 72),
-       "height": 27.94 - (0.0 if ("left" in margin or "right" in margin) else 2.54 / 72),
+       "width": 21.59 - (0.0 if ("top" in margin or "bottom" in margin) else inch_in_cm / inch_in_point),
+       "height": 27.94 - (0.0 if ("left" in margin or "right" in margin) else inch_in_cm / inch_in_point),
     })
 
 

--- a/webdriver/tests/bidi/browsing_context/print/margin.py
+++ b/webdriver/tests/bidi/browsing_context/print/margin.py
@@ -138,6 +138,7 @@ async def test_minimum_page_size_with_individual_margins(
     top_context,
     inline,
     assert_pdf_content,
+    assert_pdf_dimensions,
     margin,
 ):
     page = inline("Text")

--- a/webdriver/tests/bidi/browsing_context/print/margin.py
+++ b/webdriver/tests/bidi/browsing_context/print/margin.py
@@ -153,8 +153,15 @@ async def test_margin_minimum_page_size(
         margin=margin
     )
 
-    expected_width = 21.59 - (0.0 if ("top" in margin or "bottom" in margin) else inch_in_cm / inch_in_point)
-    expected_height = 27.94 - (0.0 if ("left" in margin or "right" in margin) else inch_in_cm / inch_in_point),
+    if "top" in margin or "bottom" in margin:
+        expected_width = 21.59
+    else:
+        expected_width = 21.59 - (inch_in_cm / inch_in_point)
+
+    if "left" in margin or "right" in margin:
+        expected_height = 27.94
+    else:
+        expected_height = 27.94 - (inch_in_cm / inch_in_point)
 
     # Check that margins don't affect page dimensions and equal defaults.
     await assert_pdf_dimensions(value, {

--- a/webdriver/tests/bidi/browsing_context/print/margin.py
+++ b/webdriver/tests/bidi/browsing_context/print/margin.py
@@ -67,7 +67,9 @@ async def test_margin_default(
 ):
     default_content_page = inline(get_content(css))
     await bidi_session.browsing_context.navigate(
-        context=top_context["context"], url=default_content_page, wait="complete"
+        context=top_context["context"],
+        url=default_content_page,
+        wait="complete"
     )
     value_with_margin = await bidi_session.browsing_context.print(
         context=top_context["context"],
@@ -102,7 +104,6 @@ async def test_margin_same_as_page_dimension(
     bidi_session,
     top_context,
     inline,
-    assert_pdf_content,
     margin,
 ):
     page = inline("Text")
@@ -134,7 +135,7 @@ async def test_margin_same_as_page_dimension(
         "bottom",
     ],
 )
-async def test_minimum_page_size_with_individual_margins(
+async def test_margin_minimum_page_size(
     bidi_session,
     top_context,
     inline,

--- a/webdriver/tests/bidi/browsing_context/print/margin.py
+++ b/webdriver/tests/bidi/browsing_context/print/margin.py
@@ -110,7 +110,7 @@ async def test_margin_same_as_page_dimension(
         context=top_context["context"], url=page, wait="complete"
     )
 
-    # This yields and empty content area: https://github.com/w3c/webdriver-bidi/issues/473
+    # This yields an empty content area: https://github.com/w3c/webdriver-bidi/issues/473
     with pytest.raises(UnsupportedOperationException):
         await bidi_session.browsing_context.print(
             context=top_context["context"],

--- a/webdriver/tests/bidi/browsing_context/print/margin.py
+++ b/webdriver/tests/bidi/browsing_context/print/margin.py
@@ -120,6 +120,46 @@ async def test_margin_same_as_page_dimension(
 @pytest.mark.parametrize(
     "margin",
     [
+        {"top": 27.94 - 2.54 / 72},
+        {"left": 21.59 - 2.54 / 72},
+        {"right": 21.59 - 2.54 / 72},
+        {"bottom": 27.94 - 2.54 / 72},
+    ],
+    ids=[
+        "top",
+        "left",
+        "right",
+        "bottom",
+    ],
+)
+async def test_minimum_page_size_with_individual_margins(
+    bidi_session,
+    top_context,
+    inline,
+    assert_pdf_content,
+    margin,
+):
+    page = inline("Text")
+    await bidi_session.browsing_context.navigate(
+        context=top_context["context"], url=page, wait="complete"
+    )
+
+    value = await bidi_session.browsing_context.print(
+        context=top_context["context"],
+        shrink_to_fit=False,
+        margin=margin
+    )
+
+    # Check that margins don't affect page dimensions and equal in this case defaults.
+    await assert_pdf_dimensions(value, {
+       "width": 21.59 - (0.0 if ("top" in margin or "bottom" in margin) else 2.54 / 72),
+       "height": 27.94 - (0.0 if ("left" in margin or "right" in margin) else 2.54 / 72),
+    })
+
+
+@pytest.mark.parametrize(
+    "margin",
+    [
         {},
         {"top": 0, "left": 0, "right": 0, "bottom": 0},
         {"top": 2, "left": 2, "right": 2, "bottom": 2}
@@ -146,5 +186,5 @@ async def test_margin_does_not_affect_page_size(
         margin=margin
     )
 
-    # Check that margins don't affect page dimencions and equal in this case defaults.
+    # Check that margins don't affect page dimensions and equal in this case defaults.
     await assert_pdf_dimensions(value, {"width": 21.59, "height": 27.94})

--- a/webdriver/tests/bidi/browsing_context/print/margin.py
+++ b/webdriver/tests/bidi/browsing_context/print/margin.py
@@ -21,7 +21,7 @@ def get_content(css=""):
             }}
             div {{
                 background-color: black;
-                height: 27.94cm;
+                height: {DEFAULT_PAGE_HEIGHT}cm;
                 {css}
             }}
         </style>

--- a/webdriver/tests/support/image.py
+++ b/webdriver/tests/support/image.py
@@ -17,6 +17,10 @@ def px_to_cm(px: float) -> float:
     return px * inch_in_cm / inch_in_pixel
 
 
+def pt_to_cm(pt: float) -> float:
+    return pt * inch_in_cm / inch_in_point
+
+
 def png_dimensions(screenshot) -> Tuple[int, int]:
     image = assert_png(screenshot)
     width, height = struct.unpack(">LL", image[16:24])

--- a/webdriver/tests/support/image.py
+++ b/webdriver/tests/support/image.py
@@ -6,6 +6,7 @@ from tests.support.asserts import assert_png
 
 PPI = 96
 inch_in_cm = 2.54
+inch_in_point = 72
 
 
 def cm_to_px(cm: float) -> float:

--- a/webdriver/tests/support/image.py
+++ b/webdriver/tests/support/image.py
@@ -4,17 +4,17 @@ from typing import NamedTuple, Tuple
 from tests.support.asserts import assert_png
 
 
-PPI = 96
 inch_in_cm = 2.54
+inch_in_pixel = 96
 inch_in_point = 72
 
 
 def cm_to_px(cm: float) -> float:
-    return round(cm * PPI / inch_in_cm)
+    return round(cm * inch_in_pixel / inch_in_cm)
 
 
 def px_to_cm(px: float) -> float:
-    return px * inch_in_cm / PPI
+    return px * inch_in_cm / inch_in_pixel
 
 
 def png_dimensions(screenshot) -> Tuple[int, int]:


### PR DESCRIPTION
Content area with less than 1x1 point should fail.

Spec: https://github.com/w3c/webdriver-bidi/pull/522
Closes: #40870