### PR TITLE
[wptrunner] Log which browser (PID) ran each test

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -773,6 +773,8 @@ class TestRunnerManager(threading.Thread):
                                             test.max_assertion_count)
 
         file_result.extra["test_timeout"] = test.timeout * self.executor_kwargs['timeout_multiplier']
+        if self.browser.browser_pid:
+            file_result.extra["browser_pid"] = self.browser.browser_pid
 
         self.logger.test_end(test.id,
                              status,


### PR DESCRIPTION
`mozlog` allows `process_output` events to be [interspersed between any `test_*` events][0]. When running tests in parallel, there's currently no structured way to tell which test a `process_event` corresponds to, which prevents us from extracting per-test browser logs. (The required `pid` field is unhelpfully that of the main `testrunner` process.)

Log the browser PID during `test_end` as `extra.browser_pid` so that it can be joined against `process_output`'s `process` field.

[0]: https://firefox-source-docs.mozilla.org/mozbase/mozlog.html#testsuite-protocol

For https://crbug.com/41494889