### PR TITLE
Add test for external script hashes in content-security-policy/script-src/script-src-strict_dynamic_hashes

### DIFF
--- a/content-security-policy/script-src/script-src-strict_dynamic_hashes.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_hashes.html
@@ -54,9 +54,8 @@
     <script src='./externalScript.js'
         integrity="sha256-wIc3KtqOuTFEu6t17sIBuOswgkV406VJvhSk79Gw6U0="></script>
     <script nonce='dummy'>
-        async_test(function(t) {
+        test(function(t) {
             assert_true(externalRan);
-            t.done();
         }, "External script in a script tag with matching SRI hash is allowed with `strict-dynamic`.");
     </script>
 </body>

--- a/content-security-policy/script-src/script-src-strict_dynamic_hashes.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_hashes.html
@@ -6,7 +6,7 @@
     <script src='/resources/testharness.js' nonce='dummy'></script>
     <script src='/resources/testharnessreport.js' nonce='dummy'></script>
 
-    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' 'sha256-yU6Q7nD1TCBB9JvY06iIJ8ONLOPU4g8ml5JCDgXkv+M=' 'sha256-EEoi70frWHkGFhK51NVIJkXpq72aPxSCNZEow37ZmRA=' -->
+    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' 'sha256-yU6Q7nD1TCBB9JvY06iIJ8ONLOPU4g8ml5JCDgXkv+M=' 'sha256-EEoi70frWHkGFhK51NVIJkXpq72aPxSCNZEow37ZmRA=' 'sha256-wIc3KtqOuTFEu6t17sIBuOswgkV406VJvhSk79Gw6U0=' -->
 </head>
 
 <body>
@@ -46,6 +46,18 @@
             e.onerror = t.unreached_func('Error should not be triggered.');
             document.body.appendChild(e);
         }, 'Script injected via `appendChild` from a script matching SHA256 hash is allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        var externalRan = false;
+    </script>
+    <script src='./externalScript.js'
+        integrity="sha256-wIc3KtqOuTFEu6t17sIBuOswgkV406VJvhSk79Gw6U0="></script>
+    <script nonce='dummy'>
+        async_test(function(t) {
+            assert_true(externalRan);
+            t.done();
+        }, "External script in a script tag with matching SRI hash is allowed with `strict-dynamic`.");
     </script>
 </body>
 

--- a/content-security-policy/script-src/script-src-strict_dynamic_hashes.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_hashes.html.headers
@@ -2,4 +2,4 @@ Expires: Mon, 26 Jul 1997 05:00:00 GMT
 Cache-Control: no-store, no-cache, must-revalidate
 Cache-Control: post-check=0, pre-check=0, false
 Pragma: no-cache
-Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy' 'sha256-yU6Q7nD1TCBB9JvY06iIJ8ONLOPU4g8ml5JCDgXkv+M=' 'sha256-EEoi70frWHkGFhK51NVIJkXpq72aPxSCNZEow37ZmRA='
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy' 'sha256-yU6Q7nD1TCBB9JvY06iIJ8ONLOPU4g8ml5JCDgXkv+M=' 'sha256-EEoi70frWHkGFhK51NVIJkXpq72aPxSCNZEow37ZmRA=' 'sha256-wIc3KtqOuTFEu6t17sIBuOswgkV406VJvhSk79Gw6U0='


### PR DESCRIPTION
This PR adds one test case to `content-security-policy/script-src/script-src-strict_dynamic_hashes`, specifically an external script with an SRI hash.

This comes from a real discrepancy that we have seen at work: Chrome and Firefox support the tested behaviour, but Safari does not. We ran into this when deploying our new CSP, utilising `script-src` with `'strict-dynamic'` and external script hashes. We based the design on existing documentation and tests, but it did not work out in the end 😅 We ended up backing off to browser sniffing for this.

There are [existing tests about external script hashes (SRI) in WPT](https://wpt.live/content-security-policy/script-src/script-src-sri_hash.sub.html) ([latest relevant WPT PR](https://github.com/web-platform-tests/wpt/pull/40469)). However, none of those tests exercise the presence of `strict-dynamic` directive. There was some relevant discussion regarding this behaviour in the [Firefox bug tracker](https://bugzilla.mozilla.org/show_bug.cgi?id=1409200), but I could not find specific tests.

## Alternatives that I considered

I can imagine this test as a variant of [content-security-policy/script-src/script-src-sri_hash.sub.html](https://github.com/web-platform-tests/wpt/blob/master/content-security-policy/script-src/script-src-sri_hash.sub.html). For example, we could copy over most of those assertions, but with the addition of `'strict-dynamic'` in the CSP header. I am happy to implement it like that, if you think it is better.

Please let me know if there is any other information that I can provide, and I'll do my best! This is my first time contributing to WPT, so it's likely I missed something 😌 