### PR TITLE
Remove `infrastructure/` metadata for a test that no longer exists

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/test_win_open_with_interaction.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/test_win_open_with_interaction.html.ini
@@ -1,5 +1,0 @@
-[test_win_open_with_interaction.html]
-  expected: [OK, TIMEOUT]
-
-  [Tests pointer move/click in a window opened with `window.open.`]
-    expected: [FAIL, TIMEOUT, PASS]


### PR DESCRIPTION
See #43860