### PR TITLE
Map custom elements to two different features

### DIFF
--- a/custom-elements/WEB_FEATURES.yml
+++ b/custom-elements/WEB_FEATURES.yml
@@ -1,3 +1,47 @@
 features:
-- name: custom-elements
-  files: "**"
+- name: autonomous-custom-elements
+  # TODO: Replace this list by an exclusion pattern. It is simply all tests
+  # except the ones for customized built-in elements.
+  files:
+  - adopted-callback.html
+  - attribute-changed-callback.html
+  - connected-callbacks-html-fragment-parsing.html
+  - connected-callbacks-template.html
+  - connected-callbacks.html
+  - cross-realm-callback-report-exception.html
+  - custom-element-reaction-queue.html
+  - CustomElementRegistry-constructor-and-callbacks-are-held-strongly.html
+  - CustomElementRegistry-getName.html
+  - CustomElementRegistry.html
+  - disconnected-callbacks.html
+  - Document-createElement-svg.svg
+  - Document-createElement.html
+  - Document-createElementNS.html
+  - element-internals-aria-element-reflection.html
+  - element-internals-shadowroot.html
+  - ElementInternals-accessibility.html
+  - enqueue-custom-element-callback-reactions-inside-another-callback.html
+  - historical.html
+  - HTMLElement-attachInternals.html
+  - HTMLElement-constructor.html
+  - microtasks-and-constructors.html
+  - overwritten-customElements-global.html
+  - perform-microtask-checkpoint-before-construction-xml-parser.xhtml
+  - perform-microtask-checkpoint-before-construction.html
+  - pseudo-class-defined-print.html
+  - pseudo-class-defined.html
+  - range-and-constructors.html
+  - reaction-timing.html
+  - throw-on-dynamic-markup-insertion-counter-construct-xml-parser.xhtml
+  - throw-on-dynamic-markup-insertion-counter-construct.html
+  - throw-on-dynamic-markup-insertion-counter-reactions-xml-parser.xhtml
+  - throw-on-dynamic-markup-insertion-counter-reactions.html
+  - upgrading.html
+- name: customized-built-in-elements
+  files:
+  - builtin-coverage.html
+  - customized-built-in-constructor-exceptions.html
+  - Document-createElement-customized-builtins.html
+  - Document-createElementNS-customized-builtins.html
+  - HTMLElement-constructor-customized-builtins.html
+  - pseudo-class-defined-customized-builtins.html

--- a/custom-elements/custom-element-registry/WEB_FEATURES.yml
+++ b/custom-elements/custom-element-registry/WEB_FEATURES.yml
@@ -1,0 +1,9 @@
+features:
+- name: autonomous-custom-elements
+  files:
+  - define.html
+  - per-global.html
+  - upgrade.html
+- name: customized-built-in-elements
+  files:
+  - define-customized-builtins.html

--- a/custom-elements/htmlconstructor/WEB_FEATURES.yml
+++ b/custom-elements/htmlconstructor/WEB_FEATURES.yml
@@ -1,0 +1,7 @@
+features:
+- name: autonomous-custom-elements
+  files:
+  - newtarget.html
+- name: customized-built-in-elements
+  files:
+  - newtarget-customized-builtins.html

--- a/custom-elements/parser/WEB_FEATURES.yml
+++ b/custom-elements/parser/WEB_FEATURES.yml
@@ -1,0 +1,17 @@
+features:
+- name: autonomous-custom-elements
+  files:
+  - parser-constructs-custom-element-in-document-write.html
+  - parser-constructs-custom-element-synchronously.html
+  - parser-constructs-custom-elements-with-is.html
+  - parser-constructs-custom-elements.html
+  - parser-custom-element-in-foreign-content.html
+  - parser-fallsback-to-unknown-element.html
+  - parser-sets-attributes-and-children.html
+  - parser-uses-constructed-element.html
+  - parser-uses-registry-of-owner-document.html
+- name: customized-built-in-elements
+  files:
+  - serializing-html-fragments-customized-builtins.html
+# Note that parser-uses-create-an-element-for-a-token-svg.svg isn't listed
+# as it has one subtest for autonomous and one for customized built-ins.

--- a/custom-elements/reactions/WEB_FEATURES.yml
+++ b/custom-elements/reactions/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: autonomous-custom-elements
+  files: "**"

--- a/custom-elements/reactions/customized-builtins/WEB_FEATURES.yml
+++ b/custom-elements/reactions/customized-builtins/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: customized-built-in-elements
+  files: "**"

--- a/custom-elements/upgrading/WEB_FEATURES.yml
+++ b/custom-elements/upgrading/WEB_FEATURES.yml
@@ -1,0 +1,11 @@
+features:
+- name: autonomous-custom-elements
+  files:
+  - Document-importNode.html
+  - Node-cloneNode.html
+  - upgrading-enqueue-reactions.html
+  - upgrading-parser-created-element.html
+- name: customized-built-in-elements
+  files:
+  - Document-importNode-customized-builtins.html
+  - Node-cloneNode-customized-builtins.html


### PR DESCRIPTION
This should match https://github.com/web-platform-dx/web-features/pull/1089.

The test results on wpt.fyi were used as a guide for where there might
be tests involving customized built-in elements, and all tests with
failures were given a quick review before deciding where to map it.
Mistakes are still possible.

This is the most complicated mapping to web-features so far, and shows
some limitations of the WEB_FEATURES.yml format. This could be
simplified with exclusion patterns in the format, but would still not be
simple.

Two files were renamed in the process of preparing this:
https://github.com/web-platform-tests/wpt/pull/46305
https://github.com/web-platform-tests/wpt/pull/46306
