### PR TITLE
test: clean up cookies

### DIFF
--- a/tools/webdriver/webdriver/bidi/error.py
+++ b/tools/webdriver/webdriver/bidi/error.py
@@ -91,6 +91,10 @@ class UnableToSetCookieException(BidiException):
     error_code = "unable to set cookie"
 
 
+class UnderspecifiedStoragePartitionException(BidiException):
+    error_code = "underspecified storage partition"
+
+
 class UnknownCommandException(BidiException):
     error_code = "unknown command"
 

--- a/tools/webdriver/webdriver/bidi/modules/storage.py
+++ b/tools/webdriver/webdriver/bidi/modules/storage.py
@@ -62,6 +62,10 @@ class Storage(BidiModule):
             cookie: PartialCookie,
             partition: Optional[PartitionDescriptor] = None
     ) -> Mapping[str, Any]:
+        """
+        Use with caution: this command will not clean the cookie up after the test is done, which can lead to unexpected
+        test failures. Use `set_cookie` fixture instead.
+        """
         params: MutableMapping[str, Any] = {
             "cookie": cookie
         }

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_domain.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_domain.py
@@ -12,8 +12,8 @@ pytestmark = pytest.mark.asyncio
         ("alt", ""),
         ("alt", "www"),
     ])
-async def test_cookie_domain(bidi_session, test_page, domain_value, domain_key, subdomain_key):
+async def test_cookie_domain(bidi_session, set_cookie, test_page, domain_value, domain_key, subdomain_key):
     domain = domain_value(domain_key, subdomain_key)
 
-    await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain))
+    await set_cookie(cookie=create_cookie(domain=domain))
     await assert_cookie_is_set(bidi_session, domain=domain)

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_expiry.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_expiry.py
@@ -6,8 +6,8 @@ import time
 pytestmark = pytest.mark.asyncio
 
 
-async def test_cookie_expiry_unset(bidi_session, test_page, domain_value):
-    set_cookie_result = await bidi_session.storage.set_cookie(
+async def test_cookie_expiry_unset(bidi_session, set_cookie, test_page, domain_value):
+    set_cookie_result = await set_cookie(
         cookie=create_cookie(
             domain=domain_value(),
             expiry=None))
@@ -19,11 +19,11 @@ async def test_cookie_expiry_unset(bidi_session, test_page, domain_value):
     await assert_cookie_is_set(bidi_session, expiry=None, domain=domain_value())
 
 
-async def test_cookie_expiry_future(bidi_session, test_page, domain_value):
+async def test_cookie_expiry_future(bidi_session, set_cookie, test_page, domain_value):
     tomorrow = datetime.now() + timedelta(1)
     tomorrow_timestamp = time.mktime(tomorrow.timetuple())
 
-    set_cookie_result = await bidi_session.storage.set_cookie(
+    set_cookie_result = await set_cookie(
         cookie=create_cookie(
             domain=domain_value(),
             expiry=tomorrow_timestamp))
@@ -35,11 +35,11 @@ async def test_cookie_expiry_future(bidi_session, test_page, domain_value):
     await assert_cookie_is_set(bidi_session, expiry=tomorrow_timestamp, domain=domain_value())
 
 
-async def test_cookie_expiry_past(bidi_session, test_page, domain_value):
+async def test_cookie_expiry_past(bidi_session, set_cookie, test_page, domain_value):
     yesterday = datetime.now() - timedelta(1)
     yesterday_timestamp = time.mktime(yesterday.timetuple())
 
-    set_cookie_result = await bidi_session.storage.set_cookie(
+    set_cookie_result = await set_cookie(
         cookie=create_cookie(
             domain=domain_value(),
             expiry=yesterday_timestamp))

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_http_only.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_http_only.py
@@ -11,8 +11,8 @@ pytestmark = pytest.mark.asyncio
         False,
         None
     ])
-async def test_cookie_http_only(bidi_session, test_page, domain_value, http_only):
-    set_cookie_result = await bidi_session.storage.set_cookie(
+async def test_cookie_http_only(bidi_session, set_cookie, test_page, domain_value, http_only):
+    set_cookie_result = await set_cookie(
         cookie=create_cookie(domain=domain_value(), http_only=http_only))
 
     assert set_cookie_result == {

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_name.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_name.py
@@ -11,6 +11,6 @@ pytestmark = pytest.mark.asyncio
         "cookie name with special symbols !@#$%&*()_+-{}[]|\\:\"'<>,.?/`~",
         "123cookie",
     ])
-async def test_cookie_name(bidi_session, test_page, domain_value, name):
-    await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value(), name=name))
+async def test_cookie_name(bidi_session, set_cookie, test_page, domain_value, name):
+    await set_cookie(cookie=create_cookie(domain=domain_value(), name=name))
     await assert_cookie_is_set(bidi_session, name=name, domain=domain_value())

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_path.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_path.py
@@ -13,8 +13,8 @@ pytestmark = pytest.mark.asyncio
         None
     ]
 )
