### PR TITLE
Update expectations for webauthn infrastructure tests for Firefox

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/virtual_authenticator.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/virtual_authenticator.html.ini
@@ -4,28 +4,28 @@
 
   [Can create an authenticator]
     expected:
-      if product != "chrome": FAIL
+      if product == "safari": FAIL
 
   [Can add a credential]
     expected:
-      if product != "chrome": FAIL
+      if product == "safari": FAIL
 
   [Can get the credentials]
     expected:
-      if product != "chrome": FAIL
+      if product == "safari": FAIL
 
   [Can remove a credential]
     expected:
-      if product != "chrome": FAIL
+      if product == "safari": FAIL
 
   [Can remove all credentials]
     expected:
-      if product != "chrome": FAIL
+      if product == "safari": FAIL
 
   [Can set user verified]
     expected:
-      if product != "chrome": FAIL
+      if product == "safari": FAIL
 
   [Can remove a virtual authenticator]
     expected:
-      if product != "chrome": FAIL
+      if product == "safari": FAIL


### PR DESCRIPTION
This is a follow-up patch for PR #41377 where we missed to actually update expectations for the WebAuthn infrastructure tests.