### PR TITLE
Add 'libegl1-mesa-dev' needed by Servo to the Docker image

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -57,7 +57,7 @@ tasks:
             owner: ${owner}
             source: ${event.repository.clone_url}
           payload:
-            image: webplatformtests/wpt:0.56
+            image: webplatformtests/wpt:0.57
             maxRunTime: 7200
             artifacts:
               public/results:

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -4,7 +4,7 @@ components:
     workerType: ci
     schedulerId: taskcluster-github
     deadline: "24 hours"
-    image: webplatformtests/wpt:0.56
+    image: webplatformtests/wpt:0.57
     maxRunTime: 7200
     artifacts:
       public/results:

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get -qqy update \
     glib-networking-services \
     gstreamer1.0-plugins-bad \
     gstreamer1.0-gl \
+    libegl1-mesa-dev \
     libosmesa6-dev \
     libproxy1-plugin-webkit \
     libvirt-daemon-system \


### PR DESCRIPTION
Servo now requires 'libegl1-mesa-dev' as a runtime dependency. This should fix the crashes in wdspec:

https://github.com/web-platform-tests/wpt/runs/20476263011