### PR TITLE
fix #42496. better getCS with backgroundBlendMode

### DIFF
--- a/css/compositing/parsing/background-blend-mode-computed-multiple.html
+++ b/css/compositing/parsing/background-blend-mode-computed-multiple.html
@@ -4,45 +4,46 @@
 <meta charset="utf-8">
 <title>Compositing and Blending Level 1: getComputedStyle().backgroundBlendMode</title>
 <link rel="help" href="https://drafts.fxtf.org/compositing-1/#propdef-background-blend-mode">
-<meta name="assert" content="background-blend-mode computed value is as specified.">
+<meta name="assert" content="background-blend-mode computed value is as specified even when the number of images vary.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/computed-testcommon.js"></script>
+<style>
+    #target {
+        background-image: linear-gradient(green, green), linear-gradient(green, green), linear-gradient(green, green);
+    }
+</style>
 </head>
 <body>
 <div id="target"></div>
 <script>
-test_computed_value("background-blend-mode", "normal");
-test_computed_value("background-blend-mode", "multiply");
-test_computed_value("background-blend-mode", "screen");
-test_computed_value("background-blend-mode", "overlay");
-test_computed_value("background-blend-mode", "darken");
-test_computed_value("background-blend-mode", "lighten");
-test_computed_value("background-blend-mode", "color-dodge");
-test_computed_value("background-blend-mode", "color-burn");
-test_computed_value("background-blend-mode", "hard-light");
-test_computed_value("background-blend-mode", "soft-light");
-test_computed_value("background-blend-mode", "difference");
-test_computed_value("background-blend-mode", "exclusion");
-test_computed_value("background-blend-mode", "hue");
-test_computed_value("background-blend-mode", "saturation");
-test_computed_value("background-blend-mode", "color");
-test_computed_value("background-blend-mode", "luminosity");
-
-// Per spec, excess values should not be used,
-// BUT the computed style should be similar to the specified values.
+// This is testing the case with multiple background images
+//
 // see https://drafts.fxtf.org/compositing-1/#background-blend-mode
 // and https://drafts.csswg.org/css-backgrounds-3/#layering
 // > The lists are matched up from the first value: excess values at the end are not used.
+// and
+// > If a property doesn’t have enough comma-separated values
+// > to match the number of layers, the UA must calculate its used value
+// > by repeating the list of values until there are enough.
 // but in https://drafts.csswg.org/css-values-4/#linked-properties
 // it was decided that
 // > The computed values of the coordinating list properties are not affected by such truncation or repetition.
 //
 // There is a distinction between specified values, used values, and computed values.
 
+// if three images and one value, just send back the specified list.
+test_computed_value("background-blend-mode", "normal");
+test_computed_value("background-blend-mode", "multiply");
+
+// if three images and two values, just send back the specified list.
 test_computed_value("background-blend-mode", "normal, luminosity");
 test_computed_value("background-blend-mode", "screen, overlay");
 test_computed_value("background-blend-mode", "color, saturation");
+
+// if three images and three values, just send back the specified list.
+test_computed_value("background-blend-mode", "normal, luminosity, color");
+test_computed_value("background-blend-mode", "screen, overlay, screen");
 </script>
 </body>
 </html>


### PR DESCRIPTION
fix #42496. better getCS with backgroundBlendMode
    
    This was discussed in
    https://github.com/w3c/csswg-drafts/issues/7164#issuecomment-1201340918
    
    > Don't specifically say the computed value is same as specified value,
    > it's implied. can be louder in the spec so it's obvious
    
    The specification for CSS values 4 makes it more explicit
    https://drafts.csswg.org/css-values-4/#linked-properties
    
    > The computed values of the coordinating list properties are
    > not affected by such truncation or repetition.
    
    So this patch add comments in the code to make sure this is understood
    and add a test to cover the case of multiple images.