### PR TITLE
Add missing `tabindex="0"` to popover-focus.html

### DIFF
--- a/html/semantics/popovers/popover-focus.html
+++ b/html/semantics/popovers/popover-focus.html
@@ -50,11 +50,11 @@
 </div>
 
 <dialog popover=auto data-test='Opening dialogs as popovers should use dialog initial focus algorithm.'>
-  <button class=should-be-focused>button</button>
+  <button class=should-be-focused tabindex="0">button</button>
 </dialog>
 
 <dialog popover=auto autofocus class=should-be-focused data-test='Opening dialogs as popovers which have autofocus should focus the dialog.'>
-  <button>button</button>
+  <button tabindex="0">button</button>
 </dialog>
 
 <style>


### PR DESCRIPTION
On Safari, buttons are not focusable by default unless a setting is enabled, or if the button has `tabindex="0"`. Add missing `tabindex="0"` so the buttons can be focus delegates.