### PR TITLE
Start dbus for Chrome

### DIFF
--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -155,6 +155,7 @@ def install_chrome(channel):
     with open(dest, "wb") as f:
         get_download_to_descriptor(f, deb_url)
 
+    run(["sudo", "service", "dbus", "start"])
     run(["sudo", "apt-get", "-qqy", "update"])
     run(["sudo", "gdebi", "-qn", "/tmp/%s" % deb_archive])
 

--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -140,6 +140,10 @@ def install_certificates():
     run(["sudo", "update-ca-certificates"])
 
 
+def start_dbus():
+    run(["sudo", "service", "dbus", "start"])
+
+
 def install_chrome(channel):
     if channel in ("experimental", "dev"):
         deb_archive = "google-chrome-unstable_current_amd64.deb"
@@ -155,7 +159,6 @@ def install_chrome(channel):
     with open(dest, "wb") as f:
         get_download_to_descriptor(f, deb_url)
 
-    run(["sudo", "service", "dbus", "start"])
     run(["sudo", "apt-get", "-qqy", "update"])
     run(["sudo", "gdebi", "-qn", "/tmp/%s" % deb_archive])
 
@@ -258,6 +261,7 @@ def setup_environment(args):
     if "chrome" in args.browser:
         assert args.channel is not None
         install_chrome(args.channel)
+        start_dbus()
 
     if args.xvfb:
         start_xvfb()

--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -142,6 +142,9 @@ def install_certificates():
 
 def start_dbus():
     run(["sudo", "service", "dbus", "start"])
+    # Enable dbus autolaunch for Chrome
+    # https://source.chromium.org/chromium/chromium/src/+/main:content/app/content_main.cc;l=220;drc=0bcc023b8cdbc073aa5c48db373810db3f765c87.
+    os.environ["DBUS_SESSION_BUS_ADDRESS"] = "autolaunch:"
 
 
 def install_chrome(channel):
@@ -261,6 +264,7 @@ def setup_environment(args):
     if "chrome" in args.browser:
         assert args.channel is not None
         install_chrome(args.channel)
+        # Chrome is using dbus for various features.
         start_dbus()
 
     if args.xvfb:

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get -qqy update \
     bzip2 \
     ca-certificates \
     curl \
-    dbug \
+    dbus \
     dbus-x11 \
     earlyoom \
     fluxbox \

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get -qqy update \
     bzip2 \
     ca-certificates \
     curl \
-    dbus \
     dbus-x11 \
     earlyoom \
     fluxbox \

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get -qqy update \
     bzip2 \
     ca-certificates \
     curl \
+    dbug \
     dbus-x11 \
     earlyoom \
     fluxbox \


### PR DESCRIPTION
This PR adds a command to start dbus. As discovered in #42220 Chrome prints many errors that it is not able to access dbus and one of the reasons might be that the dbus service is not started in CI.