### PR TITLE
[wdspec] fix test for `contexts` fields in add_intercept

### DIFF
--- a/webdriver/tests/bidi/network/add_intercept/invalid.py
+++ b/webdriver/tests/bidi/network/add_intercept/invalid.py
@@ -147,7 +147,8 @@ async def test_params_url_patterns_pattern_protocol_file_invalid_value(bidi_sess
     with pytest.raises(error.InvalidArgumentException):
         await bidi_session.network.add_intercept(
             phases=["beforeRequestSent"],
-            url_patterns=[{"type": "pattern", "protocol": value, "hostname": "example.com"}],
+            url_patterns=[
+                {"type": "pattern", "protocol": value, "hostname": "example.com"}],
         )
 
 
@@ -190,7 +191,7 @@ async def test_params_url_patterns_pattern_search_invalid_value(bidi_session, va
 @pytest.mark.parametrize("value", [False, 42, {}, ""])
 async def test_params_contexts_invalid_type(bidi_session, value):
     with pytest.raises(error.InvalidArgumentException):
-        await bidi_session.network.add_intercept(phases=[value])
+        await bidi_session.network.add_intercept(phases=["beforeRequestSent"], contexts=value)
 
 
 async def test_params_contexts_empty_list(bidi_session):
@@ -198,7 +199,7 @@ async def test_params_contexts_empty_list(bidi_session):
         await bidi_session.network.add_intercept(phases=["beforeRequestSent"], contexts=[])
 
 
-async def test_params_contexts_invalid_value(bidi_session):
+async def test_params_contexts_context_invalid_value(bidi_session):
     with pytest.raises(error.NoSuchFrameException):
         await bidi_session.network.add_intercept(phases=["beforeRequestSent"], contexts=["does not exist"])
 

--- a/webdriver/tests/bidi/network/add_intercept/invalid.py
+++ b/webdriver/tests/bidi/network/add_intercept/invalid.py
@@ -193,10 +193,14 @@ async def test_params_contexts_invalid_type(bidi_session, value):
         await bidi_session.network.add_intercept(phases=[value])
 
 
-@pytest.mark.parametrize("value", [[], ["does not exist"]])
-async def test_params_contexts_invalid_value(bidi_session, value):
+async def test_params_contexts_empty_list(bidi_session):
     with pytest.raises(error.InvalidArgumentException):
-        await bidi_session.network.add_intercept(phases=["beforeRequestSent"], contexts=value)
+        await bidi_session.network.add_intercept(phases=["beforeRequestSent"], contexts=[])
+
+
+async def test_params_contexts_invalid_value(bidi_session):
+    with pytest.raises(error.NoSuchFrameException):
+        await bidi_session.network.add_intercept(phases=["beforeRequestSent"], contexts=["does not exist"])
 
 
 async def test_params_contexts_context_non_top_level(bidi_session, new_tab, test_page_same_origin_frame):

--- a/webdriver/tests/bidi/script/add_preload_script/invalid.py
+++ b/webdriver/tests/bidi/script/add_preload_script/invalid.py
@@ -204,6 +204,14 @@ async def test_params_contexts_empty_list(bidi_session):
         ),
 
 
+async def test_params_contexts_invalid_value(bidi_session):
+    with pytest.raises(error.NoSuchFrameException):
+        await bidi_session.script.add_preload_script(
+            function_declaration="() => {}",
+            contexts=['does no exist']
+        ),
+
+
 @pytest.mark.parametrize("value", [None, False, 42, {}, []])
 async def test_params_contexts_context_invalid_type(bidi_session, value):
     with pytest.raises(error.InvalidArgumentException):

--- a/webdriver/tests/bidi/script/add_preload_script/invalid.py
+++ b/webdriver/tests/bidi/script/add_preload_script/invalid.py
@@ -204,14 +204,6 @@ async def test_params_contexts_empty_list(bidi_session):
         ),
 
 
-async def test_params_contexts_invalid_value(bidi_session):
-    with pytest.raises(error.NoSuchFrameException):
-        await bidi_session.script.add_preload_script(
-            function_declaration="() => {}",
-            contexts=['does no exist']
-        ),
-
-
 @pytest.mark.parametrize("value", [None, False, 42, {}, []])
 async def test_params_contexts_context_invalid_type(bidi_session, value):
     with pytest.raises(error.InvalidArgumentException):


### PR DESCRIPTION
When we provide a wrong `context` value the correct error to expect is `NoSuchFrame`. 
WebDriver BiDi spec [get a browsing context](https://w3c.github.io/webdriver-bidi/#get-a-browsing-context).

Let context be the result of **trying** to **get a browsing context** with context id.

In `AddPreloadScript` [Step 4.2.1](https://w3c.github.io/webdriver-bidi/#command-script-addPreloadScript).
In `AddIntercept` [Step 4.2.1](https://w3c.github.io/webdriver-bidi/#command-network-addIntercept).