### PR TITLE
Fix crash caused by arithmetic underflow in layout2020

### DIFF
--- a/css/css-text/text-justify/text-justify-and-trailing-spaces-crash.html
+++ b/css/css-text/text-justify/text-justify-and-trailing-spaces-crash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en" >
+<head>
+    <meta charset="utf-8">
+    <style>
+        p {
+            width: 200px;
+            text-align: justify;
+        }
+    </style>
+</head>
+<link rel="help" href="https://github.com/servo/servo/issues/30878">
+<link rel="author" href="mailto:atbrakhi@igalia.com">
+<body>
+    <p>This is a test sentence with trailing spaces.  </p>
+</body>
+</html>


### PR DESCRIPTION
Currently we are trying to subtract a non-zero number from 0 in `self.justification_opportunities -= spaces_trimmed`, which is resulting in an arithmetic underflow in the `trim_trailing_whitespace` inside `inline.rs`, hence the crash.

This PR prevents the underflow by using `checked_sub` for safe subtraction.

Reviewed in servo/servo#30897