### PR TITLE
Payment Request: fix permission policy tests

### DIFF
--- a/permissions-policy/payment-allowed-by-permissions-policy-attribute.https.sub.html
+++ b/permissions-policy/payment-allowed-by-permissions-policy-attribute.https.sub.html
@@ -1,39 +1,47 @@
 <!DOCTYPE html>
 <body>
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-    <script src="/permissions-policy/resources/permissions-policy.js"></script>
-    <script>
-        "use strict";
-        const same_origin_src =
-            "/permissions-policy/resources/permissions-policy-payment.html";
-        const cross_origin_src =
-            "https://{{hosts[alt][]}}:{{ports[https][0]}}" + same_origin_src;
-        const feature_name = 'permissions policy "payment"';
-        const header = 'allow="payment" attribute';
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script>
+    "use strict";
+    const same_origin_src =
+      "/permissions-policy/resources/permissions-policy-payment.html";
+    const cross_origin_src =
+      "https://{{hosts[alt][]}}:{{ports[https][0]}}" + same_origin_src;
+    const feature_name = 'permissions policy "payment"';
+    const header = 'allow="payment" attribute';
 
-        promise_test((t) => {
-            return test_feature_availability(
-                "PaymentRequest()",
-                t,
-                same_origin_src,
-                expect_feature_available_default,
-                "payment",
-                undefined,
-                true
-            );
-        }, feature_name + " can be enabled in same-origin iframe using " + header);
+    promise_test((test) => {
+      return test_feature_availability({
+        feature_description: "PaymentRequest()",
+        test,
+        src: same_origin_src,
+        expect_feature_available: expect_feature_available_default,
+        is_promise_test: true
+      });
+    }, `${feature_name} is enabled by default`);
 
-        promise_test((t) => {
-            return test_feature_availability(
-                "PaymentRequest()",
-                t,
-                cross_origin_src,
-                expect_feature_available_default,
-                "payment",
-                undefined,
-                true
-            );
-        }, feature_name + " can be enabled in cross-origin iframe using " + header);
-    </script>
+    promise_test((test) => {
+      return test_feature_availability({
+        feature_description: "PaymentRequest()",
+        test,
+        src: same_origin_src,
+        expect_feature_available: expect_feature_available_default,
+        feature_name: "payment",
+        is_promise_test: true,
+      });
+    }, `${feature_name} can be enabled in same-origin iframe using ${header}`);
+
+    promise_test((test) => {
+      return test_feature_availability({
+        feature_description: "PaymentRequest()",
+        test,
+        src: cross_origin_src,
+        expect_feature_available: expect_feature_available_default,
+        feature_name: "payment",
+        is_promise_test: true,
+      });
+    }, `${feature_name} can be enabled in cross-origin iframe using ${header}`);
+  </script>
 </body>

--- a/permissions-policy/payment-allowed-by-permissions-policy-attribute.https.sub.html
+++ b/permissions-policy/payment-allowed-by-permissions-policy-attribute.https.sub.html
@@ -1,26 +1,39 @@
 <!DOCTYPE html>
 <body>
-  <script src=/resources/testharness.js></script>
-  <script src=/resources/testharnessreport.js></script>
-  <script src=/permissions-policy/resources/permissions-policy.js></script>
-  <script>
-  'use strict';
-  var same_origin_src = '/permissions-policy/resources/permissions-policy-payment.html';
-  var cross_origin_src = 'https://{{domains[www]}}:{{ports[https][0]}}' +
-    same_origin_src;
-  var feature_name = 'permissions policy "payment"';
-  var header = 'allow="payment" attribute';
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/permissions-policy/resources/permissions-policy.js"></script>
+    <script>
+        "use strict";
+        const same_origin_src =
+            "/permissions-policy/resources/permissions-policy-payment.html";
+        const cross_origin_src =
+            "https://{{hosts[alt][]}}:{{ports[https][0]}}" + same_origin_src;
+        const feature_name = 'permissions policy "payment"';
+        const header = 'allow="payment" attribute';
 
