### PR TITLE
Update document for test type and test features

### DIFF
--- a/docs/writing-tests/file-names.md
+++ b/docs/writing-tests/file-names.md
@@ -11,10 +11,10 @@ These are individually documented for each flag that supports it.
 
 ### Test Type
 
-These flags must be the last element in the filename before the
-extension e.g. `foo-manual.html` will indicate a manual test, but
-`foo-manual-other.html` will not. Unlike test features, test types
-are mutually exclusive.
+These flags are preceded by a `-` and followed by a `.`, and must be the
+last such element in the filename, e.g. `foo-manual.html` will indicate
+a manual test, but `foo-manual-other.html` will not. Unlike test features,
+test types are mutually exclusive.
 
 
 `-manual`
@@ -26,8 +26,8 @@ are mutually exclusive.
 
 ### Test Features
 
-These flags are preceded by a `.` in the filename, and must
-themselves precede any test type flag, but are otherwise unordered.
+These flags are preceded and followed by a `.` in the filename, but are otherwise
+unordered.
 
 
 `.https`

--- a/docs/writing-tests/file-names.md
+++ b/docs/writing-tests/file-names.md
@@ -26,8 +26,8 @@ test types are mutually exclusive.
 
 ### Test Features
 
-These flags are preceded and followed by a `.` in the filename, but are otherwise
-unordered.
+These flags are preceded and followed by a `.` in the filename, and must themselves
+go after any test type flag, but are otherwise unordered.
 
 
 `.https`

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -207,9 +207,9 @@ class SourceFile:
         if "-" in name:
             type_meta = name.rsplit("-", 1)[1].split(".")
             type_flag = type_meta[0]
-            meta_flags = type_meta[1:-1]
+            meta_flags = type_meta[1:]
         else:
-            meta_flags = name.split(".")[1:-1]
+            meta_flags = name.split(".")[1:]
 
         self.tests_root: Text = tests_root
         self.rel_path: Text = rel_path

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -205,9 +205,11 @@ class SourceFile:
 
         type_flag = None
         if "-" in name:
-            type_flag = name.rsplit("-", 1)[1].split(".")[0]
-
-        meta_flags = name.split(".")[1:]
+            type_meta = name.rsplit("-", 1)[1].split(".")
+            type_flag = type_meta[0]
+            meta_flags = type_meta[1:-1]
+        else:
+            meta_flags = name.split(".")[1:-1]
 
         self.tests_root: Text = tests_root
         self.rel_path: Text = rel_path


### PR DESCRIPTION
In practice test types are preceding test features, e.g. a https manual test will be named as "test-manual.https.html".

Update the document and code to require test type will always precede test features.

Bug: 45268