### PR TITLE
[wptrunner] Fix resource leakage on exit

### DIFF
--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -6,6 +6,7 @@ import hashlib
 import itertools
 import json
 import os
+import queue
 from urllib.parse import urlsplit
 from abc import ABCMeta, abstractmethod
 from queue import Empty
@@ -15,7 +16,6 @@ from typing import cast, Any, Dict, List, Optional, Set
 from . import manifestinclude
 from . import manifestexpected
 from . import manifestupdate
-from . import mpcontext
 from . import wpttest
 from mozlog import structured
 
@@ -502,8 +502,7 @@ class TestSource:
 
     @classmethod
     def make_queue(cls, tests_by_type, **kwargs):
-        mp = mpcontext.get_context()
-        test_queue = mp.Queue()
+        test_queue = queue.SimpleQueue()
         groups = cls.make_groups(tests_by_type, **kwargs)
         processes = cls.process_count(kwargs["processes"], len(groups))
         if processes > 1:

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -46,9 +46,9 @@ class TestRunner:
     that is passed in.
 
     :param logger: Structured logger
-    :param command_queue: subprocess.Queue used to send commands to the
+    :param command_queue: multiprocessing.Queue used to send commands to the
                           process
-    :param result_queue: subprocess.Queue used to send results to the
+    :param result_queue: multiprocessing.Queue used to send results to the
                          parent TestRunnerManager process
     :param executor: TestExecutor object that will actually run a test.
     """
@@ -617,6 +617,7 @@ class TestRunnerManager(threading.Thread):
             wait_timeout = (self.state.test.timeout * self.executor_kwargs['timeout_multiplier'] +
                             3 * self.executor_cls.extra_timeout)
             self.timer = threading.Timer(wait_timeout, self._timeout)
+            self.timer.name = f"{self.name}-timeout"
 
         self.send_message("run_test", self.state.test)
         if self.timer:
@@ -869,6 +870,8 @@ class TestRunnerManager(threading.Thread):
         self.logger.debug("TestRunnerManager cleanup")
         if self.browser:
             self.browser.cleanup()
+        if self.timer:
+            self.timer.cancel()
         while True:
             try:
                 cmd, data = self.command_queue.get_nowait()
@@ -890,17 +893,6 @@ class TestRunnerManager(threading.Thread):
                 self.logger.warning(f"Command left in remote_queue during cleanup: {cmd!r}, {data!r}")
             except Empty:
                 break
-
-
-def make_test_queue(tests, test_source):
-    queue, num_of_workers = test_source.cls.make_queue(tests, **test_source.kwargs)
-
-    # There is a race condition that means sometimes we continue
-    # before the tests have been written to the underlying pipe.
-    # Polling the pipe for data here avoids that
-    queue._reader.poll(10)
-    assert not queue.empty()
-    return queue, num_of_workers
 
 
 class ManagerGroup:
@@ -945,8 +937,8 @@ class ManagerGroup:
 
     def run(self, tests):
         """Start all managers in the group"""
-
-        test_queue, size = make_test_queue(tests, self.test_source)
+        test_queue, size = self.test_source.cls.make_queue(
+            tests, **self.test_source.kwargs)
         self.logger.info("Using %i child processes" % size)
 
         for idx in range(size):


### PR DESCRIPTION
* The test `multiprocessing.Queue` starts a background thread that feeds buffered data into an underlying OS pipe. When the test run is interrupted early, the pipe can be full without `TestRunnerManager`s to drain it. As a result, the background thread may never join, blocking the program from exiting [1, 2, 3, 4]. Since the test queue is only shared among `TestRunnerManager` threads in the main process, a `queue.SimpleQueue` suffices as a drop-in replacement with (almost) the same interface. This also obviates a hack that waits for the background thread to make the first test group available.
* On cleanup, ensure that each `TestRunnerManager` cancels its timeout `timer`. Currently, the `timer` thread can outlive the main thread and fire after `logger.shutdown(...)`, which pollutes the log with `LoggerShutdownError`.
* Give each timeout `timer` thread a more descriptive name than the default of `Thread-<N>`.

[1] https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Queue.join_thread
[2] https://github.com/python/cpython/blob/3.8/Lib/multiprocessing/queues.py#L195
[3] https://github.com/python/cpython/blob/3.8/Lib/multiprocessing/util.py#L300
[4] https://docs.python.org/3/library/multiprocessing.html#all-start-methods, "Joining processes that use queues"