### PR TITLE
Make linear() easing tests no longer tentative

### DIFF
--- a/css/css-easing/linear-timing-functions-output.html
+++ b/css/css-easing/linear-timing-functions-output.html
@@ -2,7 +2,7 @@
 <meta charset=utf-8>
 <meta name="assert" content="This test checks the output of linear timing functions" />
 <title>Tests for the output of linear timing functions</title>
-<link rel="help" href="https://github.com/w3c/csswg-drafts/pull/6533">
+<link rel="help" href="https://drafts.csswg.org/css-easing-2/#the-linear-easing-function">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/util.js"></script>

--- a/css/css-easing/linear-timing-functions-syntax.html
+++ b/css/css-easing/linear-timing-functions-syntax.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Easing: getComputedStyle().animationTimingFunction with linear(...)</title>
-<link rel="help" href="https://github.com/w3c/csswg-drafts/pull/6533">
+<link rel="help" href="https://drafts.csswg.org/css-easing-2/#the-linear-easing-function">
 <meta name="assert" content="animation-timing-function: linear(...) parsing tests">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>


### PR DESCRIPTION
The spec was updated in https://github.com/w3c/csswg-drafts/pull/7484.
