### PR TITLE
Add aggregatable debug reporting routes to RoutesBuilder

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -599,6 +599,7 @@ class RoutesBuilder:
             ("*", "/.well-known/attribution-reporting/debug/report-event-attribution", handlers.PythonScriptHandler),
             ("*", "/.well-known/attribution-reporting/report-aggregate-attribution", handlers.PythonScriptHandler),
             ("*", "/.well-known/attribution-reporting/debug/report-aggregate-attribution", handlers.PythonScriptHandler),
+            ("*", "/.well-known/attribution-reporting/debug/report-aggregate-debug", handlers.PythonScriptHandler),
             ("*", "/.well-known/attribution-reporting/debug/verbose", handlers.PythonScriptHandler),
             ("GET", "/.well-known/interest-group/permissions/", handlers.PythonScriptHandler),
             ("*", "/.well-known/private-aggregation/*", handlers.PythonScriptHandler),


### PR DESCRIPTION
Attribution Reporting API supports collecting aggregatable debug reports. Adding aggregatable debug reports routes as a well-known route to the RoutesBuilder so that the WPT server can receive and return debug reports.

Explainer: https://github.com/WICG/attribution-reporting-api/blob/main/aggregate_debug_reporting.md