### PR TITLE
Move js-specific URL parser tests into their own file

### DIFF
--- a/url/README.md
+++ b/url/README.md
@@ -1,11 +1,13 @@
-## urltestdata.json
+## urltestdata.json / urltestdata-javascript-only.json
 
 `resources/urltestdata.json` contains URL parsing tests suitable for any URL parser implementation.
+`resources/urltestdata-javascript-only.json` contains URL parsing tests specifically meant
+for JavaScript's `URL()` class as well as other languages accepting non-scalar-value strings.
 
-It's used as a source of tests by `a-element.html`, `failure.html`, `url-constructor.any.js`, and
-other test files in this directory.
+These files are used as a source of tests by `a-element.html`, `failure.html`, `url-constructor.any.js`,
+and other test files in this directory.
 
-The format of `resources/urltestdata.json` is a JSON array of comments as strings and test cases as
+Both files share the same format. They consist of a JSON array of comments as strings and test cases as
 objects. The keys for each test case are:
 
 * `input`: a string to be parsed as URL.

--- a/url/a-element-origin-xhtml.xhtml
+++ b/url/a-element-origin-xhtml.xhtml
@@ -12,4 +12,8 @@
     <script src="resources/a-element-origin.js"></script>
   </body>
 </html>
-<!-- Other dependencies: resources/urltestdata.json -->
+<!--
+  Other dependencies:
+  * resources/urltestdata.json,
+  * resources/urltestdata-javascript-only.json,
+-->

--- a/url/a-element-origin.html
+++ b/url/a-element-origin.html
@@ -5,4 +5,8 @@
 <base id=base>
 <div id=log></div>
 <script src=resources/a-element-origin.js></script>
-<!-- Other dependencies: resources/urltestdata.json -->
+<!--
+  Other dependencies:
+  * resources/urltestdata.json,
+  * resources/urltestdata-javascript-only.json,
+-->

--- a/url/a-element-xhtml.xhtml
+++ b/url/a-element-xhtml.xhtml
@@ -17,4 +17,8 @@
     <script src="resources/a-element.js"></script>
   </body>
 </html>
-<!-- Other dependencies: resources/urltestdata.json -->
+<!--
+  Other dependencies:
+  * resources/urltestdata.json,
+  * resources/urltestdata-javascript-only.json,
+-->

--- a/url/a-element.html
+++ b/url/a-element.html
@@ -10,7 +10,11 @@
 <base id=base>
 <div id=log></div>
 <script src=resources/a-element.js></script>
-<!-- Other dependencies: resources/urltestdata.json -->
+<!--
+  Other dependencies:
+  * resources/urltestdata.json,
+  * resources/urltestdata-javascript-only.json,
+-->
 
 
 <a id="multline-entity" download="multline-entity.txt" href="data:text/plain;charset=utf-8,first%20line&#10;second%20line"> Link with embedded \n is parsed correctly </a>

--- a/url/failure.html
+++ b/url/failure.html
@@ -6,7 +6,10 @@
 <script src=/resources/testharnessreport.js></script>
 <div id=log></div>
 <script>
