### PR TITLE
[wptrunner] Make `TestSource.group()` safe for empty test queues

### DIFF
--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -546,9 +546,9 @@ class TestSource:
     def group(self):
         if not self.current_group.group or len(self.current_group.group) == 0:
             try:
-                self.current_group = self.test_queue.get(block=True, timeout=5)
+                self.current_group = self.test_queue.get_nowait()
             except Empty:
-                self.logger.warning("Timed out getting test group from queue")
+                self.logger.warning("No test group in the queue")
                 return TestGroup(None, None, None, None)
         return self.current_group
 

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -526,7 +526,6 @@ class TestSource:
             ))
         for item in groups:
             test_queue.put(item)
-        cls.add_sentinal(test_queue, processes)
         return test_queue, processes
 
     @classmethod
@@ -548,15 +547,8 @@ class TestSource:
             try:
                 self.current_group = self.test_queue.get_nowait()
             except Empty:
-                self.logger.warning("No test group in the queue")
                 return TestGroup(None, None, None, None)
         return self.current_group
-
-    @classmethod
-    def add_sentinal(cls, test_queue, num_of_workers):
-        # add one sentinal for each worker
-        for _ in range(num_of_workers):
-            test_queue.put(TestGroup(None, None, None, None))
 
     @classmethod
     def process_count(cls, requested_processes, num_test_groups):


### PR DESCRIPTION
In #42119, calling `TestRunnerManager.get_next_test()` during cleanup is problematic because the test queue may be empty at that point (all test and sentinel groups were consumed); reading from the queue will [needlessly block][0].

Because the queue has no producers after it's initialized, waiting with a timed `get()` serves no purpose; use `get_nowait()` instead.

[0]: https://github.com/web-platform-tests/wpt/blob/5abf5b83/tools/wptrunner/wptrunner/testloader.py#L549

See Also: https://crbug.com/1489211