### PR TITLE
[wptrunner] Fix missing tests in `SingleTestSource.tests_by_group(...)`

### DIFF
--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -591,11 +591,11 @@ class SingleTestSource(TestSource):
 
     @classmethod
     def tests_by_group(cls, tests_by_type, **kwargs):
-        rv = {}
+        groups = defaultdict(list)
         for (subsuite, test_type), tests in tests_by_type.items():
             group_name = f"{subsuite}:{cls.group_metadata(None)['scope']}"
-            rv[group_name] = [t.id for t in tests]
-        return rv
+            groups[group_name].extend(test.id for test in tests)
+        return groups
 
 
 class PathGroupedSource(TestSource):


### PR DESCRIPTION
Two test types may map to the same group, like `:/` (subsuite `""`, scope `/`), so whichever type was iterated last was overwriting the common key with its tests. Ensure that all tests are present, matching other `tests_by_group(...)` implementations.

`tests_by_group(...)` is only used for `suite_start(...)` (tests to run are gathered in another way), so this was only causing the `mach` formatter to undercount the total number of tests, like `[23/14]`.