### PR TITLE
Split out `text-wrap: pretty` parsing tests

### DIFF
--- a/css/css-text/parsing/text-wrap-computed.html
+++ b/css/css-text/parsing/text-wrap-computed.html
@@ -19,24 +19,19 @@ test_computed_value("text-wrap", "nowrap");
 test_computed_value("text-wrap", "auto", "wrap");
 test_computed_value("text-wrap", "balance");
 test_computed_value("text-wrap", "stable");
-test_computed_value("text-wrap", "pretty");
 
 test_computed_value("text-wrap", "wrap auto", "wrap");
 test_computed_value("text-wrap", "wrap balance", "balance");
-test_computed_value("text-wrap", "wrap pretty", "pretty");
 test_computed_value("text-wrap", "wrap stable", "stable");
 test_computed_value("text-wrap", "auto wrap", "wrap");
 test_computed_value("text-wrap", "balance wrap", "balance");
-test_computed_value("text-wrap", "pretty wrap", "pretty");
 test_computed_value("text-wrap", "stable wrap", "stable");
 
 test_computed_value("text-wrap", "nowrap auto", "nowrap");
 test_computed_value("text-wrap", "nowrap balance");
-test_computed_value("text-wrap", "nowrap pretty");
 test_computed_value("text-wrap", "nowrap stable");
 test_computed_value("text-wrap", "auto nowrap", "nowrap");
 test_computed_value("text-wrap", "balance nowrap", "nowrap balance");
-test_computed_value("text-wrap", "pretty nowrap", "nowrap pretty");
 test_computed_value("text-wrap", "stable nowrap", "nowrap stable");
 </script>
 </body>

--- a/css/css-text/parsing/text-wrap-pretty.html
+++ b/css/css-text/parsing/text-wrap-pretty.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Text Module Test: text-wrap: pretty parsing</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#text-wrap">
+<meta name="assert" content="text-wrap: pretty parsing">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_valid_value("text-wrap", "pretty");
+test_valid_value("text-wrap", "wrap pretty", "pretty");
+test_valid_value("text-wrap", "pretty wrap", "pretty");
+test_valid_value("text-wrap", "stable wrap", "stable");
+test_valid_value("text-wrap", "nowrap pretty");
+test_valid_value("text-wrap", "pretty nowrap", "nowrap pretty");
+test_valid_value("text-wrap-style", "pretty");
+
+test_computed_value("text-wrap", "pretty");
+test_computed_value("text-wrap", "wrap pretty", "pretty");
+test_computed_value("text-wrap", "pretty wrap", "pretty");
+test_computed_value("text-wrap", "stable wrap", "stable");
+test_computed_value("text-wrap", "nowrap pretty");
+test_computed_value("text-wrap", "pretty nowrap", "nowrap pretty");
+test_computed_value("text-wrap-style", "pretty");
+</script>
+</body>
+</html>

--- a/css/css-text/parsing/text-wrap-style-computed.html
+++ b/css/css-text/parsing/text-wrap-style-computed.html
@@ -15,7 +15,6 @@
 <script>
 test_computed_value("text-wrap-style", "auto");
 test_computed_value("text-wrap-style", "balance");
-test_computed_value("text-wrap-style", "pretty");
 test_computed_value("text-wrap-style", "stable");
 </script>
 </body>

--- a/css/css-text/parsing/text-wrap-style-valid.html
+++ b/css/css-text/parsing/text-wrap-style-valid.html
@@ -14,7 +14,6 @@
 <script>
 test_valid_value("text-wrap-style", "auto");
 test_valid_value("text-wrap-style", "balance");
-test_valid_value("text-wrap-style", "pretty");
 test_valid_value("text-wrap-style", "stable");
 
 test_valid_value("text-wrap-style", "initial");

--- a/css/css-text/parsing/text-wrap-valid.html
+++ b/css/css-text/parsing/text-wrap-valid.html
@@ -18,24 +18,19 @@ test_valid_value("text-wrap", "nowrap");
 test_valid_value("text-wrap", "auto", "wrap");
 test_valid_value("text-wrap", "balance");
 test_valid_value("text-wrap", "stable");
-test_valid_value("text-wrap", "pretty");
 
 test_valid_value("text-wrap", "wrap auto", "wrap");
 test_valid_value("text-wrap", "wrap balance", "balance");
-test_valid_value("text-wrap", "wrap pretty", "pretty");
 test_valid_value("text-wrap", "wrap stable", "stable");
 test_valid_value("text-wrap", "auto wrap", "wrap");
 test_valid_value("text-wrap", "balance wrap", "balance");
-test_valid_value("text-wrap", "pretty wrap", "pretty");
 test_valid_value("text-wrap", "stable wrap", "stable");
 
 test_valid_value("text-wrap", "nowrap auto", "nowrap");
 test_valid_value("text-wrap", "nowrap balance");
-test_valid_value("text-wrap", "nowrap pretty");
 test_valid_value("text-wrap", "nowrap stable");
 test_valid_value("text-wrap", "auto nowrap", "nowrap");
 test_valid_value("text-wrap", "balance nowrap", "nowrap balance");
-test_valid_value("text-wrap", "pretty nowrap", "nowrap pretty");
 test_valid_value("text-wrap", "stable nowrap", "nowrap stable");
 
 test_valid_value("text-wrap", "initial");


### PR DESCRIPTION
`text-wrap: balance` tests are part of Interop 2024 and should not cover the pretty value