### PR TITLE
[css-color] add missing colorscheme-aware tests

### DIFF
--- a/css/css-color/system-color-support.html
+++ b/css/css-color/system-color-support.html
@@ -57,6 +57,8 @@
       'CanvasText',
       'AppWorkspace',
       'Scrollbar',
+      'LinkText',
+      'VisitedText',
     ];
 
     for (let systemColor of SYSTEM_COLORS) {

--- a/css/css-color/system-color-support.html
+++ b/css/css-color/system-color-support.html
@@ -57,8 +57,14 @@
       'CanvasText',
       'AppWorkspace',
       'Scrollbar',
+      'ButtonFace',
+      'ButtonText',
       'LinkText',
       'VisitedText',
+      'Highlight',
+      'SelectedItem',
+      'Field',
+      'FieldText',
     ];
 
     for (let systemColor of SYSTEM_COLORS) {


### PR DESCRIPTION
Similar to #44940, this should help catch issues in system colors that *should* react to `color-scheme` but currently don't.

I've only added the ones I _know_ need to change with color-scheme. I'm sure there are more that I missed.