### PR TITLE
Fix font-size-adjust-reload.html timeout on Safari

### DIFF
--- a/css/css-fonts/font-size-adjust-reload.html
+++ b/css/css-fonts/font-size-adjust-reload.html
@@ -26,7 +26,7 @@ iframe {
             iframe.contentWindow.location.reload();
             loadCount++;
         });
-        iframe.src = "./font-size-adjust-reload-ref.html";
+        iframe.src = "font-size-adjust-reload-ref.html";
         document.body.append(iframe);
     </script>
 </body>

--- a/css/css-fonts/font-size-adjust-reload.html
+++ b/css/css-fonts/font-size-adjust-reload.html
@@ -21,8 +21,10 @@ iframe {
         let loadCount = 0;
         const iframe = document.createElement("iframe");
         iframe.addEventListener("load", function() {
-            if (loadCount == 2)
+            if (loadCount == 2) {
                 document.documentElement.classList.remove("reftest-wait");
+                return;
+            }
             iframe.contentWindow.location.reload();
             loadCount++;
         });

--- a/css/css-fonts/font-size-adjust-reload.html
+++ b/css/css-fonts/font-size-adjust-reload.html
@@ -23,11 +23,11 @@ iframe {
         iframe.addEventListener("load", function() {
             if (loadCount == 2)
                 document.documentElement.classList.remove("reftest-wait");
+            iframe.contentWindow.location.reload();
             loadCount++;
         });
-        iframe.src = "font-size-adjust-reload-ref.html";
+        iframe.src = "./font-size-adjust-reload-ref.html";
         document.body.append(iframe);
-        iframe.contentWindow.location.reload();
     </script>
 </body>
 </html>

--- a/css/css-fonts/font-size-adjust-reload.html
+++ b/css/css-fonts/font-size-adjust-reload.html
@@ -9,16 +9,24 @@ body {
     margin: 0;
     padding: 0;
 }
+iframe {
+    border: 0;
+    width: 400px;
+    height: 400px;
 </style>
 </head>
 <body>
-    <iframe id="iframe" width=400 height=400 frameBorder=0 src="font-size-adjust-reload-ref.html"></iframe>
+    <script>
+        const loadCount = 0;
+        const iframe = document.createElement("iframe");
+        iframe.src = "font-size-adjust-reload-ref.html";
+        iframe.addEventListener("load", function() {
+            if (loadCount == 2)
+                document.documentElement.classList.remove("reftest-wait");
+            loadCount++;
+        });
+        document.body.append(iframe);
+        iframe.contentWindow.location.reload();
+    </script>
 </body>
-<script>
-    const iframe = document.getElementById('iframe');
-    iframe.contentWindow.onload = function() {
-        document.documentElement.classList.remove("reftest-wait");
-    };
-    iframe.contentWindow.location.reload();
-</script>
 </html>

--- a/css/css-fonts/font-size-adjust-reload.html
+++ b/css/css-fonts/font-size-adjust-reload.html
@@ -20,12 +20,12 @@ iframe {
     <script>
         const loadCount = 0;
         const iframe = document.createElement("iframe");
-        iframe.src = "font-size-adjust-reload-ref.html";
         iframe.addEventListener("load", function() {
             if (loadCount == 2)
                 document.documentElement.classList.remove("reftest-wait");
             loadCount++;
         });
+        iframe.src = "font-size-adjust-reload-ref.html";
         document.body.append(iframe);
         iframe.contentWindow.location.reload();
     </script>

--- a/css/css-fonts/font-size-adjust-reload.html
+++ b/css/css-fonts/font-size-adjust-reload.html
@@ -18,7 +18,7 @@ iframe {
 </head>
 <body>
     <script>
-        const loadCount = 0;
+        let loadCount = 0;
         const iframe = document.createElement("iframe");
         iframe.addEventListener("load", function() {
             if (loadCount == 2)

--- a/css/css-fonts/font-size-adjust-reload.html
+++ b/css/css-fonts/font-size-adjust-reload.html
@@ -13,6 +13,7 @@ iframe {
     border: 0;
     width: 400px;
     height: 400px;
+}
 </style>
 </head>
 <body>

--- a/css/css-fonts/font-size-adjust-reload.html
+++ b/css/css-fonts/font-size-adjust-reload.html
@@ -16,9 +16,9 @@ body {
 </body>
 <script>
     const iframe = document.getElementById('iframe');
-    iframe.contentWindow.location.reload();
-    iframe.contentWindow.onload = function(){
+    iframe.contentWindow.onload = function() {
         document.documentElement.classList.remove("reftest-wait");
     };
+    iframe.contentWindow.location.reload();
 </script>
 </html>


### PR DESCRIPTION
The test was trying a reload but didn't wait, but didn't wait for an initial load. Make sure initial load (loadCount = 1) happens before reloading, and only remove the `reftest-wait` class after the reload (loadCount = 2).