### PR TITLE
Convert CSS2 visual tests into reftests where an existing ref matches

### DIFF
--- a/css/CSS2/borders/border-left-width-078.xht
+++ b/css/CSS2/borders/border-left-width-078.xht
@@ -27,6 +27,7 @@
                 border-left-width: -1ex;
             }
         </style>
+        <link rel="match" href="border-left-width-001-ref.xht" />
     </head>
     <body>
         <p>Test passes if the 2 black lines have the <strong>same width</strong>.</p>

--- a/css/CSS2/cascade-import/cascade-import-001.xht
+++ b/css/CSS2/cascade-import/cascade-import-001.xht
@@ -12,6 +12,7 @@
    @import url(data:text/css,@import%20url\(data:text/css,.test%2520%257B%2520background:%2520maroon;%2520color:%2520white;%2520%257D\);%0D%0A.test.test%20%7B%20background:%20green;%20color:%20white;%20%7D);
    p { color: yellow; background: red; }
   </style>
+  <link rel="match" href="/css/CSS2/syntax/character-encoding-041-ref.xht" />
  </head>
  <body>
   <p class="test">This line should be green.</p>

--- a/css/CSS2/fonts/font-size-119.xht
+++ b/css/CSS2/fonts/font-size-119.xht
@@ -23,6 +23,7 @@
     .p { color: green; }
 
   ]]></style>
+  <link rel="match" href="/css/CSS2/reference/ref-if-there-is-no-red.xht" />
  </head>
  <body class="test">
   <p>Test passes if there is <strong>no red</strong>.</p>

--- a/css/CSS2/linebox/vertical-align-baseline-006.xht
+++ b/css/CSS2/linebox/vertical-align-baseline-006.xht
@@ -15,6 +15,7 @@
                 vertical-align: baseline;
             }
         </style>
+        <link rel="match" href="vertical-align-baseline-007-ref.xht" />
     </head>
     <body>
         <p>Test passes if the bottoms of all the 'X's are aligned.</p>

--- a/css/CSS2/linebox/vertical-align-baseline-010.xht
+++ b/css/CSS2/linebox/vertical-align-baseline-010.xht
@@ -17,6 +17,7 @@
                 vertical-align: baseline;
             }
         </style>
+        <link rel="match" href="vertical-align-baseline-007-ref.xht" />
     </head>
     <body>
         <p>Test passes if the bottoms of all the 'X's are aligned.</p>

--- a/css/CSS2/lists/counter-increment-auto-reset-001.xht
+++ b/css/CSS2/lists/counter-increment-auto-reset-001.xht
@@ -15,6 +15,7 @@
                 content: counter(outofscope);
             }
         </style>
+        <link rel="match" href="/css/CSS2/generated-content/content-auto-reset-001-ref.html" />
     </head>
     <body>
         <p>Test passes if there is the number '0' below.</p>

--- a/css/CSS2/lists/counter-increment-display-001.xht
+++ b/css/CSS2/lists/counter-increment-display-001.xht
@@ -16,6 +16,7 @@
                 content: counter(hidden);
             }
         </style>
+        <link rel="match" href="/css/CSS2/generated-content/content-auto-reset-001-ref.html" />
     </head>
     <body>
         <p>Test passes if there is the number '0' below.</p>

--- a/css/CSS2/lists/counter-increment-not-generated-001.xht
+++ b/css/CSS2/lists/counter-increment-not-generated-001.xht
@@ -16,6 +16,7 @@
                 content: counter(notgenerated);
             }
         </style>
+        <link rel="match" href="/css/CSS2/generated-content/content-auto-reset-001-ref.html" />
     </head>
     <body>
         <p>Test passes if there is the number '0' below.</p>

--- a/css/CSS2/lists/counter-reset-display-001.xht
+++ b/css/CSS2/lists/counter-reset-display-001.xht
@@ -16,6 +16,7 @@
                 content: counter(hidden);
             }
         </style>
+        <link rel="match" href="/css/CSS2/generated-content/content-auto-reset-001-ref.html" />
     </head>
     <body>
         <p>Test passes if there is the number '0' below.</p>

--- a/css/CSS2/lists/counter-reset-not-generated-001.xht
+++ b/css/CSS2/lists/counter-reset-not-generated-001.xht
@@ -16,6 +16,7 @@
                 content: counter(notgenerated);
             }
         </style>
+        <link rel="match" href="/css/CSS2/generated-content/content-auto-reset-001-ref.html" />
     </head>
     <body>
         <p>Test passes if there is the number '0' below.</p>

