### PR TITLE
Add missing scrollbar-color on two scrollbar-color refs

### DIFF
--- a/css/css-scrollbars/scrollbar-color-007-ref.html
+++ b/css/css-scrollbars/scrollbar-color-007-ref.html
@@ -10,6 +10,7 @@
     padding: 0px;
     border: none;
     background: deepskyblue;
+    scrollbar-color: yellow blue;
   }
 
   .content {

--- a/css/css-scrollbars/scrollbar-color-008-ref.html
+++ b/css/css-scrollbars/scrollbar-color-008-ref.html
@@ -10,6 +10,7 @@
     padding: 0px;
     border: none;
     background: deepskyblue;
+    scrollbar-color: yellow blue;
   }
 
   .content {


### PR DESCRIPTION
This was an oversight in the original patch that added these tests. They passed in WebKit due to the incomplete scrollbar-color implementation. Sorry!