### PR TITLE
Adjust baseline-source + textarea tests to account for UA-specific padding & margin.

### DIFF
--- a/css/css-inline/baseline-source/baseline-source-first-textarea-001.tentative.html
+++ b/css/css-inline/baseline-source/baseline-source-first-textarea-001.tentative.html
@@ -35,6 +35,9 @@ textarea {
   height: 60px;
   vertical-align: baseline;
   font-family: Ahem;
+  line-height: 1;
+  margin: 0;
+  padding: 0;
 }
 
 </style>
@@ -43,26 +46,26 @@ textarea {
 <script src="/resources/check-layout-th.js"></script>
 <body onload="checkLayout('.target > *')">
 <div class="target">
-  <span data-offset-y="33"></span>
-  <textarea data-offset-y="11" class="inner"></textarea>
+  <span data-offset-y="29"></span>
+  <textarea data-offset-y="10" class="inner"></textarea>
 </div>
 <div class="target">
-  <span data-offset-y="33"></span>
-  <textarea data-offset-y="11" class="inner">X X X X X</textarea>
+  <span data-offset-y="29"></span>
+  <textarea data-offset-y="10" class="inner">X X X X X</textarea>
 </div>
 <div class="target">
-  <span data-offset-y="33"></span>
-  <textarea data-offset-y="11" class="inner" placeholder="X X X X X"></textarea>
+  <span data-offset-y="29"></span>
+  <textarea data-offset-y="10" class="inner" placeholder="X X X X X"></textarea>
 </div>
 <div class="target">
-  <span data-offset-y="81"></span>
-  <textarea data-offset-y="11" class="inner" style="font-size: 100px;"></textarea>
+  <span data-offset-y="80"></span>
+  <textarea data-offset-y="10" class="inner" style="font-size: 100px;"></textarea>
 </div>
 <div class="target">
-  <span data-offset-y="81"></span>
-  <textarea data-offset-y="11" class="inner" style="font-size: 100px;">X X X X X</textarea>
+  <span data-offset-y="80"></span>
+  <textarea data-offset-y="10" class="inner" style="font-size: 100px;">X X X X X</textarea>
 </div>
 <div class="target">
-  <span data-offset-y="81"></span>
-  <textarea data-offset-y="11" class="inner" style="font-size: 100px;" placeholder="X X X X X"></textarea>
+  <span data-offset-y="80"></span>
+  <textarea data-offset-y="10" class="inner" style="font-size: 100px;" placeholder="X X X X X"></textarea>
 </div>

--- a/css/css-inline/baseline-source/baseline-source-first-textarea-002.tentative.html
+++ b/css/css-inline/baseline-source/baseline-source-first-textarea-002.tentative.html
@@ -37,6 +37,8 @@ textarea {
   vertical-align: baseline;
   font-family: Ahem;
   line-height: 1;
+  margin: 0;
+  padding: 0;
 }
 
 </style>
@@ -45,26 +47,26 @@ textarea {
 <script src="/resources/check-layout-th.js"></script>
 <body onload="checkLayout('.target > *')">
 <div class="target">
-  <span data-offset-x="61"></span>
-  <textarea data-offset-x="11" class="inner"></textarea>
+  <span data-offset-x="60"></span>
+  <textarea data-offset-x="10" class="inner"></textarea>
 </div>
 <div class="target">
-  <span data-offset-x="61"></span>
-  <textarea data-offset-x="11" class="inner">X X X X X</textarea>
+  <span data-offset-x="60"></span>
+  <textarea data-offset-x="10" class="inner">X X X X X</textarea>
 </div>
 <div class="target">
-  <span data-offset-x="61"></span>
-  <textarea data-offset-x="11" class="inner" placeholder="X X X X X"></textarea>
+  <span data-offset-x="60"></span>
+  <textarea data-offset-x="10" class="inner" placeholder="X X X X X"></textarea>
 </div>
 <div class="target">
-  <span data-offset-x="26"></span>
-  <textarea data-offset-x="11" class="inner" style="font-size: 100px;"></textarea>
+  <span data-offset-x="25"></span>
+  <textarea data-offset-x="10" class="inner" style="font-size: 100px;"></textarea>
 </div>
 <div class="target">
-  <span data-offset-x="26"></span>
-  <textarea data-offset-x="11" class="inner" style="font-size: 100px;">X X X X X</textarea>
+  <span data-offset-x="25"></span>
+  <textarea data-offset-x="10" class="inner" style="font-size: 100px;">X X X X X</textarea>
 </div>
 <div class="target">
-  <span data-offset-x="26"></span>
-  <textarea data-offset-x="11" class="inner" style="font-size: 100px;" placeholder="X X X X X"></textarea>
+  <span data-offset-x="25"></span>
+  <textarea data-offset-x="10" class="inner" style="font-size: 100px;" placeholder="X X X X X"></textarea>
 </div>

--- a/css/css-inline/baseline-source/baseline-source-first-textarea-003.tentative.html
+++ b/css/css-inline/baseline-source/baseline-source-first-textarea-003.tentative.html
@@ -37,6 +37,8 @@ textarea {
   vertical-align: baseline;
   font-family: Ahem;
   line-height: 1;
+  margin: 0;
+  padding: 0;
 }
 
 </style>
@@ -45,26 +47,26 @@ textarea {
 <script src="/resources/check-layout-th.js"></script>
 <body onload="checkLayout('.target > *')">
 <div class="target">
-  <span data-offset-x="31"></span>
-  <textarea data-offset-x="11" class="inner"></textarea>
+  <span data-offset-x="30"></span>
+  <textarea data-offset-x="10" class="inner"></textarea>
 </div>
 <div class="target">
-  <span data-offset-x="31"></span>
-  <textarea data-offset-x="11" class="inner">X X X X X</textarea>
+  <span data-offset-x="30"></span>
+  <textarea data-offset-x="10" class="inner">X X X X X</textarea>
 </div>
 <div class="target">
-  <span data-offset-x="31"></span>
-  <textarea data-offset-x="11" class="inner" placeholder="X X X X X"></textarea>
+  <span data-offset-x="30"></span>
+  <textarea data-offset-x="10" class="inner" placeholder="X X X X X"></textarea>
 </div>
 <div class="target">
-  <span data-offset-x="66"></span>
-  <textarea data-offset-x="11" class="inner" style="font-size: 100px;"></textarea>
+  <span data-offset-x="65"></span>
+  <textarea data-offset-x="10" class="inner" style="font-size: 100px;"></textarea>
 </div>
 <div class="target">
-  <span data-offset-x="66"></span>
-  <textarea data-offset-x="11" class="inner" style="font-size: 100px;">X X X X X</textarea>
+  <span data-offset-x="65"></span>
+  <textarea data-offset-x="10" class="inner" style="font-size: 100px;">X X X X X</textarea>
 </div>
 <div class="target">
-  <span data-offset-x="66"></span>
-  <textarea data-offset-x="11" class="inner" style="font-size: 100px;" placeholder="X X X X X"></textarea>
+  <span data-offset-x="65"></span>
+  <textarea data-offset-x="10" class="inner" style="font-size: 100px;" placeholder="X X X X X"></textarea>
 </div>

--- a/css/css-inline/baseline-source/baseline-source-last-textarea-001.tentative.html
+++ b/css/css-inline/baseline-source/baseline-source-last-textarea-001.tentative.html
@@ -35,6 +35,9 @@ textarea {
   height: 60px;
   vertical-align: baseline;
   font-family: Ahem;
+  line-height: 1;
+  margin: 0;
+  padding: 0;
 }
 
 </style>
@@ -43,27 +46,27 @@ textarea {
 <script src="/resources/check-layout-th.js"></script>
 <body onload="checkLayout('.target > *')">
 <div class="target">
-  <span data-offset-y="81"></span>
-  <textarea data-offset-y="11" class="inner"></textarea>
+  <span data-offset-y="80"></span>
+  <textarea data-offset-y="10" class="inner"></textarea>
 </div>
 <div class="target">
-  <span data-offset-y="81"></span>
-  <textarea data-offset-y="11" class="inner">X X X X X</textarea>
+  <span data-offset-y="80"></span>
+  <textarea data-offset-y="10" class="inner">X X X X X</textarea>
 </div>
 <div class="target">
-  <span data-offset-y="81"></span>
-  <textarea data-offset-y="11" class="inner" placeholder="X X X X X"></textarea>
+  <span data-offset-y="80"></span>
+  <textarea data-offset-y="10" class="inner" placeholder="X X X X X"></textarea>
 </div>
 <div class="target">
-  <span data-offset-y="81"></span>
-  <textarea data-offset-y="11" class="inner" style="font-size: 100px;"></textarea>
+  <span data-offset-y="80"></span>
+  <textarea data-offset-y="10" class="inner" style="font-size: 100px;"></textarea>
 </div>
 <div class="target">
-  <span data-offset-y="81"></span>
-  <textarea data-offset-y="11" class="inner" style="font-size: 100px;">X X X X X</textarea>
+  <span data-offset-y="80"></span>
+  <textarea data-offset-y="10" class="inner" style="font-size: 100px;">X X X X X</textarea>
 </div>
 <div class="target">
-  <span data-offset-y="81"></span>
-  <textarea data-offset-y="11" class="inner" style="font-size: 100px;" placeholder="X X X X X"></textarea>
+  <span data-offset-y="80"></span>
+  <textarea data-offset-y="10" class="inner" style="font-size: 100px;" placeholder="X X X X X"></textarea>
 </div>
 

--- a/css/css-inline/baseline-source/baseline-source-last-textarea-002.tentative.html
+++ b/css/css-inline/baseline-source/baseline-source-last-textarea-002.tentative.html
@@ -37,6 +37,8 @@ textarea {
   vertical-align: baseline;
   font-family: Ahem;
   line-height: 1;
+  margin: 0;
+  padding: 0;
 }
 
 </style>
@@ -45,26 +47,26 @@ textarea {
 <script src="/resources/check-layout-th.js"></script>
 <body onload="checkLayout('.target > *')">
 <div class="target">
-  <span data-offset-x="46"></span>
-  <textarea data-offset-x="11" class="inner"></textarea>
+  <span data-offset-x="45"></span>
+  <textarea data-offset-x="10" class="inner"></textarea>
 </div>
 <div class="target">
-  <span data-offset-x="46"></span>
-  <textarea data-offset-x="11" class="inner">X X X X X</textarea>
+  <span data-offset-x="45"></span>
+  <textarea data-offset-x="10" class="inner">X X X X X</textarea>
 </div>
 <div class="target">
-  <span data-offset-x="46"></span>
-  <textarea data-offset-x="11" class="inner" placeholder="X X X X X"></textarea>
+  <span data-offset-x="45"></span>
+  <textarea data-offset-x="10" class="inner" placeholder="X X X X X"></textarea>
 </div>
 <div class="target">
-  <span data-offset-x="46"></span>
-  <textarea data-offset-x="11" class="inner" style="font-size: 100px;"></textarea>
+  <span data-offset-x="45"></span>
+  <textarea data-offset-x="10" class="inner" style="font-size: 100px;"></textarea>
 </div>
 <div class="target">
-  <span data-offset-x="46"></span>
-  <textarea data-offset-x="11" class="inner" style="font-size: 100px;">X X X X X</textarea>
+  <span data-offset-x="45"></span>
+  <textarea data-offset-x="10" class="inner" style="font-size: 100px;">X X X X X</textarea>
 </div>
 <div class="target">
-  <span data-offset-x="46"></span>
-  <textarea data-offset-x="11" class="inner" style="font-size: 100px;" placeholder="X X X X X"></textarea>
+  <span data-offset-x="45"></span>
+  <textarea data-offset-x="10" class="inner" style="font-size: 100px;" placeholder="X X X X X"></textarea>
 </div>

--- a/css/css-inline/baseline-source/baseline-source-last-textarea-003.tentative.html
+++ b/css/css-inline/baseline-source/baseline-source-last-textarea-003.tentative.html
@@ -37,6 +37,8 @@ textarea {
   vertical-align: baseline;
   font-family: Ahem;
   line-height: 1;
+  margin: 0;
+  padding: 0;
 }
 
 </style>
@@ -45,26 +47,26 @@ textarea {
 <script src="/resources/check-layout-th.js"></script>
 <body onload="checkLayout('.target > *')">
 <div class="target">
-  <span data-offset-x="46"></span>
-  <textarea data-offset-x="11" class="inner"></textarea>
+  <span data-offset-x="45"></span>
+  <textarea data-offset-x="10" class="inner"></textarea>
 </div>
 <div class="target">
-  <span data-offset-x="46"></span>
-  <textarea data-offset-x="11" class="inner">X X X X X</textarea>
+  <span data-offset-x="45"></span>
+  <textarea data-offset-x="10" class="inner">X X X X X</textarea>
 </div>
 <div class="target">
-  <span data-offset-x="46"></span>
-  <textarea data-offset-x="11" class="inner" placeholder="X X X X X"></textarea>
+  <span data-offset-x="45"></span>
+  <textarea data-offset-x="10" class="inner" placeholder="X X X X X"></textarea>
 </div>
 <div class="target">
-  <span data-offset-x="46"></span>
-  <textarea data-offset-x="11" class="inner" style="font-size: 100px;"></textarea>
+  <span data-offset-x="45"></span>
+  <textarea data-offset-x="10" class="inner" style="font-size: 100px;"></textarea>
 </div>
 <div class="target">
-  <span data-offset-x="46"></span>
-  <textarea data-offset-x="11" class="inner" style="font-size: 100px;">X X X X X</textarea>
+  <span data-offset-x="45"></span>
+  <textarea data-offset-x="10" class="inner" style="font-size: 100px;">X X X X X</textarea>
 </div>
 <div class="target">
-  <span data-offset-x="46"></span>
-  <textarea data-offset-x="11" class="inner" style="font-size: 100px;" placeholder="X X X X X"></textarea>
+  <span data-offset-x="45"></span>
+  <textarea data-offset-x="10" class="inner" style="font-size: 100px;" placeholder="X X X X X"></textarea>
 </div>


### PR DESCRIPTION
Context here (Thanks Ian Kilpatrick for pointing this out): https://bugzilla.mozilla.org/show_bug.cgi?id=1846982#c11 
Explicitly work with 0 padding & margin, which should be fine for the purpose of these tests.