### PR TITLE
WebKit export:  text-decoration-thickness should support percentages …

### DIFF
--- a/css/css-text-decor/animations/text-decoration-thickness-interpolation.html
+++ b/css/css-text-decor/animations/text-decoration-thickness-interpolation.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>text-decoration-thickness interpolation</title>
+<link rel="author" title="ChangSeok Oh" href="mailto:changseok@webkit.org">
+<link rel="help" href="https://www.w3.org/TR/css-text-decor-4/#text-decoration-thickness-property">
+<meta name="test" content="text-decoration-thickness supports animation by the computed value type">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/interpolation-testcommon.js"></script>
+<body>
+  <template id="target-template">T</template>
+</body>
+
+<script>
+test_interpolation({
+  property: 'text-decoration-thickness',
+  from: '16px',
+  to: '0px',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '11.2px'},
+  {at: 0.6, expect: '6.4px'},
+  {at: 1, expect: '0px'},
+]);
+
+test_interpolation({
+  property: 'text-decoration-thickness',
+  from: '16px',
+  to: '32px',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '20.8px'},
+  {at: 0.6, expect: '25.6px'},
+  {at: 1, expect: '32px'},
+]);
+
+test_interpolation({
+  property: 'text-decoration-thickness',
+  from: '1em',
+  to: '0em',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '11.2px'},
+  {at: 0.6, expect: '6.4px'},
+  {at: 1, expect: '0px'},
+]);
+
+test_interpolation({
+  property: 'text-decoration-thickness',
+  from: '1em',
+  to: '2em',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '20.8px'},
+  {at: 0.6, expect: '25.6px'},
+  {at: 1, expect: '32px'},
+]);
+
+test_interpolation({
+  property: 'text-decoration-thickness',
+  from: '100%',
+  to: '0%',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '11.2px'},
+  {at: 0.6, expect: '6.4px'},
+  {at: 1, expect: '0px'},
+]);
+
+test_interpolation({
+  property: 'text-decoration-thickness',
+  from: '100%',
+  to: '200%',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '20.8px'},
+  {at: 0.6, expect: '25.6px'},
+  {at: 1, expect: '32px'},
+]);
+
+test_interpolation({
+  property: 'text-decoration-thickness',
+  from: '16px',
+  to: '0em',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '11.2px'},
+  {at: 0.6, expect: '6.4px'},
+  {at: 1, expect: '0px'},
+]);
+
+test_interpolation({
+  property: 'text-decoration-thickness',
+  from: '16px',
+  to: '2em',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '20.8px'},
+  {at: 0.6, expect: '25.6px'},
+  {at: 1, expect: '32px'},
+]);
+
+test_interpolation({
+  property: 'text-decoration-thickness',
+  from: '16px',
+  to: '0%',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '11.2px'},
+  {at: 0.6, expect: '6.4px'},
+  {at: 1, expect: '0px'},
+]);
+
+test_interpolation({
+  property: 'text-decoration-thickness',
+  from: '16px',
+  to: '200%',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '20.8px'},
+  {at: 0.6, expect: '25.6px'},
+  {at: 1, expect: '32px'},
+]);
+
+test_interpolation({
+  property: 'text-decoration-thickness',
+  from: '1em',
+  to: '0px',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '11.2px'},
+  {at: 0.6, expect: '6.4px'},
+  {at: 1, expect: '0px'},
+]);
+
+test_interpolation({
+  property: 'text-decoration-thickness',
+  from: '1em',
+  to: '32px',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '20.8px'},
+  {at: 0.6, expect: '25.6px'},
+  {at: 1, expect: '32px'},
+]);
+
+test_interpolation({
+  property: 'text-decoration-thickness',
+  from: '1em',
+  to: '0%',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '11.2px'},
+  {at: 0.6, expect: '6.4px'},
+  {at: 1, expect: '0px'},
+]);
+
+test_interpolation({
+  property: 'text-decoration-thickness',
+  from: '1em',
+  to: '200%',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '20.8px'},
+  {at: 0.6, expect: '25.6px'},
+  {at: 1, expect: '32px'},
+]);
+
+test_interpolation({
+  property: 'text-decoration-thickness',
+  from: '100%',
+  to: '0px',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '11.2px'},
+  {at: 0.6, expect: '6.4px'},
+  {at: 1, expect: '0px'},
+]);
+
+test_interpolation({
+  property: 'text-decoration-thickness',
+  from: '100%',
+  to: '32px',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '20.8px'},
+  {at: 0.6, expect: '25.6px'},
+  {at: 1, expect: '32px'},
+]);
+
+test_interpolation({
+  property: 'text-decoration-thickness',
+  from: '100%',
+  to: '0em',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '11.2px'},
+  {at: 0.6, expect: '6.4px'},
+  {at: 1, expect: '0px'},
+]);
+
+test_interpolation({
+  property: 'text-decoration-thickness',
+  from: '100%',
+  to: '2em',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '20.8px'},
+  {at: 0.6, expect: '25.6px'},
+  {at: 1, expect: '32px'},
+]);
+</script>

