### PR TITLE
[css-text] balance and pretty are not values of white-space

### DIFF
--- a/css/css-text/parsing/white-space-invalid.html
+++ b/css/css-text/parsing/white-space-invalid.html
@@ -15,6 +15,8 @@ test_invalid_value("white-space", "auto");
 test_invalid_value("white-space", "normal pre");
 test_invalid_value("white-space", "nowrap pre-wrap");
 test_invalid_value("white-space", "pre-line break-spaces");
+test_invalid_value("white-space", "balance");
+test_invalid_value("white-space", "pretty");
 </script>
 </body>
 </html>


### PR DESCRIPTION
related to https://bugs.chromium.org/p/chromium/issues/detail?id=1501748