### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=263310

### DIFF
--- a/css/css-grid/grid-with-aspect-ratio-uses-content-box-height-for-track-sizing.html
+++ b/css/css-grid/grid-with-aspect-ratio-uses-content-box-height-for-track-sizing.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<meta name="assert" content="Grid's definite free space for row track sizing should be the content box logical height when computed from the aspect ratio">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-stretch">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#free-space">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#definite">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+.grid {
+	display: grid;
+	width: 100px;
+	border-block: 10px solid green;
+	padding-block: 20px;
+	background: green;
+	aspect-ratio: 5 / 2;
+}
+</style>
+</head>
+<body>
+	<p>Test passes if there is a filled green square.</p>
+	<div class="grid">
+		<div></div>
+	</div>
+</body>
+</html>

--- a/css/css-grid/grid-with-aspect-ratio-uses-content-box-height-for-track-sizing.html
+++ b/css/css-grid/grid-with-aspect-ratio-uses-content-box-height-for-track-sizing.html
@@ -9,19 +9,19 @@
 <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
 <style>
 .grid {
-	display: grid;
-	width: 100px;
-	border-block: 10px solid green;
-	padding-block: 20px;
-	background: green;
-	aspect-ratio: 5 / 2;
+  display: grid;
+  width: 100px;
+  border-block: 10px solid green;
+  padding-block: 20px;
+  background: green;
+  aspect-ratio: 5 / 2;
 }
 </style>
 </head>
 <body>
-	<p>Test passes if there is a filled green square.</p>
-	<div class="grid">
-		<div></div>
-	</div>
+  <p>Test passes if there is a filled green square.</p>
+  <div class="grid">
+    <div></div>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
WebKit export from bug: [grid position/ size seems based on `border-box` height when element sized using `aspect-ratio`](https://bugs.webkit.org/show_bug.cgi?id=263310)