### PR TITLE
mousemove_prevent_default_action.tentative.html unnecessarily listens for selectionchange events when asserting dragstart is fired

### DIFF
--- a/uievents/mouse/mousemove_prevent_default_action.tentative.html
+++ b/uievents/mouse/mousemove_prevent_default_action.tentative.html
@@ -27,12 +27,13 @@
 
   // Deliberately avoiding mouseup here because the last selectionchange
   // may be fired before or after the mouseup.
-  ["mousedown", "mousemove", "selectionchange", "dragstart"].forEach(ename => {
-    document.addEventListener(ename, logEvents);
-  });
+  document.addEventListener("mousedown", logEvents);
+  document.addEventListener("mousemove", logEvents);
   document.addEventListener("mousemove", e => e.preventDefault());
 
-  promise_test(async () => {
+  promise_test(async test => {
+    document.addEventListener("selectionchange", logEvents);
+    test.add_cleanup(() => { document.removeEventListener("selectionchange", logEvents); });
     event_log = [];
 
     const a = document.getElementById("a");
@@ -60,7 +61,9 @@
         "received events");
   }, "selectionchange event firing when mousemove event is prevented");
 
-  promise_test(async () => {
+  promise_test(async test => {
+    document.addEventListener("dragstart", logEvents);
+    test.add_cleanup(() => { document.removeEventListener("dragstart", logEvents); });
     event_log = [];
 
     const b = document.getElementById("b");


### PR DESCRIPTION
Since the two subtests in mousemove_prevent_default_action.tentative.html assert that either a selectionchange or a dragstart event is fired on a cancelled mousemove event by comparing a set of logged events (obtained from respective event listeners) against a static set of expected events, it is important to not listen for events a subtest does not care about, as that may produce an unnecessary test failure.

For example, we should not care whether or not a selectionchange event was fired in the second subtest, since we only want to assert that a dragstart event fires from a cancelled mousemove event on a draggable element. These two events are not mutually exclusive in any manner relevant to this WPT.

Thus, this commit makes sure we follow the invariant of listening only for selectionchange events, and not also dragstart events, in the first subtest, and similarly listening only for dragstart events, and not also selectionchange events, in the second subtest.

This PR implements the test change proposed in https://github.com/web-platform-tests/interop/issues/576.