### PR TITLE
wait_for_service should give up when the server process exits

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -347,8 +347,13 @@ class WebDriverBrowser(Browser):
         self._output_handler.after_process_start(self._proc.pid)
 
         try:
-            wait_for_service(self.logger, self.host, self.port,
-                             timeout=self.init_timeout)
+            wait_for_service(
+                self.logger,
+                self.host,
+                self.port,
+                timeout=self.init_timeout,
+                server_process=self._proc,
+            )
         except Exception:
             self.logger.error(
                 "WebDriver was not accessible "


### PR DESCRIPTION
It makes no sense to keep waiting and retrying when we know the server process has already exited; it's never going to succeed in this case.