### PR TITLE
Test interaction between `object-fit` and `contain: size`

### DIFF
--- a/css/css-images/object-fit-containcontainintrinsicsize-png-001i.tentative.html
+++ b/css/css-images/object-fit-containcontainintrinsicsize-png-001i.tentative.html
@@ -14,7 +14,7 @@
       img {
         border: 1px dashed gray;
         padding: 1px;
-        image-rendering: crisp-edges;
+        image-rendering: pixelated;
         float: left;
         object-position: top left;
         contain: size;

--- a/css/css-images/object-fit-containcontainintrinsicsize-png-001i.tentative.html
+++ b/css/css-images/object-fit-containcontainintrinsicsize-png-001i.tentative.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CSS Test: 'object-fit: contain' and 'contain-intrinsic-size' on img element, embedding a PNG image</title>
+    <link rel="author" title="Eric Portis" href="mailto:e@ericportis.com">
+    <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/10116">
+    <link rel="match" href="object-fit-containsize-png-001-ref.tentative.html">
+    <style type="text/css">
+      img {
+        border: 1px dashed gray;
+        padding: 1px;
+        image-rendering: crisp-edges;
+        float: left;
+        object-position: top left;
+        contain: size;
+      }
+      br {
+        clear: both;
+      }
+      .big {
+        contain-intrinsic-width: 32px;
+        contain-intrinsic-height: 48px;
+      }
+      .small {
+        contain-intrinsic-width: 8px;
+        contain-intrinsic-height: 8px;
+      }
+      
+      .cover { object-fit: cover }
+      .contain { object-fit: contain }
+      .fill { object-fit: fill }
+      .none { object-fit: none }
+      .scaledown { object-fit: scale-down }
+      
+    </style>
+  </head>
+  <body>
+    <!-- big: -->
+    <img src="support/colors-16x8.png" class="big cover">
+    <img src="support/colors-16x8.png" class="big contain">
+    <img src="support/colors-16x8.png" class="big fill">
+    <img src="support/colors-16x8.png" class="big none">
+    <img src="support/colors-16x8.png" class="big scaledown">
+    <br>
+    <!-- small: -->
+    <img src="support/colors-16x8.png" class="small cover">
+    <img src="support/colors-16x8.png" class="small contain">
+    <img src="support/colors-16x8.png" class="small fill">
+    <img src="support/colors-16x8.png" class="small none">
+    <img src="support/colors-16x8.png" class="small scaledown">
+    <br>
+  </body>
+</html>

--- a/css/css-images/object-fit-containcontainintrinsicsize-png-001i.tentative.html
+++ b/css/css-images/object-fit-containcontainintrinsicsize-png-001i.tentative.html
@@ -30,13 +30,13 @@
         contain-intrinsic-width: 8px;
         contain-intrinsic-height: 8px;
       }
-      
+
       .cover { object-fit: cover }
       .contain { object-fit: contain }
       .fill { object-fit: fill }
       .none { object-fit: none }
       .scaledown { object-fit: scale-down }
-      
+
     </style>
   </head>
   <body>

--- a/css/css-images/object-fit-containsize-png-001-ref.tentative.html
+++ b/css/css-images/object-fit-containsize-png-001-ref.tentative.html
@@ -31,14 +31,14 @@
         width: 8px;
         height: 8px;
       }
-      
+
       .cover { background-size: cover; }
       .contain { background-size: contain; }
       .fill { background-size: 100% 100%; }
       .none { background-size: auto auto; }
       .scaledown { background-size: auto auto; }
       .small.scaledown { background-size: contain; }
-      
+
     </style>
   </head>
   <body>

