### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=267619

### DIFF
--- a/css/css-view-transitions/parsing/view-transition-name-invalid.html
+++ b/css/css-view-transitions/parsing/view-transition-name-invalid.html
@@ -12,6 +12,7 @@
 </head>
 <body>
 <script>
+test_invalid_value("view-transition-name", "auto"); // `auto` is excluded.
 test_invalid_value("view-transition-name", "default"); // `default` isn't allowed by the `<custom-ident>` syntax.
 test_invalid_value("view-transition-name", "none none");
 test_invalid_value("view-transition-name", `"none"`);


### PR DESCRIPTION
WebKit export from bug: [\[view-transitions\] `auto` is disallowed on `view-transition-name`](https://bugs.webkit.org/show_bug.cgi?id=267619)