### PR TITLE
Un-enum-ify IndependentFormattingContext

### DIFF
--- a/css/css-sizing/aspect-ratio/box-sizing-dimensions.html
+++ b/css/css-sizing/aspect-ratio/box-sizing-dimensions.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS aspect-ratio: uses content box when "auto" is present and box-sizing dimensions when it is absent</title>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">
+<meta name="assert" content='CSS aspect-ratio: uses content box when "auto" is present and box-sizing dimensions when it is absent.'>
+<style>
+img {
+    border: 20px solid blue;
+    width: 100px;
+    height: auto;
+}
+
+.aspect {
+    aspect-ratio: 2 / 1;
+}
+
+.aspect-auto {
+    aspect-ratio: auto 2 / 1;
+}
+
+.border-box {
+    box-sizing: border-box;
+}
+
+.non-replaced {
+    background: green;
+    border: 20px solid blue;
+    width: 100px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+
+<body onload="checkLayout('.item')">
+
+<img class="item aspect" src="./support/20x50-green.png" width="20" height="50" data-expected-width="140" data-expected-height="90">
+
+<img class="item aspect border-box" src="./support/20x50-green.png" width="20" height="50" data-expected-width="100" data-expected-height="50">
+
+<img class="item aspect-auto" src="./support/20x50-green.png" width="20" height="50" data-expected-width="140" data-expected-height="290">
+
+<img class="item aspect-auto border-box" src="./support/20x50-green.png" width="20" height="50" data-expected-width="100" data-expected-height="190">
+
+<div class="item non-replaced aspect" data-expected-width="140" data-expected-height="90"></div>
+
+<div class="item non-replaced aspect border-box" data-expected-width="100" data-expected-height="50"></div>
+
+<div class="item non-replaced aspect-auto" data-expected-width="140" data-expected-height="90"></div>
+
+<div class="item non-replaced aspect-auto border-box" data-expected-width="100" data-expected-height="70"></div>

--- a/css/css-sizing/aspect-ratio/box-sizing-squashed.html
+++ b/css/css-sizing/aspect-ratio/box-sizing-squashed.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS aspect-ratio: correct ratio maintained when box-sizing: border-box and one axis is clamped to 0</title>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">
+<meta name="assert" content='CSS aspect-ratio: correct ratio maintained when box-sizing: border-box and one axis is clamped to 0.'>
+<style>
+.item {
+    box-sizing: border-box;
+    border: 20px solid blue;
+}
+
+.horizontal {
+    aspect-ratio: 2 / 1;
+}
+
+.vertical {
+    aspect-ratio: 1 / 2;
+}
+
+.non-replaced {
+    background: green;
+    /* Break the items apart to make them individually distinguishable */
+    margin-bottom: 10px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+
+<body onload="checkLayout('.item')">
+
+<img class="item horizontal" style="width: 50px; height: auto" src="./support/20x50-green.png" width="20" height="50" data-expected-width="50" data-expected-height="40">
+
+<img class="item horizontal"  style="width: auto; height: 20px" src="./support/20x50-green.png" width="20" height="50" data-expected-width="80" data-expected-height="40">
+
+<img class="item horizontal" style="max-width: 50px; height: auto" src="./support/20x50-green.png" width="20" height="50" data-expected-width="40" data-expected-height="40">
+
+<img class="item horizontal" style="width: auto; max-height: 20px" src="./support/20x50-green.png" width="20" height="50" data-expected-width="80" data-expected-height="40">
+
+<img class="item vertical" style="height: 50px; width: auto" src="./support/20x50-green.png" width="20" height="50" data-expected-width="40" data-expected-height="50">
+
+<img class="item vertical"  style="height: auto; width: 20px" src="./support/20x50-green.png" width="20" height="50" data-expected-width="40" data-expected-height="80">
+
+<img class="item vertical" style="max-height: 50px; width: auto" src="./support/20x50-green.png" width="20" height="50" data-expected-width="40" data-expected-height="50">
+
+<img class="item vertical" style="height: auto; max-width: 20px" src="./support/20x50-green.png" width="20" height="50" data-expected-width="40" data-expected-height="80">
+
+<div class="non-replaced item horizontal" style="width: 50px; height: auto" width="20" height="50" data-expected-width="50" data-expected-height="40"></div>
+
+<div class="non-replaced item horizontal"  style="width: auto; height: 20px" width="20" height="50" data-expected-width="80" data-expected-height="40"></div>
+
+<div class="non-replaced item horizontal" style="max-width: 50px; height: auto" width="20" height="50" data-expected-width="50" data-expected-height="40"></div>
+
+<div class="non-replaced item horizontal" style="width: auto; max-height: 20px" width="20" height="50" data-expected-width="80" data-expected-height="40"></div>
+
+<div class="non-replaced item vertical" style="height: 50px; width: auto" width="20" height="50" data-expected-width="40" data-expected-height="50"></div>
+
+<div class="non-replaced item vertical"  style="height: auto; width: 20px" width="20" height="50" data-expected-width="40" data-expected-height="80"></div>
+
+<div class="non-replaced item vertical" style="max-height: 50px; width: auto" width="20" height="50" data-expected-width="40" data-expected-height="50"></div>
+
+<div class="non-replaced item vertical" style="height: auto; max-width: 20px" width="20" height="50" data-expected-width="40" data-expected-height="80"></div>


### PR DESCRIPTION
This builds on top of https://github.com/servo/servo/pull/32800 because later work will probably overlap with it and I want to avoid merge conflicts.

The layout code currently has a strong distinction between replaced and non-replaced elements, most of which comes from `IndependentFormattingContext` being an enum with `Replaced` and `NonReplaced` variants. In order to implement `aspect-ratio`, we need to stop treating elements as "replaced"/"not replaced" and instead treat them as "has a preferred aspect ratio"/"does not have a preferred aspect ratio".

The CSS spec [says that calculating the automatic sizes of an element with a preferred aspect ratio involves treating it as a replaced element](https://drafts.csswg.org/css-sizing-4/#aspect-ratio-automatic), so we should be able to treat every element as replaced for the purposes of size calculation, in case they have `aspect-ratio` set.

This is a draft PR because actually implementing the "has a preferred ratio" check is left for a future commit, and I added a bunch of TODO comments so that I can remember to come back and place them in the appropriate spots. I'm opening it up for review to make sure I'm on the right track and there aren't any major concerns.

There are a few commits, but the first ("[Un-enum-ify IndependentFormattingContext](https://github.com/servo/servo/pull/32818/commits/1536cfdcbd3dd6945163a33e320e74f8492ed1af)") is probably the most useful one to review individually. You may want to hide whitespace changes because I moved some functions around scope-wise. After that is a pretty rote one that replaces all uses of the `style` and `base_fragment_info` getters with property accesses now that `IndependentFormattingContext` is not an enum, which makes a lot of one-line changes scattered throughout the code.

Reviewed in servo/servo#32818