### PR TITLE
Geolocation: make test less racy

### DIFF
--- a/geolocation-API/non-fully-active.https.html
+++ b/geolocation-API/non-fully-active.https.html
@@ -17,14 +17,13 @@
 
     // Create the iframe, wait for it to load...
     const iframe = document.createElement("iframe");
-    iframe.src = "resources/iframe.html";
-    iframe.allow = "geolocation";
-    document.body.appendChild(iframe);
-
     // ...wait for the iframe to load...
-    await new Promise((resolve) =>
-      iframe.addEventListener("load", resolve, { once: true })
-    );
+    await new Promise((resolve) => {
+      iframe.src = "resources/iframe.html";
+      iframe.allow = "geolocation";
+      iframe.addEventListener("load", resolve, { once: true });
+      document.body.appendChild(iframe);
+    });
 
     // Steal geolocation.
     const geo = iframe.contentWindow.navigator.geolocation;


### PR DESCRIPTION
appending the iframe to the document before creating the promise was potentially making the test racy. 