### PR TITLE
CSS: offset-rotate test incorrectly relies on scientific notation

### DIFF
--- a/css/motion/animation/offset-rotate-interpolation.html
+++ b/css/motion/animation/offset-rotate-interpolation.html
@@ -163,15 +163,6 @@
         {at: 1.5, expect: '70deg'},
       ]);
 
-      // Regression test for crbug.com/918430.
-      test_interpolation({
-        property: 'offset-rotate',
-        from: '800deg',
-        to: '900deg'
-      }, [
-        {at: -3.40282e+38, expect: '-3.40282e+38deg'},
-      ]);
-
       // Interpolation between auto angles.
       test_interpolation({
         property: 'offset-rotate',


### PR DESCRIPTION
This serialization is not defined by the current set of CSS specifications and the test infrastructure does not account for serializing the number without scientific notation (it only rounds decimal notation).