### PR TITLE
Support two more test types for iOS wptrunner

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome_ios.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_ios.py
@@ -4,7 +4,9 @@ from .base import WebDriverBrowser, require_arg
 from .base import get_timeout_multiplier   # noqa: F401
 from ..executors import executor_kwargs as base_executor_kwargs
 from ..executors.base import WdspecExecutor  # noqa: F401
-from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
+from ..executors.executorchrome import ChromeDriverPrintRefTestExecutor  # noqa: F401
+from ..executors.executorwebdriver import (WebDriverCrashtestExecutor,  # noqa: F401
+                                           WebDriverTestharnessExecutor,  # noqa: F401
                                            WebDriverRefTestExecutor)  # noqa: F401
 
 
@@ -12,7 +14,9 @@ __wptrunner__ = {"product": "chrome_ios",
                  "check_args": "check_args",
                  "browser": "ChromeiOSBrowser",
                  "executor": {"testharness": "WebDriverTestharnessExecutor",
-                              "reftest": "WebDriverRefTestExecutor"},
+                              "reftest": "WebDriverRefTestExecutor",
+                              "print-reftest": "ChromeDriverPrintRefTestExecutor",
+                              "crashtest": "WebDriverCrashtestExecutor"},
                  "browser_kwargs": "browser_kwargs",
                  "executor_kwargs": "executor_kwargs",
                  "env_extras": "env_extras",


### PR DESCRIPTION
Support the print-reftest and crashtest test type for iOS wptrunner.
Tested in:
https://ci.chromium.org/ui/p/chromium/builders/try/ios-wpt-fyi-rel/171/overview