### PR TITLE
[webdriver] Enhance tests for implicitly accepting "beforeunload" prompts

### DIFF
--- a/webdriver/tests/classic/back/back.py
+++ b/webdriver/tests/classic/back/back.py
@@ -76,28 +76,6 @@ def test_data_urls(session, inline):
     assert session.url == test_pages[0]
 
 
-def test_dismissed_beforeunload(session, inline):
-    url_beforeunload = inline("""
-      <input type="text">
-      <script>
-        window.addEventListener("beforeunload", function (event) {
-          event.preventDefault();
-        });
-      </script>
-    """)
-
-    session.url = inline("<div id=foo>")
-    session.url = url_beforeunload
-
-    element = session.find.css("input", all=False)
-    element.send_keys("bar")
-
-    response = back(session)
-    assert_success(response)
-
-    assert session.url != url_beforeunload
-
-
 def test_fragments(session, url):
     test_pages = [
         url("/common/blank.html"),

--- a/webdriver/tests/classic/back/user_prompts.py
+++ b/webdriver/tests/classic/back/user_prompts.py
@@ -1,6 +1,7 @@
 # META: timeout=long
 
 import pytest
+from webdriver import error
 
 from tests.support.asserts import assert_dialog_handled, assert_error, assert_success
 
@@ -21,6 +22,31 @@ def pages(session, inline):
         session.url = page
 
     return pages
+
+
+@pytest.fixture
+def check_beforeunload_implicitly_accepted(session, url):
+    def check_beforeunload_implicitly_accepted():
+        page_beforeunload = url(
+            "/webdriver/tests/support/html/beforeunload.html")
+        page_target = url("/webdriver/tests/support/html/default.html")
+
+        session.url = page_target
+        session.url = page_beforeunload
+
+        element = session.find.css("input", all=False)
+        element.send_keys("bar")
+
+        response = back(session)
+        assert_success(response)
+
+        assert session.url == page_target
+
+        # navigation auto-dismissed beforeunload prompt
+        with pytest.raises(error.NoSuchAlertException):
+            session.alert.text
+
+    return check_beforeunload_implicitly_accepted
 
 
 @pytest.fixture
@@ -70,49 +96,96 @@ def check_user_prompt_not_closed_but_exception(session, create_dialog, pages):
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "accept"})
-@pytest.mark.parametrize("dialog_type", ["alert", "confirm", "prompt"])
-def test_accept(check_user_prompt_closed_without_exception, dialog_type):
-    # retval not testable for confirm and prompt because window is gone
-    check_user_prompt_closed_without_exception(dialog_type, None)
+@pytest.mark.parametrize("dialog_type", ["alert", "beforeunload", "confirm", "prompt"])
+def test_accept(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_without_exception,
+    dialog_type
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        # retval not testable for confirm and prompt because window is gone
+        check_user_prompt_closed_without_exception(dialog_type, None)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "accept and notify"})
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", True),
     ("prompt", ""),
 ])
-def test_accept_and_notify(check_user_prompt_closed_with_exception, dialog_type, retval):
-    check_user_prompt_closed_with_exception(dialog_type, retval)
+def test_accept_and_notify(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_with_exception,
+    dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_with_exception(dialog_type, retval)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "dismiss"})
-@pytest.mark.parametrize("dialog_type", ["alert", "confirm", "prompt"])
-def test_dismiss(check_user_prompt_closed_without_exception, dialog_type):
-    # retval not testable for confirm and prompt because window is gone
-    check_user_prompt_closed_without_exception(dialog_type, None)
+@pytest.mark.parametrize("dialog_type", ["alert", "beforeunload", "confirm", "prompt"])
+def test_dismiss(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_without_exception,
+    dialog_type
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        # retval not testable for confirm and prompt because window is gone
+        check_user_prompt_closed_without_exception(dialog_type, None)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "dismiss and notify"})
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", False),
     ("prompt", None),
 ])
