### PR TITLE
[wdspec] add a test for creating a browsing context in a user context

### DIFF
--- a/tools/webdriver/webdriver/bidi/modules/browsing_context.py
+++ b/tools/webdriver/webdriver/bidi/modules/browsing_context.py
@@ -81,7 +81,8 @@ class BrowsingContext(BidiModule):
     def create(self,
                type_hint: str,
                reference_context: Optional[str] = None,
-               background: Optional[bool] = None) -> Mapping[str, Any]:
+               background: Optional[bool] = None,
+               user_context: Union[Optional[str], Undefined] = UNDEFINED) -> Mapping[str, Any]:
         params: MutableMapping[str, Any] = {"type": type_hint}
 
         if reference_context is not None:
@@ -89,6 +90,9 @@ class BrowsingContext(BidiModule):
 
         if background is not None:
             params["background"] = background
+
+        if user_context is not UNDEFINED:
+            params["userContext"] = user_context
 
         return params
 

--- a/tools/webdriver/webdriver/bidi/modules/browsing_context.py
+++ b/tools/webdriver/webdriver/bidi/modules/browsing_context.py
@@ -82,7 +82,7 @@ class BrowsingContext(BidiModule):
                type_hint: str,
                reference_context: Optional[str] = None,
                background: Optional[bool] = None,
-               user_context: Union[Optional[str], Undefined] = UNDEFINED) -> Mapping[str, Any]:
+               user_context: Optional[str] = None) -> Mapping[str, Any]:
         params: MutableMapping[str, Any] = {"type": type_hint}
 
         if reference_context is not None:
@@ -91,7 +91,7 @@ class BrowsingContext(BidiModule):
         if background is not None:
             params["background"] = background
 
-        if user_context is not UNDEFINED:
+        if user_context is not None:
             params["userContext"] = user_context
 
         return params

--- a/webdriver/tests/bidi/browsing_context/__init__.py
+++ b/webdriver/tests/bidi/browsing_context/__init__.py
@@ -11,7 +11,7 @@ from .. import (
 
 
 def assert_browsing_context(
-    info, context, children=None, is_root=True, parent=None, url=None, user_context = 'default'
+    info, context, children=None, is_root=True, parent=None, url=None, user_context = None
 ):
     assert "children" in info
     if children is not None:
@@ -44,7 +44,8 @@ def assert_browsing_context(
     assert "url" in info
     assert isinstance(info["url"], str)
     assert info["url"] == url
-    assert info["userContext"] == user_context
+    if user_context is not None:
+      assert info["userContext"] == user_context
 
 
 def assert_navigation_info(event, expected_navigation_info):

--- a/webdriver/tests/bidi/browsing_context/__init__.py
+++ b/webdriver/tests/bidi/browsing_context/__init__.py
@@ -11,7 +11,7 @@ from .. import (
 
 
 def assert_browsing_context(
-    info, context, children=None, is_root=True, parent=None, url=None
+    info, context, children=None, is_root=True, parent=None, url=None, user_context = 'default'
 ):
     assert "children" in info
     if children is not None:
@@ -44,6 +44,7 @@ def assert_browsing_context(
     assert "url" in info
     assert isinstance(info["url"], str)
     assert info["url"] == url
+    assert info["userContext"] == user_context
 
 
 def assert_navigation_info(event, expected_navigation_info):

--- a/webdriver/tests/bidi/browsing_context/create/invalid.py
+++ b/webdriver/tests/bidi/browsing_context/create/invalid.py
@@ -57,3 +57,15 @@ async def test_params_type_invalid_value(bidi_session, value):
 async def test_params_background_invalid_type(bidi_session, value):
     with pytest.raises(error.InvalidArgumentException):
         await bidi_session.browsing_context.create(type_hint="tab", background = value)
+
+
+@pytest.mark.parametrize("value", [False, 42, {}, []])
+async def test_params_user_context_invalid_type(bidi_session, value):
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.browsing_context.create(type_hint="tab", user_context=value)
+
+
+@pytest.mark.parametrize("value", ["", "unknown"])
+async def test_params_user_context_invalid_value(bidi_session, value):
+    with pytest.raises(error.NoSuchUserContextException):
+        await bidi_session.browsing_context.create(type_hint="tab", user_context=value)

--- a/webdriver/tests/bidi/browsing_context/create/user_context.py
+++ b/webdriver/tests/bidi/browsing_context/create/user_context.py
@@ -1,0 +1,34 @@
+import pytest
+
+from .. import assert_browsing_context
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.mark.parametrize("type_hint", ["tab", "window"])
+async def test_user_context(bidi_session, type_hint, create_user_context):
+    contexts = await bidi_session.browsing_context.get_tree(max_depth=0)
+    assert len(contexts) == 1
+
+    user_context = await create_user_context()
+
+    contexts = await bidi_session.browsing_context.get_tree(max_depth=0)
+    assert len(contexts) == 1
+
+    new_context = await bidi_session.browsing_context.create(
+        user_context=user_context,
+        type_hint=type_hint
+    )
+
+    contexts = await bidi_session.browsing_context.get_tree(max_depth=0)
+    assert len(contexts) == 2
+
+    assert_browsing_context(
+        contexts[1],
+        new_context["context"],
+        children=None,
+        is_root=True,
+        parent=None,
+        url="about:blank",
+        user_context=user_context
+    )


### PR DESCRIPTION
This PR only includes changes to the browsing context create module and browsing context info assertion as well as a test to check creation of tabs and windows in a new user context. More tests will follow in the subsequent PRs.