### PR TITLE
Use clearer variable names in grid WPT to avoid spurious MISSING test results.

### DIFF
--- a/css/css-grid/parsing/grid-shorthand-serialization.html
+++ b/css/css-grid/parsing/grid-shorthand-serialization.html
@@ -33,11 +33,12 @@
     }
 
     if (declarations) {
-      let cssText = div.style.cssText;
+      let cssTextSerialization = div.style.cssText;
       declarations.forEach(decl => {
         test(function(){
-          assert_true(cssText.indexOf(decl) !== -1, `cssText ('${cssText}') must contain '${decl}'`);
-        }, `cssText ('${cssText}') must contain '${decl}'`);
+          assert_true(cssTextSerialization.indexOf(decl) !== -1,
+                      `cssText serialization ('${cssTextSerialization}') must contain contain '${decl}'`);
+        }, `cssText ('${cssText}') must contain '${decl}' in its serialization`);
       });
     }
   }


### PR DESCRIPTION
Fixes https://github.com/web-platform-tests/interop/issues/646

This patch improves WPT grid-shorthand-serialization.html to better distinguish between the `cssText` function-param vs. the serialization of that string that the test reads back from the style system.

As of this patch, we'll now use the function-param (not its serialization) when generating the subtest "name" value that we pass to the test(...) function. This makes for more consistent output and removes the possibility for browser-specific serialization-quirks to influence the subtest-name, as discussed in https://github.com/web-platform-tests/interop/issues/646

The test continues to use the serialized value (under a new/clearer variable name) in the assert_true() expression, though; this way, if the test fails, it remains easy to see the actual strings that are involved in the `indexOf` operation that's causing the test-failure.