### PR TITLE
replace img src=# with single pixel datauri

### DIFF
--- a/accname/name/comp_host_language_label.html
+++ b/accname/name/comp_host_language_label.html
@@ -16,7 +16,7 @@
 
 <h2>HTML input with value, alt, etc.</h2>
 <input type="button" value="button label" data-expectedlabel="button label" data-testname="html: input[type=button]" class="ex">
-<input type="image" src="#" alt="image input label" data-expectedlabel="image input label" data-testname="html: input[type=image]" class="ex">
+<input type="image" alt="image input label" data-expectedlabel="image input label" data-testname="html: input[type=image]" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 <input type="reset" value="reset label" data-expectedlabel="reset label" data-testname="html: input[type=reset]" class="ex">
 <input type="submit" value="submit label" data-expectedlabel="submit label" data-testname="html: input[type=submit]" class="ex">
 
@@ -117,10 +117,10 @@
 <h2>HTML img/picture</h2>
 <!-- skipped: img:not([alt]) -->
 <!-- skipped: img[alt=""] -->
-<img src="#" alt="image label" data-expectedlabel="image label" data-testname="html: img[alt] (non-empty)" class="ex">
+<img alt="image label" data-expectedlabel="image label" data-testname="html: img[alt] (non-empty)" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 <picture>
   <source srcset="#">
-  <img src="#" alt="picture label" data-expectedlabel="picture label" data-testname="html: picture > img[alt] (non-empty)" class="ex">
+  <img alt="picture label" data-expectedlabel="picture label" data-testname="html: picture > img[alt] (non-empty)" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 </picture>
 <!-- elsewhere: image map area alt -> ./fragile/area-alt.html -->
 

--- a/accname/name/comp_name_from_content.html
+++ b/accname/name/comp_name_from_content.html
@@ -136,16 +136,16 @@
 <br>
 
 <h1>simple for each child with image</h1>
-<button data-expectedlabel="one two three" data-testname="button name from content for each child including image" class="ex"><span>one</span> <img src="#" alt="two"> <span>three</span></button><br>
-<h3 data-expectedlabel="one two three" data-testname="heading name from content for each child including image" class="ex"><span>one</span> <img src="#" alt="two"> <span>three</span></h3>
-<a href="#" data-expectedlabel="one two three" data-testname="link name from content for each child including image" class="ex"><span>one</span> <img src="#" alt="two"> <span>three</span></a><br>
+<button data-expectedlabel="one two three" data-testname="button name from content for each child including image" class="ex"><span>one</span> <img alt="two" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="> <span>three</span></button><br>
+<h3 data-expectedlabel="one two three" data-testname="heading name from content for each child including image" class="ex"><span>one</span> <img alt="two" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="> <span>three</span></h3>
+<a href="#" data-expectedlabel="one two three" data-testname="link name from content for each child including image" class="ex"><span>one</span> <img alt="two" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="> <span>three</span></a><br>
 <br>
 
 
 <h1>simple for each child with extra nesting containing image</h1>
-<button data-expectedlabel="one two three four" data-testname="button name from content for each child including nested image" class="ex"><span>one</span> <span>two <img src="#" alt="three"></span> <span>four</span></button><br>
-<h3 data-expectedlabel="one two three four" data-testname="heading name from content for each child including nested image" class="ex"><span>one</span> <span>two <img src="#" alt="three"></span> <span>four</span></h3>
-<a href="#" data-expectedlabel="one two three four" data-testname="link name from content for each child including nested image" class="ex"><span>one</span> <span>two <img src="#" alt="three"></span> <span>four</span></a><br>
+<button data-expectedlabel="one two three four" data-testname="button name from content for each child including nested image" class="ex"><span>one</span> <span>two <img alt="three" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="></span> <span>four</span></button><br>
+<h3 data-expectedlabel="one two three four" data-testname="heading name from content for each child including nested image" class="ex"><span>one</span> <span>two <img alt="three" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="></span> <span>four</span></h3>
+<a href="#" data-expectedlabel="one two three four" data-testname="link name from content for each child including nested image" class="ex"><span>one</span> <span>two <img alt="three" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="></span> <span>four</span></a><br>
 <br>
 
 <h1>heading with nested button with nested image</h1>
@@ -153,7 +153,7 @@
   heading
   <button>
     button
-    <img src="#" alt="image">
+    <img alt="image" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
     button
   </button>
   heading
@@ -164,7 +164,7 @@
   heading
   <a href="#">
     link
-    <img src="#" alt="image">
+    <img alt="image" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
     link
   </a>
   heading
@@ -175,7 +175,7 @@
   heading
   <a href="#" aria-label="link aria-label"><!-- should skip the other link text -->
     ignored link text
-    <img id="nested_image_label_1" src="#" alt="ignored image alt">
+    <img id="nested_image_label_1" alt="ignored image alt" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
     ignored link text
   </a>
   heading
@@ -186,7 +186,7 @@
   heading
   <a href="#" aria-labelledby="nested_image_label1"><!-- should skip the other link text -->
     ignored link text
-    <img id="nested_image_label1" src="#" alt="image">
+    <img id="nested_image_label1" alt="image" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
     ignored link text
   </a>
   heading
@@ -199,7 +199,7 @@
   </a>
   <a href="#" data-expectedlabel="link2 image link3" data-testname="link name from content for each child including nested image (referenced elsewhere via labelledby)" class="ex">
     link2
