### PR TITLE
Add exclusion syntax for WEB_FEATURES.yml

### DIFF
--- a/tools/metadata/webfeatures/schema.py
+++ b/tools/metadata/webfeatures/schema.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from dataclasses import dataclass
 from fnmatch import fnmatchcase
+from functools import cached_property
 from typing import Any, Dict, Sequence, Union
 
 from ..schema import SchemaValue, validate_dict
@@ -16,11 +17,26 @@ class SpecialFileEnum(Enum):
     RECURSIVE = "**"
 
 
+class FileMatchingMode(Enum):
+    """Defines how a FeatureFile pattern is used for matching."""
+    INCLUDE = 1  # Include files that match the pattern
+    EXCLUDE = 2  # Exclude files that match the pattern
+
 class FeatureFile(str):
+    @cached_property
+    def matching_mode(self) -> FileMatchingMode:
+        """Determines if the pattern should include or exclude matches."""
+        return FileMatchingMode.EXCLUDE if self.startswith("!") else FileMatchingMode.INCLUDE
+
+    @cached_property
+    def processed_filename(self) -> str:
+        """Removes the exclusion prefix "!" from the pattern."""
+        return self.removeprefix("!")
+
     def match_files(self, base_filenames: Sequence[str]) -> Sequence[str]:
         """
         Given the input base file names, returns the subset of base file names
-        that match the given FeatureFile.
+        that match the given FeatureFile based on matching_mode.
         If the FeatureFile contains any number of "*" characters, fnmatch is
         used check each file name.
         If the FeatureFile does not contain any "*" characters, the base file name
@@ -32,10 +48,10 @@ class FeatureFile(str):
         # If our file name contains a wildcard, use fnmatch
         if "*" in self:
             for base_filename in base_filenames:
-                if fnmatchcase(base_filename, self):
+                if fnmatchcase(base_filename, self.processed_filename):
                     result.append(base_filename)
-        elif self.__str__() in base_filenames:
-            result.append(self)
+        elif self.processed_filename in base_filenames:
+            result.append(self.processed_filename)
         return result
 
 

--- a/tools/metadata/webfeatures/schema.py
+++ b/tools/metadata/webfeatures/schema.py
@@ -35,7 +35,7 @@ class FeatureFile(str):
     def processed_filename(self) -> str:
         """Removes the exclusion prefix "!" from the pattern."""
         # TODO. After moving to Python3.9, use: return self.removeprefix(EXCLUSION_PREFIX)
-        return self[self.startswith(EXCLUSION_PREFIX) and len(EXCLUSION_PREFIX):]
+        return self[len(EXCLUSION_PREFIX):] if self.startswith(EXCLUSION_PREFIX) else self
 
     def match_files(self, base_filenames: Sequence[str]) -> Sequence[str]:
         """

--- a/tools/metadata/webfeatures/schema.py
+++ b/tools/metadata/webfeatures/schema.py
@@ -11,6 +11,9 @@ YAML filename for meta files
 """
 WEB_FEATURES_YML_FILENAME = "WEB_FEATURES.yml"
 
+# File prefix to indicate that this FeatureFile should run in EXCLUDE mode.
+EXCLUSION_PREFIX = "!"
+
 
 class SpecialFileEnum(Enum):
     """All files recursively"""
@@ -26,12 +29,13 @@ class FeatureFile(str):
     @cached_property
     def matching_mode(self) -> FileMatchingMode:
         """Determines if the pattern should include or exclude matches."""
-        return FileMatchingMode.EXCLUDE if self.startswith("!") else FileMatchingMode.INCLUDE
+        return FileMatchingMode.EXCLUDE if self.startswith(EXCLUSION_PREFIX) else FileMatchingMode.INCLUDE
 
     @cached_property
     def processed_filename(self) -> str:
         """Removes the exclusion prefix "!" from the pattern."""
-        return self.removeprefix("!")
+        # TODO. After moving to Python3.9, use: return self.removeprefix(EXCLUSION_PREFIX)
+        return self[self.startswith(EXCLUSION_PREFIX) and len(EXCLUSION_PREFIX):]
 
     def match_files(self, base_filenames: Sequence[str]) -> Sequence[str]:
         """

