### PR TITLE
fetch: fix redirect-referrer-override.any.js

### DIFF
--- a/fetch/api/redirect/redirect-referrer-override.any.js
+++ b/fetch/api/redirect/redirect-referrer-override.any.js
@@ -3,7 +3,7 @@
 // META: script=../resources/utils.js
 // META: script=/common/get-host-info.sub.js
 
-function getExpectation(expectations, init, initScenario, redirectPolicy, redirectScenario) {
+function getExpectation(expectations, initPolicy, initScenario, redirectPolicy, redirectScenario) {
   let policies = [
     expectations[initPolicy][initScenario],
     expectations[redirectPolicy][redirectScenario]


### PR DESCRIPTION
It seems, that the original developer wanted to name the parameter initPolicy but somehow... well. 

It did not fail, because initPolicy is a var and so it is globally available. 