### PR TITLE
Check thread id is in current frames

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -215,8 +215,10 @@ class TimedRunner:
             else:
                 if self.protocol.is_alive():
                     message = "Executor hit external timeout (this may indicate a hang)\n"
-                    # get a traceback for the current stack of the executor thread
-                    message += "".join(traceback.format_stack(sys._current_frames()[executor.ident]))
+                    if executor.ident in sys._current_frames():
+                        # get a traceback for the current stack of the executor thread
+                        message += "".join(traceback.format_stack(
+                            sys._current_frames()[executor.ident]))
                     self.result = False, ("EXTERNAL-TIMEOUT", message)
                 else:
                     self.logger.info("Browser not responding, setting status to CRASH")


### PR DESCRIPTION
On Chromium Windows bot, we are seeing KeyError as below. Check the thread id is in sys._current_frames() before format_stack, otherwise do not include the stack in the error message.

Error message:
00:02:16.943 WARNING: Exception in TestExecutor.run:
  File "C:\b\s\w\ir\third_party\wpt_tools\wpt\tools\wptrunner\wptrunner\executors\base.py", line 219, in run
    message += "".join(traceback.format_stack(sys._current_frames()[executor.ident]))
KeyError: 8372