### PR TITLE
Avoid crash in PlacementAmongFloats

### DIFF
--- a/css/CSS2/floats/floats-wrap-bfc-with-margin-010-ref.html
+++ b/css/CSS2/floats/floats-wrap-bfc-with-margin-010-ref.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<title>CSS Test Reference</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<style>
+body {
+  position: relative;
+}
+.wrapper {
+  position: absolute;
+  width: 100px;
+  border: 5px solid;
+  top: 75px;
+}
+.float {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  left: 0;
+  top: 0;
+  background: cyan;
+}
+.bfc {
+  position: absolute;
+  height: 50px;
+  background: green;
+}
+</style>
+<div class="wrapper" style="left: 10px; height: 50px">
+  <div class="float"></div>
+  <div class="bfc" style="width: 50px; left: 0; top: -75px"></div>
+</div>
+<div class="wrapper" style="left: 140px; height: 50px">
+  <div class="float"></div>
+  <div class="bfc" style="width: 75px; left: 0; top: -75px"></div>
+</div>
+<div class="wrapper" style="left: 270px; height: 50px">
+  <div class="float"></div>
+  <div class="bfc" style="width: 50px; left: 50px; top: -25px"></div>
+</div>
+<div class="wrapper" style="left: 400px; height: 100px">
+  <div class="float"></div>
+  <div class="bfc" style="width: 75px; left: 0px; top: 50px"></div>
+</div>

--- a/css/CSS2/floats/floats-wrap-bfc-with-margin-010.html
+++ b/css/CSS2/floats/floats-wrap-bfc-with-margin-010.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<title>CSS Test: Float followed by a BFC root with a negative margin-top</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css2/#floats">
+<link rel="match" href="floats-wrap-bfc-with-margin-010-ref.html">
+<meta name="assert" content="
+  If the negative margin places the BFC root entirely above the float,
+  then they don't overlap so we are done.
+  If the negative margin is not enough to prevent them from overlapping,
+  then the BFC root needs to be placed adjacent to the float if there
+  is enough available space, or be cleared below the float.">
+<style>
+.wrapper {
+  float: left;
+  width: 100px;
+  border: 5px solid;
+  margin: 75px 10px;
+}
+.float {
+  float: left;
+  width: 50px;
+  height: 50px;
+  background: cyan;
+}
+.bfc {
+  overflow: hidden;
+  height: 50px;
+  background: green;
+}
+</style>
+<div class="wrapper">
+  <div class="float"></div>
+  <div class="bfc" style="margin-top: -75px; width: 50px"></div>
+</div>
+<div class="wrapper">
+  <div class="float"></div>
+  <div class="bfc" style="margin-top: -75px; width: 75px"></div>
+</div>
+<div class="wrapper">
+  <div class="float"></div>
+  <div class="bfc" style="margin-top: -25px; width: 50px"></div>
+</div>
+<div class="wrapper">
+  <div class="float"></div>
+  <div class="bfc" style="margin-top: -25px; width: 75px"></div>
+</div>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
PlacementAmongFloats was assuming that there would always be a FloatBand at a position smaller than or equal to the given ceiling, but this was not the case for negative ceilings.

The reason is that the FloatContext initialized the FloatBandTree with a band at 0, and another at +∞.

This patch changes the initial bands to −∞ and +∞. This seems more consistent and matches the expectation of PlacementAmongFloats.

Reviewed in servo/servo#30235