### PR TITLE
Simplify WebVTT snap-to-line test by avoiding cue alignment settings

### DIFF
--- a/webvtt/rendering/cues-with-video/processing-model/support/snap-to-line.vtt
+++ b/webvtt/rendering/cues-with-video/processing-model/support/snap-to-line.vtt
@@ -1,5 +1,5 @@
 WEBVTT
 
 NOTE set line as percentage would make 'snap-to-line' to false
-00:00:00.000 --> 00:00:05.000 align:start position:50%,line-left line:50%,start
+00:00:00.000 --> 00:00:05.000 align:start position:50% line:50%
 foo


### PR DESCRIPTION
The test passes in Firefox before and after these changes. The rendering
isn't affected because these settings are the defaults.
