### PR TITLE
Correct assorted issues with standalone pseudo elements

### DIFF
--- a/css/css-view-transitions/only-child-on-root-element-with-view-transition.html
+++ b/css/css-view-transitions/only-child-on-root-element-with-view-transition.html
@@ -36,7 +36,7 @@ promise_test(() => {
     let transition = document.startViewTransition();
     transition.ready.then(() => {
       let style = getComputedStyle(
-        document.documentElement, ":view-transition");
+        document.documentElement, "::view-transition");
       if (style.backgroundColor == "rgb(255, 0, 0)")
         resolve();
       else

--- a/css/css-view-transitions/only-child-view-transition.html
+++ b/css/css-view-transitions/only-child-view-transition.html
@@ -23,7 +23,7 @@ promise_test(() => {
     let transition = document.startViewTransition();
     transition.ready.then(() => {
       let style = getComputedStyle(
-        document.documentElement, ":view-transition");
+        document.documentElement, "::view-transition");
       if (style.backgroundColor == "rgb(255, 0, 0)")
         resolve();
       else

--- a/css/css-view-transitions/style-inheritance.html
+++ b/css/css-view-transitions/style-inheritance.html
@@ -34,20 +34,20 @@ promise_test(() => {
   return new Promise(async (resolve, reject) => {
     let transition = document.startViewTransition();
     transition.ready.then(() => {
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition").backgroundColor, "rgb(255, 0, 0)", ":view-transition");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition").backgroundColor, "rgb(255, 0, 0)", ":view-transition");
 
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(root)").backgroundColor, "rgb(255, 0, 0)", "group");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(root)").color, "rgb(0, 0, 255)", "group");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(root)").animationDuration, "0.321s", "group");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").backgroundColor, "rgb(255, 0, 0)", "group");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").color, "rgb(0, 0, 255)", "group");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").animationDuration, "0.321s", "group");
 
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(root)").color, "rgb(0, 0, 255)", "wrapper");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(root)").overflowX, "clip", "wrapper");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(root)").animationDuration, "0.321s", "wrapper");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(root)").color, "rgb(0, 0, 255)", "wrapper");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(root)").overflowX, "clip", "wrapper");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(root)").animationDuration, "0.321s", "wrapper");
 
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(root)").overflowX, "clip", "outgoing");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(root)").animationDuration, "0.321s", "outgoing");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-new(root)").overflowX, "clip", "incoming");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-new(root)").animationDuration, "0.321s", "incoming");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(root)").overflowX, "clip", "outgoing");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(root)").animationDuration, "0.321s", "outgoing");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-new(root)").overflowX, "clip", "incoming");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-new(root)").animationDuration, "0.321s", "incoming");
     });
     await transition.finished;
     resolve();

--- a/css/css-view-transitions/style-inheritance.html
+++ b/css/css-view-transitions/style-inheritance.html
@@ -34,7 +34,7 @@ promise_test(() => {
   return new Promise(async (resolve, reject) => {
     let transition = document.startViewTransition();
     transition.ready.then(() => {
-      assert_equals(getComputedStyle(document.documentElement, "::view-transition").backgroundColor, "rgb(255, 0, 0)", ":view-transition");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition").backgroundColor, "rgb(255, 0, 0)", "::view-transition");
 
       assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").backgroundColor, "rgb(255, 0, 0)", "group");
       assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").color, "rgb(0, 0, 255)", "group");

--- a/web-animations/interfaces/Animatable/animate.html
+++ b/web-animations/interfaces/Animatable/animate.html
@@ -331,7 +331,6 @@ for (const pseudo of [
   'before',
   ':abc',
   '::abc',
-  '::placeholder',
 ]) {
   test(t => {
     const div = createDiv(t);
@@ -341,6 +340,11 @@ for (const pseudo of [
   }, `animate() with a non-null invalid pseudoElement '${pseudo}' throws a ` +
      `SyntaxError`);
 }
+
+test(t => {
+  const div = createDiv(t);
+  div.animate(null, { pseudoElement: '::placeHOLDER' });
+}, `animate() with pseudoElement ::placeholder does not throw`);
 
 promise_test(async t => {
   const div = createDiv(t);

--- a/web-animations/interfaces/KeyframeEffect/target.html
+++ b/web-animations/interfaces/KeyframeEffect/target.html
@@ -253,7 +253,6 @@ for (const pseudo of [
   'before',
   ':abc',
   '::abc',
-  '::placeholder',
 ]) {
   test(t => {
     const effect = new KeyframeEffect(null, gKeyFrames, 100 * MS_PER_SEC);
@@ -261,6 +260,12 @@ for (const pseudo of [
   }, `Changing pseudoElement to a non-null invalid pseudo-selector ` +
      `'${pseudo}' throws a SyntaxError`);
 }
+
+test(t => {
+  const effect = new KeyframeEffect(null, gKeyFrames, 100 * MS_PER_SEC);
+  effect.pseudoElement = '::placeHOLDER';
+  assert_equals(effect.pseudoElement, '::placeholder');
+}, `Changing pseudoElement to ::placeHOLDER works`);
 
 </script>
 </body>


### PR DESCRIPTION
I discovered these issues while writing https://github.com/WebKit/WebKit/pull/22231. Standalone pseudo-elements still need to be properly formatted.

And ::placeholder is a valid pseudo-element.

Closes https://github.com/w3c/csswg-drafts/issues/9751.