### PR TITLE
Remove the version pin now that #40525 is fixed

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -141,8 +141,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      # TODO(#40525): Revert back to 3.7 once the Mac agent's Python v3.7 contains bz2 again.
-      versionSpec: '3.7.16'
+      versionSpec: '3.7'
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
@@ -174,8 +173,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      # TODO(#40525): Revert back to 3.7 once the Mac agent's Python v3.7 contains bz2 again.
-      versionSpec: '3.7.16'
+      versionSpec: '3.7'
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
@@ -208,8 +206,7 @@ jobs:
   # full checkout required
   - task: UsePythonVersion@0
     inputs:
-      # TODO(#40525): Revert back to 3.7 once the Mac agent's Python v3.7 contains bz2 again.
-      versionSpec: '3.7.16'
+      versionSpec: '3.7'
   - template: tools/ci/azure/install_chrome.yml
   - template: tools/ci/azure/install_firefox.yml
   - template: tools/ci/azure/update_hosts.yml


### PR DESCRIPTION
According to [this comment](https://github.com/web-platform-tests/wpt/issues/40525#issuecomment-1809355124) the Python pin should no longer be necessary.