### PR TITLE
[webdriver-client] Use the type field to differentiate message types

### DIFF
--- a/tools/webdriver/webdriver/bidi/client.py
+++ b/tools/webdriver/webdriver/bidi/client.py
@@ -178,32 +178,31 @@ class BidiSession:
 
     async def on_message(self, data: Mapping[str, Any]) -> None:
         """Handle a message from the remote server"""
-        if "id" in data:
+        if data["type"] in ["error", "success"]:
             # This is a command response or error
             future = self.pending_commands.get(data["id"])
             if future is None:
                 raise ValueError(f"No pending command with id {data['id']}")
-            if "result" in data:
+            if data["type"] == "success":
+                assert isinstance(data["result"], dict)
                 future.set_result(data["result"])
-            elif "error" in data and "message" in data:
+            else:
                 assert isinstance(data["error"], str)
                 assert isinstance(data["message"], str)
                 exception = from_error_details(data["error"],
                                                data["message"],
                                                data.get("stacktrace"))
                 future.set_exception(exception)
-            else:
-                raise ValueError(f"Unexpected message: {data!r}")
-        elif "method" in data and "params" in data:
+        elif data["type"] == "event":
             # This is an event
-            method = data["method"]
-            params = data["params"]
+            assert isinstance(data["method"], str)
+            assert isinstance(data["params"], dict)
 
-            listeners = self.event_listeners.get(method, [])
+            listeners = self.event_listeners.get(data["method"], [])
             if not listeners:
                 listeners = self.event_listeners.get(None, [])
             for listener in listeners:
-                await listener(method, params)
+                await listener(data["method"], data["params"])
         else:
             raise ValueError(f"Unexpected message: {data!r}")
 

--- a/webdriver/tests/bidi/browsing_context/dom_content_loaded/dom_content_loaded.py
+++ b/webdriver/tests/bidi/browsing_context/dom_content_loaded/dom_content_loaded.py
@@ -11,6 +11,7 @@ DOM_CONTENT_LOADED_EVENT = "browsingContext.domContentLoaded"
 
 
 async def test_unsubscribe(bidi_session, inline, top_context):
+    # test
     await bidi_session.session.subscribe(events=[DOM_CONTENT_LOADED_EVENT])
     await bidi_session.session.unsubscribe(events=[DOM_CONTENT_LOADED_EVENT])
 


### PR DESCRIPTION
These changes are a follow-up from https://github.com/w3c/webdriver-bidi/pull/484. Specfic tests aren't really needed but the BiDi client can handle the various messages by type now instead of checking arbitrary fields.

Note that merging this PR might be blocked because [newer chromedriver binaries cannot be downloaded](https://github.com/web-platform-tests/wpt/issues/40119). At least that is happening for me locally and this change would break my local testing.