### PR TITLE
Fix content-visibility-050.html on WebKit

### DIFF
--- a/css/css-contain/content-visibility/content-visibility-050.html
+++ b/css/css-contain/content-visibility/content-visibility-050.html
@@ -28,10 +28,11 @@ async_test((t) => {
     focusable.tabIndex = 0;
     container.appendChild(focusable);
     focusable.focus();
-    requestAnimationFrame(() => {
-      t.step(() => assert_greater_than(document.scrollingElement.scrollTop, 500));
-      t.done();
-    });
+    step_timeout(finish, 0);
+  }
+  function finish() {
+    t.step(() => assert_greater_than(document.scrollingElement.scrollTop, 500));
+    t.done();
   }
   onload = requestAnimationFrame(() => requestAnimationFrame(runTest));
 }, "Using tabindex to focus an newly constructed element in an auto subtree focuses element");


### PR DESCRIPTION
In WebKit the focus() will schedule an async scroll, so use a timeout to make sure the scroll has been performed before moving on to finish the test.