### PR TITLE
HTML: align XHR URL encoding expectations with the specification

### DIFF
--- a/html/infrastructure/urls/resolving-urls/query-encoding/resources/resolve-url.js
+++ b/html/infrastructure/urls/resolving-urls/query-encoding/resources/resolve-url.js
@@ -499,7 +499,7 @@ onload = function() {
     var xhr = new XMLHttpRequest();
     xhr.open('GET', input_url_html);
     xhr.onload = this.step_func_done(function() {
-      assert_equals(xhr.response, expected_utf8);
+      assert_equals(xhr.response, expected_current);
     });
     xhr.send();
   }, 'XMLHttpRequest#open()');


### PR DESCRIPTION
https://xhr.spec.whatwg.org/#dom-xmlhttprequest-open never said UTF-8 it seems like.