### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=265300

### DIFF
--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -1435,6 +1435,12 @@ const gCSSProperties2 = {
     types: [
     ]
   },
+  'view-transition-name': {
+    // https://drafts.csswg.org/css-view-transitions/#propdef-view-transition-name
+    types: [
+      { type: 'discrete', options: [ [ 'none', 'header' ] ] },
+    ]
+  },
   'visibility': {
     // https://drafts.csswg.org/css2/visufx.html#propdef-visibility
     types: [ 'visibility' ]


### PR DESCRIPTION
WebKit export from bug: [\[view-transitions\] Support `view-transition-name` discrete animations](https://bugs.webkit.org/show_bug.cgi?id=265300)