### PR TITLE
[css-color] use `color-mix()` in relative color syntax

### DIFF
--- a/css/css-color/parsing/color-computed-relative-color.html
+++ b/css/css-color/parsing/color-computed-relative-color.html
@@ -119,6 +119,8 @@
   fuzzy_test_computed_color(`rgb(from rgb(20% none 60%) r g b)`, `color(srgb 0.2 0 0.6)`);
   fuzzy_test_computed_color(`rgb(from rgb(20% 40% 60% / none) r g b / alpha)`, `color(srgb 0.2 0.4 0.6 / 0)`);
 
+  // color-mix
+  fuzzy_test_computed_color(`rgb(from color-mix(in srgb, red, red) r g b / alpha)`, `color(srgb 1 0 0)`);
 
   // hsl(from ...)
 
@@ -192,6 +194,9 @@
   fuzzy_test_computed_color(`hsl(from hsl(120deg 20% 50% / none) h s l / alpha)`, `color(srgb 0.4 0.6 0.4 / 0)`);
   fuzzy_test_computed_color(`hsl(from hsl(none 20% 50% / .5) h s l / alpha)`, `color(srgb 0.6 0.4 0.4 / 0.5)`);
 
+  // color-mix
+  fuzzy_test_computed_color(`hsl(from color-mix(in srgb, red, red) h s l / alpha)`, `color(srgb 1 0 0)`);
+
   // hwb(from ...)
 
   // Testing no modifications.
@@ -263,6 +268,9 @@
   fuzzy_test_computed_color(`hwb(from hwb(120deg 20% 50% / none) h w b / alpha)`, `color(srgb 0.2 0.5 0.2 / 0)`);
   fuzzy_test_computed_color(`hwb(from hwb(none 20% 50% / .5) h w b / alpha)`, `color(srgb 0.5 0.2 0.2 / 0.5)`);
 
+  // color-mix
+  fuzzy_test_computed_color(`hwb(from color-mix(in srgb, red, red) h w b / alpha)`, `color(srgb 1 0 0)`);
+
   // lab()
 
   // Testing no modifications.
@@ -327,6 +335,9 @@
   fuzzy_test_computed_color(`lab(from lab(25 none 50) l a b)`, `lab(25 0 50)`);
   fuzzy_test_computed_color(`lab(from lab(25 20 50 / none) l a b / alpha)`, `lab(25 20 50 / 0)`);
 
+  // color-mix
+  fuzzy_test_computed_color(`lab(from color-mix(in lab, lab(25 20 50), lab(25 20 50)) l a b / alpha)`, `lab(25 20 50)`);
+
   // oklab()
 
   // Testing no modifications.
@@ -390,6 +401,9 @@
   fuzzy_test_computed_color(`oklab(from oklab(none none none / none) l a b / alpha)`, `oklab(0 0 0 / 0)`);
   fuzzy_test_computed_color(`oklab(from oklab(0.25 none 0.5) l a b)`, `oklab(0.25 0 0.5)`);
   fuzzy_test_computed_color(`oklab(from oklab(0.25 0.2 0.5 / none) l a b / alpha)`, `oklab(0.25 0.2 0.5 / 0)`);
+
+  // color-mix
+  fuzzy_test_computed_color(`oklab(from color-mix(in oklab, oklab(0.25 0.2 0.5), oklab(0.25 0.2 0.5)) l a b / alpha)`, `oklab(0.25 0.2 0.5)`);
 
   // lch()
 
@@ -463,6 +477,9 @@
   fuzzy_test_computed_color(`lch(from lch(0.7 none 30) l c h)`,                                          `lch(0.7 0 30)`);
   fuzzy_test_computed_color(`lch(from lch(0.7 45 30 / none) l c h / alpha)`,                             `lch(0.7 45 30 / 0)`);
 
+  // color-mix
+  fuzzy_test_computed_color(`lch(from color-mix(in lch, lch(70 45 30), lch(70 45 30)) l c h / alpha)`, `lch(70 45 30)`);
+
   // oklch()
 
   // Testing no modifications.
