### PR TITLE
Replace missed `assert` in import attributes tests

### DIFF
--- a/html/semantics/scripting-1/the-script-element/import-attributes/dynamic-import-with-attributes-argument.any.js
+++ b/html/semantics/scripting-1/the-script-element/import-attributes/dynamic-import-with-attributes-argument.any.js
@@ -13,6 +13,6 @@ promise_test(async test => {
 
 promise_test(test => {
     return promise_rejects_js(test, TypeError,
-        import("./export-hello.js", { assert: { type: "notARealType"} } ),
+        import("./export-hello.js", { with: { type: "notARealType"} } ),
         "Dynamic import with an unsupported type attribute should fail");
 }, "Dynamic import with an unsupported type attribute should fail");


### PR DESCRIPTION
Caught by @gsnedders (https://github.com/web-platform-tests/interop/issues/596#issuecomment-1789841681)

I'm not sure how it's possible I replaced just two of the three `assert`s in this file 🙃