### PR TITLE
Shadow DOM Leaks (Selection API)

### DIFF
--- a/shadow-dom/leaktests/selection.html
+++ b/shadow-dom/leaktests/selection.html
@@ -6,6 +6,9 @@
 <link rel='help' href='https://w3c.github.io/webcomponents/spec/shadow/'>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 </head>
 <body>
 <div id='log'></div>
@@ -21,16 +24,29 @@
     const shadow = host.attachShadow({mode: 'closed'});
     const child = shadow.appendChild(document.createElement('span'));
     child.textContent = text;
-    return shadow;
+    return host;
   }
 
-  test(() => {
-    const text = 'text inside shadow';
-    const shadow = reset(text);
-    find(text);
-    const node = getSelection().anchorNode;
-    assert_equals(node, container, 'getSelection().anchorNode should return the host of the shadow');
-    assert_not_equals(node.textContent, text, 'getSelection().anchorNode textContent should not be the text contents of the shadow');
+  function dblclick(target) {
+      return new test_driver.Actions()
+          .pointerMove(0, 0, {origin: target})
+          .pointerDown()
+          .pointerUp()
+          .pointerDown()
+          .pointerUp()
+          .send();
+  }
+
+  test((t) => {
+    const text = 'text_inside_shadow';
+    const host = reset(text);
+    const actions_promise = dblclick(host);
+    t.add_cleanup(() => actions_promise);
+    setTimeout(() => {
+        const node = getSelection().anchorNode;
+        assert_equals(container, node, 'getSelection().anchorNode should return the host of the shadow');
+        assert_not_equals(node.textContent, text, 'getSelection().anchorNode textContent should not be the text contents of the shadow');
+    }, 1000);
   }, 'selection API should not leak nodes in Shadow DOM.');
 </script>
 </html>

--- a/shadow-dom/leaktests/selection.html
+++ b/shadow-dom/leaktests/selection.html
@@ -47,7 +47,7 @@
     const host = reset(text);
     await dblclick(t, host);
     const node = getSelection().anchorNode;
-    assert_equals(container, node, 'getSelection().anchorNode should return the host of the shadow');
+    assert_equals(node, container, 'getSelection().anchorNode should return the host of the shadow');
     assert_not_equals(node.textContent, text, 'getSelection().anchorNode textContent should not be the text contents of the shadow');
   }, 'selection API should not leak nodes in Shadow DOM.');
 </script>

--- a/shadow-dom/leaktests/selection.html
+++ b/shadow-dom/leaktests/selection.html
@@ -48,7 +48,7 @@
     await dblclick(t, host);
     const node = getSelection().anchorNode;
     assert_equals(node, container, 'getSelection().anchorNode should return the host of the shadow');
-    assert_not_equals(node.textContent, text, 'getSelection().anchorNode textContent should not be the text contents of the shadow');
+    assert_not_equals(node.textContent, text, 'getSelection().anchorNode textContent should not be the text contents of an element inside the shadow root');
   }, 'selection API should not leak nodes in Shadow DOM.');
 </script>
 </html>

--- a/shadow-dom/leaktests/selection.html
+++ b/shadow-dom/leaktests/selection.html
@@ -15,7 +15,7 @@
   'use strict';
 
   const container = document.getElementById('container');
-  
+
   function reset(text) {
     const host = container.appendChild(document.createElement('div'));
     const shadow = host.attachShadow({mode: 'closed'});
@@ -23,7 +23,7 @@
     child.textContent = text;
     return shadow;
   }
