### PR TITLE
layout: Allow transforming inline replaced elements

### DIFF
--- a/css/css-transforms/support/transform-iframe-002-contents.html
+++ b/css/css-transforms/support/transform-iframe-002-contents.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Iframe (contents)</title>
+    <link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+    <style>
+        body {
+            background: green;
+        }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>

--- a/css/css-transforms/transform-iframe-002.html
+++ b/css/css-transforms/transform-iframe-002.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Iframe</title>
+    <link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-rendering">
+    <meta name="assert" content="This test ensures that an iframe element can be transformed.">
+    <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+    <style>
+      iframe {
+        height: 50px;
+        width: 50px;
+        transform: translate(25px, 25px) scale(2, 2);
+        border: none;
+      }
+    </style>
+    <p>Test passes if there is a filled green square.</p>
+    <iframe src="support/transform-iframe-002-contents.html"></iframe>
+  </body>
+</html>


### PR DESCRIPTION
This requires passing through information about whether or not the
element in question is replaced when checking to see if it's
transformable and transitively all functions that make decisions about
containing blocks. A new FragmentFlag is added to help track this -- it
will be set on both the replaced items BoxFragment container as well as
the Fragment for the replaced item itself.

Fixes #<!-- nolink -->31806.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#31833