### PR TITLE
Increase fuzzy thresholds for font-size-adjust-{012,013}.html

### DIFF
--- a/css/css-fonts/font-size-adjust-012.html
+++ b/css/css-fonts/font-size-adjust-012.html
@@ -5,7 +5,7 @@
     <title>CSS Test: font-size-adjust property</title>
     <link rel="match" href="font-size-adjust-012-ref.html">
     <link rel="help" href="https://www.w3.org/TR/css-fonts-4/#font-size-adjust-prop">
-    <meta name="fuzzy" content="maxDifference=0-120;totalPixels=0-160">
+    <meta name="fuzzy" content="maxDifference=0-130;totalPixels=0-350">
     <style>
         @font-face {
             font-family: 'ahem-ex-500';

--- a/css/css-fonts/font-size-adjust-013.html
+++ b/css/css-fonts/font-size-adjust-013.html
@@ -6,7 +6,7 @@
     <link rel="match" href="font-size-adjust-013-ref.html">
     <link rel="help" href="https://www.w3.org/TR/css-fonts-5/#font-size-adjust-prop">
     <meta name="assert" content="Test whether from-font automatically determines a font-size-adjust value based on the primary font.">
-    <meta name="fuzzy" content="maxDifference=0-120;totalPixels=0-160">
+    <meta name="fuzzy" content="maxDifference=0-130;totalPixels=0-350">
     <style>
         @font-face {
             font-family: 'primary-font-ahem-ex-500';


### PR DESCRIPTION
This is similar to https://github.com/web-platform-tests/wpt/pull/43234
but for Chrome. The previous values were from the Safari failures, with
totalPixels rounded up to a multiple of 10.

The new values are from the Chrome failures, also rounded up:
https://wpt.fyi/analyzer?screenshot=sha1%3A2d727aab490a434ed59a9ab5ceab7fe7f34eb022&screenshot=sha1%3A1acdbc09ce6d26dcef3f974d47efecc3b1dc1939
https://wpt.fyi/analyzer?screenshot=sha1%3A597bc69c19c190d57d5be679954e5455c21b2341&screenshot=sha1%3A3fa742f03a6b2ead2ac9eaf26a0ad6c8b3585fe4
