### PR TITLE
adjust privileged scope for android emulator runs

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -57,7 +57,7 @@ tasks:
             owner: ${owner}
             source: ${event.repository.clone_url}
           payload:
-            image: webplatformtests/wpt:0.54
+            image: webplatformtests/wpt:0.55
             maxRunTime: 7200
             artifacts:
               public/results:

--- a/infrastructure/metadata/infrastructure/server/context.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/context.any.js.ini
@@ -6,3 +6,14 @@
 [context.any.serviceworker-module.html]
   expected:
     if product == "firefox": ERROR
+    if product == "firefox_android": ERROR
+
+[context.any.worker-module.html]
+
+[context.any.sharedworker-module.html]
+
+[context.any.sharedworker.html]
+
+[context.any.html]
+
+[context.any.worker.html]

--- a/infrastructure/metadata/infrastructure/server/webtransport-h3.https.sub.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/webtransport-h3.https.sub.any.js.ini
@@ -1,29 +1,45 @@
 [webtransport-h3.https.sub.any.html]
+  expected:
+    if product == "firefox_android": TIMEOUT
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
-      if product == "chrome" or product == "firefox": PASS
+      if (product == "chrome") or (product == "firefox"): PASS
+      if product == "firefox_android": TIMEOUT
       FAIL
+
 
 [webtransport-h3.https.sub.any.window.html]
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
-      if product == "chrome" or product == "firefox": PASS
+      if (product == "chrome") or (product == "firefox"): PASS
       FAIL
+
 
 [webtransport-h3.https.sub.any.worker.html]
+  expected:
+    if product == "firefox_android": TIMEOUT
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
-      if product == "chrome" or product == "firefox": PASS
+      if (product == "chrome") or (product == "firefox"): PASS
+      if product == "firefox_android": TIMEOUT
       FAIL
+
 
 [webtransport-h3.https.sub.any.sharedworker.html]
+  expected:
+    if product == "firefox_android": TIMEOUT
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
-      if product == "chrome" or product == "firefox": PASS
+      if (product == "chrome") or (product == "firefox"): PASS
+      if product == "firefox_android": TIMEOUT
       FAIL
 
+
 [webtransport-h3.https.sub.any.serviceworker.html]
+  expected:
+    if product == "firefox_android": TIMEOUT
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
-      if product == "chrome" or product == "firefox": PASS
+      if (product == "chrome") or (product == "firefox"): PASS
+      if product == "firefox_android": TIMEOUT
       FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/actions/elementTiming.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/elementTiming.html.ini
@@ -1,0 +1,4 @@
+[elementTiming.html]
+  [TestDriver actions: element timing]
+    expected:
+      if product == "firefox_android": FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/actions/mouseClickCount.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/mouseClickCount.html.ini
@@ -1,4 +1,5 @@
 [mouseClickCount.html]
   [TestDriver actions: test the mouse click counts at different cases]
     expected:
-      if product == "firefox" or product == "safari": FAIL
+      if (product == "firefox") or (product == "safari"): FAIL
+      if product == "firefox_android": FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/actions/penPointerEventProperties.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/penPointerEventProperties.html.ini
@@ -1,4 +1,5 @@
 [penPointerEventProperties.html]
   [TestDriver actions: pointerevent properties of pen type]
     expected:
-      if product == "safari" or product == "firefox": FAIL
+      if (product == "safari") or (product == "firefox"): FAIL
+      if product == "firefox_android": FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/actions/penPointerEvents.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/penPointerEvents.html.ini
@@ -1,4 +1,5 @@
 [penPointerEvents.html]
   [TestDriver actions: pointerevent properties of pen type]
     expected:
-      if product == "safari" or product == "firefox": FAIL
+      if (product == "safari") or (product == "firefox"): FAIL
+      if product == "firefox_android": FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/file_upload.sub.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/file_upload.sub.html.ini
@@ -4,3 +4,4 @@
   [File upload using testdriver]
     expected:
       if (product == "epiphany") or (product == "webkit"): FAIL
+      if product == "firefox_android": FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/generate_test_report.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/generate_test_report.html.ini
@@ -1,4 +1,5 @@
 [generate_test_report.html]
   [TestDriver generate_test_report method]
     expected:
