### PR TITLE
Fix `console.countReset` manual test

### DIFF
--- a/console/console-countReset-logging-manual.html
+++ b/console/console-countReset-logging-manual.html
@@ -24,21 +24,25 @@
 console.count();
 console.countReset();
 console.count();
+console.countReset();
 
 console.count(undefined);
 console.countReset(undefined);
 console.count(undefined);
+console.countReset(undefined);
 
 console.count("default");
 console.countReset("default");
 console.count("default");
+console.countReset("default");
 
 console.count({toString() {return "default"}});
 console.countReset({toString() {return "default"}});
 console.count({toString() {return "default"}});
+console.countReset({toString() {return "default"}});
 
 console.count("a label");
-console.countReset();
+console.countReset("a label");
 console.count("a label");
 
 console.countReset("b"); // should produce a warning


### PR DESCRIPTION
The test wasn't resetting the count between blocks of console calls, so a spec-compliant browser would produce output that doesn't match the expectation. Also, it wasn't specifying the label in the "a label" test, so it was unintentionally resetting the default count instead of the "a label" count.

(In Firefox, the test outputs "default: 0" in the console a lot - this is actually a spec violation.)