### PR TITLE
[WebDriverBiDi] Add test for `originalOpener` to `browsingContext.created`

### DIFF
--- a/webdriver/tests/bidi/browsing_context/__init__.py
+++ b/webdriver/tests/bidi/browsing_context/__init__.py
@@ -18,6 +18,7 @@ def assert_browsing_context(
     parent=None,
     url=None,
     user_context="default",
+    originalOpener=None
 ):
     assert "children" in info
     if children is not None:
@@ -51,6 +52,7 @@ def assert_browsing_context(
     assert isinstance(info["url"], str)
     assert info["url"] == url
     assert info["userContext"] == user_context
+    assert info["originalOpener"] == originalOpener
 
 
 async def assert_document_status(bidi_session, context, visible, focused):

--- a/webdriver/tests/bidi/browsing_context/__init__.py
+++ b/webdriver/tests/bidi/browsing_context/__init__.py
@@ -18,7 +18,7 @@ def assert_browsing_context(
     parent=None,
     url=None,
     user_context="default",
-    originalOpener=None
+    original_opener=None
 ):
     assert "children" in info
     if children is not None:
@@ -52,7 +52,7 @@ def assert_browsing_context(
     assert isinstance(info["url"], str)
     assert info["url"] == url
     assert info["userContext"] == user_context
-    assert info["originalOpener"] == originalOpener
+    assert info["originalOpener"] == original_opener
 
 
 async def assert_document_status(bidi_session, context, visible, focused):

--- a/webdriver/tests/bidi/browsing_context/context_created/original_opener.py
+++ b/webdriver/tests/bidi/browsing_context/context_created/original_opener.py
@@ -1,0 +1,58 @@
+import pytest
+from webdriver.bidi.modules.script import ContextTarget
+
+from .. import assert_browsing_context
+
+pytestmark = pytest.mark.asyncio
+
+CONTEXT_CREATED_EVENT = "browsingContext.contextCreated"
+
+
+@pytest.mark.parametrize("type_hint", ["tab", "window"])
+async def test_original_opener_null(bidi_session, wait_for_event, wait_for_future_safe, subscribe_events, type_hint):
+
+    await subscribe_events([CONTEXT_CREATED_EVENT])
+    on_entry = wait_for_event(CONTEXT_CREATED_EVENT)
+
+    top_level_context = await bidi_session.browsing_context.create(type_hint=type_hint)
+
+    context_info = await wait_for_future_safe(on_entry)
+
+    assert_browsing_context(
+        context_info,
+        # We use None here as evaluate no always returns value
+        context=top_level_context["context"],
+        children=None,
+        url="about:blank",
+        parent=None,
+        user_context="default",
+        originalOpener=None
+    )
+
+
+@pytest.mark.parametrize("type_hint", ["tab", "window"])
+@pytest.mark.parametrize("window_features", ["", "popup", "noopener", "noreferrer"])
+async def test_original_opener_present(bidi_session, wait_for_event, wait_for_future_safe, subscribe_events, type_hint, window_features):
+
+    top_level_context = await bidi_session.browsing_context.create(type_hint=type_hint)
+
+    await subscribe_events([CONTEXT_CREATED_EVENT])
+    on_entry = wait_for_event(CONTEXT_CREATED_EVENT)
+
+    await bidi_session.script.evaluate(
+        expression=f"""window.open("", undefined, "{window_features}");""",
+        target=ContextTarget(top_level_context["context"]),
+        await_promise=False)
+
+    context_info = await wait_for_future_safe(on_entry)
+
+    assert_browsing_context(
+        context_info,
+        # We use None here as evaluate no always returns value
+        context=None,
+        children=None,
+        url="about:blank",
+        parent=None,
+        user_context="default",
+        originalOpener=top_level_context["context"]
+    )

--- a/webdriver/tests/bidi/browsing_context/context_created/original_opener.py
+++ b/webdriver/tests/bidi/browsing_context/context_created/original_opener.py
@@ -51,7 +51,7 @@ async def test_original_opener_window_open(bidi_session, wait_for_event, wait_fo
 
     context_info = await wait_for_future_safe(on_entry)
 
-    # We use None here as evaluate no always returns value
+    # We use None here as evaluate not always returns value.
     context = None
     if returns_window:
         context = result["value"]["context"]

--- a/webdriver/tests/bidi/browsing_context/context_created/original_opener.py
+++ b/webdriver/tests/bidi/browsing_context/context_created/original_opener.py
@@ -9,7 +9,7 @@ CONTEXT_CREATED_EVENT = "browsingContext.contextCreated"
 
 
 @pytest.mark.parametrize("type_hint", ["tab", "window"])
-async def test_original_opener_null(bidi_session, wait_for_event, wait_for_future_safe, subscribe_events, type_hint):
+async def test_original_opener_context_create(bidi_session, wait_for_event, wait_for_future_safe, subscribe_events, type_hint):
 
     await subscribe_events([CONTEXT_CREATED_EVENT])
     on_entry = wait_for_event(CONTEXT_CREATED_EVENT)


### PR DESCRIPTION
Note both `<a target="<X>" />` and `window.open("","<X>")` result to the same algorithm to get/create navigable - https://html.spec.whatwg.org/#the-rules-for-choosing-a-navigable
