### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=266844

### DIFF
--- a/custom-state-pseudo-class/state-css-selector-shadow-dom.tentative.html
+++ b/custom-state-pseudo-class/state-css-selector-shadow-dom.tentative.html
@@ -28,7 +28,7 @@
               :host {
                 color: #f00;
               }
-              :host:state(green) {
+              :host(:state(green)) {
                 color: #0f0;
               }
             `);


### PR DESCRIPTION
WebKit export of [Incorrect Web Platform Test for State CSS ShadowDOM Selector](https://bugs.webkit.org/show_bug.cgi?id=266844).