### PR TITLE
Remove shebang line for non executable python scripts

### DIFF
--- a/tools/third_party_modified/mozlog/mozlog/formatters/html/html.py
+++ b/tools/third_party_modified/mozlog/mozlog/formatters/html/html.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/tools/third_party_modified/mozlog/mozlog/formatters/unittest.py
+++ b/tools/third_party_modified/mozlog/mozlog/formatters/unittest.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/tools/third_party_modified/mozlog/mozlog/handlers/valgrindhandler.py
+++ b/tools/third_party_modified/mozlog/mozlog/handlers/valgrindhandler.py
@@ -31,7 +31,7 @@ class ValgrindFilter(object):
     ==60741==    by 0x63AEF65: PR_Calloc (prmem.c:443)
     ==60741==    by 0x69F236E: PORT_ZAlloc_Util (secport.c:117)
     ==60741==    by 0x69F1336: SECITEM_AllocItem_Util (secitem.c:28)
-    ==60741==    by 0xA04280B: ffi_call_unix64 (in /builds/slave/m-in-l64-valgrind-000000000000/objdir/toolkit/library/libxul.so) # noqa
+    ==60741==    by 0xA04280B: ffi_call_unix64 (in /builds/worker/m-in-l64-valgrind-000000000000/objdir/toolkit/library/libxul.so) # noqa
     ==60741==    by 0xA042443: ffi_call (ffi64.c:485)
 
     For each such error, this class extracts most or all of the first (error

--- a/tools/third_party_modified/mozlog/mozlog/scripts/__init__.py
+++ b/tools/third_party_modified/mozlog/mozlog/scripts/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
Also fixed one non-inclusive word error.