### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=267695

### DIFF
--- a/trusted-types/support/navigation-report-only-support.html
+++ b/trusted-types/support/navigation-report-only-support.html
@@ -31,7 +31,7 @@
   // Navigate to the non-report-only version of the test. That has the same
   // event listening setup as this, but is a different target URI.
   const target_script = `location.href='${location.href.replace("-report-only", "") + "#continue"}';`;
-  const target = `javascript:"<script>${target_script}</scri${""}pt>"`;
+  const target = `javascript:${target_script}`;
 
   // Navigate the anchor, but only after the content is loaded (so that we
   // won't disturb delivery of that event to the opener.

--- a/trusted-types/support/navigation-support.html
+++ b/trusted-types/support/navigation-support.html
@@ -32,7 +32,7 @@
   // re-use the messageing mechanisms above. In order to not end up in a loop,
   // we'll only click if we don't find fragment in the current URL.
   const target_script = `location.href='${location.href}&continue';`;
-  const target = `javascript:"<script>${target_script}</scri${""}pt>"`;
+  const target = `javascript:${target_script}`;
 
   const anchor = document.getElementById("anchor");
   anchor.href = target;


### PR DESCRIPTION
WebKit doesn't support JavaScript URLs containing `<script>` tags so this test fails within WebKit regardless of what it should actually be testing. I'm unaware why the test uses this odd construction in the first place.