--- a/css/CSS2/margin-padding-clear/margin-collapse-012.xht
+++ b/css/CSS2/margin-padding-clear/margin-collapse-012.xht
@@ -33,6 +33,7 @@
                 position: absolute;
             }
         </style>
+        <link rel="match" href="margin-collapse-002-ref.xht" />
     </head>
     <body>
         <p>Test passes if there is <strong>no red</strong>.</p>

--- a/css/CSS2/margin-padding-clear/margin-collapse-clear-001.xht
+++ b/css/CSS2/margin-padding-clear/margin-collapse-clear-001.xht
@@ -14,6 +14,7 @@
     div.box2 { background-color: aqua; float: left; width: 20px; height: 20px; }
     div.box3 { margin-top: 50px; height: 50px; background-color: orange; }
   </style>
+  <link rel="match" href="/css/CSS2/floats-clear/margin-collapse-clear-002-ref.xht" />
  </head>
  <body>
   <p>The coloured bars on the left should match the coloured boxes in the black box.</p>

--- a/css/CSS2/margin-padding-clear/margin-collapse-clear-007.xht
+++ b/css/CSS2/margin-padding-clear/margin-collapse-clear-007.xht
@@ -15,6 +15,7 @@
     div.box2 { background-color: aqua; float: left; width: 20px; height: 20px; }
     div.box3 { overflow: hidden; margin-top: 50px; height: 50px; background-color: orange; }
   </style>
+  <link rel="match" href="/css/CSS2/floats-clear/margin-collapse-clear-002-ref.xht" />
  </head>
  <body>
   <p>The coloured bars on the left should match the coloured boxes in the black box.</p>

--- a/css/CSS2/margin-padding-clear/margin-left-applies-to-008.xht
+++ b/css/CSS2/margin-padding-clear/margin-left-applies-to-008.xht
@@ -22,6 +22,7 @@
                 margin-left: 50px;
             }
         </style>
+        <link rel="match" href="padding-left-applies-to-008-ref.xht" />
     </head>
     <body>
         <p>Test passes if there is space between the blue and orange lines.</p>

--- a/css/CSS2/margin-padding-clear/padding-applies-to-016.xht
+++ b/css/CSS2/margin-padding-clear/padding-applies-to-016.xht
@@ -19,6 +19,7 @@
    span.control { background: green; color: white; }
    span.test { padding-top: 10em; }
   </style>
+  <link rel="match" href="/css/CSS2/floats-clear/floats-125-ref.xht" />
  </head>
  <body>
   <table>

--- a/css/CSS2/margin-padding-clear/padding-applies-to-017.xht
+++ b/css/CSS2/margin-padding-clear/padding-applies-to-017.xht
@@ -18,6 +18,7 @@
    span.control { background: green; color: white; }
    span.test { padding-bottom: 10em; }
   </style>
+  <link rel="match" href="/css/CSS2/floats-clear/floats-124-ref.xht" />
  </head>
  <body>
   <table>

--- a/css/CSS2/normal-flow/block-non-replaced-width-002.xht
+++ b/css/CSS2/normal-flow/block-non-replaced-width-002.xht
@@ -31,6 +31,7 @@
                 width: 150px;
             }
         </style>
+        <link rel="match" href="block-non-replaced-width-001-ref.xht" />
     </head>
     <body>
         <p>Test passes if the orange and blue rectangles have the <strong>same width</strong>.</p>

--- a/css/CSS2/normal-flow/max-width-014.xht
+++ b/css/CSS2/normal-flow/max-width-014.xht
@@ -16,6 +16,7 @@
                 width: 72pt;
             }
         </style>
+        <link rel="match" href="max-width-003-ref.xht" />
     </head>
     <body>
         <p>Test passes if there is a thin vertical line.</p>

--- a/css/CSS2/normal-flow/min-width-014.xht
+++ b/css/CSS2/normal-flow/min-width-014.xht
@@ -16,6 +16,7 @@
                 width: 0;
             }
         </style>
+        <link rel="match" href="max-width-003-ref.xht" />
     </head>
     <body>
         <p>Test passes if there is a thin vertical line.</p>

--- a/css/CSS2/normal-flow/width-014.xht
+++ b/css/CSS2/normal-flow/width-014.xht
@@ -15,6 +15,7 @@
                 width: 1pt;
             }
         </style>
+        <link rel="match" href="max-width-003-ref.xht" />
     </head>
     <body>
         <p>Test passes if there is a thin vertical line.</p>

