### PR TITLE
[CSS Nesting] Always serialize relative selector with &

### DIFF
--- a/css/css-nesting/parsing.html
+++ b/css/css-nesting/parsing.html
@@ -47,15 +47,15 @@
 
   // relative selector
   testNestedSelector("> .bar", {expected:"& > .bar"});
-  testNestedSelector("> & .bar", {expected: "& > & .bar"});
+  testNestedSelector("> & .bar", {expected:"& > & .bar"});
   testNestedSelector("+ .bar &", {expected:"& + .bar &"});
-  testNestedSelector("+ .bar, .foo, > .baz", {expected:"& + .bar, .foo, & > .baz"});
+  testNestedSelector("+ .bar, .foo, > .baz", {expected:"& + .bar, & .foo, & > .baz"});
 
   // implicit relative (and not)
-  testNestedSelector(".foo");
+  testNestedSelector(".foo", {expected:"& .foo"});
   testNestedSelector(".test > & .bar");
-  testNestedSelector(".foo, .foo &");
-  testNestedSelector(":is(.bar, .baz)");
+  testNestedSelector(".foo, .foo &", {expected:"& .foo, .foo &"});
+  testNestedSelector(":is(.bar, .baz)", {expected:"& :is(.bar, .baz)"});
   testNestedSelector("&:is(.bar, .baz)");
   testNestedSelector(":is(.bar, &.baz)");
   testNestedSelector("&:is(.bar, &.baz)");


### PR DESCRIPTION
The current spec mandates to always serialize the implicit &, even when it's not necessary (such as .foo)

https://github.com/web-platform-tests/wpt/pull/41213#discussion_r1301267518