### PR TITLE
Add comments to explain how expected statuses are modified

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -703,8 +703,12 @@ class TestRunnerManager(threading.Thread):
                 expected_fail_message = test.expected_fail_message(result.name)
                 if expected_fail_message is not None and result.message.strip() != expected_fail_message:
                     is_unexpected = True
+
                     if result.status in known_intermittent:
                         known_intermittent.remove(result.status)
+                    # At this point result.status should equal expected. Promote
+                    # a known intermittent result to expected, or change
+                    # expected to PASS if no known intermittent.
                     elif len(known_intermittent) > 0:
                         expected = known_intermittent[0]
                         known_intermittent = known_intermittent[1:]


### PR DESCRIPTION
This is a follow up change for #43030. As suggested, add comments to make the change easier to understand.