### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=274436

### DIFF
--- a/css/css-view-transitions/new-content-ancestor-clipped-2-ref.html
+++ b/css/css-view-transitions/new-content-ancestor-clipped-2-ref.html
@@ -1,0 +1,22 @@
+<!doctype HTML>
+<html>
+<head>
+<style>
+html {
+  background: lightpink;
+}
+div {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  background-color: red;
+  left: 150px;
+  top: 150px;
+}
+
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/css/css-view-transitions/new-content-ancestor-clipped-2.html
+++ b/css/css-view-transitions/new-content-ancestor-clipped-2.html
@@ -36,7 +36,6 @@ html::view-transition { background: lightpink; }
   <div class="inner"></div>
 </div>
 <script>
-
 async function runTest() {
   let t = document.startViewTransition(() => {
     requestAnimationFrame(() => requestAnimationFrame(takeScreenshot));

--- a/css/css-view-transitions/new-content-ancestor-clipped-2.html
+++ b/css/css-view-transitions/new-content-ancestor-clipped-2.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: clips from ancestor elements are not applied to captures</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" href="mailto:mattwoodrow@apple.com">
+<link rel="match" href="new-content-ancestor-clipped-2-ref.html">
+<script src="/common/reftest-wait.js"></script>
+<style>
+.outer {
+  background-color: blue;
+  overflow: hidden;
+  position: relative;
+  left: 100px;
+  top: 100px;
+  width: 200px;
+  height: 200px;
+}
+.inner {
+  background-color: red;
+  position: relative;
+  left: 50px;
+  top: 50px;
+  width: 200px;
+  height: 200px;
+  view-transition-name: inner;
+}
+/* We're verifying what we capture, so just display the new contents for 5 minutes.  */
+html::view-transition-group(*) { animation-duration: 300s; }
+html::view-transition-new(*) { animation: unset; opacity: 1; }
+html::view-transition-old(*) { animation: unset; opacity: 0; }
+/* hide the root so we show transition background to ensure we're in a transition */
+html::view-transition-group(root) { animation: unset; opacity: 0; }
+html::view-transition { background: lightpink; }
+</style>
+<div class="outer">
+  <div class="inner"></div>
+</div>
+<script>
+
+async function runTest() {
+  let t = document.startViewTransition(() => {
+    requestAnimationFrame(() => requestAnimationFrame(takeScreenshot));
+  });
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>
+


### PR DESCRIPTION
WebKit export from bug: [\[view-transitions\] https://pokedex-dev.vercel.app/pokemons incorrectly applies clips from ancestors of the captured element](https://bugs.webkit.org/show_bug.cgi?id=274436)