### PR TITLE
orientation-event: Add Permissions Policy integration tests

### DIFF
--- a/orientation-event/motion/permissions-policy/devicemotion-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
+++ b/orientation-event/motion/permissions-policy/devicemotion-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
@@ -52,6 +52,6 @@ promise_test(async t => {
     'NO-EVENT',
     "accelerometer; gyroscope",
   );
-}, `"allow" disallows allows cross-origin navigantion in an iframe`);
+}, `"allow" disallows cross-origin navigation in an iframe`);
 </script>
 </body>

--- a/orientation-event/motion/permissions-policy/devicemotion-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
+++ b/orientation-event/motion/permissions-policy/devicemotion-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
@@ -34,7 +34,7 @@ promise_test(async t => {
     JSON.stringify(motionData),
     "accelerometer; gyroscope",
   );
-}, `"allow" attribute allows same-origin navigantion in an iframe`);
+}, `"allow" attribute allows same-origin navigation in an iframe`);
 
 promise_test(async t => {
   const helper = new SensorTestHelper(t, 'devicemotion');

--- a/orientation-event/motion/permissions-policy/devicemotion-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
+++ b/orientation-event/motion/permissions-policy/devicemotion-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/orientation-event.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../../resources/orientation-event-helpers.js"></script>
+<script>
+"use strict";
+
+const relative_path =
+  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=devicemotion";
+const base_src = "/permissions-policy/resources/redirect-on-load.html#";
+const same_origin_src = base_src + relative_path;
+const cross_origin_src =
+  base_src + get_host_info().HTTPS_REMOTE_ORIGIN + relative_path;
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'devicemotion');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const motionData = generateMotionData(1, 2, 3,
+                                        4, 5, 6,
+                                        7, 8, 9);
+  await helper.setData(motionData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    same_origin_src,
+    JSON.stringify(motionData),
+    "accelerometer; gyroscope",
+  );
+}, `"allow" attribute allows same-origin navigantion in an iframe`);
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'devicemotion');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const motionData = generateMotionData(1, 2, 3,
+                                        4, 5, 6,
+                                        7, 8, 9);
+  await helper.setData(motionData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    cross_origin_src,
+    'NO-EVENT',
+    "accelerometer; gyroscope",
+  );
+}, `"allow" disallows allows cross-origin navigantion in an iframe`);
+</script>
+</body>

--- a/orientation-event/motion/permissions-policy/devicemotion-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
+++ b/orientation-event/motion/permissions-policy/devicemotion-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
@@ -1,57 +1,53 @@
 <!DOCTYPE html>
 <body>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
-<script src="/permissions-policy/resources/orientation-event.js"></script>
-<script src="/permissions-policy/resources/permissions-policy.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="../../resources/orientation-event-helpers.js"></script>
-<script>
-"use strict";
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/permissions-policy/resources/orientation-event.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script src="/common/get-host-info.sub.js"></script>
+  <script src="../../resources/orientation-event-helpers.js"></script>
+  <script>
+    "use strict";
 
-const relative_path =
-  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=devicemotion";
-const base_src = "/permissions-policy/resources/redirect-on-load.html#";
-const same_origin_src = base_src + relative_path;
-const cross_origin_src =
-  base_src + get_host_info().HTTPS_REMOTE_ORIGIN + relative_path;
+    const relative_path =
+      "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=devicemotion";
+    const base_src = "/permissions-policy/resources/redirect-on-load.html#";
+    const same_origin_src = base_src + relative_path;
+    const cross_origin_src =
+      base_src + get_host_info().HTTPS_REMOTE_ORIGIN + relative_path;
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'devicemotion');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "devicemotion");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const motionData = generateMotionData(1, 2, 3,
-                                        4, 5, 6,
-                                        7, 8, 9);
-  await helper.setData(motionData);
+      const motionData = generateMotionData(1, 2, 3, 4, 5, 6, 7, 8, 9);
+      await helper.setData(motionData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    same_origin_src,
-    JSON.stringify(motionData),
-    "accelerometer; gyroscope",
-  );
-}, `"allow" attribute allows same-origin navigation in an iframe`);
+      return test_feature_availability_with_post_message_result(
+        t,
+        same_origin_src,
+        JSON.stringify(motionData),
+        "accelerometer; gyroscope"
+      );
+    }, `"allow" attribute allows same-origin navigation in an iframe`);
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'devicemotion');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "devicemotion");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const motionData = generateMotionData(1, 2, 3,
-                                        4, 5, 6,
-                                        7, 8, 9);
-  await helper.setData(motionData);
+      const motionData = generateMotionData(1, 2, 3, 4, 5, 6, 7, 8, 9);
+      await helper.setData(motionData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    cross_origin_src,
-    'NO-EVENT',
-    "accelerometer; gyroscope",
-  );
-}, `"allow" disallows cross-origin navigation in an iframe`);
-</script>
+      return test_feature_availability_with_post_message_result(
+        t,
+        cross_origin_src,
+        "NO-EVENT",
+        "accelerometer; gyroscope"
+      );
+    }, `"allow" disallows cross-origin navigation in an iframe`);
+  </script>
 </body>

--- a/orientation-event/motion/permissions-policy/devicemotion-allowed-by-permissions-policy-attribute.https.html
+++ b/orientation-event/motion/permissions-policy/devicemotion-allowed-by-permissions-policy-attribute.https.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/orientation-event.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../../resources/orientation-event-helpers.js"></script>
+<script>
+"use strict";
+
+const same_origin_src =
+  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=devicemotion";
+const cross_origin_src =
+  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'devicemotion');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const motionData = generateMotionData(1, 2, 3,
+                                        4, 5, 6,
+                                        7, 8, 9);
+  await helper.setData(motionData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    same_origin_src,
+    'NO-EVENT',
+    "accelerometer 'none'; gyroscope 'none'",
+  );
+}, `Device Motion can be disabled in same-origin iframes using "allow" attribute`);
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'devicemotion');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const motionData = generateMotionData(1, 2, 3,
+                                        4, 5, 6,
+                                        7, 8, 9);
+  await helper.setData(motionData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    cross_origin_src,
+    JSON.stringify(motionData),
+    "accelerometer; gyroscope",
+  );
+}, `Device Motion can be enabled in cross-origin iframes using "allow" attribute`);
+</script>
+</body>

--- a/orientation-event/motion/permissions-policy/devicemotion-allowed-by-permissions-policy-attribute.https.html
+++ b/orientation-event/motion/permissions-policy/devicemotion-allowed-by-permissions-policy-attribute.https.html
@@ -1,55 +1,51 @@
 <!DOCTYPE html>
 <body>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
-<script src="/permissions-policy/resources/orientation-event.js"></script>
-<script src="/permissions-policy/resources/permissions-policy.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="../../resources/orientation-event-helpers.js"></script>
-<script>
-"use strict";
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/permissions-policy/resources/orientation-event.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script src="/common/get-host-info.sub.js"></script>
+  <script src="../../resources/orientation-event-helpers.js"></script>
+  <script>
+    "use strict";
 
-const same_origin_src =
-  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=devicemotion";
-const cross_origin_src =
-  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+    const same_origin_src =
+      "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=devicemotion";
+    const cross_origin_src =
+      get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'devicemotion');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "devicemotion");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const motionData = generateMotionData(1, 2, 3,
-                                        4, 5, 6,
-                                        7, 8, 9);
-  await helper.setData(motionData);
+      const motionData = generateMotionData(1, 2, 3, 4, 5, 6, 7, 8, 9);
+      await helper.setData(motionData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    same_origin_src,
-    'NO-EVENT',
-    "accelerometer 'none'; gyroscope 'none'",
-  );
-}, `Device Motion can be disabled in same-origin iframes using "allow" attribute`);
+      return test_feature_availability_with_post_message_result(
+        t,
+        same_origin_src,
+        "NO-EVENT",
+        "accelerometer 'none'; gyroscope 'none'"
+      );
+    }, `Device Motion can be disabled in same-origin iframes using "allow" attribute`);
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'devicemotion');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "devicemotion");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const motionData = generateMotionData(1, 2, 3,
-                                        4, 5, 6,
-                                        7, 8, 9);
-  await helper.setData(motionData);
+      const motionData = generateMotionData(1, 2, 3, 4, 5, 6, 7, 8, 9);
+      await helper.setData(motionData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    cross_origin_src,
-    JSON.stringify(motionData),
-    "accelerometer; gyroscope",
-  );
-}, `Device Motion can be enabled in cross-origin iframes using "allow" attribute`);
-</script>
+      return test_feature_availability_with_post_message_result(
+        t,
+        cross_origin_src,
+        JSON.stringify(motionData),
+        "accelerometer; gyroscope"
+      );
+    }, `Device Motion can be enabled in cross-origin iframes using "allow" attribute`);
+  </script>
 </body>

