### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=258813

### DIFF
--- a/css/css-logical/animations/padding-block-interpolation.html
+++ b/css/css-logical/animations/padding-block-interpolation.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>padding-block interpolation</title>
+<link rel="help" href="https://drafts.csswg.org/css-logical/#propdef-padding-block">
+<meta name="assert" content="padding-block supports animation">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/interpolation-testcommon.js"></script>
+
+<body>
+<script>
+test_interpolation({
+  property: 'padding-block',
+  from: '10px',
+  to: '20px',
+}, [
+  {at: -0.3, expect: '7px'},
+  {at: 0, expect: '10px'},
+  {at: 0.3, expect: '13px'},
+  {at: 0.6, expect: '16px'},
+  {at: 1, expect: '20px'},
+  {at: 1.5, expect: '25px'},
+]);
+</script>
+</body>

--- a/css/css-logical/animations/padding-inline-interpolation.html
+++ b/css/css-logical/animations/padding-inline-interpolation.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>padding-inline interpolation</title>
+<link rel="help" href="https://drafts.csswg.org/css-logical/#propdef-padding-inline">
+<meta name="assert" content="padding-inline supports animation">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/interpolation-testcommon.js"></script>
+
+<body>
+<script>
+test_interpolation({
+  property: 'padding-inline',
+  from: '10px',
+  to: '20px',
+}, [
+  {at: -0.3, expect: '7px'},
+  {at: 0, expect: '10px'},
+  {at: 0.3, expect: '13px'},
+  {at: 0.6, expect: '16px'},
+  {at: 1, expect: '20px'},
+  {at: 1.5, expect: '25px'},
+]);
+</script>
+</body>


### PR DESCRIPTION
WebKit export from bug: [Animation using padding-block doesnt override set padding style](https://bugs.webkit.org/show_bug.cgi?id=258813)