### PR TITLE
Test oklab()/oklch() with lightness close to 0/1

### DIFF
--- a/css/css-color/oklab-l-almost-0-ref.html
+++ b/css/css-color/oklab-l-almost-0-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+    .ref { background-color: oklab(0 0.15 0.15); border: 1px solid black; width: 200px; height: 200px; }
+</style>
+<body>
+    <p>Test passes if you see a square border with a single color inside.</p>
+    <div class="ref"></div>
+</body>

--- a/css/css-color/oklab-l-almost-0.html
+++ b/css/css-color/oklab-l-almost-0.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: OKLab and OKLCH</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-oklab-oklch">
+<link rel="match" href="oklab-l-almost-0-ref.html">
+<meta name="assert" content="oklab() with lightness very close to 0 should render the same as 0">
+<style>
+    .square { border: 1px solid black; width: 200px; height: 200px; }
+    .test { background-color: red; height: 100px; }
+    /* Non-zero a/b is used to show if the result is black or not, but the
+     * test passes as long as it's the same color. */
+    .ref { background-color: oklab(0 0.15 0.15); height: 100px; }
+    .test { background-color: oklab(0.0001% 0.15 0.15); }
+</style>
+<body>
+    <p>Test passes if you see a square border with a single color inside.</p>
+    <div class="square">
+        <div class="ref"></div>
+        <div class="test"></div>
+    </div>
+</body>

--- a/css/css-color/oklab-l-almost-1-ref.html
+++ b/css/css-color/oklab-l-almost-1-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+    .ref { background-color: oklab(1 0.15 0.15); border: 1px solid black; width: 200px; height: 200px; }
+</style>
+<body>
+    <p>Test passes if you see a square border with a single color inside.</p>
+    <div class="ref"></div>
+</body>

--- a/css/css-color/oklab-l-almost-1.html
+++ b/css/css-color/oklab-l-almost-1.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: OKLab and OKLCH</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-oklab-oklch">
+<link rel="match" href="oklab-l-almost-1-ref.html">
+<meta name="assert" content="oklab() with lightness very close to 1 should render the same as 1">
+<style>
+    .square { border: 1px solid black; width: 200px; height: 200px; }
+    .test { background-color: red; height: 100px; }
+    /* Non-zero a/b is used to show if the result is white or not, but the
+     * test passes as long as it's the same color. */
+    .ref { background-color: oklab(1 0.15 0.15); height: 100px; }
+    .test { background-color: oklab(99.9999% 0.15 0.15); }
+</style>
+<body>
+    <p>Test passes if you see a square border with a single color inside.</p>
+    <div class="square">
+        <div class="ref"></div>
+        <div class="test"></div>
+    </div>
+</body>

--- a/css/css-color/oklch-l-almost-0-ref.html
+++ b/css/css-color/oklch-l-almost-0-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+    .ref { background-color: oklch(0 0.2 45); border: 1px solid black; width: 200px; height: 200px; }
+</style>
+<body>
+    <p>Test passes if you see a square border with a single color inside.</p>
+    <div class="ref"></div>
+</body>

--- a/css/css-color/oklch-l-almost-0.html
+++ b/css/css-color/oklch-l-almost-0.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: OKLab and OKLCH</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-oklab-oklch">
+<link rel="match" href="oklch-l-almost-0-ref.html">
+<meta name="assert" content="oklch() with lightness very close to 0 should render the same as 0">
+<style>
+    .square { border: 1px solid black; width: 200px; height: 200px; }
+    .test { background-color: red; height: 100px; }
+    /* Non-zero chroma is used to show if the result is black or not, but the
+     * test passes as long as it's the same color. */
+    .ref { background-color: oklch(0 0.2 45); height: 100px; }
+    .test { background-color: oklch(0.0001% 0.2 45); }
+</style>
+<body>
+    <p>Test passes if you see a square border with a single color inside.</p>
+    <div class="square">
+        <div class="ref"></div>
+        <div class="test"></div>
+    </div>
+</body>

--- a/css/css-color/oklch-l-almost-1-ref.html
+++ b/css/css-color/oklch-l-almost-1-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+    .ref { background-color: oklch(1 0.2 45); border: 1px solid black; width: 200px; height: 200px; }
+</style>
+<body>
+    <p>Test passes if you see a square border with a single color inside.</p>
+    <div class="ref"></div>
+</body>

--- a/css/css-color/oklch-l-almost-1.html
+++ b/css/css-color/oklch-l-almost-1.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: OKLab and OKLCH</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-oklab-oklch">
+<link rel="match" href="oklch-l-almost-1-ref.html">
+<meta name="assert" content="oklch() with lightness very close to 1 should render the same as 1">
+<style>
+    .square { border: 1px solid black; width: 200px; height: 200px; }
+    .test { background-color: red; height: 100px; }
+    /* Non-zero chroma is used to show if the result is white or not, but the
+     * test passes as long as it's the same color. */
+    .ref { background-color: oklch(1 0.2 45); height: 100px; }
+    .test { background-color: oklch(99.9999% 0.2 45); }
+</style>
+<body>
+    <p>Test passes if you see a square border with a single color inside.</p>
+    <div class="square">
+        <div class="ref"></div>
+        <div class="test"></div>
+    </div>
+</body>


### PR DESCRIPTION
This is an interop issue where Chrome's behavior is different from
Firefox and Safari's: https://crbug.com/329106317
    
These tests don't care what the color is, as long as it is the same.