### PR TITLE
bypass bogus AOM crashtests that assume abandoned syntax will be added.

### DIFF
--- a/accessibility/crashtests/aom-in-destroyed-iframe.html
+++ b/accessibility/crashtests/aom-in-destroyed-iframe.html
@@ -1,6 +1,11 @@
 <html class="test-wait">
 <body></body>
 <script>
+
+// Bypass this abandoned API in all but the engines that implement it.
+if (typeof getComputedAccessibleNode !== 'undefined') {
+
+  // presumed chromium only
   const frameElem = document.createElement('iframe');
 
   frameElem.srcdoc = '<html><head><title>X</title></head><body><div>-</div></body></html>';
@@ -21,7 +26,11 @@
       });
     });
   };
-
   document.body.appendChild(frameElem);
+
+} else {
+  // Pass in other engines that have not implemented the abandoned API
+  document.documentElement.className = '';
+}
 </script>
 </html>

--- a/accessibility/crashtests/aom-in-destroyed-iframe.html
+++ b/accessibility/crashtests/aom-in-destroyed-iframe.html
@@ -5,7 +5,6 @@
 // Bypass this abandoned API in all but the engines that implement it.
 if (typeof getComputedAccessibleNode !== 'undefined') {
 
-  // presumed chromium only
   const frameElem = document.createElement('iframe');
 
   frameElem.srcdoc = '<html><head><title>X</title></head><body><div>-</div></body></html>';

--- a/accessibility/crashtests/aom-in-destroyed-iframe.html
+++ b/accessibility/crashtests/aom-in-destroyed-iframe.html
@@ -2,7 +2,7 @@
 <body></body>
 <script>
 
-// Bypass this abandoned API in all but the engines that implement it.
+// Bypass this abandoned syntax in all but the engines that implement it.
 if (typeof getComputedAccessibleNode !== 'undefined') {
 
   const frameElem = document.createElement('iframe');

--- a/accessibility/crashtests/computed-accessible-child-of-pseudo-element.html
+++ b/accessibility/crashtests/computed-accessible-child-of-pseudo-element.html
@@ -6,17 +6,28 @@
 <h1>Heading</h1>
 
 <script>
-async function trigger1() {
-  let heading = document.querySelector('h1');
-  let computed_accessible_node = await self.getComputedAccessibleNode(heading);
-  let first_child = computed_accessible_node.firstChild;
-  // The first child of the heading is a pseudo element <table>.
-  await first_child.ensureUpToDate();
-  // The next child down has an accessibility object but no node.
-  let grand_child = first_child.firstChild;
-  await grand_child.ensureUpToDate();
+
+// Bypass this abandoned API in all but the engines that implement it.
+if (typeof getComputedAccessibleNode !== 'undefined') {
+
+  // presumed chromium only
+  async function trigger1() {
+    let heading = document.querySelector('h1');
+    let computed_accessible_node = await self.getComputedAccessibleNode(heading);
+    let first_child = computed_accessible_node.firstChild;
+    // The first child of the heading is a pseudo element <table>.
+    await first_child.ensureUpToDate();
+    // The next child down has an accessibility object but no node.
+    let grand_child = first_child.firstChild;
+    await grand_child.ensureUpToDate();
+    document.documentElement.className = '';
+  }
+  trigger1();
+
+} else {
+  // Pass in other engines that have not implemented the abandoned API
   document.documentElement.className = '';
 }
-trigger1();
+
 </script>
 </html>

--- a/accessibility/crashtests/computed-accessible-child-of-pseudo-element.html
+++ b/accessibility/crashtests/computed-accessible-child-of-pseudo-element.html
@@ -7,7 +7,7 @@
 
 <script>
 
-// Bypass this abandoned API in all but the engines that implement it.
+// Bypass this abandoned syntax in all but the engines that implement it.
 if (typeof getComputedAccessibleNode !== 'undefined') {
 
   async function trigger1() {

--- a/accessibility/crashtests/computed-accessible-child-of-pseudo-element.html
+++ b/accessibility/crashtests/computed-accessible-child-of-pseudo-element.html
@@ -10,7 +10,6 @@
 // Bypass this abandoned API in all but the engines that implement it.
 if (typeof getComputedAccessibleNode !== 'undefined') {
 
-  // presumed chromium only
   async function trigger1() {
     let heading = document.querySelector('h1');
     let computed_accessible_node = await self.getComputedAccessibleNode(heading);

--- a/accessibility/crashtests/computed-accessible-text-node.html
+++ b/accessibility/crashtests/computed-accessible-text-node.html
@@ -1,14 +1,25 @@
 <html class="test-wait">
 <img id="img1">text
 <script>
-async function trigger1() {
-  let img = document.getElementById('img1');
-  let computed_accessible_node = await self.getComputedAccessibleNode(img);
-  // The next sibling is a text node.
-  let next_sibling = computed_accessible_node.nextSibling;
-  await next_sibling.ensureUpToDate();
+
+// Bypass this abandoned API in all but the engines that implement it.
+if (typeof getComputedAccessibleNode !== 'undefined') {
+
+  // presumed chromium only
+  async function trigger1() {
+    let img = document.getElementById('img1');
+    let computed_accessible_node = await self.getComputedAccessibleNode(img);
+    // The next sibling is a text node.
+    let next_sibling = computed_accessible_node.nextSibling;
+    await next_sibling.ensureUpToDate();
+    document.documentElement.className = '';
+  }
+  trigger1();
+
+} else {
+  // Pass in other engines that have not implemented the abandoned API
   document.documentElement.className = '';
 }
-trigger1();
+
 </script>
 </html>

--- a/accessibility/crashtests/computed-accessible-text-node.html
+++ b/accessibility/crashtests/computed-accessible-text-node.html
@@ -2,7 +2,7 @@
 <img id="img1">text
 <script>
 
-// Bypass this abandoned API in all but the engines that implement it.
+// Bypass this abandoned syntax in all but the engines that implement it.
 if (typeof getComputedAccessibleNode !== 'undefined') {
 
   async function trigger1() {

--- a/accessibility/crashtests/computed-accessible-text-node.html
+++ b/accessibility/crashtests/computed-accessible-text-node.html
@@ -5,7 +5,6 @@
 // Bypass this abandoned API in all but the engines that implement it.
 if (typeof getComputedAccessibleNode !== 'undefined') {
 
-  // presumed chromium only
   async function trigger1() {
     let img = document.getElementById('img1');
     let computed_accessible_node = await self.getComputedAccessibleNode(img);

--- a/accessibility/crashtests/computed-node-checked.html
+++ b/accessibility/crashtests/computed-node-checked.html
@@ -19,6 +19,11 @@ if (window.chrome && chrome.gpuBenchmarking) {
 </script>
 <script>step_timeout(gc, 50);</script>
 <script>
+
+// Bypass this abandoned API in all but the engines that implement it.
+if (typeof getComputedAccessibleNode !== 'undefined') {
+
+  // presumed chromium only
   const frameElem = document.createElement('iframe');
 
   frameElem.srcdoc = '<div></div>';
@@ -34,5 +39,12 @@ if (window.chrome && chrome.gpuBenchmarking) {
     });
   };
   document.body.appendChild(frameElem);
+
+} else {
+  // Pass in other engines that have not implemented the abandoned API
+  document.documentElement.className = '';
+}
+
+
 </script>
 </html>

--- a/accessibility/crashtests/computed-node-checked.html
+++ b/accessibility/crashtests/computed-node-checked.html
@@ -20,7 +20,7 @@ if (window.chrome && chrome.gpuBenchmarking) {
 <script>step_timeout(gc, 50);</script>
 <script>
 
-// Bypass this abandoned API in all but the engines that implement it.
+// Bypass this abandoned syntax in all but the engines that implement it.
 if (typeof getComputedAccessibleNode !== 'undefined') {
 
   const frameElem = document.createElement('iframe');

--- a/accessibility/crashtests/computed-node-checked.html
+++ b/accessibility/crashtests/computed-node-checked.html
@@ -23,7 +23,6 @@ if (window.chrome && chrome.gpuBenchmarking) {
 // Bypass this abandoned API in all but the engines that implement it.
 if (typeof getComputedAccessibleNode !== 'undefined') {
 
-  // presumed chromium only
   const frameElem = document.createElement('iframe');
 
   frameElem.srcdoc = '<div></div>';


### PR DESCRIPTION
Closes https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/56