### PR TITLE
Implement form-associated custom elements and their ElementInternals

### DIFF
--- a/custom-elements/form-associated/form-associated-callback.html
+++ b/custom-elements/form-associated/form-associated-callback.html
@@ -122,7 +122,7 @@ test(() => {
     }
   }
   customElements.define('will-be-defined', WillBeDefined);
-  customElements.upgrade(container);
+  customElements.upgrade($('#container'));
 
   controls = $('#form1').elements;
   assert_equals(controls.length, 3, 'form.elements.length');


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Form-associated elements are now working.

Remaining test failures in custom-elements/form-associated/ are:

- https://github.com/whatwg/html/pull/4658 hasn't made it into the standard yet, and ElementInternals-accessibility is all about that functionality.
- ElementInternals-setFormValue hits many race conditions with our iframe order of operations. Isolating just the "submit this form with these custom elements, look at the query" part, the payload of each test actually does pass! Running the tests as written, we end up with different tests overwriting each other's elements and getting very confused. One problem is the about:blank double-load-event thing, but fixing that doesn't fix everything.
- ElementInternals-validation doesn't work because we don't have form validation in general; I've commented the relevant stubs.
- ElementInternals-form-disabled-callback fails on https://github.com/servo/servo/issues/25713.

This patch is originally from https://github.com/servo/servo/pull/25705

Reviewed in servo/servo#31980