### PR TITLE
Enable shadowrealm testing for wasm api

### DIFF
--- a/wasm/jsapi/constructor/toStringTag.any.js
+++ b/wasm/jsapi/constructor/toStringTag.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 
 "use strict";
 // https://webidl.spec.whatwg.org/#es-namespaces

--- a/wasm/jsapi/exception/toString.tentative.any.js
+++ b/wasm/jsapi/exception/toString.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 
 test(() => {
   const argument = { parameters: [] };

--- a/wasm/jsapi/global/toString.any.js
+++ b/wasm/jsapi/global/toString.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 
 test(() => {
   const argument = { "value": "i32" };

--- a/wasm/jsapi/global/value-get-set.any.js
+++ b/wasm/jsapi/global/value-get-set.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 
 test(() => {
   const thisValues = [

--- a/wasm/jsapi/global/valueOf.any.js
+++ b/wasm/jsapi/global/valueOf.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 
 test(() => {
   const argument = { "value": "i32" };

--- a/wasm/jsapi/table/length.any.js
+++ b/wasm/jsapi/table/length.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 
 test(() => {
   const thisValues = [

--- a/wasm/jsapi/table/toString.any.js
+++ b/wasm/jsapi/table/toString.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 
 test(() => {
   const argument = { "element": "anyfunc", "initial": 0 };

--- a/wasm/jsapi/tag/toString.tentative.any.js
+++ b/wasm/jsapi/tag/toString.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 
 test(() => {
   const argument = { parameters: [] };


### PR DESCRIPTION
Starting with tests that don't have additional dependencies.