### PR TITLE
Revert "[wptrunner] Log which browser (PID) ran each test"

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -773,8 +773,6 @@ class TestRunnerManager(threading.Thread):
                                             test.max_assertion_count)
 
         file_result.extra["test_timeout"] = test.timeout * self.executor_kwargs['timeout_multiplier']
-        if self.browser.browser_pid:
-            file_result.extra["browser_pid"] = self.browser.browser_pid
 
         self.logger.test_end(test.id,
                              status,


### PR DESCRIPTION
Reverts web-platform-tests/wpt#44716

Causing [widespread `wpt-firefox-nightly-stability` failures](https://community-tc.services.mozilla.com/tasks/M-dW8vVuTbyTdCEeA1KMMQ/runs/0/logs/live/public/logs/live.log) like:

```
mozlog.structuredlog: Failure calling log handler:
Traceback (most recent call last):
  File "/home/test/web-platform-tests/tools/third_party_modified/mozlog/mozlog/structuredlog.py", line 311, in _handle_log
    handler(data)
  File "/home/test/web-platform-tests/tools/third_party_modified/mozlog/mozlog/handlers/base.py", line 62, in __call__
    formatted = self.formatter(data)
  File "/home/test/web-platform-tests/tools/third_party_modified/mozlog/mozlog/formatters/__init__.py", line 20, in <lambda>
    return lambda x: json.dumps(x) + "\n"
  File "/usr/lib/python3.8/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python3.8/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.8/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type method is not JSON serializable
```

... because `FirefoxBrowser` defines `pid` as a plain instance method:

https://github.com/web-platform-tests/wpt/blob/a9c74d5a999b5fbf5fd8895078b0fd6c4cf1f3b3/tools/wptrunner/wptrunner/browsers/firefox.py#L866-L868

... but `WebDriverBrowser` (which `chrome` is based on) makes `pid` a property:

https://github.com/web-platform-tests/wpt/blob/a9c74d5a999b5fbf5fd8895078b0fd6c4cf1f3b3/tools/wptrunner/wptrunner/browsers/base.py#L395-L398