### PR TITLE
Add tests for `calc(1fr)` in CSS grid

### DIFF
--- a/css/css-grid/grid-definition/grid-inline-support-flexible-lengths-001.html
+++ b/css/css-grid/grid-definition/grid-inline-support-flexible-lengths-001.html
@@ -70,6 +70,12 @@ document.fonts.ready.then(()=> {
   TestingUtils.testGridTemplateColumnsRows("grid", "1000px 1fr", "700px 1fr", "1000px 0px", "700px 0px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "calc(50px + 50%) 1fr", "calc(50px + 50%) 1fr", "450px 350px", "350px 250px");
   TestingUtils.testGridTemplateColumnsRows("grid", "calc(50px + 50%) 1fr", "calc(50px + 50%) 1fr", "450px 350px", "350px 250px");
+  TestingUtils.testGridTemplateColumnsRows("emptyGrid", "200px calc(1fr)", "300px calc(1fr)", "200px 600px", "300px 300px");
+  TestingUtils.testGridTemplateColumnsRows("grid", "200px calc(1fr)", "300px calc(1fr)", "200px 600px", "300px 300px");
+  TestingUtils.testGridTemplateColumnsRows("emptyGrid", "250px calc(2 * 0.5fr)", "350px calc(2 * 0.5fr)", "250px 550px", "350px 250px");
+  TestingUtils.testGridTemplateColumnsRows("grid", "250px calc(2 * 0.5fr)", "350px calc(2 * 0.5fr)", "250px 550px", "350px 250px");
+  TestingUtils.testGridTemplateColumnsRows("emptyGrid", "200px calc(1fr / 2)", "300px calc(1fr / 2)", "200px 300px", "300px 150px");
+  TestingUtils.testGridTemplateColumnsRows("grid", "200px calc(1fr / 2)", "300px calc(1fr / 2)", "200px 300px", "300px 150px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(100px, 300px) 1fr", "minmax(100px, 200px) 1fr", "300px 500px", "200px 400px");
   TestingUtils.testGridTemplateColumnsRows("grid", "minmax(100px, 300px) 1fr", "minmax(100px, 200px) 1fr", "300px 500px", "200px 400px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "repeat(4, 1fr)", "repeat(4, 1fr)", ["200px 200px 200px 200px", "repeat(4, 200px)"], ["150px 150px 150px 150px", "repeat(4, 150px)"]);

--- a/css/css-grid/grid-definition/grid-support-flexible-lengths-001.html
+++ b/css/css-grid/grid-definition/grid-support-flexible-lengths-001.html
@@ -70,6 +70,12 @@ document.fonts.ready.then(()=> {
   TestingUtils.testGridTemplateColumnsRows("grid", "1000px 1fr", "700px 1fr", "1000px 0px", "700px 0px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "calc(50px + 50%) 1fr", "calc(50px + 50%) 1fr", "450px 350px", "350px 250px");
   TestingUtils.testGridTemplateColumnsRows("grid", "calc(50px + 50%) 1fr", "calc(50px + 50%) 1fr", "450px 350px", "350px 250px");
+  TestingUtils.testGridTemplateColumnsRows("emptyGrid", "200px calc(1fr)", "300px calc(1fr)", "200px 600px", "300px 300px");
+  TestingUtils.testGridTemplateColumnsRows("grid", "200px calc(1fr)", "300px calc(1fr)", "200px 600px", "300px 300px");
+  TestingUtils.testGridTemplateColumnsRows("emptyGrid", "250px calc(2 * 0.5fr)", "350px calc(2 * 0.5fr)", "250px 550px", "350px 250px");
+  TestingUtils.testGridTemplateColumnsRows("grid", "250px calc(2 * 0.5fr)", "350px calc(2 * 0.5fr)", "250px 550px", "350px 250px");
+  TestingUtils.testGridTemplateColumnsRows("emptyGrid", "200px calc(1fr / 2)", "300px calc(1fr / 2)", "200px 300px", "300px 150px");
+  TestingUtils.testGridTemplateColumnsRows("grid", "200px calc(1fr / 2)", "300px calc(1fr / 2)", "200px 300px", "300px 150px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(100px, 300px) 1fr", "minmax(100px, 200px) 1fr", "300px 500px", "200px 400px");
   TestingUtils.testGridTemplateColumnsRows("grid", "minmax(100px, 300px) 1fr", "minmax(100px, 200px) 1fr", "300px 500px", "200px 400px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "repeat(4, 1fr)", "repeat(4, 1fr)", ["200px 200px 200px 200px", "repeat(4, 200px)"], ["150px 150px 150px 150px", "repeat(4, 150px)"]);


### PR DESCRIPTION
I've noticed that while it is present in the specs, the math functions do not work for flexible units (`fr`) in grids.

This was brought up by @leaverou and clarified by @tabatkins: https://github.com/w3c/csswg-drafts/issues/6989

> Definitely a bug; `fr` units should be math'able just fine. That note is, indeed, just observing that `fr` is not a `<length>` so `calc(1px + 1fr)` is invalid, but `calc(1fr / 3)` should be just fine.

There was an [existing Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=993136&q=calc%20fr&can=2) (open from 2019), and I did open the corresponding bugs for [WebKit](https://bugs.webkit.org/show_bug.cgi?id=265276) and [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1866236).

I did not find test cases covering this in WPT, so I have decided to add them. Adding them in a way consistent with other tests for `fr` (so for both regular and inline grids), and added three different tests: just `calc(1fr)`, one where it uses a fractional `fr` and combines it into a regular — `calc(2 * 0.5fr)`, and one where it returns a fractional one — `calc(1fr / 2)`.

Please tell me if some of these tests are excessive and could be removed.

No browser would pass these now, I did ensure the tests would pass if the `calc()` is removed (and the values are calculated manually).

P.S. One thing I did notice is that the `TestingUtils.testGridTemplateColumnsRows` is a bit awkward to work with. It does not ensure that it sets the value correctly, and if it fails to apply some value, it checks the previously set value. This can be seen in the “Wrong values” part of the tests, where it expects the reset values. Should this be opened as a separate issue? As, right now, it might be very easy to introduce a false-positive test if it would contain the same computed values as the tests before them. I did initially do this, and had to modify the tests to contain different `px` values for the non-fractional columns.