### PR TITLE
Fix: multiple typos inside /docs

### DIFF
--- a/docs/writing-tests/channels.md
+++ b/docs/writing-tests/channels.md
@@ -27,7 +27,7 @@ Channels can be used in any global and are not specifically linked to
 The high level API provides a way to message another global, and to
 execute functions in that global and return the result.
 
-Globals wanting to recieve messages using the high level API have to
+Globals wanting to receive messages using the high level API have to
 be loaded with a `uuid` query parameter in their URL, with a value
 that's a UUID. This will be used to identify the channel dedicated to
 messages sent to that context.

--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -146,7 +146,7 @@ scripts directly in the relevant document, and use the
 specify the browsing context containing testharness.js. Commands are
 then sent via `postMessage` to the test context. For convenience there
 is also a [`test_driver.message_test`](#test_driver.message_test)
-function that can be used to send arbitary messages to the test
+function that can be used to send arbitrary messages to the test
 window. For example, in an auxillary browsing context:
 
 ```js


### PR DESCRIPTION
Multiple typos inside /docs directory have been fixed.