### PR TITLE
[WebDriver BiDi] extend `storage.setCookie` tests

### DIFF
--- a/webdriver/tests/bidi/storage/__init__.py
+++ b/webdriver/tests/bidi/storage/__init__.py
@@ -1,15 +1,13 @@
-from webdriver.bidi.modules.storage import PartitionDescriptor
+from webdriver.bidi.modules.storage import StorageKeyPartitionDescriptor
 from .. import any_int, recursive_compare
 
-PROTOCOL_HTTPS = "https"
-PROTOCOL_HTTP = "http"
 
-
-async def assert_cookie_is_set(bidi_session, name: str, str_value: str, domain: str, partition: PartitionDescriptor):
+async def assert_cookie_is_set(bidi_session, name: str, str_value: str, domain: str, origin: str):
     """
     Asserts the cookie is set.
     """
-    all_cookies = await bidi_session.storage.get_cookies(partition=partition)
+    all_cookies = await bidi_session.storage.get_cookies(partition=StorageKeyPartitionDescriptor(
+        source_origin=origin))
 
     assert 'cookies' in all_cookies
     cookie = next(c for c in all_cookies['cookies'] if c['name'] == name)

--- a/webdriver/tests/bidi/storage/__init__.py
+++ b/webdriver/tests/bidi/storage/__init__.py
@@ -1,0 +1,30 @@
+from webdriver.bidi.modules.storage import PartitionDescriptor
+from .. import any_int, recursive_compare
+
+PROTOCOL_HTTPS = "https"
+PROTOCOL_HTTP = "http"
+
+
+async def assert_cookie_is_set(bidi_session, name: str, str_value: str, domain: str, partition: PartitionDescriptor):
+    """
+    Asserts the cookie is set.
+    """
+    all_cookies = await bidi_session.storage.get_cookies(partition=partition)
+
+    assert 'cookies' in all_cookies
+    cookie = next(c for c in all_cookies['cookies'] if c['name'] == name)
+
+    recursive_compare({
+        'domain': domain,
+        'httpOnly': False,
+        'name': name,
+        'path': '/',
+        'sameSite': 'none',
+        'secure': True,
+        # Varies depending on the cookie name and value.
+        'size': any_int,
+        'value': {
+            'type': 'string',
+            'value': str_value,
+        },
+    }, cookie)

--- a/webdriver/tests/bidi/storage/set_cookie/page_protocols.py
+++ b/webdriver/tests/bidi/storage/set_cookie/page_protocols.py
@@ -1,7 +1,7 @@
 import pytest
 from webdriver.bidi.modules.network import NetworkStringValue
 from webdriver.bidi.modules.storage import PartialCookie, BrowsingContextPartitionDescriptor
-from .. import assert_cookie_is_set, PROTOCOL_HTTP, PROTOCOL_HTTPS
+from .. import assert_cookie_is_set
 
 pytestmark = pytest.mark.asyncio
 
@@ -12,14 +12,14 @@ COOKIE_VALUE = 'SOME_COOKIE_VALUE'
 @pytest.mark.parametrize(
     "protocol",
     [
-        PROTOCOL_HTTP,
-        PROTOCOL_HTTPS,
-    ],
+        "http",
+        "https",
+    ]
 )
-async def test_set_cookie_protocol(bidi_session, top_context, inline, origin, domain_value, protocol):
+async def test_page_protocols(bidi_session, top_context, get_test_page, origin, domain_value, protocol):
     # Navigate to a page with a required protocol.
     await bidi_session.browsing_context.navigate(
-        context=top_context["context"], url=(inline("<div>foo</div>", protocol=protocol)), wait="complete"
+        context=top_context["context"], url=get_test_page(protocol=protocol), wait="complete"
     )
 
     source_origin = origin(protocol)
@@ -42,4 +42,4 @@ async def test_set_cookie_protocol(bidi_session, top_context, inline, origin, do
 
     # Assert the cookie is actually set.
     await assert_cookie_is_set(bidi_session, name=COOKIE_NAME, str_value=COOKIE_VALUE,
-                               domain=domain_value(), partition=partition)
+                               domain=domain_value(), origin=source_origin)