--- a/orientation-event/motion/permissions-policy/devicemotion-disabled-by-permissions-policy.https.html
+++ b/orientation-event/motion/permissions-policy/devicemotion-disabled-by-permissions-policy.https.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<body>
+<meta name=timeout content=long> <!-- This test wais for several timeouts -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/orientation-event.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../../resources/orientation-event-helpers.js"></script>
+<script>
+"use strict";
+
+const same_origin_src =
+  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=devicemotion";
+const cross_origin_src =
+  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+
+const header = 'Permissions-Policy header "accelerometer=(), gyroscope=()"';
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'devicemotion');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const motionData = generateMotionData(1, 2, 3,
+                                        4, 5, 6,
+                                        7, 8, 9);
+  await helper.setData(motionData);
+
+  assert_equals(await waitForOrientationEvent('devicemotion'), 'NO-EVENT');
+}, '${header} disallows the top-level document');
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'devicemotion');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const motionData = generateMotionData(1, 2, 3,
+                                        4, 5, 6,
+                                        7, 8, 9);
+  await helper.setData(motionData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    same_origin_src,
+    'NO-EVENT',
+  );
+}, `${header} disallows same-origin iframes.`);
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'devicemotion');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const motionData = generateMotionData(1, 2, 3,
+                                        4, 5, 6,
+                                        7, 8, 9);
+  await helper.setData(motionData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    cross_origin_src,
+    'NO-EVENT',
+  );
+}, `${header} disallows cross-origin iframes.`);
+</script>
+</body>

--- a/orientation-event/motion/permissions-policy/devicemotion-disabled-by-permissions-policy.https.html
+++ b/orientation-event/motion/permissions-policy/devicemotion-disabled-by-permissions-policy.https.html
@@ -1,69 +1,64 @@
 <!DOCTYPE html>
 <body>
-<meta name=timeout content=long> <!-- This test wais for several timeouts -->
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
-<script src="/permissions-policy/resources/orientation-event.js"></script>
-<script src="/permissions-policy/resources/permissions-policy.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="../../resources/orientation-event-helpers.js"></script>
-<script>
-"use strict";
+  <meta name="timeout" content="long" />
+  <!-- This test wais for several timeouts -->
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/permissions-policy/resources/orientation-event.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script src="/common/get-host-info.sub.js"></script>
+  <script src="../../resources/orientation-event-helpers.js"></script>
+  <script>
+    "use strict";
 
-const same_origin_src =
-  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=devicemotion";
-const cross_origin_src =
-  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+    const same_origin_src =
+      "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=devicemotion";
+    const cross_origin_src =
+      get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
-const header = 'Permissions-Policy header "accelerometer=(), gyroscope=()"';
+    const header = 'Permissions-Policy header "accelerometer=(), gyroscope=()"';
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'devicemotion');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "devicemotion");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const motionData = generateMotionData(1, 2, 3,
-                                        4, 5, 6,
-                                        7, 8, 9);
-  await helper.setData(motionData);
+      const motionData = generateMotionData(1, 2, 3, 4, 5, 6, 7, 8, 9);
+      await helper.setData(motionData);
 
-  assert_equals(await waitForOrientationEvent('devicemotion'), 'NO-EVENT');
-}, '${header} disallows the top-level document');
+      assert_equals(await waitForOrientationEvent("devicemotion"), "NO-EVENT");
+    }, "${header} disallows the top-level document");
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'devicemotion');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "devicemotion");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const motionData = generateMotionData(1, 2, 3,
-                                        4, 5, 6,
-                                        7, 8, 9);
-  await helper.setData(motionData);
+      const motionData = generateMotionData(1, 2, 3, 4, 5, 6, 7, 8, 9);
+      await helper.setData(motionData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    same_origin_src,
-    'NO-EVENT',
-  );
-}, `${header} disallows same-origin iframes.`);
+      return test_feature_availability_with_post_message_result(
+        t,
+        same_origin_src,
+        "NO-EVENT"
+      );
+    }, `${header} disallows same-origin iframes.`);
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'devicemotion');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "devicemotion");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const motionData = generateMotionData(1, 2, 3,
-                                        4, 5, 6,
-                                        7, 8, 9);
-  await helper.setData(motionData);
+      const motionData = generateMotionData(1, 2, 3, 4, 5, 6, 7, 8, 9);
+      await helper.setData(motionData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    cross_origin_src,
-    'NO-EVENT',
-  );
-}, `${header} disallows cross-origin iframes.`);
-</script>
+      return test_feature_availability_with_post_message_result(
+        t,
+        cross_origin_src,
+        "NO-EVENT"
+      );
+    }, `${header} disallows cross-origin iframes.`);
+  </script>
 </body>

--- a/orientation-event/motion/permissions-policy/devicemotion-disabled-by-permissions-policy.https.html.headers
+++ b/orientation-event/motion/permissions-policy/devicemotion-disabled-by-permissions-policy.https.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: accelerometer=(), gyroscope=()

--- a/orientation-event/motion/permissions-policy/devicemotion-enabled-by-permissions-policy.https.html
+++ b/orientation-event/motion/permissions-policy/devicemotion-enabled-by-permissions-policy.https.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/orientation-event.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../../resources/orientation-event-helpers.js"></script>
+<script>
+"use strict";
+
+const same_origin_src =
+  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=devicemotion";
+const cross_origin_src =
+  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+
+const header = 'Permissions-Policy header "accelerometer=*, gyroscope=*"';
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'devicemotion');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const motionData = generateMotionData(1, 2, 3,
+                                        4, 5, 6,
+                                        7, 8, 9);
+  await helper.setData(motionData);
+
+  assert_equals(await waitForOrientationEvent('devicemotion'),
+                JSON.stringify(motionData));
+}, '${header} allows the top-level document');
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'devicemotion');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const motionData = generateMotionData(1, 2, 3,
+                                        4, 5, 6,
+                                        7, 8, 9);
+  await helper.setData(motionData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    same_origin_src,
+    JSON.stringify(motionData),
+  );
+}, `${header} allows same-origin iframes.`);
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'devicemotion');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const motionData = generateMotionData(1, 2, 3,
+                                        4, 5, 6,
+                                        7, 8, 9);
+  await helper.setData(motionData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    cross_origin_src,
+    JSON.stringify(motionData),
+    'accelerometer; gyroscope',
+  );
+}, `${header} allows cross-origin iframes.`);
+</script>
+</body>

--- a/orientation-event/motion/permissions-policy/devicemotion-enabled-by-permissions-policy.https.html
+++ b/orientation-event/motion/permissions-policy/devicemotion-enabled-by-permissions-policy.https.html
@@ -1,70 +1,66 @@
 <!DOCTYPE html>
 <body>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
-<script src="/permissions-policy/resources/orientation-event.js"></script>
-<script src="/permissions-policy/resources/permissions-policy.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="../../resources/orientation-event-helpers.js"></script>
-<script>
-"use strict";
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/permissions-policy/resources/orientation-event.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script src="/common/get-host-info.sub.js"></script>
+  <script src="../../resources/orientation-event-helpers.js"></script>
+  <script>
+    "use strict";
 
-const same_origin_src =
-  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=devicemotion";
-const cross_origin_src =
-  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+    const same_origin_src =
+      "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=devicemotion";
+    const cross_origin_src =
+      get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
-const header = 'Permissions-Policy header "accelerometer=*, gyroscope=*"';
+    const header = 'Permissions-Policy header "accelerometer=*, gyroscope=*"';
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'devicemotion');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "devicemotion");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const motionData = generateMotionData(1, 2, 3,
-                                        4, 5, 6,
-                                        7, 8, 9);
-  await helper.setData(motionData);
+      const motionData = generateMotionData(1, 2, 3, 4, 5, 6, 7, 8, 9);
+      await helper.setData(motionData);
 
