### PR TITLE
[css-grid][masonry] Remove First Track Support from Tests

### DIFF
--- a/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001-ref.html
+++ b/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001-ref.html
@@ -8,38 +8,38 @@
   <title>Reference: Masonry layout using `grid-column/row`</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <style>
-html,body {
-  color:black; background-color:white; font:25px/1 monospace; padding:0; margin:0;
-}
+    html,body {
+      color:black; background-color:white; font:25px/1 monospace; padding:0; margin:0;
+    }
 
-grid {
-  display: inline-grid;
-  gap: 10px 20px;
-  grid-template-columns: repeat(4,80px);
-  grid-template-rows: masonry;
-  color: #444;
-  border: 1px solid;
-  padding: 2px;
-}
+    grid {
+      display: inline-grid;
+      gap: 10px 20px;
+      grid-template-columns: repeat(4,80px);
+      grid-template-rows: masonry;
+      color: #444;
+      border: 1px solid;
+      padding: 2px;
+    }
 
-item {
-  background-color: #444;
-  color: #fff;
-  padding: 20px;
-  margin: 3px;
-  border: 5px solid blue;
-}
-</style>
+    item {
+      background-color: #444;
+      color: #fff;
+      padding: 20px;
+      margin: 3px;
+      border: 5px solid blue;
+    }
+  </style>
 </head>
 <body>
 
 <grid>
+  <item style="grid-column:1">6</item>
+  <item style="grid-column:2">5</item>
+  <item style="grid-column:span 2">4</item>
   <item style="margin-top:10px">3</item>
   <item style="grid-column:span 2">1</item>
   <item>2</item>
-  <item style="grid-column:2">5</item>
-  <item style="grid-column:span 2">4</item>
-  <item style="grid-column:1">6</item>
 </grid>
 
 </body>

--- a/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001.html
+++ b/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001.html
@@ -10,38 +10,38 @@
   <link rel="help" href="https://drafts.csswg.org/css-grid-2">
   <link rel="match" href="masonry-item-placement-001-ref.html">
   <style>
-html,body {
-  color:black; background-color:white; font:25px/1 monospace; padding:0; margin:0;
-}
+    html,body {
+      color:black; background-color:white; font:25px/1 monospace; padding:0; margin:0;
+    }
 
-grid {
-  display: inline-grid;
-  gap: 10px 20px;
-  grid-template-columns: repeat(4,80px);
-  grid-template-rows: masonry;
-  color: #444;
-  border: 1px solid;
-  padding: 2px;
-}
+    grid {
+      display: inline-grid;
+      gap: 10px 20px;
+      grid-template-columns: repeat(4,80px);
+      grid-template-rows: masonry;
+      color: #444;
+      border: 1px solid;
+      padding: 2px;
+    }
 
-item {
-  background-color: #444;
-  color: #fff;
-  padding: 20px;
-  margin: 3px;
-  border: 5px solid blue;
-}
-</style>
+    item {
+      background-color: #444;
+      color: #fff;
+      padding: 20px;
+      margin: 3px;
+      border: 5px solid blue;
+    }
+  </style>
 </head>
 <body>
 
 <grid>
-  <item style="grid-column:2/span 2">1</item>
-  <item>2</item>
-  <item style="margin-top:10px">3</item>
-  <item style="grid-column:3/span 2">4</item>
+  <item style="grid-column:1">6</item>
   <item>5</item>
-  <item>6</item>
+  <item style="margin-top:10px">3</item>
+  <item style="grid-column:span 2">1</item>
+  <item>2</item>
+  <item style="grid-column:3/span 2">4</item>
 </grid>
 
 </body>

--- a/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-002.html
+++ b/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-002.html
@@ -10,38 +10,38 @@
   <link rel="help" href="https://drafts.csswg.org/css-grid-2">
   <link rel="match" href="masonry-item-placement-002-ref.html">
   <style>
-html,body {
-  color:black; background-color:white; font:25px/1 monospace; padding:0; margin:0;
-}
+    html,body {
+      color:black; background-color:white; font:25px/1 monospace; padding:0; margin:0;
+    }
 
-grid {
-  display: inline-grid;
-  gap: 10px 20px;
-  grid-auto-columns: 80px;
-  grid-template-rows: masonry;
-  color: #444;
-  border: 1px solid;
-  padding: 2px;
-}
+    grid {
+      display: inline-grid;
+      gap: 10px 20px;
+      grid-auto-columns: 80px;
+      grid-template-rows: masonry;
+      color: #444;
+      border: 1px solid;
+      padding: 2px;
+    }
 
-item {
-  background-color: #444;
-  color: #fff;
-  padding: 20px;
-  margin: 3px;
-  border: 5px solid blue;
-}
-</style>
+    item {
+      background-color: #444;
+      color: #fff;
+      padding: 20px;
+      margin: 3px;
+      border: 5px solid blue;
+    }
+  </style>
 </head>
 <body>
 
 <grid>
-  <item style="grid-column:foo 2; grid-row:span 2">2</item>
+  <item style="grid-column:1/span 4;">1</item>
   <item>3</item>
