### PR TITLE
Add Test for text selection when Shadow Root has delegatesFocus enabled

### DIFF
--- a/shadow-dom/focus/text-selection-with-delegatesFocus.html
+++ b/shadow-dom/focus/text-selection-with-delegatesFocus.html
@@ -6,7 +6,7 @@
 <script src="/resources/testdriver-vendor.js"></script>
 
 <body>
-	<x-shadow id="withoutFocus"></x-shadow>
+    <x-shadow id="withoutFocus"></x-shadow>
     <x-shadow id="withFocus"></x-shadow>
 </body>
 
@@ -17,13 +17,13 @@
  * build shadow-root with delegates focus, a focusable element, and an (ideally) selectable text
  */
 function buildShadowRootWithSelectableText( element, shouldDelegateFocus ) {
-	element.attachShadow({ mode: 'open', delegatesFocus: shouldDelegateFocus });
-	const span = document.createElement('span');
-	span.textContent = 'Example Text to Select ';
-	const button = document.createElement('button');
-	button.textContent = 'Button';
-	element.shadowRoot.append(span);
-	element.shadowRoot.append(button);
+    element.attachShadow({ mode: 'open', delegatesFocus: shouldDelegateFocus });
+    const span = document.createElement('span');
+    span.textContent = 'Example Text to Select ';
+    const button = document.createElement('button');
+    button.textContent = 'Button';
+    element.shadowRoot.append(span);
+    element.shadowRoot.append(button);
 }
 
 /**
@@ -40,10 +40,10 @@ function selectText(element, start, end) {
 }
 
 promise_test(async () => {
-	const xShadow = document.getElementById('withoutFocus');
+    const xShadow = document.getElementById('withoutFocus');
     buildShadowRootWithSelectableText(xShadow, false);
     await selectText(xShadow, -40, 45)
-	const s = getSelection();
+    const s = getSelection();
     assert_equals(s.toString(), "Text to Select", "toString");
 }, 'shadow root has selectable text when focus is not delegated');
 
@@ -51,7 +51,7 @@ promise_test(async () => {
     const xShadow = document.getElementById('withFocus');
     buildShadowRootWithSelectableText(xShadow, true);
     await selectText(xShadow, -40, 45)
-	const s = getSelection();
+    const s = getSelection();
     assert_equals(s.toString(), "Text to Select", "toString");
 }, 'shadow root has selectable text when focus is delegated');
 

--- a/shadow-dom/focus/text-selection-with-delegatesFocus.html
+++ b/shadow-dom/focus/text-selection-with-delegatesFocus.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<body>
+	<x-shadow id="withoutFocus"></x-shadow>
+    <x-shadow id="withFocus"></x-shadow>
+</body>
+
+<script>
+'use strict';
+
+/**
+ * build shadow-root with delegates focus, a focusable element, and an (ideally) selectable text
+ */
+function buildShadowRootWithSelectableText( element, shouldDelegateFocus ) {
+	element.attachShadow({ mode: 'open', delegatesFocus: shouldDelegateFocus });
+	const span = document.createElement('span');
+	span.textContent = 'Example Text to Select ';
+	const button = document.createElement('button');
+	button.textContent = 'Button';
+	element.shadowRoot.append(span);
+	element.shadowRoot.append(button);
+}
+
+/**
+ * command to select text in shadow-root
+ */
+function selectText(element, start, end) {
+    getSelection().empty();
+    const actions = new test_driver.Actions();
+    actions.pointerMove(start, 0, {origin: element});
+    actions.pointerDown();
+    actions.pointerMove(end, 0, {origin: element});
+    actions.pointerUp();
+    return actions.send();
+}
+
+promise_test(async () => {
+	const xShadow = document.getElementById('withoutFocus');
+    buildShadowRootWithSelectableText(xShadow, false);
+    await selectText(xShadow, -40, 45)
+	const s = getSelection();
+    assert_equals(s.toString(), "Text to Select", "toString");
+}, 'shadow root has selectable text when focus is not delegated');
+
+promise_test(async () => {
+    const xShadow = document.getElementById('withFocus');
+    buildShadowRootWithSelectableText(xShadow, true);
+    await selectText(xShadow, -40, 45)
+	const s = getSelection();
+    assert_equals(s.toString(), "Text to Select", "toString");
+}, 'shadow root has selectable text when focus is delegated');
+
+</script>

