### PR TITLE
Remove non-round result test in acos-asin-atan-atan2-serialize.html

### DIFF
--- a/css/css-values/acos-asin-atan-atan2-serialize.html
+++ b/css/css-values/acos-asin-atan-atan2-serialize.html
@@ -40,7 +40,6 @@ var test_map = {
     "acos(pi - pi)"                                     :"calc(90deg)",
     "asin(pi - pi + 1)"                                 :"calc(90deg)",
     "atan(1)"                                           :"calc(45deg)",
-    "atan(0.5)"                                         :"calc(26.5651deg)",
     "atan(0.577350269)"                                 :"calc(30deg)",
     "atan(0)"                                           :"calc(0deg)",
     "atan(infinity)"                                    :"calc(90deg)",


### PR DESCRIPTION
Safari gives 26.565051deg, while other browsers give 26.5651deg.

Both results are correct, one having more precision than the other. Since precision is implementation defined, we should not test it in this test.