--- a/webdriver/tests/bidi/storage/set_cookie/partition.py
+++ b/webdriver/tests/bidi/storage/set_cookie/partition.py
@@ -36,4 +36,4 @@ async def test_storage_key_partition_source_origin(bidi_session, top_context, in
     await assert_cookie_is_set(bidi_session, name=COOKIE_NAME, str_value=COOKIE_VALUE,
                                domain=domain_value(), partition=partition)
 
-# TODO: test `StorageKeyPartitionDescriptor.userContext` parameter.
+# TODO: test `test_storage_key_partition_user_context`.

--- a/webdriver/tests/bidi/storage/set_cookie/partition.py
+++ b/webdriver/tests/bidi/storage/set_cookie/partition.py
@@ -1,7 +1,7 @@
 import pytest
 from webdriver.bidi.modules.network import NetworkStringValue
-from webdriver.bidi.modules.storage import PartialCookie, BrowsingContextPartitionDescriptor
-from .. import assert_cookie_is_set, PROTOCOL_HTTP, PROTOCOL_HTTPS
+from webdriver.bidi.modules.storage import PartialCookie, StorageKeyPartitionDescriptor
+from .. import assert_cookie_is_set, PROTOCOL_HTTPS
 
 pytestmark = pytest.mark.asyncio
 
@@ -9,21 +9,14 @@ COOKIE_NAME = 'SOME_COOKIE_NAME'
 COOKIE_VALUE = 'SOME_COOKIE_VALUE'
 
 
-@pytest.mark.parametrize(
-    "protocol",
-    [
-        PROTOCOL_HTTP,
-        PROTOCOL_HTTPS,
-    ],
-)
-async def test_set_cookie_protocol(bidi_session, top_context, inline, origin, domain_value, protocol):
-    # Navigate to a page with a required protocol.
+async def test_storage_key_partition_source_origin(bidi_session, top_context, inline, origin, domain_value):
+    # Navigate to a secure context.
     await bidi_session.browsing_context.navigate(
-        context=top_context["context"], url=(inline("<div>foo</div>", protocol=protocol)), wait="complete"
+        context=top_context["context"], url=(inline("<div>foo</div>", protocol=PROTOCOL_HTTPS)), wait="complete"
     )
 
-    source_origin = origin(protocol)
-    partition = BrowsingContextPartitionDescriptor(top_context["context"])
+    source_origin = origin(PROTOCOL_HTTPS)
+    partition = StorageKeyPartitionDescriptor(source_origin=source_origin)
 
     set_cookie_result = await bidi_session.storage.set_cookie(
         cookie=PartialCookie(
@@ -40,6 +33,7 @@ async def test_set_cookie_protocol(bidi_session, top_context, inline, origin, do
         },
     }
 
-    # Assert the cookie is actually set.
     await assert_cookie_is_set(bidi_session, name=COOKIE_NAME, str_value=COOKIE_VALUE,
                                domain=domain_value(), partition=partition)
+
+# TODO: test `StorageKeyPartitionDescriptor.userContext` parameter.

--- a/webdriver/tests/bidi/storage/set_cookie/partition_storage_key.py
+++ b/webdriver/tests/bidi/storage/set_cookie/partition_storage_key.py
@@ -1,0 +1,37 @@
+import pytest
+from webdriver.bidi.modules.network import NetworkStringValue
+from webdriver.bidi.modules.storage import PartialCookie, StorageKeyPartitionDescriptor
+from .. import assert_cookie_is_set
+
+pytestmark = pytest.mark.asyncio
+
+COOKIE_NAME = 'SOME_COOKIE_NAME'
+COOKIE_VALUE = 'SOME_COOKIE_VALUE'
+
+
+async def test_storage_key_partition_source_origin(bidi_session, top_context, test_page, origin, domain_value):
+    # Navigate to a secure context.
+    await bidi_session.browsing_context.navigate(context=top_context["context"], url=test_page, wait="complete")
+
+    source_origin = origin()
+    partition = StorageKeyPartitionDescriptor(source_origin=source_origin)
+
+    set_cookie_result = await bidi_session.storage.set_cookie(
+        cookie=PartialCookie(
+            name=COOKIE_NAME,
+            value=NetworkStringValue(COOKIE_VALUE),
+            domain=domain_value(),
+            secure=True
+        ),
+        partition=partition)
+
+    assert set_cookie_result == {
+        'partitionKey': {
+            'sourceOrigin': source_origin
+        },
+    }
+
+    await assert_cookie_is_set(bidi_session, name=COOKIE_NAME, str_value=COOKIE_VALUE,
+                               domain=domain_value(), origin=source_origin)
+
+# TODO: test `test_storage_key_partition_user_context`.

--- a/webdriver/tests/bidi/storage/set_cookie/set_cookie.py
+++ b/webdriver/tests/bidi/storage/set_cookie/set_cookie.py
@@ -4,12 +4,15 @@ from webdriver.bidi.modules.storage import PartialCookie, BrowsingContextPartiti
 
 pytestmark = pytest.mark.asyncio
 
+PROTOCOL_HTTPS = "https"
+PROTOCOL_HTTP = "http"
+
 
 @pytest.mark.parametrize(
     "protocol",
     [
-        "http",
-        "https",
+        PROTOCOL_HTTP,
+        PROTOCOL_HTTPS,
     ],
 )
 async def test_set_cookie_protocol(bidi_session, top_context, inline, origin, domain_value, protocol):


### PR DESCRIPTION
* Cover `context` partition happy case
* Cover `storageKey` partition happy case
* Refactor cookie assertion

Tracking issue: https://github.com/web-platform-tests/wpt/issues/43996