### PR TITLE
Add test to check events when parent of `pointerdown` target captures pointer

### DIFF
--- a/pointerevents/pointerevent_click_during_parent_capture.html
+++ b/pointerevents/pointerevent_click_during_parent_capture.html
@@ -1,0 +1,276 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="variant" content="?pointerType=mouse&preventDefault=" />
+    <meta
+      name="variant"
+      content="?pointerType=mouse&preventDefault=pointerdown"
+    />
+    <meta name="variant" content="?pointerType=touch&preventDefault=" />
+    <meta
+      name="variant"
+      content="?pointerType=touch&preventDefault=pointerdown"
+    />
+    <meta
+      name="variant"
+      content="?pointerType=touch&preventDefault=touchstart"
+    />
+    <title>
+      Test `click` event target when a parent element captures the pointer
+    </title>
+    <style>
+      #parent {
+        background: green;
+        border: 1px solid black;
+        width: 40px;
+        height: 40px;
+      }
+
+      #target {
+        background: blue;
+        border: 1px solid black;
+        width: 20px;
+        height: 20px;
+        margin: 10px;
+      }
+    </style>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <script src="/resources/testdriver-actions.js"></script>
+    <script>
+      "use strict";
+
+      const searchParams = new URLSearchParams(document.location.search);
+      const pointerType = searchParams.get("pointerType");
+      const preventDefaultType = searchParams.get("preventDefault");
+
+      addEventListener(
+        "load",
+        () => {
+          const iframe = document.querySelector("iframe");
+          iframe.contentDocument.head.innerHTML = `<style>${
+            document.querySelector("style").textContent
+          }</style>`;
+
+          async function runTest(win, doc) {
+            let pointerId;
+            const parent = doc.getElementById("parent");
+            const target = doc.getElementById("target");
+            const body = doc.body;
+            const html = doc.documentElement;
+            let eventTypes = [];
+            let composedPaths = [];
+            function stringifyIfElement(eventTarget) {
+              if (!(eventTarget instanceof win.Node)) {
+                return eventTarget;
+              }
+              switch (eventTarget.nodeType) {
+                case win.Node.ELEMENT_NODE:
+                  return `<${eventTarget.localName}${
+                    eventTarget.id ? ` id="${eventTarget.id}"` : ""
+                  }>`;
+                default:
+                  return eventTarget;
+              }
+            }
+            function stringifyElements(eventTargets) {
+              return eventTargets.map(stringifyIfElement);
+            }
+            function captureEvent(e) {
+              eventTypes.push(e.type);
+              composedPaths.push(e.composedPath());
+            }
+            const expectedEvents = (() => {
+              if (pointerType == "mouse") {
+                if (preventDefaultType == "pointerdown") {
+                  return {
+                    types: ["pointerdown", "pointerup", "click"],
+                    composedPaths: [
+                      [target, parent, body, html, doc, win],
+                      [parent, body, html, doc, win],
+                      // Captured by the parent element, `click` should be fired on it.
+                      [parent, body, html, doc, win],
+                    ],
+                  };
+                }
+                return {
+                  types: [
+                    "pointerdown",
+                    "mousedown",
+                    "pointerup",
+                    "mouseup",
+                    "click",
+                  ],
+                  composedPaths: [
+                    [target, parent, body, html, doc, win],
+                    // `mousedown` target should be considered without the capturing
+                    // element.
+                    [target, parent, body, html, doc, win],
+                    [parent, body, html, doc, win],
+                    // However, `mouseup` target should be considered with the capturing
+                    // element.
+                    [parent, body, html, doc, win],
+                    // Captured by the parent element, `click` should be fired on it.
+                    [parent, body, html, doc, win],
+                  ],
+                };
+              }
+              if (preventDefaultType == "pointerdown") {
+                return {
+                  types: [
+                    "pointerdown",
+                    "touchstart",
+                    "pointerup",
+                    "touchend",
+                    "click",
+                  ],
+                  composedPaths: [
+                    [target, parent, body, html, doc, win],
+                    // `touchstart` target should be considered without the capturing
+                    // element.
+                    [target, parent, body, html, doc, win],
+                    [parent, body, html, doc, win],
+                    // Different from `mouseup`, `touchend` should always be fired on
+                    // same target as `touchstart`.
+                    [target, parent, body, html, doc, win],
+                    // `click` event is not a compatibility mouse event of Touch Events
+                    // because canceling `pointerdown` should cancel them.  However,
+                    // the event target should be considered with `userEvent` which
+                    // caused this `click` event.  In this case, it's the preceding
+                    // `touchend`.  Therefore, this should be considered with its
+                    // target rather than the capturing element.
+                    [target, parent, body, html, doc, win],
+                  ],
+                };
+              }
+              if (preventDefaultType == "touchstart") {
+                return {
+                  types: ["pointerdown", "touchstart", "pointerup", "touchend"],
+                  composedPaths: [
+                    [target, parent, body, html, doc, win],
+                    // `touchstart` target should be considered without the capturing
+                    // element.
+                    [target, parent, body, html, doc, win],
+                    [parent, body, html, doc, win],
+                    // Different from `mouseup`, `touchend` should always be fired on
+                    // same target as `touchstart`.
+                    [target, parent, body, html, doc, win],
+                    // `click` shouldn't be fired if `touchstart` is canceled especially
+                    // for the backward compatibility.
+                  ],
+                };
+              }
+              return {
+                types: [
+                  "pointerdown",
+                  "touchstart",
+                  "pointerup",
+                  "touchend",
+                  "mousedown",
+                  "mouseup",
+                  "click",
+                ],
+                composedPaths: [
+                  [target, parent, body, html, doc, win],
+                  // `touchstart` target should be considered without the capturing
+                  // element.
+                  [target, parent, body, html, doc, win],
+                  [parent, body, html, doc, win],
+                  // Different from `mouseup`, `touchend` should always be fired on
+                  // same target as `touchstart`.
+                  [target, parent, body, html, doc, win],
+                  // Compatibility mouse events should be fired on the element at the
+                  // touch point.
+                  [target, parent, body, html, doc, win],
+                  [target, parent, body, html, doc, win],
+                  // `click` should be a compatibility mouse event of the Touch Events.
+                  // So, it should be fired on same target as the other compatibility
+                  // mouse events.
+                  [target, parent, body, html, doc, win],
+                ],
+              };
+            })();
+
+            win.addEventListener(
+              "pointerdown",
+              (e) => {
+                captureEvent(e);
+                pointerId = e.pointerId;
+                parent.setPointerCapture(pointerId);
+                if (preventDefaultType == e.type) {
+                  e.preventDefault();
+                }
+              },
+              { once: true, passive: false }
+            );
+            win.addEventListener(
+              "pointerup",
+              (e) => {
+                captureEvent(e);
+                parent.releasePointerCapture(pointerId);
+              },
+              { once: true }
+            );
+            win.addEventListener(
+              "touchstart",
+              (e) => {
+                captureEvent(e);
+                if (preventDefaultType == e.type) {
+                  e.preventDefault();
+                }
+              },
+              { once: true, passive: false }
+            );
+            win.addEventListener(
+              "touchend",
+              (e) => {
+                captureEvent(e);
+              },
+              { once: true }
+            );
+            win.addEventListener("mousedown", captureEvent, { once: true });
+            win.addEventListener("mouseup", captureEvent, { once: true });
+            win.addEventListener("click", captureEvent, { once: true });
+
+            await new test_driver.Actions()
+              .addPointer("TestPointer", pointerType)
+              .pointerMove(0, 0, { origin: target })
+              .pointerDown()
+              .pointerUp()
+              .send();
+
+            assert_array_equals(
+              eventTypes,
+              expectedEvents.types,
+              "all expected events should be fired"
+            );
+            for (let i = 0; i < expectedEvents.types.length; i++) {
+              assert_array_equals(
+                stringifyElements(composedPaths[i]),
+                stringifyElements(expectedEvents.composedPaths[i]),
+                `"${expectedEvents.types[i]}" event should be fired on expected target`
+              );
+            }
+          }
+
+          promise_test(async () => {
+            await runTest(window, document);
+          }, "Test in the topmost document");
+          promise_test(async () => {
+            await runTest(iframe.contentWindow, iframe.contentDocument);
+          }, "Test in the iframe");
+        },
+        { once: true }
+      );
+    </script>
+  </head>
+  <body>
+    <div id="parent">
+      <div id="target"></div>
+    </div>
+    <iframe srcdoc="<div id='parent'><div id='target'></div></div>"></iframe>
+  </body>
+</html>


