### PR TITLE
Fix invalid-roles.html nbsp instances to always include semicolon

### DIFF
--- a/wai-aria/role/invalid-roles.html
+++ b/wai-aria/role/invalid-roles.html
@@ -39,7 +39,7 @@
 <nav role="&#8203" data-testname="nav with zero-width space as role (should be treated as whitespace)" data-expectedrole="navigation" class="ex">x</nav>
 <nav role="&#10240" data-testname="nav with braille space (10240) as role" data-expectedrole="navigation" class="ex">x</nav>
 <nav role="&#x2800" data-testname="nav with braille space (x2800) as role" data-expectedrole="navigation" class="ex">x</nav>
-<nav role="&nbsp" data-testname="nav with non-breaking space (nbsp) as role" data-expectedrole="navigation" class="ex">x</nav>
+<nav role="&nbsp;" data-testname="nav with non-breaking space (nbsp) as role" data-expectedrole="navigation" class="ex">x</nav>
 <nav role="&#20" data-testname="nav with standard space (nbsp) as role" data-expectedrole="navigation" class="ex">x</nav>
 
 <!-- Escaped whitespace tests with <span> (including line breaks, tabs, zero-width space, braille space, non-breaking space, standard space) -->
@@ -49,7 +49,7 @@
 <span role="&#8203" data-testname="span with escaped zero-width space as role (should be treated as whitespace)" class="ex-generic">x</span>
 <span role="&#10240" data-testname="span with escaped braille space (10240) as role" class="ex-generic">x</span>
 <span role="&#x2800" data-testname="span with escaped braille space (x2800) as role" class="ex-generic">x</span>
-<span role="&nbsp" data-testname="span with escaped non-breaking space (nbsp) as role" class="ex-generic">x</span>
+<span role="&nbsp;" data-testname="span with escaped non-breaking space (nbsp) as role" class="ex-generic">x</span>
 <span role="&#20" data-testname="span with escaped standard space (nbsp) as role" class="ex-generic">x</span>
 
 <!-- Unescaped whitespace tests with <span> (including line breaks, tabs, zero-width space, braille space, non-breaking space, standard space) -->


### PR DESCRIPTION
Minor syntax fixes for https://github.com/web-platform-tests/wpt/pull/42013.