--- a/tools/metadata/webfeatures/tests/test_schema.py
+++ b/tools/metadata/webfeatures/tests/test_schema.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from dataclasses import asdict
-from ..schema import WebFeaturesFile, FeatureEntry, SpecialFileEnum, FeatureFile
+from ..schema import FileMatchingMode, WebFeaturesFile, FeatureEntry, SpecialFileEnum, FeatureFile
 
 import pytest
 import re
@@ -69,23 +69,39 @@ def test_does_feature_apply_recursively(input, expected_result):
     assert input.does_feature_apply_recursively() == expected_result
 
 @pytest.mark.parametrize(
-    "input_feature,input_files,expected_result",
+    "input_feature,input_files,expected_result,expected_match_mode",
     [
         (
             FeatureFile("*"),
             ["test.html", "TEST.HTML"],
-            ["test.html", "TEST.HTML"]
+            ["test.html", "TEST.HTML"],
+            FileMatchingMode.INCLUDE,
         ),
         (
             FeatureFile("test.html"),
             ["test.html", "TEST.HTML"],
-            ["test.html"]
+            ["test.html"],
+            FileMatchingMode.INCLUDE,
+        ),
+        (
+            FeatureFile("!test.html"),
+            ["test.html", "TEST.HTML"],
+            ["test.html"],
+            FileMatchingMode.EXCLUDE,
         ),
         (
             FeatureFile("test*.html"),
             ["test.html", "test1.html", "TEST1.HTML", "test2.html", "test-2.html", "foo.html"],
-            ["test.html", "test1.html", "test2.html", "test-2.html"]
+            ["test.html", "test1.html", "test2.html", "test-2.html"],
+            FileMatchingMode.INCLUDE,
+        ),
+        (
+            FeatureFile("!test*.html"),
+            ["test.html", "test1.html", "TEST1.HTML", "test2.html", "test-2.html", "foo.html"],
+            ["test.html", "test1.html", "test2.html", "test-2.html"],
+            FileMatchingMode.EXCLUDE,
         ),
     ])
-def test_feature_file_match_files(input_feature, input_files, expected_result):
+def test_feature_file_match_files(input_feature, input_files, expected_result, expected_match_mode):
     assert input_feature.match_files(input_files) == expected_result
+    assert input_feature.matching_mode == expected_match_mode

--- a/tools/web_features/tests/test_web_feature_map.py
+++ b/tools/web_features/tests/test_web_feature_map.py
@@ -71,6 +71,25 @@ def test_process_non_recursive_feature():
         ]
     }
 
+def test_process_non_recursive_feature_negation():
+    feature_name = "feature1"
+    feature_files = [
+        FeatureFile("*range*"),  # Matches all files with *range* in the file name
+        # Removes blob-range.any.js which removes blob-range.any.html and blob-range.any.worker.html
+        FeatureFile("!blob-range.any.*"),
+    ]
+
+    mapper = WebFeatureToTestsDirMapper(TEST_FILES, None)
+    result = WebFeaturesMap()
+
+    mapper._process_non_recursive_feature(feature_name, feature_files, result)
+
+    assert result.to_dict() == {
+        "feature1": [
+            "/root/foo-range.any.html",
+            "/root/foo-range.any.worker.html",
+        ]
+    }
 
 def test_process_inherited_features():
     mapper = WebFeatureToTestsDirMapper(TEST_FILES, None)


### PR DESCRIPTION
Before this change, developers needed to list explicitly list all files in case there was one file that they wanted to ignore.

This change allows developers to use an exclusion syntax by prefixing the file with a `!`.

For example, given the following yaml:
```yaml
features:
- name: featureA
  files:
  - grid*
  - !grid-foo.html
```

All files with grid in that directory will match except grid-foo.html

This avoids the need to list all files explicitly when only a few should be omitted.