### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=254693

### DIFF
--- a/wasm/jsapi/exception/basic.tentative.any.js
+++ b/wasm/jsapi/exception/basic.tentative.any.js
@@ -11,8 +11,7 @@ function assert_throws_wasm(fn, message) {
 }
 
 promise_test(async () => {
-  const kWasmAnyRef = 0x6f;
-  const kSig_v_r = makeSig([kWasmAnyRef], []);
+  const kSig_v_r = makeSig([kWasmExternRef], []);
   const builder = new WasmModuleBuilder();
   const tagIndex = builder.addTag(kSig_v_r);
   builder.addFunction("throw_param", kSig_v_r)
@@ -48,7 +47,7 @@ promise_test(async () => {
   const tagIndex = builder.addTag(kSig_v_a);
   builder.addFunction("throw_null", kSig_v_v)
     .addBody([
-      kExprRefNull, kWasmAnyFunc,
+      kExprRefNull, kAnyFuncCode,
       kExprThrow, tagIndex,
     ])
     .exportFunc();
@@ -82,7 +81,7 @@ promise_test(async () => {
       kExprCatch, tagIndex,
         kExprReturn,
       kExprEnd,
-      kExprRefNull, kWasmAnyRef,
+      kExprRefNull, kExternRefCode,
     ])
     .exportFunc();
 
@@ -106,7 +105,7 @@ promise_test(async () => {
       kExprCatchAll,
         kExprRethrow, 0x00,
       kExprEnd,
-      kExprRefNull, kWasmAnyRef,
+      kExprRefNull, kExternRefCode,
     ])
     .exportFunc();
 

--- a/wasm/jsapi/gc/casts.tentative.any.js
+++ b/wasm/jsapi/gc/casts.tentative.any.js
@@ -1,0 +1,332 @@
+// META: global=window,dedicatedworker,jsshell
+// META: script=/wasm/jsapi/wasm-module-builder.js
+
+let exports = {};
+setup(() => {
+  const builder = new WasmModuleBuilder();
+  const structIndex = builder.addStruct([makeField(kWasmI32, true)]);
+  const arrayIndex = builder.addArray(kWasmI32, true);
+  const structIndex2 = builder.addStruct([makeField(kWasmF32, true)]);
+  const arrayIndex2 = builder.addArray(kWasmF32, true);
+  const funcIndex = builder.addType({ params: [], results: [] });
+  const funcIndex2 = builder.addType({ params: [], results: [kWasmI32] });
+
+  const argFunctions = [
+    { name: "any", code: kWasmAnyRef },
+    { name: "eq", code: kWasmEqRef },
+    { name: "struct", code: kWasmStructRef },
+    { name: "array", code: kWasmArrayRef },
+    { name: "i31", code: kWasmI31Ref },
+    { name: "func", code: kWasmFuncRef },
+    { name: "extern", code: kWasmExternRef },
+    { name: "none", code: kWasmNullRef },
+    { name: "nofunc", code: kWasmNullFuncRef },
+    { name: "noextern", code: kWasmNullExternRef },
+    { name: "concreteStruct", code: structIndex },
+    { name: "concreteArray", code: arrayIndex },
+    { name: "concreteFunc", code: funcIndex },
+  ];
+
+  for (const desc of argFunctions) {
+    builder
+      .addFunction(desc.name + "Arg", makeSig_v_x(wasmRefType(desc.code)))
+      .addBody([])
+      .exportFunc();
+
+    builder
+      .addFunction(desc.name + "NullableArg", makeSig_v_x(wasmRefNullType(desc.code)))
+      .addBody([])
+      .exportFunc();
+  }
+
+  builder
+    .addFunction("makeStruct", makeSig_r_v(wasmRefType(structIndex)))
+    .addBody([...wasmI32Const(42),
+              ...GCInstr(kExprStructNew), structIndex])
+    .exportFunc();
+
+  builder
+    .addFunction("makeArray", makeSig_r_v(wasmRefType(arrayIndex)))
+    .addBody([...wasmI32Const(5), ...wasmI32Const(42),
+              ...GCInstr(kExprArrayNew), arrayIndex])
+    .exportFunc();
+
+  builder
+    .addFunction("makeStruct2", makeSig_r_v(wasmRefType(structIndex2)))
+    .addBody([...wasmF32Const(42),
+              ...GCInstr(kExprStructNew), structIndex2])
+    .exportFunc();
+
+  builder
+    .addFunction("makeArray2", makeSig_r_v(wasmRefType(arrayIndex2)))
+    .addBody([...wasmF32Const(42), ...wasmI32Const(5),
+              ...GCInstr(kExprArrayNew), arrayIndex2])
+    .exportFunc();
+
+  builder
+    .addFunction("testFunc", funcIndex)
+    .addBody([])
+    .exportFunc();
+
+  builder
+    .addFunction("testFunc2", funcIndex2)
+    .addBody([...wasmI32Const(42)])
+    .exportFunc();
+
+  const buffer = builder.toBuffer();
+  const module = new WebAssembly.Module(buffer);
+  const instance = new WebAssembly.Instance(module, {});
+  exports = instance.exports;
+});
+
+test(() => {
+  exports.anyArg(exports.makeStruct());
+  exports.anyArg(exports.makeArray());
+  exports.anyArg(42);
+  exports.anyArg(42n);
+  exports.anyArg("foo");
+  exports.anyArg({});
+  exports.anyArg(() => {});
+  exports.anyArg(exports.testFunc);
+  assert_throws_js(TypeError, () => exports.anyArg(null));
+
+  exports.anyNullableArg(null);
+  exports.anyNullableArg(exports.makeStruct());
+  exports.anyNullableArg(exports.makeArray());
+  exports.anyNullableArg(42);
+  exports.anyNullableArg(42n);
+  exports.anyNullableArg("foo");
+  exports.anyNullableArg({});
+  exports.anyNullableArg(() => {});
+  exports.anyNullableArg(exports.testFunc);
+}, "anyref casts");
+
+test(() => {
+  exports.eqArg(exports.makeStruct());
+  exports.eqArg(exports.makeArray());
+  exports.eqArg(42);
+  assert_throws_js(TypeError, () => exports.eqArg(42n));
+  assert_throws_js(TypeError, () => exports.eqArg("foo"));
+  assert_throws_js(TypeError, () => exports.eqArg({}));
+  assert_throws_js(TypeError, () => exports.eqArg(exports.testFunc));
+  assert_throws_js(TypeError, () => exports.eqArg(() => {}));
+  assert_throws_js(TypeError, () => exports.eqArg(null));
+
+  exports.eqNullableArg(null);
+  exports.eqNullableArg(exports.makeStruct());
+  exports.eqNullableArg(exports.makeArray());
+  exports.eqNullableArg(42);
+  assert_throws_js(TypeError, () => exports.eqNullableArg(42n));
+  assert_throws_js(TypeError, () => exports.eqNullableArg("foo"));
+  assert_throws_js(TypeError, () => exports.eqNullableArg({}));
+  assert_throws_js(TypeError, () => exports.eqNullableArg(exports.testFunc));
+  assert_throws_js(TypeError, () => exports.eqNullableArg(() => {}));
+}, "eqref casts");
+
+test(() => {
+  exports.structArg(exports.makeStruct());
+  assert_throws_js(TypeError, () => exports.structArg(exports.makeArray()));
+  assert_throws_js(TypeError, () => exports.structArg(42));
+  assert_throws_js(TypeError, () => exports.structArg(42n));
+  assert_throws_js(TypeError, () => exports.structArg("foo"));
+  assert_throws_js(TypeError, () => exports.structArg({}));
+  assert_throws_js(TypeError, () => exports.structArg(exports.testFunc));
+  assert_throws_js(TypeError, () => exports.structArg(() => {}));
+  assert_throws_js(TypeError, () => exports.structArg(null));
+
+  exports.structNullableArg(null);
+  exports.structNullableArg(exports.makeStruct());
+  assert_throws_js(TypeError, () => exports.structNullableArg(exports.makeArray()));
+  assert_throws_js(TypeError, () => exports.structNullableArg(42));
+  assert_throws_js(TypeError, () => exports.structNullableArg(42n));
+  assert_throws_js(TypeError, () => exports.structNullableArg("foo"));
+  assert_throws_js(TypeError, () => exports.structNullableArg({}));
+  assert_throws_js(TypeError, () => exports.structNullableArg(exports.testFunc));
+  assert_throws_js(TypeError, () => exports.structNullableArg(() => {}));
+}, "structref casts");
+
+test(() => {
+  exports.arrayArg(exports.makeArray());
+  assert_throws_js(TypeError, () => exports.arrayArg(exports.makeStruct()));
+  assert_throws_js(TypeError, () => exports.arrayArg(42));
+  assert_throws_js(TypeError, () => exports.arrayArg(42n));
+  assert_throws_js(TypeError, () => exports.arrayArg("foo"));
+  assert_throws_js(TypeError, () => exports.arrayArg({}));
+  assert_throws_js(TypeError, () => exports.arrayArg(exports.testFunc));
+  assert_throws_js(TypeError, () => exports.arrayArg(() => {}));
+  assert_throws_js(TypeError, () => exports.arrayArg(null));
+
+  exports.arrayNullableArg(null);
+  exports.arrayNullableArg(exports.makeArray());
+  assert_throws_js(TypeError, () => exports.arrayNullableArg(exports.makeStruct()));
+  assert_throws_js(TypeError, () => exports.arrayNullableArg(42));
+  assert_throws_js(TypeError, () => exports.arrayNullableArg(42n));
+  assert_throws_js(TypeError, () => exports.arrayNullableArg("foo"));
+  assert_throws_js(TypeError, () => exports.arrayNullableArg({}));
+  assert_throws_js(TypeError, () => exports.arrayNullableArg(exports.testFunc));
+  assert_throws_js(TypeError, () => exports.arrayNullableArg(() => {}));
+}, "arrayref casts");
+
+test(() => {
+  exports.i31Arg(42);
+  assert_throws_js(TypeError, () => exports.i31Arg(exports.makeStruct()));
+  assert_throws_js(TypeError, () => exports.i31Arg(exports.makeArray()));
+  assert_throws_js(TypeError, () => exports.i31Arg(42n));
+  assert_throws_js(TypeError, () => exports.i31Arg("foo"));
+  assert_throws_js(TypeError, () => exports.i31Arg({}));
+  assert_throws_js(TypeError, () => exports.i31Arg(exports.testFunc));
+  assert_throws_js(TypeError, () => exports.i31Arg(() => {}));
+  assert_throws_js(TypeError, () => exports.i31Arg(null));
+
+  exports.i31NullableArg(null);
+  exports.i31NullableArg(42);
+  assert_throws_js(TypeError, () => exports.i31NullableArg(exports.makeStruct()));
+  assert_throws_js(TypeError, () => exports.i31NullableArg(exports.makeArray()));
+  assert_throws_js(TypeError, () => exports.i31NullableArg(42n));
+  assert_throws_js(TypeError, () => exports.i31NullableArg("foo"));
+  assert_throws_js(TypeError, () => exports.i31NullableArg({}));
+  assert_throws_js(TypeError, () => exports.i31NullableArg(exports.testFunc));
+  assert_throws_js(TypeError, () => exports.i31NullableArg(() => {}));
+}, "i31ref casts");
+
+test(() => {
+  exports.funcArg(exports.testFunc);
+  assert_throws_js(TypeError, () => exports.funcArg(exports.makeStruct()));
+  assert_throws_js(TypeError, () => exports.funcArg(exports.makeArray()));
+  assert_throws_js(TypeError, () => exports.funcArg(42));
+  assert_throws_js(TypeError, () => exports.funcArg(42n));
+  assert_throws_js(TypeError, () => exports.funcArg("foo"));
+  assert_throws_js(TypeError, () => exports.funcArg({}));
+  assert_throws_js(TypeError, () => exports.funcArg(() => {}));
+  assert_throws_js(TypeError, () => exports.funcArg(null));
+
+  exports.funcNullableArg(null);
+  exports.funcNullableArg(exports.testFunc);
+  assert_throws_js(TypeError, () => exports.funcNullableArg(exports.makeStruct()));
+  assert_throws_js(TypeError, () => exports.funcNullableArg(exports.makeArray()));
+  assert_throws_js(TypeError, () => exports.funcNullableArg(42));
+  assert_throws_js(TypeError, () => exports.funcNullableArg(42n));
+  assert_throws_js(TypeError, () => exports.funcNullableArg("foo"));
+  assert_throws_js(TypeError, () => exports.funcNullableArg({}));
+  assert_throws_js(TypeError, () => exports.funcNullableArg(() => {}));
+}, "funcref casts");
+
+test(() => {
+  exports.externArg(exports.makeArray());
+  exports.externArg(exports.makeStruct());
+  exports.externArg(42);
+  exports.externArg(42n);
+  exports.externArg("foo");
+  exports.externArg({});
+  exports.externArg(exports.testFunc);
+  exports.externArg(() => {});
+  assert_throws_js(TypeError, () => exports.externArg(null));
+
+  exports.externNullableArg(null);
+  exports.externNullableArg(exports.makeArray());
+  exports.externNullableArg(exports.makeStruct());
+  exports.externNullableArg(42);
+  exports.externNullableArg(42n);
+  exports.externNullableArg("foo");
+  exports.externNullableArg({});
+  exports.externNullableArg(exports.testFunc);
+  exports.externNullableArg(() => {});
+}, "externref casts");
+
+test(() => {
+  for (const nullfunc of [exports.noneArg, exports.nofuncArg, exports.noexternArg]) {
+    assert_throws_js(TypeError, () => nullfunc(exports.makeStruct()));
+    assert_throws_js(TypeError, () => nullfunc(exports.makeArray()));
+    assert_throws_js(TypeError, () => nullfunc(42));
+    assert_throws_js(TypeError, () => nullfunc(42n));
+    assert_throws_js(TypeError, () => nullfunc("foo"));
+    assert_throws_js(TypeError, () => nullfunc({}));
+    assert_throws_js(TypeError, () => nullfunc(exports.testFunc));
+    assert_throws_js(TypeError, () => nullfunc(() => {}));
+    assert_throws_js(TypeError, () => nullfunc(null));
+  }
+
+  for (const nullfunc of [exports.noneNullableArg, exports.nofuncNullableArg, exports.noexternNullableArg]) {
+    nullfunc(null);
+    assert_throws_js(TypeError, () => nullfunc(exports.makeStruct()));
+    assert_throws_js(TypeError, () => nullfunc(exports.makeArray()));
+    assert_throws_js(TypeError, () => nullfunc(42));
+    assert_throws_js(TypeError, () => nullfunc(42n));
+    assert_throws_js(TypeError, () => nullfunc("foo"));
+    assert_throws_js(TypeError, () => nullfunc({}));
+    assert_throws_js(TypeError, () => nullfunc(exports.testFunc));
+    assert_throws_js(TypeError, () => nullfunc(() => {}));
+  }
+}, "null casts");
+
+test(() => {
+  exports.concreteStructArg(exports.makeStruct());
+  assert_throws_js(TypeError, () => exports.concreteStructArg(exports.makeStruct2()));
+  assert_throws_js(TypeError, () => exports.concreteStructArg(exports.makeArray()));
+  assert_throws_js(TypeError, () => exports.concreteStructArg(42));
+  assert_throws_js(TypeError, () => exports.concreteStructArg(42n));
+  assert_throws_js(TypeError, () => exports.concreteStructArg("foo"));
+  assert_throws_js(TypeError, () => exports.concreteStructArg({}));
+  assert_throws_js(TypeError, () => exports.concreteStructArg(exports.testFunc));
+  assert_throws_js(TypeError, () => exports.concreteStructArg(() => {}));
+  assert_throws_js(TypeError, () => exports.concreteStructArg(null));
+
+  exports.concreteStructNullableArg(null);
+  exports.concreteStructNullableArg(exports.makeStruct());
+  assert_throws_js(TypeError, () => exports.concreteStructNullableArg(exports.makeStruct2()));
+  assert_throws_js(TypeError, () => exports.concreteStructNullableArg(exports.makeArray()));
+  assert_throws_js(TypeError, () => exports.concreteStructNullableArg(42));
+  assert_throws_js(TypeError, () => exports.concreteStructNullableArg(42n));
+  assert_throws_js(TypeError, () => exports.concreteStructNullableArg("foo"));
+  assert_throws_js(TypeError, () => exports.concreteStructNullableArg({}));
+  assert_throws_js(TypeError, () => exports.concreteStructNullableArg(exports.testFunc));
+  assert_throws_js(TypeError, () => exports.concreteStructNullableArg(() => {}));
+}, "concrete struct casts");
+
+test(() => {
+  exports.concreteArrayArg(exports.makeArray());
+  assert_throws_js(TypeError, () => exports.concreteArrayArg(exports.makeArray2()));
+  assert_throws_js(TypeError, () => exports.concreteArrayArg(exports.makeStruct()));
+  assert_throws_js(TypeError, () => exports.concreteArrayArg(42));
+  assert_throws_js(TypeError, () => exports.concreteArrayArg(42n));
+  assert_throws_js(TypeError, () => exports.concreteArrayArg("foo"));
+  assert_throws_js(TypeError, () => exports.concreteArrayArg({}));
+  assert_throws_js(TypeError, () => exports.concreteArrayArg(exports.testFunc));
+  assert_throws_js(TypeError, () => exports.concreteArrayArg(() => {}));
+  assert_throws_js(TypeError, () => exports.concreteArrayArg(null));
+
+  exports.concreteArrayNullableArg(null);
+  exports.concreteArrayNullableArg(exports.makeArray());
+  assert_throws_js(TypeError, () => exports.concreteArrayNullableArg(exports.makeArray2()));
+  assert_throws_js(TypeError, () => exports.concreteArrayNullableArg(exports.makeStruct()));
+  assert_throws_js(TypeError, () => exports.concreteArrayNullableArg(42));
+  assert_throws_js(TypeError, () => exports.concreteArrayNullableArg(42n));
+  assert_throws_js(TypeError, () => exports.concreteArrayNullableArg("foo"));
+  assert_throws_js(TypeError, () => exports.concreteArrayNullableArg({}));
+  assert_throws_js(TypeError, () => exports.concreteArrayNullableArg(exports.testFunc));
+  assert_throws_js(TypeError, () => exports.concreteArrayNullableArg(() => {}));
+}, "concrete array casts");
+
+test(() => {
+  exports.concreteFuncArg(exports.testFunc);
+  assert_throws_js(TypeError, () => exports.concreteFuncArg(exports.testFunc2));
+  assert_throws_js(TypeError, () => exports.concreteFuncArg(exports.makeArray()));
+  assert_throws_js(TypeError, () => exports.concreteFuncArg(exports.makeStruct()));
+  assert_throws_js(TypeError, () => exports.concreteFuncArg(42));
+  assert_throws_js(TypeError, () => exports.concreteFuncArg(42n));
+  assert_throws_js(TypeError, () => exports.concreteFuncArg("foo"));
+  assert_throws_js(TypeError, () => exports.concreteFuncArg({}));
+  assert_throws_js(TypeError, () => exports.concreteFuncArg(() => {}));
+  assert_throws_js(TypeError, () => exports.concreteFuncArg(null));
+
+  exports.concreteFuncNullableArg(null);
+  exports.concreteFuncNullableArg(exports.testFunc);
+  assert_throws_js(TypeError, () => exports.concreteFuncNullableArg(exports.testFunc2));
+  assert_throws_js(TypeError, () => exports.concreteFuncNullableArg(exports.makeArray()));
+  assert_throws_js(TypeError, () => exports.concreteFuncNullableArg(exports.makeStruct()));
+  assert_throws_js(TypeError, () => exports.concreteFuncNullableArg(42));
+  assert_throws_js(TypeError, () => exports.concreteFuncNullableArg(42n));
+  assert_throws_js(TypeError, () => exports.concreteFuncNullableArg("foo"));
+  assert_throws_js(TypeError, () => exports.concreteFuncNullableArg({}));
+  assert_throws_js(TypeError, () => exports.concreteFuncNullableArg(() => {}));
+}, "concrete func casts");

--- a/wasm/jsapi/gc/exported-object.tentative.any.js
+++ b/wasm/jsapi/gc/exported-object.tentative.any.js
@@ -1,0 +1,190 @@
+// META: global=window,dedicatedworker,jsshell
+// META: script=/wasm/jsapi/wasm-module-builder.js
+
+let functions = {};
+setup(() => {
+  const builder = new WasmModuleBuilder();
+
+  const structIndex = builder.addStruct([makeField(kWasmI32, true)]);
+  const arrayIndex = builder.addArray(kWasmI32, true);
+  const structRef = wasmRefType(structIndex);
+  const arrayRef = wasmRefType(arrayIndex);
+
+  builder
+    .addFunction("makeStruct", makeSig_r_v(structRef))
+    .addBody([...wasmI32Const(42),
+              ...GCInstr(kExprStructNew), structIndex])
+    .exportFunc();
+
+  builder
+    .addFunction("makeArray", makeSig_r_v(arrayRef))
+    .addBody([...wasmI32Const(5), ...wasmI32Const(42),
+              ...GCInstr(kExprArrayNew), arrayIndex])
+    .exportFunc();
+
+  const buffer = builder.toBuffer();
+  const module = new WebAssembly.Module(buffer);
+  const instance = new WebAssembly.Instance(module, {});
+  functions = instance.exports;
+});
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  assert_equals(struct.foo, undefined);
+  assert_equals(struct[0], undefined);
+  assert_equals(array.foo, undefined);
+  assert_equals(array[0], undefined);
+}, "property access");
+
+test(() => {
+  "use strict";
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  assert_throws_js(TypeError, () => { struct.foo = 5; });
+  assert_throws_js(TypeError, () => { array.foo = 5; });
+  assert_throws_js(TypeError, () => { struct[0] = 5; });
+  assert_throws_js(TypeError, () => { array[0] = 5; });
+}, "property assignment (strict mode)");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  assert_throws_js(TypeError, () => { struct.foo = 5; });
+  assert_throws_js(TypeError, () => { array.foo = 5; });
+  assert_throws_js(TypeError, () => { struct[0] = 5; });
+  assert_throws_js(TypeError, () => { array[0] = 5; });
+}, "property assignment (non-strict mode)");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  assert_equals(Object.getOwnPropertyNames(struct).length, 0);
+  assert_equals(Object.getOwnPropertyNames(array).length, 0);
+}, "ownPropertyNames");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  assert_throws_js(TypeError, () => Object.defineProperty(struct, "foo", { value: 1 }));
+  assert_throws_js(TypeError, () => Object.defineProperty(array, "foo", { value: 1 }));
+}, "defineProperty");
+
+test(() => {
+  "use strict";
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  assert_throws_js(TypeError, () => delete struct.foo);
+  assert_throws_js(TypeError, () => delete struct[0]);
+  assert_throws_js(TypeError, () => delete array.foo);
+  assert_throws_js(TypeError, () => delete array[0]);
+}, "delete (strict mode)");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  assert_throws_js(TypeError, () => delete struct.foo);
+  assert_throws_js(TypeError, () => delete struct[0]);
+  assert_throws_js(TypeError, () => delete array.foo);
+  assert_throws_js(TypeError, () => delete array[0]);
+}, "delete (non-strict mode)");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  assert_equals(Object.getPrototypeOf(struct), null);
+  assert_equals(Object.getPrototypeOf(array), null);
+}, "getPrototypeOf");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  assert_throws_js(TypeError, () => Object.setPrototypeOf(struct, {}));
+  assert_throws_js(TypeError, () => Object.setPrototypeOf(array, {}));
+}, "setPrototypeOf");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  assert_false(Object.isExtensible(struct));
+  assert_false(Object.isExtensible(array));
+}, "isExtensible");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  assert_throws_js(TypeError, () => Object.preventExtensions(struct));
+  assert_throws_js(TypeError, () => Object.preventExtensions(array));
+}, "preventExtensions");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  assert_throws_js(TypeError, () => Object.seal(struct));
+  assert_throws_js(TypeError, () => Object.seal(array));
+}, "sealing");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  assert_equals(typeof struct, "object");
+  assert_equals(typeof array, "object");
+}, "typeof");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  assert_throws_js(TypeError, () => struct.toString());
+  assert_equals(Object.prototype.toString.call(struct), "[object Object]");
+  assert_throws_js(TypeError, () => array.toString());
+  assert_equals(Object.prototype.toString.call(array), "[object Object]");
+}, "toString");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  assert_throws_js(TypeError, () => struct.valueOf());
+  assert_equals(Object.prototype.valueOf.call(struct), struct);
+  assert_throws_js(TypeError, () => array.valueOf());
+  assert_equals(Object.prototype.valueOf.call(array), array);
+}, "valueOf");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  const map = new Map();
+  map.set(struct, "struct");
+  map.set(array, "array");
+  assert_equals(map.get(struct), "struct");
+  assert_equals(map.get(array), "array");
+}, "GC objects as map keys");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  const set = new Set();
+  set.add(struct);
+  set.add(array);
+  assert_true(set.has(struct));
+  assert_true(set.has(array));
+}, "GC objects as set element");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  const map = new WeakMap();
+  map.set(struct, "struct");
+  map.set(array, "array");
+  assert_equals(map.get(struct), "struct");
+  assert_equals(map.get(array), "array");
+}, "GC objects as weak map keys");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  const set = new WeakSet();
+  set.add(struct);
+  set.add(array);
+  assert_true(set.has(struct));
+  assert_true(set.has(array));
+}, "GC objects as weak set element");

