### PR TITLE
[wdspec] Synchronize network/response_started/response_started.py wit…

### DIFF
--- a/webdriver/tests/bidi/network/response_started/response_started.py
+++ b/webdriver/tests/bidi/network/response_started/response_started.py
@@ -220,11 +220,11 @@ async def test_www_authenticate(
     events = network_events[RESPONSE_STARTED_EVENT]
 
     on_response_started = wait_for_event(RESPONSE_STARTED_EVENT)
-
-    # Note that here we explicitly do not navigate to the auth_url and instead
-    # simply do a fetch, because otherwise Firefox fails to cleanly cancel the
-    # authentication prompt on test teardown.
-    asyncio.ensure_future(fetch(auth_url, context=new_tab, method="GET"))
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"],
+        url=auth_url,
+        wait="none",
+    )
 
     await wait_for_future_safe(on_response_started)
 


### PR DESCRIPTION
…h mozilla-central

See https://bugzilla.mozilla.org/show_bug.cgi?id=1826198#c31 for some context. There was a desync due to backouts, but I think the most sensible here is to align on mozilla-central, since the version on wpt essentially contains a gecko-only workaround which must have been addressed on platform side in-between. 