### PR TITLE
[wdspec] network intercept: navigate instead of fetch

### DIFF
--- a/webdriver/tests/bidi/network/remove_intercept/remove_intercept.py
+++ b/webdriver/tests/bidi/network/remove_intercept/remove_intercept.py
@@ -1,7 +1,8 @@
 # META: timeout=long
 
+import asyncio
+
 import pytest
-from webdriver.bidi.modules.script import ScriptEvaluateResultException
 
 from .. import (
     assert_before_request_sent_event,
@@ -19,7 +20,7 @@ PAGE_OTHER_TEXT = "/webdriver/tests/bidi/network/support/other.txt"
     "responseStarted",
 ])
 async def test_remove_intercept(
-    bidi_session, wait_for_event, url, setup_network_test, add_intercept, fetch, top_context, wait_for_future_safe, phase
+    bidi_session, wait_for_event, url, setup_network_test, add_intercept, top_context, wait_for_future_safe, phase
 ):
     network_events = await setup_network_test(
         events=[
@@ -40,10 +41,13 @@ async def test_remove_intercept(
 
     on_network_event = wait_for_event(f"network.{phase}")
 
-    # Request to top_context should be blocked and throw a ScriptEvaluateResultException
-    # from the AbortController.
-    with pytest.raises(ScriptEvaluateResultException):
-        await fetch(text_url)
+    # Request to top_context should be blocked.
+    # TODO(https://github.com/w3c/webdriver-bidi/issues/188): Use a timeout argument when available.
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(
+            asyncio.shield(bidi_session.browsing_context.navigate(context=top_context["context"], url=text_url, wait="complete")),
+            timeout=2.0,
+        )
 
     await wait_for_future_safe(on_network_event)
 


### PR DESCRIPTION
Use navigation with an expected timeout instead of fetch with an expected exception.

From a test implementation perspective this is a no-op as, when the network interception triggers, the navigation is expected to not complete (and thus timeout).