### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=242685

### DIFF
--- a/html-aam/roles-contextual.html
+++ b/html-aam/roles-contextual.html
@@ -40,6 +40,9 @@
   <header data-testname="el-header" aria-label="x" class="ex-generic">x</header>
 </nav>
 <header data-testname="el-header-ancestorbody" data-expectedrole="banner" class="ex">x</header>
+<main>
+  <header data-testname="el-header-ancestormain" data-expectedrole="generic" class="ex-generic">x</header>
+</main>
 
 <!-- el-section -->
 <section data-testname="el-section" aria-label="x" data-expectedrole="region" class="ex">x</section>


### PR DESCRIPTION
WebKit export from bug: [AX: Header elements inside main elements should not be banner landmarks](https://bugs.webkit.org/show_bug.cgi?id=242685)