### PR TITLE
[WebDriverBiDi] refactor test to use `bidi_session.<module>.<command>` syntax

### DIFF
--- a/tools/webdriver/webdriver/bidi/modules/script.py
+++ b/tools/webdriver/webdriver/bidi/modules/script.py
@@ -78,11 +78,11 @@ Target = Union[RealmTarget, ContextTarget]
 class SerializationOptions(Dict[str, Any]):
     def __init__(
             self,
-            max_dom_depth: Optional[int] = None,
+            max_dom_depth: Optional[Union[int, None]] = 0,
             max_object_depth: Optional[int] = None,
             include_shadow_tree: Optional[str] = None
     ):
-        if max_dom_depth is not None:
+        if max_dom_depth != 0:
             self["maxDomDepth"] = max_dom_depth
         if max_object_depth is not None:
             self["maxObjectDepth"] = max_object_depth

--- a/tools/webdriver/webdriver/bidi/modules/script.py
+++ b/tools/webdriver/webdriver/bidi/modules/script.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Union
 
 from ..error import UnknownErrorException
 from ._module import BidiModule, command
+from ..undefined import UNDEFINED, Undefined
 
 
 class ScriptEvaluateResultException(Exception):
@@ -78,15 +79,15 @@ Target = Union[RealmTarget, ContextTarget]
 class SerializationOptions(Dict[str, Any]):
     def __init__(
             self,
-            max_dom_depth: Optional[Union[int, None]] = 0,
-            max_object_depth: Optional[int] = None,
-            include_shadow_tree: Optional[str] = None
+            max_dom_depth: Union[Optional[int], Undefined] = UNDEFINED,
+            max_object_depth: Union[Optional[int], Undefined] = UNDEFINED,
+            include_shadow_tree: Union[Optional[str], Undefined] = UNDEFINED
     ):
-        if max_dom_depth != 0:
+        if max_dom_depth is not UNDEFINED:
             self["maxDomDepth"] = max_dom_depth
-        if max_object_depth is not None:
+        if max_object_depth is not UNDEFINED:
             self["maxObjectDepth"] = max_object_depth
-        if include_shadow_tree is not None:
+        if include_shadow_tree is not UNDEFINED and include_shadow_tree is not None:
             self["includeShadowTree"] = include_shadow_tree
 
 

