### PR TITLE
Fix error reporting in tools/serve/serve.py

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -829,7 +829,8 @@ def start_http_server(logger, host, port, paths, routes, bind_address, config, *
                                      key_file=None,
                                      certificate=None,
                                      latency=kwargs.get("latency"))
-    except Exception:
+    except Exception as error:
+        logger.critical(f"start_http_server: Caught exception from wptserve.WebTestHttpd: {error}")
         startup_failed(logger)
 
 
@@ -847,7 +848,8 @@ def start_https_server(logger, host, port, paths, routes, bind_address, config, 
                                      certificate=config.ssl_config["cert_path"],
                                      encrypt_after_connect=config.ssl_config["encrypt_after_connect"],
                                      latency=kwargs.get("latency"))
-    except Exception:
+    except Exception as error:
+        logger.critical(f"start_https_server: Caught exception from wptserve.WebTestHttpd: {error}")
         startup_failed(logger)
 
 
@@ -868,7 +870,8 @@ def start_http2_server(logger, host, port, paths, routes, bind_address, config, 
                                      encrypt_after_connect=config.ssl_config["encrypt_after_connect"],
                                      latency=kwargs.get("latency"),
                                      http2=True)
-    except Exception:
+    except Exception as error:
+        logger.critical(f"start_http2_server: Caught exception from wptserve.WebTestHttpd: {error}")
         startup_failed(logger)
 
 
@@ -935,7 +938,8 @@ def start_ws_server(logger, host, port, paths, routes, bind_address, config, **k
                                config.paths["ws_doc_root"],
                                bind_address,
                                ssl_config=None)
-    except Exception:
+    except Exception as error:
+        logger.critical(f"start_ws_server: Caught exception from WebSocketDomain: {error}")
         startup_failed(logger)
 
 
@@ -947,7 +951,8 @@ def start_wss_server(logger, host, port, paths, routes, bind_address, config, **
                                config.paths["ws_doc_root"],
                                bind_address,
                                config.ssl_config)
-    except Exception:
+    except Exception as error:
+        logger.critical(f"start_wss_server: Caught exception from WebSocketDomain: {error}")
         startup_failed(logger)
 
 


### PR DESCRIPTION
In #45686 I reported the following log output:

```
❯ ./wpt serve
<irrelevant parts removed>
[2024-04-12 17:08:01,479 wss on port 33453] CRITICAL - Please ensure all the necessary WPT subdomains are mapped to a loopback device in /etc/hosts.
See https://web-platform-tests.org/running-tests/from-local-system.html#system-setup for instructions.
```

The underlying problem was actually https://github.com/GoogleChromeLabs/pywebsocket3/issues/38 and had nothing to do with the content of `/etc/hosts` (which had already been set up).

The problem is that `tools/serve/serve.py` contains numerous points like the following:

```python
try:
    # <do something>
except Exception:
    startup_failed(logger)
```

This swallows the actual exception, while `startup_failed` logs the message above. Since the actual problem is not as described, the logs are extremely misleading.

This change adds a log of the original exception to each location where the exception was swallowed. The log message includes enough context to help diagnose the problem.

With this change, the log output is as follows:

```
➜ ./wpt serve
<irrelevant parts removed>
[2024-04-29 18:01:15,751 wss on port 33175] CRITICAL - start_wss_server: Caught exception from WebSocketDomain: module 'ssl' has no attribute 'wrap_socket'
[2024-04-29 18:01:15,751 wss on port 33175] CRITICAL - Please ensure all the necessary WPT subdomains are mapped to a loopback device in /etc/hosts.
See https://web-platform-tests.org/running-tests/from-local-system.html#system-setup for instructions.
```