### PR TITLE
Fix html/semantics/embedded-content/media-elements/location-of-the-media-resource/currentSrc.html

### DIFF
--- a/html/semantics/embedded-content/media-elements/location-of-the-media-resource/currentSrc.html
+++ b/html/semantics/embedded-content/media-elements/location-of-the-media-resource/currentSrc.html
@@ -14,14 +14,16 @@
       var e = document.createElement(tagName);
       e.src = src;
       assert_equals(e.currentSrc, '');
-      t.step_timeout(function() {
-        if (src == '') {
-          assert_equals(e.currentSrc, '');
-        } else {
-          assert_equals(e.currentSrc, e.src);
-        }
-        t.done();
-      }, 0);
+      e.addEventListener('loadstart', function () {
+        t.step_timeout(function () {
+          if (src == '') {
+            assert_equals(e.currentSrc, '');
+          } else {
+            assert_equals(e.currentSrc, e.src);
+          }
+          t.done();
+        }, 0);
+      })
     }, tagName + '.currentSrc after setting src attribute "' + src + '"');
 
     async_test(function(t) {
@@ -30,14 +32,16 @@
       s.src = src;
       e.appendChild(s);
       assert_equals(e.currentSrc, '');
-      t.step_timeout(function() {
-        if (src == '') {
-          assert_equals(e.currentSrc, '');
-        } else {
-          assert_equals(e.currentSrc, s.src);
-        }
-        t.done();
-      }, 0);
+      e.addEventListener('loadstart', function() {
+        t.step_timeout(function () {
+          if (src == '') {
+            assert_equals(e.currentSrc, '');
+          } else {
+            assert_equals(e.currentSrc, s.src);
+          }
+          t.done();
+        }, 0);
+      });
     }, tagName + '.currentSrc after adding source element with src attribute "' + src + '"');
   });
 });


### PR DESCRIPTION
The flakiness was caused by the 0s timer sometimes firing before the media task had a chance to run til completion. Avoid this non-determinism by waiting for loadstart event before scheduling the 0s timer.