### PR TITLE
Add an initial GitHub Actions config to run Safari stable

### DIFF
--- a/.github/workflows/safari_stable.yml
+++ b/.github/workflows/safari_stable.yml
@@ -1,0 +1,100 @@
+name: "All Tests: Safari (stable)"
+
+# We never interact with the GitHub API, thus we can simply disable all
+# permissions the GitHub token would have.
+permissions: {}
+
+on:
+  push:
+    branches:
+      - epochs/daily
+      - triggers/safari_stable
+
+env:
+  # Set SAFARIDRIVER_DIAGNOSE to true to enable safaridriver diagnostics. The
+  # logs won't appear in `./wpt run` output but will be uploaded as an
+  # artifact.
+  SAFARIDRIVER_DIAGNOSE: false
+
+jobs:
+  safari-stable-results:
+    name: "All Tests: Safari (stable)"
+    runs-on:
+      - self-hosted
+      - webkit-ews
+    timeout-minutes: 180
+    strategy:
+      matrix:
+        current-chunk: [1, 2, 3, 4, 5, 6, 7, 8]
+        total-chunks: [8]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4.1.0
+        with:
+          fetch-depth: 1
+      - name: Enable safaridriver diagnostics
+        if: env.SAFARIDRIVER_DIAGNOSE == true
+        run: |-
+          rm -rf ~/Library/Logs/com.apple.WebDriver/
+          defaults write com.apple.WebDriver DiagnosticsEnabled 1
+      - name: Enable safaridriver
+        run: |-
+          set -eux -o pipefail
+          sudo safaridriver --enable
+          defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically 1
+      - name: Update hosts
+        run: |-
+          set -eux -o pipefail
+          ./wpt make-hosts-file | sudo tee -a /etc/hosts
+      - name: Update manifest
+        run: ./wpt manifest
+      - name: Run tests
+        run: |-
+          set -eux -o pipefail
+          export SYSTEM_VERSION_COMPAT=0
+          ./wpt run \
+            --no-manifest-update \
+            --no-restart-on-unexpected \
+            --no-fail-on-unexpected \
+            --this-chunk=${{ matrix.current-chunk }} \
+            --total-chunks=${{ matrix.total-chunks }} \
+            --chunk-type hash \
+            --log-wptreport ${{ runner.temp }}/wpt_report_${{ matrix.current-chunk }}.json \
+            --log-wptscreenshot ${{ runner.temp }}/wpt_screenshot_${{ matrix.current-chunk }}.txt \
+            --log-mach - \
+            --log-mach-level info \
+            --channel stable \
+            --kill-safari \
+            --max-restarts 100 \
+            safari
+      - name: Publish results
+        uses: actions/upload-artifact@v4.1.0
+        with:
+          name: safari-results-${{ matrix.current-chunk }}
+          path: |
+            ${{ runner.temp }}/wpt_report_*.json
+            ${{ runner.temp }}/wpt_screenshot_*.txt
+          if-no-files-found: "error"
+      - name: Publish safaridriver logs
+        if: env.SAFARIDRIVER_DIAGNOSE == true
+        uses: actions/upload-artifact@v4.1.0
+        with:
+          name: safaridriver-logs-${{ matrix.current-chunk }}
+          path: ~/Library/Logs/com.apple.WebDriver/
+          if-no-files-found: warn
+      - name: Disable safaridriver diagnostics
+        if: env.SAFARIDRIVER_DIAGNOSE == true
+        run: |-
+          defaults write com.apple.WebDriver DiagnosticsEnabled 0
+          rm -rf ~/Library/Logs/com.apple.WebDriver/
+      - name: Cleanup
+        if: always()
+        run: |-
+            set -ux
+            sudo sed -i '' '/^# Start web-platform-tests hosts$/,/^# End web-platform-tests hosts$/d' /etc/hosts
+
+  safari-stable-results-notify:
+    needs: safari-stable-results
+    uses: ./.github/workflows/wpt_fyi_notify.yml
+    with:
+      artifact-name: 'safari-results-*'

