### PR TITLE
Fix type annotations for remove_user_context command interface

### DIFF
--- a/tools/webdriver/webdriver/bidi/modules/browser.py
+++ b/tools/webdriver/webdriver/bidi/modules/browser.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, MutableMapping, Optional
+from typing import Any, Mapping, MutableMapping
 
 from ._module import BidiModule, command
 
@@ -34,7 +34,7 @@ class Browser(BidiModule):
 
     @command
     def remove_user_context(
-        self, user_context: Optional[str] = None
+        self, user_context: str
     ) -> Mapping[str, Any]:
         params: MutableMapping[str, Any] = {}
 


### PR DESCRIPTION
In [the upstream PR ](https://github.com/web-platform-tests/wpt/pull/44192) to fix the type error I've assumed that `user_context` should be optional, but the argument is actually required, so the right way to fix it would be to remove the default value.