### PR TITLE
Update webcodecs decoder test as error callback is now executed before flush promise callbacks

### DIFF
--- a/webcodecs/videoDecoder-codec-specific.https.any.js
+++ b/webcodecs/videoDecoder-codec-specific.https.any.js
@@ -418,7 +418,7 @@ promise_test(async t => {
 
   await promise_rejects_dom(t, "EncodingError",
     decoder.flush().catch((e) => {
-      assert_equals(errors, 0);
+      assert_equals(errors, 1);
       throw e;
     })
   );
@@ -453,7 +453,7 @@ promise_test(async t => {
 
   await promise_rejects_dom(t, "EncodingError",
     decoder.flush().catch((e) => {
-      assert_equals(errors, 0);
+      assert_equals(errors, 1);
       throw e;
     })
   );


### PR DESCRIPTION
This align the test with spec change at https://github.com/w3c/webcodecs/commit/3856bbf7091a292b18ac32e703f18ae666a6e17c