### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=260201

### DIFF
--- a/css/css-contain/contain-inline-size-grid-stretches-auto-rows.html
+++ b/css/css-contain/contain-inline-size-grid-stretches-auto-rows.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-stretch">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="grid with inline-size containment, and min-height will still distribute extra space to auto rows">
+<style>
+grid {
+    display: grid;
+    min-height: 100px;
+    grid-template-rows: auto;
+    contain: inline-size;
+}
+.absolute {
+    position: absolute;
+}
+.align-end {
+    align-self: end;
+}
+.item {
+    width: 100px;
+    height: 50px;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+    <p>Test passes if there is a filled green square.</p>
+    <grid>
+        <div class="absolute item"></div>
+        <div class="item align-end"></div>
+    </grid>
+</body>
+</html>

--- a/css/css-contain/contain-size-grid-stretches-auto-rows.html
+++ b/css/css-contain/contain-size-grid-stretches-auto-rows.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain/#size-containment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-stretch">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="grid with size containment, and min-height will still distribute extra space to auto rows">
+<style>
+grid {
+    display: grid;
+    min-height: 100px;
+    grid-template-rows: auto;
+    contain: size;
+}
+.absolute {
+    position: absolute;
+}
+.align-end {
+    align-self: end;
+}
+.item {
+    width: 100px;
+    height: 50px;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+    <p>Test passes if there is a filled green square.</p>
+    <grid>
+        <div class="absolute item"></div>
+        <div class="item align-end"></div>
+    </grid>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [REGRESSION(261003@main): \[css-contain\] contain: inline-size breaks grid-template-rows: auto in Safari iOS 17](https://bugs.webkit.org/show_bug.cgi?id=260201)