### PR TITLE
Remove invalid listitem label tests assuming namefrom:contents

### DIFF
--- a/css/css-display/accessibility/display-contents-role-and-label.html
+++ b/css/css-display/accessibility/display-contents-role-and-label.html
@@ -186,18 +186,18 @@
   </ol>
 
   <div role="list" style="display: contents;" data-expectedrole="list" data-testname="div with list role and display: contents has list role" class="ex-role">
-    <div role="listitem" data-expectedrole="listitem" data-expectedlabel="x" data-testname="div with listitem role, as child of div with display: contents, has listitem role" class="ex-role-and-label">x</div>
+    <div role="listitem" data-expectedrole="listitem" data-testname="div with listitem role, as child of div with display: contents, has listitem role" class="ex-role">x</div>
     <div>y</div>
   </div>
 
   <div role="list" style="display: contents;" data-expectedrole="list" data-testname="div with list role and display: contents has list role (child div with listitem role has display: contents)" class="ex-role">
     <div>x</div>
-    <div role="listitem" style="display: contents;" data-expectedrole="listitem" data-expectedlabel="y" data-testname="div with listitem role (as child of div with list role), both with display: contents, has listitem role" class="ex-role-and-label">y</div>
+    <div role="listitem" style="display: contents;" data-expectedrole="listitem" data-testname="div with listitem role (as child of div with list role), both with display: contents, has listitem role" class="ex-role">y</div>
   </div>
 
   <div role="list">
     <div>x</div>
-    <div role="listitem" style="display: contents;" data-expectedrole="listitem" data-expectedlabel="y" data-testname="div with listitem role with display: contents, as child of div with list role, has listitem role" class="ex-role-and-label">y</div>
+    <div role="listitem" style="display: contents;" data-expectedrole="listitem"  data-testname="div with listitem role with display: contents, as child of div with list role, has listitem role" class="ex-role">y</div>
   </div>
 
   <!-- Lists: description/definition lists -> wpt/html-aam/roles.html -->


### PR DESCRIPTION
Closes https://github.com/web-platform-tests/interop-accessibility/issues/128

Remove expectedlabel checks that incorrectly assume an element with listitem role should have namefrom:contents.

Resolves this issue: https://github.com/web-platform-tests/interop-accessibility/issues/128.

See related PR https://github.com/web-platform-tests/interop-accessibility/issues/118.