### PR TITLE
Add tests for dynamic content-visibility/contain changes and used value of contain.

### DIFF
--- a/css/css-contain/contain-layout-dynamic-001.html
+++ b/css/css-contain/contain-layout-dynamic-001.html
@@ -3,15 +3,16 @@
 <title>Dynamic change to layout containment</title>
 <link rel="help" href="https://drafts.csswg.org/css-contain/#contain-property">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="Verify absolutely/fixed-positioned descendants are handled when updating layout containment .">
+<meta name="assert" content="Verify layout containment is properly updated after dynamic change to the contain property.">
 <style>
+  /* Selectors for testing absolute/fixed positioned elements */
   #top_spacer {
       height: 100px;
       background: lightgray;
   }
-
   .absolute_pos {
       position: absolute;
       top: 42px;
@@ -21,16 +22,28 @@
       top: 42px;
   }
 
-  #none {
+  /* Selectors for testing baseline */
+  .flex {
+      display: inline-flex;
+      align-items: baseline;
+  }
+  .rect {
+      background: black;
+      width: 50px;
+      height: 100px;
+  }
+
+  /* Selectors for contain */
+  #none .wrapper {
       contain: none;
   }
-  #layout {
+  #layout .wrapper {
       contain: layout;
   }
-  #none_to_layout {
+  #none_to_layout .wrapper {
       content-visibility: none;
   }
-  #layout_to_none {
+  #layout_to_none .wrapper {
       content-visibility: layout;
   }
 </style>
@@ -40,60 +53,101 @@
   <div id="top_spacer"></div>
 
   <div id="none">
-    <div class="absolute_pos"></div>
-    <div class="fixed_pos"></div>
+    <div class="wrapper">
+      <div class="absolute_pos"></div>
+      <div class="fixed_pos"></div>
+    </div>
+    <div class="flex">
+      <div class="rect"></div>
+      <div class="wrapper rect">X</div>
+    </div>
   </div>
 
   <div id="layout">
-    <div class="absolute_pos"></div>
-    <div class="fixed_pos"></div>
+    <div class="wrapper">
+      <div class="absolute_pos"></div>
+      <div class="fixed_pos"></div>
+    </div>
+    <div class="flex">
+      <div class="rect"></div>
+      <div class="wrapper rect">X</div>
+    </div>
   </div>
 
   <div id="none_to_layout">
-    <div class="absolute_pos"></div>
-    <div class="fixed_pos"></div>
+    <div class="wrapper">
+      <div class="absolute_pos"></div>
+      <div class="fixed_pos"></div>
+    </div>
+    <div class="flex">
+      <div class="rect"></div>
+      <div class="wrapper rect">X</div>
+    </div>
   </div>
 
   <div id="layout_to_none">
-    <div class="absolute_pos"></div>
-    <div class="fixed_pos"></div>
+    <div class="wrapper">
+      <div class="absolute_pos"></div>
+      <div class="fixed_pos"></div>
+    </div>
+    <div class="flex">
+      <div class="rect"></div>
+      <div class="wrapper rect">X</div>
+    </div>
   </div>
 
   <script>
     function verifyLayoutContainment(id, applied) {
         let container = document.getElementById(id);
-        let containerTop = container.getBoundingClientRect().top;
+        let wrappers = container.getElementsByClassName("wrapper");
 
-        let abs_top = container.getElementsByClassName("absolute_pos")[0]
+        // To verify the containment box establishes an absolute positioning
+        // containing block and a fixed positioning containing block, we test
+        // positions of absolutely/fixed positioned children (a bit below the
+        // containment box rather than a bit below the top of the viewport).
+        let containingBlock = wrappers[0];
+        let containingBlockTop = wrappers[0].getBoundingClientRect().top;
+        let absTop = container.getElementsByClassName("absolute_pos")[0]
             .getBoundingClientRect().top;
-        assert_equals(abs_top > containerTop, applied, "absolute positioning containing block");
+        assert_equals(absTop > containingBlockTop, applied, "absolute positioning containing block");
+        let fixedTop = container.getElementsByClassName("fixed_pos")[0]
+            .getBoundingClientRect().top;
+        assert_equals(fixedTop > containingBlockTop, applied, "fixed positioning containing block");
 
-        let fixed_top = container.getElementsByClassName("fixed_pos")[0]
-            .getBoundingClientRect().top;
-        assert_equals(fixed_top > containerTop, applied, "fixed positioning containing block");
+        // To verify the containment box suppresses baseline, we verify that
+        // the two items in the flex container are properly aligned.
+        let item1 = wrappers[1];
+        let item2 = item1.previousElementSibling;
+        let aligned = Math.abs(item1.getBoundingClientRect().top - item2.getBoundingClientRect().top) <= 1;
+        assert_equals(aligned, applied, "vertical baseline suppressed");
     }
 
     function setContain(id, value) {
         let container = document.getElementById(id);
-        container.style.contain = value;
+        Array.from(container.getElementsByClassName("wrapper"))
+            .forEach(element => element.style.contain = value);
     }
 
     promise_test(async () => {
+        await document.fonts.ready;
         verifyLayoutContainment("none", /* applied=*/false);
-    }, "handling of absolutely/fixed positioned descendants of contain: none");
+    }, "contain: none");
 
     promise_test(async () => {
+        await document.fonts.ready;
         verifyLayoutContainment("layout", /* applied=*/true);
-    }, "handling of absolutely/fixed positioned descendants of contain: layout");
+    }, "contain: layout");
 
     promise_test(async () => {
+        await document.fonts.ready;
         setContain("none_to_layout", "layout");
         verifyLayoutContainment("none_to_layout", /* applied=*/true)
-    }, "handling of absolutely/fixed positioned descendants when switching contain from none to layout");
+    }, "switching contain from none to layout");
 
     promise_test(async () => {
+        await document.fonts.ready;
         setContain("layout_to_none", "none");
         verifyLayoutContainment("layout_to_none", /* applied=*/false);
-    }, "handling of absolutely/fixed positioned descendants when switching contain from layout to none");
+    }, "switching contain from layout to none");
   </script>
 </body>

--- a/css/css-contain/contain-layout-dynamic-001.html
+++ b/css/css-contain/contain-layout-dynamic-001.html
@@ -16,10 +16,10 @@
       contain: layout;
   }
   #none_to_layout .wrapper {
-      content-visibility: none;
+      contain: none;
   }
   #layout_to_none .wrapper {
-      content-visibility: layout;
+      contain: layout;
   }
 
   /* Selectors for testing absolute/fixed positioned elements */

--- a/css/css-contain/contain-layout-dynamic-001.html
+++ b/css/css-contain/contain-layout-dynamic-001.html
@@ -8,6 +8,20 @@
 <script src="/resources/testharnessreport.js"></script>
 <meta name="assert" content="Verify layout containment is properly updated after dynamic change to the contain property.">
 <style>
+  /* Selectors for contain */
+  #none .wrapper {
+      contain: none;
+  }
+  #layout .wrapper {
+      contain: layout;
+  }
+  #none_to_layout .wrapper {
+      content-visibility: none;
+  }
+  #layout_to_none .wrapper {
+      content-visibility: layout;
+  }
+
   /* Selectors for testing absolute/fixed positioned elements */
   #top_spacer {
       height: 100px;
@@ -31,20 +45,6 @@
       background: black;
       width: 50px;
       height: 100px;
-  }
-
-  /* Selectors for contain */
-  #none .wrapper {
-      contain: none;
-  }
-  #layout .wrapper {
-      contain: layout;
-  }
-  #none_to_layout .wrapper {
-      content-visibility: none;
-  }
-  #layout_to_none .wrapper {
-      content-visibility: layout;
   }
 </style>
 <body>

--- a/css/css-contain/contain-layout-dynamic-001.html
+++ b/css/css-contain/contain-layout-dynamic-001.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Dynamic change to layout containment</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain/#contain-property">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name="assert" content="Verify absolutely/fixed-positioned descendants are handled when updating layout containment .">
+<style>
+  #top_spacer {
+      height: 100px;
+      background: lightgray;
+  }
+
+  .absolute_pos {
+      position: absolute;
+      top: 42px;
+  }
+  .fixed_pos {
+      position: fixed;
+      top: 42px;
+  }
+
+  #none {
+      contain: none;
+  }
+  #layout {
+      contain: layout;
+  }
+  #none_to_layout {
+      content-visibility: none;
+  }
+  #layout_to_none {
+      content-visibility: layout;
+  }
+</style>
+<body>
+  <div id="log"></div>
+
+  <div id="top_spacer"></div>
+
+  <div id="none">
+    <div class="absolute_pos"></div>
+    <div class="fixed_pos"></div>
+  </div>
+
+  <div id="layout">
+    <div class="absolute_pos"></div>
+    <div class="fixed_pos"></div>
+  </div>
+
+  <div id="none_to_layout">
+    <div class="absolute_pos"></div>
+    <div class="fixed_pos"></div>
+  </div>
+
+  <div id="layout_to_none">
+    <div class="absolute_pos"></div>
+    <div class="fixed_pos"></div>
+  </div>
+
+  <script>
+    function verifyLayoutContainment(id, applied) {
+        let container = document.getElementById(id);
+        let containerTop = container.getBoundingClientRect().top;
+
+        let abs_top = container.getElementsByClassName("absolute_pos")[0]
+            .getBoundingClientRect().top;
+        assert_equals(abs_top > containerTop, applied, "absolute positioning containing block");
+
+        let fixed_top = container.getElementsByClassName("fixed_pos")[0]
+            .getBoundingClientRect().top;
+        assert_equals(fixed_top > containerTop, applied, "fixed positioning containing block");
+    }
+
+    function setContain(id, value) {
+        let container = document.getElementById(id);
+        container.style.contain = value;
+    }
+
+    promise_test(async () => {
+        verifyLayoutContainment("none", /* applied=*/false);
+    }, "handling of absolutely/fixed positioned descendants of contain: none");
+
+    promise_test(async () => {
+        verifyLayoutContainment("layout", /* applied=*/true);
+    }, "handling of absolutely/fixed positioned descendants of contain: layout");
+
+    promise_test(async () => {
+        setContain("none_to_layout", "layout");
+        verifyLayoutContainment("none_to_layout", /* applied=*/true)
+    }, "handling of absolutely/fixed positioned descendants when switching contain from none to layout");
+
+    promise_test(async () => {
+        setContain("layout_to_none", "none");
+        verifyLayoutContainment("layout_to_none", /* applied=*/false);
+    }, "handling of absolutely/fixed positioned descendants when switching contain from layout to none");
+  </script>
+</body>

--- a/css/css-contain/contain-paint-dynamic-001.html
+++ b/css/css-contain/contain-paint-dynamic-001.html
@@ -3,15 +3,16 @@
 <title>Dynamic change to paint containment</title>
 <link rel="help" href="https://drafts.csswg.org/css-contain/#contain-property">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="Verify absolutely/fixed-positioned descendants are handled when updating paint containment.">
+<meta name="assert" content="Verify paint containment is properly updated after dynamic change to the contain property.">
 <style>
+  /* Selectors for testing absolute/fixed positioned elements */
   #top_spacer {
       height: 100px;
       background: lightgray;
   }
-
   .absolute_pos {
       position: absolute;
       top: 42px;
@@ -21,16 +22,17 @@
       top: 42px;
   }
 
-  #none {
+  /* Selectors for contain */
+  #none .wrapper {
       contain: none;
   }
-  #paint {
+  #paint .wrapper {
       contain: paint;
   }
-  #none_to_paint {
+  #none_to_paint .wrapper {
       content-visibility: none;
   }
-  #paint_to_none {
+  #paint_to_none .wrapper {
       content-visibility: paint;
   }
 </style>
@@ -40,60 +42,78 @@
   <div id="top_spacer"></div>
 
   <div id="none">
-    <div class="absolute_pos"></div>
-    <div class="fixed_pos"></div>
+    <div class="wrapper">
+      <div class="absolute_pos"></div>
+      <div class="fixed_pos"></div>
+    </div>
   </div>
 
   <div id="paint">
-    <div class="absolute_pos"></div>
-    <div class="fixed_pos"></div>
+    <div class="wrapper">
+      <div class="absolute_pos"></div>
+      <div class="fixed_pos"></div>
+    </div>
   </div>
 
   <div id="none_to_paint">
-    <div class="absolute_pos"></div>
-    <div class="fixed_pos"></div>
+    <div class="wrapper">
+      <div class="absolute_pos"></div>
+      <div class="fixed_pos"></div>
+    </div>
   </div>
 
   <div id="paint_to_none">
-    <div class="absolute_pos"></div>
-    <div class="fixed_pos"></div>
+    <div class="wrapper">
+      <div class="absolute_pos"></div>
+      <div class="fixed_pos"></div>
+    </div>
   </div>
 
   <script>
     function verifyPaintContainment(id, applied) {
         let container = document.getElementById(id);
-        let containerTop = container.getBoundingClientRect().top;
+        let wrappers = container.getElementsByClassName("wrapper");
 
-        let abs_top = container.getElementsByClassName("absolute_pos")[0]
+        // To verify the containment box establishes an absolute positioning
+        // containing block and a fixed positioning containing block, we test
+        // positions of absolutely/fixed positioned children (a bit below the
+        // containment box rather than a bit below the top of the viewport).
+        let containingBlock = wrappers[0];
+        let containingBlockTop = wrappers[0].getBoundingClientRect().top;
+        let absTop = container.getElementsByClassName("absolute_pos")[0]
             .getBoundingClientRect().top;
-        assert_equals(abs_top > containerTop, applied, "absolute positioning containing block");
-
-        let fixed_top = container.getElementsByClassName("fixed_pos")[0]
+        assert_equals(absTop > containingBlockTop, applied, "absolute positioning containing block");
+        let fixedTop = container.getElementsByClassName("fixed_pos")[0]
             .getBoundingClientRect().top;
-        assert_equals(fixed_top > containerTop, applied, "fixed positioning containing block");
+        assert_equals(fixedTop > containingBlockTop, applied, "fixed positioning containing block");
     }
 
     function setContain(id, value) {
         let container = document.getElementById(id);
-        container.style.contain = value;
+        Array.from(container.getElementsByClassName("wrapper"))
+            .forEach(element => element.style.contain = value);
     }
 
     promise_test(async () => {
+        await document.fonts.ready;
         verifyPaintContainment("none", /* applied=*/false);
-    }, "handling of absolutely/fixed positioned descendants of contain: none");
+    }, "contain: none");
 
     promise_test(async () => {
+        await document.fonts.ready;
         verifyPaintContainment("paint", /* applied=*/true);
-    }, "handling of absolutely/fixed positioned descendants of contain: paint");
+    }, "contain: paint");
 
     promise_test(async () => {
+        await document.fonts.ready;
         setContain("none_to_paint", "paint");
         verifyPaintContainment("none_to_paint", /* applied=*/true)
-    }, "handling of absolutely/fixed positioned descendants when switching contain from none to paint");
+    }, "switching contain from none to paint");
 
     promise_test(async () => {
+        await document.fonts.ready;
         setContain("paint_to_none", "none");
         verifyPaintContainment("paint_to_none", /* applied=*/false);
-    }, "handling of absolutely/fixed positioned descendants when switching contain from paint to none");
+    }, "switching contain from paint to none");
   </script>
 </body>

--- a/css/css-contain/contain-paint-dynamic-001.html
+++ b/css/css-contain/contain-paint-dynamic-001.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="Verify absolutely/fixed-positioned descendants are handled when updating paint containment .">
+<meta name="assert" content="Verify absolutely/fixed-positioned descendants are handled when updating paint containment.">
 <style>
   #top_spacer {
       height: 100px;

--- a/css/css-contain/contain-paint-dynamic-001.html
+++ b/css/css-contain/contain-paint-dynamic-001.html
@@ -16,10 +16,10 @@
       contain: paint;
   }
   #none_to_paint .wrapper {
-      content-visibility: none;
+      contain: none;
   }
   #paint_to_none .wrapper {
-      content-visibility: paint;
+      contain: paint;
   }
 
   /* Selectors for testing absolute/fixed positioned elements */

--- a/css/css-contain/contain-paint-dynamic-001.html
+++ b/css/css-contain/contain-paint-dynamic-001.html
@@ -8,20 +8,6 @@
 <script src="/resources/testharnessreport.js"></script>
 <meta name="assert" content="Verify paint containment is properly updated after dynamic change to the contain property.">
 <style>
-  /* Selectors for testing absolute/fixed positioned elements */
-  #top_spacer {
-      height: 100px;
-      background: lightgray;
-  }
-  .absolute_pos {
-      position: absolute;
-      top: 42px;
-  }
-  .fixed_pos {
-      position: fixed;
-      top: 42px;
-  }
-
   /* Selectors for contain */
   #none .wrapper {
       contain: none;
