### PR TITLE
Tests for an explicit `initial` and “space” style queries

### DIFF
--- a/css/css-contain/container-queries/custom-property-style-queries.html
+++ b/css/css-contain/container-queries/custom-property-style-queries.html
@@ -206,6 +206,9 @@
     --inherit-no: bar;
     --unset-no: baz;
     --initial-no: baz;
+    --space-no: baz;
+    --explicit-initial: initial;
+    --space: ;
   }
   @container style(--initial: initial) {
     #initial { color: green; }
@@ -225,6 +228,18 @@
   @container not style(--inherit-no: inherit) {
     #inherit-no { color: green; }
   }
+  @container style(--explicit-initial: initial) {
+    #explicit-initial { color: green; }
+  }
+  @container not style(--explicit-initial) {
+    #explicit-initial-implicit { color: green; }
+  }
+  @container style(--space: ) {
+    #space { color: green; }
+  }
+  @container not style(--space-no: ) {
+    #space-no { color: green; }
+  }
   @container style(--unset: unset) {
     #unset { color: green; }
   }
@@ -238,6 +253,10 @@
     <div id="initial-implicit"></div>
     <div id="initial-no"></div>
     <div id="initial-no-implicit"></div>
+    <div id="explicit-initial"></div>
+    <div id="explicit-initial-implicit"></div>
+    <div id="space"></div>
+    <div id="space-no"></div>
     <div id="inherit"></div>
     <div id="inherit-no"></div>
     <div id="unset"></div>
@@ -260,6 +279,22 @@
   test(() => {
     assert_equals(getComputedStyle(document.querySelector("#initial-no-implicit")).color, green);
   }, "Style query matching value-less query against non-initial value");
+
+  test(() => {
+    assert_equals(getComputedStyle(document.querySelector("#explicit-initial")).color, green);
+  }, "Style query 'initial' matching (with explicit 'initial' value)");
+
+  test(() => {
+    assert_equals(getComputedStyle(document.querySelector("#explicit-initial-implicit")).color, green);
+  }, "Style query matching negated value-less query against initial value (with explicit 'initial' value)");
+
+  test(() => {
+    assert_equals(getComputedStyle(document.querySelector("#space")).color, green);
+  }, "Style query 'space' matching");
+
+  test(() => {
+    assert_equals(getComputedStyle(document.querySelector("#space-no")).color, green);
+  }, "Style query 'space' not matching");
 
   test(() => {
     assert_equals(getComputedStyle(document.querySelector("#inherit")).color, green);


### PR DESCRIPTION
I was playing with style queries and using “space toggles” to apply them ([article 1](https://kizu.dev/layered-toggles/#using-with-style-queries), [article 2](https://kizu.dev/alternating-style-queries/#cyclic-toggles-abstraction)), and discovered an issue with an explicit `initial` value in Safari Technology Preview.

I did open a bug: https://bugs.webkit.org/show_bug.cgi?id=270739, and now I am submitting the tests that cover this case, as well as additional tests for the “space” value (which pass in Chrome and WebKit, making testing for the space a good workaround for this for now), just in case, so it would be explicitly covered.