### PR TITLE
[wptrunner] Add `testloader.TestFilter(...)` tests

### DIFF
--- a/tools/wptrunner/wptrunner/tests/test_testloader.py
+++ b/tools/wptrunner/wptrunner/tests/test_testloader.py
@@ -7,6 +7,7 @@ import tempfile
 import pytest
 
 from mozlog import structured
+from .. import testloader
 from ..testloader import (
     DirectoryHashChunker,
     IDHashChunker,
@@ -21,10 +22,11 @@ from .test_wpttest import make_mock_manifest
 
 here = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(here, os.pardir, os.pardir, os.pardir))
+from manifest import manifest
 from manifest.manifest import Manifest as WPTManifest
 
 structured.set_default_logger(structured.structuredlog.StructuredLogger("TestLoader"))
-
+testloader.manifest = manifest
 TestFilter.__test__ = False
 TestLoader.__test__ = False
 
@@ -36,7 +38,7 @@ skip: true
 
 
 @pytest.fixture
-def manifest():
+def manifest0():
     manifest_json = {
         "items": {
             "testharness": {
@@ -50,14 +52,45 @@ def manifest():
                         "uvwxyz987654",
                         [None, {}],
                     ],
-                }
-            }
+                },
+            },
         },
         "url_base": "/",
         "version": 8,
     }
     return WPTManifest.from_json("/", manifest_json)
 
+
+@pytest.fixture
+def manifest1():
+    manifest_json = {
+        "items": {
+            "testharness": {
+                "a": {
+                    "foo.https.any.js": [
+                        "abcdef123456",
+                        ["a/foo.https.any.html?b", {}],
+                        ["a/foo.https.any.html?c", {}],
+                        ["a/foo.https.any.worker.html?b", {}],
+                        ["a/foo.https.any.worker.html?c", {}],
+                    ],
+                    "b": {
+                        "bar.html": [
+                            "uvwxyz987654",
+                            [None, {}],
+                        ],
+                        "c.html": [
+                            "123456abcdef",
+                            [None, {}],
+                        ],
+                    },
+                },
+            },
+        },
+        "url_base": "/",
+        "version": 8,
+    }
+    return WPTManifest.from_json("/", manifest_json)
 
 
 def test_loader_h2_tests():
@@ -133,6 +166,110 @@ def test_filter_unicode():
         f.flush()
 
         TestFilter(manifest_path=f.name, test_manifests=tests)
+
+
+def test_filter_directory(manifest1):
+    with tempfile.TemporaryDirectory() as tmp:
+        include = os.path.normpath(os.path.join(tmp, "a", "b"))
+        os.makedirs(include)
+        test_filter = TestFilter({manifest1: {"tests_path": tmp}}, include=[include])
+        items = sorted(test_filter(manifest1), key=lambda item: item[1])
+    assert len(items) == 2
+    test_type, test_path, tests = items[0]
+    assert test_type == "testharness"
+    assert test_path == os.path.join("a", "b", "bar.html")
+    assert {test.id for test in tests} == {"/a/b/bar.html"}
+    test_type, test_path, tests = items[1]
+    assert test_type == "testharness"
+    assert test_path == os.path.join("a", "b", "c.html")
+    assert {test.id for test in tests} == {"/a/b/c.html"}
+
+
+def test_filter_variants_for_scope(manifest1):
+    with tempfile.TemporaryDirectory() as tmp:
+        test_filter = TestFilter({manifest1: {"tests_path": tmp}},
+                                 include=["/a/foo.https.any.html"])
+        items = list(test_filter(manifest1))
+    assert len(items) == 1
+    test_type, test_path, tests = items[0]
+    assert test_type == "testharness"
+    assert test_path == os.path.join("a", "foo.https.any.js")
+    assert {test.id for test in tests} == {
+        "/a/foo.https.any.html?b",
+        "/a/foo.https.any.html?c",
+    }
+
+
+def test_filter_multiglobal_file(manifest1):
+    with tempfile.TemporaryDirectory() as tmp:
+        include = os.path.normpath(os.path.join(tmp, "a", "foo.https.any.js"))
+        os.makedirs(os.path.dirname(include))
+        with open(include, "w"):
+            pass
+        test_filter = TestFilter({manifest1: {"tests_path": tmp}}, include=[include])
+        items = list(test_filter(manifest1))
+    assert len(items) == 1
+    test_type, test_path, tests = items[0]
+    assert test_type == "testharness"
+    assert test_path == os.path.join("a", "foo.https.any.js")
+    assert {test.id for test in tests} == {
+        "/a/foo.https.any.html?b",
+        "/a/foo.https.any.html?c",
+        "/a/foo.https.any.worker.html?b",
+        "/a/foo.https.any.worker.html?c",
+    }
+
+
+def test_filter_glob(manifest1):
+    with tempfile.TemporaryDirectory() as tmp:
+        include = os.path.normpath(os.path.join(tmp, "a", "b"))
+        os.makedirs(include)
+        for filename in ["bar.html", "c.html"]:
+            with open(os.path.join(include, filename), "w"):
+                pass
+        test_filter = TestFilter({manifest1: {"tests_path": tmp}},
+                                 include=[os.path.join(include, "b*.html")])
+        items = list(test_filter(manifest1))
+    assert len(items) == 1
+    test_type, test_path, tests = items[0]
+    assert test_type == "testharness"
+    assert test_path == os.path.join("a", "b", "bar.html")
+    assert {test.id for test in tests} == {"/a/b/bar.html"}
+
+
+def test_filter_nonexistent_directory(manifest1):
+    with tempfile.TemporaryDirectory() as tmp:
+        test_filter = TestFilter({manifest1: {"tests_path": tmp}},
+                                 include=[os.path.join(tmp, "a")])
+        items = list(test_filter(manifest1))
+    assert items == []
+
+
+def test_filter_most_specific_rule(manifest1):
+    test_filter = TestFilter({manifest1: {}}, include=["/a/b"],
+                             exclude=["/a/b/c.html"])
+    items = list(test_filter(manifest1))
+    assert len(items) == 1
+    test_type, test_path, tests = items[0]
+    assert test_type == "testharness"
+    assert test_path == os.path.join("a", "b", "bar.html")
+    assert {test.id for test in tests} == {"/a/b/bar.html"}
+
+
+def test_filter_include_by_default(manifest1):
+    with tempfile.TemporaryDirectory() as tmp:
+        dir_exclude = os.path.normpath(os.path.join(tmp, "a", "b"))
+        os.makedirs(dir_exclude)
+        test_filter = TestFilter({manifest1: {"tests_path": tmp}},
+                                 exclude=[dir_exclude,
+                                          "/a/foo.https.any.html",
+                                          "/a/foo.https.any.worker.html?b"])
+        items = list(test_filter(manifest1))
+    assert len(items) == 1
+    test_type, test_path, tests = items[0]
+    assert test_type == "testharness"
+    assert test_path == os.path.join("a", "foo.https.any.js")
+    assert {test.id for test in tests} == {"/a/foo.https.any.worker.html?c"}
 
 
 def test_tag_filter():
