### PR TITLE
[wdspec] Fix BiDiSession.add_event_listener to handle several listeners

### DIFF
--- a/tools/webdriver/webdriver/bidi/client.py
+++ b/tools/webdriver/webdriver/bidi/client.py
@@ -205,7 +205,7 @@ class BidiSession:
             if not listeners:
                 listeners = self.event_listeners.get(None, [])
             for listener in listeners:
-                await listener(data["method"], data["params"])
+                asyncio.create_task(listener(data["method"], data["params"]))
         else:
             raise ValueError(f"Unexpected message: {data!r}")
 


### PR DESCRIPTION
This is most likely a blocker for #44702 

With the current implementation the `for` loop awaits indefinitely if the listener does not return a future and never calls other listeners for a given event.