### PR TITLE
clipboard-api: user WebKit-infra-friendly remote URL

### DIFF
--- a/clipboard-apis/feature-policy/clipboard-read/clipboard-read-disabled-by-feature-policy.tentative.https.sub.html
+++ b/clipboard-apis/feature-policy/clipboard-read/clipboard-read-disabled-by-feature-policy.tentative.https.sub.html
@@ -12,7 +12,7 @@
 const same_origin_src =
   '/feature-policy/resources/feature-policy-clipboard-read.html';
 const cross_origin_src =
-  'https://{{domains[www]}}:{{ports[https][0]}}' + same_origin_src;
+  'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
 promise_test(async t => {
   await tryGrantReadPermission();

--- a/clipboard-apis/feature-policy/clipboard-read/clipboard-read-enabled-by-feature-policy-attribute-cross-origin-tentative.https.sub.html
+++ b/clipboard-apis/feature-policy/clipboard-read/clipboard-read-enabled-by-feature-policy-attribute-cross-origin-tentative.https.sub.html
@@ -12,7 +12,7 @@
 const same_origin_src =
   '/feature-policy/resources/feature-policy-clipboard-read.html';
 const cross_origin_src =
-  'https://{{domains[www]}}:{{ports[https][0]}}' + same_origin_src;
+  'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
 // TODO(https://github.com/whatwg/html/issues/5493, https://crbug.com/1074482):
 // In Chrome and Firefox, Cross-origin focus requires user gesture. In Chrome

--- a/clipboard-apis/feature-policy/clipboard-read/clipboard-read-enabled-by-feature-policy-cross-origin-tentative.https.sub.html
+++ b/clipboard-apis/feature-policy/clipboard-read/clipboard-read-enabled-by-feature-policy-cross-origin-tentative.https.sub.html
@@ -12,7 +12,7 @@
 const same_origin_src =
   '/feature-policy/resources/feature-policy-clipboard-read.html';
 const cross_origin_src =
-  'https://{{domains[www]}}:{{ports[https][0]}}' + same_origin_src;
+  'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
 // TODO(https://github.com/whatwg/html/issues/5493, https://crbug.com/1074482):
 // In Chrome and Firefox, Cross-origin focus requires user gesture. In Chrome

--- a/clipboard-apis/feature-policy/clipboard-read/clipboard-read-enabled-by-feature-policy.tentative.https.sub.html
+++ b/clipboard-apis/feature-policy/clipboard-read/clipboard-read-enabled-by-feature-policy.tentative.https.sub.html
@@ -12,7 +12,7 @@
 const same_origin_src =
   '/feature-policy/resources/feature-policy-clipboard-read.html';
 const cross_origin_src =
-  'https://{{domains[www]}}:{{ports[https][0]}}' + same_origin_src;
+  'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
 promise_test(async t => {
   await tryGrantReadPermission();

--- a/clipboard-apis/feature-policy/clipboard-read/clipboard-read-enabled-on-self-origin-by-feature-policy.tentative.https.sub.html
+++ b/clipboard-apis/feature-policy/clipboard-read/clipboard-read-enabled-on-self-origin-by-feature-policy.tentative.https.sub.html
@@ -12,7 +12,7 @@
 const same_origin_src =
   '/feature-policy/resources/feature-policy-clipboard-read.html';
 const cross_origin_src =
-  'https://{{domains[www]}}:{{ports[https][0]}}' + same_origin_src;
+  'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
 promise_test(async t => {
   await tryGrantReadPermission();

--- a/clipboard-apis/feature-policy/clipboard-write/clipboard-write-disabled-by-feature-policy.tentative.https.sub.html
+++ b/clipboard-apis/feature-policy/clipboard-write/clipboard-write-disabled-by-feature-policy.tentative.https.sub.html
@@ -12,7 +12,7 @@
 const same_origin_src =
   '/feature-policy/resources/feature-policy-clipboard-write.html';
 const cross_origin_src =
-  'https://{{domains[www]}}:{{ports[https][0]}}' + same_origin_src;
+  'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
 promise_test(async t => {
   await tryGrantWritePermission();

--- a/clipboard-apis/feature-policy/clipboard-write/clipboard-write-enabled-by-feature-policy-attribute-cross-origin-tentative.https.sub.html
+++ b/clipboard-apis/feature-policy/clipboard-write/clipboard-write-enabled-by-feature-policy-attribute-cross-origin-tentative.https.sub.html
@@ -12,7 +12,7 @@
 const same_origin_src =
   '/feature-policy/resources/feature-policy-clipboard-write.html';
 const cross_origin_src =
-  'https://{{domains[www]}}:{{ports[https][0]}}' + same_origin_src;
+  'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
 // TODO(https://github.com/whatwg/html/issues/5493, https://crbug.com/1074482):
 // In Chrome and Firefox, Cross-origin focus requires user gesture. In Chrome

--- a/clipboard-apis/feature-policy/clipboard-write/clipboard-write-enabled-by-feature-policy-cross-origin-tentative.https.sub.html
+++ b/clipboard-apis/feature-policy/clipboard-write/clipboard-write-enabled-by-feature-policy-cross-origin-tentative.https.sub.html
@@ -12,7 +12,7 @@
 const same_origin_src =
   '/feature-policy/resources/feature-policy-clipboard-write.html';
 const cross_origin_src =
-  'https://{{domains[www]}}:{{ports[https][0]}}' + same_origin_src;
+  'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
 // TODO(https://github.com/whatwg/html/issues/5493, https://crbug.com/1074482):
 // In Chrome and Firefox, Cross-origin focus requires user gesture. In Chrome

--- a/clipboard-apis/feature-policy/clipboard-write/clipboard-write-enabled-by-feature-policy.tentative.https.sub.html
+++ b/clipboard-apis/feature-policy/clipboard-write/clipboard-write-enabled-by-feature-policy.tentative.https.sub.html
@@ -12,7 +12,7 @@
 const same_origin_src =
   '/feature-policy/resources/feature-policy-clipboard-write.html';
 const cross_origin_src =
-  'https://{{domains[www]}}:{{ports[https][0]}}' + same_origin_src;
+  'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
 promise_test(async t => {
   await tryGrantWritePermission();

--- a/clipboard-apis/feature-policy/clipboard-write/clipboard-write-enabled-on-self-origin-by-feature-policy.tentative.https.sub.html
+++ b/clipboard-apis/feature-policy/clipboard-write/clipboard-write-enabled-on-self-origin-by-feature-policy.tentative.https.sub.html
@@ -12,7 +12,7 @@
 const same_origin_src =
   '/feature-policy/resources/feature-policy-clipboard-write.html';
 const cross_origin_src =
-  'https://{{domains[www]}}:{{ports[https][0]}}' + same_origin_src;
+  'https://{{hosts[alt][]}}:{{ports[https][0]}}' + same_origin_src;
 
 promise_test(async t => {
   await tryGrantWritePermission();


### PR DESCRIPTION
Unfortunately, WebKit's bots can't talk to whatever https://{{domains[www]}} resolves to. This still makes the tests cross origin, but using a slightly different URL... and let's us run these tests in WebKit's infrastructure. 