### PR TITLE
[WebDriver BiDi] allow non-empty default cookie partition key

### DIFF
--- a/webdriver/tests/bidi/storage/__init__.py
+++ b/webdriver/tests/bidi/storage/__init__.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 from webdriver.bidi.modules.network import NetworkBytesValue, NetworkStringValue
-from webdriver.bidi.modules.storage import PartialCookie, PartitionDescriptor
+from webdriver.bidi.modules.storage import PartialCookie, PartitionDescriptor, BrowsingContextPartitionDescriptor
 from .. import any_int, recursive_compare
 
 COOKIE_NAME = 'SOME_COOKIE_NAME'
@@ -88,3 +88,11 @@ def format_expiry_string(date):
     # same formatting as Date.toUTCString() in javascript
     utc_string_format = "%a, %d %b %Y %H:%M:%S GMT"
     return date.strftime(utc_string_format)
+
+
+async def get_default_partition_key(bidi_session, context=None):
+    if context is None:
+        result = await bidi_session.storage.get_cookies()
+    else:
+        result = await bidi_session.storage.get_cookies(partition=BrowsingContextPartitionDescriptor(context))
+    return result['partitionKey']

--- a/webdriver/tests/bidi/storage/delete_cookies/filter.py
+++ b/webdriver/tests/bidi/storage/delete_cookies/filter.py
@@ -7,6 +7,7 @@ from .. import (
     assert_cookie_is_set,
     create_cookie,
     format_expiry_string,
+    get_default_partition_key,
     generate_expiry_date,
 )
 
