### PR TITLE
[wptrunner] Log the reason for skipping tests without executor support

### DIFF
--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -223,10 +223,14 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
         if test_type == "testharness":
             tests_to_run[test_type] = []
             for test in test_loader.tests[test_type]:
-                if ((test.testdriver and not executor_cls.supports_testdriver) or
-                        (test.jsshell and not executor_cls.supports_jsshell)):
+                skip_reason = None
+                if test.testdriver and not executor_cls.supports_testdriver:
+                    skip_reason = "Executor does not support testdriver.js"
+                elif test.jsshell and not executor_cls.supports_jsshell:
+                    skip_reason = "Executor does not support jsshell"
+                if skip_reason:
                     logger.test_start(test.id)
-                    logger.test_end(test.id, status="SKIP")
+                    logger.test_end(test.id, status="SKIP", message=skip_reason)
                     test_status.skipped += 1
                 else:
                     tests_to_run[test_type].append(test)


### PR DESCRIPTION
Make some types of `SKIP`s less [surprising] using the optional [`message` field] of `test_end`. Not a functional change.

[surprising]: https://crbug.com/1470587
[`message` field]: https://firefox-source-docs.mozilla.org/mozbase/mozlog.html#mozlog.structuredlog.StructuredLogger.test_end