### PR TITLE
Corrected transparent-accent-color tests to compute expected values based on canvas color

### DIFF
--- a/css/css-ui/reference/transparent-accent-color-001-ref.html
+++ b/css/css-ui/reference/transparent-accent-color-001-ref.html
@@ -4,22 +4,22 @@
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#widget-accent">
 <style>
 
-  div {
-      border: solid orange;
-      padding: 1ch;
-      margin: 1ch;
-      float: left;
-  }
-  
-  input { color-scheme: light;}
-  #extract-canvas{ accent-color: canvas; display:none;}
-  #t3 { background: orange;}
-  
+.container {
+    border: solid orange;
+    padding: 1ch;
+    margin: 1ch;
+    float: left;
+}
+
+input, #extract-canvas { color-scheme: light; }
+#extract-canvas{ background-color: canvas; }
+#t3 { background: orange; }
+
 </style>
-  
+
 <p>Test passes if in each box below, you see a pair of identically colored check-boxes.
 
-<input id='extract-canvas' type=checkbox>
+<div id='extract-canvas'></div>
 <div id=t1 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
@@ -37,34 +37,27 @@
 
 <script>
 
-  var testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]]
+  let testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]];
 
-  function getColorComponents(color){
-    var components = []
-    color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").forEach((s) => {
-      components.push(parseFloat(s));
-    });
-    return components;
+  function getColorComponents(color) {
+    return color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").map(parseFloat);
   }
 
-  function constructCSSColor(components){
-    if (components.length == 4)
-      return "rgba(" + components[0] + ", " + components[1] + ", " + components[2] + ", " + components[3] + ")";
-    return "rgb(" + components[0] + ", " + components[1] + ", " + components[2] + ")";
+  function constructCSSColor(components) {
+    return (components.length == 4 ? "rgba(" : "rgb(") + components.join(", ") + ")";
   }
 
-  function computeExpectedColor(canvasColor,colorWithAlpha){
-    var expected = []
+  function computeExpectedColor(canvasColor, colorWithAlpha) {
+    let expected = [];
     for (var i = 0; i < 3; i++)
-      expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3])
+      expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3]);
     return expected;
   }
 
-  var testContainers = document.getElementsByClassName("container");
-  var canvasColorComponents = getColorComponents(window.getComputedStyle(document.getElementById('extract-canvas')).accentColor);
-  for (var i = 0; i < testContainers.length; i++){
-    testContainers[i].getElementsByClassName("test")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents,testColors[i]));
-    testContainers[i].getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents,testColors[i]));
+  let canvasColorComponents = getColorComponents(getComputedStyle(document.getElementById('extract-canvas')).backgroundColor);
+  for (const [i, container] of Array.from(document.getElementsByClassName("container")).entries()) {
+    container.getElementsByClassName("test")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));
+    container.getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));
   }
 
 </script>

--- a/css/css-ui/reference/transparent-accent-color-001-ref.html
+++ b/css/css-ui/reference/transparent-accent-color-001-ref.html
@@ -12,14 +12,14 @@
 }
 
 input, #extract-canvas { color-scheme: light; }
-#extract-canvas{ background-color: canvas; }
+#extract-canvas { background-color: canvas; }
 #t3 { background: orange; }
 
 </style>
 
 <p>Test passes if in each box below, you see a pair of identically colored check-boxes.
 
-<div id='extract-canvas'></div>
+<div id="extract-canvas"></div>
 <div id=t1 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
@@ -37,7 +37,7 @@ input, #extract-canvas { color-scheme: light; }
 
 <script>
 
-  let testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]];
+  const testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]];
 
   function getColorComponents(color) {
     return color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").map(parseFloat);
@@ -48,14 +48,14 @@ input, #extract-canvas { color-scheme: light; }
   }
 
   function computeExpectedColor(canvasColor, colorWithAlpha) {
-    let expected = [];
-    for (var i = 0; i < 3; i++)
+    const expected = [];
+    for (let i = 0; i < 3; i++)
       expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3]);
     return expected;
   }
 
