### PR TITLE
Add additional tests for multiplication/division of mixed units

### DIFF
--- a/css/css-text/tab-size/tab-size-computed-value-001.html
+++ b/css/css-text/tab-size/tab-size-computed-value-001.html
@@ -40,7 +40,7 @@
 
   var targetElement = document.getElementById("target");
 
-    function verifyComputedStyle(property_name, specified_value, expected_value, description)
+    function verifyComputedStyle(property_name, specified_value, expected_value)
     {
 
     test(function()
@@ -60,10 +60,10 @@
 
       assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
 
-      }, description);
+      }, `testing ${property_name}: ${specified_value}`);
     }
 
-    function compareValueCloseTo(property_name, specified_value, epsilon, expected_value, description)
+    function compareValueCloseTo(property_name, specified_value, epsilon, expected_value)
     {
 
     test(function()
@@ -83,60 +83,60 @@
 
       assert_array_approx_equals(computedSpecifiedValue, computedExpectedValue, epsilon);
 
-    } , description);
+    }, `testing ${property_name}: ${specified_value}`);
 
   }
 
-    verifyComputedStyle("tab-size", "4", "4", "testing tab-size: 4");
+    verifyComputedStyle("tab-size", "4", "4");
 
- /* verifyComputedStyle(property_name, initial_value, specified_value, expected_value, description) */
+ /* verifyComputedStyle(property_name, initial_value, specified_value, expected_value) */
 
   /* absolute length units: in, cm, mm, pt, pc, Q, px */
 
-    verifyComputedStyle("tab-size", "0.5in", "48px", "testing tab-size: 0.5in");
+    verifyComputedStyle("tab-size", "0.5in", "48px");
 
-    verifyComputedStyle("tab-size", "2.54cm", "96px", "testing tab-size: 2.54cm");
+    verifyComputedStyle("tab-size", "2.54cm", "96px");
 
-    verifyComputedStyle("tab-size", "25.4mm", "96px", "testing tab-size: 25.4mm");
+    verifyComputedStyle("tab-size", "25.4mm", "96px");
 
-    verifyComputedStyle("tab-size", "18pt", "24px", "testing tab-size: 18pt");
+    verifyComputedStyle("tab-size", "18pt", "24px");
 
-    verifyComputedStyle("tab-size", "5pc", "80px", "testing tab-size: 5pc");
+    verifyComputedStyle("tab-size", "5pc", "80px");
 
-    verifyComputedStyle("tab-size", "101.6Q", "96px", "testing tab-size: 101.6Q");
+    verifyComputedStyle("tab-size", "101.6Q", "96px");
 
-    verifyComputedStyle("tab-size", "7px", "7px", "testing tab-size: 7px");
+    verifyComputedStyle("tab-size", "7px", "7px");
 
- /* verifyComputedStyle(property_name, specified_value, expected_value, description) */
+ /* verifyComputedStyle(property_name, specified_value, expected_value) */
 
   /* relative length units: em, ex, rem */
 
-    verifyComputedStyle("tab-size", "1em", "20px", "testing tab-size: 1em");
+    verifyComputedStyle("tab-size", "1em", "20px");
 
- /* compareValueCloseTo(property_name, specified_value, epsilon, expected_value, description)  */
+ /* compareValueCloseTo(property_name, specified_value, epsilon, expected_value)  */
 
-    compareValueCloseTo("tab-size", "2ex", 0.001, "32px", "testing tab-size: 2ex");
+    compareValueCloseTo("tab-size", "2ex", 0.001, "32px");
 
     /*
     For this sub-test, we set the tolerance precision (epsilon)
     to (0.001 === 1 thousandth).
     */
 
-    verifyComputedStyle("tab-size", "3rem", "48px", "testing tab-size: 3rem");
+    verifyComputedStyle("tab-size", "3rem", "48px");
 
   /*
 
   NOT tested are: vw, vh, vmin, vmax and ch units
 
-    verifyComputedStyle("tab-size", "4vw", "?px", "testing tab-size: 4vw");
+    verifyComputedStyle("tab-size", "4vw", "?px");
 
-    verifyComputedStyle("tab-size", "5vh", "?px", "testing tab-size: 5vh");
+    verifyComputedStyle("tab-size", "5vh", "?px");
 
-    verifyComputedStyle("tab-size", "6vmin", "?px", "testing tab-size: 6vmin");
+    verifyComputedStyle("tab-size", "6vmin", "?px");
 
-    verifyComputedStyle("tab-size", "7vmax", "?px", "testing tab-size: 7vmax");
+    verifyComputedStyle("tab-size", "7vmax", "?px");
 
-    verifyComputedStyle("tab-size", "8ch", "?px", "testing tab-size: 8ch");
+    verifyComputedStyle("tab-size", "8ch", "?px");
 
   */
 

--- a/css/css-text/word-spacing/word-spacing-computed-001.html
+++ b/css/css-text/word-spacing/word-spacing-computed-001.html
@@ -30,7 +30,7 @@
 
   var targetElement = document.getElementById("target");
 
-    function verifyComputedStyle(property_name, specified_value, expected_value, description)
+    function verifyComputedStyle(property_name, specified_value, expected_value)
     {
 
     test(function()
@@ -50,32 +50,32 @@
 
       assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
 
-      }, description);
+      }, `testing ${property_name}: ${specified_value}`);
     }
 
-    verifyComputedStyle("word-spacing", "normal", "0px", "testing word-spacing: normal");
+    verifyComputedStyle("word-spacing", "normal", "0px");
 
-    verifyComputedStyle("word-spacing", "0", "0px", "testing word-spacing: 0");
+    verifyComputedStyle("word-spacing", "0", "0px");
 
-    verifyComputedStyle("word-spacing", "1.27cm", "48px", "testing word-spacing: 1.27cm");
+    verifyComputedStyle("word-spacing", "1.27cm", "48px");
 
-    verifyComputedStyle("word-spacing", "1em", "20px", "testing word-spacing: 1em");
+    verifyComputedStyle("word-spacing", "1em", "20px");
 
-    verifyComputedStyle("word-spacing", "0.5in", "48px", "testing word-spacing: 0.5in");
+    verifyComputedStyle("word-spacing", "0.5in", "48px");
 
-    verifyComputedStyle("word-spacing", "25.4mm", "96px", "testing word-spacing: 25.4mm");
+    verifyComputedStyle("word-spacing", "25.4mm", "96px");
 
-    verifyComputedStyle("word-spacing", "5pc", "80px", "testing word-spacing: 5pc");
+    verifyComputedStyle("word-spacing", "5pc", "80px");
 
-    verifyComputedStyle("word-spacing", "18pt", "24px", "testing word-spacing: 18pt");
+    verifyComputedStyle("word-spacing", "18pt", "24px");
 
-    verifyComputedStyle("word-spacing", "7px", "7px", "testing word-spacing: 7px");
+    verifyComputedStyle("word-spacing", "7px", "7px");
 
-    verifyComputedStyle("word-spacing", "101.6Q", "96px", "testing word-spacing: 101.6Q");
+    verifyComputedStyle("word-spacing", "101.6Q", "96px");
 
-    verifyComputedStyle("word-spacing", "3rem", "48px", "testing word-spacing: 3rem");
+    verifyComputedStyle("word-spacing", "3rem", "48px");
 
-    verifyComputedStyle("word-spacing", "0ch", "0px", "testing word-spacing: 0ch");
+    verifyComputedStyle("word-spacing", "0ch", "0px");
 
   }
 

--- a/css/css-values/calc-background-position-002.html
+++ b/css/css-values/calc-background-position-002.html
@@ -21,7 +21,7 @@
 
   var targetElement = document.getElementById("target");
 
