### PR TITLE
Bump wptserve to version 4.0.2

### DIFF
--- a/tools/wptserve/setup.py
+++ b/tools/wptserve/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-PACKAGE_VERSION = '4.0.1'
+PACKAGE_VERSION = '4.0.2'
 deps = [
     "h2>=4.1.0",
     "pywebsocket3>=4.0.2",


### PR DESCRIPTION
Bumps the version to 4.0.2 for the next release on PyPI (#35978).