### PR TITLE
A browser init failure should cause a restart

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -354,7 +354,8 @@ class WebDriverBrowser(Browser):
                 "WebDriver was not accessible "
                 f"within the timeout:\n{traceback.format_exc()}")
             raise
-        self._output_handler.start(group_metadata=group_metadata, **kwargs)
+        finally:
+            self._output_handler.start(group_metadata=group_metadata, **kwargs)
         self.logger.debug("_run complete")
 
     def stop(self, force=False):

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -514,12 +514,10 @@ class TestRunnerManager(threading.Thread):
         self.browser.update_settings(self.state.test)
 
         result = self.browser.init(self.state.group_metadata)
-        if result is Stop:
-            return RunnerManagerState.error()
-        elif not result:
+        if not result:
             return self.init_failed()
-        else:
-            self.start_test_runner()
+
+        self.start_test_runner()
 
     def start_test_runner(self):
         # Note that we need to be careful to start the browser before the

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -177,6 +177,7 @@ class BrowserManager:
 
         self.started = False
 
+        self.browser_pid = None
         self.init_timer = None
         self.command_queue = command_queue
 
@@ -516,11 +517,7 @@ class TestRunnerManager(threading.Thread):
         if result is Stop:
             return RunnerManagerState.error()
         elif not result:
-            return RunnerManagerState.initializing(self.state.test_type,
-                                                   self.state.test,
-                                                   self.state.test_group,
-                                                   self.state.group_metadata,
-                                                   self.state.failure_count + 1)
+            return self.init_failed()
         else:
             self.start_test_runner()
 

--- a/tools/wptrunner/wptrunner/tests/browsers/test_base.py
+++ b/tools/wptrunner/wptrunner/tests/browsers/test_base.py
@@ -1,0 +1,52 @@
+# mypy: allow-untyped-defs
+
+import sys
+from os.path import dirname, join
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, join(dirname(__file__), "..", "..", ".."))
+
+from mozlog import structuredlog
+
+from wptrunner.browsers import base
+
+
+class MozLogTestHandler(object):
+    def __init__(self):
+        self.items = []
+
+    def __call__(self, data):
+        self.items.append(data)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Relies on echo, which isn't an executable on Windows",
+)
+def test_logging_immediate_exit():
+    logger = structuredlog.StructuredLogger("test")
+    handler = MozLogTestHandler()
+    logger.add_handler(handler)
+
+    class CustomException(Exception):
+        pass
+
+    with mock.patch.object(base, "wait_for_service", side_effect=CustomException):
+        browser = base.WebDriverBrowser(
+            logger, webdriver_binary="echo", webdriver_args=["sample output"]
+        )
+        try:
+            with pytest.raises(CustomException):
+                browser.start(group_metadata={})
+        finally:
+            # Ensure the `echo` process actually exits
+            browser._proc.wait()
+
+    process_output_actions = [
+        data for data in handler.items if data["action"] == "process_output"
+    ]
+
+    assert len(process_output_actions) == 1
+    assert process_output_actions[0]["data"] == "sample output"

--- a/tools/wptrunner/wptrunner/tests/browsers/test_sauce.py
+++ b/tools/wptrunner/wptrunner/tests/browsers/test_sauce.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 
+import gc
 import logging
 import sys
 from unittest import mock
@@ -15,6 +16,12 @@ sauce = pytest.importorskip("wptrunner.browsers.sauce")
 from wptserve.config import ConfigBuilder
 
 logger = logging.getLogger()
+
+
+def setup_module(module):
+    # Do a full GC collection, as mozprocess often creates garbage which then
+    # breaks when its __del__ is called while subprocess.Popen is mocked below.
+    gc.collect()
 
 
 def test_sauceconnect_success():


### PR DESCRIPTION
It makes no sense to call the `init` function and then not call `init_failure`, aside from the fact that it previously caused an `AttributeError` due to `browser_pid` not being initialized.

This means that if the browser has partially started (e.g., if the WebDriver server has started, but `wait_for_service` never actually connected) we actually stop it before retrying.

While we're at it, add a test for what we do with `process_output`  when `wait_for_service` never connects. (I am happy to entertain the idea that the current behaviour is wrong and change the implementation and expectation.)