### PR TITLE
Fix 'TypeError: can't subtract offset-naive and offset-aware datetimes' error in test_add_non_session_cookie test

### DIFF
--- a/webdriver/tests/classic/add_cookie/add.py
+++ b/webdriver/tests/classic/add_cookie/add.py
@@ -154,7 +154,7 @@ def test_add_cookie_for_ip(session, server_config):
 
 def test_add_non_session_cookie(session, url):
     a_day_from_now = int(
-        (datetime.now(timezone.utc) + timedelta(days=1) - datetime.utcfromtimestamp(0)).total_seconds())
+        (datetime.now(timezone.utc) + timedelta(days=1) - datetime.fromtimestamp(0, timezone.utc)).total_seconds())
 
     new_cookie = {
         "name": "hello",


### PR DESCRIPTION
Changes from #45929 introduced the 'TypeError: can't subtract offset-naive and offset-aware datetimes' error in test_add_non_session_cookie test (see [the log](https://github.com/web-platform-tests/wpt/runs/24505341575)).