### PR TITLE
Add tests for trusted types enforcement on setHTMLUnsafe and parseHTMLUnsafe

### DIFF
--- a/trusted-types/block-string-assignment-to-Document-parseHTMLUnsafe.html
+++ b/trusted-types/block-string-assignment-to-Document-parseHTMLUnsafe.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="author" title="Luke Warlow" href="mailto:lwarlow@igalia.com">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="support/helper.sub.js"></script>
+
+  <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script';">
+</head>
+<body>
+<script>
+  test(t => {
+    let p = createHTML_policy(window, 1);
+    let html = p.createHTML(INPUTS.HTML);
+    let doc = Document.parseHTMLUnsafe(html);
+    assert_equals(doc.body.innerText, RESULTS.HTML);
+  }, "Document.parseHTMLUnsafe assigned via policy (successful HTML transformation).");
+
+  // String assignments throw.
+  test(t => {
+    assert_throws_js(TypeError, _ => {
+      var doc = Document.parseHTMLUnsafe("Fail");
+    });
+  }, "`Document.parseHTMLUnsafe(string)` throws.");
+
+  // Null assignment throws.
+  test(t => {
+    assert_throws_js(TypeError, _ => {
+      var doc = Document.parseHTMLUnsafe(null);
+    });
+  }, "'Document.parseHTMLUnsafe(null)' throws");
+
+  // After default policy creation string assignment implicitly calls createHTML.
+  test(t => {
+    let p = window.trustedTypes.createPolicy("default", { createHTML: createHTMLJS }, true);
+    let doc = Document.parseHTMLUnsafe(INPUTS.HTML, "text/html");
+    assert_equals(doc.body.innerText, RESULTS.HTML);
+  }, "'Document.parseHTMLUnsafe(string)' assigned via default policy (successful HTML transformation).");
+
+  // After default policy creation null assignment implicitly calls createHTML.
+  test(t => {
+    var doc = Document.parseHTMLUnsafe(null, "text/html");
+    assert_equals(doc.body.innerText, "null");
+  }, "'Document.parseHTMLUnsafe(null)' assigned via default policy does not throw");
+</script>
+</body>
+</html>

--- a/trusted-types/block-string-assignment-to-Element-setHTMLUnsafe.html
+++ b/trusted-types/block-string-assignment-to-Element-setHTMLUnsafe.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="author" title="Luke Warlow" href="mailto:lwarlow@igalia.com">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="support/helper.sub.js"></script>
+
+  <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script';">
+</head>
+<body>
+<div id="container"></div>
+<script>
+  var container = document.querySelector('#container')
+
+  // TrustedHTML assignments do not throw.
+  test(t => {
+    let p = createHTML_policy(window, 1);
+    let html = p.createHTML(INPUTS.HTML);
+
+    var d = document.createElement('div');
+    document.querySelector('#container').appendChild(d);
+    d.setHTMLUnsafe(html);
+    assert_equals(container.innerText, RESULTS.HTML);
+
+    while (container.firstChild)
+      container.firstChild.remove();
+  }, "element.setHTMLUnsafe(html) assigned via policy (successful HTML transformation).");
+
+  // String assignments throw.
+  test(t => {
+    var d = document.createElement('div');
+    container.appendChild(d);
+    assert_throws_js(TypeError, _ => {
+      d.setHTMLUnsafe("Fail");
+    });
+    assert_equals(container.innerText, "");
+    while (container.firstChild)
+      container.firstChild.remove();
+  }, "`element.setHTMLUnsafe(string)` throws.");
+
+  // Null assignment throws.
+  test(t => {
+    var d = document.createElement('div');
+    container.appendChild(d);
+    assert_throws_js(TypeError, _ => {
+      d.outerHTML = null;
+    });
+    assert_equals(container.innerText, "");
+    while (container.firstChild)
+      container.firstChild.remove();
+  }, "`element.setHTMLUnsafe(null)` throws.");
+
+  // After default policy creation string assignment implicitly calls createHTML.
+  test(t => {
+    let p = window.trustedTypes.createPolicy("default", { createHTML: createHTMLJS }, true);
+
+    var d = document.createElement('div');
+    document.querySelector('#container').appendChild(d);
+    d.setHTMLUnsafe(INPUTS.HTML);
+    assert_equals(container.innerText, RESULTS.HTML);
+
+    while (container.firstChild)
+      container.firstChild.remove();
+  }, "`element.setHTMLUnsafe(string)` assigned via default policy (successful HTML transformation).");
+
+  // After default policy creation null assignment implicitly calls createHTML.
+  test(t => {
+    var d = document.createElement('div');
+    container.appendChild(d);
+    d.setHTMLUnsafe(null);
+    assert_equals(container.innerText, "null");
+
+    while (container.firstChild)
+      container.firstChild.remove();
+  }, "`element.setHTMLUnsafe(string)` assigned via default policy does not throw");
+</script>
+</body>
+</html>

