### PR TITLE
Storage Access API behavior with cross-origin requests with PROMPT permission state 

### DIFF
--- a/storage-access-api/requestStorageAccess.sub.https.window.js
+++ b/storage-access-api/requestStorageAccess.sub.https.window.js
@@ -69,23 +69,12 @@ promise_test(
 if (testPrefix.includes('cross-site')) {
   promise_test(
       async t => {
-        await CommonSetup();
-        await RunCallbackWithGesture(() => {
-          return promise_rejects_dom(t, "NotAllowedError", document.requestStorageAccess(),
-            "document.requestStorageAccess() call without permission");
-        });
-      },
-      '[' + testPrefix +
-          '] document.requestStorageAccess() should be rejected with a NotAllowedError without permission grant');
-
-  promise_test(
-      async t => {
         await test_driver.set_permission(
             {name: 'storage-access'}, 'denied');
 
         await RunCallbackWithGesture(() => {
           return promise_rejects_dom(t, "NotAllowedError", document.requestStorageAccess(),
-            "document.requestStorageAccess() call without permission");
+            "document.requestStorageAccess() call with denied permission");
         });
       },
       '[' + testPrefix +


### PR DESCRIPTION
I'm removing this check because showing a prompt is one acceptable behavior here, so we can't test this option easily.