### PR TITLE
Enable shadowrealm testing for compression api

### DIFF
--- a/compression/compression-bad-chunks.tentative.any.js
+++ b/compression/compression-bad-chunks.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 
 'use strict';
 

--- a/compression/compression-constructor-error.tentative.any.js
+++ b/compression/compression-constructor-error.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 
 'use strict';
 

--- a/compression/compression-including-empty-chunk.tentative.any.js
+++ b/compression/compression-including-empty-chunk.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 // META: script=third_party/pako/pako_inflate.min.js
 // META: timeout=long
 

--- a/compression/compression-large-flush-output.any.js
+++ b/compression/compression-large-flush-output.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 // META: script=third_party/pako/pako_inflate.min.js
 // META: script=resources/concatenate-stream.js
 // META: timeout=long

--- a/compression/compression-multiple-chunks.tentative.any.js
+++ b/compression/compression-multiple-chunks.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 // META: script=third_party/pako/pako_inflate.min.js
 // META: timeout=long
 

--- a/compression/compression-output-length.tentative.any.js
+++ b/compression/compression-output-length.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 
 'use strict';
 

--- a/compression/compression-stream.tentative.any.js
+++ b/compression/compression-stream.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 // META: script=third_party/pako/pako_inflate.min.js
 // META: timeout=long
 

--- a/compression/compression-with-detach.tentative.window.js
+++ b/compression/compression-with-detach.tentative.window.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 // META: script=resources/concatenate-stream.js
 
 'use strict';

--- a/compression/decompression-bad-chunks.tentative.any.js
+++ b/compression/decompression-bad-chunks.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 
 'use strict';
 

--- a/compression/decompression-buffersource.tentative.any.js
+++ b/compression/decompression-buffersource.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 
 'use strict';
 

--- a/compression/decompression-constructor-error.tentative.any.js
+++ b/compression/decompression-constructor-error.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 
 'use strict';
 

--- a/compression/decompression-correct-input.tentative.any.js
+++ b/compression/decompression-correct-input.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 
 'use strict';
 

--- a/compression/decompression-corrupt-input.tentative.any.js
+++ b/compression/decompression-corrupt-input.tentative.any.js
@@ -1,4 +1,4 @@
-// META global=window,worker
+// META global=window,worker,shadowrealm
 
 // This test checks that DecompressionStream behaves according to the standard
 // when the input is corrupted. To avoid a combinatorial explosion in the

--- a/compression/decompression-empty-input.tentative.any.js
+++ b/compression/decompression-empty-input.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 
 'use strict';
 

--- a/compression/decompression-split-chunk.tentative.any.js
+++ b/compression/decompression-split-chunk.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 
 'use strict';
 

--- a/compression/decompression-uint8array-output.tentative.any.js
+++ b/compression/decompression-uint8array-output.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 // META: timeout=long
 //
 // This test isn't actually slow usually, but sometimes it takes >10 seconds on

--- a/compression/decompression-with-detach.tentative.window.js
+++ b/compression/decompression-with-detach.tentative.window.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 // META: script=resources/concatenate-stream.js
 
 'use strict';


### PR DESCRIPTION
### For Firefox Nightly:  

Open "about:config", type: 

```
javascript.options.experimental.shadow_realms
```
Toggle to true

 

### For Safari Technology Preview: 

```
env JSC_useShadowRealm=1 __XPC_JSC_useShadowRealm=1 /Applications/Safari\ Technology\ Preview.app/Contents/MacOS/Safari\ Technology\ Preview 
```

### For Chrome Canary: 

```
/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary --js-flags="--harmony-shadow-realm"
```
 