### PR TITLE
Create accname/name/comp_labelledby_hidden_nodes.html

### DIFF
--- a/accname/name/comp_labelledby_hidden_nodes.html
+++ b/accname/name/comp_labelledby_hidden_nodes.html
@@ -176,9 +176,9 @@
     <button aria-labelledby="d21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden hidden span (with nested aria-hidden spans, depth 2)" class="ex"></button>>x</button>
     <span id="d21" aria-hidden="true">
         foo
-        <span id="d22" aria-hidden="true">
+        <span id="d22">
             bar
-        <span id="d23" aria-hidden="true">baz</span>
+            <span id="d23">baz</span>
         </span>
     </span>
 

--- a/accname/name/comp_labelledby_hidden_nodes.html
+++ b/accname/name/comp_labelledby_hidden_nodes.html
@@ -100,8 +100,8 @@
     <button aria-labelledby="b41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden hidden span (with nested visibility:hidden sibling spans)" class="ex"></button>>x</button>
     <span id="b41" style="visibility: hidden;">
         foo
-        <span id="b42" style="visibility: hidden;">bar</span>
-        <span id="b43" style="visibility: hidden;">baz</span>
+        <span id="b42">bar</span>
+        <span id="b43">baz</span>
     </span>
 
     <button aria-labelledby="b51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:hidden (with nested visibility:hidden sibling spans)" class="ex"></button>>x</button>

--- a/accname/name/comp_labelledby_hidden_nodes.html
+++ b/accname/name/comp_labelledby_hidden_nodes.html
@@ -13,7 +13,102 @@
 
 <p>Tests hidden node name computation as part of the <a href="https://w3c.github.io/accname/#comp_labelledby">#comp_labelledby</a> portion of the AccName <em>Name Computation</em> algorithm.</p>
 
+<!--
 
+  These tests verify browser conformance with the following note as part of accName computation Step 2G:
+
+  "The result of LabelledBy Recursion in combination with Hidden Not Referenced means
+  that user agents MUST include all nodes in the subtree as part of
+  the accessible name or accessible description, when the node referenced
+  by aria-labelledby or aria-describedby is hidden."
+
+-->
+
+<h2>Testing with <code>display:none</code></h2>
+
+    <button aria-labelledby="a11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using display:none hidden span (with nested span)" class="ex"></button>>x</button>
+    <span id="a11" style="display: none;">
+        foo
+        <span id="a12" style="display: none;">bar</span>
+    </span>
+
+    <button aria-labelledby="a21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using display:none hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <span id="a21" style="display: none;">
+        foo
+        <span id="a22" style="display: none;">
+            bar
+        <span id="a23" style="display: none;">baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="a31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without display:none (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <span id="a31">
+        foo
+        <span id="a32" style="display: none;">
+            bar
+        <span id="a33" style="display: none;">baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="a41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using display:none hidden span (with nested sibling spans)" class="ex"></button>>x</button>
+    <span id="a41" style="display: none;">
+        foo
+        <span id="a42" style="display: none;">bar</span>
+        <span id="a43" style="display: none;">baz</span>
+    </span>
+
+    <button aria-labelledby="a51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without display:none (with nested sibling spans)" class="ex"></button>>x</button>
+    <span id="a51">
+        foo
+        <span id="a52" style="display: none;">bar</span>
+        <span id="a53" style="display: none;">baz</span>
+    </span>
+
+<h2>Testing with <code>visibility:hidden</code></h2>
+
+    <button aria-labelledby="b11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using visibility:hidden span (with nested span)" class="ex"></button>>x</button>
+    <span id="b11" style="visibility: hidden;">
+        foo
+        <span id="b12" style="visibility: hidden;">bar</span>
+    </span>
+
+    <button aria-labelledby="b21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <span id="b21" style="visibility: hidden;">
+        foo
+        <span id="a22" style="visibility: hidden;">
+            bar
+        <span id="a23" style="visibility: hidden;">baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="b31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:hidden (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <span id="b31">
+        foo
+        <span id="b32" style="visibility:hidden;">
+            bar
+        <span id="b33" style="visibility:hidden;">baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="b41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden hidden span (with nested sibling spans)" class="ex"></button>>x</button>
+    <span id="b41" style="visibility:hidden;">
+        foo
+        <span id="b42" style="visibility:hidden;">bar</span>
+        <span id="b43" style="visibility:hidden;">baz</span>
+    </span>
+
+    <button aria-labelledby="b51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:hidden; (with nested sibling spans)" class="ex"></button>>x</button>
+    <span id="b51">
+        foo
+        <span id="b52" style="visibility:hidden;">bar</span>
+        <span id="b53" style="visibility:hidden;">baz</span>
+    </span>
+
+<h2>Testing with <code>visibility:collapse</code></h2>
+
+<h2>Testing with <code>aria-hidden</code></h2>
+
+<h2>Testing with <code>hidden</code> attribute</h2>
 
 <script>
 AriaUtils.verifyLabelsBySelector(".ex");

--- a/accname/name/comp_labelledby_hidden_nodes.html
+++ b/accname/name/comp_labelledby_hidden_nodes.html
@@ -26,13 +26,13 @@
 
 <h2>Testing with <code>display:none</code></h2>
 
-    <button aria-labelledby="a11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using display:none hidden span (with nested span)" class="ex"></button>>x</button>
+    <button aria-labelledby="a11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using display:none hidden span (with nested display:none span)" class="ex"></button>>x</button>
     <span id="a11" style="display: none;">
         foo
         <span id="a12" style="display: none;">bar</span>
     </span>
 
-    <button aria-labelledby="a21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using display:none hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="a21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using display:none hidden span (with nested display:none spans, depth 2)" class="ex"></button>>x</button>
     <span id="a21" style="display: none;">
         foo
         <span id="a22" style="display: none;">
@@ -41,7 +41,7 @@
         </span>
     </span>
 
