### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=260494

### DIFF
--- a/css/css-grid/parsing/grid-template-shorthand-valid.html
+++ b/css/css-grid/parsing/grid-template-shorthand-valid.html
@@ -41,6 +41,7 @@ test_valid_value("grid-template", '"a" [a] [b] "b"', '"a" [a b] "b"');
 test_valid_value("grid-template", '"a" [a] "b"');
 test_valid_value("grid-template", '"a" / 0', '"a" / 0px');
 test_valid_value("grid-template", '"a" 10px / 10px');
+test_valid_value("grid-template", '"a" calc(100% - 10px) / calc(10px)');
 test_valid_value("grid-template", '"a" [a] "b" 10px');
 test_valid_value("grid-template", '"a" [a] "b" 10px [a]');
 test_valid_value("grid-template", '"a" [a] [a] "b" 10px', '"a" [a a] "b" 10px');


### PR DESCRIPTION
WebKit export from bug: [grid-template not serialized correctly if grid-template-areas was not set from shorthand](https://bugs.webkit.org/show_bug.cgi?id=260494)