### PR TITLE
[css-color] add test for LinkText and dark color-scheme

### DIFF
--- a/css/css-color/system-color-consistency.html
+++ b/css/css-color/system-color-consistency.html
@@ -29,11 +29,8 @@
     <textarea name="text area"></textarea>
   </div>
   <mark id="mark">Marked text</mark>
-  <!-- Links -->
-  <div>
-    <a href="#" id="link">Link</a>
-    <a href="" id="visited">Visited link</a>
-  </div>
+  <!-- Link -->
+  <a href="#" id="link">Link</a>
   </div>
 
   <script>
@@ -64,11 +61,9 @@
       test_computed_value('color', 'Mark', style.getPropertyValue('background-color'), `has the same color as the background-color of a mark element (${colorScheme})`);
       test_computed_value('color', 'MarkText', style.getPropertyValue('color'), `has the same color as the color of a mark element (${colorScheme})`);
 
-      // LinkText and VisitedText
+      // LinkText
       style = document.defaultView.getComputedStyle(document.getElementById('link'));
       test_computed_value('color', 'LinkText', style.getPropertyValue('color'), `has the same color as the color of an anchor element (${colorScheme})`);
-      style = document.defaultView.getComputedStyle(document.getElementById('visited'));
-      test_computed_value('color', 'VisitedText', style.getPropertyValue('color'), `has the same color as the color of a visited anchor element (${colorScheme})`);
     });
   </script>
 </body>

--- a/css/css-color/system-color-consistency.html
+++ b/css/css-color/system-color-consistency.html
@@ -40,30 +40,30 @@
       // Buttons
       for (let element of document.getElementById("buttons").children) {
         style = document.defaultView.getComputedStyle(element);
-        test_computed_value('color', 'ButtonBorder', style.getPropertyValue('border-color'), 'resolves to the same color as the border-color of a ' + element.name);
-        test_computed_value('color', 'ButtonFace', style.getPropertyValue('background-color'), 'resolves to the same color as the background-color of a ' + element.name);
-        test_computed_value('color', 'ButtonText', style.getPropertyValue('color'), 'resolves to the same color as text on a ' + element.name);
+        test_computed_value('color', 'ButtonBorder', style.getPropertyValue('border-color'), `resolves to the same color as the border-color of a ${element.name} (${colorScheme})`);
+        test_computed_value('color', 'ButtonFace', style.getPropertyValue('background-color'), `resolves to the same color as the background-color of a ${element.name} (${colorScheme})`);
+        test_computed_value('color', 'ButtonText', style.getPropertyValue('color'), `resolves to the same color as text on a ${element.name} (${colorScheme})`);
       }
 
       // CanvasText
       style = document.defaultView.getComputedStyle(document.getElementsByTagName('html')[0]);
-      test_computed_value('color', 'CanvasText', style.getPropertyValue('color'), 'has the same color as the color of the html element');
+      test_computed_value('color', 'CanvasText', style.getPropertyValue('color'), `has the same color as the color of the html element (${colorScheme})`);
 
       // Field and FieldText
       for (let element of document.getElementById("fields").children) {
         style = document.defaultView.getComputedStyle(element);
-        test_computed_value('color', 'Field', style.getPropertyValue('background-color'), 'resolves to the same color as the background-color of a ' + element.name);
-        test_computed_value('color', 'FieldText', style.getPropertyValue('color'), 'resolves to the same color as text on a ' + element.name);
+        test_computed_value('color', 'Field', style.getPropertyValue('background-color'), `resolves to the same color as the background-color of a ${element.name} (${colorScheme})`);
+        test_computed_value('color', 'FieldText', style.getPropertyValue('color'), `resolves to the same color as text on a ${element.name} (${colorScheme})`);
       }
 
       // Mark and MarkText
       style = document.defaultView.getComputedStyle(document.getElementById('mark'));