--- a/css/CSS2/selectors/first-line-pseudo-007.xht
+++ b/css/CSS2/selectors/first-line-pseudo-007.xht
@@ -10,6 +10,7 @@
    div div { float: right; }
    :first-line { color: green; }
   </style>
+  <link rel="match" href="/css/CSS2/cascade/cascade-012-ref.xht" />
  </head>
  <body>
   <div>

--- a/css/CSS2/selectors/first-line-pseudo-008.xht
+++ b/css/CSS2/selectors/first-line-pseudo-008.xht
@@ -10,6 +10,7 @@
    div div { display: none; }
    :first-line { color: green; }
   </style>
+  <link rel="match" href="/css/CSS2/cascade/cascade-012-ref.xht" />
  </head>
  <body>
   <div>

--- a/css/CSS2/selectors/first-line-selector-004.xht
+++ b/css/CSS2/selectors/first-line-selector-004.xht
@@ -11,6 +11,7 @@
                 color: green;
             }
         </style>
+        <link rel="match" href="/css/CSS2/reference/filler-text-below-green.xht" />
     </head>
     <body>
         <p>Test passes if the "Filler Text" below is green.</p>

--- a/css/CSS2/syntax/character-encoding-031.xht
+++ b/css/CSS2/syntax/character-encoding-031.xht
@@ -11,6 +11,7 @@
    p { background: red; color: yellow; }
   </style>
   <link rel="stylesheet" href="support/character-encoding-031.css"/>
+  <link rel="match" href="character-encoding-041-ref.xht" />
  </head>
  <body>
   <p class="t&#xE9;st">This line should be green.</p>

--- a/css/CSS2/syntax/character-encoding-032.xht
+++ b/css/CSS2/syntax/character-encoding-032.xht
@@ -11,6 +11,7 @@
    p { background: red; color: yellow; }
   </style>
   <link rel="stylesheet" href="support/character-encoding-032.css"/>
+  <link rel="match" href="character-encoding-041-ref.xht" />
  </head>
  <body>
   <p class="t&#x0E49;st">This line should be green.</p>

--- a/css/CSS2/syntax/character-encoding-033.xht
+++ b/css/CSS2/syntax/character-encoding-033.xht
@@ -11,6 +11,7 @@
    p { background: red; color: yellow; }
   </style>
   <link rel="stylesheet" href="support/character-encoding-033.css"/>
+  <link rel="match" href="character-encoding-041-ref.xht" />
  </head>
  <body>
   <p class="t&#x0449;st">This line should be green.</p>

--- a/css/CSS2/syntax/character-encoding-034.xht
+++ b/css/CSS2/syntax/character-encoding-034.xht
@@ -11,6 +11,7 @@
    p { background: red; color: yellow; }
   </style>
   <link rel="stylesheet" href="support/character-encoding-034.css"/>
+  <link rel="match" href="character-encoding-041-ref.xht" />
  </head>
  <body>
   <p class="t&#x0649;st">This line should be green.</p>

--- a/css/CSS2/syntax/character-encoding-035.xht
+++ b/css/CSS2/syntax/character-encoding-035.xht
@@ -11,6 +11,7 @@
    p { background: red; color: yellow; }
   </style>
   <link rel="stylesheet" href="support/character-encoding-035.css"/>
+  <link rel="match" href="character-encoding-041-ref.xht" />
  </head>
  <body>
   <p class="t&#x03B9;st">This line should be green.</p>

--- a/css/CSS2/syntax/character-encoding-036.xht
+++ b/css/CSS2/syntax/character-encoding-036.xht
@@ -11,6 +11,7 @@
    p { background: red; color: yellow; }
   </style>
   <link rel="stylesheet" href="support/character-encoding-036.css"/>
+  <link rel="match" href="character-encoding-041-ref.xht" />
  </head>
  <body>
   <p class="t&#x05D9;st">This line should be green.</p>

--- a/css/CSS2/syntax/character-encoding-037.xht
+++ b/css/CSS2/syntax/character-encoding-037.xht
@@ -11,6 +11,7 @@
    p { background: red; color: yellow; }
   </style>
   <link rel="stylesheet" href="support/character-encoding-037.css"/>
+  <link rel="match" href="character-encoding-041-ref.xht" />
  </head>
  <body>
   <p class="t&#x0418;st">This line should be green.</p>


### PR DESCRIPTION
These are potentially higher value than the average CSS2 testcase, as this likely implies they failed in 2016 when many of these were previously converted to reftests, as the grouping was done based on existing browser behaviour.