### PR TITLE
Interop Accessibility: add test_driver.get_accessibility_tree

### DIFF
--- a/infrastructure/testdriver/get_accessibility_tree.html
+++ b/infrastructure/testdriver/get_accessibility_tree.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>TestDriver get_accessibility_tree method</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<script>
+async_test(t => {
+  test_driver
+    .get_accessibility_tree()
+    .then(() => t.done())
+    .catch(t.unreached_func("get_accessibility_tree failed"));
+});
+</script>

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -1004,6 +1004,23 @@
          */
         get_virtual_sensor_information: function(sensor_type, context=null) {
             return window.test_driver_internal.get_virtual_sensor_information(sensor_type, context);
+        },
+
+        /**
+         * Get the accessibility tree.
+         *
+         * Matches the `Accessibility.getFullAXTree
+         * <https://chromedevtools.github.io/devtools-protocol/tot/Accessibility/#method-getFullAXTree>`_
+         * Chrome Devtools Protocol method.
+         *
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} Fulfilled with an array of objects.
+         */
+        get_accessibility_tree: function(context=null) {
+            return window.test_driver_internal.get_accessibility_tree(context);
         }
     };
 
@@ -1180,6 +1197,10 @@
 
         async get_virtual_sensor_information(sensor_type, context=null) {
             throw new Error("get_virtual_sensor_information() is not implemented by testdriver-vendor.js");
+        },
+
+        async get_accessibility_tree(context=null) {
+            throw new Error("get_accessibility_tree() is not implemented by testdriver-vendor.js");
         }
     };
 })();

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -435,6 +435,17 @@ class GetVirtualSensorInformationAction:
         return self.protocol.virtual_sensor.get_virtual_sensor_information(sensor_type)
 
 
+class GetAccessibilityTreeAction(object):
+    name = "get_accessibility_tree"
+
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        self.logger.debug("Getting accessibility tree")
+        return self.protocol.get_accessibility_tree.get_accessibility_tree()
+
 actions = [ClickAction,
            DeleteAllCookiesAction,
            GetAllCookiesAction,
@@ -467,4 +478,5 @@ actions = [ClickAction,
            CreateVirtualSensorAction,
            UpdateVirtualSensorAction,
            RemoveVirtualSensorAction,
-           GetVirtualSensorInformationAction]
+           GetVirtualSensorInformationAction,
+           GetAccessibilityTreeAction]

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -22,7 +22,7 @@ from .executorwebdriver import (
     WebDriverTestharnessExecutor,
     WebDriverTestharnessProtocolPart,
 )
-from .protocol import PrintProtocolPart
+from .protocol import GetAccessibilityTreeProtocolPart, PrintProtocolPart
 
 here = os.path.dirname(__file__)
 
@@ -189,6 +189,17 @@ render('%s').then(result => callback(result))""" % pdf_base64)
         finally:
             self.webdriver.window_handle = handle
 
+class ChromeDriverGetAccessibilityTreeProtocolPart(GetAccessibilityTreeProtocolPart):
+    def setup(self):
+        self.webdriver = self.parent.webdriver
+
+    def get_accessibility_tree(self):
+        body = {
+            "cmd": "Accessibility.getFullAXTree",
+            "params": {
+            }
+        }
+        return self.webdriver.send_session_command("POST", "goog/cdp/execute", body=body)
 
 class ChromeDriverFedCMProtocolPart(WebDriverFedCMProtocolPart):
     def setup(self):
@@ -207,6 +218,7 @@ class ChromeDriverProtocol(WebDriverProtocol):
         ChromeDriverFedCMProtocolPart,
         ChromeDriverPrintProtocolPart,
         ChromeDriverTestharnessProtocolPart,
+        ChromeDriverGetAccessibilityTreeProtocolPart,
         *(part for part in WebDriverProtocol.implements
           if part.name != ChromeDriverTestharnessProtocolPart.name and
             part.name != ChromeDriverFedCMProtocolPart.name)

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -797,3 +797,14 @@ class VirtualSensorProtocolPart(ProtocolPart):
     @abstractmethod
     def get_virtual_sensor_information(self, sensor_type):
         pass
+
+class GetAccessibilityTreeProtocolPart(ProtocolPart):
+    """Protocol part for getting accessibility tree"""
+    __metaclass__ = ABCMeta
+
+    name = "get_accessibility_tree"
+
+    @abstractmethod
+    def get_accessibility_tree(self):
+        """Get the accessibility tree"""
+        pass

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -320,4 +320,8 @@
     window.test_driver_internal.get_virtual_sensor_information = function(sensor_type, context=null) {
         return create_action("get_virtual_sensor_information", {sensor_type, context});
     };
+
+    window.test_driver_internal.get_accessibility_tree = function(context=null) {
+        return create_action("get_accessibility_tree", {context});
+    };
 })();


### PR DESCRIPTION
Add `get_accessibility_tree` endpoint to `testdriver`. In this change the endpoint presents the interface in Chrome Devtools Protocol's [`Accessibility.getFullAXTree`](https://chromedevtools.github.io/devtools-protocol/tot/Accessibility/#method-getFullAXTree).

This API can be used to test aria attributes like aria-orientation and aria-invalid and that the browser uses the correct default values when they are not set in the html element.

Related: https://github.com/web-platform-tests/interop-accessibility/issues/51