-    function verifyComputedStyle(property_name, initial_value, specified_value, expected_value, description)
+    function verifyComputedStyle(property_name, initial_value, specified_value, expected_value)
     {
 
     test(function()
@@ -42,20 +42,20 @@
 
       assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
 
-      }, description);
+      }, `testing ${property_name}: ${specified_value}`);
     }
 
- /* verifyComputedStyle(property_name, initial_value, specified_value, expected_value, description) */
+ /* verifyComputedStyle(property_name, initial_value, specified_value, expected_value) */
 
-    verifyComputedStyle("background-position", "initial", "calc(2px + 3px) calc(4px + 5px)", "5px 9px", "testing background-position: calc(2px + 3px) calc(4px + 5px)");
+    verifyComputedStyle("background-position", "initial", "calc(2px + 3px) calc(4px + 5px)", "5px 9px");
 
-    verifyComputedStyle("background-position", "initial", "calc(18px - 7px) calc(19px - 7px)", "11px 12px", "testing background-position: calc(18px - 7px) calc(19px - 7px)");
+    verifyComputedStyle("background-position", "initial", "calc(18px - 7px) calc(19px - 7px)", "11px 12px");
 
-    verifyComputedStyle("background-position", "initial", "calc(4 * 5px) calc(6px * 4)", "20px 24px", "testing background-position: calc(4 * 5px) calc(6px * 4)");
+    verifyComputedStyle("background-position", "initial", "calc(4 * 5px) calc(6px * 4)", "20px 24px");
 
-    verifyComputedStyle("background-position", "initial", "calc(100px / 4) calc(119px / 7)", "25px 17px", "testing background-position: calc(100px / 4) calc(119px / 7)");
+    verifyComputedStyle("background-position", "initial", "calc(100px / 4) calc(119px / 7)", "25px 17px");
 
-    verifyComputedStyle("background-position", "initial", "calc(6px + 21%) calc(7em + 22%)", "calc(21% + 6px) calc(22% + 112px)", "testing background-position: calc(6px + 21%) calc(7em + 22%)");
+    verifyComputedStyle("background-position", "initial", "calc(6px + 21%) calc(7em + 22%)", "calc(21% + 6px) calc(22% + 112px)");
 
   /*
     "
@@ -67,9 +67,9 @@
     https://www.w3.org/TR/css-values-3/#calc-computed-value
   */
 
-    verifyComputedStyle("background-position", "initial", "calc(-8px + 23%) calc(-9em + 24%)", "calc(23% - 8px) calc(24% - 144px)", "testing background-position: calc(-8px + 23%) calc(-9em + 24%)");
+    verifyComputedStyle("background-position", "initial", "calc(-8px + 23%) calc(-9em + 24%)", "calc(23% - 8px) calc(24% - 144px)");
 
- /* verifyComputedStyle(property_name, initial_value, specified_value, expected_value, description) */
+ /* verifyComputedStyle(property_name, initial_value, specified_value, expected_value) */
   }
 
   startTesting();

--- a/css/css-values/calc-in-media-queries-with-mixed-units.html
+++ b/css/css-values/calc-in-media-queries-with-mixed-units.html
@@ -7,12 +7,18 @@
     <link rel="help" href="https://www.w3.org/TR/css3-values/#calc-computed-value">
   </head>
   <body>
