### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=261099

### DIFF
--- a/webcodecs/video-decoder.https.any.js
+++ b/webcodecs/video-decoder.https.any.js
@@ -59,6 +59,10 @@ const validButUnsupportedConfigs = [
     config: {codec: 'vp9'},
   },
   {
+    comment: 'Codec with bad casing',
+    config: {codec: 'Vp09.00.10.08'},
+  },
+  {
     comment: 'Codec with MIME type',
     config: {codec: 'video/webm; codecs="vp8"'},
   },

--- a/webcodecs/video-encoder-config.https.any.js
+++ b/webcodecs/video-encoder-config.https.any.js
@@ -90,6 +90,14 @@ const validButUnsupportedConfigs = [
     },
   },
   {
+    comment: 'Codec with bad casing',
+    config: {
+      codec: 'vP8',
+      width: 640,
+      height: 480,
+    },
+  },
+  {
     comment: 'Width is too large',
     config: {
       codec: 'vp8',


### PR DESCRIPTION
WebKit export from bug: [WebRTC remote video codec factories should check video format strings in a case insensitive way](https://bugs.webkit.org/show_bug.cgi?id=261099)