### PR TITLE
[wdspec] asyncio exceptions should not be read from asyncio.exceptions

### DIFF
--- a/webdriver/tests/support/fixtures_bidi.py
+++ b/webdriver/tests/support/fixtures_bidi.py
@@ -149,7 +149,7 @@ def wait_for_future_safe(configuration):
                 asyncio.shield(future),
                 timeout=timeout * configuration["timeout_multiplier"],
             )
-        except asyncio.exceptions.TimeoutError:
+        except asyncio.TimeoutError:
             raise TimeoutException("Future did not resolve within the given timeout")
 
     return wait_for_future_safe


### PR DESCRIPTION
asyncio.exceptions is an internal module.
Exceptions should be accessed directly, eg asyncio.exceptions.TimeoutError -> asyncio.TimeoutError