### PR TITLE
Add `type: "json"` to JSON module parser error test

### DIFF
--- a/html/semantics/scripting-1/the-script-element/json-module-assertions/parse-error.html
+++ b/html/semantics/scripting-1/the-script-element/json-module-assertions/parse-error.html
@@ -17,5 +17,5 @@ async_test(t => {
 });
 </script>
 <script type="module">
-import v from "./parse-error.json";
+import v from "./parse-error.json" assert { type: "json" };
 </script>

--- a/html/semantics/scripting-1/the-script-element/json-module/parse-error.html
+++ b/html/semantics/scripting-1/the-script-element/json-module/parse-error.html
@@ -17,5 +17,5 @@ async_test(t => {
 });
 </script>
 <script type="module">
-import v from "./parse-error.json";
+import v from "./parse-error.json" with { type: "json" };
 </script>


### PR DESCRIPTION
Without the attribute, the import fails due to the type mismatch before even attempting to parse the file as JSON.