### PR TITLE
Digital Credentials: test create and get

### DIFF
--- a/digital-credentials/dc-types.ts
+++ b/digital-credentials/dc-types.ts
@@ -1,0 +1,70 @@
+export type ProviderType = "default" | "openid4vp";
+
+/**
+ * @see https://wicg.github.io/digital-credentials/#dom-identityrequestprovider
+ */
+export interface IdentityRequestProvider {
+  protocol: string;
+  request: object;
+}
+
+/**
+ * @see https://wicg.github.io/digital-credentials/#dom-digitalcredentialrequestoptions
+ */
+export interface DigitalCredentialRequestOptions {
+  /**
+   * The list of identity request providers
+   */
+  providers: IdentityRequestProvider[] | any;
+}
+
+/**
+ * @see https://wicg.github.io/digital-credentials/#extensions-to-credentialrequestoptions-dictionary
+ */
+export interface CredentialRequestOptions {
+  /**
+   * The digital credential request options.
+   */
+  digital: DigitalCredentialRequestOptions;
+}
+
+/**
+ * The actions that can be performed on the API via the iframe.
+ */
+export type IframeActionType = "create" | "get" | "preventSilentAccess";
+
+/**
+ * If present, when the abort controller should be aborted
+ * relative the invocation of the API.
+ */
+export type AbortType = "before" | "after";
+
+export interface EventData {
+  /**
+   * Action to perform on the API.
+   */
+  action: IframeActionType;
+  /**
+   * If the action should be aborted, and when.
+   */
+  abort?: AbortType;
+  /**
+   * The options to pass to the API.
+   */
+  options?: object;
+}
+
+
+
+export interface SendMessageData {
+  action: IframeActionType;
+  options?: CredentialRequestOptions;
+}
+
+/**
+ * @param {HTMLIFrameElement} iframe - The iframe element to send the message to.
+ * @param {SendMessageData} data - The data to be sent to the iframe.
+ * @returns {Promise<any>} - A promise that resolves with the response from the iframe.
+ */
+export type SendMessage = (iframe: HTMLIFrameElement, data: SendMessageData) => Promise<any>;
+

--- a/digital-credentials/dc-types.ts
+++ b/digital-credentials/dc-types.ts
@@ -52,19 +52,13 @@ export interface EventData {
    * The options to pass to the API.
    */
   options?: object;
+  /**
+  * If the API needs to blessed before the action is performed.
+  */
+  needsUserActivation?: boolean;
 }
-
-
 
 export interface SendMessageData {
   action: IframeActionType;
   options?: CredentialRequestOptions;
 }
-
-/**
- * @param {HTMLIFrameElement} iframe - The iframe element to send the message to.
- * @param {SendMessageData} data - The data to be sent to the iframe.
- * @returns {Promise<any>} - A promise that resolves with the response from the iframe.
- */
-export type SendMessage = (iframe: HTMLIFrameElement, data: SendMessageData) => Promise<any>;
-

