### PR TITLE
[WebDriver BiDi] `userPromptOpened` supports `defaultValue`

### DIFF
--- a/webdriver/tests/bidi/browsing_context/user_prompt_opened/user_prompt_opened.py
+++ b/webdriver/tests/bidi/browsing_context/user_prompt_opened/user_prompt_opened.py
@@ -56,8 +56,9 @@ async def test_prompt_type(
     }
 
 
-async def test_prompt_default_value(bidi_session, subscribe_events, inline, new_tab,
-                           wait_for_event, prompt_type):
+async def test_prompt_default_value(
+    bidi_session, inline, new_tab, subscribe_events, wait_for_event
+):
     await subscribe_events(events=[USER_PROMPT_OPENED_EVENT])
     on_entry = wait_for_event(USER_PROMPT_OPENED_EVENT)
 

--- a/webdriver/tests/bidi/browsing_context/user_prompt_opened/user_prompt_opened.py
+++ b/webdriver/tests/bidi/browsing_context/user_prompt_opened/user_prompt_opened.py
@@ -74,7 +74,7 @@ async def test_prompt_default_value(
 
     assert event == {
         "context": new_tab["context"],
-        "type": prompt_type,
+        "type": "prompt",
         "message": text,
         "defaultValue": default,
     }

--- a/webdriver/tests/bidi/browsing_context/user_prompt_opened/user_prompt_opened.py
+++ b/webdriver/tests/bidi/browsing_context/user_prompt_opened/user_prompt_opened.py
@@ -56,6 +56,28 @@ async def test_prompt_type(
     }
 
 
+async def test_prompt_default_value(bidi_session, subscribe_events, inline, new_tab,
+                           wait_for_event, prompt_type):
+    await subscribe_events(events=[USER_PROMPT_OPENED_EVENT])
+    on_entry = wait_for_event(USER_PROMPT_OPENED_EVENT)
+
+    text = "test"
+    default = "default"
+
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"],
+        url=inline(f"<script>window.prompt('{text}', '{default}')</script>"),
+    )
+
+    event = await on_entry
+
+    assert event == {
+        "context": new_tab["context"],
+        "type": prompt_type,
+        "message": text,
+        "defaultValue": default,
+    }
+
 @pytest.mark.parametrize("type_hint", ["tab", "window"])
 async def test_subscribe_to_one_context(
     bidi_session, subscribe_events, inline, wait_for_event, type_hint


### PR DESCRIPTION
Issue on BiDi spec: https://github.com/w3c/webdriver-bidi/issues/521