### PR TITLE
[lint] Ban multiple `/resources/testharness{,report}.js` for `.js` tests

### DIFF
--- a/docs/writing-tests/testharness.md
+++ b/docs/writing-tests/testharness.md
@@ -203,6 +203,9 @@ In window environments, the script will be included using a classic `<script>` t
 worker environments, the script will be imported using `importScripts()`. In module worker
 environments, the script will be imported using a static `import`.
 
+wptserve generates markup with `/resources/testharness.js` and `/resources/testharnessreport.js`
+included automatically, so there's no need to include those scripts from the `.js` test file.
+
 ### Specifying a timeout of long
 
 Use `// META: timeout=long` at the beginning of the resource.

--- a/html/cross-origin-embedder-policy/credentialless/websocket.https.window.js
+++ b/html/cross-origin-embedder-policy/credentialless/websocket.https.window.js
@@ -1,4 +1,4 @@
-// META: TIMEOUT=long
+// META: timeout=long
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
 // META: script=/common/dispatcher/dispatcher.js

--- a/performance-timeline/not-restored-reasons/abort-block-bfcache.window.js
+++ b/performance-timeline/not-restored-reasons/abort-block-bfcache.window.js
@@ -1,6 +1,4 @@
 // META: title=Aborting a parser should block bfcache
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: timeout=long
 
 

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -603,7 +603,7 @@ def check_global_metadata(value: bytes) -> Iterable[Tuple[Type[rules.Rule], Tupl
 
 
 def check_script_metadata(repo_root: Text, path: Text, f: IO[bytes]) -> List[rules.Error]:
-    if path.endswith((".worker.js", ".any.js")):
+    if path.endswith((".window.js", ".worker.js", ".any.js")):
         meta_re = js_meta_re
         broken_metadata = broken_js_metadata
     elif path.endswith(".py"):
@@ -614,7 +614,7 @@ def check_script_metadata(repo_root: Text, path: Text, f: IO[bytes]) -> List[rul
 
     done = False
     errors = []
-    for idx, line in enumerate(f):
+    for line_no, line in enumerate(f, 1):
         assert isinstance(line, bytes), line
 
         m = meta_re.match(line)
@@ -622,29 +622,32 @@ def check_script_metadata(repo_root: Text, path: Text, f: IO[bytes]) -> List[rul
             key, value = m.groups()
             if key == b"global":
                 for rule_class, context in check_global_metadata(value):
-                    errors.append(rule_class.error(path, context, idx + 1))
+                    errors.append(rule_class.error(path, context, line_no))
             elif key == b"timeout":
                 if value != b"long":
                     errors.append(rules.UnknownTimeoutMetadata.error(path,
-                                                                     line_no=idx + 1))
+                                                                     line_no=line_no))
             elif key == b"variant":
                 if is_variant_malformed(value.decode()):
                     value = f"{path} `META: variant=...` value"
-                    errors.append(rules.MalformedVariant.error(path, (value,), idx + 1))
-            elif key not in (b"title", b"script", b"quic"):
-                errors.append(rules.UnknownMetadata.error(path,
-                                                          line_no=idx + 1))
+                    errors.append(rules.MalformedVariant.error(path, (value,), line_no))
+            elif key == b"script":
+                if value == b"/resources/testharness.js":
+                    errors.append(rules.MultipleTestharness.error(path, line_no=line_no))
+                elif value == b"/resources/testharnessreport.js":
+                    errors.append(rules.MultipleTestharnessReport.error(path, line_no=line_no))
+            elif key not in (b"title", b"quic"):
+                errors.append(rules.UnknownMetadata.error(path, line_no=line_no))
         else:
             done = True
 
         if done:
             if meta_re.match(line):
-                errors.append(rules.StrayMetadata.error(path, line_no=idx + 1))
+                errors.append(rules.StrayMetadata.error(path, line_no=line_no))
             elif meta_re.search(line):
-                errors.append(rules.IndentedMetadata.error(path,
-                                                           line_no=idx + 1))
+                errors.append(rules.IndentedMetadata.error(path, line_no=line_no))
             elif broken_metadata.search(line):
-                errors.append(rules.BrokenMetadata.error(path, line_no=idx + 1))
+                errors.append(rules.BrokenMetadata.error(path, line_no=line_no))
 
     return errors
 

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -156,8 +156,10 @@ class MultipleTestharness(Rule):
     name = "MULTIPLE-TESTHARNESS"
     description = "More than one `<script src='/resources/testharness.js'>`"
     to_fix = """
-        ensure each test has only one `<script
-        src='/resources/testharnessreport.js'>` instance
+        Ensure each test has only one `<script
+        src='/resources/testharness.js'>` instance.
+        For `.js` tests, remove `// META: script=/resources/testharness.js`,
+        which wptserve already adds to the boilerplate markup.
     """
 
 
@@ -181,6 +183,12 @@ class MissingTestharnessReport(Rule):
 class MultipleTestharnessReport(Rule):
     name = "MULTIPLE-TESTHARNESSREPORT"
     description = "More than one `<script src='/resources/testharnessreport.js'>`"
+    to_fix = """
+        Ensure each test has only one `<script
+        src='/resources/testharnessreport.js'>` instance.
+        For `.js` tests, remove `// META: script=/resources/testharnessreport.js`,
+        which wptserve already adds to the boilerplate markup.
+    """
 
 
 class VariantMissing(Rule):

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -975,6 +975,8 @@ def test_css_missing_file_tentative():
     (b"""// META: foobar\n""", (1, "BROKEN-METADATA")),
     (b"""// META: foo=bar\n""", (1, "UNKNOWN-METADATA")),
     (b"""// META: timeout=bar\n""", (1, "UNKNOWN-TIMEOUT-METADATA")),
+    (b"""// META: script=/resources/testharness.js""", (1, "MULTIPLE-TESTHARNESS")),
+    (b"""// META: script=/resources/testharnessreport.js""", (1, "MULTIPLE-TESTHARNESSREPORT")),
 ])
 def test_script_metadata(filename, input, error):
     errors = check_file_contents("", filename, io.BytesIO(input))
@@ -991,6 +993,10 @@ def test_script_metadata(filename, input, error):
             "MALFORMED-VARIANT": (
                 f"{filename} `META: variant=...` value must be a non empty "
                 "string and start with '?' or '#'"),
+            "MULTIPLE-TESTHARNESS": (
+                "More than one `<script src='/resources/testharness.js'>`"),
+            "MULTIPLE-TESTHARNESSREPORT": (
+                "More than one `<script src='/resources/testharnessreport.js'>`"),
         }
         assert errors == [
             (kind,


### PR DESCRIPTION
wptserve already injects `<script src="/resources/testharness.js">` into the boilerplate markup, so `// META: script=...` to do the same is redundant and should be disallowed by `wpt lint`.

`wpt lint` should also check script metadata for `.window.js` tests. Following up on #43984, clean up this and other latent lint errors.

See Also: https://crbug.com/1518022

Closes #36071