### PR TITLE
JPEG XL: relax max difference

### DIFF
--- a/jpegxl/3x3_srgb_lossy.html
+++ b/jpegxl/3x3_srgb_lossy.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>JPEG XL test</title>
-<meta name=fuzzy content="0-4;0-9">
+<meta name=fuzzy content="0-10;0-9">
 <link rel="help" href="https://jpeg.org/jpegxl/">
 <link rel="match" href="3x3_srgb_lossy-ref.html">
 <meta name="assert" content="JPEG XL image is rendered correctly">

--- a/jpegxl/3x3a_srgb_lossy.html
+++ b/jpegxl/3x3a_srgb_lossy.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>JPEG XL test</title>
-<meta name=fuzzy content="0-4;0-9">
+<meta name=fuzzy content="0-10;0-9">
 <link rel="help" href="https://jpeg.org/jpegxl/">
 <link rel="match" href="3x3a_srgb_lossy-ref.html">
 <meta name="assert" content="JPEG XL image is rendered correctly">


### PR DESCRIPTION
For the current stable Safari, "5" and "8" would suffice, but we change both to "10" to have let it have some leeway.