### PR TITLE
Refactor TestSource

### DIFF
--- a/tools/wpt/update.py
+++ b/tools/wpt/update.py
@@ -13,8 +13,8 @@ def manifest_update(test_paths):
     from manifest import manifest  # type: ignore
     for url_base, paths in test_paths.items():
         manifest.load_and_update(
-            paths["tests_path"],
-            paths["manifest_path"],
+            paths.tests_path,
+            paths.manifest_path,
             url_base)
 
 

--- a/tools/wptrunner/wptrunner/config.py
+++ b/tools/wptrunner/wptrunner/config.py
@@ -4,23 +4,25 @@ from configparser import ConfigParser
 import os
 import sys
 from collections import OrderedDict
-from typing import Any, Dict
+from typing import Any, Dict, Mapping
 
 here = os.path.dirname(__file__)
 
+
 class ConfigDict(Dict[str, Any]):
-    def __init__(self, base_path, *args, **kwargs):
+    def __init__(self, base_path: str, *args: Any, **kwargs: Any):
         self.base_path = base_path
         dict.__init__(self, *args, **kwargs)
 
-    def get_path(self, key, default=None):
+    def get_path(self, key: str, default:Any = None) -> Any:
         if key not in self:
             return default
         path = self[key]
         os.path.expanduser(path)
         return os.path.abspath(os.path.join(self.base_path, path))
 
-def read(config_path):
+
+def read(config_path: str) -> Mapping[str, ConfigDict]:
     config_path = os.path.abspath(config_path)
     config_root = os.path.dirname(config_path)
     parser = ConfigParser()
@@ -36,6 +38,7 @@ def read(config_path):
             rv[section][key] = parser.get(section, key, raw=False, vars=subns)
 
     return rv
+
 
 def path(argv=None):
     if argv is None:
@@ -58,6 +61,7 @@ def path(argv=None):
             path = os.path.join(here, "..", "wptrunner.default.ini")
 
     return os.path.abspath(path)
+
 
 def load():
     return read(path(sys.argv))

--- a/tools/wptrunner/wptrunner/config.py
+++ b/tools/wptrunner/wptrunner/config.py
@@ -4,17 +4,17 @@ from configparser import ConfigParser
 import os
 import sys
 from collections import OrderedDict
-from typing import Any, Dict, Mapping
+from typing import Dict, Mapping, Optional
 
 here = os.path.dirname(__file__)
 
 
-class ConfigDict(Dict[str, Any]):
-    def __init__(self, base_path: str, *args: Any, **kwargs: Any):
+class ConfigDict(Dict[str, str]):
+    def __init__(self, base_path: str, *args: str, **kwargs: str):
         self.base_path = base_path
         dict.__init__(self, *args, **kwargs)
 
-    def get_path(self, key: str, default:Any = None) -> Any:
+    def get_path(self, key: str, default:Optional[str] = None) -> Optional[str]:
         if key not in self:
             return default
         path = self[key]

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -45,7 +45,7 @@ def do_delayed_imports(logger, test_paths):
 
 
 def serve_path(test_paths):
-    return test_paths["/"]["tests_path"]
+    return test_paths["/"].tests_path
 
 
 def webtranport_h3_server_is_running(host, port, timeout):
@@ -249,10 +249,10 @@ class TestEnvironment:
 
         route_builder.add_handler("GET", "/resources/testdriver.js", TestdriverLoader())
 
-        for url_base, paths in self.test_paths.items():
+        for url_base, test_root in self.test_paths.items():
             if url_base == "/":
                 continue
-            route_builder.add_mount_point(url_base, paths["tests_path"])
+            route_builder.add_mount_point(url_base, test_root.tests_path)
 
         if "/" not in self.test_paths:
             del route_builder.mountpoint_routes["/"]

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -326,19 +326,20 @@ class ManifestLoader:
 
     def load(self):
         rv = {}
-        for url_base, paths in self.test_paths.items():
-            manifest_file = self.load_manifest(url_base=url_base,
-                                               **paths)
-            path_data = {"url_base": url_base}
-            path_data.update(paths)
+        for url_base, test_root in self.test_paths.items():
+            manifest_file = self.load_manifest(url_base, test_root)
+            path_data = {"url_base": url_base,
+                         "tests_path": test_root.tests_path,
+                         "metadata_path": test_root.metadata_path,
+                         "manifest_path": test_root.manifest_path}
             rv[manifest_file] = path_data
         return rv
 
-    def load_manifest(self, tests_path, manifest_path, metadata_path, url_base="/", **kwargs):
-        cache_root = os.path.join(metadata_path, ".cache")
+    def load_manifest(self, url_base, test_root):
+        cache_root = os.path.join(test_root.metadata_path, ".cache")
         if self.manifest_download:
