### PR TITLE
[Azure Pipelines] Upgrade to macOS 14

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
   displayName: 'affected tests: Safari Technology Preview'
   condition: eq(variables['Build.Reason'], 'PullRequest')
   pool:
-    vmImage: 'macOS-13'
+    vmImage: 'macOS-14'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -52,7 +52,7 @@ jobs:
   displayName: 'affected tests without changes: Safari Technology Preview'
   condition: eq(variables['Build.Reason'], 'PullRequest')
   pool:
-    vmImage: 'macOS-13'
+    vmImage: 'macOS-14'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -94,7 +94,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_infrastructure']
   pool:
-    vmImage: 'macOS-13'
+    vmImage: 'macOS-14'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -125,7 +125,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.tools_unittest']
   pool:
-    vmImage: 'macOS-13'
+    vmImage: 'macOS-14'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -141,7 +141,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.tools_unittest']
   pool:
-    vmImage: 'macOS-13'
+    vmImage: 'macOS-14'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -157,7 +157,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_unittest']
   pool:
-    vmImage: 'macOS-13'
+    vmImage: 'macOS-14'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -173,7 +173,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_unittest']
   pool:
-    vmImage: 'macOS-13'
+    vmImage: 'macOS-14'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -189,7 +189,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wpt_integration']
   pool:
-    vmImage: 'macOS-13'
+    vmImage: 'macOS-14'
   steps:
   # full checkout required
   - task: UsePythonVersion@0
@@ -209,7 +209,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wpt_integration']
   pool:
-    vmImage: 'macOS-13'
+    vmImage: 'macOS-14'
   steps:
   # full checkout required
   - task: UsePythonVersion@0
@@ -455,7 +455,7 @@ jobs:
     parallel: 8 # chosen to make runtime ~2h
   timeoutInMinutes: 180
   pool:
-    vmImage: 'macOS-13'
+    vmImage: 'macOS-14'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -495,7 +495,7 @@ jobs:
     parallel: 8 # chosen to make runtime ~2h
   timeoutInMinutes: 180
   pool:
-    vmImage: 'macOS-13'
+    vmImage: 'macOS-14'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -532,7 +532,7 @@ jobs:
     parallel: 8 # chosen to make runtime ~2h
   timeoutInMinutes: 180
   pool:
-    vmImage: 'macOS-13'
+    vmImage: 'macOS-14'
   steps:
   - task: UsePythonVersion@0
     inputs:


### PR DESCRIPTION
Fixes #43940.

Per https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#software macOS 14 now officially exists as a preview image, but should be workable now.