### PR TITLE
c-v: auto descendant in dialog is shown on showModal

### DIFF
--- a/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-and-auto-descendant-ref.html
+++ b/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-and-auto-descendant-ref.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf8">
+<title>CSS Content Visibility: content-visibility: auto descendant in popover is shown on showPopover"</title>
+<meta name="assert" content="content-visibility: auto descendant in popover is shown on showPopover">
+
+<div id="spacer" style="height: 100vh"></div>
+<div popover="manual" style="display: block; position: static;" id="popover">
+  <span>Test passes if this is visible</span>
+</div>
+
+<script>
+  popover.showPopover();
+</script>

--- a/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-and-auto-descendant.html
+++ b/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-and-auto-descendant.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html class="reftest-wait">
 <meta charset="utf8">
-<title>CSS Content Visibility: content-visibility: auto descendant in dialog is shown on showModal</title>
+<title>CSS Content Visibility: content-visibility: auto descendant in popover is shown on showPopover</title>
 <link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
-<link rel="match" href="content-visibility-with-top-layer-and-auto-descendant-ref.html">
-<meta name="assert" content="content-visibility: auto descendant in dialog is shown on showModal">
+<link rel="match" href="content-visibility-with-popover-top-layer-and-auto-descendant-ref.html">
+<meta name="assert" content="content-visibility: auto descendant in popover is shown on showPopover">
 <script src="/common/reftest-wait.js"></script>
 
 <style>
@@ -16,13 +16,13 @@
 </style>
 
 <div id="spacer" style="height: 100vh"></div>
-<dialog id="dialog" style="display: block; position: static;">
+<div popover="manual" style="display: block; position: static;" id="popover">
   <span id="inner">Test passes if this is visible</span>
-</dialog>
+</div>
 
 <script>
 function runTest() {
-  dialog.showModal();
+  popover.showPopover();
   requestAnimationFrame(takeScreenshot);
 }
 

--- a/css/css-contain/content-visibility/content-visibility-with-top-layer-and-auto-descendant-ref.html
+++ b/css/css-contain/content-visibility/content-visibility-with-top-layer-and-auto-descendant-ref.html
@@ -1,13 +1,13 @@
 <!doctype html>
 <meta charset="utf8">
-<title>CSS Content Visibility: content-visibility: auto descendant in popover is shown on showPopover"</title>
-<meta name="assert" content="content-visibility: auto descendant in popover is shown on showPopover">
+<title>CSS Content Visibility: content-visibility: auto descendant in dialog is shown on showModal"</title>
+<meta name="assert" content="content-visibility: auto descendant in dialog is shown on showModal">
 
 <div id="spacer" style="height: 100vh"></div>
-<div popover="manual" style="display: block; position: static;" id="popover">
+<dialog id="dialog" style="display: block; position: static;">
   <span>Test passes if this is visible</span>
-</div>
+</dialog>
 
 <script>
-  popover.showPopover();
+  dialog.showModal();
 </script>


### PR DESCRIPTION
Verify that content-visibility: auto descendant in dialog is shown on showModal.

Also rename the previous equivalent test that was testing popover instead of dialog.