@@ -535,6 +552,9 @@
   fuzzy_test_computed_color(`oklch(from oklch(none none none / none) l c h / alpha)`,                        `oklch(0 0 0 / 0)`);
   fuzzy_test_computed_color(`oklch(from oklch(0.7 none 30) l c h)`,                                          `oklch(0.7 0 30)`);
   fuzzy_test_computed_color(`oklch(from oklch(0.7 0.45 30 / none) l c h / alpha)`,                             `oklch(0.7 0.45 30 / 0)`);
+
+  // color-mix
+  fuzzy_test_computed_color(`oklch(from color-mix(in oklch, oklch(0.7 0.45 30), oklch(0.7 0.45 30)) l c h / alpha)`, `oklch(0.7 0.45 30)`);
 
   for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb", "display-p3" ]) {
       // Testing no modifications.
@@ -622,6 +642,9 @@
       fuzzy_test_computed_color(`color(from color(${colorSpace} none none none / none) ${colorSpace} r g b / alpha)`,            `color(${colorSpace} 0 0 0 / 0)`);
       fuzzy_test_computed_color(`color(from color(${colorSpace} 0.7 none 0.3) ${colorSpace} r g b)`,                             `color(${colorSpace} 0.7 0 0.3)`);
       fuzzy_test_computed_color(`color(from color(${colorSpace} 0.7 0.5 0.3 / none) ${colorSpace} r g b / alpha)`,               `color(${colorSpace} 0.7 0.5 0.3 / 0)`);
+
+      // color-mix
+      fuzzy_test_computed_color(`color(from color-mix(in xyz, color(${colorSpace} 0.7 0.5 0.3), color(${colorSpace} 0.7 0.5 0.3)) ${colorSpace} r g b / alpha)`, `color(${colorSpace} 0.7 0.5 0.3)`);
   }
 
   for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
@@ -683,6 +706,9 @@
       fuzzy_test_computed_color(`color(from color(${colorSpace} none none none / none) ${colorSpace} x y z / alpha)`,            `color(${resultColorSpace} 0 0 0 / 0)`);
       fuzzy_test_computed_color(`color(from color(${colorSpace} 7 none 100) ${colorSpace} x y z)`,                               `color(${resultColorSpace} 7 0 100)`);
       fuzzy_test_computed_color(`color(from color(${colorSpace} 7 -20.5 100 / none) ${colorSpace} x y z / alpha)`,               `color(${resultColorSpace} 7 -20.5 100 / 0)`);
+
+      // color-mix
+      fuzzy_test_computed_color(`color(from color-mix(in xyz, color(${colorSpace} 0.7 0.5 0.3), color(${colorSpace} 0.7 0.5 0.3)) ${colorSpace} r g b / alpha)`, `color(${resultColorSpace} 0.7 0.5 0.3)`);
   }
 
   // Test origin colors with different color spaces, going both to and from srgb.

--- a/css/css-color/parsing/color-valid-relative-color.html
+++ b/css/css-color/parsing/color-valid-relative-color.html
@@ -120,6 +120,9 @@
     // Testing with 'currentColor'
     fuzzy_test_valid_color(`rgb(from currentColor r g b)`, `rgb(from currentColor r g b)`);
 
+    // color-mix
+    fuzzy_test_valid_color(`rgb(from color-mix(in srgb, red, red) r g b / alpha)`, `color(srgb 1 0 0)`);
+
     // hsl(from ...)
 
     // Testing no modifications.
@@ -198,6 +201,9 @@
     // Testing with 'currentColor'
     fuzzy_test_valid_color(`hsl(from currentColor h s l)`, `hsl(from currentColor h s l)`);
 
+    // color-mix
+    fuzzy_test_valid_color(`hsl(from color-mix(in srgb, red, red) h s l / alpha)`, `color(srgb 1 0 0)`);
+
     // hwb(from ...)
 
     // Testing no modifications.
@@ -271,6 +277,9 @@
     // Testing with 'currentColor'
     fuzzy_test_valid_color(`hwb(from currentColor h w b)`, `hwb(from currentColor h w b)`);
 
