### PR TITLE
Fetch: test `name` and `length` for `Response` static methods

### DIFF
--- a/fetch/api/response/response-static-error.any.js
+++ b/fetch/api/response/response-static-error.any.js
@@ -20,3 +20,8 @@ test(function() {
 
   assert_throws_js(TypeError, function () { headers.append('name', 'value'); });
 }, "the 'guard' of the Headers instance should be immutable");
+
+test(function() {
+  assert_equals(Response.error.name, 'error');
+  assert_equals(Response.error.length, 0);
+}, "Response.error has correct name and length");

--- a/fetch/api/response/response-static-json.any.js
+++ b/fetch/api/response/response-static-json.any.js
@@ -94,3 +94,8 @@ for (const [input, expected] of encodingChecks) {
     assert_array_equals(data, expected);
   }, `Check response returned by static json() with input ${input}`);
 }
+
+test(function() {
+  assert_equals(Response.json.name, 'json');
+  assert_equals(Response.json.length, 1);
+}, "Response.json has correct name and length");

--- a/fetch/api/response/response-static-redirect.any.js
+++ b/fetch/api/response/response-static-redirect.any.js
@@ -38,3 +38,8 @@ invalidRedirectStatus.forEach(function(invalidStatus) {
         "Expect RangeError exception");
   }, "Check error returned when giving invalid status to redirect(), status = " + invalidStatus);
 });
+
+test(function() {
+  assert_equals(Response.redirect.name, 'redirect');
+  assert_equals(Response.redirect.length, 1);
+}, "Response.redirect has correct name and length");


### PR DESCRIPTION
Make sure that names and number of mandatory arguments is correct for [`Response` static methods](https://fetch.spec.whatwg.org/#ref-for-dom-response-error)