### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=274403

### DIFF
--- a/css/css-view-transitions/new-content-root-scrollbar-with-fixed-background.html
+++ b/css/css-view-transitions/new-content-root-scrollbar-with-fixed-background.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html class=reftest-wait style="background: lightblue;">
+<title>When the root element has scrollbars, these should be excluded in new snapshot</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" href="mailto:khushalsagar@chromium.org">
+<link rel="match" href="root-scrollbar-with-fixed-background-ref.html">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-4500">
+
+<script src="/common/rendering-utils.js"></script>
+<script src="/common/reftest-wait.js"></script>
+
+<style>
+#hide {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  width: 10px;
+  height: 10px;
+  background: red;
+  contain: paint;
+  view-transition-name: hide;
+}
+#first {
+  width: 10px;
+  background: linear-gradient(green, blue);
+  height: 1000px;
+}
+body {
+  margin: 0px;
+  padding: 0px;
+}
+
+/* Set a no-op animation to screenshot the pseudo transition DOM. */
+html::view-transition-group(hide) {
+  animation-duration: 300s;
+  opacity: 0;
+}
+html::view-transition-new(*) {
+  animation: unset;
+  filter: invert(1);
+  height: 100%;
+}
+html::view-transition-old(*) {
+  animation: unset;
+  opacity: 0;
+  height: 100%;
+}
+</style>
+
+<div id=hide></div>
+<div id=first></div>
+
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+async function runTest() {
+  await waitForAtLeastOneFrame();
+
+  await new Promise((resolve) => {
+    addEventListener("scroll", () => {
+      requestAnimationFrame(() => requestAnimationFrame(resolve));
+    }, { once: true, capture: true });
+
+    document.documentElement.scrollTop = 500;
+  });
+  document.startViewTransition(() => {
+    requestAnimationFrame(() => requestAnimationFrame(takeScreenshot));
+  });
+}
+
+onload = () => requestAnimationFrame(runTest);
+</script>
+
+</html>

--- a/css/css-view-transitions/old-content-root-scrollbar-with-fixed-background.html
+++ b/css/css-view-transitions/old-content-root-scrollbar-with-fixed-background.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html class=reftest-wait style="background: lightblue;">
-<title>When the root element has scrollbars, these should be excluded in snapshot</title>
+<title>When the root element has scrollbars, these should be excluded in old snapshot</title>
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="root-scrollbar-with-fixed-background-ref.html">
@@ -37,12 +37,12 @@ html::view-transition-group(hide) {
 }
 html::view-transition-new(*) {
   animation: unset;
-  filter: invert(1);
+  opacity: 0;
   height: 100%;
 }
 html::view-transition-old(*) {
   animation: unset;
-  opacity: 0;
+  filter: invert(1);
   height: 100%;
 }
 </style>


### PR DESCRIPTION
WebKit export from bug: [\[view-transitions\] Tab active indicator animation flashes on https://malcolmkee.com/blog/view-transition-api-in-react-app/#practical-use-cases](https://bugs.webkit.org/show_bug.cgi?id=274403)