### PR TITLE
Enable shadowrealm testing for wasm api (tests with dependencies)

### DIFF
--- a/wasm/jsapi/assertions.js
+++ b/wasm/jsapi/assertions.js
@@ -6,6 +6,7 @@ function assert_function_name(fn, name, description) {
   assert_true(propdesc.configurable, "configurable", `${description} name should be configurable`);
   assert_equals(propdesc.value, name, `${description} name should be ${name}`);
 }
+globalThis.assert_function_name = assert_function_name;
 
 function assert_function_length(fn, length, description) {
   const propdesc = Object.getOwnPropertyDescriptor(fn, "length");
@@ -15,6 +16,7 @@ function assert_function_length(fn, length, description) {
   assert_true(propdesc.configurable, "configurable", `${description} length should be configurable`);
   assert_equals(propdesc.value, length, `${description} length should be ${length}`);
 }
+globalThis.assert_function_length = assert_function_length;
 
 function assert_exported_function(fn, { name, length }, description) {
   if (WebAssembly.Function === undefined) {
@@ -28,6 +30,7 @@ function assert_exported_function(fn, { name, length }, description) {
   assert_function_name(fn, name, description);
   assert_function_length(fn, length, description);
 }
+globalThis.assert_exported_function = assert_exported_function;
 
 function assert_Instance(instance, expected_exports) {
   assert_equals(Object.getPrototypeOf(instance), WebAssembly.Instance.prototype,
@@ -77,6 +80,7 @@ function assert_Instance(instance, expected_exports) {
     }
   }
 }
+globalThis.assert_Instance = assert_Instance;
 
 function assert_WebAssemblyInstantiatedSource(actual, expected_exports={}) {
   assert_equals(Object.getPrototypeOf(actual), Object.prototype,
@@ -98,3 +102,4 @@ function assert_WebAssemblyInstantiatedSource(actual, expected_exports={}) {
   assert_true(instance.configurable, "instance: configurable");
   assert_Instance(instance.value, expected_exports);
 }
+globalThis.assert_WebAssemblyInstantiatedSource = assert_WebAssemblyInstantiatedSource;

--- a/wasm/jsapi/bad-imports.js
+++ b/wasm/jsapi/bad-imports.js
@@ -183,3 +183,4 @@ function test_bad_imports(t) {
       });
   }
 }
+globalThis.test_bad_imports = test_bad_imports;

--- a/wasm/jsapi/constructor/compile.any.js
+++ b/wasm/jsapi/constructor/compile.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 function assert_Module(module) {

--- a/wasm/jsapi/constructor/instantiate-bad-imports.any.js
+++ b/wasm/jsapi/constructor/instantiate-bad-imports.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 // META: script=/wasm/jsapi/bad-imports.js
 

--- a/wasm/jsapi/constructor/instantiate.any.js
+++ b/wasm/jsapi/constructor/instantiate.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 // META: script=/wasm/jsapi/assertions.js
 // META: script=/wasm/jsapi/instanceTestFactory.js

--- a/wasm/jsapi/constructor/multi-value.any.js
+++ b/wasm/jsapi/constructor/multi-value.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 // META: script=/wasm/jsapi/assertions.js
 

--- a/wasm/jsapi/constructor/validate.any.js
+++ b/wasm/jsapi/constructor/validate.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 let emptyModuleBinary;

--- a/wasm/jsapi/exception/basic.tentative.any.js
+++ b/wasm/jsapi/exception/basic.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,jsshell
+// META: global=window,worker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 function assert_throws_wasm(fn, message) {

--- a/wasm/jsapi/exception/constructor.tentative.any.js
+++ b/wasm/jsapi/exception/constructor.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 test(() => {

--- a/wasm/jsapi/exception/getArg.tentative.any.js
+++ b/wasm/jsapi/exception/getArg.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/memory/assertions.js
 
 test(() => {

--- a/wasm/jsapi/exception/identity.tentative.any.js
+++ b/wasm/jsapi/exception/identity.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 // META: script=/wasm/jsapi/wasm-module-builder.js
 

--- a/wasm/jsapi/exception/is.tentative.any.js
+++ b/wasm/jsapi/exception/is.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/memory/assertions.js
 
 test(() => {

--- a/wasm/jsapi/function/call.tentative.any.js
+++ b/wasm/jsapi/function/call.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function addxy(x, y) {

--- a/wasm/jsapi/function/constructor.tentative.any.js
+++ b/wasm/jsapi/function/constructor.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function addxy(x, y) {

--- a/wasm/jsapi/function/table.tentative.any.js
+++ b/wasm/jsapi/function/table.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function testfunc(n) {}

--- a/wasm/jsapi/function/type.tentative.any.js
+++ b/wasm/jsapi/function/type.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function addNumbers(x, y, z) {

--- a/wasm/jsapi/global/constructor.any.js
+++ b/wasm/jsapi/global/constructor.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function assert_Global(actual, expected) {

--- a/wasm/jsapi/global/type.tentative.any.js
+++ b/wasm/jsapi/global/type.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function assert_type(argument) {

--- a/wasm/jsapi/instance/constructor-bad-imports.any.js
+++ b/wasm/jsapi/instance/constructor-bad-imports.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 // META: script=/wasm/jsapi/bad-imports.js
 

--- a/wasm/jsapi/instance/constructor-caching.any.js
+++ b/wasm/jsapi/instance/constructor-caching.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 function getExports() {

--- a/wasm/jsapi/instance/constructor.any.js
+++ b/wasm/jsapi/instance/constructor.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 // META: script=/wasm/jsapi/assertions.js
 // META: script=/wasm/jsapi/instanceTestFactory.js

--- a/wasm/jsapi/instance/exports.any.js
+++ b/wasm/jsapi/instance/exports.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 let emptyModuleBinary;

--- a/wasm/jsapi/instance/toString.any.js
+++ b/wasm/jsapi/instance/toString.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 test(() => {

--- a/wasm/jsapi/instanceTestFactory.js
+++ b/wasm/jsapi/instanceTestFactory.js
@@ -759,3 +759,5 @@ const instanceTestFactory = [
     }
   ],
 ];
+
+globalThis.instanceTestFactory = instanceTestFactory;

--- a/wasm/jsapi/interface.any.js
+++ b/wasm/jsapi/interface.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function test_operations(object, object_name, operations) {

--- a/wasm/jsapi/memory/constructor-shared.tentative.any.js
+++ b/wasm/jsapi/memory/constructor-shared.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 // META: script=/wasm/jsapi/memory/assertions.js
 

--- a/wasm/jsapi/memory/constructor-types.tentative.any.js
+++ b/wasm/jsapi/memory/constructor-types.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 // META: script=/wasm/jsapi/memory/assertions.js
 

--- a/wasm/jsapi/memory/constructor.any.js
+++ b/wasm/jsapi/memory/constructor.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 // META: script=/wasm/jsapi/memory/assertions.js
 

--- a/wasm/jsapi/memory/grow.any.js
+++ b/wasm/jsapi/memory/grow.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/memory/assertions.js
 
 test(() => {

--- a/wasm/jsapi/memory/type.tentative.any.js
+++ b/wasm/jsapi/memory/type.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function assert_type(argument) {

--- a/wasm/jsapi/module/constructor.any.js
+++ b/wasm/jsapi/module/constructor.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 // META: script=/wasm/jsapi/assertions.js
 

--- a/wasm/jsapi/module/customSections.any.js
+++ b/wasm/jsapi/module/customSections.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 function assert_ArrayBuffer(buffer, expected) {

--- a/wasm/jsapi/module/exports.any.js
+++ b/wasm/jsapi/module/exports.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 let emptyModuleBinary;

--- a/wasm/jsapi/module/imports.any.js
+++ b/wasm/jsapi/module/imports.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 function assert_ModuleImportDescriptor(import_, expected) {

--- a/wasm/jsapi/module/toString.any.js
+++ b/wasm/jsapi/module/toString.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 
 test(() => {

--- a/wasm/jsapi/prototypes.any.js
+++ b/wasm/jsapi/prototypes.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 // META: script=/wasm/jsapi/wasm-module-builder.js
 

--- a/wasm/jsapi/table/constructor-types.tentative.any.js
+++ b/wasm/jsapi/table/constructor-types.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 // META: script=/wasm/jsapi/table/assertions.js
 

--- a/wasm/jsapi/table/constructor.any.js
+++ b/wasm/jsapi/table/constructor.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 // META: script=/wasm/jsapi/assertions.js
 // META: script=/wasm/jsapi/table/assertions.js

--- a/wasm/jsapi/table/get-set.any.js
+++ b/wasm/jsapi/table/get-set.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 // META: script=assertions.js
 

--- a/wasm/jsapi/table/grow.any.js
+++ b/wasm/jsapi/table/grow.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/wasm-module-builder.js
 // META: script=assertions.js
 

--- a/wasm/jsapi/table/type.tentative.any.js
+++ b/wasm/jsapi/table/type.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function assert_type(argument) {

--- a/wasm/jsapi/tag/constructor.tentative.any.js
+++ b/wasm/jsapi/tag/constructor.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 test(() => {

--- a/wasm/jsapi/tag/type.tentative.any.js
+++ b/wasm/jsapi/tag/type.tentative.any.js
@@ -1,4 +1,4 @@
-// META: global=window,dedicatedworker,jsshell
+// META: global=window,dedicatedworker,jsshell,shadowrealm
 // META: script=/wasm/jsapi/assertions.js
 
 function assert_type(argument) {

--- a/wasm/jsapi/wasm-module-builder.js
+++ b/wasm/jsapi/wasm-module-builder.js
@@ -1284,6 +1284,7 @@ class WasmModuleBuilder {
     return new WebAssembly.Module(this.toBuffer(debug));
   }
 }
+globalThis.WasmModuleBuilder = WasmModuleBuilder;
 
 function wasmSignedLeb(val, max_len = 5) {
   let res = [];
@@ -1300,10 +1301,12 @@ function wasmSignedLeb(val, max_len = 5) {
   throw new Error(
       'Leb value <' + val + '> exceeds maximum length of ' + max_len);
 }
+globalThis.wasmSignedLeb = wasmSignedLeb;
 
 function wasmI32Const(val) {
   return [kExprI32Const, ...wasmSignedLeb(val, 5)];
 }
+globalThis.wasmI32Const = wasmI32Const;
 
 function wasmF32Const(f) {
   // Write in little-endian order at offset 0.
@@ -1312,6 +1315,7 @@ function wasmF32Const(f) {
     kExprF32Const, byte_view[0], byte_view[1], byte_view[2], byte_view[3]
   ];
 }
+globalThis.wasmI32Const = wasmI32Const;
 
 function wasmF64Const(f) {
   // Write in little-endian order at offset 0.
@@ -1321,3 +1325,4 @@ function wasmF64Const(f) {
     byte_view[3], byte_view[4], byte_view[5], byte_view[6], byte_view[7]
   ];
 }
+globalThis.wasmF64Const = wasmF64Const;


### PR DESCRIPTION
Supports tests that have helper dependencies. Exposes "expose" in testharness.js to enable exposing wasm-local helper functions