### PR TITLE
[FedCM] Pass the button to click_fedcm_dialog_button

### DIFF
--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -319,7 +319,7 @@ class ClickFedCMDialogButtonAction:
     def __call__(self, payload):
         dialog_button = payload["dialog_button"]
         self.logger.debug(f"Clicking FedCM dialog button: {dialog_button}")
-        return self.protocol.fedcm.click_fedcm_dialog_button()
+        return self.protocol.fedcm.click_fedcm_dialog_button(dialog_button)
 
 class SelectFedCMAccountAction:
     name = "select_fedcm_account"


### PR DESCRIPTION
This was caused by f3d1eb9c1787cf2276ea867b7fda2622b9835c13

Should fix this test:
https://wpt.fyi/results/credential-management/fedcm-login-status/confirm-idp-login.https.html?label=experimental&label=master