@@ -287,12 +424,12 @@ def test_loader_filter_tags():
         assert len(loader.tests[""]["testharness"]) == 0
 
 
-def test_chunk_hash(manifest):
+def test_chunk_hash(manifest0):
     chunker1 = PathHashChunker(total_chunks=2, chunk_number=1)
     chunker2 = PathHashChunker(total_chunks=2, chunk_number=2)
     # Check that the chunkers partition the manifest (i.e., each item is
     # assigned to exactly one chunk).
-    items = sorted([*chunker1(manifest), *chunker2(manifest)],
+    items = sorted([*chunker1(manifest0), *chunker2(manifest0)],
                    key=lambda item: item[1])
     assert len(items) == 2
     test_type, test_path, tests = items[0]
@@ -305,11 +442,11 @@ def test_chunk_hash(manifest):
     assert {test.id for test in tests} == {"/a/foo.html?b", "/a/foo.html?c"}
 
 
-def test_chunk_id_hash(manifest):
+def test_chunk_id_hash(manifest0):
     chunker1 = IDHashChunker(total_chunks=2, chunk_number=1)
     chunker2 = IDHashChunker(total_chunks=2, chunk_number=2)
     items = []
-    for test_type, test_path, tests in [*chunker1(manifest), *chunker2(manifest)]:
+    for test_type, test_path, tests in [*chunker1(manifest0), *chunker2(manifest0)]:
         assert len(tests) > 0
         items.extend((test_type, test_path, test) for test in tests)
     assert len(items) == 3
@@ -328,14 +465,14 @@ def test_chunk_id_hash(manifest):
     assert test.id == "/a/foo.html?c"
 
 
-def test_chunk_dir_hash(manifest):
+def test_chunk_dir_hash(manifest0):
     chunker1 = DirectoryHashChunker(total_chunks=2, chunk_number=1)
     chunker2 = DirectoryHashChunker(total_chunks=2, chunk_number=2)
     # Check that tests in the same directory are located in the same chunk
     # (which particular chunk is irrelevant).
     empty_chunk, chunk_a = sorted([
-        list(chunker1(manifest)),
-        list(chunker2(manifest)),
+        list(chunker1(manifest0)),
+        list(chunker2(manifest0)),
     ], key=len)
     assert len(empty_chunk) == 0
     assert len(chunk_a) == 2


### PR DESCRIPTION
Capture the current test include/exclude behavior to provide confidence that refactoring/optimizations (#42377) don't regress functionality.