### PR TITLE
Test harness and docs improvements for ShadowRealm testing

### DIFF
--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -823,6 +823,29 @@ eventWatcher.wait_for('animationstart').then(t.step_func(function() {
 }));
 ```
 
+### Loading test data from JSON files ###
+
+```eval_rst
+.. js:autofunction:: fetch_json
+```
+
+Loading test data from a JSON file would normally be accomplished by
+something like this:
+
+```js
+promise_test(() => fetch('resources/my_data.json').then((res) => res.json()).then(runTests));
+function runTests(myData) {
+  /// ...
+}
+```
+
+However, `fetch()` is not exposed inside ShadowRealm scopes, so if the
+test is to be run inside a ShadowRealm, use `fetch_json()` instead:
+
+```js
+promise_test(() => fetch_json('resources/my_data.json').then(runTests));
+```
+
 ### Utility Functions ###
 
 ```eval_rst

--- a/docs/writing-tests/testharness.md
+++ b/docs/writing-tests/testharness.md
@@ -171,11 +171,12 @@ are:
   [ShadowRealm](https://github.com/tc39/proposal-shadowrealm) context hosted in
   an ordinary Window context; to be run at <code><var>x</var>.any.shadowrealm.html</code>
 
-To check if your test is run from a window or worker you can use the following two methods that will
+To check what scope your test is run from, you can use the following methods that will
 be made available by the framework:
 
     self.GLOBAL.isWindow()
     self.GLOBAL.isWorker()
+    self.GLOBAL.isShadowRealm()
 
 Although [the global `done()` function must be explicitly invoked for most
 dedicated worker tests and shared worker

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -4777,6 +4777,15 @@
         return "Untitled";
     }
 
+    /** Fetches a JSON resource and parses it */
+    async function fetch_json(resource) {
+        const response = await fetch(resource);
+        return await response.json();
+    }
+    if (!global_scope.GLOBAL || !global_scope.GLOBAL.isShadowRealm()) {
+        expose(fetch_json, 'fetch_json');
+    }
+
     /**
      * Setup globals
      */

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1201,6 +1201,23 @@
         object.addEventListener(event, callback, false);
     }
 
+    // Internal helper function to provide timeout-like functionality in
+    // environments where there is no setTimeout(). (No timeout ID or
+    // clearTimeout().)
+    function fake_set_timeout(callback, delay) {
+        var p = Promise.resolve();
+        var start = Date.now();
+        var end = start + delay;
+        function check() {
+            if ((end - Date.now()) > 0) {
+                p.then(check);
+            } else {
+                callback();
+            }
+        }
+        p.then(check);
+    }
+
     /**
      * Global version of :js:func:`Test.step_timeout` for use in single page tests.
      *
@@ -1212,7 +1229,8 @@
     function step_timeout(func, timeout) {
         var outer_this = this;
         var args = Array.prototype.slice.call(arguments, 2);
-        return setTimeout(function() {
+        var local_set_timeout = typeof global_scope.setTimeout === "undefined" ? fake_set_timeout : setTimeout;
+        return local_set_timeout(function() {
             func.apply(outer_this, args);
         }, timeout * tests.timeout_multiplier);
     }
@@ -2720,7 +2738,8 @@
     Test.prototype.step_timeout = function(func, timeout) {
         var test_this = this;
         var args = Array.prototype.slice.call(arguments, 2);
-        return setTimeout(this.step_func(function() {
+        var local_set_timeout = typeof global_scope.setTimeout === "undefined" ? fake_set_timeout : setTimeout;
+        return local_set_timeout(this.step_func(function() {
             return func.apply(test_this, args);
         }), timeout * tests.timeout_multiplier);
     };
@@ -2751,6 +2770,7 @@
         var timeout_full = timeout * tests.timeout_multiplier;
         var remaining = Math.ceil(timeout_full / interval);
         var test_this = this;
+        var local_set_timeout = typeof global_scope.setTimeout === 'undefined' ? fake_set_timeout : setTimeout;
 
         const step = test_this.step_func((result) => {
             if (result) {
@@ -2761,7 +2781,7 @@
                            "Timed out waiting on condition");
                 }
                 remaining--;
-                setTimeout(wait_for_inner, interval);
+                local_set_timeout(wait_for_inner, interval);
             }
         });
 

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -432,6 +432,9 @@ class ShadowRealmHandler(HtmlWrapperHandler):
   }`)((resource) => function (resolve, reject) {
     fetch(resource).then(res => res.text(), String).then(resolve, reject);
   });
+  r.evaluate(`s => {
+    globalThis.location = { search: s };
+  }`)(location.search);
   await new Promise(r.evaluate(`
     (resolve, reject) => {
       (async () => {

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -424,6 +424,14 @@ class ShadowRealmHandler(HtmlWrapperHandler):
 (async function() {
   const r = new ShadowRealm();
   r.evaluate("globalThis.self = globalThis; undefined;");
+  r.evaluate(`func => {
+    globalThis.fetch_json = (resource) => {
+      const thenMethod = func(resource);
+      return new Promise((resolve, reject) => thenMethod((s) => resolve(JSON.parse(s)), reject));
+    };
+  }`)((resource) => function (resolve, reject) {
+    fetch(resource).then(res => res.text(), String).then(resolve, reject);
+  });
   await new Promise(r.evaluate(`
     (resolve, reject) => {
       (async () => {


### PR DESCRIPTION
We allow running tests in ShadowRealm scopes. This PR contains some improvements that help adapt existing tests to run in a ShadowRealm:

- `GLOBAL.isShadowRealm()` already exists; this documents it.
- Many tests use `fetch()` to import test data from a JSON file. `fetch()` isn't exposed in ShadowRealm globals. This adds a new `fetch_json()` function to the test harness, which works like `fetch()` but can only fetch JSON data, and decodes it before returning.
- The 'variant' mechanism works by appending search params to the URL, but `location` is not exposed in ShadowRealm globals. This adds a dummy `location` object to ShadowRealm scopes with a `search` property, so that ShadowRealm tests can be subsetted by variant.
- The `step_timeout()` and `step_wait_func()` functionality in the test harness relies on `setTimeout()`, which isn't exposed in ShadowRealm globals. This adds a fake `setTimeout()` to ShadowRealm scopes so that this timed test functionality can work in ShadowRealm tests.