-  async_test(t => {
-    test_feature_availability(
-        'PaymentRequest()', t, same_origin_src,
-        expect_feature_available_default, 'payment');
-  }, feature_name + ' can be enabled in same-origin iframe using ' + header);
+        promise_test((t) => {
+            return test_feature_availability(
+                "PaymentRequest()",
+                t,
+                same_origin_src,
+                expect_feature_available_default,
+                "payment",
+                undefined,
+                true
+            );
+        }, feature_name + " can be enabled in same-origin iframe using " + header);
 
-  async_test(t => {
-    test_feature_availability(
-        'PaymentRequest()', t, cross_origin_src,
-        expect_feature_available_default, 'payment');
-  }, feature_name + ' can be enabled in cross-origin iframe using ' + header);
-  </script>
+        promise_test((t) => {
+            return test_feature_availability(
+                "PaymentRequest()",
+                t,
+                cross_origin_src,
+                expect_feature_available_default,
+                "payment",
+                undefined,
+                true
+            );
+        }, feature_name + " can be enabled in cross-origin iframe using " + header);
+    </script>
 </body>

--- a/permissions-policy/payment-allowed-by-permissions-policy.https.sub.html
+++ b/permissions-policy/payment-allowed-by-permissions-policy.https.sub.html
@@ -1,70 +1,64 @@
 <!DOCTYPE html>
 <body>
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-    <script src="/permissions-policy/resources/permissions-policy.js"></script>
-    <script>
-        "use strict";
-        const same_origin_src =
-            "/permissions-policy/resources/permissions-policy-payment.html";
-        const cross_origin_src =
-            "https://{{hosts[alt][]}}:{{ports[https][0]}}" + same_origin_src;
-        const header = 'permissions policy header "payment=*"';
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script>
+    "use strict";
+    const same_origin_src =
+      "/permissions-policy/resources/permissions-policy-payment.html";
+    const cross_origin_src =
+      "https://{{hosts[alt][]}}:{{ports[https][0]}}" + same_origin_src;
+    const header = 'permissions policy header "payment=*"';
 
-        test(() => {
-            const supportedMethods = [
-                {
-                    supportedMethods:
-                        "https://{{domains[nonexistent]}}/payment-request",
-                },
-            ];
-            const details = {
-                total: {
-                    label: "Test",
-                    amount: { currency: "USD", value: "5.00" },
-                },
-            };
-            try {
-                new PaymentRequest(supportedMethods, details);
-            } catch (e) {
-                assert_unreached();
-            }
-        }, header + " allows the top-level document.");
+    test(() => {
+      const supportedMethods = [
+        {
+          supportedMethods: "https://{{domains[nonexistent]}}/payment-request",
+        },
+      ];
+      const details = {
+        total: {
+          label: "Test",
+          amount: { currency: "USD", value: "5.00" },
+        },
+      };
+      try {
+        new PaymentRequest(supportedMethods, details);
+      } catch (e) {
+        assert_unreached();
+      }
+    }, `${header} allows Payment Request API the top-level document.`);
 
-        promise_test((t) => {
-            return test_feature_availability(
-                "PaymentRequest()",
-                t,
-                same_origin_src,
-                expect_feature_available_default,
-                undefined,
-                undefined,
-                true
-            );
-        }, header + " allows same-origin iframes.");
+    promise_test((test) => {
+      return test_feature_availability({
+        feature_description: "PaymentRequest()",
+        test,
+        src: same_origin_src,
+        expect_feature_available: expect_feature_available_default,
+        is_promise_test: true,
+      });
+    }, `${header} allows Payment Request API same-origin iframes.`);
 
-        promise_test(async (t) => {
-            return test_feature_availability(
-                "PaymentRequest()",
-                t,
-                cross_origin_src,
-                expect_feature_unavailable_default,
-                undefined,
-                undefined,
-                true
-            );
-        }, header + " disallows cross-origin iframes.");
+    promise_test(async (test) => {
+      return test_feature_availability({
+        feature_description: "PaymentRequest()",
+        test,
+        src: cross_origin_src,
+        expect_feature_available: expect_feature_unavailable_default,
+        is_promise_test: true,
+      });
+    }, `${header} disallows Payment Request API cross-origin iframes.`);
 
