### PR TITLE
[css-color] test conversion lossiness in relative color syntax

### DIFF
--- a/css/css-color/parsing/color-computed-relative-color.html
+++ b/css/css-color/parsing/color-computed-relative-color.html
@@ -744,26 +744,21 @@
   fuzzy_test_computed_color(`oklch(from color(srgb 0.25 0.5 0.75) l c h)`, `oklch(0.585502 0.118254 250.546)`, 0.02); // Larger values means larger epsilon.
   fuzzy_test_computed_color(`color(from oklch(72.322% 0.12403 247.996) srgb r g b)`, `color(srgb 0.382631 0.672756 0.938904)`, 0.001);
 
-  // Test that conversions are relatively lossless.
+  // Test that conversion are relatively lossless.
   for (const colorSpace of ["xyz-d50", "xyz-d65"]) {
-    // minimum 10 bits when serializing
-    fuzzy_test_computed_color(`color(from rgb(from color(${colorSpace} 0.99 0.88 0.77) r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.001);
-    fuzzy_test_computed_color(`color(from hsl(from color(${colorSpace} 0.99 0.88 0.77) h s l) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.001);
-    fuzzy_test_computed_color(`color(from hwb(from color(${colorSpace} 0.99 0.88 0.77) h w b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.001);
-    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) srgb r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.001);
-    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) display-p3 r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.001);
-    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) a98-rgb r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.001);
-
-    // minimum 12 bits when serializing
-    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) srgb-linear r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.001);
-    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) prophoto-rgb r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.001);
-    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) rec2020 r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.001);
-
-    // minimum 16 bits when serializing
+    fuzzy_test_computed_color(`color(from rgb(from color(${colorSpace} 0.99 0.88 0.77) r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
+    fuzzy_test_computed_color(`color(from hsl(from color(${colorSpace} 0.99 0.88 0.77) h s l) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
+    fuzzy_test_computed_color(`color(from hwb(from color(${colorSpace} 0.99 0.88 0.77) h w b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
     fuzzy_test_computed_color(`color(from lab(from color(${colorSpace} 0.99 0.88 0.77) l a b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
     fuzzy_test_computed_color(`color(from lch(from color(${colorSpace} 0.99 0.88 0.77) l c h) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
     fuzzy_test_computed_color(`color(from oklab(from color(${colorSpace} 0.99 0.88 0.77) l a b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
     fuzzy_test_computed_color(`color(from oklch(from color(${colorSpace} 0.99 0.88 0.77) l c h) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
+    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) srgb r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
+    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) srgb-linear r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
+    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) display-p3 r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
+    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) a98-rgb r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
+    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) prophoto-rgb r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
+    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) rec2020 r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
     fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) xyz x y z) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
     fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) xyz-d50 x y z) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
     fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) xyz-d65 x y z) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);

--- a/css/css-color/parsing/color-computed-relative-color.html
+++ b/css/css-color/parsing/color-computed-relative-color.html
@@ -744,262 +744,30 @@
   fuzzy_test_computed_color(`oklch(from color(srgb 0.25 0.5 0.75) l c h)`, `oklch(0.585502 0.118254 250.546)`, 0.02); // Larger values means larger epsilon.
   fuzzy_test_computed_color(`color(from oklch(72.322% 0.12403 247.996) srgb r g b)`, `color(srgb 0.382631 0.672756 0.938904)`, 0.001);
 
