### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=263655

### DIFF
--- a/html/dom/elements/global-attributes/lang-attribute.window.html
+++ b/html/dom/elements/global-attributes/lang-attribute.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->


### PR DESCRIPTION
WebKit export from bug: [lang attribute in no namespace should be honored only on HTML and SVG elements](https://bugs.webkit.org/show_bug.cgi?id=263655)