### PR TITLE
Add WebCodecs full cycle test using realtime `latencyMode`

### DIFF
--- a/webcodecs/full-cycle-test.https.any.js
+++ b/webcodecs/full-cycle-test.https.any.js
@@ -34,11 +34,10 @@ promise_setup(async () => {
       hardwareAcceleration: 'prefer-software',
     },
     '?h264_avc': {
-      codec: 'avc1.640028',
+      codec: 'avc1.42001E',
       avc: {format: 'avc'},
       hasEmbeddedColorSpace: true,
       hardwareAcceleration: 'prefer-software',
-      latencyMode: 'realtime',
     },
     '?h264_annexb': {
       codec: 'avc1.42001E',
@@ -64,6 +63,9 @@ promise_setup(async () => {
   config.bitrate = 1000000;
   config.bitrateMode = "constant";
   config.framerate = 30;
+  if (options.realTimeLatencyMode) {
+    config.latencyMode = 'realtime';
+  }
   ENCODER_CONFIG = config;
 });
 
@@ -161,6 +163,10 @@ async function runFullCycleTest(t, options) {
 promise_test(async t => {
   return runFullCycleTest(t, {});
 }, 'Encoding and decoding cycle');
+
+promise_test(async t => {
+  return runFullCycleTest(t, {realTimeLatencyMode: true});
+}, 'Encoding and decoding cycle w/ realtime latency mode');
 
 promise_test(async t => {
   if (ENCODER_CONFIG.hasEmbeddedColorSpace)

--- a/webcodecs/full-cycle-test.https.any.js
+++ b/webcodecs/full-cycle-test.https.any.js
@@ -63,14 +63,14 @@ promise_setup(async () => {
   config.bitrate = 1000000;
   config.bitrateMode = "constant";
   config.framerate = 30;
-  if (options.realTimeLatencyMode) {
-    config.latencyMode = 'realtime';
-  }
   ENCODER_CONFIG = config;
 });
 
 async function runFullCycleTest(t, options) {
   let encoder_config = { ...ENCODER_CONFIG };
+  if (options.realTimeLatencyMode) {
+    encoder_config.latencyMode = 'realtime';
+  }
   let encoder_color_space = {};
   const w = encoder_config.width;
   const h = encoder_config.height;

--- a/webcodecs/full-cycle-test.https.any.js
+++ b/webcodecs/full-cycle-test.https.any.js
@@ -34,10 +34,11 @@ promise_setup(async () => {
       hardwareAcceleration: 'prefer-software',
     },
     '?h264_avc': {
-      codec: 'avc1.42001E',
+      codec: 'avc1.640028',
       avc: {format: 'avc'},
       hasEmbeddedColorSpace: true,
       hardwareAcceleration: 'prefer-software',
+      latencyMode: 'realtime',
     },
     '?h264_annexb': {
       codec: 'avc1.42001E',

--- a/webcodecs/full-cycle-test.https.any.js
+++ b/webcodecs/full-cycle-test.https.any.js
@@ -166,7 +166,7 @@ promise_test(async t => {
 
 promise_test(async t => {
   return runFullCycleTest(t, {realTimeLatencyMode: true});
-}, 'Encoding and decoding cycle w/ realtime latency mode');
+}, 'Encoding and decoding cycle with realtime latency mode');
 
 promise_test(async t => {
   if (ENCODER_CONFIG.hasEmbeddedColorSpace)


### PR DESCRIPTION
I noticed that encoding and decoding in Safari did not properly work when using `latencyMode: "realtime"`. This adds a new test to run the full cycle tests using the realtime mode.