### PR TITLE
[wptrunner] Report crash when WebDriver browser is not alive

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -313,7 +313,7 @@ class TestExecutor:
             result = self.do_test(test)
         except Exception as e:
             exception_string = traceback.format_exc()
-            message = f"Exception in TextExecutor.run:\n{exception_string}"
+            message = f"Exception in TestExecutor.run:\n{exception_string}"
             self.logger.warning(message)
             result = self.result_from_exception(test, e, exception_string)
 


### PR DESCRIPTION
This aligns with how the base class `TimedRunner` [differentiates `CRASH` from other failure modes][0].

An `InvalidSessionIdException` after a browser death [when executing a testdriver action][1] is now coerced to `CRASH`, not the generic `INTERNAL-ERROR` for harness exceptions.

Fixes #39617 and https://crbug.com/41485463.

[0]: https://github.com/web-platform-tests/wpt/blob/c338ceff/tools/wptrunner/wptrunner/executors/base.py#L216-L231
[1]: https://github.com/web-platform-tests/wpt/blob/c338ceff/tools/wptrunner/wptrunner/executors/base.py#L773