### PR TITLE
Download mojojs from the new CfT infrastructure

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -703,12 +703,12 @@ class ChromeChromiumBase(Browser):
 
         try:
             # MojoJS version url must match the browser binary version exactly.
-            url = ("https://storage.googleapis.com/chrome-wpt-mojom/"
-                   f"{chrome_version}/linux64/mojojs.zip")
+            url = ("https://storage.googleapis.com/chrome-for-testing-public/"
+                   f"{chrome_version}/mojojs.zip")
             # Check the status without downloading the content (this is a streaming request).
             get(url)
         except requests.RequestException:
-            # If a valid matching version cannot be found in the wpt archive,
+            # If a valid matching version cannot be found in the CfT archive,
             # download from Chromium snapshots bucket. However,
             # MojoJS is only bundled with Linux from Chromium snapshots.
             if self.platform == "Linux":


### PR DESCRIPTION
This should fix #44438 and allow us to retire the MojoJS Releaser service.