### PR TITLE
[wdspec] change assertion for viewport/test_with_scrollbars

### DIFF
--- a/webdriver/tests/bidi/browsing_context/set_viewport/viewport.py
+++ b/webdriver/tests/bidi/browsing_context/set_viewport/viewport.py
@@ -243,6 +243,6 @@ async def test_with_scrollbars(
     # The side which has scrollbar takes up space on the other side
     # (e.g. if we have a horizontal scroll height is going to be smaller than viewport height)
     if use_horizontal_scrollbar:
-        assert viewport_without_scrollbar["height"] < test_viewport["height"]
+        assert viewport_without_scrollbar["height"] <= test_viewport["height"]
     if use_vertical_scrollbar:
-        assert viewport_without_scrollbar["width"] < test_viewport["width"]
+        assert viewport_without_scrollbar["width"] <= test_viewport["width"]


### PR DESCRIPTION
As far as I see the type of the scrollbar used by the browser is not enforced and therefore the browser implementation might choose an overlay scrollbar that does not affect the layout. In that case, the viewport without scrollbar can be equal to the test viewport.