### PR TITLE
Remove test that asserts the contents of Trusted Type error messages

### DIFF
--- a/trusted-types/TrustedTypePolicyFactory-createPolicy-nameTests.html
+++ b/trusted-types/TrustedTypePolicyFactory-createPolicy-nameTests.html
@@ -20,21 +20,4 @@
     });
   }, "duplicate policy name attempt throws");
 
-  // Check error messages.
-  test(t => {
-    try {
-      trustedTypes.createPolicy("unknown name", {});
-    } catch (e) {
-      assert_true(e.toString().includes("disallowed"));
-      assert_false(e.toString().includes("already exists"));
-    }
-
-    try {
-      trustedTypes.createPolicy("SomeName", {});
-    } catch (e) {
-      assert_false(e.toString().includes("disallowed"));
-      assert_true(e.toString().includes("already exists"));
-    }
-  }, "Error messages for duplicates and unlisted policies should be different");
-
 </script>


### PR DESCRIPTION
Closes https://github.com/w3c/trusted-types/issues/511