### PR TITLE
CSS word-spacing property does not obey percentages

### DIFF
--- a/css/CSS2/css1/c541-word-sp-001-ref.xht
+++ b/css/CSS2/css1/c541-word-sp-001-ref.xht
@@ -16,6 +16,5 @@
   <div class="test">x&#xA0;&#xA0;x&#xA0;&#xA0;xx&#xA0;xx</div>
   <div class="test">x&#xA0;&#xA0;x&#xA0;&#xA0;xx&#xA0;xx</div>
   <div class="test">x&#xA0;&#xA0;x&#xA0;&#xA0;xx&#xA0;xx</div>
-  <div class="test">x&#xA0;&#xA0;x&#xA0;&#xA0;xx&#xA0;xx</div>
  </body>
 </html>

--- a/css/CSS2/css1/c541-word-sp-001.xht
+++ b/css/CSS2/css1/c541-word-sp-001.xht
@@ -14,8 +14,7 @@
    div { font: 25px/1 Ahem; width: 12em; background: yellow; color: aqua; margin: 0 0 0 2em; }
    .eight {word-spacing: 25px;}
    .nine {word-spacing: normal;}
-   .ten {word-spacing: 300%;}
-   .eleven {word-spacing: -1em;}
+   .ten {word-spacing: -1em;}
    .fill { color: yellow; }
   ]]></style>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#spacing-props" title="16.4 Letter and word spacing: the 'letter-spacing' and 'word-spacing' properties"/>
@@ -26,7 +25,6 @@
   <div class="test">x&#xA0;&#xA0;x&#xA0;&#xA0;xx&#xA0;xx</div>
   <div class="test">x&#xA0;&#xA0;x&#xA0;&#xA0;xx&#xA0;xx</div>
   <div class="eight"> x x <span class="nine">xx xx</span> </div>
-  <div class="ten"> x&#xA0; x &#xA0;xx xx </div>
-  <div class="eleven"> x&#xA0; &#xA0;<span class="nine"> &#xA0;</span>x&#xA0;&#xA0;<span class="fill">xx</span> xx&#xA0; <span class="fill">x</span>xx </div>
+  <div class="ten"> x&#xA0; &#xA0;<span class="nine"> &#xA0;</span>x&#xA0;&#xA0;<span class="fill">xx</span> xx&#xA0; <span class="fill">x</span>xx </div>
  </body>
 </html>


### PR DESCRIPTION
Export from https://bugs.webkit.org/show_bug.cgi?id=126674 / https://commits.webkit.org/144704@main

Reviewed by Simon Fraser.

One change between CSS2.1 and CSS3 is that the word-spacing CSS property can take percentages (of the width of the space character) in CSS3.

* css2.1/20110323/c541-word-sp-001-expected.html:
* css2.1/20110323/c541-word-sp-001.htm: Updated to not disregard percentages