### PR TITLE
Switch default for RTCDataChannel.binaryType to arraybuffer

### DIFF
--- a/webrtc/RTCDataChannel-binaryType.window.js
+++ b/webrtc/RTCDataChannel-binaryType.window.js
@@ -8,7 +8,7 @@ test((t) => {
   t.add_cleanup(() => pc.close());
   const dc = pc.createDataChannel('test-binary-type');
 
-  assert_equals(dc.binaryType, "blob", `dc.binaryType should be 'blob'`);
+  assert_equals(dc.binaryType, "arraybuffer", `dc.binaryType should be 'arraybuffer'`);
 }, `Default binaryType value`);
 
 for (const binaryType of validBinaryTypes) {

--- a/webrtc/RTCDataChannel-send.html
+++ b/webrtc/RTCDataChannel-send.html
@@ -261,24 +261,18 @@ for (const options of [{}, {negotiated: true, id: 0}]) {
   promise_test(t => {
     return createDataChannelPair(t, options)
     .then(([channel1, channel2]) => {
-      assert_equals(channel2.binaryType, 'blob',
-        'Expect initial binaryType value to be blob');
+      assert_equals(channel2.binaryType, 'arraybuffer',
+        'Expect initial binaryType value to be arraybuffer');
 
       channel1.send(helloBuffer);
       return awaitMessage(channel2);
-    })
-    .then(messageBlob => {
-      assert_true(messageBlob instanceof Blob,
-        'Expect received messageBlob to be a Blob');
-
-      return blobToArrayBuffer(messageBlob);
     }).then(messageBuffer => {
       assert_true(messageBuffer instanceof ArrayBuffer,
         'Expect messageBuffer to be an ArrayBuffer');
 
       assert_equals_typed_array(messageBuffer, helloBuffer.buffer);
     });
-  }, `${mode} binaryType should receive message as Blob by default`);
+  }, `${mode} binaryType should receive message as ArrayBuffer by default`);
 
   // Test sending 3 messages: helloBuffer, unicodeString, helloBlob
   async_test(t => {

--- a/webrtc/RTCPeerConnection-createDataChannel.html
+++ b/webrtc/RTCPeerConnection-createDataChannel.html
@@ -139,7 +139,7 @@ test(t => {
   assert_equals(dc.readyState, 'connecting');
   assert_equals(dc.bufferedAmount, 0);
   assert_equals(dc.bufferedAmountLowThreshold, 0);
-  assert_equals(dc.binaryType, 'blob');
+  assert_equals(dc.binaryType, 'arraybuffer');
 }, 'createDataChannel attribute default values');
 
 test(t => {
@@ -166,7 +166,7 @@ test(t => {
   assert_equals(dc.readyState, 'connecting');
   assert_equals(dc.bufferedAmount, 0);
   assert_equals(dc.bufferedAmountLowThreshold, 0);
-  assert_equals(dc.binaryType, 'blob');
+  assert_equals(dc.binaryType, 'arraybuffer');
 
   const dc2 = pc.createDataChannel('test2', {
     ordered: false,


### PR DESCRIPTION
per https://github.com/w3c/webrtc-pc/pull/2913