### PR TITLE
[webdriver] Update get_viewport_dimensions to return values based on clientWidth and clientHeigth

### DIFF
--- a/webdriver/tests/bidi/__init__.py
+++ b/webdriver/tests/bidi/__init__.py
@@ -131,8 +131,8 @@ async def get_element_dimensions(bidi_session, context, element):
 async def get_viewport_dimensions(bidi_session, context: str):
     expression = """
         ({
-          height: window.innerHeight || document.documentElement.clientHeight,
-          width: window.innerWidth || document.documentElement.clientWidth,
+          height: document.documentElement.clientHeight,
+          width: document.documentElement.clientWidth,
         });
     """
     result = await bidi_session.script.evaluate(


### PR DESCRIPTION
Draft PR to check the behavior for Chrome when returning the dimensions that are actually available for content and do not include scrollbar sizes.