### PR TITLE
[webdriver] Fix WebDriver error dunder methods

### DIFF
--- a/tools/webdriver/webdriver/bidi/error.py
+++ b/tools/webdriver/webdriver/bidi/error.py
@@ -12,14 +12,14 @@ class BidiException(Exception):
     error_code: ClassVar[str]
 
     def __init__(self, message: str, stacktrace: Optional[str] = None):
-        super()
+        super().__init__()
 
         self.message = message
         self.stacktrace = stacktrace
 
     def __repr__(self):
         """Return the object representation in string format."""
-        return f"{self.__class__.__name__}({self.error}, {self.message}, {self.stacktrace})"
+        return f"{self.__class__.__name__}({self.error_code}, {self.message}, {self.stacktrace})"
 
     def __str__(self):
         """Return the string representation of the object."""

--- a/tools/webdriver/webdriver/error.py
+++ b/tools/webdriver/webdriver/error.py
@@ -16,7 +16,7 @@ class WebDriverException(Exception):
     status_code: ClassVar[str]
 
     def __init__(self, http_status=None, status_code=None, message=None, stacktrace=None):
-        super()
+        super().__init__()
 
         if http_status is not None:
             self.http_status = http_status


### PR DESCRIPTION
* `super()` alone retrieves the superclass type. Calling `__init__()` on it actually runs the superclass constructor.
* `BidiException` doesn't have an `error` attribute. This probably should have been `error_code`.