-    <iframe src="./support/mixed-units-01.html" title="px/em" frameborder="0" height="10" width="100"></iframe>
-    <iframe src="./support/mixed-units-02.html" title="vh/em" frameborder="0" height="10" width="100"></iframe>
-    <iframe src="./support/mixed-units-03.html" title="vw/em" frameborder="0" height="10" width="100"></iframe>
-    <iframe src="./support/mixed-units-04.html" title="vw/vh" frameborder="0" height="10" width="100"></iframe>
-    <iframe src="./support/mixed-units-05.html" title="vh/px" frameborder="0" height="10" width="100"></iframe>
-    <iframe src="./support/mixed-units-06.html" title="vw/px" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-01.html" title="px-em" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-02.html" title="vh+em" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-03.html" title="vw-em" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-04.html" title="vw+vh" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-05.html" title="vh+px" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-06.html" title="vw+px" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-07.html" title="px/em*em" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-08.html" title="vh*em" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-09.html" title="vw/em*px" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-10.html" title="vw/px*vh" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-11.html" title="vh*vw/rem*px" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-12.html" title="vw*px*px" frameborder="0" height="10" width="100"></iframe>
     <script>
       for (const frame of document.querySelectorAll("iframe")) {
         async_test((t) => {

--- a/css/css-values/calc-in-media-queries-with-mixed-units.html
+++ b/css/css-values/calc-in-media-queries-with-mixed-units.html
@@ -24,7 +24,7 @@
         async_test((t) => {
           frame.addEventListener("load", t.step_func(() => {
             const body = frame.contentWindow.document.body;
-            const actual = frame.contentWindow.getComputedStyle(box).getPropertyValue("background-color");
+            const actual = frame.contentWindow.getComputedStyle(body).getPropertyValue("background-color");
             assert_equals(actual, "rgb(255, 165, 0)");
             t.done();
           }));

--- a/css/css-values/calc-in-media-queries-with-mixed-units.html
+++ b/css/css-values/calc-in-media-queries-with-mixed-units.html
@@ -15,10 +15,10 @@
     <iframe src="./support/mixed-units-06.html" title="vw+px" frameborder="0" height="10" width="100"></iframe>
     <iframe src="./support/mixed-units-07.html" title="px/em*em" frameborder="0" height="10" width="100"></iframe>
     <iframe src="./support/mixed-units-08.html" title="vh*em" frameborder="0" height="10" width="100"></iframe>
-    <iframe src="./support/mixed-units-09.html" title="vw/em*px" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-09.html" title="vh*vw/em*px/vh" frameborder="0" height="10" width="100"></iframe>
     <iframe src="./support/mixed-units-10.html" title="vw/px*vh" frameborder="0" height="10" width="100"></iframe>
-    <iframe src="./support/mixed-units-11.html" title="vh*vw/rem*px" frameborder="0" height="10" width="100"></iframe>
-    <iframe src="./support/mixed-units-12.html" title="vw*px*px" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-11.html" title="vh*vw/em*px" frameborder="0" height="10" width="100"></iframe>
+    <iframe src="./support/mixed-units-12.html" title="vw*vh*px*em/px/px/px" frameborder="0" height="10" width="100"></iframe>
     <script>
       for (const frame of document.querySelectorAll("iframe")) {
         async_test((t) => {

--- a/css/css-values/calc-in-media-queries-with-mixed-units.html
+++ b/css/css-values/calc-in-media-queries-with-mixed-units.html
@@ -23,7 +23,7 @@
       for (const frame of document.querySelectorAll("iframe")) {
         async_test((t) => {
           frame.addEventListener("load", t.step_func(() => {
-            const box = frame.contentWindow.document.querySelector(".box");
+            const body = frame.contentWindow.document.body;
             const actual = frame.contentWindow.getComputedStyle(box).getPropertyValue("background-color");
             assert_equals(actual, "rgb(255, 165, 0)");
             t.done();

--- a/css/css-values/calc-linear-radial-conic-gradient-001.html
+++ b/css/css-values/calc-linear-radial-conic-gradient-001.html
@@ -40,7 +40,7 @@
 
   var targetElement = document.getElementById("target");
 
-    function verifyComputedStyle(property_name, specified_value, expected_value, description)
+    function verifyComputedStyle(property_name, specified_value, expected_value)
     {
 
     test(function()
@@ -61,48 +61,42 @@
 
       assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
 
-      }, description);
+      }, `testing ${property_name}: ${specified_value}`);
     }
 
- /* verifyComputedStyle(property_name, specified_value, expected_value, description) */
+ /* verifyComputedStyle(property_name, specified_value, expected_value) */
 
     /* LINEAR */
 
     verifyComputedStyle(
     "background-image",
     "linear-gradient(rgb(0, 128, 0) calc(0%), rgb(0, 0, 255))",
-    "linear-gradient(rgb(0, 128, 0) 0%, rgb(0, 0, 255))",
-    "testing background-image: linear-gradient(rgb(0, 128, 0) calc(0%), rgb(0, 0, 255))");
+    "linear-gradient(rgb(0, 128, 0) 0%, rgb(0, 0, 255))");
 
     verifyComputedStyle(
     "background-image",
     "linear-gradient(calc(90deg), rgb(0, 128, 0), rgb(0, 0, 255))",
-    "linear-gradient(90deg, rgb(0, 128, 0), rgb(0, 0, 255))",
-    "testing background-image: linear-gradient(calc(90deg), rgb(0, 128, 0), rgb(0, 0, 255))");
+    "linear-gradient(90deg, rgb(0, 128, 0), rgb(0, 0, 255))");
 
     verifyComputedStyle(
     "background-image",
     "linear-gradient(calc(90deg), rgb(0, 128, 0) calc(0%), rgb(0, 0, 255))",
-    "linear-gradient(90deg, rgb(0, 128, 0) 0%, rgb(0, 0, 255))",
-    "testing background-position: linear-gradient(calc(90deg), rgb(0, 128, 0) calc(0%), rgb(0, 0, 255))");
+    "linear-gradient(90deg, rgb(0, 128, 0) 0%, rgb(0, 0, 255))");
 
     verifyComputedStyle(
     "background-image",
     "linear-gradient(calc(0.1turn + 0.15turn), rgb(0, 128, 0), rgb(0, 0, 255))",
-    "linear-gradient(90deg, rgb(0, 128, 0), rgb(0, 0, 255))",
-    "testing background-image: linear-gradient(calc(0.1turn + 0.15turn), rgb(0, 128, 0), rgb(0, 0, 255))");
+    "linear-gradient(90deg, rgb(0, 128, 0), rgb(0, 0, 255))");
 
     verifyComputedStyle(
     "background-image",
     "linear-gradient(calc(150grad - 50grad), rgb(0, 128, 0), rgb(0, 0, 255))",
-    "linear-gradient(90deg, rgb(0, 128, 0), rgb(0, 0, 255))",
-    "testing background-image: linear-gradient(calc(150grad - 50grad), rgb(0, 128, 0), rgb(0, 0, 255))");
+    "linear-gradient(90deg, rgb(0, 128, 0), rgb(0, 0, 255))");
 
     verifyComputedStyle(
     "background-image",
     "linear-gradient(calc(200grad - 90deg), rgb(0, 128, 0), rgb(0, 0, 255))",
-    "linear-gradient(90deg, rgb(0, 128, 0), rgb(0, 0, 255))",
-    "testing background-image: linear-gradient(calc(200grad - 90deg), rgb(0, 128, 0), rgb(0, 0, 255))");
+    "linear-gradient(90deg, rgb(0, 128, 0), rgb(0, 0, 255))");
 
 
     /* RADIAL */
@@ -110,8 +104,7 @@
     verifyComputedStyle(
     "background-image",
     "radial-gradient(rgb(0, 128, 0) calc(10% + 20%), rgb(0, 0, 255) calc(30% + 40%))",
-    "radial-gradient(rgb(0, 128, 0) 30%, rgb(0, 0, 255) 70%)",
-    "testing background-image: radial-gradient(rgb(0, 128, 0) calc(10% + 20%), rgb(0, 0, 255) calc(30% + 40%))");
+    "radial-gradient(rgb(0, 128, 0) 30%, rgb(0, 0, 255) 70%)");
 
 
     /* CONIC */
@@ -119,10 +112,9 @@
     verifyComputedStyle(
     "background-image",
     "conic-gradient(rgb(0, 128, 0) calc(50% + 10%), rgb(0, 0, 255) calc(60% + 20%))",
-    "conic-gradient(rgb(0, 128, 0) 60%, rgb(0, 0, 255) 80%)",
-    "testing background-image: conic-gradient(rgb(0, 128, 0) calc(50% + 10%), rgb(0, 0, 255) calc(60% + 20%))");
+    "conic-gradient(rgb(0, 128, 0) 60%, rgb(0, 0, 255) 80%)");
 
- /* verifyComputedStyle(property_name, specified_value, expected_value, description) */
+ /* verifyComputedStyle(property_name, specified_value, expected_value) */
 
   }
 

--- a/css/css-values/calc-z-index-fractions-001.html
+++ b/css/css-values/calc-z-index-fractions-001.html
@@ -21,7 +21,7 @@
 
   var targetElement = document.getElementById("target");
 
-    function verifyComputedStyle(property_name, initial_value, specified_value, expected_value, description)
+    function verifyComputedStyle(property_name, initial_value, specified_value, expected_value)
     {
 
     test(function()
@@ -42,16 +42,16 @@
 
       assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
 
-      }, description);
+      }, `testing ${property_name}: ${specified_value}`);
     }
 
- /* verifyComputedStyle(property_name, initial_value, specified_value, expected_value, description) */
-    verifyComputedStyle("z-index", "auto", "calc(2.5 / 2)", "1", "testing z-index: calc(2.5 / 2)");
-    verifyComputedStyle("z-index", "auto", "calc(3 / 2)", "2", "testing z-index: calc(3 / 2)");
-    verifyComputedStyle("z-index", "auto", "calc(3.5 / 2)", "2", "testing z-index: calc(3.5 / 2)");
-    verifyComputedStyle("z-index", "auto", "calc(-2.5 / 2)", "-1", "testing z-index: calc(-2.5 / 2)");
-    verifyComputedStyle("z-index", "auto", "calc(-3 / 2)", "-1", "testing z-index: calc(-3 / 2)");
-    verifyComputedStyle("z-index", "auto", "calc(-3.5 / 2)", "-2", "testing z-index: calc(-3.5 / 2)");
+ /* verifyComputedStyle(property_name, initial_value, specified_value, expected_value) */
+    verifyComputedStyle("z-index", "auto", "calc(2.5 / 2)", "1");
+    verifyComputedStyle("z-index", "auto", "calc(3 / 2)", "2");
+    verifyComputedStyle("z-index", "auto", "calc(3.5 / 2)", "2");
+    verifyComputedStyle("z-index", "auto", "calc(-2.5 / 2)", "-1");
+    verifyComputedStyle("z-index", "auto", "calc(-3 / 2)", "-1");
+    verifyComputedStyle("z-index", "auto", "calc(-3.5 / 2)", "-2");
   }
 
   startTesting();

--- a/css/css-values/getComputedStyle-border-radius-001.html
+++ b/css/css-values/getComputedStyle-border-radius-001.html
@@ -54,7 +54,7 @@ https://chromium.googlesource.com/chromium/src/+/c825d655f6aaf73484f9d56e9012793
 
       assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
 
-      }, `testing ${property_name}: ${specified_value}`);
+      }, `testing ${property_name}: ${expected_value}`);
     }
 
  /* verifyComputedStyle(property_name, expected_value) */

--- a/css/css-values/getComputedStyle-border-radius-001.html
+++ b/css/css-values/getComputedStyle-border-radius-001.html
@@ -46,7 +46,7 @@ https://chromium.googlesource.com/chromium/src/+/c825d655f6aaf73484f9d56e9012793
 
   var targetElement = document.getElementById("target");
 
