### PR TITLE
[Not for submit] Minimal demo of test driver bless() bug with multiple <iframe>s

### DIFF
--- a/digital-credentials/iframe-user-activation-test.tentative.https.html
+++ b/digital-credentials/iframe-user-activation-test.tentative.https.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<body>
+<!-- If first iframe is removed, 2nd iframe starts being able to request transient activation -->
+<iframe></iframe><br/>
+<iframe id="test_iframe"></iframe><br/>
+
+<script type="module">
+export function loadIframe(iframe, url) {
+  return new Promise((resolve, reject) => {
+    iframe.addEventListener("load", resolve, { once: true });
+    iframe.addEventListener("error", reject, { once: true });
+    iframe.src = url;
+  });
+}
+
+promise_test(async t=>{
+  const test_iframe = document.getElementById("test_iframe");
+  const hostInfo = get_host_info();
+  await loadIframe(
+     test_iframe,
+    `${hostInfo.HTTPS_REMOTE_ORIGIN}/digital-credentials/support/iframe2.html`
+  );
+
+  test_iframe.contentWindow.postMessage("gain_user_activation", "*");
+  await new Promise((resolve)=>{});
+}, "iframe should get user activation");
+
+</script>

--- a/digital-credentials/support/iframe2.html
+++ b/digital-credentials/support/iframe2.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body>
+<script>
+async function messageListener(event) {
+  if (event.data != "gain_user_activation") {
+    return;
+  }
+  await test_driver.bless("gain user activation", async function() {
+    console.log(navigator.userActivation.isActive ? "Has User Activation" : "Does not have user activation");
+    return;
+  });
+}
+window.addEventListener("message", messageListener);
+</script>


### PR DESCRIPTION
The purpose of this PR is to demonstrate a test driver bug.

Specifically, for a cross-origin <iframe> bless() only acquires transient user activation if it is called from the first <iframe> on the page. It does not work if called on an iframe which is not the first on the page.

In cases where bless() does not obtain transient user activation, bless() still calls the JavaScript callback