### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=273751

### DIFF
--- a/css/css-view-transitions/massive-element-below-viewport-offscreen-old.html
+++ b/css/css-view-transitions/massive-element-below-viewport-offscreen-old.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-below-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-445">
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-1497">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-old.html
+++ b/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-old.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-on-top-of-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-330">
+<meta name="fuzzy" content="maxDifference=0-16;totalPixels=0-330">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/css/css-view-transitions/massive-element-right-of-viewport-offscreen-old.html
+++ b/css/css-view-transitions/massive-element-right-of-viewport-offscreen-old.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="massive-element-right-of-viewport-offscreen-ref.html">
-<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-445">
+<meta name="fuzzy" content="maxDifference=0-3;totalPixels=0-1497777777">
 
 <script src="/common/reftest-wait.js"></script>
 <style>


### PR DESCRIPTION
WebKit export from bug: [\[view-transitions\] Offscreen elements that are visible onscreen via their pseudo are not rendered](https://bugs.webkit.org/show_bug.cgi?id=273751)