### PR TITLE
Pass a channel argument to install_webdriver_by_version()

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1452,7 +1452,7 @@ class ChromeAndroidBase(Browser):
         if browser_binary is None:
             browser_binary = self.find_binary(channel)
         chrome = Chrome(self.logger)
-        return chrome.install_webdriver_by_version(self.version(browser_binary), dest)
+        return chrome.install_webdriver_by_version(self.version(browser_binary), dest, channel)
 
     def version(self, binary=None, webdriver_binary=None):
         if not binary:


### PR DESCRIPTION
When running WPT on Chrome Android, the below error happens.

  'TypeError: Chrome.install_webdriver_by_version() missing 1 required
   positional argument: 'channel''

This PR passes the channel argument to the function in order to
avoid the error.