### PR TITLE
fonts: Store web fonts in the per-Layout `FontContext`

### DIFF
--- a/css/css-fonts/downloadable-font-scoped-to-document-ref.html
+++ b/css/css-fonts/downloadable-font-scoped-to-document-ref.html
@@ -1,0 +1,17 @@
+ <!DOCTYPE html>
+
+<html>
+    <head>
+        <title>CSS fonts: Web fonts loaded in a document are not available in other documents</title>
+        <link rel="author" title="Martin Robinson" href="mrobinson@igalia.com">
+        <link rel="author" title="Mukilan Thiyagarajan" href="mukilan@igalia.com">
+    </head>
+
+    <body>
+        <p>Test passes if Ahem is only used in the first iframe.</p>
+        <iframe src="support/iframe-using-ahem-as-web-font.html"></iframe>
+        <iframe src="support/iframe-without-web-font.html"></iframe>
+    </body>
+
+</html>
+

--- a/css/css-fonts/downloadable-font-scoped-to-document.html
+++ b/css/css-fonts/downloadable-font-scoped-to-document.html
@@ -1,0 +1,28 @@
+ <!DOCTYPE html>
+
+<html class="reftest-wait">
+    <head>
+        <title>CSS fonts: Web fonts loaded in a document are not available in other documents</title>
+        <link rel="author" title="Martin Robinson" href="mrobinson@igalia.com">
+        <link rel="author" title="Mukilan Thiyagarajan" href="mukilan@igalia.com">
+        <link rel="match" href="downloadable-font-scoped-to-document-ref.html">
+        <link rel="help" href="https://drafts.csswg.org/css-fonts/#font-face-rule">
+    </head>
+
+    <body>
+        <p>Test passes if Ahem is only used in the first iframe.</p>
+        <iframe id="iframe1" src="support/iframe-using-ahem-as-web-font.html"></iframe>
+        <iframe id="iframe2" src=""></iframe>
+
+        <script>
+            // Delay the loading of the second iframe to make it more likely that the font
+            // has loaded properly into the first iframe.
+            iframe1.onload = () => {
+                iframe2.src ="support/iframe-missing-font-face-rule.html";
+                document.documentElement.classList.remove('reftest-wait');
+            };
+        </script>
+    </body>
+
+</html>
+

--- a/css/css-fonts/support/iframe-missing-font-face-rule.html
+++ b/css/css-fonts/support/iframe-missing-font-face-rule.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="font-size: 30px; font-family: CustomFontFamily">Hello!</div>

--- a/css/css-fonts/support/iframe-using-ahem-as-web-font.html
+++ b/css/css-fonts/support/iframe-using-ahem-as-web-font.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: CustomFontFamily;
+    src: url(/fonts/Ahem.ttf);
+}
+</style>
+<div style="font-size: 30px; font-family: CustomFontFamily">Hello!</div>

--- a/css/css-fonts/support/iframe-without-web-font.html
+++ b/css/css-fonts/support/iframe-without-web-font.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="font-size: 30px;">Hello!</div>


### PR DESCRIPTION
This moves mangement of web fonts to the per-Layout `FontContext`,
preventing web fonts from being available in different Documents.

Fixes #<!-- nolink -->12920.

Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#32303