### PR TITLE
Don't update row baseline if cell is empty

### DIFF
--- a/css/CSS2/tables/table-vertical-align-baseline-008.xht
+++ b/css/CSS2/tables/table-vertical-align-baseline-008.xht
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Test: Test for baseline alignment of table cells</title>
+  <link rel="author" title="Oriol Brufau" href="obrufau@igalia.com" />
+  <link rel="help" href="https://github.com/servo/servo/issues/31722" />
+  <link rel="help" href="https://drafts.csswg.org/css2/#height-layout" />
+  <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
+  <meta name="assert" content="Since the cell is empty, the baseline of the row
+      is synthesized from the bottom content edge of the cell." />
+  <style><![CDATA[
+  .wrapper { float: left; font-size: 0; background: red }
+  .wrapper > * { width: 50px; height: 100px; background: green }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div class="wrapper">
+    <div style="display: inline-block"></div>
+    <table style="display: inline-table; border-spacing: 0">
+      <td style="vertical-align: baseline; padding: 0"></td>
+    </table>
+  </div>
+ </body>
+</html>


### PR DESCRIPTION
Gecko, Blink and WebKit agree that the if a row only has empty cells, its baseline should be at the bottom, not at the top.

There isn't interoperability when the cells are just empty-ish, so this patch takes the simplest approach, aligning with Blink: any out-of-flow or in-flow content other than collapsed whitespace counts as not empty.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#31831