### PR TITLE
layout: Add line height from preserved segment breaks in quirks mode

### DIFF
--- a/quirks/line-height-preserved-segment-break.html
+++ b/quirks/line-height-preserved-segment-break.html
@@ -1,0 +1,24 @@
+<!-- quirks mode -->
+<link rel="author" title="Martin Robinson" href="mrobinson@igalia.com">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-line-height-calculation-quirk">
+<link rel="help" href="https://drafts.csswg.org/css-text/#valdef-white-space-pre-line">
+<link rel="match" href="../css/reference/ref-filled-green-100px-square.xht">
+
+<style>
+    .container {
+        width: 100px;
+        background: green;
+        white-space: pre-line;
+    }
+
+    .inline-box {
+        line-height: 100px;
+    }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="width: 100px; height: 100px; background: red;">
+    <!-- The preserved segment break in the span should mean that "The line height calculation
+    quirk" does not apply. -->
+  <div class="container"><span class="inline-box">&#xA;</span></div>
+</div>


### PR DESCRIPTION
In quirks mode, preserved segment breaks should add line height to
lines. This matches the behavior of WebKit and Blink, but not Gecko.

This also handles the special-case of `<br>` elements, which are
implemented with preserved segment breaks via `white-space: pre-line`.
This is an implementation detail though because `<br>` has a special
behavior if the line isn't empty -- it doesn't add any line height in
this case.

Reviewed in servo/servo#31419