### PR TITLE
Lint for reftest-wait/test-wait in invalid test types

### DIFF
--- a/css/compositing/root-element-opacity-change.html
+++ b/css/compositing/root-element-opacity-change.html
@@ -1,5 +1,5 @@
 <!doctype HTML>
-<html class="test-wait" style="font-size: 200px; opacity: 0.5">
+<html class="reftest-wait" style="font-size: 200px; opacity: 0.5">
 <link rel="help" href="https://drafts.fxtf.org/compositing/#pagebackdrop">
 <link rel="match" href="root-element-opacity-change-ref.html">
 <meta name="assert" content="View background should be white after opacity changes from 0.5 to 1">
@@ -8,7 +8,7 @@ TEST
 <script>
 waitForAtLeastOneFrame().then(() => {
   document.documentElement.style.opacity=1;
-  document.documentElement.classList.remove('test-wait');
+  document.documentElement.classList.remove('reftest-wait');
 });
 </script>
 </html>

--- a/css/css-break/uncontained-oof-in-inline-after-break-000-crash.html
+++ b/css/css-break/uncontained-oof-in-inline-after-break-000-crash.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
   <link rel="author" title="Morten Stenshorne" href="mailto:mstensho@chromium.org">
   <link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1285743">
   <div style="columns:2; line-height:20px;">
@@ -18,7 +18,7 @@
       requestAnimationFrame(()=> {
         b.style.columns = "2";
         c.style.columns = "3";
-        document.documentElement.classList.remove("reftest-wait");
+        document.documentElement.classList.remove("test-wait");
       });
     });
   </script>

--- a/css/css-contain/container-queries/crashtests/chrome-layout-root-crash.html
+++ b/css/css-contain/container-queries/crashtests/chrome-layout-root-crash.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="reftest-wait">
+<html class="test-wait">
 <link rel="help" href="https://crbug.com/1371820">
 <style>
   body, div, img { container-type: size; }
@@ -12,6 +12,6 @@
     img.alt = img.src = "b";
     // Marks div size container for layout which skips style recalc for the sub-tree.
     div.style.width = "500px";
-    document.documentElement.classList.remove("reftest-wait");
+    document.documentElement.classList.remove("test-wait");
   }));
 </script>

--- a/css/css-contain/container-queries/crashtests/size-change-during-transition-crash.html
+++ b/css/css-contain/container-queries/crashtests/size-change-during-transition-crash.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
 <meta charset="utf-8">
 <title>Container Queries - Size change during transitions crash</title>
-<script src="/common/reftest-wait.js"></script>
 <link rel="help" href="https://crbug.com/1451359">
 <style>
   #outer {
@@ -32,7 +31,7 @@
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
       outer.style.width = "300px";
-      takeScreenshot();
+      document.documentElement.classList.remove("test-wait");
     });
   });
 </script>

--- a/css/css-contain/content-visibility/detach-locked-slot-children-crash.html
+++ b/css/css-contain/content-visibility/detach-locked-slot-children-crash.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="reftest-wait">
+<html class="test-wait">
 <link rel="help" href="https://crbug.com/1284278">
 <body dir="auto">
   <p>Pass if no crash.</p>
@@ -13,6 +13,6 @@
     marquee.appendChild(details.firstChild);
     img.srcset = "dummy";
     img.alt = "dummy";
-    document.documentElement.classList.remove("reftest-wait");
+    document.documentElement.classList.remove("test-wait");
   }));
 </script>

--- a/css/css-contain/content-visibility/touch-action-beside-display-locked-fixedpos-iframe-crash.html
+++ b/css/css-contain/content-visibility/touch-action-beside-display-locked-fixedpos-iframe-crash.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
   <link rel="author" title="Morten Stenshorne" href="mailto:mstensho@chromium.org">
   <link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1434550">
   <button id="boo"></button>
@@ -10,7 +10,7 @@
     requestAnimationFrame(()=> {
       requestAnimationFrame(()=> {
         boo.style.touchAction = "pan-x";
-        document.documentElement.classList.remove("reftest-wait");
+        document.documentElement.classList.remove("test-wait");
       });
     });
   </script>

