### PR TITLE
Actually use history.replaceState in test with referer headers

### DIFF
--- a/html/browsers/history/the-history-interface/009-3.html
+++ b/html/browsers/history/the-history-interface/009-3.html
@@ -18,7 +18,7 @@ parent.test(function () {
 }, 'document.referrer should use the pushed state');
 window.onload = function () {
         setTimeout(function () {
-                try { history.pushState('','','009-4.html?2345'); } catch(e) {}
+                try { history.replaceState('','','009-4.html?2345'); } catch(e) {}
                 location.href = '009-5.html?pipe=sub';
         },10);
 };

--- a/html/browsers/history/the-history-interface/010-3.html
+++ b/html/browsers/history/the-history-interface/010-3.html
@@ -16,7 +16,7 @@ parent.test(function () {
 parent.test(function () {
         parent.assert_equals( document.referrer, lastUrl );
 }, 'document.referrer should use the pushed state (before onload)');
-try { history.pushState('','','010-4.html?2345'); } catch(e) {}
+try { history.replaceState('','','010-4.html?2345'); } catch(e) {}
 location.href = '010-5.html?pipe=sub';
                 </script>
 


### PR DESCRIPTION
These two tests are called "history.pushState/replaceState and referer headers", but they currently just test history.pushState two times, and not replaceState. I assume this test is actually meant to test pushState first and then replaceState (this is also what the individual descriptions say).