### PR TITLE
Reduce flakiness of active-lock.html using about:blank

### DIFF
--- a/screen-orientation/active-lock.html
+++ b/screen-orientation/active-lock.html
@@ -5,8 +5,10 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<p id="#fragment"></p>
-<a href="#fragment">fragment</a>
+<body>
+  <p id="fragment"></p>
+  <a href="#fragment">fragment</a>
+</body>
 <script type="module">
   import {
     attachIframe,
@@ -25,31 +27,29 @@
   }, "Performing a fragment navigation must not abort the screen orientation change");
 
   promise_test(async (t) => {
-    t.add_cleanup(makeCleanup());
-    const iframe = await attachIframe();
-    iframe.contentDocument.body.innerHTML = `
-      <p id="#fragment"></p>
-      <a href="#fragment">fragment</a>
-    `;
-    await test_driver.bless("request full screen");
-    await document.documentElement.requestFullscreen();
+    const iframe = await attachIframe({ src: "./resources/nav_iframe.html" });
+    t.add_cleanup(makeCleanup(iframe));
+    await test_driver.bless("request full screen", null, iframe.contentWindow);
+    await iframe.contentDocument.documentElement.requestFullscreen();
     const orientation = getOppositeOrientation();
     const p = iframe.contentWindow.screen.orientation.lock(orientation);
-    await test_driver.click(iframe.contentDocument.querySelector("a"));
+    const anchor = iframe.contentDocument.querySelector("#clickme");
+    await test_driver.click(anchor);
     await p;
-    iframe.remove();
   }, "Performing a fragment navigation within an iframe must not abort the lock promise");
 
   promise_test(async (t) => {
-    t.add_cleanup(makeCleanup());
     const iframe = await attachIframe();
-    await test_driver.bless("request full screen");
-    await document.documentElement.requestFullscreen();
+    t.add_cleanup(makeCleanup(iframe));
+    await test_driver.bless("request full screen", null, iframe.contentWindow);
+    await iframe.contentDocument.documentElement.requestFullscreen();
     const orientation = getOppositeOrientation();
-    const p = iframe.contentWindow.screen.orientation.lock(orientation);
+    const lockPromise = iframe.contentWindow.screen.orientation.lock(orientation);
     const frameDOMException = iframe.contentWindow.DOMException;
-    iframe.contentWindow.location.href = "./resources/empty.html";
-    await promise_rejects_dom(t, "AbortError", frameDOMException, p);
-    iframe.remove();
+    await new Promise((r) => {
+      iframe.addEventListener("load", r, { once: true });
+      iframe.contentWindow.location.href = "about:blank";
+    });
+    await promise_rejects_dom(t, "AbortError", frameDOMException, lockPromise);
   }, "Unloading an iframe by navigating it must abort the lock promise");
 </script>

--- a/screen-orientation/resources/nav_iframe.html
+++ b/screen-orientation/resources/nav_iframe.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>A Document</title>
+</head>
+<body>
+  <h1 id="section1">Section 1</h1>
+  <p>This is the content of section 1.</p>
+
+  <h2 id="section2">Section 2</h2>
+  <p>This is the content of section 2.</p>
+
+  <p>
+    <a href="#section1">Go to Section 1</a> |
+    <a id="clickme" href="#section2">Go to Section 2</a>
+  </p>
+</body>
+</html>


### PR DESCRIPTION
The promise could resolve before the "empty.html" loaded. Using "about:blank" achieves the same thing, but prevents the flakiness from happening on WebKit at least.  