### PR TITLE
Enforce single threaded compositing for WPTs

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/content_shell.py
+++ b/tools/wptrunner/wptrunner/browsers/content_shell.py
@@ -43,6 +43,10 @@ def check_args(**kwargs):
 
 
 def browser_kwargs(logger, test_type, run_info_data, config, subsuite, **kwargs):
+    ENABLE_THREADED_COMPOSITING_FLAG = '--enable-threaded-compositing'
+    DISABLE_THREADED_COMPOSITING_FLAG = '--disable-threaded-compositing'
+    DISABLE_THREADED_ANIMATION_FLAG = '--disable-threaded-animation'
+
     args = []
     args.append("--ignore-certificate-errors-spki-list=%s" %
         ','.join(chrome_spki_certs.IGNORE_CERTIFICATE_ERRORS_SPKI_LIST))
@@ -58,6 +62,13 @@ def browser_kwargs(logger, test_type, run_info_data, config, subsuite, **kwargs)
     for arg in kwargs.get("binary_args", []):
         if arg not in args:
             args.append(arg)
+
+    # Temporary workaround to align with RWT behavior. Unless a vts explicitly
+    # enables threaded compositing, we should use single threaded compositing
+    if ENABLE_THREADED_COMPOSITING_FLAG not in subsuite.config.get("binary_args", []):
+        args.extend([DISABLE_THREADED_COMPOSITING_FLAG,
+                     DISABLE_THREADED_ANIMATION_FLAG])
+
     for arg in subsuite.config.get("binary_args", []):
         if arg not in args:
             args.append(arg)

--- a/tools/wptrunner/wptrunner/browsers/content_shell.py
+++ b/tools/wptrunner/wptrunner/browsers/content_shell.py
@@ -20,6 +20,10 @@ from ..executors.executorcontentshell import (  # noqa: F401
     ContentShellTestharnessExecutor,
 )
 
+ENABLE_THREADED_COMPOSITING_FLAG = '--enable-threaded-compositing'
+DISABLE_THREADED_COMPOSITING_FLAG = '--disable-threaded-compositing'
+DISABLE_THREADED_ANIMATION_FLAG = '--disable-threaded-animation'
+
 
 __wptrunner__ = {"product": "content_shell",
                  "check_args": "check_args",
@@ -43,10 +47,6 @@ def check_args(**kwargs):
 
 
 def browser_kwargs(logger, test_type, run_info_data, config, subsuite, **kwargs):
-    ENABLE_THREADED_COMPOSITING_FLAG = '--enable-threaded-compositing'
-    DISABLE_THREADED_COMPOSITING_FLAG = '--disable-threaded-compositing'
-    DISABLE_THREADED_ANIMATION_FLAG = '--disable-threaded-animation'
-
     args = []
     args.append("--ignore-certificate-errors-spki-list=%s" %
         ','.join(chrome_spki_certs.IGNORE_CERTIFICATE_ERRORS_SPKI_LIST))


### PR DESCRIPTION
We are seeing higher flaky rate at Wptrunner side than blink_wpt_tests. Disable threaded compositing to align with RWT side behavior, and see if that fixed the issue.

Bug: 1473779