--- a/trusted-types/block-string-assignment-to-ShadowRoot-setHTMLUnsafe.html
+++ b/trusted-types/block-string-assignment-to-ShadowRoot-setHTMLUnsafe.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="author" title="Luke Warlow" href="mailto:lwarlow@igalia.com">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="support/helper.sub.js"></script>
+
+  <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script';">
+</head>
+<body>
+<div id="container"></div>
+<script>
+  var container = document.querySelector('#container')
+
+  // TrustedHTML assignments do not throw.
+  test(t => {
+    let p = createHTML_policy(window, 1);
+    let html = p.createHTML(INPUTS.HTML);
+
+    let d = document.createElement('div');
+    let s = d.attachShadow({mode: 'open'});
+    document.querySelector('#container').appendChild(d);
+    s.setHTMLUnsafe(html);
+    assert_equals(s.innerHTML, RESULTS.HTML);
+
+    while (container.firstChild)
+      container.firstChild.remove();
+  }, "shadowRoot.setHTMLUnsafe(html) assigned via policy (successful HTML transformation).");
+
+  // String assignments throw.
+  test(t => {
+    let d = document.createElement('div');
+    let s = d.attachShadow({mode: 'open'});
+    container.appendChild(d);
+    assert_throws_js(TypeError, _ => {
+      s.setHTMLUnsafe("Fail");
+    });
+    assert_equals(s.innerHTML, "");
+    while (container.firstChild)
+      container.firstChild.remove();
+  }, "`shadowRoot.setHTMLUnsafe(string)` throws.");
+
+  // Null assignment throws.
+  test(t => {
+    let d = document.createElement('div');
+    let s = d.attachShadow({mode: 'open'});
+    container.appendChild(d);
+    assert_throws_js(TypeError, _ => {
+      s.setHTMLUnsafe(null);
+    });
+    assert_equals(s.innerHTML, "");
+    while (container.firstChild)
+      container.firstChild.remove();
+  }, "`shadowRoot.setHTMLUnsafe(null)` throws.");
+
+  // After default policy creation string assignment implicitly calls createHTML.
+  test(t => {
+    let p = window.trustedTypes.createPolicy("default", { createHTML: createHTMLJS }, true);
+
+    let d = document.createElement('div');
+    let s = d.attachShadow({mode: 'open'});
+    document.querySelector('#container').appendChild(d);
+    s.setHTMLUnsafe(INPUTS.HTML);
+    assert_equals(s.innerHTML, RESULTS.HTML);
+
+    while (container.firstChild)
+      container.firstChild.remove();
+  }, "`shadowRoot.setHTMLUnsafe(string)` assigned via default policy (successful HTML transformation).");
+
+  // After default policy creation null assignment implicitly calls createHTML.
+  test(t => {
+    let d = document.createElement('div');
+    let s = d.attachShadow({mode: 'open'});
+    container.appendChild(d);
+    s.setHTMLUnsafe(null);
+    assert_equals(s.innerHTML, "null");
+
+    while (container.firstChild)
+      container.firstChild.remove();
+  }, "`shadowRoot.setHTMLUnsafe(string)` assigned via default policy does not throw");
+</script>
+</body>
+</html>


### PR DESCRIPTION
Test coverage for https://github.com/w3c/trusted-types/issues/403

This is expected to fail in Chromium as it hasn't covered these functions with trusted types yet.