### PR TITLE
Adding "doc-credit" to DPUB ARIA roles

### DIFF
--- a/dpub-aam/role/roles.html
+++ b/dpub-aam/role/roles.html
@@ -28,6 +28,7 @@ AriaUtils.assignAndVerifyRolesByRoleNames([
   "doc-colophon",
   "doc-conclusion",
   "doc-cover",
+  "doc-credit",
   "doc-credits",
   "doc-dedication",
   // "doc-endnote", // deprecated

--- a/dpub-aam/role/roles.html
+++ b/dpub-aam/role/roles.html
@@ -62,3 +62,4 @@ AriaUtils.assignAndVerifyRolesByRoleNames([
 </script>
 </body>
 </html>
+


### PR DESCRIPTION
"doc-credits" was present, but "doc-credit" was missing. Now it's inline with DPUB ARIA 1.1: https://www.w3.org/TR/dpub-aria-1.1/