-      if product == "firefox" or product == "epiphany" or product == "webkit": FAIL
+      if (product == "firefox") or (product == "epiphany") or (product == "webkit"): FAIL
+      if product == "firefox_android": FAIL

--- a/tools/ci/ci_wptrunner_infrastructure.sh
+++ b/tools/ci/ci_wptrunner_infrastructure.sh
@@ -6,7 +6,7 @@ WPT_ROOT=$SCRIPT_DIR/../..
 cd $WPT_ROOT
 
 run_infra_test() {
-    TERM=dumb ./wpt run --log-mach - --yes --manifest ~/meta/MANIFEST.json --metadata infrastructure/metadata/ --install-fonts --install-webdriver $2 $1 infrastructure/
+    TERM=dumb ./wpt run --log-mach - --yes --manifest ~/meta/MANIFEST.json --metadata infrastructure/metadata/ --install-fonts --install-webdriver --log-wptreport="/home/test/artifacts/wptreport-$1.json" $2 $1 infrastructure/
 }
 
 main() {

--- a/tools/ci/ci_wptrunner_infrastructure.sh
+++ b/tools/ci/ci_wptrunner_infrastructure.sh
@@ -5,21 +5,15 @@ SCRIPT_DIR=$(cd $(dirname "$0") && pwd -P)
 WPT_ROOT=$SCRIPT_DIR/../..
 cd $WPT_ROOT
 
-test_infrastructure() {
-    TERM=dumb ./wpt run --log-mach - --yes --manifest ~/meta/MANIFEST.json --metadata infrastructure/metadata/ --install-fonts --install-webdriver $1 $PRODUCT infrastructure/
+run_infra_test() {
+    TERM=dumb ./wpt run --log-mach - --yes --manifest ~/meta/MANIFEST.json --metadata infrastructure/metadata/ --install-fonts --install-webdriver $2 $1 infrastructure/
 }
 
 main() {
-    PRODUCTS=( "firefox" "chrome" )
     ./wpt manifest --rebuild -p ~/meta/MANIFEST.json
-    for PRODUCT in "${PRODUCTS[@]}"; do
-        if [[ "$PRODUCT" == "chrome" ]]; then
-            # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
-            test_infrastructure "--binary=$(which google-chrome-unstable) --enable-swiftshader --channel dev" "$1"
-        else
-            test_infrastructure "--binary=~/build/firefox/firefox" "$1"
-        fi
-    done
+    run_infra_test "chrome" "--binary=$(which google-chrome-unstable) --enable-swiftshader --channel dev $1"
+    run_infra_test "firefox" "--binary=~/build/firefox/firefox $1"
+    run_infra_test "firefox_android" "--install-browser --logcat-dir=/home/test/artifacts/ $1"
 }
 
 main $1

--- a/tools/ci/tc/decision.py
+++ b/tools/ci/tc/decision.py
@@ -249,6 +249,7 @@ def create_tc_task(event, task, taskgroup_id, depends_on_ids, env_extra=None):
         "provisionerId": task["provisionerId"],
         "schedulerId": task["schedulerId"],
         "workerType": task["workerType"],
+        "scopes": task.get("scopes", []),
         "metadata": {
             "name": task["name"],
             "description": task.get("description", ""),
@@ -269,6 +270,10 @@ def create_tc_task(event, task, taskgroup_id, depends_on_ids, env_extra=None):
     }
     if "extra" in task:
         task_data["extra"].update(task["extra"])
+    if task.get("privileged"):
+        if "capabilities" not in task_data["payload"]:
+            task_data["payload"]["capabilities"] = {}
+        task_data["payload"]["capabilities"]["privileged"] = True
     if env_extra:
         task_data["payload"]["env"].update(env_extra)
     if depends_on_ids:

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -4,7 +4,7 @@ components:
     workerType: ci
     schedulerId: taskcluster-github
     deadline: "24 hours"
-    image: webplatformtests/wpt:0.54
+    image: webplatformtests/wpt:0.55
     maxRunTime: 7200
     artifacts:
       public/results:

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -108,6 +108,11 @@ components:
 
   browser-servo: {}
 
+  browser-firefox_android:
+    privileged: true
+    scopes:
+      - "docker-worker:capability:privileged"
+
   tox-python3_7:
     env:
       TOXENV: py37
@@ -220,6 +225,11 @@ tasks:
                 channel: nightly
               use:
                 - trigger-weekly
+                - trigger-push
+            - vars:
+                browser: firefox_android
+                channel: nightly
+              use:
                 - trigger-push
           do:
             - ${vars.browser}-${vars.channel}-${vars.suite}:
@@ -532,6 +542,7 @@ tasks:
         - wpt-base
         - trigger-pr
         - browser-firefox
+        - browser-firefox_android
       command: ./tools/ci/ci_wptrunner_infrastructure.sh
       install:
         - python3-pip
@@ -543,6 +554,7 @@ tasks:
         browser:
           - firefox
           - chrome
+          - firefox_android
         channel: experimental
         xvfb: true
         hosts: false

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get -qqy update \
     libunwind8 \
     libxcb-shape0-dev \
     locales \
-    openjdk-8-jre-headless \
+    openjdk-17-jre-headless \
     pulseaudio \
     python3 \
     python3-dev \
@@ -80,6 +80,7 @@ RUN useradd test \
          --shell /bin/bash  \
          --create-home \
   && usermod -a -G sudo test \
+  && usermod -a -G kvm test \
   && usermod -a -G libvirt test \
   && usermod -a -G libvirt-qemu test \
   && echo 'ALL ALL = (ALL) NOPASSWD: ALL' >> /etc/sudoers \

--- a/tools/docker/frontend.py
+++ b/tools/docker/frontend.py
@@ -129,6 +129,7 @@ def run(*args, **kwargs):
                  os.path.join(wpt_root, "tools", "docker", "seccomp.json")])
     if kwargs["privileged"]:
         args.append("--privileged")
