### PR TITLE
Add a workflow to publish the container image to ghcr.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,48 @@
+name: Publish Docker image
+
+permissions: read-all
+
+on:
+  # For initial testing and we can remove it later.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag for the container image'
+        required: true
+        type: string
+
+jobs:
+  docker-publish:
+    name: Publish Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      # Based on https://docs.github.com/en/actions/publishing-packages/publishing-docker-images.
+      - name: Log in to the Container registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4.6.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            latest
+            type=raw,value=${{ inputs.tag }}
+      - name: Build and push the Docker image
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: ./tools/docker
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR adds a job that would allow GitHub users with [the write access](https://docs.github.com/en/packages/learn-github-packages/publishing-a-package) to publish the Docker image to the GitHub registry. The current version requires manually defining the GitHub image tag but it could be further automated in the future. 

The goal of this PR is to test publishing before testing if taskcluster can use the published image. 

More details about publishing packages https://docs.github.com/en/packages/learn-github-packages/publishing-a-package

Issue #28903