### PR TITLE
Corrected proper linkage to image used for origin-* reference files

### DIFF
--- a/css/css-backgrounds/reference/origin-border-box-ref.html
+++ b/css/css-backgrounds/reference/origin-border-box-ref.html
@@ -23,6 +23,6 @@
     }
   </style>
 
-<div style="height: 288px; width: 514px;"><img src="../support/yellow-orange-blue-160x160.png" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
+<div style="height: 288px; width: 514px;"><img src="../background-origin/support/yellow-orange-blue-160x160.png" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
 
-<div style="height: 288px; width: 514px; background-image: url('../support/yellow-orange-blue-160x160.png'); margin-top: 8px;"></div><div class="light-blue-border"></div>
+<div style="height: 288px; width: 514px; background-image: url('../background-origin/support/yellow-orange-blue-160x160.png'); margin-top: 8px;"></div><div class="light-blue-border"></div>

--- a/css/css-backgrounds/reference/origin-border-box_with_position-ref.html
+++ b/css/css-backgrounds/reference/origin-border-box_with_position-ref.html
@@ -31,4 +31,4 @@
     }
   </style>
 
-<div style="height: 288px; width: 514px; position: relative;"><img src="../support/yellow-orange-blue-160x160.png" alt="Image download support must be enabled"></div><div class="light-blue-border"></div>
+<div style="height: 288px; width: 514px; position: relative;"><img src="../background-origin/support/yellow-orange-blue-160x160.png" alt="Image download support must be enabled"></div><div class="light-blue-border"></div>

--- a/css/css-backgrounds/reference/origin-border-box_with_radius-ref.html
+++ b/css/css-backgrounds/reference/origin-border-box_with_radius-ref.html
@@ -24,6 +24,6 @@
     }
   </style>
 
-<div style="height: 288px; width: 514px;"><img src="../support/yellow-orange-blue-160x160.png" style="border-top-left-radius: 60px;" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
+<div style="height: 288px; width: 514px;"><img src="../background-origin/support/yellow-orange-blue-160x160.png" style="border-top-left-radius: 60px;" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
 
-<div style="height: 288px; width: 514px; background-image: url('../support/yellow-orange-blue-160x160.png'); margin-top: 8px;"></div><div class="light-blue-border"></div>
+<div style="height: 288px; width: 514px; background-image: url('../background-origin/support/yellow-orange-blue-160x160.png'); margin-top: 8px;"></div><div class="light-blue-border"></div>

--- a/css/css-backgrounds/reference/origin-border-box_with_size-ref.html
+++ b/css/css-backgrounds/reference/origin-border-box_with_size-ref.html
@@ -23,6 +23,6 @@
     }
   </style>
 
-<div style="height: 288px; width: 514px;"><img src="../support/yellow-orange-blue-160x160.png" width="50%" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
+<div style="height: 288px; width: 514px;"><img src="../background-origin/support/yellow-orange-blue-160x160.png" width="50%" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
 
-<div style="height: 288px; width: 514px; background-image: url('../support/yellow-orange-blue-160x160.png'); background-size: 257px auto; margin-top: 8px;"></div><div class="light-blue-border"></div>
+<div style="height: 288px; width: 514px; background-image: url('../background-origin/support/yellow-orange-blue-160x160.png'); background-size: 257px auto; margin-top: 8px;"></div><div class="light-blue-border"></div>

--- a/css/css-backgrounds/reference/origin-content-box-ref.html
+++ b/css/css-backgrounds/reference/origin-content-box-ref.html
@@ -28,6 +28,6 @@
   </style>
 
 
-<div class="light-blue-border"><img src="../support/yellow-orange-blue-160x160.png" alt="Image download support must be enabled"></div><br>
+<div class="light-blue-border"><img src="../background-origin/support/yellow-orange-blue-160x160.png" alt="Image download support must be enabled"></div><br>
 
-<div class="light-blue-border" style="background-image: url('../support/yellow-orange-blue-160x160.png'); background-position: 16px 16px; margin-top: 8px;"></div>
+<div class="light-blue-border" style="background-image: url('../background-origin/support/yellow-orange-blue-160x160.png'); background-position: 16px 16px; margin-top: 8px;"></div>

--- a/css/css-backgrounds/reference/origin-content-box_with_position-ref.html
+++ b/css/css-backgrounds/reference/origin-content-box_with_position-ref.html
@@ -30,4 +30,4 @@
     }
   </style>
 
-<div style="height: 288px; width: 514px; position: relative;"><img src="../support/yellow-orange-blue-160x160.png" alt="Image download support must be enabled"></div><div class="light-blue-border"></div>
+<div style="height: 288px; width: 514px; position: relative;"><img src="../background-origin/support/yellow-orange-blue-160x160.png" alt="Image download support must be enabled"></div><div class="light-blue-border"></div>

--- a/css/css-backgrounds/reference/origin-content-box_with_radius-ref.html
+++ b/css/css-backgrounds/reference/origin-content-box_with_radius-ref.html
@@ -28,6 +28,6 @@
     }
   </style>
 
-<div class="light-blue-border"><img src="../support/yellow-orange-blue-160x160.png" alt="Image download support must be enabled"></div><br>
+<div class="light-blue-border"><img src="../background-origin/support/yellow-orange-blue-160x160.png" alt="Image download support must be enabled"></div><br>
 
