### PR TITLE
[wdspec] handle connection close exception

### DIFF
--- a/tools/webdriver/webdriver/bidi/transport.py
+++ b/tools/webdriver/webdriver/bidi/transport.py
@@ -70,10 +70,14 @@ class Transport:
 
     async def read_messages(self) -> None:
         assert self.connection is not None
-        async for msg in self.connection:
-            if not isinstance(msg, str):
-                raise ValueError("Got a binary message")
-            await self.handle(msg)
+        try:
+            async for msg in self.connection:
+                if not isinstance(msg, str):
+                    raise ValueError("Got a binary message")
+                await self.handle(msg)
+        except websockets.exceptions.ConnectionClosed:
+            logger.debug("connection closed while reading messages")
+            return
 
     async def wait_closed(self) -> None:
         if self.connection and not self.connection.closed:

--- a/tools/webdriver/webdriver/bidi/transport.py
+++ b/tools/webdriver/webdriver/bidi/transport.py
@@ -77,7 +77,6 @@ class Transport:
                 await self.handle(msg)
         except websockets.exceptions.ConnectionClosed:
             logger.debug("connection closed while reading messages")
-            return
 
     async def wait_closed(self) -> None:
         if self.connection and not self.connection.closed:

--- a/tools/webdriver/webdriver/bidi/transport.py
+++ b/tools/webdriver/webdriver/bidi/transport.py
@@ -6,6 +6,8 @@ from typing import Any, Callable, Coroutine, List, Optional, Mapping
 
 import websockets
 
+from websockets.exceptions import ConnectionClosed
+
 logger = logging.getLogger("webdriver.bidi")
 
 
@@ -75,7 +77,7 @@ class Transport:
                 if not isinstance(msg, str):
                     raise ValueError("Got a binary message")
                 await self.handle(msg)
-        except websockets.exceptions.ConnectionClosed:
+        except ConnectionClosed:
             logger.debug("connection closed while reading messages")
 
     async def wait_closed(self) -> None:


### PR DESCRIPTION
Currently, when the browser is shut down uncaught exception are printed indicating that connection closed exception has not been handled.