### PR TITLE
Fix crash on console logging large array

### DIFF
--- a/console/console-log-large-array.any.js
+++ b/console/console-log-large-array.any.js
@@ -1,0 +1,8 @@
+// META: global=window,dedicatedworker,shadowrealm
+"use strict";
+// https://console.spec.whatwg.org/
+
+test(() => {
+    console.log(new Array(10000000).fill("x"));
+    console.log(new Uint8Array(10000000));
+}, "Logging large arrays works");


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I checked for very deep objects in when adding object logging support in #<!-- nolink -->31241, but didn't check for objects with many elements (usually large arrays). This caused crashes with code like `console.log(new Array(10000000).fill("x"))`.

This PR fixes that by only logging the first 15 elements of objects.

Reviewed in servo/servo#31267