### PR TITLE
Create dir-role.tentative.html

### DIFF
--- a/html-aam/dir-role.tentative.html
+++ b/html-aam/dir-role.tentative.html
@@ -22,7 +22,6 @@
 
 <script>
 AriaUtils.verifyRolesBySelector(".ex");
-AriaUtils.verifyGenericRolesBySelector(".ex-generic");
 </script>
 
 </body>

--- a/html-aam/dir-role.tentative.html
+++ b/html-aam/dir-role.tentative.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<head>
+  <title>HTML-AAM dir Element Role Verification Test</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+
+<p>Tentative test for the expected role mappings of the obsolete <code>dir</code> element. 
+  The computedrole mappings are defined in <a href="https://w3c.github.io/html-aam/">HTML-AAM</a>.<p>
+
+<p>Merge the outcome of this test into roles.html in the appropriate alphabetical order, when it is no longer considered tentative:</p>
+
+<dir data-testname="el-dir" data-expectedrole="list" class="ex"><li>x</li><li>x</li></dir>
+
+
+<script>
+AriaUtils.verifyRolesBySelector(".ex");
+AriaUtils.verifyGenericRolesBySelector(".ex-generic");
+</script>
+
+</body>
+</html>

--- a/html-aam/dir-role.tentative.html
+++ b/html-aam/dir-role.tentative.html
@@ -12,7 +12,7 @@
 <body>
 
 
-<p>Tentative test for the expected role mappings of the obsolete <code>dir</code> element. 
+<p>Tentative test for the expected role mappings of the obsolete <code>dir</code> element.
   The computedrole mappings are defined in <a href="https://w3c.github.io/html-aam/">HTML-AAM</a>.<p>
 
 <p>Merge the outcome of this test into roles.html in the appropriate alphabetical order, when it is no longer considered tentative:</p>

--- a/html-aam/roles.html
+++ b/html-aam/roles.html
@@ -51,6 +51,7 @@
 <del data-testname="el-del" data-expectedrole="deletion" class="ex">x</del>
 <details data-testname="el-details" data-expectedrole="group" class="ex"><summary>x</summary>x</details>
 <dfn data-testname="el-dfn" data-expectedrole="term" class="ex">x</dfn>
+<!-- dir -> dir-role.tentative.html -->
 <!-- div -> ./roles-generic.html -->
 <!-- todo: dl -->
 

--- a/html-aam/roles.html
+++ b/html-aam/roles.html
@@ -51,7 +51,7 @@
 <del data-testname="el-del" data-expectedrole="deletion" class="ex">x</del>
 <details data-testname="el-details" data-expectedrole="group" class="ex"><summary>x</summary>x</details>
 <dfn data-testname="el-dfn" data-expectedrole="term" class="ex">x</dfn>
-<!-- dir -> dir-role.tentative.html -->
+<!-- dir -> ./dir-role.tentative.html -->
 <!-- div -> ./roles-generic.html -->
 <!-- todo: dl -->
 


### PR DESCRIPTION
add test for the `dir` element, which is defined as obsolete in HTML, but that it should be treated the same as `ul` - and thus be exposed with an implicit role=list