### PR TITLE
Add tests for https://github.com/w3c/webrtc-pc/pull/2691

### DIFF
--- a/webrtc/RTCConfiguration-rtcpMuxPolicy.html
+++ b/webrtc/RTCConfiguration-rtcpMuxPolicy.html
@@ -116,6 +116,15 @@
 
   test(() => {
     let pc;
+    pc = new RTCPeerConnection({ rtcpMuxPolicy: 'require' });
+    // default rtcpMuxPolicy is 'require', so this is allowed
+    pc.setConfiguration({});
+    assert_equals(pc.getConfiguration().rtcpMuxPolicy, 'require');
+  }, `setConfiguration({}) with initial rtcpMuxPolicy require should leave rtcpMuxPolicy to require`);
+
+  
+  test(() => {
+    let pc;
     try {
       pc = new RTCPeerConnection({ rtcpMuxPolicy: 'negotiate' });
     } catch(err) {

--- a/webrtc/RTCConfiguration-rtcpMuxPolicy.html
+++ b/webrtc/RTCConfiguration-rtcpMuxPolicy.html
@@ -122,7 +122,6 @@
     assert_equals(pc.getConfiguration().rtcpMuxPolicy, 'require');
   }, `setConfiguration({}) with initial rtcpMuxPolicy require should leave rtcpMuxPolicy to require`);
 
-  
   test(() => {
     let pc;
     try {


### PR DESCRIPTION
https://github.com/web-platform-tests/wpt/blob/8347f5b483e3b713443d06638d3662457107b3b0/webrtc/RTCConfiguration-bundlePolicy.html#L67 already tests it for `bundlePolicy`
https://github.com/web-platform-tests/wpt/blob/8347f5b483e3b713443d06638d3662457107b3b0/webrtc/RTCConfiguration-iceTransportPolicy.html#L84C5-L84C68 tests it for `iceTransportPolicy`
This adds the relevant test for `rtcpMuxPolicy`