-    <button aria-labelledby="a31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without display:none (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="a31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without display:none (with nested display:none spans, depth 2)" class="ex"></button>>x</button>
     <span id="a31">
         foo
         <span id="a32" style="display: none;">
@@ -50,29 +50,36 @@
         </span>
     </span>
 
-    <button aria-labelledby="a41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using display:none hidden span (with nested sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="a41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using display:none hidden span (with nested display:none sibling spans)" class="ex"></button>>x</button>
     <span id="a41" style="display: none;">
         foo
         <span id="a42" style="display: none;">bar</span>
         <span id="a43" style="display: none;">baz</span>
     </span>
 
-    <button aria-labelledby="a51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without display:none (with nested sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="a51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without display:none (with nested display:none sibling spans)" class="ex"></button>>x</button>
     <span id="a51">
         foo
         <span id="a52" style="display: none;">bar</span>
         <span id="a53" style="display: none;">baz</span>
     </span>
 
+    <button aria-labelledby="a61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with display:none (with nested non-hidden sibling spans)" class="ex"></button>>x</button>
+    <span id="a61" style="display: none;">
+        foo
+        <span id="a62">bar</span>
+        <span id="a63">baz</span>
+    </span>
+
 <h2>Testing with <code>visibility:hidden</code></h2>
 
-    <button aria-labelledby="b11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using visibility:hidden span (with nested span)" class="ex"></button>>x</button>
+    <button aria-labelledby="b11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using visibility:hidden span (with nested visibility:hidden span)" class="ex"></button>>x</button>
     <span id="b11" style="visibility: hidden;">
         foo
         <span id="b12" style="visibility: hidden;">bar</span>
     </span>
 
-    <button aria-labelledby="b21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="b21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden hidden span (with nested visibility:hidden spans, depth 2)" class="ex"></button>>x</button>
     <span id="b21" style="visibility: hidden;">
         foo
         <span id="b22" style="visibility: hidden;">
@@ -81,7 +88,7 @@
         </span>
     </span>
 
-    <button aria-labelledby="b31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:hidden (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="b31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:hidden (with nested visibility:hidden spans, depth 2)" class="ex"></button>>x</button>
     <span id="b31">
         foo
         <span id="b32" style="visibility: hidden;">
@@ -90,18 +97,25 @@
         </span>
     </span>
 
-    <button aria-labelledby="b41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden hidden span (with nested sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="b41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden hidden span (with nested visibility:hidden sibling spans)" class="ex"></button>>x</button>
     <span id="b41" style="visibility: hidden;">
         foo
         <span id="b42" style="visibility: hidden;">bar</span>
         <span id="b43" style="visibility: hidden;">baz</span>
     </span>
 
-    <button aria-labelledby="b51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:hidden (with nested sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="b51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:hidden (with nested visibility:hidden sibling spans)" class="ex"></button>>x</button>
     <span id="b51">
         foo
         <span id="b52" style="visibility: hidden;">bar</span>
         <span id="b53" style="visibility: hidden;">baz</span>
+    </span>
+
+    <button aria-labelledby="b61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with visibility:hidden (with nested visible sibling spans)" class="ex"></button>>x</button>
+    <span id="b61" style="visibility: hidden;">
+        foo
+        <span id="b62">bar</span>
+        <span id="b63">baz</span>
     </span>
 
 <h2>Testing with <code>visibility:collapse</code></h2>
@@ -112,7 +126,7 @@
         <span id="c12" style="visibility: collapse;">bar</span>
     </span>
 
-    <button aria-labelledby="c21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="c21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse hidden span (with nested visibility:collapse spans, depth 2)" class="ex"></button>>x</button>
     <span id="c21" style="visibility: collapse;">
         foo
         <span id="c22" style="visibility: collapse;">
@@ -121,7 +135,7 @@
         </span>
     </span>
 
-    <button aria-labelledby="c31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:collapse (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="c31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:collapse (with nested visibility:collapse spans, depth 2)" class="ex"></button>>x</button>
     <span id="c31">
         foo
         <span id="c32" style="visibility: collapse;">
@@ -130,29 +144,36 @@
         </span>
     </span>
 
-    <button aria-labelledby="c41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse hidden span (with nested sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="c41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse hidden span (with nested visibility:collapse sibling spans)" class="ex"></button>>x</button>
     <span id="c41" style="visibility: collapse;">
         foo
         <span id="c42" style="visibility: hidden;">bar</span>
         <span id="c43" style="visibility: hidden;">baz</span>
     </span>
 
-    <button aria-labelledby="c51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:collapse (with nested sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="c51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:collapse (with nested visibility:collapse sibling spans)" class="ex"></button>>x</button>
     <span id="c51">
         foo
         <span id="c52" style="visibility: collapse;">bar</span>
         <span id="c53" style="visibility: collapse;">baz</span>
     </span>
 
+    <button aria-labelledby="c61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with visibility:collapse (with nested visible sibling spans)" class="ex"></button>>x</button>
+    <span id="c61" style="visibility: collapse;">
+        foo
+        <span id="c62">bar</span>
+        <span id="c63">baz</span>
+    </span>
+
 <h2>Testing with <code>aria-hidden</code></h2>
 
-    <button aria-labelledby="d11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using aria-hidden span (with nested span)" class="ex"></button>>x</button>
+    <button aria-labelledby="d11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using aria-hidden span (with nested aria-hidden span)" class="ex"></button>>x</button>
     <span id="d11" aria-hidden="true">
         foo
         <span id="d12" aria-hidden="true">bar</span>
     </span>
 
-    <button aria-labelledby="d21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="d21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden hidden span (with nested aria-hidden spans, depth 2)" class="ex"></button>>x</button>
     <span id="d21" aria-hidden="true">
         foo
         <span id="d22" aria-hidden="true">
@@ -161,7 +182,7 @@
         </span>
     </span>
 
