### PR TITLE
[WebDriver BiDi] missing `unhandledPromptBehavior`

### DIFF
--- a/webdriver/tests/bidi/browsing_context/user_prompt_closed/beforeunload.py
+++ b/webdriver/tests/bidi/browsing_context/user_prompt_closed/beforeunload.py
@@ -9,6 +9,7 @@ USER_PROMPT_CLOSED_EVENT = "browsingContext.userPromptClosed"
 USER_PROMPT_OPENED_EVENT = "browsingContext.userPromptOpened"
 
 
+@pytest.mark.capabilities({"unhandledPromptBehavior": {'default': 'ignore'}})
 @pytest.mark.parametrize("accept", [False, True])
 async def test_beforeunload(
     bidi_session,

--- a/webdriver/tests/bidi/browsing_context/user_prompt_closed/user_prompt_closed.py
+++ b/webdriver/tests/bidi/browsing_context/user_prompt_closed/user_prompt_closed.py
@@ -8,6 +8,7 @@ USER_PROMPT_CLOSED_EVENT = "browsingContext.userPromptClosed"
 USER_PROMPT_OPENED_EVENT = "browsingContext.userPromptOpened"
 
 
+@pytest.mark.capabilities({"unhandledPromptBehavior": {'default': 'ignore'}})
 async def test_unsubscribe(
     bidi_session, inline, new_tab, wait_for_event, wait_for_future_safe
 ):
@@ -45,6 +46,7 @@ async def test_unsubscribe(
     remove_listener()
 
 
+@pytest.mark.capabilities({"unhandledPromptBehavior": {'default': 'ignore'}})
 async def test_prompt_type_alert(
     bidi_session,
     subscribe_events,
@@ -78,6 +80,7 @@ async def test_prompt_type_alert(
     }
 
 
+@pytest.mark.capabilities({"unhandledPromptBehavior": {'default': 'ignore'}})
 @pytest.mark.parametrize("accept", [True, False])
 async def test_prompt_type_confirm(
     bidi_session,
@@ -115,6 +118,7 @@ async def test_prompt_type_confirm(
     }
 
 
+@pytest.mark.capabilities({"unhandledPromptBehavior": {'default': 'ignore'}})
 @pytest.mark.parametrize("accept", [True, False])
 async def test_prompt_type_prompt(
     bidi_session,
@@ -161,6 +165,7 @@ async def test_prompt_type_prompt(
         }
 
 
+@pytest.mark.capabilities({"unhandledPromptBehavior": {'default': 'ignore'}})
 async def test_prompt_with_defaults(
     bidi_session,
     subscribe_events,
@@ -194,6 +199,7 @@ async def test_prompt_with_defaults(
     }
 
 
+@pytest.mark.capabilities({"unhandledPromptBehavior": {'default': 'ignore'}})
 @pytest.mark.parametrize("type_hint", ["tab", "window"])
 async def test_subscribe_to_one_context(
     bidi_session,
@@ -273,6 +279,7 @@ async def test_subscribe_to_one_context(
     await bidi_session.browsing_context.close(context=another_new_context["context"])
 
 
+@pytest.mark.capabilities({"unhandledPromptBehavior": {'default': 'ignore'}})
 async def test_iframe(
     bidi_session,
     new_tab,

--- a/webdriver/tests/bidi/browsing_context/user_prompt_opened/user_prompt_opened.py
+++ b/webdriver/tests/bidi/browsing_context/user_prompt_opened/user_prompt_opened.py
@@ -60,6 +60,7 @@ async def test_prompt_type(
         "context": new_tab["context"],
         "type": prompt_type,
         "message": text,
+        "handler": "dismiss",
         **({"defaultValue": ""} if prompt_type == "prompt" else {}),
     }
 
@@ -95,18 +96,13 @@ async def test_prompt_default_value(
 
     event = await wait_for_future_safe(on_entry)
 
-    expected_event = {
+    assert event == {
         "context": new_tab["context"],
         "type": "prompt",
         "message": text,
+        "handler": "dismiss",
+        "defaultValue": default if default is not None else ""
     }
-
-    if default is None:
-        expected_event["defaultValue"] = ""
-    else:
-        expected_event["defaultValue"] = default
-
-    assert event == expected_event
 
 
 @pytest.mark.parametrize("type_hint", ["tab", "window"])
@@ -160,6 +156,7 @@ async def test_subscribe_to_one_context(
     assert event == {
         "context": new_context["context"],
         "type": "alert",
+        "handler": "dismiss",
         "message": "first tab",
     }
 
@@ -202,5 +199,6 @@ async def test_iframe(
     assert event == {
         "context": new_tab["context"],
         "type": "alert",
+        "handler": "dismiss",
         "message": "in iframe",
     }


### PR DESCRIPTION
The default `unhandledPromptBehavior` falls back to `dismiss`, which does not allow testing prompt handling. This PR provides `ignore` `unhandledPromptBehavior` to keep the prompts for testing.
+ add missing `handler` field to `browsingContext.userPromptOpened` events.