### PR TITLE
Workers: Fix timeout for failing tests

### DIFF
--- a/workers/shared-worker-options-mismatch.html
+++ b/workers/shared-worker-options-mismatch.html
@@ -8,10 +8,18 @@ const mismatch_test = (testName, firstOptions, secondOptions) => {
   promise_test(async () => {
     firstOptions.name = testName;
     secondOptions.name = testName;
-    const scriptURL = 'support/empty-worker.js';
+    const scriptURL = 'support/SharedWorker-common.js';
     const firstWorker = new SharedWorker(scriptURL, firstOptions);
     const secondWorker = new SharedWorker(scriptURL, secondOptions);
-    return new Promise(resolve => secondWorker.onerror = resolve);
+    const result = new Promise((resolve, reject) => {
+      secondWorker.onerror = resolve;
+      secondWorker.port.onmessage = () => reject("Worker loaded succesfully");
+    });
+    secondWorker.port.postMessage("ping");
+    await result;
+    firstWorker.port.postMessage("close");
+    secondWorker.port.postMessage("close");
+    return result;
   }, 'Connecting to shared worker with different options should be blocked: '
   + testName);
 };


### PR DESCRIPTION
This is a small improvement to #21651.

If the browser fails a test in `shared-worker-options-mismatch.html`, it simply stalls until the test harness fails with a `TIMEOUT`. That makes it seem like the test is broken, and it also means that if you do like Firefox and fail the first subtest, you won't know if the other subtests fail or pass.

I have fixed the issue by pinging the worker, and if the worker responds to the ping, we can be sure that the browser did not block the worker, so we can fail the subtest. Now Firefox is able to quickly fail all the tests ;)

I also made sure to close the workers after the test run. Mobile browsers have limits on SharedWorker resources, and this test was initializing tens of them without closing them again. I don't know if it was actually a problem but now we know for sure it won't ever be a problem :)