### PR TITLE
Sync paths that trigger the update_built CI job

### DIFF
--- a/fetch/metadata/tools/fetch-metadata.conf.yml
+++ b/fetch/metadata/tools/fetch-metadata.conf.yml
@@ -43,8 +43,8 @@ cases:
         origins: [httpCrossSite]
         description: Not sent to non-trustworthy cross-site destination
     template_axes:
-      # The `audioWorklet` interface is only available in secure contexts
-      # https://webaudio.github.io/web-audio-api/#BaseAudioContext
+      # The `AudioWorklet` interface is only available in secure contexts
+      # https://webaudio.github.io/web-audio-api/#AudioWorklet
       audioworklet.https.sub.html: []
       # Service workers are only available in secure context
       fetch-via-serviceworker.https.sub.html: []
@@ -230,8 +230,8 @@ cases:
         expected: cross-site
     template_axes:
       # Unused
-      # The `audioWorklet` interface is only available in secure contexts
-      # https://webaudio.github.io/web-audio-api/#BaseAudioContext
+      # The `AudioWorklet` interface is only available in secure contexts
+      # https://webaudio.github.io/web-audio-api/#AudioWorklet
       audioworklet.https.sub.html: []
       # Service workers are only available in secure context
       fetch-via-serviceworker.https.sub.html: []

--- a/tools/ci/jobs.py
+++ b/tools/ci/jobs.py
@@ -23,7 +23,7 @@ EXCLUDES = [
 ]
 
 # Rules are just regex on the path, with a leading ! indicating a regex that must not
-# match for the job. Paths should be kept in sync with update-built-tests.sh.
+# match for the job. Paths should be kept in sync with scripts in update_built.py.
 job_path_map = {
     "affected_tests": [".*/.*", "!resources/(?!idlharness.js)"] + EXCLUDES,
     "stability": [".*/.*", "!resources/.*"] + EXCLUDES,
@@ -32,10 +32,11 @@ job_path_map = {
     "resources_unittest": ["resources/", "tools/"],
     "tools_unittest": ["tools/"],
     "wptrunner_unittest": ["tools/"],
-    "update_built": ["update-built-tests\\.sh",
-                     "conformance-checkers/",
+    "update_built": ["conformance-checkers/",
+                     "css/css-images/",
                      "css/css-ui/",
                      "css/css-writing-modes/",
+                     "fetch/metadata/",
                      "html/",
                      "infrastructure/",
                      "mimesniff/"],

--- a/tools/ci/update_built.py
+++ b/tools/ci/update_built.py
@@ -9,6 +9,7 @@ logger = logging.getLogger()
 
 wpt_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
 
+# These paths should be kept in sync with job_path_map in jobs.py.
 scripts = {
     "canvas": ["html/canvas/tools/gentest.py"],
     "conformance-checkers": ["conformance-checkers/tools/dl.py",


### PR DESCRIPTION
Note that html/ covers a lot of it.

update-built-tests.sh was removed in https://github.com/web-platform-tests/wpt/pull/31243.

This would have avoided https://github.com/web-platform-tests/wpt/pull/46050.
