### PR TITLE
Fix `animateColor` test to work across browsers

### DIFF
--- a/svg/import/animate-elem-30-t-manual.svg
+++ b/svg/import/animate-elem-30-t-manual.svg
@@ -95,7 +95,7 @@
 
       <defs>
         <rect id="rectID" x="10" y="60" width="60" height="20" fill="blue" stroke="black" stroke-width="2">
-          <animateColor attributeName="fill" from="white" to="rgb(16, 93, 140)" begin="0" dur="3" fill="freeze"/>
+          <animate attributeName="fill" from="white" to="rgb(16, 93, 140)" begin="0" dur="3" fill="freeze"/>
           <animate attributeName="height" from="20" to="40" begin="0" dur="3" fill="freeze"/>
         </rect>
       </defs>

--- a/svg/import/animate-elem-85-t-manual.svg
+++ b/svg/import/animate-elem-85-t-manual.svg
@@ -15,7 +15,7 @@
     version="$Revision: 1.8 $" testname="$RCSfile: animate-elem-85-t.svg,v $">
     <d:testDescription xmlns="http://www.w3.org/1999/xhtml" href="http://www.w3.org/TR/SVG11/animate.html#Animation">
         <p>
-          The first subtest tests animateColor with 'to' and 'from' values including
+          The first subtest tests animate with 'to' and 'from' values including
           currentColor. The second subtest checks that the value of currentColor is the
            current animated value of the color property, by animating the color property
            at the same time as animating fill with a 'from' or 'to' value of currentColor.
@@ -50,29 +50,29 @@
   <g id="subtest_1">
     <rect fill="#f00" x="30" y="50" height="100" width="90">
     <!-- basic test from two numeric hex values -->
-      <animateColor attributeName="fill" from="#000000" to="#008000" begin="0s" dur="5s" fill="freeze"/>
+      <animate attributeName="fill" from="#000000" to="#008000" begin="0s" dur="5s" fill="freeze"/>
     </rect>
     <rect fill="#f00" x="140" y="50" height="100" width="90">
     <!-- same, check color keywords accepted in animations -->
-      <animateColor attributeName="fill" from="#000000" to="green" begin="0s" dur="5s" fill="freeze"/>
+      <animate attributeName="fill" from="#000000" to="green" begin="0s" dur="5s" fill="freeze"/>
     </rect>
     <rect color="green" fill="#f00" x="250" y="50" height="100" width="90">
     <!-- same, static value of currentColor in 'to' -->
-      <animateColor attributeName="fill" from="#000000" to="currentColor" begin="0s" dur="5s" fill="freeze"/>
+      <animate attributeName="fill" from="#000000" to="currentColor" begin="0s" dur="5s" fill="freeze"/>
     </rect>
     <rect color="black" fill="#f00" x="360" y="50" height="100" width="90">
     <!-- same, static value of currentColor in 'from' -->
-      <animateColor attributeName="fill" to="#008000" from="currentColor" begin="0s" dur="5s" fill="freeze"/>
+      <animate attributeName="fill" to="#008000" from="currentColor" begin="0s" dur="5s" fill="freeze"/>
     </rect>
     </g>
     <g id="subtest_2">
     <rect color="black" fill="blue" x="100" y="180" height="60" width="280">
-      <animateColor attributeName="color" to="cyan" from="blue" begin="5s" dur="5s" fill="freeze"/>
-      <animateColor attributeName="fill" from="#008000" to="currentColor" begin="5s" dur="5s" fill="freeze"/>
+      <animate attributeName="color" to="cyan" from="blue" begin="5s" dur="5s" fill="freeze"/>
+      <animate attributeName="fill" from="#008000" to="currentColor" begin="5s" dur="5s" fill="freeze"/>
     </rect>
     <rect color="black" fill="blue" x="100" y="245" height="60" width="280">
-      <animateColor attributeName="fill" from="#008000" to="currentColor" begin="5s" dur="5s" fill="freeze"/>
-      <animateColor attributeName="color" to="cyan" from="blue" begin="5s" dur="5s" fill="freeze"/>
+      <animate attributeName="fill" from="#008000" to="currentColor" begin="5s" dur="5s" fill="freeze"/>
+      <animate attributeName="color" to="cyan" from="blue" begin="5s" dur="5s" fill="freeze"/>
     </rect>
     <!--
             color     fill

--- a/svg/import/animate-pservers-grad-01-b-manual.svg
+++ b/svg/import/animate-pservers-grad-01-b-manual.svg
@@ -47,8 +47,8 @@
   <g id="test-body-content" font-family="SVGFreeSansASCII,sans-serif" font-size="18">
     <defs>
       <g id="g0" stop-color="yellow" stop-opacity="0" color="yellow">
-        <animateColor id="a1" attributeName="stop-color" from="red" to="green" dur="5" fill="freeze"/>
-        <animateColor id="a2" attributeName="color" from="yellow" to="green" dur="5" fill="freeze"/>
+        <animate id="a1" attributeName="stop-color" from="red" to="green" dur="5" fill="freeze"/>
+        <animate id="a2" attributeName="color" from="yellow" to="green" dur="5" fill="freeze"/>
         <animate id="a3" attributeName="stop-opacity" from="0.5" to="1" dur="5" fill="freeze"/>
 
         <linearGradient id="MyGradient1" stop-color="inherit">
@@ -73,7 +73,7 @@
       </g>
     </defs>
     <g id="g1" stop-color="blue">
-      <animateColor id="a4" attributeName="stop-color" from="blue" to="red" dur="5" fill="freeze"/>
+      <animate id="a4" attributeName="stop-color" from="blue" to="red" dur="5" fill="freeze"/>
       <rect id="r1" fill="url(#MyGradient1)" width="100" height="100" x="50" y="50"/>
     </g>
     <g id="g2" stop-opacity="1">
@@ -81,12 +81,12 @@
       <rect id="r2" fill="url(#MyGradient2)" width="100" height="100" x="200" y="50"/>
     </g>
     <g id="g3" stop-opacity="1" stop-color="blue">
-      <animateColor id="a6" attributeName="stop-color" from="blue" to="red" dur="5" fill="freeze"/>
+      <animate id="a6" attributeName="stop-color" from="blue" to="red" dur="5" fill="freeze"/>
       <animate id="a7" attributeName="stop-opacity" from="1" to="0" dur="5" fill="freeze"/>
       <rect id="r3" fill="url(#MyGradient3)" width="100" height="100" x="50" y="200"/>
     </g>
     <g id="g4" color="blue">
-      <animateColor id="a7" attributeName="color" from="blue" to="red" dur="5" fill="freeze"/>
+      <animate id="a7" attributeName="color" from="blue" to="red" dur="5" fill="freeze"/>
       <rect id="r4" fill="url(#MyGradient4)" width="100" height="100" x="200" y="200"/>
     </g>
   </g>


### PR DESCRIPTION
Hi Team,

This PR is to update `animateColor` SVG animation tests from SVG1.1 suite to align with all browsers.

Blink removed it with following in 2014 - https://src.chromium.org/viewvc/blink?view=revision&revision=165071

Firefox / Gecko - never supported it (https://bugzilla.mozilla.org/show_bug.cgi?id=436296) ^ Since all use cases can be done via `animate`

Safari / WebKit - trying to remove - https://github.com/WebKit/WebKit/pull/25671

Just raising this PR so we fix the tests on upstream as well, so on next import, we don't have to fix them and all future engines importing also align with other browsers.

Thanks!