### PR TITLE
Remove unused references to utils.js from content-visibility tests

### DIFF
--- a/css/css-contain/content-visibility/content-visibility-019.sub.https.html
+++ b/css/css-contain/content-visibility/content-visibility-019.sub.https.html
@@ -6,7 +6,6 @@
 <link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
 <link rel="match" href="content-visibility-019-ref.html">
 <script src="/common/reftest-wait.js"></script>
-<script src="../resources/utils.js"></script>
 
 <style>
 div {

--- a/css/css-contain/content-visibility/content-visibility-020.html
+++ b/css/css-contain/content-visibility/content-visibility-020.html
@@ -8,7 +8,6 @@
 <meta name="assert" content="content-visibility hidden iframe does not paint">
 
 <script src="/common/reftest-wait.js"></script>
-<script src="../resources/utils.js"></script>
 
 <style>
 div {

--- a/css/css-contain/content-visibility/content-visibility-028.html
+++ b/css/css-contain/content-visibility/content-visibility-028.html
@@ -8,7 +8,6 @@
 <meta name="assert" content="content-visibility hidden can be used in a shadow DOM">
 
 <script src="/common/reftest-wait.js"></script>
-<script src="resources/utils.js"></script>
 
 <style>
 .hidden {

--- a/css/css-contain/content-visibility/content-visibility-029.html
+++ b/css/css-contain/content-visibility/content-visibility-029.html
@@ -8,7 +8,6 @@
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="resources/utils.js"></script>
 
 This text should be visible.
 <div id="container" style="content-visibility: hidden">

--- a/css/css-contain/content-visibility/content-visibility-040.html
+++ b/css/css-contain/content-visibility/content-visibility-040.html
@@ -8,7 +8,6 @@
 <meta name="assert" content="content-visibility hidden flex and abspos descendants don't paint">
 
 <script src="/common/reftest-wait.js"></script>
-<script src="resources/utils.js"></script>
 
 <style>
 #container {

--- a/css/css-contain/content-visibility/content-visibility-049.html
+++ b/css/css-contain/content-visibility/content-visibility-049.html
@@ -8,7 +8,6 @@
 <meta name="assert" content="content-visibility auto subtrees respond to anchor links">
 
 <script src="/common/reftest-wait.js"></script>
-<script src="../resources/utils.js"></script>
 
 <style>
 .spacer {

--- a/css/css-contain/content-visibility/content-visibility-086.html
+++ b/css/css-contain/content-visibility/content-visibility-086.html
@@ -8,7 +8,6 @@
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="resources/utils.js"></script>
 
 <div id="container">
 This text should be visible.

--- a/css/css-contain/content-visibility/content-visibility-animation-and-scroll.html
+++ b/css/css-contain/content-visibility/content-visibility-animation-and-scroll.html
@@ -7,7 +7,6 @@
 <meta name="assert" content="animations in content-visibility: auto subtree should restart when scrolled to">
 
 <script src="/common/reftest-wait.js"></script>
-<script src="../resources/utils.js"></script>
 
 <style>
 #container {

--- a/css/css-contain/content-visibility/content-visibility-animation-becomes-visible.html
+++ b/css/css-contain/content-visibility/content-visibility-animation-becomes-visible.html
@@ -7,7 +7,6 @@
 <meta name="assert" content="animations in content-visibility: hidden subtree should restart once visible">
 
 <script src="/common/reftest-wait.js"></script>
-<script src="../resources/utils.js"></script>
 
 <style>
 #container {

--- a/css/css-contain/content-visibility/content-visibility-auto-nested-scroll.html
+++ b/css/css-contain/content-visibility/content-visibility-auto-nested-scroll.html
@@ -8,7 +8,6 @@
 <meta name="assert" content="content in nested `content-visibility: auto` element can be scrolled to">
 
 <script src="/common/reftest-wait.js"></script>
-<script src="../resources/utils.js"></script>
 
 <style>
 div {

--- a/css/css-contain/content-visibility/content-visibility-auto-nested.html
+++ b/css/css-contain/content-visibility/content-visibility-auto-nested.html
@@ -8,7 +8,6 @@
 <meta name="assert" content="content in nested `content-visibility: auto` elements is considered relevant">
 
 <script src="/common/reftest-wait.js"></script>
-<script src="../resources/utils.js"></script>
 
 <style>
 div {


### PR DESCRIPTION
The following files don't exist:

css/css-contain/resources/utils.js
css/css-contain/content-visibility/resources/utils.js