### PR TITLE
Fix rangeToString method to handle case where range is already a string

### DIFF
--- a/scroll-animations/view-timelines/testcommon.js
+++ b/scroll-animations/view-timelines/testcommon.js
@@ -92,6 +92,9 @@ async function runTimelineBoundsTest(t, options, message) {
 // });
 async function runTimelineRangeTest(t, options) {
   const rangeToString = range => {
+    if (typeof range === 'string')
+      return range;
+
     const parts = [];
     if (range.rangeName)
       parts.push(range.rangeName);


### PR DESCRIPTION
Some tests in [view-timeline-range.html](https://github.com/web-platform-tests/wpt/blob/3d4528724bca7062f8c39d879ac45f342a3291c0/scroll-animations/view-timelines/view-timeline-range.html#L168) cause `rangeToString` to be called with a string and not a TimelineRangeOffset. 

The current implementation of `rangeToString` will return an empty string if it receives a string argument. That makes it hard to identify what assertions are failing. 

This PR remedies this by returning the argument if it is already a string.