### PR TITLE
WebAudio: remove unused and incorrect resource

### DIFF
--- a/webaudio/the-audio-api/the-waveshapernode-interface/waveshaper.html
+++ b/webaudio/the-audio-api/the-waveshapernode-interface/waveshaper.html
@@ -8,7 +8,6 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="../../resources/audit-util.js"></script>
     <script src="../../resources/audit.js"></script>
-    <script src="../../resources/buffer-loader.js"></script>
   </head>
   <body>
     <script id="layout-test-code">


### PR DESCRIPTION
The file /webaudio/resources/buffer-loader.js does not exist, it lives in /webaudio/js instead. It is unused however.


My apologies to bother you again with a housekeeping PR, the other ones https://github.com/web-platform-tests/wpt/pull/44749 (open) and https://github.com/web-platform-tests/wpt/pull/43824 (merged)
We're using a NodeJs wpt runner that is particularly sensitive to these imperfections, so it would be very helpful if this could be resolved