### PR TITLE
Remove referecen to `error` from BidiException

### DIFF
--- a/tools/webdriver/webdriver/bidi/error.py
+++ b/tools/webdriver/webdriver/bidi/error.py
@@ -19,7 +19,7 @@ class BidiException(Exception):
 
     def __repr__(self):
         """Return the object representation in string format."""
-        return f"{self.__class__.__name__} {self.message}, {self.stacktrace})"
+        return f"{self.__class__.__name__}({self.message}, {self.stacktrace})"
 
     def __str__(self):
         """Return the string representation of the object."""

--- a/tools/webdriver/webdriver/bidi/error.py
+++ b/tools/webdriver/webdriver/bidi/error.py
@@ -19,7 +19,7 @@ class BidiException(Exception):
 
     def __repr__(self):
         """Return the object representation in string format."""
-        return f"{self.__class__.__name__}({self.error}, {self.message}, {self.stacktrace})"
+        return f"{self.__class__.__name__} {self.message}, {self.stacktrace})"
 
     def __str__(self):
         """Return the string representation of the object."""


### PR DESCRIPTION
This property does not exist and so an exception is thrown if `__repr__` is called.

This should fix #44463 