### PR TITLE
HTML: stylesheet with non-CSS MIME type quirk origin check

### DIFF
--- a/html/links/stylesheet/quirk-origin-check-recursive-import.html
+++ b/html/links/stylesheet/quirk-origin-check-recursive-import.html
@@ -1,0 +1,15 @@
+<!-- quirks -->
+<title>Origin check for stylesheet with non-CSS MIME type quirk: recursive @import</title>
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1477672">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1850965">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({ single_test: true });
+let errors = 0;
+onload = () => {
+  assert_equals(errors, 1);
+  done();
+};
+</script>
+<link rel="stylesheet" href="data:/,@import url('x/');" onerror="errors++">

--- a/html/links/stylesheet/quirk-origin-check.html
+++ b/html/links/stylesheet/quirk-origin-check.html
@@ -1,0 +1,13 @@
+<!-- quirks -->
+<title>Origin check for stylesheet with non-CSS MIME type quirk</title>
+<link rel="stylesheet" href="data:text/plain,.test { background: red }">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<p class=test>There should be no red.</p>
+<script>
+setup({ single_test: true });
+onload = () => {
+  assert_equals(getComputedStyle(document.querySelector('.test')).backgroundColor, 'rgba(0, 0, 0, 0)');
+  done();
+};
+</script>


### PR DESCRIPTION
The origin of the stylesheet's URL should be checked for being same-origin with the document, per spec. A data: URL's origin is an opaque origin, which is not same origin with the document.

Also see https://github.com/whatwg/html/issues/2249#issuecomment-591378914