### PR TITLE
[WebDriver BiDi] fix `browsing_context/locate_nodes/locator.py:test_find_by_inner_text`

### DIFF
--- a/webdriver/tests/bidi/browsing_context/locate_nodes/locator.py
+++ b/webdriver/tests/bidi/browsing_context/locate_nodes/locator.py
@@ -48,134 +48,88 @@ async def test_find_by_locator(bidi_session, inline, top_context, type, value):
     recursive_compare(expected, result["nodes"])
 
 
-@pytest.mark.parametrize("ignore_case,match_type,max_depth,value,expected", [
-    (True, "full", None, "bar", [
-        {
-            "type": "node",
-            "sharedId": any_string,
-            "value": {
-                "attributes": {},
-                "childNodeCount": 1,
-                "children": [],
-                "localName": "strong",
-                "namespaceURI": "http://www.w3.org/1999/xhtml",
-                "nodeType": 1,
-            }
-        },
-        {
-            "type": "node",
-            "sharedId": any_string,
-            "value": {
-                "attributes": {},
-                "childNodeCount": 1,
-                "localName": "span",
-                "namespaceURI": "http://www.w3.org/1999/xhtml",
-                "nodeType": 1,
-            }
-        }]
-    ),
-    (False, "full", None, "BAR", [
-        {
-            "type": "node",
-            "sharedId": any_string,
-            "value": {
-                "attributes": {},
-                "childNodeCount": 1,
-                "localName": "span",
-                "namespaceURI": "http://www.w3.org/1999/xhtml",
-                "nodeType": 1,
-            }
-        }]
-    ),
-    (True, "partial", None, "ba", [
-        {
-            "type": "node",
-            "sharedId": any_string,
-            "value": {
-                "attributes": {},
-                "childNodeCount": 1,
-                "localName": "strong",
-                "namespaceURI": "http://www.w3.org/1999/xhtml",
-                "nodeType": 1,
-            }
-        },
-        {
-            "type": "node",
-            "sharedId": any_string,
-            "value": {
-                "attributes": {},
-                "childNodeCount": 1,
-                "localName": "span",
-                "namespaceURI": "http://www.w3.org/1999/xhtml",
-                "nodeType": 1,
-            }
-        }]
-    ),
-    (False, "partial", None, "ba", [
-        {
-            "type": "node",
-            "sharedId": any_string,
-            "value": {
-                "attributes": {},
-                "childNodeCount": 1,
-                "localName": "span",
-                "namespaceURI": "http://www.w3.org/1999/xhtml",
-                "nodeType": 1,
-            }
-        }]
-    ),
-    (True, "full", 0, "foobarbarbaz", [
-        {
-            "type": "node",
-            "sharedId": any_string,
-            "value": {
-                "attributes": {},
-                "childNodeCount": 4,
-                "localName": "span",
-                "namespaceURI": "http://www.w3.org/1999/xhtml",
-                "nodeType": 1,
-            }
-        }]
-    ),
-    (False, "full", 0, "foobarBARbaz", [
-        {
-            "type": "node",
-            "sharedId": any_string,
-            "value": {
-                "attributes": {},
-                "childNodeCount": 4,
-                "localName": "span",
-                "namespaceURI": "http://www.w3.org/1999/xhtml",
-                "nodeType": 1,
-            }
-        }]
-    ),
-    (True, "partial", 0, "bar", [
-        {
-            "type": "node",
-            "sharedId": any_string,
-            "value": {
-                "attributes": {},
-                "childNodeCount": 4,
-                "localName": "span",
-                "namespaceURI": "http://www.w3.org/1999/xhtml",
-                "nodeType": 1,
-            }
-        }]
-    ),
-    (False, "partial", 0, "BAR", [
-        {
-            "type": "node",
-            "sharedId": any_string,
-            "value": {
-                "attributes": {},
-                "childNodeCount": 4,
-                "localName": "span",
-                "namespaceURI": "http://www.w3.org/1999/xhtml",
-                "nodeType": 1,
-            }
-        }]
-    )
+@pytest.mark.parametrize("locator,expected_nodes_values", [
+    ({
+         "type": "innerText",
+         "ignoreCase": True,
+         "matchType": "full",
+         "value": "bar"
+     }, ["strong", "span"]),
+    ({
+         "type": "innerText",
+         "ignoreCase": False,
+         "matchType": "full",
+         "value": "BAR"
+     }, ["span"]),
+    ({
+         "type": "innerText",
+         "ignoreCase": True,
+         "matchType": "partial",
+         "value": "ba"
+     }, ["strong", "span"]),
+    ({
+         "type": "innerText",
+         "ignoreCase": False,
+         "matchType": "partial",
+         "value": "ba"
+     }, ["strong"]),
+    ({
+         "type": "innerText",
+         "ignoreCase": True,
+         "matchType": "full",
+         "maxDepth": 0,
+         "value": "foobarbarbaz"
+     }, ["body"]),
+    ({
+         "type": "innerText",
+         "ignoreCase": False,
+         "matchType": "full",
+         "maxDepth": 0,
+         "value": "foobarBARbaz"
+     }, ["body"]),
+    ({
+         "type": "innerText",
+         "ignoreCase": True,
+         "matchType": "partial",
+         "maxDepth": 0,
+         "value": "bar"
+     }, ["body"]),
+    ({
+         "type": "innerText",
+         "ignoreCase": False,
+         "matchType": "partial",
+         "maxDepth": 0,
+         "value": "BAR"
+     }, ["body"]),
+    ({
+
+         "type": "innerText",
+         "ignoreCase": True,
+         "matchType": "full",
+         "maxDepth": 1,
+         "value": "foobarbarbaz"
+     }, ["div"]),
+    ({
+         "type": "innerText",
+         "ignoreCase": False,
+         "matchType": "full",
+         "maxDepth": 1,
+         "value": "foobarBARbaz"
+     }, ["div"]),
+    ({
+         "type": "innerText",
+         "ignoreCase": True,
+         "matchType": "partial",
+         "maxDepth": 1,
+         "value": "bar"
+     }, ["div"]),
+    ({
+         "type": "innerText",
+         "ignoreCase": False,
+         "matchType": "partial",
+         "maxDepth": 1,
+         "value": "BAR"
+     }, ["div"]),
 ], ids=[
     "ignore_case_true_full_match_no_max_depth",
     "ignore_case_false_full_match_no_max_depth",
@@ -185,23 +139,29 @@ async def test_find_by_locator(bidi_session, inline, top_context, type, value):
     "ignore_case_false_full_match_max_depth_zero",
     "ignore_case_true_partial_match_max_depth_zero",
     "ignore_case_false_partial_match_max_depth_zero",
+    "ignore_case_true_full_match_max_depth_one",
+    "ignore_case_false_full_match_max_depth_one",
+    "ignore_case_true_partial_match_max_depth_one",
+    "ignore_case_false_partial_match_max_depth_one",
 ])
 @pytest.mark.asyncio
-async def test_find_by_inner_text(bidi_session, inline, top_context, ignore_case, match_type, max_depth, value, expected):
+async def test_find_by_inner_text(bidi_session, inline, top_context, locator, expected_nodes_values):
     url = inline("""<div>foo<span><strong>bar</strong></span><span>BAR</span>baz</div>""")
     await bidi_session.browsing_context.navigate(
         context=top_context["context"], url=url, wait="complete"
     )
 
+    # Construct expected nodes list with the expected nodes values emitting other fields.
+    expected = [{
+        "type": "node",
+        "value": {
+            "localName": node_value,
+        }
+    } for node_value in expected_nodes_values]
+
     result = await bidi_session.browsing_context.locate_nodes(
         context=top_context["context"],
-        locator={
-            "type": "innerText",
-            "value": value,
-            "ignoreCase": ignore_case,
-            "matchType": match_type,
-            "maxDepth": max_depth
-        }
+        locator=locator
     )
 
     recursive_compare(expected, result["nodes"])


### PR DESCRIPTION
* Fix the logic in `maxDepth`. When `maxDepth` is set to `0`, document body should be returned.
* Do not allow passing `maxDepth: null`. Spec allows only missing or int values.