### PR TITLE
Remove <link rel="match"> from a testharness.js tests

### DIFF
--- a/css/css-shadow-parts/invalidation-part-pseudo.html
+++ b/css/css-shadow-parts/invalidation-part-pseudo.html
@@ -3,7 +3,6 @@
 <link rel="help" href="https://drafts.csswg.org/css-shadow-parts" >
 <link rel="help" href="https://drafts.csswg.org/selectors/#matches">
 <link href="https://drafts.csswg.org/selectors/#matches" rel="help">
-<link rel="match" href="interaction-with-nested-pseudo-class-ref.html">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>


### PR DESCRIPTION
The test is a testharness.js tests, this is likely left because it was based on a reftest.