### PR TITLE
[wptrunner] Add option to skip subtest checks for incomplete tests

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -7,11 +7,11 @@ from .base import get_timeout_multiplier   # noqa: F401
 from .base import cmd_arg
 from ..executors import executor_kwargs as base_executor_kwargs
 from ..executors.executorwebdriver import WebDriverCrashtestExecutor  # noqa: F401
-from ..executors.base import WdspecExecutor  # noqa: F401
 from ..executors.executorchrome import (  # noqa: F401
     ChromeDriverPrintRefTestExecutor,
     ChromeDriverRefTestExecutor,
     ChromeDriverTestharnessExecutor,
+    ChromeDriverWdspecExecutor,
 )
 
 
@@ -21,7 +21,7 @@ __wptrunner__ = {"product": "chrome",
                  "executor": {"testharness": "ChromeDriverTestharnessExecutor",
                               "reftest": "ChromeDriverRefTestExecutor",
                               "print-reftest": "ChromeDriverPrintRefTestExecutor",
-                              "wdspec": "WdspecExecutor",
+                              "wdspec": "ChromeDriverWdspecExecutor",
                               "crashtest": "WebDriverCrashtestExecutor"},
                  "browser_kwargs": "browser_kwargs",
                  "executor_kwargs": "executor_kwargs",
@@ -63,6 +63,7 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     executor_kwargs["close_after_done"] = True
     executor_kwargs["sanitizer_enabled"] = sanitizer_enabled
     executor_kwargs["reuse_window"] = kwargs.get("reuse_window", False)
+    executor_kwargs["check_incomplete_subtests"] = kwargs["check_incomplete_subtests"]
 
     capabilities = {
         "goog:chromeOptions": {

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -383,6 +383,11 @@ scheme host and port.""")
         dest="sanitizer_enabled",
         help="Only alert on sanitizer-related errors and crashes.")
     chrome_group.add_argument(
+        "--no-check-incomplete-subtests",
+        action="store_false",
+        dest="check_incomplete_subtests",
+        help="Do not check or report subtest results for tests that time out or crash.")
+    chrome_group.add_argument(
         "--reuse-window",
         action="store_true",
         help=("Reuse a window across `testharness.js` tests where possible, "


### PR DESCRIPTION
Some testharness/wdspec tests can racily time out on different subtests between runs, which makes writing stable subtest `TIMEOUT` and `NOTRUN` expectations that won't flake difficult.

`--no-check-incomplete-subtests` discards subtest results for tests that time out or crash, meaning only the harness-level statuses contribute to determining whether those tests ran expectedly. Subtests are always checked if the harness is `OK`/`ERROR`, since their subtest results are generally more stable.

See also: https://crrev.com/c/5112639