-promise_test(() => fetch("resources/urltestdata.json").then(res => res.json()).then(runTests), "Loading data…")
+promise_test(() => Promise.all([
+  fetch("resources/urltestdata.json").then(res => res.json()),
+  fetch("resources/urltestdata-javascript-only.json").then(res => res.json()),
+]).then((tests) => tests.flat()).then(runTests), "Loading data…");
 
 function runTests(testData) {
   for (const test of testData) {

--- a/url/resources/a-element-origin.js
+++ b/url/resources/a-element-origin.js
@@ -1,4 +1,7 @@
-promise_test(() => fetch("resources/urltestdata.json").then(res => res.json()).then(runURLTests), "Loading data…");
+promise_test(() => Promise.all([
+  fetch("resources/urltestdata.json").then(res => res.json()),
+  fetch("resources/urltestdata-javascript-only.json").then(res => res.json()),
+]).then((tests) => tests.flat()).then(runURLTests), "Loading data…");
 
 function setBase(base) {
   document.getElementById("base").href = base

--- a/url/resources/a-element.js
+++ b/url/resources/a-element.js
@@ -1,4 +1,7 @@
-promise_test(() => fetch("resources/urltestdata.json").then(res => res.json()).then(runURLTests), "Loading data…");
+promise_test(() => Promise.all([
+  fetch("resources/urltestdata.json").then(res => res.json()),
+  fetch("resources/urltestdata-javascript-only.json").then(res => res.json()),
+]).then((tests) => tests.flat()).then(runURLTests), "Loading data…");
 
 function setBase(base) {
   document.getElementById("base").href = base;

--- a/url/resources/urltestdata-javascript-only.json
+++ b/url/resources/urltestdata-javascript-only.json
@@ -1,0 +1,18 @@
+[
+    "See ../README.md for a description of the format.",
+    {
+        "input": "http://example.com/\uD800\uD801\uDFFE\uDFFF\uFDD0\uFDCF\uFDEF\uFDF0\uFFFE\uFFFF?\uD800\uD801\uDFFE\uDFFF\uFDD0\uFDCF\uFDEF\uFDF0\uFFFE\uFFFF",
+        "base": null,
+        "href": "http://example.com/%EF%BF%BD%F0%90%9F%BE%EF%BF%BD%EF%B7%90%EF%B7%8F%EF%B7%AF%EF%B7%B0%EF%BF%BE%EF%BF%BF?%EF%BF%BD%F0%90%9F%BE%EF%BF%BD%EF%B7%90%EF%B7%8F%EF%B7%AF%EF%B7%B0%EF%BF%BE%EF%BF%BF",
+        "origin": "http://example.com",
+        "protocol": "http:",
+        "username": "",
+        "password": "",
+        "host": "example.com",
+        "hostname": "example.com",
+        "port": "",
+        "pathname": "/%EF%BF%BD%F0%90%9F%BE%EF%BF%BD%EF%B7%90%EF%B7%8F%EF%B7%AF%EF%B7%B0%EF%BF%BE%EF%BF%BF",
+        "search": "?%EF%BF%BD%F0%90%9F%BE%EF%BF%BD%EF%B7%90%EF%B7%8F%EF%B7%AF%EF%B7%B0%EF%BF%BE%EF%BF%BF",
+        "hash": ""
+    }
+]

--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -4849,21 +4849,6 @@
     "search": "",
     "hash": ""
   },
-  {
-    "input": "http://example.com/\uD800\uD801\uDFFE\uDFFF\uFDD0\uFDCF\uFDEF\uFDF0\uFFFE\uFFFF?\uD800\uD801\uDFFE\uDFFF\uFDD0\uFDCF\uFDEF\uFDF0\uFFFE\uFFFF",
-    "base": null,
-    "href": "http://example.com/%EF%BF%BD%F0%90%9F%BE%EF%BF%BD%EF%B7%90%EF%B7%8F%EF%B7%AF%EF%B7%B0%EF%BF%BE%EF%BF%BF?%EF%BF%BD%F0%90%9F%BE%EF%BF%BD%EF%B7%90%EF%B7%8F%EF%B7%AF%EF%B7%B0%EF%BF%BE%EF%BF%BF",
-    "origin": "http://example.com",
-    "protocol": "http:",
-    "username": "",
-    "password": "",
-    "host": "example.com",
-    "hostname": "example.com",
-    "port": "",
-    "pathname": "/%EF%BF%BD%F0%90%9F%BE%EF%BF%BD%EF%B7%90%EF%B7%8F%EF%B7%AF%EF%B7%B0%EF%BF%BE%EF%BF%BF",
-    "search": "?%EF%BF%BD%F0%90%9F%BE%EF%BF%BD%EF%B7%90%EF%B7%8F%EF%B7%AF%EF%B7%B0%EF%BF%BE%EF%BF%BF",
-    "hash": ""
-  },
   "Forbidden host code points",
   {
     "input": "sc://a\u0000b/",

--- a/url/url-constructor.any.js
+++ b/url/url-constructor.any.js
@@ -50,4 +50,7 @@ function runURLTests(urlTests) {
   }
 }
 
-promise_test(() => fetch("resources/urltestdata.json").then(res => res.json()).then(runURLTests), "Loading data…");
+promise_test(() => Promise.all([
+  fetch("resources/urltestdata.json").then(res => res.json()),
+  fetch("resources/urltestdata-javascript-only.json").then(res => res.json()),
+]).then((tests) => tests.flat()).then(runURLTests), "Loading data…");

--- a/url/url-origin.any.js
+++ b/url/url-origin.any.js
@@ -1,4 +1,7 @@
-promise_test(() => fetch("resources/urltestdata.json").then(res => res.json()).then(runURLTests), "Loading data…");
+promise_test(() => Promise.all([
+  fetch("resources/urltestdata.json").then(res => res.json()),
+  fetch("resources/urltestdata-javascript-only.json").then(res => res.json()),
+]).then((tests) => tests.flat()).then(runURLTests), "Loading data…");
 
 function runURLTests(urlTests) {
   for (const expected of urlTests) {


### PR DESCRIPTION
The test in question contains UTF-16 surrogates, but the input to a url parser is defined to be a "scalar value string", which is a string containing *no* surrogates.

Fixes https://github.com/web-platform-tests/wpt/issues/46941, refer to this issue for more information.
