### PR TITLE
[WebDriver] fix `test_scroll_iframe` for Chrome

### DIFF
--- a/webdriver/tests/bidi/input/perform_actions/wheel.py
+++ b/webdriver/tests/bidi/input/perform_actions/wheel.py
@@ -87,16 +87,13 @@ async def test_scroll_iframe(
         actions=actions, context=top_context["context"]
     )
 
-    events = []
-
     # Chrome requires some time to process the event from the iframe, so we wait for it.
     async def wait_for_events(_):
-        nonlocal events
-        events = await get_events(bidi_session, top_context["context"])
-        return len(events) > 0
+        return len(await get_events(bidi_session, top_context["context"])) > 0
 
     wait = AsyncPoll(bidi_session, timeout=0.5)
     await wait.until(wait_for_events)
+    events = await get_events()
 
     assert len(events) == 1
     assert events[0]["type"] == "wheel"

--- a/webdriver/tests/bidi/input/perform_actions/wheel.py
+++ b/webdriver/tests/bidi/input/perform_actions/wheel.py
@@ -85,7 +85,13 @@ async def test_scroll_iframe(
     await bidi_session.input.perform_actions(
         actions=actions, context=top_context["context"]
     )
-    events = await get_events(bidi_session, top_context["context"])
+
+    # Chrome requires some time to process the event from the iframe, so we wait for it.
+    while True:
+        events = await get_events(bidi_session, top_context["context"])
+        if len(events) > 0:
+            break
+
     assert len(events) == 1
     assert events[0]["type"] == "wheel"
     assert events[0]["deltaX"] == delta_x

--- a/webdriver/tests/bidi/input/perform_actions/wheel.py
+++ b/webdriver/tests/bidi/input/perform_actions/wheel.py
@@ -93,7 +93,7 @@ async def test_scroll_iframe(
 
     wait = AsyncPoll(bidi_session, timeout=0.5)
     await wait.until(wait_for_events)
-    events = await get_events()
+    events = await get_events(bidi_session, top_context["context"])
 
     assert len(events) == 1
     assert events[0]["type"] == "wheel"

--- a/webdriver/tests/classic/perform_actions/wheel.py
+++ b/webdriver/tests/classic/perform_actions/wheel.py
@@ -2,7 +2,7 @@ import pytest
 
 from webdriver.error import NoSuchWindowException
 
-
+import time
 from tests.classic.perform_actions.support.refine import get_events
 from tests.support.keys import Keys
 
@@ -55,13 +55,16 @@ def test_scroll_iframe(session, test_actions_scroll_page, wheel_chain):
 
     wheel_chain.scroll(0, 0, 5, 10, origin=target).perform()
 
-    # Chrome requires some time to process the event from the iframe, so we wait for it.
-    while True:
+    events = get_events(session)
+
+    timeout_start = time.time()
+    # Chrome requires some time (~10ms) to process the event from the iframe, so try to get events until they are in
+    # place, for not longer than for 500ms.
+    while time.time() < timeout_start + 0.5:
         events = get_events(session)
         if len(events) > 0:
             break
 
-    events = get_events(session)
     assert len(events) == 1
     assert events[0]["type"] == "wheel"
     assert events[0]["deltaX"] == 5

--- a/webdriver/tests/classic/perform_actions/wheel.py
+++ b/webdriver/tests/classic/perform_actions/wheel.py
@@ -55,6 +55,12 @@ def test_scroll_iframe(session, test_actions_scroll_page, wheel_chain):
 
     wheel_chain.scroll(0, 0, 5, 10, origin=target).perform()
 
+    # Chrome requires some time to process the event from the iframe, so we wait for it.
+    while True:
+        events = get_events(session)
+        if len(events) > 0:
+            break
+
     events = get_events(session)
     assert len(events) == 1
     assert events[0]["type"] == "wheel"


### PR DESCRIPTION
Chrome requires some time to process the events form the iframe, so poll the events until the required one is present.