### PR TITLE
[wptserve] Don't log unactionable `SSLEOFError` on startup

### DIFF
--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -236,7 +236,11 @@ class WebTestServer(http.server.ThreadingHTTPServer):
              isinstance(error.args, tuple) and
              error.args[0] in self.acceptable_errors) or
             (isinstance(error, IOError) and
-             error.errno in self.acceptable_errors)):
+             error.errno in self.acceptable_errors) or
+            # `SSLEOFError` may occur when a client (e.g., wptrunner's
+            # `TestEnvironment`) tests for connectivity but doesn't perform the
+            # handshake.
+            isinstance(error, ssl.SSLEOFError)):
             pass  # remote hang up before the result is sent
         else:
             msg = traceback.format_exc()


### PR DESCRIPTION
When testing that each server is alive, wptrunner connects to the server's port but [doesn't perform the TLS handshake][1]. As of #44428, the connectivity test causes `wptserve` to log an [error we should ignore][2]:

```
wptserve Starting WebTransport over HTTP/3 server on 127.0.0.1:11000
 0:14.82 wptserve WARNING <class 'ssl.SSLEOFError'> EOF occurred in violation of protocol (_ssl.c:1131)
wptserve <class 'ssl.SSLEOFError'> EOF occurred in violation of protocol (_ssl.c:1131)
 0:14.82 wptserve INFO Traceback (most recent call last):
  File "/usr/lib/python3.8/socketserver.py", line 683, in process_request_thread
    self.finish_request(request, client_address)
  File "/home/test/web-platform-tests/tools/wptserve/wptserve/server.py", line 229, in finish_request
    request.do_handshake()
  File "/usr/lib/python3.8/ssl.py", line 1309, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLEOFError: EOF occurred in violation of protocol (_ssl.c:1131)
```

[1]: https://github.com/web-platform-tests/wpt/blob/af4ba0985/tools/wptrunner/wptrunner/environment.py#L304
[2]: https://community-tc.services.mozilla.com/tasks/d5b9ZE23RJ26nBTTsFQ05g/runs/0/logs/live/public/logs/live.log#L658-666