### PR TITLE
More declarative shadow tree test coverage

### DIFF
--- a/shadow-dom/declarative/declarative-shadow-dom-repeats-2.html
+++ b/shadow-dom/declarative/declarative-shadow-dom-repeats-2.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<title>Duplicate declarative shadow trees</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<div id=multiple1>
+  <template shadowrootmode=open>1</template>
+  <template shadowrootmode=open>2</template>
+  <template shadowrootmode=open>3</template>
+</div>
+
+<div id=multiple2>
+  <template shadowrootmode=closed>1</template>
+  <template shadowrootmode=closed>2</template>
+  <template shadowrootmode=open>3</template>
+</div>
+
+<script>
+test((t) => {
+  t.add_cleanup(() => {
+    multiple1.remove();
+    multiple2.remove();
+  });
+  let shadow = multiple1.shadowRoot;
+  assert_true(!!shadow,'Remaining shadow root should be open');
+  assert_equals(shadow.textContent,"1");
+  assert_equals(multiple1.childElementCount, 2);
+  assert_equals(multiple1.firstElementChild.content.textContent, "2");
+  assert_equals(multiple1.lastElementChild.content.textContent, "3");
+  shadow = multiple2.shadowRoot;
+  assert_false(!!shadow,'Remaining shadow root should be closed');
+  assert_equals(multiple2.childElementCount, 2);
+  assert_equals(multiple2.firstElementChild.content.textContent, "2");
+  assert_equals(multiple2.lastElementChild.content.textContent, "3");
+},'Repeated declarative shadow roots keep only the first');
+</script>

--- a/shadow-dom/declarative/declarative-shadow-dom-repeats.html
+++ b/shadow-dom/declarative/declarative-shadow-dom-repeats.html
@@ -22,13 +22,19 @@
 
 <script>
 test((t) => {
+  t.add_cleanup(() => {
+    multiple1.remove();
+    multiple2.remove();
+  });
   let shadow = multiple1.shadowRoot;
   assert_true(!!shadow,'Remaining shadow root should be open');
   assert_equals(shadow.textContent,"Open");
+  assert_equals(multiple1.childElementCount, 1);
+  assert_equals(multiple1.firstElementChild.shadowRootMode, "closed");
   shadow = multiple2.shadowRoot;
   assert_false(!!shadow,'Remaining shadow root should be closed');
-  multiple1.remove(); // Cleanup
-  multiple2.remove();
+  assert_equals(multiple2.childElementCount, 1);
+  assert_equals(multiple2.firstElementChild.shadowRootMode, "open");
 },'Repeated declarative shadow roots keep only the first');
 </script>
 
@@ -59,20 +65,16 @@ test((t) => {
 test((t) => {
   assert_throws_dom("NotSupportedError",() => {
     open2.attachShadow({mode: "closed", delegatesFocus: true, slotAssignment: "named", clonable: true});
-  },'Mismatched shadow root type should throw');
-  assert_throws_dom("NotSupportedError",() => {
-    open2.attachShadow({mode: "open", delegatesFocus: false, slotAssignment: "named", clonable: true});
-  },'Mismatched shadow root delegatesFocus should throw');
-  assert_throws_dom("NotSupportedError",() => {
-    open2.attachShadow({mode: "open", delegatesFocus: true, slotAssignment: "manual", clonable: true});
-  },'Mismatched shadow root slotAssignment should throw');
-  assert_throws_dom("NotSupportedError",() => {
-    open2.attachShadow({mode: "open", delegatesFocus: true, slotAssignment: "named", clonable: false});
-  },'Mismatched shadow root clonable should throw');
+  },'Mismatched shadow root mode should throw');
 
   const initialShadow = open2.shadowRoot;
   const shadow = open2.attachShadow({mode: "open", delegatesFocus: true, slotAssignment: "named", clonable: true}); // Shouldn't throw
   assert_equals(shadow,initialShadow,'Same shadow should be returned');
   assert_equals(shadow.textContent,'','Shadow should be empty');
+
+  assert_throws_dom("NotSupportedError",() => {
+    open2.attachShadow({mode: "open"});
+  },'Invoking attachShadow() on a non-declarative shadow root should throw');
+
 },'Calling attachShadow() on declarative shadow root must match all parameters');
 </script>


### PR DESCRIPTION
We only care about mode mismatching. And we should also test with multiple <template> elements that have the same mode, to avoid triggering the mode mismatch exception.