### PR TITLE
Add tests for get_title with multibyte characters

### DIFF
--- a/webdriver/tests/classic/get_title/get.py
+++ b/webdriver/tests/classic/get_title/get.py
@@ -1,4 +1,4 @@
-from tests.support.asserts import assert_error, assert_success
+﻿from tests.support.asserts import assert_error, assert_success
 
 
 def get_title(session):
@@ -54,3 +54,17 @@ def test_strip_and_collapse(session, inline):
 
     result = get_title(session)
     assert_success(result, "a b c d e")
+
+
+def test_title_included_entity_references(session, inline):
+    session.url = inline("<title>&reg; &copy; &cent; &pound; &yen;</title>")
+
+    result = get_title(session)
+    assert_success(result, u'® © ¢ £ ¥')
+
+
+def test_title_included_multibyte_char(session, inline):
+    session.url = inline(u"<title>日本語</title>")
+
+    result = get_title(session)
+    assert_success(result, u"日本語")


### PR DESCRIPTION
This PR adds tests for <title> tag values containing multibyte characters, such as entity references and CJK languages.

We want to use these tests to confirm bugs reported in WebKit https://bugs.webkit.org/show_bug.cgi?id=270063.