### PR TITLE
Add ARIA reflection tests for ariaBrailleLabel and ariaBrailleRoleDescription

### DIFF
--- a/html/dom/aria-attribute-reflection.html
+++ b/html/dom/aria-attribute-reflection.html
@@ -455,4 +455,26 @@ test(function(t) {
     testNullable(element, "ariaValueText", "aria-valuetext");
 }, "aria-valuetext attribute reflects.");
 </script>
+
+<div id="braillelabel" aria-braillelabel="x"></div>
+<script>
+test(function(t) {
+    var element = document.getElementById("braillelabel");
+    assert_equals(element.ariaBrailleLabel, "x");
+    element.ariaBrailleLabel = "y";
+    assert_equals(element.getAttribute("aria-braillelabel"), "y");
+    testNullable(element, "ariaBrailleLabel", "aria-braillelabel");
+}, "aria-braillelabel attribute reflects.");
+</script>
+
+<div id="brailleroledescription" aria-brailleroledescription="x"></div>
+<script>
+test(function(t) {
+    var element = document.getElementById("brailleroledescription");
+    assert_equals(element.ariaBrailleRoleDescription, "x");
+    element.ariaBrailleRoleDescription = "y";
+    assert_equals(element.getAttribute("aria-brailleroledescription"), "y");
+    testNullable(element, "ariaBrailleRoleDescription", "aria-brailleroledescription");
+}, "aria-brailleroledescription attribute reflects.");
+</script>
 </html>


### PR DESCRIPTION
Per https://github.com/w3c/aria/pull/2039

Adds reflection tests for `ariaBrailleLabel` <-> `aria-braillelabel` and `ariaBrailleRoleDescription` <-> `aria-brailleroledescription`.