### PR TITLE
Apply SVG paint-order to text-decorations

### DIFF
--- a/svg/painting/reftests/paintorder-text-decorations-ref.svg
+++ b/svg/painting/reftests/paintorder-text-decorations-ref.svg
@@ -1,0 +1,66 @@
+<svg viewBox="-10 -10 280 220" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    text {
+      text-decoration: underline;
+    }
+  </style>
+  <defs>
+    <marker id="m" refX="5" refY="5" viewBox="0 0 10 10" overflow="visible">
+      <circle cx="5" cy="5" r="3" fill="black" stroke="black" fill-opacity="0.5"/>
+    </marker>
+    <svg id="poly" viewBox="-10 -10 420 420">
+      <text y="300" font-family="sans-serif" font-size="200" fill="blue" stroke="lime" stroke-width="10" stroke-opacity="0.5" style="marker: url(#m)">test</text>
+    </svg>
+    <svg id="poly-f-m-s" viewBox="-10 -10 420 420">
+      <text y="300" font-family="sans-serif" font-size="200" fill="blue" stroke-width="10" stroke-opacity="0.5" style="marker: url(#m); text-decoration: underline">test</text>
+      <text y="300" font-family="sans-serif" font-size="200" fill="none" stroke="lime" stroke-width="10" stroke-opacity="0.5">test</text>
+    </svg>
+    <svg id="poly-m-f-s" viewBox="-10 -10 420 420">
+      <text y="300" font-family="sans-serif" font-size="200" fill="none" stroke-width="10" stroke-opacity="0.5" style="marker: url(#m)">test</text>
+      <text y="300" font-family="sans-serif" font-size="200" fill="blue" stroke-width="10" stroke-opacity="0.5">test</text>
+      <text y="300" font-family="sans-serif" font-size="200" fill="none" stroke="lime" stroke-width="10" stroke-opacity="0.5">test</text>
+    </svg>
+    <svg id="poly-s-m-f" viewBox="-10 -10 420 420">
+      <text y="300" font-family="sans-serif" font-size="200" fill="none" stroke="lime" stroke-width="10" stroke-opacity="0.5">test</text>
+      <text y="300" font-family="sans-serif" font-size="200" fill="none" stroke-width="10" stroke-opacity="0.5" style="marker: url(#m)">test</text>
+      <text y="300" font-family="sans-serif" font-size="200" fill="blue" stroke-width="10" stroke-opacity="0.5">test</text>
+    </svg>
+    <svg id="poly-s-f-m" viewBox="-10 -10 420 420">
+      <text y="300" font-family="sans-serif" font-size="200" fill="none" stroke="lime" stroke-width="10" stroke-opacity="0.5">test</text>
+      <text y="300" font-family="sans-serif" font-size="200" fill="blue" stroke-width="10" stroke-opacity="0.5">test</text>
+      <text y="300" font-family="sans-serif" font-size="200" fill="none" stroke-width="10" stroke-opacity="0.5" style="marker: url(#m)">test</text>
+    </svg>
+    <svg id="poly-m-s-f" viewBox="-10 -10 420 420">
+      <text y="300" font-family="sans-serif" font-size="200" fill="none" stroke-width="10" stroke-opacity="0.5" style="marker: url(#m)">test</text>
+      <text y="300" font-family="sans-serif" font-size="200" fill="none" stroke="lime" stroke-width="10" stroke-opacity="0.5">test</text>
+      <text y="300" font-family="sans-serif" font-size="200" fill="blue" stroke-width="10" stroke-opacity="0.5">test</text>
+    </svg>
+  </defs>
+
+  <use xlink:href="#poly" width="50" height="50"/>
+  <use xlink:href="#poly" width="50" height="50" x="50"/>
+
+  <g transform="translate(0,50)">
+    <use xlink:href="#poly" width="50" height="50" x="0"/>
+    <use xlink:href="#poly" width="50" height="50" x="50"/>
+    <use xlink:href="#poly" width="50" height="50" x="100"/>
+    <use xlink:href="#poly-f-m-s" width="50" height="50" x="150"/>
+    <use xlink:href="#poly-f-m-s" width="50" height="50" x="200" />
+  </g>
+
+  <g transform="translate(0,100)">
+    <use xlink:href="#poly-s-f-m" width="50" height="50" x="0"/>
+    <use xlink:href="#poly-s-f-m" width="50" height="50" x="50"/>
+    <use xlink:href="#poly-s-f-m" width="50" height="50" x="100"/>
+    <use xlink:href="#poly-s-m-f" width="50" height="50" x="150"/>
+    <use xlink:href="#poly-s-m-f" width="50" height="50" x="200"/>
+  </g>
+
+  <g transform="translate(0,150)">
+    <use xlink:href="#poly-m-f-s" width="50" height="50" x="0"/>
+    <use xlink:href="#poly-m-s-f" width="50" height="50" x="50"/>
+    <use xlink:href="#poly-m-s-f" width="50" height="50" x="100"/>
+    <use xlink:href="#poly-m-f-s" width="50" height="50" x="150"/>
+    <use xlink:href="#poly-m-f-s" width="50" height="50" x="200"/>
+  </g>
+</svg>

