### PR TITLE
End ongoing IFC when inserting anonymous block-level table

### DIFF
--- a/css/CSS2/tables/table-anonymous-objects-212-ref.xht
+++ b/css/CSS2/tables/table-anonymous-objects-212-ref.xht
@@ -1,0 +1,11 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com"/>
+</head>
+<body>
+  above<br />
+  below
+</body>
+</html>

--- a/css/CSS2/tables/table-anonymous-objects-212.xht
+++ b/css/CSS2/tables/table-anonymous-objects-212.xht
@@ -1,0 +1,16 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>CSS Test: Anonymous table objects</title>
+  <link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com"/>
+  <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
+  <link rel="help" href="https://github.com/servo/servo/issues/31603"/>
+  <link rel="match" href="table-anonymous-objects-212-ref.xht"/>
+  <meta assert="The table cell is wrapped inside an anonymous block-level table,
+                so the text 'below' should appear below 'above'."/>
+</head>
+<body>
+  above
+  <span style="display: table-cell">below</span>
+</body>
+</html>


### PR DESCRIPTION
So that the table appears after preceding inline-level contents. Fixes #<!-- nolink -->31603.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#31606