### PR TITLE
Use the standard-compliant forbidden character '^' as an invalid URL.

### DIFF
--- a/docs/running-tests/android_webview.md
+++ b/docs/running-tests/android_webview.md
@@ -32,7 +32,7 @@ If you have an issue with ChromeDriver version mismatch, try one of the followin
 
 Configure host remap rules in the [webview commandline file](https://cs.chromium.org/chromium/src/android_webview/docs/commandline-flags.md?l=57):
 ```
-adb shell "echo '_ --host-resolver-rules=\"MAP nonexistent.*.test ~NOTFOUND, MAP *.test 127.0.0.1\"' > /data/local/tmp/webview-command-line"
+adb shell "echo '_ --host-resolver-rules=\"MAP nonexistent.*.test ^NOTFOUND, MAP *.test 127.0.0.1\"' > /data/local/tmp/webview-command-line"
 ```
 
 Ensure that `adb` can be found on your system's PATH.

--- a/docs/running-tests/android_webview.md
+++ b/docs/running-tests/android_webview.md
@@ -32,7 +32,7 @@ If you have an issue with ChromeDriver version mismatch, try one of the followin
 
 Configure host remap rules in the [webview commandline file](https://cs.chromium.org/chromium/src/android_webview/docs/commandline-flags.md?l=57):
 ```
-adb shell "echo '_ --host-resolver-rules=\"MAP nonexistent.*.test ^NOTFOUND, MAP *.test 127.0.0.1\"' > /data/local/tmp/webview-command-line"
+adb shell "echo '_ --host-resolver-rules=\"MAP nonexistent.*.test ~NOTFOUND, MAP *.test 127.0.0.1\"' > /data/local/tmp/webview-command-line"
 ```
 
 Ensure that `adb` can be found on your system's PATH.

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -88,7 +88,7 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     # Shorten delay for Reporting <https://w3c.github.io/reporting/>.
     chrome_options["args"].append("--short-reporting-delay")
     # Point all .test domains to localhost for Chrome
-    chrome_options["args"].append("--host-resolver-rules=MAP nonexistent.*.test ~NOTFOUND, MAP *.test 127.0.0.1")
+    chrome_options["args"].append("--host-resolver-rules=MAP nonexistent.*.test ^NOTFOUND, MAP *.test 127.0.0.1")
     # Enable Secure Payment Confirmation for Chrome. This is normally disabled
     # on Linux as it hasn't shipped there yet, but in WPT we enable virtual
     # authenticator devices anyway for testing and so SPC works.


### PR DESCRIPTION
Currently, in the rewriting rule of the WPT runner for Chrome, "~NOTFOUND" is used as an invalid URL. However, '~' is NOT a forbidden character according to the URL standard.

Chromium is addressing [1] this non-compliant behavior and will permit '~' character in URL hosts. Thus, we can no longer use "~NOTFOUND" as it will become a valid URL.

As an alternative, any invalid character is acceptable. Let's use '^' because '^' is a forbidden character both before and after the CL [1].

[1]: https://crrev.com/c/4823237