-        promise_test(async (t) => {
-            return test_feature_availability(
-                "PaymentRequest()",
-                t,
-                cross_origin_src,
-                expect_feature_available_default,
-                "payment",
-                undefined,
-                true
-            );
-        }, header + ' allow="payment" allows cross-origin iframes.');
-    </script>
+    promise_test(async (test) => {
+      return test_feature_availability({
+        feature_description: "PaymentRequest()",
+        test,
+        src: cross_origin_src,
+        expect_feature_available: expect_feature_available_default,
+        feature_name: "payment",
+        is_promise_test: true,
+      });
+    }, `${header} allow="payment" allows Payment Request in cross-origin iframes.`);
+  </script>
 </body>

--- a/permissions-policy/payment-allowed-by-permissions-policy.https.sub.html
+++ b/permissions-policy/payment-allowed-by-permissions-policy.https.sub.html
@@ -1,40 +1,70 @@
 <!DOCTYPE html>
 <body>
-  <script src=/resources/testharness.js></script>
-  <script src=/resources/testharnessreport.js></script>
-  <script src=/permissions-policy/resources/permissions-policy.js></script>
-  <script>
-  'use strict';
-  var same_origin_src = '/permissions-policy/resources/permissions-policy-payment.html';
-  var cross_origin_src = 'https://{{domains[www]}}:{{ports[https][0]}}' +
-    same_origin_src;
-  var header = 'permissions policy header "payment=*"';
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/permissions-policy/resources/permissions-policy.js"></script>
+    <script>
+        "use strict";
+        const same_origin_src =
+            "/permissions-policy/resources/permissions-policy-payment.html";
+        const cross_origin_src =
+            "https://{{hosts[alt][]}}:{{ports[https][0]}}" + same_origin_src;
+        const header = 'permissions policy header "payment=*"';
 
-  test(() => {
-    var supportedMethods = [ { supportedMethods: 'https://{{domains[nonexistent]}}/payment-request' } ];
-    var details = {
-      total: { label: 'Test', amount: { currency: 'USD', value: '5.00' } }
-    };
-    try {
-      new PaymentRequest(supportedMethods, details);
-    } catch (e) {
-      assert_unreached();
-    }
-  }, header + ' allows the top-level document.');
+        test(() => {
+            const supportedMethods = [
+                {
+                    supportedMethods:
+                        "https://{{domains[nonexistent]}}/payment-request",
+                },
+            ];
+            const details = {
+                total: {
+                    label: "Test",
+                    amount: { currency: "USD", value: "5.00" },
+                },
+            };
+            try {
+                new PaymentRequest(supportedMethods, details);
+            } catch (e) {
+                assert_unreached();
+            }
+        }, header + " allows the top-level document.");
 
-  async_test(t => {
-    test_feature_availability('PaymentRequest()', t, same_origin_src,
-        expect_feature_available_default);
-  }, header + ' allows same-origin iframes.');
+        promise_test((t) => {
+            return test_feature_availability(
+                "PaymentRequest()",
+                t,
+                same_origin_src,
+                expect_feature_available_default,
+                undefined,
+                undefined,
+                true
+            );
+        }, header + " allows same-origin iframes.");
 
-  async_test(t => {
-    test_feature_availability('PaymentRequest()', t, cross_origin_src,
-        expect_feature_unavailable_default);
-  }, header + ' disallows cross-origin iframes.');
+        promise_test(async (t) => {
+            return test_feature_availability(
+                "PaymentRequest()",
+                t,
+                cross_origin_src,
+                expect_feature_unavailable_default,
+                undefined,
+                undefined,
+                true
+            );
+        }, header + " disallows cross-origin iframes.");
 
