### PR TITLE
Add a MathML test for italic mi with border, padding and margin

### DIFF
--- a/mathml/relations/css-styling/padding-border-margin/padding-border-margin-004-ref.html
+++ b/mathml/relations/css-styling/padding-border-margin/padding-border-margin-004-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Padding/border/margin on an mi with italic mathvariant (reference)</title>
+<style>
+  @font-face {
+    font-family: TestFont;
+    src: url("/fonts/math/mathvariant-italic.woff");
+  }
+  math  {
+    font-family: TestFont;
+    font-size: 300px;
+  }
+</style>
+<body>
+  <p>This test passes if you see the text <code>1d434</code> in cyan on a blue
+    background, surrounded by a 10px padding, surrounded by a 10px
+    yellow dashed border, itself surrounded by a 10px pink margin.</p>
+  <div style="background: pink; position: absolute; left: 10px; top: 4em;">
+    <math>
+      <mtext style="background: blue; border: 10px dashed yellow; padding: 10px; margin: 10px; color: cyan;">&#x1D434;</mtext>
+    </math>
+  </div>
+</body>
+</html>

--- a/mathml/relations/css-styling/padding-border-margin/padding-border-margin-004.html
+++ b/mathml/relations/css-styling/padding-border-margin/padding-border-margin-004.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Padding/border/margin on an mi with italic mathvariant</title>
+<link rel="help" href="https://w3c.github.io/mathml-core/#layout-algorithms">
+<link rel="help" href="https://w3c.github.io/mathml-core/#css-styling">
+<link rel="help" href="https://w3c.github.io/mathml-core/#the-mathvariant-attribute">
+<link rel="help" href="https://w3c.github.io/mathml-core/#new-text-transform-values">
+<link rel="help" href="https://w3c.github.io/mathml-core/#italic-mappings">
+<link rel="match" href="padding-border-margin-004-ref.html"/>
+<meta name="assert" content="Verify visual rendering of padding/border/margin on an mi with italic mathvariant.">
+<style>
+  @font-face {
+    font-family: TestFont;
+    src: url("/fonts/math/mathvariant-italic.woff");
+  }
+  math  {
+    font-family: TestFont;
+    font-size: 300px;
+  }
+</style>
+<body>
+  <p>This test passes if you see the text <code>1d434</code> in cyan on a blue
+    background, surrounded by a 10px padding, surrounded by a 10px
+    yellow dashed border, itself surrounded by a 10px pink margin.</p>
+  <div style="background: pink; position: absolute; left: 10px; top: 4em;">
+    <math>
+      <mi style="background: blue; border: 10px dashed yellow; padding: 10px; margin: 10px; color: cyan;">&#x41;</mi>
+    </math>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
padding-border-margin-002.html and padding-border-margin-003.html verify handling of border, padding and margin on a stretchy or largeop `<mo>` elements, since browsers implement special layout/painting for them. This patch verifies handling of border, padding and margin on a single-char `<mi>` (i.e. that picks italic mathvariant [1]) comparing it to the an `<mtext>` element with the transformed character. That covers WebKit's special layout/painting for this case [2].

[1] https://w3c.github.io/mathml-core/#the-mi-element
[2] https://bugs.webkit.org/show_bug.cgi?id=276317