### PR TITLE
Change leftover `assert` to `with` in import attributes test

### DIFF
--- a/html/semantics/scripting-1/the-script-element/import-attributes/unsupported-attribute.js
+++ b/html/semantics/scripting-1/the-script-element/import-attributes/unsupported-attribute.js
@@ -1,2 +1,2 @@
-import "./hello.js" assert { unsupportedAttributeKey: "unsupportedAttributeValue" };
+import "./hello.js" with { unsupportedAttributeKey: "unsupportedAttributeValue" };
 log.push("unsupported-attribute");


### PR DESCRIPTION
I missed this when migrating the tests.