### PR TITLE
Add null-check to aria_utils verifyLabelsBySelector

### DIFF
--- a/wai-aria/scripts/aria-utils.js
+++ b/wai-aria/scripts/aria-utils.js
@@ -144,6 +144,8 @@ const AriaUtils = {
       promise_test(async t => {
         const expectedLabel = el.getAttribute("data-expectedlabel");
         let computedLabel = await test_driver.get_computed_label(el);
+        assert_not_equals(computedLabel, null,
+                          `get_computed_label(el) shouldn't return null for ${el.outerHTML}`);
 
         // See:
         // - https://github.com/w3c/accname/pull/165

--- a/wai-aria/scripts/aria-utils.js
+++ b/wai-aria/scripts/aria-utils.js
@@ -144,8 +144,7 @@ const AriaUtils = {
       promise_test(async t => {
         const expectedLabel = el.getAttribute("data-expectedlabel");
         let computedLabel = await test_driver.get_computed_label(el);
-        assert_not_equals(computedLabel, null,
-                          `get_computed_label(el) shouldn't return null for ${el.outerHTML}`);
+        assert_not_equals(computedLabel, null, `get_computed_label(el) shouldn't return null for ${el.outerHTML}`);
 
         // See:
         // - https://github.com/w3c/accname/pull/165


### PR DESCRIPTION
Before this commit, verifyLabelsBySelector calls test_driver.get_computed_label and then does string-manipulation on the result. For some reason, this get_computed_label invocation returns null in Firefox, and so the string-manipulation causes a JS exception to be thrown, which makes for awkward test failure results.

Let's just explicitly assert that the result is not-null, to make that expectation clearer and to give a cleaner test-failure in cases where it is unexpectedly null.