### PR TITLE
Fix CanvasRenderingContext2D.reset transformation matrix and line dash tests

### DIFF
--- a/html/canvas/element/reset/2d.reset.state.line_dash.html
+++ b/html/canvas/element/reset/2d.reset.state.line_dash.html
@@ -19,12 +19,10 @@
 var t = async_test("check that the line dash is reset");
 _addTest(function(canvas, ctx) {
 
-  const default_value = ctx.getLineDash();
-
   ctx.setLineDash([1, 2]);
 
   ctx.reset();
-  _assert(ctx.getLineDash() == default_value, "ctx.getLineDash() == default_value");
+  _assert(ctx.getLineDash().length == 0, "ctx.getLineDash().length == 0");
 
 });
 </script>

--- a/html/canvas/element/reset/2d.reset.state.transformation_matrix.html
+++ b/html/canvas/element/reset/2d.reset.state.transformation_matrix.html
@@ -19,12 +19,10 @@
 var t = async_test("check that the state is reset");
 _addTest(function(canvas, ctx) {
 
-  const default_value = ctx.getTransform();
-
   ctx.scale(2, 2);
 
   ctx.reset();
-  _assert(ctx.getTransform() == default_value, "ctx.getTransform() == default_value");
+  _assert(ctx.getTransform().isIdentity, "ctx.getTransform().isIdentity");
 
 });
 </script>

--- a/html/canvas/offscreen/reset/2d.reset.state.line_dash.html
+++ b/html/canvas/offscreen/reset/2d.reset.state.line_dash.html
@@ -20,12 +20,10 @@ t.step(function() {
   var canvas = new OffscreenCanvas(100, 50);
   var ctx = canvas.getContext('2d');
 
-  const default_value = ctx.getLineDash();
-
   ctx.setLineDash([1, 2]);
 
   ctx.reset();
-  _assert(ctx.getLineDash() == default_value, "ctx.getLineDash() == default_value");
+  _assert(ctx.getLineDash().length == 0, "ctx.getLineDash().length == 0");
   t.done();
 
 });

--- a/html/canvas/offscreen/reset/2d.reset.state.line_dash.worker.js
+++ b/html/canvas/offscreen/reset/2d.reset.state.line_dash.worker.js
@@ -16,12 +16,10 @@ t.step(function() {
   var canvas = new OffscreenCanvas(100, 50);
   var ctx = canvas.getContext('2d');
 
-  const default_value = ctx.getLineDash();
-
   ctx.setLineDash([1, 2]);
 
   ctx.reset();
-  _assert(ctx.getLineDash() == default_value, "ctx.getLineDash() == default_value");
+  _assert(ctx.getLineDash().length == 0, "ctx.getLineDash().length == 0");
   t.done();
 });
 done();

--- a/html/canvas/offscreen/reset/2d.reset.state.transformation_matrix.html
+++ b/html/canvas/offscreen/reset/2d.reset.state.transformation_matrix.html
@@ -20,12 +20,10 @@ t.step(function() {
   var canvas = new OffscreenCanvas(100, 50);
   var ctx = canvas.getContext('2d');
 
-  const default_value = ctx.getTransform();
-
   ctx.scale(2, 2);
 
   ctx.reset();
-  _assert(ctx.getTransform() == default_value, "ctx.getTransform() == default_value");
+  _assert(ctx.getTransform().isIdentity, "ctx.getTransform().isIdentity");
   t.done();
 
 });

--- a/html/canvas/offscreen/reset/2d.reset.state.transformation_matrix.worker.js
+++ b/html/canvas/offscreen/reset/2d.reset.state.transformation_matrix.worker.js
@@ -16,12 +16,10 @@ t.step(function() {
   var canvas = new OffscreenCanvas(100, 50);
   var ctx = canvas.getContext('2d');
 
-  const default_value = ctx.getTransform();
-
   ctx.scale(2, 2);
 
   ctx.reset();
-  _assert(ctx.getTransform() == default_value, "ctx.getTransform() == default_value");
+  _assert(ctx.getTransform().isIdentity, "ctx.getTransform().isIdentity");
   t.done();
 });
 done();

--- a/html/canvas/tools/yaml-new/reset.yaml
+++ b/html/canvas/tools/yaml-new/reset.yaml
@@ -135,12 +135,10 @@
 - name: 2d.reset.state.transformation_matrix
   desc: check that the state is reset
   code: |
-    const default_value = ctx.getTransform();
-
     ctx.scale(2, 2);
 
     ctx.reset();
-    @assert ctx.getTransform() == default_value;
+    @assert ctx.getTransform().isIdentity;
 
 - name: 2d.reset.state.clip
   desc: check that the clip is reset
@@ -161,9 +159,7 @@
 - name: 2d.reset.state.line_dash
   desc: check that the line dash is reset
   code: |
-    const default_value = ctx.getLineDash();
-
     ctx.setLineDash([1, 2]);
 
     ctx.reset();
-    @assert ctx.getLineDash() == default_value;
+    @assert ctx.getLineDash().length == 0;


### PR DESCRIPTION
The transformation matrix and line dash tests (introduced in #41371)  check that they are reset back to their default values in an incorrect way, so fix that.