### PR TITLE
Add tests for `ShadowRoot.importNode`

### DIFF
--- a/custom-elements/scoped-registry/ShadowRoot-importNode.tentative.html
+++ b/custom-elements/scoped-registry/ShadowRoot-importNode.tentative.html
@@ -1,5 +1,5 @@
-<title>Tests ShadowRoot.importNode APIs work with scoped custom element registries</title>
 <!DOCTYPE html>
+<title>Tests ShadowRoot.importNode APIs work with scoped custom element registries</title>
 <meta name="author" title="Kristján Oddsson" href="mailto:wpt@koddsson.com">
 <link rel="help" href="https://wicg.github.io/webcomponents/proposals/Scoped-Custom-Element-Registries">
 <script src="/resources/testharness.js"></script>

--- a/custom-elements/scoped-registry/ShadowRoot-importNode.tentative.html
+++ b/custom-elements/scoped-registry/ShadowRoot-importNode.tentative.html
@@ -87,6 +87,78 @@ test(t => {
   assert_equals(newDiv.firstChild, shadow);
 }, "ShadowRoot.importNode(Node, true)")
 
+
+test(t => {
+  const registry = new CustomElementRegistry;
+  const shadow = attachShadowForTest(t, registry);
+
+  // Create a new element in a new HTML document.
+  const doc = document.implementation.createHTMLDocument("ShadowRoot importNode test document");
+
+  document.customElements.define('my-element', class extends HTMLElement {});
+  const myElement = doc.body.appendChild(doc.createElement("my-element"));
+  myElement.appendChild(doc.createElement("span"));
+  assert_equals(myElement.ownerDocument, doc);
+  assert_equals(myElement.firstChild.ownerDocument, doc);
+
+  // Import the created element into the ShadowRoot.
+  const importedMyElement = shadow.importNode(myElement);
+  assert_equals(myElement.firstChild.ownerDocument, doc);
+  assert_equals(importedMyElement.ownerDocument, shadow);
+  assert_equals(importedMyElement.firstChild, null);
+}, "ShadowRoot.importNode(<my-element>)")
+
+test(t => {
+  const registry = new CustomElementRegistry;
+  const shadow = attachShadowForTest(t, registry);
+
+  // Create a new element in a new HTML document.
+  const doc = document.implementation.createHTMLDocument("ShadowRoot importNode test document");
+
+  document.customElements.define('my-element', class extends HTMLElement {});
+  const myElement = doc.body.appendChild(doc.createElement("my-element"));
+  myElement.appendChild(doc.createElement("span"));
+  assert_equals(myElement.ownerDocument, doc);
+  assert_equals(myElement.firstChild.ownerDocument, doc);
+
+  // Import the created element into the ShadowRoot.
+  const importedMyElement = shadow.importNode(myElement, true);
+  assert_equals(myElement.firstChild.ownerDocument, doc);
+  assert_equals(importedMyElement.ownerDocument, shadow);
+  assert_equals(importedMyElement.firstChild, shadow);
+}, "ShadowRoot.importNode(<my-element>, true)")
+
+test(t => {
+  const registry = new CustomElementRegistry;
+  const shadow = attachShadowForTest(t, registry);
+
+  // Create a new element in a new HTML document.
+  const doc = document.implementation.createHTMLDocument("ShadowRoot importNode test document");
+
+  let connectedCallbackCount = 0;
+  let disconnectedCallbackCount = 0;
+
+  document.customElements.define('my-element', class extends HTMLElement {
+    connectedCallback() { connectedCallbackCount += 1 }
+    disconnectedCallback() { disconnectedCallbackCount += 1 }
+  });
+
+  const myElement = doc.body.appendChild(doc.createElement("my-element"));
+  myElement.appendChild(doc.createElement("span"));
+  assert_equals(myElement.ownerDocument, doc);
+  assert_equals(myElement.firstChild.ownerDocument, doc);
+  assert_equals(connectedCallbackCount, 1);
+  assert_equals(connectedCallbackCount, 0);
+
+  // Import the created element into the ShadowRoot.
+  const importedMyElement = shadow.importNode(myElement);
+  assert_equals(myElement.firstChild.ownerDocument, doc);
+  assert_equals(importedMyElement.ownerDocument, shadow);
+  assert_equals(importedMyElement.firstChild, null);
+  assert_equals(connectedCallbackCount, 2);
+  assert_equals(connectedCallbackCount, 1);
+}, "Check connected callbacks when importing custom element into shadowroot");
+
 test(t => {
   const registry = new CustomElementRegistry;
   const shadow = attachShadowForTest(t, registry);

--- a/custom-elements/scoped-registry/ShadowRoot-importNode.tentative.html
+++ b/custom-elements/scoped-registry/ShadowRoot-importNode.tentative.html
@@ -1,0 +1,109 @@
+<title>Tests ShadowRoot.importNode APIs work with scoped custom element registries</title>
+<!DOCTYPE html>
+<meta name="author" title="Kristján Oddsson" href="mailto:wpt@koddsson.com">
+<link rel="help" href="https://wicg.github.io/webcomponents/proposals/Scoped-Custom-Element-Registries">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+function attachShadowForTest(t, registry) {
+  const host = document.createElement('div');
+  const shadow = host.attachShadow({mode: 'open', registry});
+  document.body.appendChild(host);
+  t.add_cleanup(() => host.remove());
+  return shadow;
+}
+
+test(t => {
+  const registry = new CustomElementRegistry;
+  const shadow = attachShadowForTest(t, registry);
+
+  // Create a new element in a new HTML document.
+  const doc = document.implementation.createHTMLDocument("ShadowRoot importNode test document");
+  const div = doc.body.appendChild(doc.createElement("div"));
+  div.appendChild(doc.createElement("span"));
+  assert_equals(div.ownerDocument, doc);
+  assert_equals(div.firstChild.ownerDocument, doc);
+
+  // Import the created element into the ShadowRoot.
+  const newDiv = shadow.importNode(div);
+  assert_equals(div.ownerDocument, doc);
+  assert_equals(div.firstChild.ownerDocument, doc);
+  assert_equals(newDiv.ownerDocument, shadow);
+  assert_equals(newDiv.firstChild, null);
+}, 'ShadowRoot.importNode(Node)');
+
+test(t => {
+  const registry = new CustomElementRegistry;
+  const shadow = attachShadowForTest(t, registry);
+
+  // Create a new element in a new HTML document.
+  const doc = document.implementation.createHTMLDocument("ShadowRoot importNode test document");
+  const div = doc.body.appendChild(doc.createElement("div"));
+  div.appendChild(doc.createElement("span"));
+  assert_equals(div.ownerDocument, doc);
+  assert_equals(div.firstChild.ownerDocument, doc);
+
+  // Import the created element into the ShadowRoot.
+  const newDiv = shadow.importNode(div, undefined);
+  assert_equals(div.ownerDocument, doc);
+  assert_equals(div.firstChild.ownerDocument, doc);
+  assert_equals(newDiv.ownerDocument, shadow);
+  assert_equals(newDiv.firstChild, null);
+}, "ShadowRoot.importNode(Node, undefined)")
+
+test(t => {
+  const registry = new CustomElementRegistry;
+  const shadow = attachShadowForTest(t, registry);
+
+  // Create a new element in a new HTML document.
+  const doc = document.implementation.createHTMLDocument("ShadowRoot importNode test document");
+  const div = doc.body.appendChild(doc.createElement("div"));
+  div.appendChild(doc.createElement("span"));
+  assert_equals(div.ownerDocument, doc);
+  assert_equals(div.firstChild.ownerDocument, doc);
+
+  // Import the created element into the ShadowRoot.
+  const newDiv = shadow.importNode(div);
+  assert_equals(div.ownerDocument, doc);
+  assert_equals(div.firstChild.ownerDocument, doc);
+  assert_equals(newDiv.ownerDocument, shadow);
+  assert_equals(newDiv.firstChild, null);
+}, 'ShadowRoot.importNode(Node, false)');
+
+test(t => {
+  const registry = new CustomElementRegistry;
+  const shadow = attachShadowForTest(t, registry);
+
+  // Create a new element in a new HTML document.
+  const doc = document.implementation.createHTMLDocument("ShadowRoot importNode test document");
+  const div = doc.body.appendChild(doc.createElement("div"));
+  div.appendChild(doc.createElement("span"));
+  assert_equals(div.ownerDocument, doc);
+  assert_equals(div.firstChild.ownerDocument, doc);
+
+  // Import the created element into the ShadowRoot.
+  assert_equals(div.ownerDocument, doc);
+  const newDiv = shadow.importNode(div, true);
+  assert_equals(div.firstChild.ownerDocument, doc);
+  assert_equals(newDiv.ownerDocument, shadow);
+  assert_equals(newDiv.firstChild, shadow);
+}, "ShadowRoot.importNode(Node, true)")
+
+test(t => {
+  const registry = new CustomElementRegistry;
+  const shadow = attachShadowForTest(t, registry);
+
+  const doc = document.implementation.createHTMLDocument("ShadowRoot importNode test document");
+  doc.body.setAttributeNS("http://example.com/", "p:name", "value");
+  const originalAttr = doc.body.getAttributeNodeNS("http://example.com/", "name");
+  const imported = shadow.importNode(originalAttr, true);
+  assert_equals(imported.prefix, originalAttr.prefix);
+  assert_equals(imported.namespaceURI, originalAttr.namespaceURI);
+  assert_equals(imported.localName, originalAttr.localName);
+}, "Import an Attr node with namespace/prefix correctly.");
+
+</script>
+</body>
+

--- a/custom-elements/scoped-registry/ShadowRoot-importNode.tentative.html
+++ b/custom-elements/scoped-registry/ShadowRoot-importNode.tentative.html
@@ -29,7 +29,7 @@ test(t => {
   // Import the created element into the ShadowRoot.
   const newDiv = shadow.importNode(div);
   assert_equals(div.firstChild.ownerDocument, doc);
-  assert_equals(newDiv.ownerDocument, shadow);
+  assert_equals(newDiv.ownerDocument, document);
   assert_equals(newDiv.firstChild, null);
 }, 'ShadowRoot.importNode(Node)');
 
@@ -47,7 +47,7 @@ test(t => {
   // Import the created element into the ShadowRoot.
   const newDiv = shadow.importNode(div, undefined);
   assert_equals(div.firstChild.ownerDocument, doc);
-  assert_equals(newDiv.ownerDocument, shadow);
+  assert_equals(newDiv.ownerDocument, document);
   assert_equals(newDiv.firstChild, null);
 }, "ShadowRoot.importNode(Node, undefined)")
 
@@ -65,7 +65,7 @@ test(t => {
   // Import the created element into the ShadowRoot.
   const newDiv = shadow.importNode(div);
   assert_equals(div.firstChild.ownerDocument, doc);
-  assert_equals(newDiv.ownerDocument, shadow);
+  assert_equals(newDiv.ownerDocument, document);
   assert_equals(newDiv.firstChild, null);
 }, 'ShadowRoot.importNode(Node, false)');
 
@@ -83,8 +83,8 @@ test(t => {
   // Import the created element into the ShadowRoot.
   const newDiv = shadow.importNode(div, true);
   assert_equals(div.firstChild.ownerDocument, doc);
-  assert_equals(newDiv.ownerDocument, shadow);
-  assert_equals(newDiv.firstChild, shadow);
+  assert_equals(newDiv.ownerDocument, document);
+  assert_equals(newDiv.firstChild.ownerDocument, document);
 }, "ShadowRoot.importNode(Node, true)")
 
 
@@ -124,8 +124,8 @@ test(t => {
   // Import the created element into the ShadowRoot.
   const importedMyElement = shadow.importNode(myElement, true);
   assert_equals(myElement.firstChild.ownerDocument, doc);
-  assert_equals(importedMyElement.ownerDocument, shadow);
-  assert_equals(importedMyElement.firstChild, shadow);
+  assert_equals(importedMyElement.ownerDocument, document);
+  assert_equals(importedMyElement.firstChild.ownerDocument, document);
 }, "ShadowRoot.importNode(<my-element>, true)")
 
 test(t => {
@@ -153,7 +153,7 @@ test(t => {
   // Import the created element into the ShadowRoot.
   const importedMyElement = shadow.importNode(myElement);
   assert_equals(myElement.firstChild.ownerDocument, doc);
-  assert_equals(importedMyElement.ownerDocument, shadow);
+  assert_equals(importedMyElement.ownerDocument, document);
   assert_equals(importedMyElement.firstChild, null);
   assert_equals(connectedCallbackCount, 2);
   assert_equals(connectedCallbackCount, 1);

--- a/custom-elements/scoped-registry/ShadowRoot-importNode.tentative.html
+++ b/custom-elements/scoped-registry/ShadowRoot-importNode.tentative.html
@@ -28,7 +28,6 @@ test(t => {
 
   // Import the created element into the ShadowRoot.
   const newDiv = shadow.importNode(div);
-  assert_equals(div.ownerDocument, doc);
   assert_equals(div.firstChild.ownerDocument, doc);
   assert_equals(newDiv.ownerDocument, shadow);
   assert_equals(newDiv.firstChild, null);
@@ -47,7 +46,6 @@ test(t => {
 
   // Import the created element into the ShadowRoot.
   const newDiv = shadow.importNode(div, undefined);
-  assert_equals(div.ownerDocument, doc);
   assert_equals(div.firstChild.ownerDocument, doc);
   assert_equals(newDiv.ownerDocument, shadow);
   assert_equals(newDiv.firstChild, null);
@@ -66,7 +64,6 @@ test(t => {
 
   // Import the created element into the ShadowRoot.
   const newDiv = shadow.importNode(div);
-  assert_equals(div.ownerDocument, doc);
   assert_equals(div.firstChild.ownerDocument, doc);
   assert_equals(newDiv.ownerDocument, shadow);
   assert_equals(newDiv.firstChild, null);
@@ -84,7 +81,6 @@ test(t => {
   assert_equals(div.firstChild.ownerDocument, doc);
 
   // Import the created element into the ShadowRoot.
-  assert_equals(div.ownerDocument, doc);
   const newDiv = shadow.importNode(div, true);
   assert_equals(div.firstChild.ownerDocument, doc);
   assert_equals(newDiv.ownerDocument, shadow);


### PR DESCRIPTION
I followed `dom/nodes/Document-importNode.html` since I think these should work the same. Otherwise I tried to align with how the existing scoped registry tests are structured.