### PR TITLE
[wdspec] Extend timeout for bidi/script/call_function/invalid.py

### DIFF
--- a/webdriver/tests/bidi/script/call_function/invalid.py
+++ b/webdriver/tests/bidi/script/call_function/invalid.py
@@ -1,3 +1,5 @@
+# META: timeout=long
+
 import pytest
 import webdriver.bidi.error as error
 


### PR DESCRIPTION
Works around the Chrome slowness reported in https://github.com/web-platform-tests/wpt/issues/42220