-    <button aria-labelledby="d31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without aria-hidden (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="d31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without aria-hidden (with nested aria-hidden spans, depth 2)" class="ex"></button>>x</button>
     <span id="d31">
         foo
         <span id="d32" aria-hidden="true">
@@ -170,29 +191,36 @@
         </span>
     </span>
 
-    <button aria-labelledby="d41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden hidden span (with nested sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="d41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden hidden span (with nested aria-hidden sibling spans)" class="ex"></button>>x</button>
     <span id="d41" style="visibility: collapse;">
         foo
         <span id="d42" aria-hidden="true">bar</span>
         <span id="d43" aria-hidden="true">baz</span>
     </span>
 
-    <button aria-labelledby="d51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without aria-hidden (with nested sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="d51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without aria-hidden (with nested aria-hidden sibling spans)" class="ex"></button>>x</button>
     <span id="d51">
         foo
         <span id="d52" aria-hidden="true">bar</span>
         <span id="d53" aria-hidden="true">baz</span>
     </span>
 
+    <button aria-labelledby="d61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with aria-hidden (with nested visible sibling spans)" class="ex"></button>>x</button>
+    <span id="d61" aria-hidden="true">
+        foo
+        <span id="d62">bar</span>
+        <span id="d63">baz</span>
+    </span>
+
 <h2>Testing with <code>hidden</code> attribute</h2>
 
-    <button aria-labelledby="e11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using HTML5 hidden span (with nested span)" class="ex"></button>>x</button>
+    <button aria-labelledby="e11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using HTML5 hidden span (with nested hidden span)" class="ex"></button>>x</button>
     <span id="e11" hidden>
         foo
         <span id="e12" hidden>bar</span>
     </span>
 
-    <button aria-labelledby="e21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using HTML5 hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="e21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using HTML5 hidden span (with nested hidden spans, depth 2)" class="ex"></button>>x</button>
     <span id="e21" hidden>
         foo
         <span id="e22" hidden>
@@ -201,7 +229,7 @@
         </span>
     </span>
 
-    <button aria-labelledby="e31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without HTML5 hidden (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="e31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without HTML5 hidden (with nested hidden spans, depth 2)" class="ex"></button>>x</button>
     <span id="e31">
         foo
         <span id="e32" hidden>
@@ -210,18 +238,25 @@
         </span>
     </span>
 
-    <button aria-labelledby="e41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using HTML5 hidden span (with nested sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="e41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using HTML5 hidden span (with nested hidden sibling spans)" class="ex"></button>>x</button>
     <span id="e41" hidden>
         foo
         <span id="e42" hidden>bar</span>
         <span id="e43" hidden>baz</span>
     </span>
 
-    <button aria-labelledby="e51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without HTML5 hidden (with nested sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="e51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without HTML5 hidden (with nested hidden sibling spans)" class="ex"></button>>x</button>
     <span id="e51">
         foo
         <span id="e52" hidden>bar</span>
         <span id="e53" hidden>baz</span>
+    </span>
+
+    <button aria-labelledby="e61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with HTML5 hidden (with nested visible sibling spans)" class="ex"></button>>x</button>
+    <span id="e61" hidden>
+        foo
+        <span id="e62">bar</span>
+        <span id="e63">baz</span>
     </span>
 
 <script>

--- a/accname/name/comp_labelledby_hidden_nodes.html
+++ b/accname/name/comp_labelledby_hidden_nodes.html
@@ -26,18 +26,18 @@
 
 <h2>Testing with <code>display:none</code></h2>
 
-    <button aria-labelledby="a11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using display:none hidden span (with nested display:none span)" class="ex"></button>>x</button>
+    <button aria-labelledby="a11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using display:none hidden span (with nested span)" class="ex"></button>>x</button>
     <span id="a11" style="display: none;">
         foo
-        <span id="a12" style="display: none;">bar</span>
+        <span id="a12">bar</span>
     </span>
 
     <button aria-labelledby="a21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using display:none hidden span (with nested display:none spans, depth 2)" class="ex"></button>>x</button>
     <span id="a21" style="display: none;">
         foo
-        <span id="a22" style="display: none;">
+        <span id="a22">
             bar
-        <span id="a23" style="display: none;">baz</span>
+            <span id="a23">baz</span>
         </span>
     </span>
 
@@ -46,15 +46,15 @@
         foo
         <span id="a32" style="display: none;">
             bar
-        <span id="a33" style="display: none;">baz</span>
+            <span id="a33">baz</span>
         </span>
     </span>
 
-    <button aria-labelledby="a41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using display:none hidden span (with nested display:none sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="a41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using display:none hidden span (with nested sibling spans)" class="ex"></button>>x</button>
     <span id="a41" style="display: none;">
         foo
-        <span id="a42" style="display: none;">bar</span>
-        <span id="a43" style="display: none;">baz</span>
+        <span id="a42">bar</span>
+        <span id="a43">baz</span>
     </span>
 
     <button aria-labelledby="a51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without display:none (with nested display:none sibling spans)" class="ex"></button>>x</button>
@@ -67,19 +67,19 @@
     <button aria-labelledby="a61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with display:none (with nested non-hidden sibling spans)" class="ex"></button>>x</button>
     <span id="a61" style="display: none;">
         foo
-        <span id="a62">bar</span>
-        <span id="a63">baz</span>
+        <span id="a62" style="display: inline;">bar</span>
+        <span id="a63" style="display: inline;">baz</span>
     </span>
 
 <h2>Testing with <code>visibility:hidden</code></h2>
 
-    <button aria-labelledby="b11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using visibility:hidden span (with nested visibility:hidden span)" class="ex"></button>>x</button>
+    <button aria-labelledby="b11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using visibility:hidden span (with nested span)" class="ex"></button>>x</button>
     <span id="b11" style="visibility: hidden;">
         foo
         <span id="b12">bar</span>
     </span>
 
-    <button aria-labelledby="b21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden hidden span (with nested visibility:hidden spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="b21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
     <span id="b21" style="visibility: hidden;">
         foo
         <span id="b22">