+        args.extend(["--device", "/dev/kvm"])
     if kwargs["checkout"]:
         args.extend(["--env", "REF==%s" % kwargs["checkout"]])
     else:

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -622,18 +622,18 @@ class ServerProc:
     def start(self, init_func, host, port, paths, routes, bind_address, config, log_handlers, **kwargs):
         self.proc = self.mp_context.Process(target=self.create_daemon,
                                             args=(init_func, host, port, paths, routes, bind_address,
-                                                  config, log_handlers),
+                                                  config, log_handlers, dict(**os.environ)),
                                             name='%s on port %s' % (self.scheme, port),
                                             kwargs=kwargs)
         self.proc.daemon = True
         self.proc.start()
 
     def create_daemon(self, init_func, host, port, paths, routes, bind_address,
-                      config, log_handlers, **kwargs):
+                      config, log_handlers, env, **kwargs):
         # Ensure that when we start this in a new process we have the global lock
         # in the logging module unlocked
         importlib.reload(logging)
-
+        os.environ = env
         logger = get_logger(config.logging["level"], log_handlers)
 
         if sys.platform == "darwin":

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -411,7 +411,7 @@ class Firefox(Browser):
         if version:
             dest = os.path.join(dest, version)
         have_cache = False
-        if os.path.exists(dest) and len(os.listdir(dest)) > 0:
+        if os.path.exists(dest) and os.path.exists(os.path.join(dest, "profiles.json")):
             if channel != "nightly":
                 have_cache = True
             else:
@@ -427,7 +427,7 @@ class Firefox(Browser):
 
             url = self.get_profile_bundle_url(version, channel)
 
-            self.logger.info("Installing test prefs from %s" % url)
+            self.logger.info(f"Downloading test prefs from {url}")
             try:
                 extract_dir = tempfile.mkdtemp()
                 unzip(get(url).raw, dest=extract_dir)
@@ -438,8 +438,9 @@ class Firefox(Browser):
                     shutil.move(path, dest)
             finally:
                 rmtree(extract_dir)
+            self.logger.info(f"Test prefs downloaded to {dest}")
         else:
-            self.logger.info("Using cached test prefs from %s" % dest)
+            self.logger.info(f"Using cached test prefs from {dest}")
 
         return dest
 

