### PR TITLE
[webnn] Fixed tests with keepDimensions=false for argMax and argMin

### DIFF
--- a/webnn/resources/test_data/arg_max.json
+++ b/webnn/resources/test_data/arg_max.json
@@ -460,7 +460,7 @@
         }
       },
       "options": {
-        "keepDimensions": true
+        "keepDimensions": false
       },
       "expected": {
         "name": "output",

--- a/webnn/resources/test_data/arg_min.json
+++ b/webnn/resources/test_data/arg_min.json
@@ -460,7 +460,7 @@
         }
       },
       "options": {
-        "keepDimensions": true
+        "keepDimensions": false
       },
       "expected": {
         "name": "output",


### PR DESCRIPTION
Thanks @bbernhar for reporting this issue on https://github.com/web-platform-tests/wpt/pull/45306#issuecomment-2035802533. It's my faults, I made mistakes for these two tests by given the wrong `keepDimensions` value. 

@fdwr @Honry PTAL, thanks.