### PR TITLE
Update `browsingContext.locateNodes` according to the spec

### DIFF
--- a/webdriver/tests/bidi/browsing_context/locate_nodes/locator.py
+++ b/webdriver/tests/bidi/browsing_context/locate_nodes/locator.py
@@ -85,55 +85,55 @@ async def test_find_by_locator(bidi_session, inline, top_context, type, value):
          "matchType": "full",
          "maxDepth": 0,
          "value": "foobarbarbaz"
-     }, ["body"]),
+     }, []),
     ({
          "type": "innerText",
          "ignoreCase": False,
          "matchType": "full",
          "maxDepth": 0,
          "value": "foobarBARbaz"
-     }, ["body"]),
+     }, []),
     ({
          "type": "innerText",
          "ignoreCase": True,
          "matchType": "partial",
          "maxDepth": 0,
          "value": "bar"
-     }, ["body"]),
+     }, []),
     ({
          "type": "innerText",
          "ignoreCase": False,
          "matchType": "partial",
          "maxDepth": 0,
          "value": "BAR"
-     }, ["body"]),
+     }, []),
     ({
 
          "type": "innerText",
          "ignoreCase": True,
          "matchType": "full",
-         "maxDepth": 1,
+         "maxDepth": 2,
          "value": "foobarbarbaz"
      }, ["div"]),
     ({
          "type": "innerText",
          "ignoreCase": False,
          "matchType": "full",
-         "maxDepth": 1,
+         "maxDepth": 2,
          "value": "foobarBARbaz"
      }, ["div"]),
     ({
          "type": "innerText",
          "ignoreCase": True,
          "matchType": "partial",
-         "maxDepth": 1,
+         "maxDepth": 2,
          "value": "bar"
      }, ["div"]),
     ({
          "type": "innerText",
          "ignoreCase": False,
          "matchType": "partial",
-         "maxDepth": 1,
+         "maxDepth": 2,
          "value": "BAR"
      }, ["div"]),
 ], ids=[


### PR DESCRIPTION
1. Respect maxdepth in document -> html -> body chain.
2. In case of maxdepth is reached on the non-html element, return an empty array.