### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=261576

### DIFF
--- a/css/css-grid/parsing/grid-row-invalid.html
+++ b/css/css-grid/parsing/grid-row-invalid.html
@@ -43,8 +43,6 @@
     test_invalid_value("grid-row", "2 span first / last");
     test_invalid_value("grid-row", "5 nav / last span 7");
     test_invalid_value("grid-row", "5 / 3 span 3");
-
-// FIXME: add more values to test full syntax
 </script>
 </body>
 </html>

--- a/css/css-grid/parsing/grid-row-invalid.html
+++ b/css/css-grid/parsing/grid-row-invalid.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#placement-shorthands">
+<meta name="assert" content="Tests invalid values for grid-row"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+    test_invalid_value("grid-row", "5 8");
+    test_invalid_value("grid-row", "5 /");
+    test_invalid_value("grid-row", "8 auto");
+    test_invalid_value("grid-row", "8 / /");
+    test_invalid_value("grid-row", "0 / 6");
+    test_invalid_value("grid-row", "8 / 0");
+    test_invalid_value("grid-row", "0");
+    test_invalid_value("grid-row", "span");
+    test_invalid_value("grid-row", "span / span");
+    test_invalid_value("grid-row", "span span / span span");
+    test_invalid_value("grid-row", "4 4 / 3 span");
+    test_invalid_value("grid-row", "first 4 last / 3 span");
+    test_invalid_value("grid-row", "4 / first 3 last");
+    test_invalid_value("grid-row", "first last / 3 span");
+    test_invalid_value("grid-row", "4 / first last");
+    test_invalid_value("grid-row", "span 4 4 / 3");
+    test_invalid_value("grid-row", "5 span 4 / 3");
+    test_invalid_value("grid-row", "span first last / 3");
+    test_invalid_value("grid-row", "3 / span first last");
+    test_invalid_value("grid-row", "span first last 7 / 3");
+    test_invalid_value("grid-row", "3 / span first 5 last");
+    test_invalid_value("grid-row", "1 span last 7 / 3");
+    test_invalid_value("grid-row", "3 / 5 span first 5");
+    test_invalid_value("grid-row", "-3 span / -4");
+    test_invalid_value("grid-row", "-3 / span -4");
+    test_invalid_value("grid-row", "span 0 / 0");
+    test_invalid_value("grid-row", "0 / 0 span");
+    test_invalid_value("grid-row", "last -2 span / 1 nav");
+    test_invalid_value("grid-row", "2 span first / last");
+    test_invalid_value("grid-row", "5 nav / last span 7");
+    test_invalid_value("grid-row", "5 / 3 span 3");
+
+// FIXME: add more values to test full syntax
+</script>
+</body>
+</html>

--- a/css/css-grid/parsing/grid-row-shortest-serialization.html
+++ b/css/css-grid/parsing/grid-row-shortest-serialization.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#placement-shorthands"/>
+<meta name="assert" content="grid-row computed value should be the shortest serialization possible"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+    test_computed_value("grid-row", "auto / auto", "auto");
+    test_computed_value("grid-row", "auto", "auto");
+    test_computed_value("grid-row", "10 / auto", "10");
+    test_computed_value("grid-row", "10");
+    test_computed_value("grid-row", "-10 / auto", "-10");
+    test_computed_value("grid-row", "-10");
+    test_computed_value("grid-row", "span 2 / auto", "span 2");
+    test_computed_value("grid-row", "span 2");
+    test_computed_value("grid-row", "3 last / auto", "3 last");
+    test_computed_value("grid-row", "3 last");
+    test_computed_value("grid-row", "span first / auto", "span first");
+    test_computed_value("grid-row", "span first");
+    test_computed_value("grid-row", "span 2 first / auto", "span 2 first");
+    test_computed_value("grid-row", "span 2 first");
+    test_computed_value("grid-row", "last / last", "last");
+</script>
+</body>
+</html>

--- a/css/css-grid/parsing/grid-row-shorthand.html
+++ b/css/css-grid/parsing/grid-row-shorthand.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#placement-shorthands">
+<meta name="assert" content="grid-row should set values for grid-row-start and grid-row-end">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/shorthand-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_shorthand_value("grid-row", "auto / auto", {
+    "grid-row-start": "auto",
+    "grid-row-end": "auto"
+});
+test_shorthand_value("grid-row", "auto", {
+    "grid-row-start": "auto",
+    "grid-row-end": "auto"
+});
+
+test_shorthand_value("grid-row", "10 / auto", {
+    "grid-row-start": "10",
+    "grid-row-end": "auto"
+});
+test_shorthand_value("grid-row", "10", {
+    "grid-row-start": "10",
+    "grid-row-end": "auto"
+});
+
+test_shorthand_value("grid-row", "-10 / auto", {
+    "grid-row-start": "-10",
+    "grid-row-end": "auto"
+});
+test_shorthand_value("grid-row", "-10", {
+    "grid-row-start": "-10",
+    "grid-row-end": "auto"
+});
+
+test_shorthand_value("grid-row", "span 2 / auto", {
+    "grid-row-start": "span 2",
+    "grid-row-end": "auto"
+});
+test_shorthand_value("grid-row", "span 2", {
+    "grid-row-start": "span 2",
+    "grid-row-end": "auto"
+});
+
+test_shorthand_value("grid-row", "3 last / auto", {
+    "grid-row-start": "3 last",
+    "grid-row-end": "auto"
+});
+test_shorthand_value("grid-row", "3 last", {
+    "grid-row-start": "3 last",
+    "grid-row-end": "auto"
+});
+
+test_shorthand_value("grid-row", "span first / auto", {
+    "grid-row-start": "span first",
+    "grid-row-end": "auto"
+});
+test_shorthand_value("grid-row", "span first", {
+    "grid-row-start": "span first",
+    "grid-row-end": "auto"
+});
+test_shorthand_value("grid-row", "span 2 first / auto", {
+    "grid-row-start": "span 2 first",
+    "grid-row-end": "auto"
+});
+test_shorthand_value("grid-row", "span 2 first", {
+    "grid-row-start": "span 2 first",
+    "grid-row-end": "auto"
+});
+
+test_shorthand_value("grid-row", "last / last", {
+    "grid-row-start": "last",
+    "grid-row-end": "last"
+});
+test_shorthand_value("grid-row", "last", {
+    "grid-row-start": "last",
+    "grid-row-end": "last"
+});
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[css-grid\] Use ShorthandSerializer for grid-row computed style](https://bugs.webkit.org/show_bug.cgi?id=261576)