### PR TITLE
Map font-synthesis-* tests to web-features

### DIFF
--- a/css/css-fonts/WEB_FEATURES.yml
+++ b/css/css-fonts/WEB_FEATURES.yml
@@ -6,7 +6,19 @@ features:
   - palette-values-rule-*
 - name: font-synthesis
   files:
-  - font-synthesis-*
+  - font-synthesis-0*.html
+- name: font-synthesis-position
+  files:
+  - font-synthesis-position*
+- name: font-synthesis-small-caps
+  files:
+  - font-synthesis-small-caps*
+- name: font-synthesis-style
+  files:
+  - font-synthesis-style*
+- name: font-synthesis-weight
+  files:
+  - font-synthesis-weight*
 - name: font-variant-alternates
   files:
   - alternates-order.html

--- a/css/css-fonts/parsing/WEB_FEATURES.yml
+++ b/css/css-fonts/parsing/WEB_FEATURES.yml
@@ -8,7 +8,21 @@ features:
   - font-palette-values-*
 - name: font-synthesis
   files:
-  - font-synthesis-*
+  - font-synthesis-computed.html
+  - font-synthesis-invalid.html
+  - font-synthesis-valid.html
+- name: font-synthesis-position
+  files:
+  - font-synthesis-position*
+- name: font-synthesis-small-caps
+  files:
+  - font-synthesis-small-caps*
+- name: font-synthesis-style
+  files:
+  - font-synthesis-style*
+- name: font-synthesis-weight
+  files:
+  - font-synthesis-weight*
 - name: font-variant-alternates
   files:
   - font-variant-alternates-*


### PR DESCRIPTION
The existing font-synthesis mapping was too broad and is now narrowed to
just the shorthand property.
