### PR TITLE
Use email.utils.parsedate_to_datetime to parse RFC (2)822 dates

### DIFF
--- a/tools/wptserve/wptserve/sslutils/openssl.py
+++ b/tools/wptserve/wptserve/sslutils/openssl.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import tempfile
 from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
 
 # Amount of time beyond the present to consider certificates "expired." This
 # allows certificates to be proactively re-generated in the "buffer" period
@@ -310,12 +311,9 @@ class OpenSSLEnvironment:
                                    "-noout",
                                    "-enddate",
                                    "-in", cert_path).decode("utf8").split("=", 1)[1].strip()
-            # Not sure if this works in other locales
-            end_date = datetime.strptime(end_date_str, "%b %d %H:%M:%S %Y %Z")
+            # openssl outputs an RFC 822 date
+            end_date = parsedate_to_datetime(end_date_str)
             time_buffer = timedelta(**CERT_EXPIRY_BUFFER)
-            # Because `strptime` does not account for time zone offsets, it is
-            # always in terms of UTC, so the current time should be calculated
-            # accordingly.
             if end_date < datetime.now(timezone.utc) + time_buffer:
                 return False
 


### PR DESCRIPTION
After c3a572d, checking the key cert via OpenSSL failed with a mismatch between aware and naive datetime objects. This happened because strptime creates a naive datetime object even when "%Z" is in the format string.

Instead, use the RFC 2822 date parser in email.utils, as this is the output format of OpenSSL, which produces an aware datetime object.

Fixes #46040.