### PR TITLE
script: Prevent "scroll to fragment" from scrolling offscreen

### DIFF
--- a/html/browsers/browsing-the-web/scroll-to-fragid/scroll-position-inline-nearest.html
+++ b/html/browsers/browsing-the-web/scroll-to-fragid/scroll-position-inline-nearest.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html style="writing-mode: vertical-lr;">
+<head>
+<meta charset="UTF-8">
+<title>Fragment Navigation: inline start position should not scroll out of content range</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#scroll-to-the-fragment-identifier">
+<link rel="author" href="mailto:mrobinson@igalia.com" title="Martin Robinson">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+    <!-- When scrolling to this fragment the viewport inline position should not
+        change because, it is already fully enclosed by the viewport and page width. -->
+    <div id="test1" style="position: absolute; top: 5000px; left: 100px; height: 100px; width: 100px;"></div>
+<script>
+
+var t = async_test("ScrollToFragment");
+t.step(() => {
+    location.hash = "test1";
+    setTimeout(t.step_func(() => {
+        assert_true(window.scrollY > 0);
+        assert_true(window.scrollY < 5000);
+        assert_equals(window.scrollX, 0);
+        t.done();
+    }));
+});
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
Previously, the "scroll to fragment" operation could scroll past the edge
of the screen, because the scroll position was not clamped to viewport
boundaries. Correct this by using the `Window::scroll()` method which
handles this case.
    
In addition, ensure that `Window`'s `current_viewport` member is
initialized properly when it is created.

Reviewed in servo/servo#32129