### PR TITLE
Firefox Bug 1886918: Remove optional trailing semicolon from CSP

### DIFF
--- a/content-security-policy/generic/304-response-should-update-csp.sub.html
+++ b/content-security-policy/generic/304-response-should-update-csp.sub.html
@@ -28,7 +28,7 @@
     window.onmessage = function(e) {
       if (e.source == i1.contentWindow) {
         if (e.data == "abc_executed") { t1.done(); return; }
-        if (e.data == "script-src 'nonce-abc' 'sha256-IIB78ZS1RMMrAWpsLg/RrDbVPhI14rKm3sFOeKPYulw=';") { t2.done(); return; }
+        if (e.data == "script-src 'nonce-abc' 'sha256-IIB78ZS1RMMrAWpsLg/RrDbVPhI14rKm3sFOeKPYulw='") { t2.done(); return; }
 
         t1.step(function() { assert_unreached("Unexpected message received"); });
         t2.step(function() { assert_unreached("Unexpected message received"); });
@@ -36,7 +36,7 @@
 
       if (e.source == i2.contentWindow) {
         if (e.data == "def_executed") { t3.done(); return; }
-        if (e.data == "script-src 'nonce-def' 'sha256-IIB78ZS1RMMrAWpsLg/RrDbVPhI14rKm3sFOeKPYulw=';") { t4.done(); return; }
+        if (e.data == "script-src 'nonce-def' 'sha256-IIB78ZS1RMMrAWpsLg/RrDbVPhI14rKm3sFOeKPYulw='") { t4.done(); return; }
 
         t3.step(function() { assert_unreached("Unexpected message received"); });
         t4.step(function() { assert_unreached("Unexpected message received"); });

--- a/content-security-policy/generic/support/304-response.py
+++ b/content-security-policy/generic/support/304-response.py
@@ -4,13 +4,13 @@ def main(request, response):
         # with the 304 response
         response.status = 304
         headers = [(b"Content-Type", b"text/html"),
-                   (b"Content-Security-Policy", b"script-src 'nonce-def' 'sha256-IIB78ZS1RMMrAWpsLg/RrDbVPhI14rKm3sFOeKPYulw=';"),
+                   (b"Content-Security-Policy", b"script-src 'nonce-def' 'sha256-IIB78ZS1RMMrAWpsLg/RrDbVPhI14rKm3sFOeKPYulw='"),
                    (b"Cache-Control", b"private, max-age=0, must-revalidate"),
                    (b"ETag", b"123456")]
         return headers, u""
     else:
         headers = [(b"Content-Type", b"text/html"),
-                   (b"Content-Security-Policy", b"script-src 'nonce-abc' 'sha256-IIB78ZS1RMMrAWpsLg/RrDbVPhI14rKm3sFOeKPYulw=';"),
+                   (b"Content-Security-Policy", b"script-src 'nonce-abc' 'sha256-IIB78ZS1RMMrAWpsLg/RrDbVPhI14rKm3sFOeKPYulw='"),
                    (b"Cache-Control", b"private, max-age=0, must-revalidate"),
                    (b"Etag", b"123456")]
         return headers, u'''


### PR DESCRIPTION
This is an alternative to https://github.com/web-platform-tests/wpt/pull/46511

It works in Chrome, Edge, Safari and Firefox