### PR TITLE
Avoid asserting default sizes in {progress,meter}-native-computed-style.optional.html writing mode tests

### DIFF
--- a/css/css-writing-modes/forms/meter-appearance-native-computed-style.optional.html
+++ b/css/css-writing-modes/forms/meter-appearance-native-computed-style.optional.html
@@ -13,8 +13,11 @@
 test(() => {
   const meter = document.querySelector(`meter[style="writing-mode: horizontal-tb"]`);
   const style = getComputedStyle(meter);
-  assert_equals(style.blockSize, "16px");
-  assert_equals(style.inlineSize, "80px");
+  const blockSize = parseInt(style.blockSize, 10);
+  const inlineSize = parseInt(style.inlineSize, 10);
+  assert_not_equals(blockSize, 0);
+  assert_not_equals(inlineSize, 0);
+  assert_greater_than(inlineSize, blockSize);
   assert_equals(style.blockSize, style.height);
   assert_equals(style.inlineSize, style.width);
 }, `meter[style="writing-mode: horizontal-tb"] block size should match height and inline size should match width`);
@@ -23,8 +26,11 @@ for (const writingMode of ["vertical-lr", "vertical-rl"]) {
   test(() => {
     const meter = document.querySelector(`meter[style="writing-mode: ${writingMode}"]`);
     const style = getComputedStyle(meter);
-    assert_equals(style.blockSize, "16px");
-    assert_equals(style.inlineSize, "80px");
+    const blockSize = parseInt(style.blockSize, 10);
+    const inlineSize = parseInt(style.inlineSize, 10);
+    assert_not_equals(blockSize, 0);
+    assert_not_equals(inlineSize, 0);
+    assert_greater_than(inlineSize, blockSize);
     assert_equals(style.blockSize, style.width);
     assert_equals(style.inlineSize, style.height);
   }, `meter[style="writing-mode: ${writingMode}"] block size should match width and inline size should match height`);

--- a/css/css-writing-modes/forms/progress-appearance-native-computed-style.optional.html
+++ b/css/css-writing-modes/forms/progress-appearance-native-computed-style.optional.html
@@ -13,8 +13,11 @@
 test(() => {
   const progress = document.querySelector(`progress[style="writing-mode: horizontal-tb"]`);
   const style = getComputedStyle(progress);
-  assert_equals(style.blockSize, "16px");
-  assert_equals(style.inlineSize, "160px");
+  const blockSize = parseInt(style.blockSize, 10);
+  const inlineSize = parseInt(style.inlineSize, 10);
+  assert_not_equals(blockSize, 0);
+  assert_not_equals(inlineSize, 0);
+  assert_greater_than(inlineSize, blockSize);
   assert_equals(style.blockSize, style.height);
   assert_equals(style.inlineSize, style.width);
 }, `progress[style="writing-mode: horizontal-tb"] block size should match height and inline size should match width`);
@@ -23,8 +26,11 @@ for (const writingMode of ["vertical-lr", "vertical-rl"]) {
   test(() => {
     const progress = document.querySelector(`progress[style="writing-mode: ${writingMode}"]`);
     const style = getComputedStyle(progress);
-    assert_equals(style.blockSize, "16px");
-    assert_equals(style.inlineSize, "160px");
+    const blockSize = parseInt(style.blockSize, 10);
+    const inlineSize = parseInt(style.inlineSize, 10);
+    assert_not_equals(blockSize, 0);
+    assert_not_equals(inlineSize, 0);
+    assert_greater_than(inlineSize, blockSize);
     assert_equals(style.blockSize, style.width);
     assert_equals(style.inlineSize, style.height);
   }, `progress[style="writing-mode: ${writingMode}"] block size should match width and inline size should match height`);


### PR DESCRIPTION
These tests currently assume that the default inline and block sizes of <progress> and <meter> are the same across all browsers. That is not the case, and is irrelevant to the purpose of the test, which is to assert that the block size should match height/width and inline size should match width/height depending on the writing mode.

Replace the exact value assertions with assertions that test for an appropriate aspect ratio (inline size greater than block size).