### PR TITLE
Add .consume_user_activation to test_driver.js

### DIFF
--- a/html/user-activation/resources/utils.js
+++ b/html/user-activation/resources/utils.js
@@ -13,7 +13,7 @@ function delayByFrames(f, num_frames) {
 // fired.
 function getEvent(eventType) {
   return new Promise((resolve) => {
-    document.body.addEventListener(eventType, (e) => resolve(e), {
+    document.body.addEventListener(eventType, resolve, {
       once: true,
     });
   });

--- a/html/user-activation/resources/utils.js
+++ b/html/user-activation/resources/utils.js
@@ -1,9 +1,10 @@
 function delayByFrames(f, num_frames) {
   function recurse(depth) {
-    if (depth == 0)
+    if (depth == 0) {
       f();
-    else
-      requestAnimationFrame(() => recurse(depth-1));
+    } else {
+      requestAnimationFrame(() => recurse(depth - 1));
+    }
   }
   recurse(num_frames);
 }
@@ -11,8 +12,10 @@ function delayByFrames(f, num_frames) {
 // Returns a Promise which is resolved with the event object when the event is
 // fired.
 function getEvent(eventType) {
-  return new Promise(resolve => {
-    document.body.addEventListener(eventType, e => resolve(e), {once: true});
+  return new Promise((resolve) => {
+    document.body.addEventListener(eventType, (e) => resolve(e), {
+      once: true,
+    });
   });
 }
 
@@ -27,14 +30,17 @@ async function consumeTransientActivation(context = window) {
       "User activation is not active so can't be consumed. Something is probably wrong with the test."
     );
   }
-  if (test_driver?.consume_user_activation) {
-    return test_driver.consume_user_activation(context);
+  try {
+    if (test_driver?.consume_user_activation) {
+      return await test_driver.consume_user_activation(context);
+    }
+  } catch {
+    // Fallback to Fullscreen API so to not break tests.
+    if (!context.document.fullscreenElement) {
+      await context.document.documentElement.requestFullscreen();
+    }
+    await context.document.exitFullscreen();
   }
-  // fallback to Fullscreen API.
-  if (!context.document.fullscreenElement) {
-    await context.document.documentElement.requestFullscreen();
-  }
-  await context.document.exitFullscreen();
   return !context.navigator.userActivation.isActive;
 }
 

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -1067,6 +1067,27 @@
         clear_device_posture: function(context=null) {
             return window.test_driver_internal.clear_device_posture(context);
         }
+
+        /**
+         * Consumes the user activation
+         *
+         * Matches the consume-user-activation WebDriver command:
+         * https://html.spec.whatwg.org/#user-activation-user-agent-automation
+         *
+         * Which corresponds to these steps in HTML:
+         * https://html.spec.whatwg.org/#consume-user-activation
+         *
+         * @example
+         * await test_driver.consume_user_activation();
+         * await test_driver.consume_user_activation(iframe.contentWindow);
+         *
+         * @param {WindowProxy?} [context=null] - Browsing context in which to run the
+         *                                        call.
+         * @returns {Promise<boolean>} fulfilled when user activation is consumed.
+         */
+        consume_user_activation(context=null) {
+            return window.test_driver_internal.consume_user_activation(context);
+        },
     };
 
     window.test_driver_internal = {
@@ -1254,6 +1275,10 @@
 
         async clear_device_posture(context=null) {
             throw new Error("clear_device_posture() is not implemented by testdriver-vendor.js");
-        }
+        },
+
+        async consume_user_activation(context=null) {
+            throw new Error("consume_user_activation() is not implemented by testdriver-vendor.js");
+        },
     };
 })();

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -1066,7 +1066,7 @@
          */
         clear_device_posture: function(context=null) {
             return window.test_driver_internal.clear_device_posture(context);
-        }
+        },
 
         /**
          * Consumes the user activation

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -335,4 +335,9 @@
     window.test_driver_internal.clear_device_posture = function(context=null) {
         return create_action("clear_device_posture", {context});
     };
+
+    window.test_driver_internal.consume_user_activation = function(context=null) {
+        return create_action("consume_user_activation", {context});
+    };
+
 })();


### PR DESCRIPTION
Splitting #40699 into two parts. 

This adds consume_user_activation to test_driver.js, as we rely on this in WebKit already. 