### PR TITLE
[css-color] color-mix, relative colors and missing components interaction

### DIFF
--- a/css/css-color/color-mix-currentcolor-004-ref.html
+++ b/css/css-color/color-mix-currentcolor-004-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: currentColor is inherited correctly in color-mix()</title>
+<style>
+div {
+    color: color(srgb 0.25 0.75 0.25);
+}
+</style>
+<div>
+    <div>This text should be pale green</div>
+</div>

--- a/css/css-color/color-mix-currentcolor-004.html
+++ b/css/css-color/color-mix-currentcolor-004.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="match" href="color-mix-currentcolor-004-ref.html">
+<title>currentColor with missing components is inherited correctly in color-mix()</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-5/#color-mix">
+<link rel="author" title="Romain Menke" href="https://github.com/romainmenke">
+<style>
+body {
+    color: hsl(none 50% 50%);
+}
+div {
+    color: color-mix(in hsl, currentColor 50%, hsl(120deg 50% 50%));
+}
+div > div {
+    color: inherit;
+}
+</style>
+<div>
+    <div>This text should be green</div>
+</div>

--- a/css/css-color/color-mix-currentcolor-005-ref.html
+++ b/css/css-color/color-mix-currentcolor-005-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: currentColor is inherited correctly in color-mix()</title>
+<style>
+div {
+    color: color(srgb 0.25 0.75 0.25);
+}
+</style>
+<div>
+    <div>This text should be pale green</div>
+</div>

--- a/css/css-color/color-mix-currentcolor-005.html
+++ b/css/css-color/color-mix-currentcolor-005.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="match" href="color-mix-currentcolor-005-ref.html">
+<title>currentColor with missing components is inherited correctly in color-mix()</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-5/#color-mix">
+<link rel="author" title="Romain Menke" href="https://github.com/romainmenke">
+<style>
+body {
+    color: hsl(from hsl(0deg 50% 50%) none s l);
+}
+div {
+    color: color-mix(in hsl, currentColor 50%, hsl(120deg 50% 50%));
+}
+div > div {
+    color: inherit;
+}
+</style>
+<div>
+    <div>This text should be green</div>
+</div>


### PR DESCRIPTION
`none` defined in absolute or relative syntax is expected to result in missing components.

Chromium and Webkit do not agree here:  https://codepen.io/romainmenke/pen/YzMxemX

Seems that Chromium is converting any inputs to number/percentage in relative color and isn't preserving `none`.