### PR TITLE
Interop: correct invalid nbsp trimming label tests

### DIFF
--- a/accname/name/comp_text_node.html
+++ b/accname/name/comp_text_node.html
@@ -101,11 +101,11 @@
 <br>
 
 <h1>text node, with leading/trailing non-breaking space</h1>
-<span role="button" tabindex="0" class="ex" data-expectedlabel="button&nbsp;label" data-testname="span[role=button] with text node, with leading/trailing non-breaking space">&nbsp;button&nbsp;label&nbsp;</span>
-<div role="heading" class="ex" data-expectedlabel="heading&nbsp;label" data-testname="div[role=heading] with text node, with leading/trailing non-breaking space">&nbsp;heading&nbsp;label&nbsp;</div>
-<button class="ex" data-expectedlabel="button&nbsp;label" data-testname="button with text node, with leading/trailing non-breaking space">&nbsp;button&nbsp;label&nbsp;</button>
-<h3 class="ex" data-expectedlabel="heading&nbsp;label" data-testname="heading with text node, with leading/trailing non-breaking space">&nbsp;heading&nbsp;label&nbsp;</h3>
-<a href="#" class="ex" data-expectedlabel="link&nbsp;label" data-testname="link with text node, with leading/trailing non-breaking space">&nbsp;link&nbsp;label&nbsp;</a>
+<span role="button" tabindex="0" class="ex" data-expectedlabel="&nbsp;button&nbsp;label&nbsp;" data-testname="span[role=button] with text node, with leading/trailing non-breaking space">&nbsp;button&nbsp;label&nbsp;</span>
+<div role="heading" class="ex" data-expectedlabel="&nbsp;heading&nbsp;label&nbsp;" data-testname="div[role=heading] with text node, with leading/trailing non-breaking space">&nbsp;heading&nbsp;label&nbsp;</div>
+<button class="ex" data-expectedlabel="&nbsp;button&nbsp;label&nbsp;" data-testname="button with text node, with leading/trailing non-breaking space">&nbsp;button&nbsp;label&nbsp;</button>
+<h3 class="ex" data-expectedlabel="&nbsp;heading&nbsp;label&nbsp;" data-testname="heading with text node, with leading/trailing non-breaking space">&nbsp;heading&nbsp;label&nbsp;</h3>
+<a href="#" class="ex" data-expectedlabel="&nbsp;link&nbsp;label&nbsp;" data-testname="link with text node, with leading/trailing non-breaking space">&nbsp;link&nbsp;label&nbsp;</a>
 <br>
 
 <h1>text node, with mixed space and non-breaking space</h1>


### PR DESCRIPTION
Resolves https://github.com/web-platform-tests/interop-accessibility/issues/115

Correcting invalid tests that are skewing Interop results.