### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=265153

### DIFF
--- a/css/css-view-transitions/parsing/view-transition-name-invalid.html
+++ b/css/css-view-transitions/parsing/view-transition-name-invalid.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS View Transitions Test: view-transition-name with invalid values</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<meta name="assert" content="view-transition-name does not support invalid values">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("view-transition-name", "none none");
+test_invalid_value("view-transition-name", `"none"`);
+test_invalid_value("view-transition-name", `"foo"`);
+test_invalid_value("view-transition-name", "foo foo");
+test_invalid_value("view-transition-name", "bar bar");
+test_invalid_value("view-transition-name", "baz baz");
+test_invalid_value("view-transition-name", "#fff");
+test_invalid_value("view-transition-name", "12px");
+test_invalid_value("view-transition-name", "12em");
+test_invalid_value("view-transition-name", "12%");
+</script>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[view-transitions\] Parse `view-transition-name` CSS property](https://bugs.webkit.org/show_bug.cgi?id=265153)