### PR TITLE
Adding 'image-rendering: pixelated' to overcome antialias fuzziness 3 tests

### DIFF
--- a/css/css-backgrounds/border-image-repeat-round-003.html
+++ b/css/css-backgrounds/border-image-repeat-round-003.html
@@ -8,7 +8,7 @@
 
   Created: June 21st 2023
 
-  Last modified: June 25th 2023
+  Last modified: August 23rd 2023
 
   -->
 
@@ -44,6 +44,7 @@
       border-image-slice: 64 fill; /* the center will be black */
       border-image-source: url("support/4bicolor-squares.png");
       display: inline-block;
+      image-rendering: pixelated; /* attempt to overcome antialias fuzziness */
       margin-right: 1em;
       vertical-align: bottom;
    }

--- a/css/css-backgrounds/border-image-repeat-round-stretch-001.html
+++ b/css/css-backgrounds/border-image-repeat-round-stretch-001.html
@@ -8,7 +8,7 @@
 
   Created: June 23rd 2023
 
-  Last modified: June 23rd 2023
+  Last modified: August 23rd 2023
 
   -->
 
@@ -53,6 +53,7 @@
       border-image-slice: 64 fill; /* the center will be black */
       border-image-source: url("support/4bicolor-squares.png");
       display: inline-block;
+      image-rendering: pixelated; /* attempt to overcome antialias fuzziness */
       margin-right: 1em;
    }
 

--- a/css/css-backgrounds/border-image-repeat-stretch-round-001.html
+++ b/css/css-backgrounds/border-image-repeat-stretch-round-001.html
@@ -8,7 +8,7 @@
 
   Created: June 23rd 2023
 
-  Last modified: June 23rd 2023
+  Last modified: August 23rd 2023
 
   -->
 
@@ -53,6 +53,7 @@
       border-image-slice: 64 fill; /* the center will be black */
       border-image-source: url("support/4bicolor-squares.png");
       display: inline-block;
+      image-rendering: pixelated; /* attempt to overcome antialias fuzziness */
       margin-right: 1em;
    }
 


### PR DESCRIPTION
This is a follow-up to
https://github.com/web-platform-tests/wpt/pull/40715

https://github.com/web-platform-tests/wpt/pull/40731

Adding 'image-rendering: pixelated' in order to avoid or overcome subpixel antialias fuzziness in the following 3 border-image-repeat-* tests:

https://wpt.fyi/results/css/css-backgrounds/border-image-repeat-round-003.html

https://wpt.fyi/results/css/css-backgrounds/border-image-repeat-round-stretch-001.html

https://wpt.fyi/results/css/css-backgrounds/border-image-repeat-stretch-round-001.html

If this does not succeed, then I will resort to use
`<meta name=fuzzy content="i, j">`

Credits should go to @fantasai for those recommandations.

`image-rendering: pixelated` appears to be supported well by current mainstream browsers as indicated by/according to:
https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering#browser_compatibility
