### PR TITLE
[wptrunner] Add debugger support for `content_shell`

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -31,6 +31,18 @@ __wptrunner__ = {"product": "chrome",
                  "timeout_multiplier": "get_timeout_multiplier",}
 
 
+def debug_args(debug_info):
+    if debug_info.interactive:
+        # Keep in sync with:
+        # https://chromium.googlesource.com/chromium/src/+/main/third_party/blink/tools/debug_renderer
+        return [
+            "--no-sandbox",
+            "--disable-hang-monitor",
+            "--wait-for-debugger-on-navigation",
+        ]
+    return []
+
+
 def check_args(**kwargs):
     require_arg(kwargs, "webdriver_binary")
 
@@ -148,6 +160,8 @@ def env_extras(**kwargs):
 
 
 def env_options():
+    # TODO(crbug.com/1440021): Support text-based debuggers for `chrome` through
+    # `chromedriver`.
     return {"server_host": "127.0.0.1"}
 
 

--- a/tools/wptrunner/wptrunner/executors/executorcontentshell.py
+++ b/tools/wptrunner/wptrunner/executors/executorcontentshell.py
@@ -224,6 +224,12 @@ def _convert_exception(test, exception, errors):
     raise exception
 
 
+def timeout_for_test(executor, test):
+    if executor.debug_info and executor.debug_info.interactive:
+        return None
+    return test.timeout * executor.timeout_multiplier
+
+
 class ContentShellCrashtestExecutor(CrashtestExecutor):
     def __init__(self, logger, browser, server_config, timeout_multiplier=1, debug_info=None,
             **kwargs):
@@ -232,7 +238,8 @@ class ContentShellCrashtestExecutor(CrashtestExecutor):
 
     def do_test(self, test):
         try:
-            _ = self.protocol.content_shell_test.do_test(self.test_url(test), test.timeout * self.timeout_multiplier)
+            _ = self.protocol.content_shell_test.do_test(self.test_url(test),
+                                                         timeout_for_test(self, test))
             self.protocol.content_shell_errors.read_errors()
             return self.convert_result(test, {"status": "PASS", "message": None})
         except BaseException as exception:
@@ -275,12 +282,11 @@ class ContentShellRefTestExecutor(RefTestExecutor, _SanitizerMixin):  # type: ig
             # source tree (i.e., without looking at a reference). This is not
             # possible in `wpt`, so pass an empty hash here to force a dump.
             command += "''print"
-        _, image = self.protocol.content_shell_test.do_test(
-            command, test.timeout * self.timeout_multiplier)
 
+        _, image = self.protocol.content_shell_test.do_test(command,
+                                                            timeout_for_test(self, test))
         if not image:
             return False, ("ERROR", self.protocol.content_shell_errors.read_errors())
-
         return True, b64encode(image).decode()
 
 
@@ -303,8 +309,7 @@ class ContentShellTestharnessExecutor(TestharnessExecutor, _SanitizerMixin):  # 
     def do_test(self, test):
         try:
             text, _ = self.protocol.content_shell_test.do_test(self.test_url(test),
-                    test.timeout * self.timeout_multiplier)
-
+                                                               timeout_for_test(self, test))
             errors = self.protocol.content_shell_errors.read_errors()
             if not text:
                 return (test.result_cls("ERROR", errors), [])

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -685,7 +685,7 @@ class WebDriverCrashtestExecutor(CrashtestExecutor):
     def __init__(self, logger, browser, server_config, timeout_multiplier=1,
                  screenshot_cache=None, close_after_done=True,
                  debug_info=None, capabilities=None, **kwargs):
-        """WebDriver-based executor for reftests"""
+        """WebDriver-based executor for crashtests"""
         CrashtestExecutor.__init__(self,
                                    logger,
                                    browser,


### PR DESCRIPTION
Prefix the `content_shell` command with a debugger wrapper prefix [to support `rr record`](https://crbug.com/1482362), and set an indefinite test timeout for interactive debuggers.

Tested downstream with:

```sh
./run_wpt_test.py -t Default external/wpt/badging -vv --wrapper='time -o /dev/null'
```

Also, use protocol mode's [`QUIT` command](https://chromium.googlesource.com/chromium/src.git/+/4e1b7bc3/content/web_test/browser/test_info_extractor.h#51) before sending SIGTERM/SIGKILL. This probably fixes [ungraceful shutdown on Windows](https://crbug.com/1392771), which doesn't generate SIGTERM, and stops `--wrapper` from hanging.