### PR TITLE
[webdriver] Revert workaround for Chrome when setting window rect

### DIFF
--- a/webdriver/tests/support/fixtures.py
+++ b/webdriver/tests/support/fixtures.py
@@ -174,12 +174,8 @@ async def session(capabilities, configuration):
 
     # Enforce a fixed default window size and position
     if _current_session.capabilities.get("setWindowRect"):
-        # Only resize and reposition if needed to workaround a bug for Chrome:
-        # https://bugs.chromium.org/p/chromedriver/issues/detail?id=4642#c4
-        if _current_session.window.size != defaults.WINDOW_SIZE:
-            _current_session.window.size = defaults.WINDOW_SIZE
-        if _current_session.window.position != defaults.WINDOW_POSITION:
-            _current_session.window.position = defaults.WINDOW_POSITION
+        _current_session.window.size = defaults.WINDOW_SIZE
+        _current_session.window.position = defaults.WINDOW_POSITION
 
     # Set default timeouts
     multiplier = configuration["timeout_multiplier"]
@@ -226,12 +222,8 @@ async def bidi_session(capabilities, configuration):
 
     # Enforce a fixed default window size and position
     if _current_session.capabilities.get("setWindowRect"):
-        # Only resize and reposition if needed to workaround a bug for Chrome:
-        # https://bugs.chromium.org/p/chromedriver/issues/detail?id=4642#c4
-        if _current_session.window.size != defaults.WINDOW_SIZE:
-            _current_session.window.size = defaults.WINDOW_SIZE
-        if _current_session.window.position != defaults.WINDOW_POSITION:
-            _current_session.window.position = defaults.WINDOW_POSITION
+        _current_session.window.size = defaults.WINDOW_SIZE
+        _current_session.window.position = defaults.WINDOW_POSITION
 
     yield _current_session.bidi_session
 

--- a/webdriver/tests/support/helpers.py
+++ b/webdriver/tests/support/helpers.py
@@ -55,19 +55,10 @@ def cleanup_session(session):
         """Reset window to an acceptable size.
 
         This also includes bringing it out of maximized, minimized,
-        or fullscreened state.
+        or fullscreen state.
         """
         if session.capabilities.get("setWindowRect"):
-            # Only restore if needed to workaround a bug for Chrome:
-            # https://bugs.chromium.org/p/chromedriver/issues/detail?id=4642#c4
-            if (
-                session.capabilities.get("browserName") != "chrome" or
-                session.window.size != defaults.WINDOW_SIZE
-                or document_hidden(session)
-                or is_fullscreen(session)
-                or is_maximized(session)
-            ):
-                session.window.size = defaults.WINDOW_SIZE
+            session.window.size = defaults.WINDOW_SIZE
 
     @ignore_exceptions
     def _restore_windows(session):


### PR DESCRIPTION
This reverts parts of https://github.com/web-platform-tests/wpt/pull/43853 (without the meta timeout changes). Lets see how it works. CC @nechaev-chromium @sadym-chromium.