### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=275335

### DIFF
--- a/css/css-view-transitions/reset-state-after-scrolled-view-transition-ref.html
+++ b/css/css-view-transitions/reset-state-after-scrolled-view-transition-ref.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+    <title>Reference: Finishing a View Transition on a scrolled page should properly reset state</title>
+    <style>
+        html {
+            background: lightblue;
+        }
+        body {
+            background-color: lightgreen;
+        }
+    </style>
+</head>
+<body>
+    <p>Start</p>
+    <div style="height: 200vh"></div>
+    <p>End</p>
+
+    <script>
+        function scrollBy(y) {
+            return new Promise(resolve => {
+                addEventListener("scroll", () => {
+                    requestAnimationFrame(() => {
+                        requestAnimationFrame(resolve);
+                    });
+                }, { once: true, capture: true });
+                document.documentElement.scrollBy({
+                    top: y,
+                    behavior: "instant"
+                });
+            });
+        }
+        addEventListener("load", async () => {
+            await scrollBy(document.documentElement.scrollHeight);
+            document.documentElement.classList.remove("reftest-wait");
+        });
+    </script>
+</body>
+</html>

--- a/css/css-view-transitions/reset-state-after-scrolled-view-transition.html
+++ b/css/css-view-transitions/reset-state-after-scrolled-view-transition.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+    <title>Finishing a View Transition on a scrolled page should properly reset state</title>
+    <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+    <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+    <link rel="match" href="reset-state-after-scrolled-view-transition-ref.html">
+    <style>
+        html {
+            background: lightblue;
+        }
+        body {
+            background-color: lightgreen;
+        }
+        ::view-transition-group(*) {
+            animation-duration: 2s;
+        }
+    </style>
+</head>
+<body>
+    <p>Start</p>
+    <div id="block" style="height: 150vh"></div>
+    <p>End</p>
+
+    <script>
+        function scrollBy(y) {
+            return new Promise(resolve => {
+                addEventListener("scroll", () => {
+                    requestAnimationFrame(() => {
+                        requestAnimationFrame(resolve);
+                    });
+                }, { once: true, capture: true });
+                document.documentElement.scrollBy({
+                    top: y,
+                    behavior: "instant"
+                });
+            });
+        }
+        addEventListener("load", async () => {
+            await scrollBy(document.documentElement.scrollHeight / 2);
+            const transition = document.startViewTransition(() => { block.style.height = '200vh' });
+            await transition.ready;
+            scrollBy(document.documentElement.scrollHeight / 2);
+            await transition.finished;
+            document.documentElement.classList.remove("reftest-wait");
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [REGRESSION(279372@main): Blank space and offset clicks after running a view transition on a scrolled page](https://bugs.webkit.org/show_bug.cgi?id=275335)