-async def test_cookie_path(bidi_session, test_page, domain_value, path):
-    set_cookie_result = await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value(), path=path))
+async def test_cookie_path(bidi_session, test_page, set_cookie, domain_value, path):
+    set_cookie_result = await set_cookie(cookie=create_cookie(domain=domain_value(), path=path))
 
     assert set_cookie_result == {
         'partitionKey': {},

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_same_site.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_same_site.py
@@ -13,8 +13,8 @@ pytestmark = pytest.mark.asyncio
         None
     ]
 )
-async def test_cookie_secure(bidi_session, test_page, domain_value, same_site):
-    set_cookie_result = await bidi_session.storage.set_cookie(
+async def test_cookie_secure(bidi_session, set_cookie, test_page, domain_value, same_site):
+    set_cookie_result = await set_cookie(
         cookie=create_cookie(domain=domain_value(), same_site=same_site))
 
     assert set_cookie_result == {

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_secure.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_secure.py
@@ -12,8 +12,8 @@ pytestmark = pytest.mark.asyncio
         None
     ]
 )
-async def test_cookie_secure(bidi_session, test_page, domain_value, secure):
-    set_cookie_result = await bidi_session.storage.set_cookie(
+async def test_cookie_secure(bidi_session, set_cookie, test_page, domain_value, secure):
+    set_cookie_result = await set_cookie(
         cookie=create_cookie(domain=domain_value(), secure=secure))
 
     assert set_cookie_result == {

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_value.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_value.py
@@ -11,10 +11,10 @@ pytestmark = pytest.mark.asyncio
         "simple_value",
         "special_symbols =!@#$%^&*()_+-{}[]|\\:\"'<>,.?/`~"
     ])
-async def test_cookie_value_string(bidi_session, test_page, domain_value, str_value):
+async def test_cookie_value_string(bidi_session, set_cookie, test_page, domain_value, str_value):
     value = NetworkStringValue(str_value)
 
-    await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value(), value=value))
+    await set_cookie(cookie=create_cookie(domain=domain_value(), value=value))
     await assert_cookie_is_set(bidi_session, value=value, domain=domain_value())
 
 # TODO: test `test_cookie_value_base64`.

--- a/webdriver/tests/bidi/storage/set_cookie/invalid.py
+++ b/webdriver/tests/bidi/storage/set_cookie/invalid.py
@@ -8,21 +8,21 @@ pytestmark = pytest.mark.asyncio
 
 
 @pytest.mark.parametrize("domain", [None, False, 42, {}, []])
-async def test_cookie_domain_invalid_type(bidi_session, test_page, domain):
+async def test_cookie_domain_invalid_type(set_cookie, test_page, domain):
     with pytest.raises(error.InvalidArgumentException):
-        await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain))
+        await set_cookie(cookie=create_cookie(domain=domain))
 
 
 @pytest.mark.parametrize("expiry", [False, "SOME_STRING_VALUE", {}, []])
-async def test_cookie_expiry_invalid_type(bidi_session, test_page, domain_value, expiry):
+async def test_cookie_expiry_invalid_type(set_cookie, test_page, domain_value, expiry):
     with pytest.raises(error.InvalidArgumentException):
