### PR TITLE
Fix wpt run --list-test-groups

### DIFF
--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -497,16 +497,6 @@ class TestLoader:
         self.tests = tests_enabled
         self.disabled_tests = tests_disabled
 
-    def groups(self, test_types, chunk_type="none", total_chunks=1, chunk_number=1):
-        groups = set()
-
-        for test_type in test_types:
-            for test in self.tests[test_type]:
-                group = test.url.split("/")[1]
-                groups.add(group)
-
-        return groups
-
 
 
 def get_test_queue_builder(**kwargs: Any) -> Tuple[TestQueueBuilder, Mapping[str, Any]]:

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -128,11 +128,15 @@ def get_loader(test_paths: wptcommandline.TestPaths,
 def list_test_groups(test_paths, product, **kwargs):
     env.do_delayed_imports(logger, test_paths)
 
-    _, test_loader = get_loader(test_paths,
-                                product,
-                                **kwargs)
+    test_queue_builder, test_loader = get_loader(test_paths,
+                                                 product,
+                                                 **kwargs)
 
-    for item in sorted(test_loader.groups(kwargs["test_types"])):
+    tests_by_type = {(subsuite_name, test_type): tests
+                     for subsuite_name, subsuite_tests in test_loader.tests.items()
+                     for test_type, tests in subsuite_tests.items()}
+
+    for item in sorted(test_queue_builder.tests_by_group(tests_by_type)):
         print(item)
 
 


### PR DESCRIPTION
This was broken during the subsuite addition. However this fix also slightly changes the behaviour; now we list the _actual_ test groups, not just the first element of the URL. The previous behaviour is nearly equivalent to passing in --run-by-dir=1 with no defined subsuites, although the new output will have an additional leading / on each group name.