### PR TITLE
width_offset and height_offset should never be negative

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -696,6 +696,9 @@ class WebDriverRefTestExecutor(RefTestExecutor):
             """return [window.outerWidth - window.innerWidth,
                        window.outerHeight - window.innerHeight];"""
         )
+        # width_offset and height_offset should never be negative
+        width_offset = max(width_offset, 0)
+        height_offset = max(height_offset, 0)
         try:
             self.protocol.webdriver.window.position = (0, 0)
         except error.InvalidArgumentException:


### PR DESCRIPTION
Reftests all failing on Mac because windows size is set to 0. The reason windows size is zero is because width_offset and height_offset are negative -800 and -600 respectively, and when they are added to the expected size, the final size is 0.

This seems to be some mac side syncronazation issue. Add this sanite check to bypass this issue for now.

Bug: https://g-issues.chromium.org/issues/339909604