-      test_computed_value('color', 'Mark', style.getPropertyValue('background-color'), 'has the same color as the background-color of a mark element');
-      test_computed_value('color', 'MarkText', style.getPropertyValue('color'), 'has the same color as the color of a mark element');
+      test_computed_value('color', 'Mark', style.getPropertyValue('background-color'), `has the same color as the background-color of a mark element (${colorScheme})`);
+      test_computed_value('color', 'MarkText', style.getPropertyValue('color'), `has the same color as the color of a mark element (${colorScheme})`);
 
       // LinkText
       style = document.defaultView.getComputedStyle(document.getElementById('link'));
-      test_computed_value('color', 'LinkText', style.getPropertyValue('color'), 'has the same color as the color of an anchor element');
+      test_computed_value('color', 'LinkText', style.getPropertyValue('color'), `has the same color as the color of an anchor element (${colorScheme})`);
     });
   </script>
 </body>

--- a/css/css-color/system-color-consistency.html
+++ b/css/css-color/system-color-consistency.html
@@ -29,31 +29,42 @@
     <textarea name="text area"></textarea>
   </div>
   <mark id="mark">Marked text</mark>
+  <!-- Link -->
+  <a href="#" id="link">Link</a>
   </div>
+
   <script>
-    // Buttons
-    for (let element of document.getElementById("buttons").children) {
-      style = document.defaultView.getComputedStyle(element);
-      test_computed_value('color', 'ButtonBorder', style.getPropertyValue('border-color'), 'resolves to the same color as the border-color of a ' + element.name);
-      test_computed_value('color', 'ButtonFace', style.getPropertyValue('background-color'), 'resolves to the same color as the background-color of a ' + element.name);
-      test_computed_value('color', 'ButtonText', style.getPropertyValue('color'), 'resolves to the same color as text on a ' + element.name);
-    }
+    ['light', 'dark'].forEach(colorScheme => {
+      document.documentElement.style.colorScheme = colorScheme;
 
-    // CanvasText
-    style = document.defaultView.getComputedStyle(document.getElementsByTagName('html')[0]);
-    test_computed_value('color', 'CanvasText', style.getPropertyValue('color'), 'has the same color as the color of the html element');
-
-    // Field and FieldText
-    for (let element of document.getElementById("fields").children) {
-      style = document.defaultView.getComputedStyle(element);
-      test_computed_value('color', 'Field', style.getPropertyValue('background-color'), 'resolves to the same color as the background-color of a ' + element.name);
-      test_computed_value('color', 'FieldText', style.getPropertyValue('color'), 'resolves to the same color as text on a ' + element.name);
-    }
-
-    // Mark and MarkText
-    style = document.defaultView.getComputedStyle(document.getElementById('mark'));
-    test_computed_value('color', 'Mark', style.getPropertyValue('background-color'), 'has the same color as the background-color of a mark element');
-    test_computed_value('color', 'MarkText', style.getPropertyValue('color'), 'has the same color as the color of a mark element');
+      // Buttons
+      for (let element of document.getElementById("buttons").children) {
+        style = document.defaultView.getComputedStyle(element);
+        test_computed_value('color', 'ButtonBorder', style.getPropertyValue('border-color'), 'resolves to the same color as the border-color of a ' + element.name);
+        test_computed_value('color', 'ButtonFace', style.getPropertyValue('background-color'), 'resolves to the same color as the background-color of a ' + element.name);
+        test_computed_value('color', 'ButtonText', style.getPropertyValue('color'), 'resolves to the same color as text on a ' + element.name);
+      }
+  
+      // CanvasText
+      style = document.defaultView.getComputedStyle(document.getElementsByTagName('html')[0]);
+      test_computed_value('color', 'CanvasText', style.getPropertyValue('color'), 'has the same color as the color of the html element');
+  
+      // Field and FieldText
+      for (let element of document.getElementById("fields").children) {
+        style = document.defaultView.getComputedStyle(element);
+        test_computed_value('color', 'Field', style.getPropertyValue('background-color'), 'resolves to the same color as the background-color of a ' + element.name);
+        test_computed_value('color', 'FieldText', style.getPropertyValue('color'), 'resolves to the same color as text on a ' + element.name);
+      }
+  
+      // Mark and MarkText
+      style = document.defaultView.getComputedStyle(document.getElementById('mark'));
+      test_computed_value('color', 'Mark', style.getPropertyValue('background-color'), 'has the same color as the background-color of a mark element');
+      test_computed_value('color', 'MarkText', style.getPropertyValue('color'), 'has the same color as the color of a mark element');
+  
+      // LinkText
+      style = document.defaultView.getComputedStyle(document.getElementById('link'));
+      test_computed_value('color', 'LinkText', style.getPropertyValue('color'), 'has the same color as the color of an anchor element');
+    });
   </script>
 </body>
 

