### PR TITLE
Name unhandledrejection event correctly

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/choice-of-error-1.html
+++ b/html/semantics/scripting-1/the-script-element/module/choice-of-error-1.html
@@ -9,7 +9,7 @@
     window.log = [];
 
     window.addEventListener("error", ev => log.push(ev.error));
-    window.addEventListener("onunhandledrejection", unreachable);
+    window.addEventListener("unhandledrejection", unreachable);
 
     const test_load = async_test(
         "Parse errors in different files should be reported " +

--- a/html/semantics/scripting-1/the-script-element/module/choice-of-error-2.html
+++ b/html/semantics/scripting-1/the-script-element/module/choice-of-error-2.html
@@ -9,7 +9,7 @@
     window.log = [];
 
     window.addEventListener("error", ev => log.push(ev.error));
-    window.addEventListener("onunhandledrejection", unreachable);
+    window.addEventListener("unhandledrejection", unreachable);
 
     const test_load = async_test(
         "Instantiation errors in different files should be reported " +

--- a/html/semantics/scripting-1/the-script-element/module/choice-of-error-3.html
+++ b/html/semantics/scripting-1/the-script-element/module/choice-of-error-3.html
@@ -9,7 +9,7 @@
     window.log = [];
 
     window.addEventListener("error", ev => log.push(ev.error));
-    window.addEventListener("onunhandledrejection", unreachable);
+    window.addEventListener("unhandledrejection", unreachable);
 
     const test_load = async_test(
         "Evaluation errors are cached in intermediate module scripts");

--- a/html/semantics/scripting-1/the-script-element/module/error-type-1.html
+++ b/html/semantics/scripting-1/the-script-element/module/error-type-1.html
@@ -9,7 +9,7 @@
     window.log = [];
 
     window.addEventListener("error", ev => log.push(ev.error));
-    window.addEventListener("onunhandledrejection", unreachable);
+    window.addEventListener("unhandledrejection", unreachable);
 
     const test_load = async_test(
         "network error has higher priority than parse error");

--- a/html/semantics/scripting-1/the-script-element/module/error-type-2.html
+++ b/html/semantics/scripting-1/the-script-element/module/error-type-2.html
@@ -9,7 +9,7 @@
     window.log = [];
 
     window.addEventListener("error", ev => log.push(ev.error));
-    window.addEventListener("onunhandledrejection", unreachable);
+    window.addEventListener("unhandledrejection", unreachable);
 
     const test_load = async_test(
         "parse error has higher priority than instantiation error");

--- a/html/semantics/scripting-1/the-script-element/module/error-type-3.html
+++ b/html/semantics/scripting-1/the-script-element/module/error-type-3.html
@@ -9,7 +9,7 @@
     window.log = [];
 
     window.addEventListener("error", ev => log.push(ev.error));
-    window.addEventListener("onunhandledrejection", unreachable);
+    window.addEventListener("unhandledrejection", unreachable);
 
     const test_load = async_test(
         "instantiation error has higher priority than evaluation error");

--- a/html/semantics/scripting-1/the-script-element/module/evaluation-error-1.html
+++ b/html/semantics/scripting-1/the-script-element/module/evaluation-error-1.html
@@ -9,7 +9,7 @@
     window.log = [];
 
     window.addEventListener("error", ev => log.push(ev.error));
-    window.addEventListener("onunhandledrejection", unreachable);
+    window.addEventListener("unhandledrejection", unreachable);
 
     const test_load = async_test(
         "Test that exceptions during evaluation lead to error events on " +

--- a/html/semantics/scripting-1/the-script-element/module/evaluation-error-2.html
+++ b/html/semantics/scripting-1/the-script-element/module/evaluation-error-2.html
@@ -9,7 +9,7 @@
     window.log = [];
 
     window.addEventListener("error", ev => log.push(ev.error));
-    window.addEventListener("onunhandledrejection", unreachable);
+    window.addEventListener("unhandledrejection", unreachable);
 
     const test_load = async_test(
         "Test that ill-founded cyclic dependencies cause ReferenceError " +

--- a/html/semantics/scripting-1/the-script-element/module/evaluation-error-3.html
+++ b/html/semantics/scripting-1/the-script-element/module/evaluation-error-3.html
@@ -9,7 +9,7 @@
     window.log = [];
 
     window.addEventListener("error", ev => log.push(ev.error));
-    window.addEventListener("onunhandledrejection", unreachable);
+    window.addEventListener("unhandledrejection", unreachable);
 
     const test_load = async_test(
         "Test that exceptions during evaluation lead to error events on " +

--- a/html/semantics/scripting-1/the-script-element/module/evaluation-error-4.html
+++ b/html/semantics/scripting-1/the-script-element/module/evaluation-error-4.html
@@ -9,7 +9,7 @@
     window.log = [];
 
     window.addEventListener("error", ev => log.push(ev.error));
-    window.addEventListener("onunhandledrejection", unreachable);
+    window.addEventListener("unhandledrejection", unreachable);
 
     const test_load = async_test(
         "Test that exceptions during evaluation lead to error events on " +


### PR DESCRIPTION
Some tests in `html/semantics/scripting-1/the-script-element/module` do `window.addEventListener("onunhandledrejection", unreachable)`, when they should do `window.addEventListener("unhandledrejection", unreachable);` - the event is called `unhandledrejection`, not `onunhandledrejection`.

This event handler should never be run when these tests pass, so this change ensures that `unhandledrejection` must not be fired to pass the test.