### PR TITLE
HTML: forbid data: and javascript: URLs in the <base> element

### DIFF
--- a/html/semantics/document-metadata/the-base-element/base-data.html
+++ b/html/semantics/document-metadata/the-base-element/base-data.html
@@ -12,14 +12,14 @@ test(() => {
   const link = document.createElement("a");
   link.href = "blah";
   assert_equals(link.href, new URL("blah", document.URL).href);
-});
+}, "First <base> has a data: URL so fallback is used");
 
 test(() => {
   document.querySelector("base").remove();
   const link = document.createElement("a");
   link.href = "blah";
   assert_equals(link.href, new URL("blah", "https://example.com/").href);
-});
+}, "First <base> is removed so second is used");
 
 test(() => {
   const base = document.createElement("base");
@@ -28,5 +28,5 @@ test(() => {
   const link = document.createElement("a");
   link.href = "blah";
   assert_equals(link.href, new URL("blah", document.URL).href);
-});
+}, "Dynamically inserted first <base> has a data: URL so fallback is used");
 </script>

--- a/html/semantics/document-metadata/the-base-element/base-data.html
+++ b/html/semantics/document-metadata/the-base-element/base-data.html
@@ -1,0 +1,32 @@
+<!-- Please update base-javascript.html together with this -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>&lt;base> and data: URLs</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<base href="data:/,test">
+<base href="https://example.com/">
+<div id=log></div>
+<script>
+test(() => {
+  const link = document.createElement("a");
+  link.href = "blah";
+  assert_equals(link.href, new URL("blah", document.URL).href);
+});
+
+test(() => {
+  document.querySelector("base").remove();
+  const link = document.createElement("a");
+  link.href = "blah";
+  assert_equals(link.href, new URL("blah", "https://example.com/").href);
+});
+
+test(() => {
+  const base = document.createElement("base");
+  base.href = "data:/,more-test";
+  document.head.prepend(base);
+  const link = document.createElement("a");
+  link.href = "blah";
+  assert_equals(link.href, new URL("blah", document.URL).href);
+});
+</script>

--- a/html/semantics/document-metadata/the-base-element/base-javascript.html
+++ b/html/semantics/document-metadata/the-base-element/base-javascript.html
@@ -1,0 +1,32 @@
+<!-- Please update base-data.html together with this -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>&lt;base> and javascript: URLs</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<base href="javascript:/,test">
+<base href="https://example.com/">
+<div id=log></div>
+<script>
+test(() => {
+  const link = document.createElement("a");
+  link.href = "blah";
+  assert_equals(link.href, new URL("blah", document.URL).href);
+});
+
+test(() => {
+  document.querySelector("base").remove();
+  const link = document.createElement("a");
+  link.href = "blah";
+  assert_equals(link.href, new URL("blah", "https://example.com/").href);
+});
+
+test(() => {
+  const base = document.createElement("base");
+  base.href = "javascript:/,more-test";
+  document.head.prepend(base);
+  const link = document.createElement("a");
+  link.href = "blah";
+  assert_equals(link.href, new URL("blah", document.URL).href);
+});
+</script>

--- a/html/semantics/document-metadata/the-base-element/base-javascript.html
+++ b/html/semantics/document-metadata/the-base-element/base-javascript.html
@@ -12,14 +12,14 @@ test(() => {
   const link = document.createElement("a");
   link.href = "blah";
   assert_equals(link.href, new URL("blah", document.URL).href);
-});
+}, "First <base> has a javascript: URL so fallback is used");
 
 test(() => {
   document.querySelector("base").remove();
   const link = document.createElement("a");
   link.href = "blah";
   assert_equals(link.href, new URL("blah", "https://example.com/").href);
-});
+}, "First <base> is removed so second is used");
 
 test(() => {
   const base = document.createElement("base");
@@ -28,5 +28,5 @@ test(() => {
   const link = document.createElement("a");
   link.href = "blah";
   assert_equals(link.href, new URL("blah", document.URL).href);
-});
+}, "Dynamically inserted first <base> has a javascript: URL so fallback is used");
 </script>

--- a/url/resources/a-element-origin.js
+++ b/url/resources/a-element-origin.js
@@ -21,6 +21,10 @@ function runURLTests(urlTests) {
     if (expected.base === null && expected.input.startsWith("#"))
       continue;
 
+    // HTML special cases data: and javascript: URLs in <base>
+    if (expected.base !== null && (expected.base.startsWith("data:") || expected.base.startsWith("javascript:")))
+      continue;
+
     // We cannot use a null base for HTML tests
     const base = expected.base === null ? "about:blank" : expected.base;
 

--- a/url/resources/a-element.js
+++ b/url/resources/a-element.js
@@ -21,6 +21,10 @@ function runURLTests(urlTests) {
     if (expected.relativeTo === "any-base")
       continue;
 
+    // HTML special cases data: and javascript: URLs in <base>
+    if (expected.base !== null && (expected.base.startsWith("data:") || expected.base.startsWith("javascript:")))
+      continue;
+
     // We cannot use a null base for HTML tests
     const base = expected.base === null ? "about:blank" : expected.base;
 


### PR DESCRIPTION
I created these for https://github.com/whatwg/html/issues/2249.

The third test fails in Chromium and WebKit as the insertion of a new `<base>` element with a `data:` or `javascript:` URL does not result in an update to the document base URL. That seems like a bug to me as it makes the dynamic case different from the static case.