### PR TITLE
Add lints for lone testharnessreport.js & testdriver-vendor.js

### DIFF
--- a/domxpath/xpath-evaluate-crash.html
+++ b/domxpath/xpath-evaluate-crash.html
@@ -3,7 +3,6 @@
 <title>Evaluating XPath expressions with orhpaned Attr as context node doesn't crash</title>
 <link rel=author href="mailto:jarhar@chromium.org">
 <link rel=help href="https://bugs.chromium.org/p/chromium/issues/detail?id=1236967">
-<script src="/resources/testharnessreport.js"></script>
 <body>
 <script>
 for (const expression of [

--- a/editing/other/shadow_root_iteration_in_block_style.html
+++ b/editing/other/shadow_root_iteration_in_block_style.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<script src='/resources/testdriver.js'></script>
 <script src='/resources/testdriver-vendor.js'></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -16,11 +16,6 @@ from typing import (Any, Callable, Dict, IO, Iterable, List, Optional, Sequence,
 
 from urllib.parse import urlsplit, urljoin, parse_qs
 
-try:
-    from xml.etree import cElementTree as ElementTree
-except ImportError:
-    from xml.etree import ElementTree as ElementTree  # type: ignore
-
 from . import fnmatch
 from . import rules
 from .. import localpaths
@@ -483,7 +478,10 @@ def check_parsed(repo_root: Text, path: Text, f: IO[bytes]) -> List[rules.Error]
         if len(testharnessreport_nodes) > 1:
             errors.append(rules.MultipleTestharnessReport.error(path))
 
-    testdriver_vendor_nodes: List[ElementTree.Element] = []
+    testdriver_vendor_nodes = source_file.root.findall(
+        ".//{http://www.w3.org/1999/xhtml}script[@src='/resources/testdriver-vendor.js']"
+    )
+
     if source_file.testdriver_nodes:
         if test_type not in {"testharness", "reftest", "print-reftest", "crashtest", "support"}:
             errors.append(rules.TestdriverInUnsupportedType.error(path, (test_type,)))
@@ -491,16 +489,19 @@ def check_parsed(repo_root: Text, path: Text, f: IO[bytes]) -> List[rules.Error]
         if len(source_file.testdriver_nodes) > 1:
             errors.append(rules.MultipleTestdriver.error(path))
 
-        testdriver_vendor_nodes = source_file.root.findall(".//{http://www.w3.org/1999/xhtml}script[@src='/resources/testdriver-vendor.js']")
         if not testdriver_vendor_nodes:
             errors.append(rules.MissingTestdriverVendor.error(path))
-        else:
-            if len(testdriver_vendor_nodes) > 1:
-                errors.append(rules.MultipleTestdriverVendor.error(path))
 
         required_elements.append("testdriver")
         if len(testdriver_vendor_nodes) > 0:
             required_elements.append("testdriver-vendor")
+
+    if testdriver_vendor_nodes:
+        if not source_file.testdriver_nodes:
+            errors.append(rules.TestdriverVendorWithoutTestdriver.error(path))
+
+        if len(testdriver_vendor_nodes) > 1:
+            errors.append(rules.MultipleTestdriverVendor.error(path))
 
     if required_elements:
         seen_elements = defaultdict(bool)

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -457,24 +457,31 @@ def check_parsed(repo_root: Text, path: Text, f: IO[bytes]) -> List[rules.Error]
 
     required_elements: List[Text] = []
 
-    testharnessreport_nodes: List[ElementTree.Element] = []
+    testharnessreport_nodes = source_file.root.findall(
+        ".//{http://www.w3.org/1999/xhtml}script[@src='/resources/testharnessreport.js']"
+    )
+
     if source_file.testharness_nodes:
         if test_type not in ("testharness", "manual"):
             errors.append(rules.TestharnessInOtherType.error(path, (test_type,)))
+
         if len(source_file.testharness_nodes) > 1:
             errors.append(rules.MultipleTestharness.error(path))
 
-        testharnessreport_nodes = source_file.root.findall(".//{http://www.w3.org/1999/xhtml}script[@src='/resources/testharnessreport.js']")
         if not testharnessreport_nodes:
             errors.append(rules.MissingTestharnessReport.error(path))
-        else:
-            if len(testharnessreport_nodes) > 1:
-                errors.append(rules.MultipleTestharnessReport.error(path))
 
         required_elements.extend(key for key, value in {"testharness": True,
                                                         "testharnessreport": len(testharnessreport_nodes) > 0,
                                                         "timeout": len(source_file.timeout_nodes) > 0}.items()
                                  if value)
+
+    if testharnessreport_nodes:
+        if not source_file.testharness_nodes:
+            errors.append(rules.TestharnessReportWithoutTestharness.error(path))
+
+        if len(testharnessreport_nodes) > 1:
+            errors.append(rules.MultipleTestharnessReport.error(path))
 
     testdriver_vendor_nodes: List[ElementTree.Element] = []
     if source_file.testdriver_nodes:

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -180,6 +180,15 @@ class MissingTestharnessReport(Rule):
     """
 
 
+class TestharnessReportWithoutTestharness(Rule):
+    name = "TESTHARNESSREPORT-WITHOUT-TESTHARNESS"
+    description = "File contains <script src='/resources/testharnessreport.js'> but not `testharness.js`"
+    to_fix = """
+        ensure each test file contains `<script
+        src='/resources/testharness.js'>`
+    """
+
+
 class MultipleTestharnessReport(Rule):
     name = "MULTIPLE-TESTHARNESSREPORT"
     description = "More than one `<script src='/resources/testharnessreport.js'>`"

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -268,6 +268,11 @@ class MultipleTestdriverVendor(Rule):
     description = "More than one `<script src='/resources/testdriver-vendor.js'>`"
 
 
+class TestdriverVendorWithoutTestdriver(Rule):
+    name = "TESTDRIVER-VENDOR-WITHOUT-TESTDRIVER"
+    description = "File contains `<script src='/resources/testdriver-vendor.js'>` but not `testdriver.js`"
+
+
 class TestharnessPath(Rule):
     name = "TESTHARNESS-PATH"
     description = "testharness.js script seen with incorrect path"

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -178,6 +178,15 @@ class MissingTestharnessReport(Rule):
     """
 
 
+class TestharnessReportWithoutTestharness(Rule):
+    name = "TESTHARNESSREPORT-WITHOUT-TESTHARNESS"
+    description = "File contains <script src='/resources/testharnessreport.js'> but not `testharness.js`"
+    to_fix = """
+        ensure each test file contains `<script
+        src='/resources/testharness.js'>`
+    """
+
+
 class MultipleTestharnessReport(Rule):
     name = "MULTIPLE-TESTHARNESSREPORT"
     description = "More than one `<script src='/resources/testharnessreport.js'>`"

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -266,6 +266,11 @@ class MultipleTestdriverVendor(Rule):
     description = "More than one `<script src='/resources/testdriver-vendor.js'>`"
 
 
+class TestdriverVendorWithoutTestdriver(Rule):
+    name = "TESTDRIVER-VENDOR-WITHOUT-TESTDRIVER"
+    description = "File contains `<script src='/resources/testdriver-vendor.js'>` but not `testdriver.js`"
+
+
 class TestharnessPath(Rule):
     name = "TESTHARNESS-PATH"
     description = "testharness.js script seen with incorrect path"

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -562,6 +562,12 @@ def test_testdriver_path():
             expected.append(("PARSE-FAILED", "Unable to parse file", filename, 1))
         elif kind in ["web-lax", "web-strict"]:
             expected.extend([
+                (
+                    "TESTDRIVER-VENDOR-WITHOUT-TESTDRIVER",
+                    "File contains `<script src='/resources/testdriver-vendor.js'>` but not `testdriver.js`",
+                    filename,
+                    None,
+                ),
                 ("TESTDRIVER-PATH", "testdriver.js script seen with incorrect path", filename, None),
                 ("TESTDRIVER-PATH", "testdriver.js script seen with incorrect path", filename, None),
                 ("TESTDRIVER-PATH", "testdriver.js script seen with incorrect path", filename, None),

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -781,6 +781,60 @@ def test_missing_testdriver_vendor():
             ]
 
 
+def test_testdriver_vendor_without_testdriver():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind in ["web-lax", "web-strict"]:
+            assert errors == [
+                ("TESTDRIVER-VENDOR-WITHOUT-TESTDRIVER",
+                    "File contains `<script src='/resources/testdriver-vendor.js'>` but not `testdriver.js`",
+                    filename,
+                    None),
+            ]
+        elif kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 2),
+            ]
+
+
+def test_multiple_testdriver_vendor_without_testdriver():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind in ["web-lax", "web-strict"]:
+            assert errors == [
+                ("TESTDRIVER-VENDOR-WITHOUT-TESTDRIVER",
+                    "File contains `<script src='/resources/testdriver-vendor.js'>` but not `testdriver.js`",
+                    filename,
+                    None),
+                ("MULTIPLE-TESTDRIVER-VENDOR", "More than one `<script src='/resources/testdriver-vendor.js'>`", filename, None),
+            ]
+        elif kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 2),
+            ]
+
+
 def test_testharness_path():
     code = b"""\
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -858,6 +912,12 @@ def test_testdriver_path():
             expected.append(("PARSE-FAILED", "Unable to parse file", filename, 1))
         elif kind in ["web-lax", "web-strict"]:
             expected.extend([
+                (
+                    "TESTDRIVER-VENDOR-WITHOUT-TESTDRIVER",
+                    "File contains `<script src='/resources/testdriver-vendor.js'>` but not `testdriver.js`",
+                    filename,
+                    None,
+                ),
                 ("TESTDRIVER-PATH", "testdriver.js script seen with incorrect path", filename, None),
                 ("TESTDRIVER-PATH", "testdriver.js script seen with incorrect path", filename, None),
                 ("TESTDRIVER-PATH", "testdriver.js script seen with incorrect path", filename, None),

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -357,6 +357,56 @@ def test_multiple_testharnessreport():
             ]
 
 
+def test_testharnessreport_without_testharness():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharnessreport.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind in ["web-lax", "web-strict"]:
+            assert errors == [
+                ("TESTHARNESSREPORT-WITHOUT-TESTHARNESS",
+                    "File contains <script src='/resources/testharnessreport.js'> but not `testharness.js`",
+                    filename,
+                    None),
+            ]
+        elif kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 2),
+            ]
+
+
+def test_multiple_testharnessreport_without_testharness():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind in ["web-lax", "web-strict"]:
+            assert errors == [
+                ("TESTHARNESSREPORT-WITHOUT-TESTHARNESS",
+                    "File contains <script src='/resources/testharnessreport.js'> but not `testharness.js`",
+                    filename,
+                    None),
+                ("MULTIPLE-TESTHARNESSREPORT", "More than one `<script src='/resources/testharnessreport.js'>`", filename, None),
+            ]
+        elif kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 2),
+            ]
+
+
 def test_testdriver_in_unsupported():
     code = b"""
 <html xmlns="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
Both of these seemed like obvious cases where we don't currently have lints, and the fact that they caught an error suggests it's not totally silly to include them.