-  async_test(t => {
-    test_feature_availability('PaymentRequest()', t, cross_origin_src,
-        expect_feature_available_default, 'payment');
-  }, header + ' allow="payment" allows cross-origin iframes.');
-  </script>
+        promise_test(async (t) => {
+            return test_feature_availability(
+                "PaymentRequest()",
+                t,
+                cross_origin_src,
+                expect_feature_available_default,
+                "payment",
+                undefined,
+                true
+            );
+        }, header + ' allow="payment" allows cross-origin iframes.');
+    </script>
 </body>

--- a/permissions-policy/payment-default-permissions-policy.https.sub.html
+++ b/permissions-policy/payment-default-permissions-policy.https.sub.html
@@ -1,35 +1,53 @@
 <!DOCTYPE html>
 <body>
-  <script src=/resources/testharness.js></script>
-  <script src=/resources/testharnessreport.js></script>
-  <script src=/permissions-policy/resources/permissions-policy.js></script>
-  <script>
-  'use strict';
-  var same_origin_src = '/permissions-policy/resources/permissions-policy-payment.html';
-  var cross_origin_src = 'https://{{domains[www]}}:{{ports[https][0]}}' +
-    same_origin_src;
-  var header = 'Default "payment" permissions policy';
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/permissions-policy/resources/permissions-policy.js"></script>
+    <script>
+        "use strict";
+        const same_origin_src =
+            "/permissions-policy/resources/permissions-policy-payment.html";
+        const cross_origin_src =
+            "https://{{hosts[alt][]}}:{{ports[https][0]}}" + same_origin_src;
+        const header = 'Default "payment" permissions policy';
 
-  test(() => {
-    var supportedInstruments = [ { supportedMethods: 'visa' } ];
-    var details = {
-      total: { label: 'Test', amount: { currency: 'USD', value: '5.00' } }
-    };
-    try {
-      new PaymentRequest(supportedInstruments, details);
-    } catch (e) {
-      assert_unreached();
-    }
-  }, header + ' allows the top-level document.');
+        test(() => {
+            const supportedInstruments = [{ supportedMethods: "visa" }];
+            const details = {
+                total: {
+                    label: "Test",
+                    amount: { currency: "USD", value: "5.00" },
+                },
+            };
+            try {
+                new PaymentRequest(supportedInstruments, details);
+            } catch (e) {
+                assert_unreached();
+            }
+        }, header + " allows the top-level document.");
 
-  async_test(t => {
-    test_feature_availability('PaymentRequest()', t, same_origin_src,
-        expect_feature_available_default);
-  }, header + ' allows same-origin iframes.');
+        promise_test((t) => {
+            return test_feature_availability(
+                "PaymentRequest()",
+                t,
+                same_origin_src,
+                expect_feature_available_default,
+                undefined,
+                undefined,
+                true
+            );
+        }, header + " allows same-origin iframes.");
 
-  async_test(t => {
-    test_feature_availability('PaymentRequest()', t, cross_origin_src,
-        expect_feature_unavailable_default);
-  }, header + ' disallows cross-origin iframes.');
-  </script>
+        promise_test((t) => {
+            return test_feature_availability(
+                "PaymentRequest()",
+                t,
+                cross_origin_src,
+                expect_feature_unavailable_default,
+                undefined,
+                undefined,
+                true
+            );
+        }, header + " disallows cross-origin iframes.");
+    </script>
 </body>

--- a/permissions-policy/payment-default-permissions-policy.https.sub.html
+++ b/permissions-policy/payment-default-permissions-policy.https.sub.html
@@ -9,7 +9,6 @@
       "/permissions-policy/resources/permissions-policy-payment.html";
     const cross_origin_src =
       "https://{{hosts[alt][]}}:{{ports[https][0]}}" + same_origin_src;