-def test_dismiss_and_notify(check_user_prompt_closed_with_exception, dialog_type, retval):
-    check_user_prompt_closed_with_exception(dialog_type, retval)
+def test_dismiss_and_notify(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_with_exception, dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_with_exception(dialog_type, retval)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "ignore"})
-@pytest.mark.parametrize("dialog_type", ["alert", "confirm", "prompt"])
-def test_ignore(check_user_prompt_not_closed_but_exception, dialog_type):
-    check_user_prompt_not_closed_but_exception(dialog_type)
+@pytest.mark.parametrize("dialog_type", ["alert", "beforeunload", "confirm", "prompt"])
+def test_ignore(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_not_closed_but_exception,
+    dialog_type
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_not_closed_but_exception(dialog_type)
 
 
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", False),
     ("prompt", None),
 ])
-def test_default(check_user_prompt_closed_with_exception, dialog_type, retval):
-    check_user_prompt_closed_with_exception(dialog_type, retval)
+def test_default(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_with_exception,
+    dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_with_exception(dialog_type, retval)

--- a/webdriver/tests/classic/execute_async_script/user_prompts.py
+++ b/webdriver/tests/classic/execute_async_script/user_prompts.py
@@ -1,9 +1,44 @@
 # META: timeout=long
 
 import pytest
+from webdriver import error
 
 from tests.support.asserts import assert_dialog_handled, assert_error, assert_success
+from tests.support.sync import Poll
 from . import execute_async_script
+
+
+@pytest.fixture
+def check_beforeunload_implicitly_accepted(session, url):
+    def check_beforeunload_implicitly_accepted():
+        page_beforeunload = url(
+            "/webdriver/tests/support/html/beforeunload.html")
+        page_target = url("/webdriver/tests/support/html/default.html")
+
+        session.url = page_beforeunload
+
+        element = session.find.css("input", all=False)
+        element.send_keys("bar")
+
+        response = execute_async_script(
+            session, """
+                const [url, resolve] = arguments;
+                window.location.href = url;
+                resolve();
+            """, args=(page_target,))
+        assert_success(response)
+
+        wait = Poll(
+            session,
+            timeout=5,
+            message="Target page did not load")
+        wait.until(lambda s: s.url == page_target)
+
+        # navigation auto-dismissed beforeunload prompt
+        with pytest.raises(error.NoSuchAlertException):
+            session.alert.text
+
+    return check_beforeunload_implicitly_accepted
 
 
 @pytest.fixture
@@ -57,53 +92,104 @@ def check_user_prompt_not_closed_but_exception(session, create_dialog):
 @pytest.mark.capabilities({"unhandledPromptBehavior": "accept"})
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", True),
     ("prompt", ""),
 ])
-def test_accept(check_user_prompt_closed_without_exception, dialog_type, retval):
-    check_user_prompt_closed_without_exception(dialog_type, retval)
+def test_accept(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_without_exception,
+    dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_without_exception(dialog_type, retval)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "accept and notify"})
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", True),
     ("prompt", ""),
 ])
-def test_accept_and_notify(check_user_prompt_closed_with_exception, dialog_type, retval):
-    check_user_prompt_closed_with_exception(dialog_type, retval)
+def test_accept_and_notify(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_with_exception,
+    dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_with_exception(dialog_type, retval)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "dismiss"})
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", False),
     ("prompt", None),
 ])
-def test_dismiss(check_user_prompt_closed_without_exception, dialog_type, retval):
-    check_user_prompt_closed_without_exception(dialog_type, retval)
+def test_dismiss(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_without_exception,
+    dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_without_exception(dialog_type, retval)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "dismiss and notify"})
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", False),
     ("prompt", None),
 ])
-def test_dismiss_and_notify(check_user_prompt_closed_with_exception, dialog_type, retval):
-    check_user_prompt_closed_with_exception(dialog_type, retval)
+def test_dismiss_and_notify(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_with_exception, dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_with_exception(dialog_type, retval)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "ignore"})
-@pytest.mark.parametrize("dialog_type", ["alert", "confirm", "prompt"])
-def test_ignore(check_user_prompt_not_closed_but_exception, dialog_type):
-    check_user_prompt_not_closed_but_exception(dialog_type)
+@pytest.mark.parametrize("dialog_type", ["alert", "beforeunload", "confirm", "prompt"])
+def test_ignore(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_not_closed_but_exception,
+    dialog_type
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_not_closed_but_exception(dialog_type)
 
 
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", False),
     ("prompt", None),
 ])