--- a/tools/wpt/install.py
+++ b/tools/wpt/install.py
@@ -7,6 +7,7 @@ latest_channels = {
     'android_weblayer': 'dev',
     'android_webview': 'dev',
     'firefox': 'nightly',
+    'firefox_android': 'nightly',
     'chrome': 'canary',
     'chrome_android': 'dev',
     'chromium': 'nightly',

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import platform
+import subprocess
 import sys
 from shutil import which
 from typing import ClassVar, Tuple, Type
@@ -57,6 +58,8 @@ def create_parser():
     parser.add_argument("--install-webdriver", action="store_true",
                         help="Install WebDriver from the release channel specified by --channel "
                         "(or the nightly channel by default).")
+    parser.add_argument("--logcat-dir", action="store", default=None,
+                        help="Directory to write Android logcat files to")
     parser._add_container_actions(wptcommandline.create_parser())
     return parser
 
@@ -158,6 +161,62 @@ in PowerShell with Administrator privileges.""" % (wpt_path, hosts_path)
                 raise WptrunError(message)
 
 
+class AndroidLogcat:
+    def __init__(self, adb_path, base_path=None):
+        self.adb_path = adb_path
+        self.base_path = base_path if base_path is not None else os.curdir
+        self.procs = {}
+
+    def start(self, device_serial):
+        """
+        Start recording logcat. Writes logcat to the upload directory.
+        """
+        # Start logcat for the device. The adb process runs until the
+        # corresponding device is stopped. Output is written directly to
+        # the blobber upload directory so that it is uploaded automatically
+        # at the end of the job.
+        if device_serial in self.procs:
+            logger.warning(f"Logcat for {device_serial} already started")
+            return
+
+        logcat_path = os.path.join(self.base_path, f"logcat-{device_serial}.log")
+        out_file = open(logcat_path, "w")
+        cmd = [
+            self.adb_path,
+            "-s",
+            device_serial,
+            "logcat",
+            "-v",
+            "threadtime",
+            "Trace:S",
+            "StrictMode:S",
+            "ExchangeService:S",
+        ]
+        logger.debug(" ".join(cmd))
+        proc = subprocess.Popen(
+            cmd, stdout=out_file, stdin=subprocess.PIPE
+        )
+        logger.info(f"Started logcat for device {device_serial} pid {proc.pid}")
+        self.procs[device_serial] = (proc, out_file)
+
+    def stop(self, device_serial=None):
+        """
+        Stop logcat process started by logcat_start.
+        """
+        if device_serial is None:
+            for key in list(self.procs.keys()):
+                self.stop(key)
+            return
+
+        proc, out_file = self.procs.get(device_serial, (None, None))
+        if proc is not None:
+            try:
+                proc.kill()
+                out_file.close()
+            finally:
+                del self.procs[device_serial]
+
+
 class BrowserSetup:
     name: ClassVar[str]
     browser_cls: ClassVar[Type[browser.Browser]]
@@ -188,6 +247,9 @@ class BrowserSetup:
 
     def setup(self, kwargs):
         self.setup_kwargs(kwargs)
+
+    def teardown(self):
+        pass
 
 
 def safe_unsetenv(env_var):
@@ -340,16 +402,22 @@ class FirefoxAndroid(BrowserSetup):
             os.environ["ADB_PATH"] = adb_path
         adb_path = os.environ["ADB_PATH"]
 
+        self._logcat = AndroidLogcat(adb_path, base_path=kwargs["logcat_dir"])
+
         for device_serial in kwargs["device_serial"]:
             device = mozdevice.ADBDeviceFactory(adb=adb_path,
                                                 device=device_serial)
-
+            self._logcat.start(device_serial)
             if self.browser.apk_path:
                 device.uninstall_app(app)
                 device.install_app(self.browser.apk_path)
             elif not device.is_app_installed(app):
                 raise WptrunError("app %s not installed on device %s" %
                                   (app, device_serial))
+
+    def teardown(self):
+        if hasattr(self, "_logcat"):
+            self._logcat.stop()
 
 
 class Chrome(BrowserSetup):
@@ -921,7 +989,8 @@ def setup_wptrunner(venv, **kwargs):
                   "install_browser",
                   "install_webdriver",
                   "channel",
-                  "prompt"]:
+                  "prompt",
+                  "logcat_dir"]:
         del wptrunner_kwargs[kwarg]
 
     wptcommandline.check_args(wptrunner_kwargs)
@@ -934,15 +1003,18 @@ def setup_wptrunner(venv, **kwargs):
             webdriver_binary=wptrunner_kwargs.get("webdriver_binary"),
         )
 
-    return wptrunner_kwargs
+    return setup_cls, wptrunner_kwargs
 
 
 def run(venv, **kwargs):
     setup_logging(kwargs)
 
-    wptrunner_kwargs = setup_wptrunner(venv, **kwargs)
+    setup_cls, wptrunner_kwargs = setup_wptrunner(venv, **kwargs)
 
-    rv = run_single(venv, **wptrunner_kwargs) > 0
+    try:
+        rv = run_single(venv, **wptrunner_kwargs) > 0
+    finally:
+        setup_cls.teardown()
 
     return rv
 

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -653,14 +653,7 @@ class ProfileCreator:
                     elif name != 'unittest-features':
                         pref_paths.append(os.path.join(self.prefs_root, name, 'user.js'))
         else:
-            # Old preference files used before the creation of profiles.json (remove when no longer supported)
-            legacy_pref_paths = (
-                os.path.join(self.prefs_root, 'prefs_general.js'),   # Used in Firefox 60 and below
-                os.path.join(self.prefs_root, 'common', 'user.js'),  # Used in Firefox 61
-            )
-            for path in legacy_pref_paths:
-                if os.path.isfile(path):
-                    pref_paths.append(path)
+            self.logger.warning(f"Failed to load profiles from {profiles}")
 
         for path in pref_paths:
             if os.path.exists(path):

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -666,7 +666,7 @@ class ProfileCreator:
             if os.path.exists(path):
                 prefs.add(Preferences.read_prefs(path))
             else:
-                self.logger.warning("Failed to find base prefs file in %s" % path)
+                self.logger.warning(f"Failed to find prefs file in {path}")
 
         # Add any custom preferences
         prefs.add(self.extra_prefs, cast=True)


### PR DESCRIPTION
Initially tried to use the kvm scope but then I [saw](https://github.com/mozilla/community-tc-config/blob/0d7d45f2b72fdb38e5c037a7469e65010170da89/config/projects/wpt.yml) that the worker did not grant the capability for the kvm device. However, upon reading the config, I also saw that we grant  the capability not on the project level (`docker-worker:capability:privileged`). This PR adjusts the scope to `docker-worker:capability:privileged`

I see that the kvm is now present when only using the privileged scope (so we don't need to use the kvm capability).

Here are some diffs between #41334 and this PR infrastructure [log](https://community-tc.services.mozilla.com/tasks/ZzeHe2ioT4KnX7DxxOkNvQ/runs/0/logs/live/public/logs/live.log)

```diff
-+ REF=refs/pull/41334/merge
++ REF=refs/pull/41561/merge
 + cd /home/test
 + '[' -e /dev/kvm ']'
++ sudo chmod a+rw /dev/kvm
 + '[' '!' -d web-platform-tests ']'
 + mkdir web-platform-tests
 + cd web-platform-tests
 + git init
```

```diff
DEBUG: EMULATOR not set
DEBUG: emulator found at /home/test/web-platform-tests/_venv3/android/android-sdk-linux/emulator/emulator
-DEBUG:   ...with creation time Wed Aug  9 11:58:02 2023
+DEBUG:   ...with creation time Mon Aug 21 15:34:45 2023
DEBUG:   ...with SDK version in /home/test/web-platform-tests/_venv3/android/android-sdk-linux/emulator/source.properties: Pkg.Revision=32.1.14
-WARNING: Command '['/home/test/web-platform-tests/_venv3/android/android-sdk-linux/emulator/emulator', '-accel-check']' returned non-zero exit status 8.
-WARNING: Unable to verify kvm acceleration!
-WARNING: The x86/x86_64 emulator may fail to start without kvm.
DEBUG: Starting the emulator with this command: /home/test/web-platform-tests/_venv3/android/android-sdk-linux/emulator/emulator -avd mozemulator-x86_64 -gpu on -skip-adb-auth -verbose -show-kernel -ranchu -selinux permissive -memory 3072 -cores 4 -skin 800x1280 -prop ro.test_harness=true -no-snapstorage -no-snapshot
```


It gets further now.


But now there's an error stating that `WebDriver server binary must be given to --webdriver-binary`.
