### PR TITLE
Test that `[Replaceable]` setter throws TypeError if fails to reconfigure the property

### DIFF
--- a/webidl/ecmascript-binding/replaceable-setter-throws-if-defineownproperty-fails.html
+++ b/webidl/ecmascript-binding/replaceable-setter-throws-if-defineownproperty-fails.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>[Replaceable] setter throws TypeError if [[DefineOwnProperty]] fails</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="author" title="Alexey Shvayka" href="shvaikalesh@gmail.com">
+<link rel="help" href="https://webidl.spec.whatwg.org/#Replaceable">
+
+<body>
+<script>
+for (const key of ["self", "parent", "origin", "innerWidth"]) {
+    test(() => {
+        Object.defineProperty(window, key, { configurable: false });
+        assert_throws_js(TypeError, () => { window[key] = 1; });
+
+        const desc = Object.getOwnPropertyDescriptor(window, key);
+        assert_false("value" in desc);
+        assert_equals(typeof desc.get, "function");
+        assert_equals(typeof desc.set, "function");
+        assert_true(desc.enumerable);
+        assert_false(desc.configurable);
+    }, `window.${key} setter throws TypeError if called on non-configurable accessor property`);
+}
+
+for (const key of ["screen", "length", "event", "outerHeight"]) {
+    test(() => {
+        const { set } = Object.getOwnPropertyDescriptor(window, key);
+        Object.defineProperty(window, key, { value: 1, writable: false, configurable: false });
+        assert_throws_js(TypeError, () => { set.call(window, 2); });
+
+        const desc = Object.getOwnPropertyDescriptor(window, key);
+        assert_equals(desc.value, 1);
+        assert_false(desc.writable);
+        assert_true(desc.enumerable);
+        assert_false(desc.configurable);
+    }, `window.${key} setter throws TypeError if called on non-configurable non-writable data property`);
+}
+</script>


### PR DESCRIPTION
For https://github.com/whatwg/webidl/pull/1360.
Implemented in https://github.com/WebKit/WebKit/commit/1e336abec35481176bd436ef85e1e19bfd24057b.