### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=261382

### DIFF
--- a/css/selectors/invalidation/input-pseudo-classes-in-has.html
+++ b/css/selectors/invalidation/input-pseudo-classes-in-has.html
@@ -16,6 +16,7 @@
   .ancestor:has(#numberinput:out-of-range) { color: darkgreen }
   .ancestor:has(#numberinput:required) { color: pink }
   .ancestor:has(#progress:indeterminate) { color: orange }
+  .ancestor:has(#checkboxinput:default) { color: purple; }
 </style>
 <div id=subject class=ancestor>
   <input type="checkbox" name="my-checkbox" id="checkme">
@@ -24,6 +25,7 @@
   <input id="radioinput" checked>
   <input id="numberinput" type="number" min="1" max="10" value="5">
   <progress id="progress" value="50" max="100"></progress>
+  <input id="checkboxinput" type="checkbox">
 </div>
 <script>
   test(function() {
@@ -138,4 +140,25 @@
     assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 128)",
                   "ancestor should be navy");
   }, ":placeholder-shown invalidation");
+
+  test(function() {
+    this.add_cleanup(() => {
+      checkboxinput.checked = false;
+      checkboxinput.removeAttribute("checked");
+    });
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+    checkboxinput.checked = true;
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should still be black");
+    checkboxinput.setAttribute("checked", "");
+    assert_equals(getComputedStyle(subject).color, "rgb(128, 0, 128)",
+                  "ancestor should be purple");
+    checkboxinput.checked = false;
+    assert_equals(getComputedStyle(subject).color, "rgb(128, 0, 128)",
+                  "ancestor should still be purple");
+    checkboxinput.removeAttribute("checked");
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+  }, ":default invalidation with input[type=checkbox] and assignment to .checked");
 </script>


### PR DESCRIPTION
WebKit export from bug: [invalidate :default pseudo-class changes on input elements](https://bugs.webkit.org/show_bug.cgi?id=261382)