### PR TITLE
Remove erroneous ref from event-pseudo-name.html

### DIFF
--- a/css/css-view-transitions/event-pseudo-name.html
+++ b/css/css-view-transitions/event-pseudo-name.html
@@ -2,7 +2,6 @@
 <title>View transitions: event pseudo name</title>
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
-<link rel="match" href="web-animations-api-ref.html">
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>


### PR DESCRIPTION
This test fails in WebKit because it is a testharness.js test and also tries to compare itself to a reference file that doesn't use testharness.js.