### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=272117

### DIFF
--- a/css/css-view-transitions/update-callback-timeout.html
+++ b/css/css-view-transitions/update-callback-timeout.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <title>View transitions: Transition has implementation-defined timeout.</title>
+  <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+  <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+  <meta name="timeout" content="long">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script>
+    promise_test(async t => {
+      assert_implements(document.startViewTransition, "Missing document.startViewTransition");
+      const transition = document.startViewTransition(() => {
+        return new Promise(() => {});
+      });
+      transition.updateCallbackDone.then(() => {
+        assert_unreached();
+      });
+      transition.finished.then(() => {
+        assert_unreached();
+      });
+      await promise_rejects_dom(t, "TimeoutError", transition.ready);
+    }, "View transition should have an implementation-defined timeout on the update callback");
+</script>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[view-transitions\] Add a timeout to the update callback](https://bugs.webkit.org/show_bug.cgi?id=272117)