--- a/shadow-dom/focus/text-selection-with-delegatesFocus.html
+++ b/shadow-dom/focus/text-selection-with-delegatesFocus.html
@@ -22,8 +22,7 @@ function buildShadowRootWithSelectableText( element, shouldDelegateFocus ) {
     span.textContent = 'Example Text to Select ';
     const button = document.createElement('button');
     button.textContent = 'Button';
-    element.shadowRoot.append(span);
-    element.shadowRoot.append(button);
+    element.shadowRoot.append(span, button);
 }
 
 /**
@@ -42,16 +41,27 @@ function selectText(element, start, end) {
 promise_test(async () => {
     const xShadow = document.getElementById('withoutFocus');
     buildShadowRootWithSelectableText(xShadow, false);
-    await selectText(xShadow, -40, 45)
+
+    // starting selection from the center of the element, and going right.
+    // The important part here is that we start the selection in the center
+    //   (where mouse-down events may be delegated)
+    await selectText(xShadow, 0, 50)
     const s = getSelection();
+
+    // because browsers may handle rendering differently, we can get different amounts of
+    //   text selected, even when using the same start-end values. We opt in this case to
+    //   verify just if any text is selected, since all we care about is if some text is
+    //   selected.
     assert_greater_than(s.toString().length, 0);
 }, 'shadow root has selectable text when focus is not delegated');
 
 promise_test(async () => {
     const xShadow = document.getElementById('withFocus');
     buildShadowRootWithSelectableText(xShadow, true);
-    await selectText(xShadow, -40, 45)
+
+    await selectText(xShadow, 0, 50)
     const s = getSelection();
+
     assert_greater_than(s.toString().length, 0);
 }, 'shadow root has selectable text when focus is delegated');
 

--- a/shadow-dom/focus/text-selection-with-delegatesFocus.html
+++ b/shadow-dom/focus/text-selection-with-delegatesFocus.html
@@ -44,7 +44,7 @@ promise_test(async () => {
     buildShadowRootWithSelectableText(xShadow, false);
     await selectText(xShadow, -40, 45)
     const s = getSelection();
-    assert_equals(s.toString(), "Text to Select", "toString");
+    assert_greater_than(s.toString().length, 0);
 }, 'shadow root has selectable text when focus is not delegated');
 
 promise_test(async () => {
@@ -52,7 +52,7 @@ promise_test(async () => {
     buildShadowRootWithSelectableText(xShadow, true);
     await selectText(xShadow, -40, 45)
     const s = getSelection();
-    assert_equals(s.toString(), "Text to Select", "toString");
+    assert_greater_than(s.toString().length, 0);
 }, 'shadow root has selectable text when focus is delegated');
 
 </script>


### PR DESCRIPTION
I recently discovered that text selection has inconsistent behavior across browsers when `delegatesFocus` is enabled for shadow DOM.

The behavior appears at the moment to be:
* On Chromium browser (specifically Chrome and Edge), text selection of a non-focusable element (like `<span>`) does not work if another element in the shadow-root could retrieve focus (like a `<button>`).
* On other browsers, like Firefox and Safari, text can be selected and works as it might if the content had been written in the light DOM.

Here's a codepen with two shadow roots, one with `delegatesFocus` is `true`, and one where `delegatesFocus` is `false` - it has mostly similar content to the test being proposed here: https://codepen.io/JRJurman/pen/gOqvxXz

It's actually not totally obvious what the expected behavior here is, given the description on mdn: https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus

> If true, **when a non-focusable part of the shadow DOM is clicked**, or .focus() is called on the host element, **the first focusable part is given focus**, and the shadow host is given any available :focus styling.

I believe the expected behavior here is the implementation found in Firefox and Safari, where text-selection still works as expected. 

-------

This has also been documented in the past on stack overflow (however these posts were dismissed by the authors because the feature was experimental at the time).
* https://stackoverflow.com/q/60260078/864715
* https://stackoverflow.com/q/62766250/864715

--------

I've brought this up in the Web-Components Community Group discord, and they suggested that a test be written to track this behavior. They didn't have specific sentiments on the exact behavior expected here, and this is my first contribution to this repo, so happy to tweak / change / and move discussions! 