### PR TITLE
venv lib_path detection compatible with 3.10+

### DIFF
--- a/tools/wpt/virtualenv.py
+++ b/tools/wpt/virtualenv.py
@@ -81,7 +81,11 @@ class Virtualenv:
             if IS_WIN:
                 site_packages = os.path.join(base, "Lib", "site-packages")
             else:
-                site_packages = os.path.join(base, "lib", f"python{sys.version[:3]}", "site-packages")
+                version = sys.version[:3]
+                # Assume version 3.10+ if detecting version substring is 3.1.
+                if version == '3.1':
+                    version = sys.version[:4]
+                site_packages = os.path.join(base, "lib", f"python{version}", "site-packages")
 
         return site_packages
 

--- a/tools/wpt/virtualenv.py
+++ b/tools/wpt/virtualenv.py
@@ -81,10 +81,7 @@ class Virtualenv:
             if IS_WIN:
                 site_packages = os.path.join(base, "Lib", "site-packages")
             else:
-                version = sys.version[:3]
-                # Assume version 3.10+ if detecting version substring is 3.1.
-                if version == '3.1':
-                    version = sys.version[:4]
+                version = f"{sys.version_info.major}.{sys.version_info.minor}"
                 site_packages = os.path.join(base, "lib", f"python{version}", "site-packages")
 
         return site_packages


### PR DESCRIPTION
I was noticing that my venv folder was being removed and rebuilt with each `./wpt` invocation. This seems to be caused by the `lib_path` detection code for virtualenv, as it assumes the Python version string is 3 characters long. This change adds logic to assume that if version `3.1` is detected, then the Python version should be Python 3.10+. [Previous logic](https://github.com/web-platform-tests/wpt/blob/master/wpt#L5-L7) should already ensure that Python 3.7 or higher is running.