-    function verifyComputedStyle(property_name, expected_value, description)
+    function verifyComputedStyle(property_name, expected_value)
     {
 
     test(function()
@@ -54,20 +54,20 @@ https://chromium.googlesource.com/chromium/src/+/c825d655f6aaf73484f9d56e9012793
 
       assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
 
-      }, description);
+      }, `testing ${property_name}: ${specified_value}`);
     }
 
- /* verifyComputedStyle(property_name, expected_value, description) */
+ /* verifyComputedStyle(property_name, expected_value) */
 
-    verifyComputedStyle("border-top-left-radius", "calc(25% + 10px) calc(25% + 20px)", "testing border-top-left-radius: calc(10px + 25%) calc(20px + 25%)");
+    verifyComputedStyle("border-top-left-radius", "calc(25% + 10px) calc(25% + 20px)");
 
-    verifyComputedStyle("border-top-right-radius", "calc(25% + 16px)", "testing border-top-right-radius: calc(1em + 25%)");
+    verifyComputedStyle("border-top-right-radius", "calc(25% + 16px)");
 
-    verifyComputedStyle("border-bottom-right-radius", "25%", "testing border-bottom-right-radius: calc(25%)");
+    verifyComputedStyle("border-bottom-right-radius", "25%");
 
-    verifyComputedStyle("border-bottom-left-radius", "25px", "testing border-bottom-left-radius: calc(25px);");
+    verifyComputedStyle("border-bottom-left-radius", "25px");
 
-    verifyComputedStyle("border-radius", "calc(25% + 10px) calc(25% + 16px) 25% 25px / calc(25% + 20px) calc(25% + 16px) 25% 25px", "testing border-radius shorthand");
+    verifyComputedStyle("border-radius", "calc(25% + 10px) calc(25% + 16px) 25% 25px / calc(25% + 20px) calc(25% + 16px) 25% 25px");
 
   /*
 

--- a/css/css-values/getComputedStyle-border-radius-003.html
+++ b/css/css-values/getComputedStyle-border-radius-003.html
@@ -40,7 +40,7 @@
 
   var targetElement = document.getElementById("target");
 
-    function verifyComputedStyle(property_name, expected_value, description)
+    function verifyComputedStyle(property_name, expected_value)
     {
 
     test(function()
@@ -48,12 +48,12 @@
 
       assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
 
-      }, description);
+      }, `testing ${property_name}: ${specified_value}`);
     }
 
- /* verifyComputedStyle(property_name, expected_value, description) */
+ /* verifyComputedStyle(property_name, expected_value) */
 
-    verifyComputedStyle("border-radius", "calc(1% + 1px) calc(2% + 2px) calc(3% + 3px) calc(4% + 4px) / calc(5% + 5px) calc(6% + 6px) calc(7% + 7px) calc(8% + 8px)", "testing border-radius shorthand");
+    verifyComputedStyle("border-radius", "calc(1% + 1px) calc(2% + 2px) calc(3% + 3px) calc(4% + 4px) / calc(5% + 5px) calc(6% + 6px) calc(7% + 7px) calc(8% + 8px)");
 
   /*
 

--- a/css/css-values/getComputedStyle-border-radius-003.html
+++ b/css/css-values/getComputedStyle-border-radius-003.html
@@ -48,7 +48,7 @@
 
       assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
 
-      }, `testing ${property_name}: ${specified_value}`);
+      }, `testing ${property_name}: ${expected_value}`);
     }
 
  /* verifyComputedStyle(property_name, expected_value) */

--- a/css/css-values/getComputedStyle-calc-mixed-units-001.html
+++ b/css/css-values/getComputedStyle-calc-mixed-units-001.html
@@ -54,7 +54,7 @@
 
   var targetElement = document.getElementById("target");
 
-    function verifyComputedStyle(property_name, specified_value, expected_value, description)
+    function verifyComputedStyle(property_name, specified_value, expected_value)
     {
 
     test(function()
@@ -64,10 +64,10 @@
 
       assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
 
-      }, description);
+      }, `testing ${property_name}: ${specified_value}`);
     }
 
-    verifyComputedStyle("background-size", "calc(67% - 54% + 4em) 50%", "calc(13% + 64px) 50%", "testing background-size: calc(67% - 54% + 4em) 50%");
+    verifyComputedStyle("background-size", "calc(67% - 54% + 4em) 50%", "calc(13% + 64px) 50%");
 
     /*
     "Where percentages are not resolved at computed-value time,
@@ -79,7 +79,7 @@
     must be resolved though.
     */
 
-    verifyComputedStyle("background-position", "calc(100% - 100% + 20em)", "calc(0% + 320px) 50%", "testing background-position: calc(100% - 100% + 20em)");
+    verifyComputedStyle("background-position", "calc(100% - 100% + 20em)", "calc(0% + 320px) 50%");
 
     /*
     Here too, the percentage is preserved and
@@ -88,7 +88,7 @@
     */
 
 
-    verifyComputedStyle("height", "calc(60% - 50% + 3em)", "105px", "testing height: calc(60% - 50% + 3em)");
+    verifyComputedStyle("height", "calc(60% - 50% + 3em)", "105px");
 
     /*
 

--- a/css/css-values/getComputedStyle-calc-mixed-units-002.html
+++ b/css/css-values/getComputedStyle-calc-mixed-units-002.html
@@ -65,7 +65,7 @@
 
   var targetElement = document.getElementById("target");
 
-    function verifyComputedStyle(property_name, specified_value, expected_value, description)
+    function verifyComputedStyle(property_name, specified_value, expected_value)
     {
 
     test(function()
@@ -77,10 +77,10 @@
 
       assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
 
-      }, description);
+      }, `testing ${property_name}: ${specified_value}`);
     }
 
-    verifyComputedStyle("width", "calc(10% + 2em)", "84px", "testing width: calc(10% + 2em)");
+    verifyComputedStyle("width", "calc(10% + 2em)", "84px");
 
     /*
 
@@ -97,7 +97,7 @@
     */
 
 
-    verifyComputedStyle("width", "calc(5% + 4rem)", "146px", "testing width: calc(5% + 4rem)");
+    verifyComputedStyle("width", "calc(5% + 4rem)", "146px");
 
     /*
 
@@ -114,7 +114,7 @@
     */
 
 
-    verifyComputedStyle("width", "calc(8lh + 7px)", "167px", "testing width: calc(8lh + 7px)");
+    verifyComputedStyle("width", "calc(8lh + 7px)", "167px");
 
     /*
 
@@ -131,7 +131,7 @@
     */
 
 
-    verifyComputedStyle("height", "calc(10% + 6pt)", "58px", "testing height: calc(10% + 6pt)");
+    verifyComputedStyle("height", "calc(10% + 6pt)", "58px");
 
     /*
 
@@ -148,7 +148,7 @@
     */
 
 
-    verifyComputedStyle("width", "calc(4em + 2.6458333cm)", "164px", "testing width: calc(4em + 2.6458333cm)");
+    verifyComputedStyle("width", "calc(4em + 2.6458333cm)", "164px");
 
     /*
 
@@ -165,7 +165,7 @@
     */
 
 
-    verifyComputedStyle("height", "calc(5em + 26.458333mm)", "180px", "testing height: calc(5em + 26.458333mm)");
+    verifyComputedStyle("height", "calc(5em + 26.458333mm)", "180px");
 
     /*
 
@@ -182,7 +182,7 @@
     */
 
 
-    verifyComputedStyle("width", "calc(2in + 101.6Q)", "288px", "testing width: calc(2in + 101.6Q)");
+    verifyComputedStyle("width", "calc(2in + 101.6Q)", "288px");
 
     /*
 
@@ -199,7 +199,7 @@
     */
 
 
