### PR TITLE
2 table-cell-background-local tests and their related references

### DIFF
--- a/css/css-backgrounds/reference/table-cell-background-local-002-ref.html
+++ b/css/css-backgrounds/reference/table-cell-background-local-002-ref.html
@@ -1,0 +1,21 @@
+ <!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      background-color: green;
+      height: 100px;
+      margin: 120px 0px 0px 104px;
+      width: 100px;
+    }
+  </style>
+
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.
+
+  <div></div>

--- a/css/css-backgrounds/reference/table-cell-background-local-003-ref.html
+++ b/css/css-backgrounds/reference/table-cell-background-local-003-ref.html
@@ -1,0 +1,32 @@
+ <!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div#outer
+    {
+      height: 100px;
+      margin: 120px 0px 0px 104px;
+      overflow: auto;
+      width: 100px;
+    }
+
+  div#inner
+    {
+      background-color: green;
+      height: 300px;
+      width: 300px;
+    }
+  </style>
+
+ <body onload="document.getElementById('outer').scrollTop = 200; document.getElementById('outer').scrollLeft = 200;">
+
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.
+
+  <div id="outer">
+    <div id="inner"></div>
+  </div>

--- a/css/css-backgrounds/table-cell-background-local-002.html
+++ b/css/css-backgrounds/table-cell-background-local-002.html
@@ -15,7 +15,7 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#background-attachment">
   <link rel="help" href="https://www.w3.org/TR/css-overflow-3/#overflow-control">
-  <link rel="match" href="table-cell-background-local-002-ref.html">
+  <link rel="match" href="reference/table-cell-background-local-002-ref.html">
 
   <style>
   td

--- a/css/css-backgrounds/table-cell-background-local-002.html
+++ b/css/css-backgrounds/table-cell-background-local-002.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Backgrounds and Borders Test: table cell background-image with local attachment</title>
+
+  <!--
+
+  Created: December 8th 2023
+
+  Last modified: December 8th 2023
+
+  -->
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#background-attachment">
+  <link rel="help" href="https://www.w3.org/TR/css-overflow-3/#overflow-control">
+  <link rel="match" href="table-cell-background-local-002-ref.html">
+
+  <style>
+  td
+    {
+      height: 100px;
+      padding: 0px;
+      vertical-align: top;
+      width: 100px;
+    }
+
+  td#middle-cell
+    {
+      background: url("support/500x500-red-with-green-center.png") local;
+      overflow: hidden;
+    }
+
+  div#outer
+    {
+      height: 0px;
+      width: 0px;
+    }
+
+  div#inner
+    {
+      height: 300px;
+      width: 300px;
+    }
+  </style>
+
+ <body onload="document.getElementById('middle-cell').scrollTop = 200; document.getElementById('middle-cell').scrollLeft = 200;">
+
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.
+
+  <table>
+
+    <tr><td><td><td>
+
+    <tr>
+      <td>
+      <td id="middle-cell">
+        <div id="outer">
+          <div id="inner"></div>
+        </div>
+      <td>
+
+    <tr><td><td><td>
+
+  </table>

--- a/css/css-backgrounds/table-cell-background-local-003.html
+++ b/css/css-backgrounds/table-cell-background-local-003.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Backgrounds and Borders Test: table cell background-image with local attachment</title>
+
+  <!--
+
+  Created: December 8th 2023
+
+  Last modified: December 8th 2023
+
+  -->
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#background-attachment">
+  <link rel="help" href="https://www.w3.org/TR/css-overflow-3/#overflow-control">
+  <link rel="match" href="table-cell-background-local-003-ref.html">
+
+  <style>
+  td
+    {
+      height: 100px;
+      padding: 0px;
+      vertical-align: top;
+      width: 100px;
+    }
+
+  td#middle-cell
+    {
+      background: url("support/500x500-red-with-green-center.png") local;
+      overflow: auto;
+    }
+
+  div#outer
+    {
+      height: 0px;
+      width: 0px;
+    }
+
+  div#inner
+    {
+      height: 300px;
+      width: 300px;
+    }
+  </style>
+
+ <body onload="document.getElementById('middle-cell').scrollTop = 200; document.getElementById('middle-cell').scrollLeft = 200;">
+
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.
+
+  <table>
+
+    <tr><td><td><td>
+
+    <tr>
+      <td>
+      <td id="middle-cell">
+        <div id="outer">
+          <div id="inner"></div>
+        </div>
+      <td>
+
+    <tr><td><td><td>
+
+  </table>

--- a/css/css-backgrounds/table-cell-background-local-003.html
+++ b/css/css-backgrounds/table-cell-background-local-003.html
@@ -15,7 +15,7 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#background-attachment">
   <link rel="help" href="https://www.w3.org/TR/css-overflow-3/#overflow-control">
-  <link rel="match" href="table-cell-background-local-003-ref.html">
+  <link rel="match" href="reference/table-cell-background-local-003-ref.html">
 
   <style>
   td


### PR DESCRIPTION
These 2 tests are additions to and complement the test

http://wpt.live/css/css-backgrounds/table-cell-background-local.html

These 2 tests are variations of the test

http://wpt.live/css/css-backgrounds/table-cell-background-local.html

and these 2 tests are a bit more constraining, restricting. For example, these 2 tests do not use a mono-cell row but a 3rows x 3columns table.

Over at my website:

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/table-cell-background-local-002-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/table-cell-background-local-002-GT-ref.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/table-cell-background-local-003-GT.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/table-cell-background-local-003-GT-ref.html