### PR TITLE
WebCryptoAPI: check EdDSA and HMAC for expected signatures coming from sign()

### DIFF
--- a/WebCryptoAPI/sign_verify/eddsa.js
+++ b/WebCryptoAPI/sign_verify/eddsa.js
@@ -167,6 +167,7 @@ function run_test() {
           promise_test(function(test) {
               return subtle.sign(algorithm, vector.privateKey, vector.data)
               .then(function(signature) {
+                  assert_true(equalBuffers(signature, vector.signature), "Signing did not give the expected output");
                   // Can we verify the signature?
                   return subtle.verify(algorithm, vector.publicKey, signature, vector.data)
                   .then(function(is_verified) {

--- a/WebCryptoAPI/sign_verify/hmac.js
+++ b/WebCryptoAPI/sign_verify/hmac.js
@@ -117,6 +117,7 @@ function run_test() {
             promise_test(function(test) {
                 return subtle.sign({name: "HMAC", hash: vector.hash}, vector.key, vector.plaintext)
                 .then(function(signature) {
+                    assert_true(equalBuffers(signature, vector.signature), "Signing did not give the expected output");
                     // Can we get the verify the new signature?
                     return subtle.verify({name: "HMAC", hash: vector.hash}, vector.key, signature, vector.plaintext)
                     .then(function(is_verified) {


### PR DESCRIPTION
Adds equal buffer check for deterministic algorithms (HMAC and EdDSA). `RSASSA-PKCS1-v1_5` already has this exact check.