### PR TITLE
Test Web Compatibility requirements for implementation-defined locale-specific ECMAScript APIs

### DIFF
--- a/ecmascript/README.md
+++ b/ecmascript/README.md
@@ -1,0 +1,8 @@
+# ECMAScript tests
+
+This directory contains tests related to the [ECMA-262](https://tc39.es/ecma262/) and [ECMA-402](https://tc39.es/ecma402/) specifications.
+
+Although these specifications are already covered through [Test262](https://github.com/tc39/test262), occasionally it’s useful to have Web Platform Tests coverage for a subset of ECMAScript functionality. Examples include:
+
+- Any functionality that ECMAScript specifies as “implementation-defined” despite Web Compatibility requiring specific semantics. ([example](https://github.com/web-platform-tests/wpt/pull/41760))
+- Any ECMAScript functionality that needs to be reported via wpt.fyi (for [example](https://github.com/web-platform-tests/wpt/pull/37928), because it’s included in Interop 2023).

--- a/ecmascript/locale-compat.html
+++ b/ecmascript/locale-compat.html
@@ -34,4 +34,13 @@ test(t => { // https://bugs.chromium.org/p/chromium/issues/detail?id=1414292
 
 }, '`Intl.DateTimeFormat.prototype.format` produces U+0020 instead of U+202F for `en` locale');
 
+test(t => { // https://bugs.chromium.org/p/chromium/issues/detail?id=1418727
+
+  const date = new Date('2022-03-31T23:59:42');
+
+  assert_true(date.toLocaleString('en-CA').includes('2022-03-31'));
+  assert_equals(date.toLocaleString('en-CA', {dateStyle: 'short'}), '2022-03-31');
+
+}, '`Date.prototype.toLocaleString` produces `yyyy-mm-dd` instead of `m/d/yyyy` for `en-CA` locale');
+
 </script>

--- a/ecmascript/locale-compat.html
+++ b/ecmascript/locale-compat.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<!--
+Copyright (C) 2023 the V8 project authors. All rights reserved.
+This code is governed by the BSD license found in the LICENSE file.
+-->
+<title>Web Compatibility requirements for implementation-defined locale-specific JavaScript APIs</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+test(t => { // https://bugs.chromium.org/p/chromium/issues/detail?id=1414292
+
+  const date = new Date('2022-12-31T23:59:42');
+  const localeString = date.toLocaleString('en-US');
+
+  // No U+202F NARROW NO-BREAK SPACE must be present.
+  assert_false(localeString.includes('\u202F'));
+  // The character between the time and AM/PM should be U+0020 SPACE.
+  assert_regexp_match(localeString, /:\d\d:\d\d\x20[AP]M/);
+
+}, '`Date.prototype.toLocaleString` produces U+0020 instead of U+202F for `en-US` locale');
+
+test(t => { // https://bugs.chromium.org/p/chromium/issues/detail?id=1414292
+
+  const date = new Date('2022-12-31T23:59:42');
+  const formatter = new Intl.DateTimeFormat('en', {timeStyle: 'long'})
+  const formattedString = formatter.format(date);
+
+  // No U+202F NARROW NO-BREAK SPACE must be present.
+  assert_false(formattedString.includes('\u202F'));
+  // The character between the time and AM/PM should be U+0020 SPACE.
+  assert_regexp_match(formattedString, /:\d\d:\d\d\x20[AP]M/);
+
+}, '`Intl.DateTimeFormat.prototype.format` produces U+0020 instead of U+202F for `en` locale');
+
+</script>


### PR DESCRIPTION
https://bugs.chromium.org/p/chromium/issues/detail?id=1414292 is an example of a high-impact Web Compatibility issue resulting in an emergency Chrome respin earlier this year. It was caused by `new Date('…').toLocaleString('en-US')` changing from `'2/15/2023, 12:00:00 AM'` (using U+0020 as the space character) to `'2/15/2023, 12:00:00\u202FAM'` in ICU 72, following a Unicode CLDR change. (Other locale-sensitive APIs such as `Intl.DateTimeFormat.prototype.format` were similarly affected.)

Unfortunately, adding Test262 tests for this now-known Web Compat issue is not an option since [`Date.prototype.toLocaleString`](https://tc39.es/ecma262/#sec-date.prototype.tolocalestring) and other locale-sensitive ECMAScript APIs tend to be specified as [implementation-defined](https://tc39.es/ecma262/#implementation-defined).

However, given the demonstrated Web Compat impact, I’d argue that this specific aspect of the output is now a de facto requirement, and I’m proposing to add Web Platform Tests coverage for it.