### PR TITLE
Geolocation: simplify feature check

### DIFF
--- a/permissions-policy/resources/permissions-policy-geolocation.html
+++ b/permissions-policy/resources/permissions-policy-geolocation.html
@@ -1,22 +1,11 @@
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
 <script>
-  "use strict";
-
-  Promise.resolve().then(async () => {
-    test_driver.set_test_context(window.parent);
-    await test_driver.set_permission(
-      { name: "geolocation" },
-      "granted"
-    );
-    let enabled = true;
-    try {
-      await new Promise((resolve, reject) => {
-        navigator.geolocation.getCurrentPosition(resolve, reject);
-      });
-    } catch (e) {
-      enabled = false;
+  const type = "availability-result";
+  navigator.geolocation.getCurrentPosition(
+    () => {
+      window.parent.postMessage({ type, enabled: true }, "*");
+    },
+    () => {
+      window.parent.postMessage({ type, enabled: false }, "*");
     }
-    window.parent.postMessage({ type: "availability-result", enabled }, "*");
-  });
+  );
 </script>


### PR DESCRIPTION
Simplify the feature check to its absolute simplest.

Enabling the permission should be done at the top level instead as part of the test. 