### PR TITLE
Check use of NavigateEvent.sourceElement

### DIFF
--- a/navigation-api/navigate-event/event-constructor.html
+++ b/navigation-api/navigate-event/event-constructor.html
@@ -78,7 +78,8 @@ async_test(t => {
     assert_equals(event.downloadRequest, downloadRequest);
     assert_equals(event.info, info);
     assert_equals(event.hasUAVisualTransition, hasUAVisualTransition);
-    assert_equals(event.sourceElement, sourceElement);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(event.sourceElement, sourceElement);
   });
   history.pushState(2, null, "#2");
 }, "all properties are reflected back");
@@ -98,7 +99,8 @@ async_test(t => {
     assert_equals(event.formData, null);
     assert_equals(event.downloadRequest, null);
     assert_equals(event.info, undefined);
-    assert_equals(event.sourceElement, null);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(event.sourceElement, null);
   });
   history.pushState(3, null, "#3");
 }, "defaults are as expected");

--- a/navigation-api/navigate-event/navigate-anchor-cross-origin.html
+++ b/navigation-api/navigate-event/navigate-anchor-cross-origin.html
@@ -17,7 +17,8 @@ async_test(t => {
     assert_equals(e.destination.key, "");
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
-    assert_equals(e.sourceElement, document.getElementById("a"));
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, document.getElementById("a"));
     e.preventDefault();
   });
   a.click();

--- a/navigation-api/navigate-event/navigate-anchor-download-userInitiated.html
+++ b/navigation-api/navigate-event/navigate-anchor-download-userInitiated.html
@@ -21,7 +21,8 @@ async_test(t => {
     assert_equals(e.destination.key, "");
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
-    assert_equals(e.sourceElement, document.getElementById("a"));
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, document.getElementById("a"));
     e.preventDefault();
     t.step_timeout(t.step_func_done(() => assert_equals(location.hash, "")), 0);
   });

--- a/navigation-api/navigate-event/navigate-anchor-download.html
+++ b/navigation-api/navigate-event/navigate-anchor-download.html
@@ -25,7 +25,8 @@ for (const [tag, download_attr] of tests) {
       assert_equals(e.destination.key, "");
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
-      assert_equals(e.sourceElement, a);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, a);
       e.preventDefault();
     });
     a.click();

--- a/navigation-api/navigate-event/navigate-anchor-fragment.html
+++ b/navigation-api/navigate-event/navigate-anchor-fragment.html
@@ -17,7 +17,8 @@ async_test(t => {
     assert_equals(e.destination.key, "");
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
-    assert_equals(e.sourceElement, document.getElementById("a"));
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, document.getElementById("a"));
     e.preventDefault();
     t.step_timeout(t.step_func_done(() => assert_equals(location.hash, "")), 0);
   });

--- a/navigation-api/navigate-event/navigate-anchor-same-origin-cross-document.html
+++ b/navigation-api/navigate-event/navigate-anchor-same-origin-cross-document.html
@@ -18,7 +18,8 @@ async_test(t => {
     assert_equals(e.destination.key, "");
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
-    assert_equals(e.sourceElement, document.getElementById("a"));
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, document.getElementById("a"));
     e.preventDefault();
   });
   a.click();

--- a/navigation-api/navigate-event/navigate-anchor-userInitiated.html
+++ b/navigation-api/navigate-event/navigate-anchor-userInitiated.html
@@ -20,7 +20,8 @@ async_test(t => {
     assert_equals(e.destination.key, "");
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
-    assert_equals(e.sourceElement, document.getElementById("a"));
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, document.getElementById("a"));
     e.preventDefault();
     t.step_timeout(t.step_func_done(() => assert_equals(location.hash, "")), 0);
   });

--- a/navigation-api/navigate-event/navigate-anchor-with-target.html
+++ b/navigation-api/navigate-event/navigate-anchor-with-target.html
@@ -20,10 +20,11 @@ async_test(t => {
       assert_equals(new URL(e.destination.url).pathname,
                     "/navigation-api/navigate-event/foo.html");
       assert_false(e.destination.sameDocument);
-    assert_equals(e.destination.key, "");
-    assert_equals(e.destination.id, "");
+      assert_equals(e.destination.key, "");
+      assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       e.preventDefault();
     });
     a.click();

--- a/navigation-api/navigate-event/navigate-destination-getState-back-forward.html
+++ b/navigation-api/navigate-event/navigate-destination-getState-back-forward.html
@@ -19,7 +19,8 @@ async_test(t => {
       assert_equals(e.destination.key, "");
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
     });
     navigation.back();
   }), 0);

--- a/navigation-api/navigate-event/navigate-destination-getState-navigate.html
+++ b/navigation-api/navigate-event/navigate-destination-getState-navigate.html
@@ -16,7 +16,8 @@ async_test(t => {
       assert_equals(e.destination.key, "");
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
     });
     navigation.navigate("#foo", { state: navState });
   }, 0);

