### PR TITLE
 Add link, clarifying justification for orphaned role tests

### DIFF
--- a/wai-aria/role/grid-roles.html
+++ b/wai-aria/role/grid-roles.html
@@ -43,6 +43,12 @@
     </div>
   </div>
 
+  <!--
+    CORE-AAM requires that, for elements with roles not contained in the
+    required context, user agents must ignore the role token and return the
+    computed role as if the ignored role token had not been included.
+    See https://w3c.github.io/core-aam/#roleMappingComputedRole
+  -->
   <span role="row" data-testname="orphaned row outside the context of table" class="ex-generic">x</span>
   <span role="rowgroup" data-testname="orphaned rowgroup outside the context of row" class="ex-generic">x</span>
   <div role="gridcell" data-testname="orphaned div with gridcell role outside the context of row" class="ex-generic">x</div>

--- a/wai-aria/role/list-roles.html
+++ b/wai-aria/role/list-roles.html
@@ -18,6 +18,12 @@
   <div role="listitem" data-testname="last simple listitem" data-expectedrole="listitem" class="ex">x</div>
 </div>
 
+<!--
+  CORE-AAM requires that, for elements with roles not contained in the
+  required context, user agents must ignore the role token and return the
+  computed role as if the ignored role token had not been included.
+  See https://w3c.github.io/core-aam/#roleMappingComputedRole
+-->
 <div role="listitem" data-testname="orphan div with listitem role" class="ex-generic">x</div>
 <p role="listitem" data-testname="orphan p with listitem role" data-expectedrole="paragraph" class="ex">x</p>
 

--- a/wai-aria/role/listbox-roles.html
+++ b/wai-aria/role/listbox-roles.html
@@ -31,6 +31,12 @@
     </li>
 </ul>
 
+<!--
+  CORE-AAM requires that, for elements with roles not contained in the
+  required context, user agents must ignore the role token and return the
+  computed role as if the ignored role token had not been included.
+  See https://w3c.github.io/core-aam/#roleMappingComputedRole
+-->
 <nav role="option" data-testname="orphaned option outside the context of listbox" data-expectedrole="navigation"
      class="ex">x
 </nav>

--- a/wai-aria/role/menu-roles.html
+++ b/wai-aria/role/menu-roles.html
@@ -55,6 +55,12 @@
     </div>
 </div>
 
+<!--
+  CORE-AAM requires that, for elements with roles not contained in the
+  required context, user agents must ignore the role token and return the
+  computed role as if the ignored role token had not been included.
+  See https://w3c.github.io/core-aam/#roleMappingComputedRole
+-->
 <nav role="menuitem" data-testname="orphaned menuitem outside the context of menu/menubar" data-expectedrole="navigation"
      class="ex">x
 </nav>

--- a/wai-aria/role/tab-roles.html
+++ b/wai-aria/role/tab-roles.html
@@ -82,7 +82,12 @@
     <div role="tabpanel" data-testname="role is tabpanel as sibling to ul with child role none li elements" data-expectedrole="tabpanel" class="ex">Tab one's stuff</div>
     <div role="tabpanel" data-testname="role is tabpanel as sibling to ul with child role none li elements (duplicate)" data-expectedrole="tabpanel" class="ex">Tab two's stuff</div>
 
-<!--orphan tab semantics -->
+<!--
+  CORE-AAM requires that, for elements with roles not contained in the
+  required context, user agents must ignore the role token and return the
+  computed role as if the ignored role token had not been included.
+  See https://w3c.github.io/core-aam/#roleMappingComputedRole
+-->
 <button role="tab" data-testname="orphan button with tab role" data-expectedrole="button" class="ex">x</button>
 <span role="tab" data-testname="orphan span with tab role" class="ex-generic">x</span>
 

--- a/wai-aria/role/tree-roles.html
+++ b/wai-aria/role/tree-roles.html
@@ -102,6 +102,12 @@
   </tbody>
 </table>
 
+<!--
+  CORE-AAM requires that, for elements with roles not contained in the
+  required context, user agents must ignore the role token and return the
+  computed role as if the ignored role token had not been included.
+  See https://w3c.github.io/core-aam/#roleMappingComputedRole
+-->
 <nav role="treeitem" data-testname="orphaned treeitem outside the context of tree" data-expectedrole="navigation" class="ex">x</nav>
 <button role="treeitem" data-testname="orphaned button with treeitem role outside tree context" data-expectedrole="button" class="ex">x</button>
 


### PR DESCRIPTION
### UPDATE
This PR adds comments explaining the purpose of and justification for the orphaned role tests in various files. This comment includes a link to the relevant piece of the CORE-AAM specification.

The previous version of this PR moved the orphaned tests. See that description below.

---
### Original Intent

Closes https://github.com/web-platform-tests/interop-accessibility/issues/109

See longer description of the issue: https://github.com/web-platform-tests/interop-accessibility/issues/109
See test change proposal issue: https://github.com/web-platform-tests/interop/issues/645
See related ARIA issue: https://github.com/w3c/aria/issues/2137

This PR moves disputed/invalid orphaned role tests to a unified tentative test file. These cases are considered author errors, which, as of the current ARIA spec language, is explicitly not the responsibility of user agents to remedy.

This PR does move some tests that weren't previously running in their source files (due to lack of `verify[Generic]RolesBySelector` calls). I presume those were meant to be running. Either way, they suffer from the same issues and should be grouped in the tentative file.

By my count, this should remove 17 currently-running tests from WPT. All tested browsers are currently failing these tests, so I expect a ~1.4% increase in the accessibility focus area score across the board when this merges.

This is my first non-automated WPT PR, so please assign reviewers as needed. Thanks!