### PR TITLE
Enabled subsuite support for chrome

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -53,13 +53,13 @@ def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
             "webdriver_args": kwargs.get("webdriver_args")}
 
 
-def executor_kwargs(logger, test_type, test_environment, run_info_data,
+def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite,
                     **kwargs):
     sanitizer_enabled = kwargs.get("sanitizer_enabled")
     if sanitizer_enabled:
         test_type = "crashtest"
     executor_kwargs = base_executor_kwargs(test_type, test_environment, run_info_data,
-                                           **kwargs)
+                                           subsuite, **kwargs)
     executor_kwargs["close_after_done"] = True
     executor_kwargs["sanitizer_enabled"] = sanitizer_enabled
     executor_kwargs["reuse_window"] = kwargs.get("reuse_window", False)
@@ -156,6 +156,10 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
 
     # Copy over any other flags that were passed in via `--binary-arg`
     for arg in kwargs.get("binary_args", []):
+        if arg not in chrome_options["args"]:
+            chrome_options["args"].append(arg)
+
+    for arg in subsuite.config.get("binary_args", []):
         if arg not in chrome_options["args"]:
             chrome_options["args"].append(arg)
 


### PR DESCRIPTION
This is needed as we plan to run virtual tests with headless shell. Whether to run the virtual tests or not is controlled by the wrapper.