### PR TITLE
Make console methods take `any` instead of `string`

### DIFF
--- a/console/console-log-symbol.any.js
+++ b/console/console-log-symbol.any.js
@@ -1,0 +1,10 @@
+// META: global=window,dedicatedworker,shadowrealm
+"use strict";
+// https://console.spec.whatwg.org/
+
+test(() => {
+    console.log(Symbol());
+    console.log(Symbol("abc"));
+    console.log(Symbol.for("def"));
+    console.log(Symbol.isConcatSpreadable);
+}, "Logging a symbol doesn't throw");


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Match the [Console spec](https://console.spec.whatwg.org/) by having the console methods take `any` instead of a string. This fixes #<!-- nolink -->29460, where `console.log(Symbol())` throws because Symbols can't be implicitly converted to a string.

I used `JS_ValueToSource` to convert all JS values to strings. This change results in better logging for objects (`({a:{b:{c:5, d:new Number(3), e:new Boolean(false), g:4324324423432423423423n, h:3.333, i:(void 0)}}})` instead of `[object Object]`).

Reviewed in servo/servo#31241