### PR TITLE
Add tests for Invokers proposal

### DIFF
--- a/html/semantics/invokers/invokeevent-dispatch-shadow.tentative.html
+++ b/html/semantics/invokers/invokeevent-dispatch-shadow.tentative.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Keith Cirkel" href="mailto:keithamus@github.com" />
+<link rel="help" href="https://github.com/keithamus/invoker-buttons-proposal" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="div"></div>
+<button id="button"></button>
+
+<script>
+  test(function () {
+    var button = document.getElementById("button");
+    var div = document.getElementById("div");
+    var event = new InvokeEvent("invoke", {
+      bubbles: true,
+      relatedTarget: button,
+    });
+    div.dispatchEvent(event);
+
+    assert_equals(event.target, div);
+    assert_equals(event.relatedTarget, button);
+  }, "InvokeEvent relatedTarget reflects light-dom nodes");
+
+  test(function () {
+    var host = document.createElement("div");
+    var child = host.appendChild(document.createElement("p"));
+    var shadow = host.attachShadow({ mode: "closed" });
+    var slot = shadow.appendChild(document.createElement("slot"));
+    var childCalled = false;
+    var hostCalled = false;
+    slot.addEventListener(
+      "invoke",
+      () => {
+        childCalled = true;
+        assert_equals(
+          event.target,
+          slot,
+          "target is child inside shadow boundary",
+        );
+        assert_equals(
+          event.relatedTarget,
+          slot,
+          "relatedTarget is child inside shadow boundary",
+        );
+      },
+      { once: true },
+    );
+    host.addEventListener(
+      "invoke",
+      () => {
+        hostCalled = true;
+      },
+      { once: true },
+    );
+    const event = new InvokeEvent("invoke", {
+      bubbles: true,
+      relatedTarget: slot,
+      composed: true,
+    });
+    slot.dispatchEvent(event);
+    assert_true(childCalled, "event dispatch fired inside shadow-tree");
+    assert_false(hostCalled, "event dispatch not fired outside shadow-tree");
+  }, "InvokeEvent does not bubble across shadow boundaries because relatedTarget is set");
+
+  test(function () {
+    var host = document.createElement("div");
+    var shadow = host.attachShadow({ mode: "closed" });
+    var button = shadow.appendChild(document.createElement("button"));
+    var invokee = host.appendChild(document.createElement("div"));
+    button.invokeTargetElement = invokee;
+    var called = false;
+    invokee.addEventListener(
+      "invoke",
+      () => {
+        called = true;
+        assert_equals(event.target, invokee, "target is invokee");
+        assert_equals(event.relatedTarget, host, "relatedTarget is host");
+      },
+      { once: true },
+    );
+    button.click();
+    assert_true(called, "event dispatch fired inside shadow-tree");
+  }, "cross shadow InvokeEvent retargets relatedTarget to host element");
+</script>

