### PR TITLE
Created 4 background-attachment: [ local | fixed ] tests on [ block | inline ] with scroll() method

### DIFF
--- a/css/css-backgrounds/background-attachment-fixed-block-002.html
+++ b/css/css-backgrounds/background-attachment-fixed-block-002.html
@@ -4,13 +4,13 @@
 
   <meta charset="UTF-8">
 
-  <title>CSS Backgrounds Test: 'background-attachment: fixed' applied on a block element</title>
+  <title>CSS Backgrounds and Borders Test: 'background-attachment: fixed' applied on a block element</title>
 
   <!--
 
   Created: November 25th 2023
 
-  Last modified: December 5th 2023
+  Last modified: December 17th 2023
 
   -->
 
@@ -23,36 +23,30 @@
   <meta name="assert" content="This test checks the interaction between a block element with a 'background-attachment: fixed' background-image and the expected behavior of the scroll() method which applies to the viewport window.">
 
   <style>
-  html
-    {
-      height: 600px;
-      width: 600px;
-    }
-
   body
     {
-      font-size: 200px;
-      line-height: 3;
+      color: transparent;
+      font-family: Ahem;
+      font-size: 50vh;
+      height: 50vh;
+      line-height: 2;
       margin: 0px;
-    }
-
-  div#test-failed
-    {
-       background-color: red;
-       color: yellow;
     }
 
   div#test-passed
     {
       background-attachment: fixed;
-      background-image: linear-gradient(green 50%, lime 50%);
-      color: transparent;
-      font-family: Ahem;
+      background-image: linear-gradient(to bottom, blue 25%, orange 25% 50%, lime 50% 75%, purple 75% 100%);
     }
   </style>
 
-  <body onload="window.scroll(0, 600); document.documentElement.classList.remove('reftest-wait');">
+  <body onload="window.scroll(0, document.body.offsetHeight); document.documentElement.classList.remove('reftest-wait');">
 
-  <div id="test-failed">FAIL</div>
+  <div>F</div>
 
-  <div id="test-passed">PAS</div>
+  <!--
+  Having more than 1 character may trigger
+  unneedlessly an horizontal scrollbar
+  -->
+
+  <div id="test-passed">P</div>

--- a/css/css-backgrounds/background-attachment-fixed-block-002.html
+++ b/css/css-backgrounds/background-attachment-fixed-block-002.html
@@ -56,4 +56,3 @@
   <div id="test-failed">FAIL</div>
 
   <div id="test-passed">PAS</div>
- 

--- a/css/css-backgrounds/background-attachment-fixed-block-002.html
+++ b/css/css-backgrounds/background-attachment-fixed-block-002.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+
+ <html class="reftest-wait">
+
+  <meta charset="UTF-8">
+
+  <title>CSS Backgrounds Test: 'background-attachment: fixed' applied on a block element</title>
+
+  <!--
+
+  Created: November 25th 2023
+
+  Last modified: December 5th 2023
+
+  -->
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#background-attachment">
+  <link rel="help" href="https://www.w3.org/TR/cssom-view-1/#dom-window-scroll">
+  <link rel="match" href="reference/background-attachment-fixed-block-002-ref.html">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+  <meta name="assert" content="This test checks the interaction between a block element with a 'background-attachment: fixed' background-image and the expected behavior of the scroll() method which applies to the viewport window.">
+
+  <style>
+  html
+    {
+      height: 600px;
+      width: 600px;
+    }
+
+  body
+    {
+      font-size: 200px;
+      line-height: 3;
+      margin: 0px;
+    }
+
+  div#test-failed
+    {
+       background-color: red;
+       color: yellow;
+    }
+
+  div#test-passed
+    {
+      background-attachment: fixed;
+      background-image: linear-gradient(green 50%, lime 50%);
+      color: transparent;
+      font-family: Ahem;
+    }
+  </style>
+
+  <body onload="window.scroll(0, 600); document.documentElement.classList.remove('reftest-wait');">
+
+  <div id="test-failed">FAIL</div>
+
+  <div id="test-passed">PAS</div>
+ 

--- a/css/css-backgrounds/background-attachment-fixed-inline-002.html
+++ b/css/css-backgrounds/background-attachment-fixed-inline-002.html
@@ -4,13 +4,13 @@
 
   <meta charset="UTF-8">
 
