### PR TITLE
[wptrunner] On exit, re-register prior `SIGINT` handler, not `SIG_DFL`

### DIFF
--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 
+import contextlib
 import errno
 import json
 import os
@@ -113,6 +114,7 @@ class TestEnvironment:
         self.options = options if options is not None else {}
 
         mp_context = mpcontext.get_context()
+        self._stack = contextlib.ExitStack()
         self.cache_manager = mp_context.Manager()
         self.stash = serve.stash.StashServer(mp_context=mp_context)
         self.env_extras = env_extras
@@ -124,13 +126,13 @@ class TestEnvironment:
         self.suppress_handler_traceback = suppress_handler_traceback
 
     def __enter__(self):
-        server_log_handler = self.server_logging_ctx.__enter__()
+        server_log_handler = self._stack.enter_context(self.server_logging_ctx)
         self.config_ctx = self.build_config()
 
-        self.config = self.config_ctx.__enter__()
+        self.config = self._stack.enter_context(self.config_ctx)
 
-        self.stash.__enter__()
-        self.cache_manager.__enter__()
+        self._stack.enter_context(self.stash)
+        self._stack.enter_context(self.cache_manager)
 
         assert self.env_extras_cms is None, (
             "A TestEnvironment object cannot be nested")
@@ -139,7 +141,7 @@ class TestEnvironment:
 
         for env in self.env_extras:
             cm = env(self.options, self.config)
-            cm.__enter__()
+            self._stack.enter_context(cm)
             self.env_extras_cms.append(cm)
 
         self.servers = serve.start(self.server_logger,
@@ -162,15 +164,9 @@ class TestEnvironment:
         for servers in self.servers.values():
             for _, server in servers:
                 server.wait()
-        for cm in self.env_extras_cms:
-            cm.__exit__(exc_type, exc_val, exc_tb)
 
+        self._stack.__exit__(exc_type, exc_val, exc_tb)
         self.env_extras_cms = None
-
-        self.cache_manager.__exit__(exc_type, exc_val, exc_tb)
-        self.stash.__exit__()
-        self.config_ctx.__exit__(exc_type, exc_val, exc_tb)
-        self.server_logging_ctx.__exit__(exc_type, exc_val, exc_tb)
 
     def ignore_interrupts(self):
         signal.signal(signal.SIGINT, signal.SIG_IGN)


### PR DESCRIPTION
libc's default `SIGINT` behavior is to simply terminate the process (see
[section 24.2.2 "Termination Signals"][0]). This means that
interrupting wptrunner just after `TestEnvironment.process_interrupts()`
will orphan the server subprocesses, as the code to stop them won't run.

This PR fixes this by restoring the previous handler, which defaults to
a different Python-provided handler that [raises `KeyboardInterrupt`
instead][1]:

```
$ python
Python 3.11.7 (main, Dec  8 2023, 14:22:46) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import signal
>>> # Hit Ctrl+C here
KeyboardInterrupt
>>> signal.signal(signal.SIGINT, signal.SIG_DFL)
<built-in function default_int_handler>
>>> # Hit Ctrl+C again, this will terminate `python` instead
```

In particular, because Python won't terminate abruptly, the [`daemon`
setting of `multiprocessing.Process`][2] will be respected.

Also, there's no need to switch handlers at all in a noninteractive
session.

This is a partial fix for https://crbug.com/330236796.

[0]: https://www.gnu.org/software/libc/manual/pdf/libc.pdf
[1]: https://docs.python.org/3/library/signal.html#signal.SIGINT
[2]: https://github.com/web-platform-tests/wpt/blob/9417ab60/tools/serve/serve.py#L655