### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=262009

### DIFF
--- a/css/css-masking/parsing/clip-path-valid.html
+++ b/css/css-masking/parsing/clip-path-valid.html
@@ -73,10 +73,10 @@ test_valid_value("clip-path", "stroke-box");
 test_valid_value("clip-path", "view-box");
 
 // <basic-shape> <geometry-box>
-test_valid_value("clip-path", "circle(7% at 8% 9%) border-box");
+test_valid_value("clip-path", "circle(7% at 8% 9%) border-box", "circle(7% at 8% 9%)");
 
 // <geometry-box> <basic-shape>
-test_valid_value("clip-path", "border-box circle(7% at 8% 9%)", ["border-box circle(7% at 8% 9%)", "circle(7% at 8% 9%) border-box"]);
+test_valid_value("clip-path", "border-box circle(7% at 8% 9%)", "circle(7% at 8% 9%)");
 
 // <clip-source>
 test_valid_value("clip-path", "url(https://example.com/)", ["url(https://example.com/)", "url(\"https://example.com/\")"]);


### PR DESCRIPTION
WebKit export from bug: [\[CSS\] Fix serialization issues with clip-path & offset-path](https://bugs.webkit.org/show_bug.cgi?id=262009)