### PR TITLE
webkitgtk_minibrowser: fix getting binary_args parameter after ba277d1dd0

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
+++ b/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
@@ -64,7 +64,7 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     executor_kwargs["close_after_done"] = True
     executor_kwargs["capabilities"] = capabilities(test_environment.config, **kwargs)
     if test_type == "wdspec":
-        executor_kwargs["binary_args"] = capabilities["webkitgtk:browserOptions"]["args"]
+        executor_kwargs["binary_args"] = executor_kwargs["capabilities"]["webkitgtk:browserOptions"]["args"]
     return executor_kwargs
 
 


### PR DESCRIPTION
Commit ba277d1dd0 implemented a way of passing the browser `binary_args` for the `wdspec` session config but the way of getting this info for the browser webkigtk_minibrowser was not working.

Fix it by getting the info from the dictionary that the capabilities() function returns.

This was causing [the following error on the CI](https://community-tc.services.mozilla.com/tasks/XzD6337US9mrGtX55KPEYA/runs/0/logs/live/public/logs/live.log):

```
Traceback (most recent call last):
  File "./wpt", line 10, in <module>
    wpt.main()
  File "/home/test/web-platform-tests/tools/wpt/wpt.py", line 233, in main
    rv = script(*args, **kwargs)
  File "/home/test/web-platform-tests/tools/wpt/run.py", line 894, in run
    rv = run_single(venv, **wptrunner_kwargs) > 0
  File "/home/test/web-platform-tests/tools/wpt/run.py", line 901, in run_single
    return wptrunner.start(**kwargs)
  File "/home/test/web-platform-tests/tools/wptrunner/wptrunner/wptrunner.py", line 536, in start
    rv = not run_tests(**kwargs)[0] or logged_critical.has_log
  File "/home/test/web-platform-tests/tools/wptrunner/wptrunner/wptrunner.py", line 473, in run_tests
    iter_success = run_test_iteration(test_status, test_loader, test_source,
  File "/home/test/web-platform-tests/tools/wptrunner/wptrunner/wptrunner.py", line 217, in run_test_iteration
    executor_kwargs = product.get_executor_kwargs(logger,
  File "/home/test/web-platform-tests/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py", line 67, in executor_kwargs
    executor_kwargs["binary_args"] = capabilities["webkitgtk:browserOptions"]["args"]
TypeError: 'function' object is not subscriptable
[taskcluster 2023-08-28 01:26:39.572Z] === Task Finished ===
[taskcluster 2023-08-28 01:26:40.435Z] Unsuccessful task run with exit code: 1 completed in 164.001 seconds
```

Related: https://github.com/web-platform-tests/wpt/issues/40901