-  assert_equals(await waitForOrientationEvent('devicemotion'),
-                JSON.stringify(motionData));
-}, '${header} allows the top-level document');
+      assert_equals(
+        await waitForOrientationEvent("devicemotion"),
+        JSON.stringify(motionData)
+      );
+    }, "${header} allows the top-level document");
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'devicemotion');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "devicemotion");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const motionData = generateMotionData(1, 2, 3,
-                                        4, 5, 6,
-                                        7, 8, 9);
-  await helper.setData(motionData);
+      const motionData = generateMotionData(1, 2, 3, 4, 5, 6, 7, 8, 9);
+      await helper.setData(motionData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    same_origin_src,
-    JSON.stringify(motionData),
-  );
-}, `${header} allows same-origin iframes.`);
+      return test_feature_availability_with_post_message_result(
+        t,
+        same_origin_src,
+        JSON.stringify(motionData)
+      );
+    }, `${header} allows same-origin iframes.`);
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'devicemotion');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "devicemotion");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const motionData = generateMotionData(1, 2, 3,
-                                        4, 5, 6,
-                                        7, 8, 9);
-  await helper.setData(motionData);
+      const motionData = generateMotionData(1, 2, 3, 4, 5, 6, 7, 8, 9);
+      await helper.setData(motionData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    cross_origin_src,
-    JSON.stringify(motionData),
-    'accelerometer; gyroscope',
-  );
-}, `${header} allows cross-origin iframes.`);
-</script>
+      return test_feature_availability_with_post_message_result(
+        t,
+        cross_origin_src,
+        JSON.stringify(motionData),
+        "accelerometer; gyroscope"
+      );
+    }, `${header} allows cross-origin iframes.`);
+  </script>
 </body>

--- a/orientation-event/motion/permissions-policy/devicemotion-enabled-by-permissions-policy.https.html.headers
+++ b/orientation-event/motion/permissions-policy/devicemotion-enabled-by-permissions-policy.https.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: accelerometer=*, gyroscope=*

--- a/orientation-event/motion/permissions-policy/devicemotion-enabled-on-self-origin-by-permissions-policy.https.html
+++ b/orientation-event/motion/permissions-policy/devicemotion-enabled-on-self-origin-by-permissions-policy.https.html
@@ -1,69 +1,66 @@
 <!DOCTYPE html>
 <body>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
-<script src="/permissions-policy/resources/orientation-event.js"></script>
-<script src="/permissions-policy/resources/permissions-policy.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="../../resources/orientation-event-helpers.js"></script>
-<script>
-"use strict";
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/permissions-policy/resources/orientation-event.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script src="/common/get-host-info.sub.js"></script>
+  <script src="../../resources/orientation-event-helpers.js"></script>
+  <script>
+    "use strict";
 
-const same_origin_src =
-  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=devicemotion";
-const cross_origin_src =
-  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+    const same_origin_src =
+      "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=devicemotion";
+    const cross_origin_src =
+      get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
-const header = 'Permissions-Policy header "accelerometer=self, gyroscope=self"';
+    const header =
+      'Permissions-Policy header "accelerometer=self, gyroscope=self"';
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'devicemotion');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "devicemotion");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const motionData = generateMotionData(1, 2, 3,
-                                        4, 5, 6,
-                                        7, 8, 9);
-  await helper.setData(motionData);
+      const motionData = generateMotionData(1, 2, 3, 4, 5, 6, 7, 8, 9);
+      await helper.setData(motionData);
 
-  assert_equals(await waitForOrientationEvent('devicemotion'),
-                JSON.stringify(motionData));
-}, '${header} allows the top-level document');
+      assert_equals(
+        await waitForOrientationEvent("devicemotion"),
+        JSON.stringify(motionData)
+      );
+    }, "${header} allows the top-level document");
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'devicemotion');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "devicemotion");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const motionData = generateMotionData(1, 2, 3,
-                                        4, 5, 6,
-                                        7, 8, 9);
-  await helper.setData(motionData);
+      const motionData = generateMotionData(1, 2, 3, 4, 5, 6, 7, 8, 9);
+      await helper.setData(motionData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    same_origin_src,
-    JSON.stringify(motionData),
-  );
-}, `${header} allows same-origin iframes.`);
+      return test_feature_availability_with_post_message_result(
+        t,
+        same_origin_src,
+        JSON.stringify(motionData)
+      );
+    }, `${header} allows same-origin iframes.`);
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'devicemotion');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "devicemotion");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const motionData = generateMotionData(1, 2, 3,
-                                        4, 5, 6,
-                                        7, 8, 9);
-  await helper.setData(motionData);
+      const motionData = generateMotionData(1, 2, 3, 4, 5, 6, 7, 8, 9);
+      await helper.setData(motionData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    cross_origin_src,
-    'NO-EVENT',
-  );
-}, `${header} disallows cross-origin iframes.`);
-</script>
+      return test_feature_availability_with_post_message_result(
+        t,
+        cross_origin_src,
+        "NO-EVENT"
+      );
+    }, `${header} disallows cross-origin iframes.`);
+  </script>
 </body>

--- a/orientation-event/motion/permissions-policy/devicemotion-enabled-on-self-origin-by-permissions-policy.https.html
+++ b/orientation-event/motion/permissions-policy/devicemotion-enabled-on-self-origin-by-permissions-policy.https.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/orientation-event.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../../resources/orientation-event-helpers.js"></script>
+<script>
+"use strict";
+
+const same_origin_src =
+  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=devicemotion";
+const cross_origin_src =
+  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+
+const header = 'Permissions-Policy header "accelerometer=self, gyroscope=self"';
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'devicemotion');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const motionData = generateMotionData(1, 2, 3,
+                                        4, 5, 6,
+                                        7, 8, 9);
+  await helper.setData(motionData);
+
+  assert_equals(await waitForOrientationEvent('devicemotion'),
+                JSON.stringify(motionData));
+}, '${header} allows the top-level document');
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'devicemotion');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const motionData = generateMotionData(1, 2, 3,
+                                        4, 5, 6,
+                                        7, 8, 9);
+  await helper.setData(motionData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    same_origin_src,
+    JSON.stringify(motionData),
+  );
+}, `${header} allows same-origin iframes.`);
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'devicemotion');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const motionData = generateMotionData(1, 2, 3,
+                                        4, 5, 6,
+                                        7, 8, 9);
+  await helper.setData(motionData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    cross_origin_src,
+    'NO-EVENT',
+  );
+}, `${header} disallows cross-origin iframes.`);
+</script>
+</body>

--- a/orientation-event/motion/permissions-policy/devicemotion-enabled-on-self-origin-by-permissions-policy.https.html.headers
+++ b/orientation-event/motion/permissions-policy/devicemotion-enabled-on-self-origin-by-permissions-policy.https.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: accelerometer=self, gyroscope=self

--- a/orientation-event/orientation/permissions-policy/deviceorientation-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientation-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
@@ -1,53 +1,53 @@
 <!DOCTYPE html>
 <body>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
-<script src="/permissions-policy/resources/orientation-event.js"></script>
-<script src="/permissions-policy/resources/permissions-policy.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="../../resources/orientation-event-helpers.js"></script>
-<script>
-"use strict";
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/permissions-policy/resources/orientation-event.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script src="/common/get-host-info.sub.js"></script>
+  <script src="../../resources/orientation-event-helpers.js"></script>
+  <script>
+    "use strict";
 
-const relative_path =
-  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientation";
-const base_src = "/permissions-policy/resources/redirect-on-load.html#";
-const same_origin_src = base_src + relative_path;
-const cross_origin_src =
-  base_src + get_host_info().HTTPS_REMOTE_ORIGIN + relative_path;
+    const relative_path =
+      "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientation";
+    const base_src = "/permissions-policy/resources/redirect-on-load.html#";
+    const same_origin_src = base_src + relative_path;
+    const cross_origin_src =
+      base_src + get_host_info().HTTPS_REMOTE_ORIGIN + relative_path;
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientation');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientation");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, false);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, false);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    same_origin_src,
-    JSON.stringify(orientationData),
-    "accelerometer; gyroscope",
-  );
-}, `"allow" attribute allows same-origin navigation in an iframe`);
+      return test_feature_availability_with_post_message_result(
+        t,
+        same_origin_src,
+        JSON.stringify(orientationData),
+        "accelerometer; gyroscope"
+      );
+    }, `"allow" attribute allows same-origin navigation in an iframe`);
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientation');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientation");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, false);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, false);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    cross_origin_src,
-    'NO-EVENT',
-    "accelerometer; gyroscope",
-  );
-}, `"allow" disallows cross-origin navigation in an iframe`);
-</script>
+      return test_feature_availability_with_post_message_result(
+        t,
+        cross_origin_src,
+        "NO-EVENT",
+        "accelerometer; gyroscope"
+      );
+    }, `"allow" disallows cross-origin navigation in an iframe`);
+  </script>
 </body>

