### PR TITLE
Update integrity hashes in JSON/CSS modules tests

### DIFF
--- a/html/semantics/scripting-1/the-script-element/css-module/integrity.html
+++ b/html/semantics/scripting-1/the-script-element/css-module/integrity.html
@@ -12,7 +12,7 @@ window.matchesEvents = [];
 window.mismatchesLog = [];
 window.mismatchesEvents = [];
 </script>
-<script type="module" src="resources/integrity-matches.js" integrity="sha384-xvbfmg9iJFHqmCoOS4VNMCwnFPPxEoIlW1Ojzl+fgEd+Wf8Pyez+SMWue+KNovjA"  onload="window.matchesEvents.push('load');" onerror="window.matchesEvents.push('error')"></script>
+<script type="module" src="resources/integrity-matches.js" integrity="sha384-KtvB2Fgbhx2NAEizVeuGMa+QgvBzlBvVRxdpRnIECuGUvzzQsnVejyDL5J0fVP9M"  onload="window.matchesEvents.push('load');" onerror="window.matchesEvents.push('error')"></script>
 <script type="module" src="resources/integrity-mismatches.js" integrity="sha384-doesnotmatch" onload="window.mismatchesEvents.push('load');" onerror="window.mismatchesEvents.push('error')"></script>
 
 <script type="module">

--- a/html/semantics/scripting-1/the-script-element/json-module/integrity.html
+++ b/html/semantics/scripting-1/the-script-element/json-module/integrity.html
@@ -12,7 +12,7 @@ window.matchesEvents = [];
 window.mismatchesLog = [];
 window.mismatchesEvents = [];
 </script>
-<script type="module" src="integrity-matches.js" integrity="sha384-VmQQfGzBiLKdyzw4FA4kL4ohu4tyujV68ddgW1aN/1v3cBZNNBn2gDFdVQxfL7+a"  onload="window.matchesEvents.push('load');" onerror="window.matchesEvents.push('error')"></script>
+<script type="module" src="integrity-matches.js" integrity="sha384-kc1K2KFKQhnYE1AdnpmUUpFVnxz1GCgGbQ19e3zmXrZw23rgpwa9il4/pHp7NYWA"  onload="window.matchesEvents.push('load');" onerror="window.matchesEvents.push('error')"></script>
 <script type="module" src="integrity-mismatches.js" integrity="sha384-doesnotmatch" onload="window.mismatchesEvents.push('load');" onerror="window.mismatchesEvents.push('error')"></script>
 
 <script type="module">


### PR DESCRIPTION
In https://github.com/web-platform-tests/wpt/commit/b62c015e63c9bca18ab31c6739d1e0588b5bd299 I just copied the hashes for the files using `assert`, and I forgot to update them due to the changed contents.

Tbh I don't understand the value of these two tests, given that the integrity attribute applies to the top-level modules (which is JS) and not to the JSON/CSS file, but let's at least make sure that they are correct.