### PR TITLE
Test inserted async script execution order

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/inline-async-inserted-execorder.html
+++ b/html/semantics/scripting-1/the-script-element/module/inline-async-inserted-execorder.html
@@ -10,7 +10,7 @@
 "use strict";
 setup({ allow_uncaught_exception: true });
 
-async_test(t => {
+promise_test(async t => {
   window.log = ["before any script execution"];
 
   window.addEventListener("error", ev => {
@@ -22,7 +22,7 @@ async_test(t => {
   noErrorScript.async = true;
   noErrorScript.textContent = "window.log.push('no error script executed');";
 
-  // This should queue a microtask to run the script, but not run it immediately.
+  // This should queue a task to run the script, but not run it immediately.
   document.head.append(noErrorScript);
 
   log.push("after inserting noErrorScript");
@@ -36,7 +36,7 @@ async_test(t => {
   parseErrorScript.async = true;
   parseErrorScript.textContent = "+++++";
 
-  // This should queue a microtask to fire the error event, but not fire it immediately.
+  // This should queue a task to fire the error event, but not fire it immediately.
   document.head.append(parseErrorScript);
 
   log.push("after inserting parseErrorScript");
@@ -46,14 +46,25 @@ async_test(t => {
     "after inserting parseErrorScript"
   ]);
 
-  queueMicrotask(t.step_func_done(() => {
+  // After a microtask, the script run / error event must not happen.
+  queueMicrotask(t.step_func(() => {
     assert_array_equals(window.log, [
       "before any script execution",
       "after inserting noErrorScript",
-      "after inserting parseErrorScript",
-      "no error script executed",
-      "error event on Window"
+      "after inserting parseErrorScript"
     ]);
   }));
+
+  // But it must eventually happen, after a full task.
+  await t.step_wait(() => window.log.length == 5, "5 items must eventually be logged");
+
+  // And when it does the order must be correct.
+  assert_array_equals(window.log, [
+    "before any script execution",
+    "after inserting noErrorScript",
+    "after inserting parseErrorScript",
+    "no error script executed",
+    "error event on Window"
+  ]);
 });
 </script>

--- a/html/semantics/scripting-1/the-script-element/module/inline-async-inserted-execorder.html
+++ b/html/semantics/scripting-1/the-script-element/module/inline-async-inserted-execorder.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Inline async="" module scripts execute or throw parse errors synchronously</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+"use strict";
+setup({ allow_uncaught_exception: true });
+
+test(() => {
+  window.log = ["before any script execution"];
+
+  window.addEventListener("error", ev => {
+    window.log.push("error event on Window");
+  });
+
+  const noErrorScript = document.createElement("script");
+  noErrorScript.type = "module";
+  noErrorScript.async = true;
+  noErrorScript.textContent = "window.log.push('no error script executed');";
+  document.head.append(noErrorScript);
+
+  assert_array_equals(window.log, ["before any script execution", "no error script executed"]);
+
+  const parseErrorScript = document.createElement("script");
+  parseErrorScript.type = "module";
+  parseErrorScript.async = true;
+  parseErrorScript.textContent = "+++++";
+  document.head.append(parseErrorScript);
+
+  assert_array_equals(window.log, ["before any script execution", "no error script executed", "error event on Window"]);
+});
+</script>

--- a/html/semantics/scripting-1/the-script-element/module/inline-async-inserted-execorder.html
+++ b/html/semantics/scripting-1/the-script-element/module/inline-async-inserted-execorder.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Inline async="" module scripts execute or throw parse errors synchronously</title>
+<title>Inline async="" module scripts execute or throw parse errors asynchronously</title>
+<link rel="help" href="https://github.com/whatwg/html/issues/9864">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
@@ -9,7 +10,7 @@
 "use strict";
 setup({ allow_uncaught_exception: true });
 
-test(() => {
+async_test(t => {
   window.log = ["before any script execution"];
 
   window.addEventListener("error", ev => {
@@ -20,16 +21,39 @@ test(() => {
   noErrorScript.type = "module";
   noErrorScript.async = true;
   noErrorScript.textContent = "window.log.push('no error script executed');";
+
+  // This should queue a microtask to run the script, but not run it immediately.
   document.head.append(noErrorScript);
 
-  assert_array_equals(window.log, ["before any script execution", "no error script executed"]);
+  log.push("after inserting noErrorScript");
+  assert_array_equals(window.log, [
+    "before any script execution",
+    "after inserting noErrorScript"
+  ]);
 
   const parseErrorScript = document.createElement("script");
   parseErrorScript.type = "module";
   parseErrorScript.async = true;
   parseErrorScript.textContent = "+++++";
+
+  // This should queue a microtask to fire the error event, but not fire it immediately.
   document.head.append(parseErrorScript);
 
-  assert_array_equals(window.log, ["before any script execution", "no error script executed", "error event on Window"]);
+  log.push("after inserting parseErrorScript");
+  assert_array_equals(window.log, [
+    "before any script execution",
+    "after inserting noErrorScript",
+    "after inserting parseErrorScript"
+  ]);
+
+  queueMicrotask(t.step_func_done(() => {
+    assert_array_equals(window.log, [
+      "before any script execution",
+      "after inserting noErrorScript",
+      "after inserting parseErrorScript",
+      "no error script executed",
+      "error event on Window"
+    ]);
+  }));
 });
 </script>


### PR DESCRIPTION
- Chromium passes these tests
- WebKit almost passes, but suffers from https://bugs.webkit.org/show_bug.cgi?id=272505: for some reason it fires the `error` event from script 2 before executing script 1
- Gecko fails these tests. It both executes script 1 and fires the `error` event from script 2 synchronously.

https://github.com/whatwg/html/issues/9864 discusses the issue. https://github.com/whatwg/html/pull/10272 matches what is tested here.