### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=266384

### DIFF
--- a/html/dom/aria-element-reflection.html
+++ b/html/dom/aria-element-reflection.html
@@ -611,7 +611,6 @@
   </script>
 
   <div id="sameScopeContainer">
-    <div id="labeledby" aria-labeledby="headingLabel1 headingLabel2">Misspelling</div>
     <div id="headingLabel1">Wonderful</div>
     <div id="headingLabel2">Fantastic</div>
 
@@ -625,8 +624,6 @@
       const headingLabel1 = document.getElementById("headingLabel1")
       const headingLabel2 = document.getElementById("headingLabel2")
       shadowRoot.appendChild(headingElement);
-
-      assert_array_equals(labeledby.ariaLabelledByElements, [headingLabel1, headingLabel2], "aria-labeled by is supported by IDL getter.");
 
       // Explicitly set elements are in a lighter shadow DOM, so that's ok.
       headingElement.ariaLabelledByElements = [headingLabel1, headingLabel2];


### PR DESCRIPTION
Description added by @cookiecrook

This reverts a bogus portion of https://github.com/web-platform-tests/wpt/commit/3a5dc6aeda7470d9a0ae9e772b4cb8e3ef1605cd

…that included a purposeful misspelling "aria-labeledby" of "aria-labelledby" which both WebKit and Chrome supported, but was never documented or specified... 

FWIW, the original file also seems like a bad test structure to me, since most subtests include more than one assertion. For example, it's unclear from the test results if Gecko fails this test because it (correctly?) does not support the missspelling, or because it fails one of the other assertions in this subtest.

I'm going to spawn several other issues to address those discrepancies. - jc