### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=264617

### DIFF
--- a/css/css-writing-modes/forms/date-input-appearance-native-computed-style.html
+++ b/css/css-writing-modes/forms/date-input-appearance-native-computed-style.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes/#block-flow">
+<title>Date input appearance native writing mode computed style</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<input type="date" id="horizontal-empty">
+<input type="date" id="horizontal-with-value" value="2023-11-10">
+<input type="date" id="vertical-lr-empty" style="writing-mode: vertical-lr">
+<input type="date" id="vertical-lr-with-value" value="2023-11-10" style="writing-mode: vertical-lr">
+<input type="date" id="vertical-rl-empty" style="writing-mode: vertical-rl">
+<input type="date" id="vertical-rl-with-value" value="2023-11-10" style="writing-mode: vertical-rl">
+
+<script>
+for (const element of document.querySelectorAll("[id^='horizontal-']")) {
+    test(() => {
+        const style = getComputedStyle(element);
+        const blockSize = parseInt(style.blockSize, 10);
+        const inlineSize = parseInt(style.inlineSize, 10);
+        assert_not_equals(blockSize, 0);
+        assert_not_equals(inlineSize, 0);
+        assert_greater_than(inlineSize, blockSize);
+        assert_equals(style.blockSize, style.height);
+        assert_equals(style.inlineSize, style.width);
+    }, `${element.id} block size should match height and inline size should match width`);
+}
+
+for (const element of document.querySelectorAll("[id^='vertical-']")) {
+    test(() => {
+        const style = getComputedStyle(element);
+        const blockSize = parseInt(style.blockSize, 10);
+        const inlineSize = parseInt(style.inlineSize, 10);
+        assert_not_equals(blockSize, 0);
+        assert_not_equals(inlineSize, 0);
+        assert_greater_than(inlineSize, blockSize);
+        assert_equals(style.blockSize, style.width);
+        assert_equals(style.inlineSize, style.height);
+    }, `${element.id} block size should match width and inline size should match height`);
+}
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[iOS\] Fix appearance of date inputs in vertical writing mode](https://bugs.webkit.org/show_bug.cgi?id=264617)