### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=267059

### DIFF
--- a/css/css-animations/computed-style-animation-parsing.html
+++ b/css/css-animations/computed-style-animation-parsing.html
@@ -47,6 +47,23 @@ test(() => {
 }, "Test a non-conflicting animation name.");
 
 test(() => {
+  testAnimation("ease", "none");
+  testAnimation("ease-in", "none");
+  testAnimation("ease-in-out", "none");
+  testAnimation("ease-out", "none");
+  testAnimation("linear", "none");
+  testAnimation("step-end", "none");
+  testAnimation("step-start", "none");
+  testAnimation("ease ease", "ease");
+  testAnimation("ease linear", "linear");
+}, "Test an animation name that is the same as a possible animation timing-function.");
+
+test(() => {
+  testAnimation("infinite", "none");
+  testAnimation("infinite infinite", "infinite");
+}, "Test an animation name that is the same as a possible animation iteration-count.");
+
+test(() => {
   testAnimation("none", "none");
   testAnimation("forwards", "none");
   testAnimation("none forwards", "forwards");

--- a/css/css-animations/parsing/animation-computed.html
+++ b/css/css-animations/parsing/animation-computed.html
@@ -18,26 +18,35 @@
 // [ none | <keyframes-name> ]
 
 test(() => {
-  assert_equals(getComputedStyle(document.getElementById('target')).animation, "0s ease 0s 1 normal none running none");
+  assert_equals(getComputedStyle(document.getElementById('target')).animation, "none");
 }, "Default animation value");
 
-test_computed_value("animation", "1s", "1s ease 0s 1 normal none running none");
-test_computed_value("animation", "cubic-bezier(0, -2, 1, 3)", "0s cubic-bezier(0, -2, 1, 3) 0s 1 normal none running none");
-test_computed_value("animation", "1s -3s", "1s ease -3s 1 normal none running none");
-test_computed_value("animation", "4", "0s ease 0s 4 normal none running none");
-test_computed_value("animation", "reverse", "0s ease 0s 1 reverse none running none");
-test_computed_value("animation", "both", "0s ease 0s 1 normal both running none");
-test_computed_value("animation", "paused", "0s ease 0s 1 normal none paused none");
-test_computed_value("animation", "none", "0s ease 0s 1 normal none running none");
-test_computed_value("animation", "anim", "0s ease 0s 1 normal none running anim");
+test_computed_value("animation", "1s", "1s");
+test_computed_value("animation", "cubic-bezier(0, -2, 1, 3)", "cubic-bezier(0, -2, 1, 3)");
+test_computed_value("animation", "ease-in-out", "ease-in-out");
+test_computed_value("animation", "1s -3s", "1s -3s");
+test_computed_value("animation", "4", "4");
+test_computed_value("animation", "reverse", "reverse");
+test_computed_value("animation", "both", "both");
+test_computed_value("animation", "paused", "paused");
+test_computed_value("animation", "none", "none");
+test_computed_value("animation", "anim", "anim");
 
 test_computed_value("animation", "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)",
   "1s cubic-bezier(0, -2, 1, 3) -3s 4 reverse both paused anim");
 
 test_computed_value("animation", "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)",
-  "0s ease 0s 1 reverse both paused anim, 1s cubic-bezier(0, -2, 1, 3) -3s 4 normal none running none");
+  "reverse both paused anim, 1s cubic-bezier(0, -2, 1, 3) -3s 4");
 
-// TODO: Add test with a single timing-function keyword.
+test_computed_value("animation", "none, none", "none, none");
+
+test(() => {
+  const target = document.getElementById('target');
+  target.style.animation = "initial";
+  target.style.animationDelay = "1s";
+  assert_equals(getComputedStyle(target).animation, "0s 1s");
+}, "Animation with a delay but no duration");
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
WebKit export from bug: [\[css-animations\] `animation` property should use shortest serialization rule](https://bugs.webkit.org/show_bug.cgi?id=267059)