### PR TITLE
[wdspec] serialization: fix incorrect call_function test with Promise

### DIFF
--- a/webdriver/tests/bidi/script/call_function/remote_values.py
+++ b/webdriver/tests/bidi/script/call_function/remote_values.py
@@ -8,12 +8,12 @@ pytestmark = pytest.mark.asyncio
 
 
 @pytest.mark.parametrize("await_promise", [True, False])
-@pytest.mark.parametrize("expression, expected", REMOTE_VALUES)
+@pytest.mark.parametrize("expression, expected", [
+    remote_value
+    for remote_value in REMOTE_VALUES if remote_value[1]["type"] != "promise"
+])
 async def test_remote_values(bidi_session, top_context, await_promise,
                              expression, expected):
-    if expected["type"] == "promise":
-        return
-
     function_declaration = f"()=>{expression}"
     if await_promise:
         function_declaration = "async" + function_declaration


### PR DESCRIPTION
An earlier refactoring has accidentally introduced a test case that is invalid, namely, script.callFunction with await_promise=True.

Currently, the test expects a result of type Promise, but it should actually expect the value wrapped by the Promise.

Furthermore, do a drive-by refactoring, merging the promise test into a single function.