--- a/html/semantics/invokers/invokeevent-interface.tentative.html
+++ b/html/semantics/invokers/invokeevent-interface.tentative.html
@@ -1,0 +1,214 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Keith Cirkel" href="mailto:keithamus@github.com" />
+<link rel="help" href="https://github.com/keithamus/invoker-buttons-proposal" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+  test(function () {
+    var event = new InvokeEvent("");
+    assert_true(event instanceof window.InvokeEvent);
+  }, "the event is an instance of InvokeEvent");
+
+  test(function () {
+    var event = new InvokeEvent("");
+    assert_true(event instanceof window.Event);
+  }, "the event inherits from Event");
+
+  test(function () {
+    assert_throws_js(
+      TypeError,
+      function () {
+        new InvokeEvent();
+      },
+      "First argument (type) is required, so was expecting a TypeError.",
+    );
+  }, "Missing type argument");
+
+  test(function () {
+    var event = new InvokeEvent("test");
+    assert_equals(event.type, "test");
+  }, "type argument is string");
+
+  test(function () {
+    var event = new InvokeEvent(null);
+    assert_equals(event.type, "null");
+  }, "type argument is null");
+
+  test(function () {
+    var event = new InvokeEvent(undefined);
+    assert_equals(event.type, "undefined");
+  }, "event type set to undefined");
+
+  test(function () {
+    var event = new InvokeEvent("test");
+    assert_equals(event.action, "auto");
+  }, "action has default value of 'auto'");
+
+  test(function () {
+    var event = new InvokeEvent("test");
+    assert_readonly(event, "action", "readonly attribute value");
+  }, "action is readonly");
+
+  test(function () {
+    var event = new InvokeEvent("test");
+    assert_equals(event.relatedTarget, null);
+  }, "relatedTarget has default value of null");
+
+  test(function () {
+    var event = new InvokeEvent("test");
+    assert_readonly(event, "relatedTarget", "readonly attribute value");
+  }, "relatedTarget is readonly");
+
+  test(function () {
+    var event = new InvokeEvent("test", null);
+    assert_equals(event.action, "auto");
+    assert_equals(event.relatedTarget, null);
+  }, "InvokeEventInit argument is null");
+
+  test(function () {
+    var event = new InvokeEvent("test", undefined);
+    assert_equals(event.action, "auto");
+    assert_equals(event.relatedTarget, null);
+  }, "InvokeEventInit argument is undefined");
+
+  test(function () {
+    var event = new InvokeEvent("test", {});
+    assert_equals(event.action, "auto");
+    assert_equals(event.relatedTarget, null);
+  }, "InvokeEventInit argument is empty dictionary");
+
+  test(function () {
+    var event = new InvokeEvent("test", { action: "sample" });
+    assert_equals(event.action, "sample");
+  }, "action set to 'sample'");
+
+  test(function () {
+    var event = new InvokeEvent("test", { action: undefined });
+    assert_equals(event.action, "auto");
+  }, "action set to undefined");
+
+  test(function () {
+    var event = new InvokeEvent("test", { action: null });
+    assert_equals(event.action, "null");
+  }, "action set to null");
+
+  test(function () {
+    var event = new InvokeEvent("test", { action: false });
+    assert_equals(event.action, "false");
+  }, "action set to false");
+
+  test(function () {
+    var event = new InvokeEvent("test", { action: true });
+    assert_equals(event.action, "true");
+  }, "action set to true");
+
+  test(function () {
+    var event = new InvokeEvent("test", { action: 0.5 });
+    assert_equals(event.action, "0.5");
+  }, "action set to a number");
+
+  test(function () {
+    var event = new InvokeEvent("test", { action: [] });
+    assert_equals(event.action, "");
+  }, "action set to []");
+
+  test(function () {
+    var event = new InvokeEvent("test", { action: [1, 2, 3] });
+    assert_equals(event.action, "1,2,3");
+  }, "action set to [1, 2, 3]");
+
+  test(function () {
+    var event = new InvokeEvent("test", { action: { sample: 0.5 } });
+    assert_equals(event.action, "[object Object]");
+  }, "action set to an object");
+
+  test(function () {
+    var event = new InvokeEvent("test", {
+      action: {
+        valueOf: function () {
+          return "sample";
+        },
+      },
+    });
+    assert_equals(event.action, "[object Object]");
+  }, "action set to an object with a valueOf function");
+
+  test(function () {
+    var eventInit = { action: "sample", relatedTarget: document.body };
+    var event = new InvokeEvent("test", eventInit);
+    assert_equals(event.action, "sample");
+    assert_equals(event.relatedTarget, document.body);
+  }, "InvokeEventInit properties set value");
+
+  test(function () {
+    var eventInit = {
+      action: "open",
+      relatedTarget: document.getElementById("div"),
+    };
+    var event = new InvokeEvent("beforetoggle", eventInit);
+    assert_equals(event.action, "open");
+    assert_equals(event.relatedTarget, document.getElementById("div"));
+  }, "InvokeEventInit properties set value 2");
+
+  test(function () {
+    var eventInit = {
+      action: "closed",
+      relatedTarget: document.getElementById("button"),
+    };
+    var event = new InvokeEvent("toggle", eventInit);
+    assert_equals(event.action, "closed");
+    assert_equals(event.relatedTarget, document.getElementById("button"));
+  }, "InvokeEventInit properties set value 3");
+
+  test(function () {
+    var eventTarget = new XMLHttpRequest();
+    var eventInit = { action: "closed", relatedTarget: eventTarget };
+    var event = new InvokeEvent("toggle", eventInit);
+    assert_equals(event.action, "closed");
+    assert_equals(event.relatedTarget, eventTarget);
+  }, "InvokeEventInit properties set value 4");
+
+  test(function () {
+    var event = new InvokeEvent("test", { relatedTarget: undefined });
+    assert_equals(event.relatedTarget, null);
+  }, "relatedTarget set to undefined");
+
+  test(function () {
+    var event = new InvokeEvent("test", { relatedTarget: null });
+    assert_equals(event.relatedTarget, null);
+  }, "relatedTarget set to null");
+
+  test(function () {
+    assert_throws_js(
+      TypeError,
+      function () {
+        new InvokeEvent("test", { relatedTarget: false });
+      },
+      "relatedTarget is not an object",
+    );
+  }, "relatedTarget set to false");
+
+  test(function () {
+    assert_throws_js(
+      TypeError,
+      function () {
+        var event = new InvokeEvent("test", { relatedTarget: true });
+      },
+      "relatedTarget is not an object",
+    );
+  }, "relatedTarget set to true");
+
+  test(function () {
+    assert_throws_js(
+      TypeError,
+      function () {
+        var event = new InvokeEvent("test", { relatedTarget: {} });
+      },
+      "relatedTarget is not an object",
+    );
+  }, "relatedTarget set to {}");
+</script>
+<div id="div"></div>
+<button id="button"></button>

