### PR TITLE
Convert /_mozilla/css/iframe/multiple_external.html into a WPT crashtest

### DIFF
--- a/html/semantics/embedded-content/the-iframe-element/multiple-iframes-with-allow-scripts-crash.html
+++ b/html/semantics/embedded-content/the-iframe-element/multiple-iframes-with-allow-scripts-crash.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <style>
+          iframe {
+            margin: 10px;
+            float: left;
+            width: 300px;
+            height: 300px;
+            border: none;
+          }
+        </style>
+        <iframe sandbox="allow-scripts" src="resources/hello-world.html"> </iframe>
+        <iframe sandbox="allow-scripts" src="resources/hello-world.html"> </iframe>
+    </body>
+</html>


### PR DESCRIPTION
This test was made before the use of WPT tests, much less WPT
crashtests, but it was originally made to test a crash. Initially, it
had an empty result, but text was added. The new reference for the test
relied on the bad float layout of legacy layout so was always incorrect.

This change converts the test into a WPT crashtest.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#30246