-    verifyComputedStyle("height", "calc(1pc + 3pt)", "20px", "testing height: calc(1pc + 3pt)");
+    verifyComputedStyle("height", "calc(1pc + 3pt)", "20px");
 
     /*
 

--- a/css/css-values/getComputedStyle-calc-mixed-units-003.html
+++ b/css/css-values/getComputedStyle-calc-mixed-units-003.html
@@ -20,9 +20,9 @@
   body {
       font-size: 16px;
       line-height: 1.25; /* computed value: 20px */
+      width: 520px;
       height: 500px;
       margin: 20px;
-      width: 520px;
   }
 
   div#target {
@@ -45,66 +45,66 @@
       }, description);
     }
 
-    verifyComputedStyle("width", "calc(10% * 8.4 + 2em)", "468px", "testing width: calc(10% * 8.4 + 2em)");
+    verifyComputedStyle("width", "calc(10% * 10 + 2em)", "552px", "testing width: calc(10% * 10 + 2em)");
     /*
       10% of 520px = 52px
-      52px * 8.4 = 436.8 (but we still add 2em in the formula)
       2em = 32px
-      Total = 468.8px (rounded to 468px)
+      52px * 10 + 32px = 520px + 32px = 552px
+      Total = 552px
     */
 
-    verifyComputedStyle("width", "calc(5% * 29.2 + 4rem)", "146px", "testing width: calc(5% * 29.2 + 4rem)");
+    verifyComputedStyle("width", "calc(5% * 10 + 4em)", "324px", "testing width: calc(5% * 10 + 4em)");
     /*
       5% of 520px = 26px
-      26px * 29.2 = 758.2 (but we still add 4rem in the formula)
-      4rem = 120px
-      Total = 878.2px (rounded to 878px)
+      4em = 64px
+      26px * 10 + 64px = 260px + 64px = 324px
+      Total = 324px
     */
 
-    verifyComputedStyle("width", "calc(20.875 * 8lh + 7px)", "167px", "testing width: calc(20.875 * 8lh + 7px)");
+    verifyComputedStyle("width", "calc(20.875 * 8lh + 7px)", "3347px", "testing width: calc(20.875 * 8lh + 7px)");
     /*
       8lh = 160px
-      160px * 20.875 = 3340 (but we still add 7px in the formula)
+      20.875 * 160px + 7px = 3340px + 7px = 3347px
       Total = 3347px
     */
 
-    verifyComputedStyle("height", "calc(10% * 5.8 + 6pt)", "58px", "testing height: calc(10% * 5.8 + 6pt)");
+    verifyComputedStyle("height", "calc(10% * 5.8 + 6pt)", "298px", "testing height: calc(10% * 5.8 + 6pt)");
     /*
       10% of 500px = 50px
-      50px * 5.8 = 290px (but we still add 6pt in the formula)
       6pt = 8px
+      50px * 5.8 + 8px = 290px + 8px = 298px
       Total = 298px
     */
 
-    verifyComputedStyle("width", "calc(2.56 * 4em + 2.6458333cm)", "164px", "testing width: calc(2.56 * 4em + 2.6458333cm)");
+    verifyComputedStyle("width", "calc(2 * 4em + 2.6458333cm)", "228px", "testing width: calc(2 * 4em + 2.6458333cm)");
     /*
       4em = 64px
-      64px * 2.56 = 163.84 (but we still add 2.6458333cm in the formula)
       2.6458333cm = 100px
-      Total = 263.84px (rounded to 264px)
+      2 * 64px + 100px = 128px + 100px = 228px
+      Total = 228px
     */
 
-    verifyComputedStyle("height", "calc(3.6 * 5em + 26.458333mm)", "180px", "testing height: calc(3.6 * 5em + 26.458333mm)");
+    verifyComputedStyle("height", "calc(3.6 * 5em + 26.458333mm)", "388px", "testing height: calc(3.6 * 5em + 26.458333mm)");
     /*
       5em = 80px
-      80px * 3.6 = 288px (but we still add 26.458333mm in the formula)
       26.458333mm = 100px
+      3.6 * 80px + 100px = 288px + 100px = 388px
       Total = 388px
     */
 
-    verifyComputedStyle("width", "calc(3 * 2in + 101.6Q)", "288px", "testing width: calc(3 * 2in + 101.6Q)");
+    verifyComputedStyle("width", "calc(3 * 2in + 101.6Q)", "672px", "testing width: calc(3 * 2in + 101.6Q)");
     /*
       2in = 192px
-      192px * 3 = 576px (but we still add 101.6Q in the formula)
       101.6Q = 96px
+      3 * 192px + 96px = 576px + 96px = 672px
       Total = 672px
     */
 
-    verifyComputedStyle("height", "calc(5 * 1pc + 3pt)", "20px", "testing height: calc(5 * 1pc + 3pt)");
+    verifyComputedStyle("height", "calc(5 * 1pc + 3pt)", "84px", "testing height: calc(5 * 1pc + 3pt)");
     /*
       1pc = 16px
-      16px * 5 = 80px (but we still add 3pt in the formula)
       3pt = 4px
+      5 * 16px + 4px = 80px + 4px = 84px
       Total = 84px
     */
 

--- a/css/css-values/getComputedStyle-calc-mixed-units-003.html
+++ b/css/css-values/getComputedStyle-calc-mixed-units-003.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Values Test: computed value of calc() values using multiplication/division with mixed units</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-values-4/#calc-computed-value">
+
+  <meta name="flags" content="">
+  <meta content="This meta-test checks for the resolution and absolutization of computed values with mixed units to 'px' when multiplication/division is used." name="assert">
+
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+
+  <style>
+  html {
+      font-size: 30px;
+  }
+
+  body {
+      font-size: 16px;
+      line-height: 1.25; /* computed value: 20px */
+      height: 500px;
+      margin: 20px;
+      width: 520px;
+  }
+
+  div#target {
+      height: 100px;
+      width: 100px;
+  }
+  </style>
+
+  <div id="target"></div>
+
+  <script>
+  function startTesting() {
+    var targetElement = document.getElementById("target");
+
+    function verifyComputedStyle(property_name, specified_value, expected_value, description) {
+      test(function() {
+        targetElement.style.setProperty(property_name, "initial");
+        targetElement.style.setProperty(property_name, specified_value);
+        assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
+      }, description);
+    }
+
+    verifyComputedStyle("width", "calc(10% * 8.4 + 2em)", "84px", "testing width: calc(10% * 8.4 + 2em)");
+    /*
+      10% of 520px = 52px
+      52px * 8.4 = 436.8 (but we still add 2em in the formula)
+      2em = 32px
+      Total = 468.8px (rounded to 468px)
+    */
+
+    verifyComputedStyle("width", "calc(5% * 29.2 + 4rem)", "146px", "testing width: calc(5% * 29.2 + 4rem)");
+    /*
+      5% of 520px = 26px
+      26px * 29.2 = 758.2 (but we still add 4rem in the formula)
+      4rem = 120px
+      Total = 878.2px (rounded to 878px)
+    */
+
+    verifyComputedStyle("width", "calc(20.875 * 8lh + 7px)", "167px", "testing width: calc(20.875 * 8lh + 7px)");
+    /*
+      8lh = 160px
+      160px * 20.875 = 3340 (but we still add 7px in the formula)
+      Total = 3347px
+    */
+
+    verifyComputedStyle("height", "calc(10% * 5.8 + 6pt)", "58px", "testing height: calc(10% * 5.8 + 6pt)");
+    /*
+      10% of 500px = 50px
+      50px * 5.8 = 290px (but we still add 6pt in the formula)
+      6pt = 8px
+      Total = 298px
+    */
+
+    verifyComputedStyle("width", "calc(2.56 * 4em + 2.6458333cm)", "164px", "testing width: calc(2.56 * 4em + 2.6458333cm)");
+    /*
+      4em = 64px
+      64px * 2.56 = 163.84 (but we still add 2.6458333cm in the formula)
+      2.6458333cm = 100px
+      Total = 263.84px (rounded to 264px)
+    */
+
+    verifyComputedStyle("height", "calc(3.6 * 5em + 26.458333mm)", "180px", "testing height: calc(3.6 * 5em + 26.458333mm)");
+    /*
+      5em = 80px
+      80px * 3.6 = 288px (but we still add 26.458333mm in the formula)
+      26.458333mm = 100px
+      Total = 388px
+    */
+
+    verifyComputedStyle("width", "calc(3 * 2in + 101.6Q)", "288px", "testing width: calc(3 * 2in + 101.6Q)");
+    /*
+      2in = 192px
+      192px * 3 = 576px (but we still add 101.6Q in the formula)
+      101.6Q = 96px
+      Total = 672px
+    */
+
+    verifyComputedStyle("height", "calc(5 * 1pc + 3pt)", "20px", "testing height: calc(5 * 1pc + 3pt)");
+    /*
+      1pc = 16px
+      16px * 5 = 80px (but we still add 3pt in the formula)
+      3pt = 4px
+      Total = 84px
+    */
+
+  }
+
+  startTesting();
+
+  </script>

