### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=267169

### DIFF
--- a/css/selectors/parsing/invalid-pseudos.html
+++ b/css/selectors/parsing/invalid-pseudos.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Selectors: Test that various prefixed pseudos are not web exposed</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/selectors/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../support/parsing-testcommon.js"></script>
+<script>
+// Pseudo-classes
+test_invalid_selector(":-internal-html-document");
+
+// Pseudo-elements
+test_invalid_selector("::-apple-attachment-controls-container");
+test_invalid_selector("::-internal-loading-auto-fill-button");
+</script>


### PR DESCRIPTION
WebKit export from bug: [Make `::-webkit-loading-auto-fill-button` an internal pseudo-element](https://bugs.webkit.org/show_bug.cgi?id=267169)