-<div class="light-blue-border" style="background-image: url('../support/yellow-orange-blue-160x160.png'); background-position: 16px 16px; margin-top: 8px;"></div>
+<div class="light-blue-border" style="background-image: url('../background-origin/support/yellow-orange-blue-160x160.png'); background-position: 16px 16px; margin-top: 8px;"></div>

--- a/css/css-backgrounds/reference/origin-content-box_with_size-ref.html
+++ b/css/css-backgrounds/reference/origin-content-box_with_size-ref.html
@@ -23,6 +23,6 @@
     }
   </style>
 
-<div style="height: 288px; width: 514px;"><img src="../support/yellow-orange-blue-160x160.png" style="position: relative; top: 32px; left: 32px;" width="225" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
+<div style="height: 288px; width: 514px;"><img src="../background-origin/support/yellow-orange-blue-160x160.png" style="position: relative; top: 32px; left: 32px;" width="225" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
 
-<div style="height: 288px; width: 514px; background-image: url('../support/yellow-orange-blue-160x160.png'); background-size: 225px auto; background-position: 32px 32px; margin-top: 8px;"></div><div class="light-blue-border"></div>
+<div style="height: 288px; width: 514px; background-image: url('../background-origin/support/yellow-orange-blue-160x160.png'); background-size: 225px auto; background-position: 32px 32px; margin-top: 8px;"></div><div class="light-blue-border"></div>

--- a/css/css-backgrounds/reference/origin-padding-box-ref.html
+++ b/css/css-backgrounds/reference/origin-padding-box-ref.html
@@ -21,6 +21,6 @@
     }
   </style>
 
-<div class="light-blue-border"><img src="../support/yellow-orange-blue-160x160.png" alt="Image download support must be enabled"></div><br>
+<div class="light-blue-border"><img src="../background-origin/support/yellow-orange-blue-160x160.png" alt="Image download support must be enabled"></div><br>
 
-<div class="light-blue-border" style="background-image: url('../support/yellow-orange-blue-160x160.png'); margin-top: 8px;"></div>
+<div class="light-blue-border" style="background-image: url('../background-origin/support/yellow-orange-blue-160x160.png'); margin-top: 8px;"></div>

--- a/css/css-backgrounds/reference/origin-padding-box_with_position-ref.html
+++ b/css/css-backgrounds/reference/origin-padding-box_with_position-ref.html
@@ -30,4 +30,4 @@
     }
   </style>
 
-<div style="height: 288px; width: 514px; position: relative;"><img src="../support/yellow-orange-blue-160x160.png" alt="Image download support must be enabled"></div><div class="light-blue-border"></div>
+<div style="height: 288px; width: 514px; position: relative;"><img src="../background-origin/support/yellow-orange-blue-160x160.png" alt="Image download support must be enabled"></div><div class="light-blue-border"></div>

--- a/css/css-backgrounds/reference/origin-padding-box_with_radius-ref.html
+++ b/css/css-backgrounds/reference/origin-padding-box_with_radius-ref.html
@@ -22,6 +22,6 @@
     }
   </style>
 
-<div class="light-blue-border"><img src="../support/yellow-orange-blue-160x160.png" style="position: relative; z-index: -1;" alt="Image download support must be enabled"></div><br>
+<div class="light-blue-border"><img src="../background-origin/support/yellow-orange-blue-160x160.png" style="position: relative; z-index: -1;" alt="Image download support must be enabled"></div><br>
 
-<div class="light-blue-border" style="background-image: url('../support/yellow-orange-blue-160x160.png'); margin-top: 8px;"></div>
+<div class="light-blue-border" style="background-image: url('../background-origin/support/yellow-orange-blue-160x160.png'); margin-top: 8px;"></div>

--- a/css/css-backgrounds/reference/origin-padding-box_with_size-ref.html
+++ b/css/css-backgrounds/reference/origin-padding-box_with_size-ref.html
@@ -23,6 +23,6 @@
     }
   </style>
 
-<div style="height: 288px; width: 514px;"><img src="../support/yellow-orange-blue-160x160.png" style="position: relative; top: 16px; left: 16px;" width="241" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
+<div style="height: 288px; width: 514px;"><img src="../background-origin/support/yellow-orange-blue-160x160.png" style="position: relative; top: 16px; left: 16px;" width="241" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
 
-<div style="height: 288px; width: 514px; background-image: url('../support/yellow-orange-blue-160x160.png'); background-size: 241px auto; background-position: 16px 16px; margin-top: 8px;"></div><div class="light-blue-border"></div>
+<div style="height: 288px; width: 514px; background-image: url('../background-origin/support/yellow-orange-blue-160x160.png'); background-size: 241px auto; background-position: 16px 16px; margin-top: 8px;"></div><div class="light-blue-border"></div>


### PR DESCRIPTION
This is an unfortunate follow-up to #43086 .

The 12  origin-* tests

https://wpt.fyi/results/css/css-backgrounds/background-origin

now fail only because I mislinked the image for the reference files in #43086 . Now, it is fixed. The 12 reference files should now fetch and load the image
 /background-origin/support/yellow-orange-blue-160x160.png 