### PR TITLE
Include more in sysdiagnoses on macOS

### DIFF
--- a/tools/ci/azure/sysdiagnose.yml
+++ b/tools/ci/azure/sysdiagnose.yml
@@ -1,8 +1,7 @@
 steps:
 - script: |
     mkdir -p /Users/runner/sysdiagnose
-    # No UI, and no time sensitive, generated, or archived logs
-    sudo sysdiagnose -ub -PGR -f /Users/runner/sysdiagnose -A sysdiagnose_$(System.JobPositionInPhase)
+    sudo sysdiagnose -ub -f /Users/runner/sysdiagnose -A sysdiagnose_$(System.JobPositionInPhase)
   displayName: 'Collect sysdiagnose'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 - task: PublishBuildArtifacts@1


### PR DESCRIPTION
Try and get further with https://github.com/web-platform-tests/wpt/issues/41386. We did this before with #41182, but let's just do this for every run at this point. The current data isn't overly useful, as it is just too minimal.