### PR TITLE
Remove the content attribute when a JS ARIA attribute is set to undefined

### DIFF
--- a/html/dom/aria-attribute-reflection.html
+++ b/html/dom/aria-attribute-reflection.html
@@ -8,7 +8,14 @@
 
 <script>
 function testNullable(element, jsAttr, contentAttr) {
+    var originalValue = element[jsAttr];
+    assert_false(originalValue === null);
     element[jsAttr] = null;
+    assert_equals(element[jsAttr], null);
+    assert_false(element.hasAttribute(contentAttr));
+    // Setting to undefined results in same state as setting to null.
+    element[jsAttr] = originalValue;
+    element[jsAttr] = undefined;
     assert_equals(element[jsAttr], null);
     assert_false(element.hasAttribute(contentAttr));
 }


### PR DESCRIPTION
Per https://github.com/w3c/aria/pull/2057. Setting an ARIA property to `undefined` is equivalent to setting it to `null`.