### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=262030

### DIFF
--- a/html/semantics/document-metadata/the-link-element/resources/302-no-Location-header-text-css.asis
+++ b/html/semantics/document-metadata/the-link-element/resources/302-no-Location-header-text-css.asis
@@ -1,0 +1,4 @@
+HTTP/1.1 302 Found
+Content-Type: text/css
+
+body { background-color: red; }

--- a/html/semantics/document-metadata/the-link-element/stylesheet-non-OK-status.html
+++ b/html/semantics/document-metadata/the-link-element/stylesheet-non-OK-status.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>stylesheet served with non-OK status</title>
+<link rel="author" title="Michael[tm] Smith" href="mailto:mike@w3.org">
+<link rel="help" href="https://html.spec.whatwg.org/#fetching-and-processing-a-resource-from-a-link-element:processresponseconsumebody">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  async_test((t) => {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = "resources/302-no-Location-header-text-css.asis";
+    link.onload = t.unreached_func();
+    link.onerror = t.step_func_done();
+    document.head.append(link);
+  }, "'load' event does not fire at link@rel=stylesheet having resource with non-OK response status");
+</script>


### PR DESCRIPTION
WebKit export from bug: [Link-stylesheet elements fire load events for non-2XX responses (e.g., 3XX responses that do not redirect)](https://bugs.webkit.org/show_bug.cgi?id=262030)