### PR TITLE
Update metadata of mouseClickCount.html for firefox and disable infra tests on Android

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/actions/mouseClickCount.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/mouseClickCount.html.ini
@@ -1,5 +1,5 @@
 [mouseClickCount.html]
   [TestDriver actions: test the mouse click counts at different cases]
     expected:
-      if (product == "firefox") or (product == "safari"): FAIL
+      if product == "safari": FAIL
       if product == "firefox_android": FAIL

--- a/tools/ci/ci_wptrunner_infrastructure.sh
+++ b/tools/ci/ci_wptrunner_infrastructure.sh
@@ -13,7 +13,6 @@ run_infra_test() {
 main() {
   run_infra_test "chrome" "dev"
   run_infra_test "firefox" "nightly"
-  run_infra_test "firefox_android" "nightly"
 }
 
 main

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -545,7 +545,6 @@ tasks:
         - wpt-base
         - trigger-pr
         - browser-firefox
-        - browser-firefox_android
       command: ./tools/ci/ci_wptrunner_infrastructure.sh
       install:
         - python3-pip
@@ -557,7 +556,6 @@ tasks:
         browser:
           - firefox
           - chrome
-          - firefox_android
         channel: experimental
         xvfb: true
         hosts: false


### PR DESCRIPTION
The logic around resetting double click when the mouse is moved was fixed in https://bugzilla.mozilla.org/show_bug.cgi?id=1681076, so this test passes now.