### PR TITLE
Fixed the role of the element

### DIFF
--- a/core-aam/aria-readonly_false-manual.html
+++ b/core-aam/aria-readonly_false-manual.html
@@ -69,7 +69,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for aria-readonly=false.</p>
-    <div role='checkbox' id='test' aria-readonly='false'>content</div>
+    <div role='searchbox' id='test' aria-readonly='false'>content</div>
 
   <div id="manualMode"></div>
   <div id="log"></div>


### PR DESCRIPTION
This corrects the semantics and exposes the readonly states

This is a duplicate of https://github.com/web-platform-tests/wpt/pull/7927

For some reason that PR can be merged because of "Some checks haven’t completed yet" -- but there is no way to run them or start them, it seems like some broken state, and the PR is quite old now. I've pulled the code and am opening a new PR to see if I can get it to land.