-  // Test that conversion are relatively lossless.
-  fuzzy_test_computed_color(
-    `color(
-      from
-      color(
-        from
-        color(rec2020 0.99 0.88 0.77)
-        srgb
-        r g b
-      )
-      rec2020 r g b
-    )`,
-    `color(rec2020 0.99 0.88 0.77)`,
-    0.0001
-  );
-  fuzzy_test_computed_color(
-    `color(
-      from
-      rgb(
-        from
-        color(rec2020 0.99 0.88 0.77)
-        r g b
-      )
-      rec2020 r g b
-    )`,
-    `color(rec2020 0.99 0.88 0.77)`,
-    0.0001
-  );
-  fuzzy_test_computed_color(
-    `color(
-      from
-      rgb(
-        from
-        hsl(
-          from
-          hwb(
-            from
-            color(rec2020 0.99 0.88 0.77)
-            h w b
-          )
-          h s l
-        )
-        r g b
-      )
-      rec2020 r g b
-    )`,
-    `color(rec2020 0.99 0.88 0.77)`,
-    0.0001
-  );
-  fuzzy_test_computed_color(
-    `color(
-      from
-        lab(
-          from
-          lch(
-            from
-            oklab(
-              from
-              oklch(
-                from
-                color(rec2020 0.99 0.88 0.77)
-                l c h
-              )
-              l a b
-            )
-            l c h
-          )
-          l a b
-      )
-      rec2020 r g b
-    )`,
-    `color(rec2020 0.99 0.88 0.77)`,
-    0.0001
-  );
+  // Test that conversions are relatively lossless.
+  for (const colorSpace of ["xyz-d50", "xyz-d65"]) {
+    // minimum 10 bits when serializing
+    fuzzy_test_computed_color(`color(from rgb(from color(${colorSpace} 0.99 0.88 0.77) r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.001);
+    fuzzy_test_computed_color(`color(from hsl(from color(${colorSpace} 0.99 0.88 0.77) h s l) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.001);
+    fuzzy_test_computed_color(`color(from hwb(from color(${colorSpace} 0.99 0.88 0.77) h w b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.001);
+    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) srgb r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.001);
+    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) display-p3 r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.001);
+    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) a98-rgb r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.001);
 
-  fuzzy_test_computed_color(
-    `color(
-      from
-      rgb(
-        from
-        hsl(
-          from
-          hwb(
-            from
-            lab(
-              from
-              lch(
-                from
-                oklab(
-                  from
-                  oklch(
-                    from
-                    color(
-                      from
-                      color(
-                        from
-                        color(
-                          from
-                          color(rec2020 0.99 0.88 0.77)
-                          display-p3
-                          r g b
-                        )
-                        xyz-d50
-                        x y z
-                      )
-                      xyz-d65
-                      x y z
-                    )
-                    l c h
-                  )
-                  l a b
-                )
-                l c h
-              )
-              l a b
-            )
-            h w b
-          )
-          h s l
-        )
-        r g b
-      )
-      rec2020 r g b
-    )`,
-    `color(rec2020 0.99 0.88 0.77)`,
-    0.0001
-  );
+    // minimum 12 bits when serializing
+    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) srgb-linear r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.001);
+    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) prophoto-rgb r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.001);
+    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) rec2020 r g b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.001);
 
-  fuzzy_test_computed_color(
-    `oklch(
-      from
-      rgb(
-        from
-        hsl(
-          from
-          hwb(
-            from
-            lab(
-              from
-              lch(
-                from
-                oklab(
-                  from
-                  oklch(
-                    from
-                    color(
-                      from
-                      color(
-                        from
-                        color(
-                          from
-                          oklch(0.5 0.1 50)
-                          display-p3
-                          r g b
-                        )
-                        xyz-d50
-                        x y z
-                      )
-                      xyz-d65
-                      x y z
-                    )
-                    l c h
-                  )
-                  l a b
-                )
-                l c h
-              )
-              l a b
-            )
-            h w b
-          )
-          h s l
-        )
-        r g b
-      )
-      l c h
-    )`,
-    `oklch(0.5 0.1 50)`,
-    0.00001
-  );
-
-  fuzzy_test_computed_color(
-    `oklch(
-      from
-      rgb(
-        from
-        oklch(
-          from
-          rgb(
-            from
-            oklch(
-              from
-              rgb(
-                from
-                oklch(
-                  from
-                  rgb(
-                    from
-                    oklch(0.5 0.1 50)
-                    r g b
-                  )
-                  l c h
-                )
-                r g b
-              )
-              l c h
-            )
-            r g b
-          )
-          l c h
-        )
-        r g b
-      )
-      l c h
-    )`,
-    `oklch(0.5 0.1 50)`,
-    0.00001
-  );
-
-  fuzzy_test_computed_color(
-    `oklch(
-      from
-      lab(
-        from
-        oklch(
-          from
-          lab(
-            from
-            oklch(
-              from
-              lab(
-                from
-                oklch(
-                  from
-                  lab(
-                    from
-                    oklch(0.5 0.1 50)
-                    l a b
-                  )
-                  l c h
-                )
-                l a b
-              )
-              l c h
-            )
-            l a b
-          )
-          l c h
-        )
-        l a b
-      )
-      l c h
-    )`,
-    `oklch(0.5 0.1 50)`,
-    0.00001
-  );
+    // minimum 16 bits when serializing
+    fuzzy_test_computed_color(`color(from lab(from color(${colorSpace} 0.99 0.88 0.77) l a b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
+    fuzzy_test_computed_color(`color(from lch(from color(${colorSpace} 0.99 0.88 0.77) l c h) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
+    fuzzy_test_computed_color(`color(from oklab(from color(${colorSpace} 0.99 0.88 0.77) l a b) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
+    fuzzy_test_computed_color(`color(from oklch(from color(${colorSpace} 0.99 0.88 0.77) l c h) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
+    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) xyz x y z) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
+    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) xyz-d50 x y z) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
+    fuzzy_test_computed_color(`color(from color(from color(${colorSpace} 0.99 0.88 0.77) xyz-d65 x y z) ${colorSpace} x y z)`, `color(${colorSpace} 0.99 0.88 0.77)`, 0.0001);
+  }
 
   // Spec Examples: https://www.w3.org/TR/css-color-5/#relative-colors
   // All examples here have multiple stages of calculations so minor disagreements in the values of keyword colors and other constants can compound.

--- a/css/css-color/parsing/color-computed-relative-color.html
+++ b/css/css-color/parsing/color-computed-relative-color.html
@@ -744,6 +744,263 @@
   fuzzy_test_computed_color(`oklch(from color(srgb 0.25 0.5 0.75) l c h)`, `oklch(0.585502 0.118254 250.546)`, 0.02); // Larger values means larger epsilon.
   fuzzy_test_computed_color(`color(from oklch(72.322% 0.12403 247.996) srgb r g b)`, `color(srgb 0.382631 0.672756 0.938904)`, 0.001);
 
+  // Test that conversion are relatively lossless.
+  fuzzy_test_computed_color(
+    `color(
+      from
+      color(
+        from
+        color(rec2020 0.99 0.88 0.77)
+        srgb
+        r g b
+      )
+      rec2020 r g b
+    )`,
+    `color(rec2020 0.99 0.88 0.77)`,
+    0.0001
+  );
+  fuzzy_test_computed_color(
+    `color(
+      from
+      rgb(
+        from
+        color(rec2020 0.99 0.88 0.77)
+        r g b
+      )
+      rec2020 r g b
+    )`,
+    `color(rec2020 0.99 0.88 0.77)`,
+    0.0001
+  );
+  fuzzy_test_computed_color(
+    `color(
+      from
+      rgb(
+        from
+        hsl(
+          from
+          hwb(
+            from
+            color(rec2020 0.99 0.88 0.77)
+            h w b
+          )
+          h s l
+        )
+        r g b
+      )
+      rec2020 r g b
+    )`,
+    `color(rec2020 0.99 0.88 0.77)`,
+    0.0001
+  );
+  fuzzy_test_computed_color(
+    `color(
+      from
+        lab(
+          from
+          lch(
+            from
+            oklab(
+              from
+              oklch(
+                from
+                color(rec2020 0.99 0.88 0.77)
+                l c h
+              )
+              l a b
+            )
+            l c h
+          )
+          l a b
+      )
+      rec2020 r g b
+    )`,
+    `color(rec2020 0.99 0.88 0.77)`,
+    0.0001
+  );
+
+  fuzzy_test_computed_color(
+    `color(
+      from
+      rgb(
+        from
+        hsl(
+          from
+          hwb(
+            from
+            lab(
+              from
+              lch(
+                from
+                oklab(
+                  from
+                  oklch(
+                    from
+                    color(
+                      from
+                      color(
+                        from
+                        color(
+                          from
+                          color(rec2020 0.99 0.88 0.77)
+                          display-p3
+                          r g b
+                        )
+                        xyz-d50
+                        x y z
+                      )
+                      xyz-d65
+                      x y z
+                    )
+                    l c h
+                  )
+                  l a b
+                )
+                l c h
+              )
+              l a b
+            )
+            h w b
+          )
+          h s l
+        )
+        r g b
+      )
+      rec2020 r g b
+    )`,
+    `color(rec2020 0.99 0.88 0.77)`,
+    0.0001
+  );
+
+  fuzzy_test_computed_color(
+    `oklch(
+      from
+      rgb(
+        from
+        hsl(
+          from
+          hwb(
+            from
+            lab(
+              from
+              lch(
+                from
+                oklab(
+                  from
+                  oklch(
+                    from
+                    color(
+                      from
+                      color(
+                        from
+                        color(
+                          from
+                          oklch(0.5 0.1 50)
+                          display-p3
+                          r g b
+                        )
+                        xyz-d50
+                        x y z
+                      )
+                      xyz-d65
+                      x y z
+                    )
+                    l c h
+                  )
+                  l a b
+                )
+                l c h
+              )
+              l a b
+            )
+            h w b
+          )
+          h s l
+        )
+        r g b
+      )
+      l c h
+    )`,
+    `oklch(0.5 0.1 50)`,
+    0.00001
+  );
+
+  fuzzy_test_computed_color(
+    `oklch(
+      from
+      rgb(
+        from
+        oklch(
+          from
+          rgb(
+            from
+            oklch(
+              from
+              rgb(
+                from
+                oklch(
+                  from
+                  rgb(
+                    from
+                    oklch(0.5 0.1 50)
+                    r g b
+                  )
+                  l c h
+                )
+                r g b
+              )
+              l c h
+            )
+            r g b
+          )
+          l c h
+        )
+        r g b
+      )
+      l c h
+    )`,
+    `oklch(0.5 0.1 50)`,
+    0.00001
+  );
+
+  fuzzy_test_computed_color(
+    `oklch(
+      from
+      lab(
+        from
+        oklch(
+          from
+          lab(
+            from
+            oklch(
+              from
+              lab(
+                from
+                oklch(
+                  from
+                  lab(
+                    from
+                    oklch(0.5 0.1 50)
+                    l a b
+                  )
+                  l c h
+                )
+                l a b
+              )
+              l c h
+            )
+            l a b
+          )
+          l c h
+        )
+        l a b
+      )
+      l c h
+    )`,
+    `oklch(0.5 0.1 50)`,
+    0.00001
+  );
+
   // Spec Examples: https://www.w3.org/TR/css-color-5/#relative-colors
   // All examples here have multiple stages of calculations so minor disagreements in the values of keyword colors and other constants can compound.
   // These tests require a wider epsilon of 0.02.


### PR DESCRIPTION
Relative color syntax is expected to be somewhat resilient to cumulative errors.
Converting from A to B and back to A should result in the original value up to a some precision. This is only a single round trip.

I am making the assumption that implementers are using either `xyz-d50` or `xyz-d65` as intermediary space to convert color values for features like `color-mix` and relative color syntax. This is also what I did.

This tests that converting from `xyz-d50` to another notation and back results in the original value. The same for `xyz-d60`.
 
It is currently unspecified what the internal precision must be for color values.
`css-color-4` only defined precision for serialization. I've now used 5 decimal places which I think is fairly reasonable. It based on the serialization precision for `color(xyz ...)`, which is 16 bits.
