### PR TITLE
@font-face tests for shadow dom

### DIFF
--- a/css/css-scoping/font-face-001.html
+++ b/css/css-scoping/font-face-001.html
@@ -7,7 +7,7 @@
 
 <style>
 #in-document {
-  font-family: ff-ahem;
+  font-family: ff-16-wide;
 }
 </style>
 <div id="host"><span id="in-document">1234567890</span></div>
@@ -16,11 +16,11 @@ test(function() {
   host.attachShadow({ mode: "open" }).innerHTML = `
     <style>
       @font-face {
-        font-family: ff-ahem;
+        font-family: ff-16-wide;
         src: url(/fonts/Ahem.ttf);
       }
       #in-shadow {
-        font-family: ff-ahem;
+        font-family: ff-16-wide;
       }
     </style>
     <slot></slot>

--- a/css/css-scoping/font-face-001.html
+++ b/css/css-scoping/font-face-001.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<title>CSS Test: @font-face applies in the shadow tree.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="author" title="Alan Stearns" href="mailto:stearns@adobe.com">
+<link rel="help" href="https://drafts.csswg.org/css-scoping/#shadow-names">
+
+<style>
+#in-document {
+  font-family: ff-ahem;
+}
+</style>
+<div id="host"><span id="in-document">1234567890</span></div>
+<script>
+test(function() {
+  host.attachShadow({ mode: "open" }).innerHTML = `
+    <style>
+      @font-face {
+        font-family: ff-ahem;
+        src: url(/fonts/Ahem.ttf);
+      }
+      #in-shadow {
+        font-family: ff-ahem;
+      }
+    </style>
+    <slot></slot>
+    <span id="in-shadow">0123456789</span>
+  `;
+
+  assert_not_equals(document.getElementById('in-document').offsetWidth, 160);
+  assert_equals(host.shadowRoot.getElementById('in-shadow').offsetWidth, 160);
+}, "@font-face applies in the shadow tree")
+</script>

--- a/css/css-scoping/font-face-002.html
+++ b/css/css-scoping/font-face-002.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<title>CSS Test: @font-face from the document applies in the shadow tree.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="author" title="Alan Stearns" href="mailto:stearns@adobe.com">
+<link rel="help" href="https://drafts.csswg.org/css-scoping/#shadow-names">
+
+<style>
+@font-face {
+  font-family: ff-ahem;
+  src: url(/fonts/Ahem.ttf);
+}
+</style>
+<div id="host"><span id="in-document">1234567890</span></div>
+<script>
+test(function() {
+  host.attachShadow({ mode: "open" }).innerHTML = `
+    <style>
+      #in-shadow {
+        font-family: ff-ahem;
+      }
+    </style>
+    <slot></slot>
+    <span id="in-shadow">0123456789</span>
+  `;
+
+  assert_not_equals(document.getElementById('in-document').offsetWidth, 160);
+  assert_equals(host.shadowRoot.getElementById('in-shadow').offsetWidth, 160);
+}, "@font-face from the document applies in the shadow tree");
+</script>

--- a/css/css-scoping/font-face-002.html
+++ b/css/css-scoping/font-face-002.html
@@ -7,7 +7,7 @@
 
 <style>
 @font-face {
-  font-family: ff-ahem;
+  font-family: ff-16-wide;
   src: url(/fonts/Ahem.ttf);
 }
 </style>
@@ -17,7 +17,7 @@ test(function() {
   host.attachShadow({ mode: "open" }).innerHTML = `
     <style>
       #in-shadow {
-        font-family: ff-ahem;
+        font-family: ff-16-wide;
       }
     </style>
     <slot></slot>

