### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=261898

### DIFF
--- a/css/css-color/oklch-l-over-1-1.html
+++ b/css/css-color/oklch-l-over-1-1.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: Verify lightness in Oklch is always clamped to a value between 0 to 1</title>
+<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="match" href="oklch-l-over-1-ref.html">
+<meta name="assert" content="oklch() with lightness greater than 1">
+<style>
+    .ref { background-color: oklch(1 0.5 50); width: 100px; height: 100px}
+    /* l = 1.5 should clamp back to 1 */
+    .test { background-color: oklch(1.5 0.5 50); width: 100px; height: 100px}
+</style>
+
+<body>
+    <p>Test passes if you see a single color.</p>
+    <div class="ref"></div>
+    <div class="test"></div>
+</body>

--- a/css/css-color/oklch-l-over-1-2.html
+++ b/css/css-color/oklch-l-over-1-2.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: Verify lightness in Oklch is always clamped to a value between 0% to 100%</title>
+<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="match" href="oklch-l-over-1-ref.html">
+<meta name="assert" content="oklch() with lightness greater than 100%">
+<style>
+    .ref { background-color: oklch(100% 0.5 50); width: 100px; height: 100px}
+    /* l = 150% should clamp back to 100% */
+    .test { background-color: oklch(150% 0.5 50); width: 100px; height: 100px}
+</style>
+
+<body>
+    <p>Test passes if you see a single color.</p>
+    <div class="ref"></div>
+    <div class="test"></div>
+</body>

--- a/css/css-color/oklch-l-over-1-ref.html
+++ b/css/css-color/oklch-l-over-1-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: Verify lightness in Oklch is always clamped to a value between 0 to 1</title>
+<style>
+    .ref { background-color: oklch(1 0.5 50); width: 100px; height: 200px}
+</style>
+
+<body>
+    <p>Test passes if you see a single color.</p>
+    <div class="ref"></div>
+</body>


### PR DESCRIPTION
WebKit export from bug: [\[css-color\] oklab-l-over-1-2.html fails](https://bugs.webkit.org/show_bug.cgi?id=261898)