### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=273906

### DIFF
--- a/file-system-access/getDirectory.https.any.js
+++ b/file-system-access/getDirectory.https.any.js
@@ -1,0 +1,12 @@
+// META: global=window,worker
+// META: script=resources/test-helpers.js
+
+promise_test(async t => {
+    const directory = await navigator.storage.getDirectory();
+    return directory.getFileHandle("testFile", { create: true });
+}, "Call getFileHandle successfully");
+
+promise_test(async t => {
+    const directory = await navigator.storage.getDirectory();
+    return directory.getDirectoryHandle("testDirectory", { create: true });
+}, "Call getDirectoryHandle successfully");


### PR DESCRIPTION
WebKit export from bug: [`navigator.storage.getDirectory()` fails in service workers with an `NotSupportedError: The operation is not supported`](https://bugs.webkit.org/show_bug.cgi?id=273906)