### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=260777

### DIFF
--- a/css/css-values/calc-z-index-fractions-001.html
+++ b/css/css-values/calc-z-index-fractions-001.html
@@ -46,11 +46,12 @@
     }
 
  /* verifyComputedStyle(property_name, initial_value, specified_value, expected_value, description) */
-
+    verifyComputedStyle("z-index", "auto", "calc(2.5 / 2)", "1", "testing z-index: calc(2.5 / 2)");
     verifyComputedStyle("z-index", "auto", "calc(3 / 2)", "2", "testing z-index: calc(3 / 2)");
-
+    verifyComputedStyle("z-index", "auto", "calc(3.5 / 2)", "2", "testing z-index: calc(3.5 / 2)");
+    verifyComputedStyle("z-index", "auto", "calc(-2.5 / 2)", "-1", "testing z-index: calc(-2.5 / 2)");
     verifyComputedStyle("z-index", "auto", "calc(-3 / 2)", "-1", "testing z-index: calc(-3 / 2)");
-
+    verifyComputedStyle("z-index", "auto", "calc(-3.5 / 2)", "-2", "testing z-index: calc(-3.5 / 2)");
   }
 
   startTesting();


### PR DESCRIPTION
WebKit export from bug: [\[css-values\] Rounding of <integer> type should round half towards positive infinity](https://bugs.webkit.org/show_bug.cgi?id=260777)