### PR TITLE
[webdriver]: add test to verify consistency in color serialization

### DIFF
--- a/webdriver/tests/classic/get_element_css_value/get.py
+++ b/webdriver/tests/classic/get_element_css_value/get.py
@@ -105,3 +105,10 @@ def test_property_name_not_existent(session, inline):
 
     result = get_element_css_value(session, element.id, "foo")
     assert_success(result, "")
+
+def test_consistent_color_serialization(session):
+    session.url = inline("""<div style="background-color: red">""")
+    element = session.find.css("div", all=False)
+
+    result = get_element_css_value(session, element.id, "background-color")
+    assert_success(result, "rgba(255, 0, 0, 1)")


### PR DESCRIPTION
An issue has been raised in https://github.com/w3c/webdriver/issues/1447 describing discrepancies serializing colors using the element css value command. The specification refers to the [computed value](https://drafts.csswg.org/css-cascade-4/#computed-value) which doesn't have clear definition on this for colors. However the WebDriver specification should have an interest normalizing these values as it is used for testing purposes.