--- a/orientation-event/orientation/permissions-policy/deviceorientation-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientation-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
@@ -32,7 +32,7 @@ promise_test(async t => {
     JSON.stringify(orientationData),
     "accelerometer; gyroscope",
   );
-}, `"allow" attribute allows same-origin navigantion in an iframe`);
+}, `"allow" attribute allows same-origin navigation in an iframe`);
 
 promise_test(async t => {
   const helper = new SensorTestHelper(t, 'deviceorientation');

--- a/orientation-event/orientation/permissions-policy/deviceorientation-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientation-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/orientation-event.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../../resources/orientation-event-helpers.js"></script>
+<script>
+"use strict";
+
+const relative_path =
+  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientation";
+const base_src = "/permissions-policy/resources/redirect-on-load.html#";
+const same_origin_src = base_src + relative_path;
+const cross_origin_src =
+  base_src + get_host_info().HTTPS_REMOTE_ORIGIN + relative_path;
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientation');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, false);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    same_origin_src,
+    JSON.stringify(orientationData),
+    "accelerometer; gyroscope",
+  );
+}, `"allow" attribute allows same-origin navigantion in an iframe`);
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientation');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, false);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    cross_origin_src,
+    'NO-EVENT',
+    "accelerometer; gyroscope",
+  );
+}, `"allow" disallows allows cross-origin navigantion in an iframe`);
+</script>
+</body>

--- a/orientation-event/orientation/permissions-policy/deviceorientation-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientation-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
@@ -48,6 +48,6 @@ promise_test(async t => {
     'NO-EVENT',
     "accelerometer; gyroscope",
   );
-}, `"allow" disallows allows cross-origin navigantion in an iframe`);
+}, `"allow" disallows cross-origin navigation in an iframe`);
 </script>
 </body>

--- a/orientation-event/orientation/permissions-policy/deviceorientation-allowed-by-permissions-policy-attribute.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientation-allowed-by-permissions-policy-attribute.https.html
@@ -1,51 +1,51 @@
 <!DOCTYPE html>
 <body>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
-<script src="/permissions-policy/resources/orientation-event.js"></script>
-<script src="/permissions-policy/resources/permissions-policy.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="../../resources/orientation-event-helpers.js"></script>
-<script>
-"use strict";
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/permissions-policy/resources/orientation-event.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script src="/common/get-host-info.sub.js"></script>
+  <script src="../../resources/orientation-event-helpers.js"></script>
+  <script>
+    "use strict";
 
-const same_origin_src =
-  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientation";
-const cross_origin_src =
-  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+    const same_origin_src =
+      "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientation";
+    const cross_origin_src =
+      get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientation');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientation");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, false);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, false);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    same_origin_src,
-    'NO-EVENT',
-    "accelerometer 'none'; gyroscope 'none'",
-  );
-}, `Device Orientation can be disabled in same-origin iframes using "allow" attribute`);
+      return test_feature_availability_with_post_message_result(
+        t,
+        same_origin_src,
+        "NO-EVENT",
+        "accelerometer 'none'; gyroscope 'none'"
+      );
+    }, `Device Orientation can be disabled in same-origin iframes using "allow" attribute`);
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientation');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientation");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, false);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, false);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    cross_origin_src,
-    JSON.stringify(orientationData),
-    "accelerometer; gyroscope",
-  );
-}, `Device Orientation can be enabled in cross-origin iframes using "allow" attribute`);
-</script>
+      return test_feature_availability_with_post_message_result(
+        t,
+        cross_origin_src,
+        JSON.stringify(orientationData),
+        "accelerometer; gyroscope"
+      );
+    }, `Device Orientation can be enabled in cross-origin iframes using "allow" attribute`);
+  </script>
 </body>

--- a/orientation-event/orientation/permissions-policy/deviceorientation-allowed-by-permissions-policy-attribute.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientation-allowed-by-permissions-policy-attribute.https.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/orientation-event.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../../resources/orientation-event-helpers.js"></script>
+<script>
+"use strict";
+
+const same_origin_src =
+  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientation";
+const cross_origin_src =
+  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientation');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, false);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    same_origin_src,
+    'NO-EVENT',
+    "accelerometer 'none'; gyroscope 'none'",
+  );
+}, `Device Orientation can be disabled in same-origin iframes using "allow" attribute`);
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientation');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, false);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    cross_origin_src,
+    JSON.stringify(orientationData),
+    "accelerometer; gyroscope",
+  );
+}, `Device Orientation can be enabled in cross-origin iframes using "allow" attribute`);
+</script>
+</body>

--- a/orientation-event/orientation/permissions-policy/deviceorientation-disabled-by-permissions-policy.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientation-disabled-by-permissions-policy.https.html
@@ -1,63 +1,67 @@
 <!DOCTYPE html>
 <body>
-<meta name=timeout content=long> <!-- This test wais for several timeouts -->
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
-<script src="/permissions-policy/resources/orientation-event.js"></script>
-<script src="/permissions-policy/resources/permissions-policy.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="../../resources/orientation-event-helpers.js"></script>
-<script>
-"use strict";
+  <meta name="timeout" content="long" />
+  <!-- This test wais for several timeouts -->
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/permissions-policy/resources/orientation-event.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script src="/common/get-host-info.sub.js"></script>
+  <script src="../../resources/orientation-event-helpers.js"></script>
+  <script>
+    "use strict";
 
-const same_origin_src =
-  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientation";
-const cross_origin_src =
-  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+    const same_origin_src =
+      "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientation";
+    const cross_origin_src =
+      get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
-const header = 'Permissions-Policy header "accelerometer=(), gyroscope=()"';
+    const header = 'Permissions-Policy header "accelerometer=(), gyroscope=()"';
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientation');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientation");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, false);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, false);
+      await helper.setData(orientationData);
 
-  assert_equals(await waitForOrientationEvent('deviceorientation'), 'NO-EVENT');
-}, '${header} disallows the top-level document');
+      assert_equals(
+        await waitForOrientationEvent("deviceorientation"),
+        "NO-EVENT"
+      );
+    }, "${header} disallows the top-level document");
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientation');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientation");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, false);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, false);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    same_origin_src,
-    'NO-EVENT',
-  );
-}, `${header} disallows same-origin iframes.`);
+      return test_feature_availability_with_post_message_result(
+        t,
+        same_origin_src,
+        "NO-EVENT"
+      );
+    }, `${header} disallows same-origin iframes.`);
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientation');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientation");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, false);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, false);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    cross_origin_src,
-    'NO-EVENT',
-  );
-}, `${header} disallows cross-origin iframes.`);
-</script>
+      return test_feature_availability_with_post_message_result(
+        t,
+        cross_origin_src,
+        "NO-EVENT"
+      );
+    }, `${header} disallows cross-origin iframes.`);
+  </script>
 </body>

--- a/orientation-event/orientation/permissions-policy/deviceorientation-disabled-by-permissions-policy.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientation-disabled-by-permissions-policy.https.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<body>
+<meta name=timeout content=long> <!-- This test wais for several timeouts -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/orientation-event.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../../resources/orientation-event-helpers.js"></script>
+<script>
+"use strict";
+
+const same_origin_src =
+  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientation";
+const cross_origin_src =
+  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+
+const header = 'Permissions-Policy header "accelerometer=(), gyroscope=()"';
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientation');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, false);
+  await helper.setData(orientationData);
+
+  assert_equals(await waitForOrientationEvent('deviceorientation'), 'NO-EVENT');
+}, '${header} disallows the top-level document');
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientation');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, false);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    same_origin_src,
+    'NO-EVENT',
+  );
+}, `${header} disallows same-origin iframes.`);
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientation');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, false);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    cross_origin_src,
+    'NO-EVENT',
+  );
+}, `${header} disallows cross-origin iframes.`);
+</script>
+</body>

--- a/orientation-event/orientation/permissions-policy/deviceorientation-disabled-by-permissions-policy.https.html.headers
+++ b/orientation-event/orientation/permissions-policy/deviceorientation-disabled-by-permissions-policy.https.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: accelerometer=(), gyroscope=()

