### PR TITLE
Use the docker image from the GitHub registry

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -57,7 +57,7 @@ tasks:
             owner: ${owner}
             source: ${event.repository.clone_url}
           payload:
-            image: webplatformtests/wpt:0.57
+            image: ghcr.io/web-platform-tests/wpt:test-do-not-use
             maxRunTime: 7200
             artifacts:
               public/results:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -57,7 +57,7 @@ tasks:
             owner: ${owner}
             source: ${event.repository.clone_url}
           payload:
-            image: ghcr.io/web-platform-tests/wpt:test-do-not-use
+            image: ghcr.io/web-platform-tests/wpt:0.58
             maxRunTime: 7200
             artifacts:
               public/results:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -57,7 +57,7 @@ tasks:
             owner: ${owner}
             source: ${event.repository.clone_url}
           payload:
-            image: ghcr.io/web-platform-tests/wpt:0.58
+            image: ghcr.io/web-platform-tests/wpt:1
             maxRunTime: 7200
             artifacts:
               public/results:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,3 +4,6 @@
 
 # Prevent accidentally touching tools/third_party
 /tools/third_party/ @web-platform-tests/wpt-core-team
+
+# Require a review for Dockerfile
+tools/docker/Dockerfile @web-platform-tests/wpt-core-team # @web-platform-tests/admins

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,5 +6,5 @@
 /tools/third_party/ @web-platform-tests/wpt-core-team
 
 # Require a review for Dockerfile
-tools/docker/Dockerfile @web-platform-tests/wpt-core-team # @web-platform-tests/admins
-.taskcluster.yml @web-platform-tests/wpt-core-team # @web-platform-tests/admins
+tools/docker/Dockerfile @web-platform-tests/wpt-core-team @web-platform-tests/admins
+.taskcluster.yml @web-platform-tests/wpt-core-team @web-platform-tests/admins

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,3 +7,4 @@
 
 # Require a review for Dockerfile
 tools/docker/Dockerfile @web-platform-tests/wpt-core-team # @web-platform-tests/admins
+.taskcluster.yml @web-platform-tests/wpt-core-team # @web-platform-tests/admins

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -4,7 +4,7 @@ components:
     workerType: ci
     schedulerId: taskcluster-github
     deadline: "24 hours"
-    image: webplatformtests/wpt:0.57
+    image: ghcr.io/web-platform-tests/wpt:test-do-not-use
     maxRunTime: 7200
     artifacts:
       public/results:

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -4,7 +4,7 @@ components:
     workerType: ci
     schedulerId: taskcluster-github
     deadline: "24 hours"
-    image: ghcr.io/web-platform-tests/wpt:test-do-not-use
+    image: ghcr.io/web-platform-tests/wpt:0.58
     maxRunTime: 7200
     artifacts:
       public/results:

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -4,7 +4,7 @@ components:
     workerType: ci
     schedulerId: taskcluster-github
     deadline: "24 hours"
-    image: ghcr.io/web-platform-tests/wpt:0.58
+    image: ghcr.io/web-platform-tests/wpt:1
     maxRunTime: 7200
     artifacts:
       public/results:

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -4,11 +4,13 @@ images must be updated as well. Doing this requires you to have write
 permissions to the repository.
 
 The tag for a new docker image is of the form
-`{current-version + 0.01}`
+`ghcr.io/web-platform-tests/wpt:${PREV_VERSION++}`.
 
 To update the docker image:
 
-* Run the workflow https://github.com/web-platform-tests/wpt/actions/workflows/docker.yml
+* Run the workflow
+  https://github.com/web-platform-tests/wpt/actions/workflows/docker.yml via the
+  GitHub UI.
 
 * Update the following Taskcluster configurations to use the new image:
  - `.taskcluster.yml` (the decision task)

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,16 +1,15 @@
 This docker images is used for testing Chrome, Firefox, WebKitGTK and running
 other tasks on Taskcluster. When any of the files in this directory change, the
-images must be updated as well. Doing this requires you be part of the
-'webplatformtests' organization on Docker Hub; ping @foolip or @jpchase
-if you are not a member.
+images must be updated as well. Doing this requires you to have write
+permissions to the repository.
 
 The tag for a new docker image is of the form
-`webplatformtests/wpt:{current-version + 0.01}`
+`{current-version + 0.01}`
 
 To update the docker image:
