### PR TITLE
Fix auto-scrollbars.html to allow laying out with or without scrollbars

### DIFF
--- a/css/css-contain/container-queries/auto-scrollbars.html
+++ b/css/css-contain/container-queries/auto-scrollbars.html
@@ -45,7 +45,7 @@
 
   test(() => {
     inner.style.borderBottomWidth = "2px";
-    assert_equals(initialScrollerWidth, scroller.clientWidth, "Scrollbar visibility is consistent after reflow.");
+    assert_equals(scroller.clientWidth, initialScrollerWidth, "Scrollbar visibility is consistent after reflow.");
     assert_equals(getComputedStyle(inner).height, "50px",
                   "Layout with a scrollbar means the container query applies");
   }, "Same result after a reflow");

--- a/css/css-contain/container-queries/auto-scrollbars.html
+++ b/css/css-contain/container-queries/auto-scrollbars.html
@@ -37,15 +37,15 @@
                                "Tests do not work with overlay scrollbars");
   });
 
+  let initialScrollerWidth = scroller.clientWidth;
   test(() => {
-    assert_less_than(scroller.clientWidth, 100, "Expects a vertical scrollbar");
     assert_equals(getComputedStyle(inner).height, "50px",
                   "Layout with a scrollbar means the container query applies");
   }, "Initial layout - expecting a scrollbar without overflowing content instead of overflowing content without a scrollbar");
 
   test(() => {
     inner.style.borderBottomWidth = "2px";
-    assert_less_than(scroller.clientWidth, 100, "Expects a vertical scrollbar");
+    assert_equals(initialScrollerWidth, scroller.clientWidth, "Scrollbar visibility is consistent after reflow.");
     assert_equals(getComputedStyle(inner).height, "50px",
                   "Layout with a scrollbar means the container query applies");
   }, "Same result after a reflow");


### PR DESCRIPTION
See https://github.com/web-platform-tests/interop/issues/460

WebKit & Gecko lay out without a scrollbar, but this isn't incorrect.