### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=267803

### DIFF
--- a/css/selectors/parsing/invalid-pseudos.html
+++ b/css/selectors/parsing/invalid-pseudos.html
@@ -8,6 +8,7 @@
 <script src="../../support/parsing-testcommon.js"></script>
 <script>
 // Pseudo-classes
+test_invalid_selector(":-internal-animating-full-screen-transition");
 test_invalid_selector(":-internal-html-document");
 
 // Pseudo-elements


### PR DESCRIPTION
WebKit export from bug: [Make `:-webkit-animating-full-screen-transition` an internal pseudo-class](https://bugs.webkit.org/show_bug.cgi?id=267803)