### PR TITLE
[WebDriver BiDi] allow grapheme in key input

### DIFF
--- a/webdriver/tests/bidi/input/perform_actions/invalid.py
+++ b/webdriver/tests/bidi/input/perform_actions/invalid.py
@@ -376,9 +376,16 @@ async def test_params_key_action_value_invalid_type(perform_actions,
 
 @pytest.mark.parametrize(
     "value",
-    ["fa", "\u0BA8\u0BBFb", "\u0BA8\u0BBF\u0BA8", "\u1100\u1161\u11A8c"],
+    [
+        "fa",  # 2 symbols.
+        "\U0001F604a",  # "😄a" a codepoint with a symbol.
+        "\u0BA8\u0BBFa",  # "நிa" a grapheme with a symbol.
+        "\u1100\u1161\u11A8a",  # "각a" a grapheme with a symbol.
+        "\u2764\ufe0fa",  # "❤️a" a grapheme with a symbol.
+        "\U0001F604\U0001F60D",  # "😄😍" 2 graphemes.
+    ],
 )
-async def test_params_key_action_value_invalid_multiple_codepoints(
+async def test_params_key_action_value_invalid_multiple_graphemes(
         perform_actions, value):
     actions = [
         create_key_action("keyDown", {"value": value}),

--- a/webdriver/tests/bidi/input/perform_actions/key.py
+++ b/webdriver/tests/bidi/input/perform_actions/key.py
@@ -33,13 +33,13 @@ async def test_key_backspace(bidi_session, top_context, setup_key_test):
 @pytest.mark.parametrize(
     "value",
     [
-        ("\U0001F604"),
-        ("\U0001F60D"),
-        ("\u0BA8\u0BBF"),
-        ("\u1100\u1161\u11A8"),
+        "\U0001F604",  # "😄" (\ud83d\ude04), a single surrogate codepoint.
+        "\u0BA8\u0BBF",  # "நி" (\u0BA8\u0BBF), a grapheme containing several chars.
+        "\u1100\u1161\u11A8",  # "각" (\u1100\u1161\u11A8), a grapheme containing several chars.
+        "\u2764\ufe0f",  # "❤️" (\u2764\ufe0f), a grapheme containing several codepoints.
     ],
 )
-async def test_key_codepoint(
+async def test_key_grapheme(
     bidi_session, top_context, setup_key_test, value
 ):
     # Not using send_keys() because we always want to treat value as


### PR DESCRIPTION
[As discussed](https://github.com/web-platform-tests/wpt/pull/46019#issuecomment-2114496675) in wg meeting, allow graphemes in key input.

Updating WebDriver Classic tests is out of scope.