--- a/orientation-event/orientation/permissions-policy/deviceorientation-enabled-by-permissions-policy.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientation-enabled-by-permissions-policy.https.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/orientation-event.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../../resources/orientation-event-helpers.js"></script>
+<script>
+"use strict";
+
+const same_origin_src =
+  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientation";
+const cross_origin_src =
+  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+
+const header = 'Permissions-Policy header "accelerometer=*, gyroscope=*"';
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientation');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, false);
+  await helper.setData(orientationData);
+
+  assert_equals(await waitForOrientationEvent('deviceorientation'),
+                JSON.stringify(orientationData));
+}, '${header} allows the top-level document');
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientation');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, false);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    same_origin_src,
+    JSON.stringify(orientationData),
+  );
+}, `${header} allows same-origin iframes.`);
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientation');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, false);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    cross_origin_src,
+    JSON.stringify(orientationData),
+    'accelerometer; gyroscope',
+  );
+}, `${header} allows cross-origin iframes.`);
+</script>
+</body>

--- a/orientation-event/orientation/permissions-policy/deviceorientation-enabled-by-permissions-policy.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientation-enabled-by-permissions-policy.https.html
@@ -1,64 +1,66 @@
 <!DOCTYPE html>
 <body>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
-<script src="/permissions-policy/resources/orientation-event.js"></script>
-<script src="/permissions-policy/resources/permissions-policy.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="../../resources/orientation-event-helpers.js"></script>
-<script>
-"use strict";
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/permissions-policy/resources/orientation-event.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script src="/common/get-host-info.sub.js"></script>
+  <script src="../../resources/orientation-event-helpers.js"></script>
+  <script>
+    "use strict";
 
-const same_origin_src =
-  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientation";
-const cross_origin_src =
-  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+    const same_origin_src =
+      "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientation";
+    const cross_origin_src =
+      get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
-const header = 'Permissions-Policy header "accelerometer=*, gyroscope=*"';
+    const header = 'Permissions-Policy header "accelerometer=*, gyroscope=*"';
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientation');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientation");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, false);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, false);
+      await helper.setData(orientationData);
 
-  assert_equals(await waitForOrientationEvent('deviceorientation'),
-                JSON.stringify(orientationData));
-}, '${header} allows the top-level document');
+      assert_equals(
+        await waitForOrientationEvent("deviceorientation"),
+        JSON.stringify(orientationData)
+      );
+    }, "${header} allows the top-level document");
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientation');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientation");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, false);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, false);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    same_origin_src,
-    JSON.stringify(orientationData),
-  );
-}, `${header} allows same-origin iframes.`);
+      return test_feature_availability_with_post_message_result(
+        t,
+        same_origin_src,
+        JSON.stringify(orientationData)
+      );
+    }, `${header} allows same-origin iframes.`);
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientation');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientation");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, false);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, false);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    cross_origin_src,
-    JSON.stringify(orientationData),
-    'accelerometer; gyroscope',
-  );
-}, `${header} allows cross-origin iframes.`);
-</script>
+      return test_feature_availability_with_post_message_result(
+        t,
+        cross_origin_src,
+        JSON.stringify(orientationData),
+        "accelerometer; gyroscope"
+      );
+    }, `${header} allows cross-origin iframes.`);
+  </script>
 </body>

--- a/orientation-event/orientation/permissions-policy/deviceorientation-enabled-by-permissions-policy.https.html.headers
+++ b/orientation-event/orientation/permissions-policy/deviceorientation-enabled-by-permissions-policy.https.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: accelerometer=*, gyroscope=*

--- a/orientation-event/orientation/permissions-policy/deviceorientation-enabled-on-self-origin-by-permissions-policy.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientation-enabled-on-self-origin-by-permissions-policy.https.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/orientation-event.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../../resources/orientation-event-helpers.js"></script>
+<script>
+"use strict";
+
+const same_origin_src =
+  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientation";
+const cross_origin_src =
+  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+
+const header = 'Permissions-Policy header "accelerometer=self, gyroscope=self"';
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientation');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, false);
+  await helper.setData(orientationData);
+
+  assert_equals(await waitForOrientationEvent('deviceorientation'),
+                JSON.stringify(orientationData));
+}, '${header} allows the top-level document');
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientation');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, false);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    same_origin_src,
+    JSON.stringify(orientationData),
+  );
+}, `${header} allows same-origin iframes.`);
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientation');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, false);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    cross_origin_src,
+    'NO-EVENT',
+  );
+}, `${header} disallows cross-origin iframes.`);
+</script>
+</body>

--- a/orientation-event/orientation/permissions-policy/deviceorientation-enabled-on-self-origin-by-permissions-policy.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientation-enabled-on-self-origin-by-permissions-policy.https.html
@@ -1,63 +1,66 @@
 <!DOCTYPE html>
 <body>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
-<script src="/permissions-policy/resources/orientation-event.js"></script>
-<script src="/permissions-policy/resources/permissions-policy.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="../../resources/orientation-event-helpers.js"></script>
-<script>
-"use strict";
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/permissions-policy/resources/orientation-event.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script src="/common/get-host-info.sub.js"></script>
+  <script src="../../resources/orientation-event-helpers.js"></script>
+  <script>
+    "use strict";
 
-const same_origin_src =
-  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientation";
-const cross_origin_src =
-  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+    const same_origin_src =
+      "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientation";
+    const cross_origin_src =
+      get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
-const header = 'Permissions-Policy header "accelerometer=self, gyroscope=self"';
+    const header =
+      'Permissions-Policy header "accelerometer=self, gyroscope=self"';
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientation');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientation");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, false);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, false);
+      await helper.setData(orientationData);
 
-  assert_equals(await waitForOrientationEvent('deviceorientation'),
-                JSON.stringify(orientationData));
-}, '${header} allows the top-level document');
+      assert_equals(
+        await waitForOrientationEvent("deviceorientation"),
+        JSON.stringify(orientationData)
+      );
+    }, "${header} allows the top-level document");
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientation');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientation");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, false);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, false);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    same_origin_src,
-    JSON.stringify(orientationData),
-  );
-}, `${header} allows same-origin iframes.`);
+      return test_feature_availability_with_post_message_result(
+        t,
+        same_origin_src,
+        JSON.stringify(orientationData)
+      );
+    }, `${header} allows same-origin iframes.`);
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientation');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientation");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, false);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, false);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    cross_origin_src,
-    'NO-EVENT',
-  );
-}, `${header} disallows cross-origin iframes.`);
-</script>
+      return test_feature_availability_with_post_message_result(
+        t,
+        cross_origin_src,
+        "NO-EVENT"
+      );
+    }, `${header} disallows cross-origin iframes.`);
+  </script>
 </body>

--- a/orientation-event/orientation/permissions-policy/deviceorientation-enabled-on-self-origin-by-permissions-policy.https.html.headers
+++ b/orientation-event/orientation/permissions-policy/deviceorientation-enabled-on-self-origin-by-permissions-policy.https.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: accelerometer=self, gyroscope=self

--- a/orientation-event/orientation/permissions-policy/deviceorientationabsolute-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientationabsolute-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
@@ -32,7 +32,7 @@ promise_test(async t => {
     JSON.stringify(orientationData),
     "accelerometer; gyroscope; magnetometer",
   );
-}, `"allow" attribute allows same-origin navigantion in an iframe`);
+}, `"allow" attribute allows same-origin navigation in an iframe`);
 
 promise_test(async t => {
   const helper = new SensorTestHelper(t, 'deviceorientationabsolute');

--- a/orientation-event/orientation/permissions-policy/deviceorientationabsolute-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientationabsolute-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
@@ -48,6 +48,6 @@ promise_test(async t => {
     'NO-EVENT',
     "accelerometer; gyroscope; magnetometer",
   );
-}, `"allow" disallows allows cross-origin navigantion in an iframe`);
+}, `"allow" disallows cross-origin navigation in an iframe`);
 </script>
 </body>

