### PR TITLE
[WebDriver BiDi] Remove `context` from Realm expectation 

### DIFF
--- a/webdriver/tests/bidi/script/get_realms/get_realms.py
+++ b/webdriver/tests/bidi/script/get_realms/get_realms.py
@@ -14,7 +14,6 @@ async def test_payload_types(bidi_session):
     recursive_compare(
         [
             {
-                "context": any_string,
                 "origin": any_string,
                 "realm": any_string,
                 "type": any_string,


### PR DESCRIPTION
Not all realm types include it so we should not expect it when getting all realms.