### PR TITLE
Strip spaces when comparing message with expected-fail-message

### DIFF
--- a/infrastructure/metadata/infrastructure/webdriver/tests/test_load_file.py.ini
+++ b/infrastructure/metadata/infrastructure/webdriver/tests/test_load_file.py.ini
@@ -1,0 +1,3 @@
+[test_load_file.py]
+  expected:
+    if product == "firefox": ERROR

--- a/infrastructure/metadata/infrastructure/webdriver/tests/test_load_file.py.ini
+++ b/infrastructure/metadata/infrastructure/webdriver/tests/test_load_file.py.ini
@@ -1,3 +1,2 @@
-[test_load_file.py]
-  expected:
-    if product == "firefox": [ERROR, OK]
+disabled:
+  if product == "firefox": @True

--- a/infrastructure/metadata/infrastructure/webdriver/tests/test_load_file.py.ini
+++ b/infrastructure/metadata/infrastructure/webdriver/tests/test_load_file.py.ini
@@ -1,3 +1,3 @@
 [test_load_file.py]
   expected:
-    if product == "firefox": ERROR
+    if product == "firefox": [ERROR, OK]

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -701,7 +701,7 @@ class TestRunnerManager(threading.Thread):
                 # change result to unexpected if expected_fail_message does not
                 # match
                 expected_fail_message = test.expected_fail_message(result.name)
-                if expected_fail_message is not None and result.message != expected_fail_message:
+                if expected_fail_message is not None and result.message.strip() != expected_fail_message:
                     is_unexpected = True
 
             if is_unexpected:


### PR DESCRIPTION
This is to align with current Chromium side behavior.

Bug: Chromium: 1481730