### PR TITLE
Map CSS mask tests to web-features

### DIFF
--- a/css/css-masking/WEB_FEATURES.yml
+++ b/css/css-masking/WEB_FEATURES.yml
@@ -1,0 +1,6 @@
+features:
+- name: masks
+  # To match the scope of the feature in web-features, this should only include
+  # tests for https://drafts.fxtf.org/css-masking-1/#positioned-masks.
+  files:
+  - mask-shorthand-subproperties-reset.html

--- a/css/css-masking/animations/WEB_FEATURES.yml
+++ b/css/css-masking/animations/WEB_FEATURES.yml
@@ -1,0 +1,8 @@
+features:
+- name: masks
+  # To match the scope of the feature in web-features, this should only include
+  # tests for https://drafts.fxtf.org/css-masking-1/#positioned-masks.
+  files:
+  - mask-image-interpolation.html
+  - mask-no-interpolation.html
+  - mask-position-interpolation.html

--- a/css/css-masking/mask-image/WEB_FEATURES.yml
+++ b/css/css-masking/mask-image/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: masks
+  files: "**"

--- a/css/css-masking/parsing/WEB_FEATURES.yml
+++ b/css/css-masking/parsing/WEB_FEATURES.yml
@@ -1,0 +1,10 @@
+features:
+- name: masks
+  # To match the scope of the feature in web-features, this should only include
+  # tests for https://drafts.fxtf.org/css-masking-1/#positioned-masks.
+  files:
+  - mask-composite-*
+  - mask-computed.html
+  - mask-invalid.html
+  - mask-position-*
+  - mask-repeat-*


### PR DESCRIPTION
Tests for clipping, border masks and SVG mask sources are not included,
to align with the feature scope in web-features.
