### PR TITLE
Add coverage for `webkit` prefixed historical interface

### DIFF
--- a/uievents/historical.html
+++ b/uievents/historical.html
@@ -8,4 +8,8 @@ test(function() {
   assert_false("initWheelEvent" in WheelEvent.prototype,
                "Should not be supported on the prototype");
 }, "WheelEvent#initWheelEvent");
+test(function() {
+  assert_false("initWebKitWheelEvent" in WheelEvent.prototype,
+               "Should not be supported on the prototype");
+}, "WheelEvent#initWebKitWheelEvent");
 </script>


### PR DESCRIPTION
Hi Team,

It was supported by Safari / WebKit until recently and it was removed days ago, I think it would be good to add coverage for it.

Thanks!