### PR TITLE
WebKit export: Implement field-sizing support for input and textarea

### DIFF
--- a/html/rendering/widgets/field-sizing-textarea.html
+++ b/html/rendering/widgets/field-sizing-textarea.html
@@ -3,6 +3,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>
+textarea {
+  font-family: monospace;
+}
+
 .disable-default {
   field-sizing: content;
 }


### PR DESCRIPTION
This fixes a test relying on UA specific stylesheet which isn't cross browser by adding the monospace font-family.