### PR TITLE
[Azure Pipelines] fix Firefox Nightly cask URL

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/click_iframe_crossorigin.sub.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/click_iframe_crossorigin.sub.html.ini
@@ -2,3 +2,4 @@
   [TestDriver click on a document in an iframe]
     expected:
       if product == "chrome": [PASS, FAIL]  # https://github.com/web-platform-tests/wpt/issues/26295
+      if product == "firefox": [PASS, FAIL]  # https://github.com/web-platform-tests/wpt/issues/45987

--- a/infrastructure/metadata/infrastructure/testdriver/click_iframe_crossorigin.sub.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/click_iframe_crossorigin.sub.html.ini
@@ -2,4 +2,4 @@
   [TestDriver click on a document in an iframe]
     expected:
       if product == "chrome": [PASS, FAIL]  # https://github.com/web-platform-tests/wpt/issues/26295
-      if product == "firefox": [PASS, FAIL]  # https://github.com/web-platform-tests/wpt/issues/45987
+      if os == "mac" and product == "firefox": [PASS, FAIL]  # https://github.com/web-platform-tests/wpt/issues/45987

--- a/tools/ci/azure/install_chrome.yml
+++ b/tools/ci/azure/install_chrome.yml
@@ -1,6 +1,6 @@
 steps:
 # The conflicting google-chrome and chromedriver casks are first uninstalled.
-# The raw google-chrome-dev cask URL is used to bypass caching.
+# The raw google-chrome@dev.rb cask URL is used to bypass caching.
 - script: |
     set -eux -o pipefail
     HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall --cask google-chrome || true

--- a/tools/ci/azure/install_firefox.yml
+++ b/tools/ci/azure/install_firefox.yml
@@ -1,9 +1,8 @@
 steps:
-# This is equivalent to `Homebrew/homebrew-cask-versions/firefox-nightly`,
-# but the raw URL is used to bypass caching.
+# The raw firefox@nightly.rb cask URL is used to bypass caching.
 - script: |
     set -eux -o pipefail
-    curl https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/master/Casks/firefox-nightly.rb > firefox-nightly.rb
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask firefox-nightly.rb
+    curl https://raw.githubusercontent.com/Homebrew/homebrew-cask/HEAD/Casks/f/firefox@nightly.rb > firefox@nightly.rb
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask firefox@nightly.rb
   displayName: 'Install Firefox Nightly'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))


### PR DESCRIPTION
This broke with https://github.com/Homebrew/homebrew-cask-versions/pull/20196.
