### PR TITLE
Add a heuristic to detect collapse through in IFCs

### DIFF
--- a/css/CSS2/floats/float-in-inline-margin-collapse.html
+++ b/css/CSS2/floats/float-in-inline-margin-collapse.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>CSS Test: float inside inline surrounded by elements with margins</title>
+<link rel="author" href="mailto:obrufrau@igalia.com" title="Oriol Brufrau">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<link rel="help" href="https://www.w3.org/TR/CSS2/box.html#collapsing-margins">
+<link rel="help" href="https://www.w3.org/TR/CSS2/visuren.html#inline-formatting">
+<link rel="help" href="https://www.w3.org/TR/CSS2/visuren.html#floats">
+<meta name="assert" content="The float is out-of-flow so it doesn't prevent the line box
+  from being empty, and empty line boxes don't prevent margins from collapsing.
+  So the float and the inline-block should appear side by side.">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="overflow: hidden; margin-top: -200px; width: 100px">
+  <div style="margin-top: 200px"></div>
+  <div style="background: red">
+    <span>
+      <div style="float: left; width: 50px; height: 100px; background: green"></div>
+    </span>
+    <div style="margin-top: 200px"></div>
+    <div style="display: inline-block; vertical-align: top; width: 50px; height: 100px; background: green"></div>
+  </div>
+</div>


### PR DESCRIPTION
When inline formatting contexts collapse through, margins before and
after can collapse. Previously the IFC code was assuming that margins
never collapses through them. This change adds a heuristic to detect the
most common cases of collapse through. Note that there are still
situations where do not know if an IFC will collapse through until we
actually try to lay it out. A proper implementation would be able to
rewind and relayout to fix float placement.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#30580