### PR TITLE
Make the css-scrollbars reftest fail when properties are not implemented

### DIFF
--- a/css/css-scrollbars/scrollbar-color-006-mis-ref.html
+++ b/css/css-scrollbars/scrollbar-color-006-mis-ref.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<style>
+  .container {
+    scrollbar-gutter: stable;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+<div id="one" class="container">
+  <div class="content"></div>
+</div>

--- a/css/css-scrollbars/scrollbar-color-006.html
+++ b/css/css-scrollbars/scrollbar-color-006.html
@@ -3,6 +3,7 @@
 <title>CSS Scrollbars: scrollbar-color on scrollable areas correctly interacts with ::-webkit-scrollbar-corner</title>
 <link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
 <link rel="match" href="scrollbar-color-006-ref.html" />
+<link rel="mismatch" href="scrollbar-color-006-mis-ref.html" />
 <link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
 <style>
   .container {

--- a/css/css-scrollbars/scrollbar-color-007-mis-ref.html
+++ b/css/css-scrollbars/scrollbar-color-007-mis-ref.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<style>
+  .container {
+    scrollbar-gutter: stable;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+<div id="one" class="container">
+  <div class="content"></div>
+</div>

--- a/css/css-scrollbars/scrollbar-color-007.html
+++ b/css/css-scrollbars/scrollbar-color-007.html
@@ -3,6 +3,7 @@
 <title>CSS Scrollbars: scrollbar-color on scrollable areas correctly interacts with ::-webkit-scrollbar-corner on container</title>
 <link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
 <link rel="match" href="scrollbar-color-007-ref.html" />
+<link rel="mismatch" href="scrollbar-color-007-mis-ref.html" />
 <link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
 <style>
   .container {

--- a/css/css-scrollbars/scrollbar-color-008-mis-ref.html
+++ b/css/css-scrollbars/scrollbar-color-008-mis-ref.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<style>
+  .container {
+    scrollbar-gutter: stable;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+<div id="one" class="container">
+  <div class="content"></div>
+</div>

--- a/css/css-scrollbars/scrollbar-color-008.html
+++ b/css/css-scrollbars/scrollbar-color-008.html
@@ -3,6 +3,7 @@
 <title>CSS Scrollbars: scrollbar-color on body correctly interacts with ::-webkit-scrollbar-corner on container</title>
 <link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
 <link rel="match" href="scrollbar-color-008-ref.html" />
+<link rel="mismatch" href="scrollbar-color-008-mis-ref.html" />
 <link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
 <style>
   body {

--- a/css/css-scrollbars/scrollbar-color-009-mis-ref.html
+++ b/css/css-scrollbars/scrollbar-color-009-mis-ref.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+<style>
+  body {
+    overflow: scroll;
+  }
+</style>

--- a/css/css-scrollbars/scrollbar-color-009.html
+++ b/css/css-scrollbars/scrollbar-color-009.html
@@ -3,6 +3,7 @@
 <title>CSS Scrollbars: scrollbar-color on root correctly interacts with ::-webkit-scrollbar-corner</title>
 <link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
 <link rel="match" href="scrollbar-color-009-ref.html" />
+<link rel="mismatch" href="scrollbar-color-009-mis-ref.html" />
 <link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
 <style>
   :root {

--- a/css/css-scrollbars/scrollbar-color-010-mis-ref.html
+++ b/css/css-scrollbars/scrollbar-color-010-mis-ref.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+<style>
+  body {
+    overflow: scroll;
+  }
+</style>

--- a/css/css-scrollbars/scrollbar-color-010.html
+++ b/css/css-scrollbars/scrollbar-color-010.html
@@ -3,6 +3,7 @@
 <title>CSS Scrollbars: scrollbar-color on root correctly interacts with ::-webkit-scrollbar-corner on body</title>
 <link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
 <link rel="match" href="scrollbar-color-010-ref.html" />
+<link rel="mismatch" href="scrollbar-color-010-mis-ref.html" />
 <link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
 <style>
   :root {

--- a/css/css-scrollbars/scrollbar-color-011-mis-ref.html
+++ b/css/css-scrollbars/scrollbar-color-011-mis-ref.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<style>
+  :root {
+    color: blue;
+  }
+
+  body {
+    overflow: scroll;
+  }
+</style>

--- a/css/css-scrollbars/scrollbar-color-011.html
+++ b/css/css-scrollbars/scrollbar-color-011.html
@@ -3,6 +3,7 @@
 <title>CSS Scrollbars: scrollbar-color with current color works correctly</title>
 <link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
 <link rel="match" href="scrollbar-color-011-ref.html" />
+<link rel="mismatch" href="scrollbar-color-011-mis-ref.html" />
 <link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
 <style>
   :root {

--- a/css/css-scrollbars/scrollbar-color-dynamic-1-mis-ref.html
+++ b/css/css-scrollbars/scrollbar-color-dynamic-1-mis-ref.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<style>
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    width: 200vw;
+    height: 200vh;
+  }
+
+  .container {
+    scrollbar-gutter: stable;
+    flex: 0 0;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+
+<div class="container">
+  <div class="content"></div>
+</div>

--- a/css/css-scrollbars/scrollbar-color-dynamic-1.html
+++ b/css/css-scrollbars/scrollbar-color-dynamic-1.html
@@ -4,6 +4,7 @@
 <link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
 <link rel="help" href="https://drafts.csswg.org/css-scrollbars" />
 <link rel="match" href="scrollbar-color-dynamic-1-ref.html" />
+<link rel="mismatch" href="scrollbar-color-dynamic-1-mis-ref.html" />
 <script src="/common/reftest-wait.js"></script>
 <style>
   :root {

--- a/css/css-scrollbars/scrollbar-color-dynamic-2-mis-ref.html
+++ b/css/css-scrollbars/scrollbar-color-dynamic-2-mis-ref.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<style>
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    overflow: scroll;
+  }
+  .container {
+    scrollbar-gutter: stable;
+    overflow: scroll;
+    flex: 0 0;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+</style>
+<div class="container"></div>

--- a/css/css-scrollbars/scrollbar-color-dynamic-2.html
+++ b/css/css-scrollbars/scrollbar-color-dynamic-2.html
@@ -4,6 +4,7 @@
 <link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
 <link rel="help" href="https://drafts.csswg.org/css-scrollbars/#valdef-scrollbar-color-auto" />
 <link rel="match" href="scrollbar-color-dynamic-2-ref.html" />
+<link rel="mismatch" href="scrollbar-color-dynamic-2-mis-ref.html" />
 <script src="/common/reftest-wait.js"></script>
 <style>
   :root {

--- a/css/css-scrollbars/scrollbar-color-dynamic-3-mis-ref.html
+++ b/css/css-scrollbars/scrollbar-color-dynamic-3-mis-ref.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<style>
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    width: 200vw;
+    height: 200vh;
+  }
+
+  .container {
+    scrollbar-color: blue green;
+    scrollbar-gutter: stable;
+    flex: 0 0;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+
+<div class="container">
+  <div class="content"></div>
+</div>

--- a/css/css-scrollbars/scrollbar-color-dynamic-3.html
+++ b/css/css-scrollbars/scrollbar-color-dynamic-3.html
@@ -4,6 +4,7 @@
 <link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
 <link rel="help" href="https://drafts.csswg.org/css-scrollbars/#valdef-scrollbar-color-auto" />
 <link rel="match" href="scrollbar-color-dynamic-3-ref.html" />
+<link rel="mismatch" href="scrollbar-color-dynamic-3-mis-ref.html" />
 <script src="/common/reftest-wait.js"></script>
 <style>
   :root {

--- a/css/css-scrollbars/scrollbar-color-dynamic-4-mis-ref.html
+++ b/css/css-scrollbars/scrollbar-color-dynamic-4-mis-ref.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<style>
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    overflow: scroll;
+  }
+  .container {
+    scrollbar-color: blue green;
+    scrollbar-gutter: stable;
+    overflow: scroll;
+    flex: 0 0;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+</style>
+<div class="container"></div>

--- a/css/css-scrollbars/scrollbar-color-dynamic-4.html
+++ b/css/css-scrollbars/scrollbar-color-dynamic-4.html
@@ -4,6 +4,7 @@
 <link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
 <link rel="help" href="https://drafts.csswg.org/css-scrollbars/#valdef-scrollbar-color-auto" />
 <link rel="match" href="scrollbar-color-dynamic-4-ref.html" />
+<link rel="mismatch" href="scrollbar-color-dynamic-4-mis-ref.html" />
 <script src="/common/reftest-wait.js"></script>
 <style>
   :root {

--- a/css/css-scrollbars/scrollbar-color-dynamic-5-mis-ref.html
+++ b/css/css-scrollbars/scrollbar-color-dynamic-5-mis-ref.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<style>
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    width: 200vw;
+    height: 200vh;
+  }
+
+  .container {
+    scrollbar-gutter: stable;
+    flex: 0 0;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+
+<div class="container">
+  <div class="content"></div>
+</div>

--- a/css/css-scrollbars/scrollbar-color-dynamic-5.html
+++ b/css/css-scrollbars/scrollbar-color-dynamic-5.html
@@ -4,6 +4,7 @@
 <link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
 <link rel="help" href="https://drafts.csswg.org/css-scrollbars" />
 <link rel="match" href="scrollbar-color-dynamic-5-ref.html" />
+<link rel="mismatch" href="scrollbar-color-dynamic-5-mis-ref.html" />
 <script src="/common/reftest-wait.js"></script>
 <style>
   :root {

--- a/css/css-scrollbars/scrollbar-color-dynamic-6-mis-ref.html
+++ b/css/css-scrollbars/scrollbar-color-dynamic-6-mis-ref.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<style>
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    width: 200vw;
+    height: 200vh;
+  }
+
+  .container {
+    scrollbar-gutter: stable;
+    flex: 0 0;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+    scrollbar-color: green green;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+
+<div class="container">
+  <div class="content"></div>
+</div>

--- a/css/css-scrollbars/scrollbar-color-dynamic-6.html
+++ b/css/css-scrollbars/scrollbar-color-dynamic-6.html
@@ -4,6 +4,7 @@
 <link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
 <link rel="help" href="https://drafts.csswg.org/css-scrollbars" />
 <link rel="match" href="scrollbar-color-dynamic-6-ref.html" />
+<link rel="mismatch" href="scrollbar-color-dynamic-6-mis-ref.html" />
 <script src="/common/reftest-wait.js"></script>
 <style>
   :root {

--- a/css/css-scrollbars/scrollbar-color-dynamic-7-mis-ref.html
+++ b/css/css-scrollbars/scrollbar-color-dynamic-7-mis-ref.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<style>
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    width: 200vw;
+    height: 200vh;
+  }
+
+  .container {
+    scrollbar-gutter: stable;
+    flex: 0 0;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+
+<div class="container">
+  <div class="content"></div>
+</div>

--- a/css/css-scrollbars/scrollbar-color-dynamic-7.html
+++ b/css/css-scrollbars/scrollbar-color-dynamic-7.html
@@ -4,6 +4,7 @@
 <link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
 <link rel="help" href="https://drafts.csswg.org/css-scrollbars" />
 <link rel="match" href="scrollbar-color-dynamic-7-ref.html" />
+<link rel="mismatch" href="scrollbar-color-dynamic-7-mis-ref.html" />
 <script src="/common/reftest-wait.js"></script>
 <style>
   :root {

--- a/css/css-scrollbars/scrollbar-width-paint-001-mis-ref.html
+++ b/css/css-scrollbars/scrollbar-width-paint-001-mis-ref.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<style>
+  body {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .container {
+    scrollbar-gutter: stable;
+    flex: 0 0;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+  }
+
+  .content.plain {
+    background: red;
+  }
+
+  .content.gradient {
+    background: linear-gradient(135deg, red, blue);
+  }
+</style>
+<div id="one" class="container thin">
+  <div class="content plain"></div>
+</div>
+<div id="two" class="container auto">
+  <div class="content plain"></div>
+</div>
+<div id="three" class="container auto">
+  <div class="content plain"></div>
+</div>
+<div id="four" class="container none">
+  <div class="content gradient"></div>
+</div>
+<div id="five" class="container none">
+  <div class="content gradient"></div>
+</div>
+<div id="six" class="container thin">
+  <div class="content gradient"></div>
+</div>

--- a/css/css-scrollbars/scrollbar-width-paint-001.html
+++ b/css/css-scrollbars/scrollbar-width-paint-001.html
@@ -3,6 +3,7 @@
 <title>CSS Scrollbars: paint test when updating scrollbar-width, with scrolling content</title>
 <link rel="author" title="Felipe Erias Morandeira" href="mailto:felipeerias@gmail.com" />
 <link rel="match" href="scrollbar-width-paint-001-ref.html" />
+<link rel="mismatch" href="scrollbar-width-paint-001-mis-ref.html" />
 <link rel="help" href="https://www.w3.org/TR/css-scrollbars-1/" />
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-scrollbars/scrollbar-width-paint-002-mis-ref.html
+++ b/css/css-scrollbars/scrollbar-width-paint-002-mis-ref.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<style>
+  body {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .container {
+    scrollbar-gutter: stable;
+    overflow: scroll;
+    flex: 0 0;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 100%;
+    width: 100%;
+  }
+
+  .content.plain {
+    background: red;
+  }
+
+  .content.gradient {
+    background: linear-gradient(135deg, red, blue);
+  }
+</style>
+<div id="one" class="container thin">
+  <div class="content plain"></div>
+</div>
+<div id="two" class="container auto">
+  <div class="content plain"></div>
+</div>
+<div id="three" class="container auto">
+  <div class="content plain"></div>
+</div>
+<div id="four" class="container none">
+  <div class="content gradient"></div>
+</div>
+<div id="five" class="container none">
+  <div class="content gradient"></div>
+</div>
+<div id="six" class="container thin">
+  <div class="content gradient"></div>
+</div>

--- a/css/css-scrollbars/scrollbar-width-paint-002.html
+++ b/css/css-scrollbars/scrollbar-width-paint-002.html
@@ -3,6 +3,7 @@
 <title>CSS Scrollbars: paint test when updating scrollbar-width, with overflow:auto</title>
 <link rel="author" title="Felipe Erias Morandeira" href="mailto:felipeerias@gmail.com" />
 <link rel="match" href="scrollbar-width-paint-002-ref.html" />
+<link rel="mismatch" href="scrollbar-width-paint-002-mis-ref.html" />
 <link rel="help" href="https://www.w3.org/TR/css-scrollbars-1/" />
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-scrollbars/scrollbar-width-paint-004-mis-ref.html
+++ b/css/css-scrollbars/scrollbar-width-paint-004-mis-ref.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<title>CSS Test Reference</title>
+<style>
+  :root { overflow: scroll; scrollbar-width: none; }
+</style>

--- a/css/css-scrollbars/scrollbar-width-paint-004.html
+++ b/css/css-scrollbars/scrollbar-width-paint-004.html
@@ -4,6 +4,7 @@
 <title>CSS Scrollbars: scrollbar-width on viewport none -> thin</title>
 <link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev">
 <link rel="match" href="scrollbar-width-paint-004-ref.html">
+<link rel="mismatch" href="scrollbar-width-paint-004-mis-ref.html">
 <link rel="help" href="https://www.w3.org/TR/css-scrollbars-1/">
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-scrollbars/scrollbar-width-paint-006-mis-ref.html
+++ b/css/css-scrollbars/scrollbar-width-paint-006-mis-ref.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<style>
+  body {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .container {
+    scrollbar-gutter: stable;
+    flex: 0 0;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+  }
+
+  .content.plain {
+    background: red;
+  }
+
+  .content.gradient {
+    background: linear-gradient(135deg, red, blue);
+  }
+</style>
+<div id="one" class="container none">
+  <div class="content plain"></div>
+</div>
+<div id="two" class="container none">
+  <div class="content plain"></div>
+</div>
+<div id="three" class="container thin">
+  <div class="content plain"></div>
+</div>
+<div id="four" class="container thin">
+  <div class="content gradient"></div>
+</div>
+<div id="five" class="container auto">
+  <div class="content gradient"></div>
+</div>
+<div id="six" class="container auto">
+  <div class="content gradient"></div>
+</div>

--- a/css/css-scrollbars/scrollbar-width-paint-006.html
+++ b/css/css-scrollbars/scrollbar-width-paint-006.html
@@ -3,6 +3,7 @@
 <title>CSS Scrollbars: paint test when updating scrollbar-width twice, with scrolling content</title>
 <link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev">
 <link rel="match" href="scrollbar-width-paint-006-ref.html">
+<link rel="mismatch" href="scrollbar-width-paint-006-mis-ref.html">
 <link rel="help" href="https://www.w3.org/TR/css-scrollbars-1/" />
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-scrollbars/viewport-scrollbar-body-mis-ref.html
+++ b/css/css-scrollbars/viewport-scrollbar-body-mis-ref.html
@@ -1,16 +1,22 @@
 <!DOCTYPE html>
 <meta charset="UTF-8">
-<title>CSS Test: scrollbar style on body element should not be propagated to the viewport</title>
+<title>CSS Reference: unstyled scrollbars</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/#scrollbar-color-properties">
-<link rel="match" href="viewport-scrollbar-body-ref.html">
-<link rel="mismatch" href="viewport-scrollbar-body-mis-ref.html">
 <style>
-iframe {
+#outer {
   border: 1px solid black;
   width: 200px; height: 200px;
+  overflow: scroll;
+  scrollbar-color: yellow blue;
+}
+#inner {
+  width: 400px; height: 400px;
 }
 </style>
 <p>Test passes if the scrollbars in the following box are NOT styled:</p>
-<iframe src="support/viewport-scrollbar-body-frame.html"></iframe>
+<div id="outer">
+  <div id="inner">
+  </div>
+</div>

--- a/css/css-scrollbars/viewport-scrollbar-mis-ref.html
+++ b/css/css-scrollbars/viewport-scrollbar-mis-ref.html
@@ -1,16 +1,21 @@
 <!DOCTYPE html>
 <meta charset="UTF-8">
-<title>CSS Test: scrollbar style on root element should be propagated to the viewport</title>
+<title>CSS Reference: styled scrollbars</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/#scrollbar-color-properties">
-<link rel="match" href="viewport-scrollbar-ref.html">
-<link rel="mismatch" href="viewport-scrollbar-mis-ref.html">
 <style>
-iframe {
+#outer {
   border: 1px solid black;
   width: 200px; height: 200px;
+  overflow: scroll;
+}
+#inner {
+  width: 400px; height: 400px;
 }
 </style>
 <p>Test passes if the scrollbars in the following box are styled:</p>
-<iframe src="support/viewport-scrollbar-frame.html"></iframe>
+<div id="outer">
+  <div id="inner">
+  </div>
+</div>


### PR DESCRIPTION
This is the reftest part of
https://github.com/web-platform-tests/wpt/issues/44185

Similar work may be needed for testharness tests.

Note however that these are minimal modifications of the test that do not account for overlay scrollbars anymore than the original tests did, as dicussed in https://github.com/web-platform-tests/wpt/issues/44196

It's likely that some tests that used to pass with overlay scrollbars regardless of what the browser did now fail even even if it does the right thing. That's unfortunate, but it seems better than claiming a PASS when we didn't effectively test anything, as we now at least have a failure to investigate, even if it's a limitation in the test rather than a bug in the browser.