### PR TITLE
[WebDriver] update input key codepoint tests

### DIFF
--- a/webdriver/tests/bidi/input/perform_actions/invalid.py
+++ b/webdriver/tests/bidi/input/perform_actions/invalid.py
@@ -376,7 +376,12 @@ async def test_params_key_action_value_invalid_type(perform_actions,
 
 @pytest.mark.parametrize(
     "value",
-    ["fa", "\u0BA8\u0BBFb", "\u0BA8\u0BBF\u0BA8", "\u1100\u1161\u11A8c"],
+    [
+        "fa",  # 2 codepoints.
+        "\u0BA8\u0BBF",  # "நிb", 2 codepoints forming a grapheme.
+        "\u1100\u1161\u11A8",  # "각", 3 codepoints forming a grapheme.
+        "\u2764\ufe0f",  # "❤️",  2 codepoints: a base character and a variation selector.
+    ],
 )
 async def test_params_key_action_value_invalid_multiple_codepoints(
         perform_actions, value):

--- a/webdriver/tests/bidi/input/perform_actions/key.py
+++ b/webdriver/tests/bidi/input/perform_actions/key.py
@@ -33,8 +33,8 @@ async def test_key_backspace(bidi_session, top_context, setup_key_test):
 @pytest.mark.parametrize(
     "value",
     [
-        "\U0001F604",  # 😄 U+1F604 (\ud83d\ude04) Smiling Face with Open Mouth and Smiling Eyes.
-        "\U0001F60D",  # 😍 U+1F60D (\ud83d\ude0d) Smiling Face with Heart-Eyes.
+        "\U0001F604",  # "😄" (\ud83d\ude04), a single surrogate codepoint.
+        "\U0001F60D",  # "😍" (\ud83d\ude0d), a single surrogate codepoint.
     ],
 )
 async def test_key_codepoint(

--- a/webdriver/tests/bidi/input/perform_actions/key.py
+++ b/webdriver/tests/bidi/input/perform_actions/key.py
@@ -33,10 +33,8 @@ async def test_key_backspace(bidi_session, top_context, setup_key_test):
 @pytest.mark.parametrize(
     "value",
     [
-        ("\U0001F604"),
-        ("\U0001F60D"),
-        ("\u0BA8\u0BBF"),
-        ("\u1100\u1161\u11A8"),
+        "\U0001F604",  # 😄 U+1F604 (\ud83d\ude04) Smiling Face with Open Mouth and Smiling Eyes.
+        "\U0001F60D",  # 😍 U+1F60D (\ud83d\ude0d) Smiling Face with Heart-Eyes.
     ],
 )
 async def test_key_codepoint(

--- a/webdriver/tests/classic/perform_actions/key_special_keys.py
+++ b/webdriver/tests/classic/perform_actions/key_special_keys.py
@@ -6,10 +6,8 @@ from tests.classic.perform_actions.support.refine import get_keys
 
 
 @pytest.mark.parametrize("value", [
-    (u"\U0001F604"),
-    (u"\U0001F60D"),
-    (u"\u0BA8\u0BBF"),
-    (u"\u1100\u1161\u11A8"),
+    "\U0001F604",  # "😄" (\ud83d\ude04), a single surrogate codepoint.
+    "\U0001F60D",  # "😍" (\ud83d\ude0d), a single surrogate codepoint.
 ])
 def test_codepoint_keys_behave_correctly(session, key_reporter, key_chain, value):
     # Not using key_chain.send_keys() because we always want to treat value as
@@ -25,10 +23,10 @@ def test_codepoint_keys_behave_correctly(session, key_reporter, key_chain, value
 
 
 @pytest.mark.parametrize("value", [
-    (u"fa"),
-    (u"\u0BA8\u0BBFb"),
-    (u"\u0BA8\u0BBF\u0BA8"),
-    (u"\u1100\u1161\u11A8c")
+    "fa",  # 2 unicode codepoints.
+    "\u0BA8\u0BBF",  # "நிb", 2 unicode codepoints forming a grapheme.
+    "\u1100\u1161\u11A8",  # "각", 3 unicode codepoints forming a grapheme.
+    "\u2764\ufe0f",  # "❤️",  2 codepoints: a base character and a variation selector.
 ])
 def test_invalid_multiple_codepoint_keys_fail(session, key_reporter, key_chain, value):
     with pytest.raises(error.InvalidArgumentException):


### PR DESCRIPTION
According to step 6 of [Test the input key single codepoint.](https://w3c.github.io/webdriver/#dfn-process-a-key-action):
> 6. If key is not a [String](https://w3c.github.io/webdriver/#dfn-string) containing a single [unicode code point](https://w3c.github.io/webdriver/#dfn-unicode-code-point) _or grapheme cluster?_ return [error](https://w3c.github.io/webdriver/#dfn-error) with [error code](https://w3c.github.io/webdriver/#dfn-error-code) [invalid argument](https://w3c.github.io/webdriver/#dfn-invalid-argument).

The "**or grapheme cluster?**" is not specified, so aligning the tests with the spec.

Alternatively, this tests can be marked as tentative until the spec is updated.