### PR TITLE
update tests which are generic across all TypedArrays for Float16Array

### DIFF
--- a/FileAPI/blob/Blob-constructor.any.js
+++ b/FileAPI/blob/Blob-constructor.any.js
@@ -290,10 +290,11 @@ test_blob(function() {
     new Int16Array([0x4150, 0x5353]),
     new Uint32Array([0x53534150]),
     new Int32Array([0x53534150]),
+    new Float16Array([2.65625, 58.59375]),
     new Float32Array([0xD341500000])
   ]);
 }, {
-  expected: "PASSPASSPASSPASSPASSPASSPASS",
+  expected: "PASSPASSPASSPASSPASSPASSPASSPASS",
   type: "",
   desc: "Passing typed arrays as elements of the blobParts array should work."
 });

--- a/IndexedDB/idb-binary-key-roundtrip.htm
+++ b/IndexedDB/idb-binary-key-roundtrip.htm
@@ -83,6 +83,7 @@ function view_type_test(type) {
   'Int16Array',
   'Uint32Array',
   'Int32Array',
+  'Float16Array',
   'Float32Array',
   'Float64Array'
 ].forEach((type) => { view_type_test(type); });

--- a/IndexedDB/structured-clone.any.js
+++ b/IndexedDB/structured-clone.any.js
@@ -179,6 +179,7 @@ cloneObjectTest(new Uint8Array([0, 1, 254, 255]).buffer, (orig, clone) => {
   new Int16Array([0x0000, 0x0001, 0xFFFE, 0xFFFF]),
   new Int32Array([0x00000000, 0x00000001, 0xFFFFFFFE, 0xFFFFFFFF]),
   new Uint8ClampedArray([0, 1, 254, 255]),
+  new Float16Array([-Infinity, -1.5, -1, -0.5, 0, 0.5, 1, 1.5, Infinity, NaN]),
   new Float32Array([-Infinity, -1.5, -1, -0.5, 0, 0.5, 1, 1.5, Infinity, NaN]),
   new Float64Array([-Infinity, -Number.MAX_VALUE, -Number.MIN_VALUE, 0,
                     Number.MIN_VALUE, Number.MAX_VALUE, Infinity, NaN])

--- a/WebCryptoAPI/getRandomValues.any.js
+++ b/WebCryptoAPI/getRandomValues.any.js
@@ -1,12 +1,19 @@
 // Step 1.
 test(function() {
     assert_throws_dom("TypeMismatchError", function() {
+        self.crypto.getRandomValues(new Float16Array(6))
+    }, "Float16Array")
+    assert_throws_dom("TypeMismatchError", function() {
         self.crypto.getRandomValues(new Float32Array(6))
     }, "Float32Array")
     assert_throws_dom("TypeMismatchError", function() {
         self.crypto.getRandomValues(new Float64Array(6))
     }, "Float64Array")
 
+    assert_throws_dom("TypeMismatchError", function() {
+        const len = 65536 / Float16Array.BYTES_PER_ELEMENT + 1;
+        self.crypto.getRandomValues(new Float16Array(len));
+    }, "Float16Array (too long)")
     assert_throws_dom("TypeMismatchError", function() {
         const len = 65536 / Float32Array.BYTES_PER_ELEMENT + 1;
         self.crypto.getRandomValues(new Float32Array(len));

--- a/compression/decompression-buffersource.tentative.any.js
+++ b/compression/decompression-buffersource.tentative.any.js
@@ -48,6 +48,10 @@ const bufferSourceChunksForDeflate = [
     value: new Uint32Array(new Uint8Array(compressedBytesWithDeflate).buffer)
   },
   {
+    name: 'Float16Array',
+    value: new Float16Array(new Uint8Array(compressedBytesWithDeflate).buffer)
+  },
+  {
     name: 'Float32Array',
     value: new Float32Array(new Uint8Array(compressedBytesWithDeflate).buffer)
   },
@@ -95,6 +99,10 @@ const bufferSourceChunksForGzip = [
     value: new Uint32Array(new Uint8Array(compressedBytesWithGzip).buffer)
   },
   {
+    name: 'Float16Array',
+    value: new Float16Array(new Uint8Array(compressedBytesWithGzip).buffer)
+  },
+  {
     name: 'Float32Array',
     value: new Float32Array(new Uint8Array(compressedBytesWithGzip).buffer)
   },
@@ -140,6 +148,10 @@ const bufferSourceChunksForDeflateRaw = [
   {
     name: 'Uint32Array',
     value: new Uint32Array(new Uint8Array(compressedBytesWithDeflateRaw).buffer)
+  },
+  {
+    name: 'Float16Array',
+    value: new Float16Array(new Uint8Array(compressedBytesWithDeflateRaw).buffer)
   },
   {
     name: 'Float32Array',

--- a/encoding/encodeInto.any.js
+++ b/encoding/encodeInto.any.js
@@ -129,6 +129,7 @@
  "Uint8ClampedArray",
  "BigInt64Array",
  "BigUint64Array",
+ "Float16Array",
  "Float32Array",
  "Float64Array"].forEach(type => {
   ["ArrayBuffer", "SharedArrayBuffer"].forEach((arrayBufferOrSharedArrayBuffer) => {

--- a/fetch/api/basic/request-headers.any.js
+++ b/fetch/api/basic/request-headers.any.js
@@ -54,6 +54,7 @@ requestHeaders("Fetch with POST with Blob body", url, "POST", new Blob(["Test"])
 requestHeaders("Fetch with POST with ArrayBuffer body", url, "POST", new ArrayBuffer(4), location.origin, "4");
 requestHeaders("Fetch with POST with Uint8Array body", url, "POST", new Uint8Array(4), location.origin, "4");
 requestHeaders("Fetch with POST with Int8Array body", url, "POST", new Int8Array(4), location.origin, "4");
+requestHeaders("Fetch with POST with Float16Array body", url, "POST", new Float16Array(1), location.origin, "2");
 requestHeaders("Fetch with POST with Float32Array body", url, "POST", new Float32Array(1), location.origin, "4");
 requestHeaders("Fetch with POST with Float64Array body", url, "POST", new Float64Array(1), location.origin, "8");
 requestHeaders("Fetch with POST with DataView body", url, "POST", new DataView(new ArrayBuffer(8), 0, 4), location.origin, "4");

--- a/fetch/api/basic/request-upload.any.js
+++ b/fetch/api/basic/request-upload.any.js
@@ -60,6 +60,10 @@ testUpload("Fetch with POST with Int8Array body", url,
   "POST",
   () => new Int8Array(4),
   "\0\0\0\0");
+testUpload("Fetch with POST with Float16Array body", url,
+  "POST",
+  () => new Float16Array(2),
+  "\0\0\0\0");
 testUpload("Fetch with POST with Float32Array body", url,
   "POST",
   () => new Float32Array(1),

--- a/fetch/api/response/response-clone.any.js
+++ b/fetch/api/response/response-clone.any.js
@@ -135,6 +135,7 @@ testReadableStreamClone(new Uint16Array(arrayBuffer, 2), "Uint16Array");
 testReadableStreamClone(new Uint32Array(arrayBuffer), "Uint32Array");
 testReadableStreamClone(typeof BigInt64Array === "function" ? new BigInt64Array(arrayBuffer) : undefined, "BigInt64Array");
 testReadableStreamClone(typeof BigUint64Array === "function" ? new BigUint64Array(arrayBuffer) : undefined, "BigUint64Array");
+testReadableStreamClone(typeof Float16Array === "function" ? new Float16Array(arrayBuffer) : undefined, "Float16Array");
 testReadableStreamClone(new Float32Array(arrayBuffer), "Float32Array");
 testReadableStreamClone(new Float64Array(arrayBuffer), "Float64Array");
 testReadableStreamClone(new DataView(arrayBuffer, 2, 8), "DataView");

--- a/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-simple-success.https.html
+++ b/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-simple-success.https.html
@@ -23,6 +23,7 @@
   "Uint32Array",
   "BigInt64Array",
   "BigUint64Array",
+  "Float16Array",
   "Float32Array",
   "Float64Array"
 ].forEach(type => {

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -566,6 +566,7 @@ IdlArray.prototype.is_json_type = function(type)
        case "Uint8ClampedArray":
        case "BigInt64Array":
        case "BigUint64Array":
+       case "Float16Array":
        case "Float32Array":
        case "Float64Array":
        case "ArrayBuffer":

--- a/resources/test/tests/unit/IdlArray/is_json_type.html
+++ b/resources/test/tests/unit/IdlArray/is_json_type.html
@@ -39,6 +39,7 @@
         assert_false(idl.is_json_type(typeFrom("Uint8ClampedArray")));
         assert_false(idl.is_json_type(typeFrom("BigInt64Array")));
         assert_false(idl.is_json_type(typeFrom("BigUint64Array")));
+        assert_false(idl.is_json_type(typeFrom("Float16Array")));
         assert_false(idl.is_json_type(typeFrom("Float32Array")));
         assert_false(idl.is_json_type(typeFrom("Float64Array")));
         assert_false(idl.is_json_type(typeFrom("ArrayBuffer")));

--- a/websockets/Send-binary-arraybufferview-float16.any.js
+++ b/websockets/Send-binary-arraybufferview-float16.any.js
@@ -1,0 +1,40 @@
+// META: script=constants.sub.js
+// META: variant=?default
+// META: variant=?wpt_flags=h2
+// META: variant=?wss
+
+var test = async_test("Send binary data on a WebSocket - ArrayBufferView - Float16Array - Connection should be closed");
+
+var data = "";
+var datasize = 4;
+var view;
+var wsocket = CreateWebSocket(false, false);
+var isOpenCalled = false;
+var isMessageCalled = false;
+
+wsocket.addEventListener('open', test.step_func(function(evt) {
+  wsocket.binaryType = "arraybuffer";
+  data = new ArrayBuffer(datasize);
+  view = new Float16Array(data);
+  for (var i = 0; i < 2; i++) {
+    view[i] = i;
+  }
+  wsocket.send(view);
+  isOpenCalled = true;
+}), true);
+
+wsocket.addEventListener('message', test.step_func(function(evt) {
+  isMessageCalled = true;
+  var resultView = new Float16Array(evt.data);
+  for (var i = 0; i < resultView.length; i++) {
+    assert_equals(resultView[i], view[i], "ArrayBufferView returned is the same");
+  }
+  wsocket.close();
+}), true);
+
+wsocket.addEventListener('close', test.step_func(function(evt) {
+  assert_true(isOpenCalled, "WebSocket connection should be open");
+  assert_true(isMessageCalled, "message should be received")
+  assert_equals(evt.wasClean, true, "wasClean should be true");
+  test.done();
+}), true);

--- a/workers/semantics/interface-objects/001.worker.js
+++ b/workers/semantics/interface-objects/001.worker.js
@@ -30,6 +30,7 @@ var expected = [
   "Uint16Array",
   "Int32Array",
   "Uint32Array",
+  "Float16Array",
   "Float32Array",
   "Float64Array",
   "DataView",

--- a/workers/semantics/interface-objects/003.any.js
+++ b/workers/semantics/interface-objects/003.any.js
@@ -30,6 +30,7 @@ var expected = [
   "Uint16Array",
   "Int32Array",
   "Uint32Array",
+  "Float16Array",
   "Float32Array",
   "Float64Array",
   "DataView",

--- a/xhr/send-data-sharedarraybuffer.any.js
+++ b/xhr/send-data-sharedarraybuffer.any.js
@@ -13,7 +13,7 @@ test(() => {
 
 ["Int8Array", "Uint8Array", "Uint8ClampedArray", "Int16Array", "Uint16Array",
  "Int32Array", "Uint32Array", "BigInt64Array", "BigUint64Array",
- "Float32Array", "Float64Array", "DataView"].forEach((type) => {
+ "Float16Array", "Float32Array", "Float64Array", "DataView"].forEach((type) => {
     test(() => {
         const xhr = new XMLHttpRequest();
         // See https://github.com/whatwg/html/issues/5380 for why not `new SharedArrayBuffer()`


### PR DESCRIPTION
The [Float16Array](https://github.com/tc39/proposal-float16array) proposal for JavaScript adds a new TypedArray type holding IEEE binary16 floats. This PR adds it to all of the tests which are generic across all or almost all TypedArray types.

Corresponding webidl change at https://github.com/whatwg/webidl/pull/1398 and webidl2.js change at https://github.com/w3c/webidl2.js/pull/777 might need to be included before this can land.

These tests will all immediately fail in all engines, since no one is shipping Float16Array yet. Only one pre-existing test, [`fetch/api/response/response-clone.any.js`](fetch/api/response/response-clone.any.js), had accommodations for new TA types not existing yet. If maintainers want to suggest an approach for similar accommodations for the other tests I'm happy to make those changes.