### PR TITLE
[wdspec] use subscribe_events instead of session.subscribe

### DIFF
--- a/webdriver/tests/bidi/log/entry_added/console.py
+++ b/webdriver/tests/bidi/log/entry_added/console.py
@@ -24,9 +24,9 @@ from ... import any_string, int_interval
     ],
 )
 async def test_text_with_argument_variation(
-    bidi_session, top_context, wait_for_event, log_argument, expected_text,
+    bidi_session, subscribe_events, top_context, wait_for_event, log_argument, expected_text,
 ):
-    await bidi_session.session.subscribe(events=["log.entryAdded"])
+    await subscribe_events(events=["log.entryAdded"])
 
     on_entry_added = wait_for_event("log.entryAdded")
     await create_console_api_message_from_string(
@@ -51,9 +51,9 @@ async def test_text_with_argument_variation(
     ],
 )
 async def test_level(
-    bidi_session, top_context, wait_for_event, log_method, expected_level
+    bidi_session, subscribe_events, top_context, wait_for_event, log_method, expected_level
 ):
-    await bidi_session.session.subscribe(events=["log.entryAdded"])
+    await subscribe_events(events=["log.entryAdded"])
 
     on_entry_added = wait_for_event("log.entryAdded")
 
@@ -73,8 +73,8 @@ async def test_level(
 
 
 @pytest.mark.asyncio
-async def test_timestamp(bidi_session, top_context, wait_for_event, current_time):
-    await bidi_session.session.subscribe(events=["log.entryAdded"])
+async def test_timestamp(bidi_session, subscribe_events, top_context, wait_for_event, current_time):
+    await subscribe_events(events=["log.entryAdded"])
 
     on_entry_added = wait_for_event("log.entryAdded")
 
@@ -101,8 +101,8 @@ async def test_timestamp(bidi_session, top_context, wait_for_event, current_time
 
 
 @pytest.mark.asyncio
-async def test_new_context_with_new_window(bidi_session, top_context, wait_for_event):
-    await bidi_session.session.subscribe(events=["log.entryAdded"])
+async def test_new_context_with_new_window(bidi_session, subscribe_events, top_context, wait_for_event):
+    await subscribe_events(events=["log.entryAdded"])
 
     on_entry_added = wait_for_event("log.entryAdded")
     await create_console_api_message_from_string(
@@ -120,8 +120,8 @@ async def test_new_context_with_new_window(bidi_session, top_context, wait_for_e
 
 
 @pytest.mark.asyncio
-async def test_new_context_with_refresh(bidi_session, top_context, wait_for_event):
-    await bidi_session.session.subscribe(events=["log.entryAdded"])
+async def test_new_context_with_refresh(bidi_session, subscribe_events, top_context, wait_for_event):
+    await subscribe_events(events=["log.entryAdded"])
 
     on_entry_added = wait_for_event("log.entryAdded")
     await create_console_api_message_from_string(
@@ -144,6 +144,7 @@ async def test_new_context_with_refresh(bidi_session, top_context, wait_for_even
 @pytest.mark.asyncio
 async def test_different_contexts(
     bidi_session,
+    subscribe_events,
     top_context,
     wait_for_event,
     test_page_same_origin_frame,
@@ -155,7 +156,7 @@ async def test_different_contexts(
     assert len(contexts[0]["children"]) == 1
     frame_context = contexts[0]["children"][0]
 
-    await bidi_session.session.subscribe(events=["log.entryAdded"])
+    await subscribe_events(events=["log.entryAdded"])
 
     on_entry_added = wait_for_event("log.entryAdded")
     await create_console_api_message_from_string(

--- a/webdriver/tests/bidi/log/entry_added/console_args.py
+++ b/webdriver/tests/bidi/log/entry_added/console_args.py
@@ -30,9 +30,9 @@ pytestmark = pytest.mark.asyncio
     "bigint",
 ])
 async def test_primitive_types(
-    bidi_session, top_context, wait_for_event, data, remote_value
+    bidi_session, subscribe_events, top_context, wait_for_event, data, remote_value
 ):
-    await bidi_session.session.subscribe(events=["log.entryAdded"])
+    await subscribe_events(events=["log.entryAdded"])
 
     on_entry_added = wait_for_event("log.entryAdded")
     await create_console_api_message_from_string(
@@ -192,9 +192,9 @@ async def test_primitive_types(
     ],
 )
 async def test_remote_values(
-    bidi_session, top_context, wait_for_event, data, remote_value
+    bidi_session, subscribe_events, top_context, wait_for_event, data, remote_value
 ):
-    await bidi_session.session.subscribe(events=["log.entryAdded"])
+    await subscribe_events(events=["log.entryAdded"])
 
     on_entry_added = wait_for_event("log.entryAdded")
     await create_console_api_message_from_string(
@@ -255,12 +255,12 @@ async def test_remote_values(
     ids=["basic", "shadowRoot"],
 )
 async def test_node(
-    bidi_session, get_test_page, top_context, wait_for_event, data, expected
+    bidi_session, subscribe_events, get_test_page, top_context, wait_for_event, data, expected
 ):
     await bidi_session.browsing_context.navigate(
         context=top_context["context"], url=get_test_page(), wait="complete"
     )
-    await bidi_session.session.subscribe(events=["log.entryAdded"])
+    await subscribe_events(events=["log.entryAdded"])
 
     on_entry_added = wait_for_event("log.entryAdded")
     await create_console_api_message_from_string(

--- a/webdriver/tests/bidi/log/entry_added/javascript.py
+++ b/webdriver/tests/bidi/log/entry_added/javascript.py
@@ -6,9 +6,9 @@ from ... import int_interval
 
 @pytest.mark.asyncio
 async def test_types_and_values(
-    bidi_session, current_time, top_context, wait_for_event
+    bidi_session, subscribe_events, current_time, top_context, wait_for_event
 ):
-    await bidi_session.session.subscribe(events=["log.entryAdded"])
+    await subscribe_events(events=["log.entryAdded"])
 
     on_entry_added = wait_for_event("log.entryAdded")
 

--- a/webdriver/tests/bidi/log/entry_added/realm.py
+++ b/webdriver/tests/bidi/log/entry_added/realm.py
@@ -11,8 +11,8 @@ pytestmark = pytest.mark.asyncio
     ["", "sandbox_1"],
     ids=["default realm", "sandbox"],
 )
-async def test_realm(bidi_session, top_context, wait_for_event, sandbox_name):
-    await bidi_session.session.subscribe(events=["log.entryAdded"])
+async def test_realm(bidi_session, subscribe_events, top_context, wait_for_event, sandbox_name):
+    await subscribe_events(events=["log.entryAdded"])
 
     on_entry_added = wait_for_event("log.entryAdded")
     expected_text = "foo"

--- a/webdriver/tests/bidi/log/entry_added/stacktrace.py
+++ b/webdriver/tests/bidi/log/entry_added/stacktrace.py
@@ -18,7 +18,7 @@ from . import assert_console_entry, assert_javascript_entry
     ],
 )
 async def test_console_entry_sync_callstack(
-    bidi_session, inline, top_context, wait_for_event, log_method, expect_stack
+    bidi_session, subscribe_events, inline, top_context, wait_for_event, log_method, expect_stack
 ):
     if log_method == "assert":
         # assert has to be called with a first falsy argument to trigger a log.
@@ -42,7 +42,7 @@ async def test_console_entry_sync_callstack(
             """
         )
 
-    await bidi_session.session.subscribe(events=["log.entryAdded"])
+    await subscribe_events(events=["log.entryAdded"])
 
     on_entry_added = wait_for_event("log.entryAdded")
 
@@ -78,7 +78,7 @@ async def test_console_entry_sync_callstack(
 
 @pytest.mark.asyncio
 async def test_javascript_entry_sync_callstack(
-    bidi_session, inline, top_context, wait_for_event
+    bidi_session, subscribe_events, inline, top_context, wait_for_event
 ):
     url = inline(
         """
@@ -90,7 +90,7 @@ async def test_javascript_entry_sync_callstack(
         """
     )
 
-    await bidi_session.session.subscribe(events=["log.entryAdded"])
+    await subscribe_events(events=["log.entryAdded"])
 
     on_entry_added = wait_for_event("log.entryAdded")
 

--- a/webdriver/tests/bidi/network/before_request_sent/before_request_sent.py
+++ b/webdriver/tests/bidi/network/before_request_sent/before_request_sent.py
@@ -17,8 +17,8 @@ PAGE_REDIRECTED_HTML = "/webdriver/tests/bidi/network/support/redirected.html"
 
 
 @pytest.mark.asyncio
-async def test_subscribe_status(bidi_session, top_context, wait_for_event, url, fetch):
-    await bidi_session.session.subscribe(events=["network.beforeRequestSent"])
+async def test_subscribe_status(bidi_session, subscribe_events, top_context, wait_for_event, url, fetch):
+    await subscribe_events(events=["network.beforeRequestSent"])
 
     await bidi_session.browsing_context.navigate(
         context=top_context["context"],

--- a/webdriver/tests/bidi/network/response_completed/response_completed.py
+++ b/webdriver/tests/bidi/network/response_completed/response_completed.py
@@ -17,8 +17,8 @@ RESPONSE_COMPLETED_EVENT = "network.responseCompleted"
 
 
 @pytest.mark.asyncio
-async def test_subscribe_status(bidi_session, top_context, wait_for_event, url, fetch):
-    await bidi_session.session.subscribe(events=[RESPONSE_COMPLETED_EVENT])
+async def test_subscribe_status(bidi_session, subscribe_events, top_context, wait_for_event, url, fetch):
+    await subscribe_events(events=[RESPONSE_COMPLETED_EVENT])
 
     # Track all received network.responseCompleted events in the events array
     events = []

--- a/webdriver/tests/bidi/network/response_started/response_started.py
+++ b/webdriver/tests/bidi/network/response_started/response_started.py
@@ -16,8 +16,8 @@ RESPONSE_STARTED_EVENT = "network.responseStarted"
 
 
 @pytest.mark.asyncio
-async def test_subscribe_status(bidi_session, top_context, wait_for_event, url, fetch):
-    await bidi_session.session.subscribe(events=[RESPONSE_STARTED_EVENT])
+async def test_subscribe_status(bidi_session, subscribe_events, top_context, wait_for_event, url, fetch):
+    await subscribe_events(events=[RESPONSE_STARTED_EVENT])
 
     await bidi_session.browsing_context.navigate(
         context=top_context["context"],


### PR DESCRIPTION
subscribe_event properly cleans up by unsubscribing at the end of the test.