### PR TITLE
Fix input-text-size.html rounding error

### DIFF
--- a/html/rendering/widgets/input-text-size.html
+++ b/html/rendering/widgets/input-text-size.html
@@ -34,7 +34,7 @@ test(() => {
 test(() => {
   const computedString = getComputedStyle(computed).width;
   assert_equals(computed.offsetWidth,
-      parseInt(computedString.substring(0, computedString.length - 2)));
+      Math.round(computedString.substring(0, computedString.length - 2)));
 }, 'Size attribute value affects layout-dependent computed style');
 
 test(() => {


### PR DESCRIPTION
parseInt('132.99') results in 132, when this test actually wants 133. So swap to Math.round which will result in the correct number.