### PR TITLE
Update wptserve dependency for mod_pywebsocket and bump version to 4.0.1

### DIFF
--- a/tools/wptserve/setup.py
+++ b/tools/wptserve/setup.py
@@ -1,7 +1,10 @@
 from setuptools import setup
 
 PACKAGE_VERSION = '4.0'
-deps = ["h2>=4.1.0"]
+deps = [
+    "h2>=4.1.0",
+    "mod_pywebsocket @ https://github.com/GoogleChromeLabs/pywebsocket3/archive/50602a14f1b6da17e0b619833a13addc6ea78bc2.zip#sha256=4dadd116e67af5625606f883e1973178d4121e8a1dc87b096ba2bb43c692f958",  # noqa
+]
 
 setup(name='wptserve',
       version=PACKAGE_VERSION,

--- a/tools/wptserve/setup.py
+++ b/tools/wptserve/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-PACKAGE_VERSION = '4.0'
+PACKAGE_VERSION = '4.0.1'
 deps = [
     "h2>=4.1.0",
     "mod_pywebsocket @ https://github.com/GoogleChromeLabs/pywebsocket3/archive/50602a14f1b6da17e0b619833a13addc6ea78bc2.zip#sha256=4dadd116e67af5625606f883e1973178d4121e8a1dc87b096ba2bb43c692f958",  # noqa


### PR DESCRIPTION
Closes #35978.

Follow-up from #42910 which had a missing dependency for mod_pywebsocket.