### PR TITLE
Use the 'verified' field of the test vectors.

### DIFF
--- a/WebCryptoAPI/sign_verify/eddsa.js
+++ b/WebCryptoAPI/sign_verify/eddsa.js
@@ -229,10 +229,10 @@ function run_test() {
                   publicKey = await subtle.importKey("raw", test.keyData, algorithm, false, ["verify"])
                   isVerified = await subtle.verify(algorithm, publicKey, test.signature, test.message);
               } catch (err) {
-                  assert_false(publicKey === undefined, "importKey failed for " + vector.name + ". Message: ''" + err.message + "''");
+                  assert_true(publicKey !== undefined, "Public key should be valid.");
                   assert_unreached("The operation shouldn't fail, but it thown this error: " + err.name + ": " + err.message + ".");
               }
-              assert_false(isVerified, "Signature verification result.");
+              assert_equals(isVerified, test.verified, "Signature verification result.");
           }, algorithmName + " Verification checks with small-order key of order - Test " + test.id);
       });
   });


### PR DESCRIPTION
We had a filed in the test vectors to define the expected result, but we were not using it.