@@ -34,6 +20,20 @@
   }
   #paint_to_none .wrapper {
       content-visibility: paint;
+  }
+
+  /* Selectors for testing absolute/fixed positioned elements */
+  #top_spacer {
+      height: 100px;
+      background: lightgray;
+  }
+  .absolute_pos {
+      position: absolute;
+      top: 42px;
+  }
+  .fixed_pos {
+      position: fixed;
+      top: 42px;
   }
 </style>
 <body>

--- a/css/css-contain/contain-paint-dynamic-001.html
+++ b/css/css-contain/contain-paint-dynamic-001.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Dynamic change to paint containment</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain/#contain-property">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name="assert" content="Verify absolutely/fixed-positioned descendants are handled when updating paint containment .">
+<style>
+  #top_spacer {
+      height: 100px;
+      background: lightgray;
+  }
+
+  .absolute_pos {
+      position: absolute;
+      top: 42px;
+  }
+  .fixed_pos {
+      position: fixed;
+      top: 42px;
+  }
+
+  #none {
+      contain: none;
+  }
+  #paint {
+      contain: paint;
+  }
+  #none_to_paint {
+      content-visibility: none;
+  }
+  #paint_to_none {
+      content-visibility: paint;
+  }
+</style>
+<body>
+  <div id="log"></div>
+
+  <div id="top_spacer"></div>
+
+  <div id="none">
+    <div class="absolute_pos"></div>
+    <div class="fixed_pos"></div>
+  </div>
+
+  <div id="paint">
+    <div class="absolute_pos"></div>
+    <div class="fixed_pos"></div>
+  </div>
+
+  <div id="none_to_paint">
+    <div class="absolute_pos"></div>
+    <div class="fixed_pos"></div>
+  </div>
+
+  <div id="paint_to_none">
+    <div class="absolute_pos"></div>
+    <div class="fixed_pos"></div>
+  </div>
+
+  <script>
+    function verifyPaintContainment(id, applied) {
+        let container = document.getElementById(id);
+        let containerTop = container.getBoundingClientRect().top;
+
+        let abs_top = container.getElementsByClassName("absolute_pos")[0]
+            .getBoundingClientRect().top;
+        assert_equals(abs_top > containerTop, applied, "absolute positioning containing block");
+
+        let fixed_top = container.getElementsByClassName("fixed_pos")[0]
+            .getBoundingClientRect().top;
+        assert_equals(fixed_top > containerTop, applied, "fixed positioning containing block");
+    }
+
+    function setContain(id, value) {
+        let container = document.getElementById(id);
+        container.style.contain = value;
+    }
+
+    promise_test(async () => {
+        verifyPaintContainment("none", /* applied=*/false);
+    }, "handling of absolutely/fixed positioned descendants of contain: none");
+
+    promise_test(async () => {
+        verifyPaintContainment("paint", /* applied=*/true);
+    }, "handling of absolutely/fixed positioned descendants of contain: paint");
+
+    promise_test(async () => {
+        setContain("none_to_paint", "paint");
+        verifyPaintContainment("none_to_paint", /* applied=*/true)
+    }, "handling of absolutely/fixed positioned descendants when switching contain from none to paint");
+
+    promise_test(async () => {
+        setContain("paint_to_none", "none");
+        verifyPaintContainment("paint_to_none", /* applied=*/false);
+    }, "handling of absolutely/fixed positioned descendants when switching contain from paint to none");
+  </script>
+</body>

--- a/css/css-contain/contain-paint-dynamic-002-ref.html
+++ b/css/css-contain/contain-paint-dynamic-002-ref.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<title>Dynamic change to paint containment (reference)</title>
+
+<style>
+  #container {
+      width: 100px;
+      height: 100px;
+      background: green;
+      contain: paint;
+  }
+  #overflowing {
+      width: 400px;
+      height: 100px;
+  }
+  .square {
+      display: inline-block;
+      width: 50px;
+      height: 50px;
+      margin: 5px;
+  }
+  .red {
+      background: red;
+  }
+</style>
+
+<body>
+  <p>PASS if you see a green square and no red.</p>
+  <div id="container">
+    <div id="overflowing"><div class="square"></div><div class="square"></div><div class="red square"></div></div>
+  </div>
+</body>
+</html>

--- a/css/css-contain/contain-paint-dynamic-002.html
+++ b/css/css-contain/contain-paint-dynamic-002.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>Dynamic change to paint containment</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain/#contain-property">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
+<meta name="assert" content="Verify paint containment is properly updated after dynamic change to the contain property.">
+<link rel="match" href="contain-paint-dynamic-002-ref.html">
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<style>
+  #container {
+      width: 100px;
+      height: 100px;
+      background: green;
+  }
+  #overflowing {
+      width: 400px;
+      height: 100px;
+  }
+  .square {
+      display: inline-block;
+      width: 50px;
+      height: 50px;
+      margin: 5px;
+  }
+  .red {
+      background: red;
+  }
+</style>
+
+<body>
+  <p>PASS if you see a green square and no red.</p>
+  <div id="container">
+    <div id="overflowing"><div class="square"></div><div class="square"></div><div class="red square"></div></div>
+  </div>
+  <script>
+    window.addEventListener("TestRendered", async () => {
+        container.style.contain = "paint";
+        await waitForAtLeastOneFrame();
+        takeScreenshot();
+    });
+  </script>
+</body>
+</html>

--- a/css/css-contain/contain-paint-dynamic-003-ref.html
+++ b/css/css-contain/contain-paint-dynamic-003-ref.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<title>Dynamic change to paint containment (reference)</title>
+
+<style>
+  #container {
+      width: 100px;
+      height: 100px;
+      background: green;
+      contain: none;
+  }
+  #overflowing {
+      width: 400px;
+      height: 100px;
+  }
+  .square {
+      display: inline-block;
+      width: 50px;
+      height: 50px;
+      margin: 5px;
+  }
+  .red {
+      background: green;
+  }
+</style>
+
+<body>
+  <p>PASS if you see <em>two</em> green squares.</p>
+  <div id="container">
+    <div id="overflowing"><div class="square"></div><div class="square"></div><div class="red square"></div></div>
+  </div>
+</body>
+</html>

--- a/css/css-contain/contain-paint-dynamic-003.html
+++ b/css/css-contain/contain-paint-dynamic-003.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>Dynamic change to paint containment</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain/#contain-property">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
+<meta name="assert" content="Verify paint containment is properly updated after dynamic change to the contain property.">
+<link rel="match" href="contain-paint-dynamic-003-ref.html">
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<style>
+  #container {
+      width: 100px;
+      height: 100px;
+      background: green;
+      contain: paint;
+  }
+  #overflowing {
+      width: 400px;
+      height: 100px;
+  }
+  .square {
+      display: inline-block;
+      width: 50px;
+      height: 50px;
+      margin: 5px;
+  }
+  .red {
+      background: green;
+  }
+</style>
+
+<body>
+  <p>PASS if you see <em>two</em> green squares.</p>
+  <div id="container">
+    <div id="overflowing"><div class="square"></div><div class="square"></div><div class="red square"></div></div>
+  </div>
+  <script>
+    window.addEventListener("TestRendered", async () => {
+        container.style.contain = "none";
+        await waitForAtLeastOneFrame();
+        takeScreenshot();
+    });
+  </script>
+</body>
+</html>

--- a/css/css-contain/contain-size-dynamic-001.html
+++ b/css/css-contain/contain-size-dynamic-001.html
@@ -5,7 +5,8 @@
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="Verify layout of containment box after dynamic change to size containment">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<meta name="assert" content="Verify size containment is properly updated after dynamic change to the contain property.">
 <style>
   .wrapper {
       display: inline-block;
@@ -17,16 +18,16 @@
       background: black;
   }
 
-  #none > .wrapper {
+  #none .wrapper {
       containt: none;
   }
-  #size > .wrapper {
+  #size .wrapper {
       contain: size;
   }
-  #none_to_size > .wrapper {
+  #none_to_size .wrapper {
       containt: none;
   }
-  #size_to_none > .wrapper {
+  #size_to_none .wrapper {
       contain: size;
   }
 </style>
@@ -51,9 +52,11 @@
 
   <script>
     function verifySizeContainment(id, applied) {
+        // To verify size containment applies, we test whether it is sized as
+        // if empty i.e. the size of its inner box is ignored.
         let container = document.getElementById(id);
         let wrapper = container.getElementsByClassName("wrapper")[0];
-	let wrapperBox = wrapper.getBoundingClientRect();
+        let wrapperBox = wrapper.getBoundingClientRect();
         assert_equals(wrapperBox.width == 0, applied, "width is zero");
         assert_equals(wrapperBox.height == 0, applied, "height is zero");
     }
@@ -66,20 +69,20 @@
 
     promise_test(async () => {
         verifySizeContainment("none", /*applied=*/false);
-    }, "size containment does not apply to containt: none");
+    }, "contain: none");
 
     promise_test(async () => {
         verifySizeContainment("size", /*applied=*/true);
-    }, "size containment applies to contain: size");
+    }, "contain: size");
 
     promise_test(async () => {
         setContain("none_to_size", "size");
         verifySizeContainment("none_to_size", /*applied=*/true);
-    }, "size containment updated when switching content-visibility from none to size");
+    }, "switching content-visibility from none to size");
 
     promise_test(async () => {
         setContain("size_to_none", "none");
         verifySizeContainment("size_to_none", /*applied=*/false);
-    }, "size containment updated when switching content-visibility from size to none");
+    }, "switching content-visibility from size to none");
   </script>
 </body>

--- a/css/css-contain/contain-size-dynamic-001.html
+++ b/css/css-contain/contain-size-dynamic-001.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Dynamic change to size containment</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain/#contain-property">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name="assert" content="Verify layout of containment box after dynamic change to size containment">
+<style>
+  .wrapper {
+      display: inline-block;
+  }
+  .box {
+      display: inline-block;
+      width: 50px;
+      height: 5px;
+      background: black;
+  }
+
+  #none > .wrapper {
+      containt: none;
+  }
+  #size > .wrapper {
+      contain: size;
+  }
+  #none_to_size > .wrapper {
+      containt: none;
+  }
+  #size_to_none > .wrapper {
+      contain: size;
+  }
+</style>
+<body>
+  <div id="log"></div>
+
+  <div id="none">
+    <div class="wrapper"><div class="box"></div></div>
+  </div>
+
+  <div id="size">
+    <div class="wrapper"><div class="box"></div></div>
+  </div>
+
+  <div id="none_to_size">
+    <div class="wrapper"><div class="box"></div></div>
+  </div>
+
+  <div id="size_to_none">
+    <div class="wrapper"><div class="box"></div></div>
+  </div>
+
+  <script>
+    function verifySizeContainment(id, applied) {
+        let container = document.getElementById(id);
+        let wrapper = container.getElementsByClassName("wrapper")[0];
+	let wrapperBox = wrapper.getBoundingClientRect();
+        assert_equals(wrapperBox.width == 0, applied, "width is zero");
+        assert_equals(wrapperBox.height == 0, applied, "height is zero");
+    }
+
+    function setContain(id, value) {
+        let container = document.getElementById(id);
+        let wrapper = container.getElementsByClassName("wrapper")[0];
+        wrapper.style.contain = value;
+    }
+
+    promise_test(async () => {
+        verifySizeContainment("none", /*applied=*/false);
+    }, "size containment does not apply to containt: none");
+
+    promise_test(async () => {
+        verifySizeContainment("size", /*applied=*/true);
+    }, "size containment applies to contain: size");
+
+    promise_test(async () => {
+        setContain("none_to_size", "size");
+        verifySizeContainment("none_to_size", /*applied=*/true);
+    }, "size containment updated when switching content-visibility from none to size");
+
+    promise_test(async () => {
+        setContain("size_to_none", "none");
+        verifySizeContainment("size_to_none", /*applied=*/false);
+    }, "size containment updated when switching content-visibility from size to none");
+  </script>
+</body>

--- a/css/css-contain/contain-size-dynamic-001.html
+++ b/css/css-contain/contain-size-dynamic-001.html
@@ -80,11 +80,11 @@
     promise_test(async () => {
         setContain("none_to_size", "size");
         verifySizeContainment("none_to_size", /*applied=*/true);
-    }, "switching content-visibility from none to size");
+    }, "switching contain from none to size");
 
     promise_test(async () => {
         setContain("size_to_none", "none");
         verifySizeContainment("size_to_none", /*applied=*/false);
-    }, "switching content-visibility from size to none");
+    }, "switching contain from size to none");
   </script>
 </body>

--- a/css/css-contain/contain-size-dynamic-001.html
+++ b/css/css-contain/contain-size-dynamic-001.html
@@ -8,16 +8,7 @@
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <meta name="assert" content="Verify size containment is properly updated after dynamic change to the contain property.">
 <style>
-  .wrapper {
-      display: inline-block;
-  }
-  .box {
-      display: inline-block;
-      width: 50px;
-      height: 5px;
-      background: black;
-  }
-
+  /* Selectors for contain */
   #none .wrapper {
       containt: none;
   }
@@ -29,6 +20,17 @@
   }
   #size_to_none .wrapper {
       contain: size;
+  }
+
+  /* Selectors for testing sizing as empty */
+  .wrapper {
+      display: inline-block;
+  }
+  .box {
+      display: inline-block;
+      width: 50px;
+      height: 5px;
+      background: black;
   }
 </style>
 <body>

