### PR TITLE
[WebDriver BiDi] `storage.setCookie` `path`

### DIFF
--- a/tools/webdriver/webdriver/bidi/error.py
+++ b/tools/webdriver/webdriver/bidi/error.py
@@ -87,6 +87,10 @@ class UnableToCaptureScreenException(BidiException):
     error_code = "unable to capture screen"
 
 
+class UnableToSetCookieException(BidiException):
+    error_code = "unable to set cookie"
+
+
 class UnknownCommandException(BidiException):
     error_code = "unknown command"
 

--- a/webdriver/tests/bidi/storage/__init__.py
+++ b/webdriver/tests/bidi/storage/__init__.py
@@ -2,7 +2,7 @@ from webdriver.bidi.modules.storage import StorageKeyPartitionDescriptor
 from .. import any_int, recursive_compare
 
 
-async def assert_cookie_is_set(bidi_session, name: str, str_value: str, domain: str, origin: str):
+async def assert_cookie_is_set(bidi_session, name: str, str_value: str, domain: str, origin: str, path: str = "/"):
     """
     Asserts the cookie is set.
     """
@@ -16,7 +16,7 @@ async def assert_cookie_is_set(bidi_session, name: str, str_value: str, domain: 
         'domain': domain,
         'httpOnly': False,
         'name': name,
-        'path': '/',
+        'path': path,
         'sameSite': 'none',
         'secure': True,
         # Varies depending on the cookie name and value.

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_path.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_path.py
@@ -1,0 +1,44 @@
+import pytest
+from webdriver.bidi.modules.network import NetworkStringValue
+from webdriver.bidi.modules.storage import PartialCookie, BrowsingContextPartitionDescriptor
+from .. import assert_cookie_is_set
+
+pytestmark = pytest.mark.asyncio
+
+COOKIE_NAME = 'SOME_COOKIE_NAME'
+COOKIE_VALUE = 'SOME_COOKIE_VALUE'
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/",
+        "/some_path",
+        "/some/nested/path",
+    ]
+)
+async def test_cookie_path(bidi_session, top_context, test_page, origin, domain_value, path):
+    # Navigate to a secure context.
+    await bidi_session.browsing_context.navigate(context=top_context["context"], url=test_page, wait="complete")
+
+    source_origin = origin()
+    partition = BrowsingContextPartitionDescriptor(top_context["context"])
+
+    set_cookie_result = await bidi_session.storage.set_cookie(
+        cookie=PartialCookie(
+            name=COOKIE_NAME,
+            value=NetworkStringValue(COOKIE_VALUE),
+            domain=domain_value(),
+            path=path,
+            secure=True
+        ),
+        partition=partition)
+
+    assert set_cookie_result == {
+        'partitionKey': {
+            'sourceOrigin': source_origin
+        },
+    }
+
+    await assert_cookie_is_set(bidi_session, name=COOKIE_NAME, str_value=COOKIE_VALUE, path=path,
+                               domain=domain_value(), origin=source_origin)

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_path_invalid.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_path_invalid.py
@@ -1,0 +1,34 @@
+import pytest
+from webdriver.bidi.modules.network import NetworkStringValue
+from webdriver.bidi.modules.storage import PartialCookie, BrowsingContextPartitionDescriptor
+from .. import assert_cookie_is_set
+import webdriver.bidi.error as error
+
+pytestmark = pytest.mark.asyncio
+
+COOKIE_NAME = 'SOME_COOKIE_NAME'
+COOKIE_VALUE = 'SOME_COOKIE_VALUE'
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "no_leading_forward_slash"
+    ]
+)
+async def test_path_invalid_values(bidi_session, top_context, test_page, origin, domain_value, path):
+    # Navigate to a secure context.
+    await bidi_session.browsing_context.navigate(context=top_context["context"], url=test_page, wait="complete")
+
+    partition = BrowsingContextPartitionDescriptor(top_context["context"])
+
+    with pytest.raises(error.UnableToSetCookieException):
+        await bidi_session.storage.set_cookie(
+            cookie=PartialCookie(
+                name=COOKIE_NAME,
+                value=NetworkStringValue(COOKIE_VALUE),
+                domain=domain_value(),
+                path=path,
+                secure=True
+            ),
+            partition=partition)

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_path_invalid.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_path_invalid.py
@@ -13,6 +13,7 @@ COOKIE_VALUE = 'SOME_COOKIE_VALUE'
 @pytest.mark.parametrize(
     "path",
     [
+        ""
         "no_leading_forward_slash"
     ]
 )


### PR DESCRIPTION
Add tests for `path` cookie parameter.
* Valid values
* Invalid values

Out of scope: invalid value types.