--- a/css/css-lists/list-item-counter-crash.html
+++ b/css/css-lists/list-item-counter-crash.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="reftest-wait">
+<html class="test-wait">
 <link rel="help" href="http://crbug.com/1487174">
 <style>
 * { counter-increment: c; }
@@ -7,7 +7,7 @@
 <script>
   function error_fn() {
     test.style.setProperty("text-orientation", "upright");
-    document.documentElement.classList.remove("reftest-wait");
+    document.documentElement.classList.remove("test-wait");
   }
 </script>
 <li id="test"></li>

--- a/css/css-multicol/crashtests/chrome-bug-1301281.html
+++ b/css/css-multicol/crashtests/chrome-bug-1301281.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
   <link rel="author" title="Morten Stenshorne" href="mailto:mstensho@chromium.org">
   <link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1301281">
   <div style="columns:2; column-fill:auto; height:30px; line-height:20px; width:fit-content;">
@@ -13,7 +13,7 @@
         requestAnimationFrame(()=> {
           requestAnimationFrame(()=> {
             document.body.style.color = "blue";
-            document.documentElement.classList.remove("reftest-wait");
+            document.documentElement.classList.remove("test-wait");
           });
         });
       });

--- a/css/css-multicol/crashtests/floated-input-in-inline-next-column.html
+++ b/css/css-multicol/crashtests/floated-input-in-inline-next-column.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
   <link rel="author" title="Morten Stenshorne" href="mailto:mstensho@chromium.org">
   <link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1451185">
   <div id="container" style="opacity:0.0;">
@@ -12,7 +12,7 @@
     requestAnimationFrame(()=> {
       requestAnimationFrame(()=> {
         container.style.opacity = "1";
-        document.documentElement.classList.remove("reftest-wait");
+        document.documentElement.classList.remove("test-wait");
       });
     });
   </script>

--- a/css/css-multicol/crashtests/inline-float-parallel-flow.html
+++ b/css/css-multicol/crashtests/inline-float-parallel-flow.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
   <link rel="author" title="Morten Stenshorne" href="mailto:mstensho@chromium.org">
   <link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1489177">
   <div style="columns:2; column-fill:auto; height:200px; line-height:20px; orphans:1; widows:1;">
@@ -16,7 +16,7 @@
     requestAnimationFrame(()=> {
       requestAnimationFrame(()=> {
         e57.style.display = "block";
-        document.documentElement.classList.remove("reftest-wait");
+        document.documentElement.classList.remove("test-wait");
       });
     });
   </script>

--- a/css/css-multicol/crashtests/move-linebreak-to-different-column.html
+++ b/css/css-multicol/crashtests/move-linebreak-to-different-column.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
   <link rel="author" title="Morten Stenshorne" href="mailto:mstensho@chromium.org">
   <link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1322739">
   <div id="container">
@@ -12,7 +12,7 @@
       requestAnimationFrame(()=> {
         mc.style.height = "80px";
         container.setAttribute("ontouchstart", "nonValidFunctionName()");
-        document.documentElement.classList.remove("reftest-wait");
+        document.documentElement.classList.remove("test-wait");
       });
     });
   </script>

--- a/css/css-multicol/crashtests/move-newline-pre-text.html
+++ b/css/css-multicol/crashtests/move-newline-pre-text.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
   <link rel="author" title="Morten Stenshorne" href="mailto:mstensho@chromium.org">
   <link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1386676">
   <div id="container" style="columns:10; column-fill:auto; height:30px; line-height:20px; orphans:1; widows:1; white-space:pre;">
@@ -14,7 +14,7 @@
         requestAnimationFrame(()=> {
           requestAnimationFrame(()=> {
             container.style.width = "88%";
-            document.documentElement.classList.remove("reftest-wait");
+            document.documentElement.classList.remove("test-wait");
           });
         });
       });

--- a/css/css-multicol/crashtests/oof-in-additional-column-before-spanner.html
+++ b/css/css-multicol/crashtests/oof-in-additional-column-before-spanner.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
   <link rel="author" title="Morten Stenshorne" href="mailto:mstensho@chromium.org">
   <link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1361902">
   <div style="columns:1;">
