### PR TITLE
Enable shadowrealm testing for encoding api

### DIFF
--- a/encoding/api-basics.any.js
+++ b/encoding/api-basics.any.js
@@ -1,3 +1,4 @@
+// META: global=window,dedicatedworker,shadowrealm
 // META: title=Encoding API: Basics
 
 test(function() {

--- a/encoding/api-surrogates-utf8.any.js
+++ b/encoding/api-surrogates-utf8.any.js
@@ -1,3 +1,4 @@
+// META: global=window,dedicatedworker,shadowrealm
 // META: title=Encoding API: Invalid UTF-16 surrogates with UTF-8 encoding
 
 var badStrings = [

--- a/encoding/iso-2022-jp-decoder.any.js
+++ b/encoding/iso-2022-jp-decoder.any.js
@@ -1,3 +1,5 @@
+// META: global=window,dedicatedworker,shadowrealm
+//
 function decode(input, output, desc) {
   test(function() {
     var d = new TextDecoder("iso-2022-jp"),

--- a/encoding/streams/backpressure.any.js
+++ b/encoding/streams/backpressure.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 
 'use strict';
 

--- a/encoding/streams/decode-attributes.any.js
+++ b/encoding/streams/decode-attributes.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 
 'use strict';
 

--- a/encoding/streams/decode-bad-chunks.any.js
+++ b/encoding/streams/decode-bad-chunks.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 
 'use strict';
 

--- a/encoding/streams/decode-non-utf8.any.js
+++ b/encoding/streams/decode-non-utf8.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 
 'use strict';
 

--- a/encoding/streams/readable-writable-properties.any.js
+++ b/encoding/streams/readable-writable-properties.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 
 // This just tests that the "readable" and "writable" properties pass the brand
 // checks. All other relevant attributes are covered by the IDL tests.

--- a/encoding/textdecoder-arguments.any.js
+++ b/encoding/textdecoder-arguments.any.js
@@ -1,3 +1,4 @@
+// META: global=window,dedicatedworker,shadowrealm
 // META: title=Encoding API: TextDecoder decode() optional arguments
 
 test(t => {

--- a/encoding/textdecoder-byte-order-marks.any.js
+++ b/encoding/textdecoder-byte-order-marks.any.js
@@ -1,3 +1,4 @@
+// META: global=window,dedicatedworker,shadowrealm
 // META: title=Encoding API: Byte-order marks
 
 var testCases = [

--- a/encoding/textdecoder-fatal-streaming.any.js
+++ b/encoding/textdecoder-fatal-streaming.any.js
@@ -1,3 +1,4 @@
+// META: global=window,dedicatedworker,shadowrealm
 // META: title=Encoding API: End-of-file
 
 test(function() {

--- a/encoding/textdecoder-fatal.any.js
+++ b/encoding/textdecoder-fatal.any.js
@@ -1,3 +1,4 @@
+// META: global=window,dedicatedworker,shadowrealm
 // META: title=Encoding API: Fatal flag
 
 var bad = [

--- a/encoding/textdecoder-ignorebom.any.js
+++ b/encoding/textdecoder-ignorebom.any.js
@@ -1,3 +1,4 @@
+// META: global=window,dedicatedworker,shadowrealm
 // META: title=Encoding API: TextDecoder ignoreBOM option
 
 var cases = [

--- a/encoding/textdecoder-utf16-surrogates.any.js
+++ b/encoding/textdecoder-utf16-surrogates.any.js
@@ -1,3 +1,4 @@
+// META: global=window,dedicatedworker,shadowrealm
 // META: title=Encoding API: UTF-16 surrogate handling
 
 var bad = [

--- a/encoding/textencoder-utf16-surrogates.any.js
+++ b/encoding/textencoder-utf16-surrogates.any.js
@@ -1,3 +1,4 @@
+// META: global=window,dedicatedworker,shadowrealm
 // META: title=Encoding API: USVString surrogate handling when encoding
 
 var bad = [


### PR DESCRIPTION
Starting with tests that don't have additional dependencies.