-  let canvasColorComponents = getColorComponents(getComputedStyle(document.getElementById('extract-canvas')).backgroundColor);
-  for (const [i, container] of Array.from(document.getElementsByClassName("container")).entries()) {
+  const canvasColorComponents = getColorComponents(getComputedStyle(document.getElementById("extract-canvas")).backgroundColor);
+  for (const [i, container] of document.querySelectorAll(".container").entries()) {
     container.getElementsByClassName("test")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));
     container.getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));
   }

--- a/css/css-ui/reference/transparent-accent-color-001-ref.html
+++ b/css/css-ui/reference/transparent-accent-color-001-ref.html
@@ -4,38 +4,67 @@
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#widget-accent">
 <style>
 
-div {
-    border: solid orange;
-    padding: 1ch;
-    margin: 1ch;
-    float: left;
-}
-
-#t1 input { color-scheme: light;}
-#t1 input { accent-color: white; }
-
-#t2 input { color-scheme: light;}
-#t2 input { accent-color: #7f7fff; }
-
-#t3 { background: orange;}
-#t3 input { color-scheme: light;}
-#t3 input { accent-color: #7f7fff; }
-
+  div {
+      border: solid orange;
+      padding: 1ch;
+      margin: 1ch;
+      float: left;
+  }
+  
+  input { color-scheme: light;}
+  #extract-canvas{ accent-color: canvas; display:none;}
+  #t3 { background: orange;}
+  
 </style>
+  
+<p>Test passes if in each box below, you see a pair of identically colored check-boxes.
 
-<p>Test passes if in each box bellow, you see a pair of identically colored check-boxes.
-
-<div id=t1>
+<input id='extract-canvas' type=checkbox>
+<div id=t1 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
 </div>
 
-<div id=t2>
+<div id=t2 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
 </div>
 
-<div id=t3>
+<div id=t3 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
 </div>
+
+<script>
+
+  var testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]]
+
+  function getColorComponents(color){
+    var components = []
+    color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").forEach((s) => {
+      components.push(parseFloat(s));
+    });
+    return components;
+  }
+
+  function constructCSSColor(components){
+    if (components.length == 4)
+      return "rgba(" + components[0] + ", " + components[1] + ", " + components[2] + ", " + components[3] + ")";
+    return "rgb(" + components[0] + ", " + components[1] + ", " + components[2] + ")";
+  }
+
+  function computeExpectedColor(canvasColor,colorWithAlpha){
+    var expected = []
+    for (var i = 0; i < 3; i++)
+      expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3])
+    return expected;
+  }
+
+  var testContainers = document.getElementsByClassName("container");
+  var canvasColorComponents = getColorComponents(window.getComputedStyle(document.getElementById('extract-canvas')).accentColor);
+  for (var i = 0; i < testContainers.length; i++){
+    testContainers[i].getElementsByClassName("test")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents,testColors[i]));
+    testContainers[i].getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents,testColors[i]));
+  }
+
+</script>

--- a/css/css-ui/reference/transparent-accent-color-002-ref.html
+++ b/css/css-ui/reference/transparent-accent-color-002-ref.html
@@ -4,22 +4,22 @@
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#widget-accent">
 <style>
 
-  div {
-      border: solid orange;
-      padding: 1ch;
-      margin: 1ch;
-      float: left;
-  }
-  
-  input { color-scheme: dark;}
-  #extract-canvas{ accent-color: canvas; display:none;}
-  #t3 { background: orange;}
-  
+.container {
+    border: solid orange;
+    padding: 1ch;
+    margin: 1ch;
+    float: left;
+}
+
+input, #extract-canvas { color-scheme: dark; }
+#extract-canvas{ background-color: canvas; }
+#t3 { background: orange; }
+
 </style>
-  
+
 <p>Test passes if in each box below, you see a pair of identically colored check-boxes.
 
-<input id='extract-canvas' type=checkbox>
+<div id='extract-canvas'></div>
 <div id=t1 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
@@ -36,35 +36,28 @@
 </div>
 
 <script>
-  
-  var testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]]
 
-  function getColorComponents(color){
-    var components = []
-    color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").forEach((s) => {
-      components.push(parseFloat(s));
-    });
-    return components;
+  let testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]];
+
+  function getColorComponents(color) {
+    return color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").map(parseFloat);
   }
 
