### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=268234

### DIFF
--- a/css/selectors/parsing/invalid-pseudos.html
+++ b/css/selectors/parsing/invalid-pseudos.html
@@ -9,9 +9,15 @@
 <script>
 // Pseudo-classes
 test_invalid_selector(":-internal-animating-full-screen-transition");
+test_invalid_selector(":-internal-fullscreen-document");
 test_invalid_selector(":-internal-html-document");
+test_invalid_selector(":-internal-media-document");
 test_invalid_selector(":-khtml-drag");
 test_invalid_selector(":-webkit-animating-full-screen-transition");
+test_invalid_selector(":-webkit-full-page-media");
+test_invalid_selector(":-webkit-full-screen-ancestor");
+test_invalid_selector(":-webkit-full-screen-controls-hidden");
+test_invalid_selector(":-webkit-full-screen-document");
 
 // Pseudo-elements
 test_invalid_selector("::-apple-attachment-controls-container");


### PR DESCRIPTION
WebKit export from bug: [Make `:-webkit-full-screen-document` an internal pseudo-class](https://bugs.webkit.org/show_bug.cgi?id=268234)