### PR TITLE
Fix harness error in SVG AAM test

### DIFF
--- a/svg-aam/role/roles-generic.html
+++ b/svg-aam/role/roles-generic.html
@@ -36,7 +36,6 @@
 
 <script>
 AriaUtils.verifyGenericRolesBySelector(".ex-generic");
-AriaUtils.verifyRolesBySelector(".ex");
 </script>
 
 </body>


### PR DESCRIPTION
There's no `class="ex"` in the test, so `AriaUtils.verifyRolesBySelector(".ex")` causes a harness error:
https://wpt.fyi/results/svg-aam/role/roles-generic.html?run_id=5135477220311040&run_id=5138374846840832&run_id=6328746709090304&run_id=5203259454652416

Example of a test where this works:
https://github.com/web-platform-tests/wpt/blob/master/html-aam/roles-contextual.html

Remove the culprit call.