### PR TITLE
Remove L1T2 from webcodecs/reconfiguring-encoder.https.any.js

### DIFF
--- a/webcodecs/reconfiguring-encoder.https.any.js
+++ b/webcodecs/reconfiguring-encoder.https.any.js
@@ -19,7 +19,6 @@ promise_setup(async () => {
   }[location.search];
   config.hardwareAcceleration = 'prefer-software';
   config.bitrateMode = "constant";
-  config.scalabilityMode = "L1T2";
   config.framerate = 30;
   ENCODER_CONFIG = config;
 });


### PR DESCRIPTION
L1T2 may not always be supported everywhere, especially in non realtime encoders.
This test is not testing L1T2 per se so it is not necessary to keep it.