### PR TITLE
Add gradient tests using single-stop longer hue interpolation

### DIFF
--- a/css/css-images/gradient/gradient-single-stop-longer-hue-hsl-ref.html
+++ b/css/css-images/gradient/gradient-single-stop-longer-hue-hsl-ref.html
@@ -2,21 +2,22 @@
 <html lang="en">
 
 <head>
-  <meta charset="utf-8">
-  <title>Gradient in HSL space</title>
-  <style>
-      body {
-        background: #fff;
-      }
-      div {
-        width: 300px;
-        height: 300px;
-        background-image: linear-gradient(in hsl shorter hue 45deg, #f00 0%, #00f 33.333%, #0f0 66.667%, #f00 100%);
-      }
-  </style>
+    <meta charset="utf-8">
+    <title>Gradient in HSL space</title>
+    <style>
+        body {
+            background: #fff;
+        }
+
+        div {
+            width: 300px;
+            height: 300px;
+            background-image: linear-gradient(in hsl shorter hue 0deg, #ff0000 0%, #0000ff 33.3333%, #00ff00 66.6667%, #ff0000 100%);
+        }
+    </style>
 </head>
 
 <body>
-  <div></div>
+    <div></div>
 </body>
 </html>

--- a/css/css-images/gradient/gradient-single-stop-longer-hue-hsl-ref.html
+++ b/css/css-images/gradient/gradient-single-stop-longer-hue-hsl-ref.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Gradient in HSL space</title>
+  <style>
+      body {
+        background: #fff;
+      }
+      div {
+        width: 300px;
+        height: 300px;
+        background-image: linear-gradient(in hsl shorter hue 45deg, #f00 0%, #00f 33.333%, #0f0 66.667%, #f00 100%);
+      }
+  </style>
+</head>
+
+<body>
+  <div></div>
+</body>
+</html>

--- a/css/css-images/gradient/gradient-single-stop-longer-hue-hsl-ref.html
+++ b/css/css-images/gradient/gradient-single-stop-longer-hue-hsl-ref.html
@@ -12,7 +12,7 @@
         div {
             width: 300px;
             height: 300px;
-            background-image: linear-gradient(in hsl shorter hue 0deg, #ff0000 0%, #0000ff 33.3333%, #00ff00 66.6667%, #ff0000 100%);
+            background-image: linear-gradient(in hsl shorter hue 0deg, #ff0000 0%, #00ff00 33.3333%, #0000ff 66.6667%, #ff0000 100%);
         }
     </style>
 </head>

--- a/css/css-images/gradient/gradient-single-stop-longer-hue-hsl-ref.html
+++ b/css/css-images/gradient/gradient-single-stop-longer-hue-hsl-ref.html
@@ -12,7 +12,7 @@
         div {
             width: 300px;
             height: 300px;
-            background-image: linear-gradient(in hsl shorter hue 0deg, #ff0000 0%, #00ff00 33.3333%, #0000ff 66.6667%, #ff0000 100%);
+            background-image: linear-gradient(in hsl shorter hue 0deg, hsl(0, 100%, 50%) 0%, hsl(120, 100%, 50%) 33.3333%, hsl(240, 100%, 50%) 66.6667%, hsl(0, 100%, 50%) 100%);
         }
     </style>
 </head>

--- a/css/css-images/gradient/gradient-single-stop-longer-hue-hsl.html
+++ b/css/css-images/gradient/gradient-single-stop-longer-hue-hsl.html
@@ -17,7 +17,7 @@
         div {
             width: 300px;
             height: 300px;
-            background-image: linear-gradient(in hsl longer hue 0deg, #ff0000 0 0);
+            background-image: linear-gradient(in hsl longer hue 0deg, hsl(0, 100%, 50%) 0 0);
         }
     </style>
 </head>

--- a/css/css-images/gradient/gradient-single-stop-longer-hue-hsl.html
+++ b/css/css-images/gradient/gradient-single-stop-longer-hue-hsl.html
@@ -7,7 +7,7 @@
     <meta name="fuzzy" content="maxDifference=0-15;totalPixels=0-90000">
     <link rel="author" title="Ashley Hale" href="mailto:ahale@mozilla.com">
     <link rel="help" href="https://www.w3.org/TR/css-color-4/#interpolation">
-    <meta name="assert" content="Tests gradient interpolation in Hsl space when a single stop is specified in sRGB with longer hue to make it wrap">
+    <meta name="assert" content="Tests gradient interpolation in Hsl space when a single stop is specified with longer hue to make it wrap">
     <link rel="match" href="gradient-single-stop-longer-hue-hsl-ref.html">
     <style>
         body {

--- a/css/css-images/gradient/gradient-single-stop-longer-hue-hsl.html
+++ b/css/css-images/gradient/gradient-single-stop-longer-hue-hsl.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <title>Gradient in HSL space</title>
-    <meta name="fuzzy" content="maxDifference=1-2;totalPixels=0-10000">
+    <meta name="fuzzy" content="maxDifference=0-15;totalPixels=0-90000">
     <link rel="author" title="Ashley Hale" href="mailto:ahale@mozilla.com">
     <link rel="help" href="https://www.w3.org/TR/css-color-4/#interpolation">
     <meta name="assert" content="Tests gradient interpolation in Hsl space when a single stop is specified in sRGB with longer hue to make it wrap">
@@ -17,12 +17,12 @@
         div {
             width: 300px;
             height: 300px;
-            background-image: linear-gradient(in hsl longer hue 45deg, #f00 0 0);
+            background-image: linear-gradient(in hsl longer hue 0deg, #ff0000 0 0);
         }
     </style>
 </head>
 
 <body>
-  <div></div>
+    <div></div>
 </body>
 </html>

--- a/css/css-images/gradient/gradient-single-stop-longer-hue-hsl.html
+++ b/css/css-images/gradient/gradient-single-stop-longer-hue-hsl.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Gradient in HSL space</title>
+  <style>
+      body {
+        background: #fff;
+      }
+      div {
+        width: 300px;
+        height: 300px;
+        background-image: linear-gradient(in hsl longer hue 45deg, #f00 0 0);
+      }
+  </style>
+</head>
+
+<body>
+  <div></div>
+</body>
+</html>

--- a/css/css-images/gradient/gradient-single-stop-longer-hue-hsl.html
+++ b/css/css-images/gradient/gradient-single-stop-longer-hue-hsl.html
@@ -2,18 +2,24 @@
 <html lang="en">
 
 <head>
-  <meta charset="utf-8">
-  <title>Gradient in HSL space</title>
-  <style>
-      body {
-        background: #fff;
-      }
-      div {
-        width: 300px;
-        height: 300px;
-        background-image: linear-gradient(in hsl longer hue 45deg, #f00 0 0);
-      }
-  </style>
+    <meta charset="utf-8">
+    <title>Gradient in HSL space</title>
+    <meta name="fuzzy" content="maxDifference=1-2;totalPixels=0-10000">
+    <link rel="author" title="Ashley Hale" href="mailto:ahale@mozilla.com">
+    <link rel="help" href="https://www.w3.org/TR/css-color-4/#interpolation">
+    <meta name="assert" content="Tests gradient interpolation in Hsl space when a single stop is specified in sRGB with longer hue to make it wrap">
+    <link rel="match" href="gradient-single-stop-longer-hue-hsl-ref.html">
+    <style>
+        body {
+            background: #fff;
+        }
+
+        div {
+            width: 300px;
+            height: 300px;
+            background-image: linear-gradient(in hsl longer hue 45deg, #f00 0 0);
+        }
+    </style>
 </head>
 
 <body>

--- a/css/css-images/gradient/gradient-single-stop-longer-hue-oklch-ref.html
+++ b/css/css-images/gradient/gradient-single-stop-longer-hue-oklch-ref.html
@@ -12,7 +12,7 @@
         div {
             width: 300px;
             height: 300px;
-            background-image: linear-gradient(in oklch shorter hue 0deg, #ff0000 0%, #00ad05 33.3333%, #4d71ff 66.6667%, #ff0000 100%);
+            background-image: linear-gradient(in oklch shorter hue 0deg, oklch(0.62796 0.25768 29.23388) 0%, oklch(0.62796 0.25768 149.23388) 33.3333%, oklch(0.62796 0.25768 269.23388) 66.6667%, oklch(0.62796 0.25768 29.23388) 100%);
         }
     </style>
 </head>

--- a/css/css-images/gradient/gradient-single-stop-longer-hue-oklch-ref.html
+++ b/css/css-images/gradient/gradient-single-stop-longer-hue-oklch-ref.html
@@ -12,7 +12,7 @@
         div {
             width: 300px;
             height: 300px;
-            background-image: linear-gradient(in oklch shorter hue 0deg, #ff0000 0%, #4d71ff 33.3333%, #00ad05 66.6667%, #ff0000 100%);
+            background-image: linear-gradient(in oklch shorter hue 0deg, #ff0000 0%, #00ad05 33.3333%, #4d71ff 66.6667%, #ff0000 100%);
         }
     </style>
 </head>

--- a/css/css-images/gradient/gradient-single-stop-longer-hue-oklch-ref.html
+++ b/css/css-images/gradient/gradient-single-stop-longer-hue-oklch-ref.html
@@ -2,21 +2,22 @@
 <html lang="en">
 
 <head>
-  <meta charset="utf-8">
-  <title>Gradient in OKLCH space</title>
-  <style>
-      body {
-        background: #fff;
-      }
-      div {
-        width: 300px;
-        height: 300px;
-        background-image: linear-gradient(in oklch longer hue 45deg, red, red 100%);
-      }
-  </style>
+    <meta charset="utf-8">
+    <title>Gradient in OKLCH space</title>
+    <style>
+        body {
+            background: #fff;
+        }
+
+        div {
+            width: 300px;
+            height: 300px;
+            background-image: linear-gradient(in oklch shorter hue 0deg, #ff0000 0%, #4d71ff 33.3333%, #00ad05 66.6667%, #ff0000 100%);
+        }
+    </style>
 </head>
 
 <body>
-  <div></div>
+    <div></div>
 </body>
 </html>

--- a/css/css-images/gradient/gradient-single-stop-longer-hue-oklch-ref.html
+++ b/css/css-images/gradient/gradient-single-stop-longer-hue-oklch-ref.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Gradient in OKLCH space</title>
+  <style>
+      body {
+        background: #fff;
+      }
+      div {
+        width: 300px;
+        height: 300px;
+        background-image: linear-gradient(in oklch longer hue 45deg, red, red 100%);
+      }
+  </style>
+</head>
+
+<body>
+  <div></div>
+</body>
+</html>

--- a/css/css-images/gradient/gradient-single-stop-longer-hue-oklch.html
+++ b/css/css-images/gradient/gradient-single-stop-longer-hue-oklch.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Gradient in OKLCH space</title>
+  <style>
+      body {
+        background: #fff;
+      }
+      div {
+        width: 300px;
+        height: 300px;
+        background-image: linear-gradient(in oklch longer hue 45deg, #f00 0 0);
+      }
+  </style>
+</head>
+
+<body>
+  <div></div>
+</body>
+</html>

--- a/css/css-images/gradient/gradient-single-stop-longer-hue-oklch.html
+++ b/css/css-images/gradient/gradient-single-stop-longer-hue-oklch.html
@@ -2,18 +2,24 @@
 <html lang="en">
 
 <head>
-  <meta charset="utf-8">
-  <title>Gradient in OKLCH space</title>
-  <style>
-      body {
-        background: #fff;
-      }
-      div {
-        width: 300px;
-        height: 300px;
-        background-image: linear-gradient(in oklch longer hue 45deg, #f00 0 0);
-      }
-  </style>
+    <meta charset="utf-8">
+    <title>Gradient in OKLCH space</title>
+    <meta name="fuzzy" content="maxDifference=1-2;totalPixels=0-10000">
+    <link rel="author" title="Ashley Hale" href="mailto:ahale@mozilla.com">
+    <link rel="help" href="https://www.w3.org/TR/css-color-4/#interpolation">
+    <meta name="assert" content="Tests gradient interpolation in Oklch space when a single stop is specified in sRGB with longer hue to make it wrap">
+    <link rel="match" href="gradient-single-stop-longer-hue-oklch-ref.html">
+    <style>
+        body {
+            background: #fff;
+        }
+
+        div {
+            width: 300px;
+            height: 300px;
+            background-image: linear-gradient(in oklch longer hue 45deg, #f00 0 0);
+        }
+    </style>
 </head>
 
 <body>

--- a/css/css-images/gradient/gradient-single-stop-longer-hue-oklch.html
+++ b/css/css-images/gradient/gradient-single-stop-longer-hue-oklch.html
@@ -7,7 +7,7 @@
     <meta name="fuzzy" content="maxDifference=0-90;totalPixels=0-90000">
     <link rel="author" title="Ashley Hale" href="mailto:ahale@mozilla.com">
     <link rel="help" href="https://www.w3.org/TR/css-color-4/#interpolation">
-    <meta name="assert" content="Tests gradient interpolation in Oklch space when a single stop is specified in sRGB with longer hue to make it wrap">
+    <meta name="assert" content="Tests gradient interpolation in Oklch space when a single stop is specified with longer hue to make it wrap">
     <link rel="match" href="gradient-single-stop-longer-hue-oklch-ref.html">
     <style>
         body {

--- a/css/css-images/gradient/gradient-single-stop-longer-hue-oklch.html
+++ b/css/css-images/gradient/gradient-single-stop-longer-hue-oklch.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <title>Gradient in OKLCH space</title>
-    <meta name="fuzzy" content="maxDifference=1-2;totalPixels=0-10000">
+    <meta name="fuzzy" content="maxDifference=0-90;totalPixels=0-90000">
     <link rel="author" title="Ashley Hale" href="mailto:ahale@mozilla.com">
     <link rel="help" href="https://www.w3.org/TR/css-color-4/#interpolation">
     <meta name="assert" content="Tests gradient interpolation in Oklch space when a single stop is specified in sRGB with longer hue to make it wrap">
@@ -17,12 +17,12 @@
         div {
             width: 300px;
             height: 300px;
-            background-image: linear-gradient(in oklch longer hue 45deg, #f00 0 0);
+            background-image: linear-gradient(in oklch longer hue 0deg, #ff0000 0 0);
         }
     </style>
 </head>
 
 <body>
-  <div></div>
+    <div></div>
 </body>
 </html>

--- a/css/css-images/gradient/gradient-single-stop-longer-hue-oklch.html
+++ b/css/css-images/gradient/gradient-single-stop-longer-hue-oklch.html
@@ -17,7 +17,7 @@
         div {
             width: 300px;
             height: 300px;
-            background-image: linear-gradient(in oklch longer hue 0deg, #ff0000 0 0);
+            background-image: linear-gradient(in oklch longer hue 0deg, oklch(0.62796 0.25768 29.23388) 0 0);
         }
     </style>
 </head>


### PR DESCRIPTION
When using longer hue interpolation with the same color (or a single color stop), it's important that browsers are consistent about the interpolation direction they choose, so let's add a couple tests.  These use multi-stop gradients as ref to verify the direction, color accuracy isn't really the point of these tests so a fairly large fuzzy tolerance is used.