### PR TITLE
[wptrunner] Propagate `subsuite` when rerunning tests

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -773,6 +773,7 @@ class TestRunnerManager(threading.Thread):
                 self.logger.info("Restarting browser for new test group")
                 restart = True
         else:
+            subsuite = self.state.subsuite
             test_type = self.state.test_type
             test_group = self.state.test_group
             group_metadata = self.state.group_metadata


### PR DESCRIPTION
Follow-up fix for #39711. Otherwise, we get an `UnboundLocalError` in `after_test_end`.