### PR TITLE
[a11y] Move thead, tbody, tfoot role tests to tentative file

### DIFF
--- a/html-aam/roles.tentative.html
+++ b/html-aam/roles.tentative.html
@@ -18,6 +18,19 @@
 
 <input type="checkbox" switch data-testname="el-input-checkbox-switch" data-expectedrole="switch" class="ex">
 
+<!--
+  These thead, tbody, and tfoot role tests are pending spec discussion.
+  See https://github.com/w3c/html-aam/issues/474
+-->
+<table>
+  <thead data-testname="el-thead" data-expectedrole="rowgroup" class="ex">
+  </thead>
+  <tbody data-testname="el-tbody" data-expectedrole="rowgroup" class="ex">
+  </tbody>
+  <tfoot data-testname="el-tfoot" data-expectedrole="rowgroup" class="ex">
+  </tfoot>
+</table>
+
 <script>
 AriaUtils.verifyRolesBySelector(".ex");
 </script>

--- a/html-aam/roles.tentative.html
+++ b/html-aam/roles.tentative.html
@@ -24,10 +24,30 @@
 -->
 <table>
   <thead data-testname="el-thead" data-expectedrole="rowgroup" class="ex">
+    <tr>
+      <th>a</th>
+      <th>b</th>
+      <th>c</th>
+    </tr>
   </thead>
   <tbody data-testname="el-tbody" data-expectedrole="rowgroup" class="ex">
+    <tr>
+      <th>1</th>
+      <td>2</td>
+      <td>3</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>5</td>
+      <td>6</td>
+    </tr>
   </tbody>
   <tfoot data-testname="el-tfoot" data-expectedrole="rowgroup" class="ex">
+    <tr>
+      <th>x</th>
+      <th>y</th>
+      <th>z</th>
+    </tr>
   </tfoot>
 </table>
 

--- a/html-aam/table-roles.html
+++ b/html-aam/table-roles.html
@@ -17,14 +17,14 @@
 
 <table data-testname="el-table" data-expectedrole="table" class="ex">
   <caption data-testname="el-caption" data-expectedrole="caption" class="ex">caption</caption>
-  <thead data-testname="el-thead" data-expectedrole="rowgroup" class="ex">
+  <thead>
     <tr data-testname="el-tr-thead" data-expectedrole="row" class="ex">
       <th data-testname="el-th" data-expectedrole="columnheader" class="ex">a</th>
       <th>b</th>
       <th>c</th>
     </tr>
   </thead>
-  <tbody data-testname="el-tbody" data-expectedrole="rowgroup" class="ex">
+  <tbody>
     <tr data-testname="el-tr-tbody" data-expectedrole="row" class="ex">
       <th data-testname="el-th-in-row" data-expectedrole="rowheader" class="ex">1</th>
       <td data-testname="el-td" data-expectedrole="cell" class="ex">2</td>
@@ -36,7 +36,7 @@
       <td>6</td>
     </tr>
   </tbody>
-  <tfoot data-testname="el-tfoot" data-expectedrole="rowgroup" class="ex">
+  <tfoot>
     <tr>
       <th>x</th>
       <th>y</th>


### PR DESCRIPTION
Closes https://github.com/web-platform-tests/interop-accessibility/issues/129

There is [a pending spec discussion](https://github.com/w3c/html-aam/issues/474) surrounding these tests - we're not sure if they're valid as written. This commit moves them to the tentative role tests file pending resolution of that question.