### PR TITLE
[wptrunner] Don't honor per-request timeout for now

### DIFF
--- a/tools/webdriver/webdriver/transport.py
+++ b/tools/webdriver/webdriver/transport.py
@@ -204,8 +204,6 @@ class HTTPWireProtocol:
             ``json.JSONEncoder`` unless specified.
         :param decoder: JSON decoder class, which defaults to
             ``json.JSONDecoder`` unless specified.
-        :param timeout: Optional timeout for the underlying socket. `None` will
-            retain the existing timeout.
         :param codec_kwargs: Surplus arguments passed on to `encoder`
             and `decoder` on construction.
 
@@ -233,7 +231,7 @@ class HTTPWireProtocol:
         # runner thread. We use the boolean below to check for that and restart
         # the connection in that case.
         self._last_request_is_blocked = True
-        response = self._request(method, uri, payload, headers, timeout=timeout)
+        response = self._request(method, uri, payload, headers, timeout=None)
         self._last_request_is_blocked = False
         return Response.from_http(response, decoder=decoder, **codec_kwargs)
 


### PR DESCRIPTION
This is a partial revert of #46869. Using a nondefault timeout fails with:

```
  ▶ ERROR [expected OK] external/wpt/IndexedDB/idbindex-query-exception-order.html
  └   → WebDriverRun.run_func didn't set a result

Exception in thread Thread-4:
Traceback (most recent call last):
  File "/tmp/wpt/tools/webdriver/webdriver/transport.py", line 259, in _request
    previous_timeout = self._conn.gettimeout()
AttributeError: 'HTTPConnection' object has no attribute 'gettimeout'
```

... because `{get,set}timeout` are methods on [`socket.socket`](https://docs.python.org/3/library/socket.html#socket.socket.gettimeout), not [`http.client.HTTP(S)Connection`](https://docs.python.org/3.11/library/http.client.html#httpconnection-objects).