### PR TITLE
Do not require results from Chrome on PRs

### DIFF
--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -322,13 +322,16 @@ tasks:
             channel: nightly
             stability-exclude-users:
               - moz-wptsync-bot
-            required: true
+            stability-required: true
+            results-required: true
         - vars:
             browser: chrome
             channel: dev
             stability-exclude-users:
               - chromium-wpt-export-bot
-            required: false
+            stability-required: false
+            # https://github.com/web-platform-tests/wpt/issues/42545
+            results-required: false
       do:
         - wpt-${vars.browser}-${vars.channel}-stability:
             use:
@@ -353,7 +356,7 @@ tasks:
               --verify-repeat-restart=10
               --github-checks-text-file="/home/test/artifacts/checkrun.md"
             exclude-users: ${vars.stability-exclude-users}
-            required: ${vars.required}
+            required: ${vars.stability-required}
 
         - wpt-${vars.browser}-${vars.channel}-results:
             use:
@@ -375,6 +378,7 @@ tasks:
               --no-fail-on-unexpected
               --log-wptreport=../artifacts/wpt_report.json
               --log-wptscreenshot=../artifacts/wpt_screenshot.txt
+            required: ${vars.results-required}
 
         - wpt-${vars.browser}-${vars.channel}-results-without-changes:
             use:
@@ -398,6 +402,7 @@ tasks:
               --no-fail-on-unexpected
               --log-wptreport=../artifacts/wpt_report.json
               --log-wptscreenshot=../artifacts/wpt_screenshot.txt
+            required: ${vars.results-required}
   - $map:
       for:
         - vars:

--- a/tools/ci/tc/tests/test_valid.py
+++ b/tools/ci/tc/tests/test_valid.py
@@ -79,7 +79,15 @@ def test_sink_task_depends():
 
         assert set(sink_task["dependencies"]) == (
             set(task_id for (task_name, (task_id, _)) in task_id_map.items()
-                if task_name not in {"sink-task", "wpt-chrome-dev-stability"}))
+                if task_name not in {
+                    "sink-task",
+                    "wpt-chrome-dev-results",
+                    "wpt-chrome-dev-results-without-changes",
+                    "wpt-chrome-dev-stability",
+            }
+            )
+        )
+
 
 
 def test_verify_payload():


### PR DESCRIPTION
This works-around Chrome infrastructure breakage where they have managed to ship a browser without a corresponding WebDriver binary or have managed to not update the JSON file mapping browser versions to WebDriver binaries: https://github.com/web-platform-tests/wpt/issues/42545