### PR TITLE
Fix PlacementAmongFloats to avoid missing some bands

### DIFF
--- a/css/CSS2/floats/floats-wrap-bfc-008.html
+++ b/css/CSS2/floats/floats-wrap-bfc-008.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<title>CSS Test: BFC root after 2 floats</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css2/#floats">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The BFC root doesn't fit next to the 1st float, but fits next to the 2nd one,
+  so it should be placed next to the 2nd one.">
+<style>
+.wrapper {
+  width: 100px;
+}
+.float {
+  float: left;
+  height: 50px;
+  background: green;
+}
+.bfc {
+  overflow: hidden;
+  width: 50px;
+  height: 50px;
+  background: green;
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class="wrapper">
+  <div class="float" style="width: 100px"></div>
+  <div class="float" style="width: 50px"></div>
+  <div class="bfc" style=""></div>
+</div>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
PlacementAmongFloats would stop iterating when current_bands would be empty, even if next_band wasn't at infinity.

Then the BFC root or replaced block was placed after all the floats, even if it could fit next to some of them.

This patch moves the next_band into current_bands so that the loop keeps considering bands.

Reviewed in servo/servo#30280