### PR TITLE
Stop running Chrome+Firefox infrastructure/ tests on macOS

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -103,21 +103,9 @@ jobs:
   - template: tools/ci/azure/install_fonts.yml
   - template: tools/ci/azure/install_certs.yml
   - template: tools/ci/azure/color_profile.yml
-  - template: tools/ci/azure/install_chrome.yml
-  - template: tools/ci/azure/install_firefox.yml
   - template: tools/ci/azure/install_safari.yml
   - template: tools/ci/azure/update_hosts.yml
   - template: tools/ci/azure/update_manifest.yml
-  - script: |
-      set -eux -o pipefail
-      ./wpt run --yes --no-manifest-update --manifest MANIFEST.json --metadata infrastructure/metadata/ --log-mach - --log-mach-level info --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_macos_chrome.json --channel dev chrome infrastructure/
-    condition: succeededOrFailed()
-    displayName: 'Run tests (Chrome Dev)'
-  - script: |
-      set -eux -o pipefail
-      ./wpt run --yes --no-manifest-update --manifest MANIFEST.json --metadata infrastructure/metadata/ --log-mach - --log-mach-level info --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_macos_firefox.json --channel nightly firefox infrastructure/
-    condition: succeededOrFailed()
-    displayName: 'Run tests (Firefox Nightly)'
   - script: |
       set -eux -o pipefail
       export SYSTEM_VERSION_COMPAT=0

--- a/infrastructure/metadata/infrastructure/reftest/legacy/fuzzy-ref-2.html.ini
+++ b/infrastructure/metadata/infrastructure/reftest/legacy/fuzzy-ref-2.html.ini
@@ -1,4 +1,3 @@
 [fuzzy-ref-2.html]
   fuzzy:
-    if os == "mac" and product == "chrome": maxDifference=254-255;100-100
     maxDifference=255;100-100

--- a/infrastructure/metadata/infrastructure/reftest/legacy/reftest_fuzzy_chain_ini.html.ini
+++ b/infrastructure/metadata/infrastructure/reftest/legacy/reftest_fuzzy_chain_ini.html.ini
@@ -1,4 +1,3 @@
 [reftest_fuzzy_chain_ini.html]
   fuzzy:
-    if os == "mac" and product == "chrome": maxDifference=254-255;100-100
     maxDifference=255;100-100

--- a/infrastructure/metadata/infrastructure/reftest/reftest_fuzzy_1.html.ini
+++ b/infrastructure/metadata/infrastructure/reftest/reftest_fuzzy_1.html.ini
@@ -1,3 +1,0 @@
-[reftest_fuzzy_1.html]
-  fuzzy:
-    if os == "mac" and product == "chrome": fuzzy-ref-1.html:254-255;100

--- a/infrastructure/metadata/infrastructure/reftest/reftest_fuzzy_ini_full.html.ini
+++ b/infrastructure/metadata/infrastructure/reftest/reftest_fuzzy_ini_full.html.ini
@@ -1,6 +1,4 @@
 [reftest_fuzzy_ini_full.html]
   fuzzy:
-    if os == "mac" and product == "chrome": [maxDifference=1;100-100,
-        reftest_fuzzy_ini_full.html==fuzzy-ref-1.html:254-255;100]
     if 1 == 1: [maxDifference=1;100-100,  # 'if 1 == 1:' is a workaround for a parser bug
         reftest_fuzzy_ini_full.html==fuzzy-ref-1.html:255;100]

--- a/infrastructure/metadata/infrastructure/reftest/reftest_fuzzy_ini_ref_only.html.ini
+++ b/infrastructure/metadata/infrastructure/reftest/reftest_fuzzy_ini_ref_only.html.ini
@@ -1,8 +1,5 @@
 [reftest_fuzzy_ini_ref_only.html]
   fuzzy:
-    if os == "mac" and product == "chrome": [maxDifference=1;100-100,
-        fuzzy-ref-1.html:maxDifference=254-255;100-100,
-        reftest_fuzzy==fuzzy-ref-2.html:maxDifference=1;100-100]
     if 1 == 1: [maxDifference=1;100-100,  # 1 == 1 is a workaround for a parser bug.
         fuzzy-ref-1.html:maxDifference=255;100-100,
         reftest_fuzzy==fuzzy-ref-2.html:maxDifference=1;100-100]

--- a/infrastructure/metadata/infrastructure/reftest/reftest_fuzzy_ini_short.html.ini
+++ b/infrastructure/metadata/infrastructure/reftest/reftest_fuzzy_ini_short.html.ini
@@ -1,4 +1,3 @@
 [reftest_fuzzy_ini_short.html]
   fuzzy:
-    if os == "mac" and product == "chrome": maxDifference=254-255;100-100
     maxDifference=255;100-100

--- a/infrastructure/metadata/infrastructure/testdriver/click_iframe_crossorigin.sub.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/click_iframe_crossorigin.sub.html.ini
@@ -2,4 +2,3 @@
   [TestDriver click on a document in an iframe]
     expected:
       if product == "chrome": [PASS, FAIL]  # https://github.com/web-platform-tests/wpt/issues/26295
-      if os == "mac" and product == "firefox": [PASS, FAIL]  # https://github.com/web-platform-tests/wpt/issues/45987


### PR DESCRIPTION
Maintaining the expectations is work, and we don't actually run these on
Azure Pipelines for wpt.fyi.
