### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=246911

### DIFF
--- a/css/css-typed-om/the-stylepropertymap/properties/font-variant-emoji.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/font-variant-emoji.html
@@ -14,9 +14,10 @@
 'use strict';
 
 runPropertyTests('font-variant-emoji', [
-  { syntax: 'auto' },
+  { syntax: 'normal' },
   { syntax: 'text' },
   { syntax: 'emoji' },
+  { syntax: 'unicode' },
 ]);
 
 </script>

--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -575,6 +575,12 @@ const gCSSProperties1 = {
       { type: 'discrete', options: [ [ 'full-width', 'proportional-width' ] ] }
     ]
   },
+  'font-variant-emoji': {
+    // https://drafts.csswg.org/css-fonts/#propdef-font-variant-emoji
+    types: [
+      { type: 'discrete', options: [ [ 'text', 'emoji' ] ] }
+    ]
+  },
   'font-variant-ligatures': {
     // https://drafts.csswg.org/css-fonts-3/#propdef-font-variant-ligatures
     types: [


### PR DESCRIPTION
WebKit export from bug: [\[css-fonts\] Implement `font-variant-emoji` CSS property](https://bugs.webkit.org/show_bug.cgi?id=246911)