### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=261811

### DIFF
--- a/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type-empty.css.headers
+++ b/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type-empty.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html

--- a/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type.css
+++ b/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type.css
@@ -1,0 +1,3 @@
+body {
+    background-color: green;
+}

--- a/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type.css.headers
+++ b/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html

--- a/html/semantics/document-metadata/the-link-element/stylesheet-bad-mime-type.html
+++ b/html/semantics/document-metadata/the-link-element/stylesheet-bad-mime-type.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>stylesheets served with bad MIME types</title>
+<link rel="author" title="Michael[tm] Smith" href="mailto:mike@w3.org">
+<link rel="help" href="https://html.spec.whatwg.org/#link-type-stylesheet:process-the-linked-resource">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  async_test((t) => {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = "resources/stylesheet-bad-mime-type.css";
+    link.onload = t.unreached_func();
+    link.onerror = t.step_func_done();
+    document.head.append(link);
+  }, "'load' event does not fire at link@rel=stylesheet having non-empty resource with bad MIME type");
+  async_test((t) => {
+    t.step_timeout(() => {
+      const link = document.createElement("link");
+      link.rel = "stylesheet";
+      link.href = "resources/stylesheet-bad-mime-type-empty.css";
+      link.onload = t.unreached_func();
+      link.onerror = t.step_func_done();
+      document.head.append(link);
+    }, 2000);
+  }, "'load' event does not fire at link@rel=stylesheet having empty resource with bad MIME type");
+</script>


### PR DESCRIPTION
WebKit export from bug: [Link-stylesheet elements fire load events for non-text/css and non-2XX responses](https://bugs.webkit.org/show_bug.cgi?id=261811)