### PR TITLE
[wdspec] Only resize and re-position window in session setup and teardown if needed

### DIFF
--- a/webdriver/tests/bidi/browsing_context/set_viewport/invalid.py
+++ b/webdriver/tests/bidi/browsing_context/set_viewport/invalid.py
@@ -1,5 +1,3 @@
-# META: timeout=long
-
 import pytest
 
 import webdriver.bidi.error as error

--- a/webdriver/tests/bidi/input/perform_actions/invalid.py
+++ b/webdriver/tests/bidi/input/perform_actions/invalid.py
@@ -1,5 +1,3 @@
-# META: timeout=long
-
 import pytest
 import pytest_asyncio
 

--- a/webdriver/tests/bidi/script/call_function/invalid.py
+++ b/webdriver/tests/bidi/script/call_function/invalid.py
@@ -1,5 +1,3 @@
-# META: timeout=long
-
 import pytest
 import webdriver.bidi.error as error
 

--- a/webdriver/tests/classic/element_clear/clear.py
+++ b/webdriver/tests/classic/element_clear/clear.py
@@ -1,5 +1,3 @@
-# META: timeout=long
-
 import pytest
 from webdriver import WebElement
 

--- a/webdriver/tests/classic/fullscreen_window/stress.py
+++ b/webdriver/tests/classic/fullscreen_window/stress.py
@@ -1,5 +1,8 @@
 # META: timeout=long
 
+# Longer timeout required due to a bug in Chrome:
+# https://bugs.chromium.org/p/chromedriver/issues/detail?id=4642#c4
+
 import pytest
 
 from tests.support.asserts import assert_success

--- a/webdriver/tests/classic/maximize_window/maximize.py
+++ b/webdriver/tests/classic/maximize_window/maximize.py
@@ -1,5 +1,8 @@
 # META: timeout=long
 
