### PR TITLE
[wdspec] Introduce shared constants for bidi network tests

### DIFF
--- a/webdriver/tests/bidi/network/__init__.py
+++ b/webdriver/tests/bidi/network/__init__.py
@@ -275,3 +275,19 @@ HTTP_STATUS_AND_STATUS_TEXT = [
     (504, "Gateway Timeout"),
     (505, "HTTP Version Not Supported"),
 ]
+
+PAGE_EMPTY_HTML = "/webdriver/tests/bidi/network/support/empty.html"
+PAGE_EMPTY_IMAGE = "/webdriver/tests/bidi/network/support/empty.png"
+PAGE_EMPTY_SCRIPT = "/webdriver/tests/bidi/network/support/empty.js"
+PAGE_EMPTY_SVG = "/webdriver/tests/bidi/network/support/empty.svg"
+PAGE_EMPTY_TEXT = "/webdriver/tests/bidi/network/support/empty.txt"
+PAGE_OTHER_TEXT = "/webdriver/tests/bidi/network/support/other.txt"
+PAGE_REDIRECT_HTTP_EQUIV = (
+    "/webdriver/tests/bidi/network/support/redirect_http_equiv.html"
+)
+PAGE_REDIRECTED_HTML = "/webdriver/tests/bidi/network/support/redirected.html"
+
+AUTH_REQUIRED_EVENT = "network.authRequired"
+BEFORE_REQUEST_SENT_EVENT = "network.beforeRequestSent"
+RESPONSE_COMPLETED_EVENT = "network.responseCompleted"
+RESPONSE_STARTED_EVENT = "network.responseStarted"

--- a/webdriver/tests/bidi/network/add_intercept/add_intercept.py
+++ b/webdriver/tests/bidi/network/add_intercept/add_intercept.py
@@ -4,11 +4,15 @@ import uuid
 import pytest
 from webdriver.bidi.modules.script import ScriptEvaluateResultException
 
-from .. import assert_before_request_sent_event
-
-PAGE_EMPTY_HTML = "/webdriver/tests/bidi/network/support/empty.html"
-PAGE_EMPTY_TEXT = "/webdriver/tests/bidi/network/support/empty.txt"
-PAGE_OTHER_TEXT = "/webdriver/tests/bidi/network/support/other.txt"
+from .. import (
+    assert_before_request_sent_event,
+    PAGE_EMPTY_HTML,
+    PAGE_EMPTY_TEXT,
+    PAGE_OTHER_TEXT,
+    BEFORE_REQUEST_SENT_EVENT,
+    RESPONSE_COMPLETED_EVENT,
+    RESPONSE_STARTED_EVENT,
+)
 
 
 @pytest.mark.asyncio
