### PR TITLE
Update expected results when expected fail message does not match

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -703,6 +703,13 @@ class TestRunnerManager(threading.Thread):
                 expected_fail_message = test.expected_fail_message(result.name)
                 if expected_fail_message is not None and result.message.strip() != expected_fail_message:
                     is_unexpected = True
+                    if result.status in known_intermittent:
+                        known_intermittent.remove(result.status)
+                    elif len(known_intermittent) > 0:
+                        expected = known_intermittent[0]
+                        known_intermittent = known_intermittent[1:]
+                    else:
+                        expected = "PASS"
 
             if is_unexpected:
                 subtest_unexpected = True


### PR DESCRIPTION
As per the RFC, when expected fail message does not match, we should turn an expected FAIL to an unexpected FAIL. Modify known intermittened or the expected status as necessary to achieve this.