### PR TITLE
Improved 12 background-origin-* tests and created 12 related references

### DIFF
--- a/css/css-backgrounds/background-origin/origin-border-box.html
+++ b/css/css-backgrounds/background-origin/origin-border-box.html
@@ -5,41 +5,29 @@
   <title>CSS Backgrounds Test:  background-origin:border-box</title>
   <link rel="author" title="finscn" href="mailto:finscn@gmail.com" >
   <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-origin" >
-  <meta name="flags" content="image">
-  <meta name="assert" content="border-box : The position is relative to the border box." >
+  <meta name="flags" content="">
+  <link rel="match" href="../reference/origin-border-box-ref.html">
 
 
 
 <style type="text/css">
 
-  .infomation {
-    padding : 10px;
-    font-size : 16pt;
-    margin : 5px;
-  }
-
-  .test-case {
-    padding : 5px;
-    margin : 5px;
-  }
-
-  .view {
-    border : 30px solid rgba(60,150,255,0.4);
-    width : 320px;
-    height : 240px;
-    padding : 30px;
-    margin : 10px;
-    font-size : 16pt;
-    color : #ff9933;
+  div {
+    border : 16px solid rgba(60,150,255,0.4);
+    width : 450px;
+    height : 224px;
+    padding : 16px;
+    margin-top : 8px;
     background-image : url("../support/css3.png");
+    background-origin : border-box;
   }
 
   .no-repeat {
     background-repeat : no-repeat;
   }
 
-  .case {
-    background-origin : border-box;
+  .repeat {
+    background-repeat : repeat;
   }
 
 </style>
@@ -47,22 +35,9 @@
 </head>
 <body>
 
-<div class="infomation">
-Test Passed If : The background is painted. The paint area includes the area covered by border , and the area surrounded by border.<br>
-</div>
+  <div class="no-repeat" ></div>
 
-<div class="test-case">
-
-  <div class="view case no-repeat" >
-      Test background-origin
-  </div>
-
-  <div class="view case" >
-      Test background-origin
-  </div>
-
-
-</div>
+  <div class="repeat" ></div>
 
 </body>
 

--- a/css/css-backgrounds/background-origin/origin-border-box_with_position.html
+++ b/css/css-backgrounds/background-origin/origin-border-box_with_position.html
@@ -5,68 +5,39 @@
   <title>CSS Backgrounds Test:  background-origin:border-box & background-position</title>
   <link rel="author" title="finscn" href="mailto:finscn@gmail.com" >
   <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-origin" >
-  <meta name="flags" content="image">
-  <meta name="assert" content="border-box : The position is relative to the border box." >
+  <meta name="flags" content="">
+  <link rel="match" href="../reference/origin-border-box_with_position-ref.html">
 
   <meta charset="utf-8">
 
 
 <style type="text/css">
 
-  .infomation {
-    padding : 10px;
-    font-size : 16pt;
-    margin : 5px;
-  }
-
-  .test-case {
-    padding : 5px;
-    margin : 5px;
-  }
-
-  .view {
-    border : 30px solid rgba(60,150,255,0.4);
-    width : 320px;
-    height : 240px;
-    padding : 30px;
-    margin : 10px;
-    font-size : 16pt;
-    color : #ff9933;
+  div {
+    border : 16px solid rgba(60,150,255,0.4);
+    width : 450px;
+    height : 224px;
+    padding : 16px;
+    margin-top : 8px;
     background-image : url("../support/css3.png");
+    background-origin : border-box;
+    background-position: -15px -15px;
   }
 
   .no-repeat {
     background-repeat : no-repeat;
   }
 
-  .case {
-    background-origin : border-box;
-    background-position: -15px -15px;
+  .repeat {
+    background-repeat : repeat;
   }
 
-
- </style>
+</style>
 
 </head>
 <body>
 
-<div class="infomation">
-Test Passed If : The background is painted. The paint area includes the area covered by border , and the area surrounded by border.<br>
-When background-position is enabled, the browser should paint the background correctly.
-</div>
-
-<div class="test-case">
-
-  <div class="view case no-repeat" >
-      Test background-origin:
-  </div>
-
-  <div class="view case" >
-      Test background-origin:
-  </div>
-
-
-</div>
+  <div class="no-repeat" ></div>
 
 </body>
 

--- a/css/css-backgrounds/background-origin/origin-border-box_with_radius.html
+++ b/css/css-backgrounds/background-origin/origin-border-box_with_radius.html
@@ -5,68 +5,41 @@
   <title>CSS Backgrounds Test:  background-origin:border-box & border-radius</title>
   <link rel="author" title="finscn" href="mailto:finscn@gmail.com" >
   <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-origin" >
-  <meta name="flags" content="image">
-  <meta name="assert" content="border-box : The position is relative to the border box." >
+  <meta name="flags" content="">
+  <link rel="match" href="../reference/origin-border-box_with_radius-ref.html">
 
   <meta charset="utf-8">
 
 
 <style type="text/css">
 
-  .infomation {
-    padding : 10px;
-    font-size : 16pt;
-    margin : 5px;
-  }
-
-  .test-case {
-    padding : 5px;
-    margin : 5px;
-  }
-
-  .view {
-    border : 30px solid rgba(60,150,255,0.4);
-    width : 320px;
-    height : 240px;
-    padding : 30px;
-    margin : 10px;
-    font-size : 16pt;
-    color : #ff9933;
+  div {
+    border : 16px solid rgba(60,150,255,0.4);
+    width : 450px;
+    height : 224px;
+    padding : 16px;
+    margin-top : 8px;
     background-image : url("../support/css3.png");
+    background-origin : border-box;
+    border-radius: 60px;
   }
 
   .no-repeat {
     background-repeat : no-repeat;
   }
 
-  .case {
-    background-origin : border-box;
-    border-radius: 60px;
+  .repeat {
+    background-repeat : repeat;
   }
 
-
- </style>
+</style>
 
 </head>
 <body>
 
-<div class="infomation">
-Test Passed If : The background is painted. The paint area includes the area covered by border , and the area surrounded by border.<br>
-When border-radius is enabled, the browser should paint the background correctly.
-</div>
+  <div class="no-repeat" ></div>
 
-<div class="test-case">
-
-  <div id="border-box" class="view case no-repeat" >
-      Test background-origin:
-  </div>
-
-  <div id="border-box" class="view case" >
-      Test background-origin:
-  </div>
-
-
-</div>
+  <div class="repeat" ></div>
 
 </body>
 

--- a/css/css-backgrounds/background-origin/origin-border-box_with_size.html
+++ b/css/css-backgrounds/background-origin/origin-border-box_with_size.html
@@ -5,67 +5,41 @@
   <title>CSS Backgrounds Test:  background-origin:border-box & background-size</title>
   <link rel="author" title="finscn" href="mailto:finscn@gmail.com" >
   <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-origin" >
-  <meta name="flags" content="image">
-  <meta name="assert" content="border-box : The position is relative to the border box." >
+  <meta name="flags" content="">
+  <link rel="match" href="../reference/origin-border-box_with_size-ref.html">
 
   <meta charset="utf-8">
 
 
 <style type="text/css">
 
-  .infomation {
-    padding : 10px;
-    font-size : 16pt;
-    margin : 5px;
-  }
-
-  .test-case {
-    padding : 5px;
-    margin : 5px;
-  }
-
-  .view {
-    border : 30px solid rgba(60,150,255,0.4);
-    width : 320px;
-    height : 240px;
-    padding : 30px;
-    margin : 10px;
-    font-size : 16pt;
-    color : #ff9933;
+  div {
+    border : 16px solid rgba(60,150,255,0.4);
+    width : 450px;
+    height : 224px;
+    padding : 16px;
+    margin-top : 8px;
     background-image : url("../support/css3.png");
+    background-origin : border-box;
+    background-size : 50%;
   }
 
   .no-repeat {
     background-repeat : no-repeat;
   }
 
-  .case {
-    background-origin : border-box;
-    background-size : 50%;
+  .repeat {
+    background-repeat : repeat;
   }
 
-
- </style>
+</style>
 
 </head>
 <body>
 
-<div class="infomation">
-Test Passed If : The background is painted. The paint area includes the area covered by border , and the area surrounded by border.<br>
-When background-size is enabled, the browser should paint the background correctly.
-</div>
+  <div class="no-repeat" ></div>
 
-<div class="test-case">
-
-  <div id="border-box" class="view case no-repeat" >
-      Test background-origin:
-  </div>
-
-  <div id="border-box" class="view case" >
-      Test background-origin:
-  </div>
-
-</div>
+  <div class="repeat" ></div>
 
 </body>
 

--- a/css/css-backgrounds/background-origin/origin-content-box.html
+++ b/css/css-backgrounds/background-origin/origin-content-box.html
@@ -5,66 +5,40 @@
   <title>CSS Backgrounds Test:  background-origin:content-box</title>
   <link rel="author" title="finscn" href="mailto:finscn@gmail.com" >
   <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-origin" >
-  <meta name="flags" content="image">
-  <meta name="assert" content="content-box : The position is relative to the content box." >
+  <meta name="flags" content="">
+  <link rel="match" href="../reference/origin-content-box-ref.html">
 
   <meta charset="utf-8">
 
 
 <style type="text/css">
 
-  .infomation {
-    padding : 10px;
-    font-size : 16pt;
-    margin : 5px;
-  }
-
-  .test-case {
-    padding : 5px;
-    margin : 5px;
-  }
-
-  .view {
-    border : 30px solid rgba(60,150,255,0.4);
-    width : 320px;
-    height : 240px;
-    padding : 30px;
-    margin : 10px;
-    font-size : 16pt;
-    color : #ff9933;
+  div {
+    border : 16px solid rgba(60,150,255,0.4);
+    width : 450px;
+    height : 224px;
+    padding : 16px;
+    margin-top : 8px;
     background-image : url("../support/css3.png");
+    background-origin : content-box;
   }
 
   .no-repeat {
     background-repeat : no-repeat;
   }
 
-  .case {
-    background-origin : content-box;
+  .repeat {
+    background-repeat : repeat;
   }
 
-
 </style>
-
 
 </head>
 <body>
 
-<div class="infomation">
-Test Passed If : The background is painted. The paint area is the content-area(excludes padding-area ) of the DIV.
-</div>
+  <div class="no-repeat" ></div>
 
-<div class="test-case">
-
-  <div class="view case no-repeat" >
-      Test background-origin
-  </div>
-
-  <div class="view case" >
-      Test background-origin
-  </div>
-
-</div>
+  <div class="repeat" ></div>
 
 </body>
 

--- a/css/css-backgrounds/background-origin/origin-content-box_with_position.html
+++ b/css/css-backgrounds/background-origin/origin-content-box_with_position.html
@@ -5,69 +5,35 @@
   <title>CSS Backgrounds Test:  background-origin:content-box & background-position</title>
   <link rel="author" title="finscn" href="mailto:finscn@gmail.com" >
   <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-origin" >
-  <meta name="flags" content="image">
-  <meta name="assert" content="content-box : The position is relative to the content box." >
+  <meta name="flags" content="">
+  <link rel="match" href="../reference/origin-content-box_with_position-ref.html">
 
   <meta charset="utf-8">
 
 
 <style type="text/css">
 
-  .infomation {
-    padding : 10px;
-    font-size : 16pt;
-    margin : 5px;
-  }
-
-  .test-case {
-    padding : 5px;
-    margin : 5px;
-  }
-
-  .view {
-    border : 30px solid rgba(60,150,255,0.4);
-    width : 320px;
-    height : 240px;
-    padding : 30px;
-    margin : 10px;
-    font-size : 16pt;
-    color : #ff9933;
+  div {
+    border : 16px solid rgba(60,150,255,0.4);
+    width : 450px;
+    height : 224px;
+    padding : 16px;
+    margin-top : 8px;
     background-image : url("../support/css3.png");
+    background-origin : content-box;
+    background-position: -15px -15px;
   }
 
   .no-repeat {
     background-repeat : no-repeat;
   }
 
-  .case {
-    background-origin : content-box;
-    background-position: -15px -15px;
-  }
-
-
- </style>
+</style>
 
 </head>
 <body>
 
-<div class="infomation">
-
-
-Test Passed If : The background is painted. The paint area is the content-area(excludes padding-area ) of the DIV.<br>
-When background-position is enabled, the browser should paint the background correctly.
-</div>
-
-<div class="test-case">
-
-  <div class="view case no-repeat" >
-      Test background-origin
-  </div>
-
-  <div class="view case" >
-      Test background-origin
-  </div>
-
-</div>
+  <div class="no-repeat" ></div>
 
 </body>
 

--- a/css/css-backgrounds/background-origin/origin-content-box_with_radius.html
+++ b/css/css-backgrounds/background-origin/origin-content-box_with_radius.html
@@ -2,70 +2,44 @@
 <!doctype html>
 <html>
 <head>
-  <title>CSS Backgrounds Test:  background-origin:content-box & border-radius</title>
+  <title>CSS Backgrounds Test:  background-origin:content-box & background-size</title>
   <link rel="author" title="finscn" href="mailto:finscn@gmail.com" >
   <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-origin" >
-  <meta name="flags" content="image">
-  <meta name="assert" content="content-box : The position is relative to the content box." >
+  <meta name="flags" content="">
+  <link rel="match" href="../reference/origin-content-box_with_radius-ref.html">
 
   <meta charset="utf-8">
 
 
 <style type="text/css">
 
-  .infomation {
-    padding : 10px;
-    font-size : 16pt;
-    margin : 5px;
-  }
-
-  .test-case {
-    padding : 5px;
-    margin : 5px;
-  }
-
-  .view {
-    border : 30px solid rgba(60,150,255,0.4);
-    width : 320px;
-    height : 240px;
-    padding : 30px;
-    margin : 10px;
-    font-size : 16pt;
-    color : #ff9933;
+  div {
+    border : 16px solid rgba(60,150,255,0.4);
+    width : 450px;
+    height : 224px;
+    padding : 16px;
+    margin-top : 8px;
     background-image : url("../support/css3.png");
+    background-origin : content-box;
+    border-radius: 60px;
   }
 
   .no-repeat {
     background-repeat : no-repeat;
   }
 
-  .case {
-    background-origin : content-box;
-    border-radius: 60px;
+  .repeat {
+    background-repeat : repeat;
   }
 
-
- </style>
+</style>
 
 </head>
 <body>
 
-<div class="infomation">
-Test Passed If : The background is painted. The paint area is the content-area(excludes padding-area ) of the DIV.<br>
-When border-radius is enabled, the browser should paint the background correctly.
-</div>
+  <div class="no-repeat" ></div>
 
-<div class="test-case">
-
-  <div class="view case no-repeat" >
-      Test background-origin
-  </div>
-
-  <div class="view case" >
-      Test background-origin
-  </div>
-
-</div>
+  <div class="repeat" ></div>
 
 </body>
 

--- a/css/css-backgrounds/background-origin/origin-content-box_with_size.html
+++ b/css/css-backgrounds/background-origin/origin-content-box_with_size.html
@@ -5,65 +5,41 @@
   <title>CSS Backgrounds Test:  background-origin:content-box & background-size</title>
   <link rel="author" title="finscn" href="mailto:finscn@gmail.com" >
   <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-origin" >
-  <meta name="flags" content="image">
-  <meta name="assert" content="content-box : The position is relative to the content box." >
+  <meta name="flags" content="">
+  <link rel="match" href="../reference/origin-content-box_with_size-ref.html">
 
   <meta charset="utf-8">
 
 
 <style type="text/css">
 
-  .infomation {
-    padding : 10px;
-    font-size : 16pt;
-    margin : 5px;
-  }
-
-  .test-case {
-    padding : 5px;
-    margin : 5px;
-  }
-
-  .view {
-    border : 30px solid rgba(60,150,255,0.4);
-    width : 320px;
-    height : 240px;
-    padding : 30px;
-    margin : 10px;
-    font-size : 16pt;
-    color : #ff9933;
+  div {
+    border : 16px solid rgba(60,150,255,0.4);
+    width : 450px;
+    height : 224px;
+    padding : 16px;
+    margin-top : 8px;
     background-image : url("../support/css3.png");
+    background-origin : content-box;
+    background-size : 50%;
   }
 
   .no-repeat {
     background-repeat : no-repeat;
   }
 
-  .case {
-    background-origin : content-box;
-    background-size : 50%;
+  .repeat {
+    background-repeat : repeat;
   }
 
- </style>
+</style>
 
 </head>
 <body>
-<div class="infomation">
-Test Passed If : The background is painted. The paint area is the content-area(excludes padding-area ) of the DIV.<br>
-When background-size is enabled, the browser should paint the background correctly.
-</div>
 
-<div class="test-case">
+  <div class="no-repeat" ></div>
 
-  <div class="view case no-repeat" >
-      Test background-origin
-  </div>
-
-  <div class="view case" >
-      Test background-origin
-  </div>
-
-</div>
+  <div class="repeat" ></div>
 
 </body>
 

--- a/css/css-backgrounds/background-origin/origin-padding-box.html
+++ b/css/css-backgrounds/background-origin/origin-padding-box.html
@@ -5,66 +5,39 @@
   <title>CSS Backgrounds Test:  background-origin:padding-box</title>
   <link rel="author" title="finscn" href="mailto:finscn@gmail.com" >
   <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-origin" >
-  <meta name="flags" content="image">
-  <meta name="assert" content="padding-box : The position is relative to the padding box. (For single boxes ‘0 0’ is the upper left corner of the padding edge, ‘100% 100%’ is the lower right corner.)" >
+  <meta name="flags" content="">
+  <link rel="match" href="../reference/origin-padding-box-ref.html">
 
 
 
 <style type="text/css">
 
-  .infomation {
-    padding : 10px;
-    font-size : 16pt;
-    margin : 5px;
-  }
-
-  .test-case {
-    padding : 5px;
-    margin : 5px;
-  }
-
-  .view {
-    border : 30px solid rgba(60,150,255,0.4);
-    width : 320px;
-    height : 240px;
-    padding : 30px;
-    margin : 10px;
-    font-size : 16pt;
-    color : #ff9933;
+  div {
+    border : 16px solid rgba(60,150,255,0.4);
+    width : 450px;
+    height : 224px;
+    padding : 16px;
+    margin-top : 8px;
     background-image : url("../support/css3.png");
+    background-origin : padding-box;
   }
 
   .no-repeat {
     background-repeat : no-repeat;
   }
 
-  .case {
-    background-origin : padding-box;
+  .repeat {
+    background-repeat : repeat;
   }
 
-
 </style>
-
 
 </head>
 <body>
 
-<div class="infomation">
-Test Passed If : The background is painted. The paint area is the area covered by border(includes padding-area ).
-</div>
+  <div class="no-repeat" ></div>
 
-<div class="test-case">
-
-
-  <div class="view case no-repeat" >
-      Test background-origin
-  </div>
-
-  <div class="view case" >
-      Test background-origin
-  </div>
-
-</div>
+  <div class="repeat" ></div>
 
 </body>
 

--- a/css/css-backgrounds/background-origin/origin-padding-box_with_position.html
+++ b/css/css-backgrounds/background-origin/origin-padding-box_with_position.html
@@ -5,66 +5,35 @@
   <title>CSS Backgrounds Test:  background-origin:padding-box & background-position</title>
   <link rel="author" title="finscn" href="mailto:finscn@gmail.com" >
   <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-origin" >
-  <meta name="flags" content="image">
-  <meta name="assert" content="padding-box : The position is relative to the padding box. (For single boxes ‘0 0’ is the upper left corner of the padding edge, ‘100% 100%’ is the lower right corner.)" >
+  <meta name="flags" content="">
+  <link rel="match" href="../reference/origin-padding-box_with_position-ref.html">
 
   <meta charset="utf-8">
 
 
 <style type="text/css">
 
-  .infomation {
-    padding : 10px;
-    font-size : 16pt;
-    margin : 5px;
-  }
-
-  .test-case {
-    padding : 5px;
-    margin : 5px;
-  }
-
-  .view {
-    border : 30px solid rgba(60,150,255,0.4);
-    width : 320px;
-    height : 240px;
-    padding : 30px;
-    margin : 10px;
-    font-size : 16pt;
-    color : #ff9933;
+  div {
+    border : 16px solid rgba(60,150,255,0.4);
+    width : 450px;
+    height : 224px;
+    padding : 16px;
+    margin-top : 8px;
     background-image : url("../support/css3.png");
+    background-origin : padding-box;
+    background-position: -15px -15px;
   }
 
   .no-repeat {
     background-repeat : no-repeat;
   }
 
-  .case {
-    background-origin : padding-box;
-    background-position: -15px -15px;
-  }
-
- </style>
+</style>
 
 </head>
 <body>
 
-<div class="infomation">
-Test Passed If : The background is painted. The paint area is the area covered by border(includes padding-area ).<br>
-When background-position is enabled, the browser should paint the background correctly.
-</div>
-
-<div class="test-case">
-
-  <div class="view case no-repeat" >
-      Test background-origin
-  </div>
-
-  <div class="view case" >
-      Test background-origin
-  </div>
-
-</div>
+  <div class="no-repeat" ></div>
 
 </body>
 

--- a/css/css-backgrounds/background-origin/origin-padding-box_with_radius.html
+++ b/css/css-backgrounds/background-origin/origin-padding-box_with_radius.html
@@ -5,66 +5,41 @@
   <title>CSS Backgrounds Test:  background-origin:padding-box & border-radius</title>
   <link rel="author" title="finscn" href="mailto:finscn@gmail.com" >
   <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-origin" >
-  <meta name="flags" content="image">
-  <meta name="assert" content="padding-box : The position is relative to the padding box. (For single boxes ‘0 0’ is the upper left corner of the padding edge, ‘100% 100%’ is the lower right corner.)" >
+  <meta name="flags" content="">
+  <link rel="match" href="../reference/origin-padding-box_with_radius-ref.html">
 
   <meta charset="utf-8">
 
 
 <style type="text/css">
 
-  .infomation {
-    padding : 10px;
-    font-size : 16pt;
-    margin : 5px;
-  }
-
-  .test-case {
-    padding : 5px;
-    margin : 5px;
-  }
-
-  .view {
-    border : 30px solid rgba(60,150,255,0.4);
-    width : 320px;
-    height : 240px;
-    padding : 30px;
-    margin : 10px;
-    font-size : 16pt;
-    color : #ff9933;
+  div {
+    border : 16px solid rgba(60,150,255,0.4);
+    width : 450px;
+    height : 224px;
+    padding : 16px;
+    margin-top : 8px;
     background-image : url("../support/css3.png");
+    background-origin : padding-box;
+    border-radius: 60px;
   }
 
   .no-repeat {
     background-repeat : no-repeat;
   }
 
-  .case {
-    background-origin : padding-box;
-    border-radius: 60px;
+  .repeat {
+    background-repeat : repeat;
   }
 
- </style>
+</style>
 
 </head>
 <body>
 
-<div class="infomation">
-Test Passed If : The background is painted. The paint area is the area covered by border(includes padding-area ).<br>
-When border-radius is enabled, the browser should paint the background correctly.
-</div>
+  <div class="no-repeat" ></div>
 
-<div class="test-case">
-
-  <div class="view case no-repeat" >
-      Test background-origin
-  </div>
-
-  <div class="view case" >
-      Test background-origin
-  </div>
-
-</div>
+  <div class="repeat" ></div>
 
 </body>
 

--- a/css/css-backgrounds/background-origin/origin-padding-box_with_size.html
+++ b/css/css-backgrounds/background-origin/origin-padding-box_with_size.html
@@ -5,66 +5,41 @@
   <title>CSS Backgrounds Test:  background-origin:padding-box & background-size</title>
   <link rel="author" title="finscn" href="mailto:finscn@gmail.com" >
   <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-origin" >
-  <meta name="flags" content="image">
-  <meta name="assert" content="padding-box : The position is relative to the padding box. (For single boxes ‘0 0’ is the upper left corner of the padding edge, ‘100% 100%’ is the lower right corner.)" >
+  <meta name="flags" content="">
+  <link rel="match" href="../reference/origin-padding-box_with_size-ref.html">
 
   <meta charset="utf-8">
 
 
 <style type="text/css">
 
-  .infomation {
-    padding : 10px;
-    font-size : 16pt;
-    margin : 5px;
-  }
-
-  .test-case {
-    padding : 5px;
-    margin : 5px;
-  }
-
-  .view {
-    border : 30px solid rgba(60,150,255,0.4);
-    width : 320px;
-    height : 240px;
-    padding : 30px;
-    margin : 10px;
-    font-size : 16pt;
-    color : #ff9933;
+  div {
+    border : 16px solid rgba(60,150,255,0.4);
+    width : 450px;
+    height : 224px;
+    padding : 16px;
+    margin-top : 8px;
     background-image : url("../support/css3.png");
+    background-origin : padding-box;
+    background-size : 50%;
   }
 
   .no-repeat {
     background-repeat : no-repeat;
   }
 
-  .case {
-    background-origin : padding-box;
-    background-size : 50%;
+  .repeat {
+    background-repeat : repeat;
   }
 
- </style>
+</style>
 
 </head>
 <body>
 
-<div class="infomation">
-Test Passed If : The background is painted. The paint area is the area covered by border(includes padding-area ).<br>
-When background-size is enabled, the browser should paint the background correctly.
-</div>
+  <div class="no-repeat" ></div>
 
-<div class="test-case">
-
-  <div class="view case no-repeat" >
-      Test background-origin
-  </div>
-
-  <div class="view case" >
-      Test background-origin
-  </div>
-
-</div>
+  <div class="repeat" ></div>
 
 </body>
 

--- a/css/css-backgrounds/reference/origin-border-box-ref.html
+++ b/css/css-backgrounds/reference/origin-border-box-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest reference</title>
+
+  <style>
+  div
+    {
+      display: inline-block;
+      vertical-align: bottom;
+    }
+
+  div.light-blue-border
+    {
+      border: 16px solid rgba(60, 150, 255, 0.4);
+      height: 256px;
+      position: relative;
+      right: 514px;
+      width: 482px;
+    }
+  </style>
+
+<div style="height: 288px; width: 514px;"><img src="../support/css3.png" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
+
+<div style="height: 288px; width: 514px; background-image: url('../support/css3.png'); margin-top: 8px;"></div><div class="light-blue-border"></div>

--- a/css/css-backgrounds/reference/origin-border-box_with_position-ref.html
+++ b/css/css-backgrounds/reference/origin-border-box_with_position-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest reference</title>
+
+  <style>
+  div
+    {
+      display: inline-block;
+      vertical-align: bottom;
+    }
+
+  img
+    {
+      clip: rect(15px, auto, auto, 15px);
+      left: -15px;
+      position: absolute;
+      top: -15px;
+    }
+
+  div.light-blue-border
+    {
+      border: 16px solid rgba(60, 150, 255, 0.4);
+      height: 256px;
+      position: relative;
+      right: 514px;
+      width: 482px;
+    }
+  </style>
+
+<div style="height: 288px; width: 514px; position: relative;"><img src="../support/css3.png" alt="Image download support must be enabled"></div><div class="light-blue-border"></div>

--- a/css/css-backgrounds/reference/origin-border-box_with_radius-ref.html
+++ b/css/css-backgrounds/reference/origin-border-box_with_radius-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest reference</title>
+
+  <style>
+  div
+    {
+      border-radius: 60px;
+      display: inline-block;
+      vertical-align: bottom;
+    }
+
+  div.light-blue-border
+    {
+      border: 16px solid rgba(60, 150, 255, 0.4);
+      height: 256px;
+      position: relative;
+      right: 514px;
+      width: 482px;
+    }
+  </style>
+
+<div style="height: 288px; width: 514px;"><img src="../support/css3.png" style="border-top-left-radius: 60px;" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
+
+<div style="height: 288px; width: 514px; background-image: url('../support/css3.png'); margin-top: 8px;"></div><div class="light-blue-border"></div>

--- a/css/css-backgrounds/reference/origin-border-box_with_size-ref.html
+++ b/css/css-backgrounds/reference/origin-border-box_with_size-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest reference</title>
+
+  <style>
+  div
+    {
+      display: inline-block;
+      vertical-align: bottom;
+    }
+
+  div.light-blue-border
+    {
+      border: 16px solid rgba(60, 150, 255, 0.4);
+      height: 256px;
+      position: relative;
+      right: 514px;
+      width: 482px;
+    }
+  </style>
+
+<div style="height: 288px; width: 514px;"><img src="../support/css3.png" width="50%" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
+
+<div style="height: 288px; width: 514px; background-image: url('../support/css3.png'); background-size: 257px auto; margin-top: 8px;"></div><div class="light-blue-border"></div>

--- a/css/css-backgrounds/reference/origin-content-box-ref.html
+++ b/css/css-backgrounds/reference/origin-content-box-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest reference</title>
+
+  <style>
+  div
+    {
+      display: inline-block;
+      vertical-align: bottom;
+    }
+
+  img
+    {
+      padding-left: 16px;
+      padding-top: 16px;
+    }
+
+  div.light-blue-border
+    {
+      border: 16px solid rgba(60, 150, 255, 0.4);
+      height: 256px;
+      width: 482px;
+    }
+  </style>
+
+
+<div class="light-blue-border"><img src="../support/css3.png" alt="Image download support must be enabled"></div><br>
+
+<div class="light-blue-border" style="background-image: url('../support/css3.png'); background-position: 16px 16px; margin-top: 8px;"></div>

--- a/css/css-backgrounds/reference/origin-content-box_with_position-ref.html
+++ b/css/css-backgrounds/reference/origin-content-box_with_position-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest reference</title>
+
+  <style>
+  div
+    {
+      display: inline-block;
+      vertical-align: bottom;
+    }
+
+  img
+    {
+      left: 17px;
+      position: absolute;
+      top: 17px;
+    }
+
+  div.light-blue-border
+    {
+      border: 16px solid rgba(60, 150, 255, 0.4);
+      height: 256px;
+      position: relative;
+      right: 514px;
+      width: 482px;
+    }
+  </style>
+
+<div style="height: 288px; width: 514px; position: relative;"><img src="../support/css3.png" alt="Image download support must be enabled"></div><div class="light-blue-border"></div>

--- a/css/css-backgrounds/reference/origin-content-box_with_radius-ref.html
+++ b/css/css-backgrounds/reference/origin-content-box_with_radius-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest reference</title>
+
+  <style>
+  div
+    {
+      border-radius: 60px;
+      display: inline-block;
+      vertical-align: bottom;
+    }
+
+  img
+    {
+      padding-left: 16px;
+      padding-top: 16px;
+    }
+
+  div.light-blue-border
+    {
+      border: 16px solid rgba(60, 150, 255, 0.4);
+      height: 256px;
+      width: 482px;
+    }
+  </style>
+
+
+<div class="light-blue-border"><img src="../support/css3.png" alt="Image download support must be enabled"></div><br>
+
+<div class="light-blue-border" style="background-image: url('../support/css3.png'); background-position: 16px 16px; margin-top: 8px;"></div>

--- a/css/css-backgrounds/reference/origin-content-box_with_size-ref.html
+++ b/css/css-backgrounds/reference/origin-content-box_with_size-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest reference</title>
+
+  <style>
+  div
+    {
+      display: inline-block;
+      vertical-align: bottom;
+    }
+
+  div.light-blue-border
+    {
+      border: 16px solid rgba(60, 150, 255, 0.4);
+      height: 256px;
+      position: relative;
+      right: 514px;
+      width: 482px;
+    }
+  </style>
+
+<div style="height: 288px; width: 514px;"><img src="../support/css3.png" style="position: relative; top: 32px; left: 32px;" width="225" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
+
+<div style="height: 288px; width: 514px; background-image: url('../support/css3.png'); background-size: 225px auto; background-position: 32px 32px; margin-top: 8px;"></div><div class="light-blue-border"></div>

--- a/css/css-backgrounds/reference/origin-padding-box-ref.html
+++ b/css/css-backgrounds/reference/origin-padding-box-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest reference</title>
+
+  <style>
+  div
+    {
+      display: inline-block;
+      vertical-align: bottom;
+    }
+
+  div.light-blue-border
+    {
+      border: 16px solid rgba(60, 150, 255, 0.4);
+      height: 256px;
+      width: 482px;
+    }
+  </style>
+
+<div class="light-blue-border"><img src="../support/css3.png" alt="Image download support must be enabled"></div><br>
+
+<div class="light-blue-border" style="background-image: url('../support/css3.png'); margin-top: 8px;"></div>

--- a/css/css-backgrounds/reference/origin-padding-box_with_position-ref.html
+++ b/css/css-backgrounds/reference/origin-padding-box_with_position-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest reference</title>
+
+  <style>
+  div
+    {
+      display: inline-block;
+      vertical-align: bottom;
+    }
+
+  img
+    {
+      left: 1px;
+      position: absolute;
+      top: 1px;
+    }
+
+  div.light-blue-border
+    {
+      border: 16px solid rgba(60, 150, 255, 0.4);
+      height: 256px;
+      position: relative;
+      right: 514px;
+      width: 482px;
+    }
+  </style>
+
+<div style="height: 288px; width: 514px; position: relative;"><img src="../support/css3.png" alt="Image download support must be enabled"></div><div class="light-blue-border"></div>

--- a/css/css-backgrounds/reference/origin-padding-box_with_radius-ref.html
+++ b/css/css-backgrounds/reference/origin-padding-box_with_radius-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest reference</title>
+
+  <style>
+  div
+    {
+      display: inline-block;
+      vertical-align: bottom;
+    }
+
+  div.light-blue-border
+    {
+      border-radius: 60px;
+      border: 16px solid rgba(60, 150, 255, 0.4);
+      height: 256px;
+      width: 482px;
+    }
+  </style>
+
+<div class="light-blue-border"><img src="../support/css3.png" style="position: relative; z-index: -1;" alt="Image download support must be enabled"></div><br>
+
+<div class="light-blue-border" style="background-image: url('../support/css3.png'); margin-top: 8px;"></div>

--- a/css/css-backgrounds/reference/origin-padding-box_with_size-ref.html
+++ b/css/css-backgrounds/reference/origin-padding-box_with_size-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest reference</title>
+
+  <style>
+  div
+    {
+      display: inline-block;
+      vertical-align: bottom;
+    }
+
+  div.light-blue-border
+    {
+      border: 16px solid rgba(60, 150, 255, 0.4);
+      height: 256px;
+      position: relative;
+      right: 514px;
+      width: 482px;
+    }
+  </style>
+
+<div style="height: 288px; width: 514px;"><img src="../support/css3.png" style="position: relative; top: 16px; left: 16px;" width="241" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
+
+<div style="height: 288px; width: 514px; background-image: url('../support/css3.png'); background-size: 241px auto; background-position: 16px 16px; margin-top: 8px;"></div><div class="light-blue-border"></div>


### PR DESCRIPTION
At my website:


http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/background-origin/origin-border-box-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-border-box-ref.html

- - -

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/background-origin/origin-border-box_with_position-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-border-box_with_position-ref.html

- - -

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/background-origin/origin-border-box_with_radius-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-border-box_with_radius-ref.html

- - -

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/background-origin/origin-border-box_with_size-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-border-box_with_size-ref.html

- - -

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/background-origin/origin-content-box-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-content-box-ref.html

- - -

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/background-origin/origin-content-box_with_position-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-content-box_with_position-ref.html

- - -

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/background-origin/origin-content-box_with_radius-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-content-box_with_radius-ref.html

- - -

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/background-origin/origin-content-box_with_size-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-content-box_with_size-ref.html

- - -

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/background-origin/origin-padding-box-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-padding-box-ref.html

- - -

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/background-origin/origin-padding-box_with_position-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-padding-box_with_position-ref.html

- - -

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/background-origin/origin-padding-box_with_radius-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-padding-box_with_radius-ref.html

- - -

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/background-origin/origin-padding-box_with_size-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-padding-box_with_size-ref.html

The reasons for the changes made in the 12 tests are given in  [Issue 10015](https://github.com/web-platform-tests/wpt/issues/10015) and I am repeating them in here: 

- the 12 tests are not streamlined; the tests usually have 4 rules and more than 15 declarations. The .information and .test-case classes are not necessary, are not needed for the tests and they are not part of the testing itself.
- the 12 tests have no reference file. The 2nd (bottom) div is not a    reference but a `'background-repeat : repeat'` variation of the 1st (top) div which uses `'background-repeat: no-repeat'` 
- the 12 tests are long; as designed, many testers taken those tests will likely have to scroll up-and-down to see both tested divs unless the testers use a very tall monitor screen. The document box height of all 12 tests exceeds 600px viewport testing constraint.
- the pass-or-fail-conditions sentences are long, technical, not obvious and not helpful. Typically, it always ends like this: "When [some boolean condition], the browser should paint the background correctly." which does not help at all. An ordinary person - any normal person - should read the pass-fail conditions sentence and figure out easily and quickly if the test is passed or failed.
- the
```
    margin: 10px;
    font-size: 16pt;
    color: #ff9933;
```
declarations of the .view class are not part of the tests, are not useful or helpful to the tests

Successfully merging this pull request will close [Issue 10015](https://github.com/web-platform-tests/wpt/issues/10015) .