+# Longer timeout required due to a bug in Chrome:
+# https://bugs.chromium.org/p/chromedriver/issues/detail?id=4642#c4
+
 from tests.support.asserts import assert_error, assert_success
 from tests.support.helpers import (
     document_hidden,

--- a/webdriver/tests/classic/maximize_window/stress.py
+++ b/webdriver/tests/classic/maximize_window/stress.py
@@ -1,5 +1,8 @@
 # META: timeout=long
 
+# Longer timeout required due to a bug in Chrome:
+# https://bugs.chromium.org/p/chromedriver/issues/detail?id=4642#c4
+
 import time
 
 import pytest

--- a/webdriver/tests/classic/minimize_window/minimize.py
+++ b/webdriver/tests/classic/minimize_window/minimize.py
@@ -1,5 +1,8 @@
 # META: timeout=long
 
+# Longer timeout required due to a bug in Chrome:
+# https://bugs.chromium.org/p/chromedriver/issues/detail?id=4642#c4
+
 from tests.support.asserts import assert_error, assert_success
 from tests.support.helpers import document_hidden, is_fullscreen, is_maximized
 

--- a/webdriver/tests/classic/minimize_window/stress.py
+++ b/webdriver/tests/classic/minimize_window/stress.py
@@ -1,5 +1,8 @@
 # META: timeout=long
 
+# Longer timeout required due to a bug in Chrome:
+# https://bugs.chromium.org/p/chromedriver/issues/detail?id=4642#c4
+
 import pytest
 
 from tests.support.asserts import assert_success

--- a/webdriver/tests/classic/perform_actions/invalid.py
+++ b/webdriver/tests/classic/perform_actions/invalid.py
@@ -1,5 +1,3 @@
-# META: timeout=long
-
 import pytest
 
 from webdriver.error import InvalidArgumentException

--- a/webdriver/tests/classic/perform_actions/pointer_mouse.py
+++ b/webdriver/tests/classic/perform_actions/pointer_mouse.py
@@ -1,5 +1,3 @@
-# META: timeout=long
-
 import pytest
 
 from webdriver.error import InvalidArgumentException, NoSuchWindowException, StaleElementReferenceException

--- a/webdriver/tests/classic/perform_actions/pointer_pen.py
+++ b/webdriver/tests/classic/perform_actions/pointer_pen.py
@@ -1,5 +1,3 @@
-# META: timeout=long
-
 import pytest
 
 from webdriver.error import NoSuchWindowException, StaleElementReferenceException

--- a/webdriver/tests/classic/perform_actions/pointer_touch.py
+++ b/webdriver/tests/classic/perform_actions/pointer_touch.py
@@ -1,5 +1,3 @@
-# META: timeout=long
-
 import pytest
 
 from webdriver.error import NoSuchWindowException, StaleElementReferenceException

--- a/webdriver/tests/classic/perform_actions/sequence.py
+++ b/webdriver/tests/classic/perform_actions/sequence.py
@@ -1,5 +1,3 @@
-# META: timeout=long
-
 from tests.classic.perform_actions.support.refine import get_events, get_keys
 
 

--- a/webdriver/tests/classic/release_actions/sequence.py
+++ b/webdriver/tests/classic/release_actions/sequence.py
@@ -1,4 +1,3 @@
-# META: timeout=long
 import pytest
 
 from tests.classic.release_actions.support.refine import get_events, get_keys

--- a/webdriver/tests/classic/set_window_rect/set.py
+++ b/webdriver/tests/classic/set_window_rect/set.py
@@ -1,5 +1,8 @@
 # META: timeout=long
 
+# Longer timeout required due to a bug in Chrome:
+# https://bugs.chromium.org/p/chromedriver/issues/detail?id=4642#c4
+
 import pytest
 
 from webdriver.transport import Response

--- a/webdriver/tests/support/fixtures.py
+++ b/webdriver/tests/support/fixtures.py
@@ -174,8 +174,12 @@ async def session(capabilities, configuration):
 
     # Enforce a fixed default window size and position
     if _current_session.capabilities.get("setWindowRect"):
-        _current_session.window.size = defaults.WINDOW_SIZE
-        _current_session.window.position = defaults.WINDOW_POSITION
+        # Only resize and reposition if needed to workaround a bug for Chrome:
+        # https://bugs.chromium.org/p/chromedriver/issues/detail?id=4642#c4
+        if _current_session.window.size != defaults.WINDOW_SIZE:
+            _current_session.window.size = defaults.WINDOW_SIZE
+        if _current_session.window.position != defaults.WINDOW_POSITION:
+            _current_session.window.position = defaults.WINDOW_POSITION
 
     # Set default timeouts
     multiplier = configuration["timeout_multiplier"]
@@ -222,8 +226,12 @@ async def bidi_session(capabilities, configuration):
 
     # Enforce a fixed default window size and position
     if _current_session.capabilities.get("setWindowRect"):
-        _current_session.window.size = defaults.WINDOW_SIZE
-        _current_session.window.position = defaults.WINDOW_POSITION
+        # Only resize and reposition if needed to workaround a bug for Chrome:
+        # https://bugs.chromium.org/p/chromedriver/issues/detail?id=4642#c4
+        if _current_session.window.size != defaults.WINDOW_SIZE:
+            _current_session.window.size = defaults.WINDOW_SIZE
+        if _current_session.window.position != defaults.WINDOW_POSITION:
+            _current_session.window.position = defaults.WINDOW_POSITION
 
     yield _current_session.bidi_session
 

--- a/webdriver/tests/support/helpers.py
+++ b/webdriver/tests/support/helpers.py
@@ -57,7 +57,10 @@ def cleanup_session(session):
         or fullscreened state.
         """
         if session.capabilities.get("setWindowRect"):
-            session.window.size = defaults.WINDOW_SIZE
+            # Only resize if needed to workaround a bug for Chrome:
+            # https://bugs.chromium.org/p/chromedriver/issues/detail?id=4642#c4
+            if session.window.size != defaults.WINDOW_SIZE:
+                session.window.size = defaults.WINDOW_SIZE
 
     @ignore_exceptions
     def _restore_windows(session):


### PR DESCRIPTION
This is a workaround until the [underlying bug in Chrome](https://bugs.chromium.org/p/chromedriver/issues/detail?id=4642#c4) has been fixed. Potentially we can remove a lot of longer timeout requests as well. Lets see what tests results show us.