### PR TITLE
[wdspec] Remove uses of navigation with `wait=none`

### DIFF
--- a/webdriver/tests/bidi/network/auth_required/auth_required.py
+++ b/webdriver/tests/bidi/network/auth_required/auth_required.py
@@ -1,11 +1,13 @@
 import pytest
 
+import asyncio
+
 from .. import assert_response_event, AUTH_REQUIRED_EVENT, PAGE_EMPTY_HTML
 
 
 @pytest.mark.asyncio
 async def test_subscribe_status(
-    bidi_session, new_tab, subscribe_events, wait_for_event, wait_for_future_safe, url
+    bidi_session, new_tab, subscribe_events, wait_for_event, wait_for_future_safe, url, fetch
 ):
     await subscribe_events(events=[AUTH_REQUIRED_EVENT])
 
@@ -15,7 +17,8 @@ async def test_subscribe_status(
     async def on_event(method, data):
         events.append(data)
 
-    remove_listener = bidi_session.add_event_listener(AUTH_REQUIRED_EVENT, on_event)
+    remove_listener = bidi_session.add_event_listener(
+        AUTH_REQUIRED_EVENT, on_event)
 
     auth_url = url(
         "/webdriver/tests/support/http_handlers/authentication.py?realm=testrealm"
@@ -23,13 +26,7 @@ async def test_subscribe_status(
 
     on_auth_required = wait_for_event(AUTH_REQUIRED_EVENT)
 
-    # navigate using wait="none" as other wait conditions would hang because of
-    # the authentication prompt.
-    await bidi_session.browsing_context.navigate(
-        context=new_tab["context"],
-        url=auth_url,
-        wait="none",
-    )
+    asyncio.ensure_future(fetch(url=auth_url, context=new_tab))
 
     await wait_for_future_safe(on_auth_required)
 
@@ -63,7 +60,8 @@ async def test_no_authentication(
     async def on_event(method, data):
         events.append(data)
 
-    remove_listener = bidi_session.add_event_listener(AUTH_REQUIRED_EVENT, on_event)
+    remove_listener = bidi_session.add_event_listener(
+        AUTH_REQUIRED_EVENT, on_event)
 
     # Navigate to a page which should not trigger any authentication.
     await bidi_session.browsing_context.navigate(

--- a/webdriver/tests/bidi/network/auth_required/auth_required.py
+++ b/webdriver/tests/bidi/network/auth_required/auth_required.py
@@ -9,6 +9,12 @@ from .. import assert_response_event, AUTH_REQUIRED_EVENT, PAGE_EMPTY_HTML
 async def test_subscribe_status(
     bidi_session, new_tab, subscribe_events, wait_for_event, wait_for_future_safe, url, fetch
 ):
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"],
+        url=url(PAGE_EMPTY_HTML),
+        wait="complete",
+    )
+
     await subscribe_events(events=[AUTH_REQUIRED_EVENT])
 
     # Track all received network.authRequired events in the events array.

--- a/webdriver/tests/bidi/network/auth_required/unsubscribe.py
+++ b/webdriver/tests/bidi/network/auth_required/unsubscribe.py
@@ -1,5 +1,7 @@
 import pytest
 
+import asyncio
+
 from webdriver.bidi.modules.script import ScriptEvaluateResultException
 
 from .. import AUTH_REQUIRED_EVENT, PAGE_EMPTY_HTML
@@ -27,11 +29,9 @@ async def test_unsubscribe(bidi_session, new_tab, url, fetch):
     remove_listener = bidi_session.add_event_listener(
         AUTH_REQUIRED_EVENT, on_event)
 
-    # The fetch should fails as there is no authentication
-    with pytest.raises(ScriptEvaluateResultException):
-        await fetch(url=url(
-            "/webdriver/tests/support/http_handlers/authentication.py?realm=testrealm"
-        ), context=new_tab)
+    asyncio.ensure_future(fetch(url=url(
+        "/webdriver/tests/support/http_handlers/authentication.py?realm=testrealm"
+    ), context=new_tab))
 
     assert len(events) == 0
 

--- a/webdriver/tests/bidi/network/auth_required/unsubscribe.py
+++ b/webdriver/tests/bidi/network/auth_required/unsubscribe.py
@@ -1,15 +1,20 @@
-import asyncio
-
 import pytest
 
-pytestmark = pytest.mark.asyncio
+from webdriver.bidi.modules.script import ScriptEvaluateResultException
 
 from .. import AUTH_REQUIRED_EVENT, PAGE_EMPTY_HTML
 
+pytestmark = pytest.mark.asyncio
 
 # This test can be moved back to `auth_required.py` when all implementations
 # support handing of HTTP auth prompt.
-async def test_unsubscribe(bidi_session, new_tab, url):
+async def test_unsubscribe(bidi_session, new_tab, url, fetch):
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"],
+        url=url(PAGE_EMPTY_HTML),
+        wait="complete",
+    )
+
     await bidi_session.session.subscribe(events=[AUTH_REQUIRED_EVENT])
     await bidi_session.session.unsubscribe(events=[AUTH_REQUIRED_EVENT])
 
@@ -19,17 +24,15 @@ async def test_unsubscribe(bidi_session, new_tab, url):
     async def on_event(method, data):
         events.append(data)
 
-    remove_listener = bidi_session.add_event_listener(AUTH_REQUIRED_EVENT, on_event)
+    remove_listener = bidi_session.add_event_listener(
+        AUTH_REQUIRED_EVENT, on_event)
 
-    # Navigate to authentication.py again and check no event is received.
-    await bidi_session.browsing_context.navigate(
-        context=new_tab["context"],
-        url=url(
+    # The fetch should fails as there is no authentication
+    with pytest.raises(ScriptEvaluateResultException):
+        await fetch(url=url(
             "/webdriver/tests/support/http_handlers/authentication.py?realm=testrealm"
-        ),
-        wait="none",
-    )
-    await asyncio.sleep(0.5)
+        ), context=new_tab)
+
     assert len(events) == 0
 
     remove_listener()

--- a/webdriver/tests/bidi/network/response_started/response_started.py
+++ b/webdriver/tests/bidi/network/response_started/response_started.py
@@ -245,6 +245,11 @@ async def test_response_mime_type_file(
 async def test_www_authenticate(
     bidi_session, url, fetch, new_tab, wait_for_event, wait_for_future_safe, setup_network_test
 ):
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"],
+        url=url(PAGE_EMPTY_HTML),
+        wait="complete",
+    )
     auth_url = url(
         "/webdriver/tests/support/http_handlers/authentication.py?realm=testrealm"
     )
@@ -253,11 +258,8 @@ async def test_www_authenticate(
     events = network_events[RESPONSE_STARTED_EVENT]
 
     on_response_started = wait_for_event(RESPONSE_STARTED_EVENT)
-    await bidi_session.browsing_context.navigate(
-        context=new_tab["context"],
-        url=auth_url,
-        wait="none",
-    )
+
+    asyncio.ensure_future(fetch(url=auth_url, context=new_tab))
 
     await wait_for_future_safe(on_response_started)
 


### PR DESCRIPTION
Changing the test to not rely on the `browsingContext.navigate`. This makes the test more isolated as it does not rely on the browser module. This also unblocks the `chromium-bidi` implementation of interception as there are issue related to `wait=none`.