### PR TITLE
[WebDriver] Align `unhandledPromptBehavior` capability with spec

### DIFF
--- a/webdriver/tests/classic/new_session/unhandled_prompt_behavior.py
+++ b/webdriver/tests/classic/new_session/unhandled_prompt_behavior.py
@@ -90,13 +90,13 @@ def test_unhandled_prompt_behavior_as_string(
     [
         (  # Check the default behavior with no handlers defined
             {},
-            "dismiss and notify",
+            {},
             True,
             True,
         ),
         (  # Check the default behavior with a custom value defined
             {"default": "accept"},
-            "accept",
+            {"default": "accept"},
             True,
             False,
         ),
@@ -155,11 +155,7 @@ def test_unhandled_prompt_behavior_as_object(
         }
     )
     value = assert_success(response)
-    if prompt == "default":
-        # For a single default handler the capability is serialized as a string
-        assert value["capabilities"]["unhandledPromptBehavior"] == handler
-    else:
-        assert value["capabilities"]["unhandledPromptBehavior"] == {prompt: handler}
+    assert value["capabilities"]["unhandledPromptBehavior"] == {prompt: handler}
 
 
 @pytest.mark.parametrize("handler", PROMPT_HANDLERS)


### PR DESCRIPTION
During `unhandledPromptBehavior` serialization, the dict is never serialized to string. https://w3c.github.io/webdriver/#dfn-serialize-the-user-prompt-handler