--- a/css/css-scoping/font-face-003.html
+++ b/css/css-scoping/font-face-003.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<title>CSS Test: @font-face from document applies to :host.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="author" title="Alan Stearns" href="mailto:stearns@adobe.com">
+<link rel="help" href="https://drafts.csswg.org/css-scoping/#shadow-names">
+
+<style>
+@font-face {
+  font-family: ff-ahem;
+  src: url(/fonts/Ahem.ttf);
+}
+</style>
+<div id="host"><span id="in-document">1234567890</span></div>
+<script>
+test(function() {
+  host.attachShadow({ mode: "open" }).innerHTML = `
+    <style>
+      :host {
+        font-family: ff-ahem;
+      }
+    </style>
+    <slot></slot>
+    <span id="in-shadow">0123456789</span>
+  `;
+
+  assert_equals(document.getElementById('in-document').offsetWidth, 160);
+  assert_equals(host.shadowRoot.getElementById('in-shadow').offsetWidth, 160);
+}, "@font-face from document applies to :host");
+</script>

--- a/css/css-scoping/font-face-003.html
+++ b/css/css-scoping/font-face-003.html
@@ -7,7 +7,7 @@
 
 <style>
 @font-face {
-  font-family: ff-ahem;
+  font-family: ff-16-wide;
   src: url(/fonts/Ahem.ttf);
 }
 </style>
@@ -17,7 +17,7 @@ test(function() {
   host.attachShadow({ mode: "open" }).innerHTML = `
     <style>
       :host {
-        font-family: ff-ahem;
+        font-family: ff-16-wide;
       }
     </style>
     <slot></slot>

--- a/css/css-scoping/font-face-004.html
+++ b/css/css-scoping/font-face-004.html
@@ -8,7 +8,7 @@
 
 <style>
 @font-face {
-  font-family: ff-ahem;
+  font-family: ff-16-wide;
   src: url(/fonts/Ahem.ttf);
 }
 </style>
@@ -18,7 +18,7 @@ test(function() {
   host.attachShadow({ mode: "open" }).innerHTML = `
     <style>
       ::slotted(#in-document) {
-        font-family: ff-ahem;
+        font-family: ff-16-wide;
       }
     </style>
     <slot></slot>

--- a/css/css-scoping/font-face-004.html
+++ b/css/css-scoping/font-face-004.html
@@ -1,0 +1,31 @@
+
+<!doctype html>
+<title>CSS Test: @font-face from document applies to ::slotted.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="author" title="Alan Stearns" href="mailto:stearns@adobe.com">
+<link rel="help" href="https://drafts.csswg.org/css-scoping/#shadow-names">
+
+<style>
+@font-face {
+  font-family: ff-ahem;
+  src: url(/fonts/Ahem.ttf);
+}
+</style>
+<div id="host"><span id="in-document">1234567890</span></div>
+<script>
+test(function() {
+  host.attachShadow({ mode: "open" }).innerHTML = `
+    <style>
+      ::slotted(#in-document) {
+        font-family: ff-ahem;
+      }
+    </style>
+    <slot></slot>
+    <span id="in-shadow">0123456789</span>
+  `;
+
+  assert_equals(document.getElementById('in-document').offsetWidth, 160);
+  assert_not_equals(host.shadowRoot.getElementById('in-shadow').offsetWidth, 160);
+}, "@font-face from document applies to a slotted element");
+</script>

--- a/css/css-scoping/font-face-005.html
+++ b/css/css-scoping/font-face-005.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<title>CSS Test: @font-face should not leak out of shadow tree.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="author" title="Alan Stearns" href="mailto:stearns@adobe.com">
+<link rel="help" href="https://drafts.csswg.org/css-scoping/#shadow-names">
+
+<style>
+  #in-document {
+    font-family: ff-ahem;
+  }
+</style>
+<div id="host"><span id="in-document">1234567890</span></div>
+<script>
+test(function() {
+  host.attachShadow({ mode: "open" }).innerHTML = `
+    <style>
+      @font-face {
+        font-family: ff-ahem;
+        src: url(/fonts/Ahem.ttf);
+      }
+      #in-shadow {
+        font-family: ff-ahem;
+      }
+    </style>
+    <slot></slot>
+    <span id="in-shadow">0123456789</span>
+  `;
+
+  assert_not_equals(document.getElementById('in-document').offsetWidth, 160);
+  assert_equals(host.shadowRoot.getElementById('in-shadow').offsetWidth, 160);
+}, "@font-face should not leak out of shadow tree.");
+</script>

--- a/css/css-scoping/font-face-005.html
+++ b/css/css-scoping/font-face-005.html
@@ -7,7 +7,7 @@
 
 <style>
   #in-document {
-    font-family: ff-ahem;
+    font-family: ff-16-wide;
   }
 </style>
 <div id="host"><span id="in-document">1234567890</span></div>
