### PR TITLE
test: remove unnecessary return

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1538,7 +1538,6 @@
             assert(false, "assert_equals", description,
                           "expected (" + typeof expected + ") ${expected} but got (" + typeof actual + ") ${actual}",
                           {expected:expected, actual:actual});
-            return;
         }
         assert(same_value(actual, expected), "assert_equals", description,
                                              "expected ${expected} but got ${actual}",


### PR DESCRIPTION
The `return` is not needed as `assert(false, )` will terminate the code execution.