### PR TITLE
Add tests for Image Button submitters

### DIFF
--- a/html/semantics/forms/form-submission-0/constructing-form-data-set.html
+++ b/html/semantics/forms/form-submission-0/constructing-form-data-set.html
@@ -158,4 +158,19 @@ test(() => {
   assert_equals(formDataInEvent.get('n1'), 'v1');
   assert_false(formDataInEvent.has('n2'));
 }, 'The constructed FormData object should not contain an entry for the submit button that was used to submit the form.');
+
+test(() => {
+  let form = populateForm('<input name=n1 value=v1><input type=image name=n2>');
+  let formDataInEvent = null;
+  let submitter = form.querySelector('input[type=image]');
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    formDataInEvent = new FormData(e.target);
+  });
+
+  submitter.click();
+  assert_equals(formDataInEvent.get('n1'), 'v1');
+  assert_false(formDataInEvent.has('n2.x'));
+  assert_false(formDataInEvent.has('n2.y'));
+}, 'The constructed FormData object should not contain an entry for the image submit button that was used to submit the form.');
 </script>

--- a/html/semantics/forms/form-submission-0/resources/form-submission.py
+++ b/html/semantics/forms/form-submission-0/resources/form-submission.py
@@ -1,12 +1,18 @@
-def main(request, response):
-    if request.headers.get(b'Content-Type') == b'application/x-www-form-urlencoded':
-        result = request.body == b'foo=bara'
-    elif request.headers.get(b'Content-Type') == b'text/plain':
-        result = request.body == b'qux=baz\r\n'
-    else:
-        result = request.POST.first(b'foo') == b'bar'
+from urllib.parse import parse_qsl
 
-    result = result and request.url_parts.query == u'query=1'
+def main(request, response):
+    params = dict(parse_qsl(request.url_parts.query))
+    if params.get('query') == '1':
+        if request.headers.get(b'Content-Type') == b'application/x-www-form-urlencoded':
+            result = request.body == b'foo=bara'
+        elif request.headers.get(b'Content-Type') == b'text/plain':
+            result = request.body == b'qux=baz\r\n'
+        else:
+            result = request.POST.first(b'foo') == b'bar'
+    elif params.get('expected_body') is not None:
+        result = request.body == params['expected_body'].encode('UTF-8')
+    else:
+        result = False
 
     return ([(b"Content-Type", b"text/plain")],
             b"OK" if result else b"FAIL")

--- a/html/semantics/forms/form-submission-0/submit-entity-body.html
+++ b/html/semantics/forms/form-submission-0/submit-entity-body.html
@@ -74,15 +74,22 @@ var simple_tests = [
     enctype: "application/x-www-form-urlencoded",
     submitelement: "<button id=inputsubmit type=\"submit\" name=foo value=bara>Submit</button>",
     submitaction: function(doc) { doc.getElementById("inputsubmit").click(); }
-  }
-,
+  },
   {
     name: "form submission from submit button should contain submit button value",
     input: "<input type=submit name=notclicked value=nope/>",
     enctype: "application/x-www-form-urlencoded",
     submitelement: "<input id=inputsubmit type=\"submit\" name=foo value=bara >",
     submitaction: function(doc) { doc.getElementById("inputsubmit").click(); }
-  }
+  },
+  {
+    name: "form submission from image input should contain the clicked coordinate",
+    input: "<input type=submit name=notclicked value=nope/>",
+    enctype: "application/x-www-form-urlencoded",
+    submitelement: "<input id=inputsubmit type=\"image\" name=foo>",
+    submitaction: function(doc) { doc.getElementById("inputsubmit").click(); },
+    expected_body: "foo.x=0&foo.y=0"
+  },
 ];
 simple_tests.forEach(function(test_obj) {
   test_obj.test = async_test(test_obj.name);
@@ -92,11 +99,13 @@ function run_simple_test() {
     return;
   }
   var test_obj = simple_tests.pop();
+  var enctype = test_obj.enctype || "application/x-www-form-urlencoded";
+  var query = test_obj.expected_body ? "expected_body=" + encodeURIComponent(test_obj.expected_body) : "query=1";
   var t = test_obj.test;
   var testframe = document.getElementById("testframe");
   var testdocument = testframe.contentWindow.document;
   testdocument.body.innerHTML =
-    "<form id=testform method=post action=\"/html/semantics/forms/form-submission-0/resources/form-submission.py?query=1\" enctype=\"" + test_obj.enctype + "\">" +
+    "<form id=testform method=post action=\"/html/semantics/forms/form-submission-0/resources/form-submission.py?" + query + "\" enctype=\"" + enctype + "\">" +
     test_obj.input +
     test_obj.submitelement +
     "</form>";

--- a/html/semantics/forms/form-submission-0/submit-entity-body.html
+++ b/html/semantics/forms/form-submission-0/submit-entity-body.html
@@ -91,7 +91,7 @@ var simple_tests = [
     expected_body: "foo.x=0&foo.y=0"
   },
   {
-    name: "form submission from image input should only entries for its clicked coordinate when multiple image inputs are present",
+    name: "form submission from image input should only contain entries for the submitter's clicked coordinate when multiple image inputs are present",
     input: "<input type=image name=bar>",
     enctype: "application/x-www-form-urlencoded",
     submitelement: "<input id=inputsubmit type=image name=foo>",

--- a/html/semantics/forms/form-submission-0/submit-entity-body.html
+++ b/html/semantics/forms/form-submission-0/submit-entity-body.html
@@ -83,10 +83,18 @@ var simple_tests = [
     submitaction: function(doc) { doc.getElementById("inputsubmit").click(); }
   },
   {
-    name: "form submission from image input should contain the clicked coordinate",
+    name: "form submission from image input should contain entries for its clicked coordinate",
     input: "<input type=submit name=notclicked value=nope/>",
     enctype: "application/x-www-form-urlencoded",
-    submitelement: "<input id=inputsubmit type=\"image\" name=foo>",
+    submitelement: "<input id=inputsubmit type=image name=foo>",
+    submitaction: function(doc) { doc.getElementById("inputsubmit").click(); },
+    expected_body: "foo.x=0&foo.y=0"
+  },
+  {
+    name: "form submission from image input should only entries for its clicked coordinate when multiple image inputs are present",
+    input: "<input type=image name=bar>",
+    enctype: "application/x-www-form-urlencoded",
+    submitelement: "<input id=inputsubmit type=image name=foo>",
     submitaction: function(doc) { doc.getElementById("inputsubmit").click(); },
     expected_body: "foo.x=0&foo.y=0"
   },


### PR DESCRIPTION
Add three tests around Image Button submitters:
* Ensure that a form submission contains entries for the submitter's selected coordinate
* Ensure that a form submission does not contain entries for an unrelated Image Button
* Ensure that a `new FormData(form)` created during submission does *not* contain entries for the submitter's selected coordinate, since it was not passed as an argument. The affirmative cases are already well covered by https://github.com/web-platform-tests/wpt/blob/master/xhr/formdata/constructor-submitter.html)

The first two tests pass in all implementations. The third test fails in WebKit due to https://bugs.webkit.org/show_bug.cgi?id=274214