### PR TITLE
Fix CSP test descriptions 'same' -> 'self'

### DIFF
--- a/content-security-policy/frame-ancestors/frame-ancestors-nested-cross-in-cross-self-block.html
+++ b/content-security-policy/frame-ancestors/frame-ancestors-nested-cross-in-cross-self-block.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <script>
-        test = async_test("A 'frame-ancestors' CSP directive with a value 'same' should block render in same-origin nested frames.");
+        test = async_test("A 'frame-ancestors' CSP directive with a value 'self' should block render in same-origin nested frames.");
 
         testNestedIFrame("'self'", CROSS_ORIGIN, CROSS_ORIGIN, EXPECT_BLOCK);
     </script>

--- a/content-security-policy/frame-ancestors/frame-ancestors-nested-cross-in-same-self-block.html
+++ b/content-security-policy/frame-ancestors/frame-ancestors-nested-cross-in-same-self-block.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <script>
-        test = async_test("A 'frame-ancestors' CSP directive with a value 'same' should block render in same-origin nested frames.");
+        test = async_test("A 'frame-ancestors' CSP directive with a value 'self' should block render in same-origin nested frames.");
 
         testNestedIFrame("'self'", SAME_ORIGIN, CROSS_ORIGIN, EXPECT_BLOCK);
     </script>

--- a/content-security-policy/frame-ancestors/frame-ancestors-nested-same-in-cross-self-block.html
+++ b/content-security-policy/frame-ancestors/frame-ancestors-nested-same-in-cross-self-block.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <script>
-        test = async_test("A 'frame-ancestors' CSP directive with a value 'same' should block render in same-origin nested frames.");
+        test = async_test("A 'frame-ancestors' CSP directive with a value 'self' should block render in same-origin nested frames.");
 
         testNestedIFrame("'self'", CROSS_ORIGIN, SAME_ORIGIN, EXPECT_BLOCK);
     </script>

--- a/content-security-policy/frame-ancestors/frame-ancestors-nested-same-in-same-self-allow.html
+++ b/content-security-policy/frame-ancestors/frame-ancestors-nested-same-in-same-self-allow.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <script>
-        test = async_test("A 'frame-ancestors' CSP directive with a value 'same' should block render in same-origin nested frames.");
+        test = async_test("A 'frame-ancestors' CSP directive with a value 'self' should block render in same-origin nested frames.");
 
         testNestedIFrame("'self'", SAME_ORIGIN, SAME_ORIGIN, EXPECT_LOAD);
     </script>


### PR DESCRIPTION
Several tests use 'same' in their description although they are using 'self' as the directive value.