### PR TITLE
[wptrunner] Fix additional issues with `WebDriverProtocol.is_alive()`

### DIFF
--- a/tools/webdriver/webdriver/transport.py
+++ b/tools/webdriver/webdriver/transport.py
@@ -204,6 +204,8 @@ class HTTPWireProtocol:
             ``json.JSONEncoder`` unless specified.
         :param decoder: JSON decoder class, which defaults to
             ``json.JSONDecoder`` unless specified.
+        :param timeout: Optional timeout for the underlying socket. `None` will
+            retain the existing timeout.
         :param codec_kwargs: Surplus arguments passed on to `encoder`
             and `decoder` on construction.
 
@@ -231,7 +233,7 @@ class HTTPWireProtocol:
         # runner thread. We use the boolean below to check for that and restart
         # the connection in that case.
         self._last_request_is_blocked = True
-        response = self._request(method, uri, payload, headers, timeout=None)
+        response = self._request(method, uri, payload, headers, timeout=timeout)
         self._last_request_is_blocked = False
         return Response.from_http(response, decoder=decoder, **codec_kwargs)
 

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -509,7 +509,9 @@ class WebDriverProtocol(Protocol):
             self.logger.debug(message)
         self.webdriver = None
 
-    def is_alive(self):
+    def is_alive(self) -> bool:
+        if not self.webdriver:
+            return False
         try:
             # Get a simple property over the connection, with 2 seconds of timeout
             # that should be more than enough to check if the WebDriver its


### PR DESCRIPTION
* It's possible for a thread spawned by `WebDriverRun` to outlive the runner process's main thread (https://crbug.com/348266194#comment3), in which case `WebDriverProtocol.is_alive()` may be called after the client is torn down and removed. Tolerate this case.
* #22044 didn't actually wire up `HTTPWireProtocol.send(timeout=...)` to the underlying socket timeout.