### PR TITLE
Correct id of img element in aria-labelledby test

### DIFF
--- a/accname/name/comp_name_from_content.html
+++ b/accname/name/comp_name_from_content.html
@@ -239,7 +239,7 @@
     <span class="note" id="crossref_link">link</span><!-- this text is skipped the first time around because of aria-labelledby on parent element -->
   </a>
   <!-- but it's picked up again in inverse order b/c of cross-referencial aria-labelledby edge case -->
-  <img id="nested_image_label_3" alt="image" aria-labelledby="crossref_link" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+  <img id="nested_image_label3" alt="image" aria-labelledby="crossref_link" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 </h3>
 
 <!-- self-referencial edge case-->


### PR DESCRIPTION
For issue: https://github.com/web-platform-tests/interop-accessibility/issues/122

This test includes an aria-labelledby reference to id `nested_image_label3` but that id doesn't exist. Instead, `nested_image_label_3` exists. This commit updates the id, removing the underscore to fit the pattern of the test file.