--- a/.github/workflows/safari_technology_preview.yml
+++ b/.github/workflows/safari_technology_preview.yml
@@ -1,0 +1,103 @@
+name: "All Tests: Safari Technology Preview"
+
+# We never interact with the GitHub API, thus we can simply disable all
+# permissions the GitHub token would have.
+permissions: {}
+
+on:
+  push:
+    branches:
+      - epochs/three_hourly
+      - triggers/safari_preview
+
+env:
+  # Set SAFARIDRIVER_DIAGNOSE to true to enable safaridriver diagnostics. The
+  # logs won't appear in `./wpt run` output but will be uploaded as an
+  # artifact.
+  SAFARIDRIVER_DIAGNOSE: false
+
+jobs:
+  safari-technology-preview-results:
+    name: "All Tests: Safari Technology Preview"
+    runs-on:
+      - self-hosted
+      - webkit-ews
+    timeout-minutes: 180
+    strategy:
+      matrix:
+        current-chunk: [1, 2, 3, 4, 5, 6, 7, 8]
+        total-chunks: [8]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4.1.0
+        with:
+          fetch-depth: 1
+      - name: Enable safaridriver diagnostics
+        if: env.SAFARIDRIVER_DIAGNOSE == true
+        run: |-
+          rm -rf ~/Library/Logs/com.apple.WebDriver/
+          defaults write com.apple.WebDriver DiagnosticsEnabled 1
+      - name: Enable safaridriver
+        run: |-
+          set -eux -o pipefail
+          export SYSTEM_VERSION_COMPAT=0
+          ./wpt install --channel preview --download-only -d . --rename STP safari browser
+          sudo installer -pkg STP.pkg -target LocalSystem
+          sudo /Applications/Safari\ Technology\ Preview.app/Contents/MacOS/safaridriver --enable
+          defaults write com.apple.SafariTechnologyPreview WebKitJavaScriptCanOpenWindowsAutomatically 1
+      - name: Update hosts
+        run: |-
+          set -eux -o pipefail
+          ./wpt make-hosts-file | sudo tee -a /etc/hosts
+      - name: Update manifest
+        run: ./wpt manifest
+      - name: Run tests
+        run: |-
+          set -eux -o pipefail
+          export SYSTEM_VERSION_COMPAT=0
+          ./wpt run \
+            --no-manifest-update \
+            --no-restart-on-unexpected \
+            --no-fail-on-unexpected \
+            --this-chunk=${{ matrix.current-chunk }} \
+            --total-chunks=${{ matrix.total-chunks }} \
+            --chunk-type hash \
+            --log-wptreport ${{ runner.temp }}/wpt_report_${{ matrix.current-chunk }}.json \
+            --log-wptscreenshot ${{ runner.temp }}/wpt_screenshot_${{ matrix.current-chunk }}.txt \
+            --log-mach - \
+            --log-mach-level info \
+            --channel experimental \
+            --kill-safari \
+            --max-restarts 100 \
+            safari
+      - name: Publish results
+        uses: actions/upload-artifact@v4.1.0
+        with:
+          name: safari-technology-preview-results-${{ matrix.current-chunk }}
+          path: |
+            ${{ runner.temp }}/wpt_report_*.json
+            ${{ runner.temp }}/wpt_screenshot_*.txt
+          if-no-files-found: "error"
+      - name: Publish safaridriver logs
+        if: env.SAFARIDRIVER_DIAGNOSE == true
+        uses: actions/upload-artifact@v4.1.0
+        with:
+          name: safaridriver-logs-${{ matrix.current-chunk }}
+          path: ~/Library/Logs/com.apple.WebDriver/
+          if-no-files-found: warn
+      - name: Disable safaridriver diagnostics
+        if: env.SAFARIDRIVER_DIAGNOSE == true
+        run: |-
+          defaults write com.apple.WebDriver DiagnosticsEnabled 0
+          rm -rf ~/Library/Logs/com.apple.WebDriver/
+      - name: Cleanup
+        if: always()
+        run: |-
+            set -ux
+            sudo sed -i '' '/^# Start web-platform-tests hosts$/,/^# End web-platform-tests hosts$/d' /etc/hosts
+
+  safari-technology-preview-results-notify:
+    needs: safari-technology-preview-results
+    uses: ./.github/workflows/wpt_fyi_notify.yml
+    with:
+      artifact-name: 'safari-technology-preview-results-*'

--- a/.github/workflows/wpt_fyi_notify.yml
+++ b/.github/workflows/wpt_fyi_notify.yml
@@ -1,0 +1,42 @@
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        required: true
+        type: string
+
+jobs:
+  wpt-fyi-notify:
+    name: "Notify wpt.fyi"
+    runs-on:
+      - ubuntu-22.04
+    steps:
+      - name: "wpt.fyi"
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://wpt.fyi/api/checks/github-actions/'
+          method: 'POST'
+          contentType: 'application/x-www-form-urlencoded'
+          data: |
+            ${{ format(
+                  '{{"run_id": {0}, "owner": {1}, "repo": {2}, "artifact_name": {3}}}',
+                  toJSON(github.run_id),
+                  toJSON(github.repository_owner),
+                  toJSON(github.event.repository.name),
+                  toJSON(inputs.artifact-name)
+            ) }}
+
+      - name: "staging.wpt.fyi"
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://staging.wpt.fyi/api/checks/github-actions/'
+          method: 'POST'
+          contentType: 'application/x-www-form-urlencoded'
+          data: |
+            ${{ format(
+                  '{{"run_id": {0}, "owner": {1}, "repo": {2}, "artifact_name": {3}}}',
+                  toJSON(github.run_id),
+                  toJSON(github.repository_owner),
+                  toJSON(github.event.repository.name),
+                  toJSON(inputs.artifact-name)
+            ) }}


### PR DESCRIPTION
We'll likely want to refactor this into a reusable workflow, especially for Safari Technology Preview, but potentially for any other browsers we want to run on GitHub Actions.

That said, let's start with the simple singular case and make sure this works before adding more complexity.