-def test_default(check_user_prompt_closed_with_exception, dialog_type, retval):
-    check_user_prompt_closed_with_exception(dialog_type, retval)
+def test_default(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_with_exception,
+    dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_with_exception(dialog_type, retval)

--- a/webdriver/tests/classic/execute_script/user_prompts.py
+++ b/webdriver/tests/classic/execute_script/user_prompts.py
@@ -1,9 +1,40 @@
 # META: timeout=long
 
 import pytest
+from webdriver import error
 
 from tests.support.asserts import assert_dialog_handled, assert_error, assert_success
+from tests.support.sync import Poll
 from . import execute_script
+
+
+@pytest.fixture
+def check_beforeunload_implicitly_accepted(session, url):
+    def check_beforeunload_implicitly_accepted():
+        page_beforeunload = url(
+            "/webdriver/tests/support/html/beforeunload.html")
+        page_target = url("/webdriver/tests/support/html/default.html")
+
+        session.url = page_beforeunload
+
+        element = session.find.css("input", all=False)
+        element.send_keys("bar")
+
+        response = execute_script(
+            session, "window.location.href = arguments[0];", args=(page_target,))
+        assert_success(response)
+
+        wait = Poll(
+            session,
+            timeout=5,
+            message="Target page did not load")
+        wait.until(lambda s: s.url == page_target)
+
+        # navigation auto-dismissed beforeunload prompt
+        with pytest.raises(error.NoSuchAlertException):
+            session.alert.text
+
+    return check_beforeunload_implicitly_accepted
 
 
 @pytest.fixture
@@ -55,53 +86,104 @@ def check_user_prompt_not_closed_but_exception(session, create_dialog):
 @pytest.mark.capabilities({"unhandledPromptBehavior": "accept"})
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", True),
     ("prompt", ""),
 ])
-def test_accept(check_user_prompt_closed_without_exception, dialog_type, retval):
-    check_user_prompt_closed_without_exception(dialog_type, retval)
+def test_accept(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_without_exception,
+    dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_without_exception(dialog_type, retval)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "accept and notify"})
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", True),
     ("prompt", ""),
 ])
-def test_accept_and_notify(check_user_prompt_closed_with_exception, dialog_type, retval):
-    check_user_prompt_closed_with_exception(dialog_type, retval)
+def test_accept_and_notify(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_with_exception,
+    dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_with_exception(dialog_type, retval)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "dismiss"})
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", False),
     ("prompt", None),
 ])
-def test_dismiss(check_user_prompt_closed_without_exception, dialog_type, retval):
-    check_user_prompt_closed_without_exception(dialog_type, retval)
+def test_dismiss(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_without_exception,
+    dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_without_exception(dialog_type, retval)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "dismiss and notify"})
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", False),
     ("prompt", None),
 ])
-def test_dismiss_and_notify(check_user_prompt_closed_with_exception, dialog_type, retval):
-    check_user_prompt_closed_with_exception(dialog_type, retval)
+def test_dismiss_and_notify(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_with_exception, dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_with_exception(dialog_type, retval)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "ignore"})
-@pytest.mark.parametrize("dialog_type", ["alert", "confirm", "prompt"])
-def test_ignore(check_user_prompt_not_closed_but_exception, dialog_type):
-    check_user_prompt_not_closed_but_exception(dialog_type)
+@pytest.mark.parametrize("dialog_type", ["alert", "beforeunload", "confirm", "prompt"])
+def test_ignore(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_not_closed_but_exception,
+    dialog_type
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_not_closed_but_exception(dialog_type)
 
 
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", False),
     ("prompt", None),
 ])
