### PR TITLE
Revert default mfrac's padding for mrow-fallback.html test

### DIFF
--- a/mathml/presentation-markup/mrow/mrow-fallback.html
+++ b/mathml/presentation-markup/mrow/mrow-fallback.html
@@ -11,6 +11,10 @@
 <script src="/mathml/support/fonts.js"></script>
 <script src="/mathml/support/layout-comparison.js"></script>
 <script src="/mathml/support/mathml-fragments.js"></script>
+<style>
+  /* Revert style specified in the UA style sheet that changes box size. */
+  mfrac { padding-inline: 0; }
+</style>
 <script>
   setup({ explicit_done: true });
   window.addEventListener("load", () => { loadAllFonts().then(runTests); });


### PR DESCRIPTION
This test compares the layout of invalid MathML markup and the one of an
`<mrow>` element. However, the UA style sheet adds padding around the
`<mfrac>` element by default while it doesn't for `<mrow>` [*].
Override this padding for the test, so that the size of an invalid
`<mfrac>` and the one of an `<mrow>` match perfectly.

[*] https://w3c.github.io/mathml-core/#user-agent-stylesheet