### PR TITLE
[wptrunner] Add type hints for `wptrunner.browsers.base`

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 import enum
 import errno
 import os
@@ -7,17 +5,23 @@ import platform
 import socket
 import time
 import traceback
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from typing import cast, Any, List, Optional, Tuple, Type, TypedDict
 
 import mozprocess
+from mozdebug import DebuggerInfo
+from mozlog.structuredlog import StructuredLogger
 
 from ..environment import wait_for_service
+from ..testloader import GroupMetadata
 from ..wptcommandline import require_arg  # noqa: F401
+from ..wpttest import Test
 
 here = os.path.dirname(__file__)
 
 
-def cmd_arg(name, value=None):
+def cmd_arg(name: str, value: Optional[str] = None) -> str:
     prefix = "-" if platform.system() == "Windows" else "--"
     rv = prefix + name
     if value is not None:
@@ -25,7 +29,7 @@ def cmd_arg(name, value=None):
     return rv
 
 
-def maybe_add_args(required_args, current_args):
+def maybe_add_args(required_args: List[str], current_args: List[str]) -> List[str]:
     for required_arg in required_args:
         # If the arg is in the form of "variable=value", only add it if
         # no arg with another value for "variable" is already there.
@@ -39,15 +43,20 @@ def maybe_add_args(required_args, current_args):
     return current_args
 
 
-def certificate_domain_list(list_of_domains, certificate_file):
+class Certificate(TypedDict):
+    host: str
+    certificateFile: str  # noqa: N815
+
+
+def certificate_domain_list(list_of_domains: List[str], certificate_file: str) -> List[Certificate]:
     """Build a list of domains where certificate_file should be used"""
-    cert_list = []
+    cert_list: List[Certificate] = []
     for domain in list_of_domains:
         cert_list.append({"host": domain, "certificateFile": certificate_file})
     return cert_list
 
 
-def get_free_port():
+def get_free_port() -> int:
     """Get a random unbound port"""
     while True:
         s = socket.socket()
@@ -56,27 +65,27 @@ def get_free_port():
         except OSError:
             continue
         else:
-            return s.getsockname()[1]
+            return cast(int, s.getsockname()[1])
         finally:
             s.close()
 
 
-def get_timeout_multiplier(test_type, run_info_data, **kwargs):
+def get_timeout_multiplier(test_type: str, run_info_data: Mapping[str, Any], **kwargs: Any) -> float:
     if kwargs["timeout_multiplier"] is not None:
-        return kwargs["timeout_multiplier"]
+        return cast(float, kwargs["timeout_multiplier"])
     return 1
 
 
-def browser_command(binary, args, debug_info):
+def browser_command(binary: str,
+                    args: List[str],
+                    debug_info: DebuggerInfo) -> Tuple[List[str], List[str]]:
     if debug_info:
         if debug_info.requiresEscapedArgs:
             args = [item.replace("&", "\\&") for item in args]
         debug_args = [debug_info.path] + debug_info.args
     else:
         debug_args = []
-
     command = [binary] + args
-
     return debug_args, command
 
 
@@ -84,7 +93,7 @@ class BrowserError(Exception):
     pass
 
 
-class Browser:
+class Browser(ABC):
     """Abstract class serving as the basis for Browser implementations.
 
     The Browser is used in the TestRunnerManager to start and stop the browser
@@ -92,19 +101,16 @@ class Browser:
 
     :param logger: Structured logger to use for output.
     """
-    __metaclass__ = ABCMeta
+    init_timeout: float = 30
 
-    process_cls = None
-    init_timeout = 30
-
-    def __init__(self, logger):
+    def __init__(self, logger: StructuredLogger):
         self.logger = logger
 
-    def setup(self):
+    def setup(self) -> None:
         """Used for browser-specific setup that happens at the start of a test run"""
         pass
 