--- a/navigation-api/navigate-event/navigate-destination-getState-reload.html
+++ b/navigation-api/navigate-event/navigate-destination-getState-reload.html
@@ -16,7 +16,8 @@ async_test(t => {
       assert_equals(e.destination.key, "");
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       e.intercept();
     });
     navigation.updateCurrentEntry({ state: navState });

--- a/navigation-api/navigate-event/navigate-form-get.html
+++ b/navigation-api/navigate-event/navigate-form-get.html
@@ -21,7 +21,8 @@ async_test(t => {
 
     // Because it's a GET, not a POST
     assert_equals(e.formData, null);
-    assert_equals(e.sourceElement, form);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, form);
   });
   window.onload = t.step_func(() => form.submit());
 }, "<form> submission with GET method fires navigate event but with formData null");

--- a/navigation-api/navigate-event/navigate-form-reload.html
+++ b/navigation-api/navigate-event/navigate-form-reload.html
@@ -12,7 +12,8 @@ async_test(t => {
     iframe.contentWindow.navigation.onnavigate = t.step_func(e => {
       assert_equals(e.navigationType, "push");
       assert_not_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
 
       iframe.onload = t.step_func(() => {
         iframe.contentWindow.navigation.onnavigate = t.step_func_done(e => {

--- a/navigation-api/navigate-event/navigate-form-traverse.html
+++ b/navigation-api/navigate-event/navigate-form-traverse.html
@@ -12,7 +12,8 @@ async_test(t => {
     iframe.contentWindow.navigation.onnavigate = t.step_func(e => {
       assert_equals(e.navigationType, "push");
       assert_not_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
 
       iframe.onload = t.step_func(() => {
         // Avoid the replace behavior that occurs if you navigate during the load handler

--- a/navigation-api/navigate-event/navigate-form-userInitiated.html
+++ b/navigation-api/navigate-event/navigate-form-userInitiated.html
@@ -24,7 +24,8 @@ async_test(t => {
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
     assert_not_equals(e.formData, null);
-    assert_equals(e.sourceElement, submit);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, submit);
   });
   window.onload = t.step_func(() => test_driver.click(submit));
 }, "<form> submission fires navigate event");

--- a/navigation-api/navigate-event/navigate-form-with-target.html
+++ b/navigation-api/navigate-event/navigate-form-with-target.html
@@ -22,7 +22,8 @@ async_test(t => {
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
       assert_not_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
     });
     form.submit();
   });

--- a/navigation-api/navigate-event/navigate-form.html
+++ b/navigation-api/navigate-event/navigate-form.html
@@ -19,7 +19,8 @@ async_test(t => {
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
     assert_not_equals(e.formData, null);
-    assert_equals(e.sourceElement, form);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, form);
   });
   window.onload = t.step_func(() => form.submit());
 }, "<form> submission fires navigate event");

--- a/navigation-api/navigate-event/navigate-history-back-after-fragment.html
+++ b/navigation-api/navigate-event/navigate-history-back-after-fragment.html
@@ -24,7 +24,8 @@ async_test(t => {
       assert_equals(e.destination.id, target_id);
         assert_equals(e.destination.index, start_index);
       assert_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
     });
 
     history.back();

--- a/navigation-api/navigate-event/navigate-history-back-after-pushState.html
+++ b/navigation-api/navigate-event/navigate-history-back-after-pushState.html
@@ -24,7 +24,8 @@ async_test(t => {
       assert_equals(e.destination.id, target_id);
       assert_equals(e.destination.index, start_index);
       assert_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
     });
 
     history.back();

--- a/navigation-api/navigate-event/navigate-history-back-cross-document.html
+++ b/navigation-api/navigate-event/navigate-history-back-cross-document.html
@@ -23,7 +23,8 @@ async_test(t => {
         assert_equals(e.destination.index, 0);
         assert_equals(e.formData, null);
         assert_equals(e.info, undefined);
-        assert_equals(e.sourceElement, null);
+        // NavigateEvent sourceElement is still in development, so test whether it is available.
+        if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       });
       assert_true(i.contentWindow.navigation.canGoBack);
       i.contentWindow.history.back();

--- a/navigation-api/navigate-event/navigate-history-go-0.html
+++ b/navigation-api/navigate-event/navigate-history-go-0.html
@@ -18,7 +18,8 @@ async_test(t => {
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
       assert_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       e.preventDefault();
     });
 

--- a/navigation-api/navigate-event/navigate-history-pushState.html
+++ b/navigation-api/navigate-event/navigate-history-pushState.html
@@ -17,7 +17,8 @@ async_test(t => {
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
     assert_equals(e.formData, null);
-    assert_equals(e.sourceElement, null);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, null);
     e.preventDefault();
     t.step_timeout(t.step_func_done(() => {
       assert_equals(location.hash, "");

--- a/navigation-api/navigate-event/navigate-history-replaceState.html
+++ b/navigation-api/navigate-event/navigate-history-replaceState.html
@@ -17,7 +17,8 @@ async_test(t => {
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
     assert_equals(e.formData, null);
-    assert_equals(e.sourceElement, null);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, null);
     e.preventDefault();
     t.step_timeout(t.step_func_done(() => {
       assert_equals(location.hash, "");

--- a/navigation-api/navigate-event/navigate-iframe-location.html
+++ b/navigation-api/navigate-event/navigate-iframe-location.html
@@ -21,7 +21,8 @@ async_test(t => {
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
       assert_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       e.preventDefault();
       t.step_timeout(t.step_func_done(() => assert_equals(location.hash, "")), 0);
     });

--- a/navigation-api/navigate-event/navigate-location.html
+++ b/navigation-api/navigate-event/navigate-location.html
@@ -17,7 +17,8 @@ async_test(t => {
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
     assert_equals(e.formData, null);
-    assert_equals(e.sourceElement, null);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, null);
   });
   location.href = "#1";
 }, "location API fires navigate event");

--- a/navigation-api/navigate-event/navigate-meta-refresh.html
+++ b/navigation-api/navigate-event/navigate-meta-refresh.html
@@ -20,7 +20,8 @@ async_test(t => {
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
       assert_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       e.preventDefault();
     });
   });

--- a/navigation-api/navigate-event/navigate-navigation-back-cross-document.html
+++ b/navigation-api/navigate-event/navigate-navigation-back-cross-document.html
@@ -25,7 +25,8 @@ async_test(t => {
         assert_equals(e.destination.index, 0);
         assert_equals(e.formData, null);
         assert_equals(e.info, "hi");
-        assert_equals(e.sourceElement, null);
+        // NavigateEvent sourceElement is still in development, so test whether it is available.
+        if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       });
       i.contentWindow.onbeforeunload = () => beforeunload_called = true;
       assert_true(i.contentWindow.navigation.canGoBack);

--- a/navigation-api/navigate-event/navigate-navigation-back-same-document-in-iframe.html
+++ b/navigation-api/navigate-event/navigate-navigation-back-same-document-in-iframe.html
@@ -27,7 +27,8 @@ promise_test(async t => {
     assert_equals(e.destination.index, 0);
     assert_equals(e.formData, null);
     assert_equals(e.info, "hi");
-    assert_equals(e.sourceElement, null);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, null);
   }
   await i.contentWindow.navigation.back({ info: "hi" }).finished;
 }, "navigate event for navigation.back() - same-document in an iframe");

--- a/navigation-api/navigate-event/navigate-navigation-back-same-document.html
+++ b/navigation-api/navigate-event/navigate-navigation-back-same-document.html
@@ -25,7 +25,8 @@ async_test(t => {
         assert_equals(e.formData, null);
         assert_equals(e.info, "hi");
         assert_not_equals(e.hasUAVisualTransition, undefined);
-        assert_equals(e.sourceElement, null);
+        // NavigateEvent sourceElement is still in development, so test whether it is available.
+        if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       });
       assert_true(navigation.canGoBack);
       navigation.back({ info: "hi" });

--- a/navigation-api/navigate-event/navigate-navigation-navigate.html
+++ b/navigation-api/navigate-event/navigate-navigation-navigate.html
@@ -16,7 +16,8 @@ async_test(t => {
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
     assert_equals(e.formData, null);
-    assert_equals(e.sourceElement, null);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, null);
   });
   navigation.navigate("#foo");
 }, "navigate event for navigation.navigate()");

--- a/navigation-api/navigate-event/navigate-svg-anchor-fragment.html
+++ b/navigation-api/navigate-event/navigate-svg-anchor-fragment.html
@@ -17,7 +17,8 @@ async_test(t => {
     assert_equals(e.destination.key, "");
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
-    assert_equals(e.sourceElement, document.getElementById("a"));
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, document.getElementById("a"));
     e.preventDefault();
     t.step_timeout(t.step_func_done(() => assert_equals(location.hash, "")), 0);
   });

--- a/navigation-api/navigate-event/navigate-to-srcdoc.html
+++ b/navigation-api/navigate-event/navigate-to-srcdoc.html
@@ -21,7 +21,8 @@ async_test(t => {
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
       assert_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       e.preventDefault();
 
       // Make sure it doesn't navigate anyway.

--- a/navigation-api/navigate-event/navigate-window-open-self.html
+++ b/navigation-api/navigate-event/navigate-window-open-self.html
@@ -16,7 +16,8 @@ async_test(t => {
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
     assert_equals(e.formData, null);
-    assert_equals(e.sourceElement, null);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, null);
     e.preventDefault();
   });
   window.onload = t.step_func(() => window.open("#1", "_self"));

--- a/navigation-api/navigate-event/navigate-window-open.html
+++ b/navigation-api/navigate-event/navigate-window-open.html
@@ -21,7 +21,8 @@ async_test(t => {
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
       assert_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       e.preventDefault();
     });
 


### PR DESCRIPTION
NavigateEvent.sourceElement is used in some navigation-api tests but it is not part of the specification, so check whether it is supported before using it in asserts.