@@ -111,11 +111,11 @@
         <span id="b53" style="visibility: hidden;">baz</span>
     </span>
 
-    <button aria-labelledby="b61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with visibility:hidden (with nested visible sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="b61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with visibility:hidden (with nested visibility: visible sibling spans)" class="ex"></button>>x</button>
     <span id="b61" style="visibility: hidden;">
         foo
-        <span id="b62">bar</span>
-        <span id="b63">baz</span>
+        <span id="b62" style="visibility: visible;">bar</span>
+        <span id="b63" style="visibility: visible;">baz</span>
     </span>
 
 <h2>Testing with <code>visibility:collapse</code></h2>
@@ -123,32 +123,32 @@
     <button aria-labelledby="c11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using visibility:collapse span (with nested span)" class="ex"></button>>x</button>
     <span id="c11" style="visibility: collapse;">
         foo
-        <span id="c12" style="visibility: collapse;">bar</span>
+        <span id="c12">bar</span>
     </span>
 
-    <button aria-labelledby="c21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse hidden span (with nested visibility:collapse spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="c21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
     <span id="c21" style="visibility: collapse;">
         foo
-        <span id="c22" style="visibility: collapse;">
+        <span id="c22">
             bar
-        <span id="c23" style="visibility: collapse;">baz</span>
+            <span id="c23">baz</span>
         </span>
     </span>
 
-    <button aria-labelledby="c31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:collapse (with nested visibility:collapse spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="c31" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span without visibility:collapse (with nested visibility:visible spans, depth 2)" class="ex"></button>>x</button>
     <span id="c31">
         foo
-        <span id="c32" style="visibility: collapse;">
+        <span id="c32" style="visibility: visible;">
             bar
-        <span id="c33" style="visibility: collapse;">baz</span>
+        <span id="c33" style="visibility: visible;">baz</span>
         </span>
     </span>
 
-    <button aria-labelledby="c41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse hidden span (with nested visibility:collapse sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="c41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse hidden span (with nested sibling spans)" class="ex"></button>>x</button>
     <span id="c41" style="visibility: collapse;">
         foo
-        <span id="c42" style="visibility: hidden;">bar</span>
-        <span id="c43" style="visibility: hidden;">baz</span>
+        <span id="c42">bar</span>
+        <span id="c43">baz</span>
     </span>
 
     <button aria-labelledby="c51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:collapse (with nested visibility:collapse sibling spans)" class="ex"></button>>x</button>
@@ -161,19 +161,19 @@
     <button aria-labelledby="c61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with visibility:collapse (with nested visible sibling spans)" class="ex"></button>>x</button>
     <span id="c61" style="visibility: collapse;">
         foo
-        <span id="c62">bar</span>
-        <span id="c63">baz</span>
+        <span id="c62" style="visibility: visible;">bar</span>
+        <span id="c63" style="visibility: visible;">baz</span>
     </span>
 
 <h2>Testing with <code>aria-hidden</code></h2>
 
-    <button aria-labelledby="d11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using aria-hidden span (with nested aria-hidden span)" class="ex"></button>>x</button>
+    <button aria-labelledby="d11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using aria-hidden span (with nested span)" class="ex"></button>>x</button>
     <span id="d11" aria-hidden="true">
         foo
-        <span id="d12" aria-hidden="true">bar</span>
+        <span id="d12">bar</span>
     </span>
 
-    <button aria-labelledby="d21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden hidden span (with nested aria-hidden spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="d21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
     <span id="d21" aria-hidden="true">
         foo
         <span id="d22">
@@ -187,43 +187,29 @@
         foo
         <span id="d32" aria-hidden="true">
             bar
-        <span id="d33" aria-hidden="true">baz</span>
+            <span id="d33">baz</span>
         </span>
     </span>
 
     <button aria-labelledby="d41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden hidden span (with nested aria-hidden sibling spans)" class="ex"></button>>x</button>
-    <span id="d41" style="visibility: collapse;">
+    <span id="d41" aria-hidden="true">
         foo
-        <span id="d42" aria-hidden="true">bar</span>
-        <span id="d43" aria-hidden="true">baz</span>
-    </span>
-
-    <button aria-labelledby="d51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without aria-hidden (with nested aria-hidden sibling spans)" class="ex"></button>>x</button>
-    <span id="d51">
-        foo
-        <span id="d52" aria-hidden="true">bar</span>
-        <span id="d53" aria-hidden="true">baz</span>
-    </span>
-
-    <button aria-labelledby="d61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with aria-hidden (with nested visible sibling spans)" class="ex"></button>>x</button>
-    <span id="d61" aria-hidden="true">
-        foo
-        <span id="d62">bar</span>
-        <span id="d63">baz</span>
+        <span id="d42">bar</span>
+        <span id="d43">baz</span>
     </span>
 
 <h2>Testing with <code>hidden</code> attribute</h2>
 
-    <button aria-labelledby="e11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using HTML5 hidden span (with nested hidden span)" class="ex"></button>>x</button>
+    <button aria-labelledby="e11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using HTML5 hidden span (with nested span)" class="ex"></button>>x</button>
     <span id="e11" hidden>
         foo
         <span id="e12">bar</span>
     </span>
 
-    <button aria-labelledby="e21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using HTML5 hidden span (with nested hidden spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="e21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using HTML5 hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
     <span id="e21" hidden>
         foo
-        <span id="e22" hidden>
+        <span id="e22">
             bar
             <span id="e23">baz</span>
         </span>
@@ -250,13 +236,6 @@
         foo
         <span id="e52" hidden>bar</span>
         <span id="e53" hidden>baz</span>
-    </span>
-
-    <button aria-labelledby="e61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with HTML5 hidden (with nested visible sibling spans)" class="ex"></button>>x</button>
-    <span id="e61" hidden>
-        foo
-        <span id="e62">bar</span>
-        <span id="e63">baz</span>
     </span>
 
 <script>

