### PR TITLE
Tests for round(), mod(), and rem() that has a percentage only for one value

### DIFF
--- a/css/css-values/round-mod-rem-computed.html
+++ b/css/css-values/round-mod-rem-computed.html
@@ -155,6 +155,10 @@ test_math_used('calc(round(1px + 0%, 1px + 0%))', '1px');
 test_math_used('calc(mod(3px + 0%, 2px + 0%))', '1px');
 test_math_used('calc(rem(3px + 0%, 2px + 0%))', '1px');
 
+test_math_used('round(1px + 0%, 1px)', '1px');
+test_math_used('mod(3px + 0%, 2px)', '1px');
+test_math_used('rem(3px + 0%, 2px)', '1px');
+
 // In round(A, B), if B is 0, the result is NaN. If A and B are both infinite, the result is NaN.
 // In mod(A, B) or rem(A, B), if B is 0, the result is NaN. If A is infinite, the result is NaN.
 for (let operator of ['round', 'mod', 'rem']) {


### PR DESCRIPTION
I noticed a bug in Safari (regular and TP) in how it handles mixed units for `round()`, `mod()` and `rem()` that include a `%`, but only when it does include it for one value (only A or B, not both as in the above tests).

First reduced in [this CodePen](https://codepen.io/kizu/pen/BaMaYwE?editors=1100), decided to submit it as my first WPT test :)

Current workaround: add `0%` to the other part so both contain `px` and `%`.