### PR TITLE
Update forced-colors-mode as it applies to pseudo highlights

### DIFF
--- a/forced-colors-mode/forced-colors-mode-14-ref.html
+++ b/forced-colors-mode/forced-colors-mode-14-ref.html
@@ -16,7 +16,7 @@
   }
 </style>
 <body>
-  <span class="select">AAA</span>
-  <br>
   <span class="select" id="adjust-none">AAA</span>
+  <br>
+  <span class="select">AAA</span>
 </body>

--- a/forced-colors-mode/forced-colors-mode-14.html
+++ b/forced-colors-mode/forced-colors-mode-14.html
@@ -4,6 +4,7 @@
   Forced colors mode - active selection.
 </title>
 <link rel="help" href="https://www.w3.org/TR/css-color-adjust-1/#forced-colors-properties">
+<link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-styling">
 <link rel=match href="forced-colors-mode-14-ref.html">
 <style>
   br::selection {
@@ -19,14 +20,30 @@
     background-color: rgba(255, 0, 0, 0.99); /* alpha < 1 so that we don't blend the background color with white. */
     color: blue;
   }
-  #adjust-none::selection {
+  #adjust-none {
     forced-color-adjust: none;
   }
+  #adjust-none-on-highlight::selection {
+    forced-color-adjust: none;
+  }
+
+  <!--
+  "
+  The forced-color-adjust property cannot be set on highlight pseudo-elements;
+  however a highlight pseudo-element must honor any forced colors mode applied
+  to its originating element (and is therefore subject to the control of the
+  originating element’s forced-color-adjust value).
+  "
+  coming from
+  https://www.w3.org/TR/css-pseudo-4/#highlight-styling
+  -->
+
 </style>
 <body>
-  <span class="select">AAA</span>
-  <br>
-  <span class="select" id="adjust-none">AAA</span>
+  <div id="adjust-none">
+    <span class="select">AAA</span>
+  </div>
+  <span id="adjust-none-on-highlight" class="select">AAA</span>
 </body>
 
 <script>


### PR DESCRIPTION
Updating the test to match the spec as of this change: https://github.com/w3c/csswg-drafts/issues/7264

See: https://www.w3.org/TR/css-pseudo-4/#highlight-styling

> The [forced-color-adjust](https://www.w3.org/TR/css-color-adjust-1/#propdef-forced-color-adjust) property cannot be set on [highlight pseudo-elements](https://www.w3.org/TR/css-pseudo-4/#highlight-pseudo-element); however a highlight pseudo-element must honor any [forced colors mode](https://www.w3.org/TR/css-color-adjust-1/#forced-colors-mode) applied to its [originating element](https://www.w3.org/TR/selectors-4/#originating-element) (and is therefore subject to the control of the originating element’s forced-color-adjust value).