### PR TITLE
Add `X-Content-Type-Options: nosniff` header to download_stash.py

### DIFF
--- a/html/semantics/embedded-content/the-iframe-element/support/download_stash.py
+++ b/html/semantics/embedded-content/the-iframe-element/support/download_stash.py
@@ -4,6 +4,11 @@ def main(request, response):
     token = request.GET[b"token"]
     response.status = 200
     response.headers.append(b"Content-Type", b"text/html")
+
+    # Make sure to disable sniffing because it would read enough bytes to finish
+    # the load, before even giving the client application a chance to cancel it.
+    response.headers.append(b"X-Content-Type-Options", b"nosniff")
+
     if b"verify-token" in request.GET:
       if request.server.stash.take(token):
         return u'TOKEN_SET'


### PR DESCRIPTION
The page serves the "text/html" Content-Type, which triggers sniffing in CFNetwork. As a result, CFNetwork will read 512 bytes before telling the client about the network response.

In the context of this test, 512 bytes means CFNetwork finishes the whole load before even notifying the client of the response and thus allowing the client to cancel. This means that CFNetwork clients like WebKit on Apple platforms finish the load and that the token gets set, even if the client rejected the download and tried to cancel the load.

Add the `X-Content-Type-Options: nosniff` to disable sniffing, to make sure that the network response doesn't get delayed and so that clients have a chance to cancel the load before it completes.