### PR TITLE
[wptrunner] Mark WebDriver protocol as not alive in other cases

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/virtual_authenticator.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/virtual_authenticator.html.ini
@@ -1,6 +1,6 @@
 [virtual_authenticator.html]
   expected:
-    if product == "safari": ERROR
+    if product == "safari": CRASH
 
   [Can create an authenticator]
     expected:

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -517,7 +517,7 @@ class WebDriverProtocol(Protocol):
             # 5 seconds of extra_timeout we have as maximum to end the test before
             # the external timeout from testrunner triggers.
             self.webdriver.send_session_command("GET", "window", timeout=2)
-        except (socket.timeout, error.UnknownErrorException, error.InvalidSessionIdException):
+        except (OSError, error.UnknownErrorException, error.InvalidSessionIdException):
             return False
         return True
 

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -517,7 +517,7 @@ class WebDriverProtocol(Protocol):
             # 5 seconds of extra_timeout we have as maximum to end the test before
             # the external timeout from testrunner triggers.
             self.webdriver.send_session_command("GET", "window", timeout=2)
-        except (OSError, error.UnknownErrorException, error.InvalidSessionIdException):
+        except (OSError, error.WebDriverException):
             return False
         return True
 
@@ -630,11 +630,7 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
             #
             # https://github.com/w3c/webdriver/issues/1308
             if not isinstance(result, list) or len(result) != 3:
-                try:
-                    is_alive = self.is_alive()
-                except error.WebDriverException:
-                    is_alive = False
-
+                is_alive = self.is_alive()
                 if not is_alive:
                     raise Exception("Browser crashed during script execution.")
 

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -776,9 +776,12 @@ class WdspecProtocol(ConnectionlessProtocol):
         proof enough to us that the server is alive and kicking.
         """
         conn = HTTPConnection(self.browser.host, self.browser.port)
-        conn.request("HEAD", "/invalid")
-        res = conn.getresponse()
-        return res.status == 404
+        try:
+            conn.request("HEAD", "/invalid")
+            res = conn.getresponse()
+            return res.status == 404
+        except OSError:
+            return False
 
 
 class VirtualSensorProtocolPart(ProtocolPart):


### PR DESCRIPTION
This is a follow-up improvement to #45833. `Protocol.is_alive()` should handle a browser that's unable to even establish the low-level transport. `OSError` is a sufficiently broad base exception, which encompasses [`socket.timeout`](https://docs.python.org/3/library/socket.html#socket.timeout), `IOError`, and the [`Connection*Error` family](https://docs.python.org/3/library/exceptions.html#ConnectionError).

This aligns `{WebDriver,Wdspec}Protocol` better with other implementations:

https://github.com/web-platform-tests/wpt/blob/3b3d9cb7c8ed9e8b30299df927b74a30aea1f8a1/tools/wptrunner/wptrunner/executors/executormarionette.py#L845-L846

Also, for `WebDriverProtocol`, coerce any WebDriver-specific exception to "not alive", which the testdriver loop already did.