### PR TITLE
[webaudio] Fix AudioDestinationNode asserting numberOfOutputs = 1

### DIFF
--- a/webaudio/the-audio-api/the-audionode-interface/audionode.html
+++ b/webaudio/the-audio-api/the-audionode-interface/audionode.html
@@ -41,7 +41,7 @@
             should(
                 context.destination.numberOfOutputs,
                 'AudioContext.destination.numberOfOutputs')
-                .beEqualTo(0);
+                .beEqualTo(1);
 
             // Try calling connect() method with illegal values.
             should(


### PR DESCRIPTION
cf. https://webaudio.github.io/web-audio-api/#AudioDestinationNode
related discussion: https://github.com/WebAudio/web-audio-api/issues/2578