### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=266234

### DIFF
--- a/css/css-transitions/parsing/transition-behavior.html
+++ b/css/css-transitions/parsing/transition-behavior.html
@@ -13,17 +13,17 @@ test_computed_value('transition-behavior', 'normal');
 test_valid_value('transition-behavior', 'allow-discrete');
 test_computed_value('transition-behavior', 'allow-discrete');
 
-test_valid_value('transition', 'allow-discrete display', 'display 0s ease 0s allow-discrete');
-test_computed_value('transition', 'allow-discrete display', 'display 0s ease 0s allow-discrete');
+test_valid_value('transition', 'allow-discrete display', 'display allow-discrete');
+test_computed_value('transition', 'allow-discrete display', 'display allow-discrete');
 
-test_valid_value('transition', 'allow-discrete display 3s', 'display 3s ease 0s allow-discrete');
-test_computed_value('transition', 'allow-discrete display 3s', 'display 3s ease 0s allow-discrete');
+test_valid_value('transition', 'allow-discrete display 3s', 'display 3s allow-discrete');
+test_computed_value('transition', 'allow-discrete display 3s', 'display 3s allow-discrete');
 
-test_valid_value('transition', 'allow-discrete display 3s 1s', 'display 3s ease 1s allow-discrete');
-test_computed_value('transition', 'allow-discrete display 3s 1s', 'display 3s ease 1s allow-discrete');
+test_valid_value('transition', 'allow-discrete display 3s 1s', 'display 3s 1s allow-discrete');
+test_computed_value('transition', 'allow-discrete display 3s 1s', 'display 3s 1s allow-discrete');
 
-test_valid_value('transition', 'allow-discrete display 3s ease-in-out', 'display 3s ease-in-out 0s allow-discrete');
-test_computed_value('transition', 'allow-discrete display 3s ease-in-out', 'display 3s ease-in-out 0s allow-discrete');
+test_valid_value('transition', 'allow-discrete display 3s ease-in-out', 'display 3s ease-in-out allow-discrete');
+test_computed_value('transition', 'allow-discrete display 3s ease-in-out', 'display 3s ease-in-out allow-discrete');
 
 test_valid_value('transition', 'allow-discrete display 3s ease-in-out 1s', 'display 3s ease-in-out 1s allow-discrete');
 test_computed_value('transition', 'allow-discrete display 3s ease-in-out 1s', 'display 3s ease-in-out 1s allow-discrete');
@@ -44,14 +44,14 @@ test_computed_value('transition', 'display 3s ease-in-out 1s allow-discrete', 'd
 // Serialization with multiple shorthands, including different order
 test_valid_value('transition',
   'allow-discrete display, normal opacity, color',
-  'display 0s ease 0s allow-discrete, opacity 0s ease 0s, color 0s ease 0s');
+  'display allow-discrete, opacity, color');
 test_computed_value('transition',
   'allow-discrete display, normal opacity, color',
-  'display 0s ease 0s allow-discrete, opacity 0s ease 0s, color 0s ease 0s');
+  'display allow-discrete, opacity, color');
 test_valid_value('transition',
   'normal opacity, color, allow-discrete display',
-  'opacity 0s ease 0s, color 0s ease 0s, display 0s ease 0s allow-discrete');
+  'opacity, color, display allow-discrete');
 test_computed_value('transition',
   'normal opacity, color, allow-discrete display',
-  'opacity 0s ease 0s, color 0s ease 0s, display 0s ease 0s allow-discrete');
+  'opacity, color, display allow-discrete');
 </script>

--- a/css/css-transitions/parsing/transition-computed.html
+++ b/css/css-transitions/parsing/transition-computed.html
@@ -16,17 +16,26 @@
 // <time> || <easing-function> || <time>
 
 test(() => {
-  assert_equals(getComputedStyle(document.getElementById('target')).transition, "all 0s ease 0s");
+  assert_equals(getComputedStyle(document.getElementById('target')).transition, "all");
 }, "Default transition value");
 
-test_computed_value("transition", "1s", "all 1s ease 0s");
-test_computed_value("transition", "cubic-bezier(0, -2, 1, 3)", "all 0s cubic-bezier(0, -2, 1, 3) 0s");
-test_computed_value("transition", "1s -3s", "all 1s ease -3s");
-test_computed_value("transition", "none", "none 0s ease 0s");
-test_computed_value("transition", "top", "top 0s ease 0s");
+test_computed_value("transition", "1s", "1s");
+test_computed_value("transition", "cubic-bezier(0, -2, 1, 3)", "cubic-bezier(0, -2, 1, 3)");
+test_computed_value("transition", "1s -3s", "1s -3s");
+test_computed_value("transition", "none", "none");
+test_computed_value("transition", "top", "top");
 
 test_computed_value("transition", "1s -3s cubic-bezier(0, -2, 1, 3) top", "top 1s cubic-bezier(0, -2, 1, 3) -3s");
-test_computed_value("transition", "1s -3s, cubic-bezier(0, -2, 1, 3) top", "all 1s ease -3s, top 0s cubic-bezier(0, -2, 1, 3) 0s");
+test_computed_value("transition", "1s -3s, cubic-bezier(0, -2, 1, 3) top", "1s -3s, top cubic-bezier(0, -2, 1, 3)");
+
+test_computed_value("transition", "all, all", "all, all");
+
+test(() => {
+  const target = document.getElementById('target');
+  target.style.transition = "initial";
+  target.style.transitionDelay = "1s";
+  assert_equals(getComputedStyle(target).transition, "0s 1s");
+}, "Transition with a delay but no duration");
 
 // TODO: Add test with a single timing-function keyword.
 </script>


### PR DESCRIPTION
WebKit export from bug: [\[css-transitions\] `transition` property should use shortest serialization rule](https://bugs.webkit.org/show_bug.cgi?id=266234)