### PR TITLE
[wptrunner] Improve weighting when deciding an unconditional default

### DIFF
--- a/tools/wptrunner/wptrunner/manifestupdate.py
+++ b/tools/wptrunner/wptrunner/manifestupdate.py
@@ -2,7 +2,7 @@
 
 import os
 from urllib.parse import urljoin, urlsplit
-from collections import namedtuple, defaultdict, deque
+from collections import Counter, namedtuple, defaultdict, deque
 from math import ceil
 from typing import Any, Callable, ClassVar, Dict, List, Optional
 
@@ -617,8 +617,6 @@ class PropertyUpdate:
         conditions = []
         errors = []
 
-        value_count = defaultdict(int)
-
         def to_count_value(v):
             if v is None:
                 return v
@@ -659,10 +657,6 @@ class PropertyUpdate:
                         if prev_default:
                             conditions.append((None, prev_default))
                 if error is None:
-                    count_value = to_count_value(value)
-                    value_count[count_value] += len(node.run_info)
-
-                if error is None:
                     conditions.append((expr, value))
                 else:
                     errors.append(error)
@@ -678,6 +672,7 @@ class PropertyUpdate:
                 queue.append((child, parents_and_self))
 
         conditions = conditions[::-1]
+        value_count = Counter(to_count_value(value) for _, value in conditions)
 
         # If we haven't set a default condition, add one and remove all the conditions
         # with the same value
@@ -686,9 +681,9 @@ class PropertyUpdate:
             # or the previous default
             cls_default = to_count_value(self.default_value)
             prev_default = to_count_value(prev_default)
-            commonest_value = max(value_count, key=lambda x:(value_count.get(x),
-                                                             x == cls_default,
-                                                             x == prev_default))
+            commonest_value = max(value_count, key=lambda x: (value_count[x],
+                                                              x == cls_default,
+                                                              x == prev_default))
             if isinstance(commonest_value, tuple):
                 commonest_value = list(commonest_value)
             commonest_value = self.from_ini_value(commonest_value)

--- a/tools/wptrunner/wptrunner/tests/test_manifestupdate.py
+++ b/tools/wptrunner/wptrunner/tests/test_manifestupdate.py
@@ -1,0 +1,58 @@
+# mypy: allow-untyped-defs
+
+import io
+import textwrap
+
+from .. import metadata
+from .. import manifestupdate
+from .. import wptmanifest
+
+
+def test_unconditional_default_promotion():
+    contents_before = io.BytesIO(
+        textwrap.dedent(
+            """\
+            [b.html]
+            """).encode())
+    manifest = manifestupdate.compile(
+        contents_before,
+        test_path='a/b.html',
+        url_base='/',
+        run_info_properties=(['os'], {'os': ['version']}),
+        update_intermittent=True,
+        remove_intermittent=False)
+    test = manifest.get_test('/a/b.html')
+    test.set_result(
+        metadata.RunInfo({'os': 'linux', 'version': 'jammy'}),
+        metadata.Result('TIMEOUT', [], 'PASS'))
+    test.set_result(
+        metadata.RunInfo({'os': 'win', 'version': '10'}),
+        metadata.Result('TIMEOUT', [], 'PASS'))
+    test.set_result(
+        metadata.RunInfo({'os': 'mac', 'version': '11'}),
+        metadata.Result('FAIL', [], 'PASS'))
+    test.set_result(
+        metadata.RunInfo({'os': 'mac', 'version': '12'}),
+        metadata.Result('FAIL', [], 'PASS'))
+    test.set_result(
+        metadata.RunInfo({'os': 'mac', 'version': '13'}),
+        metadata.Result('FAIL', [], 'PASS'))
+    test.update(full_update=True, disable_intermittent=False)
+
+    # The conditions before the default is created will look like:
+    #   expected:
+    #     if os == "linux": TIMEOUT
+    #     if os == "win": TIMEOUT
+    #     if os == "mac": FAIL
+    #
+    # The update should prefer promoting `TIMEOUT` over `FAIL`, since the former
+    # eliminates more conditions (both non-mac ones).
+    contents_after = io.BytesIO(
+        textwrap.dedent(
+            """\
+            [b.html]
+              expected:
+                if os == "mac": FAIL
+                TIMEOUT
+            """).encode())
+    assert manifest.node == wptmanifest.parse(contents_after)


### PR DESCRIPTION
After `manifestupdate` generates new conditions for an expectation, it attempts to promote the "most common value" to the unconditional default. At the moment, the "most common value" measure is the number of `run_info` encompassed by each condition. This measure may not actually minimize the number of lines if the promoted value encompasses more `run_info` but fewer physical conditions than another value (e.g., [0]). Change the measure to the latter to improve succinctness.

[0] https://crbug.com/1475877#c1