### PR TITLE
add test for shadowroots falling back to global scope

### DIFF
--- a/custom-elements/scoped-registry/ShadowRoot-innerHTML-upgrade.tentative.html
+++ b/custom-elements/scoped-registry/ShadowRoot-innerHTML-upgrade.tentative.html
@@ -9,6 +9,9 @@
 <div id="testdiv"></div>
 
 <script>
+class GloballyScopedElement extends HTMLElement {};
+customElements.define('globally-scoped', GloballyScopedElement);
+
 class TestAutonomous extends HTMLElement {};
 class TestCustomizedBuiltIn extends HTMLParagraphElement {};
 
@@ -113,4 +116,13 @@ test(t => {
   assert_false(shadow3.firstChild instanceof TestCustomizedBuiltIn, 'tree scope with different registry');
   assert_false(testdiv.firstChild instanceof TestCustomizedBuiltIn, 'main document');
 }, 'Upgrade into customized built-in element when definition is added');
+
+test(t => {
+  const registry = new CustomElementRegistry;
+
+  const shadow = attachShadowForTest(t, registry);
+  shadow.innerHTML = '<globally-scoped></globally-scoped>';
+  assert_false(shadow.firstChild instanceof GloballyScopedElement, 'is not GloballyScoped');
+
+}, 'Upgrade into autonomous custom element should not inherit from global registry for missing values');
 </script>


### PR DESCRIPTION
Following discussions with the WCCG it was deemed undesirable that Scoped Custom Element Registries fall back to the global registry if undefined. If scoped registries desire such a behaviour they can collect the definitions from the global registry and apply them to the local registry.

This test fails in Chrome because it defines the alternate behaviour where the registry _does_ fall back. Scoped registries are a prototype feature without a spec and so this feels like a good feedback channel for the WCCG to validate their desires and the interpretations of the explainer.