### PR TITLE
[wptrunner] Add --enable-unsafe-swiftshader for Chrome.

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -151,7 +151,7 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite
 
     if kwargs["enable_swiftshader"]:
         # https://chromium.googlesource.com/chromium/src/+/HEAD/docs/gpu/swiftshader.md
-        chrome_options["args"].extend(["--use-gl=angle", "--use-angle=swiftshader"])
+        chrome_options["args"].extend(["--use-gl=angle", "--use-angle=swiftshader", "--enable-unsafe-swiftshader"])
 
     if kwargs["enable_experimental"]:
         chrome_options["args"].extend(["--enable-experimental-web-platform-features"])


### PR DESCRIPTION
This flag will be required in the future to test Chrome with SwiftShader.

Chrome is the only chromium based browser that tests on SwiftShader based on the flags seen in the other browser scripts.