@@ -25,9 +29,9 @@ async def test_other_context(
     # Subscribe to network events only in top_context
     await setup_network_test(
         events=[
-            "network.beforeRequestSent",
-            "network.responseStarted",
-            "network.responseCompleted",
+            BEFORE_REQUEST_SENT_EVENT,
+            RESPONSE_STARTED_EVENT,
+            RESPONSE_COMPLETED_EVENT,
         ],
         contexts=[top_context["context"]],
     )
@@ -65,9 +69,9 @@ async def test_other_url(
 ):
     await setup_network_test(
         events=[
-            "network.beforeRequestSent",
-            "network.responseStarted",
-            "network.responseCompleted",
+            BEFORE_REQUEST_SENT_EVENT,
+            RESPONSE_STARTED_EVENT,
+            RESPONSE_COMPLETED_EVENT,
         ],
     )
 
@@ -107,9 +111,9 @@ async def test_two_intercepts(
 ):
     await setup_network_test(
         events=[
-            "network.beforeRequestSent",
-            "network.responseStarted",
-            "network.responseCompleted",
+            BEFORE_REQUEST_SENT_EVENT,
+            RESPONSE_STARTED_EVENT,
+            RESPONSE_COMPLETED_EVENT,
         ],
     )
 
@@ -126,7 +130,7 @@ async def test_two_intercepts(
     )
 
     # Perform a request to PAGE_EMPTY_TEXT, which should match both intercepts
-    on_network_event = wait_for_event("network.beforeRequestSent")
+    on_network_event = wait_for_event(BEFORE_REQUEST_SENT_EVENT)
     asyncio.ensure_future(fetch(text_url))
     event = await wait_for_future_safe(on_network_event)
 
@@ -137,7 +141,7 @@ async def test_two_intercepts(
     # Perform a request to PAGE_OTHER_TEXT, which should only match one intercept
     other_url = url(PAGE_OTHER_TEXT)
 
-    on_network_event = wait_for_event("network.beforeRequestSent")
+    on_network_event = wait_for_event(BEFORE_REQUEST_SENT_EVENT)
     asyncio.ensure_future(fetch(other_url))
     event = await wait_for_future_safe(on_network_event)
 
@@ -152,7 +156,7 @@ async def test_two_intercepts(
 
     # Requests to PAGE_EMPTY_TEXT should still be blocked, but only by one
     # intercept.
-    on_network_event = wait_for_event("network.beforeRequestSent")
+    on_network_event = wait_for_event(BEFORE_REQUEST_SENT_EVENT)
     asyncio.ensure_future(fetch(text_url))
     event = await wait_for_future_safe(on_network_event)
 

--- a/webdriver/tests/bidi/network/add_intercept/phase_auth_required.py
+++ b/webdriver/tests/bidi/network/add_intercept/phase_auth_required.py
@@ -5,9 +5,15 @@ from .. import (
     assert_response_event,
 )
 
-PAGE_EMPTY_TEXT = "/webdriver/tests/bidi/network/support/empty.txt"
-
-AUTH_REQUIRED_EVENT = "network.authRequired"
+from .. import (
+    assert_before_request_sent_event,
+    assert_response_event,
+    PAGE_EMPTY_TEXT,
+    AUTH_REQUIRED_EVENT,
+    BEFORE_REQUEST_SENT_EVENT,
+    RESPONSE_COMPLETED_EVENT,
+    RESPONSE_STARTED_EVENT,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -23,16 +29,16 @@ async def test_basic_authentication(
 ):
     network_events = await setup_network_test(
         events=[
-            "network.beforeRequestSent",
-            "network.responseStarted",
-            "network.authRequired",
-            "network.responseCompleted",
+            BEFORE_REQUEST_SENT_EVENT,
+            RESPONSE_STARTED_EVENT,
+            AUTH_REQUIRED_EVENT,
+            RESPONSE_COMPLETED_EVENT,
         ]
     )
-    before_request_sent_events = network_events["network.beforeRequestSent"]
-    response_started_events = network_events["network.responseStarted"]
-    auth_required_events = network_events["network.authRequired"]
-    response_completed_events = network_events["network.responseCompleted"]
+    before_request_sent_events = network_events[BEFORE_REQUEST_SENT_EVENT]
+    response_started_events = network_events[RESPONSE_STARTED_EVENT]
+    auth_required_events = network_events[AUTH_REQUIRED_EVENT]
+    response_completed_events = network_events[RESPONSE_COMPLETED_EVENT]
 
     auth_url = url("/webdriver/tests/support/http_handlers/authentication.py")
     intercept = await add_intercept(
@@ -87,16 +93,16 @@ async def test_no_authentication(
 ):
     network_events = await setup_network_test(
         events=[
-            "network.beforeRequestSent",
-            "network.responseStarted",
-            "network.authRequired",
-            "network.responseCompleted",
+            BEFORE_REQUEST_SENT_EVENT,
+            RESPONSE_STARTED_EVENT,
+            AUTH_REQUIRED_EVENT,
+            RESPONSE_COMPLETED_EVENT,
         ]
     )
-    before_request_sent_events = network_events["network.beforeRequestSent"]
-    response_started_events = network_events["network.responseStarted"]
-    auth_required_events = network_events["network.authRequired"]
-    response_completed_events = network_events["network.responseCompleted"]
+    before_request_sent_events = network_events[BEFORE_REQUEST_SENT_EVENT]
+    response_started_events = network_events[RESPONSE_STARTED_EVENT]
+    auth_required_events = network_events[AUTH_REQUIRED_EVENT]
+    response_completed_events = network_events[RESPONSE_COMPLETED_EVENT]
 
     text_url = url(PAGE_EMPTY_TEXT)
     intercept = await add_intercept(
@@ -106,7 +112,7 @@ async def test_no_authentication(
 
     assert isinstance(intercept, str)
 
-    on_network_event = wait_for_event("network.responseCompleted")
+    on_network_event = wait_for_event(RESPONSE_COMPLETED_EVENT)
 
     await fetch(text_url)
     await wait_for_future_safe(on_network_event)

--- a/webdriver/tests/bidi/network/add_intercept/phases.py
+++ b/webdriver/tests/bidi/network/add_intercept/phases.py
@@ -4,9 +4,11 @@ from webdriver.bidi.modules.script import ScriptEvaluateResultException
 from .. import (
     assert_before_request_sent_event,
     assert_response_event,
+    PAGE_EMPTY_TEXT,
+    BEFORE_REQUEST_SENT_EVENT,
+    RESPONSE_COMPLETED_EVENT,
+    RESPONSE_STARTED_EVENT,
 )
-
-PAGE_EMPTY_TEXT = "/webdriver/tests/bidi/network/support/empty.txt"
 
 
 @pytest.mark.asyncio
@@ -32,14 +34,14 @@ async def test_request_response_phases(
 ):
     network_events = await setup_network_test(
         events=[
-            "network.beforeRequestSent",
-            "network.responseStarted",
-            "network.responseCompleted",
+            BEFORE_REQUEST_SENT_EVENT,
+            RESPONSE_STARTED_EVENT,
+            RESPONSE_COMPLETED_EVENT,
         ]
     )
-    before_request_sent_events = network_events["network.beforeRequestSent"]
-    response_started_events = network_events["network.responseStarted"]
-    response_completed_events = network_events["network.responseCompleted"]
+    before_request_sent_events = network_events[BEFORE_REQUEST_SENT_EVENT]
+    response_started_events = network_events[RESPONSE_STARTED_EVENT]
+    response_completed_events = network_events[RESPONSE_COMPLETED_EVENT]
 
     text_url = url(PAGE_EMPTY_TEXT)
     intercept = await add_intercept(
@@ -97,9 +99,9 @@ async def test_not_listening_to_phase_event(
     phase,
 ):
     events = [
-        "network.beforeRequestSent",
-        "network.responseStarted",
-        "network.responseCompleted",
+        BEFORE_REQUEST_SENT_EVENT,
+        RESPONSE_STARTED_EVENT,
+        RESPONSE_COMPLETED_EVENT,
     ]
 
     # Remove the event corresponding to the intercept phase from the monitored

--- a/webdriver/tests/bidi/network/add_intercept/url_patterns.py
+++ b/webdriver/tests/bidi/network/add_intercept/url_patterns.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from .. import assert_before_request_sent_event
+from .. import assert_before_request_sent_event, BEFORE_REQUEST_SENT_EVENT
 
 
 @pytest.fixture
@@ -67,7 +67,7 @@ async def test_pattern_patterns_matching(
     patterns,
     url_template,
 ):
-    await subscribe_events(events=["network.beforeRequestSent"], contexts=[top_context["context"]])
+    await subscribe_events(events=[BEFORE_REQUEST_SENT_EVENT], contexts=[top_context["context"]])
 
     for pattern in patterns:
         for key in pattern:
@@ -77,7 +77,7 @@ async def test_pattern_patterns_matching(
 
     intercept = await add_intercept(phases=["beforeRequestSent"], url_patterns=patterns)
 
-    on_network_event = wait_for_event("network.beforeRequestSent")
+    on_network_event = wait_for_event(BEFORE_REQUEST_SENT_EVENT)
     asyncio.ensure_future(fetch(substitute_host(url_template)))
     event = await wait_for_future_safe(on_network_event)
 
@@ -114,7 +114,7 @@ async def test_pattern_patterns_not_matching(
     pattern,
     url_template,
 ):
-    await subscribe_events(events=["network.beforeRequestSent"], contexts=[top_context["context"]])
+    await subscribe_events(events=[BEFORE_REQUEST_SENT_EVENT], contexts=[top_context["context"]])
 
     for key in pattern:
         pattern[key] = substitute_host(pattern[key])
@@ -123,7 +123,7 @@ async def test_pattern_patterns_not_matching(
 
     await add_intercept(phases=["beforeRequestSent"], url_patterns=[pattern])
 
-    on_network_event = wait_for_event("network.beforeRequestSent")
+    on_network_event = wait_for_event(BEFORE_REQUEST_SENT_EVENT)
     asyncio.ensure_future(fetch(substitute_host(url_template)))
     event = await wait_for_future_safe(on_network_event)
 
@@ -164,14 +164,14 @@ async def test_string_patterns_matching(
     pattern,
     url_template,
 ):
-    await subscribe_events(events=["network.beforeRequestSent"], contexts=[top_context["context"]])
+    await subscribe_events(events=[BEFORE_REQUEST_SENT_EVENT], contexts=[top_context["context"]])
 
     intercept = await add_intercept(
         phases=["beforeRequestSent"],
         url_patterns=[{"type": "string", "pattern": substitute_host(pattern)}],
     )
 
-    on_network_event = wait_for_event("network.beforeRequestSent")
+    on_network_event = wait_for_event(BEFORE_REQUEST_SENT_EVENT)
     asyncio.ensure_future(fetch(substitute_host(url_template)))
     event = await wait_for_future_safe(on_network_event)
 
@@ -206,14 +206,14 @@ async def test_string_patterns_not_matching(
     pattern,
     url_template,
 ):
-    await subscribe_events(events=["network.beforeRequestSent"], contexts=[top_context["context"]])
+    await subscribe_events(events=[BEFORE_REQUEST_SENT_EVENT], contexts=[top_context["context"]])
 
     await add_intercept(
         phases=["beforeRequestSent"],
         url_patterns=[{"type": "string", "pattern": substitute_host(pattern)}],
     )
 
-    on_network_event = wait_for_event("network.beforeRequestSent")
+    on_network_event = wait_for_event(BEFORE_REQUEST_SENT_EVENT)
     asyncio.ensure_future(fetch(substitute_host(url_template)))
     event = await wait_for_future_safe(on_network_event)
 

--- a/webdriver/tests/bidi/network/auth_required/auth_required.py
+++ b/webdriver/tests/bidi/network/auth_required/auth_required.py
@@ -1,10 +1,6 @@
 import pytest
 
-from .. import assert_response_event
-
-PAGE_EMPTY_HTML = "/webdriver/tests/bidi/network/support/empty.html"
-
-AUTH_REQUIRED_EVENT = "network.authRequired"
+from .. import assert_response_event, AUTH_REQUIRED_EVENT, PAGE_EMPTY_HTML
 
 
 @pytest.mark.asyncio

--- a/webdriver/tests/bidi/network/auth_required/unsubscribe.py
+++ b/webdriver/tests/bidi/network/auth_required/unsubscribe.py
@@ -4,9 +4,7 @@ import pytest
 
 pytestmark = pytest.mark.asyncio
 
-PAGE_EMPTY_HTML = "/webdriver/tests/bidi/network/support/empty.html"
-
-AUTH_REQUIRED_EVENT = "network.authRequired"
+from .. import AUTH_REQUIRED_EVENT, PAGE_EMPTY_HTML
 
 
 # This test can be moved back to `auth_required.py` when all implementations

--- a/webdriver/tests/bidi/network/before_request_sent/before_request_sent.py
+++ b/webdriver/tests/bidi/network/before_request_sent/before_request_sent.py
@@ -6,19 +6,19 @@ from webdriver.bidi.modules.script import ContextTarget
 
 from tests.support.sync import AsyncPoll
 
-from .. import assert_before_request_sent_event
-
-PAGE_EMPTY_HTML = "/webdriver/tests/bidi/network/support/empty.html"
-PAGE_EMPTY_TEXT = "/webdriver/tests/bidi/network/support/empty.txt"
-PAGE_REDIRECT_HTTP_EQUIV = (
-    "/webdriver/tests/bidi/network/support/redirect_http_equiv.html"
+from .. import (
+    assert_before_request_sent_event,
+    PAGE_EMPTY_HTML,
+    PAGE_EMPTY_TEXT,
+    PAGE_REDIRECT_HTTP_EQUIV,
+    PAGE_REDIRECTED_HTML,
+    BEFORE_REQUEST_SENT_EVENT,
 )
-PAGE_REDIRECTED_HTML = "/webdriver/tests/bidi/network/support/redirected.html"
 
 
 @pytest.mark.asyncio
 async def test_subscribe_status(bidi_session, subscribe_events, top_context, wait_for_event, wait_for_future_safe, url, fetch):
-    await subscribe_events(events=["network.beforeRequestSent"])
+    await subscribe_events(events=[BEFORE_REQUEST_SENT_EVENT])
 
     await bidi_session.browsing_context.navigate(
         context=top_context["context"],
@@ -33,11 +33,11 @@ async def test_subscribe_status(bidi_session, subscribe_events, top_context, wai
         events.append(data)
 
     remove_listener = bidi_session.add_event_listener(
-        "network.beforeRequestSent", on_event
+        BEFORE_REQUEST_SENT_EVENT, on_event
     )
 
     text_url = url(PAGE_EMPTY_TEXT)
-    on_before_request_sent = wait_for_event("network.beforeRequestSent")
+    on_before_request_sent = wait_for_event(BEFORE_REQUEST_SENT_EVENT)
     await fetch(text_url)
     await wait_for_future_safe(on_before_request_sent)
 
@@ -49,7 +49,7 @@ async def test_subscribe_status(bidi_session, subscribe_events, top_context, wai
         redirect_count=0,
     )
 
-    await bidi_session.session.unsubscribe(events=["network.beforeRequestSent"])
+    await bidi_session.session.unsubscribe(events=[BEFORE_REQUEST_SENT_EVENT])
 
     # Fetch the text url again, with an additional parameter to bypass the cache
     # and check no new event is received.
@@ -66,10 +66,10 @@ async def test_load_page_twice(
 ):
     html_url = url(PAGE_EMPTY_HTML)
 
-    network_events = await setup_network_test(events=["network.beforeRequestSent"])
-    events = network_events["network.beforeRequestSent"]
+    network_events = await setup_network_test(events=[BEFORE_REQUEST_SENT_EVENT])
+    events = network_events[BEFORE_REQUEST_SENT_EVENT]
 
-    on_before_request_sent = wait_for_event("network.beforeRequestSent")
+    on_before_request_sent = wait_for_event(BEFORE_REQUEST_SENT_EVENT)
     await bidi_session.browsing_context.navigate(
         context=top_context["context"],
         url=html_url,
@@ -92,10 +92,10 @@ async def test_navigation_id(
 ):
     html_url = url(PAGE_EMPTY_HTML)
 
-    network_events = await setup_network_test(events=["network.beforeRequestSent"])
-    events = network_events["network.beforeRequestSent"]
+    network_events = await setup_network_test(events=[BEFORE_REQUEST_SENT_EVENT])
+    events = network_events[BEFORE_REQUEST_SENT_EVENT]
 
-    on_before_request_sent = wait_for_event("network.beforeRequestSent")
+    on_before_request_sent = wait_for_event(BEFORE_REQUEST_SENT_EVENT)
     result = await bidi_session.browsing_context.navigate(
         context=top_context["context"],
         url=html_url,
@@ -111,7 +111,7 @@ async def test_navigation_id(
     assert events[0]["navigation"] is not None
 
     text_url = url(PAGE_EMPTY_TEXT)
-    on_before_request_sent = wait_for_event("network.beforeRequestSent")
+    on_before_request_sent = wait_for_event(BEFORE_REQUEST_SENT_EVENT)
     await fetch(text_url, method="GET")
     await wait_for_future_safe(on_before_request_sent)
 
@@ -143,10 +143,10 @@ async def test_request_method(
 ):
     text_url = url(PAGE_EMPTY_TEXT)
 
-    network_events = await setup_network_test(events=["network.beforeRequestSent"])
-    events = network_events["network.beforeRequestSent"]
+    network_events = await setup_network_test(events=[BEFORE_REQUEST_SENT_EVENT])
+    events = network_events[BEFORE_REQUEST_SENT_EVENT]
 
-    on_before_request_sent = wait_for_event("network.beforeRequestSent")
+    on_before_request_sent = wait_for_event(BEFORE_REQUEST_SENT_EVENT)
     await fetch(text_url, method=method)
     await wait_for_future_safe(on_before_request_sent)
 
@@ -165,10 +165,10 @@ async def test_request_headers(
 ):
     text_url = url(PAGE_EMPTY_TEXT)
 
-    network_events = await setup_network_test(events=["network.beforeRequestSent"])
-    events = network_events["network.beforeRequestSent"]
+    network_events = await setup_network_test(events=[BEFORE_REQUEST_SENT_EVENT])
+    events = network_events[BEFORE_REQUEST_SENT_EVENT]
 
-    on_before_request_sent = wait_for_event("network.beforeRequestSent")
+    on_before_request_sent = wait_for_event(BEFORE_REQUEST_SENT_EVENT)
     await fetch(text_url, method="GET", headers={"foo": "bar"})
     await wait_for_future_safe(on_before_request_sent)
 
@@ -191,8 +191,8 @@ async def test_request_cookies(
 ):
     text_url = url(PAGE_EMPTY_TEXT)
 
-    network_events = await setup_network_test(events=["network.beforeRequestSent"])
-    events = network_events["network.beforeRequestSent"]
+    network_events = await setup_network_test(events=[BEFORE_REQUEST_SENT_EVENT])
+    events = network_events[BEFORE_REQUEST_SENT_EVENT]
 
     await bidi_session.script.evaluate(
         expression="document.cookie = 'foo=bar';",
@@ -200,7 +200,7 @@ async def test_request_cookies(
         await_promise=False,
     )
 
-    on_before_request_sent = wait_for_event("network.beforeRequestSent")
+    on_before_request_sent = wait_for_event(BEFORE_REQUEST_SENT_EVENT)
     await fetch(text_url, method="GET")
     await wait_for_future_safe(on_before_request_sent)
 
@@ -222,7 +222,7 @@ async def test_request_cookies(
         await_promise=False,
     )
 
-    on_before_request_sent = wait_for_event("network.beforeRequestSent")
+    on_before_request_sent = wait_for_event(BEFORE_REQUEST_SENT_EVENT)
     await fetch(text_url, method="GET")
     await wait_for_future_safe(on_before_request_sent)
 
@@ -250,8 +250,8 @@ async def test_redirect(bidi_session, wait_for_event, url, fetch, setup_network_
         f"/webdriver/tests/support/http_handlers/redirect.py?location={text_url}"
     )
 
-    network_events = await setup_network_test(events=["network.beforeRequestSent"])
-    events = network_events["network.beforeRequestSent"]
+    network_events = await setup_network_test(events=[BEFORE_REQUEST_SENT_EVENT])
+    events = network_events[BEFORE_REQUEST_SENT_EVENT]
 
     await fetch(redirect_url, method="GET")
 
@@ -284,8 +284,8 @@ async def test_redirect_http_equiv(
     http_equiv_url = url(PAGE_REDIRECT_HTTP_EQUIV)
     redirected_url = url(PAGE_REDIRECTED_HTML)
 
-    network_events = await setup_network_test(events=["network.beforeRequestSent"])
-    events = network_events["network.beforeRequestSent"]
+    network_events = await setup_network_test(events=[BEFORE_REQUEST_SENT_EVENT])
+    events = network_events[BEFORE_REQUEST_SENT_EVENT]
 
     result = await bidi_session.browsing_context.navigate(
         context=top_context["context"],
@@ -333,8 +333,8 @@ async def test_redirect_navigation(
         f"/webdriver/tests/support/http_handlers/redirect.py?location={html_url}"
     )
 
-    network_events = await setup_network_test(events=["network.beforeRequestSent"])
-    events = network_events["network.beforeRequestSent"]
+    network_events = await setup_network_test(events=[BEFORE_REQUEST_SENT_EVENT])
+    events = network_events[BEFORE_REQUEST_SENT_EVENT]
 
     result = await bidi_session.browsing_context.navigate(
         context=top_context["context"],

--- a/webdriver/tests/bidi/network/combined/network_events.py
+++ b/webdriver/tests/bidi/network/combined/network_events.py
@@ -5,10 +5,12 @@ import pytest
 from .. import (
     assert_before_request_sent_event,
     assert_response_event,
+    PAGE_EMPTY_HTML,
+    PAGE_EMPTY_TEXT,
+    BEFORE_REQUEST_SENT_EVENT,
+    RESPONSE_COMPLETED_EVENT,
+    RESPONSE_STARTED_EVENT,
 )
-
-PAGE_EMPTY_HTML = "/webdriver/tests/bidi/network/support/empty.html"
-PAGE_EMPTY_TEXT = "/webdriver/tests/bidi/network/support/empty.txt"
 
 
 @pytest.mark.asyncio
@@ -17,15 +19,15 @@ async def test_same_navigation_id(
 ):
     network_events = await setup_network_test(
         events=[
-            "network.beforeRequestSent",
-            "network.responseStarted",
-            "network.responseCompleted",
+            BEFORE_REQUEST_SENT_EVENT,
+            RESPONSE_STARTED_EVENT,
+            RESPONSE_COMPLETED_EVENT,
         ],
         contexts=[top_context["context"]],
     )
 
     html_url = url(PAGE_EMPTY_HTML)
-    on_response_completed = wait_for_event("network.responseCompleted")
+    on_response_completed = wait_for_event(RESPONSE_COMPLETED_EVENT)
     result = await bidi_session.browsing_context.navigate(
         context=top_context["context"],
         url=html_url,
@@ -33,25 +35,25 @@ async def test_same_navigation_id(
     )
     await wait_for_future_safe(on_response_completed)
 
-    assert len(network_events["network.beforeRequestSent"]) == 1
-    assert len(network_events["network.responseStarted"]) == 1
-    assert len(network_events["network.responseCompleted"]) == 1
+    assert len(network_events[BEFORE_REQUEST_SENT_EVENT]) == 1
+    assert len(network_events[RESPONSE_STARTED_EVENT]) == 1
+    assert len(network_events[RESPONSE_COMPLETED_EVENT]) == 1
     expected_request = {"method": "GET", "url": html_url}
     expected_response = {"url": html_url}
     assert_before_request_sent_event(
-        network_events["network.beforeRequestSent"][0],
+        network_events[BEFORE_REQUEST_SENT_EVENT][0],
         expected_request=expected_request,
         context=top_context["context"],
         navigation=result["navigation"],
     )
     assert_response_event(
-        network_events["network.responseStarted"][0],
+        network_events[RESPONSE_STARTED_EVENT][0],
         expected_response=expected_response,
         context=top_context["context"],
         navigation=result["navigation"],
     )
     assert_response_event(
-        network_events["network.responseCompleted"][0],
+        network_events[RESPONSE_COMPLETED_EVENT][0],
         expected_response=expected_response,
         context=top_context["context"],
         navigation=result["navigation"],
@@ -62,17 +64,17 @@ async def test_same_navigation_id(
 async def test_same_request_id(wait_for_event, wait_for_future_safe, url, setup_network_test, fetch):
     network_events = await setup_network_test(
         events=[
-            "network.beforeRequestSent",
-            "network.responseStarted",
-            "network.responseCompleted",
+            BEFORE_REQUEST_SENT_EVENT,
+            RESPONSE_STARTED_EVENT,
+            RESPONSE_COMPLETED_EVENT,
         ]
     )
-    before_request_sent_events = network_events["network.beforeRequestSent"]
-    response_started_events = network_events["network.responseStarted"]
-    response_completed_events = network_events["network.responseCompleted"]
+    before_request_sent_events = network_events[BEFORE_REQUEST_SENT_EVENT]
+    response_started_events = network_events[RESPONSE_STARTED_EVENT]
+    response_completed_events = network_events[RESPONSE_COMPLETED_EVENT]
 
     text_url = url(PAGE_EMPTY_TEXT)
-    on_response_completed = wait_for_event("network.responseCompleted")
+    on_response_completed = wait_for_event(RESPONSE_COMPLETED_EVENT)
     await fetch(text_url)
     await wait_for_future_safe(on_response_completed)
 
@@ -118,38 +120,38 @@ async def test_subscribe_to_one_context(
 
     network_events = await setup_network_test(
         events=[
-            "network.beforeRequestSent",
-            "network.responseStarted",
-            "network.responseCompleted",
+            BEFORE_REQUEST_SENT_EVENT,
+            RESPONSE_STARTED_EVENT,
+            RESPONSE_COMPLETED_EVENT,
         ],
         contexts=[top_context["context"]],
     )
 
     # Perform a fetch request in the subscribed context and wait for the response completed event.
     text_url = url(PAGE_EMPTY_TEXT)
-    on_response_completed = wait_for_event("network.responseCompleted")
+    on_response_completed = wait_for_event(RESPONSE_COMPLETED_EVENT)
     await fetch(text_url, context=top_context)
     await wait_for_future_safe(on_response_completed)
 
-    assert len(network_events["network.beforeRequestSent"]) == 1
-    assert len(network_events["network.responseStarted"]) == 1
-    assert len(network_events["network.responseCompleted"]) == 1
+    assert len(network_events[BEFORE_REQUEST_SENT_EVENT]) == 1
+    assert len(network_events[RESPONSE_STARTED_EVENT]) == 1
+    assert len(network_events[RESPONSE_COMPLETED_EVENT]) == 1
 
     # Check the received events have the correct context.
     expected_request = {"method": "GET", "url": text_url}
     expected_response = {"url": text_url}
     assert_before_request_sent_event(
-        network_events["network.beforeRequestSent"][0],
+        network_events[BEFORE_REQUEST_SENT_EVENT][0],
         expected_request=expected_request,
         context=top_context["context"],
     )
     assert_response_event(
-        network_events["network.responseStarted"][0],
+        network_events[RESPONSE_STARTED_EVENT][0],
         expected_response=expected_response,
         context=top_context["context"],
     )
     assert_response_event(
-        network_events["network.responseCompleted"][0],
+        network_events[RESPONSE_COMPLETED_EVENT][0],
         expected_response=expected_response,
         context=top_context["context"],
     )
@@ -159,6 +161,6 @@ async def test_subscribe_to_one_context(
     await asyncio.sleep(0.5)
 
     # Check that no other event was received.
-    assert len(network_events["network.beforeRequestSent"]) == 1
-    assert len(network_events["network.responseStarted"]) == 1
-    assert len(network_events["network.responseCompleted"]) == 1
+    assert len(network_events[BEFORE_REQUEST_SENT_EVENT]) == 1
+    assert len(network_events[RESPONSE_STARTED_EVENT]) == 1
+    assert len(network_events[RESPONSE_COMPLETED_EVENT]) == 1

--- a/webdriver/tests/bidi/network/conftest.py
+++ b/webdriver/tests/bidi/network/conftest.py
@@ -6,9 +6,7 @@ import pytest_asyncio
 from webdriver.bidi.error import NoSuchInterceptException
 from webdriver.bidi.modules.script import ContextTarget
 
-RESPONSE_COMPLETED_EVENT = "network.responseCompleted"
-
-PAGE_EMPTY_HTML = "/webdriver/tests/bidi/network/support/empty.html"
+from . import PAGE_EMPTY_HTML, RESPONSE_COMPLETED_EVENT
 
 
 @pytest_asyncio.fixture

--- a/webdriver/tests/bidi/network/fail_request/invalid.py
+++ b/webdriver/tests/bidi/network/fail_request/invalid.py
@@ -3,7 +3,7 @@ import webdriver.bidi.error as error
 
 pytestmark = pytest.mark.asyncio
 
-PAGE_EMPTY_TEXT = "/webdriver/tests/bidi/network/support/empty.txt"
+from .. import PAGE_EMPTY_TEXT, RESPONSE_COMPLETED_EVENT
 
 
 @pytest.mark.parametrize("value", [None, False, 42, {}, []])
@@ -22,9 +22,9 @@ async def test_params_request_no_such_request(bidi_session, setup_network_test,
                                               wait_for_event, wait_for_future_safe,
                                               fetch, url):
     await setup_network_test(events=[
-        "network.responseCompleted",
+        RESPONSE_COMPLETED_EVENT,
     ])
-    on_response_completed = wait_for_event("network.responseCompleted")
+    on_response_completed = wait_for_event(RESPONSE_COMPLETED_EVENT)
 
     text_url = url(PAGE_EMPTY_TEXT)
     await fetch(text_url)

--- a/webdriver/tests/bidi/network/remove_intercept/remove_intercept.py
+++ b/webdriver/tests/bidi/network/remove_intercept/remove_intercept.py
@@ -6,11 +6,13 @@ import pytest
 from .. import (
     assert_before_request_sent_event,
     assert_response_event,
+    PAGE_EMPTY_HTML,
+    PAGE_EMPTY_TEXT,
+    PAGE_OTHER_TEXT,
+    BEFORE_REQUEST_SENT_EVENT,
+    RESPONSE_COMPLETED_EVENT,
+    RESPONSE_STARTED_EVENT,
 )
-
-PAGE_EMPTY_HTML = "/webdriver/tests/bidi/network/support/empty.html"
-PAGE_EMPTY_TEXT = "/webdriver/tests/bidi/network/support/empty.txt"
-PAGE_OTHER_TEXT = "/webdriver/tests/bidi/network/support/other.txt"
 
 
 @pytest.mark.asyncio
@@ -23,14 +25,14 @@ async def test_remove_intercept(
 ):
     network_events = await setup_network_test(
         events=[
-            "network.beforeRequestSent",
-            "network.responseStarted",
-            "network.responseCompleted",
+            BEFORE_REQUEST_SENT_EVENT,
+            RESPONSE_STARTED_EVENT,
+            RESPONSE_COMPLETED_EVENT,
         ]
     )
-    before_request_sent_events = network_events["network.beforeRequestSent"]
-    response_started_events = network_events["network.responseStarted"]
-    response_completed_events = network_events["network.responseCompleted"]
+    before_request_sent_events = network_events[BEFORE_REQUEST_SENT_EVENT]
+    response_started_events = network_events[RESPONSE_STARTED_EVENT]
+    response_completed_events = network_events[RESPONSE_COMPLETED_EVENT]
 
     text_url = url(PAGE_EMPTY_TEXT)
     intercept = await add_intercept(
@@ -74,7 +76,7 @@ async def test_remove_intercept(
     await bidi_session.network.remove_intercept(intercept=intercept)
 
     # The next request should not be blocked
-    on_response_completed = wait_for_event("network.responseCompleted")
+    on_response_completed = wait_for_event(RESPONSE_COMPLETED_EVENT)
     await bidi_session.browsing_context.navigate(context=top_context["context"], url=text_url, wait="complete")
     await wait_for_future_safe(on_response_completed)
 

--- a/webdriver/tests/bidi/network/response_completed/response_completed.py
+++ b/webdriver/tests/bidi/network/response_completed/response_completed.py
@@ -5,15 +5,16 @@ import pytest
 
 from tests.support.sync import AsyncPoll
 
-from .. import assert_response_event, HTTP_STATUS_AND_STATUS_TEXT
-
-PAGE_EMPTY_HTML = "/webdriver/tests/bidi/network/support/empty.html"
-PAGE_EMPTY_IMAGE = "/webdriver/tests/bidi/network/support/empty.png"
-PAGE_EMPTY_SCRIPT = "/webdriver/tests/bidi/network/support/empty.js"
-PAGE_EMPTY_SVG = "/webdriver/tests/bidi/network/support/empty.svg"
-PAGE_EMPTY_TEXT = "/webdriver/tests/bidi/network/support/empty.txt"
-
-RESPONSE_COMPLETED_EVENT = "network.responseCompleted"
+from .. import (
+    assert_response_event,
+    HTTP_STATUS_AND_STATUS_TEXT,
+    PAGE_EMPTY_HTML,
+    PAGE_EMPTY_IMAGE,
+    PAGE_EMPTY_SCRIPT,
+    PAGE_EMPTY_SVG,
+    PAGE_EMPTY_TEXT,
+    RESPONSE_COMPLETED_EVENT,
+)
 
 
 @pytest.mark.asyncio

--- a/webdriver/tests/bidi/network/response_completed/response_completed_cached.py
+++ b/webdriver/tests/bidi/network/response_completed/response_completed_cached.py
@@ -3,9 +3,7 @@ import random
 
 from tests.support.sync import AsyncPoll
 
-from .. import assert_response_event
-
-PAGE_EMPTY_TEXT = "/webdriver/tests/bidi/network/support/empty.txt"
+from .. import assert_response_event, PAGE_EMPTY_TEXT, RESPONSE_COMPLETED_EVENT
 
 
 @pytest.mark.asyncio
@@ -18,15 +16,15 @@ async def test_cached(
 ):
     network_events = await setup_network_test(
         events=[
-            "network.responseCompleted",
+            RESPONSE_COMPLETED_EVENT,
         ]
     )
-    events = network_events["network.responseCompleted"]
+    events = network_events[RESPONSE_COMPLETED_EVENT]
 
     cached_url = url(
         f"/webdriver/tests/support/http_handlers/cached.py?status=200&nocache={random.random()}"
     )
-    on_response_completed = wait_for_event("network.responseCompleted")
+    on_response_completed = wait_for_event(RESPONSE_COMPLETED_EVENT)
     await fetch(cached_url)
     await wait_for_future_safe(on_response_completed)
 
@@ -46,7 +44,7 @@ async def test_cached(
         expected_response=expected_response,
     )
 
-    on_response_completed = wait_for_event("network.responseCompleted")
+    on_response_completed = wait_for_event(RESPONSE_COMPLETED_EVENT)
     await fetch(cached_url)
     await wait_for_future_safe(on_response_completed)
 
@@ -74,10 +72,10 @@ async def test_cached_redirect(
 ):
     network_events = await setup_network_test(
         events=[
-            "network.responseCompleted",
+            RESPONSE_COMPLETED_EVENT,
         ]
     )
-    events = network_events["network.responseCompleted"]
+    events = network_events[RESPONSE_COMPLETED_EVENT]
 
     text_url = url(PAGE_EMPTY_TEXT)
     cached_url = url(
@@ -145,15 +143,15 @@ async def test_cached_revalidate(
 ):
     network_events = await setup_network_test(
         events=[
-            "network.responseCompleted",
+            RESPONSE_COMPLETED_EVENT,
         ]
     )
-    events = network_events["network.responseCompleted"]
+    events = network_events[RESPONSE_COMPLETED_EVENT]
 
     revalidate_url = url(
         f"/webdriver/tests/support/http_handlers/must-revalidate.py?nocache={random.random()}"
     )
-    on_response_completed = wait_for_event("network.responseCompleted")
+    on_response_completed = wait_for_event(RESPONSE_COMPLETED_EVENT)
     await fetch(revalidate_url)
     await wait_for_future_safe(on_response_completed)
 
@@ -170,7 +168,7 @@ async def test_cached_revalidate(
         expected_response=expected_response,
     )
 
-    on_response_completed = wait_for_event("network.responseCompleted")
+    on_response_completed = wait_for_event(RESPONSE_COMPLETED_EVENT)
 
     # Note that we pass a specific header so that the must-revalidate.py handler
     # can decide to return a 304 without having to use another URL.

--- a/webdriver/tests/bidi/network/response_completed/response_completed_status.py
+++ b/webdriver/tests/bidi/network/response_completed/response_completed_status.py
@@ -11,9 +11,11 @@
 
 import pytest
 
-from .. import assert_response_event, HTTP_STATUS_AND_STATUS_TEXT
-
-RESPONSE_COMPLETED_EVENT = "network.responseCompleted"
+from .. import (
+    assert_response_event,
+    HTTP_STATUS_AND_STATUS_TEXT,
+    RESPONSE_COMPLETED_EVENT,
+)
 
 
 @pytest.mark.parametrize(

--- a/webdriver/tests/bidi/network/response_started/response_started.py
+++ b/webdriver/tests/bidi/network/response_started/response_started.py
@@ -4,15 +4,16 @@ import pytest
 
 from tests.support.sync import AsyncPoll
 
-from .. import assert_response_event, HTTP_STATUS_AND_STATUS_TEXT
-
-PAGE_EMPTY_HTML = "/webdriver/tests/bidi/network/support/empty.html"
-PAGE_EMPTY_IMAGE = "/webdriver/tests/bidi/network/support/empty.png"
-PAGE_EMPTY_SCRIPT = "/webdriver/tests/bidi/network/support/empty.js"
-PAGE_EMPTY_SVG = "/webdriver/tests/bidi/network/support/empty.svg"
-PAGE_EMPTY_TEXT = "/webdriver/tests/bidi/network/support/empty.txt"
-
-RESPONSE_STARTED_EVENT = "network.responseStarted"
+from .. import (
+    assert_response_event,
+    HTTP_STATUS_AND_STATUS_TEXT,
+    PAGE_EMPTY_HTML,
+    PAGE_EMPTY_IMAGE,
+    PAGE_EMPTY_SCRIPT,
+    PAGE_EMPTY_SVG,
+    PAGE_EMPTY_TEXT,
+    RESPONSE_STARTED_EVENT,
+)
 
 
 @pytest.mark.asyncio

--- a/webdriver/tests/bidi/network/response_started/response_started_cached.py
+++ b/webdriver/tests/bidi/network/response_started/response_started_cached.py
@@ -3,9 +3,7 @@ import random
 
 from tests.support.sync import AsyncPoll
 
-from .. import assert_response_event
-
-PAGE_EMPTY_TEXT = "/webdriver/tests/bidi/network/support/empty.txt"
+from .. import assert_response_event, PAGE_EMPTY_TEXT, RESPONSE_STARTED_EVENT
 
 
 @pytest.mark.asyncio
@@ -18,15 +16,15 @@ async def test_cached(
 ):
     network_events = await setup_network_test(
         events=[
-            "network.responseStarted",
+            RESPONSE_STARTED_EVENT,
         ]
     )
-    events = network_events["network.responseStarted"]
+    events = network_events[RESPONSE_STARTED_EVENT]
 
     cached_url = url(
         f"/webdriver/tests/support/http_handlers/cached.py?status=200&nocache={random.random()}"
     )
-    on_response_started = wait_for_event("network.responseStarted")
+    on_response_started = wait_for_event(RESPONSE_STARTED_EVENT)
     await fetch(cached_url)
     await wait_for_future_safe(on_response_started)
 
@@ -46,7 +44,7 @@ async def test_cached(
         expected_response=expected_response,
     )
 
-    on_response_started = wait_for_event("network.responseStarted")
+    on_response_started = wait_for_event(RESPONSE_STARTED_EVENT)
     await fetch(cached_url)
     await wait_for_future_safe(on_response_started)
 
@@ -74,10 +72,10 @@ async def test_cached_redirect(
 ):
     network_events = await setup_network_test(
         events=[
-            "network.responseStarted",
+            RESPONSE_STARTED_EVENT,
         ]
     )
-    events = network_events["network.responseStarted"]
+    events = network_events[RESPONSE_STARTED_EVENT]
 
     text_url = url(PAGE_EMPTY_TEXT)
     cached_url = url(
@@ -153,15 +151,15 @@ async def test_cached_revalidate(
 ):
     network_events = await setup_network_test(
         events=[
-            "network.responseStarted",
+            RESPONSE_STARTED_EVENT,
         ]
     )
-    events = network_events["network.responseStarted"]
+    events = network_events[RESPONSE_STARTED_EVENT]
 
     revalidate_url = url(
         f"/webdriver/tests/support/http_handlers/must-revalidate.py?nocache={random.random()}"
     )
-    on_response_started = wait_for_event("network.responseStarted")
+    on_response_started = wait_for_event(RESPONSE_STARTED_EVENT)
     await fetch(revalidate_url, method=method)
     await wait_for_future_safe(on_response_started)
 
@@ -178,7 +176,7 @@ async def test_cached_revalidate(
         expected_response=expected_response,
     )
 
-    on_response_started = wait_for_event("network.responseStarted")
+    on_response_started = wait_for_event(RESPONSE_STARTED_EVENT)
 
     # Note that we pass a specific header so that the must-revalidate.py handler
     # can decide to return a 304 without having to use another URL.


### PR DESCRIPTION
Extracted and expanded from PR #42667 

This PR started moving some URLs and network event names to network's __init__.py. 
To avoid mixing this with the rest of the changes, let's have a dedicated PR for this straightforward refactor.