### PR TITLE
Ensure dialog cancel events fired even without interaction

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-events.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-events.html
@@ -48,6 +48,5 @@ dialog.onclose = () => {
 };
 
 dialog.showModal();
-await blessTopLayer(dialog);
 await sendCloseRequest();
 </script>


### PR DESCRIPTION
The cancel events should not be dependent on the user having first interacted with the dialog. Because this test includes user interaction before sending the close request, it failed to catch a [regression in Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=1512224).

Removing the user interaction (i.e. call to `blessTopLayer`) so this test covers that scenario as well.