### PR TITLE
HTML: add more tentative <input type=checkbox switch> rendering tests

### DIFF
--- a/html/rendering/widgets/input-checkbox-switch-states-checked-disabled.tentative.html
+++ b/html/rendering/widgets/input-checkbox-switch-states-checked-disabled.tentative.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<link rel=mismatch href="input-checkbox-switch-states-rtl.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-rtl-checked.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-rtl-disabled.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-rtl-checked-disabled-ref.html">
+<input type=checkbox switch checked disabled>

--- a/html/rendering/widgets/input-checkbox-switch-states-checked.tentative.html
+++ b/html/rendering/widgets/input-checkbox-switch-states-checked.tentative.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<link rel=mismatch href="input-checkbox-switch-states-disabled.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-checked-disabled.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-rtl.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-rtl-checked.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-rtl-disabled.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-rtl-checked-disabled-ref.html">
+<input type=checkbox switch checked>

--- a/html/rendering/widgets/input-checkbox-switch-states-disabled.tentative.html
+++ b/html/rendering/widgets/input-checkbox-switch-states-disabled.tentative.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<link rel=mismatch href="input-checkbox-switch-states-checked-disabled.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-rtl.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-rtl-checked.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-rtl-disabled.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-rtl-checked-disabled-ref.html">
+<input type=checkbox switch disabled>

--- a/html/rendering/widgets/input-checkbox-switch-states-rtl-checked-disabled-ref.html
+++ b/html/rendering/widgets/input-checkbox-switch-states-rtl-checked-disabled-ref.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<input type=checkbox switch dir=rtl checked disabled>

--- a/html/rendering/widgets/input-checkbox-switch-states-rtl-checked.tentative.html
+++ b/html/rendering/widgets/input-checkbox-switch-states-rtl-checked.tentative.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<link rel=mismatch href="input-checkbox-switch-states-rtl-disabled.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-rtl-checked-disabled-ref.html">
+<input type=checkbox switch dir=rtl checked>

--- a/html/rendering/widgets/input-checkbox-switch-states-rtl-disabled.tentative.html
+++ b/html/rendering/widgets/input-checkbox-switch-states-rtl-disabled.tentative.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<link rel=mismatch href="input-checkbox-switch-states-rtl-checked-disabled-ref.html">
+<input type=checkbox switch dir=rtl disabled>

--- a/html/rendering/widgets/input-checkbox-switch-states-rtl.tentative.html
+++ b/html/rendering/widgets/input-checkbox-switch-states-rtl.tentative.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<link rel=mismatch href="input-checkbox-switch-states-rtl-checked.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-rtl-disabled.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-rtl-checked-disabled-ref.html">
+<input type=checkbox switch dir=rtl>

--- a/html/rendering/widgets/input-checkbox-switch-states.tentative.html
+++ b/html/rendering/widgets/input-checkbox-switch-states.tentative.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<title>Checkbox with switch attribute has a unique look</title>
+<link rel=mismatch href="input-checkbox-switch-states-checkbox.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-disabled.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-checked-disabled.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-rtl.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-rtl-checked.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-rtl-disabled.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-rtl-checked-disabled-ref.html">
+<input type=checkbox switch>

--- a/html/rendering/widgets/input-checkbox-switch-states.tentative.html
+++ b/html/rendering/widgets/input-checkbox-switch-states.tentative.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>Checkbox with switch attribute has a unique look</title>
-<link rel=mismatch href="input-checkbox-switch-states-checkbox.tentative.html">
+<link rel=mismatch href="input-checkbox-switch-states-checked.tentative.html">
 <link rel=mismatch href="input-checkbox-switch-states-disabled.tentative.html">
 <link rel=mismatch href="input-checkbox-switch-states-checked-disabled.tentative.html">
 <link rel=mismatch href="input-checkbox-switch-states-rtl.tentative.html">


### PR DESCRIPTION
This should ensure that none of the 8 (testable) state variants are a match for each other.