-    def settings(self, test):
+    def settings(self, test: Test) -> Mapping[str, Any]:
         """Dictionary of metadata that is constant for a specific launch of a browser.
 
         This is used to determine when the browser instance configuration changes, requiring
@@ -114,64 +120,66 @@ class Browser:
         return {}
 
     @abstractmethod
-    def start(self, group_metadata, **kwargs):
+    def start(self, group_metadata: GroupMetadata, **kwargs: Any) -> None:
         """Launch the browser object and get it into a state where is is ready to run tests"""
         pass
 
     @abstractmethod
-    def stop(self, force=False):
-        """Stop the running browser process."""
+    def stop(self, force: bool = False) -> bool:
+        """Stop the running browser process.
+
+        Return True iff the browser was successfully stopped.
+        """
         pass
 
+    @property
     @abstractmethod
-    def pid(self):
+    def pid(self) -> Optional[int]:
         """pid of the browser process or None if there is no pid"""
         pass
 
     @abstractmethod
-    def is_alive(self):
+    def is_alive(self) -> bool:
         """Boolean indicating whether the browser process is still running"""
         pass
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         """Browser-specific cleanup that is run after the testrun is finished"""
         pass
 
-    def executor_browser(self):
+    def executor_browser(self) -> Tuple[Type['ExecutorBrowser'], Mapping[str, Any]]:
         """Returns the ExecutorBrowser subclass for this Browser subclass and the keyword arguments
         with which it should be instantiated"""
         return ExecutorBrowser, {}
 
-    def maybe_parse_tombstone(self):
-        """Possibly parse tombstones on Android device for Android target"""
-        pass
-
-    def check_crash(self, process, test):
+    def check_crash(self, process: int, test: str) -> bool:
         """Check if a crash occured and output any useful information to the
         log. Returns a boolean indicating whether a crash occured."""
         return False
 
     @property
-    def pac(self):
+    def pac(self) -> Optional[str]:
         return None
 
+
 class NullBrowser(Browser):
-    def __init__(self, logger, **kwargs):
+    def __init__(self, logger: StructuredLogger, **kwargs: Any):
         super().__init__(logger)
 
-    def start(self, **kwargs):
+    def start(self, group_metadata: GroupMetadata, **kwargs: Any) -> None:
         """No-op browser to use in scenarios where the TestRunnerManager shouldn't
         actually own the browser process (e.g. Servo where we start one browser
         per test)"""
         pass
 
-    def stop(self, force=False):
-        pass
+    def stop(self, force: bool = False) -> bool:
+        return True
 
-    def pid(self):
+    @property
+    def pid(self) -> Optional[int]:
         return None
 
-    def is_alive(self):
+    def is_alive(self) -> bool:
         return True
 
 
@@ -184,7 +192,7 @@ class ExecutorBrowser:
     but in some cases it may have more elaborate methods for setting
     up the browser from the runner process.
     """
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any):
         for k, v in kwargs.items():
             setattr(self, k, v)
 
