### PR TITLE
Add WPT for popup heuristic

### DIFF
--- a/cookies/third-party-cookies/resources/test-helpers.js
+++ b/cookies/third-party-cookies/resources/test-helpers.js
@@ -1,10 +1,10 @@
 function testHttpCookies({desc, origin, cookieNames, expectsCookie}) {
   promise_test(async () => {
-    await assertOriginCanAccessCookies({origin, cookieNames, expectsCookie});
+    await assertHttpOriginCanAccessCookies({origin, cookieNames, expectsCookie});
   }, getCookieTestName(expectsCookie, desc, "HTTP"));
 }
 
-async function assertOriginCanAccessCookies({
+async function assertHttpOriginCanAccessCookies({
   origin,
   cookieNames,
   expectsCookie,
@@ -16,6 +16,30 @@ async function assertOriginCanAccessCookies({
       cookies.hasOwnProperty(cookieName), expectsCookie,
       getCookieAssertDesc(expectsCookie, cookieName));
   }
+}
+
+async function assertThirdPartyHttpCookies({desc, origin, cookieNames, expectsCookie, callback}) {
+  // Test that these cookies are not available on cross-site subresource requests to the
+  // origin that set them.
+  testHttpCookies({
+    desc,
+    origin,
+    cookieNames,
+    expectsCookie,
+  });
+
+  promise_test(async () => {
+    const thirdPartyHttpCookie = "3P_http"
+    await credFetch(
+      `${origin}/cookies/resources/set.py?${thirdPartyHttpCookie}=foobar;` +
+      "Secure;Path=/;SameSite=None");
+    await assertHttpOriginCanAccessCookies({
+      origin,
+      cookieNames: ["3P_http"],
+      expectsCookie,
+    });
+    if (callback) callback();
+  }, desc + ", Cross site window setting HTTP cookies");
 }
 
 function testDomCookies({desc, cookieNames, expectsCookie}) {

--- a/cookies/third-party-cookies/resources/third-party-cookies-cross-site-popup-manual.html
+++ b/cookies/third-party-cookies/resources/third-party-cookies-cross-site-popup-manual.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<meta name="timeout" content="long">
+<title>Cross-site popup</title>
+<script src="/resources/testharness.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/cookies/resources/cookie-helper.sub.js"></script>
+<script src="/cookies/third-party-cookies/resources/test-helpers.js"></script>
+
+<body>
+  <script>
+
+    const origin = window.origin
+    const crossSiteOrigin = get_host_info().HTTPS_NOTSAMESITE_ORIGIN + self.location.pathname
+
+    function userInteractionCallback() {
+      // Third-party cookies are now allowed.
+      const verify3pAllowedUrl = new URL(
+        `./third-party-cookies-cross-site-verify.html?desc=3P_fetch_with_heuristics&expectsCookie=true&origin=${encodeURIComponent(origin)}`,
+        crossSiteOrigin);
+      const verify3pAllowedPopup = window.open(verify3pAllowedUrl);
+      fetch_tests_from_window(verify3pAllowedPopup);
+    }
+
+  </script>
+
+  <button id="button" onclick="userInteractionCallback()">Click for user interaction</button>
+
+</body>

--- a/cookies/third-party-cookies/resources/third-party-cookies-cross-site-verify.html
+++ b/cookies/third-party-cookies/resources/third-party-cookies-cross-site-verify.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<meta name="timeout" content="long">
+<title>Cross-site window</title>
+<script src="/resources/testharness.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/cookies/resources/cookie-helper.sub.js"></script>
+<script src="/cookies/third-party-cookies/resources/test-helpers.js"></script>
+
+<body>
+  <script>
+
+    // Test that parent window passed its parameters in the URL correctly.
+    test(() => {
+      assert_true(window.location.search.includes("?desc="));
+      assert_true(window.location.search.includes("&expectsCookie="));
+      assert_true(window.location.search.includes("&origin="));
+
+      desc = decodeURIComponent(window.location.search.slice(
+        window.location.search.indexOf("?desc=") + 6,
+        window.location.search.indexOf("&expectsCookie=")));
+      expectsCookieStr = decodeURIComponent(window.location.search.slice(
+        window.location.search.indexOf("&expectsCookie=") + 15,
+        window.location.search.indexOf("&origin=")));
+      expectsCookie = (expectsCookieStr === 'true')
+      origin = decodeURIComponent(window.location.search.slice(
+        window.location.search.indexOf("&origin=") + 8));
+    }, "Cross-site verify opened correctly");
+
+    // Cookies set by the parent window in a 1P context.
+    const cookieNames = ["1P_http", "1P_dom"];
+    if (window.cookieStore) {
+      cookieNames.push("1P_cs");
+    }
+
+    // Third-party cookies are blocked by default.
+    assertThirdPartyHttpCookies({
+      desc,
+      origin,
+      cookieNames,
+      expectsCookie
+    });
+
+  </script>
+</body>

--- a/cookies/third-party-cookies/resources/third-party-cookies-cross-site-window.html
+++ b/cookies/third-party-cookies/resources/third-party-cookies-cross-site-window.html
@@ -25,38 +25,44 @@ if (window.cookieStore) {
   cookieNames.push("1P_cs");
 }
 
-// Test theses cookies are not available on cross-site subresource requests
-// to the origin that set them.
-testHttpCookies({
+// Third-party cookies are blocked by default.
+assertThirdPartyHttpCookies({
   desc: "3P fetch",
   origin,
   cookieNames,
   expectsCookie: false,
+  callback: testPopupHeuristic,
 });
-
-promise_test(async () => {
-  const thirdPartyHttpCookie = "3P_http"
-  await credFetch(
-    `${origin}/cookies/resources/set.py?${thirdPartyHttpCookie}=foobar;` +
-    "Secure;Path=/;SameSite=None");
-  await assertOriginCanAccessCookies({
-    origin,
-    cookieNames: ["3P_http"],
-    expectsCookie: false,
-  });
-}, "Cross site window setting HTTP cookies");
 
 // Create a cross-site <iframe> which embeds the cookies' origin into this
 // page.
 const iframe = document.createElement("iframe");
-const url = new URL(
+const iframeUrl = new URL(
     "/cookies/third-party-cookies/resources/" +
         "third-party-cookies-cross-site-embed.html",
     origin);
-iframe.src = String(url);
+iframe.src = String(iframeUrl);
 document.body.appendChild(iframe);
 
 fetch_tests_from_window(iframe.contentWindow);
+
+function testPopupHeuristic() {
+  // Open the cookies' origin in a popup to activate the heuristic.
+  const popupUrl = new URL(
+    "/cookies/third-party-cookies/resources/" +
+        "third-party-cookies-cross-site-popup-manual.html",
+    origin);
+  const popup = window.open(popupUrl);
+  fetch_tests_from_window(popup);
+
+  // Third-party cookies are now allowed.
+  // assertThirdPartyHttpCookies({
+  //   desc: "3P fetch with heuristic",
+  //   origin,
+  //   cookieNames,
+  //   expectsCookie: true,
+  // });
+}
 
 </script>
 </body>

--- a/cookies/third-party-cookies/resources/third-party-cookies-cross-site-window.html
+++ b/cookies/third-party-cookies/resources/third-party-cookies-cross-site-window.html
@@ -54,14 +54,6 @@ function testPopupHeuristic() {
     origin);
   const popup = window.open(popupUrl);
   fetch_tests_from_window(popup);
-
-  // Third-party cookies are now allowed.
-  // assertThirdPartyHttpCookies({
-  //   desc: "3P fetch with heuristic",
-  //   origin,
-  //   cookieNames,
-  //   expectsCookie: true,
-  // });
 }
 
 </script>

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -112,7 +112,6 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     chrome_options["args"].append("--enable-features=GenericSensorExtraClasses")
     # Test with third-party cookies deprecated.
     chrome_options["args"].append("--test-third-party-cookie-phaseout")
-    chrome_options["args"].append("--enable-features=TpcdHeuristicsGrants/TpcdReadHeuristicsGrants/true/TpcdWritePopupCurrentInteractionHeuristicsGrants/30d/TpcdWritePopupPastInteractionHeuristicsGrants/30d")
 
     # Classify `http-private`, `http-public` and https variants in the
     # appropriate IP address spaces.

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -110,6 +110,9 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     # The GenericSensorExtraClasses flag enables the browser-side
     # implementation of sensors such as Ambient Light Sensor.
     chrome_options["args"].append("--enable-features=GenericSensorExtraClasses")
+    # Test with third-party cookies deprecated.
+    chrome_options["args"].append("--test-third-party-cookie-phaseout")
+    chrome_options["args"].append("--enable-features=TpcdHeuristicsGrants/TpcdReadHeuristicsGrants/true/TpcdWritePopupCurrentInteractionHeuristicsGrants/30d/TpcdWritePopupPastInteractionHeuristicsGrants/30d")
 
     # Classify `http-private`, `http-public` and https variants in the
     # appropriate IP address spaces.


### PR DESCRIPTION
Add cases to the existing WPT for third-party cookies which perform the following flow:

- Open a popup from the not-same-origin to the same-origin.
- Require a manual interaction with a button.
- Open a new not-same-origin window and verify that 3P cookies are no longer blocked.

Verified this test passes on chrome-dev. Also adding the `--test-third-party-cookie-phaseout` flag to WPT startup; the existing tests were failing without it because 3P cookies were not being blocked.

Explainer: https://github.com/amaliev/3pcd-exemption-heuristics/blob/main/explainer.md
Spec (draft): https://github.com/whatwg/compat/pull/253

CC @johannhof @wanderview 