### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=269971

### DIFF
--- a/css/css-contain/container-queries/custom-property-style-queries.html
+++ b/css/css-contain/container-queries/custom-property-style-queries.html
@@ -415,7 +415,7 @@
       color: green;
     }
   }
-  @container style(--number: a b) {
+  @container style(--spaces: a b) {
     #original-text-spaces {
       color: red;
     }


### PR DESCRIPTION
WebKit export from bug: [Preserve whitespace when serializing custom properties](https://bugs.webkit.org/show_bug.cgi?id=269971)