### PR TITLE
Retry emulator.wait_for_start() if it fails

### DIFF
--- a/tools/wpt/android.py
+++ b/tools/wpt/android.py
@@ -325,7 +325,16 @@ def start(logger, dest=None, reinstall=False, prompt=True, device_serial=None):
         emulator.start()
         timer = threading.Timer(300, cancel_start(threading.get_ident()))
         timer.start()
-        emulator.wait_for_start()
+        for i in range(10):
+            logger.info(f"Wait for emulator to start attempt {i + 1}/10")
+            try:
+                emulator.wait_for_start()
+            except Exception:
+                import traceback
+                logger.warning(f"""emulator.wait_for_start() failed:
+{traceback.format_exc()}""")
+            else:
+                break
         timer.cancel()
     return emulator
 


### PR DESCRIPTION
This is a bit of a wallpaper patch, but I _think_ what's going on is that there's a race condition between calling `emulator.start()` and `emulator.wait_for_start()` during which adb commands can fail. This should probably be fixed in `mozrunner` or `mozdevice`, but for now this workaround seems to be enough; in particular https://community-tc.services.mozilla.com/tasks/IUqaruRyTCKDSqfyBov3lA/runs/0/logs/live/public/logs/live.log is an example where the initial `wait_for_start()` call failed, but the second one succeeded.