### PR TITLE
Test for a nested `:scope` inside an `:is()`

### DIFF
--- a/css/css-cascade/scope-nesting.html
+++ b/css/css-cascade/scope-nesting.html
@@ -390,12 +390,18 @@ test((t) => {
             z-index: 2;
           }
         }
+        /* The nested case can be though of the following when expanded: */
+        .c:is(:scope.x *) {
+          z-index: 3;
+        }
       }
     </style>
     <div class="b">
     </div>
     <div class="a x">
       <div class="b">
+      </div>
+      <div class="c">
       </div>
     </div>
 </div>
@@ -407,7 +413,9 @@ test((t) => {
 
   let b_outside = document.querySelector('.b');
   let b_inside = document.querySelector('.a .b');
+  let c = document.querySelector('.c');
   assert_equals(getComputedStyle(b_outside).zIndex, 'auto');
   assert_equals(getComputedStyle(b_inside).zIndex, '1');
+  assert_equals(getComputedStyle(c).zIndex, '3');
 }, 'Nested :scope inside an :is');
 </script>

--- a/css/css-cascade/scope-nesting.html
+++ b/css/css-cascade/scope-nesting.html
@@ -371,3 +371,43 @@ test((t) => {
   assert_equals(getComputedStyle(c).zIndex, 'auto');
 }, 'Implicit rule within nested @scope (proximity)');
 </script>
+
+<template id=test_nested_scope_inside_an_is>
+  <div>
+    <style>
+      @scope (.a) {
+        .b {
+          /* When nesting, because we’re  inside a defined scope,
+             the `:scope` should reference the scoping root node properly, and
+             check for the presence of an extra class on it, essentially
+             being equal to `:scope.x .b { z-index: 1 }`. */
+          &:is(:scope.x *) {
+            z-index: 1;
+          }
+          /* This should not match, as we have a defined scope, and should
+             not skip to the root. */
+          &:is(:root:scope *) {
+            z-index: 2;
+          }
+        }
+      }
+    </style>
+    <div class="b">
+    </div>
+    <div class="a x">
+      <div class="b">
+      </div>
+    </div>
+</div>
+</template>
+<script>
+test((t) => {
+  t.add_cleanup(() => main.replaceChildren());
+  main.append(test_nested_scope_inside_an_is.content.cloneNode(true));
+
+  let b_outside = document.querySelector('.b');
+  let b_inside = document.querySelector('.a .b');
+  assert_equals(getComputedStyle(b_outside).zIndex, 'auto');
+  assert_equals(getComputedStyle(b_inside).zIndex, '1');
+}, 'Nested :scope inside an :is');
+</script>


### PR DESCRIPTION
Quoting the specs for `:scope`,

> The `:scope` pseudo-class represents this scoping root […].

In the following code, there is a scoping root: the `.a`.

```CSS
      @scope (.a) {
        .b {
          &:is(:scope.x *) {
            z-index: 1;
          }
      }
```

However, right now, in the Chromium implementation, when the `:scope` is mentioned inside nesting, does not “see” the wrapping `@scope`, and treats it as `:root`, according to

> If there is no scoping root then `:scope` represents the root of the document (equivalent to `:root`).

However, this is only true if we'd take the inner `&:is(:scope.x *)` in isolation, but because it is, in fact, inside the `@scope`, it should detect the scoping root, as we can think of it as `:scope .foo:is(:scope:hover *)`, which works (see it in action in the CodePen where I stumbled upon this: https://codepen.io/kizu/pen/NWoZYwK); I did also add it as an assertion.

This is not an abstract example, and having this case to work as in the test assertion will be very useful for authors. It could allow us to use this method to clarify the conditions over the root node from inside the nesting, similar to how [`@at-root` works in Sass](https://sass-lang.com/documentation/at-rules/at-root/), or how [root reference works in Stylus](https://stylus-lang.com/docs/selectors.html#root-reference).

cc @mirisuzanne 

Update: cross-linking a Chromium bug I filled about this: https://bugs.chromium.org/p/chromium/issues/detail?id=1512217