-  
+
   test(() => {
     const text = 'text inside shadow';
     const shadow = reset(text);

--- a/shadow-dom/leaktests/selection.html
+++ b/shadow-dom/leaktests/selection.html
@@ -42,7 +42,7 @@
       assert_equals(event.target, target);
   }
 
-  test(async (t) => {
+  promise_test(async (t) => {
     const text = 'text_inside_shadow';
     const host = reset(text);
     await dblclick(t, host);

--- a/shadow-dom/leaktests/selection.html
+++ b/shadow-dom/leaktests/selection.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name='author' title='weizman' href='https://www.weizmangal.com'>
+<meta name='assert' content='Shadow DOM should not leak via Selection API'>
+<link rel='help' href='https://w3c.github.io/webcomponents/spec/shadow/'>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</head>
+<body>
+<div id='log'></div>
+<div id='container'></div>
+</body>
+<script>
+  'use strict';
+
+  const container = document.getElementById('container');
+  
+  function reset(text) {
+    const host = container.appendChild(document.createElement('div'));
+    const shadow = host.attachShadow({mode: 'closed'});
+    const child = document.createElement('span');
+    child.textContent = text;
+    return shadow;
+  }
+  
+  test(() => {
+    const shadow = reset('secret');
+    find('secret');
+    const node = getSelection().anchorNode;
+    assert_not_equals(node, shadow, 'getSelection().anchorNode should not return the shadow node');
+  }, 'selection API should not leak nodes in Shadow DOM.');
+</script>
+</html>

--- a/shadow-dom/leaktests/selection.html
+++ b/shadow-dom/leaktests/selection.html
@@ -25,10 +25,12 @@
   }
   
   test(() => {
-    const shadow = reset('secret');
-    find('secret');
+    const text = 'text inside shadow';
+    const shadow = reset(text);
+    find(text);
     const node = getSelection().anchorNode;
     assert_equals(node, container, 'getSelection().anchorNode should return the host of the shadow');
+    assert_not_equals(node.textContent, text, 'getSelection().anchorNode textContent should not be the text contents of the shadow');
   }, 'selection API should not leak nodes in Shadow DOM.');
 </script>
 </html>

--- a/shadow-dom/leaktests/selection.html
+++ b/shadow-dom/leaktests/selection.html
@@ -27,26 +27,28 @@
     return host;
   }
 
-  function dblclick(target) {
-      return new test_driver.Actions()
+  async function dblclick(t, target) {
+      const event_watcher = new EventWatcher(t, target, ["dblclick"]);
+      const actions_promise = new test_driver.Actions()
           .pointerMove(0, 0, {origin: target})
           .pointerDown()
           .pointerUp()
           .pointerDown()
           .pointerUp()
           .send();
+      t.add_cleanup(() => actions_promise);
+      const event = await event_watcher.wait_for(["dblclick"]);
+      assert_equals(event.type, "dblclick");
+      assert_equals(event.target, target);
   }
 
-  test((t) => {
+  test(async (t) => {
     const text = 'text_inside_shadow';
     const host = reset(text);
-    const actions_promise = dblclick(host);
-    t.add_cleanup(() => actions_promise);
-    setTimeout(() => {
-        const node = getSelection().anchorNode;
-        assert_equals(container, node, 'getSelection().anchorNode should return the host of the shadow');
-        assert_not_equals(node.textContent, text, 'getSelection().anchorNode textContent should not be the text contents of the shadow');
-    }, 1000);
+    await dblclick(t, host);
+    const node = getSelection().anchorNode;
+    assert_equals(container, node, 'getSelection().anchorNode should return the host of the shadow');
+    assert_not_equals(node.textContent, text, 'getSelection().anchorNode textContent should not be the text contents of the shadow');
   }, 'selection API should not leak nodes in Shadow DOM.');
 </script>
 </html>

--- a/shadow-dom/leaktests/selection.html
+++ b/shadow-dom/leaktests/selection.html
@@ -19,7 +19,7 @@
   function reset(text) {
     const host = container.appendChild(document.createElement('div'));
     const shadow = host.attachShadow({mode: 'closed'});
-    const child = document.createElement('span');
+    const child = shadow.appendChild(document.createElement('span'));
     child.textContent = text;
     return shadow;
   }
@@ -28,7 +28,7 @@
     const shadow = reset('secret');
     find('secret');
     const node = getSelection().anchorNode;
-    assert_not_equals(node, shadow, 'getSelection().anchorNode should not return the shadow node');
+    assert_equals(node, container, 'getSelection().anchorNode should return the host of the shadow');
   }, 'selection API should not leak nodes in Shadow DOM.');
 </script>
 </html>

--- a/shadow-dom/leaktests/selection.html
+++ b/shadow-dom/leaktests/selection.html
@@ -27,25 +27,24 @@
     return host;
   }
 
-  async function dblclick(t, target) {
-      const event_watcher = new EventWatcher(t, target, ["dblclick"]);
+  async function select(t, target) {
+      const event_watcher = new EventWatcher(t, target, ["mouseup"]);
       const actions_promise = new test_driver.Actions()
           .pointerMove(0, 0, {origin: target})
           .pointerDown()
-          .pointerUp()
-          .pointerDown()
+          .pointerMove(100, 0, {origin: target})
           .pointerUp()
           .send();
       t.add_cleanup(() => actions_promise);
-      const event = await event_watcher.wait_for(["dblclick"]);
-      assert_equals(event.type, "dblclick");
+      const event = await event_watcher.wait_for(["mouseup"]);
+      assert_equals(event.type, "mouseup");
       assert_equals(event.target, target);
   }
 
   promise_test(async (t) => {
     const text = 'text_inside_shadow';
     const host = reset(text);
-    await dblclick(t, host);
+    await select(t, host);
     const node = getSelection().anchorNode;
     assert_equals(node, container, 'getSelection().anchorNode should return the host of the shadow');
     assert_not_equals(node.textContent, text, 'getSelection().anchorNode textContent should not be the text contents of an element inside the shadow root');


### PR DESCRIPTION
Selection API points to different nodes when the selected text lives inside a shadow root - this test attempts to bring those differences to surface.

Given:

```html
<host/>
  <shadow/>
    <child/>
      #text
```

When selecting `text` and running `getSelection().anchorNode` you get:
* `<host/>` on Chrome/Safari (which is what we want)
* `#text` on Firefox (which is NOT what we want)