--- a/css/css-contain/contain-style-dynamic-001.html
+++ b/css/css-contain/contain-style-dynamic-001.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Dynamic change to style containment</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain/#contain-property">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name="assert" content="Verify that counters and quotes are properly updated after dynamic change to style containment">
+<style>
+  /* Selectors for testing counters */
+  .set_counter_to_9 {
+      counter-set: testcounter 9;
+  }
+  .increment_counter {
+      counter-increment: testcounter;
+  }
+  .set_counter_to_10 {
+      counter-set: testcounter 10;
+  }
+  span.print_counter::after {
+      font: 25px/1 Ahem;
+      content: counters(testcounter, ".");
+  }
+
+  /* Selectors for testing quotes */
+  .open_quote::after {
+      content: open-quote;
+  }
+  .close_quote::after {
+      content: close-quote;
+  }
+  .no_open_quote::after {
+      content: no-open-quote;
+  }
+  .no_close_quote::after {
+      content: no-close-quote;
+  }
+  span.print_quotes::before, span.print_quotes::after {
+      font: 25px/1 Ahem;
+      quotes: "A" "" "BB" "" "CCC" "" "DDDD" "" "EEEEE" "" "FFFFF" "" "GGGGGG" "" "HHHHHHH" "" "IIIIIIII" "" "JJJJJJJJJ" "";
+  }
+  span.print_quotes::before {
+      content: open-quote;
+  }
+  span.print_quotes::after {
+      content: no-close-quote;
+  }
+
+  /* Selectors for contain */
+  #none > .wrapper {
+      contain: none;
+  }
+  #style > .wrapper {
+      contain: style;
+  }
+  #none_to_style > .wrapper {
+      contain: none;
+  }
+  #style_to_none > .wrapper {
+      contain: style;
+  }
+</style>
+<body>
+  <div id="log"></div>
+
+  <div id="none">
+    <div class="set_counter_to_9"></div>
+    <span><span class="print_counter"></span></span>
+    <div class="wrapper">
+      <span class="increment_counter"></span>
+    </div>
+    <span><span class="print_counter"></span></span>
+
+    <div class="set_counter_to_9"></div>
+    <span><span class="print_counter"></span></span>
+    <div class="wrapper">
+      <span class="set_counter_to_10"></span>
+    </div>
+    <span><span class="print_counter"></span></span>
+
+    <span><span class="print_quotes"></span></span>
+    <div class="wrapper">
+      <span class="open_quote"></span>
+    </div>
+    <span><span class="print_quotes"></span></span>
+
+    <span><span class="print_quotes"></span></span>
+    <div class="wrapper">
+      <span class="close_quote"></span>
+    </div>
+    <span><span class="print_quotes"></span></span>
+
+    <span><span class="print_quotes"></span></span>
+    <div class="wrapper">
+      <span class="no_open_quote"></span>
+    </div>
+    <span><span class="print_quotes"></span></span>
+
+    <span><span class="print_quotes"></span></span>
+    <div class="wrapper">
+      <span class="no_close_quote"></span>
+    </div>
+    <span><span class="print_quotes"></span></span>
+  </div>
+
+  <div id="style">
+    <div class="set_counter_to_9"></div>
+    <span><span class="print_counter"></span></span>
+    <div class="wrapper">
+      <span class="increment_counter"></span>
+    </div>
+    <span><span class="print_counter"></span></span>
+
+    <div class="set_counter_to_9"></div>
+    <span><span class="print_counter"></span></span>
+    <div class="wrapper">
+      <span class="set_counter_to_10"></span>
+    </div>
+    <span><span class="print_counter"></span></span>
+
+    <span><span class="print_quotes"></span></span>
+    <div class="wrapper">
+      <span class="open_quote"></span>
+    </div>
+    <span><span class="print_quotes"></span></span>
+
+    <span><span class="print_quotes"></span></span>
+    <div class="wrapper">
+      <span class="close_quote"></span>
+    </div>
+    <span><span class="print_quotes"></span></span>
+
+    <span><span class="print_quotes"></span></span>
+    <div class="wrapper">
+      <span class="no_open_quote"></span>
+    </div>
+    <span><span class="print_quotes"></span></span>
+
+    <span><span class="print_quotes"></span></span>
+    <div class="wrapper">
+      <span class="no_close_quote"></span>
+    </div>
+    <span><span class="print_quotes"></span></span>
+  </div>
+
+  <div id="none_to_style">
+    <div class="set_counter_to_9"></div>
+    <span><span class="print_counter"></span></span>
+    <div class="wrapper">
+      <span class="increment_counter"></span>
+    </div>
+    <span><span class="print_counter"></span></span>
+
+    <div class="set_counter_to_9"></div>
+    <span><span class="print_counter"></span></span>
+    <div class="wrapper">
+      <span class="set_counter_to_10"></span>
+    </div>
+    <span><span class="print_counter"></span></span>
+
+    <span><span class="print_quotes"></span></span>
+    <div class="wrapper">
+      <span class="open_quote"></span>
+    </div>
+    <span><span class="print_quotes"></span></span>
+
+    <span><span class="print_quotes"></span></span>
+    <div class="wrapper">
+      <span class="close_quote"></span>
+    </div>
+    <span><span class="print_quotes"></span></span>
+
+    <span><span class="print_quotes"></span></span>
+    <div class="wrapper">
+      <span class="no_open_quote"></span>
+    </div>
+    <span><span class="print_quotes"></span></span>
+
+    <span><span class="print_quotes"></span></span>
+    <div class="wrapper">
+      <span class="no_close_quote"></span>
+    </div>
+    <span><span class="print_quotes"></span></span>
+  </div>
+
+  <div id="style_to_none">
+    <div class="set_counter_to_9"></div>
+    <span><span class="print_counter"></span></span>
+    <div class="wrapper">
+      <span class="increment_counter"></span>
+    </div>
+    <span><span class="print_counter"></span></span>
+
+    <div class="set_counter_to_9"></div>
+    <span><span class="print_counter"></span></span>
+    <div class="wrapper">
+      <span class="set_counter_to_10"></span>
+    </div>
+    <span><span class="print_counter"></span></span>
+
+    <span><span class="print_quotes"></span></span>
+    <div class="wrapper">
+      <span class="open_quote"></span>
+    </div>
+    <span><span class="print_quotes"></span></span>
+
+    <span><span class="print_quotes"></span></span>
+    <div class="wrapper">
+      <span class="close_quote"></span>
+    </div>
+    <span><span class="print_quotes"></span></span>
+
+    <span><span class="print_quotes"></span></span>
+    <div class="wrapper">
+      <span class="no_open_quote"></span>
+    </div>
+    <span><span class="print_quotes"></span></span>
+
+    <span><span class="print_quotes"></span></span>
+    <div class="wrapper">
+      <span class="no_close_quote"></span>
+    </div>
+    <span><span class="print_quotes"></span></span>
+  </div>
+
+  <script>
+    function verifyStyleContainment(id, scoped) {
+        // To verify style containment, we check whether the properties in the
+        // wrapper affect the string length of generated content.
+        function haveSameStringLength(box1, box2) {
+            const ahemFontSizePx = 25;
+            return Math.abs(box2.width - box1.width) < ahemFontSizePx / 2;
+        }
+
+        let container = document.getElementById(id);
+        let counter_box =
+            Array.from(container.getElementsByClassName("print_counter"))
+            .map(e => e.parentNode.getBoundingClientRect());
+        let quote_box =
+            Array.from(container.getElementsByClassName("print_quotes"))
+            .map(e => e.parentNode.getBoundingClientRect());
+        assert_equals(haveSameStringLength(counter_box[0], counter_box[1]), scoped, "increment-counter");
+        assert_equals(haveSameStringLength(counter_box[2], counter_box[3]), scoped, "set-counter");
+        assert_equals(haveSameStringLength(quote_box[0], quote_box[1]), scoped, "open-quote");
+        assert_equals(haveSameStringLength(quote_box[2], quote_box[3]), scoped, "close-quote");
+        assert_equals(haveSameStringLength(quote_box[4], quote_box[5]), scoped, "no-open-quote");
+        assert_equals(haveSameStringLength(quote_box[6], quote_box[7]), scoped, "no-close-quote");
+    }
+
+    function setContain(id, value) {
+        let container = document.getElementById(id);
+        Array.from(container.getElementsByClassName("wrapper"))
+            .forEach(element => element.style.contain = value);
+    }
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        verifyStyleContainment("none", /*scoped=*/ false);
+    }, "counter/quote-related properties not scoped to subtree with contain: none");
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        verifyStyleContainment("style", /*scoped=*/ true);
+    }, "counter/quote-related properties scoped to subtree with contain: style");
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        setContain("none_to_style", "style");
+        verifyStyleContainment("none_to_style", /*scoped=*/ true);
+    }, "counter/quote-related properties scoped when switching contain from none to style");
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        setContain("style_to_none", "none");
+        verifyStyleContainment("style_to_none", /*scoped=*/ false);
+    }, "counter/quote-related properties not scoped when switching contain from style to none");
+  </script>
+</body>

--- a/css/css-contain/contain-style-dynamic-001.html
+++ b/css/css-contain/contain-style-dynamic-001.html
@@ -6,7 +6,7 @@
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="Verify that counters and quotes are properly updated after dynamic change to style containment">
+<meta name="assert" content="Verify style containment is properly updated after dynamic change to the contain property.">
 <style>
   /* Selectors for testing counters */
   .set_counter_to_9 {
@@ -48,16 +48,16 @@
   }
 
   /* Selectors for contain */
-  #none > .wrapper {
+  #none .wrapper {
       contain: none;
   }
-  #style > .wrapper {
+  #style .wrapper {
       contain: style;
   }
-  #none_to_style > .wrapper {
+  #none_to_style .wrapper {
       contain: none;
   }
-  #style_to_none > .wrapper {
+  #style_to_none .wrapper {
       contain: style;
   }
 </style>
@@ -226,14 +226,15 @@
 
   <script>
     function verifyStyleContainment(id, applied) {
-        // To verify style containment, we check whether the properties in the
-        // wrapper affect the string length of generated content.
+        let container = document.getElementById(id);
+
+        // To verify style containment for counters and quotes, we check whether
+        // the properties in the wrapper affect the string length of generated
+        // content.
         function haveSameStringLength(box1, box2) {
             const ahemFontSizePx = 25;
             return Math.abs(box2.width - box1.width) < ahemFontSizePx / 2;
         }
-
-        let container = document.getElementById(id);
         let counter_box =
             Array.from(container.getElementsByClassName("print_counter"))
             .map(e => e.parentNode.getBoundingClientRect());
@@ -257,23 +258,23 @@
     promise_test(async () => {
         await document.fonts.ready;
         verifyStyleContainment("none", /*applied=*/ false);
-    }, "counter/quote-related properties not scoped to subtree with contain: none");
+    }, "contain: none");
 
     promise_test(async () => {
         await document.fonts.ready;
         verifyStyleContainment("style", /*applied=*/ true);
-    }, "counter/quote-related properties scoped to subtree with contain: style");
+    }, "contain: style");
 
     promise_test(async () => {
         await document.fonts.ready;
         setContain("none_to_style", "style");
         verifyStyleContainment("none_to_style", /*applied=*/ true);
-    }, "counter/quote-related properties scoped when switching contain from none to style");
+    }, "switching contain from none to style");
 
     promise_test(async () => {
         await document.fonts.ready;
         setContain("style_to_none", "none");
         verifyStyleContainment("style_to_none", /*applied=*/ false);
-    }, "counter/quote-related properties not scoped when switching contain from style to none");
+    }, "switching contain from style to none");
   </script>
 </body>

--- a/css/css-contain/contain-style-dynamic-001.html
+++ b/css/css-contain/contain-style-dynamic-001.html
@@ -225,7 +225,7 @@
   </div>
 
   <script>
-    function verifyStyleContainment(id, scoped) {
+    function verifyStyleContainment(id, applied) {
         // To verify style containment, we check whether the properties in the
         // wrapper affect the string length of generated content.
         function haveSameStringLength(box1, box2) {
@@ -240,12 +240,12 @@
         let quote_box =
             Array.from(container.getElementsByClassName("print_quotes"))
             .map(e => e.parentNode.getBoundingClientRect());
-        assert_equals(haveSameStringLength(counter_box[0], counter_box[1]), scoped, "increment-counter");
-        assert_equals(haveSameStringLength(counter_box[2], counter_box[3]), scoped, "set-counter");
-        assert_equals(haveSameStringLength(quote_box[0], quote_box[1]), scoped, "open-quote");
-        assert_equals(haveSameStringLength(quote_box[2], quote_box[3]), scoped, "close-quote");
-        assert_equals(haveSameStringLength(quote_box[4], quote_box[5]), scoped, "no-open-quote");
-        assert_equals(haveSameStringLength(quote_box[6], quote_box[7]), scoped, "no-close-quote");
+        assert_equals(haveSameStringLength(counter_box[0], counter_box[1]), applied, "increment-counter");
+        assert_equals(haveSameStringLength(counter_box[2], counter_box[3]), applied, "set-counter");
+        assert_equals(haveSameStringLength(quote_box[0], quote_box[1]), applied, "open-quote");
+        assert_equals(haveSameStringLength(quote_box[2], quote_box[3]), applied, "close-quote");
+        assert_equals(haveSameStringLength(quote_box[4], quote_box[5]), applied, "no-open-quote");
+        assert_equals(haveSameStringLength(quote_box[6], quote_box[7]), applied, "no-close-quote");
     }
 
     function setContain(id, value) {
@@ -256,24 +256,24 @@
 
     promise_test(async () => {
         await document.fonts.ready;
-        verifyStyleContainment("none", /*scoped=*/ false);
+        verifyStyleContainment("none", /*applied=*/ false);
     }, "counter/quote-related properties not scoped to subtree with contain: none");
 
     promise_test(async () => {
         await document.fonts.ready;
-        verifyStyleContainment("style", /*scoped=*/ true);
+        verifyStyleContainment("style", /*applied=*/ true);
     }, "counter/quote-related properties scoped to subtree with contain: style");
 
     promise_test(async () => {
         await document.fonts.ready;
         setContain("none_to_style", "style");
-        verifyStyleContainment("none_to_style", /*scoped=*/ true);
+        verifyStyleContainment("none_to_style", /*applied=*/ true);
     }, "counter/quote-related properties scoped when switching contain from none to style");
 
     promise_test(async () => {
         await document.fonts.ready;
         setContain("style_to_none", "none");
-        verifyStyleContainment("style_to_none", /*scoped=*/ false);
+        verifyStyleContainment("style_to_none", /*applied=*/ false);
     }, "counter/quote-related properties not scoped when switching contain from style to none");
   </script>
 </body>

--- a/css/css-contain/contain-style-dynamic-001.html
+++ b/css/css-contain/contain-style-dynamic-001.html
@@ -8,6 +8,20 @@
 <script src="/resources/testharnessreport.js"></script>
 <meta name="assert" content="Verify style containment is properly updated after dynamic change to the contain property.">
 <style>
+  /* Selectors for contain */
+  #none .wrapper {
+      contain: none;
+  }
+  #style .wrapper {
+      contain: style;
+  }
+  #none_to_style .wrapper {
+      contain: none;
+  }
+  #style_to_none .wrapper {
+      contain: style;
+  }
+
   /* Selectors for testing counters */
   .set_counter_to_9 {
       counter-set: testcounter 9;
@@ -45,20 +59,6 @@
   }
   span.print_quotes::after {
       content: no-close-quote;
-  }
-
-  /* Selectors for contain */
-  #none .wrapper {
-      contain: none;
-  }
-  #style .wrapper {
-      contain: style;
-  }
-  #none_to_style .wrapper {
-      contain: none;
-  }
-  #style_to_none .wrapper {
-      contain: style;
   }
 </style>
 <body>

--- a/css/css-contain/content-visibility/content-visibility-absolute-fixed-positioned-containing-block-001.html
+++ b/css/css-contain/content-visibility/content-visibility-absolute-fixed-positioned-containing-block-001.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>content-visibility and layout containment</title>
+<title>content-visibility and layout/paint containment (absolute/fixed positioned descendants)</title>
 <link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<meta name="assert" content="content-visibility: auto and elements skipping their content change the used value of the contain property to turn on layout containment.">
+<meta name="assert" content="content-visibility: auto and elements skipping their content change the used value of the contain property to turn on layout/paint containment, affecting absolute/fixed positioned descendants.">
 <style>
   /* Change to style containment can cause drastic changes such as rebuilding
      counters or quotes, so always enabled here to prevent any side effect. */
@@ -24,6 +24,10 @@
 
   .absolute_pos {
       position: absolute;
+      top: 42px;
+  }
+  .fixed_pos {
+      position: fixed;
       top: 42px;
   }
 
@@ -59,29 +63,36 @@
 
   <div id="visible" class="content_visibility">
     <div class="absolute_pos"></div>
+    <div class="fixed_pos"></div>
   </div>
 
   <div id="hidden" class="content_visibility">
     <div class="absolute_pos"></div>
+    <div class="fixed_pos"></div>
   </div>
 
   <div id="auto_close" class="content_visibility">
     <div class="absolute_pos"></div>
+    <div class="fixed_pos"></div>
   </div>
 
   <div id="visible_to_hidden" class="content_visibility">
     <div class="absolute_pos"></div>
+    <div class="fixed_pos"></div>
   </div>
 
   <div id="hidden_to_visible" class="content_visibility">
     <div class="absolute_pos"></div>
+    <div class="fixed_pos"></div>
   </div>
 
   <div id="visible_to_auto" class="content_visibility">
     <div class="absolute_pos"></div>
+    <div class="fixed_pos"></div>
   </div>
 
   <div id="auto_to_visible" class="content_visibility">
+    <div class="fixed_pos"></div>
     <div class="absolute_pos"></div>
   </div>
 
@@ -89,16 +100,25 @@
 
   <div id="auto_far" class="content_visibility">
     <div class="absolute_pos"></div>
+    <div class="fixed_pos"></div>
   </div>
 
   <script>