--- a/svg/painting/reftests/paintorder-text-decorations.svg
+++ b/svg/painting/reftests/paintorder-text-decorations.svg
@@ -1,0 +1,37 @@
+<svg viewBox="-10 -10 280 220" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <marker id="m" refX="5" refY="5" viewBox="0 0 10 10" overflow="visible">
+      <circle cx="5" cy="5" r="3" fill="black" stroke="black" fill-opacity="0.5"/>
+    </marker>
+    <svg id="poly" viewBox="-10 -10 420 420">
+      <text y="300" font-family="sans-serif" font-size="200" fill="blue" stroke="lime" stroke-width="10" stroke-opacity="0.5" style="marker: url(#m); text-decoration: underline">test</text>
+    </svg>
+  </defs>
+
+  <use xlink:href="#poly" width="50" height="50"/>
+  <use xlink:href="#poly" style="paint-order: normal" width="50" height="50" x="50"/>
+
+  <g transform="translate(0,50)">
+    <use xlink:href="#poly" style="paint-order: fill" width="50" height="50" x="0"/>
+    <use xlink:href="#poly" style="paint-order: fill stroke" width="50" height="50" x="50"/>
+    <use xlink:href="#poly" style="paint-order: fill stroke markers" width="50" height="50" x="100"/>
+    <use xlink:href="#poly" style="paint-order: fill markers" width="50" height="50" x="150"/>
+    <use xlink:href="#poly" style="paint-order: fill markers stroke" width="50" height="50" x="200" />
+  </g>
+
+  <g transform="translate(0,100)">
+    <use xlink:href="#poly" style="paint-order: stroke" width="50" height="50" x="0"/>
+    <use xlink:href="#poly" style="paint-order: stroke fill" width="50" height="50" x="50"/>
+    <use xlink:href="#poly" style="paint-order: stroke fill markers" width="50" height="50" x="100"/>
+    <use xlink:href="#poly" style="paint-order: stroke markers" width="50" height="50" x="150"/>
+    <use xlink:href="#poly" style="paint-order: stroke markers fill" width="50" height="50" x="200"/>
+  </g>
+
+  <g transform="translate(0,150)">
+    <use xlink:href="#poly" style="paint-order: markers" width="50" height="50" x="0"/>
+    <use xlink:href="#poly" style="paint-order: markers stroke" width="50" height="50" x="50"/>
+    <use xlink:href="#poly" style="paint-order: markers stroke fill" width="50" height="50" x="100"/>
+    <use xlink:href="#poly" style="paint-order: markers fill" width="50" height="50" x="150"/>
+    <use xlink:href="#poly" style="paint-order: markers fill stroke" width="50" height="50" x="200"/>
+  </g>
+</svg>


### PR DESCRIPTION
Hi Team,

This is test case from Blink Commit:

Commit - https://chromium.googlesource.com/chromium/blink/+/72eecba077f756ef4ed254541ff37dcb9baec05a

I noticed that WebKit / Safari was failing so I wanted to do merge but it was suggested that if this can be uploaded to WPT, it would be better for coverage for all browsers.

Credits to Blink Developer / Engineer (fs@opera.com).

Thanks!