### PR TITLE
[WebDriver BiDi] Fix test for window.prompt opened

### DIFF
--- a/webdriver/tests/bidi/browsing_context/user_prompt_opened/user_prompt_opened.py
+++ b/webdriver/tests/bidi/browsing_context/user_prompt_opened/user_prompt_opened.py
@@ -49,19 +49,14 @@ async def test_prompt_type(
 
     event = await wait_for_future_safe(on_entry)
 
-    if prompt_type == 'prompt':
-        assert event == {
-            "context": new_tab["context"],
-            "type": prompt_type,
-            "message": text,
+    assert event == {
+        "context": new_tab["context"],
+        "type": prompt_type,
+        "message": text,
+        **({
             "defaultValue": ""
-        }
-    else:
-        assert event == {
-            "context": new_tab["context"],
-            "type": prompt_type,
-            "message": text,
-        }
+        } if prompt_type == 'prompt' else {})
+    }
 
 
 @pytest.mark.parametrize(

--- a/webdriver/tests/bidi/browsing_context/user_prompt_opened/user_prompt_opened.py
+++ b/webdriver/tests/bidi/browsing_context/user_prompt_opened/user_prompt_opened.py
@@ -57,7 +57,7 @@ async def test_prompt_type(
 
 
 @pytest.mark.parametrize(
-    "default", [None, "", "default"], ids=["null", "empty string", "non empty string"]
+    "default", [None, "", "default"], ids=["undefined", "empty string", "non empty string"]
 )
 async def test_prompt_default_value(
     bidi_session, inline, new_tab, subscribe_events, wait_for_event, wait_for_future_safe, default
@@ -68,7 +68,7 @@ async def test_prompt_default_value(
     text = "test"
 
     if default is None:
-        script = f"<script>window.prompt('{text}', null)</script>"
+        script = f"<script>window.prompt('{text}')</script>"
     else:
         script = f"<script>window.prompt('{text}', '{default}')</script>"
 
@@ -85,7 +85,9 @@ async def test_prompt_default_value(
         "message": text,
     }
 
-    if default is not None:
+    if default is None:
+        expected_event["defaultValue"] = ""
+    else:
         expected_event["defaultValue"] = default
 
     assert event == expected_event

--- a/webdriver/tests/bidi/browsing_context/user_prompt_opened/user_prompt_opened.py
+++ b/webdriver/tests/bidi/browsing_context/user_prompt_opened/user_prompt_opened.py
@@ -49,11 +49,19 @@ async def test_prompt_type(
 
     event = await wait_for_future_safe(on_entry)
 
-    assert event == {
-        "context": new_tab["context"],
-        "type": prompt_type,
-        "message": text,
-    }
+    if prompt_type == 'prompt':
+        assert event == {
+            "context": new_tab["context"],
+            "type": prompt_type,
+            "message": text,
+            "defaultValue": ""
+        }
+    else:
+        assert event == {
+            "context": new_tab["context"],
+            "type": prompt_type,
+            "message": text,
+        }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
In the HTML IDL - https://html.spec.whatwg.org/#the-window-object the function is defined as:
`prompt(optional DOMString message = "", optional DOMString default = "");`
This means that if no value is passed it get empty string.
I also observed that all values passed to the second parameter get `toString`(ed) (I think this is the algorithm that does it https://webidl.spec.whatwg.org/#js-DOMString),
Verified this behavior for Chrome, Firefox and Safari.
