### PR TITLE
Webdriver tests should default to use the HTTPS protocol

### DIFF
--- a/webdriver/tests/bidi/browsing_context/navigate/error.py
+++ b/webdriver/tests/bidi/browsing_context/navigate/error.py
@@ -9,8 +9,8 @@ pytestmark = pytest.mark.asyncio
     "url",
     [
         "thisprotocoldoesnotexist://",
-        "http://doesnotexist.localhost/",
-        "http://localhost:0",
+        "https://doesnotexist.localhost/",
+        "https://localhost:0",
     ],
     ids=[
         "protocol",

--- a/webdriver/tests/bidi/browsing_context/navigate/invalid.py
+++ b/webdriver/tests/bidi/browsing_context/navigate/invalid.py
@@ -28,11 +28,12 @@ async def test_params_url_invalid_type(bidi_session, new_tab, value):
         )
 
 
-@pytest.mark.parametrize("value", ["http://:invalid", "http://#invalid"])
-async def test_params_url_invalid_value(bidi_session, new_tab, value):
+@pytest.mark.parametrize("protocol", ["http", "https"])
+@pytest.mark.parametrize("value", [":invalid", "#invalid"])
+async def test_params_url_invalid_value(bidi_session, new_tab, protocol, value):
     with pytest.raises(error.InvalidArgumentException):
         await bidi_session.browsing_context.navigate(
-            context=new_tab["context"], url=value
+            context=new_tab["context"], url=f"{protocol}://{value}"
         )
 
 

--- a/webdriver/tests/classic/add_cookie/add.py
+++ b/webdriver/tests/classic/add_cookie/add.py
@@ -121,7 +121,7 @@ def test_add_domain_cookie(session, url, server_config):
         cookie["domain"] == ".%s" % server_config["browser_host"]
 
 
-def test_add_cookie_for_ip(session, url, server_config, configuration):
+def test_add_cookie_for_ip(session, server_config):
     new_cookie = {
         "name": "hello",
         "value": "world",
@@ -131,7 +131,9 @@ def test_add_cookie_for_ip(session, url, server_config, configuration):
         "secure": False
     }
 
-    session.url = "http://127.0.0.1:%s/common/blank.html" % (server_config["ports"]["http"][0])
+    port = server_config["ports"]["http"][0]
+    session.url = f"http://127.0.0.1:{port}/common/blank.html"
+
     clear_all_cookies(session)
 
     result = add_cookie(session, new_cookie)

--- a/webdriver/tests/classic/element_click/navigate.py
+++ b/webdriver/tests/classic/element_click/navigate.py
@@ -14,53 +14,47 @@ def element_click(session, element):
             element_id=element.id))
 
 
-def test_numbers_link(session, server_config, inline):
+def test_numbers_link(session, inline, url):
     link = "/webdriver/tests/classic/element_click/support/input.html"
-    session.url = inline("<a href={url}>123456</a>".format(url=link))
+    session.url = inline(f"<a href={link}>123456</a>")
     element = session.find.css("a", all=False)
     response = element_click(session, element)
     assert_success(response)
-    host = server_config["browser_host"]
-    port = server_config["ports"]["http"][0]
 
-    assert session.url == "http://{host}:{port}{url}".format(host=host, port=port, url=link)
+    assert session.url == url(link)
 
 
-def test_multi_line_link(session, server_config, inline):
+def test_multi_line_link(session, inline, url):
     link = "/webdriver/tests/classic/element_click/support/input.html"
-    session.url = inline("""
+    session.url = inline(f"""
         <p style="background-color: yellow; width: 50px;">
-            <a href={url}>Helloooooooooooooooooooo Worlddddddddddddddd</a>
-        </p>""".format(url=link))
+            <a href={link}>Helloooooooooooooooooooo Worlddddddddddddddd</a>
+        </p>""")
     element = session.find.css("a", all=False)
     response = element_click(session, element)
     assert_success(response)
-    host = server_config["browser_host"]
-    port = server_config["ports"]["http"][0]
 
-    assert session.url == "http://{host}:{port}{url}".format(host=host, port=port, url=link)
+    assert session.url == url(link)
 
 
-def test_link_unload_event(session, server_config, inline):
+def test_link_unload_event(session, url, server_config, inline):
     link = "/webdriver/tests/classic/element_click/support/input.html"
-    session.url = inline("""
+    session.url = inline(f"""
         <body onunload="checkUnload()">
-            <a href={url}>click here</a>
-            <input type=checkbox>
+            <a href="{link}">click here</a>
+            <input type="checkbox">
             <script>
                 function checkUnload() {{
                     document.getElementsByTagName("input")[0].checked = true;
                 }}
             </script>
-        </body>""".format(url=link))
+        </body>""")
 
     element = session.find.css("a", all=False)
     response = element_click(session, element)
     assert_success(response)
 
-    host = server_config["browser_host"]
-    port = server_config["ports"]["http"][0]
-    assert session.url == "http://{host}:{port}{url}".format(host=host, port=port, url=link)
+    assert session.url == url(link)
 
     session.back()
 

--- a/webdriver/tests/support/fixtures.py
+++ b/webdriver/tests/support/fixtures.py
@@ -201,7 +201,7 @@ def current_session():
 
 @pytest.fixture
 def url(server_config):
-    def url(path, protocol="http", domain="", subdomain="", query="", fragment=""):
+    def url(path, protocol="https", domain="", subdomain="", query="", fragment=""):
         domain = server_config["domains"][domain][subdomain]
         port = server_config["ports"][protocol][0]
         host = "{0}:{1}".format(domain, port)

--- a/webdriver/tests/support/http_handlers/authentication.py
+++ b/webdriver/tests/support/http_handlers/authentication.py
@@ -1,12 +1,12 @@
 from urllib.parse import urlencode
 
 
-def basic_authentication(url, protocol="http"):
+def basic_authentication(url, **kwargs):
     query = {}
 
     return url("/webdriver/tests/support/http_handlers/authentication.py",
                query=urlencode(query),
-               protocol=protocol)
+               **kwargs)
 
 
 def main(request, response):


### PR DESCRIPTION
This converts all the usages of HTTP to HTTPS by default. Some tests will still use HTTP to test non-secure connections like the navigation tests.

Closes #28847.