@@ -15,7 +15,7 @@
     requestAnimationFrame(()=>{
       requestAnimationFrame(()=>{
         elm.style.display = "none";
-        document.documentElement.classList.remove("reftest-wait");
+        document.documentElement.classList.remove("test-wait");
       });
     });
   </script>

--- a/css/css-multicol/subpixel-scroll-crash.html
+++ b/css/css-multicol/subpixel-scroll-crash.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
   <link rel="author" title="Morten Stenshorne" href="mailto:mstensho@chromium.org">
   <link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1276319">
   <div style="columns:2; column-fill:auto; height:4000px;">
@@ -13,7 +13,7 @@
     var offset = 1000;
     function scrollEverSoSlightly() {
       if (offset > 1003) {
-        document.documentElement.classList.remove("reftest-wait");
+        document.documentElement.classList.remove("test-wait");
         return;
       }
       window.scrollTo(0, offset);

--- a/css/css-position/overlay/overlay-popover-backdrop-crash.html
+++ b/css/css-position/overlay/overlay-popover-backdrop-crash.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
 <title>CSS Position Test: Chrome crash for ::backdrop transitioning overlay for popover</title>
 <link rel="help" href="https://crbug.com/1446479">
-<script src="/common/reftest-wait.js"></script>
 <style>
   #popover {
     transition: overlay 60s step-end;
@@ -19,7 +18,7 @@
     popover.showPopover();
     requestAnimationFrame(() => {
       popover.hidePopover();
-      takeScreenshot();
+      document.documentElement.classList.remove("test-wait");
     });
   });
 </script>