--- a/accname/name/comp_labelledby_hidden_nodes.html
+++ b/accname/name/comp_labelledby_hidden_nodes.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+<head>
+  <title>Name Comp: Labelledby & Hidden Nodes</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<p>Tests hidden node name computation as part of the <a href="https://w3c.github.io/accname/#comp_labelledby">#comp_labelledby</a> portion of the AccName <em>Name Computation</em> algorithm.</p>
+
+
+
+<script>
+AriaUtils.verifyLabelsBySelector(".ex");
+</script>
+</body>
+</html>

--- a/accname/name/comp_labelledby_hidden_nodes.html
+++ b/accname/name/comp_labelledby_hidden_nodes.html
@@ -241,8 +241,8 @@
     <button aria-labelledby="e41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using HTML5 hidden span (with nested hidden sibling spans)" class="ex"></button>>x</button>
     <span id="e41" hidden>
         foo
-        <span id="e42" hidden>bar</span>
-        <span id="e43" hidden>baz</span>
+        <span id="e42">bar</span>
+        <span id="e43">baz</span>
     </span>
 
     <button aria-labelledby="e51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without HTML5 hidden (with nested hidden sibling spans)" class="ex"></button>>x</button>

--- a/accname/name/comp_labelledby_hidden_nodes.html
+++ b/accname/name/comp_labelledby_hidden_nodes.html
@@ -32,7 +32,7 @@
         <span id="a12">bar</span>
     </span>
 
-    <button aria-labelledby="a21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using display:none hidden span (with nested display:none spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="a21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using display:none hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
     <span id="a21" style="display: none;">
         foo
         <span id="a22">
@@ -64,7 +64,7 @@
         <span id="a53" style="display: none;">baz</span>
     </span>
 
-    <button aria-labelledby="a61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with display:none (with nested non-hidden sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="a61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with display:none (with nested display:inline sibling spans)" class="ex"></button>>x</button>
     <span id="a61" style="display: none;">
         foo
         <span id="a62" style="display: inline;">bar</span>
@@ -97,7 +97,7 @@
         </span>
     </span>
 
-    <button aria-labelledby="b41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden hidden span (with nested visibility:hidden sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="b41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden hidden span (with nested sibling spans)" class="ex"></button>>x</button>
     <span id="b41" style="visibility: hidden;">
         foo
         <span id="b42">bar</span>
@@ -111,7 +111,7 @@
         <span id="b53" style="visibility: hidden;">baz</span>
     </span>
 
-    <button aria-labelledby="b61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with visibility:hidden (with nested visibility: visible sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="b61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with visibility:hidden (with nested visibility:visible sibling spans)" class="ex"></button>>x</button>
     <span id="b61" style="visibility: hidden;">
         foo
         <span id="b62" style="visibility: visible;">bar</span>
@@ -126,7 +126,7 @@
         <span id="c12">bar</span>
     </span>
 
-    <button aria-labelledby="c21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="c21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse span (with nested spans, depth 2)" class="ex"></button>>x</button>
     <span id="c21" style="visibility: collapse;">
         foo
         <span id="c22">
@@ -140,11 +140,11 @@
         foo
         <span id="c32" style="visibility: visible;">
             bar
-        <span id="c33" style="visibility: visible;">baz</span>
+            <span id="c33" style="visibility: visible;">baz</span>
         </span>
     </span>
 
-    <button aria-labelledby="c41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse hidden span (with nested sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="c41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse span (with nested sibling spans)" class="ex"></button>>x</button>
     <span id="c41" style="visibility: collapse;">
         foo
         <span id="c42">bar</span>
@@ -173,7 +173,7 @@
         <span id="d12">bar</span>
     </span>
 
-    <button aria-labelledby="d21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="d21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
     <span id="d21" aria-hidden="true">
         foo
         <span id="d22">
@@ -191,7 +191,7 @@
         </span>
     </span>
 
-    <button aria-labelledby="d41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden hidden span (with nested aria-hidden sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="d41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden hidden span (with nested sibling spans)" class="ex"></button>>x</button>
     <span id="d41" aria-hidden="true">
         foo
         <span id="d42">bar</span>
@@ -215,7 +215,7 @@
         </span>
     </span>
 
-    <button aria-labelledby="e31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without HTML5 hidden (with nested hidden spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="e31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without HTML5 hidden (with nested HTML5 hidden spans, depth 2)" class="ex"></button>>x</button>
     <span id="e31">
         foo
         <span id="e32" hidden>

--- a/accname/name/comp_labelledby_hidden_nodes.html
+++ b/accname/name/comp_labelledby_hidden_nodes.html
@@ -15,7 +15,7 @@
 
 <!--
 
-  These tests verify browser conformance with the following note as part of accName computation Step 2G:
+  These tests verify browser conformance with the following note as part of accName computation Step 2B:
 
   "The result of LabelledBy Recursion in combination with Hidden Not Referenced means
   that user agents MUST include all nodes in the subtree as part of

--- a/accname/name/comp_labelledby_hidden_nodes.html
+++ b/accname/name/comp_labelledby_hidden_nodes.html
@@ -93,7 +93,7 @@
         foo
         <span id="b32" style="visibility: hidden;">
             bar
-        <span id="b33" style="visibility: hidden;">baz</span>
+            <span id="b33">baz</span>
         </span>
     </span>
 

--- a/accname/name/comp_labelledby_hidden_nodes.html
+++ b/accname/name/comp_labelledby_hidden_nodes.html
@@ -26,13 +26,13 @@
 
 <h2>Testing with <code>display:none</code></h2>
 
-    <button aria-labelledby="a11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using display:none hidden span (with nested span)" class="ex"></button>>x</button>
+    <button aria-labelledby="a11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using display:none hidden span (with nested span)" class="ex">x</button>
     <span id="a11" style="display: none;">
         foo
         <span id="a12">bar</span>
     </span>
 
