### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=265673

### DIFF
--- a/scroll-animations/css/view-timeline-shorthand.html
+++ b/scroll-animations/css/view-timeline-shorthand.html
@@ -148,17 +148,17 @@ test_shorthand_contraction('view-timeline', {
   'view-timeline-name': '--a, --b, --c',
   'view-timeline-axis': 'inline, inline',
   'view-timeline-inset': 'auto, auto',
-}, '');
+}, '--a inline, --b inline, --c inline');
 
 test_shorthand_contraction('view-timeline', {
   'view-timeline-name': '--a, --b',
   'view-timeline-axis': 'inline, inline, inline',
   'view-timeline-inset': 'auto, auto, auto',
-}, '');
+}, '--a inline, --b inline');
 
 test_shorthand_contraction('view-timeline', {
   'view-timeline-name': '--a, --b',
   'view-timeline-axis': 'inline, inline',
   'view-timeline-inset': 'auto, auto, auto',
-}, '');
+}, '--a inline, --b inline');
 </script>


### PR DESCRIPTION
WebKit export from bug: [\[scroll-animations\] WPT test scroll-animations/css/view-timeline-shorthand.html has incorrect contraction tests](https://bugs.webkit.org/show_bug.cgi?id=265673)