### PR TITLE
Add select change and input event tests

### DIFF
--- a/webdriver/tests/classic/element_click/select.py
+++ b/webdriver/tests/classic/element_click/select.py
@@ -1,5 +1,6 @@
 from tests.support.asserts import (
     assert_in_events,
+    assert_events_equal,
 )
 
 def test_click_option(session, inline):
@@ -214,17 +215,27 @@ def test_out_of_view_multiple(session, inline):
     assert last_option.selected
 
 
-def test_option_disabled(session, inline):
+def test_option_disabled(session, inline, add_event_listeners):
     session.url = inline("""
         <select>
           <option disabled>foo
           <option>bar
         </select>""")
-    option = session.find.css("option", all=False)
-    assert not option.selected
+    select = session.find.css("select", all=False)
+    add_event_listeners(select, ["change", "input"])
 
-    option.click()
-    assert not option.selected
+    disabled_option = session.find.css("option", all=False)
+    assert not disabled_option.selected
+
+    disabled_option.click()
+    assert not disabled_option.selected
+    assert_events_equal(session, [])
+
+    enabled_option = session.find.css("option:not([disabled])", all=False)
+    assert enabled_option.selected
+
+    enabled_option.click()
+    assert_events_equal(session, ["input"])
 
 def test_select_change_events(session, inline, add_event_listeners):
     session.url = inline("""

--- a/webdriver/tests/classic/element_click/select.py
+++ b/webdriver/tests/classic/element_click/select.py
@@ -1,3 +1,7 @@
+from tests.support.asserts import (
+    assert_in_events,
+)
+
 def test_click_option(session, inline):
     session.url = inline("""
       <select>
@@ -221,3 +225,18 @@ def test_option_disabled(session, inline):
 
     option.click()
     assert not option.selected
+
+def test_select_change_events(session, inline, add_event_listeners):
+    session.url = inline("""
+        <select id="select">
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3" id="third">3</option>
+            <option value="4">4</option>
+        </select>""")
+    select = session.find.css("select", all=False)
+    add_event_listeners(select, ["change", "input"])
+
+    option = session.find.css("select > option#third", all=False)
+    option.click()
+    assert_in_events(session, ["change", "input"])


### PR DESCRIPTION
Chromedriver doesn't emit the input event on selection being made, despite actual Chromium browsers emitting one. There are two open issues on the chromedriver project waiting for attention:

- https://bugs.chromium.org/p/chromedriver/issues/detail?id=4104
- https://bugs.chromium.org/p/chromedriver/issues/detail?id=3940

The added test should put a more formal pressure to implement a fix.

Note: The test is expected to fail with chromedriver.

-----

## Additional information:

### [WHATWG HTML5 living standard](https://html.spec.whatwg.org/multipage/form-elements.html#send-select-update-notifications) states:

> When the user agent is to send select update notifications, queue an element task on the user interaction task source given the select element to run these steps:
>
> 1. Fire an event named input at the select element, with the bubbles and composed attributes initialized to true.
> 1. Fire an event named change at the select element, with the bubbles attribute initialized to true.

### [Webdriver standard working draft](https://www.w3.org/TR/webdriver2/#element-click) states that when clicking option element, webdriver should:

> 1. Let parent node be the element’s container.
> 1. Fire a mouseOver event at parent node.
> 1. Fire a mouseMove event at parent node.
> 1. Fire a mouseDown event at parent node.
> 1. Run the focusing steps on parent node.
> 1. If element is not disabled:
>     1. **Fire an input event at parent node.**
>     1. Let previous selectedness be equal to element selectedness.
>     1. If element’s container has the multiple attribute, toggle the element’s selectedness state by setting it to the opposite value of its current selectedness.
>
>         Otherwise, set the element’s selectedness state to true.
>
>     1. **If previous selectedness is false, fire a change event at parent node.**
> 1. Fire a mouseUp event at parent node.
> 1. Fire a click event at parent node.
