### PR TITLE
Make the output of ./wpt make-hosts-file deterministic

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -754,7 +754,9 @@ def check_subdomains(logger, config, routes, mp_context, log_handlers):
 def make_hosts_file(config, host):
     rv = []
 
-    for domain in config.domains_set:
+    for domain in sorted(
+        config.domains_set, key=lambda x: tuple(reversed(x.split(".")))
+    ):
         rv.append("%s\t%s\n" % (host, domain))
 
     # Windows interpets the IP address 0.0.0.0 as non-existent, making it an
@@ -765,7 +767,9 @@ def make_hosts_file(config, host):
     #
     # https://github.com/web-platform-tests/wpt/issues/10560
     if platform.uname()[0] == "Windows":
-        for not_domain in config.not_domains_set:
+        for not_domain in sorted(
+            config.not_domains_set, key=lambda x: tuple(reversed(x.split(".")))
+        ):
             rv.append("0.0.0.0\t%s\n" % not_domain)
 
     return "".join(rv)


### PR DESCRIPTION
Previously, the ordering depended on set enumeration order, which is undefined. Instead, we sort based on labels, starting with the TLD.

This makes the output:

```
127.0.0.1	not-web-platform.test
127.0.0.1	www.not-web-platform.test
127.0.0.1	www.www.not-web-platform.test
127.0.0.1	www1.www.not-web-platform.test
127.0.0.1	www2.www.not-web-platform.test
127.0.0.1	xn--lve-6lad.www.not-web-platform.test
127.0.0.1	xn--n8j6ds53lwwkrqhv28a.www.not-web-platform.test
127.0.0.1	www1.not-web-platform.test
127.0.0.1	www.www1.not-web-platform.test
127.0.0.1	www1.www1.not-web-platform.test
127.0.0.1	www2.www1.not-web-platform.test
127.0.0.1	xn--lve-6lad.www1.not-web-platform.test
127.0.0.1	xn--n8j6ds53lwwkrqhv28a.www1.not-web-platform.test
127.0.0.1	www2.not-web-platform.test
127.0.0.1	www.www2.not-web-platform.test
127.0.0.1	www1.www2.not-web-platform.test
127.0.0.1	www2.www2.not-web-platform.test
127.0.0.1	xn--lve-6lad.www2.not-web-platform.test
127.0.0.1	xn--n8j6ds53lwwkrqhv28a.www2.not-web-platform.test
127.0.0.1	xn--lve-6lad.not-web-platform.test
127.0.0.1	www.xn--lve-6lad.not-web-platform.test
127.0.0.1	www1.xn--lve-6lad.not-web-platform.test
127.0.0.1	www2.xn--lve-6lad.not-web-platform.test
127.0.0.1	xn--lve-6lad.xn--lve-6lad.not-web-platform.test
127.0.0.1	xn--n8j6ds53lwwkrqhv28a.xn--lve-6lad.not-web-platform.test
127.0.0.1	xn--n8j6ds53lwwkrqhv28a.not-web-platform.test
127.0.0.1	www.xn--n8j6ds53lwwkrqhv28a.not-web-platform.test
127.0.0.1	www1.xn--n8j6ds53lwwkrqhv28a.not-web-platform.test
127.0.0.1	www2.xn--n8j6ds53lwwkrqhv28a.not-web-platform.test
127.0.0.1	xn--lve-6lad.xn--n8j6ds53lwwkrqhv28a.not-web-platform.test
127.0.0.1	xn--n8j6ds53lwwkrqhv28a.xn--n8j6ds53lwwkrqhv28a.not-web-platform.test
127.0.0.1	web-platform.test
127.0.0.1	www.web-platform.test
127.0.0.1	www.www.web-platform.test
127.0.0.1	www1.www.web-platform.test
127.0.0.1	www2.www.web-platform.test
127.0.0.1	xn--lve-6lad.www.web-platform.test
127.0.0.1	xn--n8j6ds53lwwkrqhv28a.www.web-platform.test
127.0.0.1	www1.web-platform.test
127.0.0.1	www.www1.web-platform.test
127.0.0.1	www1.www1.web-platform.test
127.0.0.1	www2.www1.web-platform.test
127.0.0.1	xn--lve-6lad.www1.web-platform.test
127.0.0.1	xn--n8j6ds53lwwkrqhv28a.www1.web-platform.test
127.0.0.1	www2.web-platform.test
127.0.0.1	www.www2.web-platform.test
127.0.0.1	www1.www2.web-platform.test
127.0.0.1	www2.www2.web-platform.test
127.0.0.1	xn--lve-6lad.www2.web-platform.test
127.0.0.1	xn--n8j6ds53lwwkrqhv28a.www2.web-platform.test
127.0.0.1	xn--lve-6lad.web-platform.test
127.0.0.1	www.xn--lve-6lad.web-platform.test
127.0.0.1	www1.xn--lve-6lad.web-platform.test
127.0.0.1	www2.xn--lve-6lad.web-platform.test
127.0.0.1	xn--lve-6lad.xn--lve-6lad.web-platform.test
127.0.0.1	xn--n8j6ds53lwwkrqhv28a.xn--lve-6lad.web-platform.test
127.0.0.1	xn--n8j6ds53lwwkrqhv28a.web-platform.test
127.0.0.1	www.xn--n8j6ds53lwwkrqhv28a.web-platform.test
127.0.0.1	www1.xn--n8j6ds53lwwkrqhv28a.web-platform.test
127.0.0.1	www2.xn--n8j6ds53lwwkrqhv28a.web-platform.test
127.0.0.1	xn--lve-6lad.xn--n8j6ds53lwwkrqhv28a.web-platform.test
127.0.0.1	xn--n8j6ds53lwwkrqhv28a.xn--n8j6ds53lwwkrqhv28a.web-platform.test
```