-    <button aria-labelledby="a21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using display:none hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="a21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using display:none hidden span (with nested spans, depth 2)" class="ex">x</button>
     <span id="a21" style="display: none;">
         foo
         <span id="a22">
@@ -41,7 +41,7 @@
         </span>
     </span>
 
-    <button aria-labelledby="a31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without display:none (with nested display:none spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="a31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without display:none (with nested display:none spans, depth 2)" class="ex">x</button>
     <span id="a31">
         foo
         <span id="a32" style="display: none;">
@@ -50,21 +50,21 @@
         </span>
     </span>
 
-    <button aria-labelledby="a41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using display:none hidden span (with nested sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="a41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using display:none hidden span (with nested sibling spans)" class="ex">x</button>
     <span id="a41" style="display: none;">
         foo
         <span id="a42">bar</span>
         <span id="a43">baz</span>
     </span>
 
-    <button aria-labelledby="a51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without display:none (with nested display:none sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="a51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without display:none (with nested display:none sibling spans)" class="ex">x</button>
     <span id="a51">
         foo
         <span id="a52" style="display: none;">bar</span>
         <span id="a53" style="display: none;">baz</span>
     </span>
 
-    <button aria-labelledby="a61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with display:none (with nested display:inline sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="a61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with display:none (with nested display:inline sibling spans)" class="ex">x</button>
     <span id="a61" style="display: none;">
         foo
         <span id="a62" style="display: inline;">bar</span>
@@ -73,13 +73,13 @@
 
 <h2>Testing with <code>visibility:hidden</code></h2>
 
-    <button aria-labelledby="b11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using visibility:hidden span (with nested span)" class="ex"></button>>x</button>
+    <button aria-labelledby="b11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using visibility:hidden span (with nested span)" class="ex">x</button>
     <span id="b11" style="visibility: hidden;">
         foo
         <span id="b12">bar</span>
     </span>
 
-    <button aria-labelledby="b21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="b21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden span (with nested spans, depth 2)" class="ex">x</button>
     <span id="b21" style="visibility: hidden;">
         foo
         <span id="b22">
@@ -88,7 +88,7 @@
         </span>
     </span>
 
-    <button aria-labelledby="b31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:hidden (with nested visibility:hidden spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="b31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:hidden (with nested visibility:hidden spans, depth 2)" class="ex">x</button>
     <span id="b31">
         foo
         <span id="b32" style="visibility: hidden;">
@@ -97,21 +97,21 @@
         </span>
     </span>
 
-    <button aria-labelledby="b41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden hidden span (with nested sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="b41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden hidden span (with nested sibling spans)" class="ex">x</button>
     <span id="b41" style="visibility: hidden;">
         foo
         <span id="b42">bar</span>
         <span id="b43">baz</span>
     </span>
 
-    <button aria-labelledby="b51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:hidden (with nested visibility:hidden sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="b51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:hidden (with nested visibility:hidden sibling spans)" class="ex">x</button>
     <span id="b51">
         foo
         <span id="b52" style="visibility: hidden;">bar</span>
         <span id="b53" style="visibility: hidden;">baz</span>
     </span>
 
-    <button aria-labelledby="b61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with visibility:hidden (with nested visibility:visible sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="b61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with visibility:hidden (with nested visibility:visible sibling spans)" class="ex">x</button>
     <span id="b61" style="visibility: hidden;">
         foo
         <span id="b62" style="visibility: visible;">bar</span>
@@ -120,13 +120,13 @@
 
 <h2>Testing with <code>visibility:collapse</code></h2>
 
-    <button aria-labelledby="c11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using visibility:collapse span (with nested span)" class="ex"></button>>x</button>
+    <button aria-labelledby="c11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using visibility:collapse span (with nested span)" class="ex">x</button>
     <span id="c11" style="visibility: collapse;">
         foo
         <span id="c12">bar</span>
     </span>
 
-    <button aria-labelledby="c21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse span (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="c21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse span (with nested spans, depth 2)" class="ex">x</button>
     <span id="c21" style="visibility: collapse;">
         foo
         <span id="c22">
@@ -135,7 +135,7 @@
         </span>
     </span>
 
