### PR TITLE
Remove testdriver.js from a test that doesn't use it

### DIFF
--- a/html/semantics/forms/the-selectlist-element/selectlist-option-arbitrary-content-not-displayed.tentative.html
+++ b/html/semantics/forms/the-selectlist-element/selectlist-option-arbitrary-content-not-displayed.tentative.html
@@ -3,9 +3,6 @@
 <title>HTMLSelectListElement Test: option arbitrary content not displayed</title>
 <link rel="author" title="Ionel Popescu" href="mailto:iopopesc@microsoft.com">
 <link rel=match href="selectlist-option-arbitrary-content-not-displayed-ref.tentative.html">
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-actions.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
 
 <option>
   option with image not displayed


### PR DESCRIPTION
This is a reftest, and test_driver isn't used.