### PR TITLE
Make tests for transforms on backgrounds of the root element not test scrollable overflow

### DIFF
--- a/css/css-transforms/transform-translate-background-001-ref.html
+++ b/css/css-transforms/transform-translate-background-001-ref.html
@@ -6,6 +6,6 @@
 <style>
   html {
     background: green;
-    overflow: hidden;
   }
 </style>
+</html>

--- a/css/css-transforms/transform-translate-background-001-ref.html
+++ b/css/css-transforms/transform-translate-background-001-ref.html
@@ -6,9 +6,6 @@
 <style>
   html {
     background: green;
-    /* Match scrollbar change caused by translateY transformation */
-    margin-top: -250vh;
+    overflow: hidden;
   }
 </style>
-<div style="height: 400vh;"></div>
-</html>

--- a/css/css-transforms/transform-translate-background-001.html
+++ b/css/css-transforms/transform-translate-background-001.html
@@ -11,6 +11,7 @@
   html {
     background: linear-gradient(to bottom, green 0%, green 50%, red 50%, red 100%);
     transform: translate(0, -250vh);
+    overflow: hidden;
   }
 </style>
 <div style="height: 400vh;"></div>

--- a/css/css-transforms/transform-translate-background-002.html
+++ b/css/css-transforms/transform-translate-background-002.html
@@ -11,6 +11,7 @@
 <style>
   html {
     background: linear-gradient(to bottom, green 0%, green 50%, red 50%, red 100%);
+    overflow: hidden;
   }
 </style>
 <div style="height: 400vh;"></div>


### PR DESCRIPTION
These tests are intended to test the effect of transform on the root element on backgrounds that are propagated to the canvas.  They coincidentally also test the effect of a transformed root element on the scrollable overflow that applies to the viewport's scrollbars.

The scrollbar issue is underspecified as described in w3c/csswg-drafts#9458, and implementations differ as to how a transformed root element affects scrollbar extents on the viewport.

Because of this, this change replaces the previous adjustment of these tests in web-platform-tests/wpt#36476 (from matching some implementations to matching others) with a change to the tests so that they no longer test the extent of scrollbars on the root element.