--- a/css/css-view-transitions/navigation/reload-crash.html
+++ b/css/css-view-transitions/navigation/reload-crash.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
 <title>View transitions: reload crash</title>
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
-<script src="/common/reftest-wait.js"></script>
 <script>
 onload = () => requestAnimationFrame(() => requestAnimationFrame(() => requestAnimationFrame(() => {
   let run = (new URLSearchParams(window.location.search)).get('run') || 0;
   if (run > 5) {
-    takeScreenshot();
+    document.documentElement.classList.remove("test-wait");
   } else {
     const url = window.location.href.split('?')[0];
     window.location.href = url + `?run=${run + 1}`;

--- a/css/css-view-transitions/only-child-group.html
+++ b/css/css-view-transitions/only-child-group.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait foo">
+<html class="foo">
 <title>View transitions: ensure :only-child is supported on view-transition-group</title>
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">

--- a/css/css-view-transitions/only-child-image-pair.html
+++ b/css/css-view-transitions/only-child-image-pair.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait foo">
+<html class="foo">
 <title>View transitions: ensure :only-child is supported on view-transition-image-pair</title>
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">

--- a/css/css-view-transitions/only-child-new.html
+++ b/css/css-view-transitions/only-child-new.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait foo">
+<html class="foo">
 <title>View transitions: ensure :only-child is supported on view-transition-new</title>
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">

--- a/css/css-view-transitions/only-child-no-transition.html
+++ b/css/css-view-transitions/only-child-no-transition.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class=reftest-wait>
+<html>
 <title>View transitions: :only-child style queries without transition shouldn't crash</title>
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">

--- a/css/css-view-transitions/only-child-old.html
+++ b/css/css-view-transitions/only-child-old.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait foo">
+<html class="foo">
 <title>View transitions: ensure :only-child is supported on view-transition-old</title>
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">

--- a/css/css-view-transitions/only-child-on-root-element-with-view-transition.html
+++ b/css/css-view-transitions/only-child-on-root-element-with-view-transition.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait foo">
+<html class="foo">
 <title>View transitions: ensure :only-child is supported on view-transition</title>
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">

--- a/css/css-view-transitions/only-child-view-transition.html
+++ b/css/css-view-transitions/only-child-view-transition.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class=reftest-wait>
+<html>
 <title>View transitions: ensure :only-child is supported on view-transition</title>
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">

--- a/css/css-view-transitions/root-element-display-none-crash.html
+++ b/css/css-view-transitions/root-element-display-none-crash.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
-<html class=reftest-wait>
+<html class=test-wait>
 <title>View transitions: html display none</title>
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 
-<script src="/common/reftest-wait.js"></script>
 <style>
 html {
   display: none;
@@ -12,11 +11,16 @@ html {
 </style>
 
 <script>
-failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+function endTest() {
+  document.documentElement.classList.remove("test-wait");
+}
 
 async function runTest() {
-  document.startViewTransition().finished.then(takeScreenshot, takeScreenshot);
-
+  if (document.startViewTransition) {
+    document.startViewTransition().finished.then(endTest, endTest);
+  } else {
+    endTest();
+  }
 }
 onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
 </script>

--- a/css/css-view-transitions/web-animation-pseudo-incorrect-name.html
+++ b/css/css-view-transitions/web-animation-pseudo-incorrect-name.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class=reftest-wait>
+<html>
 <title>View transitions: creating animation for non-existant view transition pseudo</title>
 <link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">

--- a/editing/crashtests/caret-display-list-002.html
+++ b/editing/crashtests/caret-display-list-002.html
@@ -1,4 +1,4 @@
-<html class="test-wait reftest-wait">
+<html class="test-wait">
 <style>
 #a {
   float: none;

--- a/editing/crashtests/caret-display-list.html
+++ b/editing/crashtests/caret-display-list.html
@@ -1,4 +1,4 @@
-<html class="test-wait reftest-wait">
+<html class="test-wait">
 <style>
 * {
   backdrop-filter: hue-rotate(0deg);

--- a/editing/crashtests/designMode-caret-change.html
+++ b/editing/crashtests/designMode-caret-change.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="test-wait reftest-wait">
+<html class="test-wait">
 <style>
 button {
   background-repeat: no-repeat;

--- a/editing/crashtests/indent-outdent-after-closing-editable-dialog-element.html
+++ b/editing/crashtests/indent-outdent-after-closing-editable-dialog-element.html
@@ -1,4 +1,4 @@
-<html class="reftest-wait">
+<html class="test-wait">
 <script>
 var eventCount = 0;
 document.addEventListener("DOMContentLoaded", () => {

--- a/fullscreen/api/fullscreen-display-contents.html
+++ b/fullscreen/api/fullscreen-display-contents.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
     <title>
         Test that display:contents on fullscreen elements acts like
         display:block

--- a/fullscreen/crashtests/chrome-1312699.html
+++ b/fullscreen/crashtests/chrome-1312699.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="reftest-wait">
+<html class="test-wait">
 <link rel="help" href="https://crbug.com/1312699">
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
@@ -9,7 +9,7 @@
     let video = document.querySelector("video");
     await video.requestFullscreen();
     video.width = null;
-    document.documentElement.classList.remove("reftest-wait");
+    document.documentElement.classList.remove("test-wait");
   }
   document.addEventListener("click", () => crash(), false);
 

--- a/html/canvas/element/manual/filters/svg-filter-lh-rlh-expected.html
+++ b/html/canvas/element/manual/filters/svg-filter-lh-rlh-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="test-wait">
+<html>
 <title>HTML Canvas reference: SVG filter using CSS font-relative line-height units</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>

--- a/html/canvas/element/manual/filters/svg-filter-lh-rlh.html
+++ b/html/canvas/element/manual/filters/svg-filter-lh-rlh.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="test-wait">
+<html class="reftest-wait">
 <title>HTML Canvas test: SVG filter using CSS font-relative line-height units</title>
 <link rel="match" href="svg-filter-lh-rlh-expected.html"/>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
@@ -26,7 +26,7 @@ function use_filter(canvas, filter_id) {
 window.addEventListener("load", async () => {
   use_filter(document.getElementById("canvas-lh"), "filter-lh");
   use_filter(document.getElementById("canvas-rlh"), "filter-rlh");
-  document.documentElement.classList.remove('test-wait');
+  document.documentElement.classList.remove('reftest-wait');
 });
 </script>
 </html>

--- a/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas-worker-font-load-crash.html
+++ b/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas-worker-font-load-crash.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="test-wait reftest-wait">
+<html class="test-wait">
 <script>
   let url = URL.createObjectURL(new Blob([`
     let font = new FontFace('Ahem', 'url(/fonts/Ahem.ttf)');

--- a/html/rendering/replaced-elements/images/revoked-blob-print.html
+++ b/html/rendering/replaced-elements/images/revoked-blob-print.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="test-wait">
+<html class="reftest-wait">
 <title>Printing an image with src="revoked-blob"</title>
 <link rel="author" href="mailto:emilio@crisal.io" title="Emilio Cobos Álvarez">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1665343">

--- a/html/semantics/embedded-content/the-embed-element/embed-change-src.html
+++ b/html/semantics/embedded-content/the-embed-element/embed-change-src.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
 <meta charset="utf-8">
 <link rel="author" title="Joey Arhar" href="mailto:jarhar@chromium.org">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element">

--- a/html/semantics/popovers/popover-dialog-crash.html
+++ b/html/semantics/popovers/popover-dialog-crash.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
 <meta charset="utf-8" />
 <title>Dialog-Popover crash</title>
 <link rel="author" href="mailto:masonf@chromium.org">
@@ -21,6 +21,6 @@
   popover.showPopover();
   clickOn(dialog)
     .then(() => {
-      document.documentElement.classList.remove("reftest-wait");
+      document.documentElement.classList.remove("test-wait");
     });
 </script>

--- a/html/semantics/popovers/popover-hint-crash.tentative.html
+++ b/html/semantics/popovers/popover-hint-crash.tentative.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
 <meta charset="utf-8" />
 <title>Popover=hint crash test</title>
 <link rel="author" href="mailto:masonf@chromium.org">
@@ -24,6 +24,6 @@ popover3.showPopover();
 popover4.showPopover();
 clickOn(popover4)
   .then(() => {
-    document.documentElement.classList.remove("reftest-wait");
+    document.documentElement.classList.remove("test-wait");
   });
 </script>

--- a/html/semantics/popovers/popover-manual-crash.html
+++ b/html/semantics/popovers/popover-manual-crash.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
 <meta charset="utf-8" />
 <title>Popover=manual crash test</title>
 <link rel="author" href="mailto:masonf@chromium.org">
@@ -27,6 +27,6 @@
   const manual = document.querySelector('[popover=manual]');
   clickOn(manual)
     .then(() => {
-      document.documentElement.classList.remove("reftest-wait");
+      document.documentElement.classList.remove("test-wait");
     });
 </script>

--- a/lint.ignore
+++ b/lint.ignore
@@ -815,6 +815,10 @@ TESTDRIVER-IN-UNSUPPORTED-TYPE: payment-handler/payment-request-event-manual.htt
 TESTDRIVER-IN-UNSUPPORTED-TYPE: payment-handler/supports-shipping-contact-delegation-manual.https.html
 TESTDRIVER-IN-UNSUPPORTED-TYPE: shadow-dom/crashtests/move-to-new-tree-1343016.html
 
+# These are supposedly reftests, but are actually manual
+REFTESTWAIT-IN-OTHER-TYPE: css/css-ui/text-overflow-017.html
+REFTESTWAIT-IN-OTHER-TYPE: css/css-view-transitions/navigation/transition-to-prerender-manual.html
+
 # Pre compressed data using Shared Brotli and Shared Zstandard.
 TRAILING WHITESPACE, INDENT TABS, CR AT EOL: fetch/compression-dictionary/resources/compressed.br-d.data
 TRAILING WHITESPACE, INDENT TABS, CR AT EOL: fetch/compression-dictionary/resources/compressed.zstd-d.data

--- a/selection/crashtests/selectall-and-find-svg-text-on-selectstart.html
+++ b/selection/crashtests/selectall-and-find-svg-text-on-selectstart.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="reftest-wait">
+<html class="test-wait">
 <head>
 <meta charset="utf-8">
 <script>

--- a/selection/crashtests/selection-clip-crash.html
+++ b/selection/crashtests/selection-clip-crash.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <link rel="author" title="Philip Rogers" href="mailto:pdr@chromium.org">
 <meta name="assert" content="Moving a selection to a different clipper should not crash">
-<html class=reftest-wait>
+<html class=test-wait>
   <script>
     function test() {
       document.designMode = "on";
@@ -19,7 +19,7 @@
           updated_range.setStart(b, 1);
           updated_range.setEnd(b, 1);
 
-          document.documentElement.classList.remove("reftest-wait");
+          document.documentElement.classList.remove("test-wait");
         });
       });
     }

--- a/selection/crashtests/selection-modify-line-boundary-around-shadow.html
+++ b/selection/crashtests/selection-modify-line-boundary-around-shadow.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="reftest-wait">
+<html class="test-wait">
 <head>
 <meta charset="utf-8">
 <script>

--- a/svg/animations/end-of-time-001-crash.html
+++ b/svg/animations/end-of-time-001-crash.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
 <title>Seeking the time container to a large value does not cause a crash (or hang)</title>
 <svg>
   <rect height="100" width="100" fill="blue">
@@ -11,5 +11,5 @@
   let svg = document.querySelector("svg");
   svg.setCurrentTime(18446744073709551557);
   let html = document.documentElement;
-  html.addEventListener("TestRendered", () => html.classList.remove("reftest-wait"));
+  html.addEventListener("TestRendered", () => html.classList.remove("test-wait"));
 </script>

--- a/svg/animations/end-of-time-002-crash.html
+++ b/svg/animations/end-of-time-002-crash.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
 <title>Seeking the time container to a large value does not cause a crash (or hang)</title>
 <svg>
   <rect height="100" width="100" fill="blue">
@@ -11,5 +11,5 @@
   let svg = document.querySelector("svg");
   svg.setCurrentTime(9000000000000000);
   let html = document.documentElement;
-  html.addEventListener("TestRendered", () => html.classList.remove("reftest-wait"));
+  html.addEventListener("TestRendered", () => html.classList.remove("test-wait"));
 </script>

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -163,6 +163,22 @@ class MultipleTestharness(Rule):
     """
 
 
+class ReftestWaitInOtherType(Rule):
+    name = "REFTESTWAIT-IN-OTHER-TYPE"
+    description = "`class=reftest-wait` on a non-reftest (%s)"
+    to_fix = """
+        ensure the test is either a reftest or remove class=reftest-wait.
+    """
+
+
+class TestWaitInOtherType(Rule):
+    name = "TESTWAIT-IN-OTHER-TYPE"
+    description = "`class=test-wait` on an unsupported test type (%s)"
+    to_fix = """
+        ensure the test is either a type which supports test-wait or remove class=test-wait.
+    """
+
+
 class MissingReftestWait(Rule):
     name = "MISSING-REFTESTWAIT"
     description = "Missing `class=reftest-wait`"

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -274,6 +274,60 @@ def test_meta_timeout():
             ]
 
 
+def test_unexpected_reftest_wait():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml" class="reftest-wait">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for filename, (errors, kind) in error_map.items():
+        check_errors(errors)
+
+        if kind in ["web-lax", "web-strict"]:
+            assert errors == [
+                (
+                    "REFTESTWAIT-IN-OTHER-TYPE",
+                    "`class=reftest-wait` on a non-reftest (testharness)",
+                    filename,
+                    None,
+                ),
+            ]
+        elif kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 2),
+            ]
+
+
+def test_unexpected_test_wait():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml" class="test-wait">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for filename, (errors, kind) in error_map.items():
+        check_errors(errors)
+
+        if kind in ["web-lax", "web-strict"]:
+            assert errors == [
+                (
+                    "TESTWAIT-IN-OTHER-TYPE",
+                    "`class=test-wait` on an unsupported test type (testharness)",
+                    filename,
+                    None,
+                ),
+            ]
+        elif kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 2),
+            ]
+
+
 def test_early_testharnessreport():
     code = b"""
 <html xmlns="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
Because @nt1m caught me doing this in https://github.com/web-platform-tests/wpt/pull/46120#discussion_r1592864059, let's lint for this.

And it shows up that we have many crashtests that are using reftest-wait and not test-wait, so this seems valuable.