--- a/css/css-text-decor/text-decoration-thickness-calc-ref.html
+++ b/css/css-text-decor/text-decoration-thickness-calc-ref.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>text-decoration-thickness calc() support</title>
+<link rel="author" title="ChangSeok Oh" href="mailto:changseok@webkit.org" />
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style type="text/css">
+div {
+  display: flex;
+  font-family: Ahem;
+  font-size: 8px;
+}
+.underline {
+  text-decoration-color: green;
+  text-decoration-line: underline;
+  text-decoration-skip-ink: none;
+}
+.overline {
+  text-decoration-color: green;
+  text-decoration-line: overline;
+  text-decoration-skip-ink: none;
+}
+.line-through {
+  text-decoration-color: green;
+  text-decoration-line: line-through;
+  text-decoration-skip-ink: none;
+}
+.ref {
+  text-decoration-thickness: 8px;
+}
+</style>
+<p>Test passes if black and green bar pairs are the same shape and size.</p>
+<div>
+  <span class="underline ref">XXXXXX</span>
+</div>
+<br>
+<br>
+<div>
+  <span class="overline ref">XXXXXX</span>
+</div>
+<br>
+<div>
+  <span class="ref">XXXXXX</span>
+</div>
+<div>
+  <span class="line-through ref">XXXXXX</span>
+</div>

--- a/css/css-text-decor/text-decoration-thickness-calc.html
+++ b/css/css-text-decor/text-decoration-thickness-calc.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>text-decoration-thickness calc() support</title>
+<link rel="author" title="ChangSeok Oh" href="mailto:changseok@webkit.org" />
+<link rel="help" href="https://www.w3.org/TR/css-text-decor-4/#text-decoration-thickness-property" />
+<link rel="match" href="text-decoration-thickness-calc-ref.html" />
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="Test checks whether text-decoration-thickness supports calc() values.">
+<style type="text/css">
+div {
+  display: flex;
+  font-family: Ahem;
+  font-size: 8px;
+}
+.underline {
+  text-decoration-color: green;
+  text-decoration-line: underline;
+  text-decoration-skip-ink: none;
+}
+.overline {
+  text-decoration-color: green;
+  text-decoration-line: overline;
+  text-decoration-skip-ink: none;
+}
+.line-through {
+  text-decoration-color: green;
+  text-decoration-line: line-through;
+  text-decoration-skip-ink: none;
+}
+.ref {
+  text-decoration-thickness: 8px;
+}
+.test1 {
+  text-decoration-thickness: calc(1em);
+}
+.test2 {
+  text-decoration-thickness: calc(100%);
+}
+.test3 {
+  text-decoration-thickness: calc(50% + 4px);
+}
+.test4 {
+  text-decoration-thickness: calc(50% + 0.5em);
+}
+.test5 {
+  text-decoration-thickness: calc(0.5em + 4px);
+}
+</style>
+<p>Test passes if black and green bar pairs are the same shape and size.</p>
+<div>
+  <span class="underline ref">X</span>
+  <span class="underline test1">X</span>
+  <span class="underline test2">X</span>
+  <span class="underline test3">X</span>
+  <span class="underline test4">X</span>
+  <span class="underline test5">X</span>
+</div>
+<br>
+<br>
+<div>
+  <span class="overline ref">X</span>
+  <span class="overline test1">X</span>
+  <span class="overline test2">X</span>
+  <span class="overline test3">X</span>
+  <span class="overline test4">X</span>
+  <span class="overline test5">X</span>
+</div>
+<br>
+<div>
+<span class="ref">XXXXXX</span>
+</div>
+<div>
+  <span class="line-through ref">X</span>
+  <span class="line-through test1">X</span>
+  <span class="line-through test2">X</span>
+  <span class="line-through test3">X</span>
+  <span class="line-through test4">X</span>
+  <span class="line-through test5">X</span>
+</div>

--- a/css/css-text-decor/text-decoration-thickness-computed.html
+++ b/css/css-text-decor/text-decoration-thickness-computed.html
@@ -15,6 +15,23 @@
 test_computed_value("text-decoration-thickness", "auto");
 test_computed_value("text-decoration-thickness", "from-font");
 test_computed_value("text-decoration-thickness", "calc(10px - 8px)", "2px");
+
+test_computed_value("text-decoration-thickness", "32px", "32px");
+test_computed_value("text-decoration-thickness", "2em", "32px");
+test_computed_value("text-decoration-thickness", "200%", "200%");
+
+test_computed_value("text-decoration-thickness", "calc(2em - 0px)", "32px");
+test_computed_value("text-decoration-thickness", "calc(200% - 0px)", "200%");
+test_computed_value("text-decoration-thickness", "calc(0.5em - 0px)", "8px");
+test_computed_value("text-decoration-thickness", "calc(50% - 0px)", "50%");
+
+test_computed_value("text-decoration-thickness", "calc(2em - 8px)", "24px");
+test_computed_value("text-decoration-thickness", "calc(2em - 0.5em)", "24px");
+test_computed_value("text-decoration-thickness", "calc(2em - 50%)", "calc(-50% + 32px)");
+
+test_computed_value("text-decoration-thickness", "calc(200% - 8px)");
+test_computed_value("text-decoration-thickness", "calc(200% - 0.5em)", "calc(200% - 8px)");
+test_computed_value("text-decoration-thickness", "calc(200% - 50%)", "150%");
 </script>
 </body>
 </html>


### PR DESCRIPTION
…(#19085)

https://bugs.webkit.org/show_bug.cgi?id=262866

This change includes an updated test and new tests that verify text-decoration-thickness from a WebKit change (269886@main).

* Updated:
  css/css-text-decor/text-decoration-thickness-computed.html
* New:
  css/css-text-decor/animations/text-decoration-thickness-interpolation.html
  css/css-text-decor/text-decoration-thickness-calc.html