### PR TITLE
[WebDriver BiDi] Decrease fetch timeout

### DIFF
--- a/webdriver/tests/bidi/network/conftest.py
+++ b/webdriver/tests/bidi/network/conftest.py
@@ -44,7 +44,7 @@ def fetch(bidi_session, top_context, configuration):
     """Perform a fetch from the page of the provided context, default to the
     top context.
     """
-    async def fetch(url, method="GET", headers=None, context=top_context, timeout_in_seconds=3):
+    async def fetch(url, method="GET", headers=None, context=top_context, timeout_in_seconds=0.5):
         method_arg = f"method: '{method}',"
 
         headers_arg = ""


### PR DESCRIPTION
Motivation of reducing the default timeout for `fetch`: 

- Server is run locally - meaning there is low latency for the response.
- Usually test either pass/fail fast or timeout at the max time.

Scenario example: 
We have 5 test in a single file. If 3 timeout at the fetch step the 2 other need to complete under 1s total.
If we look closely at our test we have 50 test in a single file (`response_completed.py`), that means if 2 test timeout most likely the whole file will timeout.
From my understanding of WPT we can't `skip` a single test it will run and will have affect ([Docs](https://web-platform-tests.org/tools/wptrunner/docs/expectation.html#web-platform-tests-metadata)).