### PR TITLE
Preload: Fix preconnect event test

### DIFF
--- a/preload/preconnect-onerror-event.html
+++ b/preload/preconnect-onerror-event.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<title>Makes sure that preloaded resources trigger the onerror event</title>
+<title>Makes sure that preconnected resources do not trigger load or error events</title>
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -10,6 +10,18 @@
 <script>
     const {HTTP_REMOTE_ORIGIN} = get_host_info();
 
+    /**
+     * Test workflow:
+     * - Create preconnect link
+     * - Wait 200 ms
+     * - Create preload link
+     * Event listeners for 'load' and 'error' are attached to both links.
+     * The first event listener that fires is tested to see which element fired it.
+     * The event should always be fired by the preload element because per spec, the preconnect link should never fire these events:
+     * https://html.spec.whatwg.org/#link-type-preconnect
+     *
+     * This test assumes that the preload link element fires 'load' and 'error' events correctly, otherwise the test will timeout.
+     */
     function test_preconnect(origin, resource, desc) {
         promise_test(async t => {
             const result = await new Promise(async didLoad => {
@@ -22,16 +34,16 @@
                     link.addEventListener('load', () => didLoad({rel, type: 'load'}));
                     link.addEventListener('error', () => didLoad({rel, type: 'error'}));
                     document.head.appendChild(link);
-                    t.step_timeout(() => resolve('timeout'), 200));
+                    await new Promise(resolve => t.step_timeout(resolve, 200));
                 }
             });
             assert_equals(result.rel, 'preload');
         }, desc);
     }
 
-    test_preconnect(HTTP_REMOTE_ORIGIN, '/preload/resources/dummy.js', 'Preconnect should not fire load events');
-    test_preconnect('http://NON-EXISTENT.origin', '/preload/resources/dummy.js', 'Preconnect should not fire error events for non-existent origins');
-    test_preconnect('some-scheme://URL', '/preload/resources/dummy.js', 'Preconnect should not fire error events for non-http(s) scheme');
+    test_preconnect(HTTP_REMOTE_ORIGIN, '/preload/resources/dummy.js', 'Preconnect should not fire load (or error) events');
+    test_preconnect('http://NON-EXISTENT.origin', '/preload/resources/dummy.js', 'Preconnect should not fire error (or load) events for non-existent origins');
+    test_preconnect('some-scheme://URL', '/preload/resources/dummy.js', 'Preconnect should not fire error (or load) events for non-http(s) scheme');
 </script>
 </body>
 </html>


### PR DESCRIPTION
In #33665 @noamr planned to push a commit that would add a comment to the test file, but instead pushed commit bd67c3acba5cf00d377e44f1197ed2d8517a61b5 which broke the JS for the test, so the test has never worked.

I have:
- Reverted the change in bd67c3acba5cf00d377e44f1197ed2d8517a61b5 so the test now works.
- Tried to write a comment that explains how the test works, addressing https://github.com/web-platform-tests/wpt/pull/33665#pullrequestreview-945148350.
- Changed the title to reflect what the test does. It seems to have been copy-pasted from a different test.
- Clarified that each subtest tests for both events. I think this would make it easier to debug a failing test.

@noamr please feel free to edit this PR or create a new PR if you think something can be improved :)