### PR TITLE
Add support for confirmidplogin

### DIFF
--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -102,7 +102,7 @@ the global scope.
 ### Federated Credential Management ###
 ```eval_rst
 .. js:autofunction:: test_driver.cancel_fedcm_dialog
-.. js:autofunction:: test_driver.confirm_idp_signin
+.. js:autofunction:: test_driver.confirm_idp_login
 .. js:autofunction:: test_driver.select_fedcm_account
 .. js:autofunction:: test_driver.get_fedcm_account_list
 .. js:autofunction:: test_driver.get_fedcm_dialog_title

--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -102,6 +102,7 @@ the global scope.
 ### Federated Credential Management ###
 ```eval_rst
 .. js:autofunction:: test_driver.cancel_fedcm_dialog
+.. js:autofunction:: test_driver.confirm_idp_signin
 .. js:autofunction:: test_driver.select_fedcm_account
 .. js:autofunction:: test_driver.get_fedcm_account_list
 .. js:autofunction:: test_driver.get_fedcm_dialog_title

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -699,21 +699,21 @@
         },
 
         /**
-         * Accepts a FedCM "Confirm IDP signin" dialog.
+         * Accepts a FedCM "Confirm IDP login" dialog.
          *
-         * Matches the `Confirm IDP Signin
-         * <https://fedidcg.github.io/FedCM/#webdriver-confirmidpsignin>`_
+         * Matches the `Confirm IDP Login
+         * <https://fedidcg.github.io/FedCM/#webdriver-confirmidplogin>`_
          * WebDriver command.
          *
          * @param {WindowProxy} context - Browsing context in which
          *                                to run the call, or null for the current
          *                                browsing context.
          *
-         * @returns {Promise} Fulfilled after the IDP signin has started,
+         * @returns {Promise} Fulfilled after the IDP login has started,
          *                    or rejected in case the WebDriver command errors
          */
