### PR TITLE
[WebDriverBiDi] Change test to match current spec

### DIFF
--- a/webdriver/tests/bidi/network/continue_response/credentials.py
+++ b/webdriver/tests/bidi/network/continue_response/credentials.py
@@ -23,8 +23,7 @@ async def test_wrong_credentials(
 
     # Continue the request blocked on authRequired, with incorrect credentials.
     on_auth_required = wait_for_event(AUTH_REQUIRED_EVENT)
-    wrong_credentials = AuthCredentials(
-        username=username, password="wrong_password")
+    wrong_credentials = AuthCredentials(username=username, password="wrong_password")
     await bidi_session.network.continue_response(
         request=request, credentials=wrong_credentials
     )
@@ -43,8 +42,7 @@ async def test_correct_credentials(
     )
 
     await subscribe_events(
-        events=[AUTH_REQUIRED_EVENT,
-                RESPONSE_COMPLETED_EVENT, "browsingContext.load"]
+        events=[AUTH_REQUIRED_EVENT, RESPONSE_COMPLETED_EVENT, "browsingContext.load"]
     )
 
     # Track all network.responseCompleted events.

--- a/webdriver/tests/bidi/network/continue_response/credentials.py
+++ b/webdriver/tests/bidi/network/continue_response/credentials.py
@@ -23,7 +23,8 @@ async def test_wrong_credentials(
 
     # Continue the request blocked on authRequired, with incorrect credentials.
     on_auth_required = wait_for_event(AUTH_REQUIRED_EVENT)
-    wrong_credentials = AuthCredentials(username=username, password="wrong_password")
+    wrong_credentials = AuthCredentials(
+        username=username, password="wrong_password")
     await bidi_session.network.continue_response(
         request=request, credentials=wrong_credentials
     )
@@ -32,7 +33,7 @@ async def test_wrong_credentials(
 
 @pytest.mark.parametrize("navigate", [False, True], ids=["fetch", "navigate"])
 async def test_correct_credentials(
-    setup_blocked_request, subscribe_events, wait_for_event, bidi_session, navigate
+    setup_blocked_request, subscribe_events, wait_for_event, bidi_session, navigate, wait_for_future_safe
 ):
     # Setup unique username / password because browsers cache credentials.
     username = f"test_wrong_credentials_{navigate}"
@@ -42,7 +43,8 @@ async def test_correct_credentials(
     )
 
     await subscribe_events(
-        events=[AUTH_REQUIRED_EVENT, RESPONSE_COMPLETED_EVENT, "browsingContext.load"]
+        events=[AUTH_REQUIRED_EVENT,
+                RESPONSE_COMPLETED_EVENT, "browsingContext.load"]
     )
 
     # Track all network.responseCompleted events.
@@ -64,15 +66,17 @@ async def test_correct_credentials(
     await bidi_session.network.continue_response(
         request=request, credentials=correct_credentials
     )
-    await on_response_completed
+    await wait_for_future_safe(on_response_completed)
     if navigate:
-        await on_load
+        await wait_for_future_safe(on_load)
 
-    # Wait until 2 responseCompleted events have been emitted:
-    # - one for the initial request
-    # - one for the continue with correct credentials
-    wait = AsyncPoll(bidi_session, timeout=2)
-    await wait.until(lambda _: len(response_completed_events) >= 2)
-    assert len(response_completed_events) == 2
+    # TODO: At the moment, the specification does not expect to receive a
+    # responseCompleted event for each authentication attempt, so only assert
+    # the last event. See https://github.com/w3c/webdriver-bidi/issues/627
+
+    # Wait until a a responseCompleted event with status 200 OK is received.
+    wait = AsyncPoll(
+        bidi_session, message="Didn't receive response completed events")
+    await wait.until(lambda _: len(response_completed_events) > 0 and response_completed_events[-1]["response"]["status"] == 200)
 
     remove_listener()


### PR DESCRIPTION
The spec expects only 1 response completed event - the discussion about this is at https://github.com/w3c/webdriver-bidi/issues/627.
This was done for other authentication test so porting it to this one as well.

Also added same subtest timeouts to test to prevent test (file) timeouts.