--- a/wasm/jsapi/gc/i31.tentative.any.js
+++ b/wasm/jsapi/gc/i31.tentative.any.js
@@ -1,0 +1,98 @@
+// META: global=window,dedicatedworker,jsshell
+// META: script=/wasm/jsapi/wasm-module-builder.js
+
+let exports = {};
+setup(() => {
+  const builder = new WasmModuleBuilder();
+  const i31Ref = wasmRefType(kWasmI31Ref);
+  const i31NullableRef = wasmRefNullType(kWasmI31Ref);
+  const anyRef = wasmRefType(kWasmAnyRef);
+
+  builder
+    .addFunction("makeI31", makeSig_r_x(i31Ref, kWasmI32))
+    .addBody([kExprLocalGet, 0,
+              ...GCInstr(kExprI31New)])
+    .exportFunc();
+
+  builder
+    .addFunction("castI31", makeSig_r_x(kWasmI32, anyRef))
+    .addBody([kExprLocalGet, 0,
+              ...GCInstr(kExprRefCast), kI31RefCode,
+              ...GCInstr(kExprI31GetU)])
+    .exportFunc();
+
+  builder
+    .addFunction("getI31", makeSig_r_x(kWasmI32, i31Ref))
+    .addBody([kExprLocalGet, 0,
+              ...GCInstr(kExprI31GetS)])
+    .exportFunc();
+
+  builder
+    .addFunction("argI31", makeSig_v_x(i31NullableRef))
+    .addBody([])
+    .exportFunc();
+
+  builder
+    .addGlobal(i31NullableRef, true, [...wasmI32Const(0), ...GCInstr(kExprI31New)])
+  builder
+    .addExportOfKind("i31Global", kExternalGlobal, 0);
+
+  builder
+    .addTable(i31NullableRef, 10)
+  builder
+    .addExportOfKind("i31Table", kExternalTable, 0);
+
+  const buffer = builder.toBuffer();
+  const module = new WebAssembly.Module(buffer);
+  const instance = new WebAssembly.Instance(module, {});
+  exports = instance.exports;
+});
+
+test(() => {
+  assert_equals(exports.makeI31(42), 42);
+  assert_equals(exports.makeI31(2 ** 30 - 1), 2 ** 30 - 1);
+  assert_equals(exports.makeI31(2 ** 30), -(2 ** 30));
+  assert_equals(exports.makeI31(-(2 ** 30)), -(2 ** 30));
+  assert_equals(exports.makeI31(2 ** 31 - 1), -1);
+  assert_equals(exports.makeI31(2 ** 31), 0);
+}, "i31ref conversion to Number");
+
+test(() => {
+  assert_equals(exports.getI31(exports.makeI31(42)), 42);
+  assert_equals(exports.getI31(42), 42);
+  assert_equals(exports.getI31(2.0 ** 30 - 1), 2 ** 30 - 1);
+  assert_equals(exports.getI31(-(2 ** 30)), -(2 ** 30));
+}, "Number conversion to i31ref");
+
+test(() => {
+  exports.argI31(null);
+  assert_throws_js(TypeError, () => exports.argI31(2 ** 30));
+  assert_throws_js(TypeError, () => exports.argI31(-(2 ** 30) - 1));
+  assert_throws_js(TypeError, () => exports.argI31(2n));
+  assert_throws_js(TypeError, () => exports.argI31(() => 3));
+  assert_throws_js(TypeError, () => exports.argI31(exports.getI31));
+}, "Check i31ref argument type");
+
+test(() => {
+  assert_equals(exports.castI31(42), 42);
+  assert_equals(exports.castI31(2 ** 30 - 1), 2 ** 30 - 1);
+  assert_throws_js(WebAssembly.RuntimeError, () => { exports.castI31(2 ** 30); });
+  assert_throws_js(WebAssembly.RuntimeError, () => { exports.castI31(-(2 ** 30) - 1); });
+  assert_throws_js(WebAssembly.RuntimeError, () => { exports.castI31(2 ** 32); });
+}, "Numbers in i31 range are i31ref, not hostref");
+
+test(() => {
+  assert_equals(exports.i31Global.value, 0);
+  exports.i31Global.value = 42;
+  assert_throws_js(TypeError, () => exports.i31Global.value = 2 ** 30);
+  assert_throws_js(TypeError, () => exports.i31Global.value = -(2 ** 30) - 1);
+  assert_equals(exports.i31Global.value, 42);
+}, "i31ref global");
+
+test(() => {
+  assert_equals(exports.i31Table.get(0), null);
+  exports.i31Table.set(0, 42);
+  assert_throws_js(TypeError, () => exports.i31Table.set(0, 2 ** 30));
+  assert_throws_js(TypeError, () => exports.i31Table.set(0, -(2 ** 30) - 1));
+  assert_equals(exports.i31Table.get(0), 42);
+}, "i31ref table");

