### PR TITLE
[anchor-position] Support testing of polyfill

### DIFF
--- a/css/css-anchor-position/pseudo-element-anchor.html
+++ b/css/css-anchor-position/pseudo-element-anchor.html
@@ -1,13 +1,9 @@
 <!DOCTYPE html>
 <title>CSS Anchor Positioning: Pseudo elements as anchors</title>
-<link
-  rel="help"
-  href="https://drafts.csswg.org/css-anchor-1/#position-anchor"
-/>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/#position-anchor">
 <script src="/resources/testharness.js"></script>
 <script src="support/test-common.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/rendering-utils.js"></script>
 <style>
   .cb {
     position: relative;
@@ -38,12 +34,8 @@
     top: anchor(bottom);
     background: orange;
   }
-  #anchored1 {
-    position-anchor: --a1;
-  }
-  #anchored2 {
-    position-anchor: --a2;
-  }
+  #anchored1 { position-anchor: --a1; }
+  #anchored2 { position-anchor: --a2; }
 </style>
 <div class="cb">
   <div id="anchor1"></div>

--- a/css/css-anchor-position/pseudo-element-anchor.html
+++ b/css/css-anchor-position/pseudo-element-anchor.html
@@ -1,8 +1,13 @@
 <!DOCTYPE html>
 <title>CSS Anchor Positioning: Pseudo elements as anchors</title>
-<link rel="help" href="https://drafts.csswg.org/css-anchor-1/#position-anchor">
+<link
+  rel="help"
+  href="https://drafts.csswg.org/css-anchor-1/#position-anchor"
+/>
 <script src="/resources/testharness.js"></script>
+<script src="support/test-common.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/rendering-utils.js"></script>
 <style>
   .cb {
     position: relative;
@@ -33,8 +38,12 @@
     top: anchor(bottom);
     background: orange;
   }
-  #anchored1 { position-anchor: --a1; }
-  #anchored2 { position-anchor: --a2; }
+  #anchored1 {
+    position-anchor: --a1;
+  }
+  #anchored2 {
+    position-anchor: --a2;
+  }
 </style>
 <div class="cb">
   <div id="anchor1"></div>
@@ -45,11 +54,11 @@
   <div id="anchored2" class="anchored"></div>
 </div>
 <script>
-  test(() => {
+  testForAnchorPos(() => {
     assert_equals(anchored1.offsetLeft, 100);
     assert_equals(anchored1.offsetTop, 100);
   }, "::before as anchor");
-  test(() => {
+  testForAnchorPos(() => {
     assert_equals(anchored2.offsetLeft, 100);
     assert_equals(anchored2.offsetTop, 100);
   }, "::after as anchor");

--- a/css/css-anchor-position/support/test-common.js
+++ b/css/css-anchor-position/support/test-common.js
@@ -42,3 +42,19 @@ window.checkLayoutForAnchorPos = async function(selectorList, callDone = true) {
   }
   return window.checkLayout(selectorList, callDone);
 }
+
+// This function is a thin wrapper around `promise_test` (from
+// resources/testharness.js). It also replaces `test`, but must be a
+// promise_test due to potential for awaits. See the description of
+// `checkLayoutForAnchorPos` for caveats and intended usage.
+window.testForAnchorPos = async function(func, name, properties){
+  promise_test(async ()=>{
+    if (window.CHECK_LAYOUT_DELAY) {
+      assert_equals(window.INJECTED_SCRIPT,undefined,'CHECK_LAYOUT_DELAY is only allowed when serving WPT with --injected-script.');
+      await waitUntilNextAnimationFrame();
+      await waitUntilNextAnimationFrame();
+      await waitUntilNextAnimationFrame();
+    }
+    await func();
+  }, name, properties)
+}


### PR DESCRIPTION
I'm contributing to the [polyfill for anchor position](https://github.com/oddbird/css-anchor-positioning), which we test against the WPT. When testing the polyfill, we need to add a bit of delay to ensure the polyfill is applied before testing.

In https://github.com/web-platform-tests/wpt/pull/38442, a `checkLayoutForAnchorPos` wrapper for `checkLayout` was added to support a way to add a delay only for the polyfill while not impacting other tests. We don't have a similar method for `test`, so we have some false negatives when testing the polyfill.

`testForAnchorPos` is intended to replace all instances of `test` and `promise_test` in the Anchor Position tests. It likely would work for `async_test` as well, but I'm not seeing any instances of that in the Anchor Position tests. Like `checkLayoutForAnchorPos`, this only adds a delay if a global `CHECK_LAYOUT_DELAY` is true AND we are testing with `--injected-script`. This should have no impact on non-polyfill tests.

I've applied this to `css/css-anchor-position/pseudo-element-anchor.html`, and if this strategy is acceptable, I will transition the other tests as well.