### PR TITLE
Use valid pseudo-element syntax in pseudo-get-computed-style.html

### DIFF
--- a/css/css-view-transitions/pseudo-get-computed-style.html
+++ b/css/css-view-transitions/pseudo-get-computed-style.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
-<title>View transitions: check pseudo element's display property</title>
-<link rel="help" href="https://github.com/WICG/view-transitions">
+<title>View transitions: check pseudo element's default styles</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 
 <script src="/resources/testharness.js"></script>
@@ -30,34 +30,34 @@ promise_test(() => {
   assert_implements(document.startViewTransition, "Missing document.startViewTransition");
   return new Promise(async (resolve, reject) => {
     let transition = document.startViewTransition(() => {
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition").position, "fixed", ":view-transition");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").position, "absolute", "container(target)");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").mixBlendMode, "multiply", "container(target)");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").textOrientation, "upright", "container(target)");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").colorScheme, "dark light", "container(target)");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(target)").position, "absolute", "wrapper(target)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition").position, "fixed", "::view-transition");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").position, "absolute", "container(target)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").mixBlendMode, "multiply", "container(target)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").textOrientation, "upright", "container(target)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").colorScheme, "dark light", "container(target)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(target)").position, "absolute", "wrapper(target)");
 
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(target)").position, "absolute", "outgoing(target)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(target)").position, "absolute", "outgoing(target)");
 
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(root)").position, "absolute", "container(root)");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(root)").mixBlendMode, "normal", "container(root)");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(root)").position, "absolute", "wrapper(root)");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(root)").position, "absolute", "outgoing(root)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").position, "absolute", "container(root)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").mixBlendMode, "normal", "container(root)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(root)").position, "absolute", "wrapper(root)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(root)").position, "absolute", "outgoing(root)");
 
       requestAnimationFrame(() => {
-        assert_equals(getComputedStyle(document.documentElement, ":view-transition").position, "fixed", "raf :view-transition");
-        assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").position, "absolute", "raf container(target)");
-        assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").mixBlendMode, "multiply", "raf container(target)");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").textOrientation, "upright", "raf container(target)");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").colorScheme, "dark light", "raf container(target)");
-        assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(target)").position, "fixed", "raf wrapper(target)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition").position, "fixed", "raf ::view-transition");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").position, "absolute", "raf container(target)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").mixBlendMode, "multiply", "raf container(target)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").textOrientation, "upright", "raf container(target)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").colorScheme, "dark light", "raf container(target)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(target)").position, "fixed", "raf wrapper(target)");
 
-        assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(target)").position, "absolute", "raf outgoing(target)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(target)").position, "absolute", "raf outgoing(target)");
 
-        assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(root)").position, "absolute", "raf container(root)");
-        assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(root)").mixBlendMode, "normal", "raf container(root)");
-        assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(root)").position, "absolute", "raf wrapper(root)");
-        assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(root)").position, "absolute", "raf outgoing(root)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").position, "absolute", "raf container(root)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").mixBlendMode, "normal", "raf container(root)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(root)").position, "absolute", "raf wrapper(root)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(root)").position, "absolute", "raf outgoing(root)");
       });
     });
     await transition.finished;
@@ -69,42 +69,42 @@ promise_test(() => {
   assert_implements(document.startViewTransition, "Missing document.startViewTransition");
   return new Promise(async (resolve, reject) => {
     let transition = document.startViewTransition(() => {
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition").position, "fixed");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").position, "absolute");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(target)").position, "absolute");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition").position, "fixed");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").position, "absolute");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(target)").position, "absolute");
 
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(target)").position, "absolute");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(target)").position, "absolute");
 
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(root)").position, "absolute");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(root)").position, "absolute");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(root)").position, "absolute");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").position, "absolute");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(root)").position, "absolute");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(root)").position, "absolute");
 
       target.remove();
     });
 
     await transition.ready;
 
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition").position, "fixed");
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").position, "absolute");
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").mixBlendMode, "multiply");
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").textOrientation, "upright");
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").colorScheme, "dark light");
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(target)").position, "fixed");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition").position, "fixed");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").position, "absolute");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").mixBlendMode, "multiply");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").textOrientation, "upright");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").colorScheme, "dark light");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(target)").position, "fixed");
 
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(target)").position, "absolute");
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-new(target)").position, "absolute");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(target)").position, "absolute");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-new(target)").position, "absolute");
 
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(root)").position, "absolute");
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(root)").position, "absolute");
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(root)").position, "absolute");
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-new(root)").position, "absolute");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").position, "absolute");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(root)").position, "absolute");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(root)").position, "absolute");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-new(root)").position, "absolute");
 
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").position, "absolute");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").position, "absolute");
 
     await transition.finished;
 
     // With custom ua sheets not applying to non-existing pseudo, the value should be the default (not absolute)
-    assert_not_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").position, "absolute");
+    assert_not_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").position, "absolute");
 
     resolve();
   });


### PR DESCRIPTION
WebKit will reject the single colon syntax in `getComputedStyle()` because it is invalid.