### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=260834

### DIFF
--- a/webcodecs/videoFrame-canvasImageSource.html
+++ b/webcodecs/videoFrame-canvasImageSource.html
@@ -85,7 +85,11 @@ test(t => {
                     'CSSImageValues are currently always tainted');
 }, 'CSSImageValue constructed VideoFrame');
 
-test(t => {
+promise_test(() => {
+  return new Promise(resolve => onload = resolve);
+}, "Wait for onload event to get access to image data");
+
+promise_test(async t => {
   let frame = new VideoFrame(document.querySelector('img'), {timestamp: 0});
   let canvas = new OffscreenCanvas(frame.displayWidth, frame.displayHeight);
   let ctx = canvas.getContext('2d');
@@ -94,7 +98,7 @@ test(t => {
   frame.close();
 }, 'Image element constructed VideoFrame');
 
-test(t => {
+promise_test(async t => {
   let frame = new VideoFrame(document.querySelector('image'), {timestamp: 0});
   let canvas = new OffscreenCanvas(frame.displayWidth, frame.displayHeight);
   let ctx = canvas.getContext('2d');


### PR DESCRIPTION
WebKit export from bug: [\[ wk2 \] imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource.html is a flaky text failure.](https://bugs.webkit.org/show_bug.cgi?id=260834)