### PR TITLE
Cookie Store: Add testing for checks on path and domain length when setting cookies

### DIFF
--- a/cookie-store/META.yml
+++ b/cookie-store/META.yml
@@ -1,4 +1,4 @@
 spec: https://wicg.github.io/cookie-store/
 suggested_reviewers:
   - inexorabletash
-  - pwnall
+  - ayuishii

--- a/cookie-store/cookieStore_set_arguments.https.any.js
+++ b/cookie-store/cookieStore_set_arguments.https.any.js
@@ -285,3 +285,27 @@ promise_test(async testCase => {
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'new-cookie-value');
 }, 'cookieStore.set with get result');
+
+promise_test(async testCase => {
+  // The maximum attribute value size is specified as 1024 bytes at https://wicg.github.io/cookie-store/#cookie-maximum-attribute-value-size.
+  await cookieStore.delete('cookie-name');
+
+  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+      { name: 'cookie-name',
+        value: 'cookie-value',
+        path: '/' + 'a'.repeat(1023) + '/' }));
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie, null);
+}, 'cookieStore.set checks if the path is too long');
+
+promise_test(async testCase => {
+  // The maximum attribute value size is specified as 1024 bytes at https://wicg.github.io/cookie-store/#cookie-maximum-attribute-value-size.
+  await cookieStore.delete('cookie-name');
+
+  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+      { name: 'cookie-name',
+        value: 'cookie-value',
+        domain: 'a'.repeat(1025) }));
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie, null);
+}, 'cookieStore.set checks if the domain is too long');


### PR DESCRIPTION
The spec (https://wicg.github.io/cookie-store/#set-cookie-algorithm) for the Cookie-Store API dictates that in the set function, if the byte sequence length of the path (in UTF8 format) is greater than the maximum attribute value size (currently 1024 bytes according to https://wicg.github.io/cookie-store/#cookie-maximum-attribute-value-size), then the promise should be rejected with a TypeError. The same is true for the domain. This patch adds testing for this check in the set function in the same file that tests other argument-related checks that the set function should be doing.