--- a/webdriver/tests/bidi/script/call_function/serialization_options.py
+++ b/webdriver/tests/bidi/script/call_function/serialization_options.py
@@ -446,21 +446,17 @@ async def test_max_dom_depth(
 
 async def test_max_dom_depth_null(
     bidi_session,
-    send_blocking_command,
     top_context,
     get_test_page,
 ):
     await bidi_session.browsing_context.navigate(
         context=top_context["context"], url=get_test_page(), wait="complete"
     )
-    result = await send_blocking_command(
-        "script.callFunction",
-        {
-            "functionDeclaration": """() => document.querySelector("div#with-children")""",
-            "target": ContextTarget(top_context["context"]),
-            "awaitPromise": True,
-            "serializationOptions": {"maxDomDepth": None},
-        },
+    result = await bidi_session.script.call_function(
+        function_declaration="""() => document.querySelector("div#with-children")""",
+        target=ContextTarget(top_context["context"]),
+        await_promise=True,
+        serialization_options=SerializationOptions(max_dom_depth=None),
     )
 
     recursive_compare(

--- a/webdriver/tests/bidi/script/call_function/serialization_options.py
+++ b/webdriver/tests/bidi/script/call_function/serialization_options.py
@@ -1,5 +1,6 @@
 import pytest
 from webdriver.bidi.modules.script import ContextTarget, SerializationOptions
+from webdriver.bidi.undefined import UNDEFINED
 
 from ... import any_string, recursive_compare
 
@@ -10,7 +11,7 @@ pytestmark = pytest.mark.asyncio
     "include_shadow_tree, shadow_root_mode, contains_children, expected",
     [
         (
-            None,
+            UNDEFINED,
             "open",
             False,
             {
@@ -20,7 +21,7 @@ pytestmark = pytest.mark.asyncio
             },
         ),
         (
-            None,
+            UNDEFINED,
             "closed",
             False,
             {
@@ -189,7 +190,7 @@ async def test_include_shadow_tree_for_custom_element(
     "include_shadow_tree, contains_children, expected",
     [
         (
-            None,
+            UNDEFINED,
             False,
             {
                 "type": "node",
@@ -438,7 +439,8 @@ async def test_max_dom_depth(
         function_declaration="""() => document.querySelector("div#with-children")""",
         target=ContextTarget(top_context["context"]),
         await_promise=True,
-        serialization_options=SerializationOptions(max_dom_depth=max_dom_depth),
+        serialization_options=SerializationOptions(
+            max_dom_depth=max_dom_depth),
     )
 
     recursive_compare(expected, result)
@@ -522,7 +524,7 @@ async def test_max_dom_depth_null(
     "max_object_depth, expected",
     [
         (
-            None,
+            UNDEFINED,
             {
                 "type": "array",
                 "value": [

--- a/webdriver/tests/bidi/script/call_function/serialization_options.py
+++ b/webdriver/tests/bidi/script/call_function/serialization_options.py
@@ -516,7 +516,7 @@ async def test_max_dom_depth_null(
                 "shadowRoot": None,
             },
         },
-        result["result"],
+        result,
     )
 
 

--- a/webdriver/tests/bidi/session/new/connect.py
+++ b/webdriver/tests/bidi/session/new/connect.py
@@ -16,17 +16,16 @@ async def test_websocket_url_connect(session):
 
 # test bidi_session send
 @pytest.mark.asyncio
-async def test_bidi_session_send(bidi_session, send_blocking_command):
-    await send_blocking_command("session.status", {})
+async def test_bidi_session_send(bidi_session):
+    await bidi_session.session.status()
 
 
 # bidi session following a bidi session with a different capabilities
 # to test session recreation
 @pytest.mark.asyncio
 @pytest.mark.capabilities({"acceptInsecureCerts": True})
-async def test_bidi_session_with_different_capability(bidi_session,
-                                                      send_blocking_command):
-    await send_blocking_command("session.status", {})
+async def test_bidi_session_with_different_capability(bidi_session):
+    await bidi_session.session.status()
 
 
 # classic session following a bidi session to test session

--- a/webdriver/tests/bidi/session/status/status.py
+++ b/webdriver/tests/bidi/session/status/status.py
@@ -4,7 +4,7 @@ import pytest
 # Check that session.status can be used. The actual values for the "ready" and
 # "message" properties are implementation specific.
 @pytest.mark.asyncio
-async def test_bidi_session_status(send_blocking_command):
-    response = await send_blocking_command("session.status", {})
+async def test_bidi_session_status(bidi_session):
+    response = await bidi_session.session.status()
     assert isinstance(response["ready"], bool)
     assert isinstance(response["message"], str)

--- a/webdriver/tests/support/fixtures_bidi.py
+++ b/webdriver/tests/support/fixtures_bidi.py
@@ -198,7 +198,7 @@ def add_and_remove_iframe(bidi_session):
                 document.documentElement.lastElementChild.append(iframe);
                 return new Promise(resolve => iframe.onload = () => resolve(id));
             }""",
-            target={"context": context["context"]},
+            target=ContextTarget(context["context"]),
             await_promise=True)
         iframe_dom_id = resp["value"]
 
@@ -210,7 +210,7 @@ def add_and_remove_iframe(bidi_session):
 
         await bidi_session.script.evaluate(
             expression=f"document.getElementById('{iframe_dom_id}').remove()",
-            target={"context": context["context"]},
+            target=ContextTarget(context["context"]),
             await_promise=False)
 
         return frame_id


### PR DESCRIPTION
For the [Serialization options](https://w3c.github.io/webdriver-bidi/#type-script-SerializationOptions) change. The spec defines `null` (in Python `None`) to be accepted value. Use `Undefined` to single don't use.

The other changes uses the `bidi_session` and it's helper to send commands. This is now widely used and provides some type safety when sending command. 

Use `ContextTarget` to abstract the context target creation.