### PR TITLE
[wdspec] serialization: add `value.context` to window

### DIFF
--- a/webdriver/tests/bidi/script/call_function/remote_values.py
+++ b/webdriver/tests/bidi/script/call_function/remote_values.py
@@ -39,3 +39,96 @@ async def test_remote_value_promise(bidi_session, top_context, await_promise):
         assert result == {"type": "number", "value": 42}
     else:
         assert result == {"type": "promise"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("await_promise", [True, False])
+async def test_window_top_level_browsing_context(bidi_session, top_context,
+                                                 await_promise):
+    function_declaration = f"()=>window"
+    if await_promise:
+        function_declaration = "async" + function_declaration
+
+    result = await bidi_session.script.call_function(
+        function_declaration=function_declaration,
+        await_promise=await_promise,
+        target=ContextTarget(top_context["context"]),
+        serialization_options=SerializationOptions(max_object_depth=1),
+    )
+
+    recursive_compare(
+        {
+            "type": "window",
+            "value": {
+                "context": top_context["context"]
+            }
+        }, result)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("await_promise", [True, False])
+async def test_window_iframe_window(bidi_session, top_context,
+                                    test_page_same_origin_frame,
+                                    await_promise):
+
+    await bidi_session.browsing_context.navigate(
+        context=top_context["context"],
+        url=test_page_same_origin_frame,
+        wait="complete",
+    )
+
+    all_contexts = await bidi_session.browsing_context.get_tree()
+    iframe_context = all_contexts[0]["children"][0]
+
+    function_declaration = f"()=>window"
+    if await_promise:
+        function_declaration = "async" + function_declaration
+
+    result = await bidi_session.script.call_function(
+        function_declaration=function_declaration,
+        await_promise=await_promise,
+        target=ContextTarget(iframe_context["context"]),
+        serialization_options=SerializationOptions(max_object_depth=1),
+    )
+
+    recursive_compare(
+        {
+            "type": "window",
+            "value": {
+                "context": iframe_context["context"]
+            }
+        }, result)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("await_promise", [True, False])
+async def test_window_remove_value_iframe_content_window(
+        bidi_session, top_context, test_page_same_origin_frame, await_promise):
+
+    await bidi_session.browsing_context.navigate(
+        context=top_context["context"],
+        url=test_page_same_origin_frame,
+        wait="complete",
+    )
+
+    all_contexts = await bidi_session.browsing_context.get_tree()
+    iframe_context = all_contexts[0]["children"][0]
+
+    function_declaration = f"()=>document.querySelector('iframe')?.contentWindow"
+    if await_promise:
+        function_declaration = "async" + function_declaration
+
+    result = await bidi_session.script.call_function(
+        function_declaration=function_declaration,
+        await_promise=await_promise,
+        target=ContextTarget(top_context["context"]),
+        serialization_options=SerializationOptions(max_object_depth=1),
+    )
+
+    recursive_compare(
+        {
+            "type": "window",
+            "value": {
+                "context": iframe_context["context"]
+            }
+        }, result)

--- a/webdriver/tests/bidi/script/call_function/remote_values.py
+++ b/webdriver/tests/bidi/script/call_function/remote_values.py
@@ -63,11 +63,12 @@ async def test_window_context_top_level(bidi_session, top_context,
             }
         }, result)
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("await_promise", [True, False])
-async def test_window_iframe_window(bidi_session, top_context,
-                                    test_page_same_origin_frame,
-                                    await_promise):
+async def test_window_context_iframe_window(bidi_session, top_context,
+                                            test_page_same_origin_frame,
+                                            await_promise):
 
     await bidi_session.browsing_context.navigate(
         context=top_context["context"],
@@ -138,6 +139,11 @@ async def test_window_context_iframe_content_window(
 async def test_window_context_same_id_after_navigation(bidi_session,
                                                        top_context, inline,
                                                        await_promise, domain):
+
+    defaultOrigin = inline(f"{domain}")
+    await bidi_session.browsing_context.navigate(
+        context=top_context["context"], url=defaultOrigin, wait="complete")
+
     url = inline(f"{domain}", domain=domain)
 
     function_declaration = f"() => window"
@@ -164,4 +170,3 @@ async def test_window_context_same_id_after_navigation(bidi_session,
     navigated_context_id = result['value']['context']
 
     assert navigated_context_id == original_context_id
-

--- a/webdriver/tests/bidi/script/evaluate/remote_values.py
+++ b/webdriver/tests/bidi/script/evaluate/remote_values.py
@@ -15,3 +15,79 @@ async def test_remote_values(bidi_session, top_context, expression, expected):
     )
 
     recursive_compare(expected, result)
+
+
+@pytest.mark.asyncio
+async def test_window_top_level_browsing_context(bidi_session, top_context):
+    result = await bidi_session.script.evaluate(
+        expression="window",
+        target=ContextTarget(top_context["context"]),
+        await_promise=False,
+        serialization_options=SerializationOptions(max_object_depth=1),
+    )
+
+    recursive_compare(
+        {
+            "type": "window",
+            "value": {
+                "context": top_context["context"]
+            }
+        }, result)
+
+
+@pytest.mark.asyncio
+async def test_window_iframe_window(
+        bidi_session, top_context, test_page_same_origin_frame):
+
+    await bidi_session.browsing_context.navigate(
+        context=top_context["context"],
+        url=test_page_same_origin_frame,
+        wait="complete",
+    )
+
+    all_contexts = await bidi_session.browsing_context.get_tree()
+    iframe_context = all_contexts[0]["children"][0]
+
+    result = await bidi_session.script.evaluate(
+        expression="window",
+        target=ContextTarget(iframe_context["context"]),
+        await_promise=False,
+        serialization_options=SerializationOptions(max_object_depth=1),
+    )
+
+    recursive_compare(
+        {
+            "type": "window",
+            "value": {
+                "context": iframe_context["context"]
+            }
+        }, result)
+
+
+@pytest.mark.asyncio
+async def test_window_remove_value_iframe_content_window(
+        bidi_session, top_context, test_page_same_origin_frame):
+
+    await bidi_session.browsing_context.navigate(
+        context=top_context["context"],
+        url=test_page_same_origin_frame,
+        wait="complete",
+    )
+
+    all_contexts = await bidi_session.browsing_context.get_tree()
+    iframe_context = all_contexts[0]["children"][0]
+
+    result = await bidi_session.script.evaluate(
+        expression="document.querySelector('iframe')?.contentWindow",
+        target=ContextTarget(top_context["context"]),
+        await_promise=False,
+        serialization_options=SerializationOptions(max_object_depth=1),
+    )
+
+    recursive_compare(
+        {
+            "type": "window",
+            "value": {
+                "context": iframe_context["context"]
+            }
+        }, result)

--- a/webdriver/tests/bidi/script/evaluate/remote_values.py
+++ b/webdriver/tests/bidi/script/evaluate/remote_values.py
@@ -18,11 +18,12 @@ async def test_remote_values(bidi_session, top_context, expression, expected):
 
 
 @pytest.mark.asyncio
-async def test_window_context_top_level(bidi_session, top_context):
+@pytest.mark.parametrize("await_promise", [True, False])
+async def test_window_context_top_level(bidi_session, top_context, await_promise):
     result = await bidi_session.script.evaluate(
         expression="window",
         target=ContextTarget(top_context["context"]),
-        await_promise=False,
+        await_promise=await_promise,
         serialization_options=SerializationOptions(max_object_depth=1),
     )
 
@@ -36,8 +37,9 @@ async def test_window_context_top_level(bidi_session, top_context):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("await_promise", [True, False])
 async def test_window_context_iframe_window(
-        bidi_session, top_context, test_page_same_origin_frame):
+        bidi_session, top_context, test_page_same_origin_frame, await_promise):
 
     await bidi_session.browsing_context.navigate(
         context=top_context["context"],
@@ -51,7 +53,7 @@ async def test_window_context_iframe_window(
     result = await bidi_session.script.evaluate(
         expression="window",
         target=ContextTarget(iframe_context["context"]),
-        await_promise=False,
+        await_promise=await_promise,
         serialization_options=SerializationOptions(max_object_depth=1),
     )
 
@@ -65,8 +67,9 @@ async def test_window_context_iframe_window(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("await_promise", [True, False])
 async def test_window_context_iframe_content_window(
-        bidi_session, top_context, test_page_same_origin_frame):
+        bidi_session, top_context, test_page_same_origin_frame, await_promise):
 
     await bidi_session.browsing_context.navigate(
         context=top_context["context"],
@@ -81,7 +84,7 @@ async def test_window_context_iframe_content_window(
     result = await bidi_session.script.evaluate(
         expression="window.frames[0]",
         target=ContextTarget(top_context["context"]),
-        await_promise=False,
+        await_promise=await_promise,
     )
 
     recursive_compare(
@@ -96,10 +99,12 @@ async def test_window_context_iframe_content_window(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("domain", ["", "alt"],
                          ids=["same_origin", "cross_origin"])
+@pytest.mark.parametrize("await_promise", [True, False])
 async def test_window_context_same_id_after_navigation(bidi_session,
                                                        top_context,
                                                        inline,
-                                                       domain):
+                                                       domain,
+                                                       await_promise):
 
     defaultOrigin = inline(f"{domain}")
     await bidi_session.browsing_context.navigate(
@@ -110,7 +115,7 @@ async def test_window_context_same_id_after_navigation(bidi_session,
     result = await bidi_session.script.evaluate(
         expression="window",
         target=ContextTarget(top_context["context"]),
-        await_promise=False,
+        await_promise=await_promise,
         serialization_options=SerializationOptions(max_object_depth=1),
     )
 
@@ -124,7 +129,7 @@ async def test_window_context_same_id_after_navigation(bidi_session,
     result = await bidi_session.script.evaluate(
         expression="window",
         target=ContextTarget(top_context["context"]),
-        await_promise=False,
+        await_promise=await_promise,
         serialization_options=SerializationOptions(max_object_depth=1),
     )
 

--- a/webdriver/tests/bidi/script/evaluate/remote_values.py
+++ b/webdriver/tests/bidi/script/evaluate/remote_values.py
@@ -35,9 +35,8 @@ async def test_window_context_top_level(bidi_session, top_context):
         }, result)
 
 
-
 @pytest.mark.asyncio
-async def test_window_iframe_window(
+async def test_window_context_iframe_window(
         bidi_session, top_context, test_page_same_origin_frame):
 
     await bidi_session.browsing_context.navigate(
@@ -95,9 +94,18 @@ async def test_window_context_iframe_content_window(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("domain", ["", "alt"],
+                         ids=["same_origin", "cross_origin"])
 async def test_window_context_same_id_after_navigation(bidi_session,
                                                        top_context,
-                                                       test_page_cross_origin):
+                                                       inline,
+                                                       domain):
+
+    defaultOrigin = inline(f"{domain}")
+    await bidi_session.browsing_context.navigate(
+        context=top_context["context"], url=defaultOrigin, wait="complete")
+
+    url = inline(f"{domain}", domain=domain)
 
     result = await bidi_session.script.evaluate(
         expression="window",
@@ -110,7 +118,7 @@ async def test_window_context_same_id_after_navigation(bidi_session,
 
     await bidi_session.browsing_context.navigate(
         context=top_context["context"],
-        url=test_page_cross_origin,
+        url=url,
         wait="complete")
 
     result = await bidi_session.script.evaluate(


### PR DESCRIPTION
Currently only the type is being tested.

Issue on BiDi spec: https://github.com/w3c/webdriver-bidi/issues/418