### PR TITLE
fix #41956. Remove the auto value from alignment-baseline

### DIFF
--- a/css/css-variables/variable-presentation-attribute.html
+++ b/css/css-variables/variable-presentation-attribute.html
@@ -51,7 +51,7 @@
         });
 
         let testproperties = [
-            { property: "alignment-baseline", valuesToTest:["auto", "baseline", "before-edge", "text-before-edge", "middle", "central", "after-edge", "text-after-edge", "ideographic", "alphabetic", "hanging", "mathematical"], default: "auto" },
+            { property: "alignment-baseline", valuesToTest:["baseline", "before-edge", "text-before-edge", "middle", "central", "after-edge", "text-after-edge", "ideographic", "alphabetic", "hanging", "mathematical"], default: "baseline" },
             { property: "baseline-shift", valuesToTest:["baseline", "sub", "super", "13%", "28px"], default: "baseline" },
             { property: "clip-rule", valuesToTest:["nonzero", "evenodd"], default: "nonzero" },
             { property: "color", valuesToTest:["rgb(128, 0, 128)"], default: "rgb(0, 0, 0)" },


### PR DESCRIPTION
See #41956 for the explanation.

According to https://drafts.csswg.org/css-inline/#alignment-baseline-property
the default value for `alignment-baseline` is `baseline`
and according to http://wpt.live/css/css-inline/parsing/alignment-baseline-invalid.html
`auto` is an invalid value for `alignment-baseline`