### PR TITLE
Stop sending " " to linebreaker for replaced content

### DIFF
--- a/css/CSS2/linebox/soft-wrap-opportunity-after-replaced-content-crash.html
+++ b/css/CSS2/linebox/soft-wrap-opportunity-after-replaced-content-crash.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <link rel="help" href="https://github.com/servo/servo/issues/30703">
+    <link rel="author" href="mailto:mrobinson@igalia.com">
+    <body>
+        <br><img>&nbsp;
+    </body>
+</html>
+


### PR DESCRIPTION
We previously sent a " " to the linebreaker in order to ensure that the
next text had a soft wrap opportunity at the start. Calling `next(" ")`
without waiting until the returned index was 1, violated some
invariants of linebreaker ultimately causing a panic.

Instead of using the linebreaker for this, simply keep a flag in the
IFC layout state, which avoids the problem entirely. This also fixes
some issues with linebreaking before character classes that should
not offer soft-wrap opportunities.

Fixes #<!-- nolink -->30703.

<!-- Please describe your changes on the following line: -->

Reviewed in servo/servo#30740