### PR TITLE
[wasm] esm integration test updates

### DIFF
--- a/wasm/jsapi/module/moduleSource.tentative.any.js
+++ b/wasm/jsapi/module/moduleSource.tentative.any.js
@@ -9,6 +9,9 @@ setup(() => {
 
 test(() => {
   assert_equals(typeof AbstractModuleSource, "undefined");
+}, "AbstractModuleSource is not a global");
+
+test(() => {
   const AbstractModuleSource = Object.getPrototypeOf(WebAssembly.Module);
   assert_equals(AbstractModuleSource.name, "AbstractModuleSource");
   assert_not_equals(AbstractModuleSource, Function);
@@ -16,22 +19,13 @@ test(() => {
 
 test(() => {
   const AbstractModuleSourceProto = Object.getPrototypeOf(WebAssembly.Module.prototype);
-  assert_not_equals(AbstractModuleSourceProto, Object);
+  assert_not_equals(AbstractModuleSourceProto, Object.prototype);
   const AbstractModuleSource = Object.getPrototypeOf(WebAssembly.Module);
   assert_equals(AbstractModuleSource.prototype, AbstractModuleSourceProto);
 }, "AbstractModuleSourceProto intrinsic");
 
 test(() => {
-  const builder = new WasmModuleBuilder();
-
-  builder
-    .addFunction("fn", kSig_v_v)
-    .addBody([])
-    .exportFunc();
-  builder.addMemory(0, 256, true);
-
-  const buffer = builder.toBuffer()
-  const module = new WebAssembly.Module(buffer);
+  const module = new WebAssembly.Module(emptyModuleBinary);
 
   const AbstractModuleSource = Object.getPrototypeOf(WebAssembly.Module);
   const toStringTag = Object.getOwnPropertyDescriptor(AbstractModuleSource.prototype, Symbol.toStringTag).get;

--- a/wasm/webapi/esm-integration/resources/worker-source-phase.js
+++ b/wasm/webapi/esm-integration/resources/worker-source-phase.js
@@ -1,3 +1,10 @@
 import source modSource from "./worker.wasm";
+import { pm } from "./worker-helper.js";
 assert_true(modSource instanceof WebAssembly.Module);
 assert_true(await import.source("./worker.wasm") === modSource);
+
+await WebAssembly.instantiate(modSource, {
+  "./worker-helper.js": {
+    "pm": pm
+  }
+});

--- a/wasm/webapi/esm-integration/script-src-allows-wasm.tentative.html
+++ b/wasm/webapi/esm-integration/script-src-allows-wasm.tentative.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>script-src allows Wasm execution</title>
+<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline';">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    setup({allow_uncaught_exception: true});
+
+    const test_load = async_test(
+        "Importing a WebAssembly module should be allowed by script-src CSP.");
+
+    window.log = [];
+    document.addEventListener("securitypolicyviolation", (e) => {
+      window.log.push(e.violatedDirective);
+    });
+
+    window.addEventListener("load", test_load.step_func_done(ev => {
+      assert_array_equals(log, ["executed"]);
+    }));
+</script>
+<script type="module" src="./resources/execute-start.wasm"></script>

--- a/wasm/webapi/esm-integration/script-src-blocks-wasm.tentative.html
+++ b/wasm/webapi/esm-integration/script-src-blocks-wasm.tentative.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>script-src blocks Wasm execution</title>
+<meta http-equiv="Content-Security-Policy" content="script-src 'unsafe-inline';">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    setup({allow_uncaught_exception: true});
+
+    const test_load = async_test(
+        "Importing a WebAssembly module should be guarded by script-src CSP.");
+
+    window.log = [];
+    document.addEventListener("securitypolicyviolation", (e) => {
+      window.log.push(e.violatedDirective);
+    });
+
+    window.addEventListener("load", test_load.step_func_done(ev => {
+      assert_array_equals(log, ["script-src"]);
+    }));
+</script>
+<script type="module" src="./resources/execute-start.wasm"></script>

--- a/wasm/webapi/esm-integration/script-src-blocks-wasm.tentative.html
+++ b/wasm/webapi/esm-integration/script-src-blocks-wasm.tentative.html
@@ -15,7 +15,7 @@
     });
 
     window.addEventListener("load", test_load.step_func_done(ev => {
-      assert_array_equals(log, ["script-src"]);
+      assert_array_equals(log, ["script-src-elem"]);
     }));
 </script>
 <script type="module" src="./resources/execute-start.wasm"></script>

--- a/wasm/webapi/esm-integration/source-phase.tentative.html
+++ b/wasm/webapi/esm-integration/source-phase.tentative.html
@@ -13,7 +13,7 @@ const AbstractModuleSource = Object.getPrototypeOf(WebAssembly.Module);
 assert_equals(AbstractModuleSource.name, "AbstractModuleSource");
 assert_true(exportedNamesSource instanceof AbstractModuleSource);
 
-assert_array_equals(WebAssembly.Module.exports(exportedNamesSource).sort(),
+assert_array_equals(WebAssembly.Module.exports(exportedNamesSource).map(({ name }) => name).sort(),
                     ["func", "glob", "mem", "tab"]);
 
 const wasmImportFromWasmSource = await import.source("./resources/wasm-import-from-wasm.wasm");

--- a/wasm/webapi/esm-integration/worker-import-source-phase.tentative.html
+++ b/wasm/webapi/esm-integration/worker-import-source-phase.tentative.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>Testing import of WebAssembly source phase from JavaScript worker</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script type=module>
+setup({ single_test: true });
+const worker = new Worker("resources/worker-source-phase.js", { type: "module" });
+worker.onmessage = (msg) => {
+  assert_equals(msg.data, 42);
+  done();
+}
+</script>


### PR DESCRIPTION
Implementation fixes and follow up on the previous test cases for the ESM Integration source phase imports that were added in https://github.com/web-platform-tests/wpt/pull/42467.

* Fixes the global test to not throw a TDZ error
* Fixes the negation test that `WebAssembly.Module` is not `Object.prototype`
* Fixes the sample Wasm to use the empty Wasm binary instead of another constructed binary
* Fixes the `WebAssembly.Module.exports` test to map the name field before asserting
* Adds the worker test entry point instead of treating it as inaccessible.
* Adds esm-integration script-src verification tests for both permitting and denying Wasm modules through CSP.