-  function constructCSSColor(components){
-    if (components.length == 4)
-      return "rgba(" + components[0] + ", " + components[1] + ", " + components[2] + ", " + components[3] + ")";
-    return "rgb(" + components[0] + ", " + components[1] + ", " + components[2] + ")";
+  function constructCSSColor(components) {
+    return (components.length == 4 ? "rgba(" : "rgb(") + components.join(", ") + ")";
   }
 
-  function computeExpectedColor(canvasColor,colorWithAlpha){
-    var expected = []
+  function computeExpectedColor(canvasColor, colorWithAlpha) {
+    let expected = [];
     for (var i = 0; i < 3; i++)
-      expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3])
+      expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3]);
     return expected;
   }
 
-  var testContainers = document.getElementsByClassName("container");
-  var canvasColorComponents = getColorComponents(window.getComputedStyle(document.getElementById('extract-canvas')).accentColor);
-  for (var i = 0; i < testContainers.length; i++){
-    testContainers[i].getElementsByClassName("test")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents,testColors[i]));
-    testContainers[i].getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents,testColors[i]));
+  let canvasColorComponents = getColorComponents(getComputedStyle(document.getElementById('extract-canvas')).backgroundColor);
+  for (const [i, container] of Array.from(document.getElementsByClassName("container")).entries()) {
+    container.getElementsByClassName("test")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));
+    container.getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));
   }
 
 </script>

--- a/css/css-ui/reference/transparent-accent-color-002-ref.html
+++ b/css/css-ui/reference/transparent-accent-color-002-ref.html
@@ -12,14 +12,14 @@
 }
 
 input, #extract-canvas { color-scheme: dark; }
-#extract-canvas{ background-color: canvas; }
+#extract-canvas { background-color: canvas; }
 #t3 { background: orange; }
 
 </style>
 
 <p>Test passes if in each box below, you see a pair of identically colored check-boxes.
 
-<div id='extract-canvas'></div>
+<div id="extract-canvas"></div>
 <div id=t1 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
@@ -37,7 +37,7 @@ input, #extract-canvas { color-scheme: dark; }
 
 <script>
 
-  let testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]];
+  const testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]];
 
   function getColorComponents(color) {
     return color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").map(parseFloat);
@@ -48,14 +48,14 @@ input, #extract-canvas { color-scheme: dark; }
   }
 
   function computeExpectedColor(canvasColor, colorWithAlpha) {
-    let expected = [];
-    for (var i = 0; i < 3; i++)
+    const expected = [];
+    for (let i = 0; i < 3; i++)
       expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3]);
     return expected;
   }
 
-  let canvasColorComponents = getColorComponents(getComputedStyle(document.getElementById('extract-canvas')).backgroundColor);
-  for (const [i, container] of Array.from(document.getElementsByClassName("container")).entries()) {
+  const canvasColorComponents = getColorComponents(getComputedStyle(document.getElementById("extract-canvas")).backgroundColor);
+  for (const [i, container] of document.querySelectorAll(".container").entries()) {
     container.getElementsByClassName("test")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));
     container.getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));
   }

--- a/css/css-ui/reference/transparent-accent-color-002-ref.html
+++ b/css/css-ui/reference/transparent-accent-color-002-ref.html
@@ -4,38 +4,67 @@
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#widget-accent">
 <style>
 
-div {
-    border: solid orange;
-    padding: 1ch;
-    margin: 1ch;
-    float: left;
-}
-
-#t1 input { color-scheme: dark;}
-#t1 input { accent-color: black; }
-
-#t2 input { color-scheme: dark;}
-#t2 input { accent-color: #00007f; }
-
-#t3 { background: orange;}
-#t3 input { color-scheme: dark;}
-#t3 input { accent-color: #00007f; }
-
+  div {
+      border: solid orange;
+      padding: 1ch;
+      margin: 1ch;
+      float: left;
+  }
+  
+  input { color-scheme: dark;}
+  #extract-canvas{ accent-color: canvas; display:none;}
+  #t3 { background: orange;}
+  
 </style>
+  
+<p>Test passes if in each box below, you see a pair of identically colored check-boxes.
 
