### PR TITLE
Test removed canvas features are removed

### DIFF
--- a/html/canvas/historical.any.js
+++ b/html/canvas/historical.any.js
@@ -1,0 +1,4 @@
+// removed in https://github.com/whatwg/html/pull/9979
+test(() => {
+  assert_equals(OffscreenCanvasRenderingContext2D.prototype.commit, undefined);
+}, "OffscreenCanvasRenderingContext2D.commit method is removed");

--- a/html/canvas/historical.window.js
+++ b/html/canvas/historical.window.js
@@ -1,0 +1,5 @@
+// removed in https://github.com/whatwg/html/pull/8229
+// was never implemented to begin with, so the name should be available.
+test(() => {
+  assert_equals(CanvasRenderingContext2D.prototype.scrollPathIntoView, undefined);
+}, "CanvasRenderingContext2D.scrollPathIntoView method is removed");


### PR DESCRIPTION
In https://github.com/whatwg/html/pull/9979 we are in the process of removing `OffscreenCanvas`'s `commit()` methods. @annevk suggested that we need tests akin to https://github.com/web-platform-tests/wpt/blob/master/html/dom/historical.html testing that this method is actually removed.
This test runs as *any* because the `OffscreenCanvasRenderingContext2D` interface is accessible in both workers and windows scopes.
Note that the original tests for `commit()` have already been removed in https://github.com/web-platform-tests/interop/issues/344

Another such feature in the canvas specs that got removed is `scrollPathIntoView`, in https://github.com/whatwg/html/pull/8229. That one affected the `CanvasRenderingContext2D` interface and thus should run only in window scopes.