### PR TITLE
Do not allow `::part()` with `:has()`, `:is()`, or `:where()`

### DIFF
--- a/css/selectors/parsing/parse-part.html
+++ b/css/selectors/parsing/parse-part.html
@@ -31,7 +31,9 @@
   test_invalid_selector(":part('foo')");
   test_invalid_selector(":part([foo])");
   test_invalid_selector('::part(foo) + ::part(bar)');
-  test_invalid_selector(":part(foo):is(ul)");
-  test_invalid_selector(":part(foo):is(nav ul)");
-  test_invalid_selector(":part(foo):has(li)");
+  test_invalid_selector("::part(foo):is(ul)");
+  test_invalid_selector("::part(foo):is(nav ul)");
+  test_invalid_selector("::part(foo):where(ul)");
+  test_invalid_selector("::part(foo):where(nav ul)");
+  test_invalid_selector("::part(foo):has(li)");
 </script>

--- a/css/selectors/parsing/parse-part.html
+++ b/css/selectors/parsing/parse-part.html
@@ -31,4 +31,7 @@
   test_invalid_selector(":part('foo')");
   test_invalid_selector(":part([foo])");
   test_invalid_selector('::part(foo) + ::part(bar)');
+  test_invalid_selector(":part(foo):is(ul)");
+  test_invalid_selector(":part(foo):is(nav ul)");
+  test_invalid_selector(":part(foo):has(li)");
 </script>


### PR DESCRIPTION
This adds failing tests for the following `::part()` selectors when combined with `:is()`, `:where()`, and `:has()`:

- `::part(foo):is(ul)`
- `::part(foo):is(nav ul)`
- `::part(foo):where(ul)`
- `::part(foo):where(nav ul)`
- `::part(foo):has(li)`

All of these leak information about the shadow tree that was not exposed and can cause consumer styling to break if the shadow tree changes.

Some related bugs:

- WebKit bug (fails for `:is()` and `:has()`): https://bugs.webkit.org/show_bug.cgi?id=267613
- Chromium bug (fails for `:is()`): https://bugs.chromium.org/p/chromium/issues/detail?id=1519006
