### PR TITLE
Make max_restarts a command-line argument

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -501,7 +501,7 @@ jobs:
   - script: |
       set -eux -o pipefail
       export SYSTEM_VERSION_COMPAT=0
-      ./wpt run --no-manifest-update --no-restart-on-unexpected --no-fail-on-unexpected --this-chunk=$(System.JobPositionInPhase) --total-chunks=$(System.TotalJobsInPhase) --chunk-type hash --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_$(System.JobPositionInPhase).json --log-wptscreenshot $(Build.ArtifactStagingDirectory)/wpt_screenshot_$(System.JobPositionInPhase).txt --log-mach - --log-mach-level info --channel stable --kill-safari safari
+      ./wpt run --no-manifest-update --no-restart-on-unexpected --no-fail-on-unexpected --this-chunk=$(System.JobPositionInPhase) --total-chunks=$(System.TotalJobsInPhase) --chunk-type hash --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_$(System.JobPositionInPhase).json --log-wptscreenshot $(Build.ArtifactStagingDirectory)/wpt_screenshot_$(System.JobPositionInPhase).txt --log-mach - --log-mach-level info --channel stable --kill-safari --max-restarts 100 safari
     displayName: 'Run tests'
     retryCountOnTaskFailure: 2
   - task: PublishBuildArtifacts@1
@@ -542,7 +542,7 @@ jobs:
   - script: |
       set -eux -o pipefail
       export SYSTEM_VERSION_COMPAT=0
-      ./wpt run --no-manifest-update --no-restart-on-unexpected --no-fail-on-unexpected --this-chunk=$(System.JobPositionInPhase) --total-chunks=$(System.TotalJobsInPhase) --chunk-type hash --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_$(System.JobPositionInPhase).json --log-wptscreenshot $(Build.ArtifactStagingDirectory)/wpt_screenshot_$(System.JobPositionInPhase).txt --log-mach - --log-mach-level info --channel preview --kill-safari safari
+      ./wpt run --no-manifest-update --no-restart-on-unexpected --no-fail-on-unexpected --this-chunk=$(System.JobPositionInPhase) --total-chunks=$(System.TotalJobsInPhase) --chunk-type hash --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_$(System.JobPositionInPhase).json --log-wptscreenshot $(Build.ArtifactStagingDirectory)/wpt_screenshot_$(System.JobPositionInPhase).txt --log-mach - --log-mach-level info --channel preview --kill-safari --max-restarts 100 safari
     displayName: 'Run tests'
     retryCountOnTaskFailure: 2
   - task: PublishBuildArtifacts@1

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -272,7 +272,7 @@ class TestRunnerManager(threading.Thread):
                  test_implementation_by_type, stop_flag, rerun=1,
                  pause_after_test=False, pause_on_unexpected=False,
                  restart_on_unexpected=True, debug_info=None,
-                 capture_stdio=True, restart_on_new_group=True, recording=None):
+                 capture_stdio=True, restart_on_new_group=True, recording=None, max_restarts=5):
         """Thread that owns a single TestRunner process and any processes required
         by the TestRunner (e.g. the Firefox binary).
 
@@ -344,7 +344,7 @@ class TestRunnerManager(threading.Thread):
 
         self.timer = None
 
-        self.max_restarts = 5
+        self.max_restarts = max_restarts
 
         self.browser = None
 
@@ -908,7 +908,8 @@ class ManagerGroup:
                  debug_info=None,
                  capture_stdio=True,
                  restart_on_new_group=True,
-                 recording=None):
+                 recording=None,
+                 max_restarts=5):
         self.suite_name = suite_name
         self.test_source_cls = test_source_cls
         self.test_source_kwargs = test_source_kwargs
@@ -922,6 +923,7 @@ class ManagerGroup:
         self.restart_on_new_group = restart_on_new_group
         self.recording = recording
         assert recording is not None
+        self.max_restarts = max_restarts
 
         self.pool = set()
         # Event that is polled by threads so that they can gracefully exit in the face
@@ -955,7 +957,8 @@ class ManagerGroup:
                                         self.debug_info,
                                         self.capture_stdio,
                                         self.restart_on_new_group,
-                                        recording=self.recording)
+                                        recording=self.recording,
+                                        max_restarts=self.max_restarts)
             manager.start()
             self.pool.add(manager)
         self.wait()

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -64,6 +64,8 @@ scheme host and port.""")
                         "directory")
     parser.add_argument("--processes", action="store", type=int, default=None,
                         help="Number of simultaneous processes to use")
+    parser.add_argument("--max-restarts", action="store", type=int, default=5,
+                        help="Maximum number of browser restart retries")
 
     parser.add_argument("--no-capture-stdio", action="store_true", default=False,
                         help="Don't capture stdio and write to logging")

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -270,7 +270,9 @@ def run_test_iteration(test_status, test_loader, test_source_kwargs, test_source
                           kwargs["debug_info"],
                           not kwargs["no_capture_stdio"],
                           kwargs["restart_on_new_group"],
-                          recording=recording) as manager_group:
+                          recording=recording,
+                          max_restarts=kwargs["max_restarts"],
+                          ) as manager_group:
             try:
                 handle_interrupt_signals()
                 manager_group.run(tests_to_run)


### PR DESCRIPTION
`--max-restarts` can be used to configure how many times we retry restarting the browser.

Keep the default as 5, but on Azure Pipelines pass 100 to full Safari runs due to ongoing flakiness with safaridriver in certain configurations, including Azure Pipelines.