### PR TITLE
Remove print ref test for iOS wptrunner for now

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome_ios.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_ios.py
@@ -6,7 +6,6 @@ from .base import get_timeout_multiplier   # noqa: F401
 from ..environment import wait_for_service
 from ..executors import executor_kwargs as base_executor_kwargs
 from ..executors.base import WdspecExecutor  # noqa: F401
-from ..executors.executorchrome import ChromeDriverPrintRefTestExecutor  # noqa: F401
 from ..executors.executorwebdriver import (WebDriverCrashtestExecutor,  # noqa: F401
                                            WebDriverTestharnessExecutor,  # noqa: F401
                                            WebDriverRefTestExecutor)  # noqa: F401
@@ -17,7 +16,6 @@ __wptrunner__ = {"product": "chrome_ios",
                  "browser": "ChromeiOSBrowser",
                  "executor": {"testharness": "WebDriverTestharnessExecutor",
                               "reftest": "WebDriverRefTestExecutor",
-                              "print-reftest": "ChromeDriverPrintRefTestExecutor",
                               "crashtest": "WebDriverCrashtestExecutor"},
                  "browser_kwargs": "browser_kwargs",
                  "executor_kwargs": "executor_kwargs",


### PR DESCRIPTION
Currently the print ref test will all fail due to unknown command error and will make the runner timeout.
Need to fix the unknown command before add the print ref test type back.