### PR TITLE
remove invalid namefrom contents expectations for td

### DIFF
--- a/css/css-display/accessibility/display-contents-role-and-label.html
+++ b/css/css-display/accessibility/display-contents-role-and-label.html
@@ -75,7 +75,7 @@
     </thead>
     <tbody>
       <tr style="display: contents;">
-        <td data-expectedrole="cell" data-expectedlabel="x" data-testname="td as child of tr with display: contents, within table with display: flex, has cell role" class="ex-role-and-label">x</td>
+        <td data-expectedrole="cell" data-testname="td as child of tr with display: contents, within table with display: flex, has cell role" class="ex-role">x</td>
         <td>x</td>
       </tr>
     </tbody>
@@ -90,7 +90,7 @@
     </thead>
     <tbody>
       <tr style="display: contents;">
-        <td data-expectedrole="cell" data-expectedlabel="x" data-testname="td as child of tr with display: contents, within table with role=table with display: flex, has cell role" class="ex-role-and-label">x</td>
+        <td data-expectedrole="cell" data-testname="td as child of tr with display: contents, within table with role=table with display: flex, has cell role" class="ex-role">x</td>
         <td>x</td>
       </tr>
     </tbody>
@@ -105,7 +105,7 @@
     </thead>
     <tbody>
       <tr style="display: contents;">
-        <td data-expectedrole="gridcell" data-expectedlabel="x" data-testname="td (no explicit role) as child of tr with display: contents, within table with role=grid with display: flex, has gridcell role" class="ex-role-and-label">x</td>
+        <td data-expectedrole="gridcell" data-testname="td (no explicit role) as child of tr with display: contents, within table with role=grid with display: flex, has gridcell role" class="ex-role">x</td>
         <td>x</td>
       </tr>
     </tbody>
@@ -212,7 +212,7 @@
     </thead>
     <tbody>
       <tr>
-        <td style="display: contents;" data-expectedrole="cell" data-expectedlabel="x" data-testname="td within tr in table with role table, all with display: contents, has cell role" class="ex-role-and-label">x</td>
+        <td style="display: contents;" data-expectedrole="cell" data-testname="td within tr in table with role table, all with display: contents, has cell role" class="ex-role">x</td>
         <td>x</td>
       </tr>
     </tbody>
@@ -242,7 +242,7 @@
     </thead>
     <tbody>
       <tr>
-        <td style="display: contents;" data-expectedrole="gridcell" data-expectedlabel="x" data-testname="td within table with role grid, both with display: contents, has gridcell role" class="ex-role-and-label">x</td>
+        <td style="display: contents;" data-expectedrole="gridcell" data-testname="td within table with role grid, both with display: contents, has gridcell role" class="ex-role">x</td>
         <td>x</td>
       </tr>
     </tbody>


### PR DESCRIPTION
Closes https://github.com/web-platform-tests/interop-accessibility/issues/119

Previous label tests assumed ARIA namefrom:contents was available on cell roles... There is an open https://github.com/w3c/aria/issues/2160 that might clarify this, but for Interop 2024, these few test test expectations did not match the current HTML-AAM spec, so we're removing them.