### PR TITLE
fix: streams/readable-byte-streams/non-transferable-buffers.any.js use minimum read instead of fill

### DIFF
--- a/streams/readable-byte-streams/non-transferable-buffers.any.js
+++ b/streams/readable-byte-streams/non-transferable-buffers.any.js
@@ -22,7 +22,7 @@ promise_test(async t => {
   const reader = rs.getReader({ mode: 'byob' });
   const memory = new WebAssembly.Memory({ initial: 1 });
   const view = new Uint8Array(memory.buffer, 0, 1);
-  await promise_rejects_js(t, TypeError, reader.fill(view));
+  await promise_rejects_js(t, TypeError, reader.read(view, { min: 1 }));
 }, 'ReadableStream with byte source: fill() with a non-transferable buffer');
 
 test(t => {


### PR DESCRIPTION
The fill method was the previous iteration of the spec, the final iteration has a `min` option on the read method instead.