### PR TITLE
Add noto fonts to the Docker image

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -57,7 +57,7 @@ tasks:
             owner: ${owner}
             source: ${event.repository.clone_url}
           payload:
-            image: webplatformtests/wpt:0.55
+            image: webplatformtests/wpt:0.56
             maxRunTime: 7200
             artifacts:
               public/results:

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -4,7 +4,7 @@ components:
     workerType: ci
     schedulerId: taskcluster-github
     deadline: "24 hours"
-    image: webplatformtests/wpt:0.55
+    image: webplatformtests/wpt:0.56
     maxRunTime: 7200
     artifacts:
       public/results:

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get -qqy update \
     curl \
     dbus-x11 \
     earlyoom \
+    fonts-noto \
     fluxbox \
     gdebi \
     git \


### PR DESCRIPTION
This ensures that we have fallback glyphs for most/all characters. This affects some tests
e.g. css/css-fonts/size-adjust-unicode-range-system-fallback.html (see https://bugzilla.mozilla.org/show_bug.cgi?id=1860124)

Covering all of unicode does mean that we end up with a rather large increase in the docker image size. If this causes problems we could just install fonts-noto-cjk to fix the known breakage.