-<p>Test passes if in each box bellow, you see a pair of identically colored check-boxes.
-
-<div id=t1>
+<input id='extract-canvas' type=checkbox>
+<div id=t1 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
 </div>
 
-<div id=t2>
+<div id=t2 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
 </div>
 
-<div id=t3>
+<div id=t3 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
 </div>
+
+<script>
+  
+  var testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]]
+
+  function getColorComponents(color){
+    var components = []
+    color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").forEach((s) => {
+      components.push(parseFloat(s));
+    });
+    return components;
+  }
+
+  function constructCSSColor(components){
+    if (components.length == 4)
+      return "rgba(" + components[0] + ", " + components[1] + ", " + components[2] + ", " + components[3] + ")";
+    return "rgb(" + components[0] + ", " + components[1] + ", " + components[2] + ")";
+  }
+
+  function computeExpectedColor(canvasColor,colorWithAlpha){
+    var expected = []
+    for (var i = 0; i < 3; i++)
+      expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3])
+    return expected;
+  }
+
+  var testContainers = document.getElementsByClassName("container");
+  var canvasColorComponents = getColorComponents(window.getComputedStyle(document.getElementById('extract-canvas')).accentColor);
+  for (var i = 0; i < testContainers.length; i++){
+    testContainers[i].getElementsByClassName("test")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents,testColors[i]));
+    testContainers[i].getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents,testColors[i]));
+  }
+
+</script>

--- a/css/css-ui/transparent-accent-color-001.html
+++ b/css/css-ui/transparent-accent-color-001.html
@@ -7,22 +7,22 @@
 <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-225">
 <style>
 
-div {
+.container {
     border: solid orange;
     padding: 1ch;
     margin: 1ch;
     float: left;
 }
 
-input { color-scheme: light;}
-#extract-canvas{ accent-color: canvas; display:none;}
-#t3 { background: orange;}
+input, #extract-canvas { color-scheme: light; }
+#extract-canvas{ background-color: canvas; }
+#t3 { background: orange; }
 
 </style>
 
 <p>Test passes if in each box below, you see a pair of identically colored check-boxes.
 
-<input id='extract-canvas' type=checkbox>
+<div id='extract-canvas'></div>
 <div id=t1 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
@@ -40,34 +40,27 @@ input { color-scheme: light;}
 
 <script>
 
-  var testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]]
+  let testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]];
 
-  function getColorComponents(color){
-    var components = []
-    color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").forEach((s) => {
-      components.push(parseFloat(s));
-    });
-    return components;
+  function getColorComponents(color) {
+    return color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").map(parseFloat);
   }
 
-  function constructCSSColor(components){
-    if (components.length == 4)
-      return "rgba(" + components[0] + ", " + components[1] + ", " + components[2] + ", " + components[3] + ")";
-    return "rgb(" + components[0] + ", " + components[1] + ", " + components[2] + ")";
+  function constructCSSColor(components) {
+    return (components.length == 4 ? "rgba(" : "rgb(") + components.join(", ") + ")";
   }
 
-  function computeExpectedColor(canvasColor,colorWithAlpha){
-    var expected = []
+  function computeExpectedColor(canvasColor, colorWithAlpha) {
+    let expected = [];
     for (var i = 0; i < 3; i++)
-      expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3])
+      expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3]);
     return expected;
   }
 
-  var testContainers = document.getElementsByClassName("container");
-  var canvasColorComponents = getColorComponents(window.getComputedStyle(document.getElementById('extract-canvas')).accentColor);
-  for (var i = 0; i < testContainers.length; i++){
-    testContainers[i].getElementsByClassName("test")[0].style.accentColor = constructCSSColor(testColors[i]);
-    testContainers[i].getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents,testColors[i]));
+  let canvasColorComponents = getColorComponents(getComputedStyle(document.getElementById('extract-canvas')).backgroundColor);
+  for (const [i, container] of Array.from(document.getElementsByClassName("container")).entries()) {
+    container.getElementsByClassName("test")[0].style.accentColor = constructCSSColor(testColors[i]);
+    container.getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));
   }
 
 </script>

--- a/css/css-ui/transparent-accent-color-001.html
+++ b/css/css-ui/transparent-accent-color-001.html
@@ -3,7 +3,8 @@
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#widget-accent">
 <link rel="match" href="reference/transparent-accent-color-001-ref.html">