-    function layoutContainmentApplied(id) {
-        let container = document.getElementById(id);
-        // If layout containment applies, absolute_pos will be positionned
-        // relative to that container.
-        let abs_box = container.getElementsByClassName("absolute_pos")[0]
-            .getBoundingClientRect();
-        return abs_box.top > 100;
+    function verifyContainmentFromAbsoluteFixedPositioning(id, applied) {
+	// content-visibility: auto and elements skipping their content change
+	// apply paint/layout containment, making them an absolute/fixed
+	// positioning container blocks.
+
+	let container = document.getElementById(id);
+        let containerTop = container.getBoundingClientRect().top;
+
+        let abs_top = container.getElementsByClassName("absolute_pos")[0]
+            .getBoundingClientRect().top;
+        assert_equals(abs_top > containerTop, applied, "absolute positioning containing block");
+
+        let fixed_top = container.getElementsByClassName("fixed_pos")[0]
+            .getBoundingClientRect().top;
+        assert_equals(fixed_top > containerTop, applied, "fixed positioning containing block");
     }
 
     function setContentVisibility(id, value) {
@@ -115,42 +135,50 @@
     }
 
     promise_test(async () => {
-        assert_false(layoutContainmentApplied("visible"));
-    }, "layout containment does not apply to content-visibility: visible");
+	verifyContainmentFromAbsoluteFixedPositioning("visible",
+						      /*applied=*/false);
+    }, "content-visibility: visible");
 
     promise_test(async () => {
-        assert_true(layoutContainmentApplied("hidden"));
-    }, "layout containment applies to content-visibility: hidden");
-
-    promise_test(async () => {
-        await tick();
-        assert_true(layoutContainmentApplied("auto_far"));
-    }, "layout containment applies to content-visibility: auto (far from viewport)");
+	verifyContainmentFromAbsoluteFixedPositioning("hidden",
+						      /*applied=*/true);
+    }, "content-visibility: hidden");
 
     promise_test(async () => {
         await tick();
-        assert_true(layoutContainmentApplied("auto_close"));
-    }, "layout containment applies to content-visibility: auto (close from viewport)");
+	verifyContainmentFromAbsoluteFixedPositioning("auto_far",
+						      /*applied=*/true);
+    }, "content-visibility: auto (far from viewport)");
+
+    promise_test(async () => {
+        await tick();
+	verifyContainmentFromAbsoluteFixedPositioning("auto_close",
+						      /*applied=*/true);
+    }, "content-visibility: auto (close from viewport)");
 
     promise_test(async () => {
         setContentVisibility("visible_to_hidden", "hidden");
-        assert_true(layoutContainmentApplied("visible_to_hidden"));
-    }, "layout containment updated when switching content-visibility from visible to hidden");
+	verifyContainmentFromAbsoluteFixedPositioning("visible_to_hidden",
+						      /*applied=*/true);
+    }, "switching content-visibility from visible to hidden");
 
     promise_test(async () => {
         setContentVisibility("hidden_to_visible", "visible");
-        assert_false(layoutContainmentApplied("hidden_to_visible"));
-    }, "layout containment updated when switching content-visibility from hidden to visible");
+	verifyContainmentFromAbsoluteFixedPositioning("hidden_to_visible",
+						      /*applied=*/false);
+    }, "switching content-visibility from hidden to visible");
 
     promise_test(async () => {
         setContentVisibility("visible_to_auto", "auto");
         await tick();
-        assert_true(layoutContainmentApplied("visible_to_auto"));
-    }, "layout containment updated when switching content-visibility from visible to auto");
+	verifyContainmentFromAbsoluteFixedPositioning("visible_to_auto",
+						      /*applied=*/true);
+    }, "switching content-visibility from visible to auto");
 
     promise_test(async () => {
         setContentVisibility("auto_to_visible", "visible");
-        assert_false(layoutContainmentApplied("auto_to_visible"));
-    }, "layout containment updated when switching content-visibility from auto to visible");
+	verifyContainmentFromAbsoluteFixedPositioning("auto_to_visible",
+						      /*applied=*/false);
+    }, "switching content-visibility from auto to visible");
   </script>
 </body>

--- a/css/css-contain/content-visibility/content-visibility-layout-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-layout-containment-001.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>content-visibility and layout containment</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name="assert" content="content-visibility: auto and elements skipping their content change the used value of the contain property to turn on layout containment.">
+<style>
+  /* Selectors for content-visibility */
+  #spacer_for_far_to_viewport {
+      height: 300vh;
+  }
+  .content_visibility {
+      /* Dynamic changes in this test may imply changes to other containment types.
+	 Try and minimize the tested changes by forcing the irrelevant ones. */
+      contain: paint size style;
+  }
+  #visible .content_visibility {
+      content-visibility: visible;
+  }
+  #hidden .content_visibility {
+      content-visibility: hidden;
+  }
+  #auto_far .content_visibility {
+      content-visibility: auto;
+  }
+  #auto_close .content_visibility {
+      content-visibility: auto;
+  }
+  #visible_to_hidden .content_visibility {
+      content-visibility: visible;
+  }
+  #hidden_to_visible .content_visibility {
+      content-visibility: hidden;
+  }
+  #visible_to_auto .content_visibility {
+      content-visibility: visible;
+  }
+  #auto_to_visible .content_visibility {
+      content-visibility: auto;
+  }
+
+  /* Selectors for testing baseline */
+  .flex {
+      display: inline-flex;
+      align-items: baseline;
+  }
+  .rect {
+      background: black;
+      width: 50px;
+      height: 100px;
+  }
+</style>
+<body>
+  <div id="log"></div>
+
+  <div id="visible">
+    <div class="flex">
+      <div class="rect"></div>
+      <div class="content_visibility rect">X</div>
+    </div>
+  </div>
+
+  <div id="hidden">
+    <div class="flex">
+      <div class="rect"></div>
+      <div class="content_visibility rect">X</div>
+    </div>
+  </div>
+
+  <div id="auto_close">
+    <div class="flex">
+      <div class="rect"></div>
+      <div class="content_visibility rect">X</div>
+    </div>
+  </div>
+
+  <div id="visible_to_hidden">
+    <div class="flex">
+      <div class="rect"></div>
+      <div class="content_visibility rect">X</div>
+    </div>
+  </div>
+
+  <div id="hidden_to_visible">
+    <div class="flex">
+      <div class="rect"></div>
+      <div class="content_visibility rect">X</div>
+    </div>
+  </div>
+
+  <div id="visible_to_auto">
+    <div class="flex">
+      <div class="rect"></div>
+      <div class="content_visibility rect">X</div>
+    </div>
+  </div>
+
+  <div id="auto_to_visible">
+    <div class="flex">
+      <div class="rect"></div>
+      <div class="content_visibility rect">X</div>
+    </div>
+  </div>
+
+  <div id="spacer_for_far_to_viewport"></div>
+
+  <div id="auto_far">
+    <div class="flex">
+      <div class="rect"></div>
+      <div class="content_visibility rect">X</div>
+    </div>
+  </div>
+
+  <script>
+    function layoutContainmentApplied(id) {
+        let container = document.getElementById(id);
+        let content_visibility = container.getElementsByClassName("content_visibility")[0];
+
+        // To verify layout containment, we test baseline suppression.
+	// See contain-layout-dynamic-001.html for more details.
+        let item1 = content_visibility;
+        let item2 = item1.previousElementSibling;
+        return Math.abs(item1.getBoundingClientRect().top - item2.getBoundingClientRect().top) <= 1;
+    }
+
+    function setContentVisibility(id, value) {
+        let container = document.getElementById(id);
+        let content_visibility = container.getElementsByClassName("content_visibility")[0];
+        content_visibility.style.contentVisibility = value;
+    }
+
+    function tick() {
+        return new Promise(resolve => {
+            requestAnimationFrame(() => {
+                requestAnimationFrame(resolve);
+            });
+        });
+    }
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        assert_false(layoutContainmentApplied("visible"));
+    }, "content-visibility: visible");
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        assert_true(layoutContainmentApplied("hidden"));
+    }, "content-visibility: hidden");
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        await tick();
+        assert_true(layoutContainmentApplied("auto_far"));
+    }, "content-visibility: auto (far from viewport)");
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        await tick();
+        assert_true(layoutContainmentApplied("auto_close"));
+    }, "content-visibility: auto (close from viewport)");
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        setContentVisibility("visible_to_hidden", "hidden");
+        assert_true(layoutContainmentApplied("visible_to_hidden"));
+    }, "switching content-visibility from visible to hidden");
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        setContentVisibility("hidden_to_visible", "visible");
+        assert_false(layoutContainmentApplied("hidden_to_visible"));
+    }, "switching content-visibility from hidden to visible");
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        setContentVisibility("visible_to_auto", "auto");
+        await tick();
+        assert_true(layoutContainmentApplied("visible_to_auto"));
+    }, "switching content-visibility from visible to auto");
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        setContentVisibility("auto_to_visible", "visible");
+        assert_false(layoutContainmentApplied("auto_to_visible"));
+    }, "switching content-visibility from auto to visible");
+  </script>
+</body>

--- a/css/css-contain/content-visibility/content-visibility-layout-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-layout-containment-001.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>content-visibility and layout containment</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name="assert" content="content-visibility: auto and elements skipping their content change the used value of the contain property to turn on layout containment.">
+<style>
+  /* Change to style containment can cause drastic changes such as rebuilding
+     counters or quotes, so always enabled here to prevent any side effect. */
+  .content_visibility {
+      contain: style;
+  }
+
+  #spacer_for_far_to_viewport {
+      height: 300vh;
+  }
+
+  #top_spacer {
+      height: 100px;
+      background: lightgray;
+  }
+
+  .absolute_pos {
+      position: absolute;
+      top: 42px;
+  }
+
+  #visible {
+      content-visibility: visible;
+  }
+  #hidden {
+      content-visibility: hidden;
+  }
+  #auto_far {
+      content-visibility: auto;
+  }
+  #auto_close {
+      content-visibility: auto;
+  }
+  #visible_to_hidden {
+      content-visibility: visible;
+  }
+  #hidden_to_visible {
+      content-visibility: hidden;
+  }
+  #visible_to_auto {
+      content-visibility: visible;
+  }
+  #auto_to_visible {
+      content-visibility: auto;
+  }
+</style>
+<body>
+  <div id="log"></div>
+
+  <div id="top_spacer"></div>
+
+  <div id="visible">
+    <div class="absolute_pos"></div>
+  </div>
+
+  <div id="hidden">
+    <div class="absolute_pos"></div>
+  </div>
+
+  <div id="auto_close">
+    <div class="absolute_pos"></div>
+  </div>
+
+  <div id="visible_to_hidden">
+    <div class="absolute_pos"></div>
+  </div>
+
+  <div id="hidden_to_visible">
+    <div class="absolute_pos"></div>
+  </div>
+
+  <div id="visible_to_auto">
+    <div class="absolute_pos"></div>
+  </div>
+
+  <div id="auto_to_visible">
+    <div class="absolute_pos"></div>
+  </div>
+
+  <div id="spacer_for_far_to_viewport"></div>
+
+  <div id="auto_far">
+    <div class="absolute_pos"></div>
+  </div>
+
+  <script>
+    function layoutContainmentApplied(id) {
+        let container = document.getElementById(id);
+        // If layout containment applies, absolute_pos will be positionned
+        // relative to that container.
+        let abs_box = container.getElementsByClassName("absolute_pos")[0]
+            .getBoundingClientRect();
+        return abs_box.top > 100;
+    }
+
+    function setContentVisibility(id, value) {
+        let container = document.getElementById(id);
+        container.style.contentVisibility = value;
+    }
+
+    function tick() {
+        return new Promise(resolve => {
+            requestAnimationFrame(() => {
+                requestAnimationFrame(resolve);
+            });
+        });
+    }
+
+    promise_test(async () => {
+        assert_true(!layoutContainmentApplied("visible"));
+    }, "layout containment does not apply to content-visibility: visible");
+
+    promise_test(async () => {
+        assert_true(layoutContainmentApplied("hidden"));
+    }, "layout containment applies to content-visibility: hidden");
+
+    promise_test(async () => {
+        await tick();
+        assert_true(layoutContainmentApplied("auto_far"));
+    }, "layout containment applies to content-visibility: auto (far from viewport)");
+
+    promise_test(async () => {
+        await tick();
+        assert_true(layoutContainmentApplied("auto_close"));
+    }, "layout containment applies to content-visibility: auto (close from viewport)");
+
+    promise_test(async () => {
+        setContentVisibility("visible_to_hidden", "hidden");
+        assert_true(layoutContainmentApplied("visible_to_hidden"));
+    }, "layout containment updated when switching content-visibility from visible to hidden");
+
+    promise_test(async () => {
+        setContentVisibility("hidden_to_visible", "visible");
+        assert_true(!layoutContainmentApplied("hidden_to_visible"));
+    }, "layout containment updated when switching content-visibility from hidden to visible");
+
+    promise_test(async () => {
+        setContentVisibility("visible_to_auto", "auto");
+        await tick();
+        assert_true(layoutContainmentApplied("visible_to_auto"));
+    }, "layout containment updated when switching content-visibility from visible to auto");
+
+    promise_test(async () => {
+        setContentVisibility("auto_to_visible", "visible");
+        assert_true(!layoutContainmentApplied("auto_to_visible"));
+    }, "layout containment updated when switching content-visibility from auto to visible");
+  </script>
+</body>

--- a/css/css-contain/content-visibility/content-visibility-layout-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-layout-containment-001.html
@@ -57,37 +57,37 @@
 
   <div id="top_spacer"></div>
 
-  <div id="visible">
+  <div id="visible" class="content_visibility">
     <div class="absolute_pos"></div>
   </div>
 
-  <div id="hidden">
+  <div id="hidden" class="content_visibility">
     <div class="absolute_pos"></div>
   </div>
 
-  <div id="auto_close">
+  <div id="auto_close" class="content_visibility">
     <div class="absolute_pos"></div>
   </div>
 
-  <div id="visible_to_hidden">
+  <div id="visible_to_hidden" class="content_visibility">
     <div class="absolute_pos"></div>
   </div>
 
-  <div id="hidden_to_visible">
+  <div id="hidden_to_visible" class="content_visibility">
     <div class="absolute_pos"></div>
   </div>
 
-  <div id="visible_to_auto">
+  <div id="visible_to_auto" class="content_visibility">
     <div class="absolute_pos"></div>
   </div>
 
-  <div id="auto_to_visible">
+  <div id="auto_to_visible" class="content_visibility">
     <div class="absolute_pos"></div>
   </div>
 
   <div id="spacer_for_far_to_viewport"></div>
 
-  <div id="auto_far">
+  <div id="auto_far" class="content_visibility">
     <div class="absolute_pos"></div>
   </div>
 

