### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=261575

### DIFF
--- a/css/css-grid/parsing/grid-column-invalid.html
+++ b/css/css-grid/parsing/grid-column-invalid.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#placement-shorthands">
+<meta name="assert" content="Tests invalid values for grid-column"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_invalid_value("grid-column", "4 5");
+test_invalid_value("grid-column", "4 /");
+test_invalid_value("grid-column", "5 5");
+test_invalid_value("grid-column", "5 / /");
+
+test_invalid_value("grid-column", "0 / 5");
+test_invalid_value("grid-column", "6 / 0");
+test_invalid_value("grid-column", "0");
+
+test_invalid_value("grid-column", "span");
+test_invalid_value("grid-column", "span / span");
+
+test_invalid_value("grid-column", "span span / span span");
+
+test_invalid_value("grid-column", "5 5 / span 2");
+test_invalid_value("grid-column", "5 first last / span 2");
+test_invalid_value("grid-column", "5 / first last 2");
+test_invalid_value("grid-column", "first last / span 2");
+test_invalid_value("grid-column", "5 / first last");
+test_invalid_value("grid-column", "5 5 span / 2", "span 4 4 / 3");
+test_invalid_value("grid-column", "span 3 5 / 1", "5 span 4 / 3");
+test_invalid_value("grid-column", "span last first / 1", "span first last / 3");
+test_invalid_value("grid-column", "2 / span last first", "3 / span first last");
+test_invalid_value("grid-column", "span 1 last first / 1", "span first last 7 / 3");
+test_invalid_value("grid-column", "2 / span last 3 first", "3 / span first 5 last");
+test_invalid_value("grid-column", "1 span 2 first / 1", "1 span last 7 / 3");
+test_invalid_value("grid-column", "2 / 3 span 3 first", "3 / 5 span first 5");
+
+test_invalid_value("grid-column", "span -1 / -2");
+test_invalid_value("grid-column", "-1 / -2 span");
+test_invalid_value("grid-column", "0 span / 0");
+test_invalid_value("grid-column", "0 / span 0");
+test_invalid_value("grid-column", "span -3 'first' / 3 last");
+
+test_invalid_value("grid-column", "first span 1 / last");
+test_invalid_value("grid-column", "3 first / 2 span last");
+test_invalid_value("grid-column", "3 / 1 span 2");
+</script>
+</body>
+</html>

--- a/css/css-grid/parsing/grid-column-shortest-serialization.html
+++ b/css/css-grid/parsing/grid-column-shortest-serialization.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#placement-shorthands"/>
+<meta name="assert" content="grid-column computed value should be the shortest serialization possible"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("grid-column", "auto / auto", "auto");
+test_computed_value("grid-column", "auto", "auto");
+test_computed_value("grid-column", "10 / auto", "10");
+test_computed_value("grid-column", "10", "10");
+test_computed_value("grid-column", "-10 / auto", "-10");
+test_computed_value("grid-column", "-10", "-10");
+test_computed_value("grid-column", "first / first", "first");
+test_computed_value("grid-column", "first", "first");
+test_computed_value("grid-column", "span 2 / auto", "span 2");
+test_computed_value("grid-column", "span 2", "span 2");
+test_computed_value("grid-column", "2 first / auto", "2 first");
+test_computed_value("grid-column", "2 first", "2 first");
+test_computed_value("grid-column", "span first / auto", "span first");
+test_computed_value("grid-column", "span first", "span first");
+test_computed_value("grid-column", "span 2 first / auto", "span 2 first");
+test_computed_value("grid-column", "span 2 first", "span 2 first");
+</script>
+</body>
+</html>

--- a/css/css-grid/parsing/grid-column-shorthand.html
+++ b/css/css-grid/parsing/grid-column-shorthand.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#placement-shorthands">
+<meta name="assert" content="grid-column should set values for grid-column-start and grid-column-end">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/shorthand-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_shorthand_value("grid-column", "auto / auto", {
+    "grid-column-start": "auto",
+    "grid-column-end": "auto"
+});
+test_shorthand_value("grid-column", "auto", {
+    "grid-column-start": "auto",
+    "grid-column-end": "auto"
+});
+
+test_shorthand_value("grid-column", "10 / auto", {
+    "grid-column-start": "10",
+    "grid-column-end": "auto"
+});
+test_shorthand_value("grid-column", "10", {
+    "grid-column-start": "10",
+    "grid-column-end": "auto"
+});
+
+test_shorthand_value("grid-column", "-10 / auto", {
+    "grid-column-start": "-10",
+    "grid-column-end": "auto"
+});
+test_shorthand_value("grid-column", "-10", {
+    "grid-column-start": "-10",
+    "grid-column-end": "auto"
+});
+
+test_shorthand_value("grid-column", "span 2 / auto", {
+    "grid-column-start": "span 2",
+    "grid-column-end": "auto"
+});
+test_shorthand_value("grid-column", "span 2", {
+    "grid-column-start": "span 2",
+    "grid-column-end": "auto"
+});
+
+test_shorthand_value("grid-column", "3 last / auto", {
+    "grid-column-start": "3 last",
+    "grid-column-end": "auto"
+});
+test_shorthand_value("grid-column", "3 last", {
+    "grid-column-start": "3 last",
+    "grid-column-end": "auto"
+});
+
+test_shorthand_value("grid-column", "span first / auto", {
+    "grid-column-start": "span first",
+    "grid-column-end": "auto"
+});
+test_shorthand_value("grid-column", "span first", {
+    "grid-column-start": "span first",
+    "grid-column-end": "auto"
+});
+test_shorthand_value("grid-column", "span 2 first / auto", {
+    "grid-column-start": "span 2 first",
+    "grid-column-end": "auto"
+});
+test_shorthand_value("grid-column", "span 2 first", {
+    "grid-column-start": "span 2 first",
+    "grid-column-end": "auto"
+});
+
+test_shorthand_value("grid-column", "last / last", {
+    "grid-column-start": "last",
+    "grid-column-end": "last"
+});
+test_shorthand_value("grid-column", "last", {
+    "grid-column-start": "last",
+    "grid-column-end": "last"
+});
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[css-grid\] Use ShorthandSerializer for grid-column computed style](https://bugs.webkit.org/show_bug.cgi?id=261575)