-<meta name="assert" content="If the color supplied is partially or fully transparent, it is precomposed over white when in light mode.">
+<meta name="assert" content="If the color supplied is partially or fully transparent, it is precomposed over the color of the light mode canvas.">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-225">
 <style>
 
 div {
@@ -13,34 +14,60 @@ div {
     float: left;
 }
 
-#t1 input { color-scheme: light;}
-#t1 .test { accent-color: #ff000000;}
-#t1 .ref { accent-color: white; }
-
-#t2 input { color-scheme: light;}
-#t2 .test { accent-color: #0000ff80;}
-#t2 .ref { accent-color: #7f7fff; }
-
+input { color-scheme: light;}
+#extract-canvas{ accent-color: canvas; display:none;}
 #t3 { background: orange;}
-#t3 input { color-scheme: light;}
-#t3 .test { accent-color: #0000ff80;}
-#t3 .ref { accent-color: #7f7fff; }
 
 </style>
 
-<p>Test passes if in each box bellow, you see a pair of identically colored check-boxes.
+<p>Test passes if in each box below, you see a pair of identically colored check-boxes.
 
-<div id=t1>
+<input id='extract-canvas' type=checkbox>
+<div id=t1 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
 </div>
 
-<div id=t2>
+<div id=t2 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
 </div>
 
-<div id=t3>
+<div id=t3 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
 </div>
+
+<script>
+
+  var testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]]
+
+  function getColorComponents(color){
+    var components = []
+    color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").forEach((s) => {
+      components.push(parseFloat(s));
+    });
+    return components;
+  }
+
+  function constructCSSColor(components){
+    if (components.length == 4)
+      return "rgba(" + components[0] + ", " + components[1] + ", " + components[2] + ", " + components[3] + ")";
+    return "rgb(" + components[0] + ", " + components[1] + ", " + components[2] + ")";
+  }
+
+  function computeExpectedColor(canvasColor,colorWithAlpha){
+    var expected = []
+    for (var i = 0; i < 3; i++)
+      expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3])
+    return expected;
+  }
+
+  var testContainers = document.getElementsByClassName("container");
+  var canvasColorComponents = getColorComponents(window.getComputedStyle(document.getElementById('extract-canvas')).accentColor);
+  for (var i = 0; i < testContainers.length; i++){
+    testContainers[i].getElementsByClassName("test")[0].style.accentColor = constructCSSColor(testColors[i]);
+    testContainers[i].getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents,testColors[i]));
+  }
+
+</script>

--- a/css/css-ui/transparent-accent-color-001.html
+++ b/css/css-ui/transparent-accent-color-001.html
@@ -15,14 +15,14 @@
 }
 
 input, #extract-canvas { color-scheme: light; }
-#extract-canvas{ background-color: canvas; }
+#extract-canvas { background-color: canvas; }
 #t3 { background: orange; }
 
 </style>
 
 <p>Test passes if in each box below, you see a pair of identically colored check-boxes.
 
-<div id='extract-canvas'></div>
+<div id="extract-canvas"></div>
 <div id=t1 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
@@ -40,7 +40,7 @@ input, #extract-canvas { color-scheme: light; }
 
 <script>
 
-  let testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]];
+  const testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]];
 
   function getColorComponents(color) {
     return color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").map(parseFloat);
@@ -51,14 +51,14 @@ input, #extract-canvas { color-scheme: light; }
   }
 
   function computeExpectedColor(canvasColor, colorWithAlpha) {
-    let expected = [];
-    for (var i = 0; i < 3; i++)
+    const expected = [];
+    for (let i = 0; i < 3; i++)
       expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3]);
     return expected;
   }
 
-  let canvasColorComponents = getColorComponents(getComputedStyle(document.getElementById('extract-canvas')).backgroundColor);
-  for (const [i, container] of Array.from(document.getElementsByClassName("container")).entries()) {
+  const canvasColorComponents = getColorComponents(getComputedStyle(document.getElementById("extract-canvas")).backgroundColor);
+  for (const [i, container] of document.querySelectorAll(".container").entries()) {
     container.getElementsByClassName("test")[0].style.accentColor = constructCSSColor(testColors[i]);
     container.getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));
   }

