### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=260941

### DIFF
--- a/css/css-values/mod-length-degrees-crash.html
+++ b/css/css-values/mod-length-degrees-crash.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=260941">
+
+<p>PASS if no crash.</p>
+<div style="height: calc(mod(0px, 0deg))"></div>

--- a/css/css-values/rem-length-degrees-crash.html
+++ b/css/css-values/rem-length-degrees-crash.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=260941">
+
+<p>PASS if no crash.</p>
+<div style="height: calc(rem(0px, 0deg))"></div>

--- a/css/css-values/round-length-degrees-crash.html
+++ b/css/css-values/round-length-degrees-crash.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=260941">
+
+<p>PASS if no crash.</p>
+<div style="height: calc(round(0px, 0deg))"></div>

--- a/css/css-values/round-mod-rem-invalid.html
+++ b/css/css-values/round-mod-rem-invalid.html
@@ -7,6 +7,11 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="../support/parsing-testcommon.js"></script>
 <script>
+function test_invalid_length_percentage(value) {
+  test_invalid_value('height', value);
+  test_invalid_value('height', `calc(${value})`);
+}
+
 function test_invalid_number(value) {
   test_invalid_value('opacity', value);
 }
@@ -91,4 +96,20 @@ test_invalid_number('rem(1, 0deg)');
 test_invalid_number('rem(1, 0Hz)');
 test_invalid_number('rem(1, 0dpi)');
 test_invalid_number('rem(1, 0fr)');
+
+test_invalid_length_percentage('round(0px, 0s)');
+test_invalid_length_percentage('round(0px, 0deg)');
+test_invalid_length_percentage('round(0px, 0Hz)');
+test_invalid_length_percentage('round(0px, 0dpi)');
+test_invalid_length_percentage('round(0px, 0fr)');
+test_invalid_length_percentage('mod(0px, 0s)');
+test_invalid_length_percentage('mod(0px, 0deg)');
+test_invalid_length_percentage('mod(0px, 0Hz)');
+test_invalid_length_percentage('mod(0px, 0dpi)');
+test_invalid_length_percentage('mod(0px, 0fr)');
+test_invalid_length_percentage('rem(0px, 0s)');
+test_invalid_length_percentage('rem(0px, 0deg)');
+test_invalid_length_percentage('rem(0px, 0Hz)');
+test_invalid_length_percentage('rem(0px, 0dpi)');
+test_invalid_length_percentage('rem(0px, 0fr)');
 </script>


### PR DESCRIPTION
WebKit export from bug: [REGRESSION(267072@main): round/mod/rem asserts when combining length & non-percentage units](https://bugs.webkit.org/show_bug.cgi?id=260941)