### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=261437

### DIFF
--- a/css/motion/offset-path-shape-inset-002.html
+++ b/css/motion/offset-path-shape-inset-002.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <title>CSS Motion Path test: &lt;basic-shape&gt; inset() path with explicit arguments and radius</title>
-<meta name=fuzzy content="0-75;0-500">
+<meta name="fuzzy" content="maxDifference=0-170; totalPixels=0-500">
 <link rel="author" title="Daniil Sakhapov" href="sakhapov@google.com">
 <link rel="match" href="offset-path-shape-inset-002-ref.html">
 <link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-basic-shape">

--- a/css/motion/offset-path-shape-rect-002.html
+++ b/css/motion/offset-path-shape-rect-002.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <title>CSS Motion Path test: &lt;basic-shape&gt; rect() path with explicit arguments and radius</title>
-<meta name=fuzzy content="0-96;0-440">
+<meta name="fuzzy" content="maxDifference=0-160; totalPixels=0-520">
 <link rel="author" title="Daniil Sakhapov" href="sakhapov@google.com">
 <link rel="match" href="offset-path-shape-rect-002-ref.html">
 <link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-basic-shape">

--- a/css/motion/offset-path-shape-xywh-002.html
+++ b/css/motion/offset-path-shape-xywh-002.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <title>CSS Motion Path test: &lt;basic-shape&gt; xywh() path with explicit arguments and radius</title>
-<meta name=fuzzy content="0-130;0-250">
+<meta name="fuzzy" content="maxDifference=0-140; totalPixels=0-500">
 <link rel="author" title="Daniil Sakhapov" href="sakhapov@google.com">
 <link rel="match" href="offset-path-shape-xywh-002-ref.html">
 <link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-basic-shape">


### PR DESCRIPTION
WebKit export from bug: [\[motion-path\] Offset path inset shape tests with border-radius are failing](https://bugs.webkit.org/show_bug.cgi?id=261437)