### PR TITLE
Use --disable-gpu instead of --enable-swiftshader for Chrome

### DIFF
--- a/tools/ci/ci_wptrunner_infrastructure.sh
+++ b/tools/ci/ci_wptrunner_infrastructure.sh
@@ -14,8 +14,8 @@ main() {
     ./wpt manifest --rebuild -p ~/meta/MANIFEST.json
     for PRODUCT in "${PRODUCTS[@]}"; do
         if [[ "$PRODUCT" == "chrome" ]]; then
-            # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
-            test_infrastructure "--binary=$(which google-chrome-unstable) --enable-swiftshader --channel dev" "$1"
+            # Taskcluster machines do not have GPUs, so use software rendering via --disable-gpu.
+            test_infrastructure "--binary=$(which google-chrome-unstable) --disable-gpu --channel dev" "$1"
         else
             test_infrastructure "--binary=~/build/firefox/firefox" "$1"
         fi

--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -20,8 +20,8 @@ def get_browser_args(product, channel):
     if product == "servo":
         return ["--install-browser", "--processes=12"]
     if product == "chrome" or product == "chromium":
-        # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
-        args = ["--enable-swiftshader"]
+        # Taskcluster machines do not have GPUs, so use software rendering via --disable-gpu.
+        args = ["--disable-gpu"]
         if channel == "nightly":
             args.extend(["--install-browser", "--install-webdriver"])
         return args


### PR DESCRIPTION
It looks like the --enable-swiftshader flag does not exist anymore. Not sure at what point it got removed but it is likely that --disable-gpu would give the desired results.

Might be related to #42220.

Also see https://peter.sh/experiments/chromium-command-line-switches/