--- a/wasm/jsapi/instanceTestFactory.js
+++ b/wasm/jsapi/instanceTestFactory.js
@@ -237,7 +237,7 @@ const instanceTestFactory = [
 
       builder.addGlobal(kWasmI32, true)
         .exportAs("")
-        .init = 7;
+        .init = wasmI32Const(7);
 
       const buffer = builder.toBuffer();
 
@@ -273,10 +273,10 @@ const instanceTestFactory = [
 
       builder.addGlobal(kWasmI32, true)
         .exportAs("global")
-        .init = 7;
+        .init = wasmI32Const(7);
       builder.addGlobal(kWasmF64, true)
         .exportAs("global2")
-        .init = 1.2;
+        .init = wasmF64Const(1.2);
 
       builder.addMemory(4, 8, true);
 

--- a/wasm/jsapi/module/exports.any.js
+++ b/wasm/jsapi/module/exports.any.js
@@ -109,10 +109,10 @@ test(() => {
 
   builder.addGlobal(kWasmI32, true)
     .exportAs("global")
-    .init = 7;
+    .init = wasmI32Const(7);
   builder.addGlobal(kWasmF64, true)
     .exportAs("global2")
-    .init = 1.2;
+    .init = wasmF64Const(1.2);
 
   builder.addMemory(0, 256, true);
 
@@ -167,7 +167,7 @@ test(() => {
 
   builder.addGlobal(kWasmI32, true)
     .exportAs("")
-    .init = 7;
+    .init = wasmI32Const(7);
 
   const buffer = builder.toBuffer()
   const module = new WebAssembly.Module(buffer);

--- a/wasm/jsapi/wasm-module-builder.js
+++ b/wasm/jsapi/wasm-module-builder.js
@@ -74,6 +74,13 @@ let kLocalNamesCode = 2;
 
 let kWasmFunctionTypeForm = 0x60;
 let kWasmAnyFunctionTypeForm = 0x70;
+let kWasmStructTypeForm = 0x5f;
+let kWasmArrayTypeForm = 0x5e;
+let kWasmSubtypeForm = 0x50;
+let kWasmSubtypeFinalForm = 0x4f;
+let kWasmRecursiveTypeGroupForm = 0x4e;
+
+let kNoSuperType = 0xFFFFFFFF;
 
 let kHasMaximumFlag = 1;
 let kSharedHasMaximumFlag = 3;
@@ -97,8 +104,43 @@ let kWasmI64 = 0x7e;
 let kWasmF32 = 0x7d;
 let kWasmF64 = 0x7c;
 let kWasmS128 = 0x7b;
-let kWasmAnyRef = 0x6f;
-let kWasmAnyFunc = 0x70;
+
+// These are defined as negative integers to distinguish them from positive type
+// indices.
+let kWasmNullFuncRef = -0x0d;
+let kWasmNullExternRef = -0x0e;
+let kWasmNullRef = -0x0f;
+let kWasmFuncRef = -0x10;
+let kWasmAnyFunc = kWasmFuncRef;  // Alias named as in the JS API spec
+let kWasmExternRef = -0x11;
+let kWasmAnyRef = -0x12;
+let kWasmEqRef = -0x13;
+let kWasmI31Ref = -0x14;
+let kWasmStructRef = -0x15;
+let kWasmArrayRef = -0x16;
+
+// Use the positive-byte versions inside function bodies.
+let kLeb128Mask = 0x7f;
+let kFuncRefCode = kWasmFuncRef & kLeb128Mask;
+let kAnyFuncCode = kFuncRefCode;  // Alias named as in the JS API spec
+let kExternRefCode = kWasmExternRef & kLeb128Mask;
+let kAnyRefCode = kWasmAnyRef & kLeb128Mask;
+let kEqRefCode = kWasmEqRef & kLeb128Mask;
+let kI31RefCode = kWasmI31Ref & kLeb128Mask;
+let kNullExternRefCode = kWasmNullExternRef & kLeb128Mask;
+let kNullFuncRefCode = kWasmNullFuncRef & kLeb128Mask;
+let kStructRefCode = kWasmStructRef & kLeb128Mask;
+let kArrayRefCode = kWasmArrayRef & kLeb128Mask;
+let kNullRefCode = kWasmNullRef & kLeb128Mask;
+
+let kWasmRefNull = 0x63;
+let kWasmRef = 0x64;
+function wasmRefNullType(heap_type) {
+  return {opcode: kWasmRefNull, heap_type: heap_type};
+}
+function wasmRefType(heap_type) {
+  return {opcode: kWasmRef, heap_type: heap_type};
+}
 
 let kExternalFunction = 0;
 let kExternalTable = 1;
@@ -146,14 +188,14 @@ let kSig_v_f = makeSig([kWasmF32], []);
 let kSig_f_f = makeSig([kWasmF32], [kWasmF32]);
 let kSig_f_d = makeSig([kWasmF64], [kWasmF32]);
 let kSig_d_d = makeSig([kWasmF64], [kWasmF64]);
-let kSig_r_r = makeSig([kWasmAnyRef], [kWasmAnyRef]);
+let kSig_r_r = makeSig([kWasmExternRef], [kWasmExternRef]);
 let kSig_a_a = makeSig([kWasmAnyFunc], [kWasmAnyFunc]);
-let kSig_i_r = makeSig([kWasmAnyRef], [kWasmI32]);
-let kSig_v_r = makeSig([kWasmAnyRef], []);
+let kSig_i_r = makeSig([kWasmExternRef], [kWasmI32]);
+let kSig_v_r = makeSig([kWasmExternRef], []);
 let kSig_v_a = makeSig([kWasmAnyFunc], []);
-let kSig_v_rr = makeSig([kWasmAnyRef, kWasmAnyRef], []);
+let kSig_v_rr = makeSig([kWasmExternRef, kWasmExternRef], []);
 let kSig_v_aa = makeSig([kWasmAnyFunc, kWasmAnyFunc], []);
-let kSig_r_v = makeSig([], [kWasmAnyRef]);
+let kSig_r_v = makeSig([], [kWasmExternRef]);
 let kSig_a_v = makeSig([], [kWasmAnyFunc]);
 let kSig_a_i = makeSig([kWasmI32], [kWasmAnyFunc]);
 
@@ -374,9 +416,49 @@ let kExprRefIsNull = 0xd1;
 let kExprRefFunc = 0xd2;
 
 // Prefix opcodes
+let kGCPrefix = 0xfb;
 let kNumericPrefix = 0xfc;
 let kSimdPrefix = 0xfd;
 let kAtomicPrefix = 0xfe;
+
+// Use these for multi-byte instructions (opcode > 0x7F needing two LEB bytes):
+function GCInstr(opcode) {
+  if (opcode <= 0x7F) return [kGCPrefix, opcode];
+  return [kGCPrefix, 0x80 | (opcode & 0x7F), opcode >> 7];
+}
+
+// GC opcodes
+let kExprStructNew = 0x00;
+let kExprStructNewDefault = 0x01;
+let kExprStructGet = 0x02;
+let kExprStructGetS = 0x03;
+let kExprStructGetU = 0x04;
+let kExprStructSet = 0x05;
+let kExprArrayNew = 0x06;
+let kExprArrayNewDefault = 0x07;
+let kExprArrayNewFixed = 0x08;
+let kExprArrayNewData = 0x09;
+let kExprArrayNewElem = 0x0a;
+let kExprArrayGet = 0x0b;
+let kExprArrayGetS = 0x0c;
+let kExprArrayGetU = 0x0d;
+let kExprArraySet = 0x0e;
+let kExprArrayLen = 0x0f;
+let kExprArrayFill = 0x10;
+let kExprArrayCopy = 0x11;
+let kExprArrayInitData = 0x12;
+let kExprArrayInitElem = 0x13;
+let kExprRefTest = 0x14;
+let kExprRefTestNull = 0x15;
+let kExprRefCast = 0x16;
+let kExprRefCastNull = 0x17;
+let kExprBrOnCast = 0x18;
+let kExprBrOnCastFail = 0x19;
+let kExprExternInternalize = 0x1a;
+let kExprExternExternalize = 0x1b;
+let kExprI31New = 0x1c;
+let kExprI31GetS = 0x1d;
+let kExprI31GetU = 0x1e;
 
 // Numeric opcodes.
 let kExprMemoryInit = 0x08;
@@ -554,6 +636,25 @@ class Binary {
     }
   }
 
+  emit_heap_type(heap_type) {
+    this.emit_bytes(wasmSignedLeb(heap_type, kMaxVarInt32Size));
+  }
+
+  emit_type(type) {
+    if ((typeof type) == 'number') {
+      this.emit_u8(type >= 0 ? type : type & kLeb128Mask);
+    } else {
+      this.emit_u8(type.opcode);
+      if ('depth' in type) this.emit_u8(type.depth);
+      this.emit_heap_type(type.heap_type);
+    }
+  }
+
+  emit_init_expr(expr) {
+    this.emit_bytes(expr);
+    this.emit_u8(kExprEnd);
+  }
+
   emit_header() {
     this.emit_bytes([
       kWasmH0, kWasmH1, kWasmH2, kWasmH3, kWasmV0, kWasmV1, kWasmV2, kWasmV3
@@ -644,11 +745,11 @@ class WasmFunctionBuilder {
 }
 
 class WasmGlobalBuilder {
-  constructor(module, type, mutable) {
+  constructor(module, type, mutable, init) {
     this.module = module;
     this.type = type;
     this.mutable = mutable;
-    this.init = 0;
+    this.init = init;
   }
 
   exportAs(name) {
@@ -658,19 +759,59 @@ class WasmGlobalBuilder {
   }
 }
 
+function checkExpr(expr) {
+  for (let b of expr) {
+    if (typeof b !== 'number' || (b & (~0xFF)) !== 0) {
+      throw new Error(
+          'invalid body (entries must be 8 bit numbers): ' + expr);
+    }
+  }
+}
+
 class WasmTableBuilder {
-  constructor(module, type, initial_size, max_size) {
+  constructor(module, type, initial_size, max_size, init_expr) {
     this.module = module;
     this.type = type;
     this.initial_size = initial_size;
     this.has_max = max_size != undefined;
     this.max_size = max_size;
+    this.init_expr = init_expr;
+    this.has_init = init_expr !== undefined;
   }
 
   exportAs(name) {
     this.module.exports.push({name: name, kind: kExternalTable,
                               index: this.index});
     return this;
+  }
+}
+
+function makeField(type, mutability) {
+  if ((typeof mutability) != 'boolean') {
+    throw new Error('field mutability must be boolean');
+  }
+  return {type: type, mutability: mutability};
+}
+
+class WasmStruct {
+  constructor(fields, is_final, supertype_idx) {
+    if (!Array.isArray(fields)) {
+      throw new Error('struct fields must be an array');
+    }
+    this.fields = fields;
+    this.type_form = kWasmStructTypeForm;
+    this.is_final = is_final;
+    this.supertype = supertype_idx;
+  }
+}
+
+class WasmArray {
+  constructor(type, mutability, is_final, supertype_idx) {
+    this.type = type;
+    this.mutability = mutability;
+    this.type_form = kWasmArrayTypeForm;
+    this.is_final = is_final;
+    this.supertype = supertype_idx;
   }
 }
 
@@ -686,6 +827,7 @@ class WasmModuleBuilder {
     this.element_segments = [];
     this.data_segments = [];
     this.explicit = [];
+    this.rec_groups = [];
     this.num_imported_funcs = 0;
     this.num_imported_globals = 0;
     this.num_imported_tables = 0;
@@ -728,25 +870,65 @@ class WasmModuleBuilder {
     this.explicit.push(this.createCustomSection(name, bytes));
   }
 
-  addType(type) {
-    this.types.push(type);
-    var pl = type.params.length;  // should have params
-    var rl = type.results.length; // should have results
+  // We use {is_final = true} so that the MVP syntax is generated for
+  // signatures.
+  addType(type, supertype_idx = kNoSuperType, is_final = true) {
+    var pl = type.params.length;   // should have params
+    var rl = type.results.length;  // should have results
+    var type_copy = {params: type.params, results: type.results,
+                     is_final: is_final, supertype: supertype_idx};
+    this.types.push(type_copy);
     return this.types.length - 1;
   }
 
-  addGlobal(local_type, mutable) {
-    let glob = new WasmGlobalBuilder(this, local_type, mutable);
+  addStruct(fields, supertype_idx = kNoSuperType, is_final = false) {
+    this.types.push(new WasmStruct(fields, is_final, supertype_idx));
+    return this.types.length - 1;
+  }
+
+  addArray(type, mutability, supertype_idx = kNoSuperType, is_final = false) {
+    this.types.push(new WasmArray(type, mutability, is_final, supertype_idx));
+    return this.types.length - 1;
+  }
+
+  static defaultFor(type) {
+    switch (type) {
+      case kWasmI32:
+        return wasmI32Const(0);
+      case kWasmI64:
+        return wasmI64Const(0);
+      case kWasmF32:
+        return wasmF32Const(0.0);
+      case kWasmF64:
+        return wasmF64Const(0.0);
+      case kWasmS128:
+        return [kSimdPrefix, kExprS128Const, ...(new Array(16).fill(0))];
+      default:
+        if ((typeof type) != 'number' && type.opcode != kWasmRefNull) {
+          throw new Error("Non-defaultable type");
+        }
+        let heap_type = (typeof type) == 'number' ? type : type.heap_type;
+        return [kExprRefNull, ...wasmSignedLeb(heap_type, kMaxVarInt32Size)];
+    }
+  }
+
+  addGlobal(type, mutable, init) {
+    if (init === undefined) init = WasmModuleBuilder.defaultFor(type);
+    checkExpr(init);
+    let glob = new WasmGlobalBuilder(this, type, mutable, init);
     glob.index = this.globals.length + this.num_imported_globals;
     this.globals.push(glob);
     return glob;
   }
 
-  addTable(type, initial_size, max_size = undefined) {
-    if (type != kWasmAnyRef && type != kWasmAnyFunc) {
-      throw new Error('Tables must be of type kWasmAnyRef or kWasmAnyFunc');
+  addTable(type, initial_size, max_size = undefined, init_expr = undefined) {
+    if (type == kWasmI32 || type == kWasmI64 || type == kWasmF32 ||
+        type == kWasmF64 || type == kWasmS128 || type == kWasmStmt) {
+      throw new Error('Tables must be of a reference type');
     }
-    let table = new WasmTableBuilder(this, type, initial_size, max_size);
+    if (init_expr != undefined) checkExpr(init_expr);
+    let table = new WasmTableBuilder(
+        this, type, initial_size, max_size, init_expr);
     table.index = this.tables.length + this.num_imported_tables;
     this.tables.push(table);
     return table;
@@ -754,9 +936,9 @@ class WasmModuleBuilder {
 
   addTag(type) {
     let type_index = (typeof type) == "number" ? type : this.addType(type);
-    let except_index = this.tags.length + this.num_imported_tags;
+    let tag_index = this.tags.length + this.num_imported_tags;
     this.tags.push(type_index);
-    return except_index;
+    return tag_index;
   }
 
   addFunction(name, type) {
@@ -877,6 +1059,21 @@ class WasmModuleBuilder {
     return this;
   }
 
+  startRecGroup() {
+    this.rec_groups.push({start: this.types.length, size: 0});
+  }
+
+  endRecGroup() {
+    if (this.rec_groups.length == 0) {
+      throw new Error("Did not start a recursive group before ending one")
+    }
+    let last_element = this.rec_groups[this.rec_groups.length - 1]
+    if (last_element.size != 0) {
+      throw new Error("Did not start a recursive group before ending one")
+    }
+    last_element.size = this.types.length - last_element.start;
+  }
+
   setName(name) {
     this.name = name;
     return this;
@@ -891,18 +1088,55 @@ class WasmModuleBuilder {
 
     // Add type section
     if (wasm.types.length > 0) {
-      if (debug) print("emitting types @ " + binary.length);
+      if (debug) print('emitting types @ ' + binary.length);
       binary.emit_section(kTypeSectionCode, section => {
-        section.emit_u32v(wasm.types.length);
-        for (let type of wasm.types) {
-          section.emit_u8(kWasmFunctionTypeForm);
-          section.emit_u32v(type.params.length);
-          for (let param of type.params) {
-            section.emit_u8(param);
+        let length_with_groups = wasm.types.length;
+        for (let group of wasm.rec_groups) {
+          length_with_groups -= group.size - 1;
+        }
+        section.emit_u32v(length_with_groups);
+
+        let rec_group_index = 0;
+
+        for (let i = 0; i < wasm.types.length; i++) {
+          if (rec_group_index < wasm.rec_groups.length &&
+              wasm.rec_groups[rec_group_index].start == i) {
+            section.emit_u8(kWasmRecursiveTypeGroupForm);
+            section.emit_u32v(wasm.rec_groups[rec_group_index].size);
+            rec_group_index++;
           }
-          section.emit_u32v(type.results.length);
-          for (let result of type.results) {
-            section.emit_u8(result);
+
+          let type = wasm.types[i];
+          if (type.supertype != kNoSuperType) {
+            section.emit_u8(type.is_final ? kWasmSubtypeFinalForm
+                                          : kWasmSubtypeForm);
+            section.emit_u8(1);  // supertype count
+            section.emit_u32v(type.supertype);
+          } else if (!type.is_final) {
+            section.emit_u8(kWasmSubtypeForm);
+            section.emit_u8(0);  // no supertypes
+          }
+          if (type instanceof WasmStruct) {
+            section.emit_u8(kWasmStructTypeForm);
+            section.emit_u32v(type.fields.length);
+            for (let field of type.fields) {
+              section.emit_type(field.type);
+              section.emit_u8(field.mutability ? 1 : 0);
+            }
+          } else if (type instanceof WasmArray) {
+            section.emit_u8(kWasmArrayTypeForm);
+            section.emit_type(type.type);
+            section.emit_u8(type.mutability ? 1 : 0);
+          } else {
+            section.emit_u8(kWasmFunctionTypeForm);
+            section.emit_u32v(type.params.length);
+            for (let param of type.params) {
+              section.emit_type(param);
+            }
+            section.emit_u32v(type.results.length);
+            for (let result of type.results) {
+              section.emit_type(result);
+            }
           }
         }
       });
@@ -918,9 +1152,9 @@ class WasmModuleBuilder {
           section.emit_string(imp.name || '');
           section.emit_u8(imp.kind);
           if (imp.kind == kExternalFunction) {
-            section.emit_u32v(imp.type);
+            section.emit_u32v(imp.type_index);
           } else if (imp.kind == kExternalGlobal) {
-            section.emit_u32v(imp.type);
+            section.emit_type(imp.type);
             section.emit_u8(imp.mutable);
           } else if (imp.kind == kExternalMemory) {
             var has_max = (typeof imp.maximum) != "undefined";
@@ -933,7 +1167,7 @@ class WasmModuleBuilder {
             section.emit_u32v(imp.initial); // initial
             if (has_max) section.emit_u32v(imp.maximum); // maximum
           } else if (imp.kind == kExternalTable) {
-            section.emit_u8(imp.type);
+            section.emit_type(imp.type);
             var has_max = (typeof imp.maximum) != "undefined";
             section.emit_u8(has_max ? 1 : 0); // flags
             section.emit_u32v(imp.initial); // initial
@@ -965,10 +1199,11 @@ class WasmModuleBuilder {
       binary.emit_section(kTableSectionCode, section => {
         section.emit_u32v(wasm.tables.length);
         for (let table of wasm.tables) {
-          section.emit_u8(table.type);
+          section.emit_type(table.type);
           section.emit_u8(table.has_max);
           section.emit_u32v(table.initial_size);
           if (table.has_max) section.emit_u32v(table.max_size);
+          if (table.has_init) section.emit_init_expr(table.init_expr);
         }
       });
     }
@@ -997,41 +1232,9 @@ class WasmModuleBuilder {
       binary.emit_section(kGlobalSectionCode, section => {
         section.emit_u32v(wasm.globals.length);
         for (let global of wasm.globals) {
-          section.emit_u8(global.type);
+          section.emit_type(global.type);
           section.emit_u8(global.mutable);
-          if ((typeof global.init_index) == "undefined") {
-            // Emit a constant initializer.
-            switch (global.type) {
-            case kWasmI32:
-              section.emit_u8(kExprI32Const);
-              section.emit_u32v(global.init);
-              break;
-            case kWasmI64:
-              section.emit_u8(kExprI64Const);
-              section.emit_u64v(global.init);
-              break;
-            case kWasmF32:
-              section.emit_bytes(wasmF32Const(global.init));
-              break;
-            case kWasmF64:
-              section.emit_bytes(wasmF64Const(global.init));
-              break;
-            case kWasmAnyFunc:
-            case kWasmAnyRef:
-              if (global.function_index !== undefined) {
-                section.emit_u8(kExprRefFunc);
-                section.emit_u32v(global.function_index);
-              } else {
-                section.emit_u8(kExprRefNull);
-              }
-              break;
-            }
-          } else {
-            // Emit a global-index initializer.
-            section.emit_u8(kExprGlobalGet);
-            section.emit_u32v(global.init_index);
-          }
-          section.emit_u8(kExprEnd);  // end of init expression
+          section.emit_init_expr(global.init);
         }
       });
     }
@@ -1161,7 +1364,7 @@ class WasmModuleBuilder {
               local_decls.push({count: l.s128_count, type: kWasmS128});
             }
             if (l.anyref_count > 0) {
-              local_decls.push({count: l.anyref_count, type: kWasmAnyRef});
+              local_decls.push({count: l.anyref_count, type: kWasmExternRef});
             }
             if (l.anyfunc_count > 0) {
               local_decls.push({count: l.anyfunc_count, type: kWasmAnyFunc});
@@ -1171,7 +1374,7 @@ class WasmModuleBuilder {
           header.emit_u32v(local_decls.length);
           for (let decl of local_decls) {
             header.emit_u32v(decl.count);
-            header.emit_u8(decl.type);
+            header.emit_type(decl.type);
           }
 
           section.emit_u32v(header.length + func.body.length);


### PR DESCRIPTION
These are exported test changes from this WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=254693

The tests are all for the JS API from the Wasm GC proposal. They are unmodified exports of the tests landed in https://github.com/WebAssembly/gc/tree/main/test/js-api

There are some conflicts between the GC tests and Wasm exceptions JS API tests (which are not landed in the main spec yet) that I've resolved in this PR. A few other tests need to be modified for the GC changes too.