### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=260760

### DIFF
--- a/css/css-typed-om/factory-font-relative-length.html
+++ b/css/css-typed-om/factory-font-relative-length.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSSOM Test: Numeric Factory Functions for font relative length</title>
+    <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+    <link rel="help" href="https://drafts.css-houdini.org/css-typed-om-1/#numeric-factory">
+    <meta name="assert" content="CSS factory functions produce expected CSSUnitValue">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+    <script>
+        "use strict";
+
+        let units = [
+            "cap",
+            "ch",
+            "em",
+            "ex",
+            "ic",
+            "lh",
+            "rcap",
+            "rch",
+            "rem",
+            "rex",
+            "ric",
+            "rlh"
+        ];
+        let counter = 1;
+        for (let unit of units) {
+            test(function(){
+                let length = CSS[unit](counter);
+                assert_true(length instanceof CSSUnitValue);
+                assert_equals(length.value, counter);
+                assert_equals(length.unit, unit);
+                counter++;
+            }, `CSS.${unit}() produces ${unit} length`);
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[css-typed-om\] Add factory functions for all font relative units](https://bugs.webkit.org/show_bug.cgi?id=260760)