### PR DESCRIPTION
https://github.com/w3c/pointerevents/issues/508

`click` event is now defined complicated.  If nothing is canceled, it should be overridden by Pointer Events.  However, if `touchstart` is canceled, it shouldn't be fired because of the backward compatibility for Touch Events.  If `pointerdown` is canceled, touch events should be fired as-is, but the compatibility mouse events shouldn't be fired except `click` event.  Therefore, in this case, `click` event should be targeted with `userEvent` which the user initiated.  So, the `click` event target may be different whether it's caused by a mouse or a touch because `mouseup` is adjusted by the pointer capture, but `touchend` should be fired on same target as the preceding `touchstart`. Therefore, `touchend` is not limited by the pointer capture but is limited by `touchstart.

However, there is a potential backward compatibility.  This test is originated in Mozilla's internal tests [1].  It was introduced when Mozilla got a compatibility report with bxSlider [2].  The report is, links in the slide won't work.  That was caused by that bxSlider makes parent element of clicked link capture the pointer.  Therefore, `click` wouldn't be fired on the link.  So, conforming to the expected results of this test may make bxSliver break again because their issue is still open.

1. https://searchfox.org/mozilla-central/rev/a26e972e97fbec860400d80df625193f4c88d64e/dom/events/test/window_bug1447993.html
2. https://bugzilla.mozilla.org/show_bug.cgi?id=1447993