--- a/orientation-event/orientation/permissions-policy/deviceorientationabsolute-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientationabsolute-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/orientation-event.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../../resources/orientation-event-helpers.js"></script>
+<script>
+"use strict";
+
+const relative_path =
+  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientationabsolute";
+const base_src = "/permissions-policy/resources/redirect-on-load.html#";
+const same_origin_src = base_src + relative_path;
+const cross_origin_src =
+  base_src + get_host_info().HTTPS_REMOTE_ORIGIN + relative_path;
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, true);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    same_origin_src,
+    JSON.stringify(orientationData),
+    "accelerometer; gyroscope; magnetometer",
+  );
+}, `"allow" attribute allows same-origin navigantion in an iframe`);
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, true);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    cross_origin_src,
+    'NO-EVENT',
+    "accelerometer; gyroscope; magnetometer",
+  );
+}, `"allow" disallows allows cross-origin navigantion in an iframe`);
+</script>
+</body>

--- a/orientation-event/orientation/permissions-policy/deviceorientationabsolute-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientationabsolute-allowed-by-permissions-policy-attribute-redirect-on-load.https.html
@@ -1,53 +1,53 @@
 <!DOCTYPE html>
 <body>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
-<script src="/permissions-policy/resources/orientation-event.js"></script>
-<script src="/permissions-policy/resources/permissions-policy.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="../../resources/orientation-event-helpers.js"></script>
-<script>
-"use strict";
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/permissions-policy/resources/orientation-event.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script src="/common/get-host-info.sub.js"></script>
+  <script src="../../resources/orientation-event-helpers.js"></script>
+  <script>
+    "use strict";
 
-const relative_path =
-  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientationabsolute";
-const base_src = "/permissions-policy/resources/redirect-on-load.html#";
-const same_origin_src = base_src + relative_path;
-const cross_origin_src =
-  base_src + get_host_info().HTTPS_REMOTE_ORIGIN + relative_path;
+    const relative_path =
+      "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientationabsolute";
+    const base_src = "/permissions-policy/resources/redirect-on-load.html#";
+    const same_origin_src = base_src + relative_path;
+    const cross_origin_src =
+      base_src + get_host_info().HTTPS_REMOTE_ORIGIN + relative_path;
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientationabsolute");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, true);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, true);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    same_origin_src,
-    JSON.stringify(orientationData),
-    "accelerometer; gyroscope; magnetometer",
-  );
-}, `"allow" attribute allows same-origin navigation in an iframe`);
+      return test_feature_availability_with_post_message_result(
+        t,
+        same_origin_src,
+        JSON.stringify(orientationData),
+        "accelerometer; gyroscope; magnetometer"
+      );
+    }, `"allow" attribute allows same-origin navigation in an iframe`);
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientationabsolute");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, true);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, true);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    cross_origin_src,
-    'NO-EVENT',
-    "accelerometer; gyroscope; magnetometer",
-  );
-}, `"allow" disallows cross-origin navigation in an iframe`);
-</script>
+      return test_feature_availability_with_post_message_result(
+        t,
+        cross_origin_src,
+        "NO-EVENT",
+        "accelerometer; gyroscope; magnetometer"
+      );
+    }, `"allow" disallows cross-origin navigation in an iframe`);
+  </script>
 </body>

--- a/orientation-event/orientation/permissions-policy/deviceorientationabsolute-allowed-by-permissions-policy-attribute.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientationabsolute-allowed-by-permissions-policy-attribute.https.html
@@ -1,51 +1,51 @@
 <!DOCTYPE html>
 <body>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
-<script src="/permissions-policy/resources/orientation-event.js"></script>
-<script src="/permissions-policy/resources/permissions-policy.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="../../resources/orientation-event-helpers.js"></script>
-<script>
-"use strict";
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/permissions-policy/resources/orientation-event.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script src="/common/get-host-info.sub.js"></script>
+  <script src="../../resources/orientation-event-helpers.js"></script>
+  <script>
+    "use strict";
 
-const same_origin_src =
-  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientationabsolute";
-const cross_origin_src =
-  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+    const same_origin_src =
+      "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientationabsolute";
+    const cross_origin_src =
+      get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientationabsolute");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, true);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, true);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    same_origin_src,
-    'NO-EVENT',
-    "accelerometer 'none'; gyroscope 'none'; magnetometer 'none'",
-  );
-}, `Device Orientation can be disabled in same-origin iframes using "allow" attribute`);
+      return test_feature_availability_with_post_message_result(
+        t,
+        same_origin_src,
+        "NO-EVENT",
+        "accelerometer 'none'; gyroscope 'none'; magnetometer 'none'"
+      );
+    }, `Device Orientation can be disabled in same-origin iframes using "allow" attribute`);
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientationabsolute");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, true);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, true);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    cross_origin_src,
-    JSON.stringify(orientationData),
-    "accelerometer; gyroscope; magnetometer",
-  );
-}, `Device Orientation can be enabled in cross-origin iframes using "allow" attribute`);
-</script>
+      return test_feature_availability_with_post_message_result(
+        t,
+        cross_origin_src,
+        JSON.stringify(orientationData),
+        "accelerometer; gyroscope; magnetometer"
+      );
+    }, `Device Orientation can be enabled in cross-origin iframes using "allow" attribute`);
+  </script>
 </body>

--- a/orientation-event/orientation/permissions-policy/deviceorientationabsolute-allowed-by-permissions-policy-attribute.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientationabsolute-allowed-by-permissions-policy-attribute.https.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/orientation-event.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../../resources/orientation-event-helpers.js"></script>
+<script>
+"use strict";
+
+const same_origin_src =
+  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientationabsolute";
+const cross_origin_src =
+  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, true);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    same_origin_src,
+    'NO-EVENT',
+    "accelerometer 'none'; gyroscope 'none'; magnetometer 'none'",
+  );
+}, `Device Orientation can be disabled in same-origin iframes using "allow" attribute`);
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, true);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    cross_origin_src,
+    JSON.stringify(orientationData),
+    "accelerometer; gyroscope; magnetometer",
+  );
+}, `Device Orientation can be enabled in cross-origin iframes using "allow" attribute`);
+</script>
+</body>

--- a/orientation-event/orientation/permissions-policy/deviceorientationabsolute-disabled-by-permissions-policy.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientationabsolute-disabled-by-permissions-policy.https.html
@@ -1,63 +1,68 @@
 <!DOCTYPE html>
 <body>
-<meta name=timeout content=long> <!-- This test wais for several timeouts -->
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
-<script src="/permissions-policy/resources/orientation-event.js"></script>
-<script src="/permissions-policy/resources/permissions-policy.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="../../resources/orientation-event-helpers.js"></script>
-<script>
-"use strict";
+  <meta name="timeout" content="long" />
+  <!-- This test wais for several timeouts -->
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/permissions-policy/resources/orientation-event.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script src="/common/get-host-info.sub.js"></script>
+  <script src="../../resources/orientation-event-helpers.js"></script>
+  <script>
+    "use strict";
 
-const same_origin_src =
-  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientationabsolute";
-const cross_origin_src =
-  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+    const same_origin_src =
+      "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientationabsolute";
+    const cross_origin_src =
+      get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
-const header = 'Permissions-Policy header "accelerometer=(), gyroscope=(), magnetometer=()"';
+    const header =
+      'Permissions-Policy header "accelerometer=(), gyroscope=(), magnetometer=()"';
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientationabsolute");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, true);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, true);
+      await helper.setData(orientationData);
 
-  assert_equals(await waitForOrientationEvent('deviceorientationabsolute'), 'NO-EVENT');
-}, '${header} disallows the top-level document');
+      assert_equals(
+        await waitForOrientationEvent("deviceorientationabsolute"),
+        "NO-EVENT"
+      );
+    }, "${header} disallows the top-level document");
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientationabsolute");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, true);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, true);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    same_origin_src,
-    'NO-EVENT',
-  );
-}, `${header} disallows same-origin iframes.`);
+      return test_feature_availability_with_post_message_result(
+        t,
+        same_origin_src,
+        "NO-EVENT"
+      );
+    }, `${header} disallows same-origin iframes.`);
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientationabsolute");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, true);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, true);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    cross_origin_src,
-    'NO-EVENT',
-  );
-}, `${header} disallows cross-origin iframes.`);
-</script>
+      return test_feature_availability_with_post_message_result(
+        t,
+        cross_origin_src,
+        "NO-EVENT"
+      );
+    }, `${header} disallows cross-origin iframes.`);
+  </script>
 </body>

