### PR TITLE
Do not use touch scrolls for scrollend tests.

### DIFF
--- a/dom/events/scrolling/scrollend-event-fired-after-snap.html
+++ b/dom/events/scrolling/scrollend-event-fired-after-snap.html
@@ -61,7 +61,7 @@ scroller.addEventListener("scrollend", () => {
 function runTests() {
   promise_test (async () => {
     await waitForCompositorCommit();
-    await touchScrollInTarget(100, scroller, 'down');
+    await scrollElementDown(scroller, 100);
     // Wait for the scroll snap animation to finish.
     await waitForAnimationEnd(scrollTop);
     await waitFor(() => { return scroll_end_arrived; });


### PR DESCRIPTION
Avoid using touch scrolls for scrollend tests.

Related: https://github.com/web-platform-tests/interop/issues/528