### PR TITLE
[wptrunner] Create conditional expectations with a stable order

### DIFF
--- a/tools/wptrunner/wptrunner/manifestupdate.py
+++ b/tools/wptrunner/wptrunner/manifestupdate.py
@@ -667,7 +667,14 @@ class PropertyUpdate:
                 else:
                     errors.append(error)
 
-            for child in node.children:
+            try:
+                # Attempt to stably order the next group of conditions by their
+                # values, which are typically string/numeric types that have an
+                # order defined.
+                children = sorted(node.children, key=lambda child: child.value)
+            except TypeError:
+                children = node.children
+            for child in children:
                 queue.append((child, parents_and_self))
 
         conditions = conditions[::-1]


### PR DESCRIPTION
Currently, the order relies on the arbitrary iteration order of a `Set[expectedtree.Node]`. Ordering conditions by value instead avoids unnecessary churn when updating expectations. This should usually be possible, as properties within a level usually share a common string or numeric type.

See also: [crbug.com/1475877](https://crbug.com/1475877)