### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=259646

### DIFF
--- a/svg/shapes/rect-rx-set-by-css-expected.svg
+++ b/svg/shapes/rect-rx-set-by-css-expected.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="40" />
+</svg>

--- a/svg/shapes/rect-rx-set-by-css-ref.svg
+++ b/svg/shapes/rect-rx-set-by-css-ref.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" rx="40" />
+</svg>

--- a/svg/shapes/rect-rx-set-by-css.svg
+++ b/svg/shapes/rect-rx-set-by-css.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <metadata>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="http://www.w3.org/TR/SVG/shapes.html#RectElement"/>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="match" href="rect-rx-set-by-css-ref.svg"/>
+    <meta xmlns="http://www.w3.org/1999/xhtml" name="assert" content="rx can be set via CSS."/>
+  </metadata>
+  <rect width="100" height="100" style="rx: 40px" />
+</svg>


### PR DESCRIPTION
WebKit export from bug: [CSS animation for SVG rect rx and ry has no effect](https://bugs.webkit.org/show_bug.cgi?id=259646)