### PR TITLE
Fixing 8 background-origin/origin-* references (viewport width related)

### DIFF
--- a/css/css-backgrounds/reference/origin-border-box-ref.html
+++ b/css/css-backgrounds/reference/origin-border-box-ref.html
@@ -7,6 +7,13 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
 
   <style>
+  body
+    {
+      height: 568px;
+      overflow-y: hidden;
+      width: 584px;
+    }
+
   div
     {
       display: inline-block;
@@ -22,19 +29,21 @@
   div#multiple
     {
       background-image: url('../background-origin/support/yellow-orange-blue-160x160.png');
+      bottom: 288px;
       margin-top: 8px;
+      position: relative;
     }
 
   div.light-blue-border
     {
       border: 16px solid rgba(60, 150, 255, 0.4);
+      bottom: 288px;
       height: 256px;
       position: relative;
-      right: 514px;
       width: 482px;
     }
   </style>
 
 <div class="image"><img src="../background-origin/support/yellow-orange-blue-160x160.png" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
 
-<div class="image" id="multiple"></div><div class="light-blue-border"></div>
+<div class="image" id="multiple"></div><div class="light-blue-border" style="bottom: 576px;"></div>

--- a/css/css-backgrounds/reference/origin-border-box_with_position-ref.html
+++ b/css/css-backgrounds/reference/origin-border-box_with_position-ref.html
@@ -7,6 +7,13 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
 
   <style>
+  body
+    {
+      height: 568px;
+      overflow-y: hidden;
+      width: 584px;
+    }
+
   div
     {
       display: inline-block;
@@ -31,8 +38,8 @@
   div.light-blue-border
     {
       border: 16px solid rgba(60, 150, 255, 0.4);
+      bottom: 288px;
       height: 256px;
-      right: 514px;
       width: 482px;
     }
   </style>

--- a/css/css-backgrounds/reference/origin-border-box_with_radius-ref.html
+++ b/css/css-backgrounds/reference/origin-border-box_with_radius-ref.html
@@ -7,6 +7,13 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
 
   <style>
+  body
+    {
+      height: 568px;
+      overflow-y: hidden;
+      width: 584px;
+    }
+
   div
     {
       border-radius: 60px;
@@ -28,19 +35,21 @@
   div#multiple
     {
       background-image: url('../background-origin/support/yellow-orange-blue-160x160.png');
+      bottom: 288px;
       margin-top: 8px;
+      position: relative;
     }
 
   div.light-blue-border
     {
       border: 16px solid rgba(60, 150, 255, 0.4);
+      bottom: 288px;
       height: 256px;
       position: relative;
-      right: 514px;
       width: 482px;
     }
   </style>
 
 <div class="image"><img src="../background-origin/support/yellow-orange-blue-160x160.png" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
 
-<div class="image" id="multiple"></div><div class="light-blue-border"></div>
+<div class="image" id="multiple"></div><div class="light-blue-border" style="bottom: 576px;"></div>

--- a/css/css-backgrounds/reference/origin-border-box_with_size-ref.html
+++ b/css/css-backgrounds/reference/origin-border-box_with_size-ref.html
@@ -7,6 +7,13 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
 
   <style>
+  body
+    {
+      height: 568px;
+      overflow-y: hidden;
+      width: 584px;
+    }
+
   div
     {
       display: inline-block;
@@ -23,19 +30,21 @@
     {
       background-image: url('../background-origin/support/yellow-orange-blue-160x160.png');
       background-size: 257px auto;
+      bottom: 288px;
       margin-top: 8px;
+      position: relative;
     }
 
   div.light-blue-border
     {
       border: 16px solid rgba(60, 150, 255, 0.4);
+      bottom: 288px;
       height: 256px;
-      position: relative;
-      right: 514px;
       width: 482px;
+      position: relative;
     }
   </style>
 
-<div class="image"><img src="../background-origin/support/yellow-orange-blue-160x160.png" width="257" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
+<div class="image"><img src="../background-origin/support/yellow-orange-blue-160x160.png" width="257" alt="Image download support must be enabled"></div><div class="light-blue-border"></div>
 
-<div class="image" id="multiple"></div><div class="light-blue-border"></div>
+<div class="image" id="multiple"></div><div class="light-blue-border" style="bottom: 576px;"></div>

--- a/css/css-backgrounds/reference/origin-content-box_with_position-ref.html
+++ b/css/css-backgrounds/reference/origin-content-box_with_position-ref.html
@@ -7,6 +7,13 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
 
   <style>
+  body
+    {
+      height: 568px;
+      overflow-y: hidden;
+      width: 584px;
+    }
+
   div
     {
       display: inline-block;
@@ -29,9 +36,9 @@
 
   div.light-blue-border
     {
+      bottom: 288px;
       border: 16px solid rgba(60, 150, 255, 0.4);
       height: 256px;
-      right: 514px;
       width: 482px;
     }
   </style>

--- a/css/css-backgrounds/reference/origin-content-box_with_size-ref.html
+++ b/css/css-backgrounds/reference/origin-content-box_with_size-ref.html
@@ -7,6 +7,13 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
 
   <style>
+  body
+    {
+      height: 568px;
+      overflow-y: hidden;
+      width: 584px;
+    }
+
   div
     {
       display: inline-block;
@@ -31,19 +38,21 @@
       background-image: url('../background-origin/support/yellow-orange-blue-160x160.png');
       background-position: 32px 32px;
       background-size: 225px auto;
+      bottom: 288px;
       margin-top: 8px;
+      position: relative;
     }
 
   div.light-blue-border
     {
       border: 16px solid rgba(60, 150, 255, 0.4);
+      bottom: 288px;
       height: 256px;
       position: relative;
-      right: 514px;
       width: 482px;
     }
   </style>
 
 <div class="image"><img src="../background-origin/support/yellow-orange-blue-160x160.png" width="225" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
 
-<div class="image" id="multiple"></div><div class="light-blue-border"></div>
+<div class="image" id="multiple"></div><div class="light-blue-border" style="bottom: 576px;"></div>

--- a/css/css-backgrounds/reference/origin-padding-box_with_position-ref.html
+++ b/css/css-backgrounds/reference/origin-padding-box_with_position-ref.html
@@ -7,6 +7,13 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
 
   <style>
+  body
+    {
+      height: 568px;
+      overflow-y: hidden;
+      width: 584px;
+    }
+
   div
     {
       display: inline-block;
@@ -30,8 +37,8 @@
   div.light-blue-border
     {
       border: 16px solid rgba(60, 150, 255, 0.4);
+      bottom: 288px;
       height: 256px;
-      right: 514px;
       width: 482px;
     }
   </style>

--- a/css/css-backgrounds/reference/origin-padding-box_with_size-ref.html
+++ b/css/css-backgrounds/reference/origin-padding-box_with_size-ref.html
@@ -7,6 +7,13 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
 
   <style>
+  body
+    {
+      height: 568px;
+      overflow-y: hidden;
+      width: 584px;
+    }
+
   div
     {
       display: inline-block;
@@ -31,19 +38,21 @@
       background-image: url('../background-origin/support/yellow-orange-blue-160x160.png');
       background-position: 16px 16px;
       background-size: 241px auto;
+      bottom: 288px;
       margin-top: 8px;
+      position: relative;
     }
 
   div.light-blue-border
     {
       border: 16px solid rgba(60, 150, 255, 0.4);
+      bottom: 288px;
       height: 256px;
       position: relative;
-      right: 514px;
       width: 482px;
     }
   </style>
 
 <div class="image"><img src="../background-origin/support/yellow-orange-blue-160x160.png" width="241" alt="Image download support must be enabled"></div><div class="light-blue-border"></div><br>
 
-<div class="image" id="multiple"></div><div class="light-blue-border"></div>
+<div class="image" id="multiple"></div><div class="light-blue-border" style="bottom: 576px;"></div>


### PR DESCRIPTION
This is a follow-up to #43329 which itself is 
a follow-up to #43269 which itself is
a follow-up to #43209 which itself is 
a follow-up to #43086 which itself is 
a follow-up to #41096

This pull request takes into account and consideration that successive and adjacent inline-blocks will wrap over onto next line box, furthermore sooner if [window viewport width is restricted and constrained to 600px in reftests](https://github.com/web-platform-tests/wpt/issues/5403).

In many spots, `'right: 514px'` has been replaced with `'bottom: 288px'` which is the height of preceding inline-block. For the last inline-block, I had to resort to `'bottom: 576px'` which is 2 times 288px.

So, over at my website, the 8 **newer** reference files (preceded by their current associated tests in http://wpt.live/css/css-backgrounds/background-origin/ ) are:

1
http://wpt.live/css/css-backgrounds/background-origin/origin-border-box.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-border-box-newer-ref.html

2
http://wpt.live/css/css-backgrounds/background-origin/origin-border-box_with_position.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-border-box_with_position-newer-ref.html

3
http://wpt.live/css/css-backgrounds/background-origin/origin-border-box_with_radius.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-border-box_with_radius-newer-ref.html

4
http://wpt.live/css/css-backgrounds/background-origin/origin-border-box_with_size.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-border-box_with_size-newer-ref.html

5
http://wpt.live/css/css-backgrounds/background-origin/origin-content-box_with_position.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-content-box_with_position-newer-ref.html

6
http://wpt.live/css/css-backgrounds/background-origin/origin-content-box_with_size.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-content-box_with_size-newer-ref.html

7
http://wpt.live/css/css-backgrounds/background-origin/origin-padding-box_with_position.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-padding-box_with_position-newer-ref.html

8
http://wpt.live/css/css-backgrounds/background-origin/origin-padding-box_with_size.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/origin-padding-box_with_size-newer-ref.html