### PR TITLE
fix : `test_computed_value` is not defined

### DIFF
--- a/css/css-color/parsing/color-valid-relative-color.html
+++ b/css/css-color/parsing/color-valid-relative-color.html
@@ -420,7 +420,7 @@
     fuzzy_test_valid_color(`oklab(from currentColor l a b)`, `oklab(from currentColor l a b)`);
 
     // color-mix
-    fuzzy_test_computed_color(`oklab(from color-mix(in oklab, oklab(0.25 0.2 0.5), oklab(0.25 0.2 0.5)) l a b / alpha)`, `oklab(0.25 0.2 0.5)`);
+    fuzzy_test_valid_color(`oklab(from color-mix(in oklab, oklab(0.25 0.2 0.5), oklab(0.25 0.2 0.5)) l a b / alpha)`, `oklab(0.25 0.2 0.5)`);
 
     // lch()
 


### PR DESCRIPTION
https://wpt.live/css/css-color/parsing/color-valid-relative-color.html

> Uncaught ReferenceError: test_computed_value is not defined
ReferenceError: test_computed_value is not defined
    at fuzzy_test_computed_color (https://wpt.live/css/support/color-testcommon.js:62:3)
    at https://wpt.live/css/css-color/parsing/color-valid-relative-color.html:423:5

I copy/pasted one incorrectly in https://github.com/web-platform-tests/wpt/pull/44745