@@ -233,20 +241,20 @@ class OutputHandler:
     but sometimes use a wrapper e.g. mozrunner.
     """
 
-    def __init__(self, logger, command, **kwargs):
+    def __init__(self, logger: StructuredLogger, command: List[str], **kwargs: Any):
         self.logger = logger
         self.command = command
-        self.pid = None
+        self.pid: Optional[int] = None
         self.state = OutputHandlerState.BEFORE_PROCESS_START
-        self.line_buffer = []
+        self.line_buffer: List[bytes] = []
 
-    def after_process_start(self, pid):
+    def after_process_start(self, pid: int) -> None:
         assert self.state == OutputHandlerState.BEFORE_PROCESS_START
         self.logger.debug("OutputHandler.after_process_start")
         self.pid = pid
         self.state = OutputHandlerState.AFTER_PROCESS_START
 
-    def start(self, **kwargs):
+    def start(self, **kwargs: Any) -> None:
         assert self.state == OutputHandlerState.AFTER_PROCESS_START
         self.logger.debug("OutputHandler.start")
         # Need to change the state here before we try to empty the buffer
@@ -254,9 +262,9 @@ class OutputHandler:
         self.state = OutputHandlerState.AFTER_HANDLER_START
         for item in self.line_buffer:
             self(item)
-        self.line_buffer = None
+        self.line_buffer.clear()
 
-    def after_process_stop(self, clean_shutdown=True):
+    def after_process_stop(self, clean_shutdown: bool = True) -> None:
         # If we didn't get as far as configure, just
         # dump all logs with no configuration
         self.logger.debug("OutputHandler.after_process_stop")
@@ -264,7 +272,7 @@ class OutputHandler:
             self.start()
         self.state = OutputHandlerState.AFTER_PROCESS_STOP
 
-    def __call__(self, line):
+    def __call__(self, line: bytes) -> None:
         if self.state < OutputHandlerState.AFTER_HANDLER_START:
             self.line_buffer.append(line)
             return
@@ -280,11 +288,17 @@ class OutputHandler:
 
 
 class WebDriverBrowser(Browser):
-    __metaclass__ = ABCMeta
-
-    def __init__(self, logger, binary=None, webdriver_binary=None,
-                 webdriver_args=None, host="127.0.0.1", port=None, base_path="/",
-                 env=None, supports_pac=True, **kwargs):
+    def __init__(self,
+                 logger: StructuredLogger,
+                 binary: Optional[str] = None,
+                 webdriver_binary: Optional[str] = None,
+                 webdriver_args: Optional[List[str]] = None,
+                 host: str = "127.0.0.1",
+                 port: Optional[int] = None,
+                 base_path: str = "/",
+                 env: Optional[Mapping[str, str]] = None,
+                 supports_pac: bool = True,
+                 **kwargs: Any):
         super().__init__(logger)
 
         if webdriver_binary is None:
@@ -303,17 +317,17 @@ class WebDriverBrowser(Browser):
         self.env = os.environ.copy() if env is None else env
         self.webdriver_args = webdriver_args if webdriver_args is not None else []
 
-        self.init_deadline = None
-        self._output_handler = None
+        self.init_deadline: float = 0
+        self._output_handler: Optional[OutputHandler] = None
         self._cmd = None
-        self._proc = None
+        self._proc: Optional[mozprocess.ProcessHandler] = None
         self._pac = None
 
-    def make_command(self):
+    def make_command(self) -> List[str]:
         """Returns the full command for starting the server process as a list."""
         return [self.webdriver_binary] + self.webdriver_args
 
-    def start(self, group_metadata, **kwargs):
+    def start(self, group_metadata: GroupMetadata, **kwargs: Any) -> None:
         self.init_deadline = time.time() + self.init_timeout
         try:
             self._run_server(group_metadata, **kwargs)
@@ -321,14 +335,14 @@ class WebDriverBrowser(Browser):
             self.stop()
             raise
 
-    def create_output_handler(self, cmd):
+    def create_output_handler(self, cmd: List[str]) -> OutputHandler:
         """Return an instance of the class used to handle application output.
 
         This can be overridden by subclasses which have particular requirements
         for parsing, or otherwise using, the output."""
         return OutputHandler(self.logger, cmd)
 
-    def _run_server(self, group_metadata, **kwargs):
+    def _run_server(self, group_metadata: GroupMetadata, **kwargs: Any) -> None:
         cmd = self.make_command()
         self._output_handler = self.create_output_handler(cmd)
 
@@ -365,10 +379,10 @@ class WebDriverBrowser(Browser):
             self._output_handler.start(group_metadata=group_metadata, **kwargs)
         self.logger.debug("_run complete")
 
-    def stop(self, force=False):
+    def stop(self, force: bool = False) -> bool:
         self.logger.debug("Stopping WebDriver")
         clean = True
-        if self.is_alive():
+        if self._proc and self.is_alive():
             # Pass a timeout value to mozprocess Processhandler.kill()
             # to ensure it always returns within it.
             # See https://bugzilla.mozilla.org/show_bug.cgi?id=1760080
@@ -383,42 +397,41 @@ class WebDriverBrowser(Browser):
             self._output_handler = None
         return success
 
-    def is_alive(self):
-        return hasattr(self._proc, "proc") and self._proc.poll() is None
+    def is_alive(self) -> bool:
+        return self._proc is not None and hasattr(self._proc, "proc") and self._proc.poll() is None
 
     @property
-    def url(self):
+    def url(self) -> str:
         if self.port is not None:
             return f"http://{self.host}:{self.port}{self.base_path}"
         raise ValueError("Can't get WebDriver URL before port is assigned")
 
     @property
-    def pid(self):
-        if self._proc is not None:
-            return self._proc.pid
+    def pid(self) -> Optional[int]:
+        return self._proc.pid if self._proc is not None else None
 
     @property
-    def port(self):
+    def port(self) -> int:
         # If no port is supplied, we'll get a free port right before we use it.
         # Nothing guarantees an absence of race conditions here.
         if self._port is None:
             self._port = get_free_port()
         return self._port
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         self.stop()
 
-    def executor_browser(self):
+    def executor_browser(self) -> Tuple[Type[ExecutorBrowser], Mapping[str, Any]]:
         return ExecutorBrowser, {"webdriver_url": self.url,
                                  "host": self.host,
                                  "port": self.port,
                                  "pac": self.pac,
                                  "env": self.env}
 
-    def settings(self, test):
+    def settings(self, test: Test) -> Mapping[str, Any]:
         self._pac = test.environment.get("pac", None) if self._supports_pac else None
         return {"pac": self._pac}
 
     @property
-    def pac(self):
+    def pac(self) -> Optional[str]:
         return self._pac

--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -6,8 +6,7 @@ import socket
 import time
 import traceback
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
-from typing import cast, Any, List, Optional, Tuple, Type, TypedDict
+from typing import cast, Any, List, Mapping, Optional, Tuple, Type
 
 import mozprocess
 from mozdebug import DebuggerInfo
@@ -43,14 +42,10 @@ def maybe_add_args(required_args: List[str], current_args: List[str]) -> List[st
     return current_args
 
 
-class Certificate(TypedDict):
-    host: str
-    certificateFile: str  # noqa: N815
-
-
-def certificate_domain_list(list_of_domains: List[str], certificate_file: str) -> List[Certificate]:
+def certificate_domain_list(list_of_domains: List[str],
+                            certificate_file: str) -> List[Mapping[str, Any]]:
     """Build a list of domains where certificate_file should be used"""
-    cert_list: List[Certificate] = []
+    cert_list: List[Mapping[str, Any]] = []
     for domain in list_of_domains:
         cert_list.append({"host": domain, "certificateFile": certificate_file})
     return cert_list

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -864,6 +864,7 @@ class FirefoxBrowser(Browser):
         self.instance_manager.stop_current(force)
         self.logger.debug("stopped")
 
+    @property
     def pid(self):
         return self.instance.pid()
 

--- a/tools/wptrunner/wptrunner/browsers/firefox_android.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox_android.py
@@ -323,6 +323,7 @@ class FirefoxAndroidBrowser(Browser):
             self.runner.cleanup()
         self.logger.debug("stopped")
 
+    @property
     def pid(self):
         if self.runner.process_handler is None:
             return None

--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -231,6 +231,7 @@ class SauceBrowser(Browser):
     def stop(self, force=False):
         pass
 
+    @property
     def pid(self):
         return None
 

--- a/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -161,6 +161,7 @@ class ServoWebDriverBrowser(Browser):
         if self.output_handler is not None:
             self.output_handler.after_process_stop()
 
+    @property
     def pid(self):
         if self.proc is None:
             return None

--- a/tools/wptrunner/wptrunner/browsers/wktr.py
+++ b/tools/wptrunner/wptrunner/browsers/wktr.py
@@ -186,6 +186,7 @@ class WKTRBrowser(Browser):
     def is_alive(self):
         return self._proc is not None and self._proc.poll() is None
 
+    @property
     def pid(self):
         return self._proc.pid if self._proc else None
 

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -7,8 +7,11 @@ import signal
 import socket
 import sys
 import time
+from typing import Optional
 
+import mozprocess
 from mozlog import get_default_logger, handlers
+from mozlog.structuredlog import StructuredLogger
 
 from . import mpcontext
 from .wptlogging import LogLevelRewriter, QueueHandler, LogQueueThread
@@ -331,7 +334,11 @@ class TestdriverLoader:
         return self._handler(request, response)
 
 
-def wait_for_service(logger, host, port, timeout=60, server_process=None):
+def wait_for_service(logger: StructuredLogger,
+                     host: str,
+                     port: int,
+                     timeout: float = 60,
+                     server_process: Optional[mozprocess.ProcessHandler] = None) -> bool:
     """Waits until network service given as a tuple of (host, port) becomes
     available, `timeout` duration is reached, or the `server_process` exits at
     which point ``socket.error`` is raised."""

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -530,6 +530,7 @@ def get_test_queue_builder(**kwargs: Any) -> Tuple[TestQueueBuilder, Mapping[str
 
 
 TestGroup = namedtuple("TestGroup", ["group", "subsuite", "test_type", "metadata"])
+GroupMetadata = Mapping[str, Any]
 
 
 class TestQueueBuilder:
@@ -573,7 +574,7 @@ class TestQueueBuilder:
     def tests_by_group(self, tests_by_type: TestsByType) -> Mapping[str, List[str]]:
         pass
 
-    def group_metadata(self, state: Mapping[str, Any]) -> Mapping[str, Any]:
+    def group_metadata(self, state: Mapping[str, Any]) -> GroupMetadata:
         return {"scope": "/"}
 
     def process_count(self, requested_processes: int, num_test_groups: int) -> int:
@@ -654,7 +655,7 @@ class PathGroupedSource(TestQueueBuilder):
                 groups[group_name].append(test.id)
         return groups
 
-    def group_metadata(self, state: Mapping[str, Any]) -> Mapping[str, Any]:
+    def group_metadata(self, state: Mapping[str, Any]) -> GroupMetadata:
         return {"scope": "/%s" % "/".join(state["prev_group_key"][2])}
 
 


### PR DESCRIPTION
web-platform-tests/wpt#44716 caused a regression because some `Browser` subclasses exposed `pid` as a property (attribute), whereas others exposed a regular instance method.

This PR makes all `pid`s properties, and adds type hints to `wptrunner.browsers.base` to document and begin machine-checking that all `Browser`s adhere to the interface. No functional change intended.

Checked with:

```sh
grep -U2 -R 'def pid' wptrunner/wptrunner/browsers
```