### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=265223

### DIFF
--- a/css/css-view-transitions/only-child-group.html
+++ b/css/css-view-transitions/only-child-group.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait foo">
 <title>View transitions: ensure :only-child is supported on view-transition-group</title>
-<link rel="help" href="https://github.com/WICG/view-transitions">
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 
 <script src="/resources/testharness.js"></script>
@@ -54,8 +54,7 @@ promise_test(() => {
   return new Promise(async (resolve, reject) => {
     let transition = document.startViewTransition();
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-group(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-group(root)");
       if (style.backgroundColor == "rgb(255, 0, 0)" && style.color == "rgb(255, 0, 0)")
         resolve();
       else
@@ -70,8 +69,7 @@ promise_test(() => {
     target.style.viewTransitionName = "target";
     let transition = document.startViewTransition();
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-group(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-group(root)");
       if (style.backgroundColor == "rgb(0, 0, 255)" && style.color == "rgb(0, 0, 255)")
         resolve();
       else
@@ -87,8 +85,7 @@ promise_test(() => {
     target.style.viewTransitionName = "target";
     let transition = document.startViewTransition();
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-group(target)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-group(target)");
       if (style.backgroundColor == "rgb(255, 0, 0)" && style.color == "rgb(255, 0, 0)")
         resolve();
       else
@@ -105,8 +102,7 @@ promise_test(() => {
     target2.style.viewTransitionName = "target2";
     let transition = document.startViewTransition();
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-group(target)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-group(target)");
       if (style.backgroundColor == "rgb(0, 0, 255)" && style.color == "rgb(0, 0, 255)")
         resolve();
       else

--- a/css/css-view-transitions/only-child-image-pair.html
+++ b/css/css-view-transitions/only-child-image-pair.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait foo">
 <title>View transitions: ensure :only-child is supported on view-transition-image-pair</title>
-<link rel="help" href="https://github.com/WICG/view-transitions">
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 
 <script src="/resources/testharness.js"></script>
@@ -38,8 +38,7 @@ promise_test(() => {
   return new Promise(async (resolve, reject) => {
     let transition = document.startViewTransition();
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-image-pair(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-image-pair(root)");
       if (style.backgroundColor == "rgb(255, 0, 0)" && style.color == "rgb(255, 0, 0)")
         resolve();
       else

--- a/css/css-view-transitions/only-child-new.html
+++ b/css/css-view-transitions/only-child-new.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait foo">
 <title>View transitions: ensure :only-child is supported on view-transition-new</title>
-<link rel="help" href="https://github.com/WICG/view-transitions">
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 
 <script src="/resources/testharness.js"></script>
@@ -61,8 +61,7 @@ promise_test(() => {
     });
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-new(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-new(root)");
       if (style.backgroundColor == matchedColor && style.color == matchedColor)
         resolve();
       else
@@ -79,8 +78,7 @@ promise_test(() => {
     let transition = document.startViewTransition();
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-new(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-new(root)");
       if (style.backgroundColor == notMatchedColor && style.color == notMatchedColor)
         resolve();
       else
@@ -100,8 +98,7 @@ promise_test(() => {
     });
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-new(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-new(root)");
       if (style.backgroundColor == notMatchedColor && style.color == notMatchedColor)
         resolve();
       else
@@ -120,8 +117,7 @@ promise_test(() => {
     });
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-new(target)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-new(target)");
       if (style.backgroundColor == matchedColor && style.color == matchedColor)
         resolve();
       else
@@ -141,8 +137,7 @@ promise_test(() => {
     });
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-new(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-new(root)");
       if (style.backgroundColor == notMatchedColor && style.color == notMatchedColor)
         resolve();
       else
@@ -159,8 +154,7 @@ promise_test(() => {
     let transition = document.startViewTransition();
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-new(target)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-new(target)");
       if (style.backgroundColor == notMatchedColor && style.color == notMatchedColor)
         resolve();
       else

--- a/css/css-view-transitions/only-child-no-transition.html
+++ b/css/css-view-transitions/only-child-no-transition.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
 <title>View transitions: :only-child style queries without transition shouldn't crash</title>
-<link rel="help" href="https://github.com/WICG/view-transitions">
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 
 <script src="/resources/testharness.js"></script>
@@ -21,11 +21,11 @@
 promise_test(() => {
   return new Promise(async (resolve, reject) => {
     let elements = [
-      "view-transition",
-      "view-transition-group(foo)",
-      "view-transition-image-pair(foo)",
-      "view-transition-old(foo)",
-      "view-transition-old(foo)"
+      "::view-transition",
+      "::view-transition-group(foo)",
+      "::view-transition-image-pair(foo)",
+      "::view-transition-old(foo)",
+      "::view-transition-old(foo)"
     ];
 
     for (let i = 0; i < elements.length; i++) {

--- a/css/css-view-transitions/only-child-old.html
+++ b/css/css-view-transitions/only-child-old.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait foo">
 <title>View transitions: ensure :only-child is supported on view-transition-old</title>
-<link rel="help" href="https://github.com/WICG/view-transitions">
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 
 <script src="/resources/testharness.js"></script>
@@ -61,8 +61,7 @@ promise_test(() => {
     });
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-old(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-old(root)");
       if (style.backgroundColor == matchedColor && style.color == matchedColor)
         resolve();
       else
@@ -79,8 +78,7 @@ promise_test(() => {
     let transition = document.startViewTransition();
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-old(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-old(root)");
       if (style.backgroundColor == notMatchedColor && style.color == notMatchedColor)
         resolve();
       else
@@ -100,8 +98,7 @@ promise_test(() => {
     });
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-old(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-old(root)");
       if (style.backgroundColor == notMatchedColor && style.color == notMatchedColor)
         resolve();
       else
@@ -121,7 +118,7 @@ promise_test(() => {
 
     transition.ready.then(() => {
       let style = getComputedStyle(
-        document.documentElement, ":view-transition-old(target)");
+        document.documentElement, "::view-transition-old(target)");
       if (style.backgroundColor == matchedColor && style.color == matchedColor)
         resolve();
       else
@@ -141,8 +138,7 @@ promise_test(() => {
     });
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-old(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-old(root)");
       if (style.backgroundColor == notMatchedColor && style.color == notMatchedColor)
         resolve();
       else
@@ -159,8 +155,7 @@ promise_test(() => {
     let transition = document.startViewTransition();
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-old(target)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-old(target)");
       if (style.backgroundColor == notMatchedColor && style.color == notMatchedColor)
         resolve();
       else


### PR DESCRIPTION
WebKit export from bug: [\[view-transitions\] Support chaining `:only-child` after pseudo-elements](https://bugs.webkit.org/show_bug.cgi?id=265223)