### PR TITLE
Make `moveToDocument` move pointer to non-(0, 0) position first

### DIFF
--- a/pointerevents/pointerevent_support.js
+++ b/pointerevents/pointerevent_support.js
@@ -401,6 +401,10 @@ function moveToDocument(pointerType) {
   var pointerId = pointerType + "Pointer1";
   return new test_driver.Actions()
     .addPointer(pointerId, pointerType)
+    // WebDriver initializes the pointer position (0, 0), therefore, we need
+    // to move different position first.  Otherwise, moving to (0, 0) may be
+    // ignored.
+    .pointerMove(1, 1)
     .pointerMove(0, 0)
     .send();
 }


### PR DESCRIPTION
WebDriver spec defines that the pointer position should be initialized to (0, 0) by default.  Therefore, a call of `pointerMove(0, 0)` at first time may be no-op.  Therefore, pointer should be moved to different point, (1, 1), first.  Then, moving to (0, 0) causes `pointerover`, `mouseover`, etc as expected by some tests.

https://github.com/web-platform-tests/interop/issues/601