### PR TITLE
[wptrunner] Add `infrastructure/expected-fail/` test for user prompts

### DIFF
--- a/infrastructure/expected-fail/user-prompt.html
+++ b/infrastructure/expected-fail/user-prompt.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>Unhandled user prompt dismisses and notifies</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name="variant" content="?type=alert">
+<meta name="variant" content="?type=confirm">
+<meta name="variant" content="?type=prompt">
+<meta name="variant" content="?type=alert&wait">
+<meta name="variant" content="?type=confirm&wait">
+<meta name="variant" content="?type=prompt&wait">
+<script>
+  let params = new URL(location).searchParams;
+  setup({ single_test: true });
+  // Waiting exercises the case where a user prompt appears while waiting for
+  // the next testdriver event. The WebDriver-specified behavior is to resolve
+  // with `null` [1, 2], which the WebDriver executor should ignore. The
+  // testdriver event loop will handle the open prompt on its next cycle. For
+  // the default "dismiss and notify" handler, this throws an unexpected alert
+  // open error in the executor.
+  //
+  // [1]: Step 5.3 of https://www.w3.org/TR/webdriver/#execute-async-script
+  // [2]: https://www.w3.org/TR/webdriver/#dfn-execute-a-function-body
+  step_timeout(() => {
+    let type = params.get("type");
+    window[type]("this user prompt should be dismissed");
+    done();
+  }, params.has("wait") ? 1000 : 0);
+</script>

--- a/infrastructure/metadata/infrastructure/expected-fail/user-prompt.html.ini
+++ b/infrastructure/metadata/infrastructure/expected-fail/user-prompt.html.ini
@@ -1,0 +1,17 @@
+[user-prompt.html?type=alert]
+  expected: ERROR
+
+[user-prompt.html?type=confirm]
+  expected: ERROR
+
+[user-prompt.html?type=prompt]
+  expected: ERROR
+
+[user-prompt.html?type=alert&wait]
+  expected: ERROR
+
+[user-prompt.html?type=confirm&wait]
+  expected: ERROR
+
+[user-prompt.html?type=prompt&wait]
+  expected: ERROR

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -614,7 +614,7 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
             # cases where the browser crashes during script execution:
             #
             # https://github.com/w3c/webdriver/issues/1308
-            if not isinstance(result, list) or len(result) != 2:
+            if not isinstance(result, list) or len(result) != 3:
                 try:
                     is_alive = self.is_alive()
                 except error.WebDriverException:
@@ -622,6 +622,16 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
 
                 if not is_alive:
                     raise Exception("Browser crashed during script execution.")
+
+            # A user prompt created after starting execution of the resume
+            # script will resolve the script with `null` [1, 2]. In that case,
+            # cycle this event loop and handle the prompt the next time the
+            # resume script executes.
+            #
+            # [1]: Step 5.3 of https://www.w3.org/TR/webdriver/#execute-async-script
+            # [2]: https://www.w3.org/TR/webdriver/#dfn-execute-a-function-body
+            if result is None:
+                continue
 
             done, rv = handler(result)
             if done:


### PR DESCRIPTION
This test exercises the handling of a testharness.js test that opens user prompts like `window.alert(...)`. For WebDriver-controlled browsers that default to "dismiss and notify", this should raise a harness error in the executor's testdriver loop.

Fix a related issue wptrunner-side where creating a user prompt can cause `testharness_webdriver_resume.js` to resolve with `null`/`None`, which would then fail to unpack in:

https://github.com/web-platform-tests/wpt/blob/da25e93244e17fa16f245a955af8e0638230acab/tools/wptrunner/wptrunner/executors/base.py#L735