### PR TITLE
[testdriver] Detect testharness context lazily

### DIFF
--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -1,7 +1,6 @@
 "use strict";
 
 (function() {
-    const is_test_context = window.__wptrunner_message_queue !== undefined;
     const pending = new Map();
 
     let result = null;
@@ -15,7 +14,7 @@
             return;
         }
 
-        if (is_test_context && data.type === "testdriver-command") {
+        if (is_test_context() && data.type === "testdriver-command") {
             const command = data.message;
             const ctx_id = command.cmd_id;
             delete command.cmd_id;
@@ -37,11 +36,15 @@
             pending.delete(cmd_id);
             const resolver = data.status === "success" ? on_success : on_failure;
             resolver(data);
-            if (is_test_context) {
+            if (is_test_context()) {
                 window.__wptrunner_process_next_event();
             }
         }
     });
+
+    function is_test_context() {
+      return window.__wptrunner_message_queue !== undefined;
+    }
 
     // Code copied from /common/utils.js
     function rand_int(bits) {
@@ -67,7 +70,7 @@
     }
 
     function get_window_id(win) {
-        if (win == window && is_test_context) {
+        if (win == window && is_test_context()) {
             return null;
         }
         if (!win.__wptrunner_id) {
@@ -130,7 +133,7 @@
         if (action_msg.context) {
           action_msg.context = get_window_id(action_msg.context);
         }
-        if (is_test_context) {
+        if (is_test_context()) {
             cmd_id = window.__wptrunner_message_queue.push(action_msg);
         } else {
             if (testharness_context === null) {


### PR DESCRIPTION
Currently, loading testdriver.js before testharness.js causes testdriver.js to think it's in a non-testharness context even after testharness.js is loaded. To reduce [surprises for test authors][0], defer evaluation of `is_test_context` to when actions actually need to be created or handled.

See Also: https://crbug.com/1517740

[0]: https://wpt.fyi/results/idle-detection/idle-detection-detached-frame.https.html?run_id=6017280944635904&run_id=5165632751927296&run_id=5188016745742336&run_id=5190361797885952