### PR TITLE
orientation-event: Test DeviceOrientationEvent's absolute value on error

### DIFF
--- a/orientation-event/orientation/null-values.https.html
+++ b/orientation-event/orientation/null-values.https.html
@@ -7,21 +7,32 @@
 <script>
 'use strict';
 
-promise_test(async (t) => {
-  const helper = new SensorTestHelper(t, 'deviceorientation');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors({disabledSensors: ['absolute-orientation', 'relative-orientation']});
+function test_null_orientation_data(eventType) {
+  promise_test(async t => {
+    const helper = new SensorTestHelper(t, eventType);
+    await helper.grantSensorsPermissions();
+    await helper.initializeSensors(
+        {disabledSensors : [ 'absolute-orientation', 'relative-orientation' ]});
 
-  const orientationData1 = generateOrientationData(1.1, 2.2, 3.3, false);
-  // Currently it is not possible to set individual values to null because the
-  // parsing algorithms used by
-  // https://w3c.github.io/sensors/#update-virtual-sensor-reading-command
-  // always expect numbers.
-  const orientationData2 = generateOrientationData(null, null, null, false);
+    const inputData = generateOrientationData(1.1, 2.2, 3.3, false);
+    // Currently it is not possible to set individual values to null because
+    // the parsing algorithms used by
+    // https://w3c.github.io/sensors/#update-virtual-sensor-reading-command
+    // always expect numbers.
+    const expectedData = generateOrientationData(
+        null, null, null,
+        /*absolute=*/ eventType === 'deviceorientationabsolute');
+    const expectedEvent = eventType === 'deviceorientationabsolute'
+                              ? getExpectedAbsoluteOrientationEvent
+                              : getExpectedOrientationEvent;
 
-  // An example how setting relative-orientation sensor as disabled will output
-  // null values. Even if we try to set non null values to sensor.
-  await helper.setData(orientationData1);
-  await waitForEvent(getExpectedOrientationEvent(orientationData2));
-}, 'Tests using null values for some of the event properties.');
+    // An example how setting the orientation sensors as disabled will always
+    // output null values.
+    await helper.setData(inputData);
+    await waitForEvent(expectedEvent(expectedData));
+  }, `${eventType}: Missing values are set to null or true/false accordingly`);
+}
+
+test_null_orientation_data('deviceorientation');
+test_null_orientation_data('deviceorientationabsolute');
 </script>


### PR DESCRIPTION
Test for https://github.com/w3c/deviceorientation/pull/139. When a reading cannot be provided, `absolute` needs to be set accordingly depending on the event type we are listening to.