### PR TITLE
Don't use resources for draft PRs

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -6,9 +6,11 @@ on:
   pull_request:
     paths:
       - 'tools/**'
+    types: [opened, reopened, synchronize, ready_for_review]
 jobs:
   build-and-tag:
     runs-on: ubuntu-20.04
+    if: github.event.pull_request.draft == false
     steps:
     - name: Set up Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
This should fix #46122. I'm not sure how to test this apart from carefully monitoring the repo after merging. Ideas welcome!