### PR TITLE
Add tests for async modules not blocking execution of sibling modules

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/top-level-await/sibling-imports-not-blocked.any.js
+++ b/html/semantics/scripting-1/the-script-element/module/top-level-await/sibling-imports-not-blocked.any.js
@@ -1,0 +1,11 @@
+promise_test(async t => {
+  const { checkMicrotask } = await import("./sibling-imports-not-blocked__microtask__parent.js");
+
+  assert_equals(checkMicrotask, "PASS");
+}, "Async modules only scheduling microtasks don't block execution of sibling modules");
+
+promise_test(async t => {
+  const { checkTask } = await import("./sibling-imports-not-blocked__task__parent.js");
+
+  assert_equals(checkTask, "PASS");
+}, "Async modules scheduling tasks don't block execution of sibling modules");

--- a/html/semantics/scripting-1/the-script-element/module/top-level-await/sibling-imports-not-blocked__microtask__check-get-sync.js
+++ b/html/semantics/scripting-1/the-script-element/module/top-level-await/sibling-imports-not-blocked__microtask__check-get-sync.js
@@ -1,0 +1,1 @@
+export const { checkMicrotask } = globalThis;

--- a/html/semantics/scripting-1/the-script-element/module/top-level-await/sibling-imports-not-blocked__microtask__check-set-async.js
+++ b/html/semantics/scripting-1/the-script-element/module/top-level-await/sibling-imports-not-blocked__microtask__check-set-async.js
@@ -1,0 +1,3 @@
+globalThis.checkMicrotask = "PASS";
+await 0;
+globalThis.checkMicrotask = "FAIL";

--- a/html/semantics/scripting-1/the-script-element/module/top-level-await/sibling-imports-not-blocked__microtask__parent.js
+++ b/html/semantics/scripting-1/the-script-element/module/top-level-await/sibling-imports-not-blocked__microtask__parent.js
@@ -1,0 +1,2 @@
+import "./sibling-imports-not-blocked__microtask__check-set-async.js";
+export { checkMicrotask } from "./sibling-imports-not-blocked__microtask__check-get-sync.js";

--- a/html/semantics/scripting-1/the-script-element/module/top-level-await/sibling-imports-not-blocked__task__check-get-sync.js
+++ b/html/semantics/scripting-1/the-script-element/module/top-level-await/sibling-imports-not-blocked__task__check-get-sync.js
@@ -1,0 +1,1 @@
+export const { checkTask } = globalThis;

--- a/html/semantics/scripting-1/the-script-element/module/top-level-await/sibling-imports-not-blocked__task__check-set-async.js
+++ b/html/semantics/scripting-1/the-script-element/module/top-level-await/sibling-imports-not-blocked__task__check-set-async.js
@@ -1,0 +1,3 @@
+globalThis.checkTask = "PASS";
+await new Promise(r => setTimeout(r, 0));
+globalThis.checkTask = "FAIL";

--- a/html/semantics/scripting-1/the-script-element/module/top-level-await/sibling-imports-not-blocked__task__parent.js
+++ b/html/semantics/scripting-1/the-script-element/module/top-level-await/sibling-imports-not-blocked__task__parent.js
@@ -1,0 +1,2 @@
+import "./sibling-imports-not-blocked__task__check-set-async.js";
+export { checkTask } from "./sibling-imports-not-blocked__task__check-get-sync.js";


### PR DESCRIPTION
Current results:

|    | Chrome, Node.js, Deno | Firefox | Safari, Bun |
|:---|:---:|:---:|:---:|
| Async modules only scheduling microtasks<br> don't block execution of sibling modules | ✅ | ❌ | ❌ |
| Async modules scheduling tasks don't block<br> execution of sibling modules           | ✅ | ✅ | ❌ |

This behavior is entirely specified in ECMA-262 (at https://tc39.es/ecma262/#sec-innermoduleevaluation) and the table above makes it look as if the behavior is engine-based.

~~However, when trying to add this as a test262 test all the engines passed it (see CI at https://github.com/tc39/test262/pull/3955). Only testing it in complete platforms show the failures, hence why the PR in this repo. This is not surprising, given how modules are implemented half in JS engines and half in embedding platforms.~~

~~**EDIT** I just misunderstood how test262 CI works, testing it in test262 might be enough.~~

I also opened an equivalent PR in test262 (https://github.com/tc39/test262/pull/3955), which only tests the microtasks behavior. However, in test262 SM passes the test. I think having this test _also_ in WPT has some value, because modules are implemented half in JS engines and half in embedding platform, so the JS engine shell behavior does not necessarily match the browser behavior.