### PR TITLE
Chrome Canary and Chromium Nightly are installed via `--install-browser` in Taskcluster

### DIFF
--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -23,7 +23,10 @@ def get_browser_args(product, channel, artifact_path):
         return ["--install-browser", "--processes=12"]
     if product == "chrome" or product == "chromium":
         # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
-        return ["--enable-swiftshader", "--install-browser", "--install-webdriver"]
+        args = ["--enable-swiftshader"]
+        if channel == "nightly" or channel == "canary":
+            args.extend(["--install-browser", "--install-webdriver"])
+        return args
     if product == "webkitgtk_minibrowser":
         # Using 4 parallel jobs gives 4x speed-up even on a 1-core machine and doesn't cause extra timeouts.
         # See: https://github.com/web-platform-tests/wpt/issues/38723#issuecomment-1470938179

--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -24,6 +24,7 @@ def get_browser_args(product, channel, artifact_path):
     if product == "chrome" or product == "chromium":
         # Taskcluster machines do not have GPUs, so use software rendering via --enable-swiftshader.
         args = ["--enable-swiftshader"]
+        # Chrome Stable-Dev are still installed in tools/ci/run_tc.py
         if channel == "nightly" or channel == "canary":
             args.extend(["--install-browser", "--install-webdriver"])
         return args


### PR DESCRIPTION
This change specifies that only Chrome Canary and Chromium Nightly are installed via the `--install-browser` command. Some test results on Chrome Dev have become flaky since [changing this last week](https://github.com/web-platform-tests/wpt/pull/43842/files#diff-98f90006ed1a76b623d518838c20d9fe1ffed0c535eedc636c5766473b34466bL26-L29), and this update will rectify the issue while the root cause is identified.