### PR TITLE
fix typo in unicode codepoints for small-kana

### DIFF
--- a/css/css-text/text-transform/reference/text-transform-full-size-kana-008-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-full-size-kana-008-ref.html
@@ -22,6 +22,6 @@ Any missing glyph should be ignored as long as it is missing in both the second 
   <tr><td>&#x1B155;<td>&#x30B3;<td>&#x30B3;
   <tr><td>&#x1B164;<td>&#x30F0;<td>&#x30F0;
   <tr><td>&#x1B165;<td>&#x30F1;<td>&#x30F1;
-  <tr><td>&#x1B166;<td>&#x30F1;<td>&#x30F1;
+  <tr><td>&#x1B166;<td>&#x30F2;<td>&#x30F2;
   <tr><td>&#x1B167;<td>&#x30F3;<td>&#x30F3;
 </table>

--- a/css/css-text/text-transform/text-transform-full-size-kana-008.html
+++ b/css/css-text/text-transform/text-transform-full-size-kana-008.html
@@ -24,6 +24,6 @@ Any missing glyph should be ignored as long as it is missing in both the second 
   <tr><td>&#x1B155;<td>&#x1B155;<td>&#x30B3;
   <tr><td>&#x1B164;<td>&#x1B164;<td>&#x30F0;
   <tr><td>&#x1B165;<td>&#x1B165;<td>&#x30F1;
-  <tr><td>&#x1B166;<td>&#x1B166;<td>&#x30F1;
+  <tr><td>&#x1B166;<td>&#x1B166;<td>&#x30F2;
   <tr><td>&#x1B167;<td>&#x1B167;<td>&#x30F3;
 </table>


### PR DESCRIPTION
Follow up on https://github.com/web-platform-tests/wpt/pull/41638 See https://github.com/w3c/csswg-drafts/issues/8442