+    // color-mix
+    fuzzy_test_valid_color(`hwb(from color-mix(in srgb, red, red) h w b / alpha)`, `color(srgb 1 0 0)`);
+
     // lab()
 
     // Testing no modifications.
@@ -339,6 +348,9 @@
     // Testing with 'currentColor'
     fuzzy_test_valid_color(`lab(from currentColor l a b)`, `lab(from currentColor l a b)`);
 
+  // color-mix
+    fuzzy_test_valid_color(`lab(from color-mix(in lab, lab(25 20 50), lab(25 20 50)) l a b / alpha)`, `lab(25 20 50)`);
+
     // oklab()
 
     // Testing no modifications.
@@ -406,6 +418,9 @@
 
     // Testing with 'currentColor'
     fuzzy_test_valid_color(`oklab(from currentColor l a b)`, `oklab(from currentColor l a b)`);
+
+    // color-mix
+    fuzzy_test_computed_color(`oklab(from color-mix(in oklab, oklab(0.25 0.2 0.5), oklab(0.25 0.2 0.5)) l a b / alpha)`, `oklab(0.25 0.2 0.5)`);
 
     // lch()
 
@@ -484,6 +499,9 @@
     // Testing with 'currentColor'
     fuzzy_test_valid_color(`lch(from currentColor) l c h)`, `lch(from currentColor) l c h)`);
 
+    // color-mix
+    fuzzy_test_valid_color(`lch(from color-mix(in lch, lch(70 45 30), lch(70 45 30)) l c h / alpha)`, `lch(70 45 30)`);
+
     // oklch()
 
     // Testing no modifications.
@@ -558,6 +576,9 @@
     fuzzy_test_valid_color(`oklch(from oklch(none none none / none) l c h / alpha)`,                        `oklch(0 0 0 / 0)`);
     fuzzy_test_valid_color(`oklch(from oklch(0.7 none 30) l c h)`,                                          `oklch(0.7 0 30)`);
     fuzzy_test_valid_color(`oklch(from oklch(0.7 0.45 30 / none) l c h / alpha)`,                             `oklch(0.7 0.45 30 / 0)`);
+
+    // color-mix
+    fuzzy_test_valid_color(`oklch(from color-mix(in oklch, oklch(0.7 0.45 30), oklch(0.7 0.45 30)) l c h / alpha)`, `oklch(0.7 0.45 30)`);
 
     // Testing with 'currentColor'
     fuzzy_test_valid_color(`oklch(from currentColor l c h)`, `oklch(from currentColor l c h)`);
@@ -651,6 +672,8 @@
         // Testing with 'currentColor'
         fuzzy_test_valid_color(`color(from currentColor ${colorSpace} r g b)`,                                                  `color(from currentColor ${colorSpace} r g b)`);
 
+        // color-mix
+        fuzzy_test_valid_color(`color(from color-mix(in xyz, color(${colorSpace} 0.7 0.5 0.3), color(${colorSpace} 0.7 0.5 0.3)) ${colorSpace} r g b / alpha)`, `color(${colorSpace} 0.7 0.5 0.3)`);
     }
 
     for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
@@ -714,6 +737,9 @@
 
         // Testing with 'currentColor'
         fuzzy_test_valid_color(`color(from currentColor ${colorSpace} x y z)`,                                                  `color(from currentColor ${colorSpace} x y z)`);
+
+        // color-mix
+        fuzzy_test_valid_color(`color(from color-mix(in xyz, color(${colorSpace} 0.7 0.5 0.3), color(${colorSpace} 0.7 0.5 0.3)) ${colorSpace} r g b / alpha)`, `color(${resultColorSpace} 0.7 0.5 0.3)`);
     }
 
     // Spec Examples: https://www.w3.org/TR/css-color-5/#relative-colors


### PR DESCRIPTION
It seems that implementations do not support `color-mix()` in relative color syntax.
Mixing these features seems like something that CSS authors will want to do.

I didn't see a reason why this shouldn't work in the `css-color-5` specification text.
So I assume that it actually must work and that it should have test coverage.

@svgeesus Do you know if this was discussed somewhere?