### PR TITLE
Fixes incorrect test names for the revert-in-fallback tests

### DIFF
--- a/css/css-variables/revert-in-fallback.html
+++ b/css/css-variables/revert-in-fallback.html
@@ -28,15 +28,15 @@
 
       test((t) => {
         assert_equals(getComputedStyle(document.body).getPropertyValue('margin'), body_ua_margin);
-      }, 'var(--unknown, revert-layer) in shorthand');
+      }, 'var(--unknown, revert) in shorthand');
 
       test((x) => {
         assert_equals(getComputedStyle(document.body).getPropertyValue('margin-left'), body_ua_margin);
-      }, 'var(--unknown, revert-layer) in shorthand observed via longhand');
+      }, 'var(--unknown, revert) in shorthand observed via longhand');
 
       test((t) => {
         assert_equals(getComputedStyle(document.body).getPropertyValue('display'), body_ua_display);
-      }, 'var(--unknown, revert-layer) in longhand');
+      }, 'var(--unknown, revert) in longhand');
     </script>
   </body>
 </html>


### PR DESCRIPTION
When looking through the tests for custom properties, I noticed that some tests in the `css/css-variables/revert-in-fallback.html` have incorrect names, likely from being copied from `css/css-variables/revert-layer-in-fallback.html` (mentioning `revert-layer` and not the `revert` that was being tested.)

This PR fixes this.