### PR TITLE
Don't test serialization of single value background-size in getComputedStyle-calc-mixed-units-001.html

### DIFF
--- a/css/css-values/getComputedStyle-calc-mixed-units-001.html
+++ b/css/css-values/getComputedStyle-calc-mixed-units-001.html
@@ -54,7 +54,7 @@
 
   var targetElement = document.getElementById("target");
 
-    function verifyComputedStyle(property_name, specified_value, expected_value, description)
+    function verifyComputedStyle(property_name, specified_value, expected_values, description)
     {
 
     test(function()
@@ -62,12 +62,12 @@
 
       targetElement.style.setProperty(property_name, specified_value);
 
-      assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
+      assert_in_array(getComputedStyle(targetElement)[property_name], expected_values);
 
       }, description);
     }
 
-    verifyComputedStyle("background-size", "calc(67% - 54% + 4em)", "calc(13% + 64px)", "testing background-size: calc(67% - 54% + 4em)");
+    verifyComputedStyle("background-size", "calc(67% - 54% + 4em)", ["calc(13% + 64px)", "calc(13% + 64px) auto"], "testing background-size: calc(67% - 54% + 4em)");
 
     /*
     "Where percentages are not resolved at computed-value time,

--- a/css/css-values/getComputedStyle-calc-mixed-units-001.html
+++ b/css/css-values/getComputedStyle-calc-mixed-units-001.html
@@ -54,7 +54,7 @@
 
   var targetElement = document.getElementById("target");
 
-    function verifyComputedStyle(property_name, specified_value, expected_values, description)
+    function verifyComputedStyle(property_name, specified_value, expected_value, description)
     {
 
     test(function()
@@ -62,12 +62,12 @@
 
       targetElement.style.setProperty(property_name, specified_value);
 
-      assert_in_array(getComputedStyle(targetElement)[property_name], expected_values);
+      assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
 
       }, description);
     }
 
-    verifyComputedStyle("background-size", "calc(67% - 54% + 4em)", ["calc(13% + 64px)", "calc(13% + 64px) auto"], "testing background-size: calc(67% - 54% + 4em)");
+    verifyComputedStyle("background-size", "calc(67% - 54% + 4em) 50%", "calc(13% + 64px) 50%", "testing background-size: calc(67% - 54% + 4em) 50%");
 
     /*
     "Where percentages are not resolved at computed-value time,


### PR DESCRIPTION
WebKit always serializes `background-size` to 2 values to avoid ambiguity, given `-webkit-background-size` and `background-size` have different meanings when given one value. The point of this test is to test `calc()`, so WebKit shouldn't fail because of this.