### PR TITLE
Test new Generic Worker pool (do not merge to master)

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -50,7 +50,7 @@ tasks:
           created: {$fromNow: ''}
           deadline: {$fromNow: '24 hours'}
           provisionerId: proj-wpt
-          workerType: ci
+          workerType: ci-gw
           metadata:
             name: "wpt-decision-task"
             description: "The task that creates all of the other tasks in the task graph"

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -1,7 +1,7 @@
 components:
   wpt-base:
     provisionerId: proj-wpt
-    workerType: ci
+    workerType: ci-gw
     schedulerId: taskcluster-github
     deadline: "24 hours"
     image: webplatformtests/wpt:0.57


### PR DESCRIPTION
This tests the task graph under Generic Worker using the new pool created in https://github.com/taskcluster/community-tc-config/pull/775.

Note, it is not intended to merge this PR, only to see if all the tests pass successfully.

If all goes well, we can just replace the old pool with the new one.