### PR TITLE
[WebDriver BiDi] Align `browsingContext.userPromptClosed` tests with spec

### DIFF
--- a/webdriver/tests/bidi/browsing_context/user_prompt_closed/beforeunload.py
+++ b/webdriver/tests/bidi/browsing_context/user_prompt_closed/beforeunload.py
@@ -1,7 +1,4 @@
 import pytest
-from webdriver.error import TimeoutException
-
-from tests.support.sync import AsyncPoll
 
 pytestmark = pytest.mark.asyncio
 
@@ -47,5 +44,4 @@ async def test_beforeunload(
     assert event == {
         "context": new_tab["context"],
         "accepted": accept,
-        "type": "beforeunload",
     }

--- a/webdriver/tests/bidi/browsing_context/user_prompt_closed/user_prompt_closed.py
+++ b/webdriver/tests/bidi/browsing_context/user_prompt_closed/user_prompt_closed.py
@@ -74,7 +74,6 @@ async def test_prompt_type_alert(
     assert event == {
         "context": new_tab["context"],
         "accepted": True,
-        "type": "alert",
     }
 
 
@@ -111,7 +110,6 @@ async def test_prompt_type_confirm(
     assert event == {
         "context": new_tab["context"],
         "accepted": accept,
-        "type": "confirm",
     }
 
 
@@ -150,14 +148,12 @@ async def test_prompt_type_prompt(
         assert event == {
             "context": new_tab["context"],
             "accepted": accept,
-            "type": "prompt",
             "userText": test_user_text,
         }
     else:
         assert event == {
             "context": new_tab["context"],
             "accepted": accept,
-            "type": "prompt",
         }
 
 
@@ -190,7 +186,6 @@ async def test_prompt_with_defaults(
     assert event == {
         "context": new_tab["context"],
         "accepted": True,
-        "type": "prompt",
     }
 
 
@@ -265,7 +260,6 @@ async def test_subscribe_to_one_context(
     assert event == {
         "context": new_context["context"],
         "accepted": True,
-        "type": "alert",
     }
 
     remove_listener()
@@ -313,5 +307,4 @@ async def test_iframe(
     assert event == {
         "context": new_tab["context"],
         "accepted": True,
-        "type": "alert",
     }


### PR DESCRIPTION
[`browsingContext.UserPromptClosedParameters`](https://w3c.github.io/webdriver-bidi/#event-browsingContext-userPromptClosed) does not have `type` field.