### PR TITLE
Handle exception thrown in caretPositionFromPoint-with-transformation.html

### DIFF
--- a/css/cssom/caretPositionFromPoint-with-transformation.html
+++ b/css/cssom/caretPositionFromPoint-with-transformation.html
@@ -25,14 +25,18 @@
       return [rect.x + rect.width / 2, rect.y + rect.height / 2];
     };
 
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       frame.srcdoc = source;
       frame.onload = () => {
-        const frameDoc = frame.contentDocument;
-        const {offset} = frameDoc.caretPositionFromPoint(
-          ...elementCenter(frameDoc.querySelector("h1"))
-        );
-        resolve(offset);
+        try {
+          const frameDoc = frame.contentDocument;
+          const {offset} = frameDoc.caretPositionFromPoint(
+            ...elementCenter(frameDoc.querySelector("h1"))
+          );
+          resolve(offset);
+        } catch (error) {
+          reject(error);
+        }
       };
     });
   };


### PR DESCRIPTION
The handled exception results in a harness error and timeout instead of failing the test quickly: https://wpt.fyi/results/css/cssom/caretPositionFromPoint-with-transformation.html?label=master&label=experimental&aligned