### PR TITLE
Remove duplicate historical `SVGPathSegList` test

### DIFF
--- a/dom/historical.html
+++ b/dom/historical.html
@@ -29,8 +29,7 @@ var removedInterfaces = [
   "Notation",
   "TypeInfo",
   "UserDataHandler",
-  "RangeException", // DOM Range
-  "SVGPathSegList"
+  "RangeException" // DOM Range
 ]
 removedInterfaces.forEach(isInterfaceRemoved)
 


### PR DESCRIPTION
Hi Team,

It seems we are testing this twice, once here:

> dom/historical.html

While we also have same in:

> svg/historical.html

I think it make sense to just test it in SVG (due to it being SVG interface).

So this is just clean-up patch.

Thanks!