### PR TITLE
Remove 'libegl1-mesa-dev' from docker image

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get -qqy update \
     glib-networking-services \
     gstreamer1.0-plugins-bad \
     gstreamer1.0-gl \
-    libegl1-mesa-dev \
     libosmesa6-dev \
     libproxy1-plugin-webkit \
     libvirt-daemon-system \


### PR DESCRIPTION
This package was added in #44576 but it is no longer needed  now because Servo has removed the runtime dependency in servo/servo#31431.

The docker image version does not need to be updated in this patch since no new image was published to Docker Hub and the version bump in #44576 actually referred to the latest published version on Docker Hub before the change landed.