--- a/css/css-values/getComputedStyle-calc-mixed-units-003.html
+++ b/css/css-values/getComputedStyle-calc-mixed-units-003.html
@@ -44,7 +44,7 @@
         assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
       }, `testing ${property_name}: ${specified_value}`);
     }
-    
+
     verifyComputedStyle("width", "calc(5px * 10lh / 1px)", "1000px");
     /*
       10lh = 200px

--- a/css/css-values/getComputedStyle-calc-mixed-units-003.html
+++ b/css/css-values/getComputedStyle-calc-mixed-units-003.html
@@ -37,15 +37,15 @@
   function startTesting() {
     var targetElement = document.getElementById("target");
 
-    function verifyComputedStyle(property_name, specified_value, expected_value, description) {
+    function verifyComputedStyle(property_name, specified_value, expected_value) {
       test(function() {
         targetElement.style.setProperty(property_name, "initial");
         targetElement.style.setProperty(property_name, specified_value);
         assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
-      }, description);
+      }, `testing ${property_name}: ${specified_value}`);
     }
 
-    verifyComputedStyle("width", "calc(10% * 10 + 2em)", "552px", "testing width: calc(10% * 10 + 2em)");
+    verifyComputedStyle("width", "calc(10% * 10 + 2em)", "552px");
     /*
       10% of 520px = 52px
       2em = 32px
@@ -53,7 +53,7 @@
       Total = 552px
     */
 
-    verifyComputedStyle("width", "calc(5% * 10 + 4em)", "324px", "testing width: calc(5% * 10 + 4em)");
+    verifyComputedStyle("width", "calc(5% * 10 + 4em)", "324px");
     /*
       5% of 520px = 26px
       4em = 64px
@@ -61,14 +61,14 @@
       Total = 324px
     */
 
-    verifyComputedStyle("width", "calc(20.875 * 8lh + 7px)", "3347px", "testing width: calc(20.875 * 8lh + 7px)");
+    verifyComputedStyle("width", "calc(20.875 * 8lh + 7px)", "3347px");
     /*
       8lh = 160px
       20.875 * 160px + 7px = 3340px + 7px = 3347px
       Total = 3347px
     */
 
-    verifyComputedStyle("height", "calc(10% * 5.8 + 6pt)", "298px", "testing height: calc(10% * 5.8 + 6pt)");
+    verifyComputedStyle("height", "calc(10% * 5.8 + 6pt)", "298px");
     /*
       10% of 500px = 50px
       6pt = 8px
@@ -76,7 +76,7 @@
       Total = 298px
     */
 
-    verifyComputedStyle("width", "calc(2 * 4em + 2.6458333cm)", "228px", "testing width: calc(2 * 4em + 2.6458333cm)");
+    verifyComputedStyle("width", "calc(2 * 4em + 2.6458333cm)", "228px");
     /*
       4em = 64px
       2.6458333cm = 100px
@@ -84,7 +84,7 @@
       Total = 228px
     */
 
-    verifyComputedStyle("height", "calc(3.6 * 5em + 26.458333mm)", "388px", "testing height: calc(3.6 * 5em + 26.458333mm)");
+    verifyComputedStyle("height", "calc(3.6 * 5em + 26.458333mm)", "388px");
     /*
       5em = 80px
       26.458333mm = 100px
@@ -92,7 +92,7 @@
       Total = 388px
     */
 
-    verifyComputedStyle("width", "calc(3 * 2in + 101.6Q)", "672px", "testing width: calc(3 * 2in + 101.6Q)");
+    verifyComputedStyle("width", "calc(3 * 2in + 101.6Q)", "672px");
     /*
       2in = 192px
       101.6Q = 96px
@@ -100,7 +100,7 @@
       Total = 672px
     */
 
-    verifyComputedStyle("height", "calc(5 * 1pc + 3pt)", "84px", "testing height: calc(5 * 1pc + 3pt)");
+    verifyComputedStyle("height", "calc(5 * 1pc + 3pt)", "84px");
     /*
       1pc = 16px
       3pt = 4px

--- a/css/css-values/getComputedStyle-calc-mixed-units-003.html
+++ b/css/css-values/getComputedStyle-calc-mixed-units-003.html
@@ -4,7 +4,6 @@
 
   <title>CSS Values Test: computed value of calc() values using multiplication/division with mixed units</title>
 
-  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-values-4/#calc-computed-value">
 
   <meta name="flags" content="">

--- a/css/css-values/getComputedStyle-calc-mixed-units-003.html
+++ b/css/css-values/getComputedStyle-calc-mixed-units-003.html
@@ -44,70 +44,43 @@
         assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
       }, `testing ${property_name}: ${specified_value}`);
     }
-
-    verifyComputedStyle("width", "calc(10% * 10 + 2em)", "552px");
+    
+    verifyComputedStyle("width", "calc(5px * 10lh / 1px)", "1000px");
     /*
-      10% of 520px = 52px
-      2em = 32px
-      52px * 10 + 32px = 520px + 32px = 552px
-      Total = 552px
+      10lh = 200px
+      5px * 200px / 1px = 1000px^2 / 1px = 1000px
+      Total = 1000px
     */
 
-    verifyComputedStyle("width", "calc(5% * 10 + 4em)", "324px");
+    verifyComputedStyle("width", "calc(20% * 0.5em / 1px)", "832px");
     /*
-      5% of 520px = 26px
-      4em = 64px
-      26px * 10 + 64px = 260px + 64px = 324px
-      Total = 324px
+      20% of 520px = 104px
+      0.5em = 8px
+      104px * 8px / 1px = 832px^2 / 1px = 832px
+      Total = 832px
     */
 
-    verifyComputedStyle("width", "calc(20.875 * 8lh + 7px)", "3347px");
-    /*
-      8lh = 160px
-      20.875 * 160px + 7px = 3340px + 7px = 3347px
-      Total = 3347px
-    */
-
-    verifyComputedStyle("height", "calc(10% * 5.8 + 6pt)", "298px");
-    /*
-      10% of 500px = 50px
-      6pt = 8px
-      50px * 5.8 + 8px = 290px + 8px = 298px
-      Total = 298px
-    */
-
-    verifyComputedStyle("width", "calc(2 * 4em + 2.6458333cm)", "228px");
+    verifyComputedStyle("width", "calc(4px * 4em / 1px)", "256px");
     /*
       4em = 64px
-      2.6458333cm = 100px
-      2 * 64px + 100px = 128px + 100px = 228px
-      Total = 228px
+      4px * 64px / 1px = 256px^2 / 1px = 256px
+      Total = 256px
     */
 
