### PR TITLE
[html] Add test for import declaration errors order

### DIFF
--- a/html/semantics/scripting-1/the-script-element/import-assertions/invalid-import-errors-order.html
+++ b/html/semantics/scripting-1/the-script-element/import-assertions/invalid-import-errors-order.html
@@ -4,6 +4,8 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+    setup({allow_uncaught_exception: true});
+
     var log = [];
     window.addEventListener("error", ev => log.push(ev.error));
 

--- a/html/semantics/scripting-1/the-script-element/import-assertions/invalid-import-errors-order.html
+++ b/html/semantics/scripting-1/the-script-element/import-assertions/invalid-import-errors-order.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>Handling of invalid module type import attributes</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    var log = [];
+    window.addEventListener("error", ev => log.push(ev.error));
+
+    const test_load = async_test(
+        "Test that the errors order for invalid import declarations is" +
+        " specifier, then attribute key, and then type attribute value.");
+    window.addEventListener("load", test_load.step_func_done(ev => {
+      assert_equals(log.length, 2);
+      assert_equals(log[0].constructor, SyntaxError);
+      assert_equals(log[1].constructor, SyntaxError);
+    }));
+
+    function unreachable() { log.push("unexpected"); }
+</script>
+<script type="module" onerror="unreachable()">
+  // unknown attribute is reported before invalid specifier
+  import "INVALID" assert { unknown: "foo" };
+</script>
+<script type="module" onerror="unreachable()">
+  // unknown attribute is reported before unknown type
+  import "./valid" assert { unknown: "foo", type: "unknown" };
+</script>

--- a/html/semantics/scripting-1/the-script-element/import-assertions/invalid-import-errors-order.html
+++ b/html/semantics/scripting-1/the-script-element/import-assertions/invalid-import-errors-order.html
@@ -11,9 +11,10 @@
         "Test that the errors order for invalid import declarations is" +
         " specifier, then attribute key, and then type attribute value.");
     window.addEventListener("load", test_load.step_func_done(ev => {
-      assert_equals(log.length, 2);
+      assert_equals(log.length, 3);
       assert_equals(log[0].constructor, SyntaxError);
       assert_equals(log[1].constructor, SyntaxError);
+      assert_equals(log[2].constructor, SyntaxError);
     }));
 
     function unreachable() { log.push("unexpected"); }
@@ -25,4 +26,9 @@
 <script type="module" onerror="unreachable()">
   // unknown attribute is reported before unknown type
   import "./valid" assert { unknown: "foo", type: "unknown" };
+</script>
+<script type="module" onerror="unreachable()">
+  // unknown attribute is reported before invalid specifier in subsequent import
+  import "./valid" assert { unknown: "foo" };
+  import "INVALID";
 </script>

--- a/html/semantics/scripting-1/the-script-element/import-attributes/invalid-import-errors-order.html
+++ b/html/semantics/scripting-1/the-script-element/import-attributes/invalid-import-errors-order.html
@@ -4,6 +4,8 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+    setup({allow_uncaught_exception: true});
+
     var log = [];
     window.addEventListener("error", ev => log.push(ev.error));
 

--- a/html/semantics/scripting-1/the-script-element/import-attributes/invalid-import-errors-order.html
+++ b/html/semantics/scripting-1/the-script-element/import-attributes/invalid-import-errors-order.html
@@ -11,9 +11,10 @@
         "Test that the errors order for invalid import declarations is" +
         " specifier, then attribute key, and then type attribute value.");
     window.addEventListener("load", test_load.step_func_done(ev => {
-      assert_equals(log.length, 2);
+      assert_equals(log.length, 3);
       assert_equals(log[0].constructor, SyntaxError);
       assert_equals(log[1].constructor, SyntaxError);
+      assert_equals(log[2].constructor, SyntaxError);
     }));
 
     function unreachable() { log.push("unexpected"); }
@@ -25,4 +26,9 @@
 <script type="module" onerror="unreachable()">
   // unknown attribute is reported before unknown type
   import "./valid" with { unknown: "foo", type: "unknown" };
+</script>
+<script type="module" onerror="unreachable()">
+  // unknown attribute is reported before invalid specifier in subsequent import
+  import "./valid" with { unknown: "foo" };
+  import "INVALID";
 </script>

--- a/html/semantics/scripting-1/the-script-element/import-attributes/invalid-import-errors-order.html
+++ b/html/semantics/scripting-1/the-script-element/import-attributes/invalid-import-errors-order.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>Handling of invalid module type import attributes</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    var log = [];
+    window.addEventListener("error", ev => log.push(ev.error));
+
+    const test_load = async_test(
+        "Test that the errors order for invalid import declarations is" +
+        " specifier, then attribute key, and then type attribute value.");
+    window.addEventListener("load", test_load.step_func_done(ev => {
+      assert_equals(log.length, 2);
+      assert_equals(log[0].constructor, SyntaxError);
+      assert_equals(log[1].constructor, SyntaxError);
+    }));
+
+    function unreachable() { log.push("unexpected"); }
+</script>
+<script type="module" onerror="unreachable()">
+  // unknown attribute is reported before invalid specifier
+  import "INVALID" with { unknown: "foo" };
+</script>
+<script type="module" onerror="unreachable()">
+  // unknown attribute is reported before unknown type
+  import "./valid" with { unknown: "foo", type: "unknown" };
+</script>


### PR DESCRIPTION
This PR adds tests for the changes in whatwg/html#9599. This case is currently untested, and current implementations do not fully implement the new semantics of the import attributes proposal yet.

See https://github.com/whatwg/html/pull/9599#issuecomment-1688266926 and https://github.com/whatwg/html/pull/9599#issuecomment-1689695624 for a description of the tests.