### PR TITLE
[wptrunner] Only load relevant tests

### DIFF
--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -113,14 +113,19 @@ class Manifest:
         self.url_base: Text = url_base
 
     def __iter__(self) -> Iterator[Tuple[Text, Text, Set[ManifestItem]]]:
-        return self.itertypes()
-
-    def itertypes(self, *types: Text) -> Iterator[Tuple[Text, Text, Set[ManifestItem]]]:
-        for item_type in (types or sorted(self._data.keys())):
+        for item_type in sorted(self._data):
             for path in self._data[item_type]:
                 rel_path = os.sep.join(path)
                 tests = self._data[item_type][path]
                 yield item_type, rel_path, tests
+
+    def itertypes(self, *types: Text) -> "Manifest":
+        filtered_manifest = Manifest(self.tests_root, self.url_base)
+        filtered_manifest._data.initialized = False
+        for item_type in (types or self._data):
+            filtered_manifest._data[item_type] = self._data[item_type]
+        filtered_manifest._data.initialized = True
+        return filtered_manifest
 
     def iterpath(self, path: Text) -> Iterable[ManifestItem]:
         tpath = tuple(path.split(os.path.sep))

--- a/tools/wptrunner/wptrunner/tests/test_testloader.py
+++ b/tools/wptrunner/wptrunner/tests/test_testloader.py
@@ -219,8 +219,7 @@ def test_filter_resolve_glob(manifest1):
 
 
 def test_filter_resolve_prefix_to_variants(manifest0):
-    test_filter = TestFilter({manifest0: Root("/fake-wpt", "/fake-wpt")},
-                             include=["/a/foo.html"])
+    test_filter = TestFilter({manifest0: {}}, include=["/a/foo.html"])
     items = list(test_filter(manifest0))
     assert len(items) == 1
     test_type, test_path, tests = items[0]
@@ -231,9 +230,7 @@ def test_filter_resolve_prefix_to_variants(manifest0):
 
 def test_filter_resolve_with_non_root_url_base(manifest0, manifest1):
     manifest1.url_base = '/_fake_root/'
-    manifests = {manifest0: Root("/fake-wpt", "/fake-wpt"),
-                 manifest1: Root("/_fake_root", "/_fake_root")}
-    test_filter = TestFilter(manifests,
+    test_filter = TestFilter({manifest0: {}, manifest1: {}},
                              include=["a/foo.html?b", "/_fake_root/a/b/"])
     items = list(test_filter(manifest0))
     assert len(items) == 1

--- a/tools/wptrunner/wptrunner/tests/test_testloader.py
+++ b/tools/wptrunner/wptrunner/tests/test_testloader.py
@@ -163,7 +163,7 @@ def test_filter_unicode():
         f.write(include_ini.encode('utf-8'))
         f.flush()
 
-        TestFilter(manifest_path=f.name, test_manifests=tests)
+        TestFilter(manifest_path=f.name, test_manifests={tests: {}})
 
 
 def test_filter_resolve_dir(manifest1):

--- a/tools/wptrunner/wptrunner/tests/test_testloader.py
+++ b/tools/wptrunner/wptrunner/tests/test_testloader.py
@@ -7,6 +7,7 @@ import tempfile
 import pytest
 
 from mozlog import structured
+from .. import testloader
 from ..testloader import (
     DirectoryHashChunker,
     IDHashChunker,
@@ -21,10 +22,11 @@ from .test_wpttest import make_mock_manifest
 
 here = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(here, os.pardir, os.pardir, os.pardir))
+from manifest import manifest
 from manifest.manifest import Manifest as WPTManifest
 
 structured.set_default_logger(structured.structuredlog.StructuredLogger("TestLoader"))
-
+testloader.manifest = manifest
 TestFilter.__test__ = False
 TestLoader.__test__ = False
 
@@ -36,7 +38,7 @@ skip: true
 
 
 @pytest.fixture
-def manifest():
+def manifest0():
     manifest_json = {
         "items": {
             "testharness": {
@@ -50,14 +52,43 @@ def manifest():
                         "uvwxyz987654",
                         [None, {}],
                     ],
-                }
-            }
+                },
+            },
         },
         "url_base": "/",
         "version": 8,
     }
     return WPTManifest.from_json("/", manifest_json)
 