@@ -51,7 +52,9 @@ async def test_filter(
     result = await bidi_session.storage.delete_cookies(
         filter=filter,
     )
-    assert result == {"partitionKey": {}}
+    assert result == {
+        "partitionKey": (await get_default_partition_key(bidi_session))
+    }
 
     # Make sure that deleted cookies are not present.
     await assert_cookies_are_not_present(bidi_session, filter)
@@ -100,7 +103,9 @@ async def test_filter_domain(
     result = await bidi_session.storage.delete_cookies(
         filter=filter,
     )
-    assert result == {"partitionKey": {}}
+    assert result == {
+        "partitionKey": (await get_default_partition_key(bidi_session))
+    }
 
     # Make sure that deleted cookies are not present.
     await assert_cookies_are_not_present(bidi_session, filter)
@@ -174,7 +179,9 @@ async def test_filter_expiry(
     result = await bidi_session.storage.delete_cookies(
         filter=CookieFilter(expiry=expiry_to_delete),
     )
-    assert result == {"partitionKey": {}}
+    assert result == {
+        "partitionKey": (await get_default_partition_key(bidi_session))
+    }
 
     # Make sure that deleted cookies are not present.
     await assert_cookies_are_not_present(bidi_session, filter)
@@ -218,7 +225,9 @@ async def test_filter_name(bidi_session, new_tab, test_page, add_cookie, domain_
     result = await bidi_session.storage.delete_cookies(
         filter=filter,
     )
-    assert result == {"partitionKey": {}}
+    assert result == {
+        "partitionKey": (await get_default_partition_key(bidi_session))
+    }
 
     # Make sure that deleted cookies are not present.
     await assert_cookies_are_not_present(bidi_session, filter)
@@ -285,7 +294,9 @@ async def test_filter_same_site(
     result = await bidi_session.storage.delete_cookies(
         filter=filter,
     )
-    assert result == {"partitionKey": {}}
+    assert result == {
+        "partitionKey": (await get_default_partition_key(bidi_session))
+    }
 
     # Make sure that deleted cookies are not present.
     await assert_cookies_are_not_present(bidi_session, filter)
@@ -347,7 +358,9 @@ async def test_filter_secure(
     result = await bidi_session.storage.delete_cookies(
         filter=filter,
     )
-    assert result == {"partitionKey": {}}
+    assert result == {
+        "partitionKey": (await get_default_partition_key(bidi_session))
+    }
 
     # Make sure that deleted cookies are not present.
     await assert_cookies_are_not_present(bidi_session, filter)
@@ -412,7 +425,9 @@ async def test_filter_path(
     result = await bidi_session.storage.delete_cookies(
         filter=filter,
     )
-    assert result == {"partitionKey": {}}
+    assert result == {
+        "partitionKey": (await get_default_partition_key(bidi_session))
+    }
 
     # Make sure that deleted cookies are not present.
     await assert_cookies_are_not_present(bidi_session, filter)
@@ -482,7 +497,9 @@ async def test_filter_http_only(
     result = await bidi_session.storage.delete_cookies(
         filter=filter,
     )
-    assert result == {"partitionKey": {}}
+    assert result == {
+        "partitionKey": (await get_default_partition_key(bidi_session))
+    }
 
     # Make sure that deleted cookies are not present.
     await assert_cookies_are_not_present(bidi_session, filter)

--- a/webdriver/tests/bidi/storage/get_cookies/filter.py
+++ b/webdriver/tests/bidi/storage/get_cookies/filter.py
@@ -2,7 +2,7 @@ import pytest
 from webdriver.bidi.modules.network import NetworkBase64Value, NetworkStringValue
 from webdriver.bidi.modules.storage import CookieFilter
 
-from .. import create_cookie, format_expiry_string, generate_expiry_date
+from .. import create_cookie, format_expiry_string, get_default_partition_key, generate_expiry_date
 from ... import recursive_compare
 
 pytestmark = pytest.mark.asyncio
@@ -37,7 +37,9 @@ async def test_filter(
         filter=filter,
     )
 
-    assert cookies["partitionKey"] == {}
+    assert cookies["partitionKey"] == {
+        **(await get_default_partition_key(bidi_session)),
+    }
     assert len(cookies["cookies"]) == 2
     # Provide consistent cookies order.
     (cookie_1, cookie_2) = sorted(cookies["cookies"], key=lambda c: c["name"])
@@ -102,7 +104,9 @@ async def test_filter_domain(
         filter=CookieFilter(domain=domain),
     )
 
-    assert cookies["partitionKey"] == {}
+    assert cookies["partitionKey"] == {
+        **(await get_default_partition_key(bidi_session)),
+    }
     assert len(cookies["cookies"]) == 2
     # Provide consistent cookies order.
     (cookie_1, cookie_2) = sorted(cookies["cookies"], key=lambda c: c["name"])
@@ -191,7 +195,9 @@ async def test_filter_expiry(
         filter=CookieFilter(expiry=cookie1_expiry),
     )
 
-    assert cookies["partitionKey"] == {}
+    assert cookies["partitionKey"] == {
+        **(await get_default_partition_key(bidi_session)),
+    }
     assert len(cookies["cookies"]) == 2
     # Provide consistent cookies order.
     (cookie_1, cookie_2) = sorted(cookies["cookies"], key=lambda c: c["name"])
@@ -303,7 +309,9 @@ async def test_filter_same_site(
         filter=CookieFilter(same_site=same_site_1),
     )
 
-    assert cookies["partitionKey"] == {}
+    assert cookies["partitionKey"] == {
+        **(await get_default_partition_key(bidi_session)),
+    }
     assert len(cookies["cookies"]) == 2
     # Provide consistent cookies order.
     (cookie_1, cookie_2) = sorted(cookies["cookies"], key=lambda c: c["name"])
@@ -371,7 +379,9 @@ async def test_filter_secure(
         filter=CookieFilter(secure=secure_1),
     )
 
-    assert cookies["partitionKey"] == {}
+    assert cookies["partitionKey"] == {
+        **(await get_default_partition_key(bidi_session)),
+    }
     assert len(cookies["cookies"]) == 2
     # Provide consistent cookies order.
     (cookie_1, cookie_2) = sorted(cookies["cookies"], key=lambda c: c["name"])
@@ -449,7 +459,9 @@ async def test_filter_path(
         filter=CookieFilter(path=path_1),
     )
 
-    assert cookies["partitionKey"] == {}
+    assert cookies["partitionKey"] == {
+        **(await get_default_partition_key(bidi_session)),
+    }
     assert len(cookies["cookies"]) == 2
     (cookie_1, cookie_2) = sorted(cookies["cookies"], key=lambda c: c["name"])
     recursive_compare(
@@ -528,7 +540,9 @@ async def test_filter_http_only(
         filter=CookieFilter(http_only=http_only_1),
     )
 
-    assert cookies["partitionKey"] == {}
+    assert cookies["partitionKey"] == {
+        **(await get_default_partition_key(bidi_session)),
+    }
     assert len(cookies["cookies"]) == 2
     (cookie_1, cookie_2) = sorted(cookies["cookies"], key=lambda c: c["name"])
     recursive_compare(

--- a/webdriver/tests/bidi/storage/get_cookies/partition.py
+++ b/webdriver/tests/bidi/storage/get_cookies/partition.py
@@ -103,11 +103,10 @@ async def test_partition_context(
         partition=BrowsingContextPartitionDescriptor(new_tab["context"])
     )
 
-    assert result == {
+    assert cookies["partitionKey"] == {
         **(await get_default_partition_key(bidi_session, new_tab["context"])),
         "userContext": "default"
     }
-
     assert len(cookies["cookies"]) == 1
     recursive_compare(
         {
@@ -129,9 +128,9 @@ async def test_partition_context(
     )
 
     assert cookies["partitionKey"] == {
-        **(await get_default_partition_key(bidi_session)),
+        **(await get_default_partition_key(bidi_session, new_context["context"])),
+        "userContext": user_context
     }
-
     assert len(cookies["cookies"]) == 0
 
 

--- a/webdriver/tests/bidi/storage/get_cookies/partition.py
+++ b/webdriver/tests/bidi/storage/get_cookies/partition.py
@@ -6,7 +6,7 @@ from webdriver.bidi.modules.storage import (
     StorageKeyPartitionDescriptor,
 )
 
-from .. import create_cookie
+from .. import create_cookie, get_default_partition_key
 from ... import recursive_compare
 
 pytestmark = pytest.mark.asyncio
@@ -38,7 +38,9 @@ async def test_default_partition(
 
     cookies = await bidi_session.storage.get_cookies()
 
-    assert cookies["partitionKey"] == {}
+    assert cookies["partitionKey"] == {
+        **(await get_default_partition_key(bidi_session)),
+    }
     assert len(cookies["cookies"]) == 2
     # Provide consistent cookies order.
     (cookie_1, cookie_2) = sorted(cookies["cookies"], key=lambda c: c["domain"])
@@ -101,9 +103,10 @@ async def test_partition_context(
         partition=BrowsingContextPartitionDescriptor(new_tab["context"])
     )
 
-    # `partitionKey` here might contain `sourceOrigin` for certain browser implementation,
-    # so use `recursive_compare` to allow additional fields to be present.
-    recursive_compare({"partitionKey": {"userContext": "default"}}, cookies)
+    assert result == {
+        **(await get_default_partition_key(bidi_session, new_tab["context"])),
+        "userContext": "default"
+    }
 
     assert len(cookies["cookies"]) == 1
     recursive_compare(
@@ -125,9 +128,10 @@ async def test_partition_context(
         partition=BrowsingContextPartitionDescriptor(new_context["context"])
     )
 
-    # `partitionKey` here might contain `sourceOrigin` for certain browser implementation,
-    # so use `recursive_compare` to allow additional fields to be present.
-    recursive_compare({"partitionKey": {"userContext": user_context}}, cookies)
+    assert cookies["partitionKey"] == {
+        **(await get_default_partition_key(bidi_session)),
+    }
+
     assert len(cookies["cookies"]) == 0
 
 
@@ -359,16 +363,6 @@ async def test_partition_user_context(
         {
             "cookies": [],
             "partitionKey": {"userContext": user_context_2},
-        },
-        result,
-    )
-
-    # Check that added cookies will also be returned when partition is not specified.
-    result = await bidi_session.storage.get_cookies()
-    recursive_compare(
-        {
-            "cookies": expected_cookies,
-            "partitionKey": {},
         },
         result,
     )

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_expiry.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_expiry.py
@@ -1,5 +1,5 @@
 import pytest
-from .. import assert_cookie_is_not_set, assert_cookie_is_set, create_cookie
+from .. import assert_cookie_is_not_set, assert_cookie_is_set, create_cookie, get_default_partition_key
 from datetime import datetime, timedelta
 import time
 
@@ -13,7 +13,7 @@ async def test_cookie_expiry_unset(bidi_session, set_cookie, test_page, domain_v
             expiry=None))
 
     assert set_cookie_result == {
-        'partitionKey': {},
+        'partitionKey': (await get_default_partition_key(bidi_session)),
     }
 
     await assert_cookie_is_set(bidi_session, expiry=None, domain=domain_value())
@@ -29,7 +29,7 @@ async def test_cookie_expiry_future(bidi_session, set_cookie, test_page, domain_
             expiry=tomorrow_timestamp))
 
     assert set_cookie_result == {
-        'partitionKey': {},
+        'partitionKey': (await get_default_partition_key(bidi_session)),
     }
 
     await assert_cookie_is_set(bidi_session, expiry=tomorrow_timestamp, domain=domain_value())
@@ -45,7 +45,7 @@ async def test_cookie_expiry_past(bidi_session, set_cookie, test_page, domain_va
             expiry=yesterday_timestamp))
 
     assert set_cookie_result == {
-        'partitionKey': {},
+        'partitionKey': (await get_default_partition_key(bidi_session)),
     }
 
     await assert_cookie_is_not_set(bidi_session)

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_http_only.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_http_only.py
@@ -1,5 +1,5 @@
 import pytest
-from .. import assert_cookie_is_set, create_cookie
+from .. import assert_cookie_is_set, create_cookie, get_default_partition_key
 
 pytestmark = pytest.mark.asyncio
 
@@ -16,7 +16,7 @@ async def test_cookie_http_only(bidi_session, set_cookie, test_page, domain_valu
         cookie=create_cookie(domain=domain_value(), http_only=http_only))
 
     assert set_cookie_result == {
-        'partitionKey': {},
+        'partitionKey': (await get_default_partition_key(bidi_session)),
     }
 
     # `httpOnly` defaults to `false`.

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_path.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_path.py
@@ -1,5 +1,5 @@
 import pytest
-from .. import assert_cookie_is_set, create_cookie
+from .. import assert_cookie_is_set, create_cookie, get_default_partition_key
 
 pytestmark = pytest.mark.asyncio
 
@@ -17,7 +17,7 @@ async def test_cookie_path(bidi_session, test_page, set_cookie, domain_value, pa
     set_cookie_result = await set_cookie(cookie=create_cookie(domain=domain_value(), path=path))
 
     assert set_cookie_result == {
-        'partitionKey': {},
+        'partitionKey': (await get_default_partition_key(bidi_session)),
     }
 
     # `path` defaults to "/".

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_same_site.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_same_site.py
@@ -1,5 +1,5 @@
 import pytest
-from .. import assert_cookie_is_set, create_cookie
+from .. import assert_cookie_is_set, create_cookie, get_default_partition_key
 
 pytestmark = pytest.mark.asyncio
 
@@ -18,7 +18,7 @@ async def test_cookie_secure(bidi_session, set_cookie, test_page, domain_value, 
         cookie=create_cookie(domain=domain_value(), same_site=same_site))
 
     assert set_cookie_result == {
-        'partitionKey': {},
+        'partitionKey': (await get_default_partition_key(bidi_session)),
     }
 
     # `same_site` defaults to "none".

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_secure.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_secure.py
@@ -1,5 +1,5 @@
 import pytest
-from .. import assert_cookie_is_set, create_cookie
+from .. import assert_cookie_is_set, create_cookie, get_default_partition_key
 
 pytestmark = pytest.mark.asyncio
 
@@ -17,7 +17,7 @@ async def test_cookie_secure(bidi_session, set_cookie, test_page, domain_value, 
         cookie=create_cookie(domain=domain_value(), secure=secure))
 
     assert set_cookie_result == {
-        'partitionKey': {},
+        'partitionKey': (await get_default_partition_key(bidi_session)),
     }
 
     # `secure` defaults to `false`.

--- a/webdriver/tests/bidi/storage/set_cookie/page_protocols.py
+++ b/webdriver/tests/bidi/storage/set_cookie/page_protocols.py
@@ -1,6 +1,6 @@
 import pytest
 from urllib.parse import urlparse
-from .. import assert_cookie_is_set, create_cookie
+from .. import assert_cookie_is_set, create_cookie, get_default_partition_key
 
 pytestmark = pytest.mark.asyncio
 
@@ -18,7 +18,7 @@ async def test_page_protocols(bidi_session, set_cookie, get_test_page, protocol)
     set_cookie_result = await set_cookie(cookie=create_cookie(domain=domain))
 
     assert set_cookie_result == {
-        'partitionKey': {},
+        'partitionKey': (await get_default_partition_key(bidi_session)),
     }
 
     # Assert the cookie is actually set.


### PR DESCRIPTION
In Chromium, [expand a storage partition spec](https://w3c.github.io/webdriver-bidi/#expand-a-storage-partition-spec) will be extended with `userContext` even for an empty partition key, as it is in the [default values for storage partition key attributes ](https://w3c.github.io/webdriver-bidi/#default-values-for-storage-partition-key-attributes).

This PR allows to get the default partition key of the endpoint and uses it in the assertions.