### PR TITLE
Fix unclosed `<style>` tag in root-to-shared-animation-incoming-ref.html

### DIFF
--- a/css/css-view-transitions/root-to-shared-animation-incoming-ref.html
+++ b/css/css-view-transitions/root-to-shared-animation-incoming-ref.html
@@ -10,4 +10,4 @@ body {
   padding: 0;
   margin: 0;
 }
-
+</style>


### PR DESCRIPTION
This trips up the WebKit test importer and ends up importing corrupted ref files.