### PR TITLE
HTML: correct typo in <area> hit testing

### DIFF
--- a/html/semantics/embedded-content/the-area-element/support/hit-test.js
+++ b/html/semantics/embedded-content/the-area-element/support/hit-test.js
@@ -20,7 +20,7 @@ var tests;
 onload = function() {
   tests.forEach(function(t) {
     test(function(t_obj) {
-      if (area.shape === null) {
+      if (t.shape === null) {
         area.removeAttribute('shape');
       } else {
         area.shape = t.shape;


### PR DESCRIPTION
The shape IDL attribute never returns null. Instead we want to check whether the test input for shape is null. This hid an issue in WebKit for a long time which I'm fixing in https://github.com/WebKit/WebKit/pull/21958.