--- a/css/css-contain/content-visibility/content-visibility-layout-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-layout-containment-001.html
@@ -115,7 +115,7 @@
     }
 
     promise_test(async () => {
-        assert_true(!layoutContainmentApplied("visible"));
+        assert_false(layoutContainmentApplied("visible"));
     }, "layout containment does not apply to content-visibility: visible");
 
     promise_test(async () => {
@@ -139,7 +139,7 @@
 
     promise_test(async () => {
         setContentVisibility("hidden_to_visible", "visible");
-        assert_true(!layoutContainmentApplied("hidden_to_visible"));
+        assert_false(layoutContainmentApplied("hidden_to_visible"));
     }, "layout containment updated when switching content-visibility from hidden to visible");
 
     promise_test(async () => {
@@ -150,7 +150,7 @@
 
     promise_test(async () => {
         setContentVisibility("auto_to_visible", "visible");
-        assert_true(!layoutContainmentApplied("auto_to_visible"));
+        assert_false(layoutContainmentApplied("auto_to_visible"));
     }, "layout containment updated when switching content-visibility from auto to visible");
   </script>
 </body>

--- a/css/css-contain/content-visibility/content-visibility-layout-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-layout-containment-001.html
@@ -15,7 +15,7 @@
   }
   .content_visibility {
       /* Dynamic changes in this test may imply changes to other containment types.
-	 Try and minimize the tested changes by forcing the irrelevant ones. */
+         Try and minimize the tested changes by forcing the irrelevant ones. */
       contain: paint size style;
   }
   #visible .content_visibility {
@@ -121,7 +121,7 @@
         let content_visibility = container.getElementsByClassName("content_visibility")[0];
 
         // To verify layout containment, we test baseline suppression.
-	// See contain-layout-dynamic-001.html for more details.
+        // See contain-layout-dynamic-001.html for more details.
         let item1 = content_visibility;
         let item2 = item1.previousElementSibling;
         return Math.abs(item1.getBoundingClientRect().top - item2.getBoundingClientRect().top) <= 1;

--- a/css/css-contain/content-visibility/content-visibility-layout-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-layout-containment-001.html
@@ -6,6 +6,7 @@
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/rendering-utils.js"></script>
 <meta name="assert" content="content-visibility: auto and elements skipping their content change the used value of the contain property to turn on layout containment.">
 <style>
   /* Selectors for content-visibility */
@@ -132,14 +133,6 @@
         content_visibility.style.contentVisibility = value;
     }
 
-    function tick() {
-        return new Promise(resolve => {
-            requestAnimationFrame(() => {
-                requestAnimationFrame(resolve);
-            });
-        });
-    }
-
     promise_test(async () => {
         await document.fonts.ready;
         assert_false(layoutContainmentApplied("visible"));
@@ -152,13 +145,13 @@
 
     promise_test(async () => {
         await document.fonts.ready;
-        await tick();
+        await waitForAtLeastOneFrame();
         assert_true(layoutContainmentApplied("auto_far"));
     }, "content-visibility: auto (far from viewport)");
 
     promise_test(async () => {
         await document.fonts.ready;
-        await tick();
+        await waitForAtLeastOneFrame();
         assert_true(layoutContainmentApplied("auto_close"));
     }, "content-visibility: auto (close from viewport)");
 
@@ -177,7 +170,7 @@
     promise_test(async () => {
         await document.fonts.ready;
         setContentVisibility("visible_to_auto", "auto");
-        await tick();
+        await waitForAtLeastOneFrame();
         assert_true(layoutContainmentApplied("visible_to_auto"));
     }, "switching content-visibility from visible to auto");
 

--- a/css/css-contain/content-visibility/content-visibility-layout-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-layout-containment-001.html
@@ -14,9 +14,11 @@
       height: 300vh;
   }
   .content_visibility {
-      /* Dynamic changes in this test may imply changes to other containment types.
-         Try and minimize the tested changes by forcing the irrelevant ones. */
-      contain: paint size style;
+      /* Dynamic modification of content-visibility may change whether style
+         containment is applied, which in turn may cause drastic invalidations
+         (e.g. rebuilding counters). Make the test more robust by forcing
+         style containment to always apply. */
+      contain: style;
   }
   #visible .content_visibility {
       content-visibility: visible;

--- a/css/css-contain/content-visibility/content-visibility-layout-paint-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-layout-paint-containment-001.html
@@ -13,9 +13,11 @@
       height: 300vh;
   }
   .content_visibility {
-      /* Dynamic changes in this test may imply changes to other containment types.
-         Try and minimize the tested changes by forcing the irrelevant ones. */
-      contain: size style;
+      /* Dynamic modification of content-visibility may change whether style
+	 containment is applied, which in turn may cause drastic invalidations
+	 (e.g. rebuilding counters). Make the test more robust by forcing
+	 style containment to always apply. */
+      contain: style;
   }
   #visible {
       content-visibility: visible;
@@ -92,8 +94,8 @@
   </div>
 
   <div id="auto_to_visible" class="content_visibility">
-    <div class="fixed_pos"></div>
     <div class="absolute_pos"></div>
+    <div class="fixed_pos"></div>
   </div>
 
   <div id="spacer_for_far_to_viewport"></div>

--- a/css/css-contain/content-visibility/content-visibility-layout-paint-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-layout-paint-containment-001.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>content-visibility and layout/paint containment (absolute/fixed positioned descendants)</title>
+<title>content-visibility and layout/paint containment</title>
 <link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="assert" content="content-visibility: auto and elements skipping their content change the used value of the contain property to turn on layout/paint containment, affecting absolute/fixed positioned descendants.">
 <style>
-  /* Change to style containment can cause drastic changes such as rebuilding
-     counters or quotes, so always enabled here to prevent any side effect. */
+  /* Dynamic changes in this test may imply changes to other containment types.
+     Try and minimize the tested changes by forcing the irrelevant ones. */
   .content_visibility {
-      contain: style;
+      contain: size style;
   }
 
   #spacer_for_far_to_viewport {
@@ -105,11 +105,11 @@
 
   <script>
     function verifyContainmentFromAbsoluteFixedPositioning(id, applied) {
-	// content-visibility: auto and elements skipping their content change
-	// apply paint/layout containment, making them an absolute/fixed
-	// positioning container blocks.
+        // content-visibility: auto and elements skipping their content change
+        // apply paint/layout containment, making them an absolute/fixed
+        // positioning container blocks.
 
-	let container = document.getElementById(id);
+        let container = document.getElementById(id);
         let containerTop = container.getBoundingClientRect().top;
 
         let abs_top = container.getElementsByClassName("absolute_pos")[0]
@@ -135,50 +135,50 @@
     }
 
     promise_test(async () => {
-	verifyContainmentFromAbsoluteFixedPositioning("visible",
-						      /*applied=*/false);
+        verifyContainmentFromAbsoluteFixedPositioning("visible",
+                                                      /*applied=*/false);
     }, "content-visibility: visible");
 
     promise_test(async () => {
-	verifyContainmentFromAbsoluteFixedPositioning("hidden",
-						      /*applied=*/true);
+        verifyContainmentFromAbsoluteFixedPositioning("hidden",
+                                                      /*applied=*/true);
     }, "content-visibility: hidden");
 
     promise_test(async () => {
         await tick();
-	verifyContainmentFromAbsoluteFixedPositioning("auto_far",
-						      /*applied=*/true);
+        verifyContainmentFromAbsoluteFixedPositioning("auto_far",
+                                                      /*applied=*/true);
     }, "content-visibility: auto (far from viewport)");
 
     promise_test(async () => {
         await tick();
-	verifyContainmentFromAbsoluteFixedPositioning("auto_close",
-						      /*applied=*/true);
+        verifyContainmentFromAbsoluteFixedPositioning("auto_close",
+                                                      /*applied=*/true);
     }, "content-visibility: auto (close from viewport)");
 
     promise_test(async () => {
         setContentVisibility("visible_to_hidden", "hidden");
-	verifyContainmentFromAbsoluteFixedPositioning("visible_to_hidden",
-						      /*applied=*/true);
+        verifyContainmentFromAbsoluteFixedPositioning("visible_to_hidden",
+                                                      /*applied=*/true);
     }, "switching content-visibility from visible to hidden");
 
     promise_test(async () => {
         setContentVisibility("hidden_to_visible", "visible");
-	verifyContainmentFromAbsoluteFixedPositioning("hidden_to_visible",
-						      /*applied=*/false);
+        verifyContainmentFromAbsoluteFixedPositioning("hidden_to_visible",
+                                                      /*applied=*/false);
     }, "switching content-visibility from hidden to visible");
 
     promise_test(async () => {
         setContentVisibility("visible_to_auto", "auto");
         await tick();
-	verifyContainmentFromAbsoluteFixedPositioning("visible_to_auto",
-						      /*applied=*/true);
+        verifyContainmentFromAbsoluteFixedPositioning("visible_to_auto",
+                                                      /*applied=*/true);
     }, "switching content-visibility from visible to auto");
 
     promise_test(async () => {
         setContentVisibility("auto_to_visible", "visible");
-	verifyContainmentFromAbsoluteFixedPositioning("auto_to_visible",
-						      /*applied=*/false);
+        verifyContainmentFromAbsoluteFixedPositioning("auto_to_visible",
+                                                      /*applied=*/false);
     }, "switching content-visibility from auto to visible");
   </script>
 </body>

--- a/css/css-contain/content-visibility/content-visibility-layout-paint-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-layout-paint-containment-001.html
@@ -7,30 +7,15 @@
 <script src="/resources/testharnessreport.js"></script>
 <meta name="assert" content="content-visibility: auto and elements skipping their content change the used value of the contain property to turn on layout/paint containment, affecting absolute/fixed positioned descendants.">
 <style>
-  /* Dynamic changes in this test may imply changes to other containment types.
-     Try and minimize the tested changes by forcing the irrelevant ones. */
-  .content_visibility {
-      contain: size style;
-  }
-
+  /* Selectors for content-visibility */
   #spacer_for_far_to_viewport {
       height: 300vh;
   }
-
-  #top_spacer {
-      height: 100px;
-      background: lightgray;
+  .content_visibility {
+      /* Dynamic changes in this test may imply changes to other containment types.
+         Try and minimize the tested changes by forcing the irrelevant ones. */
+      contain: size style;
   }
-
-  .absolute_pos {
-      position: absolute;
-      top: 42px;
-  }
-  .fixed_pos {
-      position: fixed;
-      top: 42px;
-  }
-
   #visible {
       content-visibility: visible;
   }
@@ -54,6 +39,20 @@
   }
   #auto_to_visible {
       content-visibility: auto;
+  }
+
+  /* Selectors for testing absolute/fixed positioning container blocks */
+  #top_spacer {
+      height: 100px;
+      background: lightgray;
+  }
+  .absolute_pos {
+      position: absolute;
+      top: 42px;
+  }
+  .fixed_pos {
+      position: fixed;
+      top: 42px;
   }
 </style>
 <body>
@@ -108,6 +107,7 @@
         // content-visibility: auto and elements skipping their content change
         // apply paint/layout containment, making them an absolute/fixed
         // positioning container blocks.
+	// See contain-paint-dynamic-001.html / contain-layout-dynamic-001.html.
 
         let container = document.getElementById(id);
         let containerTop = container.getBoundingClientRect().top;

--- a/css/css-contain/content-visibility/content-visibility-layout-paint-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-layout-paint-containment-001.html
@@ -5,6 +5,7 @@
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/rendering-utils.js"></script>
 <meta name="assert" content="content-visibility: auto and elements skipping their content change the used value of the contain property to turn on layout/paint containment, affecting absolute/fixed positioned descendants.">
 <style>
   /* Selectors for content-visibility */
@@ -126,14 +127,6 @@
         container.style.contentVisibility = value;
     }
 
-    function tick() {
-        return new Promise(resolve => {
-            requestAnimationFrame(() => {
-                requestAnimationFrame(resolve);
-            });
-        });
-    }
-
     promise_test(async () => {
         verifyContainmentFromAbsoluteFixedPositioning("visible",
                                                       /*applied=*/false);
@@ -145,13 +138,13 @@
     }, "content-visibility: hidden");
 
     promise_test(async () => {
-        await tick();
+        await waitForAtLeastOneFrame();
         verifyContainmentFromAbsoluteFixedPositioning("auto_far",
                                                       /*applied=*/true);
     }, "content-visibility: auto (far from viewport)");
 
     promise_test(async () => {
-        await tick();
+        await waitForAtLeastOneFrame();
         verifyContainmentFromAbsoluteFixedPositioning("auto_close",
                                                       /*applied=*/true);
     }, "content-visibility: auto (close from viewport)");
@@ -170,7 +163,7 @@
 
     promise_test(async () => {
         setContentVisibility("visible_to_auto", "auto");
-        await tick();
+        await waitForAtLeastOneFrame();
         verifyContainmentFromAbsoluteFixedPositioning("visible_to_auto",
                                                       /*applied=*/true);
     }, "switching content-visibility from visible to auto");

--- a/css/css-contain/content-visibility/content-visibility-layout-paint-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-layout-paint-containment-001.html
@@ -108,7 +108,7 @@
         // content-visibility: auto and elements skipping their content change
         // apply paint/layout containment, making them an absolute/fixed
         // positioning container blocks.
-	// See contain-paint-dynamic-001.html / contain-layout-dynamic-001.html.
+        // See contain-paint-dynamic-001.html / contain-layout-dynamic-001.html.
 
         let container = document.getElementById(id);
         let containerTop = container.getBoundingClientRect().top;

--- a/css/css-contain/content-visibility/content-visibility-layout-paint-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-layout-paint-containment-001.html
@@ -14,9 +14,9 @@
   }
   .content_visibility {
       /* Dynamic modification of content-visibility may change whether style
-	 containment is applied, which in turn may cause drastic invalidations
-	 (e.g. rebuilding counters). Make the test more robust by forcing
-	 style containment to always apply. */
+         containment is applied, which in turn may cause drastic invalidations
+         (e.g. rebuilding counters). Make the test more robust by forcing
+         style containment to always apply. */
       contain: style;
   }
   #visible {

--- a/css/css-contain/content-visibility/content-visibility-paint-containment-001-ref.html
+++ b/css/css-contain/content-visibility/content-visibility-paint-containment-001-ref.html
@@ -1,13 +1,18 @@
 <!DOCTYPE html>
 <html>
 <meta charset="utf-8">
-<title>Dynamic change to paint containment (reference)</title>
+<title>content-visibility and paint containment (reference)</title>
 
 <style>
-  #container {
+  .container {
       width: 100px;
       height: 100px;
       background: green;
+  }
+  .hidden {
+      contain: layout paint style;
+  }
+  .visible {
       contain: none;
   }
   #overflowing {
@@ -20,15 +25,22 @@
       height: 50px;
       margin: 5px;
   }
+  .red {
+      background: red;
+  }
   .green {
       background: green;
   }
 </style>
 
 <body>
-  <p>PASS if you see <em>two</em> green squares.</p>
-  <div id="container">
+  <p>PASS if you see a green square and no red.</p>
+  <div class="hidden container">
     <div id="overflowing"><div class="square"></div><div class="square"></div><div class="red square"></div></div>
+  </div>
+  <p>PASS if you see <em>two</em> green squares.</p>
+  <div class="visible container">
+    <div id="overflowing"><div class="square"></div><div class="square"></div><div class="green square"></div></div>
   </div>
 </body>
 </html>

--- a/css/css-contain/content-visibility/content-visibility-paint-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-paint-containment-001.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<title>content-visibility and paint containment</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain/#contain-property">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
+<meta name="assert" content="Verify paint containment is implied by content-visibility.">
+<link rel="match" href="contain-paint-dynamic-001-ref.html">
+
+<style>
+  .container {
+      width: 100px;
+      height: 100px;
+      background: green;
+  }
+  .hidden {
+      content-visibility: hidden;
+  }
+  .visible {
+      content-visibility: visible;
+  }
+  #overflowing {
+      width: 400px;
+      height: 100px;
+  }
+  .square {
+      display: inline-block;
+      width: 50px;
+      height: 50px;
+      margin: 5px;
+  }
+  .red {
+      background: red;
+  }
+  .green {
+      background: green;
+  }
+</style>
+
+<body>
+  <p>PASS if you see a green square and no red.</p>
+  <div class="hidden container">
+    <div id="overflowing"><div class="square"></div><div class="square"></div><div class="red square"></div></div>
+  </div>
+  <p>PASS if you see <em>two</em> green squares.</p>
+  <div class="visible container">
+    <div id="overflowing"><div class="square"></div><div class="square"></div><div class="green square"></div></div>
+  </div>
+</body>
+</html>

--- a/css/css-contain/content-visibility/content-visibility-paint-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-paint-containment-001.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-contain/#contain-property">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
 <meta name="assert" content="Verify paint containment is implied by content-visibility.">
-<link rel="match" href="contain-paint-dynamic-001-ref.html">
+<link rel="match" href="content-visibility-paint-containment-001-ref.html">
 
 <style>
   .container {

--- a/css/css-contain/content-visibility/content-visibility-paint-containment-002-ref.html
+++ b/css/css-contain/content-visibility/content-visibility-paint-containment-002-ref.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
 <html>
 <meta charset="utf-8">
-<title>Dynamic change to paint containment (reference)</title>
+<title>content-visibility and paint containment (reference)</title>
 
 <style>
   #container {
       width: 100px;
       height: 100px;
       background: green;
-      contain: none;
+      content-visibility: hidden;
+      contain: layout size style;
   }
   #overflowing {
       width: 400px;
@@ -20,13 +21,13 @@
       height: 50px;
       margin: 5px;
   }
-  .green {
-      background: green;
+  .red {
+      background: red;
   }
 </style>
 
 <body>
-  <p>PASS if you see <em>two</em> green squares.</p>
+  <p>PASS if you see a green square and no red.</p>
   <div id="container">
     <div id="overflowing"><div class="square"></div><div class="square"></div><div class="red square"></div></div>
   </div>

--- a/css/css-contain/content-visibility/content-visibility-paint-containment-002-ref.html
+++ b/css/css-contain/content-visibility/content-visibility-paint-containment-002-ref.html
@@ -9,7 +9,7 @@
       height: 100px;
       background: green;
       content-visibility: hidden;
-      contain: layout size style;
+      contain: style;
   }
   #overflowing {
       width: 400px;

--- a/css/css-contain/content-visibility/content-visibility-paint-containment-002.html
+++ b/css/css-contain/content-visibility/content-visibility-paint-containment-002.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
 <meta charset="utf-8">
-<title>Dynamic change to paint containment</title>
+<title>content-visibility and paint containment</title>
 <link rel="help" href="https://drafts.csswg.org/css-contain/#contain-property">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
-<meta name="assert" content="Verify paint containment is properly updated after dynamic change to the contain property.">
-<link rel="match" href="contain-paint-dynamic-003-ref.html">
+<meta name="assert" content="Verify paint containment is properly updated after dynamic change to the content-visibility property.">
+<link rel="match" href="contain-paint-dynamic-002-ref.html">
 
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>
@@ -15,7 +15,10 @@
       width: 100px;
       height: 100px;
       background: green;
-      contain: paint;
+      content-visibility: visible;
+      /* Dynamic changes in this test may imply changes to other containment types.
+	 Try and minimize the tested changes by forcing the irrelevant ones. */
+      contain: layout size style;
   }
   #overflowing {
       width: 400px;
@@ -27,19 +30,19 @@
       height: 50px;
       margin: 5px;
   }
-  .green {
-      background: green;
+  .red {
+      background: red;
   }
 </style>
 
 <body>
-  <p>PASS if you see <em>two</em> green squares.</p>
+  <p>PASS if you see a green square and no red.</p>
   <div id="container">
     <div id="overflowing"><div class="square"></div><div class="square"></div><div class="red square"></div></div>
   </div>
   <script>
     window.addEventListener("TestRendered", async () => {
-        container.style.contain = "none";
+        container.style.contentVisibility = "hidden";
         await waitForAtLeastOneFrame();
         takeScreenshot();
     });

--- a/css/css-contain/content-visibility/content-visibility-paint-containment-002.html
+++ b/css/css-contain/content-visibility/content-visibility-paint-containment-002.html
@@ -17,7 +17,7 @@
       background: green;
       content-visibility: visible;
       /* Dynamic changes in this test may imply changes to other containment types.
-	 Try and minimize the tested changes by forcing the irrelevant ones. */
+         Try and minimize the tested changes by forcing the irrelevant ones. */
       contain: layout size style;
   }
   #overflowing {

