### PR TITLE
WebAudio: remove unused and incorrect resource

### DIFF
--- a/webaudio/the-audio-api/the-audiobuffersourcenode-interface/sample-accurate-scheduling.html
+++ b/webaudio/the-audio-api/the-audiobuffersourcenode-interface/sample-accurate-scheduling.html
@@ -12,7 +12,6 @@ We use an impulse so we can tell exactly where the rendering is happening.
     <script src="/resources/testharnessreport.js"></script>
     <script src="/webaudio/resources/audit-util.js"></script>
     <script src="/webaudio/resources/audit.js"></script>
-    <script src="/webaudio/resources/buffer-loader.js"></script>
   </head>
   <body>
     <script id="layout-test-code">


### PR DESCRIPTION
The file /webaudio/resources/buffer-loader.js does not exist, it lives in /webaudio/js instead. It is unused however.