### PR TITLE
browser: Pass -ErrorAction to Get-Item PowerShell call

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -38,7 +38,7 @@ FIREFOX_CI_ROOT_URL = 'https://firefox-ci-tc.services.mozilla.com'
 
 
 def _get_fileversion(binary, logger=None):
-    command = "(Get-Item '%s').VersionInfo.FileVersion" % binary.replace("'", "''")
+    command = "(Get-Item -ErrorAction Stop '%s').VersionInfo.FileVersion" % binary.replace("'", "''")
     try:
         return call("powershell.exe", command).strip()
     except (subprocess.CalledProcessError, OSError):


### PR DESCRIPTION
By default, PowerShell script errors are shown but do not stop script execution. This meant that even if a given binary did not exist, `_get_fileversion()` would not return None because the Get-Item was not the latest thing to run. The error messages would end up looking very cryptic:

    0:02.08 INFO Version Get-Item could not be formatted for build matching.
    Traceback (most recent call last):
      File "C:\Users\rkubodac\src\wpt\wpt", line 10, in <module>
        wpt.main()
      File "C:\Users\rkubodac\src\wpt\tools\wpt\wpt.py", line 233, in main
        rv = script(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Users\rkubodac\src\wpt\tools\wpt\run.py", line 914, in run
        wptrunner_kwargs = setup_wptrunner(venv, **kwargs)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Users\rkubodac\src\wpt\tools\wpt\run.py", line 887, in setup_wptrunner
        setup_cls.setup(kwargs)
      File "C:\Users\rkubodac\src\wpt\tools\wpt\run.py", line 190, in setup
        self.setup_kwargs(kwargs)
      File "C:\Users\rkubodac\src\wpt\tools\wpt\run.py", line 376, in setup_kwargs
        webdriver_binary = self.browser.install_webdriver(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Users\rkubodac\src\wpt\tools\wpt\browser.py", line 1259, in install_webdriver
        chromedriver_path = self.install_webdriver_by_version(version, dest, channel)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Users\rkubodac\src\wpt\tools\wpt\browser.py", line 1269, in install_webdriver_by_version
        url = self._get_webdriver_url(version, channel)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Users\rkubodac\src\wpt\tools\wpt\browser.py", line 995, in _get_webdriver_url
        raise ValueError(f"Unknown version format: {version}")
    ValueError: Unknown version format: Get-Item

Explicitly invoke Get-Item with `-ErrorAction Stop` so that any errors there (including the item not being found) cause script execution to stop and the call to `call()` to throw a `subprocess.CalledProcessError` as expected.