### PR TITLE
Add well-known routes for Protected Audience API WPTs

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -585,6 +585,7 @@ class RoutesBuilder:
             ("*", "/.well-known/attribution-reporting/report-aggregate-attribution", handlers.PythonScriptHandler),
             ("*", "/.well-known/attribution-reporting/debug/report-aggregate-attribution", handlers.PythonScriptHandler),
             ("*", "/.well-known/attribution-reporting/debug/verbose", handlers.PythonScriptHandler),
+            ("GET", "/.well-known/interest-group/permissions/", handlers.PythonScriptHandler),
             ("*", "/.well-known/private-aggregation/*", handlers.PythonScriptHandler),
             ("*", "/.well-known/web-identity", handlers.PythonScriptHandler),
             ("*", "*.py", handlers.PythonScriptHandler),

--- a/tools/wptserve/tests/functional/docroot/defaultpy/default.py
+++ b/tools/wptserve/tests/functional/docroot/defaultpy/default.py
@@ -1,0 +1,3 @@
+def main(request, response):
+    response.headers.set("Content-Type", "text/plain")
+    return "default"

--- a/tools/wptserve/tests/functional/docroot/defaultpy/default.sub.py
+++ b/tools/wptserve/tests/functional/docroot/defaultpy/default.sub.py
@@ -1,0 +1,3 @@
+def main(request, response):
+    response.headers.set("Content-Type", "text/plain")
+    return "default.sub"

--- a/tools/wptserve/tests/functional/docroot/defaultsubpy/default.sub.py
+++ b/tools/wptserve/tests/functional/docroot/defaultsubpy/default.sub.py
@@ -1,0 +1,3 @@
+def main(request, response):
+    response.headers.set("Content-Type", "text/plain")
+    return "{{host}}"

--- a/tools/wptserve/tests/functional/test_handlers.py
+++ b/tools/wptserve/tests/functional/test_handlers.py
@@ -275,6 +275,17 @@ class TestPythonHandler(TestUsingServer):
         self.assertEqual("text/plain", resp.info()["Content-Type"])
         self.assertEqual(b"PASS", resp.read())
 
+    def test_directory(self):
+        route = ("GET", "/defaultpy", wptserve.handlers.python_script_handler)
+        self.server.router.register(*route)
+        resp = self.request("/defaultpy")
+        self.assertEqual(200, resp.getcode())
+        self.assertEqual("text/plain", resp.info()["Content-Type"])
+        # default.py returns "default", default.sub.py returns "default.sub".
+        # Because this should find the first matching default*.py file
+        # lexicographically sorted, this should have gotten "default".
+        self.assertEqual(b"default", resp.read())
+
     def test_no_main(self):
         with pytest.raises(HTTPError) as cm:
             self.request("/no_main.py")

--- a/tools/wptserve/tests/functional/test_handlers.py
+++ b/tools/wptserve/tests/functional/test_handlers.py
@@ -336,6 +336,15 @@ class TestAsIsHandler(TestUsingServer):
         self.assertEqual(b"Content", resp.read())
         #Add a check that the response is actually sane
 
+    def test_directory_fails(self):
+        route = ("GET", "/subdir", wptserve.handlers.as_is_handler)
+        self.server.router.register(*route)
+        with pytest.raises(HTTPError) as cm:
+            self.request("/subdir")
+
+        assert cm.value.code == 500
+        del cm
+
 
 class TestH2Handler(TestUsingH2Server):
     def test_handle_headers(self):

--- a/tools/wptserve/tests/functional/test_pipes.py
+++ b/tools/wptserve/tests/functional/test_pipes.py
@@ -232,6 +232,12 @@ class TestPipesWithVariousHandlers(TestUsingServer):
         resp = self.request("/document.txt", query="pipe=gzip")
         self.assertEqual(resp.getcode(), 200)
 
+    def test_sub_default_py(self):
+        route = ("GET", "/defaultsubpy", wptserve.handlers.python_script_handler)
+        self.server.router.register(*route)
+        resp = self.request("/defaultsubpy")
+        self.assertEqual(b"localhost", resp.read())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -298,7 +298,7 @@ class PythonScriptHandler:
         """
         path = filesystem_path(self.base_path, request, self.url_base)
         if os.path.isdir(path):
-          path = os.path.join(path, "default.py")
+            path = os.path.join(path, "default.py")
 
         try:
             environ = {"__file__": path}

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -297,6 +297,8 @@ class PythonScriptHandler:
         :return: The return of func
         """
         path = filesystem_path(self.base_path, request, self.url_base)
