### PR TITLE
Promisify font-relative-units-dynamic.html and wait for `document.fonts.ready`

### DIFF
--- a/css/css-contain/container-queries/font-relative-units-dynamic.html
+++ b/css/css-contain/container-queries/font-relative-units-dynamic.html
@@ -4,26 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/cq-testcommon.js"></script>
-<script>
-
-setup(() => assert_implements_container_queries());
-
-// Inflate a <template> subtree into #main, run the test function,
-// then clean up.
-function test_template(template_element, test_fn, description) {
-  test((t) => {
-    assert_equals(template_element.tagName, "TEMPLATE");
-    t.add_cleanup(() => main.replaceChildren());
-    main.append(template_element.content.cloneNode(true));
-    test_fn(t);
-  }, description);
-}
-
-const green = "rgb(0, 128, 0)";
-const red = "rgb(255, 0, 0)";
-
-</script>
-
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 <style>
   main {
     color: red;
@@ -40,7 +21,7 @@ const red = "rgb(255, 0, 0)";
 <main id=main>
 </main>
 
-<template>
+<template id="template1">
   <style>
     main { font-size: 10px; }
     main.larger { font-size: 20px; }
@@ -54,16 +35,8 @@ const red = "rgb(255, 0, 0)";
     </div>
   </div>
 </template>
-<script>
-test_template(document.currentScript.previousElementSibling, (t) => {
-  t.add_cleanup(() => main.classList.remove("larger"));
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
-  main.classList.add("larger");
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
-}, 'em units respond to changes');
-</script>
 
-<template>
+<template id="template2">
   <style>
     :root { font-size: 10px; }
     :root.larger { font-size: 50px; }
@@ -77,16 +50,8 @@ test_template(document.currentScript.previousElementSibling, (t) => {
     </div>
   </div>
 </template>
-<script>
-test_template(document.currentScript.previousElementSibling, (t) => {
-  t.add_cleanup(() => document.documentElement.classList.remove("larger"));
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
-  document.documentElement.classList.add("larger");
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
-}, 'rem units respond to changes');
-</script>
 
-<template>
+<template id="template3">
   <style>
     main { font-size: 10px; }
     main.larger { font-size: 20px; }
@@ -100,16 +65,8 @@ test_template(document.currentScript.previousElementSibling, (t) => {
     </div>
   </div>
 </template>
-<script>
-test_template(document.currentScript.previousElementSibling, (t) => {
-  t.add_cleanup(() => main.classList.remove("larger"));
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
-  main.classList.add("larger");
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
-}, 'ex units respond to changes');
-</script>
 
-<template>
+<template id="template4">
   <style>
     :root { font-size: 10px; }
     :root.larger { font-size: 20px; }
@@ -123,16 +80,8 @@ test_template(document.currentScript.previousElementSibling, (t) => {
     </div>
   </div>
 </template>
-<script>
-test_template(document.currentScript.previousElementSibling, (t) => {
-  t.add_cleanup(() => document.documentElement.classList.remove("larger"));
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
-  document.documentElement.classList.add("larger");
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
-}, 'rex units respond to changes');
-</script>
 
-<template>
+<template id="template5">
   <style>
     main { font-size: 10px; }
     main.larger { font-size: 20px; }
@@ -146,18 +95,9 @@ test_template(document.currentScript.previousElementSibling, (t) => {
     </div>
   </div>
 </template>
-<script>
-test_template(document.currentScript.previousElementSibling, (t) => {
-  t.add_cleanup(() => main.classList.remove("larger"));
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
-  main.classList.add("larger");
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
-}, 'ch units respond to changes');
-</script>
 
-<template>
+<template id="template6">
   <style>
-    @import url("/fonts/ahem.css");
     main { font-family: 'Ahem'; font-size: 10px; }
     main.larger { font-size: 20px; }
     @container (width <= 7cap) {
@@ -170,16 +110,8 @@ test_template(document.currentScript.previousElementSibling, (t) => {
     </div>
   </div>
 </template>
-<script>
-test_template(document.currentScript.previousElementSibling, (t) => {
-  t.add_cleanup(() => main.classList.remove("larger"));
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
-  main.classList.add("larger");
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
-}, 'cap units respond to changes');
-</script>
 
-<template>
+<template id="template7">
   <style>
     :root { font-size: 10px; }
     :root.larger { font-size: 20px; }
@@ -193,16 +125,8 @@ test_template(document.currentScript.previousElementSibling, (t) => {
     </div>
   </div>
 </template>
-<script>
-test_template(document.currentScript.previousElementSibling, (t) => {
-  t.add_cleanup(() => document.documentElement.classList.remove("larger"));
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
-  document.documentElement.classList.add("larger");
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
-}, 'rch units respond to changes');
-</script>
 
-<template>
+<template id="template8">
   <style>
     main {
       font-size: 10px;
@@ -219,16 +143,8 @@ test_template(document.currentScript.previousElementSibling, (t) => {
     </div>
   </div>
 </template>
-<script>
-test_template(document.currentScript.previousElementSibling, (t) => {
-  t.add_cleanup(() => main.classList.remove("larger"));
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
-  main.classList.add("larger");
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
-}, 'lh units respond to changes');
-</script>
 
-<template>
+<template id="template9">
   <style>
     :root {
       font-size: 10px;
@@ -247,16 +163,8 @@ test_template(document.currentScript.previousElementSibling, (t) => {
     </div>
   </div>
 </template>
-<script>
-test_template(document.currentScript.previousElementSibling, (t) => {
-  t.add_cleanup(() => document.documentElement.classList.remove("larger"));
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
-  document.documentElement.classList.add("larger");
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
-}, 'rlh units respond to changes');
-</script>
 
-<template>
+<template id="template10">
   <style>
     main { font-size: 10px; }
     main.larger { font-size: 20px; }
@@ -270,17 +178,9 @@ test_template(document.currentScript.previousElementSibling, (t) => {
     </div>
   </div>
 </template>
-<script>
-test_template(document.currentScript.previousElementSibling, (t) => {
-  t.add_cleanup(() => main.classList.remove("larger"));
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
-  main.classList.add("larger");
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
-}, 'ic units respond to changes');
-</script>
 
 
-<template>
+<template id="template11">
   <style>
     :root { font-size: 10px; }
     :root.larger { font-size: 20px; }
@@ -294,18 +194,9 @@ test_template(document.currentScript.previousElementSibling, (t) => {
     </div>
   </div>
 </template>
-<script>
-test_template(document.currentScript.previousElementSibling, (t) => {
-  t.add_cleanup(() => document.documentElement.classList.remove("larger"));
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
-  document.documentElement.classList.add("larger");
-  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
-}, 'ric units respond to changes');
-</script>
 
-<template>
+<template id="template12">
   <style>
-    @import url("/fonts/ahem.css");
     :root { font-family: 'Ahem'; font-size: 10px; }
     :root.larger { font-size: 20px; }
     @container (width <= 7rcap) {
@@ -318,8 +209,103 @@ test_template(document.currentScript.previousElementSibling, (t) => {
     </div>
   </div>
 </template>
+
 <script>
-test_template(document.currentScript.previousElementSibling, (t) => {
+promise_setup(async () => { assert_implements_container_queries() });
+
+// Inflate a <template> subtree into #main, run the test function,
+// then clean up.
+function test_template(template_element, test_fn, description) {
+  promise_test(async (t) => {
+    assert_equals(template_element.tagName, "TEMPLATE");
+    t.add_cleanup(() => main.replaceChildren());
+    main.append(template_element.content.cloneNode(true));
+    await document.fonts.ready;
+    test_fn(t);
+  }, description);
+}
+
+const green = "rgb(0, 128, 0)";
+const red = "rgb(255, 0, 0)";
+
+test_template(template1, (t) => {
+  t.add_cleanup(() => main.classList.remove("larger"));
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
+  main.classList.add("larger");
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
+}, 'em units respond to changes');
+
+test_template(template2, (t) => {
+  t.add_cleanup(() => document.documentElement.classList.remove("larger"));
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
+  document.documentElement.classList.add("larger");
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
+}, 'rem units respond to changes');
+
+test_template(template3, (t) => {
+  t.add_cleanup(() => main.classList.remove("larger"));
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
+  main.classList.add("larger");
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
+}, 'ex units respond to changes');
+
+test_template(template4, (t) => {
+  t.add_cleanup(() => document.documentElement.classList.remove("larger"));
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
+  document.documentElement.classList.add("larger");
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
+}, 'rex units respond to changes');
+
+test_template(template5, (t) => {
+  t.add_cleanup(() => main.classList.remove("larger"));
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
+  main.classList.add("larger");
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
+}, 'ch units respond to changes');
+
+test_template(template6, (t) => {
+  t.add_cleanup(() => main.classList.remove("larger"));
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
+  main.classList.add("larger");
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
+}, 'cap units respond to changes');
+
+test_template(template7, (t) => {
+  t.add_cleanup(() => document.documentElement.classList.remove("larger"));
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
+  document.documentElement.classList.add("larger");
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
+}, 'rch units respond to changes');
+
+test_template(template8, (t) => {
+  t.add_cleanup(() => main.classList.remove("larger"));
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
+  main.classList.add("larger");
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
+}, 'lh units respond to changes');
+
+test_template(template9, (t) => {
+  t.add_cleanup(() => document.documentElement.classList.remove("larger"));
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
+  document.documentElement.classList.add("larger");
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
+}, 'rlh units respond to changes');
+
+test_template(template10, (t) => {
+  t.add_cleanup(() => main.classList.remove("larger"));
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
+  main.classList.add("larger");
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
+}, 'ic units respond to changes');
+
+test_template(template11, (t) => {
+  t.add_cleanup(() => document.documentElement.classList.remove("larger"));
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
+  document.documentElement.classList.add("larger");
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
+}, 'ric units respond to changes');
+
+test_template(template12, (t) => {
   t.add_cleanup(() => document.documentElement.classList.remove("larger"));
   assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
   document.documentElement.classList.add("larger");


### PR DESCRIPTION
Proposed fix for issue #44840.

This follows other similar tests, such as `contain-layout-dynamic-001.html`. This stabilizes the test on Blink & Gecko, across multiple hard refreshes. 

WebKit, however, requires a double rAF after `await document.fonts.ready` to stabilize. Without any rAF, WebKit's behaviour is as described in issue #44840. With a single rAF, the test intermittently passes across hard refreshes.