### PR TITLE
Revert "Start dbus for Chrome"

### DIFF
--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -140,13 +140,6 @@ def install_certificates():
     run(["sudo", "update-ca-certificates"])
 
 
-def start_dbus():
-    run(["sudo", "service", "dbus", "start"])
-    # Enable dbus autolaunch for Chrome
-    # https://source.chromium.org/chromium/chromium/src/+/main:content/app/content_main.cc;l=220;drc=0bcc023b8cdbc073aa5c48db373810db3f765c87.
-    os.environ["DBUS_SESSION_BUS_ADDRESS"] = "autolaunch:"
-
-
 def install_chrome(channel):
     if channel in ("experimental", "dev"):
         deb_archive = "google-chrome-unstable_current_amd64.deb"
@@ -264,8 +257,6 @@ def setup_environment(args):
     if "chrome" in args.browser:
         assert args.channel is not None
         install_chrome(args.channel)
-        # Chrome is using dbus for various features.
-        start_dbus()
 
     if args.xvfb:
         start_xvfb()


### PR DESCRIPTION
Reverts web-platform-tests/wpt#42241

(Suspected of causing `tools/` integration tests failures.)