### PR TITLE
remove inactive reviewers from active accessibilty projects

### DIFF
--- a/accname/META.yml
+++ b/accname/META.yml
@@ -3,5 +3,3 @@ suggested_reviewers:
   - cookiecrook
   - spectranaut
   - jnurthen
-  - halindrome
-  - joanmarie

--- a/accname/META.yml
+++ b/accname/META.yml
@@ -3,3 +3,4 @@ suggested_reviewers:
   - cookiecrook
   - spectranaut
   - jnurthen
+  - melsumner

--- a/dpub-aam/META.yml
+++ b/dpub-aam/META.yml
@@ -1,4 +1,3 @@
 spec: https://w3c.github.io/dpub-aam/
 suggested_reviewers:
-  - halindrome
-  - joanmarie
+  - spectranaut

--- a/dpub-aria/META.yml
+++ b/dpub-aria/META.yml
@@ -1,3 +1,3 @@
 spec: https://w3c.github.io/dpub-aria/
 suggested_reviewers:
-  - halindrome
+  - spectranaut

--- a/graphics-aam/META.yml
+++ b/graphics-aam/META.yml
@@ -1,4 +1,3 @@
 spec: https://w3c.github.io/graphics-aam/
 suggested_reviewers:
-  - halindrome
-  - joanmarie
+  - spectranaut

--- a/wai-aria/META.yml
+++ b/wai-aria/META.yml
@@ -3,6 +3,3 @@ suggested_reviewers:
   - cookiecrook
   - spectranaut
   - jnurthen
-  - halindrome
-  - joanmarie
-  - michael-n-cooper


### PR DESCRIPTION
Closes https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/55