### PR TITLE
Add test expectation file for test_win_open_with_interaction

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/test_win_open_with_interaction.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/test_win_open_with_interaction.html.ini
@@ -1,0 +1,5 @@
+[test_win_open_with_interaction.html]
+  expected: [OK, TIMEOUT]
+
+  [Tests pointer move/click in a window opened with `window.open.`]
+    expected: [FAIL, TIMEOUT, PASS]


### PR DESCRIPTION
Add test expectation. I've observed the test to fail, timeout on all browsers but occasionally pass on chrome for mac.
This is needed to unblock https://github.com/web-platform-tests/wpt/pull/40478.