### PR TITLE
Remove undefined aria-label tests.

### DIFF
--- a/accname/name/comp_label.html
+++ b/accname/name/comp_label.html
@@ -154,13 +154,6 @@
 <textarea aria-label="label" data-expectedlabel="label" data-testname="label valid on textarea element" class="ex">x</textarea>
 <ul aria-label="label" data-expectedlabel="label" data-testname="label valid on list (unordered) element" class="ex">x</ul>
 
-<h2>Undefined aria-label tests</h2>
-<img alt="alt" aria-label="undefined" data-expectedlabel="alt" data-testname="aria-label undefined on img w/ alt" class="ex" />
-<img aria-label="undefined" data-expectedlabel="" data-testname="aria-label undefined on img w/o alt" class="ex" />
-<img alt="" aria-label="undefined" data-expectedlabel="" data-testname="aria-label undefined on img w/ empty alt" class="ex" />
-<img aria-label="undefined" data-expectedlabel="title" data-testname="aria-label undefined on img w/o alt but w/ title" class="ex" />
-<img alt="" aria-label="undefined" data-expectedlabel="title" data-testname="aria-label undefined on img w/ empty alt but w/ title" class="ex" />
-
 <h2>Name computation precedence tests</h2>
 <!-- Name computation: https://w3c.github.io/accname/#computation-steps -->
 


### PR DESCRIPTION
@nmlapre discovered this in his triaging and investigation of Gecko WPT failures.

Many ARIA attributes do support a value of "undefined". However, [aria-label](https://w3c.github.io/aria/#aria-label) expects a string value, which is [specified](https://w3c.github.io/aria/#valuetype_string) as an "Unconstrained value type." Thus, "undefined" is not a special value for aria-label, and these tests are incorrect. [All browsers currently fail these tests](https://wpt.fyi/results/accname/name/comp_label.html?label=master&label=experimental&aligned&q=status%3Afail).

I looked for other references in the ARIA spec that suggest that aria-label should support "undefined", but I found none. The [true/false/undefined](https://w3c.github.io/aria/#valuetype_true-false-undefined) and [tristate](https://w3c.github.io/aria/#valuetype_tristate) explicitly specify that they support undefined, but no other types do.