### PR TITLE
Set the default device_serial argument

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -565,6 +565,8 @@ class ChromeAndroidBase(BrowserSetup):
         if kwargs["package_name"] is None:
             kwargs["package_name"] = self.browser.find_binary(
                 channel=browser_channel)
+        if not kwargs["device_serial"]:
+            kwargs["device_serial"] = ["emulator-5554"]
         if kwargs["webdriver_binary"] is None:
             webdriver_binary = None
             if not kwargs["install_webdriver"]:


### PR DESCRIPTION
It appears that WPT does not run on the Chrome Android browser of the simulator unless the '--device-serial' argument is explicitly added, after the PR[1] that introduced support for multiple emulators. It looks like the CL only set the default value(emulator-5554) to Firefox Android. So this CL sets the default value to Chrome Android browsers as well.

[1] Support multiple emulators for Android browsers (#31634)