### PR TITLE
fonts: Remove web fonts when their stylesheet is removed

### DIFF
--- a/css/css-fonts/web-font-no-longer-accessible-when-stylesheet-removed-ref.html
+++ b/css/css-fonts/web-font-no-longer-accessible-when-stylesheet-removed-ref.html
@@ -1,0 +1,16 @@
+ <!DOCTYPE html>
+
+<html>
+    <head>
+        <title>CSS fonts: Web fonts from removed stylsheets should not be accessible</title>
+        <link rel="author" title="Martin Robinson" href="mrobinson@igalia.com">
+        <link rel="help" href="https://drafts.csswg.org/css-fonts/#font-face-rule">
+    </head>
+
+    <body>
+        <p>Test passes if the text below is not rendered with Ahem.</p>
+        <p>TEXT</p>
+    </body>
+
+</html>
+

--- a/css/css-fonts/web-font-no-longer-accessible-when-stylesheet-removed.html
+++ b/css/css-fonts/web-font-no-longer-accessible-when-stylesheet-removed.html
@@ -1,0 +1,29 @@
+ <!DOCTYPE html>
+
+<html>
+    <head>
+        <title>CSS fonts: Web fonts from removed stylsheets should not be accessible</title>
+        <link rel="author" title="Martin Robinson" href="mrobinson@igalia.com">
+        <link rel="match" href="web-font-no-longer-accessible-when-stylesheet-removed-ref.html">
+        <link rel="help" href="https://drafts.csswg.org/css-fonts/#font-face-rule">
+    </head>
+
+    <body>
+        <style id="web-font-stylesheet">
+        @font-face {
+            font-family: CustomFontFamily;
+            src: url(/fonts/Ahem.ttf);
+        }
+        </style>
+
+        <p>Test passes if the text below is not rendered with Ahem.</p>
+        <p style="font-family: CustomFontFamily;">TEXT</p>
+
+        <script>
+            let styleTag = document.getElementById("web-font-stylesheet");
+            styleTag.parentNode.removeChild(styleTag);
+        </script>
+    </body>
+
+</html>
+


### PR DESCRIPTION
This is the first part of ensuring that unused fonts do not leak. This
change makes it so that when a stylesheet is removed, the corresponding
web fonts are removed from the `FontContext`.

Note: WebRender assets are still leaked, which was the situation before
for all fonts. A followup change will fix this issue.

Fixes #<!-- nolink -->15139.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#32346