### PR TITLE
docs(metadata): s/default/backlog

### DIFF
--- a/tools/wptrunner/docs/expectation.rst
+++ b/tools/wptrunner/docs/expectation.rst
@@ -153,7 +153,7 @@ When used for expectation data, metadata files have the following format:
 
    :implementation-status:
      One of the values ``implementing``,
-     ``not-implementing`` or ``default``. This is used in conjunction
+     ``not-implementing`` or ``backlog``. This is used in conjunction
      with the ``--skip-implementation-status`` command line argument to
      ``wptrunner`` to ignore certain features where running the test is
      low value.


### PR DESCRIPTION
The `default` status does not exist in today's implementation of WPT, as [stated](https://matrix.to/#/!wKNaTuhRJSXtjUVpfk:matrix.org/$9xRRDOhEH-3XkfZc2WFnpNfqa9zGV2Jwc7YcnaXXpRY?via=matrix.org&via=mozilla.org&via=igalia.com) by @jgraham himself. `backlog`, however, does. So, trade them out.