### PR TITLE
Do not check contents of fetch exception message

### DIFF
--- a/service-workers/service-worker/fetch-error.https.html
+++ b/service-workers/service-worker/fetch-error.https.html
@@ -21,12 +21,8 @@ promise_test(async (test) => {
     const iframe = await with_iframe(scope);
     test.add_cleanup(() => iframe.remove());
     const response = await iframe.contentWindow.fetch("fetch-error-test");
-    try {
-      await response.text();
-      assert_unreached();
-    } catch (error) {
-      assert_true(error.message.includes("Sorry"));
-    }
+    return promise_rejects_js(test, iframe.contentWindow.TypeError,
+                              response.text(), 'text() should reject');
 }, "Make sure a load that makes progress does not time out");
 </script>
 </body>


### PR DESCRIPTION
The services-workers/service-worker/fetch-error.https.html made an assertion about the contents of the message on the exception raised by response.text(), however the standard only guarantees that the exception be a TypeError and makes no guarantees about its contents.

Relax the assertion to only require a TypeError.

See https://crbug.com/1017861.