+        if os.path.isdir(path):
+          path = os.path.join(path, "default.py")
 
         try:
             environ = {"__file__": path}
@@ -416,6 +418,7 @@ class AsIsHandler:
 
     def __call__(self, request, response):
         path = filesystem_path(self.base_path, request, self.url_base)
+        assert not os.path.isdir(path)
 
         try:
             with open(path, 'rb') as f:

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -301,6 +301,8 @@ class PythonScriptHandler:
         :return: The return of func
         """
         path = filesystem_path(self.base_path, request, self.url_base)
+
+        # Find a default Python file if the specified path is a directory
         if os.path.isdir(path):
             default_py = next(pathlib.Path(path).glob("default*.py"), None)
             if default_py:

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import pathlib
 from collections import defaultdict
 
 from urllib.parse import quote, unquote, urljoin
@@ -301,9 +302,9 @@ class PythonScriptHandler:
         """
         path = filesystem_path(self.base_path, request, self.url_base)
         if os.path.isdir(path):
-            default_py_matches = glob.glob("default*.py", root_dir=path)
-            if default_py_matches:
-                path = default_py_matches[0]
+            default_py = next(pathlib.Path(path).glob("default*.py"), None)
+            if default_py:
+                path = str(default_py)
 
         try:
             environ = {"__file__": path}

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -429,7 +429,9 @@ class AsIsHandler:
 
     def __call__(self, request, response):
         path = filesystem_path(self.base_path, request, self.url_base)
-        assert not os.path.isdir(path)
+        if os.path.isdir(path):
+            raise HTTPException(
+                500, "AsIsHandler cannot process directory, %s" % path)
 
         try:
             with open(path, 'rb') as f:

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -291,7 +291,8 @@ class PythonScriptHandler:
         This loads the requested python file as an environ variable.
 
         If the requested file is a directory, this instead loads the first
-        file found in that directory that matches "default*.py".
+        lexicographically sorted file found in that directory that matches
+        "default*.py".
 
         Once the environ is loaded, the passed `func` is run with this loaded environ.
 
@@ -304,9 +305,11 @@ class PythonScriptHandler:
 
         # Find a default Python file if the specified path is a directory
         if os.path.isdir(path):
-            default_py = next(pathlib.Path(path).glob("default*.py"), None)
-            if default_py:
-                path = str(default_py)
+            default_py_files = sorted(list(filter(
+                pathlib.Path.is_file,
+                pathlib.Path(path).glob("default*.py"))))
+            if default_py_files:
+                path = str(default_py_files[0])
 
         try:
             environ = {"__file__": path}

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -289,6 +289,9 @@ class PythonScriptHandler:
         """
         This loads the requested python file as an environ variable.
 
+        If the requested file is a directory, this instead loads the first
+        file found in that directory that matches "default*.py".
+
         Once the environ is loaded, the passed `func` is run with this loaded environ.
 
         :param request: The request object
@@ -298,7 +301,9 @@ class PythonScriptHandler:
         """
         path = filesystem_path(self.base_path, request, self.url_base)
         if os.path.isdir(path):
-            path = os.path.join(path, "default.py")
+            default_py_matches = glob.glob("default*.py", root_dir=path)
+            if default_py_matches:
+                path = default_py_matches[0]
 
         try:
             environ = {"__file__": path}


### PR DESCRIPTION
Web Platform Tests for the [Protected Audience API](https://github.com/WICG/turtledove/blob/main/FLEDGE.md) are in the process of being added. As part of this API, the browser issues a GET request to a well-known URI: `/.well-known/interest-group/permissions/`. This is described in more detail at
https://github.com/WICG/turtledove/blob/main/FLEDGE.md#13-permission-delegation.

In order to implement dynamic handling of these routes in WPT, we need to register these routes in the add_mount_point. Because this well-known URI ends in a '/', we also need special handling for directory-appearing PythonHandler-supported endpoints.