### PR TITLE
Slot element with tabindex=0 that generates a box should be focusable

### DIFF
--- a/shadow-dom/focus/focus-slot-box-generated-tabindex-0.html
+++ b/shadow-dom/focus/focus-slot-box-generated-tabindex-0.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTML Test: focus - slot with tabindex=0 that generates a box should be focusable</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/shadow-utils.js"></script>
+<body>
+<div id=host>
+  <template shadowrootmode=open>
+    <slot tabindex=0 style="display: inline-block;"></slot>
+  </template>
+  Content
+</div>
+<script>
+promise_test(async () => {
+  const host = document.getElementById("host");
+  const slot = host.shadowRoot.querySelector("slot");
+
+  resetFocus();
+  await navigateFocusForward();
+
+  return assert_equals(slot, host.shadowRoot.activeElement);
+}, "slot with tabindex=0 that generates a box should be focusable");
+</script>
+</body>


### PR DESCRIPTION
In Chromium, the `<slot>` element that is generating a box (i.e. overriding the default `display: contents`) and has its `tabindex` attribute set to `0` in this structure cannot be focused by tabbing. In Safari and Firefox, this works fine.

```html
<div>
    <template shadowrootmode=open>
        <slot tabindex=0 style="display: inline-block;"></slot>
    </template>
    Content
</div>
```

I’m borrowing utilities from other tests in the same `/shadow-dom/focus/` directory as well loosing following some of the other tests. Also, I think I might not have the correct help/spec link here — I this was from the other tests I was following.

If this seems like expected behaviour I’ll follow up with a bug report to Chromium, otherwise, I’ll file bug reports for Safari and Firefox.
