### PR TITLE
Fix accessing update_properties for product

### DIFF
--- a/tools/wpt/update.py
+++ b/tools/wpt/update.py
@@ -43,7 +43,6 @@ def update_expectations(_, **kwargs):
 
     update_properties = metadata.get_properties(properties_file=kwargs["properties_file"],
                                                 extra_properties=kwargs["extra_property"],
-                                                config=kwargs["config"],
                                                 product=kwargs["product"])
 
     manifest_update(kwargs["test_paths"])

--- a/tools/wptrunner/wptrunner/metadata.py
+++ b/tools/wptrunner/wptrunner/metadata.py
@@ -10,7 +10,6 @@ from six import ensure_str, ensure_text
 from sys import intern
 
 from . import manifestupdate
-from . import products
 from . import testloader
 from . import wptmanifest
 from . import wpttest
@@ -57,11 +56,14 @@ def get_properties(properties_file=None, extra_properties=None, config=None, pro
 
     :param properties_file: Path to a JSON file containing properties.
     :param extra_properties: List of extra properties to use
-    :param config: (deprecated) wptrunner config
-    :param Product: (deprecated) product name (requires a config argument to be used)
+    :param config: (deprecated, unused) wptrunner config
+    :param Product: (deprecated) product name
     """
     properties = []
     dependents = {}
+
+    if config is not None:
+        logger.warning("Got `config` in metadata.get_properties; this is ignored")
 
     if properties_file is not None:
         logger.debug(f"Reading update properties from {properties_file}")
@@ -99,12 +101,8 @@ def get_properties(properties_file=None, extra_properties=None, config=None, pro
     elif product is not None:
         logger.warning("Falling back to getting metadata update properties from wptrunner browser "
                        "product file, this will be removed")
-        if config is None:
-            msg = "Must provide a config together with a product"
-            logger.critical(msg)
-            raise ValueError(msg)
 
-        properties, dependents = products.load_product_update(config, product)
+        properties, dependents = product.update_properties
 
     if extra_properties is not None:
         properties.extend(extra_properties)

--- a/tools/wptrunner/wptrunner/products.py
+++ b/tools/wptrunner/wptrunner/products.py
@@ -39,22 +39,11 @@ class Product:
             cls = getattr(module, cls_name)
             self.executor_classes[test_type] = cls
 
+        self.update_properties = (getattr(module, data["update_properties"])()
+                                  if "update_properties" in data else (["product"], {}))
+
+
     def get_browser_cls(self, test_type):
         if test_type in self._browser_cls:
             return self._browser_cls[test_type]
         return self._browser_cls[None]
-
-
-def load_product_update(config, product):
-    """Return tuple of (property_order, boolean_properties) indicating the
-    run_info properties to use when constructing the expectation data for
-    this product. None for either key indicates that the default keys
-    appropriate for distinguishing based on platform will be used."""
-
-    module = product_module(config, product)
-    data = module.__wptrunner__
-
-    update_properties = (getattr(module, data["update_properties"])()
-                         if "update_properties" in data else (["product"], {}))
-
-    return update_properties

--- a/tools/wptrunner/wptrunner/update/metadata.py
+++ b/tools/wptrunner/wptrunner/update/metadata.py
@@ -2,16 +2,9 @@
 
 import os
 
-from .. import metadata, products
+from .. import metadata
 
 from .base import Step, StepRunner
-
-
-class GetUpdatePropertyList(Step):
-    provides = ["update_properties"]
-
-    def create(self, state):
-        state.update_properties = products.load_product_update(state.config, state.product.name)
 
 
 class UpdateExpected(Step):
@@ -20,7 +13,7 @@ class UpdateExpected(Step):
     def create(self, state):
         metadata.update_expected(state.paths,
                                  state.run_log,
-                                 update_properties=state.update_properties,
+                                 update_properties=state.product.update_properties,
                                  full_update=state.full_update,
                                  disable_intermittent=state.disable_intermittent,
                                  update_intermittent=state.update_intermittent,
@@ -57,6 +50,5 @@ class CreateMetadataPatch(Step):
 
 class MetadataUpdateRunner(StepRunner):
     """(Sub)Runner for updating metadata"""
-    steps = [GetUpdatePropertyList,
-             UpdateExpected,
+    steps = [UpdateExpected,
              CreateMetadataPatch]


### PR DESCRIPTION
Now that we're passing around a Product class rather than a product name, we don't need a separate `load_properties_update`, but can straightforwardly just put `update_properties` directly on the Product object we already have.