### PR TITLE
update test to expect shadow trees to find document keyframes

### DIFF
--- a/css/css-scoping/keyframes-001.html
+++ b/css/css-scoping/keyframes-001.html
@@ -4,10 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
 <link rel="help" href="https://drafts.csswg.org/css-scoping/#selectors-data-model">
-<!--
-  Beware of https://github.com/w3c/csswg-drafts/issues/1995 potentially, but
-  unlikely, changing the expected result of this test.
--->
+
 <style>
 #in-document {
   width: 100px;

--- a/css/css-scoping/keyframes-002.html
+++ b/css/css-scoping/keyframes-002.html
@@ -4,10 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
 <link rel="help" href="https://drafts.csswg.org/css-scoping/#selectors-data-model">
-<!--
-  Beware of https://github.com/w3c/csswg-drafts/issues/1995 potentially, but
-  unlikely, changing the expected result of this test.
--->
+
 <style>
 @keyframes myanim {
   from { background: red; }

--- a/css/css-scoping/keyframes-002.html
+++ b/css/css-scoping/keyframes-002.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<title>CSS Test: @keyframes from the document don't apply in the shadow tree.</title>
+<title>CSS Test: @keyframes from the document should apply in the shadow tree.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
@@ -29,6 +29,6 @@ test(function() {
     <div id="in-shadow"></div>
   `;
 
-  assert_equals(host.shadowRoot.getElementById('in-shadow').getAnimations().length, 0);
-}, "@keyframes from the document don't apply in the shadow tree");
+  assert_equals(host.shadowRoot.getElementById('in-shadow').getAnimations().length, 1);
+}, "@keyframes from the document should apply in the shadow tree");
 </script>


### PR DESCRIPTION
This updates the expectation for this test, as we decided in https://drafts.csswg.org/css-scoping/#shadow-names that names should inherit into descendant shadow trees.

There is not yet much interoperability in tree-scoped names: https://wiki.csswg.org/spec/css-scoping. I am working on `@font-face` tests based on these `@keyframe` tests and noticed this test needed fixing up.