### PR TITLE
[css-tables] Make `col-change-span-bg-invalidation*.html` tests fuzzy

### DIFF
--- a/css/css-tables/paint/col-change-span-bg-invalidation-001.html
+++ b/css/css-tables/paint/col-change-span-bg-invalidation-001.html
@@ -5,6 +5,7 @@
 <link rel="author" title="Andreu Botella" href="abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-tables-3/#drawing-cell-backgrounds">
 <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
 <meta name=assert content="Changing the span of a table column element will invalidate column backgrounds">
 <style>
 table {

--- a/css/css-tables/paint/col-change-span-bg-invalidation-002.html
+++ b/css/css-tables/paint/col-change-span-bg-invalidation-002.html
@@ -5,6 +5,7 @@
 <link rel="author" title="Andreu Botella" href="abotella@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-tables-3/#drawing-cell-backgrounds">
 <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
 <meta name=assert content="Changing the span of a table column element will invalidate column backgrounds, even if previously any columns with backgrounds spanned no cells">
 <style>
 table {


### PR DESCRIPTION
These reftests, added in #42737, use a linear background with an abrupt change between green and red, to test that the red portion is painted over. The reference uses a solid color background.

Since gradients in Mac OS and iOS Safari seem to have some dithering in same-color ranges, which seems to be at most 1 per color channel, this patch makes those tests use fuzzy matching.
