### PR TITLE
[wptrunner] Fix `UnboundLocalError` without any test implementations

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -330,7 +330,7 @@ class TestRunnerManager(threading.Thread):
 
         self.test_runner_proc = None
 
-        threading.Thread.__init__(self, name="TestRunnerManager-%s-%i" % (test_type, index))
+        super().__init__(name=f"TestRunnerManager-{index}")
         # This is started in the actual new thread
         self.logger = None
 


### PR DESCRIPTION
When there are no implementations (e.g., the product under test does not support any of `wpt run --test-types=...`), the loop will not bind the `test_type` variable used for the thread name. This change removes this unnecessary addition to the name so that wptrunner gracefully exits with no tests run instead of crashing.