### PR TITLE
Moves SVG image role test to a tentative file

### DIFF
--- a/svg-aam/role/role-img.tentative.html
+++ b/svg-aam/role/role-img.tentative.html
@@ -16,13 +16,12 @@
 
 <!-- [sic] included here b/c the spec says unlabeled, unrendered images are generic, but the spec may be wrong. -->
 <!-- Once https://github.com/w3c/svg-aam/issues/32 is resolved, this test can be moved to another file. -->
-<image data-testname="el-image (missing alt attribute)" data-expectedrole="image" class="ex"></image>
+<image data-testname="el-image (missing image>title element)" data-expectedrole="image" class="ex"></image>
 
-<!-- Undisputed tests -->
+<!-- Additional tests -->
 <image data-testname="el-image (non-empty aria-label attribute)" aria-label="x" data-expectedrole="image" class="ex"></image>
-<image data-testname="el-image (non-empty alt attribute)" alt="x" data-expectedrole="image" class="ex"></image>
-<image data-testname="el-image (non-empty title attribute)" title="x" data-expectedrole="image" class="ex"></image>
-<image data-testname="el-image (explicitly empty alt attribute)" alt="" class="ex-generic"></image>
+<image data-testname="el-image (non-empty image>title element)" data-expectedrole="image" class="ex"><title>x</title></image>
+<image data-testname="el-image (explicitly empty image>title element)" class="ex-generic"><title></title></image>
 
 <script>
 AriaUtils.verifyRolesBySelector(".ex");

--- a/svg-aam/role/role-img.tentative.html
+++ b/svg-aam/role/role-img.tentative.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+<head>
+  <title>SVG-AAM Image Role Verification Tests</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+
+<p>Currently tentative due to <a href="https://github.com/w3c/svg-aam/issues/32">SVG-AAM #32: SVG image role should align with HTML on missing versus empty alt</a>.</p>
+
+<!-- [sic] included here b/c the spec says unlabeled, unrendered images are generic, but the spec may be wrong. -->
+<!-- Once https://github.com/w3c/svg-aam/issues/32 is resolved, this test can be moved to another file. -->
+<image data-testname="el-image (missing alt attribute)" data-expectedrole="image" class="ex"></image>
+
+<!-- Undisputed tests -->
+<image data-testname="el-image (non-empty aria-label attribute)" aria-label="x" data-expectedrole="image" class="ex"></image>
+<image data-testname="el-image (non-empty alt attribute)" alt="x" data-expectedrole="image" class="ex"></image>
+<image data-testname="el-image (non-empty title attribute)" title="x" data-expectedrole="image" class="ex"></image>
+<image data-testname="el-image (explicitly empty alt attribute)" alt="" class="ex-generic"></image>
+
+<script>
+AriaUtils.verifyRolesBySelector(".ex");
+AriaUtils.verifyGenericRolesBySelector(".ex-generic");
+</script>
+
+</body>
+</html>

--- a/svg-aam/role/role-img.tentative.html
+++ b/svg-aam/role/role-img.tentative.html
@@ -15,16 +15,16 @@
 <p>Currently tentative due to <a href="https://github.com/w3c/svg-aam/issues/32">SVG-AAM #32: SVG image role should align with HTML on missing versus empty alt</a>.</p>
 
 <!-- [sic] included here b/c the spec says unlabeled, unrendered images are generic, but the spec may be wrong. -->
-<!-- Once https://github.com/w3c/svg-aam/issues/32 is resolved, this test can be moved to another file. -->
-<image data-testname="el-image (missing image>title element)" data-expectedrole="image" class="ex"></image>
+<!-- Once https://github.com/w3c/svg-aam/issues/32 is resolved, this test can be moved to another file or have `.tentative` removed. -->
+<image data-testname="el-image (empty label due to missing image>title element)" data-expectedrole="image" data-expectedlabel="" class="ex-role-label"></image>
 
 <!-- Additional tests -->
-<image data-testname="el-image (non-empty aria-label attribute)" aria-label="x" data-expectedrole="image" class="ex"></image>
-<image data-testname="el-image (non-empty image>title element)" data-expectedrole="image" class="ex"><title>x</title></image>
-<image data-testname="el-image (explicitly empty image>title element)" class="ex-generic"><title></title></image>
+<image data-testname="el-image (label from w/ aria-label)" aria-label="x" data-expectedrole="image" data-expectedlabel="x" class="ex-role-label"></image>
+<image data-testname="el-image (label from image>title element)" data-expectedrole="image" data-expectedlabel="x" class="ex-role-label"><title>x</title></image>
+<image data-testname="el-image (generic, explicitly empty image>title element)" class="ex-generic"><title></title></image>
 
 <script>
-AriaUtils.verifyRolesBySelector(".ex");
+AriaUtils.verifyRolesAndLabelsBySelector(".ex-role-label");
 AriaUtils.verifyGenericRolesBySelector(".ex-generic");
 </script>
 

--- a/svg-aam/role/roles-generic.html
+++ b/svg-aam/role/roles-generic.html
@@ -22,11 +22,7 @@
   <ellipse data-testname="el-ellipse" class="ex-generic"></ellipse>
   <foreignObject data-testname="el-foreignObject" class="ex-generic"></foreignObject>
   <g data-testname="el-g" class="ex-generic"></g>
-
-  <!-- [sic] included here b/c the spec says unlabeled, unrendered images are generic, but the spec is wrong. -->
-  <!-- Once https://github.com/w3c/svg-aam/issues/32 is resolved, this test can be moved to another file. -->
-  <image data-testname="el-image" data-expectedrole="image" class="ex"></image>
-
+  <!-- image -> in ./role-img.tentative.html -->
   <line data-testname="el-line" class="ex-generic"></line>
   <!-- skipped: mesh -->
   <path data-testname="el-path" class="ex-generic"></path>


### PR DESCRIPTION
Closes https://github.com/web-platform-tests/interop-accessibility/issues/96

Moves SVG image role test to a tentative file outside of the Interop 2024 focus area files, while dispute is resolved.