--- a/css/css-color/system-color-consistency.html
+++ b/css/css-color/system-color-consistency.html
@@ -29,8 +29,11 @@
     <textarea name="text area"></textarea>
   </div>
   <mark id="mark">Marked text</mark>
-  <!-- Link -->
-  <a href="#" id="link">Link</a>
+  <!-- Links -->
+  <div>
+    <a href="#" id="link">Link</a>
+    <a href="" id="visited">Visited link</a>
+  </div>
   </div>
 
   <script>
@@ -61,9 +64,11 @@
       test_computed_value('color', 'Mark', style.getPropertyValue('background-color'), `has the same color as the background-color of a mark element (${colorScheme})`);
       test_computed_value('color', 'MarkText', style.getPropertyValue('color'), `has the same color as the color of a mark element (${colorScheme})`);
 
-      // LinkText
+      // LinkText and VisitedText
       style = document.defaultView.getComputedStyle(document.getElementById('link'));
       test_computed_value('color', 'LinkText', style.getPropertyValue('color'), `has the same color as the color of an anchor element (${colorScheme})`);
+      style = document.defaultView.getComputedStyle(document.getElementById('visited'));
+      test_computed_value('color', 'VisitedText', style.getPropertyValue('color'), `has the same color as the color of a visited anchor element (${colorScheme})`);
     });
   </script>
 </body>

--- a/css/css-color/system-color-consistency.html
+++ b/css/css-color/system-color-consistency.html
@@ -44,23 +44,23 @@
         test_computed_value('color', 'ButtonFace', style.getPropertyValue('background-color'), 'resolves to the same color as the background-color of a ' + element.name);
         test_computed_value('color', 'ButtonText', style.getPropertyValue('color'), 'resolves to the same color as text on a ' + element.name);
       }
-  
+
       // CanvasText
       style = document.defaultView.getComputedStyle(document.getElementsByTagName('html')[0]);
       test_computed_value('color', 'CanvasText', style.getPropertyValue('color'), 'has the same color as the color of the html element');
-  
+
       // Field and FieldText
       for (let element of document.getElementById("fields").children) {
         style = document.defaultView.getComputedStyle(element);
         test_computed_value('color', 'Field', style.getPropertyValue('background-color'), 'resolves to the same color as the background-color of a ' + element.name);
         test_computed_value('color', 'FieldText', style.getPropertyValue('color'), 'resolves to the same color as text on a ' + element.name);
       }
-  
+
       // Mark and MarkText
       style = document.defaultView.getComputedStyle(document.getElementById('mark'));
       test_computed_value('color', 'Mark', style.getPropertyValue('background-color'), 'has the same color as the background-color of a mark element');
       test_computed_value('color', 'MarkText', style.getPropertyValue('color'), 'has the same color as the color of a mark element');
-  
+
       // LinkText
       style = document.defaultView.getComputedStyle(document.getElementById('link'));
       test_computed_value('color', 'LinkText', style.getPropertyValue('color'), 'has the same color as the color of an anchor element');


### PR DESCRIPTION
Changes to `system-color-consistency.html`:

1. Added a new test for `LinkText`.
   - This test is now actually accurate after https://github.com/WebKit/WebKit/pull/17512.
2. All tests are now run twice, once for `color-scheme: light` (default) and once for `color-scheme: dark`

Review with [whitespace off](https://github.com/web-platform-tests/wpt/pull/44940/files?w=1) for proper diff.

---

**Note**: I would have liked to also test for [`VisitedText`](https://www.w3.org/TR/css-color-4/#valdef-color-visitedtext) but I'm not sure how to. `<a href="">` should technically work but `getComputedValue` doesn't return the correct value (likely for security reasons).