-        await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value(), expiry=expiry))
+        await set_cookie(cookie=create_cookie(domain=domain_value(), expiry=expiry))
 
 
 @pytest.mark.parametrize("http_only", [42, "SOME_STRING_VALUE", {}, []])
-async def test_cookie_http_only_invalid_type(bidi_session, test_page, domain_value, http_only):
+async def test_cookie_http_only_invalid_type(set_cookie, test_page, domain_value, http_only):
     with pytest.raises(error.InvalidArgumentException):
-        await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value(), http_only=http_only))
+        await set_cookie(cookie=create_cookie(domain=domain_value(), http_only=http_only))
 
 
 @pytest.mark.parametrize(
@@ -36,15 +36,15 @@ async def test_cookie_http_only_invalid_type(bidi_session, test_page, domain_val
         "cookie\x0Fname",
         "cookie;name",
     ])
-async def test_cookie_name_invalid_value(bidi_session, test_page, domain_value, name):
+async def test_cookie_name_invalid_value(set_cookie, test_page, domain_value, name):
     with pytest.raises(error.UnableToSetCookieException):
-        await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value(), name=name))
+        await set_cookie(cookie=create_cookie(domain=domain_value(), name=name))
 
 
 @pytest.mark.parametrize("name", [None, False, 42, {}, []])
-async def test_cookie_name_invalid_type(bidi_session, test_page, domain_value, name):
+async def test_cookie_name_invalid_type(set_cookie, test_page, domain_value, name):
     with pytest.raises(error.InvalidArgumentException):
-        await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value(), name=name))
+        await set_cookie(cookie=create_cookie(domain=domain_value(), name=name))
 
 
 @pytest.mark.parametrize(
@@ -54,41 +54,41 @@ async def test_cookie_name_invalid_type(bidi_session, test_page, domain_value, n
         "no_leading_forward_slash"
     ]
 )
-async def test_cookie_path_invalid_value(bidi_session, test_page, domain_value, path):
+async def test_cookie_path_invalid_value(set_cookie, test_page, domain_value, path):
     with pytest.raises(error.UnableToSetCookieException):
-        await bidi_session.storage.set_cookie(
+        await set_cookie(
             cookie=create_cookie(domain=domain_value(), path=path))
 
 
 @pytest.mark.parametrize("path", [False, 42, {}, []])
-async def test_cookie_path_invalid_type(bidi_session, test_page, domain_value, path):
+async def test_cookie_path_invalid_type(set_cookie, test_page, domain_value, path):
     with pytest.raises(error.InvalidArgumentException):
-        await bidi_session.storage.set_cookie(
+        await set_cookie(
             cookie=create_cookie(domain=domain_value(), path=path))
 
 
 @pytest.mark.parametrize("same_site", ["", "INVALID_SAME_SITE_STATE"])
-async def test_cookie_same_site_invalid_value(bidi_session, test_page, domain_value, same_site):
+async def test_cookie_same_site_invalid_value(set_cookie, test_page, domain_value, same_site):
     with pytest.raises(error.InvalidArgumentException):
-        await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value(), same_site=same_site))
+        await set_cookie(cookie=create_cookie(domain=domain_value(), same_site=same_site))
 
 
 @pytest.mark.parametrize("same_site", [42, False, {}, []])
-async def test_cookie_same_site_invalid_type(bidi_session, test_page, domain_value, same_site):
+async def test_cookie_same_site_invalid_type(set_cookie, test_page, domain_value, same_site):
     with pytest.raises(error.InvalidArgumentException):
-        await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value(), same_site=same_site))
+        await set_cookie(cookie=create_cookie(domain=domain_value(), same_site=same_site))
 
 
 @pytest.mark.parametrize("secure", [42, "SOME_STRING_VALUE", {}, []])
-async def test_cookie_secure_invalid_type(bidi_session, test_page, domain_value, secure):
+async def test_cookie_secure_invalid_type(set_cookie, test_page, domain_value, secure):
     with pytest.raises(error.InvalidArgumentException):
