### PR TITLE
WebCryptoAPI: check secure curves JWK alg being ignored and not exported

### DIFF
--- a/WebCryptoAPI/import_export/okp_importKey.https.any.js
+++ b/WebCryptoAPI/import_export/okp_importKey.https.any.js
@@ -81,6 +81,11 @@
                     }
 
                     testFormat(format, algorithm, data, vector.name, usages, extractable);
+
+                    // Test for https://github.com/WICG/webcrypto-secure-curves/pull/24
+                    if (format === "jwk" && extractable) {
+                        testJwkAlgBehaviours(algorithm, data.jwk, vector.name, usages);
+                    }
                 });
 
             });
@@ -92,6 +97,11 @@
                     var data = keyData[vector.name];
 
                     testFormat(format, algorithm, data, vector.name, usages, extractable);
+
+                    // Test for https://github.com/WICG/webcrypto-secure-curves/pull/24
+                    if (format === "jwk" && extractable) {
+                        testJwkAlgBehaviours(algorithm, data.jwk, vector.name, usages);
+                    }
                 });
             });
         });
@@ -124,6 +134,28 @@
                 assert_unreached("Threw an unexpected error: " + err.toString());
             });
         }, "Good parameters: " + keySize.toString() + " bits " + parameterString(format, keyData[format], algorithm, extractable, usages));
+    }
+
+    // Test importKey/exportKey "alg" behaviours, alg is ignored upon import and alg is missing for Ed25519 and Ed448 JWK export
+    // https://github.com/WICG/webcrypto-secure-curves/pull/24
+    function testJwkAlgBehaviours(algorithm, keyData, crv, usages) {
+        promise_test(function(test) {
+            return subtle.importKey('jwk', { ...keyData, alg: 'this is ignored' }, algorithm, true, usages).
+            then(function(key) {
+                assert_equals(key.constructor, CryptoKey, "Imported a CryptoKey object");
+
+                return subtle.exportKey('jwk', key).
+                then(function(result) {
+                    assert_equals(Object.keys(result).length, keyData.d ? 6 : 5, "Correct number of JWK members");
+                    assert_equals(result.alg, undefined, 'No JWK "alg" member is present');
+                    assert_true(equalJwk(keyData, result), "Round trip works");
+                }, function(err) {
+                    assert_unreached("Threw an unexpected error: " + err.toString());
+                });
+            }, function(err) {
+                assert_unreached("Threw an unexpected error: " + err.toString());
+            });
+        }, "Good parameters with ignored JWK alg: " + crv.toString() + " " + parameterString('jwk', keyData, algorithm, true, usages));
     }
 
 


### PR DESCRIPTION
As per https://github.com/WICG/webcrypto-secure-curves/pull/24