### PR TITLE
Add tests to measure metrics in absolute positioned elements in c-v: …

### DIFF
--- a/css/css-contain/content-visibility/content-visibility-092.html
+++ b/css/css-contain/content-visibility/content-visibility-092.html
@@ -1,0 +1,24 @@
+<!doctype HTML>
+<meta charset="utf8">
+<title>CSS Content Visibility: getComputedStyle works in hidden c-v subtree and an absolutely positioned element</title>
+<link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+<meta name="assert" content="getComputedStyle works in hidden c-v subtree and an absolutely positioned element">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+#container { content-visibility: hidden }
+</style>
+
+<div id=container style="width:200px">
+<div id=target style="width:50%;position: absolute"></div>
+</div>
+
+<script>
+test(() => {
+  const computedStyle = getComputedStyle(target);
+  assert_equals(computedStyle.width, "100px");
+}, "getComputedStyle works in hidden c-v subtree and an absolutely positioned element");
+</script>

--- a/css/css-contain/content-visibility/content-visibility-093.html
+++ b/css/css-contain/content-visibility/content-visibility-093.html
@@ -1,0 +1,24 @@
+<!doctype HTML>
+<meta charset="utf8">
+<title>CSS Content Visibility: getComputedStyle works on a grid container with c-v: hidden and an absolutely positioned child</title>
+<link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+<meta name="assert" content="getComputedStyle works on a grid container with c-v: hidden and an absolutely positioned child">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+#container { content-visibility: hidden }
+</style>
+
+<div id=container style="display: grid; width:200px">
+<div id=target style="width:50%;position: absolute"></div>
+</div>
+
+<script>
+test(() => {
+  const computedStyle = getComputedStyle(target);
+  assert_equals(computedStyle.width, "100px");
+}, "getComputedStyle works on a grid container with c-v: hidden and an absolutely positioned child");
+</script>


### PR DESCRIPTION
…subtree

From WebKit bugs:
https://bugs.webkit.org/show_bug.cgi?id=262558
https://bugs.webkit.org/show_bug.cgi?id=263377