### PR TITLE
Remove invalid sub-tests in trusted-types/Element-setAttribute-respec…

### DIFF
--- a/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP.html
+++ b/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP.html
@@ -16,10 +16,7 @@
   <body>
     <div id="nonSVGTestElements">
       <iframe srcdoc="v"></iframe>
-      <embed src="v" />
       <script src="v"></script>
-      <object data="v"></object>
-      <object codebase="v"></object>
     </div>
     <svg id="svgTestElements">
       <script href="v"></script>


### PR DESCRIPTION
…ts-Elements-node-documents-globals-CSP.html.

This is to be in line with a recent spec update at https://w3c.github.io/trusted-types/dist/spec/#validate-attribute-mutation