### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=261486

### DIFF
--- a/css/compositing/root-element-background-image-transparency-001-ref.html
+++ b/css/compositing/root-element-background-image-transparency-001-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Reftest Reference</title>
+    <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+    <style>
+      html {
+        background-color: white;
+      }
+      body {
+        /* The default 8px margin makes the background not line up exactly */
+        margin: 0;
+        background: url(support/transform-triangle-left.svg) top left;
+        opacity: 0.5;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>

--- a/css/compositing/root-element-background-image-transparency-001.html
+++ b/css/compositing/root-element-background-image-transparency-001.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Opacity on Root Element With background image</title>
+    <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+    <link rel="help" href="https://drafts.fxtf.org/compositing/#pagebackdrop">
+    <meta name="assert" content="The background image should have opacity applied to
+    it as part of the Root Element Group">
+    <link rel="match" href="root-element-background-image-transparency-001-ref.html">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-9600" />
+    <style>
+      html {
+        background: url(support/transform-triangle-left.svg);
+        opacity: 0.5;
+      }
+      body {
+        /* The default 8px margin makes the background not line up exactly */
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>

--- a/css/compositing/root-element-background-image-transparency-002.html
+++ b/css/compositing/root-element-background-image-transparency-002.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Opacity on Root Element With background image</title>
+    <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+    <link rel="help" href="https://drafts.fxtf.org/compositing/#pagebackdrop">
+    <meta name="assert" content="The background image should have opacity applied to
+    it as part of the Root Element Group">
+    <link rel="match" href="root-element-background-image-transparency-001-ref.html">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-9600" />
+    <style>
+      html {
+        background: url(support/transform-triangle-left.svg) fixed;
+        opacity: 0.5;
+      }
+      body {
+        /* The default 8px margin makes the background not line up exactly */
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>

--- a/css/compositing/root-element-background-image-transparency-003.html
+++ b/css/compositing/root-element-background-image-transparency-003.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Opacity on Root Element With background image</title>
+    <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+    <link rel="help" href="https://drafts.fxtf.org/compositing/#pagebackdrop">
+    <meta name="assert" content="The background image should have opacity applied to
+    it as part of the Root Element Group">
+    <link rel="match" href="root-element-background-image-transparency-001-ref.html">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-237600" />
+    <style>
+      html {
+        background: url(support/transform-triangle-left.svg);
+        opacity: 0.5;
+        will-change: opacity;
+      }
+      body {
+        /* The default 8px margin makes the background not line up exactly */
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>

--- a/css/compositing/root-element-background-image-transparency-004.html
+++ b/css/compositing/root-element-background-image-transparency-004.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Opacity on Root Element With background image</title>
+    <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+    <link rel="help" href="https://drafts.fxtf.org/compositing/#pagebackdrop">
+    <meta name="assert" content="The background image should have opacity applied to
+    it as part of the Root Element Group">
+    <link rel="match" href="root-element-background-image-transparency-001-ref.html">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-237600" />
+    <style>
+      html {
+        background: url(support/transform-triangle-left.svg) fixed;
+        opacity: 0.5;
+        will-change: opacity;
+      }
+      body {
+        /* The default 8px margin makes the background not line up exactly */
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>

--- a/css/compositing/support/transform-triangle-left.svg
+++ b/css/compositing/support/transform-triangle-left.svg
@@ -1,0 +1,4 @@
+<svg height="100px" width="100px" viewBox="0 0 100 100"
+xmlns="http://www.w3.org/2000/svg">
+<polygon fill="blue" points="0,50 100,100 100,0" />
+</svg>


### PR DESCRIPTION
WebKit export from bug: [Opacity and root element background image doesn't render](https://bugs.webkit.org/show_bug.cgi?id=261486)