### PR TITLE
Geolocation: generalize tojson.https.window.js

### DIFF
--- a/geolocation/tojson.https.window.js
+++ b/geolocation/tojson.https.window.js
@@ -18,7 +18,7 @@ function check_equals(original, json) {
 
 promise_setup(async () => {
   await test_driver.set_permission({ name: "geolocation" }, "granted");
-}, "Grant permission and wait for the document to be fully active.");
+});
 
 promise_test(async (t) => {
   const position = await new Promise((resolve, reject) => {
@@ -31,7 +31,7 @@ promise_test(async (t) => {
     json.timestamp,
     "GeolocationPosition timestamp entry does not match its toJSON value",
   );
-  check_equals(position.coords, json.coords, GeolocationCoordinates);
 
+  check_equals(position.coords, json.coords);
   check_equals(position.coords, position.coords.toJSON());
 }, "Test toJSON() in GeolocationPosition and GeolocationCoordinates.");

--- a/geolocation/tojson.https.window.js
+++ b/geolocation/tojson.https.window.js
@@ -1,51 +1,37 @@
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
-'use strict';
+"use strict";
 
-function check_coords(original, json, prefix) {
-  for (const key of [
-    'accuracy',
-    'latitude',
-    'longitude',
-    'altitude',
-    'altitudeAccuracy',
-    'heading',
-    'speed',
-    'coords',
-    'timestamp',
-  ]) {
-    assert_equals(original[key], json[key], `${prefix} ${key} entry does not match its toJSON value`);
+function check_equals(original, json) {
+  const proto = Object.getPrototypeOf(original);
+  const keys = Object.keys(proto).filter(
+    (k) => typeof original[k] !== "function",
+  );
+  for (const key of keys) {
+    assert_equals(
+      original[key],
+      json[key],
+      `${original.constructor.name} ${key} entry does not match its toJSON value`,
+    );
   }
 }
 
 promise_setup(async () => {
   await test_driver.set_permission({ name: "geolocation" }, "granted");
-
-  if (document.readyState != 'complete') {
-    await new Promise(resolve => {
-      window.addEventListener('load', resolve, {once: true});
-    });
-  }
-}, 'Grant permission and wait for the document to be fully active.');
+}, "Grant permission and wait for the document to be fully active.");
 
 promise_test(async (t) => {
   const position = await new Promise((resolve, reject) => {
-    navigator.geolocation.getCurrentPosition(
-      t.step_func((position) => {
-        resolve(position);
-      }),
-      t.step_func((error) => {
-        reject(error.message);
-      }),
-    );
+    navigator.geolocation.getCurrentPosition(resolve, reject);
   });
 
-  assert_equals(typeof(position.toJSON), 'function');
-
   const json = position.toJSON();
-  assert_equals(position.timestamp, json.timestamp, 'GeolocationPosition timestamp entry does not match its toJSON value');
-  check_coords(position.coords, json.coords, 'GeolocationPosition coords');
+  assert_equals(
+    position.timestamp,
+    json.timestamp,
+    "GeolocationPosition timestamp entry does not match its toJSON value",
+  );
+  check_equals(position.coords, json.coords, GeolocationCoordinates);
 
-  assert_equals(typeof(position.coords.toJSON), 'function');
-  check_coords(position.coords, position.coords.toJSON(), 'GeolocationCoordinates');
-}, 'Test toJSON() in GeolocationPosition and GeolocationCoordinates.');
+  check_equals(position.coords, position.coords.toJSON());
+}, "Test toJSON() in GeolocationPosition and GeolocationCoordinates.");


### PR DESCRIPTION
Made this more generic, in case we add more attributes... WebKit supports floorLevel, for instance.  