-  <title>CSS Backgrounds Test: 'background-attachment: fixed' applied on an inline element</title>
+  <title>CSS Backgrounds and Borders Test: 'background-attachment: fixed' applied on an inline element</title>
 
   <!--
 
   Created: November 25th 2023
 
-  Last modified: December 5th 2023
+  Last modified: December 17th 2023
 
   -->
 
@@ -23,37 +23,26 @@
   <meta name="assert" content="This test checks the interaction between an inline with a 'background-attachment: fixed' background-image and the expected behavior of the scroll() method which applies to the viewport window.">
 
   <style>
-  html
-    {
-      height: 600px;
-      width: 600px;
-    }
-
   body
     {
-      font-size: 200px;
-      line-height: 3;
+      color: transparent;
+      font-family: Ahem;
+      font-size: 50vh;
+      height: 50vh;
+      line-height: 2;
       margin: 0px;
-    }
-
-  span#test-failed
-    {
-       background-color: red;
-       color: yellow;
     }
 
   span#test-passed
     {
       background-attachment: fixed;
-      background-image: linear-gradient(green 50%, lime 50%);
-      color: transparent;
-      font-family: Ahem;
+      background-image: linear-gradient(to bottom, blue 25%, orange 25% 50%, lime 50% 75%, purple 75% 100%);
       vertical-align: top;
     }
   </style>
 
-  <body onload="window.scroll(0, 600); document.documentElement.classList.remove('reftest-wait');">
+  <body onload="window.scroll(0, document.body.offsetHeight); document.documentElement.classList.remove('reftest-wait');">
 
-  <div><span id="test-failed">FAIL</span></div>
+  <div>F</div>
 
-  <div><span id="test-passed">PAS</span></div>
+  <div><span id="test-passed">P</span></div>

--- a/css/css-backgrounds/background-attachment-fixed-inline-002.html
+++ b/css/css-backgrounds/background-attachment-fixed-inline-002.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+
+ <html class="reftest-wait">
+
+  <meta charset="UTF-8">
+
+  <title>CSS Backgrounds Test: 'background-attachment: fixed' applied on an inline element</title>
+
+  <!--
+
+  Created: November 25th 2023
+
+  Last modified: December 5th 2023
+
+  -->
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#background-attachment">
+  <link rel="help" href="https://www.w3.org/TR/cssom-view-1/#dom-window-scroll">
+  <link rel="match" href="reference/background-attachment-fixed-inline-002-ref.html">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+  <meta name="assert" content="This test checks the interaction between an inline with a 'background-attachment: fixed' background-image and the expected behavior of the scroll() method which applies to the viewport window.">
+
+  <style>
+  html
+    {
+      height: 600px;
+      width: 600px;
+    }
+
+  body
+    {
+      font-size: 200px;
+      line-height: 3;
+      margin: 0px;
+    }
+
+  span#test-failed
+    {
+       background-color: red;
+       color: yellow;
+    }
+
+  span#test-passed
+    {
+      background-attachment: fixed;
+      background-image: linear-gradient(green 50%, lime 50%);
+      color: transparent;
+      font-family: Ahem;
+      vertical-align: top;
+    }
+  </style>
+
+  <body onload="window.scroll(0, 600); document.documentElement.classList.remove('reftest-wait');">
+
+  <div><span id="test-failed">FAIL</span></div>
+
+  <div><span id="test-passed">PAS</span></div>

--- a/css/css-backgrounds/background-attachment-local-block-002.html
+++ b/css/css-backgrounds/background-attachment-local-block-002.html
@@ -17,7 +17,7 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#background-attachment">
   <link rel="help" href="https://www.w3.org/TR/cssom-view-1/#dom-window-scroll">
-  <link rel="match" href="reference/background-attachment-fixed-block-002-ref.html">
+  <link rel="match" href="reference/background-attachment-local-block-002-ref.html">
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 
   <meta name="assert" content="This test checks the interaction between a block element with a 'background-attachment: local' background-image and the expected behavior of the scroll() method which applies to the viewport window.">

--- a/css/css-backgrounds/background-attachment-local-block-002.html
+++ b/css/css-backgrounds/background-attachment-local-block-002.html
@@ -4,13 +4,13 @@
 
   <meta charset="UTF-8">
 
