### PR TITLE
Better log for debugging

### DIFF
--- a/tools/third_party/pywebsocket3/pywebsocket3/request_handler.py
+++ b/tools/third_party/pywebsocket3/pywebsocket3/request_handler.py
@@ -219,6 +219,7 @@ class WebSocketRequestHandler(CGIHTTPServer.CGIHTTPRequestHandler):
                 self._logger.info('Request basic authentication')
                 return False
 
+        whole_path = self.path
         host, port, resource = http_header_util.parse_uri(self.path)
         if resource is None:
             self._logger.info('Invalid URI: %r', self.path)
@@ -247,7 +248,7 @@ class WebSocketRequestHandler(CGIHTTPServer.CGIHTTPRequestHandler):
             # Fallback to default http handler for request paths for which
             # we don't have request handlers.
             if not self._options.dispatcher.get_handler_suite(self.path):
-                self._logger.info('No handler for resource: %r', self.path)
+                self._logger.info('No handler for resource: %r', whole_path)
                 self._logger.info('Fallback to CGIHTTPRequestHandler')
                 return True
         except dispatch.DispatchException as e:

--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -359,7 +359,7 @@ class WebDriverBrowser(Browser):
             env=self.env,
             storeOutput=False)
 
-        self.logger.debug("Starting WebDriver: %s" % ' '.join(cmd))
+        self.logger.info("Starting WebDriver: %s" % ' '.join(cmd))
         try:
             self._proc.run()
         except OSError as e:
@@ -378,13 +378,12 @@ class WebDriverBrowser(Browser):
                 server_process=self._proc,
             )
         except Exception:
-            self.logger.error(
-                "WebDriver was not accessible "
-                f"within the timeout:\n{traceback.format_exc()}")
+            self.logger.error(f"WebDriver was not accessible within {self.init_timeout} seconds.")
+            self.logger.error(traceback.format_exc())
             raise
         finally:
             self._output_handler.start(group_metadata=group_metadata, **kwargs)
-        self.logger.debug("_run complete")
+        self.logger.info("Webdriver started successfully.")
 
     def stop(self, force: bool = False) -> bool:
         self.logger.debug("Stopping WebDriver")


### PR DESCRIPTION
We are seeing logs as below from Chromium bots. Add more information to log to make debugging easier.

Two kind of error log to address here:
1) No handler for resource: '/404'
2) WebDriver was not accessible within the timeout:

Bug: chromedriver:4793