### PR TITLE
Remove unsound assertion from 2d-getcontext-options.any.js

### DIFF
--- a/html/canvas/offscreen/the-offscreen-canvas/2d-getcontext-options.any.js
+++ b/html/canvas/offscreen/the-offscreen-canvas/2d-getcontext-options.any.js
@@ -37,5 +37,10 @@ test(() => {
   assert_array_equals(actual, expected, "order of operations (creation)");
   actual = [];
   assert_equals(canvas.getContext('2d', options), context, "cached context");
-  assert_array_equals(actual, expected, "order of operations (caching)");
+  // Getting the cached context does not involve the options argument at all;
+  // the context retains its existing settings, and the new options (if any)
+  // are ignored.
+  // Therefore, there is no expectation that the 'options' dictionary will be
+  // accessed again here, and we cannot predict the contents, if any, of the
+  // 'actual' array.
 });


### PR DESCRIPTION
This assertion has no basis in the spec. See https://github.com/web-platform-tests/interop/issues/381 for more detailed discussion.