### PR TITLE
Run a rAF loop instead of scheduling one rAF and expecting the idle time to happen before it.

### DIFF
--- a/requestidlecallback/deadline-max-rAF.html
+++ b/requestidlecallback/deadline-max-rAF.html
@@ -7,12 +7,16 @@
 <script src="resources/ric-utils.js"></script>
 <script>
 
+function runRAFLoop()
+{
+  requestAnimationFrame(runRAFLoop);
+}
+
 promise_test(async done => {
+  runRAFLoop();
   for (let i = 0; i < getRICRetryCount(); ++i) {
-    requestAnimationFrame(() => {})
     assert_less_than_equal(await getDeadlineForNextIdleCallback(), getPendingRenderDeadlineCap())
   }
-
 }, 'Check that the deadline is less than 16ms when there is a pending animation frame.');
 </script>
 <h1>Test of requestIdleCallback deadline behavior</h1>


### PR DESCRIPTION
Fixes https://github.com/web-platform-tests/wpt/issues/41393.