### PR TITLE
layout: Allocate inline box start space on segment

### DIFF
--- a/css/CSS2/normal-flow/inline-box-border-line-break-ref.html
+++ b/css/CSS2/normal-flow/inline-box-border-line-break-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <link
+    rel="help"
+    href="https://drafts.csswg.org/css2/#inline-formatting"
+  />
+  <link rel="help" href="https://github.com/servo/servo/pull/32486" />
+  <link rel="author" href="mrobinson@igalia.com" />
+  <link rel="author" href="atbrakhi@igalia.com" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <body>
+
+    <div style="width: 80px; outline: solid 1px black; font: 20px/1 Ahem;">
+      xx
+      <div style="display: inline-block; padding-left: 50px;">x</div>
+       xx
+    </div>
+
+  </body>
+</html>
+
+

--- a/css/CSS2/normal-flow/inline-box-border-line-break.html
+++ b/css/CSS2/normal-flow/inline-box-border-line-break.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <link
+    rel="help"
+    href="https://drafts.csswg.org/css2/#inline-formatting"
+  />
+  <link rel="help" href="https://github.com/servo/servo/pull/32486" />
+  <link rel="author" href="mrobinson@igalia.com" />
+  <link rel="author" href="atbrakhi@igalia.com" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <meta name="assert" content="Inline borders should cause content that follows to wrap." />
+  <link rel="match" href="inline-box-border-line-break-ref.html" />
+  <body>
+
+    <div style="width: 80px; outline: solid 1px black; font: 20px/1 Ahem;">
+      xx
+      <!- The left border on this span should trigger a line break before the
+          final xx. -->
+      <span style="border-left: 50px solid transparent">x</span>
+      xx
+    </div>
+
+  </body>
+</html>
+
+

--- a/css/CSS2/normal-flow/inline-box-padding-line-break.html
+++ b/css/CSS2/normal-flow/inline-box-padding-line-break.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <link
+    rel="help"
+    href="https://drafts.csswg.org/css2/#inline-formatting"
+  />
+  <link rel="help" href="https://github.com/servo/servo/pull/32486" />
+  <link rel="author" href="mrobinson@igalia.com" />
+  <link rel="author" href="atbrakhi@igalia.com" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <meta name="assert" content="Inline padding should cause content that follows to wrap." />
+  <link rel="match" href="inline-box-border-line-break-ref.html" />
+  <body>
+
+    <div style="width: 80px; outline: solid 1px black; font: 20px/1 Ahem;">
+      xx
+      <!- The left padding on this span should trigger a line break before the
+          final xx. -->
+      <span style="padding-left: 50px;">x</span>
+      xx
+    </div>
+
+  </body>
+</html>
+
+


### PR DESCRIPTION
Instead of allocating the inline padding and border space on the line,
allocate it on the segment -- which where the inline box start goes.

Co-authored-by: Rakhi Sharma <atbrakhi@igalia.com>

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#32486