### PR TITLE
Let outline-width-rounding.tentative.html pass in Firefox/Servo

### DIFF
--- a/css/css-outline/outline-width-rounding.tentative.html
+++ b/css/css-outline/outline-width-rounding.tentative.html
@@ -16,8 +16,8 @@
 <body>
   <h1>
     Test passes if outline widths are rounded up
-    when they are greater than 0 and less than 1,
-    and rounded down when they are greater than 1.
+    when they are greater than 0px and less than 1px,
+    and rounded down when they are greater than 1px.
   </h1>
 
   <script>
@@ -32,7 +32,8 @@
       { input: "1.5px", expected: "1px" },
       { input: "2px", expected: "2px" },
       { input: "2.75px", expected: "2px" },
-      { input: "2.999px", expected: "2px" },
+      { input: "2.99px", expected: "2px" },
+      { input: "3px", expected: "3px" },
     ];
 
     for (const value of values) {
@@ -41,13 +42,13 @@
       document.body.appendChild(div);
     }
 
-    test(function() {
-      var targets = document.querySelectorAll("div");
+    var targets = document.querySelectorAll("div");
 
-      for (var i=0; i < targets.length; ++i) {
+    for (var i=0; i < targets.length; ++i) {
+      test(() => {
         assert_equals(getComputedStyle(targets[i]).outlineWidth, values[i].expected);
-      }
-    }, "Test that outline widths are rounded up when they are greater than 0px but less than 1px, and rounded down when they are greater than 1px.");
+      }, values[i].input);
+    }
     </script>
 </body>
 </html>


### PR DESCRIPTION
Before snapping it as a border width, Firefox and Servo store the length with not much precision, so 2.999px becomes 3px, which is then snapped as 3px. Blink and WebKit use more precision so they can keep 2.999px as-is, and then snap it to 2px.

Note that Blink and WebKit behave like Firefox and Servo for 2.9999999px so I don't think either is wrong, just a matter of different precisions.

Therefore this changes the test to check 2.99px, which seems to work everywhere.

Also some misc changes while I'm at it.