### PR TITLE
Fix callback-idle-periods.html's flaky failure.

### DIFF
--- a/requestidlecallback/callback-idle-periods.html
+++ b/requestidlecallback/callback-idle-periods.html
@@ -16,7 +16,7 @@ async_test(function() {
     var remaining = deadline.timeRemaining();
     var new_deadline = now + remaining;
     if (previous_deadline != undefined) {
-      assert_true(new_deadline > previous_deadline, "A requestIdleCallback scheduled during an idle period should be called back with a deadline greater than that in the current idle period.");
+      assert_true(new_deadline >= previous_deadline, "A requestIdleCallback scheduled during an idle period should be called back with a deadline greater than or equal to that in the current idle period.");
     }
 
     // Schedule a new requestIdleCallback.


### PR DESCRIPTION
The test was assuming that new deadline (now + timeRemaining) to strictly monotonically advance in each idle callback. This may not be the case when multiple idle callbacks are scheduled & ran within a single millisecond.