### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=263765

### DIFF
--- a/css/cssom-view/checkVisibility.html
+++ b/css/cssom-view/checkVisibility.html
@@ -141,4 +141,10 @@ test(() => {
   cvhiddenwithupdate.getBoundingClientRect();
   assert_true(cvhiddenwithupdate.checkVisibility());
 }, 'checkVisibility on content-visibility:hidden element after forced layout update.');
+
+test(() => {
+  document.documentElement.style.contentVisibility = "hidden";
+  assert_true(document.documentElement.checkVisibility());
+  document.documentElement.style.removeProperty("content-visibility");
+}, 'checkVisibility on root element with content-visibility: hidden returns true.');
 </script>


### PR DESCRIPTION
WebKit export from bug: [\[cssom-view\] Root element with `content-visibility: hidden` should not be considered hidden by `checkVisibility`](https://bugs.webkit.org/show_bug.cgi?id=263765)