### PR TITLE
Make the test never depend on the specific behavior of WebKit and Blink

### DIFF
--- a/custom-elements/reactions/Document.html
+++ b/custom-elements/reactions/Document.html
@@ -61,6 +61,7 @@ test_with_window(function (contentWindow, contentDocument) {
     assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
 
     container.focus();
+    contentDocument.getSelection().collapse(container, 1);
     contentDocument.execCommand('delete', false, null);
 
     assert_array_equals(element.takeLog().types(), ['disconnected']);


### PR DESCRIPTION
WebKit and Blink has a feature that when selection is collapsed at start
of the editing host and there is no other positions to put caret except
when the editing host has only a `<br>`, they delete all nodes in the
editing host when user types `Backspace`.

However, this is typically an no-op case in usual editors and the test
does not check the behavior.  Therefore, it does not make sense to
depend on the specific feature of specific browser engines.

https://github.com/web-platform-tests/interop/issues/401