-  <title>CSS Backgrounds Test: 'background-attachment: local' applied on a block element</title>
+  <title>CSS Backgrounds and Borders Test: 'background-attachment: local' applied on a block element</title>
 
   <!--
 
   Created: November 25th 2023
 
-  Last modified: December 5th 2023
+  Last modified: December 17th 2023
 
   -->
 
@@ -23,36 +23,30 @@
   <meta name="assert" content="This test checks the interaction between a block element with a 'background-attachment: local' background-image and the expected behavior of the scroll() method which applies to the viewport window.">
 
   <style>
-  html
-    {
-      height: 600px;
-      width: 600px;
-    }
-
   body
     {
-      font-size: 200px;
-      line-height: 3;
+      color: transparent;
+      font-family: Ahem;
+      font-size: 50vh;
+      height: 50vh;
+      line-height: 2;
       margin: 0px;
-    }
-
-  div#test-failed
-    {
-       background-color: red;
-       color: yellow;
     }
 
   div#test-passed
     {
       background-attachment: local;
-      background-image: linear-gradient(green 50%, lime 50%);
-      color: transparent;
-      font-family: Ahem;
+      background-image: linear-gradient(to bottom, blue 25%, orange 25% 50%, lime 50% 75%, purple 75% 100%);
     }
   </style>
 
-  <body onload="window.scroll(0, 600); document.documentElement.classList.remove('reftest-wait');">
+  <body onload="window.scroll(0, document.body.offsetHeight); document.documentElement.classList.remove('reftest-wait');">
 
-  <div id="test-failed">FAIL</div>
+  <div>F</div>
 
-  <div id="test-passed">PAS</div>
+  <!--
+  Having more than 1 character may trigger
+  unneedlessly an horizontal scrollbar
+  -->
+
+  <div id="test-passed">P</div>

--- a/css/css-backgrounds/background-attachment-local-block-002.html
+++ b/css/css-backgrounds/background-attachment-local-block-002.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+
+ <html class="reftest-wait">
+
+  <meta charset="UTF-8">
+
+  <title>CSS Backgrounds Test: 'background-attachment: local' applied on a block element</title>
+
+  <!--
+
+  Created: November 25th 2023
+
+  Last modified: December 5th 2023
+
+  -->
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#background-attachment">
+  <link rel="help" href="https://www.w3.org/TR/cssom-view-1/#dom-window-scroll">
+  <link rel="match" href="reference/background-attachment-fixed-block-002-ref.html">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+  <meta name="assert" content="This test checks the interaction between a block element with a 'background-attachment: local' background-image and the expected behavior of the scroll() method which applies to the viewport window.">
+
+  <style>
+  html
+    {
+      height: 600px;
+      width: 600px;
+    }
+
+  body
+    {
+      font-size: 200px;
+      line-height: 3;
+      margin: 0px;
+    }
+
+  div#test-failed
+    {
+       background-color: red;
+       color: yellow;
+    }
+
+  div#test-passed
+    {
+      background-attachment: local;
+      background-image: linear-gradient(green 50%, lime 50%);
+      color: transparent;
+      font-family: Ahem;
+    }
+  </style>
+
+  <body onload="window.scroll(0, 600); document.documentElement.classList.remove('reftest-wait');">
+
+  <div id="test-failed">FAIL</div>
+
+  <div id="test-passed">PAS</div>

