### PR TITLE
[wdspec] don't use setup_network_test in add intercept url patterns tests

### DIFF
--- a/webdriver/tests/bidi/network/add_intercept/url_patterns.py
+++ b/webdriver/tests/bidi/network/add_intercept/url_patterns.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import pytest
-import pytest_asyncio
 
 from .. import assert_before_request_sent_event
 
@@ -59,18 +58,15 @@ def substitute_host(server_config):
 )
 async def test_pattern_patterns_matching(
     wait_for_event,
-    setup_network_test,
+    subscribe_events,
+    top_context,
     add_intercept,
     fetch,
     substitute_host,
     patterns,
     url_template,
 ):
-    await setup_network_test(
-        events=[
-            "network.beforeRequestSent",
-        ]
-    )
+    await subscribe_events(events=["network.beforeRequestSent"],  contexts=[top_context["context"]])
 
     for pattern in patterns:
         for key in pattern:
@@ -108,18 +104,15 @@ async def test_pattern_patterns_matching(
 )
 async def test_pattern_patterns_not_matching(
     wait_for_event,
-    setup_network_test,
+    subscribe_events,
+    top_context,
     add_intercept,
     fetch,
     substitute_host,
     pattern,
     url_template,
 ):
-    await setup_network_test(
-        events=[
-            "network.beforeRequestSent",
-        ]
-    )
+    await subscribe_events(events=["network.beforeRequestSent"],  contexts=[top_context["context"]])
 
     for key in pattern:
         pattern[key] = substitute_host(pattern[key])
@@ -160,18 +153,15 @@ async def test_pattern_patterns_not_matching(
 )
 async def test_string_patterns_matching(
     wait_for_event,
-    setup_network_test,
+    subscribe_events,
+    top_context,
     add_intercept,
     fetch,
     substitute_host,
     pattern,
     url_template,
 ):
-    await setup_network_test(
-        events=[
-            "network.beforeRequestSent",
-        ]
-    )
+    await subscribe_events(events=["network.beforeRequestSent"],  contexts=[top_context["context"]])
 
     intercept = await add_intercept(
         phases=["beforeRequestSent"],
@@ -204,18 +194,15 @@ async def test_string_patterns_matching(
 )
 async def test_string_patterns_not_matching(
     wait_for_event,
-    setup_network_test,
+    subscribe_events,
+    top_context,
     add_intercept,
     fetch,
     substitute_host,
     pattern,
     url_template,
 ):
-    await setup_network_test(
-        events=[
-            "network.beforeRequestSent",
-        ]
-    )
+    await subscribe_events(events=["network.beforeRequestSent"],  contexts=[top_context["context"]])
 
     await add_intercept(
         phases=["beforeRequestSent"],


### PR DESCRIPTION
…ests

There are some tests for global interecepts in this module. setup_network_test calls browsingContext.navigate. This introduces a side effect, wherein the navigation call is intercepted.

Simplify the test by using subscribe_events instead of setup_network_test.