### PR TITLE
[wptrunner] Use `--webtransport-developer-mode` for Chrome/content_shell

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/content_shell.py
+++ b/tools/wptrunner/wptrunner/browsers/content_shell.py
@@ -43,21 +43,21 @@ def check_args(**kwargs):
 
 
 def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
-    args = list(kwargs["binary_args"])
-
+    args = []
     args.append("--ignore-certificate-errors-spki-list=%s" %
         ','.join(chrome_spki_certs.IGNORE_CERTIFICATE_ERRORS_SPKI_LIST))
-
-    webtranport_h3_port = config.ports.get('webtransport-h3')
-    if webtranport_h3_port is not None:
-        args.append(
-            f"--origin-to-force-quic-on=web-platform.test:{webtranport_h3_port[0]}")
+    # For WebTransport tests.
+    args.append("--webtransport-developer-mode")
 
     if not kwargs["headless"]:
         args.append("--disable-headless-mode")
 
-    # These flags are specific to content_shell - they activate web test protocol mode.
+    # `--run-web-tests -` are specific to content_shell - they activate web
+    # test protocol mode.
     args.append("--run-web-tests")
+    for arg in kwargs.get("binary_args", []):
+        if arg not in args:
+            args.append(arg)
     args.append("-")
 
     return {"binary": kwargs["binary"],


### PR DESCRIPTION
As a replacement for the less precise `--origin-to-force-quic-on=...`, per https://crrev.com/c/4631858 and https://crbug.com/1467065. Also, dedup duplicate `--binary-arg`s to make the command line tidier to log (we plan to [use `Port.additional_driver_flags(...)`][1] to pass `--binary-arg`s in Chromium's infrastructure).

See #31008 for when `--origin-to-force-quic-on=...` was originally added.

[1]: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/tools/blinkpy/web_tests/port/base.py;l=375-399;drc=ac6d0bc0036c0c5b33486c9e92293d79493efbcd;bpv=0;bpt=0