### PR TITLE
Add a workaround for smooth scroll operations.

### DIFF
--- a/css/cssom-view/scroll-behavior-main-frame-root.html
+++ b/css/cssom-view/scroll-behavior-main-frame-root.html
@@ -39,6 +39,11 @@
 
     add_completion_callback(() => { resetScroll(scrollingElement); });
 
+    promise_test(async () => {
+      await new Promise(resolve => requestAnimationFrame(resolve));
+      await new Promise(resolve => requestAnimationFrame(resolve));
+    }, `Make sure the page content is stable`);
+
     ["scroll", "scrollTo", "scrollBy", "scrollIntoView"].forEach((scrollFunction) => {
       promise_test(() => {
         resetScroll(scrollingElement);

--- a/css/cssom-view/scroll-behavior-main-frame-window.html
+++ b/css/cssom-view/scroll-behavior-main-frame-window.html
@@ -39,6 +39,11 @@
 
     add_completion_callback(() => { resetScrollForWindow(window); });
 
+    promise_test(async () => {
+      await new Promise(resolve => requestAnimationFrame(resolve));
+      await new Promise(resolve => requestAnimationFrame(resolve));
+    }, `Make sure the page content is stable`);
+
     ["scroll", "scrollTo", "scrollBy"].forEach((scrollFunction) => {
       promise_test(() => {
         resetScrollForWindow(scrollingWindow);


### PR DESCRIPTION
In Gecko there's a bug [1] that smooth scroll operations at the beginning of page loading are sometimes omitted. The bug is caused by a race condition in our architecture that smooth scroll operations are processed in a different process. Because of the bug the first test case in scroll-behavior-main-frame-{root|window}.html sometimes fails on Firefox. Just adding two `awaiting rAFs` avoids the race. And I believe it doesn't spoil the purpose of the test case itself.

Also I guess Blink has a similar race since the same test case fails [2] on Chrome. But I am not sure whether this workaround fixes the failure on Blink since I haven't been able to reproduce the Blink's failure locally.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1845646
[2] https://wpt.fyi/results/css/cssom-view/scroll-behavior-main-frame-window.html?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2022-scrolling