### PR TITLE
Only use new headless mode for Chrome

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -139,16 +139,16 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     if kwargs["enable_experimental"]:
         chrome_options["args"].extend(["--enable-experimental-web-platform-features"])
 
+    # Copy over any other flags that were passed in via `--binary-arg`
+    for arg in kwargs.get("binary_args", []):
+        if arg not in chrome_options["args"]:
+            chrome_options["args"].append(arg)
+
     # Pass the --headless=new flag to Chrome if WPT's own --headless flag was
     # set. '--headless' should always mean the new headless mode, as the old
     # headless mode is not used anyway.
     if kwargs["headless"] and "--headless=new" not in chrome_options["args"]:
         chrome_options["args"].append("--headless=new")
-
-    # Copy over any other flags that were passed in via `--binary-arg`
-    for arg in kwargs.get("binary_args", []):
-        if arg not in chrome_options["args"]:
-            chrome_options["args"].append(arg)
 
     if test_type == "wdspec":
         executor_kwargs["binary_args"] = chrome_options["args"]

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -139,13 +139,11 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     if kwargs["enable_experimental"]:
         chrome_options["args"].extend(["--enable-experimental-web-platform-features"])
 
-    new_headless_mode = ("--headless=new" in kwargs.get("binary_args", []))
-
-    # Pass the --headless flag to Chrome if WPT's own --headless flag was set
-    # or if we're running print reftests because of crbug.com/753118
-    if ((kwargs["headless"] or test_type == "print-reftest") and
-        "--headless" not in chrome_options["args"] and not new_headless_mode):
-        chrome_options["args"].append("--headless")
+    # Pass the --headless=new flag to Chrome if WPT's own --headless flag was
+    # set. '--headless' should always mean the new headless mode, as the old
+    # headless mode is not used anyway.
+    if kwargs["headless"] and "--headless=new" not in chrome_options["args"]:
+        chrome_options["args"].append("--headless=new")
 
     # Copy over any other flags that were passed in via `--binary-arg`
     for arg in kwargs.get("binary_args", []):


### PR DESCRIPTION
We are going to use headful mode in Chromium, and results for wpt.fyi also comes from headful mode, thus there is no need to run tests in the old headless mode.

crbug.com/753118 is also fixed now. Remove the special handling for print-ref tests also.