-        await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value(), secure=secure))
+        await set_cookie(cookie=create_cookie(domain=domain_value(), secure=secure))
 
 
 @pytest.mark.parametrize("value", [None, False, 42, "SOME_STRING_VALUE", {}, {"type": "SOME_INVALID_TYPE"}, []])
-async def test_cookie_value_invalid_type(bidi_session, test_page, domain_value, value):
+async def test_cookie_value_invalid_type(set_cookie, test_page, domain_value, value):
     with pytest.raises(error.InvalidArgumentException):
-        await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value(), value=value))
+        await set_cookie(cookie=create_cookie(domain=domain_value(), value=value))
 
 
 @pytest.mark.parametrize(
@@ -98,58 +98,58 @@ async def test_cookie_value_invalid_type(bidi_session, test_page, domain_value, 
         "value\nwith\nnewline",
         "value;with;semicolon",
     ])
-async def test_cookie_value_string_invalid_value(bidi_session, test_page, domain_value, str_value):
+async def test_cookie_value_string_invalid_value(set_cookie, test_page, domain_value, str_value):
     value = NetworkStringValue(str_value)
 
     with pytest.raises(error.UnableToSetCookieException):
-        await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value(), value=value))
+        await set_cookie(cookie=create_cookie(domain=domain_value(), value=value))
 
 
 @pytest.mark.parametrize("str_value", [None, False, 42, {}, []])
-async def test_cookie_value_string_invalid_type(bidi_session, test_page, domain_value, str_value):
+async def test_cookie_value_string_invalid_type(set_cookie, test_page, domain_value, str_value):
     value = NetworkStringValue(str_value)
 
     with pytest.raises(error.InvalidArgumentException):
-        await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value(), value=value))
+        await set_cookie(cookie=create_cookie(domain=domain_value(), value=value))
 
 
 @pytest.mark.parametrize("partition", [42, False, "SOME_STRING_VALUE", {}, {"type": "SOME_INVALID_TYPE"}, []])
-async def test_partition_invalid_type(bidi_session, test_page, domain_value, partition):
+async def test_partition_invalid_type(set_cookie, test_page, domain_value, partition):
     with pytest.raises(error.InvalidArgumentException):
-        await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value()), partition=partition)
+        await set_cookie(cookie=create_cookie(domain=domain_value()), partition=partition)
 
 
 @pytest.mark.parametrize("browsing_context", [None, 42, False, {}, []])
-async def test_partition_context_invalid_type(bidi_session, test_page, origin, domain_value, browsing_context):
+async def test_partition_context_invalid_type(set_cookie, test_page, origin, domain_value, browsing_context):
     partition = BrowsingContextPartitionDescriptor(browsing_context)
 
     with pytest.raises(error.InvalidArgumentException):
-        await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value()), partition=partition)
+        await set_cookie(cookie=create_cookie(domain=domain_value()), partition=partition)
 
 
-async def test_partition_context_unknown(bidi_session, test_page, origin, domain_value):
+async def test_partition_context_unknown(set_cookie, test_page, origin, domain_value):
     partition = BrowsingContextPartitionDescriptor("UNKNOWN_CONTEXT")
 
     with pytest.raises(error.NoSuchFrameException):
-        await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value()), partition=partition)
+        await set_cookie(cookie=create_cookie(domain=domain_value()), partition=partition)
 
 
 @pytest.mark.parametrize("source_origin", [42, False, {}, []])
-async def test_partition_storage_key_source_origin_invalid_type(bidi_session, test_page, origin, domain_value,
+async def test_partition_storage_key_source_origin_invalid_type(set_cookie, test_page, origin, domain_value,
                                                                 source_origin):
     partition = StorageKeyPartitionDescriptor(source_origin=source_origin)
 
     with pytest.raises(error.InvalidArgumentException):
-        await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value()), partition=partition)
+        await set_cookie(cookie=create_cookie(domain=domain_value()), partition=partition)
 
 
 @pytest.mark.parametrize("user_context", [42, False, {}, []])