--- a/css/css-backgrounds/background-attachment-local-inline-002.html
+++ b/css/css-backgrounds/background-attachment-local-inline-002.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+
+ <html class="reftest-wait">
+
+  <meta charset="UTF-8">
+
+  <title>CSS Backgrounds Test: 'background-attachment: local' applied on an inline element</title>
+
+  <!--
+
+  Created: November 25th 2023
+
+  Last modified: December 5th 2023
+
+  -->
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#background-attachment">
+  <link rel="help" href="https://www.w3.org/TR/cssom-view-1/#dom-window-scroll">
+  <link rel="match" href="reference/background-attachment-fixed-inline-002-ref.html">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+  <meta name="assert" content="This test checks the interaction between an inline with a 'background-attachment: local' background-image and the expected behavior of the scroll() method which applies to the viewport window.">
+
+  <style>
+  html
+    {
+      height: 600px;
+      width: 600px;
+    }
+
+  body
+    {
+      font-size: 200px;
+      line-height: 3;
+      margin: 0px;
+    }
+
+  span#test-failed
+    {
+       background-color: red;
+       color: yellow;
+    }
+
+  span#test-passed
+    {
+      background-attachment: local;
+      background-image: linear-gradient(green 50%, lime 50%);
+      color: transparent;
+      font-family: Ahem;
+      vertical-align: top;
+    }
+  </style>
+
+  <body onload="window.scroll(0, 600); document.documentElement.classList.remove('reftest-wait');">
+
+  <div><span id="test-failed">FAIL</span></div>
+
+  <div><span id="test-passed">PAS</span></div>

--- a/css/css-backgrounds/background-attachment-local-inline-002.html
+++ b/css/css-backgrounds/background-attachment-local-inline-002.html
@@ -4,56 +4,45 @@
 
   <meta charset="UTF-8">
 
-  <title>CSS Backgrounds Test: 'background-attachment: local' applied on an inline element</title>
+  <title>CSS Backgrounds and Borders Test: 'background-attachment: local' applied on an inline element</title>
 
   <!--
 
   Created: November 25th 2023
 
-  Last modified: December 5th 2023
+  Last modified: December 17th 2023
 
   -->
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#background-attachment">
   <link rel="help" href="https://www.w3.org/TR/cssom-view-1/#dom-window-scroll">
-  <link rel="match" href="reference/background-attachment-fixed-inline-002-ref.html">
+  <link rel="match" href="reference/background-attachment-local-inline-002-ref.html">
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 
   <meta name="assert" content="This test checks the interaction between an inline with a 'background-attachment: local' background-image and the expected behavior of the scroll() method which applies to the viewport window.">
 
   <style>
-  html
-    {
-      height: 600px;
-      width: 600px;
-    }
-
   body
     {
-      font-size: 200px;
-      line-height: 3;
+      color: transparent;
+      font-family: Ahem;
+      font-size: 50vh;
+      height: 50vh;
+      line-height: 2;
       margin: 0px;
-    }
-
-  span#test-failed
-    {
-       background-color: red;
-       color: yellow;
     }
 
   span#test-passed
     {
       background-attachment: local;
-      background-image: linear-gradient(green 50%, lime 50%);
-      color: transparent;
-      font-family: Ahem;
+      background-image: linear-gradient(to bottom, blue 25%, orange 25% 50%, lime 50% 75%, purple 75% 100%);
       vertical-align: top;
     }
   </style>
 
-  <body onload="window.scroll(0, 600); document.documentElement.classList.remove('reftest-wait');">
+  <body onload="window.scroll(0, document.body.offsetHeight); document.documentElement.classList.remove('reftest-wait');">
 
-  <div><span id="test-failed">FAIL</span></div>
+  <div>F</div>
 
-  <div><span id="test-passed">PAS</span></div>
+  <div><span id="test-passed">P</span></div>

--- a/css/css-backgrounds/reference/background-attachment-fixed-block-002-ref.html
+++ b/css/css-backgrounds/reference/background-attachment-fixed-block-002-ref.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  html
+    {
+      height: 600px;
+      width: 600px;
+    }
+
+  body
+    {
+      margin: 0px;
+    }
+
+  div
+    {
+      height: 300px;
+    }
+
+  div#green
+    {
+      background-color: green;
+    }
+
+  div#lime
+    {
+      background-color: lime;
+    }
+  </style>
+
+  <body onload="window.scroll(0, 600);">
+
+  <div></div>
+
+  <div></div>
+
+  <div id="green"></div>
+
+  <div id="lime"></div>

--- a/css/css-backgrounds/reference/background-attachment-fixed-inline-002-ref.html
+++ b/css/css-backgrounds/reference/background-attachment-fixed-inline-002-ref.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  html
+    {
+      height: 600px;
+      width: 600px;
+    }
+
+  body
+    {
+      margin: 0px;
+    }
+
+  div
+    {
+      height: 100px;
+    }
+
+  div#green
+    {
+      background-color: green;
+    }
+
+  div#lime
+    {
+      background-color: lime;
+    }
+  </style>
+
+  <body onload="window.scroll(0, 600);">
+
+  <div style="height: 800px;"></div>
+
+  <div id="green"></div>
+
+  <div id="lime"></div>
+
+  <div style="height: 200px;"></div>

