### PR TITLE
Add some HTMLHyperlinkElementUtils tests

### DIFF
--- a/html/semantics/links/links-created-by-a-and-area-elements/non-parsable-url-getter-setter.window.js
+++ b/html/semantics/links/links-created-by-a-and-area-elements/non-parsable-url-getter-setter.window.js
@@ -1,0 +1,54 @@
+[
+  {
+    "property": "origin",
+    "set": null
+  },
+  {
+    "property": "protocol",
+    "get": ":",
+    "set": "https"
+  },
+  {
+    "property": "username"
+  },
+  {
+    "property": "password"
+  },
+  {
+    "property": "host"
+  },
+  {
+    "property": "hostname"
+  },
+  {
+    "property": "port",
+    "set": "8000"
+  },
+  {
+    "property": "pathname"
+  },
+  {
+    "property": "search"
+  },
+  {
+    "property": "hash"
+  }
+].forEach(({ property, get = "", set = "string" }) => {
+  ["a", "area"].forEach(name => {
+    test(() => {
+      const link = document.createElement(name);
+      link.href = "http://test:test/" // non-parsable URL
+      assert_equals(link[property], get);
+    }, `<${name} href="http://test:test/">.${property} getter`);
+    
+    if (set !== null) {
+      test(() => {
+        const link = document.createElement(name);
+        link.href = "http://test:test/" // non-parsable URL
+        link[property] = set;
+        assert_equals(link[property], get);
+        assert_equals(link.href, "http://test:test/");
+      }, `<${name} href="http://test:test/">.${property} setter`);
+    }
+  });
+});

