### PR TITLE
FileAPI: Remove FileReader from Blob reading utilities

### DIFF
--- a/FileAPI/reading-data-section/filereader_readAsArrayBuffer.any.js
+++ b/FileAPI/reading-data-section/filereader_readAsArrayBuffer.any.js
@@ -7,6 +7,7 @@
       reader.onload = this.step_func(function(evt) {
         assert_equals(reader.result.byteLength, 4, "The byteLength is 4");
         assert_true(reader.result instanceof ArrayBuffer, "The result is instanceof ArrayBuffer");
+        assert_array_equals(new Uint8Array(reader.result), [84, 69, 83, 84]);
         assert_equals(reader.readyState, reader.DONE);
         this.done();
       });

--- a/FileAPI/support/Blob.js
+++ b/FileAPI/support/Blob.js
@@ -5,23 +5,16 @@ self.test_blob = (fn, expectations) => {
       type = expectations.type,
       desc = expectations.desc;
 
-  var t = async_test(desc);
-  t.step(function() {
+  promise_test(async (t) => {
     var blob = fn();
     assert_true(blob instanceof Blob);
     assert_false(blob instanceof File);
     assert_equals(blob.type, type);
     assert_equals(blob.size, expected.length);
 
-    var fr = new FileReader();
-    fr.onload = t.step_func_done(function(event) {
-      assert_equals(this.result, expected);
-    }, fr);
-    fr.onerror = t.step_func(function(e) {
-      assert_unreached("got error event on FileReader");
-    });
-    fr.readAsText(blob, "UTF-8");
-  });
+    const text = await blob.text();
+    assert_equals(text, expected);
+  }, desc);
 }
 
 self.test_blob_binary = (fn, expectations) => {
@@ -29,25 +22,18 @@ self.test_blob_binary = (fn, expectations) => {
       type = expectations.type,
       desc = expectations.desc;
 
-  var t = async_test(desc);
-  t.step(function() {
+  promise_test(async (t) => {
     var blob = fn();
     assert_true(blob instanceof Blob);
     assert_false(blob instanceof File);
     assert_equals(blob.type, type);
     assert_equals(blob.size, expected.length);
 
-    var fr = new FileReader();
-    fr.onload = t.step_func_done(function(event) {
-      assert_true(this.result instanceof ArrayBuffer,
-                  "Result should be an ArrayBuffer");
-      assert_array_equals(new Uint8Array(this.result), expected);
-    }, fr);
-    fr.onerror = t.step_func(function(e) {
-      assert_unreached("got error event on FileReader");
-    });
-    fr.readAsArrayBuffer(blob);
-  });
+    const ab = await blob.arrayBuffer();
+    assert_true(ab instanceof ArrayBuffer,
+      "Result should be an ArrayBuffer");
+    assert_array_equals(new Uint8Array(ab), expected);
+  }, desc);
 }
 
 // Assert that two TypedArray objects have the same byte values


### PR DESCRIPTION
Some environments that implement Blob do not implement FileReader, forcing them to skip these tests.

For example:
https://github.com/nodejs/node/blob/main/test/wpt/status/FileAPI/blob.json#L7