### PR TITLE
The transform svg property is not allowed on <tspan>

### DIFF
--- a/css/css-contain/content-visibility/content-visibility-svg-text.html
+++ b/css/css-contain/content-visibility/content-visibility-svg-text.html
@@ -9,14 +9,14 @@ body {
   margin: 0;
   padding: 0;
 }
-div {
+#container {
   content-visibility:hidden;
 }
 </style>
 
-<div>
+<div id="container">
   <svg xmlns="http://www.w3.org/2000/svg">
-    <text><tspan id="tspan1" x="50 150 100" y="100" transform="scale(2, 2)">abc</tspan></text>
+    <text transform="scale(2, 2)"><tspan id="tspan1" x="50 150 100" y="100">abc</tspan></text>
   </svg>
 </div>
 


### PR DESCRIPTION
Property transform is not allowed on tspan svg element, move it to the parent node (text svg element). And set c-v: hidden to `#container` only, otherwise it will hide the test result table.