### PR TITLE
Use the right function to test invalid selectors inside :is()/:where().

### DIFF
--- a/css/selectors/parsing/parse-part.html
+++ b/css/selectors/parsing/parse-part.html
@@ -31,9 +31,9 @@
   test_invalid_selector(":part('foo')");
   test_invalid_selector(":part([foo])");
   test_invalid_selector('::part(foo) + ::part(bar)');
-  test_invalid_selector("::part(foo):is(ul)");
-  test_invalid_selector("::part(foo):is(nav ul)");
-  test_invalid_selector("::part(foo):where(ul)");
-  test_invalid_selector("::part(foo):where(nav ul)");
+  test_valid_forgiving_selector("::part(foo):is(ul)");
+  test_valid_forgiving_selector("::part(foo):is(nav ul)");
+  test_valid_forgiving_selector("::part(foo):where(ul)");
+  test_valid_forgiving_selector("::part(foo):where(nav ul)");
   test_invalid_selector("::part(foo):has(li)");
 </script>


### PR DESCRIPTION
:is() / :where() are forgiving selectors and thus serialize and are "valid".

test_valid_forgiving_selector is the right thing to use here.