-def test_default(check_user_prompt_closed_with_exception, dialog_type, retval):
-    check_user_prompt_closed_with_exception(dialog_type, retval)
+def test_default(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_with_exception,
+    dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_with_exception(dialog_type, retval)

--- a/webdriver/tests/classic/forward/forward.py
+++ b/webdriver/tests/classic/forward/forward.py
@@ -107,29 +107,6 @@ def test_data_urls(session, inline):
     assert session.url == test_pages[1]
 
 
-def test_dismissed_beforeunload(session, inline):
-    url_beforeunload = inline("""
-      <input type="text">
-      <script>
-        window.addEventListener("beforeunload", function (event) {
-          event.preventDefault();
-        });
-      </script>
-    """)
-
-    session.url = url_beforeunload
-    session.url = inline("<div id=foo>")
-    session.back()
-
-    element = session.find.css("input", all=False)
-    element.send_keys("bar")
-
-    response = forward(session)
-    assert_success(response)
-
-    assert session.url != url_beforeunload
-
-
 def test_fragments(session, url):
     test_pages = [
         url("/common/blank.html"),

--- a/webdriver/tests/classic/forward/user_prompts.py
+++ b/webdriver/tests/classic/forward/user_prompts.py
@@ -1,6 +1,7 @@
 # META: timeout=long
 
 import pytest
+from webdriver import error
 
 from tests.support.asserts import assert_dialog_handled, assert_error, assert_success
 
@@ -23,6 +24,32 @@ def pages(session, inline):
     session.back()
 
     return pages
+
+
+@pytest.fixture
+def check_beforeunload_implicitly_accepted(session, url):
+    def check_beforeunload_implicitly_accepted():
+        page_beforeunload = url(
+            "/webdriver/tests/support/html/beforeunload.html")
+        page_target = url("/webdriver/tests/support/html/default.html")
+
+        session.url = page_beforeunload
+        session.url = page_target
+        session.back()
+
+        element = session.find.css("input", all=False)
+        element.send_keys("bar")
+
+        response = forward(session)
+        assert_success(response)
+
+        assert session.url == page_target
+
+        # navigation auto-dismissed beforeunload prompt
+        with pytest.raises(error.NoSuchAlertException):
+            session.alert.text
+
+    return check_beforeunload_implicitly_accepted
 
 
 @pytest.fixture
@@ -73,49 +100,96 @@ def check_user_prompt_not_closed_but_exception(session, create_dialog, pages):
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "accept"})
-@pytest.mark.parametrize("dialog_type", ["alert", "confirm", "prompt"])
-def test_accept(check_user_prompt_closed_without_exception, dialog_type):
-    # retval not testable for confirm and prompt because window is gone
-    check_user_prompt_closed_without_exception(dialog_type, None)
+@pytest.mark.parametrize("dialog_type", ["alert", "beforeunload", "confirm", "prompt"])
+def test_accept(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_without_exception,
+    dialog_type
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        # retval not testable for confirm and prompt because window is gone
+        check_user_prompt_closed_without_exception(dialog_type, None)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "accept and notify"})
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", True),
     ("prompt", ""),
 ])
-def test_accept_and_notify(check_user_prompt_closed_with_exception, dialog_type, retval):
-    check_user_prompt_closed_with_exception(dialog_type, retval)
+def test_accept_and_notify(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_with_exception,
+    dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_with_exception(dialog_type, retval)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "dismiss"})
-@pytest.mark.parametrize("dialog_type", ["alert", "confirm", "prompt"])
-def test_dismiss(check_user_prompt_closed_without_exception, dialog_type):
-    # retval not testable for confirm and prompt because window is gone
-    check_user_prompt_closed_without_exception(dialog_type, None)
+@pytest.mark.parametrize("dialog_type", ["alert", "beforeunload", "confirm", "prompt"])
+def test_dismiss(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_without_exception,
+    dialog_type
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        # retval not testable for confirm and prompt because window is gone
+        check_user_prompt_closed_without_exception(dialog_type, None)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "dismiss and notify"})
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", False),
     ("prompt", None),
 ])