--- a/css/css-backgrounds/reference/background-attachment-fixed-inline-002-ref.html
+++ b/css/css-backgrounds/reference/background-attachment-fixed-inline-002-ref.html
@@ -7,39 +7,34 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
 
   <style>
-  html
-    {
-      height: 600px;
-      width: 600px;
-    }
-
   body
     {
+      height: 50vh;
       margin: 0px;
     }
 
-  div
+  div#filler-before
     {
-      height: 100px;
+      height: 125vh;
     }
 
-  div#green
+  div#purple
     {
-      background-color: green;
-    }
+      background-color: purple;
+      height: 25vh;
+      width: 50vh;
+     }
 
-  div#lime
+  div#filler-after
     {
-      background-color: lime;
+      height: 50vh;
     }
   </style>
 
-  <body onload="window.scroll(0, 600);">
+  <body onload="window.scroll(0, document.body.offsetHeight);">
 
-  <div style="height: 800px;"></div>
+  <div id="filler-before"></div>
 
-  <div id="green"></div>
+  <div id="purple"></div>
 
-  <div id="lime"></div>
-
-  <div style="height: 200px;"></div>
+  <div id="filler-after"></div>

--- a/css/css-backgrounds/reference/background-attachment-local-block-002-ref.html
+++ b/css/css-backgrounds/reference/background-attachment-local-block-002-ref.html
@@ -18,15 +18,15 @@
       height: 100vh;
     }
 
-  div#lime
+  div#blue
     {
-      background-color: lime;
+      background-color: blue;
       height: 25vh;
      }
 
-  div#purple
+  div#orange
     {
-      background-color: purple;
+      background-color: orange;
       height: 25vh;
     }
 
@@ -40,8 +40,8 @@
 
   <div id="filler-before"></div>
 
-  <div id="lime"></div>
+  <div id="blue"></div>
 
-  <div id="purple"></div>
+  <div id="orange"></div>
 
   <div id="filler-after"></div>

--- a/css/css-backgrounds/reference/background-attachment-local-inline-002-ref.html
+++ b/css/css-backgrounds/reference/background-attachment-local-inline-002-ref.html
@@ -15,19 +15,21 @@
 
   div#filler-before
     {
-      height: 100vh;
+      height: 125vh;
     }
 
-  div#lime
+  div#blue
     {
-      background-color: lime;
-      height: 25vh;
+      background-color: blue;
+      height: 12.5vh;
+      width: 50vh;
      }
 
-  div#purple
+  div#orange
     {
-      background-color: purple;
-      height: 25vh;
+      background-color: orange;
+      height: 12.5vh;
+      width: 50vh;
     }
 
   div#filler-after
@@ -40,8 +42,8 @@
 
   <div id="filler-before"></div>
 
-  <div id="lime"></div>
+  <div id="blue"></div>
 
-  <div id="purple"></div>
+  <div id="orange"></div>
 
   <div id="filler-after"></div>


### PR DESCRIPTION
Over at my website:

Block:

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/background-attachment-fixed-block-002.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/background-attachment-local-block-002.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/background-attachment-fixed-block-002-ref.html

- - - 

Inline:

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/background-attachment-fixed-inline-002.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/background-attachment-local-inline-002.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/background-attachment-fixed-inline-002-ref.html

Your viewport height dimension must be 600px tall precisely.

These 4 tests and 2 references serve to demonstrate that the test

http://wpt.live/css/css-backgrounds/background-attachment-fixed-inline-scrolled.html

http://wpt.live/css/css-backgrounds/background-attachment-fixed-inline-scrolled-ref.html

https://wpt.fyi/results/css/css-backgrounds/background-attachment-fixed-inline-scrolled.html

may not be as reliable or trustworthy as it should be. Firefox fails background-attachment-fixed-inline-scrolled.html test not because of its implementation of 'background-attachment: fixed' on inline 
but for reasons that have nothing (or very little) to do with CSS or with
Firefox's 'background-attachment: fixed' implementation.