### PR TITLE
[accname] Require specification of subtest count

### DIFF
--- a/accname/name/comp_embedded_control.html
+++ b/accname/name/comp_embedded_control.html
@@ -128,7 +128,7 @@
 
 
 <script>
-AriaUtils.verifyLabelsBySelector(".ex");
+AriaUtils.verifyLabelsBySelector(26, ".ex");
 </script>
 </body>
 </html>

--- a/accname/name/comp_hidden_not_referenced.html
+++ b/accname/name/comp_hidden_not_referenced.html
@@ -86,7 +86,7 @@
 <!--       that are both not rendered and excluded from the a11y tree. -->
 
 <script>
-AriaUtils.verifyLabelsBySelector(".ex");
+AriaUtils.verifyLabelsBySelector(5, ".ex");
 </script>
 </body>
 </html>

--- a/accname/name/comp_host_language_label.html
+++ b/accname/name/comp_host_language_label.html
@@ -167,7 +167,7 @@
 <!-- todo: does HTML input[placeholder="foo"] count as a host language labeling mechanism? -->
 
 <script>
-AriaUtils.verifyLabelsBySelector(".ex");
+AriaUtils.verifyLabelsBySelector(46, ".ex");
 </script>
 </body>
 </html>

--- a/accname/name/comp_label.html
+++ b/accname/name/comp_label.html
@@ -18,7 +18,7 @@
 <!-- Todo: test all remaining cases of https://w3c.github.io/accname/#comp_label -->
 
 <script>
-AriaUtils.verifyLabelsBySelector(".ex");
+AriaUtils.verifyLabelsBySelector(1, ".ex");
 </script>
 </body>
 </html>

--- a/accname/name/comp_labelledby.html
+++ b/accname/name/comp_labelledby.html
@@ -31,7 +31,7 @@ Todo: test all remaining cases of https://w3c.github.io/accname/#comp_labelledby
 -->
 
 <script>
-AriaUtils.verifyLabelsBySelector(".ex");
+AriaUtils.verifyLabelsBySelector(1, ".ex");
 </script>
 </body>
 </html>

--- a/accname/name/comp_name_from_content.html
+++ b/accname/name/comp_name_from_content.html
@@ -249,7 +249,7 @@
 <br>
 
 <script>
-AriaUtils.verifyLabelsBySelector(".ex");
+AriaUtils.verifyLabelsBySelector(53, ".ex");
 </script>
 </body>
 </html>

--- a/accname/name/comp_text_node.html
+++ b/accname/name/comp_text_node.html
@@ -32,7 +32,7 @@
 <!-- Todo: test all remaining cases of https://w3c.github.io/accname/#comp_text_node -->
 
 <script>
-AriaUtils.verifyLabelsBySelector(".ex");
+AriaUtils.verifyLabelsBySelector(1, ".ex");
 </script>
 </body>
 </html>

--- a/accname/name/comp_tooltip.html
+++ b/accname/name/comp_tooltip.html
@@ -46,7 +46,7 @@
 <iframe title="label" data-expectedlabel="label" data-testname="iframe with tooltip label" width="20px" height="20px" class="ex"></iframe>
 
 <script>
-AriaUtils.verifyLabelsBySelector(".ex");
+AriaUtils.verifyLabelsBySelector(19, ".ex");
 </script>
 </body>
 </html>

--- a/accname/name/shadowdom/basic.html
+++ b/accname/name/shadowdom/basic.html
@@ -32,6 +32,6 @@
 document.getElementById('host1').attachShadow({ mode: 'open' }).innerHTML = 'foo';
 document.getElementById('host2').attachShadow({ mode: 'open' }).innerHTML = '<div aria-label="bar"></div>';
 
-AriaUtils.verifyLabelsBySelector('.labelled');
+AriaUtils.verifyLabelsBySelector(2, '.labelled');
 
 </script>

--- a/accname/name/shadowdom/slot.html
+++ b/accname/name/shadowdom/slot.html
@@ -55,6 +55,6 @@ document.getElementById('host2').attachShadow({ mode: 'open' }).innerHTML = 'foo
 document.getElementById('host3').attachShadow({ mode: 'open' }).innerHTML = 'foo <slot aria-label="label"></slot> bar';
 document.getElementById('host4').attachShadow({ mode: 'open' }).innerHTML = 'foo <slot aria-label="label">default</slot> bar';
 
-AriaUtils.verifyLabelsBySelector('.labelled');
+AriaUtils.verifyLabelsBySelector(4, '.labelled');
 
 </script>

--- a/wai-aria/scripts/aria-utils.js
+++ b/wai-aria/scripts/aria-utils.js
@@ -124,13 +124,13 @@ const AriaUtils = {
         data-expectedlabel="foo"
         class="ex">
 
-      AriaUtils.verifyLabelsBySelector(".ex")
+      AriaUtils.verifyLabelsBySelector(1, ".ex")
 
   */
-  verifyLabelsBySelector: function(selector) {
+  verifyLabelsBySelector: function(expectedCount, selector) {
     const els = document.querySelectorAll(selector);
-    if (!els.length) {
-      throw `Selector passed in verifyLabelsBySelector("${selector}") should match at least one element.`;
+    if (els.length !== expectedCount) {
+      throw `verifyLabelsBySelector expected ${expectedCount} elements but received ${els.length}`;
     }
     for (const el of els) {
       let label = el.getAttribute("data-expectedlabel");


### PR DESCRIPTION
Closes https://github.com/web-platform-tests/interop-accessibility/issues/105

The accname tests use a declarative style to express tests. This style is susceptible to false positives for author errors (e.g. invalid markup or typos in CSS selectors or class names).

Extend the `verifyLabelsBySelector` utility function with a parameter for the expected number of tests in order to reduce the risk of false positives.

---

Inspired by [this test author error](https://github.com/web-platform-tests/wpt/pull/41463/files#r1372423323).