### PR TITLE
Pick the first or last baseline as appropriate

### DIFF
--- a/css/CSS2/tables/table-vertical-align-baseline-009.xht
+++ b/css/CSS2/tables/table-vertical-align-baseline-009.xht
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Test: Test for baseline alignment of table cells</title>
+  <link rel="author" title="Oriol Brufau" href="obrufau@igalia.com" />
+  <link rel="help" href="https://github.com/servo/servo/issues/31651" />
+  <link rel="help" href="https://drafts.csswg.org/css2/#height-layout" />
+  <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
+  <meta name="assert" content="The baseline of the table should be aligned with the baseline of the cell in the first row." />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <style><![CDATA[
+    span {
+      font: 50px/1 Ahem;
+      color: green;
+    }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div style="float: left; position: relative; font-size: 0; background: red">
+    <span style="position: absolute; left: 0; bottom: 0">X</span>
+    <span>X</span>
+    <span style="display: inline-table">
+      <span style="display: table-row">X</span>
+      <span style="display: table-row">X</span>
+    </span>
+  </div>
+ </body>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The old logic was always picking the last baseline, but this should only happen for inline-blocks.

Since replaced elements and flex containers aren't currently setting their baselines, this is only an improvement for inline-tables.

Reviewed in servo/servo#31705