### PR TITLE
[wdspec] Port test "test_move_to_position_in_viewport" from WebDriver classic to BiDi

### DIFF
--- a/webdriver/tests/bidi/input/perform_actions/pointer_mouse.py
+++ b/webdriver/tests/bidi/input/perform_actions/pointer_mouse.py
@@ -283,3 +283,35 @@ async def test_click_navigation(
         await click_link()
         event = await on_entry
         assert event["url"] == destination
+
+
+@pytest.mark.parametrize("x, y, event_count", [
+    (0, 0, 0),
+    (1, 0, 1),
+    (0, 1, 1),
+], ids=["default value", "x", "y"])
+async def test_move_to_position_in_viewport(
+    bidi_session, load_static_test_page, top_context, x, y, event_count
+):
+    await load_static_test_page(page="test_actions.html")
+
+    actions = Actions()
+    actions.add_pointer().pointer_move(x=x, y=y)
+
+    await bidi_session.input.perform_actions(
+        actions=actions, context=top_context["context"]
+    )
+
+    events = await get_events(bidi_session, top_context["context"])
+    assert len(events) == event_count
+
+    # Move again to check that no further mouse move event is emitted.
+    actions = Actions()
+    actions.add_pointer().pointer_move(x=x, y=y)
+
+    await bidi_session.input.perform_actions(
+        actions=actions, context=top_context["context"]
+    )
+
+    events = await get_events(bidi_session, top_context["context"])
+    assert len(events) == event_count


### PR DESCRIPTION
This is the exact same test (as requested by https://github.com/w3c/webdriver/issues/1545) as from the following PR but just to test the WebDriver BiDi implementation:

https://github.com/web-platform-tests/wpt/pull/42579

