### PR TITLE
testdriver: Stop using {@link} in the documentation

### DIFF
--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -328,9 +328,9 @@
          *                                to run the call, or null for the current
          *                                browsing context.
          *
-         * @returns {Promise} fulfilled with the previous {@link
-         *                    https://www.w3.org/TR/webdriver/#dfn-windowrect-object|WindowRect}
-         *                      value, after the window is minimized.
+         * @returns {Promise} fulfilled with the previous `WindowRect
+         *                    <https://www.w3.org/TR/webdriver/#dfn-windowrect-object>`_
+         *                    value, after the window is minimized.
          */
         minimize_window: function(context=null) {
             return window.test_driver_internal.minimize_window(context);
@@ -343,8 +343,8 @@
          * <https://www.w3.org/TR/webdriver/#set-window-rect>`_
          * WebDriver command
          *
-         * @param {Object} rect - A {@link
-         *                           https://www.w3.org/TR/webdriver/#dfn-windowrect-object|WindowRect}
+         * @param {Object} rect - A `WindowRect
+         *                        <https://www.w3.org/TR/webdriver/#dfn-windowrect-object>`_
          * @param {WindowProxy} context - Browsing context in which
          *                                to run the call, or null for the current
          *                                browsing context.


### PR DESCRIPTION
sphinx-js does not recognize inline constructs like `{@link}` and recommends using Sphinx's regular formatting instead.