### PR TITLE
[WebDriverBiDi] Use JSON.stringify with fetch

### DIFF
--- a/webdriver/tests/support/fixtures_bidi.py
+++ b/webdriver/tests/support/fixtures_bidi.py
@@ -558,7 +558,7 @@ def fetch(bidi_session, top_context, configuration):
 
         body_arg = ""
         if post_data is not None:
-            body_arg = f"body: {post_data},"
+            body_arg = f"body: JSON.stringify({post_data}),"
 
         timeout_in_seconds = timeout_in_seconds * configuration["timeout_multiplier"]
         # Wait for fetch() to resolve a response and for response.text() to

--- a/webdriver/tests/support/fixtures_bidi.py
+++ b/webdriver/tests/support/fixtures_bidi.py
@@ -558,7 +558,7 @@ def fetch(bidi_session, top_context, configuration):
 
         body_arg = ""
         if post_data is not None:
-            body_arg = f"body: JSON.stringify({post_data}),"
+            body_arg = f"body: {json.dumps(post_data)},"
 
         timeout_in_seconds = timeout_in_seconds * configuration["timeout_multiplier"]
         # Wait for fetch() to resolve a response and for response.text() to


### PR DESCRIPTION
We need to convert it to string as `fetch` does not suport object, and calls `toString` on them. Resulting in `[Object object]` string.
https://developer.mozilla.org/en-US/docs/Web/API/fetch#body