### PR TITLE
[manifest] Combine reference and variant query string parameters

### DIFF
--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -6,7 +6,7 @@ from fnmatch import fnmatch
 from io import BytesIO
 from typing import (Any, BinaryIO, Callable, Deque, Dict, Iterable, List, Optional, Pattern,
                     Set, Text, Tuple, Union, cast)
-from urllib.parse import urljoin
+from urllib.parse import parse_qsl, urlencode, urljoin, urlsplit, urlunsplit
 
 try:
     from xml.etree import cElementTree as ElementTree
@@ -1026,7 +1026,7 @@ class SourceFile:
                     self.url_base,
                     url,
                     references=[
-                        (ref[0] + variant, ref[1])
+                        (make_ref_variant_url(ref[0], variant), ref[1])
                         for ref in self.references
                     ],
                     timeout=self.timeout,
@@ -1076,3 +1076,13 @@ class SourceFile:
                 specs
             )])
         return rv
+
+
+def make_ref_variant_url(ref_url: str, variant: str) -> str:
+    """Combine a base reference URL with a `<meta name=variant ...>` value."""
+    scheme, netloc, path, query, fragment = urlsplit(ref_url)
+    variant_parts = urlsplit(variant)
+    params = parse_qsl(variant_parts.query, keep_blank_values=True)
+    params.extend(parse_qsl(query, keep_blank_values=True))
+    fragment = variant_parts.fragment or fragment
+    return urlunsplit((scheme, netloc, path, urlencode(params), fragment))

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 
 import os
+import textwrap
 
 import pytest
 
@@ -549,14 +550,43 @@ def test_reftest_variant():
     expected_tests = [
         {
             "url": "/html/test.html?first",
-            "refs": [("/html/ref.html?first", "==")],
+            "refs": [("/html/ref.html?first=", "==")],
         },
         {
             "url": "/html/test.html?second",
-            "refs": [("/html/ref.html?second", "==")],
+            "refs": [("/html/ref.html?second=", "==")],
         },
     ]
 
+    assert actual_tests == expected_tests
+
+
+def test_reftest_variant_combine_query():
+    content = textwrap.dedent(
+        """\
+        <meta name=variant content="?a&b=c">
+        <link rel="match" href="ref.html?d&e=f">
+        """).encode()
+    s = create("html/test.html", contents=content)
+    assert not s.name_is_non_test
+    assert not s.name_is_manual
+    assert not s.name_is_visual
+    assert not s.name_is_worker
+    assert not s.name_is_reference
+
+    item_type, items = s.manifest_items()
+    assert item_type == "reftest"
+
+    actual_tests = [
+        {"url": item.url, "refs": item.references}
+        for item in items
+    ]
+    expected_tests = [
+        {
+            "url": "/html/test.html?a&b=c",
+            "refs": [("/html/ref.html?a=&b=c&d=&e=f", "==")],
+        },
+    ]
     assert actual_tests == expected_tests
 
 


### PR DESCRIPTION
Both the reference URL and variant value may specify separate sets of parameters. It makes more sense to merge these parameters than to concatenate the raw values, which [can generate `?...?...`][1].

For context, #40352 originally implemented reftest variants.

[1]: https://crbug.com/1486901

CC @kojiishi 