--- a/digital-credentials/dc-types.ts
+++ b/digital-credentials/dc-types.ts
@@ -31,7 +31,7 @@ export interface CredentialRequestOptions {
 /**
  * The actions that can be performed on the API via the iframe.
  */
-export type IframeActionType = "create" | "get" | "preventSilentAccess";
+export type IframeActionType = "create" | "get" | "ping" | "preventSilentAccess" ;
 
 /**
  * If present, when the abort controller should be aborted

--- a/digital-credentials/get-user-activation.https.html
+++ b/digital-credentials/get-user-activation.https.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<title>Digital Credential API: get() consumes user activation.</title>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body></body>
+<script>
+  promise_test(async (t) => {
+    assert_false(
+        navigator.userActivation.isActive,
+        "User activation should not be active"
+    );
+    await promise_rejects_dom(t, "NotAllowedError", navigator.identity.get({}));
+  }, "navigator.identity.get() calling the API without user activation should reject with NotAllowedError.");
+
+  promise_test(async (t) => {
+    await test_driver.bless();
+    assert_true(
+        navigator.userActivation.isActive,
+        "User activation should be active after test_driver.bless()."
+    );
+    await promise_rejects_dom(
+        t,
+        "NotSupportedError",
+        navigator.identity.get({})
+    );
+    assert_false(
+        navigator.userActivation.isActive,
+        "User activation should be consumed after navigator.identity.get()."
+    );
+  }, "navigator.identity.get() consumes user activation.");
+</script>

--- a/digital-credentials/get-user-activation.https.html
+++ b/digital-credentials/get-user-activation.https.html
@@ -8,26 +8,30 @@
 <script>
   promise_test(async (t) => {
     assert_false(
-        navigator.userActivation.isActive,
-        "User activation should not be active"
+      navigator.userActivation.isActive,
+      "User activation should not be active"
     );
-    await promise_rejects_dom(t, "NotAllowedError", navigator.identity.get({}));
+    await promise_rejects_dom(
+      t,
+      "NotAllowedError",
+      navigator.identity.get({ digitial: [] })
+    );
   }, "navigator.identity.get() calling the API without user activation should reject with NotAllowedError.");
 
   promise_test(async (t) => {
     await test_driver.bless();
     assert_true(
-        navigator.userActivation.isActive,
-        "User activation should be active after test_driver.bless()."
+      navigator.userActivation.isActive,
+      "User activation should be active after test_driver.bless()."
     );
     await promise_rejects_dom(
-        t,
-        "NotSupportedError",
-        navigator.identity.get({})
+      t,
+      "NotSupportedError",
+      navigator.identity.get({ digitial: [] })
     );
     assert_false(
-        navigator.userActivation.isActive,
-        "User activation should be consumed after navigator.identity.get()."
+      navigator.userActivation.isActive,
+      "User activation should be consumed after navigator.identity.get()."
     );
   }, "navigator.identity.get() consumes user activation.");
 </script>

--- a/digital-credentials/get-user-activation.https.html
+++ b/digital-credentials/get-user-activation.https.html
@@ -4,8 +4,11 @@
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="support/helper.js" type="module"></script>
 <body></body>
-<script>
+<script type="module">
+  import { makeGetOptions } from "./support/helper.js";
+
   promise_test(async (t) => {
     assert_false(
       navigator.userActivation.isActive,
@@ -14,7 +17,7 @@
     await promise_rejects_dom(
       t,
       "NotAllowedError",
-      navigator.identity.get({ digitial: [] })
+      navigator.identity.get({ digital: { providers: [makeGetOptions("openid4vp")] } })
     );
   }, "navigator.identity.get() calling the API without user activation should reject with NotAllowedError.");
 
@@ -27,7 +30,7 @@
     await promise_rejects_dom(
       t,
       "NotSupportedError",
-      navigator.identity.get({ digitial: [] })
+      navigator.identity.get({ digital: { providers: [makeGetOptions("openid4vp")] } })
     );
     assert_false(
       navigator.userActivation.isActive,

--- a/digital-credentials/get-user-activation.https.html
+++ b/digital-credentials/get-user-activation.https.html
@@ -14,7 +14,7 @@
       navigator.userActivation.isActive,
       "User activation should not be active"
     );
-    const options = makeGetOptions();
+    const options = makeGetOptions([]);
     await promise_rejects_dom(
       t,
       "NotAllowedError",
@@ -28,12 +28,8 @@
       navigator.userActivation.isActive,
       "User activation should be active after test_driver.bless()."
     );
-    const options = makeGetOptions();
-    await promise_rejects_dom(
-      t,
-      "NotSupportedError",
-      navigator.identity.get(options)
-    );
+    const options = makeGetOptions([]);
+    await promise_rejects_js(t, TypeError, navigator.identity.get(options));
     assert_false(
       navigator.userActivation.isActive,
       "User activation should be consumed after navigator.identity.get()."

--- a/digital-credentials/get-user-activation.https.html
+++ b/digital-credentials/get-user-activation.https.html
@@ -14,10 +14,11 @@
       navigator.userActivation.isActive,
       "User activation should not be active"
     );
+    const options = makeGetOptions();
     await promise_rejects_dom(
       t,
       "NotAllowedError",
-      navigator.identity.get({ digital: { providers: [makeGetOptions("openid4vp")] } })
+      navigator.identity.get(options)
     );
   }, "navigator.identity.get() calling the API without user activation should reject with NotAllowedError.");
 
@@ -27,10 +28,11 @@
       navigator.userActivation.isActive,
       "User activation should be active after test_driver.bless()."
     );
+    const options = makeGetOptions();
     await promise_rejects_dom(
       t,
       "NotSupportedError",
-      navigator.identity.get({ digital: { providers: [makeGetOptions("openid4vp")] } })
+      navigator.identity.get(options)
     );
     assert_false(
       navigator.userActivation.isActive,

--- a/digital-credentials/identity-create.tentative.https.html
+++ b/digital-credentials/identity-create.tentative.https.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<title>Digital Identity Credential tests.</title>
+<link rel="help" href="https://wicg.github.io/digital-credentials/" />
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<body>
+  <iframe id="same-origin"></iframe>
+  <iframe id="cross-origin"></iframe>
+</body>
+
+<script type="module">
+  import { sendMessage, loadIframe } from "./support/helper.js";
+
+  const iframeSameOrigin = document.querySelector("iframe#same-origin");
+  const iframeCrossOrigin = document.querySelector("iframe#cross-origin");
+  const mediations = ["silent", "optional", "conditional", "required"];
+
+  promise_setup(async () => {
+    const hostInfo = get_host_info();
+    await Promise.all([
+      loadIframe(
+        iframeCrossOrigin,
+        `${hostInfo.HTTPS_REMOTE_ORIGIN}/digital-credentials/support/iframe.html`
+      ),
+      loadIframe(iframeSameOrigin, "/digital-credentials/support/iframe.html"),
+    ]);
+  });
+
+  promise_test(async (t) => {
+    const result = await navigator.identity.create();
+    assert_equals(result, null);
+  }, "navigator.identity.create() frame just returns null.");
+
+  promise_test(async (t) => {
+    const { contentWindow: iframeWindow } = iframeSameOrigin;
+    const result = await iframeWindow.navigator.identity.create();
+    assert_equals(result, null);
+  }, "navigator.identity.create() same-origin iframe just returns null.");
+
+  promise_test(async (t) => {
+    const result = await sendMessage(iframeCrossOrigin, {
+      action: "create",
+    });
+    assert_equals(result, null);
+  }, "navigator.identity.create() cross-origin iframe results in null.");
+
+  promise_test(async () => {
+    for (const mediation of mediations) {
+      const result = await navigator.identity.create({ mediation });
+      assert_equals(result, null);
+    }
+  }, "navigator.identity.create() ignores mediations.");
+
+  promise_test(async () => {
+    for (const mediation of mediations) {
+      const result = await navigator.identity.create({ mediation });
+      assert_equals(result, null);
+    }
+  }, "navigator.identity.create() ignores mediations in same-origin iframe.");
+
+  promise_test(async () => {
+    for (const mediation of mediations) {
+      const result = await sendMessage(iframeCrossOrigin, {
+        action: "create",
+        request: { mediation },
+      });
+      assert_equals(result, null);
+    }
+  }, "navigator.identity.create() ignores mediations in cross-origin iframe.");
+
+  promise_test(async (t) => {
+    const abortController = new AbortController();
+    const { signal } = abortController;
+    abortController.abort();
+    await promise_rejects_dom(
+      t,
+      "AbortError",
+      navigator.identity.create({
+        signal,
+      })
+    );
+  }, "navigator.identity.create() rejects if called with an aborted signal.");
+
+  promise_test(async (t) => {
+    const { contentWindow: iframeWindow } = iframeSameOrigin;
+    const abortController = new iframeWindow.AbortController();
+    const { signal } = abortController;
+    abortController.abort();
+    await promise_rejects_dom(
+      t,
+      "AbortError",
+      iframeWindow.DOMException,
+      iframeWindow.navigator.identity.create({
+        signal,
+      })
+    );
+  }, "navigator.identity.create() rejects if called with an aborted signal in same-origin iframe.");
+
+  promise_test(async (t) => {
+    const result = await sendMessage(iframeCrossOrigin, {
+      action: "create",
+      abort: "before",
+    });
+    assert_equals(result.constructor, "DOMException");
+    assert_equals(result.name, "AbortError");
+  }, "navigator.identity.create() rejects if called with an aborted signal in cross-origin iframe.");
+
+  promise_test(async (t) => {
+    const abortController = new AbortController();
+    const { signal } = abortController;
+    abortController.abort();
+    for (const mediation of mediations) {
+      const requestPromise = navigator.identity.create({
+        mediation,
+        signal,
+      });
+      await promise_rejects_dom(t, "AbortError", requestPromise);
+    }
+  }, "Adding mediations together with abort signal respects the abort signal.");
+</script>

--- a/digital-credentials/identity-get.tentative.https.html
+++ b/digital-credentials/identity-get.tentative.https.html
@@ -29,91 +29,72 @@
   });
 
   promise_test(async (t) => {
-    await test_driver.bless("user activation");
-    promise_rejects_dom(t, "NotSupportedError", navigator.identity.get());
-
-    await test_driver.bless("user activation");
-    promise_rejects_dom(t, "NotSupportedError", navigator.identity.get({}));
-
-    await test_driver.bless("user activation");
-    promise_rejects_dom(
-      t,
-      "NotSupportedError",
-      navigator.identity.get({ x: "y" })
-    );
-
-    await test_driver.bless("user activation");
-    promise_rejects_dom(
-      t,
-      "NotSupportedError",
-      navigator.identity.get({ x: "y", y: "z" })
-    );
-
-    await test_driver.bless("user activation");
-    promise_rejects_dom(
-      t,
-      "NotSupportedError",
-      navigator.identity.get({ x: "y" })
-    );
-
-    await test_driver.bless("user activation");
-    promise_rejects_dom(
-      t,
-      "NotSupportedError",
-      navigator.identity.get({ mediation: "required" })
-    );
-
-    const abortController = new AbortController();
-    const { signal } = abortController;
-
-    await test_driver.bless("user activation");
-    await promise_rejects_dom(
-      t,
-      "NotSupportedError",
-      navigator.identity.get({ signal })
-    );
-
-    await test_driver.bless("user activation");
-    await promise_rejects_dom(
-      t,
-      "NotSupportedError",
-      navigator.identity.get({ signal, mediation: "required" })
-    );
-  }, "Calling navigator.identity.get() without an digital member.");
-
-  promise_test(async (t) => {
     iframeSameOrigin.focus();
-    const { contentWindow: iframeWindow } = iframeSameOrigin;
+    for (const global of [window, iframeSameOrigin.contentWindow]) {
+      await promise_rejects_dom(
+        t,
+        "NotSupportedError",
+        global.DOMException,
+        global.navigator.identity.get()
+      );
 
-    await test_driver.bless("user activation");
-    promise_rejects_dom(
-      t,
-      "NotSupportedError",
-      iframeWindow.DOMException,
-      iframeWindow.navigator.identity.get()
-    );
+      await promise_rejects_dom(
+        t,
+        "NotSupportedError",
+        global.DOMException,
+        global.navigator.identity.get({})
+      );
 
-    await test_driver.bless("user activation");
-    promise_rejects_dom(
-      t,
-      "NotSupportedError",
-      iframeWindow.DOMException,
-      iframeWindow.navigator.identity.get({})
-    );
+      await promise_rejects_dom(
+        t,
+        "NotSupportedError",
+        global.DOMException,
+        global.navigator.identity.get({ x: "y" })
+      );
 
-    await test_driver.bless("user activation");
-    promise_rejects_dom(
-      t,
-      "NotSupportedError",
-      iframeWindow.DOMException,
-      iframeWindow.navigator.identity.get({ x: "y" })
-    );
-  }, "Calling navigator.identity.get() without an digitral member same-origin iframe.");
+      await promise_rejects_dom(
+        t,
+        "NotSupportedError",
+        global.DOMException,
+        global.navigator.identity.get({ x: "y", y: "z" })
+      );
+
+      await promise_rejects_dom(
+        t,
+        "NotSupportedError",
+        global.DOMException,
+        global.navigator.identity.get({ x: "y" })
+      );
+
+      await promise_rejects_dom(
+        t,
+        "NotSupportedError",
+        global.DOMException,
+        global.navigator.identity.get({ mediation: "required" })
+      );
+
+      const abortController = new AbortController();
+      const { signal } = abortController;
+
+      await promise_rejects_dom(
+        t,
+        "NotSupportedError",
+        global.DOMException,
+        global.navigator.identity.get({ signal })
+      );
+
+      await promise_rejects_dom(
+        t,
+        "NotSupportedError",
+        global.DOMException,
+        global.navigator.identity.get({ signal, mediation: "required" })
+      );
+    }
+  }, "Calling navigator.identity.get() without an digital member same origin.");
 
   promise_test(async (t) => {
     for (const provider of [undefined, []]) {
       const options = makeGetOptions(provider);
-      await test_driver.bless("user activation");
       await promise_rejects_js(t, TypeError, navigator.identity.get(options));
     }
   }, "navigator.identity.get() API rejects if there are no providers.");
@@ -123,7 +104,6 @@
     const { contentWindow: iframeWindow } = iframeSameOrigin;
     for (const provider of [undefined, []]) {
       const options = makeGetOptions(provider);
-      await test_driver.bless("user activation");
       await promise_rejects_js(
         t,
         iframeWindow.TypeError,
@@ -163,7 +143,6 @@
     const { signal } = abortController;
     abortController.abort();
     for (const options of [{ signal }, { signal, ...makeGetOptions([]) }]) {
-      await test_driver.bless("user activation");
       await promise_rejects_dom(
         t,
         "AbortError",

--- a/digital-credentials/identity-get.tentative.https.html
+++ b/digital-credentials/identity-get.tentative.https.html
@@ -41,6 +41,44 @@
       "NotSupportedError",
       navigator.identity.get({ x: "y" })
     );
+
+    await test_driver.bless("user activation");
+    promise_rejects_dom(
+      t,
+      "NotSupportedError",
+      navigator.identity.get({ x: "y", y: "z" })
+    );
+
+    await test_driver.bless("user activation");
+    promise_rejects_dom(
+      t,
+      "NotSupportedError",
+      navigator.identity.get({ x: "y" })
+    );
+
+    await test_driver.bless("user activation");
+    promise_rejects_dom(
+      t,
+      "NotSupportedError",
+      navigator.identity.get({ mediation: "required" })
+    );
+
+    const abortController = new AbortController();
+    const { signal } = abortController;
+
+    await test_driver.bless("user activation");
+    await promise_rejects_dom(
+      t,
+      "NotSupportedError",
+      navigator.identity.get({ signal })
+    );
+
+    await test_driver.bless("user activation");
+    await promise_rejects_dom(
+      t,
+      "NotSupportedError",
+      navigator.identity.get({ signal, mediation: "required" })
+    );
   }, "Calling navigator.identity.get() without an digital member.");
 
   promise_test(async (t) => {

--- a/digital-credentials/identity-get.tentative.https.html
+++ b/digital-credentials/identity-get.tentative.https.html
@@ -9,10 +9,10 @@
 
 <body>
   <iframe id="same-origin"></iframe>
-  <iframe id="cross-origin"></iframe>
+  <iframe id="cross-origin" allow="digital-credentials-get"></iframe>
 </body>
 <script type="module">
-  import { makeGetOptions, sendMessage, loadIFrame } from "./support/helper.js";
+  import { makeGetOptions, sendMessage, loadIframe } from "./support/helper.js";
 
   const iframeSameOrigin = document.querySelector("iframe#same-origin");
   const iframeCrossOrigin = document.querySelector("iframe#cross-origin");
@@ -29,8 +29,13 @@
   });
 
   promise_test(async (t) => {
+    await test_driver.bless("user activation");
     promise_rejects_dom(t, "NotSupportedError", navigator.identity.get());
+
+    await test_driver.bless("user activation");
     promise_rejects_dom(t, "NotSupportedError", navigator.identity.get({}));
+
+    await test_driver.bless("user activation");
     promise_rejects_dom(
       t,
       "NotSupportedError",
@@ -39,19 +44,26 @@
   }, "Calling navigator.identity.get() without an digital member.");
 
   promise_test(async (t) => {
+    iframeSameOrigin.focus();
     const { contentWindow: iframeWindow } = iframeSameOrigin;
+
+    await test_driver.bless("user activation");
     promise_rejects_dom(
       t,
       "NotSupportedError",
       iframeWindow.DOMException,
       iframeWindow.navigator.identity.get()
     );
+
+    await test_driver.bless("user activation");
     promise_rejects_dom(
       t,
       "NotSupportedError",
       iframeWindow.DOMException,
       iframeWindow.navigator.identity.get({})
     );
+
+    await test_driver.bless("user activation");
     promise_rejects_dom(
       t,
       "NotSupportedError",
@@ -63,14 +75,17 @@
   promise_test(async (t) => {
     for (const provider of [undefined, []]) {
       const options = makeGetOptions(provider);
+      await test_driver.bless("user activation");
       await promise_rejects_js(t, TypeError, navigator.identity.get(options));
     }
   }, "navigator.identity.get() API rejects if there are no providers.");
 
   promise_test(async (t) => {
+    iframeSameOrigin.focus();
     const { contentWindow: iframeWindow } = iframeSameOrigin;
     for (const provider of [undefined, []]) {
       const options = makeGetOptions(provider);
+      await test_driver.bless("user activation");
       await promise_rejects_js(
         t,
         iframeWindow.TypeError,
@@ -80,6 +95,7 @@
   }, "navigator.identity.get() API rejects if there are no providers for same-origin iframe.");
 
   promise_test(async (t) => {
+    iframeCrossOrigin.focus();
     for (const provider of [undefined, []]) {
       const options = makeGetOptions(provider);
       const result = await sendMessage(iframeCrossOrigin, {
@@ -109,11 +125,16 @@
     const { signal } = abortController;
     abortController.abort();
     for (const options of [{ signal }, { signal, ...makeGetOptions([]) }]) {
+      await test_driver.bless("user activation");
       await promise_rejects_dom(
         t,
         "AbortError",
         iframeWindow.DOMException,
         iframeWindow.navigator.identity.get(options)
+      );
+      assert_true(
+        navigator.userActivation.isActive,
+        "User activation is still active."
       );
     }
   }, "navigator.identity.get() promise is rejected if called with an aborted signal in same-origin iframe.");

--- a/digital-credentials/identity-get.tentative.https.html
+++ b/digital-credentials/identity-get.tentative.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<title>Digital Identity Credential tests.</title>
-<link rel="help" href="https://wicg.github.io/digital-identities/">
+<title>Digital Credential tests.</title>
+<link rel="help" href="https://wicg.github.io/digital-credentials/" />
 <script src="/common/get-host-info.sub.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -8,27 +8,125 @@
 <script src="/resources/testdriver-vendor.js"></script>
 
 <body>
+  <iframe id="same-origin"></iframe>
+  <iframe id="cross-origin"></iframe>
+</body>
 <script type="module">
-import { buildValidNavigatorIdentityRequest, requestIdentityWithActivation } from './support/helper.js';
+  import { makeGetOptions, sendMessage, loadIFrame } from "./support/helper.js";
 
-// This regex removes the filename from the path so that we just get
-// the directory.
-const host = get_host_info();
-const basePath = window.location.pathname.replace(/\/[^\/]*$/, '/');
-const remoteBaseURL = host.HTTPS_REMOTE_ORIGIN + basePath;
+  const iframeSameOrigin = document.querySelector("iframe#same-origin");
+  const iframeCrossOrigin = document.querySelector("iframe#cross-origin");
 
-// Requires browser to have mode where OS-presented digital-identity-prompt is
-// bypassed in favour of returning "fake_test_token" directly.
+  promise_setup(async () => {
+    const hostInfo = get_host_info();
+    await Promise.all([
+      loadIframe(
+        iframeCrossOrigin,
+        `${hostInfo.HTTPS_REMOTE_ORIGIN}/digital-credentials/support/iframe.html`
+      ),
+      loadIframe(iframeSameOrigin, "/digital-credentials/support/iframe.html"),
+    ]);
+  });
 
-promise_test(async t => {
-  let request = buildValidNavigatorIdentityRequest();
-  request.digital.providers = undefined;
-  await promise_rejects_js(t, TypeError, requestIdentityWithActivation(test_driver, request));
-}, "navigator.identity.get() API fails if DigitalCredentialRequestOptions::providers is not specified.");
+  promise_test(async (t) => {
+    promise_rejects_dom(t, "NotSupportedError", navigator.identity.get());
+    promise_rejects_dom(t, "NotSupportedError", navigator.identity.get({}));
+    promise_rejects_dom(
+      t,
+      "NotSupportedError",
+      navigator.identity.get({ x: "y" })
+    );
+  }, "Calling navigator.identity.get() without an digital member.");
 
-promise_test(async t => {
-  let request = buildValidNavigatorIdentityRequest();
-  request.digital.providers = [];
-  await promise_rejects_js(t, TypeError, requestIdentityWithActivation(test_driver, request));
-}, "navigator.identity.get() API fails if there are no providers.");
+  promise_test(async (t) => {
+    const { contentWindow: iframeWindow } = iframeSameOrigin;
+    promise_rejects_dom(
+      t,
+      "NotSupportedError",
+      iframeWindow.DOMException,
+      iframeWindow.navigator.identity.get()
+    );
+    promise_rejects_dom(
+      t,
+      "NotSupportedError",
+      iframeWindow.DOMException,
+      iframeWindow.navigator.identity.get({})
+    );
+    promise_rejects_dom(
+      t,
+      "NotSupportedError",
+      iframeWindow.DOMException,
+      iframeWindow.navigator.identity.get({ x: "y" })
+    );
+  }, "Calling navigator.identity.get() without an digitral member same-origin iframe.");
+
+  promise_test(async (t) => {
+    for (const provider of [undefined, []]) {
+      const options = makeGetOptions(provider);
+      await promise_rejects_js(t, TypeError, navigator.identity.get(options));
+    }
+  }, "navigator.identity.get() API rejects if there are no providers.");
+
+  promise_test(async (t) => {
+    const { contentWindow: iframeWindow } = iframeSameOrigin;
+    for (const provider of [undefined, []]) {
+      const options = makeGetOptions(provider);
+      await promise_rejects_js(
+        t,
+        iframeWindow.TypeError,
+        iframeWindow.navigator.identity.get(options)
+      );
+    }
+  }, "navigator.identity.get() API rejects if there are no providers for same-origin iframe.");
+
+  promise_test(async (t) => {
+    for (const provider of [undefined, []]) {
+      const options = makeGetOptions(provider);
+      const result = await sendMessage(iframeCrossOrigin, {
+        action: "get",
+        options,
+      });
+      assert_equals(result.constructor, "TypeError");
+    }
+  }, "navigator.identity.get() API rejects if there are no providers in cross-origin iframe.");
+
+  promise_test(async (t) => {
+    const abortController = new AbortController();
+    const { signal } = abortController;
+    abortController.abort();
+    for (const options of [{ signal }, { signal, ...makeGetOptions([]) }]) {
+      await promise_rejects_dom(
+        t,
+        "AbortError",
+        navigator.identity.get(options)
+      );
+    }
+  }, "navigator.identity.get() promise is rejected if called with an aborted signal.");
+
+  promise_test(async (t) => {
+    const { contentWindow: iframeWindow } = iframeSameOrigin;
+    const abortController = new iframeWindow.AbortController();
+    const { signal } = abortController;
+    abortController.abort();
+    for (const options of [{ signal }, { signal, ...makeGetOptions([]) }]) {
+      await promise_rejects_dom(
+        t,
+        "AbortError",
+        iframeWindow.DOMException,
+        iframeWindow.navigator.identity.get(options)
+      );
+    }
+  }, "navigator.identity.get() promise is rejected if called with an aborted signal in same-origin iframe.");
+
+  promise_test(async (t) => {
+    for (const options of [undefined, {}, makeGetOptions([])]) {
+      const result = await sendMessage(iframeCrossOrigin, {
+        abort: "before",
+        action: "get",
+        options,
+      });
+      assert_equals(result.constructor, "DOMException");
+      assert_equals(result.name, "AbortError");
+    }
+  }, "navigator.identity.get() promise is rejected if called with an aborted signal in cross-origin iframe.");
 </script>

--- a/digital-credentials/identity-get.tentative.https.html
+++ b/digital-credentials/identity-get.tentative.https.html
@@ -169,7 +169,7 @@
   promise_test(async (t) => {
     const abortController = new AbortController();
     const { signal } = abortController;
-    const options = makeGetOptions(["openid4vp"]);
+    const options = makeGetOptions("openid4vp");
     await test_driver.bless("user activation");
     const promise = promise_rejects_dom(
       t,
@@ -187,7 +187,7 @@
       abort: "after",
       action: "get",
       needsActivation: true,
-      options: makeGetOptions(["openid4vp"]),
+      options: makeGetOptions("openid4vp"),
     });
     assert_equals(result.constructor, "DOMException");
     assert_equals(result.name, "AbortError");

--- a/digital-credentials/identity-get.tentative.https.html
+++ b/digital-credentials/identity-get.tentative.https.html
@@ -63,13 +63,6 @@
         t,
         "NotSupportedError",
         global.DOMException,
-        global.navigator.identity.get({ x: "y" })
-      );
-
-      await promise_rejects_dom(
-        t,
-        "NotSupportedError",
-        global.DOMException,
         global.navigator.identity.get({ mediation: "required" })
       );
 

--- a/digital-credentials/identity-get.tentative.https.html
+++ b/digital-credentials/identity-get.tentative.https.html
@@ -88,6 +88,7 @@
   promise_test(async (t) => {
     for (const provider of [undefined, []]) {
       const options = makeGetOptions(provider);
+      await test_driver.bless("user activation");
       await promise_rejects_js(t, TypeError, navigator.identity.get(options));
     }
   }, "navigator.identity.get() API rejects if there are no providers.");
@@ -97,6 +98,7 @@
     const { contentWindow: iframeWindow } = iframeSameOrigin;
     for (const provider of [undefined, []]) {
       const options = makeGetOptions(provider);
+      await test_driver.bless("user activation");
       await promise_rejects_js(
         t,
         iframeWindow.TypeError,
@@ -131,11 +133,13 @@
   }, "navigator.identity.get() promise is rejected if called with an aborted signal.");
 
   promise_test(async (t) => {
+    iframeCrossOrigin.focus();
     const { contentWindow: iframeWindow } = iframeSameOrigin;
     const abortController = new iframeWindow.AbortController();
     const { signal } = abortController;
     abortController.abort();
     for (const options of [{ signal }, { signal, ...makeGetOptions([]) }]) {
+      await test_driver.bless("user activation");
       await promise_rejects_dom(
         t,
         "AbortError",
@@ -150,6 +154,7 @@
   }, "navigator.identity.get() promise is rejected if called with an aborted signal in same-origin iframe.");
 
   promise_test(async (t) => {
+    iframeCrossOrigin.focus();
     for (const options of [undefined, {}, makeGetOptions([])]) {
       const result = await sendMessage(iframeCrossOrigin, {
         abort: "before",
@@ -177,6 +182,7 @@
   }, "navigator.identity.get() promise is rejected if abort controller is aborted after call to get().");
 
   promise_test(async (t) => {
+    iframeCrossOrigin.focus();
     const result = await sendMessage(iframeCrossOrigin, {
       abort: "after",
       action: "get",

--- a/digital-credentials/identity-get.tentative.https.html
+++ b/digital-credentials/identity-get.tentative.https.html
@@ -133,7 +133,7 @@
   }, "navigator.identity.get() promise is rejected if called with an aborted signal.");
 
   promise_test(async (t) => {
-    iframeCrossOrigin.focus();
+    iframeSameOrigin.focus();
     const { contentWindow: iframeWindow } = iframeSameOrigin;
     const abortController = new iframeWindow.AbortController();
     const { signal } = abortController;

--- a/digital-credentials/identity-get.tentative.https.html
+++ b/digital-credentials/identity-get.tentative.https.html
@@ -167,4 +167,30 @@
       assert_equals(result.name, "AbortError");
     }
   }, "navigator.identity.get() promise is rejected if called with an aborted signal in cross-origin iframe.");
+
+  promise_test(async (t) => {
+    const abortController = new AbortController();
+    const { signal } = abortController;
+    const options = makeGetOptions(["openid4vp"]);
+    await test_driver.bless("user activation");
+    const promise = promise_rejects_dom(
+      t,
+      "AbortError",
+      DOMException,
+      navigator.identity.get(options)
+    );
+    abortController.abort();
+    await promise;
+  }, "navigator.identity.get() promise is rejected if abort controller is aborted after call to get().");
+
+  promise_test(async (t) => {
+    const result = await sendMessage(iframeCrossOrigin, {
+      abort: "after",
+      action: "get",
+      needsActivation: true,
+      options: makeGetOptions(["openid4vp"]),
+    });
+    assert_equals(result.constructor, "DOMException");
+    assert_equals(result.name, "AbortError");
+  }, "navigator.identity.get() promise is rejected if abort controller is aborted after call to get() in cross-origin iframe.");
 </script>

--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -1,26 +1,89 @@
-// Builds valid digital identity request for navigator.identity.get() API.
-export function buildValidNavigatorIdentityRequest() {
+// @ts-check
+// Import the types from the TypeScript file
+/**
+ * @typedef {import('../dc-types').ProviderType} ProviderType
+ * @typedef {import('../dc-types').IdentityRequestProvider} IdentityRequestProvider
+ * @typedef {import('../dc-types').DigitalCredentialRequestOptions} DigitalCredentialRequestOptions
+ * @typedef {import('../dc-types').CredentialRequestOptions} CredentialRequestOptions
+ * @typedef {import('../dc-types').SendMessage} SendMessage
+ */
+/**
+ * @param {ProviderType[]} [providersToUse=["default"]] - An array that can only contain "default" or "oid4vp".
+ * @returns {CredentialRequestOptions}
+ */
+export function makeGetOptions(providersToUse = ["default"]) {
+  if (!Array.isArray(providersToUse) || !providersToUse?.length) {
+    return { digital: { providers: providersToUse } };
+  }
+  const providers = [];
+  for (const provider of providersToUse) {
+    switch (provider) {
+      case "openid4vp":
+        providers.push(makeOID4VPDict());
+        break;
+      default:
+        providers.push(makeIdentityRequestProvider(undefined, undefined));
+        break;
+    }
+  }
+  return { digital: { providers } };
+}
+/**
+ *
+ * @param {string} protocol
+ * @param {object} request
+ * @returns {IdentityRequestProvider}
+ */
+function makeIdentityRequestProvider(protocol = "protocol", request = {}) {
   return {
-      digital: {
-        providers: [{
-          protocol: "urn:openid.net:oid4vp",
-          request: JSON.stringify({
-            // Based on https://github.com/openid/OpenID4VP/issues/125
-            client_id: "client.example.org",
-            client_id_scheme: "web-origin",
-            nonce: "n-0S6_WzA2Mj",
-            presentation_definition: {
-              // Presentation Exchange request, omitted for brevity
-            }
-          }),
-        }],
-      },
+    protocol,
+    request,
   };
 }
 
-// Requests digital identity with user activation.
-export function requestIdentityWithActivation(test_driver, request) {
-  return test_driver.bless("request identity with activation", async function() {
-    return await navigator.identity.get(request);
+/**
+ * Representation of a digital identity object with an OpenID4VP provider
+ * @returns {IdentityRequestProvider}
+ **/
+function makeOID4VPDict() {
+  return makeIdentityRequestProvider("openid4vp", {
+    // Canonical example of an OpenID4VP request coming soon.
+  });
+}
+
+/**
+ * @type {SendMessage}
+ **/
+export function sendMessage(iframe, data) {
+  return new Promise((resolve, reject) => {
+    window.addEventListener("message", function messageListener(event) {
+      if (event.source === iframe.contentWindow) {
+        window.removeEventListener("message", messageListener);
+        resolve(event.data);
+      }
+    });
+    if (!iframe.contentWindow) {
+      reject(
+        new Error("iframe.contentWindow is undefined, cannot send message.")
+      );
+      return;
+    }
+    iframe.contentWindow.postMessage(data, "*");
+  });
+}
+
+/**
+ * @param {HTMLIFrameElement} iframe
+ * @param {string|URL} url
+ * @returns {Promise<void>}
+ */
+export function loadIFrame(iframe, url) {
+  return new Promise((resolve, reject) => {
+    iframe.addEventListener("load", resolve, { once: true });
+    iframe.addEventListener("error", reject, { once: true });
+    if (!iframe.isConnected) {
+      document.body.appendChild(iframe);
+    }
+    iframe.src = url.toString();
   });
 }

--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -42,7 +42,8 @@ function makeIdentityRequestProvider(protocol = "protocol", request = {}) {
 }
 
 /**
- * Representation of a digital identity object with an OpenID4VP provider
+ * Representation of a digital identity object with an OpenID4VP provider.
+ *
  * @returns {IdentityRequestProvider}
  **/
 function makeOID4VPDict() {
@@ -52,6 +53,8 @@ function makeOID4VPDict() {
 }
 
 /**
+ * Sends a message to an iframe and return the response.
+ *
  * @param {HTMLIFrameElement} iframe - The iframe element to send the message to.
  * @param {SendMessageData} data - The data to be sent to the iframe.
  * @returns {Promise<any>} - A promise that resolves with the response from the iframe.
@@ -77,6 +80,8 @@ export function sendMessage(iframe, data) {
 }
 
 /**
+ * Load an iframe with the specified URL and wait for it to load.
+ *
  * @param {HTMLIFrameElement} iframe
  * @param {string|URL} url
  * @returns {Promise<void>}

--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -5,7 +5,7 @@
  * @typedef {import('../dc-types').IdentityRequestProvider} IdentityRequestProvider
  * @typedef {import('../dc-types').DigitalCredentialRequestOptions} DigitalCredentialRequestOptions
  * @typedef {import('../dc-types').CredentialRequestOptions} CredentialRequestOptions
- * @typedef {import('../dc-types').SendMessage} SendMessage
+ * @typedef {import('../dc-types').SendMessageData} SendMessageData
  */
 /**
  * @param {ProviderType[]} [providersToUse=["default"]] - An array that can only contain "default" or "oid4vp".
@@ -52,22 +52,26 @@ function makeOID4VPDict() {
 }
 
 /**
- * @type {SendMessage}
- **/
+ * @param {HTMLIFrameElement} iframe - The iframe element to send the message to.
+ * @param {SendMessageData} data - The data to be sent to the iframe.
+ * @returns {Promise<any>} - A promise that resolves with the response from the iframe.
+ */
 export function sendMessage(iframe, data) {
   return new Promise((resolve, reject) => {
+    if (!iframe.contentWindow) {
+      reject(
+        new Error(
+          "iframe.contentWindow is undefined, cannot send message (something is wrong with the test that called this)."
+        )
+      );
+      return;
+    }
     window.addEventListener("message", function messageListener(event) {
       if (event.source === iframe.contentWindow) {
         window.removeEventListener("message", messageListener);
         resolve(event.data);
       }
     });
-    if (!iframe.contentWindow) {
-      reject(
-        new Error("iframe.contentWindow is undefined, cannot send message.")
-      );
-      return;
-    }
     iframe.contentWindow.postMessage(data, "*");
   });
 }

--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -77,7 +77,7 @@ export function sendMessage(iframe, data) {
  * @param {string|URL} url
  * @returns {Promise<void>}
  */
-export function loadIFrame(iframe, url) {
+export function loadIframe(iframe, url) {
   return new Promise((resolve, reject) => {
     iframe.addEventListener("load", resolve, { once: true });
     iframe.addEventListener("error", reject, { once: true });

--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -8,10 +8,15 @@
  * @typedef {import('../dc-types').SendMessageData} SendMessageData
  */
 /**
- * @param {ProviderType[]} [providersToUse=["default"]] - An array that can only contain "default" or "openid4vp".
+ * @param {ProviderType | ProviderType[]} [providersToUse=["default"]]
  * @returns {CredentialRequestOptions}
  */
 export function makeGetOptions(providersToUse = ["default"]) {
+  if (typeof providersToUse === "string") {
+    if (providersToUse === "default" || providersToUse === "openid4vp"){
+      return makeGetOptions([providersToUse]);
+    }
+  }
   if (!Array.isArray(providersToUse) || !providersToUse?.length) {
     return { digital: { providers: providersToUse } };
   }
@@ -21,8 +26,10 @@ export function makeGetOptions(providersToUse = ["default"]) {
       case "openid4vp":
         providers.push(makeOID4VPDict());
         break;
-      default:
+      case "default":
         providers.push(makeIdentityRequestProvider(undefined, undefined));
+      default:
+        throw new Error(`Unknown provider type: ${provider}`);
         break;
     }
   }

--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -8,7 +8,7 @@
  * @typedef {import('../dc-types').SendMessageData} SendMessageData
  */
 /**
- * @param {ProviderType[]} [providersToUse=["default"]] - An array that can only contain "default" or "oid4vp".
+ * @param {ProviderType[]} [providersToUse=["default"]] - An array that can only contain "default" or "openid4vp".
  * @returns {CredentialRequestOptions}
  */
 export function makeGetOptions(providersToUse = ["default"]) {

--- a/digital-credentials/support/helper.js
+++ b/digital-credentials/support/helper.js
@@ -28,6 +28,7 @@ export function makeGetOptions(providersToUse = ["default"]) {
         break;
       case "default":
         providers.push(makeIdentityRequestProvider(undefined, undefined));
+        break;
       default:
         throw new Error(`Unknown provider type: ${provider}`);
         break;

--- a/digital-credentials/support/iframe.html
+++ b/digital-credentials/support/iframe.html
@@ -1,27 +1,68 @@
-<!doctype html>
+<!DOCTYPE html>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
+<body></body>
 <script type="module">
-import { buildValidNavigatorIdentityRequest, requestIdentityWithActivation } from './helper.js';
+  // @ts-check
+  /**
+   *
+   * @typedef {import('./dc-types').ActionType} IframeActionType
+   * @typedef {import('./dc-types').AbortType} AbortType
+   * @typedef {import('./dc-types').EventData} EventData
+   * @typedef {import('./dc-types').PostData} PostData
+   */
 
-// Loading digital-identity-iframe.html in the test will make a digital credential call on load, and
-// trigger a postMessage upon completion.
-//
-// message {
-//   string result: "Pass" | "Fail"
-//   string data: credential.token
-//   string errorType: error.data
-// }
-
-window.onload = async () => {
-  try {
-    let request = buildValidNavigatorIdentityRequest();
-    let credential = await requestIdentityWithActivation(test_driver, request);
-
-    window.top.postMessage({result: "Pass", data: credential.data}, '*');
-  } catch (error) {
-    window.top.postMessage({result: "Fail", errorType: error.name}, '*');
+  /**
+   * @param {MessageEvent<EventData>} event
+   */
+  async function messageListener(event) {
+    /** @type {EventData} */
+    const data = event.data ? { ...event.data } : {};
+    /** @type {PostData} */
+    const abortController = new AbortController();
+    if (data.abort) {
+      if (!data.options) {
+        data.options = {};
+      }
+      data.options.signal = abortController.signal;
+    }
+    let result;
+    try {
+      /** @type {CrendetialManager} */
+      const { identity } = navigator;
+      if (abortController && data.abort === "before") {
+        abortController.abort();
+      }
+      switch (data.action) {
+        case "ping":
+          result = "pong";
+          break;
+        case "create":
+          result = await identity.create(data.options);
+          break;
+        case "get":
+          await test_driver.bless("user activation", null, window);
+          assert_true(navigator.userActivation.isActive, "user activation must be active");
+          result = await identity.get(data.options);
+          break;
+        case "preventSilentAccess":
+          result = await identity.preventSilentAccess();
+          break;
+        default:
+          throw new Error(
+            `Unsupported action in ${window.location}: ${data.action}`
+          );
+      }
+    } catch (error) {
+      result = {
+        constructor: error.constructor.name,
+        name: error.name,
+        message: error.message,
+      };
+    } finally {
+      event.source?.postMessage(result, event.origin);
+    }
   }
-};
 
+  window.addEventListener("message", messageListener);
 </script>

--- a/digital-credentials/support/iframe.html
+++ b/digital-credentials/support/iframe.html
@@ -5,9 +5,6 @@
 <script type="module">
   // @ts-check
   /**
-   *
-   * @typedef {import('./dc-types').ActionType} IframeActionType
-   * @typedef {import('./dc-types').AbortType} AbortType
    * @typedef {import('./dc-types').EventData} EventData
    * @typedef {import('./dc-types').PostData} PostData
    */
@@ -16,9 +13,13 @@
    * @param {MessageEvent<EventData>} event
    */
   async function messageListener(event) {
+    if (!event.data || typeof event.data !== "object") {
+      throw new Error(
+        `Message data must be an object in conforming to EventData (see dc-types.js): ${event.data}`
+      );
+    }
     /** @type {EventData} */
-    const data = event.data ? { ...event.data } : {};
-    /** @type {PostData} */
+    const { data } = event;
     const abortController = new AbortController();
     if (data.abort) {
       if (!data.options) {

--- a/digital-credentials/support/iframe.html
+++ b/digital-credentials/support/iframe.html
@@ -26,10 +26,13 @@
       }
       data.options.signal = abortController.signal;
     }
+    if (data.needsActivation) {
+      await test_driver.bless("user activation", null, window);
+    }
     let result;
     try {
-      /** @type {CrendetialManager} */
-      const { identity } = navigator;
+      /** @type {CredentialsContainer} */
+      const identity = navigator.identity;
       if (abortController && data.abort === "before") {
         abortController.abort();
       }
@@ -41,8 +44,6 @@
           result = await identity.create(data.options);
           break;
         case "get":
-          await test_driver.bless("user activation", null, window);
-          assert_true(navigator.userActivation.isActive, "user activation must be active");
           result = await identity.get(data.options);
           break;
         case "preventSilentAccess":

--- a/digital-credentials/support/iframe.html
+++ b/digital-credentials/support/iframe.html
@@ -33,27 +33,32 @@
     try {
       /** @type {CredentialsContainer} */
       const identity = navigator.identity;
-      if (abortController && data.abort === "before") {
+      if (data.abort === "before") {
         abortController.abort();
       }
+      let promise;
       switch (data.action) {
         case "ping":
-          result = "pong";
+          promise = Promise.resolve("pong");
           break;
         case "create":
-          result = await identity.create(data.options);
+          promise = identity.create(data.options);
           break;
         case "get":
-          result = await identity.get(data.options);
+          promise = identity.get(data.options);
           break;
         case "preventSilentAccess":
-          result = await identity.preventSilentAccess();
+          promise = identity.preventSilentAccess();
           break;
         default:
           throw new Error(
             `Unsupported action in ${window.location}: ${data.action}`
           );
       }
+      if (data.abort === "after") {
+        abortController.abort();
+      }
+      result = await promise;
     } catch (error) {
       result = {
         constructor: error.constructor.name,

--- a/digital-credentials/tsconfig.json
+++ b/digital-credentials/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": true,
+    "lib": ["dom", "esnext"],
+    "baseUrl": "."
+  }
+}


### PR DESCRIPTION
Closes https://github.com/WICG/digital-credentials/issues/118

Creates a spec compliant set of test case and adds a more robust/flexible cross-origin testing framework:

 * helper.js
 * iframe.html

Removes/refactors the old "digital-credentials/digital-credentials.tentative.https.html", as these were not spec compliant. 

Adds TypeScript types, for better workflow in VS Code, etc. 