### PR TITLE
Add some tests for DOM XPath behaviour across documents/realms

### DIFF
--- a/domxpath/evaluator-cross-realm.tentative.html
+++ b/domxpath/evaluator-cross-realm.tentative.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Cross-realm XPath evaluator</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+  function toArray(result) {
+  var a = [];
+  while (true) {
+    var node = result.iterateNext();
+    if (node === null) break;
+    a.push(node);
+  }
+  return a;
+}
+
+var html_ns = "http://www.w3.org/1999/xhtml";
+var xml_doc = document.implementation.createDocument(html_ns, "html");
+var html_doc = document.implementation.createHTMLDocument();
+
+promise_test(async (t) => {
+  const iframe = document.createElement("iframe");
+  iframe.src = "/common/dummy.xml";
+  document.body.appendChild(iframe);
+  await new Promise(resolve => {
+    iframe.addEventListener("load", resolve, {once: true});
+  });
+  t.add_cleanup(() => iframe.remove());
+  const iframe_evaluator = new iframe.contentWindow.XPathEvaluator();
+  assert_array_equals(toArray(iframe_evaluator.evaluate("//html", xml_doc)), []);
+}, "evaluator from realm with XML associated document, context node in XML document, no namespace resolver");
+
+promise_test(async (t) => {
+  const iframe = document.createElement("iframe");
+  iframe.src = "/common/dummy.xml";
+  document.body.appendChild(iframe);
+  await new Promise(resolve => {
+    iframe.addEventListener("load", resolve, {once: true});
+  });
+  t.add_cleanup(() => iframe.remove());
+  const iframe_evaluator = new iframe.contentWindow.XPathEvaluator();
+  assert_array_equals(toArray(iframe_evaluator.evaluate("//html", html_doc)), [html_doc.documentElement]);
+}, "evaluator from realm with XML associated document, context node in HTML document, no namespace resolver");
+
+promise_test(async (t) => {
+  const iframe = document.createElement("iframe");
+  iframe.src = "/common/blank.html";
+  document.body.appendChild(iframe);
+  await new Promise(resolve => {
+    iframe.addEventListener("load", resolve, {once: true});
+  });
+  t.add_cleanup(() => iframe.remove());
+  const iframe_evaluator = new iframe.contentWindow.XPathEvaluator();
+  assert_array_equals(toArray(iframe_evaluator.evaluate("//html", xml_doc)), []);
+}, "evaluator from realm with HTML associated document, context node in XML document, no namespace resolver");
+
+promise_test(async (t) => {
+  const iframe = document.createElement("iframe");
+  iframe.src = "/common/blank.html";
+  document.body.appendChild(iframe);
+  await new Promise(resolve => {
+    iframe.addEventListener("load", resolve, {once: true});
+  });
+  t.add_cleanup(() => iframe.remove());
+  const iframe_evaluator = new iframe.contentWindow.XPathEvaluator();
+  assert_array_equals(toArray(iframe_evaluator.evaluate("//html", html_doc)), [html_doc.documentElement]);
+}, "evaluator from realm with HTML associated document, context node in HTML document, no namespace resolver");
+</script>

--- a/domxpath/evaluator-different-document.tentative.html
+++ b/domxpath/evaluator-different-document.tentative.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Cross-document XPath evaluation</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+function toArray(result) {
+  var a = [];
+  while (true) {
+    var node = result.iterateNext();
+    if (node === null) break;
+    a.push(node);
+  }
+  return a;
+}
+
+var html_ns = "http://www.w3.org/1999/xhtml";
+var xml_doc = document.implementation.createDocument(html_ns, "html");
+var html_doc = document.implementation.createHTMLDocument();
+
+function ns_resolver(x) {
+  if (x === "html") {
+    return html_ns;
+  } else {
+    return null;
+  }
+}
+
+test(function() {
+  assert_array_equals(toArray(xml_doc.evaluate("//html", xml_doc)), []);
+}, "evaluate operation on XML document, context node in XML document, no namespace resolver");
+
+test(function() {
+  assert_array_equals(toArray(html_doc.evaluate("//html", html_doc)), [html_doc.documentElement]);
+}, "evaluate operation on HTML document, context node in HTML document, no namespace resolver");
+
+test(function() {
+  assert_array_equals(toArray(xml_doc.evaluate("//html", html_doc)), [html_doc.documentElement]);
+}, "evaluate operation on XML document, context node in HTML document, no namespace resolver");
+
+test(function() {
+  assert_array_equals(toArray(html_doc.evaluate("//html", xml_doc)), []);
+}, "evaluate operation on HTML document, context node in XML document, no namespace resolver");
+
+test(function() {
+  assert_array_equals(toArray(xml_doc.evaluate("//html", xml_doc, ns_resolver)), []);
+}, "evaluate operation on XML document, context node in XML document, with namespace resolver");
+
+test(function() {
+  assert_array_equals(toArray(html_doc.evaluate("//html", html_doc, ns_resolver)), [html_doc.documentElement]);
+}, "evaluate operation on HTML document, context node in HTML document, with namespace resolver");
+
+test(function() {
+  assert_array_equals(toArray(xml_doc.evaluate("//html", html_doc, ns_resolver)), [html_doc.documentElement]);
+}, "evaluate operation on XML document, context node in HTML document, with namespace resolver");
+
+test(function() {
+  assert_array_equals(toArray(html_doc.evaluate("//html", xml_doc, ns_resolver)), []);
+}, "evaluate operation on HTML document, context node in XML document, with namespace resolver");
+</script>

