### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=267805

### DIFF
--- a/css/selectors/parsing/invalid-pseudos.html
+++ b/css/selectors/parsing/invalid-pseudos.html
@@ -10,6 +10,8 @@
 // Pseudo-classes
 test_invalid_selector(":-internal-animating-full-screen-transition");
 test_invalid_selector(":-internal-html-document");
+test_invalid_selector(":-khtml-drag");
+test_invalid_selector(":-webkit-animating-full-screen-transition");
 
 // Pseudo-elements
 test_invalid_selector("::-apple-attachment-controls-container");


### PR DESCRIPTION
WebKit export from bug: [Remove `:-khtml-drag` pseudo-class alias](https://bugs.webkit.org/show_bug.cgi?id=267805)