### PR TITLE
[WebDriver BiDi] Add tests for `browsingContext.close` for `promptUnload`

### DIFF
--- a/tools/webdriver/webdriver/bidi/modules/browsing_context.py
+++ b/tools/webdriver/webdriver/bidi/modules/browsing_context.py
@@ -7,7 +7,6 @@ from .script import SerializationOptions
 from ..undefined import UNDEFINED, Undefined
 
 
-
 class ElementOptions(Dict[str, Any]):
     def __init__(self, element: Mapping[str, Any]):
         self["type"] = "element"
@@ -69,11 +68,13 @@ class BrowsingContext(BidiModule):
         return base64.b64decode(result["data"])
 
     @command
-    def close(self, context: Optional[str] = None) -> Mapping[str, Any]:
+    def close(self, context: Optional[str] = None, prompt_unload: Optional[bool] = None) -> Mapping[str, Any]:
         params: MutableMapping[str, Any] = {}
 
         if context is not None:
             params["context"] = context
+        if prompt_unload is not None:
+            params["promptUnload"] = prompt_unload
 
         return params
 

--- a/webdriver/tests/bidi/browsing_context/close/invalid.py
+++ b/webdriver/tests/bidi/browsing_context/close/invalid.py
@@ -15,6 +15,12 @@ async def test_params_context_invalid_value(bidi_session):
         await bidi_session.browsing_context.close(context="foo")
 
 
