### PR TITLE
Improve error message on wpt.live for accessibility tests which use testdriver.js

### DIFF
--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -1100,6 +1100,14 @@
             throw new Error("get_named_cookie() is not implemented by testdriver-vendor.js");
         },
 
+        async get_computed_role(element) {
+            throw new Error("get_computed_role is a testdriver.js function which cannot be run in this context.");
+        },
+
+        async get_computed_name(element) {
+            throw new Error("get_computed_name is a testdriver.js function which cannot be run in this context.");
+        },
+
         async send_keys(element, keys) {
             if (this.in_automation) {
                 throw new Error("send_keys() is not implemented by testdriver-vendor.js");


### PR DESCRIPTION
The error message for wpt accessibility tests that use testdriver on wpt.live is kind of inscrutable (https://wpt.live/wai-aria/role/button-roles.html):
```
promise_test: Unhandled rejection with value: object "TypeError: window.test_driver_internal.get_computed_role is not a function"
```

I'm not sure if this is the best message, but I see that other testdriver.js functions, when not implemented, though a useful error message in this way.

Also I wonder if we could make clear in the documents somehow that not all tests can be run in wpt.live? I'm not sure where that information belongs, or I'd make the change. I thought about the home page of the documentation that links to wpt.live.. but I'm not sure the list of all "test types" that can't be run with wpt.live / `./wpt serve` -- is it just the testdriver.js tests?