### PR TITLE
Overcome antialias fuzziness in backgrounds tests meta name="fuzzy"

### DIFF
--- a/css/css-backgrounds/border-image-image-type-001.htm
+++ b/css/css-backgrounds/border-image-image-type-001.htm
@@ -7,8 +7,6 @@
         <link rel="match" href="reference/border-image-image-type-001-ref.html" />
         <meta name="flags" content="svg" />
         <meta name="assert" content="This test checks that the SVG image used for the border image is sliced into nine regions with inward offsets of: '40 30 20 10' vector coordinates from the top, right, bottom, and left edges of the image set by the 'border-image-slice' property." />
-        <meta name="fuzzy" content="maxDifference=0-64;totalPixels=0-400" />
-
         <style type="text/css">
             div
             {

--- a/css/css-backgrounds/border-image-image-type-001.htm
+++ b/css/css-backgrounds/border-image-image-type-001.htm
@@ -7,6 +7,8 @@
         <link rel="match" href="reference/border-image-image-type-001-ref.html" />
         <meta name="flags" content="svg" />
         <meta name="assert" content="This test checks that the SVG image used for the border image is sliced into nine regions with inward offsets of: '40 30 20 10' vector coordinates from the top, right, bottom, and left edges of the image set by the 'border-image-slice' property." />
+        <meta name="fuzzy" content="maxDifference=0-64;totalPixels=0-400" />
+
         <style type="text/css">
             div
             {

--- a/css/css-backgrounds/border-image-image-type-004.htm
+++ b/css/css-backgrounds/border-image-image-type-004.htm
@@ -7,6 +7,7 @@
         <link rel="match" href="reference/border-image-image-type-004-ref.html" />
         <meta name="flags" content="svg" />
         <meta name="assert" content="This test checks that the SVG image used for the border image is sliced into nine regions with inward offsets of: '40 30 20 10' vector coordinates from the top, right, bottom, and left edges of the image set by the 'border-image-slice' property." />
+        <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-100" />
         <style type="text/css">
             div
             {

--- a/css/css-backgrounds/border-image-image-type-005.htm
+++ b/css/css-backgrounds/border-image-image-type-005.htm
@@ -7,6 +7,7 @@
         <link rel="match" href="reference/border-image-image-type-004-ref.html" />
         <meta name="flags" content="svg" />
         <meta name="assert" content="This test checks that border image is sliced into nine regions with inward offsets of: '40% 30% 20% 10%' from the top, right, bottom, and left edges of the image. Percentages are relative to the size of the image: the width of the image for the horizontal offsets, the height for vertical offsets." />
+        <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-100" />
         <style type="text/css">
             div
             {

--- a/css/css-backgrounds/box-shadow-border-radius-001.html
+++ b/css/css-backgrounds/box-shadow-border-radius-001.html
@@ -20,6 +20,8 @@
 
   -->
 
+  <meta name="fuzzy" content="maxDifference=0-42;totalPixels=0-4">
+
   <style>
   div
     {


### PR DESCRIPTION
I added a
`<meta name="fuzzy" content="maxDifference=0-m;totalPixels=0-n" />`
in 4 tests, like this:

border-image-image-type-001.htm 
`<meta name="fuzzy" content="maxDifference=0-64;totalPixels=0-400" />`

Current test result:
https://wpt.fyi/results/css/css-backgrounds/border-image-image-type-001.htm?label=experimental&label=master&aligned

box-shadow-border-radius-001.html
`<meta name="fuzzy" content="maxDifference=0-42;totalPixels=0-4">`
Current test result:
https://wpt.fyi/results/css/css-backgrounds/box-shadow-border-radius-001.html?label=experimental&label=master&aligned

border-image-image-type-004.htm
`<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-100" />`
Current test result:
https://wpt.fyi/results/css/css-backgrounds/border-image-image-type-004.htm?label=experimental&label=master&aligned

border-image-image-type-005.htm
`<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-100" />`
Current test result:
https://wpt.fyi/results/css/css-backgrounds/border-image-image-type-005.htm?label=experimental&label=master&aligned