### PR TITLE
docs Dockerfile: Use python:3.11 base image

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:20.04
+FROM python:3.11
 
 # No interactive frontend during docker build
 ENV DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN apt-get -qqy update \
-  && apt-get -qqy install git npm python3 python3-venv
+  && apt-get -qqy install git npm
 
 WORKDIR /app/
 


### PR DESCRIPTION
Instead of using a somewhat old Ubuntu release as base and installing its somewhat old Python package, use a base image that already has Python at the same version we also use for the GitHub workflow that generates documentation.

"python:3.11" is equivalent to the latest 3.11 release installed on Debian bookworm (aka stable at the moment of writing).

I have tested this locally and the documentation generated locally finally looked similar to the published version -- there seemed to be some issue with Ubuntu 20.04's Python 3.8 and docutils and/or Sphinx that added an extra ":" after e.g. "Arguments" in the documentation.