### PR TITLE
Update Docker image version in CI configurations

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -57,7 +57,7 @@ tasks:
             owner: ${owner}
             source: ${event.repository.clone_url}
           payload:
-            image: webplatformtests/wpt:0.57
+            image: webplatformtests/wpt:0.58
             maxRunTime: 7200
             artifacts:
               public/results:

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -4,7 +4,7 @@ components:
     workerType: ci
     schedulerId: taskcluster-github
     deadline: "24 hours"
-    image: webplatformtests/wpt:0.57
+    image: webplatformtests/wpt:0.58
     maxRunTime: 7200
     artifacts:
       public/results:


### PR DESCRIPTION
PR #44493 updated the Dockerfile and also bumped
the version of docker image to use in Taskcluster
configuration from 0.56 to 0.57. However, 0.57
refers to an exiting image that was published to
Docker Hub but never used in the CI configurations.

This PR is to bump the version again so that the
changes introduced by #44493 are consumed by the
CI configuration.

**Also, a new docker image was never published to Docker Hub
before #44493 was merged, so that still needs to happen
before this PR is merged. Since I don't have permissions to
the webplatformtest org on Docker Hub, I'll need someone's
help to publish the image before merging the PR.**
