### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=264532

### DIFF
--- a/css/css-writing-modes/forms/checkbox-appearance-native-vertical-lr-baseline.optional-ref.html
+++ b/css/css-writing-modes/forms/checkbox-appearance-native-vertical-lr-baseline.optional-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Test baseline alignment of checkboxes in vertical-lr writing mode.</title>
+<meta charset="utf-8">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+input {
+    visibility: hidden;
+}
+
+</style>
+<p>The checkbox should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-lr">
+    <input type="checkbox" id="checkbox" checked>
+    <label for="checkbox">こんにちわ</label>
+</div>

--- a/css/css-writing-modes/forms/checkbox-appearance-native-vertical-lr-baseline.optional.html
+++ b/css/css-writing-modes/forms/checkbox-appearance-native-vertical-lr-baseline.optional.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#checkbox-state-(type=checkbox)">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Test baseline alignment of checkboxes in vertical-lr writing mode.</title>
+<meta charset="utf-8">
+<link rel="match" href="checkbox-appearance-native-vertical-lr-baseline.optional-ref.html">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+</style>
+<p>The checkbox should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-lr">
+    <input type="checkbox" id="checkbox" checked>
+    <label for="checkbox">こんにちわ</label>
+</div>

--- a/css/css-writing-modes/forms/checkbox-appearance-native-vertical-rl-baseline.optional-ref.html
+++ b/css/css-writing-modes/forms/checkbox-appearance-native-vertical-rl-baseline.optional-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Test baseline alignment of checkboxes in vertical-rl writing mode.</title>
+<meta charset="utf-8">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+input {
+    visibility: hidden;
+}
+
+</style>
+<p>The checkbox should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-rl">
+    <input type="checkbox" id="checkbox" checked>
+    <label for="checkbox">こんにちわ</label>
+</div>

--- a/css/css-writing-modes/forms/checkbox-appearance-native-vertical-rl-baseline.optional.html
+++ b/css/css-writing-modes/forms/checkbox-appearance-native-vertical-rl-baseline.optional.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#checkbox-state-(type=checkbox)">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Test baseline alignment of checkboxes in vertical-rl writing mode.</title>
+<meta charset="utf-8">
+<link rel="match" href="checkbox-appearance-native-vertical-rl-baseline.optional-ref.html">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+</style>
+<p>The checkbox should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-rl">
+    <input type="checkbox" id="checkbox" checked>
+    <label for="checkbox">こんにちわ</label>
+</div>

--- a/css/css-writing-modes/forms/radio-appearance-native-vertical-lr-baseline.optional-ref.html
+++ b/css/css-writing-modes/forms/radio-appearance-native-vertical-lr-baseline.optional-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Test baseline alignment of radio buttons in vertical-lr writing mode.</title>
+<meta charset="utf-8">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+input {
+    visibility: hidden;
+}
+
+</style>
+<p>The radio button should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-lr">
+    <input type="radio" id="radio" checked>
+    <label for="radio">こんにちわ</label>
+</div>

--- a/css/css-writing-modes/forms/radio-appearance-native-vertical-lr-baseline.optional.html
+++ b/css/css-writing-modes/forms/radio-appearance-native-vertical-lr-baseline.optional.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#radio-button-state-(type=radio)">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Test baseline alignment of radio buttons in vertical-lr writing mode.</title>
+<meta charset="utf-8">
+<link rel="match" href="radio-appearance-native-vertical-lr-baseline.optional-ref.html">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+</style>
+<p>The radio button should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-lr">
+    <input type="radio" id="radio" checked>
+    <label for="radio">こんにちわ</label>
+</div>

--- a/css/css-writing-modes/forms/radio-appearance-native-vertical-rl-baseline.optional-ref.html
+++ b/css/css-writing-modes/forms/radio-appearance-native-vertical-rl-baseline.optional-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Test baseline alignment of radio buttons in vertical-rl writing mode.</title>
+<meta charset="utf-8">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+input {
+    visibility: hidden;
+}
+
+</style>
+<p>The radio button should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-rl">
+    <input type="radio" id="radio" checked>
+    <label for="radio">こんにちわ</label>
+</div>

--- a/css/css-writing-modes/forms/radio-appearance-native-vertical-rl-baseline.optional.html
+++ b/css/css-writing-modes/forms/radio-appearance-native-vertical-rl-baseline.optional.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#radio-button-state-(type=radio)">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Test baseline alignment of radio buttons in vertical-rl writing mode.</title>
+<meta charset="utf-8">
+<link rel="match" href="radio-appearance-native-vertical-rl-baseline.optional-ref.html">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+</style>
+<p>The radio button should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-rl">
+    <input type="radio" id="radio" checked>
+    <label for="radio">こんにちわ</label>
+</div>


### PR DESCRIPTION
WebKit export from bug: [\[Cocoa\] Baseline alignment of checkboxes and radio buttons is incorrect in vertical writing mode](https://bugs.webkit.org/show_bug.cgi?id=264532)