-            download_from_github(manifest_path, tests_path)
-        return manifest.load_and_update(tests_path, manifest_path, url_base,
+            download_from_github(test_root.manifest_path, test_root.tests_path)
+        return manifest.load_and_update(test_root.tests_path, test_root.manifest_path, url_base,
                                         cache_root=cache_root, update=self.force_manifest_update,
                                         types=self.types)
 

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -1,4 +1,4 @@
-# mypy: allow-untyped-defs
+# mypy: allow-untyped-calls, allow-untyped-defs
 from __future__ import annotations
 
 import abc
@@ -9,9 +9,9 @@ import os
 import queue
 from urllib.parse import urlsplit
 from abc import ABCMeta, abstractmethod
-from queue import Empty
 from collections import defaultdict, deque, namedtuple
-from typing import cast, Any, Dict, List, Optional, Set
+from typing import (cast, Any, Callable, Dict, Deque, List, Mapping, MutableMapping, Optional, Set,
+                    Tuple, Type)
 
 from . import manifestinclude
 from . import manifestexpected
@@ -23,6 +23,9 @@ manifest = None
 manifest_update = None
 download_from_github = None
 
+# Mapping from (subsuite, test_type) to [Test]
+TestsByType = Mapping[Tuple[str, str], List[wpttest.Test]]
+
 
 def do_delayed_imports():
     # This relies on an already loaded module having set the sys.path correctly :(
@@ -30,6 +33,35 @@ def do_delayed_imports():
     from manifest import manifest  # type: ignore
     from manifest import update as manifest_update
     from manifest.download import download_from_github  # type: ignore
+
+
+class WriteQueue:
+    def __init__(self, queue_cls: Callable[[], Any] = queue.SimpleQueue):
+        """Queue wrapper that is only used for writing items to a queue.
+
+        Once all items are enqueued, call to_read() to get a reader for the queue.
+        This will also prevent further writes using this writer."""
+        self._raw_queue = queue_cls()
+
+    def put(self, item: Any) -> None:
+        if self._raw_queue is None:
+            raise ValueError("Tried to write to closed queue")
+        self._raw_queue.put(item)
+
+    def to_read(self) -> ReadQueue:
+        reader = ReadQueue(self._raw_queue)
+        self._raw_queue = None
+        return reader
+
+
+class ReadQueue:
+    def __init__(self, raw_queue: Any):
+        self._raw_queue = raw_queue
+
+    def get(self) -> Any:
+        """Queue wrapper that is only used for reading items from a queue."""
+        return self._raw_queue.get(False)
+
 
 
 class TestGroups:
@@ -475,46 +507,48 @@ class TestLoader:
         return groups
 
 
-TestSourceData = namedtuple("TestSourceData", ["cls", "kwargs"])
 
-
-def get_test_src(**kwargs):
-    test_source_kwargs = {"processes": kwargs["processes"],
-                          "logger": kwargs["logger"]}
+def get_test_queue_builder(**kwargs: Any) -> Tuple[TestQueueBuilder, Mapping[str, Any]]:
+    builder_kwargs = {"processes": kwargs["processes"],
+                      "logger": kwargs["logger"]}
     chunker_kwargs = {}
+    builder_cls: Type[TestQueueBuilder]
     if kwargs["fully_parallel"]:
-        test_source_cls = FullyParallelGroupedSource
+        builder_cls = FullyParallelGroupedSource
     elif kwargs["run_by_dir"] is not False:
         # A value of None indicates infinite depth
-        test_source_cls = PathGroupedSource
-        test_source_kwargs["depth"] = kwargs["run_by_dir"]
+        builder_cls = PathGroupedSource
+        builder_kwargs["depth"] = kwargs["run_by_dir"]
         chunker_kwargs["depth"] = kwargs["run_by_dir"]
     elif kwargs["test_groups"]:
-        test_source_cls = GroupFileTestSource
-        test_source_kwargs["test_groups"] = kwargs["test_groups"]
+        builder_cls = GroupFileTestSource
+        builder_kwargs["test_groups"] = kwargs["test_groups"]
     else:
-        test_source_cls = SingleTestSource
-    return TestSourceData(test_source_cls, test_source_kwargs), chunker_kwargs
+        builder_cls = SingleTestSource
+    return builder_cls(**builder_kwargs), chunker_kwargs
 
 
 TestGroup = namedtuple("TestGroup", ["group", "subsuite", "test_type", "metadata"])
 
 
-class TestSource:
+class TestQueueBuilder:
     __metaclass__ = ABCMeta
 
-    def __init__(self, test_queue):
-        self.test_queue = test_queue
-        self.current_group = TestGroup(None, None, None, None)
-        self.logger = structured.get_default_logger()
-        if self.logger is None:
-            self.logger = structured.structuredlog.StructuredLogger("TestSource")
+    def __init__(self, **kwargs: Any):
+        """Class for building a queue of groups of tests to run.
 
-    @classmethod
-    def make_queue(cls, tests_by_type, **kwargs):
-        test_queue = queue.SimpleQueue()
-        groups = cls.make_groups(tests_by_type, **kwargs)
-        processes = cls.process_count(kwargs["processes"], len(groups))
+        Each item in the queue is a TestGroup, which consists of an iterable of
+        tests to run, the name of the subsuite, the name of the test type, and
+        a dictionary containing group-specific metadata.
+
+        Tests in the same group are run in the same TestRunner in the
+        provided order."""
+        self.kwargs = kwargs
+
+    def make_queue(self, tests_by_type: TestsByType) -> Tuple[ReadQueue, int]:
+        test_queue = WriteQueue()
+        groups = self.make_groups(tests_by_type)
+        processes = self.process_count(self.kwargs["processes"], len(groups))
         if processes > 1:
             groups.sort(key=lambda group: (
                 # Place groups of the same test type together to minimize
@@ -526,46 +560,35 @@ class TestSource:
             ))
         for item in groups:
             test_queue.put(item)
-        return test_queue, processes
 
-    @classmethod
+        return test_queue.to_read(), processes
+
     @abstractmethod
-    def make_groups(cls, tests_by_type, **kwargs):  # noqa: N805
+    def make_groups(self, tests_by_type: TestsByType) -> List[TestGroup]:
+        """Divide a given set of tests into groups that will be run together."""
         pass
 
-    @classmethod
     @abstractmethod
-    def tests_by_group(cls, tests_by_type, **kwargs):  # noqa: N805
+    def tests_by_group(self, tests_by_type: TestsByType) -> Mapping[str, List[str]]:
         pass
 
-    @classmethod
-    def group_metadata(cls, state):
+    def group_metadata(self, state: Mapping[str, Any]) -> Mapping[str, Any]:
         return {"scope": "/"}
 
-    def group(self):
-        if not self.current_group.group or len(self.current_group.group) == 0:
-            try:
-                self.current_group = self.test_queue.get_nowait()
-            except Empty:
-                return TestGroup(None, None, None, None)
-        return self.current_group
-
-    @classmethod
-    def process_count(cls, requested_processes, num_test_groups):
+    def process_count(self, requested_processes: int, num_test_groups: int) -> int:
         """Get the number of processes to use.
 
         This must always be at least one, but otherwise not more than the number of test groups"""
         return max(1, min(requested_processes, num_test_groups))
 
 
-class SingleTestSource(TestSource):
-    @classmethod
-    def make_groups(cls, tests_by_type, **kwargs):
+class SingleTestSource(TestQueueBuilder):
+    def make_groups(self, tests_by_type: TestsByType) -> List[TestGroup]:
         groups = []
         for (subsuite, test_type), tests in tests_by_type.items():
-            processes = kwargs["processes"]
-            queues = [deque([]) for _ in range(processes)]
-            metadatas = [cls.group_metadata(None) for _ in range(processes)]
+            processes = self.kwargs["processes"]
+            queues: List[Deque[TestGroup]] = [deque([]) for _ in range(processes)]
+            metadatas = [self.group_metadata({}) for _ in range(processes)]
             for test in tests:
                 idx = hash(test.id) % processes
                 group = queues[idx]
@@ -581,19 +604,21 @@ class SingleTestSource(TestSource):
                     groups.append(TestGroup(*item))
         return groups
 
-    @classmethod
-    def tests_by_group(cls, tests_by_type, **kwargs):
-        groups = defaultdict(list)
+    def tests_by_group(self, tests_by_type: TestsByType) -> Mapping[str, List[str]]:
+        groups: MutableMapping[str, List[str]] = defaultdict(list)
         for (subsuite, test_type), tests in tests_by_type.items():
-            group_name = f"{subsuite}:{cls.group_metadata(None)['scope']}"
+            group_name = f"{subsuite}:{self.group_metadata({})['scope']}"
             groups[group_name].extend(test.id for test in tests)
         return groups
 
 
-class PathGroupedSource(TestSource):
-    @classmethod
-    def new_group(cls, state, subsuite, test_type, test, **kwargs):
-        depth = kwargs.get("depth")
+class PathGroupedSource(TestQueueBuilder):
+    def new_group(self,
+                  state: MutableMapping[str, Any],
+                  subsuite: str,
+                  test_type: str,
+                  test: wpttest.Test) -> bool:
+        depth = self.kwargs.get("depth")
         if depth is True or depth == 0:
             depth = None
         path = urlsplit(test.url).path.split("/")[1:-1][:depth]
@@ -601,36 +626,34 @@ class PathGroupedSource(TestSource):
         state["prev_group_key"] = (subsuite, test_type, path)
         return rv
 
-    @classmethod
-    def make_groups(cls, tests_by_type, **kwargs):
-        groups, state = [], {}
+    def make_groups(self, tests_by_type: TestsByType) -> List[TestGroup]:
+        groups = []
+        state: MutableMapping[str, Any] = {}
         for (subsuite, test_type), tests in tests_by_type.items():
             for test in tests:
-                if cls.new_group(state, subsuite, test_type, test, **kwargs):
-                    group_metadata = cls.group_metadata(state)
+                if self.new_group(state, subsuite, test_type, test):
+                    group_metadata = self.group_metadata(state)
                     groups.append(TestGroup(deque(), subsuite, test_type, group_metadata))
                 group, _, _, metadata = groups[-1]
                 group.append(test)
                 test.update_metadata(metadata)
         return groups
 
-    @classmethod
-    def tests_by_group(cls, tests_by_type, **kwargs):
+    def tests_by_group(self, tests_by_type: TestsByType) -> Mapping[str, List[str]]:
         groups = defaultdict(list)
-        state = {}
+        state: MutableMapping[str, Any] = {}
         for (subsuite, test_type), tests in tests_by_type.items():
             for test in tests:
-                if cls.new_group(state, subsuite, test_type, test, **kwargs):
-                    group = cls.group_metadata(state)['scope']
-                if subsuite is not None:
+                if self.new_group(state, subsuite, test_type, test):
+                    group = self.group_metadata(state)['scope']
+                if subsuite:
                     group_name = f"{subsuite}:{group}"
                 else:
                     group_name = group
                 groups[group_name].append(test.id)
         return groups
 
-    @classmethod
-    def group_metadata(cls, state):
+    def group_metadata(self, state: Mapping[str, Any]) -> Mapping[str, Any]:
         return {"scope": "/%s" % "/".join(state["prev_group_key"][2])}
 
 
@@ -638,24 +661,25 @@ class FullyParallelGroupedSource(PathGroupedSource):
     # Chuck every test into a different group, so that they can run
     # fully parallel with each other. Useful to run a lot of tests
     # clustered in a few directories.
-    @classmethod
-    def new_group(cls, state, subsuite, test_type, test, **kwargs):
+    def new_group(self,
+                  state: MutableMapping[str, Any],
+                  subsuite: str,
+                  test_type: str,
+                  test: wpttest.Test) -> bool:
         path = urlsplit(test.url).path.split("/")[1:-1]
         state["prev_group_key"] = (subsuite, test_type, path)
         return True
 
 
-class GroupFileTestSource(TestSource):
-    @classmethod
-    def make_groups(cls, tests_by_type, **kwargs):
+class GroupFileTestSource(TestQueueBuilder):
+    def make_groups(self, tests_by_type: TestsByType) -> List[TestGroup]:
         groups = []
         for (subsuite, test_type), tests in tests_by_type.items():
-            tests_by_group = cls.tests_by_group({(subsuite, test_type): tests},
-                                                **kwargs)
+            tests_by_group = self.tests_by_group({(subsuite, test_type): tests})
             ids_to_tests = {test.id: test for test in tests}
             for group_name, test_ids in tests_by_group.items():
                 group_metadata = {"scope": group_name}
-                group = deque()
+                group: Deque[wpttest.Test] = deque()
                 for test_id in test_ids:
                     test = ids_to_tests[test_id]
                     group.append(test)
@@ -663,9 +687,8 @@ class GroupFileTestSource(TestSource):
                 groups.append(TestGroup(group, subsuite, test_type, group_metadata))
         return groups
 
-    @classmethod
-    def tests_by_group(cls, tests_by_type, **kwargs):
-        test_groups = kwargs["test_groups"]
+    def tests_by_group(self, tests_by_type: TestsByType) -> Mapping[str, List[str]]:
+        test_groups = self.kwargs["test_groups"]
 
         tests_by_group = defaultdict(list)
         for (subsuite, test_type), tests in tests_by_type.items():

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -9,7 +9,7 @@ from typing import Any, Mapping, Optional
 
 from mozlog import structuredlog, capture
 
-from . import mpcontext
+from . import mpcontext, testloader
 
 # Special value used as a sentinal in various commands
 Stop = object()
@@ -253,6 +253,23 @@ class BrowserManager:
         return self.browser.is_alive()
 
 
+class TestSource:
+    def __init__(self, logger: structuredlog.StructuredLogger, test_queue: testloader.ReadQueue):
+        self.logger = logger
+        self.test_queue = test_queue
+        self.current_group = testloader.TestGroup(None, None, None, None)
+
+    def group(self) -> testloader.TestGroup:
+        if not self.current_group.group or len(self.current_group.group) == 0:
+            try:
+                self.current_group = self.test_queue.get()
+                self.logger.debug(f"Got new test group subsuite:{self.current_group[1]} "
+                                  f"test_type:{self.current_group[2]}")
+            except Empty:
+                return testloader.TestGroup(None, None, None, None)
+        return self.current_group
+
+
 class _RunnerManagerState:
     before_init = namedtuple("before_init", [])
     initializing = namedtuple("initializing",
@@ -269,7 +286,7 @@ RunnerManagerState = _RunnerManagerState()
 
 
 class TestRunnerManager(threading.Thread):
-    def __init__(self, suite_name, index, test_queue, test_source_cls,
+    def __init__(self, suite_name, index, test_queue,
                  test_implementations, stop_flag, retry_index=0, rerun=1,
                  pause_after_test=False, pause_on_unexpected=False,
                  restart_on_unexpected=True, debug_info=None,
@@ -290,9 +307,6 @@ class TestRunnerManager(threading.Thread):
           processes
         """
         self.suite_name = suite_name
-
-        self.test_source = test_source_cls(test_queue)
-
         self.manager_number = index
         self.test_implementation_key = None
 
@@ -311,11 +325,9 @@ class TestRunnerManager(threading.Thread):
             else:
                 self.test_implementations[key] = test_implementation
 
-        mp = mpcontext.get_context()
-
         # Flags used to shut down this thread if we get a sigint
         self.parent_stop_flag = stop_flag
-        self.child_stop_flag = mp.Event()
+        self.child_stop_flag = mpcontext.get_context().Event()
 
         # Keep track of the current retry index. The retries are meant to handle
         # flakiness, so at retry round we should restart the browser after each test.
@@ -326,36 +338,30 @@ class TestRunnerManager(threading.Thread):
         self.pause_on_unexpected = pause_on_unexpected
         self.restart_on_unexpected = restart_on_unexpected
         self.debug_info = debug_info
+        self.capture_stdio = capture_stdio
+        self.restart_on_new_group = restart_on_new_group
+        self.max_restarts = max_restarts
 
         assert recording is not None
         self.recording = recording
-
-        self.command_queue = mp.Queue()
-        self.remote_queue = mp.Queue()
-
-        self.test_runner_proc = None
-
-        super().__init__(name=f"TestRunnerManager-{index}")
-        # This is started in the actual new thread
-        self.logger = None
 
         self.test_count = 0
         self.unexpected_fail_tests = defaultdict(list)
         self.unexpected_pass_tests = defaultdict(list)
 
-        # This may not really be what we want
-        self.daemon = True
+        # Properties we initialize once the thread is started
+        self.logger = None
+        self.test_source = None
+        self.command_queue = None
+        self.remote_queue = None
 
         self.timer = None
 
-        self.max_restarts = max_restarts
-
         self.browser = None
 
-        self.capture_stdio = capture_stdio
-        self.restart_on_new_group = restart_on_new_group
+        super().__init__(name=f"TestRunnerManager-{index}", target=self.run_loop, args=[test_queue], daemon=True)
 
-    def run(self):
+    def run_loop(self, test_queue):
         """Main loop for the TestRunnerManager.
 
         TestRunnerManagers generally receive commands from their
@@ -365,6 +371,13 @@ class TestRunnerManager(threading.Thread):
         spins."""
         self.recording.set(["testrunner", "startup"])
         self.logger = structuredlog.StructuredLogger(self.suite_name)
+
+        self.test_source = TestSource(self.logger, test_queue)
+
+        mp = mpcontext.get_context()
+        self.command_queue = mp.Queue()
+        self.remote_queue = mp.Queue()
+
         dispatch = {
             RunnerManagerState.before_init: self.start_init,
             RunnerManagerState.initializing: self.init,
@@ -927,7 +940,7 @@ class TestRunnerManager(threading.Thread):
 
 class ManagerGroup:
     """Main thread object that owns all the TestRunnerManager threads."""
-    def __init__(self, suite_name, test_source, test_implementations,
+    def __init__(self, suite_name, test_queue_builder, test_implementations,
                  retry_index=0,
                  rerun=1,
                  pause_after_test=False,
@@ -939,7 +952,7 @@ class ManagerGroup:
                  recording=None,
                  max_restarts=5):
         self.suite_name = suite_name
-        self.test_source = test_source
+        self.test_queue_builder = test_queue_builder
         self.test_implementations = test_implementations
         self.pause_after_test = pause_after_test
         self.pause_on_unexpected = pause_on_unexpected
@@ -967,15 +980,13 @@ class ManagerGroup:
 
     def run(self, tests):
         """Start all managers in the group"""
-        test_queue, size = self.test_source.cls.make_queue(
-            tests, **self.test_source.kwargs)
+        test_queue, size = self.test_queue_builder.make_queue(tests)
         self.logger.info("Using %i child processes" % size)
 
         for idx in range(size):
             manager = TestRunnerManager(self.suite_name,
                                         idx,
                                         test_queue,
-                                        self.test_source.cls,
                                         self.test_implementations,
                                         self.stop_flag,
                                         self.retry_index,

--- a/tools/wptrunner/wptrunner/tests/browsers/test_webkitgtk.py
+++ b/tools/wptrunner/wptrunner/tests/browsers/test_webkitgtk.py
@@ -7,9 +7,11 @@ import pytest
 
 from wptserve.config import ConfigBuilder
 from ..base import active_products
-from wptrunner import environment, products, testloader
+from wptrunner import environment, products, testloader, wptcommandline
 
-test_paths = {"/": {"tests_path": join(dirname(__file__), "..", "..", "..", "..", "..")}}  # repo root
+wpt_root = join(dirname(__file__), "..", "..", "..", "..")
+
+test_paths = {"/": wptcommandline.TestRoot(wpt_root, wpt_root)}
 environment.do_delayed_imports(None, test_paths)
 
 logger = logging.getLogger()

--- a/tools/wptrunner/wptrunner/tests/test_products.py
+++ b/tools/wptrunner/wptrunner/tests/test_products.py
@@ -8,8 +8,11 @@ import pytest
 from .base import all_products, active_products
 from .. import environment
 from .. import products
+from .. import wptcommandline
 
-test_paths = {"/": {"tests_path": join(dirname(__file__), "..", "..", "..", "..")}}  # repo root
+wpt_root = join(dirname(__file__), "..", "..", "..", "..")
+
+test_paths = {"/": wptcommandline.TestRoot(wpt_root, wpt_root)}
 environment.do_delayed_imports(None, test_paths)
 
 

--- a/tools/wptrunner/wptrunner/tests/test_update.py
+++ b/tools/wptrunner/wptrunner/tests/test_update.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import pytest
 
-from .. import metadata, manifestupdate, wptmanifest
+from .. import metadata, manifestupdate, wptcommandline, wptmanifest
 from ..update.update import WPTUpdate
 from ..update.base import StepRunner, Step
 from mozlog import structuredlog, handlers, formatters
@@ -1771,13 +1771,14 @@ class UpdateRunner(StepRunner):
 
 def test_update_pickle():
     logger = structuredlog.StructuredLogger("expected_test")
+    wpt_root = os.path.abspath(os.path.join(here,
+                                            os.pardir,
+                                            os.pardir,
+                                            os.pardir,
+                                            os.pardir))
     args = {
         "test_paths": {
-            "/": {"tests_path": os.path.abspath(os.path.join(here,
-                                                             os.pardir,
-                                                             os.pardir,
-                                                             os.pardir,
-                                                             os.pardir))},
+            "/": wptcommandline.TestRoot(wpt_root, wpt_root),
         },
         "abort": False,
         "continue": False,

--- a/tools/wptrunner/wptrunner/update/update.py
+++ b/tools/wptrunner/wptrunner/update/update.py
@@ -25,8 +25,8 @@ class LoadConfig(Step):
                       "path": state.kwargs["sync_path"]}
 
         state.paths = state.kwargs["test_paths"]
-        state.tests_path = state.paths["/"]["tests_path"]
-        state.metadata_path = state.paths["/"]["metadata_path"]
+        state.tests_path = state.paths["/"].tests_path
+        state.metadata_path = state.paths["/"].metadata_path
 
         assert os.path.isabs(state.tests_path)
 
@@ -108,12 +108,12 @@ class RemoveObsolete(Step):
             return
 
         paths = state.kwargs["test_paths"]
-        state.tests_path = state.paths["/"]["tests_path"]
-        state.metadata_path = state.paths["/"]["metadata_path"]
+        state.tests_path = state.paths["/"].tests_path
+        state.metadata_path = state.paths["/"].metadata_path
 
         for url_paths in paths.values():
-            tests_path = url_paths["tests_path"]
-            metadata_path = url_paths["metadata_path"]
+            tests_path = url_paths.tests_path
+            metadata_path = url_paths.metadata_path
             for dirpath, dirnames, filenames in os.walk(metadata_path):
                 for filename in filenames:
                     if filename == "__dir__.ini":
@@ -144,7 +144,7 @@ class WPTUpdate:
         :param kwargs: Command line arguments
         """
         self.runner_cls = runner_cls
-        self.serve_root = kwargs["test_paths"]["/"]["tests_path"]
+        self.serve_root = kwargs["test_paths"]["/"].tests_path
 
         if not kwargs["sync"]:
             setup_paths(self.serve_root)

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -6,13 +6,7 @@ import sys
 from collections import OrderedDict
 from shutil import which
 from datetime import timedelta
-from typing import cast, Mapping
-
-try:
-    from typing import TypedDict
-except ImportError:
-    # For Python 3.7 we don't have TypedDict do alias it to a generic Mapping
-    TypedDict = Mapping
+from typing import Mapping, Optional
 
 from . import config
 from . import products
@@ -491,39 +485,34 @@ def set_from_config(kwargs):
                     new_value = kwargs["config"].get(section, config.ConfigDict({})).get_path(config_value)
                 kwargs[kw_value] = new_value
 
-    kwargs["test_paths"] = get_test_paths(kwargs["config"])
-
-    if kwargs["tests_root"]:
-        if "/" not in kwargs["test_paths"]:
-            kwargs["test_paths"]["/"] = {}
-        kwargs["test_paths"]["/"]["tests_path"] = kwargs["tests_root"]
-
-    if kwargs["metadata_root"]:
-        if "/" not in kwargs["test_paths"]:
-            kwargs["test_paths"]["/"] = {}
-        kwargs["test_paths"]["/"]["metadata_path"] = kwargs["metadata_root"]
-
-    if kwargs.get("manifest_path"):
-        if "/" not in kwargs["test_paths"]:
-            kwargs["test_paths"]["/"] = {}
-        kwargs["test_paths"]["/"]["manifest_path"] = kwargs["manifest_path"]
+    test_paths = get_test_paths(kwargs["config"],
+                                kwargs["tests_root"],
+                                kwargs["metadata_root"],
+                                kwargs["manifest_path"])
+    check_paths(test_paths)
+    kwargs["test_paths"] = test_paths
 
     kwargs["suite_name"] = kwargs["config"].get("web-platform-tests", {}).get("name", "web-platform-tests")
 
 
-    check_paths(kwargs)
 
+class TestRoot:
+    def __init__(self, tests_path: str, metadata_path: str, manifest_path: Optional[str] = None):
+        self.tests_path = tests_path
+        self.metadata_path = metadata_path
+        if manifest_path is None:
+            manifest_path = os.path.join(metadata_path, "MANIFEST.json")
 
-class TestRoot(TypedDict):
-    tests_path: str
-    metadata_path: str
-    manifest_path: str
+        self.manifest_path = manifest_path
 
 
 TestPaths = Mapping[str, TestRoot]
 
 
-def get_test_paths(config: Mapping[str, config.ConfigDict]) -> TestPaths:
+def get_test_paths(config: Mapping[str, config.ConfigDict],
+                   tests_path_override: Optional[str] = None,
+                   metadata_path_override: Optional[str] = None,
+                   manifest_path_override: Optional[str] = None) -> TestPaths:
     # Set up test_paths
     test_paths = OrderedDict()
 
@@ -531,35 +520,47 @@ def get_test_paths(config: Mapping[str, config.ConfigDict]) -> TestPaths:
         if section.startswith("manifest:"):
             manifest_opts = config[section]
             url_base = manifest_opts.get("url_base", "/")
-            test_root = {
-                "tests_path": manifest_opts.get_path("tests"),
-                "metadata_path": manifest_opts.get_path("metadata"),
-            }
-            if "manifest" in manifest_opts:
-                test_root["manifest_path"] = manifest_opts.get_path("manifest")
-            test_paths[url_base] = cast(TestRoot, test_root)
+            tests_path = manifest_opts.get_path("tests")
+            if tests_path is None:
+                raise ValueError(f"Missing `tests` key in configuration with url_base {url_base}")
+            metadata_path = manifest_opts.get_path("metadata")
+            if metadata_path is None:
+                raise ValueError(f"Missing `metadata` key in configuration with url_base {url_base}")
+            manifest_path = manifest_opts.get_path("manifest")
+
+            if url_base == "/":
+                if tests_path_override is not None:
+                    tests_path = tests_path_override
+                if metadata_path_override is not None:
+                    metadata_path = metadata_path_override
+                if manifest_path_override is not None:
+                    manifest_path = manifest_path_override
+
+            test_paths[url_base] = TestRoot(tests_path, metadata_path, manifest_path)
+
+    if "/" not in test_paths:
+        if tests_path_override is None or metadata_path_override is None:
+            raise ValueError("No ini file configures the root url, "
+                             "so --tests and --metadata arguments are mandatory")
+        test_paths["/"] = TestRoot(tests_path_override,
+                                   metadata_path_override,
+                                   manifest_path_override)
 
     return test_paths
 
 
-def exe_path(name):
+def exe_path(name: Optional[str]) -> Optional[str]:
     if name is None:
-        return
+        return None
 
     return which(name)
 
 
-def check_paths(kwargs):
-    for test_paths in kwargs["test_paths"].values():
-        if not ("tests_path" in test_paths and
-                "metadata_path" in test_paths):
-            print("Fatal: must specify both a test path and metadata path")
-            sys.exit(1)
-        if "manifest_path" not in test_paths:
-            test_paths["manifest_path"] = os.path.join(test_paths["metadata_path"],
-                                                       "MANIFEST.json")
-        for key, path in test_paths.items():
+def check_paths(test_paths: TestPaths) -> None:
+    for test_root in test_paths.values():
+        for key in ["tests_path", "metadata_path", "manifest_path"]:
             name = key.split("_", 1)[0]
+            path = getattr(test_root, key)
 
             if name == "manifest":
                 # For the manifest we can create it later, so just check the path
@@ -712,7 +713,7 @@ def check_args_metadata_update(kwargs):
             sys.exit(1)
 
     if kwargs["properties_file"] is None and not kwargs["no_properties_file"]:
-        default_file = os.path.join(kwargs["test_paths"]["/"]["metadata_path"],
+        default_file = os.path.join(kwargs["test_paths"]["/"].metadata_path,
                                     "update_properties.json")
         if os.path.exists(default_file):
             kwargs["properties_file"] = default_file

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -390,7 +390,7 @@ def run_tests(config, product, test_paths, **kwargs):
             env_extras.append(FontInstaller(
                 logger,
                 font_dir=kwargs["font_dir"],
-                ahem=os.path.join(test_paths["/"]["tests_path"], "fonts/Ahem.ttf")
+                ahem=os.path.join(test_paths["/"].tests_path, "fonts/Ahem.ttf")
             ))
 
         recording.set(["startup", "load_tests"])

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -1,4 +1,4 @@
-# mypy: allow-untyped-defs
+# mypy: allow-untyped-calls, allow-untyped-defs
 
 import json
 import os
@@ -6,6 +6,7 @@ import signal
 import sys
 from collections import defaultdict
 from datetime import datetime, timedelta
+from typing import Any, Tuple
 
 import wptserve
 from wptserve import sslutils
@@ -13,6 +14,7 @@ from wptserve import sslutils
 from . import environment as env
 from . import instruments
 from . import mpcontext
+from . import products
 from . import testloader
 from . import wptcommandline
 from . import wptlogging
@@ -47,7 +49,9 @@ def setup_logging(*args, **kwargs):
     return logger
 
 
-def get_loader(test_paths, product, **kwargs):
+def get_loader(test_paths: wptcommandline.TestPaths,
+               product: products.Product,
+               **kwargs: Any) -> Tuple[testloader.TestQueueBuilder, testloader.TestLoader]:
     run_info_extras = product.run_info_extras(**kwargs)
     base_run_info = wpttest.get_run_info(kwargs["run_info"],
                                          product.name,
@@ -98,9 +102,9 @@ def get_loader(test_paths, product, **kwargs):
     ssl_enabled = sslutils.get_cls(kwargs["ssl_type"]).ssl_enabled
     h2_enabled = wptserve.utils.http2_compatible()
 
-    test_source, chunker_kwargs = testloader.get_test_src(logger=logger,
-                                                          test_groups=test_groups,
-                                                          **kwargs)
+    test_queue_builder, chunker_kwargs = testloader.get_test_queue_builder(logger=logger,
+                                                                           test_groups=test_groups,
+                                                                           **kwargs)
 
     test_loader = testloader.TestLoader(test_manifests=test_manifests,
                                         test_types=kwargs["test_types"],
@@ -118,7 +122,7 @@ def get_loader(test_paths, product, **kwargs):
                                         skip_crash=kwargs["skip_crash"],
                                         skip_implementation_status=kwargs["skip_implementation_status"],
                                         chunker_kwargs=chunker_kwargs)
-    return test_source, test_loader
+    return test_queue_builder, test_loader
 
 
 def list_test_groups(test_paths, product, **kwargs):
@@ -181,7 +185,7 @@ def log_suite_start(tests_by_group, base_run_info, subsuites, run_by_dir):
         logger.add_subsuite(name=name, run_info=subsuite.run_info_extras)
 
 
-def run_test_iteration(test_status, test_loader, test_source,
+def run_test_iteration(test_status, test_loader, test_queue_builder,
                        recording, test_environment, product, kwargs):
     """Runs the entire test suite.
     This is called for each repeat run requested."""
@@ -195,7 +199,7 @@ def run_test_iteration(test_status, test_loader, test_source,
                 tests_by_type[(subsuite_name, test_type)].extend(type_tests_active)
                 tests_by_type[(subsuite_name, test_type)].extend(type_tests_disabled)
 
-    tests_by_group = test_source.cls.tests_by_group(tests_by_type, **test_source.kwargs)
+    tests_by_group = test_queue_builder.tests_by_group(tests_by_type)
 
     log_suite_start(tests_by_group,
                     test_loader.base_run_info,
@@ -271,7 +275,7 @@ def run_test_iteration(test_status, test_loader, test_source,
             tests_to_run = unexpected_fail_tests
             if sum(len(tests) for tests in tests_to_run.values()) == 0:
                 break
-            tests_by_group = test_source.cls.tests_by_group(tests_to_run, **kwargs)
+            tests_by_group = test_queue_builder.tests_by_group(tests_to_run)
 
             logger.suite_end()
 
@@ -281,7 +285,7 @@ def run_test_iteration(test_status, test_loader, test_source,
                             kwargs["run_by_dir"])
 
         with ManagerGroup("web-platform-tests",
-                          test_source,
+                          test_queue_builder,
                           test_implementations,
                           retry_index,
                           kwargs["rerun"],
@@ -391,9 +395,9 @@ def run_tests(config, product, test_paths, **kwargs):
 
         recording.set(["startup", "load_tests"])
 
-        test_source, test_loader = get_loader(test_paths,
-                                              product,
-                                              **kwargs)
+        test_queue_builder, test_loader = get_loader(test_paths,
+                                                     product,
+                                                     **kwargs)
 
         test_status = TestStatus()
         repeat = kwargs["repeat"]
@@ -472,9 +476,13 @@ def run_tests(config, product, test_paths, **kwargs):
                 elif repeat > 1:
                     logger.info(f"Repetition {test_status.repeated_runs} / {repeat}")
 
-                iter_success = run_test_iteration(test_status, test_loader, test_source,
+                iter_success = run_test_iteration(test_status,
+                                                  test_loader,
+                                                  test_queue_builder,
                                                   recording,
-                                                  test_environment, product, kwargs)
+                                                  test_environment,
+                                                  product,
+                                                  kwargs)
                 # if there were issues with the suite run(tests not loaded, etc.) return
                 if not iter_success:
                     return False, test_status


### PR DESCRIPTION
Previously the TestSource subclasses were used for two things:
* As class objects, for getting information about test groups, and enqueueing test groups containing tests and their metadata.
* As class instances, for getting the tests out of the queue.

This was quite akward. In particular, all the functionality on the subclasses was actually related to the first use, and we ended up passing around tuple of (class, data) to all the places we needed to get information about tests groups.

Instead of this, rename TestSource to TestQueueBuilder and make all the class methods for the first use case into normal instance methods. That allows us to just pass around a class instance like normal.

For the second use case, create a new TestSource class inside testrunner which only knows how to get test groups out of the queue when needed.

As part of this refactoring we make a couple of other changes to improve clarity:

* Since we always enqueue all test groups before we try to read any, wrap the queue classes in wrappers that only give write and read access. This makes it clear that no writing will happen after the queue has been initialised.

* Rearrange some of the code in the TestRunnerManager initialization, so that we don't initalize internal objects (e.g. the TestSource) before we have a logger available.