### PR TITLE
Move subprocess calls into a function

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -680,7 +680,7 @@ def check_all_paths(repo_root: Text, paths: List[Text]) -> List[rules.Error]:
     """
 
     errors = []
-    for paths_fn in all_paths_lints:
+    for paths_fn in all_paths_lints():
         errors.extend(paths_fn(repo_root, paths))
     return errors
 
@@ -975,17 +975,21 @@ def lint(repo_root: Text,
 
 path_lints = [check_file_type, check_path_length, check_worker_collision, check_ahem_copy,
               check_mojom_js, check_tentative_directories, check_gitignore_file]
-all_paths_lints = [check_unique_testharness_basenames,
-                   check_unique_case_insensitive_paths]
 file_lints = [check_regexp_line, check_parsed, check_python_ast, check_script_metadata,
               check_ahem_system_font]
 
-# Don't break users of the lint that don't have git installed.
-try:
-    subprocess.check_output(["git", "--version"])
-    all_paths_lints += [check_git_ignore]
-except (subprocess.CalledProcessError, FileNotFoundError):
-    print('No git present; skipping .gitignore lint.')
+
+def all_paths_lints() -> List[Callable[Any]]:
+    paths = [check_unique_testharness_basenames,
+             check_unique_case_insensitive_paths]
+    # Don't break users of the lint that don't have git installed.
+    try:
+        subprocess.check_output(["git", "--version"])
+        paths += [check_git_ignore]
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print('No git present; skipping .gitignore lint.')
+    return paths
+
 
 if __name__ == "__main__":
     args = create_parser().parse_args()

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -979,7 +979,7 @@ file_lints = [check_regexp_line, check_parsed, check_python_ast, check_script_me
               check_ahem_system_font]
 
 
-def all_paths_lints() -> List[Callable[[Any, Any], List[Tuple[str, str, str, Optional[int]]]]]:
+def all_paths_lints() -> Any:
     paths = [check_unique_testharness_basenames,
              check_unique_case_insensitive_paths]
     # Don't break users of the lint that don't have git installed.

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -979,7 +979,7 @@ file_lints = [check_regexp_line, check_parsed, check_python_ast, check_script_me
               check_ahem_system_font]
 
 
-def all_paths_lints() -> List[Callable[Any]]:
+def all_paths_lints() -> List[Callable[[Any, Any], List[Tuple[str, str, str, Optional[int]]]]]:
     paths = [check_unique_testharness_basenames,
              check_unique_case_insensitive_paths]
     # Don't break users of the lint that don't have git installed.


### PR DESCRIPTION
So that "git --version" won't be called everytime the file is imported. This both wastes CPU cycles and produces annoying logs when git is not installed on the host.

Bug: Chromium: 1489007