### PR TITLE
Partially revert "Implement parseHTMLUnsafe and setHTMLUnsafe"

### DIFF
--- a/shadow-dom/declarative/declarative-shadow-dom-attachment.html
+++ b/shadow-dom/declarative/declarative-shadow-dom-attachment.html
@@ -19,7 +19,7 @@ function addDeclarativeShadowRoot(elementType, mode, delegatesFocus) {
   const declarativeString = `<${elementType} id=theelement>${getDeclarativeContent(mode, delegatesFocus)}
      <span class='lightdom'>${lightDomTextContent}</span></${elementType}>`;
   const wrapper = document.createElement('div');
-  wrapper.setHTMLUnsafe(declarativeString);
+  setInnerHTML(wrapper, declarativeString);
   const element = wrapper.querySelector('#theelement');
   return {wrapper: wrapper, element: element};
 }

--- a/shadow-dom/declarative/declarative-shadow-dom-basic.html
+++ b/shadow-dom/declarative/declarative-shadow-dom-basic.html
@@ -5,6 +5,7 @@
 <link rel="help" href="https://github.com/whatwg/dom/issues/831">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="support/helpers.js"></script>
 
 <div id="host" style="display:none">
   <template shadowrootmode="open">
@@ -56,7 +57,7 @@ test(() => {
 
 test(() => {
   const div = document.createElement('div');
-  div.setHTMLUnsafe(`
+  setInnerHTML(div,`
     <div id="host">
       <template shadowrootmode="open">
         <slot id="s1" name="slot1"></slot>
@@ -77,7 +78,7 @@ test(() => {
 
 test(() => {
   const div = document.createElement('div');
-  div.setHTMLUnsafe(`
+  setInnerHTML(div,`
     <div id="host">
       <template shadowrootmode="invalid">
       </template>
@@ -93,7 +94,7 @@ test(() => {
 
 test(() => {
   const div = document.createElement('div');
-  div.setHTMLUnsafe(`
+  setInnerHTML(div,`
     <div id="host">
       <template shadowrootmode="closed">
       </template>
@@ -106,7 +107,7 @@ test(() => {
 
 test(() => {
   const div = document.createElement('div');
-  div.setHTMLUnsafe(`
+  setInnerHTML(div,`
     <div id="host">
       <template shadowrootmode="open">
         <slot id="s1" name="slot1"></slot>
@@ -122,7 +123,7 @@ test(() => {
 
 test(() => {
   const div = document.createElement('div');
-  div.setHTMLUnsafe(`
+  setInnerHTML(div,`
     <div id="host">
       <template shadowrootmode="open" shadowrootdelegatesfocus>
       </template>
@@ -131,7 +132,7 @@ test(() => {
   var host = div.querySelector('#host');
   assert_true(!!host.shadowRoot,"No shadow root found");
   assert_true(host.shadowRoot.delegatesFocus,"delegatesFocus should be true");
-  div.setHTMLUnsafe(`
+  setInnerHTML(div,`
     <div id="host">
       <template shadowrootmode="open">
       </template>

--- a/shadow-dom/declarative/support/helpers.js
+++ b/shadow-dom/declarative/support/helpers.js
@@ -1,0 +1,4 @@
+function setInnerHTML(el,content) {
+  const fragment = (new DOMParser()).parseFromString(`<pre>${content}</pre>`, 'text/html', {includeShadowRoots: true});
+  (el instanceof HTMLTemplateElement ? el.content : el).replaceChildren(...fragment.body.firstChild.childNodes);
+}


### PR DESCRIPTION
This partially reverts commit 17743f761d9f8bd3954bc68c60b88d251f9a2239.

There is no reason for the Declarative Shadow DOM API tests to rely on these methods, and this reduces test coverage for browsers that don't support them. Per general policy, tests shouldn't be relying on unrelated features, especially when those other features lack interoperable cross-browser support.