### PR TITLE
Ensure focus-large-element-in-overflow-hidden-container passes

### DIFF
--- a/focus/focus-large-element-in-overflow-hidden-container.html
+++ b/focus/focus-large-element-in-overflow-hidden-container.html
@@ -41,8 +41,8 @@
   left:             0;
   bottom:           0;
   background-color: red;
-  height:           5px;
-  width:            5px;
+  height:           3px;
+  width:            3px;
 }
 </style>
 </head>


### PR DESCRIPTION
Reduce the error rectangle size such that it still fails in the scroll case, but passes with the reduced focus border size of chrome.

See [bug 1858984 comment 22](https://bugzilla.mozilla.org/show_bug.cgi?id=1858984#c22)