--- a/html/semantics/links/links-created-by-a-and-area-elements/non-parsable-url-getter-setter.window.js
+++ b/html/semantics/links/links-created-by-a-and-area-elements/non-parsable-url-getter-setter.window.js
@@ -37,14 +37,14 @@
   ["a", "area"].forEach(name => {
     test(() => {
       const link = document.createElement(name);
-      link.href = "http://test:test/" // non-parsable URL
+      link.href = "http://test:test/"; // non-parsable URL
       assert_equals(link[property], get);
     }, `<${name} href="http://test:test/">.${property} getter`);
-    
+
     if (set !== null) {
       test(() => {
         const link = document.createElement(name);
-        link.href = "http://test:test/" // non-parsable URL
+        link.href = "http://test:test/"; // non-parsable URL
         link[property] = set;
         assert_equals(link[property], get);
         assert_equals(link.href, "http://test:test/");

--- a/html/semantics/links/links-created-by-a-and-area-elements/non-special-opaque-path-url-getter-setter.window.js
+++ b/html/semantics/links/links-created-by-a-and-area-elements/non-special-opaque-path-url-getter-setter.window.js
@@ -43,14 +43,14 @@
   ["a", "area"].forEach(name => {
     test(() => {
       const link = document.createElement(name);
-      link.href = "non-special:opaque"
+      link.href = "non-special:opaque";
       assert_equals(link[property], get);
     }, `<${name} href="non-special:opaque">.${property} getter`);
-    
+
     if (set !== null) {
       test(() => {
         const link = document.createElement(name);
-        link.href = "non-special:opaque"
+        link.href = "non-special:opaque";
         link[property] = set;
         assert_equals(link[property], setget);
       }, `<${name} href="non-special:opaque">.${property} setter`);

--- a/html/semantics/links/links-created-by-a-and-area-elements/non-special-opaque-path-url-getter-setter.window.js
+++ b/html/semantics/links/links-created-by-a-and-area-elements/non-special-opaque-path-url-getter-setter.window.js
@@ -1,0 +1,59 @@
+[
+  {
+    "property": "origin",
+    "get": "null",
+    "set": null
+  },
+  {
+    "property": "protocol",
+    "get": "non-special:",
+    "set": "super-special",
+    "setget": "super-special:"
+  },
+  {
+    "property": "username"
+  },
+  {
+    "property": "password"
+  },
+  {
+    "property": "host",
+  },
+  {
+    "property": "hostname",
+  },
+  {
+    "property": "port",
+    "set": "8000"
+  },
+  {
+    "property": "pathname",
+    "get": "opaque",
+    "setget": "opaque"
+  },
+  {
+    "property": "search",
+    "setget": "?string"
+  },
+  {
+    "property": "hash",
+    "setget": "#string"
+  }
+].forEach(({ property, get = "", set = "string", setget = get }) => {
+  ["a", "area"].forEach(name => {
+    test(() => {
+      const link = document.createElement(name);
+      link.href = "non-special:opaque"
+      assert_equals(link[property], get);
+    }, `<${name} href="non-special:opaque">.${property} getter`);
+    
+    if (set !== null) {
+      test(() => {
+        const link = document.createElement(name);
+        link.href = "non-special:opaque"
+        link[property] = set;
+        assert_equals(link[property], setget);
+      }, `<${name} href="non-special:opaque">.${property} setter`);
+    }
+  });
+});

--- a/html/semantics/links/links-created-by-a-and-area-elements/non-special-url-getter-setter.window.js
+++ b/html/semantics/links/links-created-by-a-and-area-elements/non-special-url-getter-setter.window.js
@@ -1,0 +1,63 @@
+[
+  {
+    "property": "origin",
+    "get": "null",
+    "set": null
+  },
+  {
+    "property": "protocol",
+    "get": "non-special:",
+    "set": "super-special",
+    "setget": "super-special:"
+  },
+  {
+    "property": "username"
+  },
+  {
+    "property": "password"
+  },
+  {
+    "property": "host",
+    "get": "test:9001",
+    "setget": "string:9001"
+  },
+  {
+    "property": "hostname",
+    "get": "test"
+  },
+  {
+    "property": "port",
+    "get": "9001",
+    "set": "8000"
+  },
+  {
+    "property": "pathname",
+    "get": "/",
+    "setget": "/string"
+  },
+  {
+    "property": "search",
+    "setget": "?string"
+  },
+  {
+    "property": "hash",
+    "setget": "#string"
+  }
+].forEach(({ property, get = "", set = "string", setget = set }) => {
+  ["a", "area"].forEach(name => {
+    test(() => {
+      const link = document.createElement(name);
+      link.href = "non-special://test:9001/"
+      assert_equals(link[property], get);
+    }, `<${name} href="non-special://test:9001/">.${property} getter`);
+    
+    if (set !== null) {
+      test(() => {
+        const link = document.createElement(name);
+        link.href = "non-special://test:9001/"
+        link[property] = set;
+        assert_equals(link[property], setget);
+      }, `<${name} href="non-special://test:9001/">.${property} setter`);
+    }
+  });
+});

--- a/html/semantics/links/links-created-by-a-and-area-elements/non-special-url-getter-setter.window.js
+++ b/html/semantics/links/links-created-by-a-and-area-elements/non-special-url-getter-setter.window.js
@@ -47,14 +47,14 @@
   ["a", "area"].forEach(name => {
     test(() => {
       const link = document.createElement(name);
-      link.href = "non-special://test:9001/"
+      link.href = "non-special://test:9001/";
       assert_equals(link[property], get);
     }, `<${name} href="non-special://test:9001/">.${property} getter`);
-    
+
     if (set !== null) {
       test(() => {
         const link = document.createElement(name);
-        link.href = "non-special://test:9001/"
+        link.href = "non-special://test:9001/";
         link[property] = set;
         assert_equals(link[property], setget);
       }, `<${name} href="non-special://test:9001/">.${property} setter`);


### PR DESCRIPTION
<a> and <area> have the unique ability to represent a non-parsable URL. Test their various properties in relation to that.

While here, also add some non-special URL tests. Those probably in part duplicate coverage in url/, but it seems reasonable to have this somewhat differing coverage.