### PR TITLE
[css-viewport] Remove assert for offsetTop after modifying zoom property

### DIFF
--- a/css/css-viewport/zoom/scroll-top-test-with-zoom.html
+++ b/css/css-viewport/zoom/scroll-top-test-with-zoom.html
@@ -23,9 +23,7 @@
   }, "Initial scrollTop with no zoom");
 
   document.body.style.zoom = 1.2;
-  test(function() {
-    assert_approx_equals(container.scrollTop, 77, 0.99, "scrollTop should remain consistent within 1 px after zooming in");
-  }, "scrollTop after increasing zoom level");
+  document.body.offsetTop;
 
   document.body.style.zoom = 1;
   test(function() {


### PR DESCRIPTION
There's no spec about what we should do with the scrollTop value after applying zoom. Which makes Firefox fail the test: css/css-viewport/zoom/scroll-top-test-with-zoom.html

Anyway checking that intermediate value is not relevant for this test, that is checking that the scrollTop value doesn't change when coming back to the initial zoom level.
So this patch removes the assert checking that value.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1891910 for more details.