### PR TITLE
Remove filenames from view transition test fuzzy data

### DIFF
--- a/css/css-view-transitions/3d-transform-incoming.html
+++ b/css/css-view-transitions/3d-transform-incoming.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="3d-transform-incoming-ref.html">
-<meta name=fuzzy content="3d-transform-incoming-ref.html:0-255;0-515">
+<meta name=fuzzy content="maxDifference=0-255; totalPixels=0-515">
 <script src="/common/reftest-wait.js"></script>
 <style>
 div { box-sizing: border-box; will-change: transform }

--- a/css/css-view-transitions/3d-transform-outgoing.html
+++ b/css/css-view-transitions/3d-transform-outgoing.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="3d-transform-outgoing-ref.html">
-<meta name=fuzzy content="3d-transform-outgoing-ref.html:0-255;0-1200">
+<meta name=fuzzy content="maxDifference=0-255; totalPixels=0-1200">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/css/css-view-transitions/block-with-overflowing-text.html
+++ b/css/css-view-transitions/block-with-overflowing-text.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="block-with-overflowing-text-ref.html">
-<meta name="fuzzy" content="block-with-overflowing-text-ref.html:maxDifference=0-2;totalPixels=0-1200">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-1200">
 
 
 <script src="/common/reftest-wait.js"></script>

