### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=266614

### DIFF
--- a/css/css-ui/parsing/resize-invalid.html
+++ b/css/css-ui/parsing/resize-invalid.html
@@ -15,6 +15,7 @@
 test_invalid_value("resize", "auto");
 test_invalid_value("resize", "horizontal vertical");
 test_invalid_value("resize", "both 0");
+test_invalid_value("resize", "-internal-textarea-auto");
 </script>
 </body>
 </html>


### PR DESCRIPTION
WebKit export from bug: [Unexpose non-standard `resize: auto` value](https://bugs.webkit.org/show_bug.cgi?id=266614)