### PR TITLE
WebDriver executor intrastructure of the Get Window Rect command

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/set_get_window_rect.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/set_get_window_rect.html.ini
@@ -1,0 +1,7 @@
+[set_get_window_rect.html]
+  [Window Size]
+    expected:
+      if product == "firefox_android": FAIL
+  [Window Position]
+    expected:
+      if product == "firefox_android": FAIL

--- a/infrastructure/testdriver/set_get_window_rect.html
+++ b/infrastructure/testdriver/set_get_window_rect.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>TestDriver set / get rect method</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<script>
+promise_test(async t => {
+    var orig_rect = await test_driver.get_window_rect();
+    var new_rect = { "width": orig_rect.width, "height": orig_rect.height, "x": 150, "y": 175 };
+    await test_driver.set_window_rect(new_rect);
+    var result = await test_driver.get_window_rect()
+    assert_equals(result.width, orig_rect.width, "The 'Width' property should not have changed");
+    assert_equals(result.height, orig_rect.height, "The 'Height' property should not have changed.");
+    assert_equals(result.x, new_rect.x, "The 'X' property has been changed.");
+    assert_equals(result.y, new_rect.y, "The 'y' property has been changed.");
+}, "Window Position");
+
+promise_test(async t => {
+    var orig_rect = await test_driver.get_window_rect();
+    var new_rect = { "width": 800, "height": 500, "x": 150, "y": 175 };
+    await test_driver.set_window_rect(new_rect);
+    var result = await test_driver.get_window_rect()
+    assert_equals(result.width, new_rect.width, "The 'Width' property has been changed");
+    assert_equals(result.height, new_rect.height, "The 'Height' property has been changed.");
+    assert_equals(result.x, orig_rect.x, "The 'X' property should not have changed.");
+    assert_equals(result.y, orig_rect.y, "The 'y' property should not have changed.");
+}, "Window Size");
+</script>

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -358,6 +358,25 @@
         },
 
         /**
+         * Gets a rect with the size and position on the screen from the current window state.
+         *
+         * Matches the behaviour of the `Get Window Rect
+         * <https://www.w3.org/TR/webdriver/#get-window-rect>`_
+         * WebDriver command
+         *
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} fulfilled after the window rect is returned, or rejected
+         * in cases the WebDriver command returns errors. Returns a
+         * `WindowRect <https://www.w3.org/TR/webdriver/#dfn-windowrect-object>`_
+         */
+        get_window_rect: function(context=null) {
+            return window.test_driver_internal.get_window_rect(context);
+        },
+
+        /**
          * Send a sequence of actions
          *
          * This function sends a sequence of actions to perform.
@@ -1080,6 +1099,10 @@
 
         async set_window_rect(rect, context=null) {
             throw new Error("set_window_rect() is not implemented by testdriver-vendor.js");
+        },
+
+        async get_window_rect(context=null) {
+            throw new Error("get_window_rect() is not implemented by testdriver-vendor.js");
         },
 
         async action_sequence(actions, context=null) {

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -116,6 +116,15 @@ class SetWindowRectAction:
         rect = payload["rect"]
         self.protocol.window.set_rect(rect)
 
+class GetWindowRectAction:
+    name = "get_window_rect"
+
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        return self.protocol.window.get_rect()
 
 class ActionSequenceAction:
     name = "action_sequence"
@@ -444,6 +453,7 @@ actions = [ClickAction,
            SendKeysAction,
            MinimizeWindowAction,
            SetWindowRectAction,
+           GetWindowRectAction,
            ActionSequenceAction,
            GenerateTestReportAction,
            SetPermissionAction,

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -497,6 +497,8 @@ class MarionetteWindowProtocolPart(WindowProtocolPart):
     def set_rect(self, rect):
         self.marionette.set_window_rect(rect["x"], rect["y"], rect["height"], rect["width"])
 
+    def get_rect(self):
+        return self.marionette.window_rect
 
 class MarionetteActionSequenceProtocolPart(ActionSequenceProtocolPart):
     def setup(self):

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -219,6 +219,9 @@ class SeleniumWindowProtocolPart(WindowProtocolPart):
         self.logger.info("Setting window rect")
         self.webdriver.window.rect = rect
 
+    def get_rect(self):
+        self.logger.info("Getting window rect")
+        return self.webdriver.window.rect
 
 class SeleniumSendKeysProtocolPart(SendKeysProtocolPart):
     def setup(self):

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -257,6 +257,9 @@ class WebDriverWindowProtocolPart(WindowProtocolPart):
         self.logger.info("Restoring")
         self.webdriver.window.rect = rect
 
+    def get_rect(self):
+        self.logger.info("Getting rect")
+        return self.webdriver.window.rect
 
 class WebDriverSendKeysProtocolPart(SendKeysProtocolPart):
     def setup(self):

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -371,6 +371,11 @@ class WindowProtocolPart(ProtocolPart):
         pass
 
     @abstractmethod
+    def get_rect(self):
+        """Gets the current window rect."""
+        pass
+
+    @abstractmethod
     def minimize(self):
         """Minimizes the window and returns the previous rect."""
         pass

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -204,6 +204,10 @@
         return create_action("set_window_rect", {rect, context});
     };
 
+    window.test_driver_internal.get_window_rect = function(context=null) {
+        return create_action("get_window_rect", {context});
+    };
+
     window.test_driver_internal.send_keys = function(element, keys) {
         const selector = get_selector(element);
         const context = get_context(element);


### PR DESCRIPTION
Adding the executor infrastructure to get the WindowRect structure of the test window, implemented in webdriver+marionette.