--- a/css/css-ui/transparent-accent-color-002.html
+++ b/css/css-ui/transparent-accent-color-002.html
@@ -15,14 +15,14 @@
 }
 
 input, #extract-canvas { color-scheme: dark; }
-#extract-canvas{ background-color: canvas; }
+#extract-canvas { background-color: canvas; }
 #t3 { background: orange; }
 
 </style>
 
 <p>Test passes if in each box below, you see a pair of identically colored check-boxes.
 
-<div id='extract-canvas'></div>
+<div id="extract-canvas"></div>
 <div id=t1 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
@@ -40,7 +40,7 @@ input, #extract-canvas { color-scheme: dark; }
 
 <script>
 
-  let testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]];
+  const testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]];
 
   function getColorComponents(color) {
     return color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").map(parseFloat);
@@ -51,14 +51,14 @@ input, #extract-canvas { color-scheme: dark; }
   }
 
   function computeExpectedColor(canvasColor, colorWithAlpha) {
-    let expected = [];
-    for (var i = 0; i < 3; i++)
+    const expected = [];
+    for (let i = 0; i < 3; i++)
       expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3]);
     return expected;
   }
 
-  let canvasColorComponents = getColorComponents(getComputedStyle(document.getElementById('extract-canvas')).backgroundColor);
-  for (const [i, container] of Array.from(document.getElementsByClassName("container")).entries()) {
+  const canvasColorComponents = getColorComponents(getComputedStyle(document.getElementById("extract-canvas")).backgroundColor);
+  for (const [i, container] of document.querySelectorAll(".container").entries()) {
     container.getElementsByClassName("test")[0].style.accentColor = constructCSSColor(testColors[i]);
     container.getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));
   }

--- a/css/css-ui/transparent-accent-color-002.html
+++ b/css/css-ui/transparent-accent-color-002.html
@@ -3,7 +3,8 @@
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#widget-accent">
 <link rel="match" href="reference/transparent-accent-color-002-ref.html">
-<meta name="assert" content="If the color supplied is partially or fully transparent, it is precomposed over black when in dark mode.">
+<meta name="assert" content="If the color supplied is partially or fully transparent, it is precomposed over the color of the dark mode canvas.">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-225">
 <style>
 
 div {
@@ -13,34 +14,60 @@ div {
     float: left;
 }
 
-#t1 input { color-scheme: dark;}
-#t1 .test { accent-color: #ff000000;}
-#t1 .ref { accent-color: black; }
-
-#t2 input { color-scheme: dark;}
-#t2 .test { accent-color: #0000ff80;}
-#t2 .ref { accent-color: #00007f; }
-
+input { color-scheme: dark;}
+#extract-canvas{ accent-color: canvas; display:none;}
 #t3 { background: orange;}
-#t3 input { color-scheme: dark;}
-#t3 .test { accent-color: #0000ff80;}
-#t3 .ref { accent-color: #00007f; }
 
 </style>
 
-<p>Test passes if in each box bellow, you see a pair of identically colored check-boxes.
+<p>Test passes if in each box below, you see a pair of identically colored check-boxes.
 
-<div id=t1>
+<input id='extract-canvas' type=checkbox>
+<div id=t1 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
 </div>
 
-<div id=t2>
+<div id=t2 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
 </div>
 
-<div id=t3>
+<div id=t3 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
 </div>
+
+<script>
+
+  var testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]]
+
+  function getColorComponents(color){
+    var components = []
+    color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").forEach((s) => {
+      components.push(parseFloat(s));
+    });
+    return components;
+  }
+
+  function constructCSSColor(components){
+    if (components.length == 4)
+      return "rgba(" + components[0] + ", " + components[1] + ", " + components[2] + ", " + components[3] + ")";
+    return "rgb(" + components[0] + ", " + components[1] + ", " + components[2] + ")";
+  }
+
+  function computeExpectedColor(canvasColor,colorWithAlpha){
+    var expected = []
+    for (var i = 0; i < 3; i++)
+      expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3])
+    return expected;
+  }
+
+  var testContainers = document.getElementsByClassName("container");
+  var canvasColorComponents = getColorComponents(window.getComputedStyle(document.getElementById('extract-canvas')).accentColor);
+  for (var i = 0; i < testContainers.length; i++){
+    testContainers[i].getElementsByClassName("test")[0].style.accentColor = constructCSSColor(testColors[i]);
+    testContainers[i].getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents,testColors[i]));
+  }
+
+</script>

