### PR TITLE
Fix #42043, test all redirect status codes

### DIFF
--- a/xhr/send-redirect.htm
+++ b/xhr/send-redirect.htm
@@ -9,15 +9,21 @@
   <body>
     <div id="log"></div>
     <script>
+      // https://fetch.spec.whatwg.org/#statuses
+      var redirect_codes = new Set([301, 302, 303, 307, 308]);
       function redirect(code) {
-        var test = async_test(document.title + " (" + code + ")")
+        var test = async_test(`${document.title}  (${code} does ${redirect_codes.has(code)? "redirect": "not redirect"})`)
         test.step(function() {
           var client = new XMLHttpRequest()
           client.onreadystatechange = function() {
             test.step(function() {
               if(client.readyState == 4) {
-                assert_equals(client.getResponseHeader("x-request-method"), "GET")
-                assert_equals(client.getResponseHeader("x-request-content-type"), "application/x-pony")
+                if (redirect_codes.has(code)) {
+                  assert_equals(client.getResponseHeader("x-request-method"), "GET")
+                  assert_equals(client.getResponseHeader("x-request-content-type"), "application/x-pony")
+                } else {
+                  assert_equals(client.getResponseHeader("x-request-method"), null)
+                }
                 test.done()
               }
             })
@@ -27,10 +33,10 @@
           client.send(null)
         })
       }
-      redirect("301")
-      redirect("302")
-      redirect("303")
-      redirect("307")
+
+      for (var number = 300; number <= 399; number++) {
+        redirect(number);
+      }
     </script>
   </body>
 </html>

--- a/xhr/send-redirect.htm
+++ b/xhr/send-redirect.htm
@@ -12,7 +12,7 @@
       // https://fetch.spec.whatwg.org/#statuses
       var redirect_codes = new Set([301, 302, 303, 307, 308]);
       function redirect(code) {
-        var test = async_test(`${document.title}  (${code} does ${redirect_codes.has(code)? "redirect": "not redirect"})`)
+        var test = async_test(`${document.title} (${code} does ${redirect_codes.has(code)? "redirect": "not redirect"})`);
         test.step(function() {
           var client = new XMLHttpRequest()
           client.onreadystatechange = function() {

--- a/xhr/send-redirect.htm
+++ b/xhr/send-redirect.htm
@@ -14,27 +14,28 @@
       function redirect(code) {
         var test = async_test(`${document.title} (${code} does ${redirect_codes.has(code)? "redirect": "not redirect"})`);
         test.step(function() {
-          var client = new XMLHttpRequest()
+          var client = new XMLHttpRequest();
           client.onreadystatechange = function() {
             test.step(function() {
               if(client.readyState == 4) {
                 if (redirect_codes.has(code)) {
-                  assert_equals(client.getResponseHeader("x-request-method"), "GET")
-                  assert_equals(client.getResponseHeader("x-request-content-type"), "application/x-pony")
+                  assert_equals(client.getResponseHeader("x-request-method"), "GET");
+                  assert_equals(client.getResponseHeader("x-request-content-type"), "application/x-pony");
                 } else {
-                  assert_equals(client.getResponseHeader("x-request-method"), null)
+                  assert_equals(client.getResponseHeader("x-request-method"), null);
+                  assert_equals(client.getResponseHeader("x-request-content-type"), null);
                 }
-                test.done()
+                test.done();
               }
             })
           }
-          client.open("GET", "resources/redirect.py?location=content.py&code=" + code)
-          client.setRequestHeader("Content-Type", "application/x-pony")
-          client.send(null)
+          client.open("GET", "resources/redirect.py?location=content.py&code=" + code);
+          client.setRequestHeader("Content-Type", "application/x-pony");
+          client.send(null);
         })
       }
 
-      for (var number = 300; number <= 399; number++) {
+      for (var number of [300, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 350, 399]) {
         redirect(number);
       }
     </script>

--- a/xhr/send-redirect.htm
+++ b/xhr/send-redirect.htm
@@ -21,9 +21,11 @@
                 if (redirect_codes.has(code)) {
                   assert_equals(client.getResponseHeader("x-request-method"), "GET");
                   assert_equals(client.getResponseHeader("x-request-content-type"), "application/x-pony");
+                  assert_equals(client.status, 200);
                 } else {
                   assert_equals(client.getResponseHeader("x-request-method"), null);
                   assert_equals(client.getResponseHeader("x-request-content-type"), null);
+                  assert_equals(client.status, code);
                 }
                 test.done();
               }


### PR DESCRIPTION
Browsers currently diverge in their handling of 3XX responses.
The fetch standard specifies that only codes 301, 302, 303, 307, and 308 should redirect: https://fetch.spec.whatwg.org/#statuses

Adding the tests in `xhr/send-redirect.htm` seemed easiest.