### PR TITLE
screen wake lock: Set "allow" attribute in more Permissions Policy tests

### DIFF
--- a/screen-wake-lock/wakelock-disabled-by-permissions-policy.https.html
+++ b/screen-wake-lock/wakelock-disabled-by-permissions-policy.https.html
@@ -25,7 +25,8 @@
       'navigator.wakeLock.request("screen")',
       t,
       same_origin_src,
-      expect_feature_unavailable_default
+      expect_feature_unavailable_default,
+      'screen-wake-lock',
     );
   }, `${header} disallows same-origin iframes.`);
 
@@ -34,7 +35,8 @@
       'navigator.wakeLock.request("screen")',
       t,
       cross_origin_src,
-      expect_feature_unavailable_default
+      expect_feature_unavailable_default,
+      'screen-wake-lock'
     );
   }, `${header} disallows cross-origin iframes.`);
 </script>

--- a/screen-wake-lock/wakelock-enabled-on-self-origin-by-permissions-policy.https.html
+++ b/screen-wake-lock/wakelock-enabled-on-self-origin-by-permissions-policy.https.html
@@ -37,7 +37,8 @@
       'navigator.wakeLock.request("screen")',
       t,
       cross_origin_src,
-      expect_feature_unavailable_default
+      expect_feature_unavailable_default,
+      'screen-wake-lock'
     );
   }, `${header} disallows cross-origin iframes.`);
 </script>


### PR DESCRIPTION
Contrary to the old Feature Policy spec, in the Permissions Policy both the
header and the "allow" attribute are checked, and even when the header
access to a given feature it might still fail if the "allow" attribute is
not set accordingly (it defaults to "src").

In the tests being changed here, we explicitly set the attribute to make
sure that the Permissions Policy checks are failing because of the header
values, not because of a lack of an "allow" attribute that would have
otherwise permitted access to the feature.