--- a/css/css-contain/content-visibility/content-visibility-paint-containment-002.html
+++ b/css/css-contain/content-visibility/content-visibility-paint-containment-002.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-contain/#contain-property">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
 <meta name="assert" content="Verify paint containment is properly updated after dynamic change to the content-visibility property.">
-<link rel="match" href="contain-paint-dynamic-002-ref.html">
+<link rel="match" href="content-visibility-paint-containment-002-ref.html">
 
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>

--- a/css/css-contain/content-visibility/content-visibility-paint-containment-002.html
+++ b/css/css-contain/content-visibility/content-visibility-paint-containment-002.html
@@ -16,9 +16,11 @@
       height: 100px;
       background: green;
       content-visibility: visible;
-      /* Dynamic changes in this test may imply changes to other containment types.
-         Try and minimize the tested changes by forcing the irrelevant ones. */
-      contain: layout size style;
+      /* Dynamic modification of content-visibility may change whether style
+         containment is applied, which in turn may cause drastic invalidations
+         (e.g. rebuilding counters). Make the test more robust by forcing
+         style containment to always apply. */
+      contain: style;
   }
   #overflowing {
       width: 400px;

--- a/css/css-contain/content-visibility/content-visibility-paint-containment-003-ref.html
+++ b/css/css-contain/content-visibility/content-visibility-paint-containment-003-ref.html
@@ -9,7 +9,7 @@
       height: 100px;
       background: green;
       content-visibility: visible;
-      contain: layout size style;
+      contain: style;
   }
   #overflowing {
       width: 400px;

--- a/css/css-contain/content-visibility/content-visibility-paint-containment-003-ref.html
+++ b/css/css-contain/content-visibility/content-visibility-paint-containment-003-ref.html
@@ -8,7 +8,8 @@
       width: 100px;
       height: 100px;
       background: green;
-      contain: none;
+      content-visibility: visible;
+      contain: layout size style;
   }
   #overflowing {
       width: 400px;
@@ -28,7 +29,7 @@
 <body>
   <p>PASS if you see <em>two</em> green squares.</p>
   <div id="container">
-    <div id="overflowing"><div class="square"></div><div class="square"></div><div class="red square"></div></div>
+    <div id="overflowing"><div class="square"></div><div class="square"></div><div class="green square"></div></div>
   </div>
 </body>
 </html>

--- a/css/css-contain/content-visibility/content-visibility-paint-containment-003.html
+++ b/css/css-contain/content-visibility/content-visibility-paint-containment-003.html
@@ -17,7 +17,7 @@
       background: green;
       content-visibility: hidden;
       /* Dynamic changes in this test may imply changes to other containment types.
-	 Try and minimize the tested changes by forcing the irrelevant ones. */
+         Try and minimize the tested changes by forcing the irrelevant ones. */
       contain: layout size style;
   }
   #overflowing {

--- a/css/css-contain/content-visibility/content-visibility-paint-containment-003.html
+++ b/css/css-contain/content-visibility/content-visibility-paint-containment-003.html
@@ -16,9 +16,11 @@
       height: 100px;
       background: green;
       content-visibility: hidden;
-      /* Dynamic changes in this test may imply changes to other containment types.
-         Try and minimize the tested changes by forcing the irrelevant ones. */
-      contain: layout size style;
+      /* Dynamic modification of content-visibility may change whether style
+         containment is applied, which in turn may cause drastic invalidations
+         (e.g. rebuilding counters). Make the test more robust by forcing
+         style containment to always apply. */
+      contain: style;
   }
   #overflowing {
       width: 400px;

--- a/css/css-contain/content-visibility/content-visibility-paint-containment-003.html
+++ b/css/css-contain/content-visibility/content-visibility-paint-containment-003.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
 <meta charset="utf-8">
-<title>Dynamic change to paint containment</title>
+<title>content-visibility and paint containment</title>
 <link rel="help" href="https://drafts.csswg.org/css-contain/#contain-property">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
-<meta name="assert" content="Verify paint containment is properly updated after dynamic change to the contain property.">
+<meta name="assert" content="Verify paint containment is properly updated after dynamic change to the content-visibility property.">
 <link rel="match" href="contain-paint-dynamic-003-ref.html">
 
 <script src="/common/reftest-wait.js"></script>
@@ -15,7 +15,10 @@
       width: 100px;
       height: 100px;
       background: green;
-      contain: paint;
+      content-visibility: hidden;
+      /* Dynamic changes in this test may imply changes to other containment types.
+	 Try and minimize the tested changes by forcing the irrelevant ones. */
+      contain: layout size style;
   }
   #overflowing {
       width: 400px;
@@ -35,11 +38,11 @@
 <body>
   <p>PASS if you see <em>two</em> green squares.</p>
   <div id="container">
-    <div id="overflowing"><div class="square"></div><div class="square"></div><div class="red square"></div></div>
+    <div id="overflowing"><div class="square"></div><div class="square"></div><div class="green square"></div></div>
   </div>
   <script>
     window.addEventListener("TestRendered", async () => {
-        container.style.contain = "none";
+        container.style.contentVisibility = "visible";
         await waitForAtLeastOneFrame();
         takeScreenshot();
     });

--- a/css/css-contain/content-visibility/content-visibility-paint-containment-003.html
+++ b/css/css-contain/content-visibility/content-visibility-paint-containment-003.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-contain/#contain-property">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
 <meta name="assert" content="Verify paint containment is properly updated after dynamic change to the content-visibility property.">
-<link rel="match" href="contain-paint-dynamic-003-ref.html">
+<link rel="match" href="content-visibility-paint-containment-003-ref.html">
 
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>

--- a/css/css-contain/content-visibility/content-visibility-size-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-size-containment-001.html
@@ -143,53 +143,53 @@
 
     promise_test(async () => {
         assert_false(sizeContainmentApplied("visible"));
-    }, "size containment does not apply to content-visibility: visible");
+    }, "content-visibility: visible");
 
     promise_test(async () => {
         assert_true(sizeContainmentApplied("hidden"));
-    }, "size containment applies to content-visibility: hidden");
+    }, "content-visibility: hidden");
 
     promise_test(async () => {
         await tick();
         assert_true(sizeContainmentApplied("auto_far"));
-    }, "size containment applies to content-visibility: auto (far from viewport)");
+    }, "content-visibility: auto (far from viewport)");
 
     promise_test(async () => {
         await tick();
         assert_false(sizeContainmentApplied("auto_close"));
-    }, "size containment does not apply to content-visibility: auto (close from viewport)");
+    }, "content-visibility: auto (close from viewport)");
 
     promise_test(async () => {
         setContentVisibility("visible_to_hidden", "hidden");
         assert_true(sizeContainmentApplied("visible_to_hidden"));
-    }, "size containment updated when switching content-visibility from visible to hidden");
+    }, "switching content-visibility from visible to hidden");
 
     promise_test(async () => {
         setContentVisibility("hidden_to_visible", "visible");
         assert_false(sizeContainmentApplied("hidden_to_visible"));
-    }, "size containment updated when switching content-visibility from hidden to visible");
+    }, "switching content-visibility from hidden to visible");
 
     promise_test(async () => {
         setContentVisibility("auto_far_to_visible", "visible");
         assert_false(sizeContainmentApplied("auto_far_to_visible"));
-    }, "size containment updated when switching content-visibility from auto (far from viewport) to visible");
+    }, "switching content-visibility from auto (far from viewport) to visible");
 
     promise_test(async () => {
         setContentVisibility("visible_to_auto_far", "auto");
         await tick();
         assert_true(sizeContainmentApplied("visible_to_auto_far"));
-    }, "size containment updated when switching content-visibility from visible to auto (far from viewport)");
+    }, "switching content-visibility from visible to auto (far from viewport)");
 
     promise_test(async () => {
         setContentVisibility("auto_close_to_hidden", "hidden");
         assert_true(sizeContainmentApplied("auto_close_to_hidden"));
-    }, "size containment updated when switching content-visibility from auto (close from viewport) to hidden");
+    }, "switching content-visibility from auto (close from viewport) to hidden");
 
     promise_test(async () => {
         setContentVisibility("hidden_to_auto_close", "auto");
         await tick();
         assert_false(sizeContainmentApplied("hidden_to_auto_close"));
-    }, "size containment updated when switching content-visibility from hidden to auto (close from viewport)");
+    }, "switching content-visibility from hidden to auto (close from viewport)");
 
 
     let contentVisibilityAuto =
@@ -225,7 +225,7 @@
         window.scrollTo(0, 0);
         assert_true(sizeContainmentApplied("auto_dynamic_relevancy"),
                     "size containment applied when changing back from close to far to the viewport");
-    }, "size containment updated when changing proximity to the viewport");
+    }, "content-visibility: auto, changing proximity to the viewport");
 
     promise_test(async (t) => {
         t.add_cleanup(clearRelevancyReasons);
@@ -243,7 +243,7 @@
             .firstElementChild.focus({preventScroll: true});
         assert_true(sizeContainmentApplied("auto_dynamic_relevancy"),
                     "size containment applied after unfocusing back");
-    }, "size containment updated when after being focused/unfocused");
+    }, "content-visibility: auto, after being focused/unfocused");
 
     promise_test(async (t) => {
         t.add_cleanup(clearRelevancyReasons);
@@ -261,7 +261,7 @@
         await tick();
         assert_true(sizeContainmentApplied("auto_dynamic_relevancy"),
                     "size containment applied when unselecting back");
-    }, "size containment updated when after being selected/unselected");
+    }, "content-visibility: auto, after being selected/unselected");
 
   </script>
 </body>

--- a/css/css-contain/content-visibility/content-visibility-size-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-size-containment-001.html
@@ -13,9 +13,11 @@
       height: 300vh;
   }
   .content_visibility {
-      /* Dynamic changes in this test may imply changes to other containment types.
-         Try and minimize the tested changes by forcing the irrelevant ones. */
-      contain: layout size style;
+      /* Dynamic modification of content-visibility may change whether style
+         containment is applied, which in turn may cause drastic invalidations
+         (e.g. rebuilding counters). Make the test more robust by forcing
+         style containment to always apply. */
+      contain: style;
   }
   #visible .content_visibility {
       content-visibility: visible;

--- a/css/css-contain/content-visibility/content-visibility-size-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-size-containment-001.html
@@ -5,6 +5,7 @@
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/rendering-utils.js"></script>
 <meta name="assert" content="elements skipping their content change the used value of the contain property to turn on size containment.">
 <style>
   /* Selectors for content-visibility */
@@ -135,14 +136,6 @@
         content_visibility.style.contentVisibility = value;
     }
 
-    function tick() {
-        return new Promise(resolve => {
-            requestAnimationFrame(() => {
-                requestAnimationFrame(resolve);
-            });
-        });
-    }
-
     promise_test(async () => {
         assert_false(sizeContainmentApplied("visible"));
     }, "content-visibility: visible");
@@ -152,12 +145,12 @@
     }, "content-visibility: hidden");
 
     promise_test(async () => {
-        await tick();
+        await waitForAtLeastOneFrame();
         assert_true(sizeContainmentApplied("auto_far"));
     }, "content-visibility: auto (far from viewport)");
 
     promise_test(async () => {
-        await tick();
+        await waitForAtLeastOneFrame();
         assert_false(sizeContainmentApplied("auto_close"));
     }, "content-visibility: auto (close from viewport)");
 
@@ -178,7 +171,7 @@
 
     promise_test(async () => {
         setContentVisibility("visible_to_auto_far", "auto");
-        await tick();
+        await waitForAtLeastOneFrame();
         assert_true(sizeContainmentApplied("visible_to_auto_far"));
     }, "switching content-visibility from visible to auto (far from viewport)");
 
@@ -189,7 +182,7 @@
 
     promise_test(async () => {
         setContentVisibility("hidden_to_auto_close", "auto");
-        await tick();
+        await waitForAtLeastOneFrame();
         assert_false(sizeContainmentApplied("hidden_to_auto_close"));
     }, "switching content-visibility from hidden to auto (close from viewport)");
 
@@ -215,12 +208,12 @@
     promise_test(async (t) => {
         t.add_cleanup(clearRelevancyReasons);
 
-        await tick();
+        await waitForAtLeastOneFrame();
         assert_true(sizeContainmentApplied("auto_dynamic_relevancy"),
                     "size containment applied when initially far to the viewport");
 
         contentVisibilityAuto.scrollIntoView();
-        await tick();
+        await waitForAtLeastOneFrame();
         assert_false(sizeContainmentApplied("auto_dynamic_relevancy"),
                     "size containment applied when changing from far to close to the viewport");
 
@@ -232,12 +225,12 @@
     promise_test(async (t) => {
         t.add_cleanup(clearRelevancyReasons);
 
-        await tick();
+        await waitForAtLeastOneFrame();
         assert_true(sizeContainmentApplied("auto_dynamic_relevancy"),
                     "size containment applied when initially unfocused");
 
         contentVisibilityAuto.focus({preventScroll: true});
-        await tick();
+        await waitForAtLeastOneFrame();
         assert_false(sizeContainmentApplied("auto_dynamic_relevancy"),
                     "size containment applied after focusing");
 
@@ -250,17 +243,17 @@
     promise_test(async (t) => {
         t.add_cleanup(clearRelevancyReasons);
 
-        await tick();
+        await waitForAtLeastOneFrame();
         assert_true(sizeContainmentApplied("auto_dynamic_relevancy"),
                     "size containment applied when initially unselected");
 
         window.getSelection().selectAllChildren(contentVisibilityAuto);
-        await tick();
+        await waitForAtLeastOneFrame();
         assert_false(sizeContainmentApplied("auto_dynamic_relevancy"),
                     "size containment applied when after selecting");
 
         window.getSelection().empty();
-        await tick();
+        await waitForAtLeastOneFrame();
         assert_true(sizeContainmentApplied("auto_dynamic_relevancy"),
                     "size containment applied when unselecting back");
     }, "content-visibility: auto, after being selected/unselected");

--- a/css/css-contain/content-visibility/content-visibility-size-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-size-containment-001.html
@@ -14,7 +14,7 @@
   }
   .content_visibility {
       /* Dynamic changes in this test may imply changes to other containment types.
-	 Try and minimize the tested changes by forcing the irrelevant ones. */
+         Try and minimize the tested changes by forcing the irrelevant ones. */
       contain: layout paint style;
   }
   #visible .content_visibility {
@@ -124,10 +124,10 @@
   <script>
     function sizeContainmentApplied(id) {
         // To verify size containment, we test the width is zero.
-	// See contain-size-dynamic-001.html for more details.
+        // See contain-size-dynamic-001.html for more details.
         let container = document.getElementById(id);
         let content_visibility = container.getElementsByClassName("content_visibility")[0];
-	return content_visibility.getBoundingClientRect().width == 0;
+        return content_visibility.getBoundingClientRect().width == 0;
     }
 
     function setContentVisibility(id, value) {

--- a/css/css-contain/content-visibility/content-visibility-size-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-size-containment-001.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>content-visibility and layout containment</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name="assert" content="elements skipping their content change the used value of the contain property to turn on size containment.">
+<style>
+  /* Change to style containment can cause drastic changes such as rebuilding
+     counters or quotes, so always enabled here to prevent any side effect. */
+  .content_visibility {
+      contain: style;
+  }
+
+  #spacer_for_far_to_viewport {
+      height: 300vh;
+  }
+
+  .content_visibility {
+      display: inline-block;
+  }
+  .box {
+      display: inline-block;
+      width: 50px;
+      height: 5px;
+      background: black;
+  }
+
+  #visible > .content_visibility {
+      content-visibility: visible;
+  }
+  #hidden > .content_visibility {
+      content-visibility: hidden;
+  }
+  #auto_far > .content_visibility {
+      content-visibility: auto;
+  }
+  #auto_close > .content_visibility {
+      content-visibility: auto;
+  }
+  #visible_to_hidden > .content_visibility {
+      content-visibility: visible;
+  }
+  #hidden_to_visible > .content_visibility {
+      content-visibility: hidden;
+  }
+  #visible_to_auto_far > .content_visibility {
+      content-visibility: visible;
+  }
+  #auto_far_to_visible > .content_visibility {
+      content-visibility: auto;
+  }
+  #hidden_to_auto_close > .content_visibility {
+      content-visibility: hidden;
+  }
+  #auto_close_to_hidden > .content_visibility {
+      content-visibility: auto;
+  }
+</style>
+<body>
+  <div id="log"></div>
+
+  <div id="visible">
+    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+  </div>
+
+  <div id="hidden">
+    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+  </div>
+
+  <div id="auto_close">
+    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+  </div>
+
+  <div id="visible_to_hidden">
+    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+  </div>
+
+  <div id="hidden_to_visible">
+    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+  </div>
+
+  <div id="hidden_to_auto">
+    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+  </div>
+
+  <div id="auto_to_hidden">
+    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+  </div>
+
+  <div id="hidden_to_auto_close">
+    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+  </div>
+
+  <div id="auto_close_to_hidden">
+    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+  </div>
+
+  <div id="spacer_for_far_to_viewport"></div>
+
+  <div id="auto_far">
+    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+  </div>
+
+  <div id="visible_to_auto_far">
+    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+  </div>
+
+  <div id="auto_far_to_visible">
+    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+  </div>
+
+  <script>
+    function sizeContainmentApplied(id) {
+        let container = document.getElementById(id);
+        let content_visibility = container.getElementsByClassName("content_visibility")[0];
+        let beforeBox = content_visibility.previousElementSibling.getBoundingClientRect();
+        let afterBox = content_visibility.nextElementSibling.getBoundingClientRect();
+        console.log(id)
+        console.log(beforeBox)
+        console.log(afterBox)
+        return afterBox.left - beforeBox.right < 25;
+    }
+
+    function setContentVisibility(id, value) {
+        let container = document.getElementById(id);
+        let content_visibility = container.getElementsByClassName("content_visibility")[0];
+        content_visibility.style.contentVisibility = value;
+    }
+
+    function tick() {
+        return new Promise(resolve => {
+            requestAnimationFrame(() => {
+                requestAnimationFrame(resolve);
+            });
+        });
+    }
+
+    promise_test(async () => {
+        assert_true(!sizeContainmentApplied("visible"));
+    }, "size containment does not apply to content-visibility: visible");
+
+    promise_test(async () => {
+        assert_true(sizeContainmentApplied("hidden"));
+    }, "size containment applies to content-visibility: hidden");
+
+    promise_test(async () => {
+        await tick();
+        assert_true(sizeContainmentApplied("auto_far"));
+    }, "size containment applies to content-visibility: auto (far from viewport)");
+
+    promise_test(async () => {
+        await tick();
+        assert_true(!sizeContainmentApplied("auto_close"));
+    }, "size containment does not apply to content-visibility: auto (close from viewport)");
+
+    promise_test(async () => {
+        setContentVisibility("visible_to_hidden", "hidden");
+        assert_true(sizeContainmentApplied("visible_to_hidden"));
+    }, "size containment updated when switching content-visibility from visible to hidden");
+
+    promise_test(async () => {
+        setContentVisibility("hidden_to_visible", "visible");
+        assert_true(!sizeContainmentApplied("hidden_to_visible"));
+    }, "size containment updated when switching content-visibility from hidden to visible");
+
+    promise_test(async () => {
+        setContentVisibility("auto_far_to_visible", "visible");
+        assert_true(!sizeContainmentApplied("auto_far_to_visible"));
+    }, "size containment updated when switching content-visibility from auto (far from viewport) to visible");
+
+    promise_test(async () => {
+        setContentVisibility("visible_to_auto_far", "auto");
+        await tick();
+        assert_true(sizeContainmentApplied("visible_to_auto_far"));
+    }, "size containment updated when switching content-visibility from visible to auto (far from viewport)");
+
+    promise_test(async () => {
+        setContentVisibility("auto_close_to_hidden", "hidden");
+        assert_true(sizeContainmentApplied("auto_close_to_hidden"));
+    }, "size containment updated when switching content-visibility from auto (close from viewport) to hidden");
+
+    promise_test(async () => {
+        setContentVisibility("hidden_to_auto_close", "auto");
+        await tick();
+        assert_true(!sizeContainmentApplied("hidden_to_auto_close"));
+    }, "size containment updated when switching content-visibility from hidden to auto (close from viewport)");
+
+  </script>
+</body>

