### PR TITLE
[wdspec] rewrite remove network interception tests to fail gracefully

### DIFF
--- a/webdriver/tests/bidi/network/remove_intercept/remove_intercept.py
+++ b/webdriver/tests/bidi/network/remove_intercept/remove_intercept.py
@@ -3,7 +3,6 @@
 import asyncio
 
 import pytest
-from webdriver.bidi.modules.script import ScriptEvaluateResultException
 
 from .. import (
     assert_before_request_sent_event,
@@ -16,9 +15,12 @@ PAGE_OTHER_TEXT = "/webdriver/tests/bidi/network/support/other.txt"
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("phase", ["beforeRequestSent", "responseStarted"])
+@pytest.mark.parametrize("phase", [
+    "beforeRequestSent",
+    "responseStarted",
+])
 async def test_remove_intercept(
-    bidi_session, wait_for_event, url, setup_network_test, add_intercept, fetch, phase
+    bidi_session, wait_for_event, url, setup_network_test, add_intercept, top_context, wait_for_future_safe, phase
 ):
     network_events = await setup_network_test(
         events=[
@@ -39,12 +41,15 @@ async def test_remove_intercept(
 
     on_network_event = wait_for_event(f"network.{phase}")
 
-    # Request to top_context should be blocked and throw a ScriptEvaluateResultException
-    # from the AbortController.
-    with pytest.raises(ScriptEvaluateResultException):
-        await fetch(text_url)
+    # Request to top_context should be blocked.
+    # TODO(https://github.com/w3c/webdriver-bidi/issues/188): Use a timeout argument when available.
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(
+            asyncio.shield(bidi_session.browsing_context.navigate(context=top_context["context"], url=text_url, wait="complete")),
+            timeout=2.0,
+        )
 
-    await on_network_event
+    await wait_for_future_safe(on_network_event)
 
     assert len(before_request_sent_events) == 1
 
@@ -70,7 +75,7 @@ async def test_remove_intercept(
 
     # The next request should not be blocked
     on_response_completed = wait_for_event("network.responseCompleted")
-    await fetch(text_url)
+    await bidi_session.browsing_context.navigate(context=top_context["context"], url=text_url, wait="complete")
     await on_response_completed
 
     # Assert the network events have the expected interception properties

--- a/webdriver/tests/bidi/network/remove_intercept/remove_intercept.py
+++ b/webdriver/tests/bidi/network/remove_intercept/remove_intercept.py
@@ -1,8 +1,7 @@
 # META: timeout=long
 
-import asyncio
-
 import pytest
+from webdriver.bidi.modules.script import ScriptEvaluateResultException
 
 from .. import (
     assert_before_request_sent_event,
@@ -20,7 +19,7 @@ PAGE_OTHER_TEXT = "/webdriver/tests/bidi/network/support/other.txt"
     "responseStarted",
 ])
 async def test_remove_intercept(
-    bidi_session, wait_for_event, url, setup_network_test, add_intercept, top_context, wait_for_future_safe, phase
+    bidi_session, wait_for_event, url, setup_network_test, add_intercept, fetch, top_context, wait_for_future_safe, phase
 ):
     network_events = await setup_network_test(
         events=[
@@ -41,13 +40,10 @@ async def test_remove_intercept(
 
     on_network_event = wait_for_event(f"network.{phase}")
 
-    # Request to top_context should be blocked.
-    # TODO(https://github.com/w3c/webdriver-bidi/issues/188): Use a timeout argument when available.
-    with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(
-            asyncio.shield(bidi_session.browsing_context.navigate(context=top_context["context"], url=text_url, wait="complete")),
-            timeout=2.0,
-        )
+    # Request to top_context should be blocked and throw a ScriptEvaluateResultException
+    # from the AbortController.
+    with pytest.raises(ScriptEvaluateResultException):
+        await fetch(text_url)
 
     await wait_for_future_safe(on_network_event)
 

--- a/webdriver/tests/support/fixtures_bidi.py
+++ b/webdriver/tests/support/fixtures_bidi.py
@@ -2,8 +2,9 @@ import base64
 
 from tests.support.asserts import assert_pdf
 from tests.support.image import cm_to_px, png_dimensions, ImageDifference
-from typing import Any, Mapping
+from typing import Any, Coroutine, Mapping
 
+import asyncio
 import pytest
 import pytest_asyncio
 from webdriver.bidi.error import (
@@ -12,6 +13,7 @@ from webdriver.bidi.error import (
     NoSuchScriptException,
 )
 from webdriver.bidi.modules.script import ContextTarget
+from webdriver.error import TimeoutException
 
 
 @pytest_asyncio.fixture
@@ -102,20 +104,37 @@ def wait_for_event(bidi_session, event_loop):
 
 
 @pytest.fixture
+def wait_for_future_safe(configuration):
+    """Wait for the given future for a given amount of time.
+    Fails gracefully if the future does not resolve within the given timeout."""
+
+    async def wait_for_future_safe(future: Coroutine, timeout: float = 2.0):
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(future),
+                timeout=timeout * configuration["timeout_multiplier"],
+            )
+        except asyncio.exceptions.TimeoutError:
+            raise TimeoutException("Future did not resolve within the given timeout")
+
+    return wait_for_future_safe
+
+
+@pytest.fixture
 def current_time(bidi_session, top_context):
     """Get the current time stamp in ms from the remote end.
 
     This is required especially when tests are run on different devices like
     for Android, where it's not guaranteed that both machines are in sync.
     """
-    async def _():
+    async def current_time():
         result = await bidi_session.script.evaluate(
             expression="Date.now()",
             target=ContextTarget(top_context["context"]),
             await_promise=True)
         return result["value"]
 
-    return _
+    return current_time
 
 
 @pytest.fixture


### PR DESCRIPTION
- ~~Use navigation with an expected timeout instead of fetch with an expected exception.~~

~~From a test implementation perspective this is a no-op as, when the network interception triggers, the navigation is expected to not complete (and thus timeout).~~

(moved this part to its own PR: https://github.com/web-platform-tests/wpt/pull/42969)

- Introduce a "wait_for_future_safe" fixture that gracefully fails the await of a future instead of making the whole test suite fail.

Instead of aborting the "wpt run" when there is a timeout, treat the timeout as a failure, effectively failing gracefully. This allows subsequent tests to run, and expectations to be updated later on.

Related: https://github.com/w3c/webdriver-bidi/issues/188

Bug: #42482