### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=276653

### DIFF
--- a/svg/path/property/d-none-expected.svg
+++ b/svg/path/property/d-none-expected.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="M 0 0 H 100 V 100 H 0 Z" fill="green" />
+</svg>

--- a/svg/path/property/d-none-ref.svg
+++ b/svg/path/property/d-none-ref.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="M 0 0 H 100 V 100 H 0 Z" fill="green" />
+</svg>

--- a/svg/path/property/d-none.svg
+++ b/svg/path/property/d-none.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#TheDProperty"/>
+    <h:link rel="match" href="d-none-ref.svg"/>
+    <h:meta name="assert" content="Setting 'd: none' overrides the 'd' SVG attribute."/>
+  </metadata>
+  <path d="M 0 0 H 100 V 100 H 0 Z" fill="green" />
+  <path d="M 0 0 H 100 V 100 H 0 Z" fill="red" style="d: none" />
+</svg>


### PR DESCRIPTION
WebKit export from bug: [\[svg\] setting `d: none` on a `<path>` does not override the `d` SVG attribute](https://bugs.webkit.org/show_bug.cgi?id=276653)