--- a/css/css-contain/content-visibility/content-visibility-size-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-size-containment-001.html
@@ -117,9 +117,8 @@
         let content_visibility = container.getElementsByClassName("content_visibility")[0];
         let beforeBox = content_visibility.previousElementSibling.getBoundingClientRect();
         let afterBox = content_visibility.nextElementSibling.getBoundingClientRect();
-        console.log(id)
-        console.log(beforeBox)
-        console.log(afterBox)
+	// If size containment applies, the container adds no space between
+	// the before/after boxes.
         return afterBox.left - beforeBox.right < 25;
     }
 

--- a/css/css-contain/content-visibility/content-visibility-size-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-size-containment-001.html
@@ -65,70 +65,66 @@
   <div id="log"></div>
 
   <div id="visible">
-    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+    <div class="content_visibility"><div class="box"></div></div>
   </div>
 
   <div id="hidden">
-    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+    <div class="content_visibility"><div class="box"></div></div>
   </div>
 
   <div id="auto_close">
-    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+    <div class="content_visibility"><div class="box"></div></div>
   </div>
 
   <div id="visible_to_hidden">
-    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+    <div class="content_visibility"><div class="box"></div></div>
   </div>
 
   <div id="hidden_to_visible">
-    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+    <div class="content_visibility"><div class="box"></div></div>
   </div>
 
   <div id="hidden_to_auto">
-    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+    <div class="content_visibility"><div class="box"></div></div>
   </div>
 
   <div id="auto_to_hidden">
-    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+    <div class="content_visibility"><div class="box"></div></div>
   </div>
 
   <div id="hidden_to_auto_close">
-    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+    <div class="content_visibility"><div class="box"></div></div>
   </div>
 
   <div id="auto_close_to_hidden">
-    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+    <div class="content_visibility"><div class="box"></div></div>
   </div>
 
   <div id="spacer_for_far_to_viewport"></div>
 
   <div id="auto_far">
-    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+    <div class="content_visibility"><div class="box"></div></div>
   </div>
 
   <div id="visible_to_auto_far">
-    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+    <div class="content_visibility"><div class="box"></div></div>
   </div>
 
   <div id="auto_far_to_visible">
-    <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
+    <div class="content_visibility"><div class="box"></div></div>
   </div>
 
 
   <div id="auto_dynamic_relevancy">
     <div tabindex="1"></div>
-    <div class="box"></div><div tabindex="2" class="content_visibility"><div class="box"></div></div><div class="box"></div>
+    <div class="content_visibility" tabindex="2"><div class="box"></div></div>
   </div>
 
   <script>
     function sizeContainmentApplied(id) {
         let container = document.getElementById(id);
         let content_visibility = container.getElementsByClassName("content_visibility")[0];
-        let beforeBox = content_visibility.previousElementSibling.getBoundingClientRect();
-        let afterBox = content_visibility.nextElementSibling.getBoundingClientRect();
-        // If size containment applies, the container adds no space between
-        // the before/after boxes.
-        return afterBox.left - beforeBox.right < 25;
+	return content_visibility.getBoundingClientRect().width == 0;
     }
 
     function setContentVisibility(id, value) {

--- a/css/css-contain/content-visibility/content-visibility-size-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-size-containment-001.html
@@ -15,7 +15,7 @@
   .content_visibility {
       /* Dynamic changes in this test may imply changes to other containment types.
          Try and minimize the tested changes by forcing the irrelevant ones. */
-      contain: layout paint style;
+      contain: layout size style;
   }
   #visible .content_visibility {
       content-visibility: visible;

--- a/css/css-contain/content-visibility/content-visibility-size-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-size-containment-001.html
@@ -57,6 +57,9 @@
   #auto_close_to_hidden > .content_visibility {
       content-visibility: auto;
   }
+  #auto_dynamic_relevancy > .content_visibility {
+      content-visibility: auto;
+  }
 </style>
 <body>
   <div id="log"></div>
@@ -111,6 +114,12 @@
     <div class="box"></div><div class="content_visibility"><div class="box"></div></div><div class="box"></div>
   </div>
 
+
+  <div id="auto_dynamic_relevancy">
+    <div tabindex="1"></div>
+    <div class="box"></div><div tabindex="2" class="content_visibility"><div class="box"></div></div><div class="box"></div>
+  </div>
+
   <script>
     function sizeContainmentApplied(id) {
         let container = document.getElementById(id);
@@ -137,7 +146,7 @@
     }
 
     promise_test(async () => {
-        assert_true(!sizeContainmentApplied("visible"));
+        assert_false(sizeContainmentApplied("visible"));
     }, "size containment does not apply to content-visibility: visible");
 
     promise_test(async () => {
@@ -151,7 +160,7 @@
 
     promise_test(async () => {
         await tick();
-        assert_true(!sizeContainmentApplied("auto_close"));
+        assert_false(sizeContainmentApplied("auto_close"));
     }, "size containment does not apply to content-visibility: auto (close from viewport)");
 
     promise_test(async () => {
@@ -161,12 +170,12 @@
 
     promise_test(async () => {
         setContentVisibility("hidden_to_visible", "visible");
-        assert_true(!sizeContainmentApplied("hidden_to_visible"));
+        assert_false(sizeContainmentApplied("hidden_to_visible"));
     }, "size containment updated when switching content-visibility from hidden to visible");
 
     promise_test(async () => {
         setContentVisibility("auto_far_to_visible", "visible");
-        assert_true(!sizeContainmentApplied("auto_far_to_visible"));
+        assert_false(sizeContainmentApplied("auto_far_to_visible"));
     }, "size containment updated when switching content-visibility from auto (far from viewport) to visible");
 
     promise_test(async () => {
@@ -183,8 +192,80 @@
     promise_test(async () => {
         setContentVisibility("hidden_to_auto_close", "auto");
         await tick();
-        assert_true(!sizeContainmentApplied("hidden_to_auto_close"));
+        assert_false(sizeContainmentApplied("hidden_to_auto_close"));
     }, "size containment updated when switching content-visibility from hidden to auto (close from viewport)");
+
+
+    let contentVisibilityAuto =
+        document.getElementById("auto_dynamic_relevancy").
+        getElementsByClassName("content_visibility")[0];
+
+    function clearRelevancyReasons() {
+        // Scrolling auto_dynamic_relevancy far from the viewport, unfocus it
+        // and unselect it. Also temporarily set its content-visibility to
+        // 'hidden' before scrolling to give more chance for browsers to
+        // re-apply size containment, especially if they fail the corresponding
+        // tests "going back to initial state" below.
+        setContentVisibility("auto_dynamic_relevancy", "hidden");
+        window.scrollTo(0, 0);
+        document.getElementById("auto_dynamic_relevancy")
+            .firstElementChild.focus({preventScroll: true});
+        window.getSelection().empty();
+        setContentVisibility("auto_dynamic_relevancy", "auto");
+    }
+
+    promise_test(async (t) => {
+        t.add_cleanup(clearRelevancyReasons);
+
+        await tick();
+        assert_true(sizeContainmentApplied("auto_dynamic_relevancy"),
+                    "size containment applied when initially far to the viewport");
+
+        contentVisibilityAuto.scrollIntoView();
+        await tick();
+        assert_false(sizeContainmentApplied("auto_dynamic_relevancy"),
+                    "size containment applied when changing from far to close to the viewport");
+
+        window.scrollTo(0, 0);
+        assert_true(sizeContainmentApplied("auto_dynamic_relevancy"),
+                    "size containment applied when changing back from close to far to the viewport");
+    }, "size containment updated when changing proximity to the viewport");
+
+    promise_test(async (t) => {
+        t.add_cleanup(clearRelevancyReasons);
+
+        await tick();
+        assert_true(sizeContainmentApplied("auto_dynamic_relevancy"),
+                    "size containment applied when initially unfocused");
+
+        contentVisibilityAuto.focus({preventScroll: true});
+        await tick();
+        assert_false(sizeContainmentApplied("auto_dynamic_relevancy"),
+                    "size containment applied after focusing");
+
+        document.getElementById("auto_dynamic_relevancy")
+            .firstElementChild.focus({preventScroll: true});
+        assert_true(sizeContainmentApplied("auto_dynamic_relevancy"),
+                    "size containment applied after unfocusing back");
+    }, "size containment updated when after being focused/unfocused");
+
+    promise_test(async (t) => {
+        t.add_cleanup(clearRelevancyReasons);
+
+        await tick();
+        assert_true(sizeContainmentApplied("auto_dynamic_relevancy"),
+                    "size containment applied when initially unselected");
+
+        window.getSelection().selectAllChildren(contentVisibilityAuto);
+        await tick();
+        assert_false(sizeContainmentApplied("auto_dynamic_relevancy"),
+                    "size containment applied when after selecting");
+
+        window.getSelection().empty();
+        await tick();
+        assert_true(sizeContainmentApplied("auto_dynamic_relevancy"),
+                    "size containment applied when unselecting back");
+    }, "size containment updated when after being selected/unselected");
 
   </script>
 </body>

--- a/css/css-contain/content-visibility/content-visibility-size-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-size-containment-001.html
@@ -7,16 +7,50 @@
 <script src="/resources/testharnessreport.js"></script>
 <meta name="assert" content="elements skipping their content change the used value of the contain property to turn on size containment.">
 <style>
-  /* Dynamic changes in this test may imply changes to other containment types.
-     Try and minimize the tested changes by forcing the irrelevant ones. */
-  .content_visibility {
-      contain: layout paint style;
-  }
-
+  /* Selectors for content-visibility */
   #spacer_for_far_to_viewport {
       height: 300vh;
   }
+  .content_visibility {
+      /* Dynamic changes in this test may imply changes to other containment types.
+	 Try and minimize the tested changes by forcing the irrelevant ones. */
+      contain: layout paint style;
+  }
+  #visible .content_visibility {
+      content-visibility: visible;
+  }
+  #hidden .content_visibility {
+      content-visibility: hidden;
+  }
+  #auto_far .content_visibility {
+      content-visibility: auto;
+  }
+  #auto_close .content_visibility {
+      content-visibility: auto;
+  }
+  #visible_to_hidden .content_visibility {
+      content-visibility: visible;
+  }
+  #hidden_to_visible .content_visibility {
+      content-visibility: hidden;
+  }
+  #visible_to_auto_far .content_visibility {
+      content-visibility: visible;
+  }
+  #auto_far_to_visible .content_visibility {
+      content-visibility: auto;
+  }
+  #hidden_to_auto_close .content_visibility {
+      content-visibility: hidden;
+  }
+  #auto_close_to_hidden .content_visibility {
+      content-visibility: auto;
+  }
+  #auto_dynamic_relevancy .content_visibility {
+      content-visibility: auto;
+  }
 
+  /* Selectors for testing sizing as empty */
   .content_visibility {
       display: inline-block;
   }
@@ -25,40 +59,6 @@
       width: 50px;
       height: 5px;
       background: black;
-  }
-
-  #visible > .content_visibility {
-      content-visibility: visible;
-  }
-  #hidden > .content_visibility {
-      content-visibility: hidden;
-  }
-  #auto_far > .content_visibility {
-      content-visibility: auto;
-  }
-  #auto_close > .content_visibility {
-      content-visibility: auto;
-  }
-  #visible_to_hidden > .content_visibility {
-      content-visibility: visible;
-  }
-  #hidden_to_visible > .content_visibility {
-      content-visibility: hidden;
-  }
-  #visible_to_auto_far > .content_visibility {
-      content-visibility: visible;
-  }
-  #auto_far_to_visible > .content_visibility {
-      content-visibility: auto;
-  }
-  #hidden_to_auto_close > .content_visibility {
-      content-visibility: hidden;
-  }
-  #auto_close_to_hidden > .content_visibility {
-      content-visibility: auto;
-  }
-  #auto_dynamic_relevancy > .content_visibility {
-      content-visibility: auto;
   }
 </style>
 <body>
@@ -122,6 +122,8 @@
 
   <script>
     function sizeContainmentApplied(id) {
+        // To verify size containment, we test the width is zero.
+	// See contain-size-dynamic-001.html for more details.
         let container = document.getElementById(id);
         let content_visibility = container.getElementsByClassName("content_visibility")[0];
 	return content_visibility.getBoundingClientRect().width == 0;

--- a/css/css-contain/content-visibility/content-visibility-size-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-size-containment-001.html
@@ -117,8 +117,8 @@
         let content_visibility = container.getElementsByClassName("content_visibility")[0];
         let beforeBox = content_visibility.previousElementSibling.getBoundingClientRect();
         let afterBox = content_visibility.nextElementSibling.getBoundingClientRect();
-	// If size containment applies, the container adds no space between
-	// the before/after boxes.
+        // If size containment applies, the container adds no space between
+        // the before/after boxes.
         return afterBox.left - beforeBox.right < 25;
     }
 

--- a/css/css-contain/content-visibility/content-visibility-size-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-size-containment-001.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>content-visibility and layout containment</title>
+<title>content-visibility and size containment</title>
 <link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="assert" content="elements skipping their content change the used value of the contain property to turn on size containment.">
 <style>