-async def test_partition_storage_key_user_context_invalid_type(bidi_session, test_page, origin, domain_value,
+async def test_partition_storage_key_user_context_invalid_type(set_cookie, test_page, origin, domain_value,
                                                                user_context):
     partition = StorageKeyPartitionDescriptor(user_context=user_context)
 
     with pytest.raises(error.InvalidArgumentException):
-        await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value()), partition=partition)
+        await set_cookie(cookie=create_cookie(domain=domain_value()), partition=partition)
 
 # TODO: test `test_cookie_domain_invalid_value`.
 # TODO: test `test_partition_storage_key_user_context_unknown`.

--- a/webdriver/tests/bidi/storage/set_cookie/page_protocols.py
+++ b/webdriver/tests/bidi/storage/set_cookie/page_protocols.py
@@ -11,8 +11,8 @@ pytestmark = pytest.mark.asyncio
         "https",
     ]
 )
-async def test_page_protocols(bidi_session, get_test_page, domain_value, protocol):
-    set_cookie_result = await bidi_session.storage.set_cookie(cookie=create_cookie(domain=domain_value()))
+async def test_page_protocols(bidi_session, set_cookie, get_test_page, domain_value, protocol):
+    set_cookie_result = await set_cookie(cookie=create_cookie(domain=domain_value()))
 
     assert set_cookie_result == {
         'partitionKey': {},

--- a/webdriver/tests/bidi/storage/set_cookie/page_protocols.py
+++ b/webdriver/tests/bidi/storage/set_cookie/page_protocols.py
@@ -1,4 +1,5 @@
 import pytest
+from urllib.parse import urlparse
 from .. import assert_cookie_is_set, create_cookie
 
 pytestmark = pytest.mark.asyncio
@@ -11,12 +12,14 @@ pytestmark = pytest.mark.asyncio
         "https",
     ]
 )
-async def test_page_protocols(bidi_session, set_cookie, get_test_page, domain_value, protocol):
-    set_cookie_result = await set_cookie(cookie=create_cookie(domain=domain_value()))
+async def test_page_protocols(bidi_session, set_cookie, get_test_page, protocol):
+    url = get_test_page(protocol=protocol)
+    domain = urlparse(url).hostname
+    set_cookie_result = await set_cookie(cookie=create_cookie(domain=domain))
 
     assert set_cookie_result == {
         'partitionKey': {},
     }
 
     # Assert the cookie is actually set.
-    await assert_cookie_is_set(bidi_session, domain=domain_value())
+    await assert_cookie_is_set(bidi_session, domain=domain)

--- a/webdriver/tests/bidi/storage/set_cookie/partition.py
+++ b/webdriver/tests/bidi/storage/set_cookie/partition.py
@@ -5,13 +5,13 @@ from .. import assert_cookie_is_set, create_cookie
 pytestmark = pytest.mark.asyncio
 
 
-async def test_partition_context(bidi_session, top_context, test_page, origin, domain_value):
+async def test_partition_context(bidi_session, set_cookie, top_context, test_page, origin, domain_value):
     await bidi_session.browsing_context.navigate(context=top_context["context"], url=test_page, wait="complete")
 
     source_origin = origin()
     partition = BrowsingContextPartitionDescriptor(top_context["context"])
 
