### PR TITLE
Add tests for Blob.prototype.bytes()

### DIFF
--- a/FileAPI/Blob-methods-from-detached-frame.html
+++ b/FileAPI/Blob-methods-from-detached-frame.html
@@ -27,6 +27,7 @@ promise_test(async () => {
 
     assert_equals(await slicedBlob.text(), "oo");
     assert_equals(charCodeBufferToString(await slicedBlob.arrayBuffer()), "oo");
+    assert_equals(charCodeArrayToString(await slicedBlob.bytes()), "oo");
 
     const reader = slicedBlob.stream().getReader();
     const { value } = await reader.read();
@@ -47,6 +48,14 @@ promise_test(async () => {
     const charCodeBuffer = await arrayBuffer.call(blob);
     assert_equals(charCodeBufferToString(charCodeBuffer), "bar");
 }, "arrayBuffer()");
+
+promise_test(async () => {
+    const { bytes } = await BlobPrototypeFromDetachedFramePromise;
+    const blob = new Blob(["bar"]);
+
+    const charCodeBytes = await bytes.call(blob);
+    assert_equals(charCodeArrayToString(charCodeBuffer), "bar");
+}, "bytes()");
 
 promise_test(async () => {
     const { stream } = await BlobPrototypeFromDetachedFramePromise;

--- a/FileAPI/Blob-methods-from-detached-frame.html
+++ b/FileAPI/Blob-methods-from-detached-frame.html
@@ -54,7 +54,7 @@ promise_test(async () => {
     const blob = new Blob(["bar"]);
 
     const charCodeBytes = await bytes.call(blob);
-    assert_equals(charCodeArrayToString(charCodeBuffer), "bar");
+    assert_equals(charCodeArrayToString(charCodeBytes), "bar");
 }, "bytes()");
 
 promise_test(async () => {

--- a/FileAPI/blob/Blob-bytes.any.js
+++ b/FileAPI/blob/Blob-bytes.any.js
@@ -1,0 +1,45 @@
+// META: title=Blob bytes()
+// META: script=../support/Blob.js
+'use strict';
+
+promise_test(async () => {
+  const input_arr = new TextEncoder().encode("PASS");
+  const blob = new Blob([input_arr]);
+  const uint8array = await blob.bytes();
+  assert_true(uint8array instanceof Uint8Array);
+  assert_equals_typed_array(uint8array, input_arr);
+}, "Blob.bytes()")
+
+promise_test(async () => {
+  const input_arr = new TextEncoder().encode("");
+  const blob = new Blob([input_arr]);
+  const uint8array = await blob.bytes();
+  assert_true(uint8array instanceof Uint8Array);
+  assert_equals_typed_array(uint8array, input_arr);
+}, "Blob.bytes() empty Blob data")
+
+promise_test(async () => {
+  const input_arr = new TextEncoder().encode("\u08B8\u000a");
+  const blob = new Blob([input_arr]);
+  const uint8array = await blob.bytes();
+  assert_equals_typed_array(uint8array, input_arr);
+}, "Blob.bytes() non-ascii input")
+
+promise_test(async () => {
+  const input_arr = [8, 241, 48, 123, 151];
+  const typed_arr = new Uint8Array(input_arr);
+  const blob = new Blob([typed_arr]);
+  const uint8array = await blob.bytes();
+  assert_equals_typed_array(uint8array, typed_arr);
+}, "Blob.bytes() non-unicode input")
+
+promise_test(async () => {
+  const input_arr = new TextEncoder().encode("PASS");
+  const blob = new Blob([input_arr]);
+  const uint8array_results = await Promise.all([blob.bytes(),
+      blob.bytes(), blob.bytes()]);
+  for (let uint8array of uint8array_results) {
+    assert_true(uint8array instanceof Uint8Array);
+    assert_equals_typed_array(uint8array, input_arr);
+  }
+}, "Blob.bytes() concurrent reads")


### PR DESCRIPTION
Tests for https://github.com/w3c/FileAPI/pull/197. That PR doesn't have stamps from all the implementations but Blob mostly mirrors Body, which [is getting this method](https://github.com/whatwg/fetch/pull/1753).