-        confirm_idp_signin: function(context=null) {
-          return window.test_driver_internal.confirm_idp_signin(context);
+        confirm_idp_login: function(context=null) {
+          return window.test_driver_internal.confirm_idp_login(context);
         },
 
         /**
@@ -954,8 +954,8 @@
             throw new Error("cancel_fedcm_dialog() is not implemented by testdriver-vendor.js");
         },
 
-        async confirm_idp_signin(context=null) {
-            throw new Error("confirm_idp_signin() is not implemented by testdriver-vendor.js");
+        async confirm_idp_login(context=null) {
+            throw new Error("confirm_idp_login() is not implemented by testdriver-vendor.js");
         },
 
         async select_fedcm_account(account_index, context=null) {

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -702,7 +702,7 @@
          * Accepts a FedCM "Confirm IDP signin" dialog.
          *
          * Matches the `Confirm IDP Signin
-         * <>`_
+         * <https://fedidcg.github.io/FedCM/#webdriver-confirmidpsignin>`_
          * WebDriver command.
          *
          * @param {WindowProxy} context - Browsing context in which

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -699,6 +699,24 @@
         },
 
         /**
+         * Accepts a FedCM "Confirm IDP signin" dialog.
+         *
+         * Matches the `Confirm IDP Signin
+         * <>`_
+         * WebDriver command.
+         *
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} Fulfilled after the IDP signin has started,
+         *                    or rejected in case the WebDriver command errors
+         */
+        confirm_idp_signin: function(context=null) {
+          return window.test_driver_internal.confirm_idp_signin(context);
+        },
+
+        /**
          * Selects an account from the Federated Credential Management dialog
          *
          * Matches the `Select account
@@ -934,6 +952,10 @@
 
         async cancel_fedcm_dialog(context=null) {
             throw new Error("cancel_fedcm_dialog() is not implemented by testdriver-vendor.js");
+        },
+
+        async confirm_idp_signin(context=null) {
+            throw new Error("confirm_idp_signin() is not implemented by testdriver-vendor.js");
         },
 
         async select_fedcm_account(account_index, context=null) {

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -288,16 +288,16 @@ class CancelFedCMDialogAction:
         self.logger.debug("Canceling FedCM dialog")
         return self.protocol.fedcm.cancel_fedcm_dialog()
 
-class ConfirmIDPSigninAction:
-    name = "confirm_idp_signin"
+class ConfirmIDPLoginAction:
+    name = "confirm_idp_login"
 
     def __init__(self, logger, protocol):
         self.logger = logger
         self.protocol = protocol
 
     def __call__(self, payload):
-        self.logger.debug("Confirming IDP signin")
-        return self.protocol.fedcm.confirm_idp_signin()
+        self.logger.debug("Confirming IDP login")
+        return self.protocol.fedcm.confirm_idp_login()
 
 class SelectFedCMAccountAction:
     name = "select_fedcm_account"
@@ -388,7 +388,7 @@ actions = [ClickAction,
            SetUserVerifiedAction,
            SetSPCTransactionModeAction,
            CancelFedCMDialogAction,
-           ConfirmIDPSigninAction,
+           ConfirmIDPLoginAction,
            SelectFedCMAccountAction,
            GetFedCMAccountListAction,
            GetFedCMDialogTitleAction,

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -288,6 +288,17 @@ class CancelFedCMDialogAction:
         self.logger.debug("Canceling FedCM dialog")
         return self.protocol.fedcm.cancel_fedcm_dialog()
 
+class ConfirmIDPSigninAction:
+    name = "confirm_idp_signin"
+
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        self.logger.debug("Confirming IDP signin")
+        return self.protocol.fedcm.confirm_idp_signin()
+
 class SelectFedCMAccountAction:
     name = "select_fedcm_account"
 
@@ -377,6 +388,7 @@ actions = [ClickAction,
            SetUserVerifiedAction,
            SetSPCTransactionModeAction,
            CancelFedCMDialogAction,
+           ConfirmIDPSigninAction,
            SelectFedCMAccountAction,
            GetFedCMAccountListAction,
            GetFedCMDialogTitleAction,

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -197,9 +197,9 @@ class ChromeDriverFedCMProtocolPart(WebDriverFedCMProtocolPart):
         self.fedcm_company_prefix = "goog"
 
 
-    def confirm_idp_signin(self):
+    def confirm_idp_login(self):
         return self.webdriver.send_session_command("POST",
-                                                   self.fedcm_company_prefix + "/fedcm/confirmidpsignin")
+                                                   self.fedcm_company_prefix + "/fedcm/confirmidplogin")
 
 
 class ChromeDriverProtocol(WebDriverProtocol):

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -208,7 +208,8 @@ class ChromeDriverProtocol(WebDriverProtocol):
         ChromeDriverPrintProtocolPart,
         ChromeDriverTestharnessProtocolPart,
         *(part for part in WebDriverProtocol.implements
-          if part.name != ChromeDriverTestharnessProtocolPart.name)
+          if part.name != ChromeDriverTestharnessProtocolPart.name and
+              part.name != ChromeDriverFedCMProtocolPart.name)
     ]
     reuse_window = False
 

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -209,7 +209,7 @@ class ChromeDriverProtocol(WebDriverProtocol):
         ChromeDriverTestharnessProtocolPart,
         *(part for part in WebDriverProtocol.implements
           if part.name != ChromeDriverTestharnessProtocolPart.name and
-              part.name != ChromeDriverFedCMProtocolPart.name)
+            part.name != ChromeDriverFedCMProtocolPart.name)
     ]
     reuse_window = False
 

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -15,6 +15,7 @@ from .base import (
 )
 from .executorwebdriver import (
     WebDriverCrashtestExecutor,
+    WebDriverFedCMProtocolPart,
     WebDriverProtocol,
     WebDriverRefTestExecutor,
     WebDriverRun,
@@ -189,8 +190,21 @@ render('%s').then(result => callback(result))""" % pdf_base64)
             self.webdriver.window_handle = handle
 
 
+class ChromeDriverFedCMProtocolPart(WebDriverFedCMProtocolPart):
+    def setup(self):
+        self.webdriver = self.parent.webdriver
+        # Company prefix to apply to vendor-specific WebDriver extension commands.
+        self.fedcm_company_prefix = "goog"
+
+
+    def confirm_idp_signin(self):
+        return self.webdriver.send_session_command("POST",
+                                                   self.fedcm_company_prefix + "/fedcm/confirmidpsignin")
+
+
 class ChromeDriverProtocol(WebDriverProtocol):
     implements = [
+        ChromeDriverFedCMProtocolPart,
         ChromeDriverPrintProtocolPart,
         ChromeDriverTestharnessProtocolPart,
         *(part for part in WebDriverProtocol.implements

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -629,6 +629,11 @@ class FedCMProtocolPart(ProtocolPart):
         pass
 
     @abstractmethod
+    def confirm_idp_signin(self):
+        """Confirm IDP signin"""
+        pass
+
+    @abstractmethod
     def select_fedcm_account(self, account_index):
         """Select a FedCM account
 

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -629,8 +629,8 @@ class FedCMProtocolPart(ProtocolPart):
         pass
 
     @abstractmethod
-    def confirm_idp_signin(self):
-        """Confirm IDP signin"""
+    def confirm_idp_login(self):
+        """Confirm IDP login"""
         pass
 
     @abstractmethod

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -273,10 +273,10 @@
         return create_action("cancel_fedcm_dialog", {context});
     };
     
-    window.test_driver_internal.confirm_idp_signin = function(context = null) {
-        return create_action("confirm_idp_signin", {context});
+    window.test_driver_internal.confirm_idp_login = function(context = null) {
+        return create_action("confirm_idp_login", {context});
     };
-    
+
     window.test_driver_internal.select_fedcm_account = function(account_index, context = null) {
         return create_action("select_fedcm_account", {account_index, context});
     };

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -273,6 +273,10 @@
         return create_action("cancel_fedcm_dialog", {context});
     };
     
+    window.test_driver_internal.confirm_idp_signin = function(context = null) {
+        return create_action("confirm_idp_signin", {context});
+    };
+    
     window.test_driver_internal.select_fedcm_account = function(account_index, context = null) {
         return create_action("select_fedcm_account", {account_index, context});
     };


### PR DESCRIPTION
As described in https://github.com/fedidcg/FedCM/pull/436/files

This is vendor-prefixed in Chrome because the spec change is not merged yet.
However, we'd like to use it in wpt tests.