--- a/css/css-images/object-fit-containsize-png-001-ref.tentative.html
+++ b/css/css-images/object-fit-containsize-png-001-ref.tentative.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CSS Reftest Reference</title>
+    <link rel="author" title="Eric Portis" href="mailto:e@ericportis.com">
+    <style type="text/css">
+      .objectOuter {
+        border: 1px dashed gray;
+        padding: 1px;
+        float: left;
+      }
+      .objectOuter > * {
+        background-image: url("support/colors-16x8.png");
+        background-repeat: no-repeat;
+        image-rendering: crisp-edges;
+        background-position: 0% 0%;
+      }
+      br {
+        clear: both;
+      }
+      .big {
+        width: 32px;
+        height: 48px;
+      }
+      .small {
+        width: 8px;
+        height: 8px;
+      }
+      
+      .cover { background-size: cover; }
+      .contain { background-size: contain; }
+      .fill { background-size: 100% 100%; }
+      .none { background-size: auto auto; }
+      .scaledown { background-size: auto auto; }
+      .small.scaledown { background-size: contain; }
+      
+    </style>
+  </head>
+  <body>
+    <!-- big: -->
+    <div class="objectOuter"><div class="big cover"></div></div>
+    <div class="objectOuter"><div class="big contain"></div></div>
+    <div class="objectOuter"><div class="big fill"></div></div>
+    <div class="objectOuter"><div class="big none"></div></div>
+    <div class="objectOuter"><div class="big scaledown"></div></div>
+    <br>
+    <!-- small: -->
+    <div class="objectOuter"><div class="small cover"></div></div>
+    <div class="objectOuter"><div class="small contain"></div></div>
+    <div class="objectOuter"><div class="small fill"></div></div>
+    <div class="objectOuter"><div class="small none"></div></div>
+    <div class="objectOuter"><div class="small scaledown"></div></div>
+    <br>
+  </body>
+</html>

--- a/css/css-images/object-fit-containsize-png-001-ref.tentative.html
+++ b/css/css-images/object-fit-containsize-png-001-ref.tentative.html
@@ -17,7 +17,7 @@
       .objectOuter > * {
         background-image: url("support/colors-16x8.png");
         background-repeat: no-repeat;
-        image-rendering: crisp-edges;
+        image-rendering: pixelated;
         background-position: 0% 0%;
       }
       br {

--- a/css/css-images/object-fit-containsize-png-001i.tentative.html
+++ b/css/css-images/object-fit-containsize-png-001i.tentative.html
@@ -30,13 +30,13 @@
         width: 8px;
         height: 8px;
       }
-      
+
       .cover { object-fit: cover }
       .contain { object-fit: contain }
       .fill { object-fit: fill }
       .none { object-fit: none }
       .scaledown { object-fit: scale-down }
-      
+
     </style>
   </head>
   <body>

--- a/css/css-images/object-fit-containsize-png-001i.tentative.html
+++ b/css/css-images/object-fit-containsize-png-001i.tentative.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CSS Test: 'object-fit: contain' and 'contain: size' on img element, embedding a PNG image</title>
+    <link rel="author" title="Eric Portis" href="mailto:e@ericportis.com">
+    <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/10116">
+    <link rel="match" href="object-fit-containsize-png-001-ref.tentative.html">
+    <style type="text/css">
+      img {
+        border: 1px dashed gray;
+        padding: 1px;
+        image-rendering: crisp-edges;
+        float: left;
+        contain: size;
+        object-position: top left;
+      }
+      br {
+        clear: both;
+      }
+      .big {
+        width: 32px;
+        height: 48px;
+      }
+      .small {
+        width: 8px;
+        height: 8px;
+      }
+      
+      .cover { object-fit: cover }
+      .contain { object-fit: contain }
+      .fill { object-fit: fill }
+      .none { object-fit: none }
+      .scaledown { object-fit: scale-down }
+      
+    </style>
+  </head>
+  <body>
+    <!-- big: -->
+    <img src="support/colors-16x8.png" class="big cover">
+    <img src="support/colors-16x8.png" class="big contain">
+    <img src="support/colors-16x8.png" class="big fill">
+    <img src="support/colors-16x8.png" class="big none">
+    <img src="support/colors-16x8.png" class="big scaledown">
+    <br>
+    <!-- small: -->
+    <img src="support/colors-16x8.png" class="small cover">
+    <img src="support/colors-16x8.png" class="small contain">
+    <img src="support/colors-16x8.png" class="small fill">
+    <img src="support/colors-16x8.png" class="small none">
+    <img src="support/colors-16x8.png" class="small scaledown">
+    <br>
+  </body>
+</html>

--- a/css/css-images/object-fit-containsize-png-001i.tentative.html
+++ b/css/css-images/object-fit-containsize-png-001i.tentative.html
@@ -14,7 +14,7 @@
       img {
         border: 1px dashed gray;
         padding: 1px;
-        image-rendering: crisp-edges;
+        image-rendering: pixelated;
         float: left;
         contain: size;
         object-position: top left;


### PR DESCRIPTION
[css-images] [css-contain]

`object-fit` should use the "real" natural aspect ratio, and `contain: size` should not ruin this

https://github.com/w3c/csswg-drafts/issues/10116
https://github.com/w3c/csswg-drafts/issues/6257