### PR TITLE
Overcome antialias fuzziness in background-clip-padding-box-with-border-radius test

### DIFF
--- a/css/css-backgrounds/background-clip-padding-box-with-border-radius.html
+++ b/css/css-backgrounds/background-clip-padding-box-with-border-radius.html
@@ -8,6 +8,7 @@
 <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-clip" />
 <link rel="help" href="http://www.w3.org/TR/css3-background/#corner-shaping" />
 <link rel="match" href="reference/background-clip-padding-box-with-border-radius-ref.html" />
+<meta name="fuzzy" content="maxDifference=0-29;totalPixels=0-80" />
 <meta name="assert" content="Backgrounds clipped to the padding box should follow the padding box curve, which should be equal to the outer border radius minus the corresponding border thickness." />
 <style>
 div {


### PR DESCRIPTION
I added
`<meta name="fuzzy" content="maxDifference=0-29;totalPixels=0-80" />`
and a carriage return at EOF

Current test result:
https://wpt.fyi/results/css/css-backgrounds/background-clip-padding-box-with-border-radius.html