### PR TITLE
Overcome antialias fuzziness in box-shadow-border-radius-001.html with meta fuzzy

### DIFF
--- a/css/css-backgrounds/box-shadow-border-radius-001.html
+++ b/css/css-backgrounds/box-shadow-border-radius-001.html
@@ -20,7 +20,7 @@
 
   -->
 
-  <meta name="fuzzy" content="maxDifference=0-42;totalPixels=0-4">
+  <meta name="fuzzy" content="maxDifference=0-56;totalPixels=0-1192">
 
   <style>
   div


### PR DESCRIPTION
I modified the **maxDifference to 56** and the **totalPixels to 1192** in the meta fuzzy of box-shadow-border-radius-001.html test like this:
`<meta name="fuzzy" content="maxDifference=0-56;totalPixels=0-1192">`
Current test result:
https://wpt.fyi/results/css/css-backgrounds/box-shadow-border-radius-001.html?label=experimental&label=master&aligned

so that Safari 181 technological preview rightfully and deservedly passes the test.