### PR TITLE
HTML: correct URL encoding loading tests for windows-1251

### DIFF
--- a/html/infrastructure/urls/resolving-urls/query-encoding/resources/resolve-url.js
+++ b/html/infrastructure/urls/resolving-urls/query-encoding/resources/resolve-url.js
@@ -165,6 +165,7 @@ onload = function() {
 
   var query_to_image_width = {
     '%E5':1,
+    '%26%23229%3B':1,
     '%C3%A5':2,
     '%3F':16,
     'unknown query':256,
@@ -230,6 +231,7 @@ onload = function() {
 
   var query_to_video_duration = {
     '%E5':3,
+    '%26%23229%3B':3,
     '%C3%A5':5,
     '%3F':30,
     'unknown query':300,

--- a/html/infrastructure/urls/resolving-urls/query-encoding/resources/resource.py
+++ b/html/infrastructure/urls/resolving-urls/query-encoding/resources/resource.py
@@ -105,7 +105,7 @@ def main(request, response):
                 (u"""<?xml-stylesheet href="?q=&#x00E5;&amp;type=css&amp;encoding=%s"?><html xmlns="http://www.w3.org/1999/xhtml"/>""" % isomorphic_decode(encoding))
                 .encode(isomorphic_decode(encoding)))
     elif type == b'png':
-        if q == u'%E5':
+        if q == u'%E5' or q == u'%26%23229%3B':
             image = u'green-1x1.png'
         elif q == u'%C3%A5':
             image = u'green-2x2.png'
@@ -117,7 +117,7 @@ def main(request, response):
         return [(b"Content-Type", b"image/png")], rv
     elif type == b'video':
         ext = request.GET[b'ext']
-        if q == u'%E5':
+        if q == u'%E5' or q == u'%26%23229%3B':
             video = u'A4' # duration: 3
         elif q == u'%C3%A5':
             video = u'movie_5' # duration: 5


### PR DESCRIPTION
It some point windows-1251 was added with an expected query of %26%23229%3B, but the loading tests were never changed to account for that query expectation. This makes them share the windows-1252 expectation which I suppose is not ideal, but unless there's a quick fix I'd prefer that to be follow-up material.

Helps with #4934.