@@ -16,11 +16,11 @@ test(function() {
   host.attachShadow({ mode: "open" }).innerHTML = `
     <style>
       @font-face {
-        font-family: ff-ahem;
+        font-family: ff-16-wide;
         src: url(/fonts/Ahem.ttf);
       }
       #in-shadow {
-        font-family: ff-ahem;
+        font-family: ff-16-wide;
       }
     </style>
     <slot></slot>

--- a/css/css-scoping/font-face-006.html
+++ b/css/css-scoping/font-face-006.html
@@ -7,7 +7,7 @@
 
 <style>
 @font-face {
-  font-family: ff-ahem;
+  font-family: ff-16-wide;
   src: url(/fonts/Ahem.ttf);
 }
 #host {
@@ -20,7 +20,7 @@ test(function() {
   host.attachShadow({ mode: "open" }).innerHTML = `
     <style>
       :host::before, :host::after {
-        font-family: ff-ahem;
+        font-family: ff-16-wide;
         content: "12345"
       }
     </style>

--- a/css/css-scoping/font-face-006.html
+++ b/css/css-scoping/font-face-006.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<title>CSS Test: @font-face from document applies to :host::before/::after.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="author" title="Alan Stearns" href="mailto:stearns@adobe.com">
+<link rel="help" href="https://drafts.csswg.org/css-scoping/#shadow-names">
+
+<style>
+@font-face {
+  font-family: ff-ahem;
+  src: url(/fonts/Ahem.ttf);
+}
+#host {
+  float: left;
+}
+</style>
+<div id="host"></div>
+<script>
+test(function() {
+  host.attachShadow({ mode: "open" }).innerHTML = `
+    <style>
+      :host::before, :host::after {
+        font-family: ff-ahem;
+        content: "12345"
+      }
+    </style>
+    <slot></slot>
+  `;
+
+  //shrinkwrapped size for a default font will be a bit more than 80-90
+  //if the font is applied, it will be a bit more than 160
+  assert_greater_than(document.getElementById('host').offsetWidth, 160);
+}, "@font-face from document applies to to :host::before/::after.");
+</script>

--- a/css/css-scoping/font-face-007.html
+++ b/css/css-scoping/font-face-007.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<title>CSS Test: @font-face from shadow applies to :host.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="author" title="Alan Stearns" href="mailto:stearns@adobe.com">
+<link rel="help" href="https://drafts.csswg.org/css-scoping/#shadow-names">
+
+<div id="host"><span id="in-document">1234567890</span></div>
+<script>
+test(function() {
+  host.attachShadow({ mode: "open" }).innerHTML = `
+    <style>
+      @font-face {
+        font-family: ff-ahem;
+        src: url(/fonts/Ahem.ttf);
+      }
+      :host {
+        font-family: ff-ahem;
+      }
+    </style>
+    <slot></slot>
+    <span id="in-shadow">0123456789</span>
+  `;
+
+  assert_equals(document.getElementById('in-document').offsetWidth, 160);
+  assert_equals(host.shadowRoot.getElementById('in-shadow').offsetWidth, 160);
+}, "@font-face from shadow applies to :host");
+</script>

--- a/css/css-scoping/font-face-007.html
+++ b/css/css-scoping/font-face-007.html
@@ -11,11 +11,11 @@ test(function() {
   host.attachShadow({ mode: "open" }).innerHTML = `
     <style>
       @font-face {
-        font-family: ff-ahem;
+        font-family: ff-16-wide;
         src: url(/fonts/Ahem.ttf);
       }
       :host {
-        font-family: ff-ahem;
+        font-family: ff-16-wide;
       }
     </style>
     <slot></slot>

--- a/css/css-scoping/font-face-008.html
+++ b/css/css-scoping/font-face-008.html
@@ -12,11 +12,11 @@ test(function() {
   host.attachShadow({ mode: "open" }).innerHTML = `
     <style>
       @font-face {
-        font-family: ff-ahem;
+        font-family: ff-16-wide;
         src: url(/fonts/Ahem.ttf);
       }
       ::slotted(#in-document) {
-        font-family: ff-ahem;
+        font-family: ff-16-wide;
       }
     </style>
     <slot></slot>

--- a/css/css-scoping/font-face-008.html
+++ b/css/css-scoping/font-face-008.html
@@ -1,0 +1,29 @@
+
+<!doctype html>
+<title>CSS Test: @font-face from shadow applies to ::slotted.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="author" title="Alan Stearns" href="mailto:stearns@adobe.com">
+<link rel="help" href="https://drafts.csswg.org/css-scoping/#shadow-names">
+
+<div id="host"><span id="in-document">1234567890</span></div>
+<script>
+test(function() {
+  host.attachShadow({ mode: "open" }).innerHTML = `
+    <style>
+      @font-face {
+        font-family: ff-ahem;
+        src: url(/fonts/Ahem.ttf);
+      }
+      ::slotted(#in-document) {
+        font-family: ff-ahem;
+      }
+    </style>
+    <slot></slot>
+    <span id="in-shadow">0123456789</span>
+  `;
+
+  assert_equals(document.getElementById('in-document').offsetWidth, 160);
+  assert_not_equals(host.shadowRoot.getElementById('in-shadow').offsetWidth, 160);
+}, "@font-face from shadow applies to a slotted element");
+</script>

--- a/css/css-scoping/font-face-009.html
+++ b/css/css-scoping/font-face-009.html
@@ -16,11 +16,11 @@ test(function() {
   host.attachShadow({ mode: "open" }).innerHTML = `
     <style>
       @font-face {
-        font-family: ff-ahem;
+        font-family: ff-16-wide;
         src: url(/fonts/Ahem.ttf);
       }
       :host::before, :host::after {
-        font-family: ff-ahem;
+        font-family: ff-16-wide;
         content: "12345"
       }
     </style>

--- a/css/css-scoping/font-face-009.html
+++ b/css/css-scoping/font-face-009.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<title>CSS Test: @font-face from shadow applies to :host::before/::after.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="author" title="Alan Stearns" href="mailto:stearns@adobe.com">
+<link rel="help" href="https://drafts.csswg.org/css-scoping/#shadow-names">
+
+<style>
+#host {
+  float: left;
+}
+</style>
+<div id="host"></div>
+<script>
+test(function() {
+  host.attachShadow({ mode: "open" }).innerHTML = `
+    <style>
+      @font-face {
+        font-family: ff-ahem;
+        src: url(/fonts/Ahem.ttf);
+      }
+      :host::before, :host::after {
+        font-family: ff-ahem;
+        content: "12345"
+      }
+    </style>
+    <slot></slot>
+  `;
+
+  //shrinkwrapped size for a default font will be a bit more than 80-90
+  //if the font is applied, it will be a bit more than 160
+  assert_greater_than(document.getElementById('host').offsetWidth, 160);
+}, "@font-face from shadow applies to to :host::before/::after.");
+</script>


### PR DESCRIPTION
Tests for declaring and using `@font-face` rules inside shadow dom, following the `@keyframe` test pattern that already exists.

There does not appear to be much interop here, but https://drafts.csswg.org/css-scoping/#shadow-names has the path forward that everyone has agreed on. There are bugs for Firefox and Chrome, at least

https://bugzilla.mozilla.org/show_bug.cgi?id=1077396
https://issues.chromium.org/issues/41085401