+@pytest.mark.parametrize("value", ["", 42, {}, []])
+async def test_params_prompt_unload_invalid_type(bidi_session, top_context, value):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.browsing_context.close(context=top_context["context"], prompt_unload=value)
+
+
 async def test_child_context(bidi_session, test_page_same_origin_frame, top_context):
     await bidi_session.browsing_context.navigate(
         context=top_context["context"], url=test_page_same_origin_frame, wait="complete"

--- a/webdriver/tests/bidi/browsing_context/close/invalid.py
+++ b/webdriver/tests/bidi/browsing_context/close/invalid.py
@@ -15,12 +15,6 @@ async def test_params_context_invalid_value(bidi_session):
         await bidi_session.browsing_context.close(context="foo")
 
 
-@pytest.mark.parametrize("value", ["", 42, {}, []])
-async def test_params_prompt_unload_invalid_type(bidi_session, top_context, value):
-    with pytest.raises(error.InvalidArgumentException):
-        await bidi_session.browsing_context.close(context=top_context["context"], prompt_unload=value)
-
-
 async def test_child_context(bidi_session, test_page_same_origin_frame, top_context):
     await bidi_session.browsing_context.navigate(
         context=top_context["context"], url=test_page_same_origin_frame, wait="complete"
@@ -35,3 +29,9 @@ async def test_child_context(bidi_session, test_page_same_origin_frame, top_cont
 
     with pytest.raises(error.InvalidArgumentException):
         await bidi_session.browsing_context.close(context=child_info["context"])
+
+
+@pytest.mark.parametrize("value", ["", 42, {}, []])
+async def test_params_prompt_unload_invalid_type(bidi_session, top_context, value):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.browsing_context.close(context=top_context["context"], prompt_unload=value)

--- a/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
+++ b/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
@@ -1,0 +1,80 @@
+import pytest
+import asyncio
+
+from webdriver.bidi.modules.input import Actions
+
+pytestmark = pytest.mark.asyncio
+
+USER_PROMPT_OPENED_EVENT = "browsingContext.userPromptOpened"
+
+
+@pytest.mark.parametrize("prompt_unload", [None, False])
+async def test_prompt_unload_not_triggering_dialog(bidi_session, inline, subscribe_events, top_context, prompt_unload):
+    url = inline(
+        "<script>window.addEventListener('beforeunload', event => {event.preventDefault();});</script>")
+
+    # Set up event listener to make sure the event is not automatically handle
+    await subscribe_events([USER_PROMPT_OPENED_EVENT])
+
+    await bidi_session.browsing_context.navigate(context=top_context["context"], url=url, wait="complete")
+
+    # We need to interact with the page to trigger the beforeunload event.
+    # https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#usage_notes
+    actions = Actions()
+    (
+        actions.add_pointer()
+        .pointer_move(x=0, y=0, duration=500)
+        .pointer_down(button=0)
+        .pointer_up(button=0)
+    )
+    await bidi_session.input.perform_actions(
+        actions=actions, context=top_context["context"]
+    )
+
+    await bidi_session.browsing_context.close(context=top_context["context"], prompt_unload=prompt_unload)
+
+
+async def test_prompt_unload_triggering_dialog(bidi_session, inline, subscribe_events, wait_for_event):
+    url = inline(
+        "<div>beforeunload</div><script>window.addEventListener('beforeunload', event => {event.preventDefault();});</script>")
+
+    new_context = await bidi_session.browsing_context.create(type_hint="tab")
+
+    # Set up event listener to make sure the event is not automatically handle
+    await subscribe_events([USER_PROMPT_OPENED_EVENT])
+
+    await bidi_session.browsing_context.navigate(context=new_context["context"], url=url, wait="complete")
+
+    # We need to interact with the page to trigger the beforeunload event.
+    # https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#usage_notes
+    actions = Actions()
+    (
+        actions.add_pointer()
+        .pointer_move(x=0, y=0, duration=500)
+        .pointer_down(button=0)
+        .pointer_up(button=0)
+    )
+    await bidi_session.input.perform_actions(
+        actions=actions, context=new_context["context"]
+    )
+
+    user_prompt_opened = wait_for_event(USER_PROMPT_OPENED_EVENT)
+    close_task = asyncio.create_task(
+        bidi_session.browsing_context.close(
+            context=new_context["context"], prompt_unload=True)
+    )
+
+    await user_prompt_opened
+
+    all_contexts = await bidi_session.browsing_context.get_tree()
+    assert len(all_contexts) == 2
+
+    await bidi_session.browsing_context.handle_user_prompt(
+        context=new_context["context"],
+    )
+
+    await close_task
+
+    all_contexts = await bidi_session.browsing_context.get_tree()
+
+    assert len(all_contexts) == 1

--- a/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
+++ b/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
@@ -1,7 +1,7 @@
 import pytest
 import asyncio
 
-from webdriver.bidi.modules.input import Actions
+from webdriver.bidi.modules.script import ContextTarget
 
 pytestmark = pytest.mark.asyncio
 
@@ -10,38 +10,43 @@ USER_PROMPT_OPENED_EVENT = "browsingContext.userPromptOpened"
 
 
 @pytest.mark.parametrize("prompt_unload", [None, False])
-async def test_prompt_unload_not_triggering_dialog(bidi_session, inline, subscribe_events, top_context, prompt_unload):
-    url = inline(
-        "<script>window.addEventListener('beforeunload', event => {event.preventDefault();});</script>")
+async def test_prompt_unload_not_triggering_dialog(bidi_session, subscribe_events, top_context, prompt_unload, url):
+    page_beforeunload = url(
+        "/webdriver/tests/support/html/beforeunload.html")
 
-    # Set up event listener to make sure the event is not automatically handle
+    # Set up event listener to make sure the "beforeunload" event is not emitted
     await subscribe_events([USER_PROMPT_OPENED_EVENT])
+    # Track all received browsingContext.userPromptOpened events in the events array
+    events = []
 
-    await bidi_session.browsing_context.navigate(context=top_context["context"], url=url, wait="complete")
+    async def on_event(_, data):
+        events.append(data)
+    bidi_session.add_event_listener(
+        USER_PROMPT_OPENED_EVENT, on_event)
+
+    await bidi_session.browsing_context.navigate(context=top_context["context"], url=page_beforeunload, wait="complete")
 
     # We need to interact with the page to trigger the beforeunload event.
     # https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#usage_notes
-    actions = Actions()
-    (
-        actions.add_pointer()
-        .pointer_move(x=0, y=0, duration=500)
-        .pointer_down(button=0)
-        .pointer_up(button=0)
-    )
-    await bidi_session.input.perform_actions(
-        actions=actions, context=top_context["context"]
-    )
+    await bidi_session.script.evaluate(
+        expression="document.body.click()",
+        target=ContextTarget(top_context["context"]),
+        await_promise=True,
+        user_activation=True)
 
     await bidi_session.browsing_context.close(context=top_context["context"], prompt_unload=prompt_unload)
 
+    assert events == []
 
-async def test_prompt_unload_triggering_dialog(bidi_session, inline, subscribe_events, wait_for_event):
-    url = inline(
-        "<div>beforeunload</div><script>window.addEventListener('beforeunload', event => {event.preventDefault();});</script>")
 
-    new_context = await bidi_session.browsing_context.create(type_hint="tab")
+@pytest.mark.parametrize("type_hint", ["window", "tab"])
+async def test_prompt_unload_triggering_dialog(bidi_session, url, subscribe_events, wait_for_event, type_hint):
+    page_beforeunload = url(
+        "/webdriver/tests/support/html/beforeunload.html")
 
-    # Set up event listener to make sure the event is not automatically handle
+    new_context = await bidi_session.browsing_context.create(type_hint=type_hint)
+
+    # Set up event listener to make sure the "beforeunload" event is not emitted
     await subscribe_events([USER_PROMPT_OPENED_EVENT, CONTEXT_DESTROYED_EVENT])
     user_prompt_opened = wait_for_event(USER_PROMPT_OPENED_EVENT)
 
@@ -54,20 +59,15 @@ async def test_prompt_unload_triggering_dialog(bidi_session, inline, subscribe_e
     remove_listener = bidi_session.add_event_listener(
         CONTEXT_DESTROYED_EVENT, on_event)
 
-    await bidi_session.browsing_context.navigate(context=new_context["context"], url=url, wait="complete")
+    await bidi_session.browsing_context.navigate(context=new_context["context"], url=page_beforeunload, wait="complete")
 
     # We need to interact with the page to trigger the beforeunload event.
     # https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#usage_notes
-    actions = Actions()
-    (
-        actions.add_pointer()
-        .pointer_move(x=0, y=0, duration=500)
-        .pointer_down(button=0)
-        .pointer_up(button=0)
-    )
-    await bidi_session.input.perform_actions(
-        actions=actions, context=new_context["context"]
-    )
+    await bidi_session.script.evaluate(
+        expression="document.body.click()",
+        target=ContextTarget(new_context["context"]),
+        await_promise=True,
+        user_activation=True)
 
     close_task = asyncio.create_task(
         bidi_session.browsing_context.close(
@@ -85,3 +85,8 @@ async def test_prompt_unload_triggering_dialog(bidi_session, inline, subscribe_e
     )
 
     await close_task
+
+    contexts = await bidi_session.browsing_context.get_tree()
+    assert len(contexts) == 1
+
+    assert contexts[0]["context"] != new_context["context"]

--- a/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
+++ b/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
@@ -9,8 +9,12 @@ CONTEXT_DESTROYED_EVENT = "browsingContext.contextDestroyed"
 USER_PROMPT_OPENED_EVENT = "browsingContext.userPromptOpened"
 
 
+@pytest.mark.parametrize("type_hint", ["window", "tab"])
 @pytest.mark.parametrize("prompt_unload", [None, False])
-async def test_prompt_unload_not_triggering_dialog(bidi_session, subscribe_events, top_context, prompt_unload, url):
+async def test_prompt_unload_not_triggering_dialog(bidi_session, subscribe_events, url, type_hint, prompt_unload):
+
+    new_context = await bidi_session.browsing_context.create(type_hint=type_hint)
+
     page_beforeunload = url(
         "/webdriver/tests/support/html/beforeunload.html")
 
@@ -21,22 +25,24 @@ async def test_prompt_unload_not_triggering_dialog(bidi_session, subscribe_event
 
     async def on_event(_, data):
         events.append(data)
-    bidi_session.add_event_listener(
+    remove_listener = bidi_session.add_event_listener(
         USER_PROMPT_OPENED_EVENT, on_event)
 
-    await bidi_session.browsing_context.navigate(context=top_context["context"], url=page_beforeunload, wait="complete")
+    await bidi_session.browsing_context.navigate(context=new_context["context"], url=page_beforeunload, wait="complete")
 
     # We need to interact with the page to trigger the beforeunload event.
     # https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#usage_notes
     await bidi_session.script.evaluate(
-        expression="document.body.click()",
-        target=ContextTarget(top_context["context"]),
+        expression="document.querySelector('input').click()",
+        target=ContextTarget(new_context["context"]),
         await_promise=True,
         user_activation=True)
 
-    await bidi_session.browsing_context.close(context=top_context["context"], prompt_unload=prompt_unload)
+    await bidi_session.browsing_context.close(context=new_context["context"], prompt_unload=prompt_unload)
 
     assert events == []
+
+    remove_listener()
 
 
 @pytest.mark.parametrize("type_hint", ["window", "tab"])

--- a/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
+++ b/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
@@ -46,7 +46,7 @@ async def test_prompt_unload_not_triggering_dialog(bidi_session, subscribe_event
 
 
 @pytest.mark.parametrize("type_hint", ["window", "tab"])
-async def test_prompt_unload_triggering_dialog(bidi_session, url, subscribe_events, wait_for_event, type_hint):
+async def test_prompt_unload_triggering_dialog(bidi_session, url, subscribe_events, wait_for_event, wait_for_future_safe, type_hint):
     page_beforeunload = url(
         "/webdriver/tests/support/html/beforeunload.html")
 
@@ -80,7 +80,7 @@ async def test_prompt_unload_triggering_dialog(bidi_session, url, subscribe_even
             context=new_context["context"], prompt_unload=True)
     )
 
-    await user_prompt_opened
+    await wait_for_future_safe(user_prompt_opened)
 
     # Events that come after the handling are OK
     remove_listener()

--- a/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
+++ b/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
@@ -22,19 +22,14 @@ async def test_prompt_unload_not_triggering_dialog(bidi_session, subscribe_event
     # Set up event listener to make sure the "beforeunload" event is not emitted
     await subscribe_events([USER_PROMPT_OPENED_EVENT, CONTEXT_DESTROYED_EVENT])
     # Track all received browsingContext.userPromptOpened events in the events array
-    prompt_opened_events = []
-    context_destroyed_events = []
+    events = []
 
     async def on_event(method, data):
         if method == USER_PROMPT_OPENED_EVENT:
-            prompt_opened_events.append(data)
-        if method == CONTEXT_DESTROYED_EVENT:
-            context_destroyed_events.append(data)
+            events.append(data)
 
-    remove_listener_1 = bidi_session.add_event_listener(
+    remove_listener = bidi_session.add_event_listener(
         USER_PROMPT_OPENED_EVENT, on_event)
-    remove_listener_2 = bidi_session.add_event_listener(
-        CONTEXT_DESTROYED_EVENT, on_event)
 
     await bidi_session.browsing_context.navigate(context=new_context["context"], url=page_beforeunload, wait="complete")
 
@@ -52,11 +47,9 @@ async def test_prompt_unload_not_triggering_dialog(bidi_session, subscribe_event
 
     await wait_for_future_safe(on_context_destroyed)
 
-    assert prompt_opened_events == []
-    assert len(context_destroyed_events) == 1
+    assert events == []
 
-    remove_listener_1()
-    remove_listener_2()
+    remove_listener()
 
 
 @pytest.mark.parametrize("type_hint", ["window", "tab"])

--- a/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
+++ b/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
@@ -11,8 +11,15 @@ USER_PROMPT_OPENED_EVENT = "browsingContext.userPromptOpened"
 
 @pytest.mark.parametrize("type_hint", ["window", "tab"])
 @pytest.mark.parametrize("prompt_unload", [None, False])
-async def test_prompt_unload_not_triggering_dialog(bidi_session, subscribe_events, setup_beforeunload_page,
-                                                   wait_for_event, wait_for_future_safe, type_hint, prompt_unload):
+async def test_prompt_unload_not_triggering_dialog(
+    bidi_session, 
+    subscribe_events, 
+    setup_beforeunload_page,
+    wait_for_event, 
+    wait_for_future_safe, 
+    type_hint, 
+    prompt_unload
+):
 
     new_context = await bidi_session.browsing_context.create(type_hint=type_hint)
 

--- a/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
+++ b/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
@@ -12,13 +12,13 @@ USER_PROMPT_OPENED_EVENT = "browsingContext.userPromptOpened"
 @pytest.mark.parametrize("type_hint", ["window", "tab"])
 @pytest.mark.parametrize("prompt_unload", [None, False])
 async def test_prompt_unload_not_triggering_dialog(
-    bidi_session, 
-    subscribe_events, 
+    bidi_session,
+    subscribe_events,
     setup_beforeunload_page,
-    wait_for_event, 
-    wait_for_future_safe, 
-    type_hint, 
-    prompt_unload
+    wait_for_event,
+    wait_for_future_safe,
+    type_hint,
+    prompt_unload,
 ):
 
     new_context = await bidi_session.browsing_context.create(type_hint=type_hint)
@@ -33,13 +33,16 @@ async def test_prompt_unload_not_triggering_dialog(
             events.append(data)
 
     remove_listener = bidi_session.add_event_listener(
-        USER_PROMPT_OPENED_EVENT, on_event)
+        USER_PROMPT_OPENED_EVENT, on_event
+    )
 
     await setup_beforeunload_page(new_context)
 
     on_context_destroyed = wait_for_event(CONTEXT_DESTROYED_EVENT)
 
-    await bidi_session.browsing_context.close(context=new_context["context"], prompt_unload=prompt_unload)
+    await bidi_session.browsing_context.close(
+        context=new_context["context"], prompt_unload=prompt_unload
+    )
 
     await wait_for_future_safe(on_context_destroyed)
 
@@ -49,7 +52,14 @@ async def test_prompt_unload_not_triggering_dialog(
 
 
 @pytest.mark.parametrize("type_hint", ["window", "tab"])
-async def test_prompt_unload_triggering_dialog(bidi_session, setup_beforeunload_page, subscribe_events, wait_for_event, wait_for_future_safe, type_hint):
+async def test_prompt_unload_triggering_dialog(
+    bidi_session,
+    setup_beforeunload_page,
+    subscribe_events,
+    wait_for_event,
+    wait_for_future_safe,
+    type_hint,
+):
 
     new_context = await bidi_session.browsing_context.create(type_hint=type_hint)
 
@@ -63,6 +73,7 @@ async def test_prompt_unload_triggering_dialog(bidi_session, setup_beforeunload_
     async def on_event(_, data):
         if data["type"] == CONTEXT_DESTROYED_EVENT:
             events.append(data)
+
     remove_listener = bidi_session.add_event_listener(
         CONTEXT_DESTROYED_EVENT, on_event)
 
@@ -70,7 +81,8 @@ async def test_prompt_unload_triggering_dialog(bidi_session, setup_beforeunload_
 
     close_task = asyncio.create_task(
         bidi_session.browsing_context.close(
-            context=new_context["context"], prompt_unload=True)
+            context=new_context["context"], prompt_unload=True
+        )
     )
 
     await wait_for_future_safe(user_prompt_opened)

--- a/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
+++ b/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
@@ -11,13 +11,10 @@ USER_PROMPT_OPENED_EVENT = "browsingContext.userPromptOpened"
 
 @pytest.mark.parametrize("type_hint", ["window", "tab"])
 @pytest.mark.parametrize("prompt_unload", [None, False])
-async def test_prompt_unload_not_triggering_dialog(bidi_session, subscribe_events, url, wait_for_event,
-                                                   wait_for_future_safe, type_hint, prompt_unload):
+async def test_prompt_unload_not_triggering_dialog(bidi_session, subscribe_events, setup_beforeunload_page,
+                                                   wait_for_event, wait_for_future_safe, type_hint, prompt_unload):
 
     new_context = await bidi_session.browsing_context.create(type_hint=type_hint)
-
-    page_beforeunload = url(
-        "/webdriver/tests/support/html/beforeunload.html")
 
     # Set up event listener to make sure the "beforeunload" event is not emitted
     await subscribe_events([USER_PROMPT_OPENED_EVENT, CONTEXT_DESTROYED_EVENT])
@@ -31,15 +28,7 @@ async def test_prompt_unload_not_triggering_dialog(bidi_session, subscribe_event
     remove_listener = bidi_session.add_event_listener(
         USER_PROMPT_OPENED_EVENT, on_event)
 
-    await bidi_session.browsing_context.navigate(context=new_context["context"], url=page_beforeunload, wait="complete")
-
-    # We need to interact with the page to trigger the beforeunload event.
-    # https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#usage_notes
-    await bidi_session.script.evaluate(
-        expression="document.querySelector('input').click()",
-        target=ContextTarget(new_context["context"]),
-        await_promise=True,
-        user_activation=True)
+    await setup_beforeunload_page(new_context)
 
     on_context_destroyed = wait_for_event(CONTEXT_DESTROYED_EVENT)
 
@@ -53,9 +42,7 @@ async def test_prompt_unload_not_triggering_dialog(bidi_session, subscribe_event
 
 
 @pytest.mark.parametrize("type_hint", ["window", "tab"])
-async def test_prompt_unload_triggering_dialog(bidi_session, url, subscribe_events, wait_for_event, wait_for_future_safe, type_hint):
-    page_beforeunload = url(
-        "/webdriver/tests/support/html/beforeunload.html")
+async def test_prompt_unload_triggering_dialog(bidi_session, setup_beforeunload_page, subscribe_events, wait_for_event, wait_for_future_safe, type_hint):
 
     new_context = await bidi_session.browsing_context.create(type_hint=type_hint)
 
@@ -72,15 +59,7 @@ async def test_prompt_unload_triggering_dialog(bidi_session, url, subscribe_even
     remove_listener = bidi_session.add_event_listener(
         CONTEXT_DESTROYED_EVENT, on_event)
 
-    await bidi_session.browsing_context.navigate(context=new_context["context"], url=page_beforeunload, wait="complete")
-
-    # We need to interact with the page to trigger the beforeunload event.
-    # https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#usage_notes
-    await bidi_session.script.evaluate(
-        expression="document.body.click()",
-        target=ContextTarget(new_context["context"]),
-        await_promise=True,
-        user_activation=True)
+    await setup_beforeunload_page(new_context)
 
     close_task = asyncio.create_task(
         bidi_session.browsing_context.close(


### PR DESCRIPTION
Add the scaffolding and test for `browsingContext.close` for parameter `promptUnload`. 
PR does not cover testing subframes that have `beforeunload` handlers (feature PR).