### PR TITLE
Pseudos after ::part() are valid

### DIFF
--- a/css/selectors/parsing/parse-part.html
+++ b/css/selectors/parsing/parse-part.html
@@ -24,11 +24,11 @@
   test_valid_selector("::part(foo):is(:focus)");
   test_valid_selector(":lang(en)::part(foo)");
   test_valid_selector(":dir(ltr)::part(foo)");
+  test_valid_selector("::part(foo):lang(en)");
+  test_valid_selector("::part(foo):dir(ltr)");
   test_invalid_selector(":part()");
   test_invalid_selector(":part(0)");
   test_invalid_selector(":part('foo')");
   test_invalid_selector(":part([foo])");
-  test_invalid_selector("::part(foo):lang(en)");
-  test_invalid_selector("::part(foo):dir(ltr)");
   test_invalid_selector('::part(foo) + ::part(bar)');
 </script>


### PR DESCRIPTION
<https://drafts.csswg.org/selectors/#pseudo-element-states> restricts pseudo-classes on pseudo-elements to the user action and logical combo ones *by default*, but allows other specs to allow other pseudos.

<https://drafts.csswg.org/css-shadow-parts/#part> allows all pseudo-classes (but defines that a few never match, if they reveal tree structure).