--- a/orientation-event/orientation/permissions-policy/deviceorientationabsolute-disabled-by-permissions-policy.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientationabsolute-disabled-by-permissions-policy.https.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<body>
+<meta name=timeout content=long> <!-- This test wais for several timeouts -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/orientation-event.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../../resources/orientation-event-helpers.js"></script>
+<script>
+"use strict";
+
+const same_origin_src =
+  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientationabsolute";
+const cross_origin_src =
+  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+
+const header = 'Permissions-Policy header "accelerometer=(), gyroscope=(), magnetometer=()"';
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, true);
+  await helper.setData(orientationData);
+
+  assert_equals(await waitForOrientationEvent('deviceorientationabsolute'), 'NO-EVENT');
+}, '${header} disallows the top-level document');
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, true);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    same_origin_src,
+    'NO-EVENT',
+  );
+}, `${header} disallows same-origin iframes.`);
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, true);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    cross_origin_src,
+    'NO-EVENT',
+  );
+}, `${header} disallows cross-origin iframes.`);
+</script>
+</body>

--- a/orientation-event/orientation/permissions-policy/deviceorientationabsolute-disabled-by-permissions-policy.https.html.headers
+++ b/orientation-event/orientation/permissions-policy/deviceorientationabsolute-disabled-by-permissions-policy.https.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: accelerometer=(), gyroscope=(), magnetometer=()

--- a/orientation-event/orientation/permissions-policy/deviceorientationabsolute-enabled-by-permissions-policy.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientationabsolute-enabled-by-permissions-policy.https.html
@@ -1,64 +1,67 @@
 <!DOCTYPE html>
 <body>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
-<script src="/permissions-policy/resources/orientation-event.js"></script>
-<script src="/permissions-policy/resources/permissions-policy.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="../../resources/orientation-event-helpers.js"></script>
-<script>
-"use strict";
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/permissions-policy/resources/orientation-event.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script src="/common/get-host-info.sub.js"></script>
+  <script src="../../resources/orientation-event-helpers.js"></script>
+  <script>
+    "use strict";
 
-const same_origin_src =
-  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientationabsolute";
-const cross_origin_src =
-  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+    const same_origin_src =
+      "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientationabsolute";
+    const cross_origin_src =
+      get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
-const header = 'Permissions-Policy header "accelerometer=*, gyroscope=*, magnetometer=*"';
+    const header =
+      'Permissions-Policy header "accelerometer=*, gyroscope=*, magnetometer=*"';
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientationabsolute");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, true);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, true);
+      await helper.setData(orientationData);
 
-  assert_equals(await waitForOrientationEvent('deviceorientationabsolute'),
-                JSON.stringify(orientationData));
-}, '${header} allows the top-level document');
+      assert_equals(
+        await waitForOrientationEvent("deviceorientationabsolute"),
+        JSON.stringify(orientationData)
+      );
+    }, "${header} allows the top-level document");
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientationabsolute");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, true);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, true);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    same_origin_src,
-    JSON.stringify(orientationData),
-  );
-}, `${header} allows same-origin iframes.`);
+      return test_feature_availability_with_post_message_result(
+        t,
+        same_origin_src,
+        JSON.stringify(orientationData)
+      );
+    }, `${header} allows same-origin iframes.`);
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientationabsolute");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, true);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, true);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    cross_origin_src,
-    JSON.stringify(orientationData),
-    'accelerometer; gyroscope; magnetometer',
-  );
-}, `${header} allows cross-origin iframes.`);
-</script>
+      return test_feature_availability_with_post_message_result(
+        t,
+        cross_origin_src,
+        JSON.stringify(orientationData),
+        "accelerometer; gyroscope; magnetometer"
+      );
+    }, `${header} allows cross-origin iframes.`);
+  </script>
 </body>

--- a/orientation-event/orientation/permissions-policy/deviceorientationabsolute-enabled-by-permissions-policy.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientationabsolute-enabled-by-permissions-policy.https.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/orientation-event.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../../resources/orientation-event-helpers.js"></script>
+<script>
+"use strict";
+
+const same_origin_src =
+  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientationabsolute";
+const cross_origin_src =
+  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+
+const header = 'Permissions-Policy header "accelerometer=*, gyroscope=*, magnetometer=*"';
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, true);
+  await helper.setData(orientationData);
+
+  assert_equals(await waitForOrientationEvent('deviceorientationabsolute'),
+                JSON.stringify(orientationData));
+}, '${header} allows the top-level document');
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, true);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    same_origin_src,
+    JSON.stringify(orientationData),
+  );
+}, `${header} allows same-origin iframes.`);
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, true);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    cross_origin_src,
+    JSON.stringify(orientationData),
+    'accelerometer; gyroscope; magnetometer',
+  );
+}, `${header} allows cross-origin iframes.`);
+</script>
+</body>

--- a/orientation-event/orientation/permissions-policy/deviceorientationabsolute-enabled-by-permissions-policy.https.html.headers
+++ b/orientation-event/orientation/permissions-policy/deviceorientationabsolute-enabled-by-permissions-policy.https.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: accelerometer=*, gyroscope=*, magnetometer=*

--- a/orientation-event/orientation/permissions-policy/deviceorientationabsolute-enabled-on-self-origin-by-permissions-policy.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientationabsolute-enabled-on-self-origin-by-permissions-policy.https.html
@@ -1,63 +1,66 @@
 <!DOCTYPE html>
 <body>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
-<script src="/permissions-policy/resources/orientation-event.js"></script>
-<script src="/permissions-policy/resources/permissions-policy.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="../../resources/orientation-event-helpers.js"></script>
-<script>
-"use strict";
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/permissions-policy/resources/orientation-event.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script src="/common/get-host-info.sub.js"></script>
+  <script src="../../resources/orientation-event-helpers.js"></script>
+  <script>
+    "use strict";
 
-const same_origin_src =
-  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientationabsolute";
-const cross_origin_src =
-  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+    const same_origin_src =
+      "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientationabsolute";
+    const cross_origin_src =
+      get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
-const header = 'Permissions-Policy header "accelerometer=self, gyroscope=self, magnetometer=self"';
+    const header =
+      'Permissions-Policy header "accelerometer=self, gyroscope=self, magnetometer=self"';
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientationabsolute");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, true);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, true);
+      await helper.setData(orientationData);
 
-  assert_equals(await waitForOrientationEvent('deviceorientationabsolute'),
-                JSON.stringify(orientationData));
-}, '${header} allows the top-level document');
+      assert_equals(
+        await waitForOrientationEvent("deviceorientationabsolute"),
+        JSON.stringify(orientationData)
+      );
+    }, "${header} allows the top-level document");
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientationabsolute");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, true);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, true);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    same_origin_src,
-    JSON.stringify(orientationData),
-  );
-}, `${header} allows same-origin iframes.`);
+      return test_feature_availability_with_post_message_result(
+        t,
+        same_origin_src,
+        JSON.stringify(orientationData)
+      );
+    }, `${header} allows same-origin iframes.`);
 
-promise_test(async t => {
-  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
-  await helper.grantSensorsPermissions();
-  await helper.initializeSensors();
+    promise_test(async (t) => {
+      const helper = new SensorTestHelper(t, "deviceorientationabsolute");
+      await helper.grantSensorsPermissions();
+      await helper.initializeSensors();
 
-  const orientationData = generateOrientationData(1, 2, 3, true);
-  await helper.setData(orientationData);
+      const orientationData = generateOrientationData(1, 2, 3, true);
+      await helper.setData(orientationData);
 
-  return test_feature_availability_with_post_message_result(
-    t,
-    cross_origin_src,
-    'NO-EVENT',
-  );
-}, `${header} disallows cross-origin iframes.`);
-</script>
+      return test_feature_availability_with_post_message_result(
+        t,
+        cross_origin_src,
+        "NO-EVENT"
+      );
+    }, `${header} disallows cross-origin iframes.`);
+  </script>
 </body>

