### PR TITLE
[WebDriver BiDi] missing unhandledPromptBehavior

### DIFF
--- a/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
+++ b/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
@@ -51,6 +51,7 @@ async def test_prompt_unload_not_triggering_dialog(
     remove_listener()
 
 
+@pytest.mark.capabilities({"unhandledPromptBehavior": {'default': 'ignore'}})
 @pytest.mark.parametrize("type_hint", ["window", "tab"])
 async def test_prompt_unload_triggering_dialog(
     bidi_session,


### PR DESCRIPTION
One more test relying on the prompt is not dismissed. https://github.com/web-platform-tests/wpt/pull/46895