### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=259140

### DIFF
--- a/css/css-logical/animations/margin-block-interpolation.html
+++ b/css/css-logical/animations/margin-block-interpolation.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>margin-block interpolation</title>
+<link rel="help" href="https://drafts.csswg.org/css-logical/#propdef-margin-block">
+<meta name="assert" content="margin-block supports animation">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/interpolation-testcommon.js"></script>
+
+<body>
+<script>
+test_interpolation({
+  property: 'margin-block',
+  from: '10px',
+  to: '20px',
+}, [
+  {at: -0.3, expect: '7px'},
+  {at: 0, expect: '10px'},
+  {at: 0.3, expect: '13px'},
+  {at: 0.6, expect: '16px'},
+  {at: 1, expect: '20px'},
+  {at: 1.5, expect: '25px'},
+]);
+</script>
+</body>

--- a/css/css-logical/animations/margin-inline-interpolation.html
+++ b/css/css-logical/animations/margin-inline-interpolation.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>margin-inline interpolation</title>
+<link rel="help" href="https://drafts.csswg.org/css-logical/#propdef-margin-inline">
+<meta name="assert" content="margin-inline supports animation">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/interpolation-testcommon.js"></script>
+
+<body>
+<script>
+test_interpolation({
+  property: 'margin-inline',
+  from: '10px',
+  to: '20px',
+}, [
+  {at: -0.3, expect: '7px'},
+  {at: 0, expect: '10px'},
+  {at: 0.3, expect: '13px'},
+  {at: 0.6, expect: '16px'},
+  {at: 1, expect: '20px'},
+  {at: 1.5, expect: '25px'},
+]);
+</script>
+</body>


### PR DESCRIPTION
WebKit export from bug: [\[css-logical\] add animation support to margin logical property shorthands](https://bugs.webkit.org/show_bug.cgi?id=259140)