### PR TITLE
Remove `httpRequestStatusCode` from `RTCError.html` test

### DIFF
--- a/webrtc/RTCError.html
+++ b/webrtc/RTCError.html
@@ -61,7 +61,6 @@ test(() => {
 
 // All of these are number types (long or unsigned long).
 const nullableAttributes = ['sdpLineNumber',
-                            'httpRequestStatusCode',
                             'sctpCauseCode',
                             'receivedAlert',
                             'sentAlert'];
@@ -86,4 +85,8 @@ nullableAttributes.forEach(attribute => {
   }, 'RTCError.' + attribute + ' is readonly');
 });
 
+test(function() {
+  assert_false("httpRequestStatusCode" in RTCError.prototype,
+               "Should not be supported on the prototype");
+}, "RTCError httpRequestStatusCode should not be supported.");
 </script>


### PR DESCRIPTION
Hi Team,

I was looking into browser specific failures in WebKit and noticed that we fail following test [1]:

[1] https://wpt.fyi/results/webrtc/RTCError.html?label=master&label=experimental&aligned&q=safari%3Afail

While the interface does not have `httpRequestStatusCode` as per web specification [2]:

[2] https://w3c.github.io/webrtc-pc/#rtcerror-interface

Additionally, I noted from GitHub repo, that it was removed in [3]:

[3] https://github.com/w3c/webrtc-pc/pull/2428

This PR is to remove it from the test, so it reflects recent changes and reduce confusions.

At the same time, I am negative test to ensure `httpRequestStatusCode`
is not supported on RTCError anymore.

Thanks!