### PR TITLE
Make the AVIF test images render larger

### DIFF
--- a/avif/animated-avif-timeout-ref.html
+++ b/avif/animated-avif-timeout-ref.html
@@ -1,1 +1,1 @@
-<img src=../images/green.avif>
+<img src=../images/green.avif style="height:500px">

--- a/avif/animated-avif-timeout.html
+++ b/avif/animated-avif-timeout.html
@@ -1,7 +1,7 @@
 <html class="reftest-wait">
 <title>Animated AVIF: Second frame displays quickly, replacing red with green.</title>
 <link rel="match" href="animated-avif-timeout-ref.html"/>
-<img src=../images/animated-avif.avif onload="loaded()"/>
+<img src=../images/animated-avif.avif onload="loaded()" style="height:500px"/>
 <script>
   function loaded() {
     setTimeout(function() {


### PR DESCRIPTION
At the moment, they're 2px x 2px images, which is kinda hard to notice on a large screen. Make this scale much larger, which should work fine.