### PR TITLE
[wptrunner] Add results for expected subtests that didn't run

### DIFF
--- a/infrastructure/metadata/infrastructure/server/secure-context.https.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/secure-context.https.any.js.ini
@@ -1,6 +1,0 @@
-[secure-context.https.any.sharedworker.html]
-
-[secure-context.https.any.serviceworker.html]
-  [secure-context]
-    expected:
-      if product == "epiphany" or product == "webkit": FAIL # https://bugs.webkit.org/show_bug.cgi?id=200815

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -265,6 +265,13 @@ class Test(ABC):
         return tuple()
 
     @property
+    def subtests(self):
+        """Get all subtests explicitly listed in the test metadata."""
+        if not self._test_metadata:
+            return frozenset()
+        return frozenset(self._test_metadata.subtests)
+
+    @property
     def abs_path(self):
         return os.path.join(self.tests_root, self.path)
 


### PR DESCRIPTION
This feature allows Chromium CI to [fail builds][0] for changes that forget to clean up expectations for deleted or renamed subtests. Subtest validity cannot be checked statically.

Assuming `infrastructure/metadata/**/*.ini` are not stale, this change has no effect on WPT CI or non-Chrome browser testing.

Closes #43499

[0]: https://ci.chromium.org/ui/p/chromium/builders/try/linux-rel/1678090/overview