### PR TITLE
allow old headless mode for chrome

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -147,7 +147,8 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     # Pass the --headless=new flag to Chrome if WPT's own --headless flag was
     # set. '--headless' should always mean the new headless mode, as the old
     # headless mode is not used anyway.
-    if kwargs["headless"] and "--headless=new" not in chrome_options["args"]:
+    if kwargs["headless"] and ("--headless=new" not in chrome_options["args"]
+                               and "--headless" not in chrome_options["args"]):
         chrome_options["args"].append("--headless=new")
 
     if test_type == "wdspec":

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -147,8 +147,8 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     # Pass the --headless=new flag to Chrome if WPT's own --headless flag was
     # set. '--headless' should always mean the new headless mode, as the old
     # headless mode is not used anyway.
-    if kwargs["headless"] and ("--headless=new" not in chrome_options["args"]
-                               and "--headless" not in chrome_options["args"]):
+    if kwargs["headless"] and ("--headless=new" not in chrome_options["args"] and
+                               "--headless" not in chrome_options["args"]):
         chrome_options["args"].append("--headless=new")
 
     if test_type == "wdspec":


### PR DESCRIPTION
While Wptrunner's '--headless' means the new headless mode, allow passing binary arg '--headless' to chrome directly to enable the old headless mode