--- a/domxpath/expression-cross-realm.tentative.html
+++ b/domxpath/expression-cross-realm.tentative.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Cross-realm XPath evaluator</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+  function toArray(result) {
+  var a = [];
+  while (true) {
+    var node = result.iterateNext();
+    if (node === null) break;
+    a.push(node);
+  }
+  return a;
+}
+
+var html_ns = "http://www.w3.org/1999/xhtml";
+var xml_doc = document.implementation.createDocument(html_ns, "html");
+var html_doc = document.implementation.createHTMLDocument();
+
+promise_test(async (t) => {
+  const iframe = document.createElement("iframe");
+  iframe.src = "/common/dummy.xml";
+  document.body.appendChild(iframe);
+  await new Promise(resolve => {
+    iframe.addEventListener("load", resolve, {once: true});
+  });
+  t.add_cleanup(() => iframe.remove());
+  const iframe_expression = iframe.contentDocument.createExpression("//html");
+  assert_array_equals(toArray(iframe_expression.evaluate(xml_doc)), []);
+}, "expression from realm with XML associated document, context node in XML document, no namespace resolver");
+
+promise_test(async (t) => {
+  const iframe = document.createElement("iframe");
+  iframe.src = "/common/dummy.xml";
+  document.body.appendChild(iframe);
+  await new Promise(resolve => {
+    iframe.addEventListener("load", resolve, {once: true});
+  });
+  t.add_cleanup(() => iframe.remove());
+  const iframe_expression = iframe.contentDocument.createExpression("//html");
+  assert_array_equals(toArray(iframe_expression.evaluate(html_doc)), [html_doc.documentElement]);
+}, "expression from realm with XML associated document, context node in HTML document, no namespace resolver");
+
+promise_test(async (t) => {
+  const iframe = document.createElement("iframe");
+  iframe.src = "/common/blank.html";
+  document.body.appendChild(iframe);
+  await new Promise(resolve => {
+    iframe.addEventListener("load", resolve, {once: true});
+  });
+  t.add_cleanup(() => iframe.remove());
+  const iframe_expression = iframe.contentDocument.createExpression("//html");
+  assert_array_equals(toArray(iframe_expression.evaluate(xml_doc)), []);
+}, "expression from realm with HTML associated document, context node in XML document, no namespace resolver");
+
+promise_test(async (t) => {
+  const iframe = document.createElement("iframe");
+  iframe.src = "/common/blank.html";
+  document.body.appendChild(iframe);
+  await new Promise(resolve => {
+    iframe.addEventListener("load", resolve, {once: true});
+  });
+  t.add_cleanup(() => iframe.remove());
+  const iframe_expression = iframe.contentDocument.createExpression("//html");
+  assert_array_equals(toArray(iframe_expression.evaluate(html_doc)), [html_doc.documentElement]);
+}, "expression from realm with HTML associated document, context node in HTML document, no namespace resolver");
+</script>

--- a/domxpath/expression-different-document.tentative.html
+++ b/domxpath/expression-different-document.tentative.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Cross-document XPath expressions</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+function toArray(result) {
+  var a = [];
+  while (true) {
+    var node = result.iterateNext();
+    if (node === null) break;
+    a.push(node);
+  }
+  return a;
+}
+
+var html_ns = "http://www.w3.org/1999/xhtml";
+var xml_doc = document.implementation.createDocument(html_ns, "html");
+var html_doc = document.implementation.createHTMLDocument();
+
+function ns_resolver(x) {
+  if (x === "html") {
+    return html_ns;
+  } else {
+    return null;
+  }
+}
+
+test(function() {
+  var xml_doc_expression = xml_doc.createExpression("//html");
+  assert_array_equals(toArray(xml_doc_expression.evaluate(xml_doc)), []);
+}, "expression from XML document, context node in XML document, no namespace resolver");
+
+test(function() {
+  var html_doc_expression = html_doc.createExpression("//html");
+  assert_array_equals(toArray(html_doc_expression.evaluate(html_doc)), [html_doc.documentElement]);
+}, "expression from HTML document, context node in HTML document, no namespace resolver");
+
+test(function() {
+  var xml_doc_expression = xml_doc.createExpression("//html");
+  assert_array_equals(toArray(xml_doc_expression.evaluate(html_doc)), [html_doc.documentElement]);
+}, "expression from XML document, context node in HTML document, no namespace resolver");
+
+test(function() {
+  var html_doc_expression = html_doc.createExpression("//html");
+  assert_array_equals(toArray(html_doc_expression.evaluate(xml_doc)), []);
+}, "expression from HTML document, context node in XML document, no namespace resolver");
+
+test(function() {
+  var xml_doc_expression = xml_doc.createExpression("//html", ns_resolver);
+  assert_array_equals(toArray(xml_doc_expression.evaluate(xml_doc)), []);
+}, "expression from XML document, context node in XML document, with namespace resolver");
+
+test(function() {
+  var html_doc_expression = html_doc.createExpression("//html", ns_resolver);
+  assert_array_equals(toArray(html_doc_expression.evaluate(html_doc)), [html_doc.documentElement]);
+}, "expression from HTML document, context node in HTML document, with namespace resolver");
+
+test(function() {
+  var xml_doc_expression = xml_doc.createExpression("//html", ns_resolver);
+  assert_array_equals(toArray(xml_doc_expression.evaluate(html_doc)), [html_doc.documentElement]);
+}, "expression from XML document, context node in HTML document, with namespace resolver");
+
+test(function() {
+  var html_doc_expression = html_doc.createExpression("//html", ns_resolver);
+  assert_array_equals(toArray(html_doc_expression.evaluate(xml_doc)), []);
+}, "expression from HTML document, context node in XML document, with namespace resolver");
+</script>


### PR DESCRIPTION
These are primarily of interest because they show the implicit namespace is effectively set based on the owner document of the context node passed to `evaluate`, rather than based on anything else.