### PR TITLE
[webtransport] Add draft-07 version of SETTINGS_WEBTRANSPORT_MAX_SESSIONS

### DIFF
--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -53,6 +53,11 @@ class H3DatagramSetting(IntEnum):
     RFC = 0x33
 
 
+class WebTransportHttp3Setting(IntEnum):
+    # https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3-07#section-8.2
+    WEBTRANSPORT_MAX_SESSIONS_DRAFT07 = 0xc671706a
+
+
 class H3ConnectionWithDatagram(H3Connection):
     """
     A H3Connection subclass, to make it work with the latest
@@ -77,12 +82,13 @@ class H3ConnectionWithDatagram(H3Connection):
         if self._datagram_setting is None:
             raise SettingsError("HTTP Datagrams support required")
 
-
     def _get_local_settings(self) -> Dict[int, int]:
         settings = super()._get_local_settings()
         settings[H3DatagramSetting.RFC] = 1
         settings[H3DatagramSetting.DRAFT04] = 1
         settings[H3ConnectionWithDatagram.ENABLE_CONNECT_PROTOCOL] = 1
+        # This connection can handle only one WebTransport session.
+        settings[WebTransportHttp3Setting.WEBTRANSPORT_MAX_SESSIONS_DRAFT07] = 1
         return settings
 
     @property


### PR DESCRIPTION
draft-02 used the SETTINGS_ENABLE_WEBTRANSPORT parameter to indicate that a HTTP/3 connection is WebTransport-capable.

draft-07 removed the SETTINGS_ENABLE_WEBTRANSPORT and introduced the SETTINGS_WEBTRANSPORT_MAX_SESSIONS parameter to indicate WebTransport capability.

Add draft-07 version of SETTINGS_WEBTRANSPORT_MAX_SESSIONS so that clients can test draft-07.