### PR TITLE
Fix GitHub Asset label generation

### DIFF
--- a/tools/ci/manifest_build.py
+++ b/tools/ci/manifest_build.py
@@ -149,7 +149,7 @@ def create_release(manifest_file_paths, owner, repo, sha, tag, body):
         for upload_ext in upload_exts:
             upload_filename = f"{upload_filename_prefix}{upload_ext}"
             params = {"name": upload_filename,
-                    "label": f"{upload_label_prefix}{upload_ext}%s"}
+                    "label": f"{upload_label_prefix}{upload_ext}"}
 
             with open(f"{manifest_path}{upload_ext}", "rb") as f:
                 upload_data = f.read()


### PR DESCRIPTION
In https://github.com/web-platform-tests/wpt/pull/44078, the label generation was changed from %s to f string. A left over %s was still present.

This fixes that. Check this [release](https://github.com/web-platform-tests/wpt/releases/tag/merge_pr_44078) for how it appears currently 