### PR TITLE
Change self to 'self' in CSP frame-ancestor test

### DIFF
--- a/content-security-policy/frame-ancestors/frame-ancestors-sandbox-same-origin-self.html
+++ b/content-security-policy/frame-ancestors/frame-ancestors-sandbox-same-origin-self.html
@@ -11,7 +11,7 @@
       "should compare the child URL (self) against each parent's origin's URL" +
       " rather then URL. When the ancestors are sandboxed, they never match.");
 
-    testNestedSandboxedIFrame('self', SAME_ORIGIN, SAME_ORIGIN, EXPECT_BLOCK);
+    testNestedSandboxedIFrame("'self'", SAME_ORIGIN, SAME_ORIGIN, EXPECT_BLOCK);
   </script>
 </body>
 </html>


### PR DESCRIPTION
The test https://wpt.fyi/results/content-security-policy/frame-ancestors/frame-ancestors-sandbox-same-origin-self.html?label=master&label=experimental&aligned
uses the value `self` instead of `'self'`.