-    const header = 'Default "payment" permissions policy';
 
     test(() => {
       const supportedInstruments = [{ supportedMethods: "visa" }];

--- a/permissions-policy/payment-default-permissions-policy.https.sub.html
+++ b/permissions-policy/payment-default-permissions-policy.https.sub.html
@@ -1,53 +1,49 @@
 <!DOCTYPE html>
 <body>
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-    <script src="/permissions-policy/resources/permissions-policy.js"></script>
-    <script>
-        "use strict";
-        const same_origin_src =
-            "/permissions-policy/resources/permissions-policy-payment.html";
-        const cross_origin_src =
-            "https://{{hosts[alt][]}}:{{ports[https][0]}}" + same_origin_src;
-        const header = 'Default "payment" permissions policy';
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script>
+    "use strict";
+    const same_origin_src =
+      "/permissions-policy/resources/permissions-policy-payment.html";
+    const cross_origin_src =
+      "https://{{hosts[alt][]}}:{{ports[https][0]}}" + same_origin_src;
+    const header = 'Default "payment" permissions policy';
 
-        test(() => {
-            const supportedInstruments = [{ supportedMethods: "visa" }];
-            const details = {
-                total: {
-                    label: "Test",
-                    amount: { currency: "USD", value: "5.00" },
-                },
-            };
-            try {
-                new PaymentRequest(supportedInstruments, details);
-            } catch (e) {
-                assert_unreached();
-            }
-        }, header + " allows the top-level document.");
+    test(() => {
+      const supportedInstruments = [{ supportedMethods: "visa" }];
+      const details = {
+        total: {
+          label: "Test",
+          amount: { currency: "USD", value: "5.00" },
+        },
+      };
+      try {
+        new PaymentRequest(supportedInstruments, details);
+      } catch (e) {
+        assert_unreached();
+      }
+    }, `Payment Request API is enabled by default the top-level document.`);
 
-        promise_test((t) => {
-            return test_feature_availability(
-                "PaymentRequest()",
-                t,
-                same_origin_src,
-                expect_feature_available_default,
-                undefined,
-                undefined,
-                true
-            );
-        }, header + " allows same-origin iframes.");
+    promise_test((test) => {
+      return test_feature_availability({
+        feature_description: "PaymentRequest()",
+        test,
+        src: same_origin_src,
+        expect_feature_available: expect_feature_available_default,
+        is_promise_test: true,
+      });
+    }, `Payment Request API is enabled by default in same-origin iframes.`);
 
-        promise_test((t) => {
-            return test_feature_availability(
-                "PaymentRequest()",
-                t,
-                cross_origin_src,
-                expect_feature_unavailable_default,
-                undefined,
-                undefined,
-                true
-            );
-        }, header + " disallows cross-origin iframes.");
-    </script>
+    promise_test((test) => {
+      return test_feature_availability({
+        feature_description: "PaymentRequest()",
+        test,
+        src: cross_origin_src,
+        expect_feature_available: expect_feature_unavailable_default,
+        is_promise_test: true,
+      });
+    }, `Payment Request API is disabled by default in cross-origin iframes.`);
+  </script>
 </body>

--- a/permissions-policy/payment-disabled-by-permissions-policy.https.sub.html
+++ b/permissions-policy/payment-disabled-by-permissions-policy.https.sub.html
@@ -1,33 +1,51 @@
 <!DOCTYPE html>
 <body>
-  <script src=/resources/testharness.js></script>
-  <script src=/resources/testharnessreport.js></script>
-  <script src=/permissions-policy/resources/permissions-policy.js></script>
-  <script>
-  'use strict';
-  var same_origin_src = '/permissions-policy/resources/permissions-policy-payment.html';
-  var cross_origin_src = 'https://{{domains[www]}}:{{ports[https][0]}}' +
-    same_origin_src;
-  var header = 'permissions policy header "payment=()"';
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/permissions-policy/resources/permissions-policy.js"></script>
+    <script>
+        "use strict";
+        const same_origin_src =
+            "/permissions-policy/resources/permissions-policy-payment.html";
+        const cross_origin_src =
+            "https://{{hosts[alt][]}}:{{ports[https][0]}}" + same_origin_src;
+        const header = 'permissions policy header "payment=()"';
 
-  test(() => {
-    var supportedInstruments = [ { supportedMethods: 'visa' } ];
-    var details = {
-      total: { label: 'Test', amount: { currency: 'USD', value: '5.00' } }
-    };
-    assert_throws_dom('SecurityError', () => {
-      new PaymentRequest(supportedInstruments, details);
-    });
-  }, header + ' disallows the top-level document.');
+        test(() => {
+            const supportedInstruments = [{ supportedMethods: "visa" }];
+            const details = {
+                total: {
+                    label: "Test",
+                    amount: { currency: "USD", value: "5.00" },
+                },
+            };
+            assert_throws_dom("SecurityError", () => {
+                new PaymentRequest(supportedInstruments, details);
+            });
+        }, header + " disallows the top-level document.");
 
-  async_test(t => {
-    test_feature_availability('PaymentRequest()', t, same_origin_src,
-        expect_feature_unavailable_default);
-  }, header + ' disallows same-origin iframes.');
+        promise_test((t) => {
+            return test_feature_availability(
+                "PaymentRequest()",
+                t,
+                same_origin_src,
+                expect_feature_unavailable_default,
+                undefined,
+                undefined,
+                true
+            );
+        }, header + " disallows same-origin iframes.");
 
-  async_test(t => {
-    test_feature_availability('PaymentRequest()', t, cross_origin_src,
-        expect_feature_unavailable_default,);
-  }, header + ' disallows cross-origin iframes.');
-  </script>
+        promise_test((t) => {
+            return test_feature_availability(
+                "PaymentRequest()",
+                t,
+                cross_origin_src,
+                expect_feature_unavailable_default,
+                undefined,
+                undefined,
+                true
+            );
+        }, header + " disallows cross-origin iframes.");
+    </script>
 </body>

--- a/permissions-policy/payment-disabled-by-permissions-policy.https.sub.html
+++ b/permissions-policy/payment-disabled-by-permissions-policy.https.sub.html
@@ -1,51 +1,47 @@
 <!DOCTYPE html>
 <body>
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-    <script src="/permissions-policy/resources/permissions-policy.js"></script>
-    <script>
-        "use strict";
-        const same_origin_src =
-            "/permissions-policy/resources/permissions-policy-payment.html";
-        const cross_origin_src =
-            "https://{{hosts[alt][]}}:{{ports[https][0]}}" + same_origin_src;
-        const header = 'permissions policy header "payment=()"';
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/permissions-policy/resources/permissions-policy.js"></script>
+  <script>
+    "use strict";
+    const same_origin_src =
+      "/permissions-policy/resources/permissions-policy-payment.html";
+    const cross_origin_src =
+      "https://{{hosts[alt][]}}:{{ports[https][0]}}" + same_origin_src;
+    const header = 'permissions policy header "payment=()"';
 
-        test(() => {
-            const supportedInstruments = [{ supportedMethods: "visa" }];
-            const details = {
-                total: {
-                    label: "Test",
-                    amount: { currency: "USD", value: "5.00" },
-                },
-            };
-            assert_throws_dom("SecurityError", () => {
-                new PaymentRequest(supportedInstruments, details);
-            });
-        }, header + " disallows the top-level document.");
+    test(() => {
+      const supportedInstruments = [{ supportedMethods: "visa" }];
+      const details = {
+        total: {
+          label: "Test",
+          amount: { currency: "USD", value: "5.00" },
+        },
+      };
+      assert_throws_dom("SecurityError", () => {
+        new PaymentRequest(supportedInstruments, details);
+      });
+    }, `${header} disallows Payment Request API in top-level document.`);
 
-        promise_test((t) => {
-            return test_feature_availability(
-                "PaymentRequest()",
-                t,
-                same_origin_src,
-                expect_feature_unavailable_default,
-                undefined,
-                undefined,
-                true
-            );
-        }, header + " disallows same-origin iframes.");
+    promise_test((test) => {
+      return test_feature_availability({
+        feature_description: "PaymentRequest()",
+        test,
+        src: same_origin_src,
+        expect_feature_available: expect_feature_unavailable_default,
+        is_promise_test: true,
+      });
+    }, `${header} disallows Payment Request API in same-origin iframes.`);
 
-        promise_test((t) => {
-            return test_feature_availability(
-                "PaymentRequest()",
-                t,
-                cross_origin_src,
-                expect_feature_unavailable_default,
-                undefined,
-                undefined,
-                true
-            );
-        }, header + " disallows cross-origin iframes.");
-    </script>
+    promise_test((test) => {
+      return test_feature_availability({
+        feature_description: "PaymentRequest()",
+        test,
+        src: cross_origin_src,
+        expect_feature_available: expect_feature_unavailable_default,
+        is_promise_test: true,
+      });
+    }, `${header} disallows Payment Request API in cross-origin iframes.`);
+  </script>
 </body>

--- a/permissions-policy/resources/permissions-policy.js
+++ b/permissions-policy/resources/permissions-policy.js
@@ -33,7 +33,7 @@ function test_feature_availability(
     feature_descriptionOrObject, test, src, expect_feature_available, feature_name,
     allowfullscreen, is_promise_test = false) {
 
-  if (typeof feature_descriptionOrObject === "object") {
+  if (feature_descriptionOrObject && feature_descriptionOrObject instanceof Object) {
     const {
       feature_description,
       test,

--- a/permissions-policy/resources/permissions-policy.js
+++ b/permissions-policy/resources/permissions-policy.js
@@ -6,8 +6,9 @@ function assert_permissions_policy_supported() {
 // Tests whether a feature that is enabled/disabled by permissions policy works
 // as expected.
 // Arguments:
-//    feature_description: a short string describing what feature is being
-//        tested. Examples: "usb.GetDevices()", "PaymentRequest()".
+//    feature_descriptionOrObject: either and object, containing the following
+//        properties, or a string describing what feature is being tested.
+//        Examples: "usb.GetDevices()", "PaymentRequest()".
 //    test: test created by testharness. Examples: async_test, promise_test.
 //    src: URL where a feature's availability is checked. Examples:
 //        "/permissions-policy/resources/permissions-policy-payment.html",
@@ -24,13 +25,36 @@ function assert_permissions_policy_supported() {
 //      feature (https://w3c.github.io/webappsec-permissions-policy/#features).
 //      See examples at:
 //      https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md
-//    allow_attribute: Optional argument, only used for testing fullscreen
+//    allowfullscreen: Optional argument, only used for testing fullscreen
 //      by passing "allowfullscreen".
 //    is_promise_test: Optional argument, true if this call should return a
 //    promise. Used by test_feature_availability_with_post_message_result()
 function test_feature_availability(
-    feature_description, test, src, expect_feature_available, feature_name,
-    allow_attribute, is_promise_test = false) {
+    feature_descriptionOrObject, test, src, expect_feature_available, feature_name,
+    allowfullscreen, is_promise_test = false) {
+
+  if (typeof feature_descriptionOrObject === "object") {
+    const {
+      feature_description,
+      test,
+      src,
+      expect_feature_available,
+      feature_name,
+      allowfullscreen,
+      is_promise_test,
+    } = feature_descriptionOrObject;
+    return test_feature_availability(
+      feature_description,
+      test,
+      src,
+      expect_feature_available,
+      feature_name,
+      allowfullscreen,
+      is_promise_test
+    );
+  }
+
+  const feature_description = feature_descriptionOrObject;
   let frame = document.createElement('iframe');
   frame.src = src;
 
@@ -38,8 +62,8 @@ function test_feature_availability(
     frame.allow = frame.allow.concat(";" + feature_name);
   }
 
-  if (typeof allow_attribute !== 'undefined') {
-    frame.setAttribute(allow_attribute, true);
+  if (typeof allowfullscreen !== 'undefined') {
+    frame.setAttribute(allowfullscreen, true);
   }
 
   function expectFeatureAvailable(evt) {


### PR DESCRIPTION
Cleanup the Permission Policy tests for Payments, and set a substitute URL that works with WebKit's infrastructure. 

Fix the tests to use promise_test instead. 
 