-  /* Change to style containment can cause drastic changes such as rebuilding
-     counters or quotes, so always enabled here to prevent any side effect. */
+  /* Dynamic changes in this test may imply changes to other containment types.
+     Try and minimize the tested changes by forcing the irrelevant ones. */
   .content_visibility {
-      contain: style;
+      contain: layout paint style;
   }
 
   #spacer_for_far_to_viewport {

--- a/css/css-contain/content-visibility/content-visibility-style-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-style-containment-001.html
@@ -8,16 +8,41 @@
 <script src="/resources/testharnessreport.js"></script>
 <meta name="assert" content="content-visibility: auto and elements skipping their content change the used value of the contain property to turn on style containment.">
 <style>
-  /* Dynamic changes in this test may imply changes to other containment types.
-     Try and minimize the tested changes by forcing the irrelevant ones. */
-  .content_visibility {
-      contain: layout paint size;
-  }
-
+  /* Selectors for content-visibility */
   #spacer_for_far_to_viewport {
       height: 300vh;
   }
+  .content_visibility {
+      /* Dynamic changes in this test may imply changes to other containment types.
+         Try and minimize the tested changes by forcing the irrelevant ones. */
+      contain: layout paint size;
+  }
+  #visible .content_visibility {
+      content-visibility: visible;
+  }
+  #hidden .content_visibility {
+      content-visibility: hidden;
+  }
+  #auto_far .content_visibility {
+      content-visibility: auto;
+  }
+  #auto_close .content_visibility {
+      content-visibility: auto;
+  }
+  #visible_to_hidden .content_visibility {
+      content-visibility: visible;
+  }
+  #hidden_to_visible .content_visibility {
+      content-visibility: hidden;
+  }
+  #visible_to_auto .content_visibility {
+      content-visibility: visible;
+  }
+  #auto_to_visible .content_visibility {
+      content-visibility: auto;
+  }
 
+  /* Selectors for testing counters */
   .set_counter_to_9 {
       counter-set: testcounter 9;
   }
@@ -29,30 +54,6 @@
       content: counters(testcounter, ".");
   }
 
-  #visible > .content_visibility {
-      content-visibility: visible;
-  }
-  #hidden > .content_visibility {
-      content-visibility: hidden;
-  }
-  #auto_far > .content_visibility {
-      content-visibility: auto;
-  }
-  #auto_close > .content_visibility {
-      content-visibility: auto;
-  }
-  #visible_to_hidden > .content_visibility {
-      content-visibility: visible;
-  }
-  #hidden_to_visible > .content_visibility {
-      content-visibility: hidden;
-  }
-  #visible_to_auto > .content_visibility {
-      content-visibility: visible;
-  }
-  #auto_to_visible > .content_visibility {
-      content-visibility: auto;
-  }
 </style>
 <body>
   <div id="log"></div>
@@ -134,14 +135,19 @@
   <script>
     function styleContainmentApplied(id) {
         let container = document.getElementById(id);
+
         let printed_counters = container.getElementsByClassName("print_counter");
+
+        // To verify style containment, we test the string length of generated
+	// content for counters.
+	// See contain-style-dynamic-001.html for more details.
+        function haveSameStringLength(box1, box2) {
+            const ahemFontSizePx = 25;
+            return Math.abs(box2.width - box1.width) < ahemFontSizePx / 2;
+        }
         let beforeBox = printed_counters[0].parentNode.getBoundingClientRect();
         let afterBox = printed_counters[1].parentNode.getBoundingClientRect();
-        // - beforeBox always has the counter set to '9'.
-        // - afterBox has the counter set to '9' or '10' depending on whether
-        //   style containment applies to the content_visibility div, which
-        //   we can thus determine by comparing the widths.
-        return afterBox.width < beforeBox.width * 1.5;
+        return haveSameStringLength(beforeBox, afterBox);
     }
 
     function setContentVisibility(id, value) {

--- a/css/css-contain/content-visibility/content-visibility-style-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-style-containment-001.html
@@ -13,11 +13,6 @@
   #spacer_for_far_to_viewport {
       height: 300vh;
   }
-  .content_visibility {
-      /* Dynamic changes in this test may imply changes to other containment types.
-         Try and minimize the tested changes by forcing the irrelevant ones. */
-      contain: layout paint size;
-  }
   #visible .content_visibility {
       content-visibility: visible;
   }

--- a/css/css-contain/content-visibility/content-visibility-style-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-style-containment-001.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>content-visibility and style containment</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1765615">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name="assert" content="content-visibility: auto and elements skipping their content change the used value of the contain property to turn on style containment.">
+<style>
+  #spacer_for_far_to_viewport {
+      height: 300vh;
+  }
+
+  .set_counter_to_9 {
+      counter-set: testcounter 9;
+  }
+  .increment_counter {
+      counter-increment: testcounter;
+  }
+  span.print_counter::after {
+      font: 25px/1 Ahem;
+      content: counters(testcounter, ".");
+  }
+
+  #visible > .content_visibility {
+      content-visibility: visible;
+  }
+  #hidden > .content_visibility {
+      content-visibility: hidden;
+  }
+  #auto_far > .content_visibility {
+      content-visibility: auto;
+  }
+  #auto_close > .content_visibility {
+      content-visibility: auto;
+  }
+  #visible_to_hidden > .content_visibility {
+      content-visibility: visible;
+  }
+  #hidden_to_visible > .content_visibility {
+      content-visibility: hidden;
+  }
+  #visible_to_auto > .content_visibility {
+      content-visibility: visible;
+  }
+  #auto_to_visible > .content_visibility {
+      content-visibility: auto;
+  }
+</style>
+<body>
+  <div id="log"></div>
+
+  <div id="visible">
+    <div class="set_counter_to_9"></div>
+    <span><span class="print_counter"></span></span>
+    <div class="content_visibility">
+      <span class="increment_counter"></span>
+    </div>
+    <span><span class="print_counter"></span></span>
+  </div>
+
+  <div id="hidden">
+    <div class="set_counter_to_9"></div>
+    <span><span class="print_counter"></span></span>
+    <div class="content_visibility">
+      <span class="increment_counter"></span>
+    </div>
+    <span><span class="print_counter"></span></span>
+  </div>
+
+  <div id="auto_close">
+    <div class="set_counter_to_9"></div>
+    <span><span class="print_counter"></span></span>
+    <div class="content_visibility">
+      <span class="increment_counter"></span>
+    </div>
+    <span><span class="print_counter"></span></span>
+  </div>
+
+  <div id="visible_to_hidden">
+    <div class="set_counter_to_9"></div>
+    <span><span class="print_counter"></span></span>
+    <div class="content_visibility">
+      <span class="increment_counter"></span>
+    </div>
+    <span><span class="print_counter"></span></span>
+  </div>
+
+  <div id="hidden_to_visible">
+    <div class="set_counter_to_9"></div>
+    <span><span class="print_counter"></span></span>
+    <div class="content_visibility">
+      <span class="increment_counter"></span>
+    </div>
+    <span><span class="print_counter"></span></span>
+  </div>
+
+  <div id="visible_to_auto">
+    <div class="set_counter_to_9"></div>
+    <span><span class="print_counter"></span></span>
+    <div class="content_visibility">
+      <span class="increment_counter"></span>
+    </div>
+    <span><span class="print_counter"></span></span>
+  </div>
+
+  <div id="auto_to_visible">
+    <div class="set_counter_to_9"></div>
+    <span><span class="print_counter"></span></span>
+    <div class="content_visibility">
+      <span class="increment_counter"></span>
+    </div>
+    <span><span class="print_counter"></span></span>
+  </div>
+
+  <div id="spacer_for_far_to_viewport"></div>
+
+  <div id="auto_far">
+    <div class="set_counter_to_9"></div>
+    <span><span class="print_counter"></span></span>
+    <div class="content_visibility">
+      <span class="increment_counter"></span>
+    </div>
+    <span><span class="print_counter"></span></span>
+  </div>
+
+  <script>
+    function styleContainmentApplied(id) {
+        let container = document.getElementById(id);
+        let printed_counters = container.getElementsByClassName("print_counter");
+        let beforeBox = printed_counters[0].parentNode.getBoundingClientRect();
+        let afterBox = printed_counters[1].parentNode.getBoundingClientRect();
+        // - beforeBox always has the counter set to '9'.
+        // - afterBox has the counter set to '9' or '10' depending on whether
+        //   style containment applies to the content_visibility div, which
+        //   we can thus determine by comparing the widths.
+        return afterBox.width < beforeBox.width * 1.5;
+    }
+
+    function setContentVisibility(id, value) {
+        let container = document.getElementById(id);
+        let content_visibility = container.getElementsByClassName("content_visibility")[0];
+        content_visibility.style.contentVisibility = value;
+    }
+
+    function tick() {
+        return new Promise(resolve => {
+            requestAnimationFrame(() => {
+                requestAnimationFrame(resolve);
+            });
+        });
+    }
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        assert_true(!styleContainmentApplied("visible"));
+    }, "style containment does not apply to content-visibility: visible");
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        assert_true(styleContainmentApplied("hidden"));
+    }, "style containment applies to content-visibility: hidden");
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        await tick();
+        assert_true(styleContainmentApplied("auto_far"));
+    }, "style containment applies to content-visibility: auto (far from viewport)");
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        await tick();
+        assert_true(styleContainmentApplied("auto_close"));
+    }, "style containment applies to content-visibility: auto (close from viewport)");
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        setContentVisibility("visible_to_hidden", "hidden");
+        assert_true(styleContainmentApplied("visible_to_hidden"));
+    }, "style containment updated when switching content-visibility from visible to hidden");
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        setContentVisibility("hidden_to_visible", "visible");
+        assert_true(!styleContainmentApplied("hidden_to_visible"));
+    }, "style containment updated when switching content-visibility from hidden to visible");
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        setContentVisibility("visible_to_auto", "auto");
+        await tick();
+        assert_true(styleContainmentApplied("visible_to_auto"));
+    }, "style containment updated when switching content-visibility from visible to auto");
+
+    promise_test(async () => {
+        await document.fonts.ready;
+        setContentVisibility("auto_to_visible", "visible");
+        assert_true(!styleContainmentApplied("auto_to_visible"));
+    }, "style containment updated when switching content-visibility from auto to visible");
+  </script>
+</body>

--- a/css/css-contain/content-visibility/content-visibility-style-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-style-containment-001.html
@@ -140,8 +140,8 @@
         let printed_counters = container.getElementsByClassName("print_counter");
 
         // To verify style containment, we test the string length of generated
-	// content for counters.
-	// See contain-style-dynamic-001.html for more details.
+        // content for counters.
+        // See contain-style-dynamic-001.html for more details.
         function haveSameStringLength(box1, box2) {
             const ahemFontSizePx = 25;
             return Math.abs(box2.width - box1.width) < ahemFontSizePx / 2;

--- a/css/css-contain/content-visibility/content-visibility-style-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-style-containment-001.html
@@ -6,6 +6,7 @@
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/rendering-utils.js"></script>
 <meta name="assert" content="content-visibility: auto and elements skipping their content change the used value of the contain property to turn on style containment.">
 <style>
   /* Selectors for content-visibility */
@@ -156,14 +157,6 @@
         content_visibility.style.contentVisibility = value;
     }
 
-    function tick() {
-        return new Promise(resolve => {
-            requestAnimationFrame(() => {
-                requestAnimationFrame(resolve);
-            });
-        });
-    }
-
     promise_test(async () => {
         await document.fonts.ready;
         assert_false(styleContainmentApplied("visible"));
@@ -176,13 +169,13 @@
 
     promise_test(async () => {
         await document.fonts.ready;
-        await tick();
+        await waitForAtLeastOneFrame();
         assert_true(styleContainmentApplied("auto_far"));
     }, "content-visibility: auto (far from viewport)");
 
     promise_test(async () => {
         await document.fonts.ready;
-        await tick();
+        await waitForAtLeastOneFrame();
         assert_true(styleContainmentApplied("auto_close"));
     }, "content-visibility: auto (close from viewport)");
 
@@ -201,7 +194,7 @@
     promise_test(async () => {
         await document.fonts.ready;
         setContentVisibility("visible_to_auto", "auto");
-        await tick();
+        await waitForAtLeastOneFrame();
         assert_true(styleContainmentApplied("visible_to_auto"));
     }, "switching content-visibility from visible to auto");
 

--- a/css/css-contain/content-visibility/content-visibility-style-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-style-containment-001.html
@@ -8,6 +8,12 @@
 <script src="/resources/testharnessreport.js"></script>
 <meta name="assert" content="content-visibility: auto and elements skipping their content change the used value of the contain property to turn on style containment.">
 <style>
+  /* Dynamic changes in this test may imply changes to other containment types.
+     Try and minimize the tested changes by forcing the irrelevant ones. */
+  .content_visibility {
+      contain: layout paint size;
+  }
+
   #spacer_for_far_to_viewport {
       height: 300vh;
   }

--- a/css/css-contain/content-visibility/content-visibility-style-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-style-containment-001.html
@@ -155,48 +155,48 @@
     promise_test(async () => {
         await document.fonts.ready;
         assert_false(styleContainmentApplied("visible"));
-    }, "style containment does not apply to content-visibility: visible");
+    }, "content-visibility: visible");
 
     promise_test(async () => {
         await document.fonts.ready;
         assert_true(styleContainmentApplied("hidden"));
-    }, "style containment applies to content-visibility: hidden");
+    }, "content-visibility: hidden");
 
     promise_test(async () => {
         await document.fonts.ready;
         await tick();
         assert_true(styleContainmentApplied("auto_far"));
-    }, "style containment applies to content-visibility: auto (far from viewport)");
+    }, "content-visibility: auto (far from viewport)");
 
     promise_test(async () => {
         await document.fonts.ready;
         await tick();
         assert_true(styleContainmentApplied("auto_close"));
-    }, "style containment applies to content-visibility: auto (close from viewport)");
+    }, "content-visibility: auto (close from viewport)");
 
     promise_test(async () => {
         await document.fonts.ready;
         setContentVisibility("visible_to_hidden", "hidden");
         assert_true(styleContainmentApplied("visible_to_hidden"));
-    }, "style containment updated when switching content-visibility from visible to hidden");
+    }, "switching content-visibility from visible to hidden");
 
     promise_test(async () => {
         await document.fonts.ready;
         setContentVisibility("hidden_to_visible", "visible");
         assert_false(styleContainmentApplied("hidden_to_visible"));
-    }, "style containment updated when switching content-visibility from hidden to visible");
+    }, "switching content-visibility from hidden to visible");
 
     promise_test(async () => {
         await document.fonts.ready;
         setContentVisibility("visible_to_auto", "auto");
         await tick();
         assert_true(styleContainmentApplied("visible_to_auto"));
-    }, "style containment updated when switching content-visibility from visible to auto");
+    }, "switching content-visibility from visible to auto");
 
     promise_test(async () => {
         await document.fonts.ready;
         setContentVisibility("auto_to_visible", "visible");
         assert_false(styleContainmentApplied("auto_to_visible"));
-    }, "style containment updated when switching content-visibility from auto to visible");
+    }, "switching content-visibility from auto to visible");
   </script>
 </body>

--- a/css/css-contain/content-visibility/content-visibility-style-containment-001.html
+++ b/css/css-contain/content-visibility/content-visibility-style-containment-001.html
@@ -154,7 +154,7 @@
 
     promise_test(async () => {
         await document.fonts.ready;
-        assert_true(!styleContainmentApplied("visible"));
+        assert_false(styleContainmentApplied("visible"));
     }, "style containment does not apply to content-visibility: visible");
 
     promise_test(async () => {
@@ -183,7 +183,7 @@
     promise_test(async () => {
         await document.fonts.ready;
         setContentVisibility("hidden_to_visible", "visible");
-        assert_true(!styleContainmentApplied("hidden_to_visible"));
+        assert_false(styleContainmentApplied("hidden_to_visible"));
     }, "style containment updated when switching content-visibility from hidden to visible");
 
     promise_test(async () => {
@@ -196,7 +196,7 @@
     promise_test(async () => {
         await document.fonts.ready;
         setContentVisibility("auto_to_visible", "visible");
-        assert_true(!styleContainmentApplied("auto_to_visible"));
+        assert_false(styleContainmentApplied("auto_to_visible"));
     }, "style containment updated when switching content-visibility from auto to visible");
   </script>
 </body>


### PR DESCRIPTION
This adds tests for checking containment update when `contain`, `content-visibility`, or relevancy changes.

This is related to https://bugzilla.mozilla.org/show_bug.cgi?id=1765615