### PR TITLE
Ensure Chromium binaries are run using chromium commands

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1282,6 +1282,11 @@ class Chrome(ChromeChromiumBase):
 
         version = self.version(browser_binary)
         if version is None:
+            # Check if the user has given a Chromium binary.
+            chromium = Chromium(self.logger)
+            if chromium.version(browser_binary):
+                raise ValueError(f"Provided binary is a Chromium binary and should be run using "
+                                 f"Chromium commands, e.g. \"./wpt run chromium\"")
             raise ValueError(f"Unable to detect browser version from binary at {browser_binary}. "
                              " Cannot install ChromeDriver without a valid version to match.")
 

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1286,7 +1286,7 @@ class Chrome(ChromeChromiumBase):
             chromium = Chromium(self.logger)
             if chromium.version(browser_binary):
                 raise ValueError("Provided binary is a Chromium binary and should be run using "
-                                 "Chromium commands, e.g. \"./wpt run chromium\"")
+                                 "\"./wpt run chromium\" or similar.")
             raise ValueError(f"Unable to detect browser version from binary at {browser_binary}. "
                              " Cannot install ChromeDriver without a valid version to match.")
 

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1285,8 +1285,8 @@ class Chrome(ChromeChromiumBase):
             # Check if the user has given a Chromium binary.
             chromium = Chromium(self.logger)
             if chromium.version(browser_binary):
-                raise ValueError(f"Provided binary is a Chromium binary and should be run using "
-                                 f"Chromium commands, e.g. \"./wpt run chromium\"")
+                raise ValueError("Provided binary is a Chromium binary and should be run using "
+                                 "Chromium commands, e.g. \"./wpt run chromium\"")
             raise ValueError(f"Unable to detect browser version from binary at {browser_binary}. "
                              " Cannot install ChromeDriver without a valid version to match.")
 


### PR DESCRIPTION
This change adds an additional check when finding matching ChromeDriver binaries in Chrome to see if the user has provided or detected a Chromium binary, and advises the user to handle the binary using "chromium" commands if so.

Chrome and Chromium use different channels to obtain matching ChromeDriver binaries, so it is advisable to ensure the correct channel is used depending on the binary.