### PR TITLE
fix: ensure that globalThis.self has been defined in shadow realm

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -423,7 +423,7 @@ class ShadowRealmHandler(HtmlWrapperHandler):
 <script>
 (async function() {
   const r = new ShadowRealm();
-
+  r.evaluate("globalThis.self = globalThis; undefined;");
   await new Promise(r.evaluate(`
     (resolve, reject) => {
       (async () => {


### PR DESCRIPTION
The same operation is done in `idl_test_shadowrealm`. Without this initial evaluation, the next step will fail.