### PR TITLE
Do not block waiting for chromedriver to start up

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -3,8 +3,6 @@ import errno
 import os
 import platform
 import socket
-import time
-import traceback
 from abc import ABCMeta, abstractmethod
 from typing import cast, Any, List, Mapping, Optional, Tuple, Type
 
@@ -12,7 +10,6 @@ import mozprocess
 from mozdebug import DebuggerInfo
 from mozlog.structuredlog import StructuredLogger
 
-from ..environment import wait_for_service
 from ..testloader import GroupMetadata
 from ..wptcommandline import require_arg  # noqa: F401
 from ..wpttest import Test
@@ -319,7 +316,6 @@ class WebDriverBrowser(Browser):
         self.env = os.environ.copy() if env is None else env
         self.webdriver_args = webdriver_args if webdriver_args is not None else []
 
-        self.init_deadline: Optional[float] = None
         self._output_handler: Optional[OutputHandler] = None
         self._cmd = None
         self._proc: Optional[mozprocess.ProcessHandler] = None
@@ -330,7 +326,6 @@ class WebDriverBrowser(Browser):
         return [self.webdriver_binary] + self.webdriver_args
 
     def start(self, group_metadata: GroupMetadata, **kwargs: Any) -> None:
-        self.init_deadline = time.time() + self.init_timeout
         try:
             self._run_server(group_metadata, **kwargs)
         except KeyboardInterrupt:
@@ -345,7 +340,6 @@ class WebDriverBrowser(Browser):
         return OutputHandler(self.logger, cmd)
 
     def _run_server(self, group_metadata: GroupMetadata, **kwargs: Any) -> None:
-        assert self.init_deadline is not None
         cmd = self.make_command()
         self._output_handler = self.create_output_handler(cmd)
 
@@ -365,21 +359,7 @@ class WebDriverBrowser(Browser):
             raise
         self._output_handler.after_process_start(self._proc.pid)
 
-        try:
-            wait_for_service(
-                self.logger,
-                self.host,
-                self.port,
-                timeout=self.init_deadline - time.time(),
-                server_process=self._proc,
-            )
-        except Exception:
-            self.logger.error(
-                "WebDriver was not accessible "
-                f"within the timeout:\n{traceback.format_exc()}")
-            raise
-        finally:
-            self._output_handler.start(group_metadata=group_metadata, **kwargs)
+        self._output_handler.start(group_metadata=group_metadata, **kwargs)
         self.logger.debug("_run complete")
 
     def stop(self, force: bool = False) -> bool:

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -910,6 +910,7 @@ class FirefoxWdSpecBrowser(WebDriverBrowser):
         self.binary = binary
         self.package_name = package_name
         self.webdriver_binary = webdriver_binary
+        self.init_deadline = None
 
         self.stackfix_dir = stackfix_dir
         self.symbols_path = symbols_path
@@ -958,6 +959,7 @@ class FirefoxWdSpecBrowser(WebDriverBrowser):
 
     def start(self, group_metadata, **kwargs):
         self.leak_report_file = setup_leak_report(self.leak_check, self.profile, self.env)
+        self.init_deadline = time.time() + self.init_timeout
         super().start(group_metadata, **kwargs)
 
     def stop(self, force=False):

--- a/tools/wptrunner/wptrunner/tests/browsers/test_base.py
+++ b/tools/wptrunner/wptrunner/tests/browsers/test_base.py
@@ -2,7 +2,6 @@
 
 import sys
 from os.path import dirname, join
-from unittest import mock
 
 import pytest
 
@@ -30,19 +29,14 @@ def test_logging_immediate_exit():
     handler = MozLogTestHandler()
     logger.add_handler(handler)
 
-    class CustomException(Exception):
-        pass
-
-    with mock.patch.object(base, "wait_for_service", side_effect=CustomException):
-        browser = base.WebDriverBrowser(
-            logger, webdriver_binary="echo", webdriver_args=["sample output"]
-        )
-        try:
-            with pytest.raises(CustomException):
-                browser.start(group_metadata={})
-        finally:
-            # Ensure the `echo` process actually exits
-            browser._proc.wait()
+    browser = base.WebDriverBrowser(
+        logger, webdriver_binary="echo", webdriver_args=["sample output"]
+    )
+    try:
+        browser.start(group_metadata={})
+    finally:
+        # Ensure the `echo` process actually exits
+        browser._proc.wait()
 
     process_output_actions = [
         data for data in handler.items if data["action"] == "process_output"


### PR DESCRIPTION
This would save approximately 0.5 second on each test runner restarts. And this should not cause a problem as another connection to the webdriver will be made to init the session, which also happens during initialization stage.

https://github.com/web-platform-tests/wpt/blob/master/tools/wptrunner/wptrunner/testrunner.py#L93