### PR TITLE
HTML: correct worker URL encoding tests

### DIFF
--- a/html/infrastructure/urls/resolving-urls/query-encoding/resources/resolve-url.js
+++ b/html/infrastructure/urls/resolving-urls/query-encoding/resources/resolve-url.js
@@ -514,13 +514,6 @@ onload = function() {
   }, 'Worker() in a dedicated worker');
 
   subsetTestByKey('workers', async_test, function() {
-    var worker = new Worker(input_url_worker_sharedworker);
-    worker.onmessage = this.step_func_done(function(e) {
-      assert_equals(e.data, expected_utf8);
-    });
-  }, 'SharedWorker() in a dedicated worker');
-
-  subsetTestByKey('workers', async_test, function() {
     var worker = new SharedWorker(input_url_sharedworker_importScripts);
     worker.port.onmessage = this.step_func_done(function(e) {
       assert_equals(e.data, expected_utf8);
@@ -533,13 +526,6 @@ onload = function() {
       assert_equals(e.data, expected_utf8);
     });
   }, 'Worker() in a shared worker');
-
-  subsetTestByKey('workers', async_test, function() {
-    var worker = new SharedWorker(input_url_sharedworker_sharedworker);
-    worker.port.onmessage = this.step_func_done(function(e) {
-      assert_equals(e.data, expected_utf8);
-    });
-  }, 'SharedWorker() in a shared worker');
 
   // WebSocket()
   subsetTestByKey('websocket', async_test, function() {

--- a/html/infrastructure/urls/resolving-urls/query-encoding/resources/resource.py
+++ b/html/infrastructure/urls/resolving-urls/query-encoding/resources/resource.py
@@ -39,23 +39,12 @@ def main(request, response):
                    } catch(ex) {
                      postMessage(String(ex));
                    }""" % encoding)
-    elif type == b'worker_sharedworker':
-        return ([(b"Content-Type", b"text/javascript; charset=%s" % encoding)], # charset should be ignored for workers
-                b"""try {
-                   var worker = new SharedWorker('?q=\\u00E5&type=sharedworker&encoding=%s');
-                     worker.port.onmessage = function(e) {
-                       postMessage(e.data);
-                       close();
-                     };
-                   } catch(ex) {
-                     postMessage(String(ex));
-                   }""" % encoding)
     elif type == b'sharedworker_importScripts':
-        return ([(b"Content-Type", b"text/javascript; charset=%s" % request.GET[b'encoding'])], # charset should be ignored for workers
-                b"""onconnect = function(e) {
+        return ([(b"Content-Type", b"text/javascript; charset=%s" % encoding)], # charset should be ignored for workers
+                b"""var x = 'importScripts failed to run';
+                     onconnect = function(e) {
                      var connect_port = e.source;
                      try {
-                       var x = 'importScripts failed to run';
                        importScripts('?q=\\u00E5&type=js&var=x&encoding=%s');
                        connect_port.postMessage(x);
                        close();
@@ -70,25 +59,6 @@ def main(request, response):
                      try {
                        var worker = new Worker('?q=\\u00E5&type=worker&encoding=%s');
                        worker.onmessage = function(e) {
-                         connect_port.postMessage(e.data);
-                         close();
-                       };
-                     } catch(ex) {
-                       connect_port.postMessage(String(ex));
-                     }
-                   };""" % encoding)
-    elif type == b'sharedworker_sharedworker':
-        return ([(b"Content-Type", b"text/javascript; charset=%s" % encoding)], # charset should be ignored for workers
-                b"""onconnect = function(e) {
-                     var connect_port = e.source;
-                     try {
-                       onerror = function(msg) {
-                         connect_port.postMessage(msg);
-                         close();
-                         return false;
-                       };
-                       var worker = new SharedWorker('?q=\\u00E5&type=sharedworker&encoding=%s');
-                       worker.port.onmessage = function(e) {
                          connect_port.postMessage(e.data);
                          close();
                        };


### PR DESCRIPTION
SharedWorker is only exposed on Window, not in any worker global.

The SharedWorker importScripts() took me a while to debug, but ultimately the problem was that the variable was declared in a function scope and importScripts would attempt to override it in the global scope. As such, the fix is declaring the variable a little earlier on, matching how it's done for Worker importScripts().

Helps with #4934.