--- a/css/css-view-transitions/break-inside-avoid-child.html
+++ b/css/css-view-transitions/break-inside-avoid-child.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="break-inside-avoid-child-ref.html">
-<meta name="fuzzy" content="break-inside-avoid-child-ref.html:0-5;0-1600">
+<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-1600">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/css/css-view-transitions/capture-with-offscreen-child.html
+++ b/css/css-view-transitions/capture-with-offscreen-child.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="capture-with-offscreen-child-ref.html">
-<meta name="fuzzy" content="capture-with-offscreen-child-ref.html:0-5;0-200">
+<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-200">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/css/css-view-transitions/capture-with-opacity-zero-child.html
+++ b/css/css-view-transitions/capture-with-opacity-zero-child.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="capture-with-visibility-hidden-child-ref.html">
-<meta name="fuzzy" content="capture-with-visibility-hidden-child-ref.html:0-5;0-300">
+<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-300">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/css/css-view-transitions/capture-with-visibility-mixed-descendants.html
+++ b/css/css-view-transitions/capture-with-visibility-mixed-descendants.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="capture-with-visibility-mixed-descendants-ref.html">
-<meta name=fuzzy content="capture-with-visibility-mixed-descendants-ref.html:0-5;0-500">
+<meta name=fuzzy content="maxDifference=0-5; totalPixels=0-500">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/css/css-view-transitions/clip-path-larger-than-border-box-on-child-of-named-element.html
+++ b/css/css-view-transitions/clip-path-larger-than-border-box-on-child-of-named-element.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="clip-path-larger-than-border-box-on-child-of-named-element-ref.html">
-<meta name="fuzzy" content="clip-path-larger-than-border-box-on-child-of-named-element-ref.html:maxDifference=0-255;totalPixels=0-400">
+<meta name="fuzzy" content="maxDifference=0-255;totalPixels=0-400">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .target {

--- a/css/css-view-transitions/content-with-transform-new-image.html
+++ b/css/css-view-transitions/content-with-transform-new-image.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="content-with-transform-ref.html">
-<meta name="fuzzy" content="content-with-transform-ref.html:0-1;0-500">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-500">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/content-with-transform-old-image.html
+++ b/css/css-view-transitions/content-with-transform-old-image.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="content-with-transform-ref.html">
-<meta name="fuzzy" content="content-with-transform-ref.html:0-1;0-400">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-400">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/css-tags-paint-order-with-entry.html
+++ b/css/css-view-transitions/css-tags-paint-order-with-entry.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="css-tags-paint-order-with-entry-ref.html">
-<meta name="fuzzy" content="css-tags-paint-order-with-entry-ref.html:0-120;0-300">
+<meta name="fuzzy" content="maxDifference=0-120; totalPixels=0-300">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/dialog-in-rtl-iframe.html
+++ b/css/css-view-transitions/dialog-in-rtl-iframe.html
@@ -5,7 +5,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
   <link rel="author" href="mailto:bokan@chromium.org">
   <link rel="match" href="dialog-in-rtl-iframe-ref.html">
-  <meta name=fuzzy content="dialog-in-rtl-iframe-ref.html:0-80;0-500">
+  <meta name=fuzzy content="maxDifference=0-80; totalPixels=0-500">
   <script src="/common/reftest-wait.js"></script>
   <style>
     iframe {

--- a/css/css-view-transitions/far-away-capture.html
+++ b/css/css-view-transitions/far-away-capture.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="far-away-capture-ref.html">
-<meta name="fuzzy" content="far-away-capture-ref.html:0-1;0-5">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-5">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .flex {

--- a/css/css-view-transitions/fractional-box-with-overflow-children-new.html
+++ b/css/css-view-transitions/fractional-box-with-overflow-children-new.html
@@ -6,7 +6,7 @@
 <link rel="match" href="fractional-box-with-overflow-children-ref.html">
 <!-- subpixel differences are ok in this test (in highdpi), but channel difference
      should not be perceptible -->
-<meta name=fuzzy content="fractional-box-with-overflow-children-ref.html:0-3;0-100">
+<meta name=fuzzy content="maxDifference=0-3; totalPixels=0-100">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .box {

--- a/css/css-view-transitions/fractional-box-with-overflow-children-old.html
+++ b/css/css-view-transitions/fractional-box-with-overflow-children-old.html
@@ -6,7 +6,7 @@
 <link rel="match" href="fractional-box-with-overflow-children-ref.html">
 <!-- subpixel differences are ok in this test (in highdpi), but channel difference
      should not be perceptible -->
-<meta name=fuzzy content="fractional-box-with-overflow-children-ref.html:0-3;0-100">
+<meta name=fuzzy content="maxDifference=0-3; totalPixels=0-100">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .box {

--- a/css/css-view-transitions/iframe-new-has-scrollbar.html
+++ b/css/css-view-transitions/iframe-new-has-scrollbar.html
@@ -5,7 +5,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
   <link rel="author" href="mailto:bokan@chromium.org">
   <link rel="match" href="iframe-new-has-scrollbar-ref.html">
-  <meta name=fuzzy content="iframe-new-has-scrollbar-ref.html:0-80;0-500">
+  <meta name=fuzzy content="maxDifference=0-80; totalPixels=0-500">
   <script src="/common/reftest-wait.js"></script>
   <style>
     iframe {

--- a/css/css-view-transitions/iframe-old-has-scrollbar.html
+++ b/css/css-view-transitions/iframe-old-has-scrollbar.html
@@ -5,7 +5,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
   <link rel="author" href="mailto:bokan@chromium.org">
   <link rel="match" href="iframe-old-has-scrollbar-ref.html">
-  <meta name=fuzzy content="iframe-old-has-scrollbar-ref.html:0-80;0-500">
+  <meta name=fuzzy content="maxDifference=0-80; totalPixels=0-500">
   <script src="/common/reftest-wait.js"></script>
   <style>
     iframe {

--- a/css/css-view-transitions/iframe-transition.sub.html
+++ b/css/css-view-transitions/iframe-transition.sub.html
@@ -6,7 +6,7 @@
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="iframe-transition-ref.html">
 <meta name="assert" content="Ensure that iframe root capture is sized and displayed correctly">
-<meta name=fuzzy content="iframe-transition-ref.html:0-200;0-200">
+<meta name=fuzzy content="maxDifference=0-200; totalPixels=0-200">
 <script src="/common/reftest-wait.js"></script>
 <style>
 iframe { width: 500px; height: 500px }

--- a/css/css-view-transitions/inline-with-offset-from-containing-block.html
+++ b/css/css-view-transitions/inline-with-offset-from-containing-block.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="inline-with-offset-from-containing-block-ref.html">
-<meta name="fuzzy" content="inline-with-offset-from-containing-block-ref.html:0-255;0-1400">
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-1400">
 
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>

--- a/css/css-view-transitions/massive-element-below-and-on-top-of-viewport-partially-onscreen-new.html
+++ b/css/css-view-transitions/massive-element-below-and-on-top-of-viewport-partially-onscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-below-and-on-top-of-viewport-partially-onscreen-ref.html">
-<meta name="fuzzy" content="massive-element-below-and-on-top-of-viewport-partially-onscreen-ref.html:maxDifference=0-2;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/massive-element-below-viewport-offscreen-new.html
+++ b/css/css-view-transitions/massive-element-below-viewport-offscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-below-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="massive-element-below-viewport-offscreen-ref.html:maxDifference=0-3;totalPixels=0-950">
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-950">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/massive-element-below-viewport-offscreen-old.html
+++ b/css/css-view-transitions/massive-element-below-viewport-offscreen-old.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-below-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="massive-element-below-viewport-offscreen-ref.html:maxDifference=0-2;totalPixels=0-445">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-445">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-new.html
+++ b/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-below-viewport-partially-onscreen-ref.html">
-<meta name="fuzzy" content="massive-element-below-viewport-partially-onscreen-ref.html:maxDifference=0-2;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/massive-element-left-of-viewport-offscreen-new.html
+++ b/css/css-view-transitions/massive-element-left-of-viewport-offscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-left-of-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="massive-element-left-of-viewport-offscreen-ref.html:maxDifference=0-2;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/massive-element-left-of-viewport-offscreen-old.html
+++ b/css/css-view-transitions/massive-element-left-of-viewport-offscreen-old.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-left-of-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="massive-element-left-of-viewport-offscreen-ref.html:maxDifference=0-3;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/massive-element-left-of-viewport-partially-onscreen-new.html
+++ b/css/css-view-transitions/massive-element-left-of-viewport-partially-onscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-left-of-viewport-partially-onscreen-ref.html">
-<meta name="fuzzy" content="massive-element-left-of-viewport-partially-onscreen-ref.html:maxDifference=0-2;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/massive-element-left-of-viewport-partially-onscreen-old.html
+++ b/css/css-view-transitions/massive-element-left-of-viewport-partially-onscreen-old.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-left-of-viewport-partially-onscreen-ref.html">
-<meta name="fuzzy" content="massive-element-left-of-viewport-partially-onscreen-ref.html:maxDifference=0-3;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-new.html
+++ b/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-on-top-of-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="massive-element-on-top-of-viewport-offscreen-ref.html:maxDifference=0-6;totalPixels=0-920">
+<meta name="fuzzy" content="maxDifference=0-6;totalPixels=0-920">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-old.html
+++ b/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-old.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-on-top-of-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="massive-element-on-top-of-viewport-offscreen-ref.html:maxDifference=0-3;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/massive-element-on-top-of-viewport-partially-onscreen-new.html
+++ b/css/css-view-transitions/massive-element-on-top-of-viewport-partially-onscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-on-top-of-viewport-partially-onscreen-ref.html">
-<meta name="fuzzy" content="massive-element-on-top-of-viewport-partially-onscreen-ref.html:maxDifference=0-2;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/massive-element-on-top-of-viewport-partially-onscreen-old.html
+++ b/css/css-view-transitions/massive-element-on-top-of-viewport-partially-onscreen-old.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-on-top-of-viewport-partially-onscreen-ref.html">
-<meta name="fuzzy" content="massive-element-on-top-of-viewport-partially-onscreen-ref.html:maxDifference=0-3;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/massive-element-right-and-left-of-viewport-partially-onscreen-new.html
+++ b/css/css-view-transitions/massive-element-right-and-left-of-viewport-partially-onscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-right-and-left-of-viewport-partially-onscreen-ref.html">
-<meta name="fuzzy" content="massive-element-right-and-left-of-viewport-partially-onscreen-ref.html:maxDifference=0-2;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/massive-element-right-of-viewport-offscreen-new.html
+++ b/css/css-view-transitions/massive-element-right-of-viewport-offscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-right-of-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="massive-element-right-of-viewport-offscreen-ref.html:maxDifference=0-2;totalPixels=0-445">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-445">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/massive-element-right-of-viewport-offscreen-old.html
+++ b/css/css-view-transitions/massive-element-right-of-viewport-offscreen-old.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-right-of-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="massive-element-right-of-viewport-offscreen-ref.html:maxDifference=0-3;totalPixels=0-445">
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-445">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/massive-element-right-of-viewport-partially-onscreen-new.html
+++ b/css/css-view-transitions/massive-element-right-of-viewport-partially-onscreen-new.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-right-of-viewport-partially-onscreen-ref.html">
-<meta name="fuzzy" content="massive-element-right-of-viewport-partially-onscreen-ref.html:maxDifference=0-2;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/massive-element-right-of-viewport-partially-onscreen-old.html
+++ b/css/css-view-transitions/massive-element-right-of-viewport-partially-onscreen-old.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-right-of-viewport-partially-onscreen-ref.html">
-<meta name="fuzzy" content="massive-element-right-of-viewport-partially-onscreen-ref.html:maxDifference=0-3;totalPixels=0-445">
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-445">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/multiline-span-with-overflowing-text-and-box-decorations.html
+++ b/css/css-view-transitions/multiline-span-with-overflowing-text-and-box-decorations.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="multiline-span-with-overflowing-text-and-box-decorations-ref.html">
-<meta name="fuzzy" content="multiline-span-with-overflowing-text-and-box-decorations-ref.html:maxDifference=0-3;totalPixels=0-4900">
+<meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-4900">
 
 
 <script src="/common/reftest-wait.js"></script>

--- a/css/css-view-transitions/new-and-old-sizes-match.html
+++ b/css/css-view-transitions/new-and-old-sizes-match.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="new-and-old-sizes-match-ref.html">
-<meta name="fuzzy" content="new-and-old-sizes-match-ref.html:0-1;0-300">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-300">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .box {

--- a/css/css-view-transitions/new-content-captures-clip-path.html
+++ b/css/css-view-transitions/new-content-captures-clip-path.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="new-content-captures-clip-path-ref.html">
-<meta name="fuzzy" content="new-content-captures-clip-path-ref.html:0-1;0-500">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-500">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .box {

--- a/css/css-view-transitions/new-content-captures-different-size.html
+++ b/css/css-view-transitions/new-content-captures-different-size.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="new-content-captures-different-size-ref.html">
-<meta name=fuzzy content="new-content-captures-different-size-ref.html:0-40;0-30000">
+<meta name=fuzzy content="maxDifference=0-40; totalPixels=0-30000">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .box {

--- a/css/css-view-transitions/new-content-has-scrollbars.html
+++ b/css/css-view-transitions/new-content-has-scrollbars.html
@@ -6,7 +6,7 @@
 <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/7859">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="new-content-has-scrollbars-ref.html">
-<meta name=fuzzy content="new-content-has-scrollbars-ref.html:0-40;0-30000">
+<meta name=fuzzy content="maxDifference=0-40; totalPixels=0-30000">
 <script src="/common/reftest-wait.js"></script>
 <style>
   html, body {

--- a/css/css-view-transitions/new-content-is-inline.html
+++ b/css/css-view-transitions/new-content-is-inline.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="new-content-is-inline-ref.html">
-<meta name="fuzzy" content="new-content-is-inline-ref.html:0-255;0-1000">
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-1000">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/css/css-view-transitions/new-content-object-fit-fill.html
+++ b/css/css-view-transitions/new-content-object-fit-fill.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="content-object-fit-fill-ref.html">
-<meta name="fuzzy" content="content-object-fit-fill-ref.html:0-60;0-20">
+<meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-20">
 <script src="/common/reftest-wait.js"></script>
 <style>
 #target {

--- a/css/css-view-transitions/new-content-scaling.html
+++ b/css/css-view-transitions/new-content-scaling.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="new-content-scaling-ref.html">
-<meta name="fuzzy" content="new-content-scaling-ref.html:maxDifference=0-16;totalPixels=0-400">
+<meta name="fuzzy" content="maxDifference=0-16; totalPixels=0-400">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .shared {

--- a/css/css-view-transitions/object-view-box-old-image.html
+++ b/css/css-view-transitions/object-view-box-old-image.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="object-view-box-ref.html">
-<meta name="fuzzy" content="object-view-box-ref.html:0-1;0-300">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-300">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/old-content-captures-clip-path.html
+++ b/css/css-view-transitions/old-content-captures-clip-path.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="old-content-captures-clip-path-ref.html">
-<meta name="fuzzy" content="old-content-captures-clip-path-ref.html:0-1;0-500">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-500">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .box {

--- a/css/css-view-transitions/old-content-captures-different-size.html
+++ b/css/css-view-transitions/old-content-captures-different-size.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="old-content-captures-different-size-ref.html">
-<meta name=fuzzy content="old-content-captures-different-size-ref.html:0-40;0-30000">
+<meta name=fuzzy content="maxDifference=0-40; totalPixels=0-30000">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .box {

--- a/css/css-view-transitions/old-content-captures-opacity.html
+++ b/css/css-view-transitions/old-content-captures-opacity.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="old-content-captures-opacity-ref.html">
-<meta name=fuzzy content="old-content-captures-opacity-ref.html:0-1;0-50000">
+<meta name=fuzzy content="maxDifference=0-1; totalPixels=0-50000">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/old-content-captures-root.html
+++ b/css/css-view-transitions/old-content-captures-root.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="old-content-captures-root-ref.html">
-<meta name="fuzzy" content="old-content-captures-root-ref.html:0-1;0-500">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-500">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .box {

--- a/css/css-view-transitions/old-content-has-scrollbars.html
+++ b/css/css-view-transitions/old-content-has-scrollbars.html
@@ -6,7 +6,7 @@
 <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/7859">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="old-content-has-scrollbars-ref.html">
-<meta name=fuzzy content="old-content-has-scrollbars-ref.html:0-40;0-30000">
+<meta name=fuzzy content="maxDifference=0-40; totalPixels=0-30000">
 <script src="/common/reftest-wait.js"></script>
 <style>
   html, body {

--- a/css/css-view-transitions/old-content-is-inline.html
+++ b/css/css-view-transitions/old-content-is-inline.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="old-content-is-inline-ref.html">
-<meta name="fuzzy" content="old-content-is-inline-ref.html:0-255;0-500">
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-500">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/css/css-view-transitions/old-content-object-fit-fill.html
+++ b/css/css-view-transitions/old-content-object-fit-fill.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="content-object-fit-fill-ref.html">
-<meta name="fuzzy" content="content-object-fit-fill-ref.html:0-60;0-20">
+<meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-20">
 <script src="/common/reftest-wait.js"></script>
 <style>
 #target {

--- a/css/css-view-transitions/old-content-object-view-box-clip-path-reference.html
+++ b/css/css-view-transitions/old-content-object-view-box-clip-path-reference.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="old-content-object-view-box-clip-path-reference-ref.html">
-<meta name="fuzzy" content="old-content-object-view-box-clip-path-reference-ref.html:0-1;0-100">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-100">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .target {

--- a/css/css-view-transitions/old-content-object-view-box-clip-path.html
+++ b/css/css-view-transitions/old-content-object-view-box-clip-path.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="old-content-object-view-box-clip-path-ref.html">
-<meta name="fuzzy" content="old-content-object-view-box-clip-path-ref.html:0-1;0-30">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-30">
 <script src="/common/reftest-wait.js"></script>
 <style>
 .target {

--- a/css/css-view-transitions/pseudo-rendering-invalidation.html
+++ b/css/css-view-transitions/pseudo-rendering-invalidation.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="pseudo-rendering-invalidation-ref.html">
-<meta name="fuzzy" content="pseudo-rendering-invalidation-ref.html:0-20;0-300">
+<meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-300">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/root-captured-as-different-tag.html
+++ b/css/css-view-transitions/root-captured-as-different-tag.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="old-content-captures-root-ref.html">
-<meta name="fuzzy" content="old-content-captures-root-ref.html:0-1;0-500">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-500">
 <script src="/common/reftest-wait.js"></script>
 <style>
 :root { view-transition-name: another-root; }

--- a/css/css-view-transitions/scroller-child-abspos.html
+++ b/css/css-view-transitions/scroller-child-abspos.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="scroller-child-abspos-ref.html">
-<meta name="fuzzy" content="scroller-child-abspos-ref.html:0-5;0-800">
+<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-800">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/css/css-view-transitions/scroller-child.html
+++ b/css/css-view-transitions/scroller-child.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="scroller-child-ref.html">
-<meta name="fuzzy" content="scroller-child-ref.html:0-5;0-800">
+<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-800">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/css/css-view-transitions/scroller.html
+++ b/css/css-view-transitions/scroller.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="scroller-ref.html">
-<meta name="fuzzy" content="scroller-ref.html:0-5;0-10">
+<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-10">
 <script src="/common/reftest-wait.js"></script>
 
 <style>

--- a/css/css-view-transitions/set-current-time.html
+++ b/css/css-view-transitions/set-current-time.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="set-current-time-ref.html">
-<meta name="fuzzy" content="set-current-time-ref.html:0-2;0-40000">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-40000">
 <script src="/common/reftest-wait.js"></script>
 <style>
 :root { view-transition-name: unset; }

--- a/css/css-view-transitions/snapshot-containing-block-absolute.html
+++ b/css/css-view-transitions/snapshot-containing-block-absolute.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="snapshot-containing-block-absolute-ref.html">
-<meta name="fuzzy" content="snapshot-containing-block-absolute-ref.html:0-20;0-100">
+<meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-100">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/snapshot-containing-block-includes-scrollbar-gutter.html
+++ b/css/css-view-transitions/snapshot-containing-block-includes-scrollbar-gutter.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="snapshot-containing-block-includes-scrollbar-gutter-ref.html">
-<meta name="fuzzy" content="snapshot-containing-block-includes-scrollbar-gutter-ref.html:0-20;0-100">
+<meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-100">
 <script src="/common/reftest-wait.js"></script>
 <style>
   :root {

--- a/css/css-view-transitions/snapshot-containing-block-static.html
+++ b/css/css-view-transitions/snapshot-containing-block-static.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="snapshot-containing-block-static-ref.html">
-<meta name="fuzzy" content="snapshot-containing-block-static-ref.html:0-20;0-100">
+<meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-100">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/span-with-overflowing-text-and-box-decorations.html
+++ b/css/css-view-transitions/span-with-overflowing-text-and-box-decorations.html
@@ -4,8 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="span-with-overflowing-text-and-box-decorations-ref.html">
-<meta name="fuzzy" content="span-with-overflowing-text-and-box-decorations-ref.html:maxDifference=0-3;totalPixels=0-4900">
-
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-4900">
 
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>

--- a/css/css-view-transitions/span-with-overflowing-text.html
+++ b/css/css-view-transitions/span-with-overflowing-text.html
@@ -4,8 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="span-with-overflowing-text-ref.html">
-<meta name="fuzzy" content="span-with-overflowing-text-ref.html:maxDifference=0-3;totalPixels=0-1100">
-
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-1100">
 
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>

--- a/css/css-view-transitions/transition-in-empty-iframe.html
+++ b/css/css-view-transitions/transition-in-empty-iframe.html
@@ -5,7 +5,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
   <link rel="author" href="mailto:bokan@chromium.org">
   <link rel="match" href="transition-in-empty-iframe-ref.html">
-  <meta name=fuzzy content="transition-in-empty-iframe-ref.html:0-80;0-1000">
+  <meta name=fuzzy content="maxDifference=0-80; totalPixels=0-1000">
   <script src="/common/reftest-wait.js"></script>
   <style>
     iframe {

--- a/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html
+++ b/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html
@@ -3,7 +3,7 @@
 <title>View transitions with web-animation API: full parsing of argument</title>
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="match" href="web-animations-api-ref.html">
-<meta name="fuzzy" content="web-animations-api-ref.html:0-2;0-500">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-500">
 <meta name="variant" content="?first-pseudo=::view-transition-group( first)">
 <meta name="variant" content="?first-pseudo=::view-transition-group(first)">
 <meta name="variant" content="?first-pseudo=::view-transition-group( first">

--- a/css/css-view-transitions/web-animations-api.html
+++ b/css/css-view-transitions/web-animations-api.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="web-animations-api-ref.html">
-<meta name="fuzzy" content="web-animations-api-ref.html:0-2;0-500">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-500">
 
 <script src="/common/reftest-wait.js"></script>
 <style>


### PR DESCRIPTION
The WebKit test exporter trips on these because the test importer rewrites them, avoid them altogether since they are unnecessary here.