### PR TITLE
[WebDriver BiDi] Fix issue with test using `document.cookie`

### DIFF
--- a/webdriver/tests/bidi/integration/cookies_with_network_events.py
+++ b/webdriver/tests/bidi/integration/cookies_with_network_events.py
@@ -22,8 +22,7 @@ async def test_top_context(
     cookie_value = "bar"
     url = inline(
         "<div>with cookies</div>",
-        parameters={
-            "pipe": f"header(Set-Cookie, {cookie_name}={cookie_value})"},
+        parameters={"pipe": f"header(Set-Cookie, {cookie_name}={cookie_value})"},
     )
 
     await bidi_session.browsing_context.navigate(
@@ -65,8 +64,7 @@ async def test_iframe(
     iframe_url = inline(
         "<div id='in-iframe'>with cookies</div>",
         domain=domain_1,
-        parameters={
-            "pipe": f"header(Set-Cookie, {cookie_name}={cookie_value})"},
+        parameters={"pipe": f"header(Set-Cookie, {cookie_name}={cookie_value})"},
     )
 
     await bidi_session.browsing_context.navigate(

--- a/webdriver/tests/bidi/integration/cookies_with_network_events.py
+++ b/webdriver/tests/bidi/integration/cookies_with_network_events.py
@@ -111,14 +111,14 @@ async def test_fetch(
     wait_for_future_safe,
     url,
     domain_1,
-    inline
 ):
     # Clean up cookies in case some other tests failed before cleaning up.
     await bidi_session.storage.delete_cookies()
 
-    # Navigate away from about:blank to make sure document.cookies can be used
+    # Navigate away from about:blank to make sure document.cookies can be used.
     await bidi_session.browsing_context.navigate(
-        context=new_tab["context"], url=inline("<div>foo</div>"),
+        context=new_tab["context"],
+        url=url("/webdriver/tests/bidi/support/empty.html"),
         wait="complete"
     )
 

--- a/webdriver/tests/bidi/integration/cookies_with_network_events.py
+++ b/webdriver/tests/bidi/integration/cookies_with_network_events.py
@@ -22,7 +22,8 @@ async def test_top_context(
     cookie_value = "bar"
     url = inline(
         "<div>with cookies</div>",
-        parameters={"pipe": f"header(Set-Cookie, {cookie_name}={cookie_value})"},
+        parameters={
+            "pipe": f"header(Set-Cookie, {cookie_name}={cookie_value})"},
     )
 
     await bidi_session.browsing_context.navigate(
@@ -64,7 +65,8 @@ async def test_iframe(
     iframe_url = inline(
         "<div id='in-iframe'>with cookies</div>",
         domain=domain_1,
-        parameters={"pipe": f"header(Set-Cookie, {cookie_name}={cookie_value})"},
+        parameters={
+            "pipe": f"header(Set-Cookie, {cookie_name}={cookie_value})"},
     )
 
     await bidi_session.browsing_context.navigate(
@@ -111,9 +113,16 @@ async def test_fetch(
     wait_for_future_safe,
     url,
     domain_1,
+    inline
 ):
     # Clean up cookies in case some other tests failed before cleaning up.
     await bidi_session.storage.delete_cookies()
+
+    # Navigate away from about:blank to make sure document.cookies can be used
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"], url=inline("<div>foo</div>"),
+        wait="complete"
+    )
 
     cookie_name = "foo"
     cookie_value = "bar"

--- a/webdriver/tests/bidi/network/continue_request/cookies.py
+++ b/webdriver/tests/bidi/network/continue_request/cookies.py
@@ -26,11 +26,12 @@ async def test_modify_cookies(
     top_context,
     document_cookies,
     modified_cookies,
-    inline
+    url
 ):
-    # Navigate away from about:blank to make sure document.cookies can be used
+    # Navigate away from about:blank to make sure document.cookies can be used.
     await bidi_session.browsing_context.navigate(
-        context=top_context["context"], url=inline("<div>foo</div>"),
+        context=top_context["context"],
+        url=url("/webdriver/tests/bidi/support/empty.html"),
         wait="complete"
     )
 

--- a/webdriver/tests/bidi/network/continue_request/cookies.py
+++ b/webdriver/tests/bidi/network/continue_request/cookies.py
@@ -49,8 +49,7 @@ async def test_modify_cookies(
 
     cookies = []
     for name, value in modified_cookies.items():
-        cookies.append(CookieHeader(
-            name=name, value=NetworkStringValue(value)))
+        cookies.append(CookieHeader(name=name, value=NetworkStringValue(value)))
 
     on_response_completed = wait_for_event(RESPONSE_COMPLETED_EVENT)
     await bidi_session.network.continue_request(request=request, cookies=cookies)

--- a/webdriver/tests/bidi/network/continue_request/headers.py
+++ b/webdriver/tests/bidi/network/continue_request/headers.py
@@ -35,8 +35,7 @@ async def test_modify_headers(
     on_response_completed = wait_for_event(RESPONSE_COMPLETED_EVENT)
     await bidi_session.network.continue_request(request=request, headers=headers)
     response_event = await on_response_completed
-    assert_response_event(response_event, expected_request={
-                          "headers": headers})
+    assert_response_event(response_event, expected_request={"headers": headers})
 
 
 async def test_override_cookies(

--- a/webdriver/tests/bidi/network/continue_request/headers.py
+++ b/webdriver/tests/bidi/network/continue_request/headers.py
@@ -35,7 +35,8 @@ async def test_modify_headers(
     on_response_completed = wait_for_event(RESPONSE_COMPLETED_EVENT)
     await bidi_session.network.continue_request(request=request, headers=headers)
     response_event = await on_response_completed
-    assert_response_event(response_event, expected_request={"headers": headers})
+    assert_response_event(response_event, expected_request={
+                          "headers": headers})
 
 
 async def test_override_cookies(
@@ -44,7 +45,14 @@ async def test_override_cookies(
     wait_for_event,
     bidi_session,
     top_context,
+    inline
 ):
+    # Navigate away from about:blank to make sure document.cookies can be used
+    await bidi_session.browsing_context.navigate(
+        context=top_context["context"], url=inline("<div>foo</div>"),
+        wait="complete"
+    )
+
     await bidi_session.script.evaluate(
         expression="document.cookie = 'foo=bar';",
         target=ContextTarget(top_context["context"]),

--- a/webdriver/tests/bidi/network/continue_request/headers.py
+++ b/webdriver/tests/bidi/network/continue_request/headers.py
@@ -44,11 +44,12 @@ async def test_override_cookies(
     wait_for_event,
     bidi_session,
     top_context,
-    inline
+    url
 ):
-    # Navigate away from about:blank to make sure document.cookies can be used
+    # Navigate away from about:blank to make sure document.cookies can be used.
     await bidi_session.browsing_context.navigate(
-        context=top_context["context"], url=inline("<div>foo</div>"),
+        context=top_context["context"],
+        url=url("/webdriver/tests/bidi/support/empty.html"),
         wait="complete"
     )
 


### PR DESCRIPTION
In Chromium you can't set cookies via `document.cookie` in `about:blank` page.
https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/document.cc;l=6225
Navigating to a valid url resolves the issue.

CC @juliandescottes 