+
+@pytest.fixture
+def manifest1():
+    manifest_json = {
+        "items": {
+            "testharness": {
+                "a": {
+                    "foo.https.any.js": [
+                        "abcdef123456",
+                        ["a/foo.https.any.html", {}],
+                        ["a/foo.https.any.worker.html", {}],
+                    ],
+                    "b": {
+                        "bar.html": [
+                            "uvwxyz987654",
+                            [None, {}],
+                        ],
+                        "c.html": [
+                            "123456abcdef",
+                            [None, {}],
+                        ],
+                    },
+                },
+            },
+        },
+        "url_base": "/",
+        "version": 8,
+    }
+    return WPTManifest.from_json("/", manifest_json)
 
 
 def test_loader_h2_tests():
@@ -133,6 +164,90 @@ def test_filter_unicode():
         f.flush()
 
         TestFilter(manifest_path=f.name, test_manifests=tests)
+
+
+def test_filter_resolve_dir(manifest1):
+    with tempfile.TemporaryDirectory() as tmp:
+        include = os.path.normpath(os.path.join(tmp, "a", "b"))
+        os.makedirs(include)
+        test_filter = TestFilter({manifest1: {"tests_path": tmp}}, include=[include])
+        items = sorted(test_filter(manifest1), key=lambda item: item[1])
+    assert len(items) == 2
+    test_type, test_path, tests = items[0]
+    assert test_type == "testharness"
+    assert test_path == os.path.join("a", "b", "bar.html")
+    assert {test.id for test in tests} == {"/a/b/bar.html"}
+    test_type, test_path, tests = items[1]
+    assert test_type == "testharness"
+    assert test_path == os.path.join("a", "b", "c.html")
+    assert {test.id for test in tests} == {"/a/b/c.html"}
+
+
+def test_filter_resolve_multiglobal_file(manifest1):
+    with tempfile.TemporaryDirectory() as tmp:
+        include = os.path.normpath(os.path.join(tmp, "a", "foo.https.any.js"))
+        os.makedirs(os.path.dirname(include))
+        with open(include, "w") as _:
+            pass
+        test_filter = TestFilter({manifest1: {"tests_path": tmp}}, include=[include])
+        items = list(test_filter(manifest1))
+    assert len(items) == 1
+    test_type, test_path, tests = items[0]
+    assert test_type == "testharness"
+    assert test_path == os.path.join("a", "foo.https.any.js")
+    assert {test.id for test in tests} == {
+        "/a/foo.https.any.html",
+        "/a/foo.https.any.worker.html",
+    }
+
+
+def test_filter_resolve_glob(manifest1):
+    with tempfile.TemporaryDirectory() as tmp:
+        include = os.path.normpath(os.path.join(tmp, "a", "b"))
+        os.makedirs(include)
+        for filename in ["bar.html", "c.html"]:
+            with open(os.path.join(include, filename), "w") as _:
+                pass
+        test_filter = TestFilter({manifest1: {"tests_path": tmp}},
+                                 include=[os.path.join(include, "b*.html")])
+        items = list(test_filter(manifest1))
+    assert len(items) == 1
+    test_type, test_path, tests = items[0]
+    assert test_type == "testharness"
+    assert test_path == os.path.join("a", "b", "bar.html")
+    assert {test.id for test in tests} == {"/a/b/bar.html"}
+
+
+def test_filter_match_none(manifest1):
+    with tempfile.TemporaryDirectory() as tmp:
+        test_filter = TestFilter({manifest1: {"tests_path": tmp}},
+                                 include=[os.path.join(tmp, "a")])
+        items = list(test_filter(manifest1))
+    assert items == []
+
+
+def test_filter_match_nearest(manifest1):
+    test_filter = TestFilter({manifest1: {}}, include=["/a/b"],
+                             exclude=["/a/b/c.html"])
+    items = list(test_filter(manifest1))
+    assert len(items) == 1
+    test_type, test_path, tests = items[0]
+    assert test_type == "testharness"
+    assert test_path == os.path.join("a", "b", "bar.html")
+    assert {test.id for test in tests} == {"/a/b/bar.html"}
+
+
+def test_filter_include_by_default(manifest1):
+    test_filter = TestFilter({manifest1: {}}, exclude=["/a/b/"])
+    items = list(test_filter(manifest1))
+    assert len(items) == 1
+    test_type, test_path, tests = items[0]
+    assert test_type == "testharness"
+    assert test_path == os.path.join("a", "foo.https.any.js")
+    assert {test.id for test in tests} == {
+        "/a/foo.https.any.html",
+        "/a/foo.https.any.worker.html",
+    }
 
 
 def test_tag_filter():
