### PR TITLE
Obey white-space when intrinsically sizing an IFC

### DIFF
--- a/css/CSS2/tables/table-anonymous-objects-213-ref.xht
+++ b/css/CSS2/tables/table-anonymous-objects-213-ref.xht
@@ -1,0 +1,10 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com"/>
+</head>
+<body>
+  <span style="border: solid; vertical-align: top">left right</span>
+</body>
+</html>

--- a/css/CSS2/tables/table-anonymous-objects-213.xht
+++ b/css/CSS2/tables/table-anonymous-objects-213.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>CSS Test: Anonymous table objects</title>
+  <link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com"/>
+  <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
+  <link rel="help" href="https://github.com/servo/servo/issues/31649"/>
+  <link rel="match" href="table-anonymous-objects-213-ref.xht"/>
+  <meta assert="The table cell is wrapped inside an anonymous inline-level table,
+                so the text 'right' should appear at the right of 'left',
+                and the border should surround both of them."/>
+</head>
+<body>
+  <span style="border: solid; vertical-align: top">
+    left
+    <span style="display: table-cell">right</span>
+  </span>
+</body>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The old logic was assuming that all whitespace was a break opportunity,
and that no newlines would be preserved.

Note that text shaping considers the advance of a newline to be the same
as a space. This was problematic because if we have a segment with a
preserved space and newline, only the advance of the space should
contrinute to the size of the block container. Therefore, I'm changing
the breaker logic in other to have newline characters in their own
segment.

Then glyph_run_is_whitespace_ending_with_preserved_newline can just be
renamed to glyph_run_is_preserved_newline.

Reviewed in servo/servo#31660