### PR TITLE
Revert "[WebDriver BiDi] Align `browsingContext.userPromptClosed` tests with spec"

### DIFF
--- a/webdriver/tests/bidi/browsing_context/user_prompt_closed/beforeunload.py
+++ b/webdriver/tests/bidi/browsing_context/user_prompt_closed/beforeunload.py
@@ -1,4 +1,7 @@
 import pytest
+from webdriver.error import TimeoutException
+
+from tests.support.sync import AsyncPoll
 
 pytestmark = pytest.mark.asyncio
 
@@ -44,4 +47,5 @@ async def test_beforeunload(
     assert event == {
         "context": new_tab["context"],
         "accepted": accept,
+        "type": "beforeunload",
     }

--- a/webdriver/tests/bidi/browsing_context/user_prompt_closed/user_prompt_closed.py
+++ b/webdriver/tests/bidi/browsing_context/user_prompt_closed/user_prompt_closed.py
@@ -74,6 +74,7 @@ async def test_prompt_type_alert(
     assert event == {
         "context": new_tab["context"],
         "accepted": True,
+        "type": "alert",
     }
 
 
@@ -110,6 +111,7 @@ async def test_prompt_type_confirm(
     assert event == {
         "context": new_tab["context"],
         "accepted": accept,
+        "type": "confirm",
     }
 
 
@@ -148,12 +150,14 @@ async def test_prompt_type_prompt(
         assert event == {
             "context": new_tab["context"],
             "accepted": accept,
+            "type": "prompt",
             "userText": test_user_text,
         }
     else:
         assert event == {
             "context": new_tab["context"],
             "accepted": accept,
+            "type": "prompt",
         }
 
 
@@ -186,6 +190,7 @@ async def test_prompt_with_defaults(
     assert event == {
         "context": new_tab["context"],
         "accepted": True,
+        "type": "prompt",
     }
 
 
@@ -260,6 +265,7 @@ async def test_subscribe_to_one_context(
     assert event == {
         "context": new_context["context"],
         "accepted": True,
+        "type": "alert",
     }
 
     remove_listener()
@@ -307,4 +313,5 @@ async def test_iframe(
     assert event == {
         "context": new_tab["context"],
         "accepted": True,
+        "type": "alert",
     }


### PR DESCRIPTION
Reverts web-platform-tests/wpt#46856
As long as the spec changes are landed: https://github.com/w3c/webdriver-bidi/pull/681