### PR TITLE
Update servo's testharnessreport

### DIFF
--- a/tools/wptrunner/wptrunner/testharnessreport-servo.js
+++ b/tools/wptrunner/wptrunner/testharnessreport-servo.js
@@ -1,4 +1,9 @@
-var props = {output:%(output)d, debug: %(debug)s};
+var props = {
+    output:%(output)d,
+    timeout_multiplier: %(timeout_multiplier)s,
+    explicit_timeout: %(explicit_timeout)s,
+    debug: %(debug)s
+};
 var start_loc = document.createElement('a');
 start_loc.href = location.href;
 setup(props);


### PR DESCRIPTION
Update servo's testharnessreport to include new props as in [general testharnessreport](https://github.com/web-platform-tests/wpt/blob/d6c9b797f371f92fb23681150148e9ec81a63510/tools/wptrunner/wptrunner/testharnessreport.js#L73).

This makes `--timeout-multiplier` actually work.


Reviewed in servo/servo#31920