-    set_cookie_result = await bidi_session.storage.set_cookie(
+    set_cookie_result = await set_cookie(
         cookie=create_cookie(domain=domain_value()),
         partition=partition)
 
@@ -24,7 +24,7 @@ async def test_partition_context(bidi_session, top_context, test_page, origin, d
     await assert_cookie_is_set(bidi_session, domain=domain_value(), partition=partition)
 
 
-async def test_partition_context_frame(bidi_session, top_context, test_page, origin, domain_value,
+async def test_partition_context_frame(bidi_session, set_cookie, top_context, test_page, origin, domain_value,
                                        inline, test_page_cross_origin_frame):
     frame_url = inline("<div>bar</div>", domain="alt")
     frame_source_origin = origin(domain="alt")
@@ -42,7 +42,7 @@ async def test_partition_context_frame(bidi_session, top_context, test_page, ori
 
     partition = BrowsingContextPartitionDescriptor(frame_context_id)
 
-    set_cookie_result = await bidi_session.storage.set_cookie(
+    set_cookie_result = await set_cookie(
         cookie=create_cookie(domain=domain_value()),
         partition=partition)
 
@@ -55,11 +55,11 @@ async def test_partition_context_frame(bidi_session, top_context, test_page, ori
     await assert_cookie_is_set(bidi_session, domain=domain_value(), partition=partition)
 
 
-async def test_partition_storage_key_source_origin(bidi_session, test_page, origin, domain_value):
+async def test_partition_storage_key_source_origin(bidi_session, set_cookie, test_page, origin, domain_value):
     source_origin = origin()
     partition = StorageKeyPartitionDescriptor(source_origin=source_origin)
 
-    set_cookie_result = await bidi_session.storage.set_cookie(
+    set_cookie_result = await set_cookie(
         cookie=create_cookie(domain=domain_value()),
         partition=partition)
 

--- a/webdriver/tests/support/fixtures_bidi.py
+++ b/webdriver/tests/support/fixtures_bidi.py
@@ -5,8 +5,11 @@ from tests.support.image import cm_to_px, png_dimensions, ImageDifference
 from typing import Any, Coroutine, Mapping
 
 import asyncio
+import copy
+from datetime import datetime, timedelta
 import pytest
 import pytest_asyncio
+import time
 from webdriver.bidi.error import (
     InvalidArgumentException,
     NoSuchFrameException,
@@ -55,6 +58,39 @@ async def subscribe_events(bidi_session):
             await bidi_session.session.unsubscribe(events=events,
                                                    contexts=contexts)
         except (InvalidArgumentException, NoSuchFrameException):
+            pass
+
+
+@pytest_asyncio.fixture
+async def set_cookie(bidi_session):
+    """
+    Set a cookie and remove them after the test is finished.
+    """
+    cookies = []
+
+    async def set_cookie(cookie, partition=None):
+        partition_descriptor = None
+        set_cookie_result = await bidi_session.storage.set_cookie(cookie=cookie, partition=partition)
+        if set_cookie_result["partitionKey"] != {}:
+            # Make a copy of the partition key, as the original dict is used for assertion.
+            partition_descriptor = copy.deepcopy(set_cookie_result["partitionKey"])
+            partition_descriptor["type"] = "storageKey"
+        # Store the cookie partition to remove the cookie after the test.
+        # The requested partition can be a browsing context, so the returned partition descriptor (it's always of type
+        # "storageKey") is used.
+        cookies.append((copy.deepcopy(cookie), partition_descriptor))
+        return set_cookie_result
+
+    yield set_cookie
+
+    yesterday = datetime.now() - timedelta(1)
+    yesterday_timestamp = time.mktime(yesterday.timetuple())
+
+    for cookie, partition in reversed(cookies):
+        try:
+            cookie["expiry"] = yesterday_timestamp
+            await bidi_session.storage.set_cookie(cookie=cookie, partition=partition)
+        except (InvalidArgumentException, UnableToSetCookieException, UnderspecifiedStoragePartitionException):
             pass
 
 

--- a/webdriver/tests/support/fixtures_bidi.py
+++ b/webdriver/tests/support/fixtures_bidi.py
@@ -14,6 +14,8 @@ from webdriver.bidi.error import (
     InvalidArgumentException,
     NoSuchFrameException,
     NoSuchScriptException,
+    UnableToSetCookieException,
+    UnderspecifiedStoragePartitionException
 )
 from webdriver.bidi.modules.script import ContextTarget
 from webdriver.error import TimeoutException


### PR DESCRIPTION
Clean up set cookies after each test run to avoid collisions. Used the same pattern as in [`subscribe_events`](https://github.com/web-platform-tests/wpt/blob/8987e793e327d74d4dac29cb19cda18d2ac2f4f8/webdriver/tests/support/fixtures_bidi.py#L44).