### PR TITLE
Reconcile `observable-constructor.any.js`

### DIFF
--- a/dom/observable/tentative/observable-constructor.any.js
+++ b/dom/observable/tentative/observable-constructor.any.js
@@ -101,27 +101,38 @@ test(() => {
   const error = new Error("error");
   const results = [];
   let errorReported = null;
+  let innerSubscriber = null;
+  let subscriptionActivityInFinallyAfterThrow;
+  let subscriptionActivityInErrorHandlerAfterThrow;
 
   self.addEventListener("error", e => errorReported = e, {once: true});
 
   const source = new Observable((subscriber) => {
+    innerSubscriber = subscriber;
     subscriber.next(1);
-    throw error;
-    // TODO(https://github.com/WICG/observable/issues/76): If we add the
-    // `subscriber.closed` attribute, consider a try-finally block to assert
-    // that `subscriber.closed` is true after throwing. Also TODO: ensure that
-    // that would even be the right behavior.
+    try {
+      throw error;
+    } finally {
+      subscriptionActivityInFinallyAfterThrow = subscriber.active;
+    }
   });
 
   source.subscribe({
     next: (x) => results.push(x),
-    error: (e) => results.push(e),
+    error: (e) => {
+      subscriptionActivityInErrorHandlerAfterThrow = innerSubscriber.active;
+      results.push(e);
+    },
     complete: () => assert_unreached("complete should not be called"),
   });
 
   assert_equals(errorReported, null, "The global error handler should not be " +
       "invoked when the subscribe callback throws an error and the " +
       "subscriber has given an error handler");
+  assert_true(subscriptionActivityInFinallyAfterThrow, "Subscriber is " +
+      "considered active in finally block before error handler is invoked");
+  assert_false(subscriptionActivityInErrorHandlerAfterThrow, "Subscriber is " +
+      "considered inactive in error handler block after thrown error");
   assert_array_equals(
     results,
     [1, error],
@@ -129,14 +140,64 @@ test(() => {
   );
 }, "Observable should error if initializer throws");
 
-// TODO(https://github.com/WICG/observable/issues/76): If we decide the
-// `subscriber.closed` attribute is needed, re-visit these two tests that were
-// originally included:
-// https://github.com/web-platform-tests/wpt/blob/0246526ca46ef4e5eae8b8e4a87dd905c40f5326/dom/observable/tentative/observable-ctor.any.js#L123-L137.
+test(t => {
+  let innerSubscriber = null;
+  let activeAfterComplete = false;
+  let activeDuringComplete = false;
 
-// TODO(domfarolino): Add a test asserting that `Subscriber#signal` != the
-// actual `AbortSignal` passed into `subscribe()`. See
-// https://github.com/web-platform-tests/wpt/pull/42219#discussion_r1361243283.
+  const source = new Observable((subscriber) => {
+    innerSubscriber = subscriber;
+
+    subscriber.complete();
+    activeAfterComplete = subscriber.active;
+  });
+
+  source.subscribe({complete: () => activeDuringComplete = innerSubscriber.active});
+  assert_false(activeDuringComplete, "Subscription is not active during complete");
+  assert_false(activeAfterComplete, "Subscription is not active after complete");
+}, "Subscription is inactive after complete()");
+
+test(t => {
+  let innerSubscriber = null;
+  let activeAfterError = false;
+  let activeDuringError = false;
+
+  const error = new Error("error");
+  const source = new Observable((subscriber) => {
+    innerSubscriber = subscriber;
+
+    subscriber.error(error);
+    activeAfterError = subscriber.active;
+  });
+
+  source.subscribe({error: () => activeDuringError = innerSubscriber.active});
+  assert_false(activeDuringError, "Subscription is not active during error");
+  assert_false(activeAfterError, "Subscription is not active after error");
+}, "Subscription is inactive after error()");
+
+test(t => {
+  let initialActivity;
+
+  const source = new Observable((subscriber) => {
+    initialActivity = subscriber.active;
+  });
+
+  const ac = new AbortController();
+  ac.abort();
+  source.subscribe({signal: ac.signal});
+  assert_false(initialActivity);
+}, "Subscription is inactive when aborted signal is passed in");
+
+test(() => {
+  let outerSubscriber = null;
+
+  const source = new Observable(subscriber => outerSubscriber = subscriber);
+
+  const controller = new AbortController();
+  source.subscribe({signal: controller.signal});
+
+  assert_not_equals(controller.signal, outerSubscriber.signal);
+}, "Subscriber#signal is not the same AbortSignal as the one passed into `subscribe()`");
 
 test(() => {
   const results = [];
@@ -395,6 +456,112 @@ test(() => {
   assert_equals(errorReported.error, error2, "Error object is equivalent");
 }, "Errors pushed by initializer function after subscriber is closed by " +
    "error are reported");
+
+test(() => {
+  const results = [];
+  const target = new EventTarget();
+
+  const source = new Observable((subscriber) => {
+    target.addEventListener('custom event', e => {
+      subscriber.next(1);
+      subscriber.complete();
+      subscriber.error('not a real error');
+    });
+  });
+
+  source.subscribe({
+    next: (x) => results.push(x),
+    error: (error) => results.push(error),
+    complete: () => {
+      results.push('complete'),
+      // Re-entrantly tries to invoke `complete()`. However, this function must
+      // only ever run once.
+      target.dispatchEvent(new Event('custom event'));
+    },
+  });
+
+  target.dispatchEvent(new Event('custom event'));
+
+  assert_array_equals(
+    results,
+    [1, 'complete'],
+    "complete() can only be called once, and cannot invoke other Observer methods"
+  );
+}, "Subscriber#complete() cannot re-entrantly invoke itself");
+
+test(() => {
+  const results = [];
+  const target = new EventTarget();
+
+  const source = new Observable((subscriber) => {
+    target.addEventListener('custom event', e => {
+      subscriber.next(1);
+      subscriber.error('not a real error');
+      subscriber.complete();
+    });
+  });
+
+  source.subscribe({
+    next: (x) => results.push(x),
+    error: (error) => {
+      results.push('error'),
+      // Re-entrantly tries to invoke `error()`. However, this function must
+      // only ever run once.
+      target.dispatchEvent(new Event('custom event'));
+    },
+    complete: () => results.push('complete'),
+  });
+
+  target.dispatchEvent(new Event('custom event'));
+
+  assert_array_equals(
+    results,
+    [1, 'error'],
+    "error() can only be called once, and cannot invoke other Observer methods"
+  );
+}, "Subscriber#error() cannot re-entrantly invoke itself");
+
+// TODO(domfarolino): Once `Subscriber#addTeardown()` and `Subscriber#active`
+// are implemented, add corresponding code for them here so we can assert the following order of everything:
+//   1. The passed-in `Observer#signal` is marked as `aborted`
+//   2. Abort event handlers are invoked for the that outer, passed-in signal.
+//   3. `Subscriber#closed` is true
+//   4. `Subscriber#signal` is marked as aborted
+//   5. Teardown callbacks are executed in the right order
+//   6. Abort event handlers are invoked for `Subscriber#signal`.
+// This ensures we have the "dependent signal" logic wired up correctly:
+// https://dom.spec.whatwg.org/#create-a-dependent-abort-signal.
+test(() => {
+  const results = [];
+  let innerSubscriber = null;
+
+  const source = new Observable((subscriber) => {
+    results.push('subscribe() callback');
+    innerSubscriber = subscriber;
+
+    subscriber.signal.addEventListener('abort', () => {
+      assert_true(subscriber.signal.aborted);
+      subscriber.next('inner abort handler');
+    });
+  });
+
+  const ac = new AbortController();
+  source.subscribe({
+    next: (x) => results.push(x),
+    signal: ac.signal,
+  });
+
+  ac.signal.addEventListener('abort', () => {
+    results.push('outer abort handler');
+    assert_true(ac.signal.aborted);
+    assert_false(innerSubscriber.signal.aborted);
+  });
+
+  assert_array_equals(results, ['subscribe() callback']);
+  ac.abort();
+  assert_array_equals(results, ['subscribe() callback',
+      'outer abort handler', 'inner abort handler']);
+}, "Unsubscription lifecycle");
 
 // TODO(domfarolino): If we add `subscriber.closed`, assert that its value is
 // `true` in this test. See https://github.com/WICG/observable/issues/76.


### PR DESCRIPTION
This patch reconciles changes to `observable-constructor.any.js` that caused the history in Chromium and WPT to diverge. The affected Chromium-side patches are:
1. https://chromium.googlesource.com/chromium/src/+/5555cc26ff
2. https://chromium.googlesource.com/chromium/src/+/d8edde7956
3. https://chromium.googlesource.com/chromium/src/+/76a7e3bdba

Metadata for the @chromium-wpt-export-bot:
Change-Id: I4ef9ab438e59326a49bd6561108b3bcc736845a5
Change-Id: If86b3f925687bea9046b7fc95b42dc5ece800325
Change-Id: I4604a80347ff30ff7be44a131bfdd3999b71252a