+  <item style="grid-column:foo 2; grid-row:span 2">2</item>
   <item style="grid-column:span 3">4</item>
   <item>5</item>
   <item>6</item>
-  <item style="grid-column:span 4; grid-row:-100">1</item>
 </grid>
 
 </body>

--- a/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-003.html
+++ b/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-003.html
@@ -10,37 +10,37 @@
   <link rel="help" href="https://drafts.csswg.org/css-grid-2">
   <link rel="match" href="masonry-item-placement-003-ref.html">
   <style>
-html,body {
-  color:black; background-color:white; font:25px/1 monospace; padding:0; margin:0;
-}
+    html,body {
+      color:black; background-color:white; font:25px/1 monospace; padding:0; margin:0;
+    }
 
-grid {
-  display: inline-grid;
-  gap: 10px 20px;
-  grid-auto-flow: dense;
-  grid-auto-columns: 80px;
-  grid-template-rows: masonry;
-  color: #444;
-  border: 1px solid;
-  padding: 2px;
-}
+    grid {
+      display: inline-grid;
+      gap: 10px 20px;
+      grid-auto-flow: dense;
+      grid-auto-columns: 80px;
+      grid-template-rows: masonry;
+      color: #444;
+      border: 1px solid;
+      padding: 2px;
+    }
 
-item {
-  background-color: #444;
-  color: #fff;
-  padding: 20px;
-  margin: 3px;
-  border: 5px solid blue;
-}
-</style>
+    item {
+      background-color: #444;
+      color: #fff;
+      padding: 20px;
+      margin: 3px;
+      border: 5px solid blue;
+    }
+  </style>
 </head>
 <body>
 
 <grid>
   <item style="grid-row:-100">1</item>
+  <item>3</item>
   <item style="grid-column:foo 2; grid-row:span 2">2</item>
   <item style="grid-column:span 3">4</item>
-  <item>3</item>
   <item>5</item>
   <item>6</item>
 </grid>

--- a/css/css-grid/masonry/tentative/order/masonry-order-001-ref.html
+++ b/css/css-grid/masonry/tentative/order/masonry-order-001-ref.html
@@ -8,28 +8,28 @@
   <title>Reference: Masonry layout using `order`</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <style>
-html,body {
-  color:black; background-color:white; font:25px/1 monospace; padding:0; margin:0;
-}
+    html,body {
+      color:black; background-color:white; font:25px/1 monospace; padding:0; margin:0;
+    }
 
-grid {
-  display: inline-grid;
-  gap: 10px 20px;
-  grid-template-columns:  repeat(4,auto);
-  grid-template-rows: masonry;
-  color: #444;
-  border: 1px solid;
-  padding: 2px;
-}
+    grid {
+      display: inline-grid;
+      gap: 10px 20px;
+      grid-template-columns:  repeat(4,auto);
+      grid-template-rows: masonry;
+      color: #444;
+      border: 1px solid;
+      padding: 2px;
+    }
 
-item {
-  background-color: #444;
-  color: #fff;
-  padding: 20px;
-  margin: 3px;
-  border: 5px solid blue;
-}
-</style>
+    item {
+      background-color: #444;
+      color: #fff;
+      padding: 20px;
+      margin: 3px;
+      border: 5px solid blue;
+    }
+  </style>
 </head>
 <body>
 