-def test_dismiss_and_notify(check_user_prompt_closed_with_exception, dialog_type, retval):
-    check_user_prompt_closed_with_exception(dialog_type, retval)
+def test_dismiss_and_notify(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_with_exception, dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_with_exception(dialog_type, retval)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "ignore"})
-@pytest.mark.parametrize("dialog_type", ["alert", "confirm", "prompt"])
-def test_ignore(check_user_prompt_not_closed_but_exception, dialog_type):
-    check_user_prompt_not_closed_but_exception(dialog_type)
+@pytest.mark.parametrize("dialog_type", ["alert", "beforeunload", "confirm", "prompt"])
+def test_ignore(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_not_closed_but_exception,
+    dialog_type
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_not_closed_but_exception(dialog_type)
 
 
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", False),
     ("prompt", None),
 ])
-def test_default(check_user_prompt_closed_with_exception, dialog_type, retval):
-    check_user_prompt_closed_with_exception(dialog_type, retval)
+def test_default(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_with_exception,
+    dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_with_exception(dialog_type, retval)

--- a/webdriver/tests/classic/get_alert_text/get.py
+++ b/webdriver/tests/classic/get_alert_text/get.py
@@ -57,6 +57,9 @@ def test_get_prompt_text(session, inline):
     assert prompt_text == "Enter Your Name: "
 
 
+# TODO: Add test for beforeunload?
+
+
 def test_unexpected_alert(session):
     session.execute_script("setTimeout(function() { alert('Hello'); }, 100);")
     wait = Poll(

--- a/webdriver/tests/classic/navigate_to/user_prompts.py
+++ b/webdriver/tests/classic/navigate_to/user_prompts.py
@@ -1,6 +1,7 @@
 # META: timeout=long
 
 import pytest
+from webdriver import error
 
 from tests.support.asserts import assert_error, assert_success, assert_dialog_handled
 
@@ -9,6 +10,31 @@ def navigate_to(session, url):
     return session.transport.send(
         "POST", "session/{session_id}/url".format(**vars(session)),
         {"url": url})
+
+
+@pytest.fixture
+def check_beforeunload_implicitly_accepted(session, url):
+    def check_beforeunload_implicitly_accepted():
+        page_beforeunload = url(
+            "/webdriver/tests/support/html/beforeunload.html")
+        page_target = url("/webdriver/tests/support/html/default.html")
+
+        response = navigate_to(session, page_beforeunload)
+        assert_success(response)
+
+        element = session.find.css("input", all=False)
+        element.send_keys("bar")
+
+        response = navigate_to(session, page_target)
+        assert_success(response)
+
+        assert session.url == page_target
+
+        # navigation auto-dismissed beforeunload prompt
+        with pytest.raises(error.NoSuchAlertException):
+            session.alert.text
+
+    return check_beforeunload_implicitly_accepted
 
 
 @pytest.fixture
@@ -64,49 +90,96 @@ def check_user_prompt_not_closed_but_exception(session, create_dialog, inline):
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "accept"})
-@pytest.mark.parametrize("dialog_type", ["alert", "confirm", "prompt"])
-def test_accept(check_user_prompt_closed_without_exception, dialog_type):
-    # retval not testable for confirm and prompt because window is gone
-    check_user_prompt_closed_without_exception(dialog_type, None)
+@pytest.mark.parametrize("dialog_type", ["alert", "beforeunload", "confirm", "prompt"])
+def test_accept(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_without_exception,
+    dialog_type
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        # retval not testable for confirm and prompt because window is gone
+        check_user_prompt_closed_without_exception(dialog_type, None)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "accept and notify"})
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", True),
     ("prompt", ""),
 ])
-def test_accept_and_notify(check_user_prompt_closed_with_exception, dialog_type, retval):
-    check_user_prompt_closed_with_exception(dialog_type, retval)
+def test_accept_and_notify(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_with_exception,
+    dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_with_exception(dialog_type, retval)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "dismiss"})
-@pytest.mark.parametrize("dialog_type", ["alert", "confirm", "prompt"])
-def test_dismiss(check_user_prompt_closed_without_exception, dialog_type):
-    # retval not testable for confirm and prompt because window is gone
-    check_user_prompt_closed_without_exception(dialog_type, None)
+@pytest.mark.parametrize("dialog_type", ["alert", "beforeunload", "confirm", "prompt"])
+def test_dismiss(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_without_exception,
+    dialog_type
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        # retval not testable for confirm and prompt because window is gone
+        check_user_prompt_closed_without_exception(dialog_type, None)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "dismiss and notify"})
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", False),
     ("prompt", None),
 ])
