### PR TITLE
Add HTMLString dependency for idlharness.js tests

### DIFF
--- a/html/dom/idlharness.https.html
+++ b/html/dom/idlharness.https.html
@@ -38,7 +38,7 @@ const waitForLoad = new Promise(resolve => { addEventListener('load', resolve); 
 
 idl_test(
   ['html'],
-  ['wai-aria', 'SVG', 'cssom', 'touch-events', 'uievents', 'dom', 'xhr', 'FileAPI', 'mediacapture-streams', 'performance-timeline'],
+  ['wai-aria', 'SVG', 'cssom', 'touch-events', 'uievents', 'dom', 'xhr', 'FileAPI', 'mediacapture-streams', 'performance-timeline', 'trusted-types'],
   async idlArray => {
     self.documentWithHandlers = new Document();
     const handler = function(e) {};


### PR DESCRIPTION
This seems necessary for #45297.