--- a/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html
+++ b/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Keith Cirkel" href="mailto:keithamus@github.com" />
+<link rel="help" href="https://github.com/keithamus/invoker-buttons-proposal" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="invokee"></div>
+<button id="invokerbutton" invoketarget="invokee"></button>
+
+<script>
+  function weGetSignal(t) {
+    const ac = new AbortController();
+    t.add_cleanup(() => ac.abort());
+    return { signal: ac.signal };
+  }
+
+  test(function (t) {
+    var called = false;
+    invokee.addEventListener(
+      "invoke",
+      (event) => {
+        called = true;
+        assert_true(event instanceof InvokeEvent);
+        assert_equals(event.type, "invoke");
+        assert_equals(event.bubbles, false);
+        assert_equals(event.composed, false);
+        assert_equals(event.isTrusted, false);
+        assert_equals(event.action, "auto");
+        assert_equals(event.target, invokee);
+        assert_equals(event.relatedTarget, invokerbutton);
+      },
+      weGetSignal(t),
+    );
+    invokerbutton.click();
+    assert_true(called, "event was called");
+  }, "event dispatches on click");
+
+  test(function (t) {
+    var called = false;
+    invokee.addEventListener(
+      "invoke",
+      (event) => {
+        called = true;
+        assert_equals(event.type, "invoke");
+        assert_equals(event.bubbles, false);
+        assert_equals(event.composed, false);
+        assert_equals(event.isTrusted, false);
+        assert_equals(event.action, "fooBar");
+      },
+      weGetSignal(t),
+    );
+    invokerbutton.invokeAction = "fooBar";
+    invokerbutton.click();
+    assert_true(called, "event was called");
+  }, "event action is set to invokeAction");
+
+  test(function (t) {
+    var called = false;
+    invokee.addEventListener(
+      "invoke",
+      (event) => {
+        called = true;
+        assert_equals(event.type, "invoke");
+        assert_equals(event.bubbles, false);
+        assert_equals(event.composed, false);
+        assert_equals(event.isTrusted, false);
+        assert_equals(event.action, "BaRbAz");
+      },
+      weGetSignal(t),
+    );
+    invokerbutton.setAttribute("invokeaction", "BaRbAz");
+    invokerbutton.click();
+    assert_true(called, "event was called");
+  }, "event action is set to invokeaction attribute");
+
+  test(function (t) {
+    var called = false;
+    invokerbutton.addEventListener(
+      "click",
+      (event) => {
+        event.preventDefault();
+      },
+      weGetSignal(t),
+    );
+    invokee.addEventListener(
+      "invoke",
+      (event) => {
+        called = true;
+      },
+      weGetSignal(t),
+    );
+    invokerbutton.click();
+    assert_false(called, "event was not called");
+  }, "event does not dispatch if click:preventDefault is called");
+
+  test(function (t) {
+    var called = false;
+    invokee.addEventListener(
+      "invoke",
+      (event) => {
+        called = true;
+      },
+      weGetSignal(t),
+    );
+    invokerbutton.setAttribute("disabled", "");
+    invokerbutton.click();
+    assert_false(called, "event was not called");
+  }, "event does not dispatch if invoker is disabled");
+</script>


### PR DESCRIPTION
This adds some basic tests for the experimental `invoketarget` and `invokeaction` attributes, as specified in the open-ui "Invokers" explainer.

(https://open-ui.org/components/invokers.explainer/)

The `invoketarget` attribute maps to the IDL `invokeTargetElement`, similar to `popoverTargetElement`, and the `invokeaction` is a freeform string.

The InvokeEvent interface has an `action` and `relatedTarget` property (invokeevent-interface-tentative.html). The `action` property defaults to `auto`. The `relatedTarget` property adheres to the rules in event dispatch and show must retarget against shadow doms
(invokeevent-dispatch-shadow.tentative.html).

The Button behaviour checks for `invokeTargetElement` in its activation behaviour, and dispatches an `InvokeEvent` if there is one (`invoketarget-button-event-dispatch.tentative.html`).