### PR TITLE
Add right-to-left and top-to-bottom tests for text-wrap: balance

### DIFF
--- a/css/css-text/white-space/text-wrap-balance-right-to-left.html
+++ b/css/css-text/white-space/text-wrap-balance-right-to-left.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#text-wrap">
+<meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#container {
+  width: 20ch;
+}
+.balance {
+  text-wrap: balance;
+}
+</style>
+<div id="container" dir="rtl" lang="AR"></div>
+<script>
+const container = document.getElementById('container');
+for (const text of [
+    'ينبغي تحقيق التوازن',
+    'يجب ألا تؤدي موازنة التفاف النص إلى تغيير عدد الأسطر',
+    'يجب ألا تؤدي موازنة التفاف النص إلى تغيير عدد الأسطر لهذه الفقرة النصية',
+  ]) {
+  const normal = document.createElement('div');
+  const balance = document.createElement('div');
+  normal.textContent = text;
+  balance.textContent = text;
+  balance.classList.add('balance');
+  container.appendChild(normal);
+  container.appendChild(balance);
+  test(() => {
+    assert_equals(normal.offsetHeight, balance.offsetHeight);
+  });
+}
+</script>

--- a/css/css-text/white-space/text-wrap-balance-right-to-left.html
+++ b/css/css-text/white-space/text-wrap-balance-right-to-left.html
@@ -29,6 +29,6 @@ for (const text of [
   container.appendChild(balance);
   test(() => {
     assert_equals(normal.offsetHeight, balance.offsetHeight);
-  }, "Ensure the number lines are the same.");
+  });
 }
 </script>

--- a/css/css-text/white-space/text-wrap-balance-right-to-left.html
+++ b/css/css-text/white-space/text-wrap-balance-right-to-left.html
@@ -29,6 +29,6 @@ for (const text of [
   container.appendChild(balance);
   test(() => {
     assert_equals(normal.offsetHeight, balance.offsetHeight);
-  });
+  }, "Ensure the number lines are the same.");
 }
 </script>

--- a/css/css-text/white-space/text-wrap-balance-top-to-bottom.html
+++ b/css/css-text/white-space/text-wrap-balance-top-to-bottom.html
@@ -30,6 +30,6 @@ for (const text of [
   container.appendChild(balance);
   test(() => {
     assert_equals(normal.offsetHeight, balance.offsetHeight);
-  }, "Ensure the number lines are the same.");
+  });
 }
 </script>

--- a/css/css-text/white-space/text-wrap-balance-top-to-bottom.html
+++ b/css/css-text/white-space/text-wrap-balance-top-to-bottom.html
@@ -30,6 +30,6 @@ for (const text of [
   container.appendChild(balance);
   test(() => {
     assert_equals(normal.offsetHeight, balance.offsetHeight);
-  });
+  }, "Ensure the number lines are the same.");
 }
 </script>

--- a/css/css-text/white-space/text-wrap-balance-top-to-bottom.html
+++ b/css/css-text/white-space/text-wrap-balance-top-to-bottom.html
@@ -29,7 +29,7 @@ for (const text of [
   container.appendChild(normal);
   container.appendChild(balance);
   test(() => {
-    assert_equals(normal.offsetHeight, balance.offsetHeight);
+    assert_equals(normal.offsetWidth, balance.offsetWidth);
   });
 }
 </script>

--- a/css/css-text/white-space/text-wrap-balance-top-to-bottom.html
+++ b/css/css-text/white-space/text-wrap-balance-top-to-bottom.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#text-wrap">
+<meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#container {
+  height: 15ch;
+  writing-mode: vertical-rl;
+}
+.balance {
+  text-wrap: balance;
+}
+</style>
+<div id="container"></div>
+<script>
+const container = document.getElementById('container');
+for (const text of [
+    '平衡应该',
+    '平衡文本换行不应改变行数',
+    '平衡文本换行不应改变该文本段落的行数',
+  ]) {
+  const normal = document.createElement('div');
+  const balance = document.createElement('div');
+  normal.textContent = text;
+  balance.textContent = text;
+  balance.classList.add('balance');
+  container.appendChild(normal);
+  container.appendChild(balance);
+  test(() => {
+    assert_equals(normal.offsetHeight, balance.offsetHeight);
+  });
+}
+</script>


### PR DESCRIPTION
Inspired from text-wrap-balance-001.html, I changed the array elements to be Arabic (right-to-left) and Chinese (top-to-bottom, right-to-left) characters to support testing for non-English characters.