### PR TITLE
[wptserve] Move the TLS handshake to the per-accept thread

### DIFF
--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -214,13 +214,20 @@ class WebTestServer(http.server.ThreadingHTTPServer):
                 ssl_context.load_cert_chain(keyfile=self.key_file, certfile=self.certificate)
                 ssl_context.set_alpn_protocols(['h2'])
                 self.socket = ssl_context.wrap_socket(self.socket,
+                                                      do_handshake_on_connect=False,
                                                       server_side=True)
 
             else:
                 ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
                 ssl_context.load_cert_chain(keyfile=self.key_file, certfile=self.certificate)
                 self.socket = ssl_context.wrap_socket(self.socket,
+                                                      do_handshake_on_connect=False,
                                                       server_side=True)
+
+    def finish_request(self, request, client_address):
+        if isinstance(self.socket, ssl.SSLSocket):
+            request.do_handshake()
+        super().finish_request(request, client_address)
 
     def handle_error(self, request, client_address):
         error = sys.exc_info()[1]


### PR DESCRIPTION
We don't want to be doing anything on the single-threaded section ideally, so defer the TLS handshake until we're on a thread.

This is also in theory a perf win, given we can have multiple sockets doing the TLS handshake simultaneously now.