### PR TITLE
Restart browser for each test at retry round

### DIFF
--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -261,8 +261,8 @@ def run_test_iteration(test_status, test_loader, test_source,
     unexpected_pass_tests = defaultdict(list)
     recording.pause()
     retry_counts = kwargs["retry_unexpected"]
-    for i in range(retry_counts + 1):
-        if i > 0:
+    for retry_index in range(retry_counts + 1):
+        if retry_index > 0:
             if kwargs["fail_on_unexpected_pass"]:
                 for (subtests, test_type), tests in unexpected_pass_tests.items():
                     unexpected_fail_tests[(subtests, test_type)].extend(tests)
@@ -281,6 +281,7 @@ def run_test_iteration(test_status, test_loader, test_source,
         with ManagerGroup("web-platform-tests",
                           test_source,
                           test_implementations,
+                          retry_index,
                           kwargs["rerun"],
                           kwargs["pause_after_test"],
                           kwargs["pause_on_unexpected"],


### PR DESCRIPTION
The retries are meant to handle flakiess, so we should always restart the browser so that there is no leaked state from the previous test.

Pass down retry index, and set restart_before_next to True for retry rounds.