### PR TITLE
streams: underlyingSource.cancel() should called when abort, even with pending pull

### DIFF
--- a/streams/piping/abort.any.js
+++ b/streams/piping/abort.any.js
@@ -183,6 +183,46 @@ for (const reason of [null, undefined, error1]) {
   }, `(reason: '${reason}') all pending writes should complete on abort`);
 }
 
+for (const reason of [null, undefined, error1]) {
+  promise_test(async t => {
+    let rejectPull;
+    const pullPromise = new Promise((_, reject) => {
+      rejectPull = reject;
+    });
+    let rejectCancel;
+    const cancelPromise = new Promise((_, reject) => {
+      rejectCancel = reject;
+    });
+    const rs = recordingReadableStream({
+      async pull() {
+        await Promise.race([
+          pullPromise,
+          cancelPromise,
+        ]);
+      },
+      cancel(reason) {
+        rejectCancel(reason);
+      },
+    });
+    const ws = new WritableStream();
+    const abortController = new AbortController();
+    const signal = abortController.signal;
+    const pipeToPromise = rs.pipeTo(ws, { signal });
+    pipeToPromise.catch(() => {}); // Prevent unhandled rejection.
+    await delay(0);
+    abortController.abort(reason);
+    rejectPull('should not catch pull rejection');
+    await delay(0);
+    assert_equals(rs.eventsWithoutPulls.length, 2, 'cancel should have been called');
+    assert_equals(rs.eventsWithoutPulls[0], 'cancel', 'first event should be cancel');
+    if (reason !== undefined) {
+      await promise_rejects_exactly(t, reason, pipeToPromise, 'pipeTo rejects with abort reason');
+    } else {
+      await promise_rejects_dom(t, 'AbortError', pipeToPromise, 'pipeTo rejects with AbortError');
+    }
+  }, `(reason: '${reason}') underlyingSource.cancel() should called when abort, even with pending pull`);
+}
+
 promise_test(t => {
   const rs = new ReadableStream({
     pull(controller) {


### PR DESCRIPTION
The spec [ReadableStreamPipeTo][] and [ReadableStreamCancel][] define that the signal aborted algorithm calls `underlyingSource.cancel()`. However, Webkit does not call `underlyingSource.cancel()` if signal aborted occurs while `underlyingSource.pull()` is pending.

[ReadableStreamPipeTo]: https://streams.spec.whatwg.org/#readable-stream-pipe-to
[ReadableStreamCancel]: https://streams.spec.whatwg.org/#readable-stream-cancel