### PR TITLE
Add Chrome parameters to disable anti-aliasing for Ahem

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -138,8 +138,14 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
         chrome_options["args"].append(
             "--ip-address-space-overrides=" + address_space_overrides_arg)
 
+    # Always disable antialiasing on the Ahem font.
+    blink_features = ['DisableAhemAntialias']
+
     if kwargs["enable_mojojs"]:
-        chrome_options["args"].append("--enable-blink-features=MojoJS,MojoJSTest")
+        blink_features.append('MojoJS')
+        blink_features.append('MojoJSTest')
+
+    chrome_options["args"].append("--enable-blink-features=" + ','.join(blink_features))
 
     if kwargs["enable_swiftshader"]:
         # https://chromium.googlesource.com/chromium/src/+/HEAD/docs/gpu/swiftshader.md


### PR DESCRIPTION
For issue https://github.com/web-platform-tests/wpt/issues/45750

This change applies a runtime flag that disable anti-aliasing for the Ahem font, as detailed in the above issue. Since there's no real use case for aliased Ahem fonts, this flag is on-by-default for Chrome (and thus inherited to Edge's runtime environment by default).

`enable_mojojs` is also using `--enable-blink-features`, so potential Blink features are added to a `list` and then combined. 

Behavior in Chromium to accept this flag was implemented in https://chromium-review.googlesource.com/c/chromium/src/+/5458787, but a build hasn't been released with this change yet. I have verified with a local Chromium build that this fixes the Ahem anti-aliasing issues and passes a handful of listed cases locally with the WPT runner.

Based on @foolip's comment in https://github.com/web-platform-tests/wpt/issues/45750, there should be no additional work to get this behavior in Edge. I'll validate this once a build is out and make any additional WPT changes if necessary.