### PR TITLE
Anonymous boxes that wrap inlines should not inherit overflow

### DIFF
--- a/css/CSS2/floats/float-in-inline-anonymous-block-with-overflow-hidden.html
+++ b/css/CSS2/floats/float-in-inline-anonymous-block-with-overflow-hidden.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Test: A float wrapped in an anonymous block should be visible within a container with overflow: hidden.</title>
+<link rel="author" href="mailto:obrufrau@igalia.com" title="Oriol Brufrau">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#anonymous-block-level" />
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="overflow: hidden; width: 100px; height: 100px; background: red">
+  <div style="height: 50px; background: green"></div>
+  <span>
+    <div style="float: left; width: 100px; height: 50px; background: green"></div>
+  </span>
+</div>


### PR DESCRIPTION
In legacy layout, anonymous text wrappers were inheriting the `overflow`
and `text-overflow` properties. This results in the creation of extra
clipping for these anonymous wrappers which could clip away floats. We
will likely implement `text-overflow` differently in non-legacy layout.

This change marks all legacy layout pseudo elements as "legacy" and also
adds a new pseudo element for non-legacy layout that does not inherit
`overflow`.

Fixes #<!-- nolink -->30562.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#30579