### PR TITLE
Decouple from chrome's --headless

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -148,6 +148,7 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     # set. '--headless' should always mean the new headless mode, as the old
     # headless mode is not used anyway.
     if kwargs["headless"] and ("--headless=new" not in chrome_options["args"] and
+                               "--headless=old" not in chrome_options["args"] and
                                "--headless" not in chrome_options["args"]):
         chrome_options["args"].append("--headless=new")
 


### PR DESCRIPTION
Chrome's --headless means the old headless now, but that could be updated to mean the new headless mode.

Also check if --headless=old presents on the binary args. If it is, do not pass in --headless=new.