-    verifyComputedStyle("height", "calc(3.6 * 5em + 26.458333mm)", "388px");
+    verifyComputedStyle("width", "calc(400px / 4lh * 1px)", "5px");
     /*
-      5em = 80px
-      26.458333mm = 100px
-      3.6 * 80px + 100px = 288px + 100px = 388px
-      Total = 388px
+      4lh = 80px
+      400px / 80px * 1px = 5 * 1px = 5px
+      Total = 5px
     */
 
-    verifyComputedStyle("width", "calc(3 * 2in + 101.6Q)", "672px");
+    verifyComputedStyle("width", "calc(20% / 0.5em * 1px)", "13px");
     /*
-      2in = 192px
-      101.6Q = 96px
-      3 * 192px + 96px = 576px + 96px = 672px
-      Total = 672px
+      20% of 520px = 104px
+      0.5em = 8px
+      104px / 8px * 1px = 13 * 1px = 13px
+      Total = 13px
     */
-
-    verifyComputedStyle("height", "calc(5 * 1pc + 3pt)", "84px");
-    /*
-      1pc = 16px
-      3pt = 4px
-      5 * 16px + 4px = 80px + 4px = 84px
-      Total = 84px
-    */
-
   }
 
   startTesting();

--- a/css/css-values/getComputedStyle-calc-mixed-units-003.html
+++ b/css/css-values/getComputedStyle-calc-mixed-units-003.html
@@ -45,7 +45,7 @@
       }, description);
     }
 