+
+* Run the workflow https://github.com/web-platform-tests/wpt/actions/workflows/docker.yml
 
 * Update the following Taskcluster configurations to use the new image:
  - `.taskcluster.yml` (the decision task)
  - `tools/ci/tc/tasks/test.yml` (all the other tasks)
-
-* Run `wpt docker-push`

--- a/tools/docker/frontend.py
+++ b/tools/docker/frontend.py
@@ -56,17 +56,16 @@ def read_image_name():
     return taskcluster_values, tests_value
 
 
-def lookup_tag(tag):
-    import requests
-    org, repo_version = tag.split("/", 1)
-    repo, version = repo_version.rsplit(":", 1)
-    resp = requests.get("https://hub.docker.com/v2/repositories/%s/%s/tags/%s" %
-                        (org, repo, version))
-    if resp.status_code == 200:
-        return True
-    if resp.status_code == 404:
+def tag_exists(tag):
+    retcode = subprocess.call(["docker",
+                        "manifest",
+                        "inspect",
+                        tag])
+    # The command succeeds if the tag exists.
+    if retcode == 0:
         return False
-    resp.raise_for_status()
+
+    return True
 
 
 def push(venv, tag=None, force=False, *args, **kwargs):
@@ -89,13 +88,13 @@ def push(venv, tag=None, force=False, *args, **kwargs):
         logger.info("Using tag %s from .taskcluster.yml" % taskcluster_tag)
         tag = taskcluster_tag
 
-    tag_re = re.compile(r"webplatformtests/wpt:\d\.\d+")
+    tag_re = re.compile(r"ghcr.io/web-platform-tests/wpt:\d+")
     if not tag_re.match(tag):
-        error_log("Tag doesn't match expected format webplatformtests/wpt:0.x")
+        error_log("Tag doesn't match expected format ghcr.io/web-platform-tests/wpt:x")
         if not force:
             sys.exit(1)
 
-    if lookup_tag(tag):
+    if tag_exists(tag):
         # No override for this case
         logger.critical("Tag %s already exists" % tag)
         sys.exit(1)

--- a/tools/docker/frontend.py
+++ b/tools/docker/frontend.py
@@ -57,10 +57,7 @@ def read_image_name():
 
 
 def tag_exists(tag):
-    retcode = subprocess.call(["docker",
-                        "manifest",
-                        "inspect",
-                        tag])
+    retcode = subprocess.call(["docker", "manifest", "inspect", tag])
     # The command succeeds if the tag exists.
     return retcode != 0
 

--- a/tools/docker/frontend.py
+++ b/tools/docker/frontend.py
@@ -62,10 +62,7 @@ def tag_exists(tag):
                         "inspect",
                         tag])
     # The command succeeds if the tag exists.
-    if retcode == 0:
-        return False
-
-    return True
+    return retcode != 0
 
 
 def push(venv, tag=None, force=False, *args, **kwargs):

--- a/tools/wptrunner/requirements_sauce.txt
+++ b/tools/wptrunner/requirements_sauce.txt
@@ -1,7 +1,11 @@
 <<<<<<< HEAD
+<<<<<<< HEAD
 selenium==4.20.0
 requests==2.32.3
 =======
 selenium==4.18.1
+=======
+selenium==4.20.0
+>>>>>>> 3ab8232d0c (downgrade hypothesis)
 requests==2.31.0
 >>>>>>> 092c86a3d4 (test previous selenium)

--- a/tools/wptrunner/requirements_sauce.txt
+++ b/tools/wptrunner/requirements_sauce.txt
@@ -1,2 +1,7 @@
+<<<<<<< HEAD
 selenium==4.20.0
 requests==2.32.3
+=======
+selenium==4.18.1
+requests==2.31.0
+>>>>>>> 092c86a3d4 (test previous selenium)

--- a/tools/wptrunner/requirements_sauce.txt
+++ b/tools/wptrunner/requirements_sauce.txt
@@ -1,11 +1,2 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
 selenium==4.20.0
 requests==2.32.3
-=======
-selenium==4.18.1
-=======
-selenium==4.20.0
->>>>>>> 3ab8232d0c (downgrade hypothesis)
-requests==2.31.0
->>>>>>> 092c86a3d4 (test previous selenium)


### PR DESCRIPTION
- updates publishing instructions for Docker images
- uses the [new image tagged `1`](https://github.com/web-platform-tests/wpt/pkgs/container/wpt/232922932?tag=1) hosted at GitHub

Closes https://github.com/web-platform-tests/wpt/issues/28903
Implements https://github.com/web-platform-tests/rfcs/pull/198