### PR TITLE
Add historical test for navigator.getUserMedia

### DIFF
--- a/mediacapture-streams/historical.https.html
+++ b/mediacapture-streams/historical.https.html
@@ -9,6 +9,10 @@ test(function() {
 }, "webkitMediaStream interface should not exist");
 
 test(function() {
+  assert_false("getUserMedia" in navigator);
+}, "navigator.getUserMedia should not exist");
+
+test(function() {
   assert_false("webkitGetUserMedia" in navigator);
 }, "navigator.webkitGetUserMedia should not exist");
 


### PR DESCRIPTION
This is only non-normatively defined, thus we should hope that implementations will not continue to surface it.