### PR TITLE
Ensure everywhere we log a traceback it says where it is from

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -304,7 +304,8 @@ class TestExecutor:
             result = self.do_test(test)
         except Exception as e:
             exception_string = traceback.format_exc()
-            self.logger.warning(exception_string)
+            message = f"Exception in TextExecutor.run:\n{exception_string}"
+            self.logger.warning(message)
             result = self.result_from_exception(test, e, exception_string)
 
         # log result of parent test

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -91,7 +91,9 @@ addEventListener("__test_restart", e => {e.preventDefault(); callback(true)})"""
             except (socket.timeout, error.NoSuchWindowException, error.UnknownErrorException, OSError):
                 break
             except Exception:
-                self.logger.error(traceback.format_exc())
+                message = "Uncaught exception in WebDriverBaseProtocolPart.wait:\n"
+                message += traceback.format_exc()
+                self.logger.error(message)
                 break
         return False
 

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -70,9 +70,10 @@ class Protocol:
             msg = "Post-connection steps failed"
             self.after_connect()
         except Exception:
-            if msg is not None:
-                self.logger.warning(msg)
-            self.logger.warning(traceback.format_exc())
+            message = "Protocol.setup caught an exception:\n"
+            message += f"{msg}\n" if msg is not None else ""
+            message += traceback.format_exc()
+            self.logger.warning(message)
             raise
 
     @abstractmethod

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -120,7 +120,9 @@ class TestRunner:
         try:
             return self.executor.run_test(test)
         except Exception:
-            self.logger.error(traceback.format_exc())
+            message = "TestRunner.run_test caught an exception:\n"
+            message += traceback.format_exc()
+            self.logger.error(message)
             raise
 
     def wait(self):
@@ -211,10 +213,9 @@ class BrowserManager:
             self.browser.start(group_metadata=group_metadata, **self.browser_settings)
             self.browser_pid = self.browser.pid
         except Exception:
-            self.logger.warning("Failure during init %s" % traceback.format_exc())
+            self.logger.error(f"Failure during init:\n{traceback.format_exc()}")
             if self.init_timer is not None:
                 self.init_timer.cancel()
-            self.logger.error(traceback.format_exc())
             succeeded = False
         else:
             succeeded = True
@@ -399,7 +400,9 @@ class TestRunnerManager(threading.Thread):
                 self.state = new_state
                 self.logger.debug(f"new state: {self.state.__class__.__name__}")
         except Exception:
-            self.logger.error(traceback.format_exc())
+            message = "Uncaught exception in TestRunnerManager.run:\n"
+            message += traceback.format_exc()
+            self.logger.error(message)
             raise
         finally:
             self.logger.debug("TestRunnerManager main loop terminating, starting cleanup")


### PR DESCRIPTION
Otherwise we end up with arbitrary tracebacks which are unclear as to where they're being logged from