### PR TITLE
Bump sphinx to the latest version to fix CI

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,5 @@ recommonmark==0.7.1
 sphinx-argparse==0.4.0
 sphinx-autobuild==2021.3.14
 sphinx-js==3.2.2
-sphinx==4.4.0
+sphinx==7.2.6
 markupsafe==2.0.1


### PR DESCRIPTION
CI task https://github.com/web-platform-tests/wpt/actions/workflows/documentation.yml is failing with message 
"The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version." 

Updating Sphinx to the latest version to address the failure.