### PR TITLE
[wptrunner] Reenable `wpt run` integration tests

### DIFF
--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -206,7 +206,6 @@ def test_run_zero_tests():
 
 @pytest.mark.slow
 @pytest.mark.remote_network
-@pytest.mark.skip(reason="https://github.com/web-platform-tests/wpt/issues/42433")
 @pytest.mark.skipif(sys.platform == "win32",
                     reason="https://github.com/web-platform-tests/wpt/issues/28745")
 def test_run_failing_test():
@@ -240,7 +239,6 @@ def test_run_failing_test():
 
 @pytest.mark.slow
 @pytest.mark.remote_network
-@pytest.mark.skip(reason="https://github.com/web-platform-tests/wpt/issues/42433")
 @pytest.mark.skipif(sys.platform == "win32",
                     reason="https://github.com/web-platform-tests/wpt/issues/28745")
 def test_run_verify_unstable(temp_test):


### PR DESCRIPTION
Apparently fixed by more recent `chromedriver` versions. Closes #42433.