### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=265350

### DIFF
--- a/scroll-animations/css/scroll-timeline-shorthand.html
+++ b/scroll-animations/css/scroll-timeline-shorthand.html
@@ -100,10 +100,10 @@ test_shorthand_contraction('scroll-timeline', {
 test_shorthand_contraction('scroll-timeline', {
   'scroll-timeline-name': '--a, --b, --c',
   'scroll-timeline-axis': 'inline, inline',
-}, '');
+}, '--a inline, --b inline, --c inline');
 
 test_shorthand_contraction('scroll-timeline', {
   'scroll-timeline-name': '--a, --b',
   'scroll-timeline-axis': 'inline, inline, inline',
-}, '');
+}, '--a inline, --b inline');
 </script>


### PR DESCRIPTION
WebKit export from bug: [\[scroll-animations\] ensure the `scroll-timeline` shorthand serializes according to the rule of a coordinating list property group](https://bugs.webkit.org/show_bug.cgi?id=265350)