### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=260900

### DIFF
--- a/wasm/webapi/esm-integration/worker.tentative.html
+++ b/wasm/webapi/esm-integration/worker.tentative.html
@@ -10,4 +10,7 @@ worker.onmessage = (msg) => {
   assert_equals(msg, 42);
   done();
 }
+worker.onerror = () => {
+  assert_unreached("worker got an error");
+}
 </script>


### PR DESCRIPTION
WebKit export from bug: [Worker/SharedWorker should fire Event instead of ErrorEvent in case of parsing error](https://bugs.webkit.org/show_bug.cgi?id=260900)