### PR TITLE
Add test for lang attribute and shadow trees.

### DIFF
--- a/html/dom/elements/global-attributes/lang-attribute-shadow.window.js
+++ b/html/dom/elements/global-attributes/lang-attribute-shadow.window.js
@@ -1,0 +1,81 @@
+const TESTS = [
+  {
+    title: "lang only on slot",
+    light_tree: `
+      <div id="host" data-expected="en-US"><span data-expected="en-US"></span></div>
+    `,
+    shadow_tree: `
+      <slot lang="en-AU" data-expected="en-AU"></slot>
+    `,
+  },
+  {
+    title: "lang only on host",
+    light_tree: `
+      <div id="host" lang="en-AU" data-expected="en-AU"><span data-expected="en-AU"></span></div>
+    `,
+    shadow_tree: `
+      <slot data-expected="en-AU"></slot>
+    `,
+  },
+  {
+    title: "lang on host and slot",
+    light_tree: `
+      <div id="host" lang="en-AU" data-expected="en-AU"><span data-expected="en-AU"></span></div>
+    `,
+    shadow_tree: `
+      <slot lang="en-GB" data-expected="en-GB"></slot>
+    `,
+  },
+  {
+    title: "lang on host and slotted element",
+    light_tree: `
+      <div id="host" lang="en-AU" data-expected="en-AU"><span lang="en-GB" data-expected="en-GB"></span></div>
+    `,
+    shadow_tree: `
+      <slot data-expected="en-AU"></slot>
+    `,
+  },
+  {
+    title: "lang on host and slot and slotted element",
+    light_tree: `
+      <div id="host" lang="en-AU" data-expected="en-AU"><span lang="en-GB" data-expected="en-GB"></span></div>
+    `,
+    shadow_tree: `
+      <slot lang="en-NZ" data-expected="en-NZ"></slot>
+    `,
+  },
+  {
+    title: "lang on slot inherits from shadow host",
+    light_tree: `
+      <div id="host" lang="en-GB" data-expected="en-GB"><span lang="en-US" data-expected="en-US"></span></div>
+    `,
+    shadow_tree: `
+      <div lang="en-CA" data-expected="en-CA">
+        <slot data-expected="en-GB"></slot>
+      </div>
+    `,
+  },
+];
+
+let container = document.createElement("div");
+document.body.append(container);
+container.lang = "en-US";
+
+for (let obj of TESTS) {
+  test(() => {
+    container.innerHTML = obj.light_tree;
+    let shadow = container.querySelector("#host").attachShadow({mode: "open"});
+    shadow.innerHTML = obj.shadow_tree;
+    for (let element of Array.from(container.querySelectorAll("[data-expected]")).concat(Array.from(shadow.querySelectorAll("[data-expected]")))) {
+      let expected = element.getAttribute("data-expected");
+      assert_true(element.matches(`:lang(${expected})`), `element matches expected language ${expected}`);
+      for (let other_lang of ["en-US", "en-AU", "en-GB", "en-NZ", "en-CA"]) {
+        if (expected != other_lang) {
+          assert_false(element.matches(`:lang(${other_lang})`), `element does not match language ${other_lang}`);
+        }
+      }
+    }
+  }, obj.title);
+}
+
+container.remove();

--- a/html/dom/elements/global-attributes/lang-attribute-shadow.window.js
+++ b/html/dom/elements/global-attributes/lang-attribute-shadow.window.js
@@ -57,19 +57,19 @@ const TESTS = [
   },
 ];
 
-let container = document.createElement("div");
+const container = document.createElement("div");
 document.body.append(container);
 container.lang = "en-US";
 
-for (let obj of TESTS) {
+for (const obj of TESTS) {
   test(() => {
     container.innerHTML = obj.light_tree;
     let shadow = container.querySelector("#host").attachShadow({mode: "open"});
     shadow.innerHTML = obj.shadow_tree;
-    for (let element of Array.from(container.querySelectorAll("[data-expected]")).concat(Array.from(shadow.querySelectorAll("[data-expected]")))) {
-      let expected = element.getAttribute("data-expected");
+    for (const element of Array.from(container.querySelectorAll("[data-expected]")).concat(Array.from(shadow.querySelectorAll("[data-expected]")))) {
+      const expected = element.getAttribute("data-expected");
       assert_true(element.matches(`:lang(${expected})`), `element matches expected language ${expected}`);
-      for (let other_lang of ["en-US", "en-AU", "en-GB", "en-NZ", "en-CA"]) {
+      for (const other_lang of ["en-US", "en-AU", "en-GB", "en-NZ", "en-CA"]) {
         if (expected != other_lang) {
           assert_false(element.matches(`:lang(${other_lang})`), `element does not match language ${other_lang}`);
         }


### PR DESCRIPTION
This tests the lang attribute changes in whatwg/html#9796.  It replaces the lang attribute tests from #29820.