@@ -287,12 +402,12 @@ def test_loader_filter_tags():
         assert len(loader.tests[""]["testharness"]) == 0
 
 
-def test_chunk_hash(manifest):
+def test_chunk_hash(manifest0):
     chunker1 = PathHashChunker(total_chunks=2, chunk_number=1)
     chunker2 = PathHashChunker(total_chunks=2, chunk_number=2)
     # Check that the chunkers partition the manifest (i.e., each item is
     # assigned to exactly one chunk).
-    items = sorted([*chunker1(manifest), *chunker2(manifest)],
+    items = sorted([*chunker1(manifest0), *chunker2(manifest0)],
                    key=lambda item: item[1])
     assert len(items) == 2
     test_type, test_path, tests = items[0]
@@ -305,11 +420,11 @@ def test_chunk_hash(manifest):
     assert {test.id for test in tests} == {"/a/foo.html?b", "/a/foo.html?c"}
 
 
-def test_chunk_id_hash(manifest):
+def test_chunk_id_hash(manifest0):
     chunker1 = IDHashChunker(total_chunks=2, chunk_number=1)
     chunker2 = IDHashChunker(total_chunks=2, chunk_number=2)
     items = []
-    for test_type, test_path, tests in [*chunker1(manifest), *chunker2(manifest)]:
+    for test_type, test_path, tests in [*chunker1(manifest0), *chunker2(manifest0)]:
         assert len(tests) > 0
         items.extend((test_type, test_path, test) for test in tests)
     assert len(items) == 3
@@ -328,14 +443,14 @@ def test_chunk_id_hash(manifest):
     assert test.id == "/a/foo.html?c"
 
 
-def test_chunk_dir_hash(manifest):
+def test_chunk_dir_hash(manifest0):
     chunker1 = DirectoryHashChunker(total_chunks=2, chunk_number=1)
     chunker2 = DirectoryHashChunker(total_chunks=2, chunk_number=2)
     # Check that tests in the same directory are located in the same chunk
     # (which particular chunk is irrelevant).
     empty_chunk, chunk_a = sorted([
-        list(chunker1(manifest)),
-        list(chunker2(manifest)),
+        list(chunker1(manifest0)),
+        list(chunker2(manifest0)),
     ], key=len)
     assert len(empty_chunk) == 0
     assert len(chunk_a) == 2

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -77,7 +77,8 @@ def get_loader(test_paths: wptcommandline.TestPaths,
 
     test_manifests = testloader.ManifestLoader(test_paths,
                                                force_manifest_update=kwargs["manifest_update"],
-                                               manifest_download=kwargs["manifest_download"]).load()
+                                               manifest_download=kwargs["manifest_download"],
+                                               types=kwargs["test_types"]).load()
 
     manifest_filters = []
     test_filters = []


### PR DESCRIPTION
Currently, wptrunner selects tests by loading all tests for enabled types via `Manifest.itertypes(...)`, then applying path exclusion/chunking. This is wasteful when only a few tests will run, and is especially slow when running many small subsuites, as each subsuite will reiterate `itertypes(...)`.

This change fixes this by:
1. Resolving a full set of URLs to include in `TestFilter`, instead of adding `--{include,exclude}` to the `IncludeManifest` tree. It's possible to do this because `--{include,exclude}` always supercede any contents of `--include-manifest`.
2. Changing `itertypes(...)` to return another `Manifest`, which is also `Iterable[Tuple[Text, Text, Set[ManifestItem]]]` (i.e., backwards-compatible when used in regular loops/containers).
3. Using `Manifest`'s identity-based hash to cache a map of URL &rightarrow; item (i.e., the manifest is only iterated once).
4. Look up items by include URL directly in `TestFilter.__call__(...)`.

Additional notes:
* The main cost is additional memory that scales with the size of the test suite (e.g., `TestFilter.include_urls` can hold every test ID).
* In Chromium CI on Linux, where many subsuites are run, this reduces the pre-run overhead [from ~50s][1] [to ~10s][2]. This should also improve the local run UX (on my machine, eliminates ~2s when running a single test).
* The existing inclusion/exclusion behavior is captured by new tests to show that the optimization has no functional change.

See also: https://crbug.com/1489723

[1]: https://chromium-swarm.appspot.com/task?id=656255bd09688410
[2]: https://chromium-swarm.appspot.com/task?id=655df0372c36f710