### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=263072

### DIFF
--- a/html/browsers/history/the-location-interface/location-replace-from-iframe.sub.html
+++ b/html/browsers/history/the-location-interface/location-replace-from-iframe.sub.html
@@ -1,0 +1,31 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>Referer with location.replace and location.assign</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <iframe src="/resources/blank.html" hidden></iframe>
+    <script>
+      async_test(function(t) {
+        function on_message(e) {
+        const referrer = e.data;
+        assert_equals(referrer, window.location.href);
+        t.done();
+      }
+      window.addEventListener('message', t.step_func(on_message), false);
+      document.querySelector("iframe").contentWindow.location.replace("resources/iframe-contents.sub.html?replace");
+      }, "Browser sends Referer header in iframe request when location.replace is called from an iframe");
+      async_test(function(t) {
+        function on_message(e) {
+        const referrer = e.data;
+        assert_equals(referrer, window.location.href);
+        t.done();
+      }
+      window.addEventListener('message', t.step_func(on_message), false);
+      document.querySelector("iframe").contentWindow.location.assign("resources/iframe-contents.sub.html?assign");
+      }, "Browser sends Referer header in iframe request when location.assign is called from an iframe");
+    </script>
+  </body>
+</html>

--- a/html/browsers/history/the-location-interface/resources/iframe-contents.sub.html
+++ b/html/browsers/history/the-location-interface/resources/iframe-contents.sub.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>Resource file for test of Referer with location.replace</title>
+  </head>
+  <body>
+    <div></div>
+    <script>
+      const referer = "{{header_or_default(referer, missing)}}"
+      window.parent.postMessage(referer);
+      document.querySelector("div").textContent = `Referer header: ${referer}`;
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [No "referer" header when iframe url set with location.replace](https://bugs.webkit.org/show_bug.cgi?id=263072)