### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=264204

### DIFF
--- a/css/css-highlight-api/highlight-pseudo-parsing.html
+++ b/css/css-highlight-api/highlight-pseudo-parsing.html
@@ -7,11 +7,12 @@
 <script src="/css/support/parsing-testcommon.js"></script>
 <script>
   const pseudo = "::highlight(foo)";
-  test_valid_selector(`${pseudo}`);
+  test_valid_selector(pseudo);
   test_valid_selector(`.a${pseudo}`);
   test_valid_selector(`div ${pseudo}`);
   test_valid_selector(`::part(my-part)${pseudo}`);
 
+  test_invalid_selector("::highlight");
   test_invalid_selector(`::before${pseudo}`);
   test_invalid_selector(`${pseudo}.a`);
   test_invalid_selector(`${pseudo} div`);

--- a/css/cssom/invalid-pseudo-elements.html
+++ b/css/cssom/invalid-pseudo-elements.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSOM: Test that rules with invalid pseudo elements are not found</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+    ::part {}
+    ::slotted {}
+    ::highlight {}
+</style>
+<script>
+    test(() => {
+        assert_equals(document.styleSheets[0].cssRules[0]?.selectorText, undefined, "No associated selectorText");
+        assert_equals(document.styleSheets[0].cssRules[0], undefined, "No invalid pseudo element rule should be found");
+    });
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[CSS Highlight API\] REGRESSION(270146@main): Crash trying to serialize `::highlight`](https://bugs.webkit.org/show_bug.cgi?id=264204)