### PR TITLE
Fetch: remove usage of FileReader

### DIFF
--- a/fetch/api/request/request-consume-empty.any.js
+++ b/fetch/api/request/request-consume-empty.any.js
@@ -10,16 +10,7 @@ function checkBodyText(test, request) {
 
 function checkBodyBlob(test, request) {
   return request.blob().then(function(bodyAsBlob) {
-    var promise = new Promise(function(resolve, reject) {
-      var reader = new FileReader();
-      reader.onload = function(evt) {
-        resolve(reader.result)
-      };
-      reader.onerror = function() {
-        reject("Blob's reader failed");
-      };
-      reader.readAsText(bodyAsBlob);
-    });
+    var promise = bodyAsBlob.text();
     return promise.then(function(body) {
       assert_equals(body, "", "Resolved value should be empty");
       assert_false(request.bodyUsed);

--- a/fetch/api/request/request-consume-empty.any.js
+++ b/fetch/api/request/request-consume-empty.any.js
@@ -8,14 +8,11 @@ function checkBodyText(test, request) {
   });
 }
 
-function checkBodyBlob(test, request) {
-  return request.blob().then(function(bodyAsBlob) {
-    var promise = bodyAsBlob.text();
-    return promise.then(function(body) {
-      assert_equals(body, "", "Resolved value should be empty");
-      assert_false(request.bodyUsed);
-    });
-  });
+async function checkBodyBlob(test, request) {
+  const bodyAsBlob = await request.blob();
+  const body = await bodyAsBlob.text();
+  assert_equals(body, "", "Resolved value should be empty");
+  assert_false(request.bodyUsed);
 }
 
 function checkBodyArrayBuffer(test, request) {

--- a/fetch/api/request/request-consume.any.js
+++ b/fetch/api/request/request-consume.any.js
@@ -14,16 +14,7 @@ function checkBodyBlob(request, expectedBody, checkContentType) {
     if (checkContentType)
       assert_equals(bodyAsBlob.type, "text/plain", "Blob body type should be computed from the request Content-Type");
 
-    var promise = new Promise(function (resolve, reject) {
-      var reader = new FileReader();
-      reader.onload = function(evt) {
-        resolve(reader.result)
-      };
-      reader.onerror = function() {
-        reject("Blob's reader failed");
-      };
-      reader.readAsText(bodyAsBlob);
-    });
+    var promise = bodyAsBlob.text();
     return promise.then(function(body) {
       assert_equals(body, expectedBody, "Retrieve and verify request's body");
       assert_true(request.bodyUsed, "body as blob: bodyUsed turned true");

--- a/fetch/api/request/request-consume.any.js
+++ b/fetch/api/request/request-consume.any.js
@@ -9,17 +9,15 @@ function checkBodyText(request, expectedBody) {
   });
 }
 
-function checkBodyBlob(request, expectedBody, checkContentType) {
-  return request.blob().then(function(bodyAsBlob) {
-    if (checkContentType)
-      assert_equals(bodyAsBlob.type, "text/plain", "Blob body type should be computed from the request Content-Type");
+async function checkBodyBlob(request, expectedBody, checkContentType) {
+  const bodyAsBlob = await request.blob();
 
-    var promise = bodyAsBlob.text();
-    return promise.then(function(body) {
-      assert_equals(body, expectedBody, "Retrieve and verify request's body");
-      assert_true(request.bodyUsed, "body as blob: bodyUsed turned true");
-    });
-  });
+  if (checkContentType)
+    assert_equals(bodyAsBlob.type, "text/plain", "Blob body type should be computed from the request Content-Type");
+
+  const body = await bodyAsBlob.text();
+  assert_equals(body, expectedBody, "Retrieve and verify request's body");
+  assert_true(request.bodyUsed, "body as blob: bodyUsed turned true");
 }
 
 function checkBodyArrayBuffer(request, expectedBody) {

--- a/fetch/api/response/response-consume-empty.any.js
+++ b/fetch/api/response/response-consume-empty.any.js
@@ -10,16 +10,7 @@ function checkBodyText(test, response) {
 
 function checkBodyBlob(test, response) {
   return response.blob().then(function(bodyAsBlob) {
-    var promise = new Promise(function(resolve, reject) {
-      var reader = new FileReader();
-      reader.onload = function(evt) {
-        resolve(reader.result)
-      };
-      reader.onerror = function() {
-        reject("Blob's reader failed");
-      };
-      reader.readAsText(bodyAsBlob);
-    });
+    var promise = bodyAsBlob.text();
     return promise.then(function(body) {
       assert_equals(body, "", "Resolved value should be empty");
       assert_false(response.bodyUsed);

--- a/fetch/api/response/response-consume-empty.any.js
+++ b/fetch/api/response/response-consume-empty.any.js
@@ -8,14 +8,12 @@ function checkBodyText(test, response) {
   });
 }
 
-function checkBodyBlob(test, response) {
-  return response.blob().then(function(bodyAsBlob) {
-    var promise = bodyAsBlob.text();
-    return promise.then(function(body) {
-      assert_equals(body, "", "Resolved value should be empty");
-      assert_false(response.bodyUsed);
-    });
-  });
+async function checkBodyBlob(test, response) {
+  const bodyAsBlob = await response.blob();
+  const body = await bodyAsBlob.text();
+
+  assert_equals(body, "", "Resolved value should be empty");
+  assert_false(response.bodyUsed);
 }
 
 function checkBodyArrayBuffer(test, response) {


### PR DESCRIPTION
Node doesn't implement FileReader and the repo where fetch tests are run
will soon be removing its FileReader shim.