-def test_dismiss_and_notify(check_user_prompt_closed_with_exception, dialog_type, retval):
-    check_user_prompt_closed_with_exception(dialog_type, retval)
+def test_dismiss_and_notify(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_with_exception, dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_with_exception(dialog_type, retval)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "ignore"})
-@pytest.mark.parametrize("dialog_type", ["alert", "confirm", "prompt"])
-def test_ignore(check_user_prompt_not_closed_but_exception, dialog_type):
-    check_user_prompt_not_closed_but_exception(dialog_type)
+@pytest.mark.parametrize("dialog_type", ["alert", "beforeunload", "confirm", "prompt"])
+def test_ignore(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_not_closed_but_exception,
+    dialog_type
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_not_closed_but_exception(dialog_type)
 
 
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", False),
     ("prompt", None),
 ])
-def test_default(check_user_prompt_closed_with_exception, dialog_type, retval):
-    check_user_prompt_closed_with_exception(dialog_type, retval)
+def test_default(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_with_exception,
+    dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_with_exception(dialog_type, retval)

--- a/webdriver/tests/classic/refresh/refresh.py
+++ b/webdriver/tests/classic/refresh/refresh.py
@@ -63,29 +63,6 @@ def test_seen_nodes(session, get_test_page, protocol, parameters):
     session.find.css("#custom-element", all=False)
 
 
-def test_dismissed_beforeunload(session, inline):
-    url_beforeunload = inline("""
-      <input type="text">
-      <script>
-        window.addEventListener("beforeunload", function (event) {
-          event.preventDefault();
-        });
-      </script>
-    """)
-
-    session.url = url_beforeunload
-    element = session.find.css("input", all=False)
-    element.send_keys("bar")
-
-    response = refresh(session)
-    assert_success(response)
-
-    with pytest.raises(error.StaleElementReferenceException):
-        element.property("id")
-
-    session.find.css("input", all=False)
-
-
 def test_history_pushstate(session, inline):
     pushstate_page = inline("""
       <script>

--- a/webdriver/tests/classic/refresh/user_prompts.py
+++ b/webdriver/tests/classic/refresh/user_prompts.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from webdriver.error import StaleElementReferenceException
+from webdriver import error
 
 from tests.support.asserts import assert_dialog_handled, assert_error, assert_success
 
@@ -10,6 +10,31 @@ from tests.support.asserts import assert_dialog_handled, assert_error, assert_su
 def refresh(session):
     return session.transport.send(
         "POST", "session/{session_id}/refresh".format(**vars(session)))
+
+
+@pytest.fixture
+def check_beforeunload_implicitly_accepted(session, url):
+    def check_beforeunload_implicitly_accepted():
+        page_beforeunload = url(
+            "/webdriver/tests/support/html/beforeunload.html")
+
+        session.url = page_beforeunload
+        element = session.find.css("input", all=False)
+        element.send_keys("bar")
+
+        response = refresh(session)
+        assert_success(response)
+
+        # navigation auto-dismissed beforeunload prompt
+        with pytest.raises(error.NoSuchAlertException):
+            session.alert.text
+
+        with pytest.raises(error.StaleElementReferenceException):
+            element.property("id")
+
+        session.find.css("input", all=False)
+
+    return check_beforeunload_implicitly_accepted
 
 
 @pytest.fixture
@@ -25,7 +50,7 @@ def check_user_prompt_closed_without_exception(session, create_dialog, inline):
 
         assert_dialog_handled(session, expected_text=dialog_type, expected_retval=retval)
 
-        with pytest.raises(StaleElementReferenceException):
+        with pytest.raises(error.StaleElementReferenceException):
             element.property("id")
 
     return check_user_prompt_closed_without_exception
@@ -69,49 +94,96 @@ def check_user_prompt_not_closed_but_exception(session, create_dialog, inline):
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "accept"})
-@pytest.mark.parametrize("dialog_type", ["alert", "confirm", "prompt"])
-def test_accept(check_user_prompt_closed_without_exception, dialog_type):
-    # retval not testable for confirm and prompt because window has been reloaded
-    check_user_prompt_closed_without_exception(dialog_type, None)
+@pytest.mark.parametrize("dialog_type", ["alert", "beforeunload", "confirm", "prompt"])
+def test_accept(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_without_exception,
+    dialog_type
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        # retval not testable for confirm and prompt because window is gone
+        check_user_prompt_closed_without_exception(dialog_type, None)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "accept and notify"})
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", True),
     ("prompt", ""),
 ])
-def test_accept_and_notify(check_user_prompt_closed_with_exception, dialog_type, retval):
-    check_user_prompt_closed_with_exception(dialog_type, retval)
+def test_accept_and_notify(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_with_exception,
+    dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_with_exception(dialog_type, retval)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "dismiss"})
-@pytest.mark.parametrize("dialog_type", ["alert", "confirm", "prompt"])
-def test_dismiss(check_user_prompt_closed_without_exception, dialog_type):
-    # retval not testable for confirm and prompt because window has been reloaded
-    check_user_prompt_closed_without_exception(dialog_type, None)
+@pytest.mark.parametrize("dialog_type", ["alert", "beforeunload", "confirm", "prompt"])
+def test_dismiss(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_without_exception,
+    dialog_type
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        # retval not testable for confirm and prompt because window is gone
+        check_user_prompt_closed_without_exception(dialog_type, None)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "dismiss and notify"})
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", False),
     ("prompt", None),
 ])
-def test_dismiss_and_notify(check_user_prompt_closed_with_exception, dialog_type, retval):
-    check_user_prompt_closed_with_exception(dialog_type, retval)
+def test_dismiss_and_notify(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_with_exception, dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_with_exception(dialog_type, retval)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "ignore"})
-@pytest.mark.parametrize("dialog_type", ["alert", "confirm", "prompt"])
-def test_ignore(check_user_prompt_not_closed_but_exception, dialog_type):
-    check_user_prompt_not_closed_but_exception(dialog_type)
+@pytest.mark.parametrize("dialog_type", ["alert", "beforeunload", "confirm", "prompt"])
+def test_ignore(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_not_closed_but_exception,
+    dialog_type
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_not_closed_but_exception(dialog_type)
 
 
 @pytest.mark.parametrize("dialog_type, retval", [
     ("alert", None),
+    ("beforeunload", None),
     ("confirm", False),
     ("prompt", None),
 ])
-def test_default(check_user_prompt_closed_with_exception, dialog_type, retval):
-    check_user_prompt_closed_with_exception(dialog_type, retval)
+def test_default(
+    check_beforeunload_implicitly_accepted,
+    check_user_prompt_closed_with_exception,
+    dialog_type,
+    retval
+):
+    if dialog_type == "beforeunload":
+        check_beforeunload_implicitly_accepted()
+    else:
+        check_user_prompt_closed_with_exception(dialog_type, retval)

--- a/webdriver/tests/support/html/beforeunload.html
+++ b/webdriver/tests/support/html/beforeunload.html
@@ -1,0 +1,16 @@
+<html>
+
+  <head>
+    <script>
+      window.addEventListener("beforeunload", function (event) {
+        event.preventDefault();
+      });
+    </script>
+  </head>
+
+  <body>
+    <input type="text" />
+    <a href="default.html" target="_top">Click</a>
+  </body>
+
+</html>

--- a/webdriver/tests/support/html/default.html
+++ b/webdriver/tests/support/html/default.html
@@ -1,0 +1,7 @@
+<html>
+
+  <body>
+    <div>Foo</div>
+  </body>
+
+</html>


### PR DESCRIPTION
With this PR I'm going to add a couple of user prompt tests specific to `beforeunload` prompts which are very poorly covered at the moment. These are important to have to see what the current cross-browser behavior is and how this feature could potentially co-work with WebDriver BiDi where we do not want to implicitly dismiss this kind of dialog by default.