### PR TITLE
Fix issues with canvas2d letter-/word-spacing tests

### DIFF
--- a/html/canvas/element/text/2d.text.drawing.style.letterSpacing.change.font.html
+++ b/html/canvas/element/text/2d.text.drawing.style.letterSpacing.change.font.html
@@ -29,7 +29,7 @@ _addTest(function(canvas, ctx) {
   // 1em = 10px. Add 10px after each letter in "Hello World",
   // makes it 110px longer.
   var width_with_spacing = ctx.measureText('Hello World').width;
-  _assertSame(width_with_spacing, width_normal + 110, "width_with_spacing", "width_normal + 110");
+  assert_approx_equals(width_with_spacing, width_normal + 110, 0.1, "letter spacing incorrect before font change");
 
   // Changing font to 20px. Without resetting the spacing, 1em letterSpacing
   // is now 20px, so it's suppose to be 220px longer without any letterSpacing set.
@@ -38,7 +38,7 @@ _addTest(function(canvas, ctx) {
   // Now calculate the reference spacing for "Hello World" with no spacing.
   ctx.letterSpacing = '0em';
   width_normal = ctx.measureText('Hello World').width;
-  _assertSame(width_with_spacing, width_normal + 220, "width_with_spacing", "width_normal + 220");
+  assert_approx_equals(width_with_spacing, width_normal + 220, 0.1, "letter spacing incorrect after font change");
 
 });
 </script>

--- a/html/canvas/element/text/2d.text.drawing.style.letterSpacing.measure.html
+++ b/html/canvas/element/text/2d.text.drawing.style.letterSpacing.measure.html
@@ -22,7 +22,7 @@ _addTest(function(canvas, ctx) {
   _assertSame(ctx.letterSpacing, '0px', "ctx.letterSpacing", "'0px'");
   _assertSame(ctx.wordSpacing, '0px', "ctx.wordSpacing", "'0px'");
   var width_normal = ctx.measureText('Hello World').width;
-  var ch_width = width_normal / 11;
+  var ch_width = ctx.measureText('0').width;
 
   function test_letter_spacing(value, difference_spacing, epsilon) {
     ctx.letterSpacing = value;

--- a/html/canvas/element/text/2d.text.drawing.style.wordSpacing.change.font.html
+++ b/html/canvas/element/text/2d.text.drawing.style.wordSpacing.change.font.html
@@ -29,7 +29,7 @@ _addTest(function(canvas, ctx) {
   // 1em = 10px. Add 10px after each word in "Hello World, again",
   // makes it 20px longer.
   var width_with_spacing = ctx.measureText('Hello World, again').width;
-  _assertSame(width_with_spacing, width_normal + 20, "width_with_spacing", "width_normal + 20");
+  assert_approx_equals(width_with_spacing, width_normal + 20, 0.1, "word spacing incorrect before font change");
 
   // Changing font to 20px. Without resetting the spacing, 1em wordSpacing
   // is now 20px, so it's suppose to be 40px longer without any wordSpacing set.
@@ -38,7 +38,7 @@ _addTest(function(canvas, ctx) {
   // Now calculate the reference spacing for "Hello World, again" with no spacing.
   ctx.wordSpacing = '0em';
   width_normal = ctx.measureText('Hello World, again').width;
-  _assertSame(width_with_spacing, width_normal + 40, "width_with_spacing", "width_normal + 40");
+  assert_approx_equals(width_with_spacing, width_normal + 40, 0.1, "word spacing incorrect after font change");
 
 });
 </script>

--- a/html/canvas/element/text/2d.text.drawing.style.wordSpacing.measure.html
+++ b/html/canvas/element/text/2d.text.drawing.style.wordSpacing.measure.html
@@ -22,7 +22,7 @@ _addTest(function(canvas, ctx) {
   _assertSame(ctx.letterSpacing, '0px', "ctx.letterSpacing", "'0px'");
   _assertSame(ctx.wordSpacing, '0px', "ctx.wordSpacing", "'0px'");
   var width_normal = ctx.measureText('Hello World, again').width;
-  var ch_width = width_normal / 18;
+  var ch_width = ctx.measureText('0').width;
 
   function test_word_spacing(value, difference_spacing, epsilon) {
     ctx.wordSpacing = value;

--- a/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.change.font.html
+++ b/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.change.font.html
@@ -30,7 +30,7 @@ t.step(function() {
   // 1em = 10px. Add 10px after each letter in "Hello World",
   // makes it 110px longer.
   var width_with_spacing = ctx.measureText('Hello World').width;
-  _assertSame(width_with_spacing, width_normal + 110, "width_with_spacing", "width_normal + 110");
+  assert_approx_equals(width_with_spacing, width_normal + 110, 0.1, "letter spacing incorrect before font change");
 
   // Changing font to 20px. Without resetting the spacing, 1em letterSpacing
   // is now 20px, so it's suppose to be 220px longer without any letterSpacing set.
@@ -39,7 +39,7 @@ t.step(function() {
   // Now calculate the reference spacing for "Hello World" with no spacing.
   ctx.letterSpacing = '0em';
   width_normal = ctx.measureText('Hello World').width;
-  _assertSame(width_with_spacing, width_normal + 220, "width_with_spacing", "width_normal + 220");
+  assert_approx_equals(width_with_spacing, width_normal + 220, 0.1, "letter spacing incorrect after font change");
   t.done();
 
 });

--- a/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.change.font.worker.js
+++ b/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.change.font.worker.js
@@ -26,7 +26,7 @@ t.step(function() {
   // 1em = 10px. Add 10px after each letter in "Hello World",
   // makes it 110px longer.
   var width_with_spacing = ctx.measureText('Hello World').width;
-  _assertSame(width_with_spacing, width_normal + 110, "width_with_spacing", "width_normal + 110");
+  assert_approx_equals(width_with_spacing, width_normal + 110, 0.1, "letter spacing incorrect before font change");
 
   // Changing font to 20px. Without resetting the spacing, 1em letterSpacing
   // is now 20px, so it's suppose to be 220px longer without any letterSpacing set.
@@ -35,7 +35,7 @@ t.step(function() {
   // Now calculate the reference spacing for "Hello World" with no spacing.
   ctx.letterSpacing = '0em';
   width_normal = ctx.measureText('Hello World').width;
-  _assertSame(width_with_spacing, width_normal + 220, "width_with_spacing", "width_normal + 220");
+  assert_approx_equals(width_with_spacing, width_normal + 220, 0.1, "letter spacing incorrect after font change");
   t.done();
 });
 done();

--- a/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.measure.html
+++ b/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.measure.html
@@ -23,7 +23,7 @@ t.step(function() {
   _assertSame(ctx.letterSpacing, '0px', "ctx.letterSpacing", "'0px'");
   _assertSame(ctx.wordSpacing, '0px', "ctx.wordSpacing", "'0px'");
   var width_normal = ctx.measureText('Hello World').width;
-  var ch_width = width_normal / 11;
+  var ch_width = ctx.measureText('0').width;
 
   function test_letter_spacing(value, difference_spacing, epsilon) {
     ctx.letterSpacing = value;

--- a/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.measure.worker.js
+++ b/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.measure.worker.js
@@ -19,7 +19,7 @@ t.step(function() {
   _assertSame(ctx.letterSpacing, '0px', "ctx.letterSpacing", "'0px'");
   _assertSame(ctx.wordSpacing, '0px', "ctx.wordSpacing", "'0px'");
   var width_normal = ctx.measureText('Hello World').width;
-  var ch_width = width_normal / 11;
+  var ch_width = ctx.measureText('0').width;
 
   function test_letter_spacing(value, difference_spacing, epsilon) {
     ctx.letterSpacing = value;

--- a/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.change.font.html
+++ b/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.change.font.html
@@ -30,7 +30,7 @@ t.step(function() {
   // 1em = 10px. Add 10px after each word in "Hello World, again",
   // makes it 20px longer.
   var width_with_spacing = ctx.measureText('Hello World, again').width;
-  _assertSame(width_with_spacing, width_normal + 20, "width_with_spacing", "width_normal + 20");
+  assert_approx_equals(width_with_spacing, width_normal + 20, 0.1, "word spacing incorrect before font change");
 
   // Changing font to 20px. Without resetting the spacing, 1em wordSpacing
   // is now 20px, so it's suppose to be 40px longer without any wordSpacing set.
@@ -39,7 +39,7 @@ t.step(function() {
   // Now calculate the reference spacing for "Hello World, again" with no spacing.
   ctx.wordSpacing = '0em';
   width_normal = ctx.measureText('Hello World, again').width;
-  _assertSame(width_with_spacing, width_normal + 40, "width_with_spacing", "width_normal + 40");
+  assert_approx_equals(width_with_spacing, width_normal + 40, 0.1, "word spacing incorrect after font change");
   t.done();
 
 });

--- a/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.change.font.worker.js
+++ b/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.change.font.worker.js
@@ -26,7 +26,7 @@ t.step(function() {
   // 1em = 10px. Add 10px after each word in "Hello World, again",
   // makes it 20px longer.
   var width_with_spacing = ctx.measureText('Hello World, again').width;
-  _assertSame(width_with_spacing, width_normal + 20, "width_with_spacing", "width_normal + 20");
+  assert_approx_equals(width_with_spacing, width_normal + 20, 0.1, "word spacing incorrect before font change");
 
   // Changing font to 20px. Without resetting the spacing, 1em wordSpacing
   // is now 20px, so it's suppose to be 40px longer without any wordSpacing set.
@@ -35,7 +35,7 @@ t.step(function() {
   // Now calculate the reference spacing for "Hello World, again" with no spacing.
   ctx.wordSpacing = '0em';
   width_normal = ctx.measureText('Hello World, again').width;
-  _assertSame(width_with_spacing, width_normal + 40, "width_with_spacing", "width_normal + 40");
+  assert_approx_equals(width_with_spacing, width_normal + 40, 0.1, "word spacing incorrect after font change");
   t.done();
 });
 done();

--- a/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.measure.html
+++ b/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.measure.html
@@ -23,7 +23,7 @@ t.step(function() {
   _assertSame(ctx.letterSpacing, '0px', "ctx.letterSpacing", "'0px'");
   _assertSame(ctx.wordSpacing, '0px', "ctx.wordSpacing", "'0px'");
   var width_normal = ctx.measureText('Hello World, again').width;
-  var ch_width = width_normal / 18;
+  var ch_width = ctx.measureText('0').width;
 
   function test_word_spacing(value, difference_spacing, epsilon) {
     ctx.wordSpacing = value;

--- a/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.measure.worker.js
+++ b/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.measure.worker.js
@@ -19,7 +19,7 @@ t.step(function() {
   _assertSame(ctx.letterSpacing, '0px', "ctx.letterSpacing", "'0px'");
   _assertSame(ctx.wordSpacing, '0px', "ctx.wordSpacing", "'0px'");
   var width_normal = ctx.measureText('Hello World, again').width;
-  var ch_width = width_normal / 18;
+  var ch_width = ctx.measureText('0').width;
 
   function test_word_spacing(value, difference_spacing, epsilon) {
     ctx.wordSpacing = value;

--- a/html/canvas/tools/yaml-new/text.yaml
+++ b/html/canvas/tools/yaml-new/text.yaml
@@ -1199,7 +1199,7 @@
     @assert ctx.letterSpacing === '0px';
     @assert ctx.wordSpacing === '0px';
     var width_normal = ctx.measureText('Hello World').width;
-    var ch_width = width_normal / 11;
+    var ch_width = ctx.measureText('0').width;
 
     function test_letter_spacing(value, difference_spacing, epsilon) {
       ctx.letterSpacing = value;
@@ -1234,7 +1234,7 @@
     @assert ctx.letterSpacing === '0px';
     @assert ctx.wordSpacing === '0px';
     var width_normal = ctx.measureText('Hello World, again').width;
-    var ch_width = width_normal / 18;
+    var ch_width = ctx.measureText('0').width;
 
     function test_word_spacing(value, difference_spacing, epsilon) {
       ctx.wordSpacing = value;
@@ -1276,7 +1276,7 @@
     // 1em = 10px. Add 10px after each letter in "Hello World",
     // makes it 110px longer.
     var width_with_spacing = ctx.measureText('Hello World').width;
-    @assert width_with_spacing === width_normal + 110;
+    assert_approx_equals(width_with_spacing, width_normal + 110, 0.1, "letter spacing incorrect before font change");
 
     // Changing font to 20px. Without resetting the spacing, 1em letterSpacing
     // is now 20px, so it's suppose to be 220px longer without any letterSpacing set.
@@ -1285,7 +1285,7 @@
     // Now calculate the reference spacing for "Hello World" with no spacing.
     ctx.letterSpacing = '0em';
     width_normal = ctx.measureText('Hello World').width;
-    @assert width_with_spacing === width_normal + 220;
+    assert_approx_equals(width_with_spacing, width_normal + 220, 0.1, "letter spacing incorrect after font change");
 
 - name: 2d.text.drawing.style.wordSpacing.change.font
   desc: Set word spacing and word spacing to font dependent value and verify it works after font change.
@@ -1300,7 +1300,7 @@
     // 1em = 10px. Add 10px after each word in "Hello World, again",
     // makes it 20px longer.
     var width_with_spacing = ctx.measureText('Hello World, again').width;
-    @assert width_with_spacing === width_normal + 20;
+    assert_approx_equals(width_with_spacing, width_normal + 20, 0.1, "word spacing incorrect before font change");
 
     // Changing font to 20px. Without resetting the spacing, 1em wordSpacing
     // is now 20px, so it's suppose to be 40px longer without any wordSpacing set.
@@ -1309,7 +1309,7 @@
     // Now calculate the reference spacing for "Hello World, again" with no spacing.
     ctx.wordSpacing = '0em';
     width_normal = ctx.measureText('Hello World, again').width;
-    @assert width_with_spacing === width_normal + 40;
+    assert_approx_equals(width_with_spacing, width_normal + 40, 0.1, "word spacing incorrect after font change");
 
 - name: 2d.text.drawing.style.fontKerning
   desc: Testing basic functionalities of fontKerning for canvas


### PR DESCRIPTION
This addresses a couple of issues with tests for the letterSpacing and wordSpacing attributes.

(1) The computation of ch_width (for the 'ch' unit) in the `*.measure.*` tests is invalid: it's calculating the average advance of the characters in the text, whereas 'ch' is defined as the advance width of the zero character. (The computation would be OK if using a monospaced font, but the tests do not ensure that. Instead, we can directly measure "0".)

(2) The precise assertions in the `*.change.*` tests may fail due to floating- point computations used in text layout, resulting in slight discrepancies between the actual measured advance and the value calculated in javascript. Convert these to approx_equal assertions with a small epsilon, similar to other existing letter- and word-spacing tests.