### PR TITLE
fix #42496. getCS for backgroundBlendMode.

### DIFF
--- a/css/compositing/parsing/background-blend-mode-computed-multiple.html
+++ b/css/compositing/parsing/background-blend-mode-computed-multiple.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Compositing and Blending Level 1: getComputedStyle().backgroundBlendMode</title>
+<link rel="help" href="https://drafts.fxtf.org/compositing-1/#propdef-background-blend-mode">
+<meta name="assert" content="background-blend-mode computed value is as specified.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<style>
+    #target {
+        background-image: none, none, none;
+    }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+// see https://drafts.fxtf.org/compositing-1/#background-blend-mode
+// and https://drafts.csswg.org/css-backgrounds-3/#layering
+// > The lists are matched up from the first value: excess values at the end are not used.
+// and
+// > If a property doesn’t have enough comma-separated values
+// > to match the number of layers, the UA must calculate its used value
+// > by repeating the list of values until there are enough.
+
+// if three images and one value the initial value should be repeated.
+test_computed_value("background-blend-mode", "normal", "normal, normal, normal");
+test_computed_value("background-blend-mode", "multiply", "multiply, multiply, multiply");
+
+// if three images and two values, just send back the same list and the first value for missing values.
+test_computed_value("background-blend-mode", "normal, luminosity", "normal, luminosity, normal");
+test_computed_value("background-blend-mode", "screen, overlay", "screen, overlay, screen");
+test_computed_value("background-blend-mode", "color, saturation", "color, saturation, color");
+
+// if three images and three values, just send back the same list.
+test_computed_value("background-blend-mode", "normal, luminosity, color");
+test_computed_value("background-blend-mode", "screen, overlay, screen");
+
+</script>
+</body>
+</html>

--- a/css/compositing/parsing/background-blend-mode-computed.html
+++ b/css/compositing/parsing/background-blend-mode-computed.html
@@ -29,9 +29,13 @@ test_computed_value("background-blend-mode", "saturation");
 test_computed_value("background-blend-mode", "color");
 test_computed_value("background-blend-mode", "luminosity");
 
-test_computed_value("background-blend-mode", "normal, luminosity");
-test_computed_value("background-blend-mode", "screen, overlay");
-test_computed_value("background-blend-mode", "color, saturation");
+// per spec, excess values should be dropped.
+// see https://drafts.fxtf.org/compositing-1/#background-blend-mode
+// and https://drafts.csswg.org/css-backgrounds-3/#layering
+// > The lists are matched up from the first value: excess values at the end are not used.
+test_computed_value("background-blend-mode", "normal, luminosity", "normal");
+test_computed_value("background-blend-mode", "screen, overlay", "screen");
+test_computed_value("background-blend-mode", "color, saturation", "color");
 </script>
 </body>
 </html>


### PR DESCRIPTION
Fix #42496 
The current test for the computed values of backgroundBlendMode were partially incorrect.
The spec says:

1. to drop the excess values depending on the number of images
2. to add the initial defined values if not enough.

This fixes the current test and add another test for multiple images.