### PR TITLE
[WebDriver BiDi] default `beforeUnload` behavior is `accept`

### DIFF
--- a/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
+++ b/webdriver/tests/bidi/browsing_context/close/prompt_unload.py
@@ -51,7 +51,7 @@ async def test_prompt_unload_not_triggering_dialog(
     remove_listener()
 
 
-@pytest.mark.capabilities({"unhandledPromptBehavior": {'default': 'ignore'}})
+@pytest.mark.capabilities({"unhandledPromptBehavior": {'beforeUnload': 'ignore'}})
 @pytest.mark.parametrize("type_hint", ["window", "tab"])
 async def test_prompt_unload_triggering_dialog(
     bidi_session,

--- a/webdriver/tests/bidi/browsing_context/handle_user_prompt/handle_user_prompt.py
+++ b/webdriver/tests/bidi/browsing_context/handle_user_prompt/handle_user_prompt.py
@@ -112,7 +112,7 @@ async def test_prompt(
         assert result == {"type": "null"}
 
 
-@pytest.mark.capabilities({"unhandledPromptBehavior": {'default': 'ignore'}})
+@pytest.mark.capabilities({"unhandledPromptBehavior": {'beforeUnload': 'ignore'}})
 @pytest.mark.parametrize("accept", [True, False])
 async def test_beforeunload(
     bidi_session,

--- a/webdriver/tests/bidi/browsing_context/user_prompt_closed/beforeunload.py
+++ b/webdriver/tests/bidi/browsing_context/user_prompt_closed/beforeunload.py
@@ -9,7 +9,7 @@ USER_PROMPT_CLOSED_EVENT = "browsingContext.userPromptClosed"
 USER_PROMPT_OPENED_EVENT = "browsingContext.userPromptOpened"
 
 
-@pytest.mark.capabilities({"unhandledPromptBehavior": {'default': 'ignore'}})
+@pytest.mark.capabilities({"unhandledPromptBehavior": {'beforeUnload': 'ignore'}})
 @pytest.mark.parametrize("accept", [False, True])
 async def test_beforeunload(
     bidi_session,


### PR DESCRIPTION
According to WebDriver Classic spec, `beforeUnload` prompt should be accepted by default. 
Step 4 of ["Get the prompt handler" algorithm](https://w3c.github.io/webdriver/#dfn-get-the-prompt-handler):
> 4. If type is "beforeUnload", return a [prompt handler configuration](https://w3c.github.io/webdriver/#dfn-prompt-handler-configuration) with [handler](https://w3c.github.io/webdriver/#dfn-handler) "accept" and [notify](https://w3c.github.io/webdriver/#dfn-notify) false.