--- a/css/css-ui/transparent-accent-color-002.html
+++ b/css/css-ui/transparent-accent-color-002.html
@@ -58,7 +58,6 @@ input, #extract-canvas { color-scheme: dark; }
   }
 
   let canvasColorComponents = getColorComponents(getComputedStyle(document.getElementById('extract-canvas')).backgroundColor);
-  console.log(canvasColorComponents);
   for (const [i, container] of Array.from(document.getElementsByClassName("container")).entries()) {
     container.getElementsByClassName("test")[0].style.accentColor = constructCSSColor(testColors[i]);
     container.getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));

--- a/css/css-ui/transparent-accent-color-002.html
+++ b/css/css-ui/transparent-accent-color-002.html
@@ -7,22 +7,22 @@
 <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-225">
 <style>
 
-div {
+.container {
     border: solid orange;
     padding: 1ch;
     margin: 1ch;
     float: left;
 }
 
-input { color-scheme: dark;}
-#extract-canvas{ accent-color: canvas; display:none;}
-#t3 { background: orange;}
+input, #extract-canvas { color-scheme: dark; }
+#extract-canvas{ background-color: canvas; }
+#t3 { background: orange; }
 
 </style>
 
 <p>Test passes if in each box below, you see a pair of identically colored check-boxes.
 
-<input id='extract-canvas' type=checkbox>
+<div id='extract-canvas'></div>
 <div id=t1 class="container">
   <input class=test type=checkbox checked>
   <input class=ref type=checkbox checked>
@@ -40,34 +40,28 @@ input { color-scheme: dark;}
 
 <script>
 
-  var testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]]
+  let testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]];
 
-  function getColorComponents(color){
-    var components = []
-    color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").forEach((s) => {
-      components.push(parseFloat(s));
-    });
-    return components;
+  function getColorComponents(color) {
+    return color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").map(parseFloat);
   }
 
-  function constructCSSColor(components){
-    if (components.length == 4)
-      return "rgba(" + components[0] + ", " + components[1] + ", " + components[2] + ", " + components[3] + ")";
-    return "rgb(" + components[0] + ", " + components[1] + ", " + components[2] + ")";
+  function constructCSSColor(components) {
+    return (components.length == 4 ? "rgba(" : "rgb(") + components.join(", ") + ")";
   }
 
-  function computeExpectedColor(canvasColor,colorWithAlpha){
-    var expected = []
+  function computeExpectedColor(canvasColor, colorWithAlpha) {
+    let expected = [];
     for (var i = 0; i < 3; i++)
-      expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3])
+      expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3]);
     return expected;
   }
 
-  var testContainers = document.getElementsByClassName("container");
-  var canvasColorComponents = getColorComponents(window.getComputedStyle(document.getElementById('extract-canvas')).accentColor);
-  for (var i = 0; i < testContainers.length; i++){
-    testContainers[i].getElementsByClassName("test")[0].style.accentColor = constructCSSColor(testColors[i]);
-    testContainers[i].getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents,testColors[i]));
+  let canvasColorComponents = getColorComponents(getComputedStyle(document.getElementById('extract-canvas')).backgroundColor);
+  console.log(canvasColorComponents);
+  for (const [i, container] of Array.from(document.getElementsByClassName("container")).entries()) {
+    container.getElementsByClassName("test")[0].style.accentColor = constructCSSColor(testColors[i]);
+    container.getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));
   }
 
 </script>


### PR DESCRIPTION
The transparent-accent-color tests currently assume the canvas color is #000000 in dark mode or #FFFFFF in light mode, which is not the case in all browsers. This change adds a script to the tests which calculates the expected color by composing the accent-color over the canvas color, which is the correct behavior according to this resolution made by the CSS working group: https://github.com/w3c/csswg-drafts/issues/9852#issuecomment-2166096835