-    <img id="nested_image_label2" src="#" alt="image">
+    <img id="nested_image_label2" alt="image" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
     <!-- image skipped in this link (when computing heading text) because it was already referenced by the first link within this heading label recursion cycle. -->
     <!-- but image not skipped when computing the text of the link itself since it has not been referenced in that context -->
     link3
@@ -213,7 +213,7 @@
     <span class="note" id="crossref_link">link</span><!-- this text is skipped the first time around because of aria-labelledby on parent element -->
   </a>
   <!-- but it's picked up again in inverse order b/c of cross-referencial aria-labelledby edge case -->
-  <img id="nested_image_label_3" src="#" alt="image" aria-labelledby="crossref_link">
+  <img id="nested_image_label_3" alt="image" aria-labelledby="crossref_link" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 </h3>
 
 <!-- self-referencial edge case-->
@@ -223,7 +223,7 @@
     <span class="note" id="crossref_link2">link</span><!-- this text is skipped the first time around because of aria-labelledby on parent element -->
   </a>
   <!-- but it's picked up again (after the self-referencial image alt) in inverse order b/c of cross-referencial aria-labelledby edge case -->
-  <img id="nested_image_label4" src="#" alt="image" aria-labelledby="nested_image_label4 crossref_link2">
+  <img id="nested_image_label4" alt="image" aria-labelledby="nested_image_label4 crossref_link2" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 </h3>
 
 

--- a/accname/name/comp_tooltip.html
+++ b/accname/name/comp_tooltip.html
@@ -13,7 +13,7 @@
 
 <p>Tests the <a href="https://w3c.github.io/accname/#comp_tooltip">#comp_tooltip</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
 
-<a href="#" title="label" data-expectedlabel="label" data-testname="link with img with tooltip label" class="ex"><img src="#" alt=""></a>
+<a href="#" title="label" data-expectedlabel="label" data-testname="link with img with tooltip label" class="ex"><img alt="" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="></a>
 <a href="#" title="label" data-expectedlabel="label" data-testname="link with text with tooltip label" class="ex">content</a>
 <div title="label" role="group" data-expectedlabel="label" data-testname="div with text with tooltip label" class="ex">content</div>
 <img src="foo.jpg" title="label" data-expectedlabel="label" data-testname="img with tooltip label without alt" class="ex">

--- a/html-aam/fragile/area-role.html
+++ b/html-aam/fragile/area-role.html
@@ -12,10 +12,10 @@
 <body>
 
 <map name="areamap">
-    <area shape="rect" coords="0,0,15,15" href="#" alt="x" data-testname="el-area" data-expectedrole="link" class="ex">
-    <area shape="rect" coords="15,15,31,31" alt="x" data-testname="el-area-no-href" class="ex-generic">
+  <area shape="rect" coords="0,0,15,15" href="#" alt="x" data-testname="el-area" data-expectedrole="link" class="ex">
+  <area shape="rect" coords="15,15,31,31" alt="x" data-testname="el-area-no-href" class="ex-generic">
 </map>
-<img usemap="#areamap" src="#" style="width: 32px; height: 32px;" alt="x">
+<img usemap="#areamap" style="width: 32px; height: 32px;" alt="x" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 
 <script>
 AriaUtils.verifyRolesBySelector(".ex");

--- a/html-aam/roles.html
+++ b/html-aam/roles.html
@@ -64,7 +64,7 @@
 <!-- todo: embed -->
 <fieldset data-testname="el-fieldset" data-expectedrole="group" class="ex"><legend>x</legend><input></fieldset>
 <!-- todo: figcaption -->
-<figure data-testname="el-figure" data-expectedrole="figure" class="ex"><img src="#" alt="x"><figcaption>x</figcaption></figure>
+<figure data-testname="el-figure" data-expectedrole="figure" class="ex"><img alt="x" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="><figcaption>x</figcaption></figure>
 <!-- footer -> ./roles-contextual.html -->
 <form data-testname="el-form" data-expectedrole="form" class="ex"><input></form>
 <!-- todo: form-associated custom element -->
@@ -85,11 +85,11 @@
 <!-- todo: html -->
 <!-- i -> ./roles-generic.html -->
 <!-- todo: iframe -->
-<img src="#" alt="x" data-testname="el-img" data-expectedrole="image" class="ex">
+<img alt="x" data-testname="el-img" data-expectedrole="image" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 
 <!-- Implementations might also be valid if ignored rather than returning 'none' for the following images. -->
-<img src="#" alt data-testname="el-img-alt-no-value" class="ex-generic">
-<img src="#" alt="" data-testname="el-img-empty-alt" class="ex-generic">
+<img alt data-testname="el-img-alt-no-value" class="ex-generic" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+<img alt="" data-testname="el-img-empty-alt" class="ex-generic" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 
 <input type="button" value="x" data-testname="el-input-button" data-expectedrole="button" class="ex">
 <input type="checkbox" data-testname="el-input-checkbox" data-expectedrole="checkbox" class="ex">


### PR DESCRIPTION
Closes https://github.com/web-platform-tests/interop-accessibility/issues/75

I gave a valid datauri image source to the other images in `html-aam` and `accname`, too. Just to further reduce the likelihood of spurious test errors. 