-    <button aria-labelledby="c31" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span without visibility:collapse (with nested visibility:visible spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="c31" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span without visibility:collapse (with nested visibility:visible spans, depth 2)" class="ex">x</button>
     <span id="c31">
         foo
         <span id="c32" style="visibility: visible;">
@@ -144,21 +144,21 @@
         </span>
     </span>
 
-    <button aria-labelledby="c41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse span (with nested sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="c41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse span (with nested sibling spans)" class="ex">x</button>
     <span id="c41" style="visibility: collapse;">
         foo
         <span id="c42">bar</span>
         <span id="c43">baz</span>
     </span>
 
-    <button aria-labelledby="c51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:collapse (with nested visibility:collapse sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="c51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:collapse (with nested visibility:collapse sibling spans)" class="ex">x</button>
     <span id="c51">
         foo
         <span id="c52" style="visibility: collapse;">bar</span>
         <span id="c53" style="visibility: collapse;">baz</span>
     </span>
 
-    <button aria-labelledby="c61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with visibility:collapse (with nested visible sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="c61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with visibility:collapse (with nested visible sibling spans)" class="ex">x</button>
     <span id="c61" style="visibility: collapse;">
         foo
         <span id="c62" style="visibility: visible;">bar</span>
@@ -167,13 +167,13 @@
 
 <h2>Testing with <code>aria-hidden</code></h2>
 
-    <button aria-labelledby="d11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using aria-hidden span (with nested span)" class="ex"></button>>x</button>
+    <button aria-labelledby="d11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using aria-hidden span (with nested span)" class="ex">x</button>
     <span id="d11" aria-hidden="true">
         foo
         <span id="d12">bar</span>
     </span>
 
-    <button aria-labelledby="d21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="d21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden span (with nested spans, depth 2)" class="ex">x</button>
     <span id="d21" aria-hidden="true">
         foo
         <span id="d22">
@@ -182,7 +182,7 @@
         </span>
     </span>
 
-    <button aria-labelledby="d31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without aria-hidden (with nested aria-hidden spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="d31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without aria-hidden (with nested aria-hidden spans, depth 2)" class="ex">x</button>
     <span id="d31">
         foo
         <span id="d32" aria-hidden="true">
@@ -191,7 +191,7 @@
         </span>
     </span>
 
-    <button aria-labelledby="d41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden hidden span (with nested sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="d41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden hidden span (with nested sibling spans)" class="ex">x</button>
     <span id="d41" aria-hidden="true">
         foo
         <span id="d42">bar</span>
@@ -200,13 +200,13 @@
 
 <h2>Testing with <code>hidden</code> attribute</h2>
 
-    <button aria-labelledby="e11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using HTML5 hidden span (with nested span)" class="ex"></button>>x</button>
+    <button aria-labelledby="e11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using HTML5 hidden span (with nested span)" class="ex">x</button>
     <span id="e11" hidden>
         foo
         <span id="e12">bar</span>
     </span>
 
-    <button aria-labelledby="e21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using HTML5 hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="e21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using HTML5 hidden span (with nested spans, depth 2)" class="ex">x</button>
     <span id="e21" hidden>
         foo
         <span id="e22">
@@ -215,7 +215,7 @@
         </span>
     </span>
 
-    <button aria-labelledby="e31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without HTML5 hidden (with nested HTML5 hidden spans, depth 2)" class="ex"></button>>x</button>
+    <button aria-labelledby="e31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without HTML5 hidden (with nested HTML5 hidden spans, depth 2)" class="ex">x</button>
     <span id="e31">
         foo
         <span id="e32" hidden>
@@ -224,14 +224,14 @@
         </span>
     </span>
 
-    <button aria-labelledby="e41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using HTML5 hidden span (with nested hidden sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="e41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using HTML5 hidden span (with nested hidden sibling spans)" class="ex">x</button>
     <span id="e41" hidden>
         foo
         <span id="e42">bar</span>
         <span id="e43">baz</span>
     </span>
 
-    <button aria-labelledby="e51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without HTML5 hidden (with nested hidden sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="e51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without HTML5 hidden (with nested hidden sibling spans)" class="ex">x</button>
     <span id="e51">
         foo
         <span id="e52" hidden>bar</span>

--- a/accname/name/comp_labelledby_hidden_nodes.html
+++ b/accname/name/comp_labelledby_hidden_nodes.html
@@ -225,7 +225,7 @@
         foo
         <span id="e22" hidden>
             bar
-        <span id="e23" hidden>baz</span>
+            <span id="e23">baz</span>
         </span>
     </span>
 

--- a/accname/name/comp_labelledby_hidden_nodes.html
+++ b/accname/name/comp_labelledby_hidden_nodes.html
@@ -82,9 +82,9 @@
     <button aria-labelledby="b21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden hidden span (with nested visibility:hidden spans, depth 2)" class="ex"></button>>x</button>
     <span id="b21" style="visibility: hidden;">
         foo
-        <span id="b22" style="visibility: hidden;">
+        <span id="b22">
             bar
-        <span id="b23" style="visibility: hidden;">baz</span>
+            <span id="b23">baz</span>
         </span>
     </span>
 

--- a/accname/name/comp_labelledby_hidden_nodes.html
+++ b/accname/name/comp_labelledby_hidden_nodes.html
@@ -217,7 +217,7 @@
     <button aria-labelledby="e11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using HTML5 hidden span (with nested hidden span)" class="ex"></button>>x</button>
     <span id="e11" hidden>
         foo
-        <span id="e12" hidden>bar</span>
+        <span id="e12">bar</span>
     </span>
 
     <button aria-labelledby="e21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using HTML5 hidden span (with nested hidden spans, depth 2)" class="ex"></button>>x</button>

--- a/accname/name/comp_labelledby_hidden_nodes.html
+++ b/accname/name/comp_labelledby_hidden_nodes.html
@@ -75,40 +75,154 @@
     <button aria-labelledby="b21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
     <span id="b21" style="visibility: hidden;">
         foo
-        <span id="a22" style="visibility: hidden;">
+        <span id="b22" style="visibility: hidden;">
             bar
-        <span id="a23" style="visibility: hidden;">baz</span>
+        <span id="b23" style="visibility: hidden;">baz</span>
         </span>
     </span>
 
     <button aria-labelledby="b31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:hidden (with nested spans, depth 2)" class="ex"></button>>x</button>
     <span id="b31">
         foo
-        <span id="b32" style="visibility:hidden;">
+        <span id="b32" style="visibility: hidden;">
             bar
-        <span id="b33" style="visibility:hidden;">baz</span>
+        <span id="b33" style="visibility: hidden;">baz</span>
         </span>
     </span>
 
     <button aria-labelledby="b41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden hidden span (with nested sibling spans)" class="ex"></button>>x</button>
-    <span id="b41" style="visibility:hidden;">
+    <span id="b41" style="visibility: hidden;">
         foo
-        <span id="b42" style="visibility:hidden;">bar</span>
-        <span id="b43" style="visibility:hidden;">baz</span>
+        <span id="b42" style="visibility: hidden;">bar</span>
+        <span id="b43" style="visibility: hidden;">baz</span>
     </span>
 
-    <button aria-labelledby="b51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:hidden; (with nested sibling spans)" class="ex"></button>>x</button>
+    <button aria-labelledby="b51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:hidden (with nested sibling spans)" class="ex"></button>>x</button>
     <span id="b51">
         foo
-        <span id="b52" style="visibility:hidden;">bar</span>
-        <span id="b53" style="visibility:hidden;">baz</span>
+        <span id="b52" style="visibility: hidden;">bar</span>
+        <span id="b53" style="visibility: hidden;">baz</span>
     </span>
 
 <h2>Testing with <code>visibility:collapse</code></h2>
 
+    <button aria-labelledby="c11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using visibility:collapse span (with nested span)" class="ex"></button>>x</button>
+    <span id="c11" style="visibility: collapse;">
+        foo
+        <span id="c12" style="visibility: collapse;">bar</span>
+    </span>
+
+    <button aria-labelledby="c21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <span id="c21" style="visibility: collapse;">
+        foo
+        <span id="c22" style="visibility: collapse;">
+            bar
+        <span id="c23" style="visibility: collapse;">baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="c31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:collapse (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <span id="c31">
+        foo
+        <span id="c32" style="visibility: collapse;">
+            bar
+        <span id="c33" style="visibility: collapse;">baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="c41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse hidden span (with nested sibling spans)" class="ex"></button>>x</button>
+    <span id="c41" style="visibility: collapse;">
+        foo
+        <span id="c42" style="visibility: hidden;">bar</span>
+        <span id="c43" style="visibility: hidden;">baz</span>
+    </span>
+
+    <button aria-labelledby="c51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:collapse (with nested sibling spans)" class="ex"></button>>x</button>
+    <span id="c51">
+        foo
+        <span id="c52" style="visibility: collapse;">bar</span>
+        <span id="c53" style="visibility: collapse;">baz</span>
+    </span>
+
 <h2>Testing with <code>aria-hidden</code></h2>
 
+    <button aria-labelledby="d11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using aria-hidden span (with nested span)" class="ex"></button>>x</button>
+    <span id="d11" aria-hidden="true">
+        foo
+        <span id="d12" aria-hidden="true">bar</span>
+    </span>
+
+    <button aria-labelledby="d21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <span id="d21" aria-hidden="true">
+        foo
+        <span id="d22" aria-hidden="true">
+            bar
+        <span id="d23" aria-hidden="true">baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="d31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without aria-hidden (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <span id="d31">
+        foo
+        <span id="d32" aria-hidden="true">
+            bar
+        <span id="d33" aria-hidden="true">baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="d41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden hidden span (with nested sibling spans)" class="ex"></button>>x</button>
+    <span id="d41" style="visibility: collapse;">
+        foo
+        <span id="d42" aria-hidden="true">bar</span>
+        <span id="d43" aria-hidden="true">baz</span>
+    </span>
+
+    <button aria-labelledby="d51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without aria-hidden (with nested sibling spans)" class="ex"></button>>x</button>
+    <span id="d51">
+        foo
+        <span id="d52" aria-hidden="true">bar</span>
+        <span id="d53" aria-hidden="true">baz</span>
+    </span>
+
 <h2>Testing with <code>hidden</code> attribute</h2>
+
+    <button aria-labelledby="e11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using HTML5 hidden span (with nested span)" class="ex"></button>>x</button>
+    <span id="e11" hidden>
+        foo
+        <span id="e12" hidden>bar</span>
+    </span>
+
+    <button aria-labelledby="e21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using HTML5 hidden span (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <span id="e21" hidden>
+        foo
+        <span id="e22" hidden>
+            bar
+        <span id="e23" hidden>baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="e31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without HTML5 hidden (with nested spans, depth 2)" class="ex"></button>>x</button>
+    <span id="e31">
+        foo
+        <span id="e32" hidden>
+            bar
+        <span id="e33" hidden>baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="e41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using HTML5 hidden span (with nested sibling spans)" class="ex"></button>>x</button>
+    <span id="e41" hidden>
+        foo
+        <span id="e42" hidden>bar</span>
+        <span id="e43" hidden>baz</span>
+    </span>
+
+    <button aria-labelledby="e51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without HTML5 hidden (with nested sibling spans)" class="ex"></button>>x</button>
+    <span id="e51">
+        foo
+        <span id="e52" hidden>bar</span>
+        <span id="e53" hidden>baz</span>
+    </span>
 
 <script>
 AriaUtils.verifyLabelsBySelector(".ex");

--- a/accname/name/comp_labelledby_hidden_nodes.html
+++ b/accname/name/comp_labelledby_hidden_nodes.html
@@ -234,7 +234,7 @@
         foo
         <span id="e32" hidden>
             bar
-        <span id="e33" hidden>baz</span>
+            <span id="e33">baz</span>
         </span>
     </span>
 

--- a/accname/name/comp_labelledby_hidden_nodes.html
+++ b/accname/name/comp_labelledby_hidden_nodes.html
@@ -76,7 +76,7 @@
     <button aria-labelledby="b11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using visibility:hidden span (with nested visibility:hidden span)" class="ex"></button>>x</button>
     <span id="b11" style="visibility: hidden;">
         foo
-        <span id="b12" style="visibility: hidden;">bar</span>
+        <span id="b12">bar</span>
     </span>
 
     <button aria-labelledby="b21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden hidden span (with nested visibility:hidden spans, depth 2)" class="ex"></button>>x</button>


### PR DESCRIPTION
WPT test as an action item from accName comp step 2B note referenced in:

-  https://github.com/w3c/accname/issues/211.

Tests the following requirement in [comp_labelledby](https://w3c.github.io/accname/#comp_labelledby):

> The result of [LabelledBy Recursion](https://w3c.github.io/accname/#comp_labelledby_recursion) in combination with [Hidden Not Referenced](https://w3c.github.io/accname/#comp_hidden_not_referenced) means that [user agents](https://infra.spec.whatwg.org/#user-agent) MUST include all nodes in the subtree as part of the [accessible name](https://w3c.github.io/accname/#dfn-accessible-name) or [accessible description](https://w3c.github.io/accname/#dfn-accessible-description), when the node referenced by aria-labelledby or aria-describedby is hidden.

Closes: https://github.com/web-platform-tests/interop-accessibility/issues/77