### PR TITLE
Fix another nesting expectaation.

### DIFF
--- a/css/css-nesting/parsing.html
+++ b/css/css-nesting/parsing.html
@@ -49,7 +49,7 @@
   testNestedSelector("> .bar", {expected:"& > .bar"});
   testNestedSelector("> & .bar", {expected: "& > & .bar"});
   testNestedSelector("+ .bar &", {expected:"& + .bar &"});
-  testNestedSelector("+ .bar, .foo, > .baz", {expected:"& + .bar, & .foo, & > .baz"});
+  testNestedSelector("+ .bar, .foo, > .baz", {expected:"& + .bar, .foo, & > .baz"});
 
   // implicit relative (and not)
   testNestedSelector(".foo");


### PR DESCRIPTION
This one is the only one that mixes relative selectors with non-relative ones. Probably missed by #41213