### PR TITLE
WebDriver BiDi: add tests for background in browsingContext.create

### DIFF
--- a/tools/webdriver/webdriver/bidi/modules/browsing_context.py
+++ b/tools/webdriver/webdriver/bidi/modules/browsing_context.py
@@ -33,11 +33,15 @@ class BrowsingContext(BidiModule):
     @command
     def create(self,
                type_hint: str,
-               reference_context: Optional[str] = None) -> Mapping[str, Any]:
+               reference_context: Optional[str] = None,
+               background: Optional[bool] = None) -> Mapping[str, Any]:
         params: MutableMapping[str, Any] = {"type": type_hint}
 
         if reference_context is not None:
             params["referenceContext"] = reference_context
+
+        if background is not None:
+            params["background"] = background
 
         return params
 

--- a/webdriver/tests/bidi/browsing_context/__init__.py
+++ b/webdriver/tests/bidi/browsing_context/__init__.py
@@ -1,3 +1,7 @@
+from typing import Any, Mapping
+
+from webdriver.bidi.modules.script import ContextTarget
+
 from .. import (
     any_int,
     any_string,
@@ -64,3 +68,13 @@ def assert_navigation_info(event, expected_navigation_info):
 
     if "url" in expected_navigation_info:
         assert event["url"] == expected_navigation_info["url"]
+
+
+async def get_visibility_state(bidi_session, context: Mapping[str, Any]) -> str:
+    result = await bidi_session.script.call_function(
+        function_declaration="""() => {
+        return document.visibilityState;
+    }""",
+        target=ContextTarget(context["context"]),
+        await_promise=False)
+    return result["value"]

--- a/webdriver/tests/bidi/browsing_context/activate/__init__.py
+++ b/webdriver/tests/bidi/browsing_context/activate/__init__.py
@@ -3,16 +3,6 @@ from typing import Any, Mapping
 from webdriver.bidi.modules.script import ContextTarget
 
 
-async def get_visibility_state(bidi_session, context: Mapping[str, Any]) -> str:
-    result = await bidi_session.script.call_function(
-        function_declaration="""() => {
-        return document.visibilityState;
-    }""",
-        target=ContextTarget(context["context"]),
-        await_promise=False)
-    return result["value"]
-
-
 async def is_selector_focused(bidi_session, context: Mapping[str, Any], selector: str) -> bool:
     result = await bidi_session.script.call_function(
         function_declaration="""(selector) => {

--- a/webdriver/tests/bidi/browsing_context/create/background.py
+++ b/webdriver/tests/bidi/browsing_context/create/background.py
@@ -1,0 +1,23 @@
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+from .. import get_visibility_state
+
+@pytest.mark.parametrize("type_hint", ["tab", "window"])
+async def test_background_default_false(bidi_session, type_hint):
+    new_context = await bidi_session.browsing_context.create(type_hint=type_hint)
+
+    assert await get_visibility_state(bidi_session, new_context) == "visible"
+
+    await bidi_session.browsing_context.close(context=new_context["context"])
+
+
+@pytest.mark.parametrize("type_hint", ["tab", "window"])
+@pytest.mark.parametrize("background", [True, False])
+async def test_background(bidi_session, type_hint, background):
+    new_context = await bidi_session.browsing_context.create(type_hint=type_hint, background=background)
+
+    assert await get_visibility_state(bidi_session, new_context) == ("hidden" if background else "visible")
+
+    await bidi_session.browsing_context.close(context=new_context["context"])

--- a/webdriver/tests/bidi/browsing_context/create/background.py
+++ b/webdriver/tests/bidi/browsing_context/create/background.py
@@ -8,9 +8,10 @@ from .. import get_visibility_state
 async def test_background_default_false(bidi_session, type_hint):
     new_context = await bidi_session.browsing_context.create(type_hint=type_hint)
 
-    assert await get_visibility_state(bidi_session, new_context) == "visible"
-
-    await bidi_session.browsing_context.close(context=new_context["context"])
+    try:
+      assert await get_visibility_state(bidi_session, new_context) == "visible"
+    finally:
+      await bidi_session.browsing_context.close(context=new_context["context"])
 
 
 @pytest.mark.parametrize("type_hint", ["tab", "window"])
@@ -18,6 +19,7 @@ async def test_background_default_false(bidi_session, type_hint):
 async def test_background(bidi_session, type_hint, background):
     new_context = await bidi_session.browsing_context.create(type_hint=type_hint, background=background)
 
-    assert await get_visibility_state(bidi_session, new_context) == ("hidden" if background else "visible")
-
-    await bidi_session.browsing_context.close(context=new_context["context"])
+    try:
+      assert await get_visibility_state(bidi_session, new_context) == ("hidden" if background else "visible")
+    finally:
+      await bidi_session.browsing_context.close(context=new_context["context"])

--- a/webdriver/tests/bidi/browsing_context/create/invalid.py
+++ b/webdriver/tests/bidi/browsing_context/create/invalid.py
@@ -51,3 +51,9 @@ async def test_params_type_invalid_type(bidi_session, value):
 async def test_params_type_invalid_value(bidi_session, value):
     with pytest.raises(error.InvalidArgumentException):
         await bidi_session.browsing_context.create(type_hint=value)
+
+
+@pytest.mark.parametrize("value", [None, '', 42, {}, []])
+async def test_params_background_invalid_type(bidi_session, value):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.browsing_context.create(type_hint="tab", background = value)


### PR DESCRIPTION
Also, moves the get_visibility_state helper to the browsing_context folder level.

- [x] tests the default value to be false (foreground) for tab and window
- [x] tests explicitly set background for tab and window
- [x] invalid type tests