--- a/orientation-event/orientation/permissions-policy/deviceorientationabsolute-enabled-on-self-origin-by-permissions-policy.https.html
+++ b/orientation-event/orientation/permissions-policy/deviceorientationabsolute-enabled-on-self-origin-by-permissions-policy.https.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/orientation-event.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="../../resources/orientation-event-helpers.js"></script>
+<script>
+"use strict";
+
+const same_origin_src =
+  "/permissions-policy/resources/permissions-policy-orientation-event.sub.html?eventName=deviceorientationabsolute";
+const cross_origin_src =
+  get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
+
+const header = 'Permissions-Policy header "accelerometer=self, gyroscope=self, magnetometer=self"';
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, true);
+  await helper.setData(orientationData);
+
+  assert_equals(await waitForOrientationEvent('deviceorientationabsolute'),
+                JSON.stringify(orientationData));
+}, '${header} allows the top-level document');
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, true);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    same_origin_src,
+    JSON.stringify(orientationData),
+  );
+}, `${header} allows same-origin iframes.`);
+
+promise_test(async t => {
+  const helper = new SensorTestHelper(t, 'deviceorientationabsolute');
+  await helper.grantSensorsPermissions();
+  await helper.initializeSensors();
+
+  const orientationData = generateOrientationData(1, 2, 3, true);
+  await helper.setData(orientationData);
+
+  return test_feature_availability_with_post_message_result(
+    t,
+    cross_origin_src,
+    'NO-EVENT',
+  );
+}, `${header} disallows cross-origin iframes.`);
+</script>
+</body>

--- a/orientation-event/orientation/permissions-policy/deviceorientationabsolute-enabled-on-self-origin-by-permissions-policy.https.html.headers
+++ b/orientation-event/orientation/permissions-policy/deviceorientationabsolute-enabled-on-self-origin-by-permissions-policy.https.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: accelerometer=self, gyroscope=self, magnetometer=self

--- a/permissions-policy/resources/orientation-event.js
+++ b/permissions-policy/resources/orientation-event.js
@@ -1,0 +1,60 @@
+'use strict';
+
+async function waitForOrientationEvent(eventName) {
+  if (eventName !== 'devicemotion' && eventName !== 'deviceorientation' && eventName !== 'deviceorientationabsolute') {
+    return 'ERROR';
+  }
+
+  let value;
+
+  try {
+    // See https://github.com/w3c/deviceorientation/issues/148: the
+    // specification currently does not fire any events when the permissions
+    // policy checks fail, so what we do here is wait for the timeout and the
+    // devicemotion event handler to race each other.
+    value = await new Promise((resolve, reject) => {
+      const timeoutId = window.setTimeout(() => {
+        window.removeEventListener(eventName, handler);
+        reject('NO-EVENT');
+      }, 1500);
+      function handler(event) {
+        window.clearTimeout(timeoutId);
+
+        let data;
+        switch (event.type) {
+          case 'devicemotion':
+            data = generateMotionData(
+              event.acceleration.x,
+              event.acceleration.y,
+              event.acceleration.z,
+              event.accelerationIncludingGravity.x,
+              event.accelerationIncludingGravity.y,
+              event.accelerationIncludingGravity.z,
+              event.rotationRate.alpha,
+              event.rotationRate.beta,
+              event.rotationRate.gamma,
+            );
+            break;
+          case 'deviceorientation':
+          case 'deviceorientationabsolute':
+            data = generateOrientationData(
+              event.alpha,
+              event.beta,
+              event.gamma,
+              event.absolute,
+            );
+            break;
+          default:
+            reject('UNEXPECTED-EVENT-TYPE');
+            break;
+        }
+        resolve(JSON.stringify(data));
+      }
+      window.addEventListener(eventName, handler, { once: true });
+    });
+  } catch (e) {
+    value = e;
+  }
+
+  return value;
+}

--- a/permissions-policy/resources/orientation-event.js
+++ b/permissions-policy/resources/orientation-event.js
@@ -1,8 +1,12 @@
-'use strict';
+"use strict";
 
 async function waitForOrientationEvent(eventName) {
-  if (eventName !== 'devicemotion' && eventName !== 'deviceorientation' && eventName !== 'deviceorientationabsolute') {
-    return 'ERROR';
+  if (
+    eventName !== "devicemotion" &&
+    eventName !== "deviceorientation" &&
+    eventName !== "deviceorientationabsolute"
+  ) {
+    return "ERROR";
   }
 
   let value;
@@ -15,14 +19,14 @@ async function waitForOrientationEvent(eventName) {
     value = await new Promise((resolve, reject) => {
       const timeoutId = window.setTimeout(() => {
         window.removeEventListener(eventName, handler);
-        reject('NO-EVENT');
+        reject("NO-EVENT");
       }, 1500);
       function handler(event) {
         window.clearTimeout(timeoutId);
 
         let data;
         switch (event.type) {
-          case 'devicemotion':
+          case "devicemotion":
             data = generateMotionData(
               event.acceleration.x,
               event.acceleration.y,
@@ -32,20 +36,20 @@ async function waitForOrientationEvent(eventName) {
               event.accelerationIncludingGravity.z,
               event.rotationRate.alpha,
               event.rotationRate.beta,
-              event.rotationRate.gamma,
+              event.rotationRate.gamma
             );
             break;
-          case 'deviceorientation':
-          case 'deviceorientationabsolute':
+          case "deviceorientation":
+          case "deviceorientationabsolute":
             data = generateOrientationData(
               event.alpha,
               event.beta,
               event.gamma,
-              event.absolute,
+              event.absolute
             );
             break;
           default:
-            reject('UNEXPECTED-EVENT-TYPE');
+            reject("UNEXPECTED-EVENT-TYPE");
             break;
         }
         resolve(JSON.stringify(data));

--- a/permissions-policy/resources/permissions-policy-orientation-event.sub.html
+++ b/permissions-policy/resources/permissions-policy-orientation-event.sub.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<body>
+<script src="/orientation-event/resources/orientation-event-helpers.js"></script>
+<script src="orientation-event.js"></script>
+<script>
+"use strict";
+
+Promise.resolve().then(async () => {
+  const name = await waitForOrientationEvent('{{GET[eventName]}}');
+  window.parent.postMessage({ type: "availability-result", name }, "*");
+});
+</script>
+</body>

--- a/permissions-policy/resources/permissions-policy-orientation-event.sub.html
+++ b/permissions-policy/resources/permissions-policy-orientation-event.sub.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <body>
-<script src="/orientation-event/resources/orientation-event-helpers.js"></script>
-<script src="orientation-event.js"></script>
-<script>
-"use strict";
+  <script src="/orientation-event/resources/orientation-event-helpers.js"></script>
+  <script src="orientation-event.js"></script>
+  <script>
+    "use strict";
 
-Promise.resolve().then(async () => {
-  const name = await waitForOrientationEvent('{{GET[eventName]}}');
-  window.parent.postMessage({ type: "availability-result", name }, "*");
-});
-</script>
+    Promise.resolve().then(async () => {
+      const name = await waitForOrientationEvent("{{GET[eventName]}}");
+      window.parent.postMessage({ type: "availability-result", name }, "*");
+    });
+  </script>
 </body>

--- a/permissions-policy/resources/permissions-policy-orientation-event.sub.html
+++ b/permissions-policy/resources/permissions-policy-orientation-event.sub.html
@@ -5,9 +5,10 @@
   <script>
     "use strict";
 
-    Promise.resolve().then(async () => {
-      const name = await waitForOrientationEvent("{{GET[eventName]}}");
-      window.parent.postMessage({ type: "availability-result", name }, "*");
+    window.addEventListener("load", () => {
+      waitForOrientationEvent("{{GET[eventName]}}").then((name) => {
+        window.parent.postMessage({ type: "availability-result", name }, "*");
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
Add tests for deviceorientationabsolute, deviceorientation and devicemotion
as described in
https://w3c.github.io/deviceorientation/#permissions-policy-integration:

- The deviceorientation event requires the "accelerometer" and "gyroscope"
  features.
- The deviceorientationabsolute event requires the "accelerometer",
  "gyroscope" and "magnetometer" features.
- The devicemotion event requires the "accelerometer" and "gyroscope"
  features.

(WebKit currently requires the "magnetometer" feature for deviceorientation
events, see https://bugs.webkit.org/show_bug.cgi?id=271891).

The tests being added follow permissions-policy/README.md's recommendations:
- Tests with different Permissions-Policy header values and how they
  influence usage in the top-level frame, same-origin iframes and
  cross-origin iframes.
- Different values for the "allow" attribute and how they influece
  same-origin and cross-origin iframes.
- Usage of the "allow" attribute with redirection.

This is the minimum amount of coverage we need. These tests can be expanded
to include:
- Calls to `run_all_fp_tests_allow_self()` to test the behavior of the
  default policy for each feature (it requires making the function work with
  more than one feature).
- The relative orientation to absolute orientation fallback behavior that
  depends on whether the "magnetometer" feature is enabled.
- Not enabling all features (it may cause an explosion in the number of
  tests though).
