### PR TITLE
Pass a Chrome flag to ignore FedCM well-known files

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -97,6 +97,9 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     chrome_options["args"].append("--use-fake-ui-for-media-stream")
     # Use a fake UI for FedCM to allow testing it.
     chrome_options["args"].append("--use-fake-ui-for-fedcm")
+    # This is needed until https://github.com/web-platform-tests/wpt/pull/40709
+    # is merged.
+    chrome_options["args"].append("--enable-features=FedCmWithoutWellKnownEnforcement")
     # Use a fake UI for digital identity to allow testing it.
     chrome_options["args"].append("--use-fake-ui-for-digital-identity")
     # Shorten delay for Reporting <https://w3c.github.io/reporting/>.


### PR DESCRIPTION
This is needed to make the tests work until the PAC support is fixed for HTTPS URLs.