### PR TITLE
[url] Add tests for trailing spaces on setters

### DIFF
--- a/url/resources/setters_tests.json
+++ b/url/resources/setters_tests.json
@@ -2021,6 +2021,24 @@
                 "href": "sc:/space%20",
                 "pathname": "/space%20"
             }
+        },
+        {
+            "comment": "Trailing space should be encoded",
+            "href": "http://example.net",
+            "new_value": " ",
+            "expected": {
+                "href": "http://example.net/%20",
+                "pathname": "/%20"
+            }
+        },
+        {
+            "comment": "Trailing C0 control should be encoded",
+            "href": "http://example.net",
+            "new_value": "\u0000",
+            "expected": {
+                "href": "http://example.net/%00",
+                "pathname": "/%00"
+            }
         }
     ],
     "search": [
@@ -2140,6 +2158,24 @@
             "expected": {
                 "href": "sc:space  #fragment",
                 "search": ""
+            }
+        },
+        {
+            "comment": "Trailing space should be encoded",
+            "href": "http://example.net",
+            "new_value": " ",
+            "expected": {
+                "href": "http://example.net/?%20",
+                "search": "?%20"
+            }
+        },
+        {
+            "comment": "Trailing C0 control should be encoded",
+            "href": "http://example.net",
+            "new_value": "\u0000",
+            "expected": {
+                "href": "http://example.net/?%00",
+                "search": "?%00"
             }
         }
     ],
@@ -2310,6 +2346,24 @@
             "expected": {
                 "href": "sc:space  ?query",
                 "hash": ""
+            }
+        },
+        {
+            "comment": "Trailing space should be encoded",
+            "href": "http://example.net",
+            "new_value": " ",
+            "expected": {
+                "href": "http://example.net/#%20",
+                "hash": "#%20"
+            }
+        },
+        {
+            "comment": "Trailing C0 control should be encoded",
+            "href": "http://example.net",
+            "new_value": "\u0000",
+            "expected": {
+                "href": "http://example.net/#%00",
+                "hash": "#%00"
             }
         }
     ],


### PR DESCRIPTION
Adding some tests around trailing spaces and C0 control characters for pathname,
search, and hash setters, because some implementations incorrectly strip them.

Simplified test case:

```js
const url = new URL('http://example.com/');
url.pathname = '/ ';
url.search = '? ';
url.hash = '# ';
console.log(url.href);
```

Implementations:

```js
// whatwg-url@13.0.0
"http://example.com/%20?%20#%20" ✅

// Chrome 117.0.5881.0
"http://example.com/%20?%20#%20" ✅

// Firefox 114.0.2
"http://example.com/%20?%20#%20" ✅

// Safari TP 171
"http://example.com/?#%20" ❌

// Deno 1.35.0
"http://example.com/?%20#%20" ❌

// node@20.4.0
"http://example.com/%20?%20#%20" ✅
```
