### PR TITLE
Fir Firefox Android runs

### DIFF
--- a/tools/wpt/android.py
+++ b/tools/wpt/android.py
@@ -100,6 +100,8 @@ def install_fixed_emulator_version(logger, paths):
 
     emulator_path = os.path.join(paths["sdk"], "emulator")
     latest_emulator_path = os.path.join(paths["sdk"], "emulator_latest")
+    if os.path.exists(latest_emulator_path):
+        shutil.rmtree(latest_emulator_path)
     os.rename(emulator_path, latest_emulator_path)
 
     download_and_extract(url, paths["sdk"])

--- a/tools/wptrunner/wptrunner/browsers/firefox_android.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox_android.py
@@ -1,8 +1,9 @@
 # mypy: allow-untyped-defs
 
 import os
-import subprocess
 import re
+import subprocess
+import traceback
 
 from mozrunner import FennecEmulatorRunner, get_app_context
 
@@ -349,7 +350,13 @@ class FirefoxAndroidBrowser(Browser):
     def check_crash(self, process, test):
         if not os.environ.get("MINIDUMP_STACKWALK", "") and self.stackwalk_binary:
             os.environ["MINIDUMP_STACKWALK"] = self.stackwalk_binary
-        return bool(self.runner.check_for_crashes(test_name=test))
+        try:
+            return bool(self.runner.check_for_crashes(test_name=test))
+        except Exception:
+            # We sometimes see failures trying to copy the minidump files
+            self.logger.warning(f"""Failed to complete crash check, assuming no crash:
+{traceback.format_exc()}""")
+            return False
 
 
 class FirefoxAndroidWdSpecBrowser(FirefoxWdSpecBrowser):


### PR DESCRIPTION
We're hitting a failure when trying to process crash dump files. This PR handles that error to make it non-fatal without fixing the underlying cause.