### PR TITLE
Enable missed '.ex-generic' orphaned role tests

### DIFF
--- a/wai-aria/role/list-roles.html
+++ b/wai-aria/role/list-roles.html
@@ -29,6 +29,7 @@
 
 <script>
 AriaUtils.verifyRolesBySelector(".ex");
+AriaUtils.verifyGenericRolesBySelector(".ex-generic");
 </script>
 
 </body>

--- a/wai-aria/role/menu-roles.html
+++ b/wai-aria/role/menu-roles.html
@@ -82,6 +82,7 @@
 
 <script>
     AriaUtils.verifyRolesBySelector(".ex");
+    AriaUtils.verifyGenericRolesBySelector(".ex-generic");
 </script>
 
 </body>

--- a/wai-aria/role/tab-roles.html
+++ b/wai-aria/role/tab-roles.html
@@ -93,6 +93,7 @@
 
 <script>
     AriaUtils.verifyRolesBySelector(".ex");
+    AriaUtils.verifyGenericRolesBySelector(".ex-generic");
 </script>
 
 </body>


### PR DESCRIPTION
Closes https://github.com/web-platform-tests/interop-accessibility/issues/111

This commit adds calls to `verifyGenericRolesBySelector` in three test files, where those calls are missing. There are orphaned role tests sitting in each file that use the 'ex-generic' class, but since we're not calling `verifyGenericRolesBySelector`, they aren't running. This commit fixes that problem.