### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=262635

### DIFF
--- a/fetch/api/body/formdata.any.js
+++ b/fetch/api/body/formdata.any.js
@@ -12,3 +12,14 @@ promise_test(async t => {
   const fd = await req.formData();
   assert_true(fd instanceof FormData);
 }, 'Consume empty request.formData() as FormData');
+
+promise_test(async t => {
+  let formdata = new FormData();
+  formdata.append('foo', new Blob([JSON.stringify({ bar: "baz", })], { type: "application/json" }));
+  let blob = await new Response(formdata).blob();
+  let body = await blob.text();
+  blob = new Blob([body.toLowerCase()], { type: blob.type.toLowerCase() });
+  let formdataWithLowercaseBody = await new Response(blob).formData();
+  assert_true(formdataWithLowercaseBody.has("foo"));
+  assert_equals(formdataWithLowercaseBody.get("foo").type, "application/json");
+}, 'Consume multipart/form-data headers case-insensitively');


### PR DESCRIPTION
WebKit export from bug: [FetchResponse.formData() should parse headers names as case insensitive](https://bugs.webkit.org/show_bug.cgi?id=262635)