### PR TITLE
Generate web features manifest during release

### DIFF
--- a/tools/ci/manifest_build.py
+++ b/tools/ci/manifest_build.py
@@ -9,6 +9,9 @@ import tempfile
 
 import requests
 
+from pathlib import Path
+
+
 here = os.path.abspath(os.path.dirname(__file__))
 wpt_root = os.path.abspath(os.path.join(here, os.pardir, os.pardir))
 
@@ -37,6 +40,10 @@ def run(cmd, return_stdout=False, **kwargs):
 
 def create_manifest(path):
     run(["./wpt", "manifest", "-p", path])
+
+
+def create_web_feature_manifest(path):
+    run(["./wpt", "web-features-manifest", "-p", path])
 
 
 def compress_manifest(path):
@@ -108,7 +115,20 @@ def get_pr(owner, repo, sha):
     return pr["number"]
 
 
-def create_release(manifest_path, owner, repo, sha, tag, body):
+def get_file_upload_details(manifest_path, sha):
+    """
+    For a given file, generate details used to upload to GitHub.
+    """
+    path = Path(manifest_path)
+    stem = path.stem
+    extension = path.suffix
+    upload_filename_prefix = f"{stem}-{sha}{extension}"
+    upload_label_prefix = path.name
+    upload_desc = f"{stem.title()} upload"
+    return upload_filename_prefix, upload_label_prefix, upload_desc
+
+
+def create_release(manifest_file_paths, owner, repo, sha, tag, body):
     logger.info(f"Creating a release for tag='{tag}', target_commitish='{sha}'")
     create_url = f"https://api.github.com/repos/{owner}/{repo}/releases"
     create_data = {"tag_name": tag,
@@ -124,20 +144,22 @@ def create_release(manifest_path, owner, repo, sha, tag, body):
     upload_url = create_resp["upload_url"].split("{", 1)[0]
 
     upload_exts = [".gz", ".bz2", ".zst"]
-    for upload_ext in upload_exts:
-        upload_filename = f"MANIFEST-{sha}.json{upload_ext}"
-        params = {"name": upload_filename,
-                  "label": "MANIFEST.json%s" % upload_ext}
+    for manifest_path in manifest_file_paths:
+        upload_filename_prefix, upload_label_prefix, upload_desc = get_file_upload_details(manifest_path, sha)
+        for upload_ext in upload_exts:
+            upload_filename = f"{upload_filename_prefix}{upload_ext}"
+            params = {"name": upload_filename,
+                    "label": f"{upload_label_prefix}{upload_ext}%s"}
 
-        with open(f"{manifest_path}{upload_ext}", "rb") as f:
-            upload_data = f.read()
+            with open(f"{manifest_path}{upload_ext}", "rb") as f:
+                upload_data = f.read()
 
-        logger.info("Uploading %s bytes" % len(upload_data))
+            logger.info("Uploading %s bytes" % len(upload_data))
 
-        upload_resp = request(upload_url, "Manifest upload", data=upload_data, params=params,
-                              headers={'Content-Type': 'application/octet-stream'})
-        if not upload_resp:
-            return False
+            upload_resp = request(upload_url, upload_desc, data=upload_data, params=params,
+                                headers={'Content-Type': 'application/octet-stream'})
+            if not upload_resp:
+                return False
 
     release_id = create_resp["id"]
     edit_url = f"https://api.github.com/repos/{owner}/{repo}/releases/{release_id}"
@@ -169,10 +191,13 @@ def main():
     dry_run = should_dry_run()
 
     manifest_path = os.path.join(tempfile.mkdtemp(), "MANIFEST.json")
+    web_features_manifest_path = os.path.join(tempfile.mkdtemp(), "WEB_FEATURES_MANIFEST.json")
 
     create_manifest(manifest_path)
+    create_web_feature_manifest(web_features_manifest_path)
 
     compress_manifest(manifest_path)
+    compress_manifest(web_features_manifest_path)
 
     owner, repo = os.environ["GITHUB_REPOSITORY"].split("/", 1)
 
@@ -188,7 +213,8 @@ def main():
         return Status.FAIL
     tag_name = "merge_pr_%s" % pr
 
-    if not create_release(manifest_path, owner, repo, head_rev, tag_name, body):
+    manifest_paths = [manifest_path, web_features_manifest_path]
+    if not create_release(manifest_paths, owner, repo, head_rev, tag_name, body):
         return Status.FAIL
 
     return Status.SUCCESS


### PR DESCRIPTION
Prior to this commit, a single manifest file was created and then uploaded to a GitHub release. Now, the web-features manifest file is also created and uploaded alongside the existing manifest file

This PR should be merged after #43828