### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=271372

### DIFF
--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
@@ -37,7 +37,6 @@ const gNonAnimatableProps = [
   'transitionTimingFunction',
   'contain',
   'direction',
-  'display',
   'textCombineUpright',
   'textOrientation',
   'unicodeBidi',


### PR DESCRIPTION
WebKit export from bug: [\[web-animations\] make the `display` property animatable](https://bugs.webkit.org/show_bug.cgi?id=271372)