@@ -38,6 +38,6 @@ item {
   <item style="margin-top:10px">4</item>
   <item>6</item>
   <item>2</item>
+  <item style="grid-column: span 2">5</item>
   <item>3</item>
-  <item style="grid-column:3/span 2">5</item>
 </grid>

--- a/css/css-grid/masonry/tentative/order/masonry-order-002-ref.html
+++ b/css/css-grid/masonry/tentative/order/masonry-order-002-ref.html
@@ -8,36 +8,36 @@
   <title>Reference: Masonry layout using `order` and `masonry-auto-flow: next`</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <style>
-html,body {
-  color:black; background-color:white; font:25px/1 monospace; padding:0; margin:0;
-}
+    html,body {
+      color:black; background-color:white; font:25px/1 monospace; padding:0; margin:0;
+    }
 
-grid {
-  display: inline-grid;
-  gap: 10px 20px;
-  grid-template-columns:  repeat(4,auto);
-  grid-template-rows: masonry;
-  color: #444;
-  border: 1px solid;
-  padding: 2px;
-}
+    grid {
+      display: inline-grid;
+      gap: 10px 20px;
+      grid-template-columns:  repeat(4,auto);
+      grid-template-rows: masonry;
+      color: #444;
+      border: 1px solid;
+      padding: 2px;
+    }
 
-item {
-  background-color: #444;
-  color: #fff;
-  padding: 20px;
-  margin: 3px;
-  border: 5px solid blue;
-}
-</style>
+    item {
+      background-color: #444;
+      color: #fff;
+      padding: 20px;
+      margin: 3px;
+      border: 5px solid blue;
+    }
+  </style>
 </head>
 <body>
 
 <grid>
-  <item>1</item>
-  <item style="margin-top:10px">4</item>
-  <item>6</item>
-  <item>2</item>
-  <item style="grid-column:1/span 2">5</item>
-  <item style="grid-column:3">3</item>
+  <item style="grid-column: 1">1</item>
+  <item style="margin-top:10px; grid-column: 2;">4</item>
+  <item style="grid-column: 3">6</item>
+  <item style="grid-column: 4">2</item>
+  <item style="grid-column: 2/span 2">5</item>
+  <item>3</item>
 </grid>

--- a/css/css-grid/masonry/tentative/order/masonry-order-002.html
+++ b/css/css-grid/masonry/tentative/order/masonry-order-002.html
@@ -10,37 +10,37 @@
   <link rel="help" href="https://drafts.csswg.org/css-grid-2">
   <link rel="match" href="masonry-order-002-ref.html">
   <style>
-html,body {
-  color:black; background-color:white; font:25px/1 monospace; padding:0; margin:0;
-}
+    html,body {
+      color:black; background-color:white; font:25px/1 monospace; padding:0; margin:0;
+    }
 
-grid {
-  display: inline-grid;
-  gap: 10px 20px;
-  grid-template-columns:  repeat(4,auto);
-  grid-template-rows: masonry;
-  masonry-auto-flow: next;
-  color: #444;
-  border: 1px solid;
-  padding: 2px;
-}
+    grid {
+      display: inline-grid;
+      gap: 10px 20px;
+      grid-template-columns:  repeat(4,auto);
+      grid-template-rows: masonry;
+      masonry-auto-flow: next;
+      color: #444;
+      border: 1px solid;
+      padding: 2px;
+    }
 
-item {
-  background-color: #444;
-  color: #fff;
-  padding: 20px;
-  margin: 3px;
-  border: 5px solid blue;
-}
-</style>
+    item {
+      background-color: #444;
+      color: #fff;
+      padding: 20px;
+      margin: 3px;
+      border: 5px solid blue;
+    }
+  </style>
 </head>
 <body>
 
 <grid>
   <item>1</item>
   <item style="order:1">2</item>
-  <item style="order:2">3</item>
+  <item style="order:1">3</item>
   <item style="margin-top:10px">4</item>
-  <item style="order:1; grid-column:span 2">5</item>
+  <item style="order:2; grid-column:span 2">5</item>
   <item>6</item>
 </grid>

--- a/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-explicit-block.html
+++ b/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-explicit-block.html
@@ -11,37 +11,35 @@
 
 <body>
 <style>
-grid {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    grid-template-rows: masonry;
-    width: 300px;
-    height: 100px;
-}
+    grid {
+        display: grid;
+        grid-template-columns: 100px 1fr;
+        grid-template-rows: masonry;
+        width: 300px;
+        height: 100px;
+    }
 
-box1 {
-    height: 50px;
-    width: 30px;
-    background-color: blue;
-}
+    box1 {
+        height: 50px;
+        width: 30px;
+        background-color: blue;
+    }
 
-box2 {
-    height: 50px;
-    background-color: red;
-}
+    box2 {
+        height: 50px;
+        background-color: red;
+    }
 
-box3 {
-    height: 50px;
-    width: 100px;
-    grid-row: 2;
-    grid-column: 1;
-    background-color: purple;
-}
+    box3 {
+        height: 50px;
+        width: 100px;
+        background-color: purple;
+    }
 
-box4 {
-    height: 50px;
-    background-color: green;
-}
+    box4 {
+        height: 50px;
+        background-color: green;
+    }
 
 </style>
 

--- a/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-span-row.html
+++ b/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-span-row.html
@@ -11,46 +11,45 @@
 
 <body>
 <style>
-grid {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    grid-template-rows: masonry;
-    width: 300px;
-    height: 100px;
-}
+    grid {
+        display: grid;
+        grid-template-columns: 50px 1fr;
+        grid-template-rows: masonry;
+        width: 300px;
+        height: 100px;
+    }
 
-box1 {
-    height: 50px;
-    width: 50px;
-    background-color: blue;
-}
+    box1 {
+        height: 50px;
+        width: 50px;
+        background-color: blue;
+    }
 
-box2 {
-    height: 50px;
-    background-color: red;
-}
+    box2 {
+        height: 50px;
+        background-color: red;
+    }
 
-box3 {
-    width: 100px;
-    height: 50px;
-    background-color: purple;
-    z-index: 1;
-}
+    box3 {
+        width: 100px;
+        height: 50px;
+        background-color: purple;
+        z-index: 1;
+    }
 
-box4 {
-    height: 50px;
-    width: 300px;
-    grid-column-start: 1;
-    grid-column-end: 3;
-    background-color: green;
-}
+    box4 {
+        height: 50px;
+        width: 300px;
+        grid-column: span 2;
+        background-color: green;
+    }
 </style>
 
 <grid>
     <box1>1</box1>
     <box2>2</box2>
-    <box3>3</box3>
     <box4>4</box4>
+    <box3>3</box3>
 </grid>
 
 </body>


### PR DESCRIPTION
This is an initial pass to align with the current spec that removes the first track support from the test cases. The first track support does affect several test cases. Another patch is needed to finish aligning fully with the spec for recent updates to masonry.