### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=267317

### DIFF
--- a/mediacapture-insertable-streams/idlharness.any.js
+++ b/mediacapture-insertable-streams/idlharness.any.js
@@ -7,6 +7,7 @@ idl_test(
   ['dom', 'html'],
   idl_array => {
     idl_array.add_objects({
+      MediaStreamTrackProcessor: ['new MediaStreamTrackProcessor({ track: new VideoTrackGenerator() })'],
       VideoTrackGenerator: ['new VideoTrackGenerator()'],
     });
   }


### PR DESCRIPTION
WebKit export from bug: [Add a MediaStreamTrackProcessor skeleton](https://bugs.webkit.org/show_bug.cgi?id=267317)