### PR TITLE
[a11y] Move disputed self/cross-referential aria-labelledby tests to tentative file

### DIFF
--- a/accname/name/comp_name_from_content.html
+++ b/accname/name/comp_name_from_content.html
@@ -232,26 +232,6 @@
   </a>
 </h3>
 
-<!-- cross-referencial edge case-->
-<h1>heading with link referencing image using aria-labelledby, that in turn references text element via aria-labelledby</h1>
-<h3 data-expectedlabel="image link" data-testname="heading with link referencing image using aria-labelledby, that in turn references text element via aria-labelledby" class="ex">
-  <a href="#" aria-labelledby="nested_image_label3">
-    <span class="note" id="crossref_link">link</span><!-- this text is skipped the first time around because of aria-labelledby on parent element -->
-  </a>
-  <!-- but it's picked up again in inverse order b/c of cross-referencial aria-labelledby edge case -->
-  <img id="nested_image_label3" alt="image" aria-labelledby="crossref_link" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
-</h3>
-
-<!-- self-referencial edge case-->
-<h1>heading with link referencing image using aria-labelledby, that in turn references itself and another element via aria-labelledby</h1>
-<h3 data-expectedlabel="image link" data-testname="heading with link referencing image using aria-labelledby, that in turn references itself and another element via aria-labelledby" class="ex">
-  <a href="#" aria-labelledby="nested_image_label4">
-    <span class="note" id="crossref_link2">link</span><!-- this text is skipped the first time around because of aria-labelledby on parent element -->
-  </a>
-  <!-- but it's picked up again (after the self-referencial image alt) in inverse order b/c of cross-referencial aria-labelledby edge case -->
-  <img id="nested_image_label4" alt="image" aria-labelledby="nested_image_label4 crossref_link2" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
-</h3>
-
 
 <!-- Note: The following test is out of line with the spec, but matching two out of three implementations at the time of writing, and spec changes are expeected. -->
 <!-- See details in https://github.com/w3c/accname/issues/205 -->

--- a/accname/name/comp_name_from_content.tentative.html
+++ b/accname/name/comp_name_from_content.tentative.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+<head>
+  <title>Name Comp: Name From Content (Tentative)</title>
+  <meta charset="utf-8">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<!--
+  These aria-labelledby tests may not be valid, pending spec discussion.
+  See https://github.com/w3c/accname/issues/209
+-->
+
+<!-- cross-referencial edge case-->
+<h1>heading with link referencing image using aria-labelledby, that in turn references text element via aria-labelledby</h1>
+<h3 data-expectedlabel="image link" data-testname="heading with link referencing image using aria-labelledby, that in turn references text element via aria-labelledby" class="ex">
+  <a href="#" aria-labelledby="nested_image_label3">
+    <span class="note" id="crossref_link">link</span><!-- this text is skipped the first time around because of aria-labelledby on parent element -->
+  </a>
+  <!-- but it's picked up again in inverse order b/c of cross-referencial aria-labelledby edge case -->
+  <img id="nested_image_label3" alt="image" aria-labelledby="crossref_link" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+</h3>
+
+<!-- self-referencial edge case-->
+<h1>heading with link referencing image using aria-labelledby, that in turn references itself and another element via aria-labelledby</h1>
+<h3 data-expectedlabel="image link" data-testname="heading with link referencing image using aria-labelledby, that in turn references itself and another element via aria-labelledby" class="ex">
+  <a href="#" aria-labelledby="nested_image_label4">
+    <span class="note" id="crossref_link2">link</span><!-- this text is skipped the first time around because of aria-labelledby on parent element -->
+  </a>
+  <!-- but it's picked up again (after the self-referencial image alt) in inverse order b/c of cross-referencial aria-labelledby edge case -->
+  <img id="nested_image_label4" alt="image" aria-labelledby="nested_image_label4 crossref_link2" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+</h3>
+
+<script>
+AriaUtils.verifyLabelsBySelector(".ex");
+</script>
+</body>
+</html>


### PR DESCRIPTION
Closes https://github.com/web-platform-tests/interop-accessibility/issues/123

There is [a pending spec discussion](https://github.com/w3c/accname/issues/209) surrounding these tests - we're not sure if they're valid as written, according to the current spec. This commit moves them to a new tentative file pending resolution of that discussion.

If we'd rather fix these tests a different way, I'm happy to change this PR. I'm suggesting moving them to a tentative file because I think that the core of what they are intended to test is in dispute.

cc @dandclark @jcsteh @zcorpan 