### PR TITLE
[css-flexbox] Fix errors in safe alignment tests.

### DIFF
--- a/css/css-flexbox/flexbox-safe-overflow-position-002.html
+++ b/css/css-flexbox/flexbox-safe-overflow-position-002.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#overflow-values">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert"
-  content="safe flex-start allows for overflow past the flex-end edge, which is top in the case of wrap-reverse" />
+  content="safe flex-start allows for overflow past the end edge, which is bottom/right even in the case of wrap-reverse" />
 
 <style>
   #reference-overlapped-red {
@@ -16,16 +16,16 @@
 
   .flex {
     display: flex;
-    width: 100px;
+    width: 90px;
     height: 90px;
     align-content: safe flex-start;
+    justify-content: safe flex-start;
     flex-wrap: wrap-reverse;
-    /* Make the green square cover the red square. */
-    translate: 0 10px;
   }
 
   .item {
     flex: 0 0 100px;
+    width: 100px;
     height: 100px;
     background: green;
   }

--- a/css/css-flexbox/flexbox-safe-overflow-position-003.html
+++ b/css/css-flexbox/flexbox-safe-overflow-position-003.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#overflow-values">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert"
-  content="safe flex-start allows for overflow past the flex-end edge, which is left in the case of row-reverse" />
+  content="safe flex-start allows for overflow past the end edge, which is bottom/right even in the case of row-reverse" />
 
 <style>
   #reference-overlapped-red {
@@ -18,14 +18,14 @@
     display: flex;
     flex-flow: row-reverse;
     width: 90px;
-    height: 100px;
+    height: 90px;
+    align-content: safe flex-start;
     justify-content: safe flex-start;
-    /* Make the green square cover the red square. */
-    translate: 10px 0;
   }
 
   .item {
     flex: 0 0 100px;
+    width: 100px;
     height: 100px;
     background: green;
   }

--- a/css/css-flexbox/flexbox-safe-overflow-position-004.html
+++ b/css/css-flexbox/flexbox-safe-overflow-position-004.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#overflow-values">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert"
-  content="safe flex-start allows for overflow past the flex-end edge, which is top in the case of column-reverse" />
+  content="safe flex-start allows for overflow past the end edge, which is bottom/right even in the case of column-reverse" />
 
 <style>
   #reference-overlapped-red {
@@ -17,15 +17,15 @@
   .flex {
     display: flex;
     flex-flow: column-reverse;
-    width: 100px;
+    width: 90px;
     height: 90px;
     align-content: safe flex-start;
-    /* Make the green square cover the red square. */
-    translate: 0 10px;
+    justify-content: safe flex-start;
   }
 
   .item {
     flex: 0 0 100px;
+    width: 100px;
     height: 100px;
     background: green;
   }

--- a/css/css-flexbox/flexbox-safe-overflow-position-005.html
+++ b/css/css-flexbox/flexbox-safe-overflow-position-005.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#overflow-values">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert"
-  content="safe flex-start allows for overflow past the flex-end edge, which is left in the case of wrap-reverse + vertical-lr" />
+  content="safe flex-start allows for overflow past the end edge, which is bottom/right in the case of wrap-reverse + vertical-lr" />
 
 <style>
   #reference-overlapped-red {
@@ -16,18 +16,18 @@
 
   .flex {
     display: flex;
-    inline-size: 100px;
+    flex-flow: wrap-reverse;
+    writing-mode: vertical-lr;
+    inline-size: 90px;
     block-size: 90px;
     align-content: safe flex-start;
-    flex-wrap: wrap-reverse;
-    writing-mode: vertical-lr;
-    /* Make the green square cover the red square. */
-    translate: 10px 0;
+    justify-content: safe flex-start;
   }
 
   .item {
     flex: 0 0 100px;
-    block-size: 100px;
+    width: 100px;
+    height: 100px;
     background: green;
   }
 


### PR DESCRIPTION
Safe alignment overflows the end edge, not the flex-end edge. Also adjust the tests to check both axes.