-    verifyComputedStyle("width", "calc(10% * 8.4 + 2em)", "84px", "testing width: calc(10% * 8.4 + 2em)");
+    verifyComputedStyle("width", "calc(10% * 8.4 + 2em)", "468px", "testing width: calc(10% * 8.4 + 2em)");
     /*
       10% of 520px = 52px
       52px * 8.4 = 436.8 (but we still add 2em in the formula)

--- a/css/css-values/support/mixed-units-01.html
+++ b/css/css-values/support/mixed-units-01.html
@@ -3,21 +3,14 @@
   <head>
     <style>
       body {
-        margin: 0;
-        font-size: 16px;
-      }
-      .box {
         background: rgb(0, 0, 255);
-        width: 100%;
-        height: 10px;
       }
-
       @media (width: calc(116px - 1em)) {
-        .box {
+        body {
           background: rgb(255, 165, 0);
         }
       }
     </style>
   </head>
-  <div class="box"></div>
+  <body></body>
 </html>

--- a/css/css-values/support/mixed-units-02.html
+++ b/css/css-values/support/mixed-units-02.html
@@ -3,21 +3,14 @@
   <head>
     <style>
       body {
-        margin: 0;
-        font-size: 16px;
-      }
-      .box {
         background: rgb(0, 0, 255);
-        width: 100%;
-        height: 10px;
       }
-
       @media (width: calc(200vh + 5em)) {
-        .box {
+        body {
           background: rgb(255, 165, 0);
         }
       }
     </style>
   </head>
-  <div class="box"></div>
+  <body></body>
 </html>

--- a/css/css-values/support/mixed-units-03.html
+++ b/css/css-values/support/mixed-units-03.html
@@ -3,21 +3,14 @@
   <head>
     <style>
       body {
-        margin: 0;
-        font-size: 16px;
-      }
-      .box {
         background: rgb(0, 0, 255);
-        width: 100%;
-        height: 10px;
       }
-
       @media (height: calc(100vw - 5.625em)) {
-        .box {
+        body {
           background: rgb(255, 165, 0);
         }
       }
     </style>
   </head>
-  <div class="box"></div>
+  <body></body>
 </html>

--- a/css/css-values/support/mixed-units-04.html
+++ b/css/css-values/support/mixed-units-04.html
@@ -3,21 +3,14 @@
   <head>
     <style>
       body {
-        margin: 0;
-        font-size: 16px;
-      }
-      .box {
         background: rgb(0, 0, 255);
-        width: 100%;
-        height: 10px;
       }
-
       @media (width: calc(10vw + 900vh)) {
-        .box {
+        body {
           background: rgb(255, 165, 0);
         }
       }
     </style>
   </head>
-  <div class="box"></div>
+  <body></body>
 </html>

--- a/css/css-values/support/mixed-units-05.html
+++ b/css/css-values/support/mixed-units-05.html
@@ -3,21 +3,14 @@
   <head>
     <style>
       body {
-        margin: 0;
-        font-size: 16px;
-      }
-      .box {
         background: rgb(0, 0, 255);
-        width: 100%;
-        height: 10px;
       }
-
       @media (width: calc(900vh + 10px)) {
-        .box {
+        body {
           background: rgb(255, 165, 0);
         }
       }
     </style>
   </head>
-  <div class="box"></div>
+  <body></body>
 </html>

--- a/css/css-values/support/mixed-units-06.html
+++ b/css/css-values/support/mixed-units-06.html
@@ -3,21 +3,14 @@
   <head>
     <style>
       body {
-        margin: 0;
-        font-size: 16px;
-      }
-      .box {
         background: rgb(0, 0, 255);
-        width: 100%;
-        height: 10px;
       }
-
       @media (width: calc(90vw + 10px)) {
-        .box {
+        body {
           background: rgb(255, 165, 0);
         }
       }
     </style>
   </head>
-  <div class="box"></div>
+  <body></body>
 </html>

--- a/css/css-values/support/mixed-units-07.html
+++ b/css/css-values/support/mixed-units-07.html
@@ -3,21 +3,14 @@
   <head>
     <style>
       body {
-        margin: 0;
-        font-size: 16px;
-      }
-      .box {
         background: rgb(0, 0, 255);
-        width: 100%;
-        height: 10px;
       }
-
       @media (width: calc(100px / 1em * 1em)) {
-        .box {
+        body {
           background: rgb(255, 165, 0);
         }
       }
     </style>
   </head>
-  <div class="box"></div>
+  <body></body>
 </html>

--- a/css/css-values/support/mixed-units-07.html
+++ b/css/css-values/support/mixed-units-07.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        margin: 0;
+        font-size: 16px;
+      }
+      .box {
+        background: rgb(0, 0, 255);
+        width: 100%;
+        height: 10px;
+      }
+
+      @media (width: calc(116px / 1em * 1em)) {
+        .box {
+          background: rgb(255, 165, 0);
+        }
+      }
+    </style>
+  </head>
+  <div class="box"></div>
+</html>

--- a/css/css-values/support/mixed-units-07.html
+++ b/css/css-values/support/mixed-units-07.html
@@ -12,7 +12,7 @@
         height: 10px;
       }
 
-      @media (width: calc(116px / 1em * 1em)) {
+      @media (width: calc(100px / 1em * 1em)) {
         .box {
           background: rgb(255, 165, 0);
         }

--- a/css/css-values/support/mixed-units-08.html
+++ b/css/css-values/support/mixed-units-08.html
@@ -3,21 +3,14 @@
   <head>
     <style>
       body {
-        margin: 0;
-        font-size: 16px;
-      }
-      .box {
         background: rgb(0, 0, 255);
-        width: 100%;
-        height: 10px;
       }
-
       @media (width: calc((50vh * 5em) / 4px)) {
-        .box {
+        body {
           background: rgb(255, 165, 0);
         }
       }
     </style>
   </head>
-  <div class="box"></div>
+  <body></body>
 </html>

--- a/css/css-values/support/mixed-units-08.html
+++ b/css/css-values/support/mixed-units-08.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        margin: 0;
+        font-size: 16px;
+      }
+      .box {
+        background: rgb(0, 0, 255);
+        width: 100%;
+        height: 10px;
+      }
+
+      @media (width: calc(50vh * 5em)) {
+        .box {
+          background: rgb(255, 165, 0);
+        }
+      }
+    </style>
+  </head>
+  <div class="box"></div>
+</html>

--- a/css/css-values/support/mixed-units-08.html
+++ b/css/css-values/support/mixed-units-08.html
@@ -12,7 +12,7 @@
         height: 10px;
       }
 
-      @media (width: calc(50vh * 5em)) {
+      @media (width: calc((50vh * 5em) / 4px)) {
         .box {
           background: rgb(255, 165, 0);
         }

--- a/css/css-values/support/mixed-units-09.html
+++ b/css/css-values/support/mixed-units-09.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        margin: 0;
+        font-size: 16px;
+      }
+      .box {
+        background: rgb(0, 0, 255);
+        width: 100%;
+        height: 10px;
+      }
+
+      @media (height: calc(50vw / 5.625em * 10px)) {
+        .box {
+          background: rgb(255, 165, 0);
+        }
+      }
+    </style>
+  </head>
+  <div class="box"></div>
+</html>

--- a/css/css-values/support/mixed-units-09.html
+++ b/css/css-values/support/mixed-units-09.html
@@ -12,7 +12,7 @@
         height: 10px;
       }
 
-      @media (height: calc(50vw / 5.625em * 10px)) {
+      @media (height: calc(50vw / 0.3125em * 10px)) {
         .box {
           background: rgb(255, 165, 0);
         }

--- a/css/css-values/support/mixed-units-09.html
+++ b/css/css-values/support/mixed-units-09.html
@@ -3,21 +3,14 @@
   <head>
     <style>
       body {
-        margin: 0;
-        font-size: 16px;
-      }
-      .box {
         background: rgb(0, 0, 255);
-        width: 100%;
-        height: 10px;
       }
-
       @media (height: calc(50vw / 0.3125em * 10px)) {
-        .box {
+        body {
           background: rgb(255, 165, 0);
         }
       }
     </style>
   </head>
-  <div class="box"></div>
+  <body></body>
 </html>

--- a/css/css-values/support/mixed-units-10.html
+++ b/css/css-values/support/mixed-units-10.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        margin: 0;
+        font-size: 16px;
+      }
+      .box {
+        background: rgb(0, 0, 255);
+        width: 100%;
+        height: 10px;
+      }
+
+      @media (width: calc(10vw / 10px * 900vh)) {
+        .box {
+          background: rgb(255, 165, 0);
+        }
+      }
+    </style>
+  </head>
+  <div class="box"></div>
+</html>

--- a/css/css-values/support/mixed-units-10.html
+++ b/css/css-values/support/mixed-units-10.html
@@ -3,21 +3,14 @@
   <head>
     <style>
       body {
-        margin: 0;
-        font-size: 16px;
-      }
-      .box {
         background: rgb(0, 0, 255);
-        width: 100%;
-        height: 10px;
       }
-
       @media (width: calc(10vw / 10px * 1000vh)) {
-        .box {
+        body {
           background: rgb(255, 165, 0);
         }
       }
     </style>
   </head>
-  <div class="box"></div>
+  <body></body>
 </html>

--- a/css/css-values/support/mixed-units-10.html
+++ b/css/css-values/support/mixed-units-10.html
@@ -12,7 +12,7 @@
         height: 10px;
       }
 
-      @media (width: calc(10vw / 10px * 900vh)) {
+      @media (width: calc(10vw / 10px * 1000vh)) {
         .box {
           background: rgb(255, 165, 0);
         }

--- a/css/css-values/support/mixed-units-11.html
+++ b/css/css-values/support/mixed-units-11.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        margin: 0;
+        font-size: 16px;
+      }
+      .box {
+        background: rgb(0, 0, 255);
+        width: 100%;
+        height: 10px;
+      }
+
+      @media (width: calc(600vh * 1vw / 10rem * 10px)) {
+        .box {
+          background: rgb(255, 165, 0);
+        }
+      }
+    </style>
+  </head>
+  <div class="box"></div>
+</html>

--- a/css/css-values/support/mixed-units-11.html
+++ b/css/css-values/support/mixed-units-11.html
@@ -3,20 +3,14 @@
   <head>
     <style>
       body {
-        margin: 0;
-        font-size: 16px;
-      }
-      .box {
         background: rgb(0, 0, 255);
-        width: 100%;
-        height: 10px;
       }
       @media (width: calc(8000vh * 1vw / 1em * 8px / 40vh)) {
-        .box {
+        body {
           background: rgb(255, 165, 0);
         }
       }
     </style>
   </head>
-  <div class="box"></div>
+  <body></body>
 </html>

--- a/css/css-values/support/mixed-units-11.html
+++ b/css/css-values/support/mixed-units-11.html
@@ -11,7 +11,7 @@
         width: 100%;
         height: 10px;
       }
-      @media (width: calc(8000vh * 1vw / 1em * 8px / .4vh)) {
+      @media (width: calc(8000vh * 1vw / 1em * 8px / 40vh)) {
         .box {
           background: rgb(255, 165, 0);
         }

--- a/css/css-values/support/mixed-units-11.html
+++ b/css/css-values/support/mixed-units-11.html
@@ -11,8 +11,7 @@
         width: 100%;
         height: 10px;
       }
-
-      @media (width: calc(600vh * 1vw / 10rem * 10px)) {
+      @media (width: calc(8000vh * 1vw / 1em * 8px / .4vh)) {
         .box {
           background: rgb(255, 165, 0);
         }

--- a/css/css-values/support/mixed-units-12.html
+++ b/css/css-values/support/mixed-units-12.html
@@ -12,7 +12,7 @@
         height: 10px;
       }
 
-      @media (width: calc(90vw * 10px * 10px)) {
+      @media (width: calc(100vw * 10vh * 1px * 0.0625em / 1px / 1px / 1px)) {
         .box {
           background: rgb(255, 165, 0);
         }

--- a/css/css-values/support/mixed-units-12.html
+++ b/css/css-values/support/mixed-units-12.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        margin: 0;
+        font-size: 16px;
+      }
+      .box {
+        background: rgb(0, 0, 255);
+        width: 100%;
+        height: 10px;
+      }
+
+      @media (width: calc(90vw * 10px * 10px)) {
+        .box {
+          background: rgb(255, 165, 0);
+        }
+      }
+    </style>
+  </head>
+  <div class="box"></div>
+</html>

--- a/css/css-values/support/mixed-units-12.html
+++ b/css/css-values/support/mixed-units-12.html
@@ -3,21 +3,14 @@
   <head>
     <style>
       body {
-        margin: 0;
-        font-size: 16px;
-      }
-      .box {
         background: rgb(0, 0, 255);
-        width: 100%;
-        height: 10px;
       }
-
       @media (width: calc(100vw * 10vh * 1px * 0.0625em / 1px / 1px / 1px)) {
-        .box {
+        body {
           background: rgb(255, 165, 0);
         }
       }
     </style>
   </head>
-  <div class="box"></div>
+  <body></body>
 </html>


### PR DESCRIPTION
This PR adds tests for testing multiplication/division of mixed units, both in simple expressions as well as `calc()` inside `@media` query expressions.

This is done in support of Interop 2024 ticket:
https://github.com/web-platform-tests/interop/issues/513