### PR TITLE
Remove unused function.

### DIFF
--- a/resources/testharnessreport.js
+++ b/resources/testharnessreport.js
@@ -14,31 +14,6 @@
  * parameters they are called with see testharness.js
  */
 
-function dump_test_results(tests, status) {
-    var results_element = document.createElement("script");
-    results_element.type = "text/json";
-    results_element.id = "__testharness__results__";
-    var test_results = tests.map(function(x) {
-        return {name:x.name, status:x.status, message:x.message, stack:x.stack}
-    });
-    var data = {test:window.location.href,
-                tests:test_results,
-                status: status.status,
-                message: status.message,
-                stack: status.stack};
-    results_element.textContent = JSON.stringify(data);
-
-    // To avoid a HierarchyRequestError with XML documents, ensure that 'results_element'
-    // is inserted at a location that results in a valid document.
-    var parent = document.body
-        ? document.body                 // <body> is required in XHTML documents
-        : document.documentElement;     // fallback for optional <body> in HTML5, SVG, etc.
-
-    parent.appendChild(results_element);
-}
-
-add_completion_callback(dump_test_results);
-
 /* If the parent window has a testharness_properties object,
  * we use this to provide the test settings. This is used by the
  * default in-browser runner to configure the timeout and the


### PR DESCRIPTION
This code was added in [1] in 2015, with the justification "This is experimental until we have a better way to integrate with saucelabs". I can't find any use of this, so I assume the experiment has concluded.

Specifically:
- This creates a `data` dictionary with result data.
- This stringifies the `data` dictionary as JSON.
- Then it sets that string in a `<script>` element.

Since JSON dictionaries do not parse as JavaScript, it would
seem that this code always errors out. There seems to be no error
handler that would catch or observe this. Even it it were to compile,
the result would just be a constant value whose parsing + execution
causes no effect.

The only way for this to have an effect would be to read the `<script>` element later in JS. I can't find any reference of the
script id in either Chromium, Firefox, or WebKit code. So I'm assuming this is dead code.

[1] https://github.com/web-platform-tests/wpt/commit/453772cc2b5c912d74801732e234bbc438706425
