### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=263584

### DIFF
--- a/webcodecs/audio-decoder.https.any.js
+++ b/webcodecs/audio-decoder.https.any.js
@@ -135,20 +135,23 @@ validButUnsupportedConfigs.forEach(entry => {
 });
 
 validButUnsupportedConfigs.forEach(entry => {
-  async_test(
+  promise_test(
       t => {
+        let isErrorCallbackCalled = false;
         let codec = new AudioDecoder({
           output: t.unreached_func('unexpected output'),
           error: t.step_func_done(e => {
+            isErrorCallbackCalled = true;
             assert_true(e instanceof DOMException);
             assert_equals(e.name, 'NotSupportedError');
             assert_equals(codec.state, 'closed', 'state');
           })
         });
         codec.configure(entry.config);
-        codec.flush()
+        return codec.flush()
             .then(t.unreached_func('flush succeeded unexpectedly'))
             .catch(t.step_func(e => {
+              assert_true(isErrorCallbackCalled, "isErrorCallbackCalled");
               assert_true(e instanceof DOMException);
               assert_equals(e.name, 'NotSupportedError');
               assert_equals(codec.state, 'closed', 'state');

--- a/webcodecs/audio-encoder-config.https.any.js
+++ b/webcodecs/audio-encoder-config.https.any.js
@@ -213,20 +213,23 @@ validButUnsupportedConfigs.forEach(entry => {
 });
 
 validButUnsupportedConfigs.forEach(entry => {
-  async_test(
+  promise_test(
       t => {
+        let isErrorCallbackCalled = false;
         let codec = new AudioEncoder({
           output: t.unreached_func('unexpected output'),
           error: t.step_func_done(e => {
+            isErrorCallbackCalled = true;
             assert_true(e instanceof DOMException);
             assert_equals(e.name, 'NotSupportedError');
             assert_equals(codec.state, 'closed', 'state');
           })
         });
         codec.configure(entry.config);
-        codec.flush()
+        return codec.flush()
             .then(t.unreached_func('flush succeeded unexpectedly'))
             .catch(t.step_func(e => {
+              assert_true(isErrorCallbackCalled, "isErrorCallbackCalled");
               assert_true(e instanceof DOMException);
               assert_equals(e.name, 'NotSupportedError');
               assert_equals(codec.state, 'closed', 'state');

--- a/webcodecs/video-decoder.https.any.js
+++ b/webcodecs/video-decoder.https.any.js
@@ -96,20 +96,23 @@ validButUnsupportedConfigs.forEach(entry => {
 });
 
 validButUnsupportedConfigs.forEach(entry => {
-  async_test(
+  promise_test(
       t => {
+        let isErrorCallbackCalled = false;
         let codec = new VideoDecoder({
           output: t.unreached_func('unexpected output'),
-          error: t.step_func_done(e => {
+          error: t.step_func(e => {
+            isErrorCallbackCalled = true;
             assert_true(e instanceof DOMException);
             assert_equals(e.name, 'NotSupportedError');
             assert_equals(codec.state, 'closed', 'state');
           })
         });
         codec.configure(entry.config);
-        codec.flush()
+        return codec.flush()
             .then(t.unreached_func('flush succeeded unexpectedly'))
             .catch(t.step_func(e => {
+              assert_true(isErrorCallbackCalled, "isErrorCallbackCalled");
               assert_true(e instanceof DOMException);
               assert_equals(e.name, 'NotSupportedError');
               assert_equals(codec.state, 'closed', 'state');

--- a/webcodecs/video-encoder-config.https.any.js
+++ b/webcodecs/video-encoder-config.https.any.js
@@ -189,20 +189,23 @@ validButUnsupportedConfigs.forEach(entry => {
 });
 
 validButUnsupportedConfigs.forEach(entry => {
-  async_test(
+  promise_test(
       t => {
+        let isErrorCallbackCalled = false;
         let codec = new VideoEncoder({
           output: t.unreached_func('unexpected output'),
           error: t.step_func_done(e => {
+            isErrorCallbackCalled = true;
             assert_true(e instanceof DOMException);
             assert_equals(e.name, 'NotSupportedError');
             assert_equals(codec.state, 'closed', 'state');
           })
         });
         codec.configure(entry.config);
-        codec.flush()
+        return codec.flush()
             .then(t.unreached_func('flush succeeded unexpectedly'))
             .catch(t.step_func(e => {
+              assert_true(isErrorCallbackCalled, "isErrorCallbackCalled");
               assert_true(e instanceof DOMException);
               assert_equals(e.name, 'NotSupportedError');
               assert_equals(codec.state, 'closed', 'state');


### PR DESCRIPTION
WebKit export from bug: [Unsupported codecs should trigger WebCodecs to close encoders/decoders asynchronously](https://bugs.webkit.org/show_bug.cgi?id=263584)