### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=267355

### DIFF
--- a/webrtc/RTCPeerConnection-GC.https.html
+++ b/webrtc/RTCPeerConnection-GC.https.html
@@ -40,15 +40,11 @@ promise_test(async t => {
     const start = performance.now();
     const width = destVideo.videoWidth;
     const height = destVideo.videoHeight;
-    const resizeEvent = new Promise(r => destVideo.onresize = r);
     while (destVideo.videoWidth == width && destVideo.videoHeight == height) {
       if (performance.now() - start > 5000) {
         throw new Error("Timeout waiting for video size change");
       }
-      await Promise.race([
-        resizeEvent,
-        new Promise(r => t.step_timeout(r, 50)),
-      ]);
+      await new Promise(r => t.step_timeout(r, 50));
     }
   };
 


### PR DESCRIPTION
WebKit export from bug: [REGRESSION(272844@main): \[ wk2 \] imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-GC.https.html is consistently failing.](https://bugs.webkit.org/show_bug.cgi?id=267355)