### PR TITLE
Add delimiters around the output of make-hosts-file

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -752,12 +752,12 @@ def check_subdomains(logger, config, routes, mp_context, log_handlers):
 
 
 def make_hosts_file(config, host):
-    rv = []
+    rv = ["# Start web-platform-tests hosts"]
 
     for domain in sorted(
         config.domains_set, key=lambda x: tuple(reversed(x.split(".")))
     ):
-        rv.append("%s\t%s\n" % (host, domain))
+        rv.append("%s\t%s" % (host, domain))
 
     # Windows interpets the IP address 0.0.0.0 as non-existent, making it an
     # appropriate alias for non-existent hosts. However, UNIX-like systems
@@ -770,9 +770,12 @@ def make_hosts_file(config, host):
         for not_domain in sorted(
             config.not_domains_set, key=lambda x: tuple(reversed(x.split(".")))
         ):
-            rv.append("0.0.0.0\t%s\n" % not_domain)
+            rv.append("0.0.0.0\t%s" % not_domain)
 
-    return "".join(rv)
+    rv.append("# End web-platform-tests hosts")
+    rv.append("")
+
+    return "\n".join(rv)
 
 
 def start_servers(logger, host, ports, paths, routes, bind_address, config,

--- a/tools/serve/test_serve.py
+++ b/tools/serve/test_serve.py
@@ -25,14 +25,18 @@ def test_make_hosts_file_nix():
                        not_subdomains={"x, y"}) as c:
         hosts = serve.make_hosts_file(c, "192.168.42.42")
         lines = hosts.split("\n")
-        assert set(lines) == {"",
-                              "192.168.42.42\tfoo.bar",
-                              "192.168.42.42\tfoo2.bar",
-                              "192.168.42.42\ta.foo.bar",
-                              "192.168.42.42\ta.foo2.bar",
-                              "192.168.42.42\tb.foo.bar",
-                              "192.168.42.42\tb.foo2.bar"}
-        assert lines[-1] == ""
+        assert lines == [
+            "# Start web-platform-tests hosts",
+            "192.168.42.42\tfoo.bar",
+            "192.168.42.42\ta.foo.bar",
+            "192.168.42.42\tb.foo.bar",
+            "192.168.42.42\tfoo2.bar",
+            "192.168.42.42\ta.foo2.bar",
+            "192.168.42.42\tb.foo2.bar",
+            "# End web-platform-tests hosts",
+            "",
+        ]
+
 
 @pytest.mark.skipif(platform.uname()[0] != "Windows",
                     reason="Expected contents are platform-dependent")
@@ -45,18 +49,21 @@ def test_make_hosts_file_windows():
                        not_subdomains={"x", "y"}) as c:
         hosts = serve.make_hosts_file(c, "192.168.42.42")
         lines = hosts.split("\n")
-        assert set(lines) == {"",
-                              "0.0.0.0\tx.foo.bar",
-                              "0.0.0.0\tx.foo2.bar",
-                              "0.0.0.0\ty.foo.bar",
-                              "0.0.0.0\ty.foo2.bar",
-                              "192.168.42.42\tfoo.bar",
-                              "192.168.42.42\tfoo2.bar",
-                              "192.168.42.42\ta.foo.bar",
-                              "192.168.42.42\ta.foo2.bar",
-                              "192.168.42.42\tb.foo.bar",
-                              "192.168.42.42\tb.foo2.bar"}
-        assert lines[-1] == ""
+        assert lines == [
+            "# Start web-platform-tests hosts",
+            "192.168.42.42\tfoo.bar",
+            "192.168.42.42\ta.foo.bar",
+            "192.168.42.42\tb.foo.bar",
+            "192.168.42.42\tfoo2.bar",
+            "192.168.42.42\ta.foo2.bar",
+            "192.168.42.42\tb.foo2.bar",
+            "0.0.0.0\tx.foo.bar",
+            "0.0.0.0\ty.foo.bar",
+            "0.0.0.0\tx.foo2.bar",
+            "0.0.0.0\ty.foo2.bar",
+            "# End web-platform-tests hosts",
+            "",
+        ]
 
 
 def test_ws_doc_root_default():


### PR DESCRIPTION
This makes it easier to figure out what WPT has added, to then be able to remove it.