### PR TITLE
[WebDriver] Use Poll in classic test_scroll_iframe

### DIFF
--- a/webdriver/tests/bidi/input/perform_actions/wheel.py
+++ b/webdriver/tests/bidi/input/perform_actions/wheel.py
@@ -87,12 +87,11 @@ async def test_scroll_iframe(
         actions=actions, context=top_context["context"]
     )
 
-    # Chrome requires some time to process the event from the iframe, so we wait for it.
+    # Chrome requires some time (~10-20ms) to process the event from the iframe, so we wait for it.
     async def wait_for_events(_):
         return len(await get_events(bidi_session, top_context["context"])) > 0
 
-    wait = AsyncPoll(bidi_session, timeout=0.5)
-    await wait.until(wait_for_events)
+    await AsyncPoll(bidi_session, timeout=0.5, interval=0.01, message='No events found').until(wait_for_events)
     events = await get_events(bidi_session, top_context["context"])
 
     assert len(events) == 1

--- a/webdriver/tests/bidi/input/perform_actions/wheel.py
+++ b/webdriver/tests/bidi/input/perform_actions/wheel.py
@@ -91,7 +91,7 @@ async def test_scroll_iframe(
     async def wait_for_events(_):
         return len(await get_events(bidi_session, top_context["context"])) > 0
 
-    await AsyncPoll(bidi_session, timeout=0.5, interval=0.01, message='No wheel events found').until(wait_for_events)
+    await AsyncPoll(bidi_session, timeout=0.5, interval=0.01, message='No wheel events emitted').until(wait_for_events)
     events = await get_events(bidi_session, top_context["context"])
 
     assert len(events) == 1

--- a/webdriver/tests/bidi/input/perform_actions/wheel.py
+++ b/webdriver/tests/bidi/input/perform_actions/wheel.py
@@ -91,7 +91,7 @@ async def test_scroll_iframe(
     async def wait_for_events(_):
         return len(await get_events(bidi_session, top_context["context"])) > 0
 
-    await AsyncPoll(bidi_session, timeout=0.5, interval=0.01, message='No events found').until(wait_for_events)
+    await AsyncPoll(bidi_session, timeout=0.5, interval=0.01, message='No wheel events found').until(wait_for_events)
     events = await get_events(bidi_session, top_context["context"])
 
     assert len(events) == 1

--- a/webdriver/tests/classic/perform_actions/wheel.py
+++ b/webdriver/tests/classic/perform_actions/wheel.py
@@ -60,7 +60,7 @@ def test_scroll_iframe(session, test_actions_scroll_page, wheel_chain):
     def wait_for_events(_):
         return len(get_events(session)) > 0
 
-    Poll(session, timeout=0.5, interval=0.01, message='No events found').until(wait_for_events)
+    Poll(session, timeout=0.5, interval=0.01, message='No wheel events found').until(wait_for_events)
     events = get_events(session)
 
     assert len(events) == 1

--- a/webdriver/tests/classic/perform_actions/wheel.py
+++ b/webdriver/tests/classic/perform_actions/wheel.py
@@ -5,6 +5,7 @@ from webdriver.error import NoSuchWindowException
 import time
 from tests.classic.perform_actions.support.refine import get_events
 from tests.support.keys import Keys
+from tests.support.sync import Poll
 
 
 def test_null_response_value(session, wheel_chain):
@@ -55,15 +56,12 @@ def test_scroll_iframe(session, test_actions_scroll_page, wheel_chain):
 
     wheel_chain.scroll(0, 0, 5, 10, origin=target).perform()
 
-    events = get_events(session)
+    # Chrome requires some time (~10-20ms) to process the event from the iframe, so we wait for it.
+    def wait_for_events(_):
+        return len(get_events(session)) > 0
 
-    timeout_start = time.time()
-    # Chrome requires some time (~10ms) to process the event from the iframe, so try to get events until they are in
-    # place, for not longer than for 500ms.
-    while time.time() < timeout_start + 0.5:
-        events = get_events(session)
-        if len(events) > 0:
-            break
+    Poll(session, timeout=0.5, interval=0.01, message='No events found').until(wait_for_events)
+    events = get_events(session)
 
     assert len(events) == 1
     assert events[0]["type"] == "wheel"


### PR DESCRIPTION
Use `tests.support.sync.Poll` in classic `test_scroll_iframe` for waiting for the events.