### PR TITLE
Test that imported module has initiator-type=script

### DIFF
--- a/resource-timing/initiator-type/script.html
+++ b/resource-timing/initiator-type/script.html
@@ -12,6 +12,7 @@
 </head>
 <body>
 <script src="/resource-timing/resources/empty_script.js"></script>
+<script type="module" src="/resource-timing/resources/parent_script.js"></script>
 <script>
   const async_xhr = new XMLHttpRequest;
   async_xhr.open('GET', '/resource-timing/resources/blue.png?id=async_xhr',
@@ -21,6 +22,7 @@
 <script>
   initiator_type_test("empty_script.js", "script", "<script>");
   initiator_type_test("blue.png?id=async_xhr", "xmlhttprequest", "an asynchronous XmlHTTPRequest");
+  initiator_type_test("child.js", "script", "script imported from another script");
 </script>
 </body>
 </html>

--- a/resource-timing/resources/child_script.js
+++ b/resource-timing/resources/child_script.js
@@ -1,0 +1,1 @@
+console.log('i was loaded!');

--- a/resource-timing/resources/child_script.js
+++ b/resource-timing/resources/child_script.js
@@ -1,1 +1,1 @@
-console.log('i was loaded!');
+

--- a/resource-timing/resources/parent_script.js
+++ b/resource-timing/resources/parent_script.js
@@ -1,0 +1,1 @@
+import './child.js';


### PR DESCRIPTION
Adding this test as we've discovered a difference in browser engines reporting `initiatorType` when importing a module from another module. I expected `script` and Safari and Firefox agree but Chrome seems to report `other`.

I've filed a chromium bug here: https://issues.chromium.org/issues/330743876