### PR TITLE
[wptrunner] Disable WebTransport H3 server for `wpt run` tests

### DIFF
--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -111,6 +111,7 @@ def test_list_tests(manifest_dir):
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--metadata", manifest_dir, "--list-tests",
                        "--channel", "dev", "--yes",
+                       "--no-enable-webtransport-h3",
                        # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
                        "--enable-swiftshader",
                        "chrome", "/dom/nodes/Element-tagName.html"])
@@ -180,6 +181,7 @@ def test_run_zero_tests():
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--no-pause", "--channel", "dev",
+                       "--no-enable-webtransport-h3",
                        # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
                        "--enable-swiftshader",
                        "chrome", "/non-existent-dir/non-existent-file.html"])
@@ -188,6 +190,7 @@ def test_run_zero_tests():
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--no-pause", "--no-fail-on-unexpected",
                        "--channel", "dev",
+                       "--no-enable-webtransport-h3",
                        # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
                        "--enable-swiftshader",
                        "chrome", "/non-existent-dir/non-existent-file.html"])
@@ -209,6 +212,7 @@ def test_run_failing_test():
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--no-pause", "--channel", "dev",
+                       "--no-enable-webtransport-h3",
                        # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
                        "--enable-swiftshader",
                        "chrome", failing_test])
@@ -217,6 +221,7 @@ def test_run_failing_test():
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--no-pause", "--no-fail-on-unexpected",
                        "--channel", "dev",
+                       "--no-enable-webtransport-h3",
                        # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
                        "--enable-swiftshader",
                        "chrome", failing_test])
@@ -244,6 +249,7 @@ def test_run_verify_unstable(temp_test):
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--verify", "--channel", "dev",
+                       "--no-enable-webtransport-h3",
                        # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
                        "--enable-swiftshader",
                        "chrome", unstable_test])
@@ -253,6 +259,7 @@ def test_run_verify_unstable(temp_test):
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--verify", "--channel", "dev",
+                       "--no-enable-webtransport-h3",
                        # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
                        "--enable-swiftshader",
                        "chrome", stable_test])

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -111,6 +111,7 @@ def test_list_tests(manifest_dir):
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--metadata", manifest_dir, "--list-tests",
                        "--channel", "dev", "--yes",
+                       # WebTransport server is not needed (web-platform-tests/wpt#41675).
                        "--no-enable-webtransport-h3",
                        # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
                        "--enable-swiftshader",
@@ -136,6 +137,8 @@ def test_list_tests_missing_manifest(manifest_dir):
                        "--metadata", manifest_dir,
                        "--list-tests",
                        "--yes",
+                       # WebTransport server is not needed (web-platform-tests/wpt#41675).
+                       "--no-enable-webtransport-h3",
                        "firefox", "/dom/nodes/Element-tagName.html"])
 
     assert excinfo.value.code == 0
@@ -164,6 +167,8 @@ def test_list_tests_invalid_manifest(manifest_dir):
                        "--metadata", manifest_dir,
                        "--list-tests",
                        "--yes",
+                       # WebTransport server is not needed (web-platform-tests/wpt#41675).
+                       "--no-enable-webtransport-h3",
                        "firefox", "/dom/nodes/Element-tagName.html"])
 
     assert excinfo.value.code == 0
@@ -181,6 +186,7 @@ def test_run_zero_tests():
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--no-pause", "--channel", "dev",
+                       # WebTransport server is not needed (web-platform-tests/wpt#41675).
                        "--no-enable-webtransport-h3",
                        # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
                        "--enable-swiftshader",
@@ -190,6 +196,7 @@ def test_run_zero_tests():
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--no-pause", "--no-fail-on-unexpected",
                        "--channel", "dev",
+                       # WebTransport server is not needed (web-platform-tests/wpt#41675).
                        "--no-enable-webtransport-h3",
                        # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
                        "--enable-swiftshader",
@@ -212,6 +219,7 @@ def test_run_failing_test():
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--no-pause", "--channel", "dev",
+                       # WebTransport server is not needed (web-platform-tests/wpt#41675).
                        "--no-enable-webtransport-h3",
                        # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
                        "--enable-swiftshader",
@@ -221,6 +229,7 @@ def test_run_failing_test():
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--no-pause", "--no-fail-on-unexpected",
                        "--channel", "dev",
+                       # WebTransport server is not needed (web-platform-tests/wpt#41675).
                        "--no-enable-webtransport-h3",
                        # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
                        "--enable-swiftshader",
@@ -249,6 +258,7 @@ def test_run_verify_unstable(temp_test):
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--verify", "--channel", "dev",
+                       # WebTransport server is not needed (web-platform-tests/wpt#41675).
                        "--no-enable-webtransport-h3",
                        # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
                        "--enable-swiftshader",
@@ -259,6 +269,7 @@ def test_run_verify_unstable(temp_test):
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--verify", "--channel", "dev",
+                       # WebTransport server is not needed (web-platform-tests/wpt#41675).
                        "--no-enable-webtransport-h3",
                        # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
                        "--enable-swiftshader",


### PR DESCRIPTION
Speculatively works around a failing cleanup in `aioquic` due to a transport not implementing `asyncio.BaseTransport.is_closing`:

```
E               pytest.PytestUnraisableExceptionWarning: Exception ignored in: <function StreamWriter.__del__ at 0x7f77affc6d40>
E
E               Traceback (most recent call last):
E                 File "/usr/lib/python3.11/asyncio/streams.py", line 395, in __del__
E                   if not self._transport.is_closing():
E                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E                 File "/usr/lib/python3.11/asyncio/transports.py", line 25, in is_closing
E                   raise NotImplementedError
E               NotImplementedError
```

This failure is blocking unrelated `infra` PRs such as #41661, #41650, and #41642.

The WebTransport over HTTP/3 server isn't needed for these tests anyway.