### PR TITLE
Confirm that roles set via Element Internals are published correctly

### DIFF
--- a/custom-elements/ElementInternals-role.html
+++ b/custom-elements/ElementInternals-role.html
@@ -5,48 +5,48 @@
 <script src="/resources/testdriver-vendor.js"></script>
 
 <body>
-	<table-element id="table-row-columnheader-test">
-		<row-element>
-			<columnheader-element></columnheader-element>
-		</row-element>
-	</table-element>
-	<grid-element id="grid-row-gridcell-test">
-		<row-element>
-			<gridcell-element></gridcell-element>
-		</row-element>
-	</grid-element>
-	<list-element id="list-listitem-test">
-		<listitem-element></listitem-element>
-	</list-element>
-	<menu-element id="menu-menuitem-test">
-		<menuitem-element></menuitem-element>
-	</menu-element>
-	<menu-element id="menu-menuitemcheckbox-test">
-		<menuitemcheckbox-element></menuitemcheckbox-element>
-	</menu-element>
-	<menu-element id="menu-menuitemradio-test">
-		<menuitemradio-element></menuitemradio-element>
-	</menu-element>
-	<listbox-element id="listbox-option-test">
-		<option-element></option-element>
-	</listbox-element>
-	<table-element id="table-row-test">
-		<row-element></row-element>
-	</table-element>
-	<table-element id="table-rowgroup-test">
-		<rowgroup-element></rowgroup-element>
-	</table-element>
-	<table-element id="table-row-rowheader-test">
-		<row-element>
-			<rowheader-element></rowheader-element>
-		</row-element>
-	</table-element>
-	<tablist-element id="tablist-tab-test">
-		<tab-element></tab-element>
-	</tablist-element>
-	<tree-element id="tree-treeitem-test">
-		<treeitem-element></treeitem-element>
-	</tree-element>
+    <table-element id="table-row-columnheader-test">
+        <row-element>
+            <columnheader-element></columnheader-element>
+        </row-element>
+    </table-element>
+    <grid-element id="grid-row-gridcell-test">
+        <row-element>
+            <gridcell-element></gridcell-element>
+        </row-element>
+    </grid-element>
+    <list-element id="list-listitem-test">
+        <listitem-element></listitem-element>
+    </list-element>
+    <menu-element id="menu-menuitem-test">
+        <menuitem-element></menuitem-element>
+    </menu-element>
+    <menu-element id="menu-menuitemcheckbox-test">
+        <menuitemcheckbox-element></menuitemcheckbox-element>
+    </menu-element>
+    <menu-element id="menu-menuitemradio-test">
+        <menuitemradio-element></menuitemradio-element>
+    </menu-element>
+    <listbox-element id="listbox-option-test">
+        <option-element></option-element>
+    </listbox-element>
+    <table-element id="table-row-test">
+        <row-element></row-element>
+    </table-element>
+    <table-element id="table-rowgroup-test">
+        <rowgroup-element></rowgroup-element>
+    </table-element>
+    <table-element id="table-row-rowheader-test">
+        <row-element>
+            <rowheader-element></rowheader-element>
+        </row-element>
+    </table-element>
+    <tablist-element id="tablist-tab-test">
+        <tab-element></tab-element>
+    </tablist-element>
+    <tree-element id="tree-treeitem-test">
+        <treeitem-element></treeitem-element>
+    </tree-element>
 </body>
 
 <script>
@@ -173,11 +173,11 @@ const child_test_roles = [
 
 child_test_roles.map((roles) => {
     promise_test(async () => {
-		// Ensure role applied elements are registered.
-		roles.forEach((role) => {
-			conditionally_register_element(role);
-		});
-		// Gather test DOM and walk children to ensure parent/child relationships are correct.
+        // Ensure role applied elements are registered.
+        roles.forEach((role) => {
+            conditionally_register_element(role);
+        });
+        // Gather test DOM and walk children to ensure parent/child relationships are correct.
         let testEl = document.getElementById([...roles, 'test'].join('-'));
         for (let i = 0; i < roles.length; i++) {
             const role = roles[i];

--- a/custom-elements/ElementInternals-role.html
+++ b/custom-elements/ElementInternals-role.html
@@ -2,148 +2,149 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 
 <body></body>
 
 <script>
 function conditionally_register_element(role) {
-	if (!customElements.get(`${role}-element`)) {
-		customElements.define(`${role}-element`, class extends HTMLElement {
-			constructor() {
-				super();
-				this._internals = this.attachInternals();
-				this._internals.role = role;
-				this._internals.ariaLabel = "Test label";
-			}
-		});
-	}
+    if (!customElements.get(`${role}-element`)) {
+        customElements.define(`${role}-element`, class extends HTMLElement {
+            constructor() {
+                super();
+                this.internals_ = this.attachInternals();
+                this.internals_.role = role;
+                this.internals_.ariaLabel = "Test label";
+            }
+        });
+    }
 }
 
 function generate_role_element(role) {
-	conditionally_register_element(role);
-	const el = document.createElement(`${role}-element`);
-	document.body.append(el);
-	return el;
+    conditionally_register_element(role);
+    const el = document.createElement(`${role}-element`);
+    document.body.append(el);
+    return el;
 }
 
 function generate_child_role_element(role, parentElement) {
-	conditionally_register_element(role);
-	const el = document.createElement(`${role}-element`);
-	parentElement.append(el);
-	return el;
+    conditionally_register_element(role);
+    const el = document.createElement(`${role}-element`);
+    parentElement.append(el);
+    return el;
 }
 
 const test_roles = [
-	'alert',
-	'alertdialog',
-	'application',
-	'article',
-	'banner',
-	'button',
-	'cell',
-	'checkbox',
-	'combobox',
-	'complementary',
-	'contentinfo',
-	'definition',
-	'dialog',
-	['directory', 'list'], // is this expected?
-	'document',
-	'figure',
-	'form',
-	'grid',
-	'group',
-	'heading',
-	['img', 'image'],
-	'feed',
-	'link',
-	'list',
-	'listbox',
-	'log',
-	'main',
-	'marquee',
-	'math',
-	'menu',
-	'menubar',
-	'meter',
-	'navigation',
-	'note',
-	'progressbar',
-	'radio',
-	'radiogroup',
-	'region',
-	'scrollbar',
-	'search',
-	'searchbox',
-	'separator',
-	'slider',
-	'spinbutton',
-	'status',
-	'switch',
-	'table',
-	'tablist',
-	'tabpanel',
-	'term',
-	'textbox',
-	'timer',
-	'toolbar',
-	'tooltip',
-	'tree',
-	'treegrid'
+    'alert',
+    'alertdialog',
+    'application',
+    'article',
+    'banner',
+    'button',
+    'cell',
+    'checkbox',
+    'combobox',
+    'complementary',
+    'contentinfo',
+    'definition',
+    'dialog',
+    ['directory', 'list'], // is this expected?
+    'document',
+    'figure',
+    'form',
+    'grid',
+    'group',
+    'heading',
+    ['img', 'image'],
+    'feed',
+    'link',
+    'list',
+    'listbox',
+    'log',
+    'main',
+    'marquee',
+    'math',
+    'menu',
+    'menubar',
+    'meter',
+    'navigation',
+    'note',
+    'progressbar',
+    'radio',
+    'radiogroup',
+    'region',
+    'scrollbar',
+    'search',
+    'searchbox',
+    'separator',
+    'slider',
+    'spinbutton',
+    'status',
+    'switch',
+    'table',
+    'tablist',
+    'tabpanel',
+    'term',
+    'textbox',
+    'timer',
+    'toolbar',
+    'tooltip',
+    'tree',
+    'treegrid'
 ];
 
 test_roles.map((testdata) => {
-	let role;
-	let roleName;
-	if (Array.isArray(testdata)) {
-		role = testdata[0];
-		roleName = testdata[1];
-	} else {
-		role = testdata;
-		roleName = testdata;
-	}
-	promise_test(async () => {
-		const el = generate_role_element(role);
-		const computedRole = await test_driver.get_computed_role(el);
-		assert_equals(computedRole, roleName, el);
-		el.remove();
-	}, `Applies "${role}" via Element Internals`);
+    let role;
+    let roleName;
+    if (Array.isArray(testdata)) {
+        role = testdata[0];
+        roleName = testdata[1];
+    } else {
+        role = testdata;
+        roleName = testdata;
+    }
+    promise_test(async () => {
+        const el = generate_role_element(role);
+        const computedRole = await test_driver.get_computed_role(el);
+        assert_equals(computedRole, roleName, el);
+        el.remove();
+    }, `Applies "${role}" via Element Internals`);
 });
 
 const child_test_roles = [
-	['table', 'row', 'columnheader'],
-	['grid', 'row', 'gridcell'],
-	['list', 'listitem'],
-	['menu', 'menuitem'],
-	['menu', 'menuitemcheckbox'],
-	['menu', 'menuitemradio'],
-	['listbox', 'option'],
-	['table', 'row'],
-	['table', 'rowgroup'],
-	['table', 'row', 'rowheader'],
-	['tablist', 'tab'],
-	['tree', 'treeitem'],
+    ['table', 'row', 'columnheader'],
+    ['grid', 'row', 'gridcell'],
+    ['list', 'listitem'],
+    ['menu', 'menuitem'],
+    ['menu', 'menuitemcheckbox'],
+    ['menu', 'menuitemradio'],
+    ['listbox', 'option'],
+    ['table', 'row'],
+    ['table', 'rowgroup'],
+    ['table', 'row', 'rowheader'],
+    ['tablist', 'tab'],
+    ['tree', 'treeitem'],
 ];
 
 child_test_roles.map((roles) => {
-	promise_test(async () => {
-		const els = roles.reduce((acc, role) => {
-			const previous = acc.at(-1);
-			if (previous) {
-				acc.push(generate_child_role_element(role, previous))
-			} else {
-				acc.push(generate_role_element(role));
-			}
-			return acc;
-		}, []);
-		const computedRoles = [];
-		for(let i=0; i < els.length; i++) {
-			computedRoles.push(await test_driver.get_computed_role(els[i]));
-		}
-		computedRoles.map((role, i) => {
-			assert_equals(role, roles[i], els[i]);
-		})
-		els[0].remove();
-	}, `Applies parent/child relationship of "${roles.join('"/"')}" via Element Internals`);
+    promise_test(async () => {
+        const els = roles.reduce((acc, role) => {
+            const previous = acc.at(-1);
+            if (previous) {
+                acc.push(generate_child_role_element(role, previous))
+            } else {
+                acc.push(generate_role_element(role));
+            }
+            return acc;
+        }, []);
+        const computedRoles = [];
+        for(let i=0; i < els.length; i++) {
+            computedRoles.push(await test_driver.get_computed_role(els[i]));
+        }
+        computedRoles.map((role, i) => {
+            assert_equals(role, roles[i], els[i]);
+        })
+        els[0].remove();
+    }, `Applies parent/child relationship of "${roles.join('"/"')}" via Element Internals`);
 });
 </script>

--- a/custom-elements/ElementInternals-role.html
+++ b/custom-elements/ElementInternals-role.html
@@ -14,7 +14,7 @@ function conditionally_register_element(role) {
                 super();
                 this.internals_ = this.attachInternals();
                 this.internals_.role = role;
-                this.internals_.ariaLabel = "Test label";
+                this.internals_.ariaLabel = `Test ${role} label`;
             }
         });
     }
@@ -105,8 +105,10 @@ test_roles.map((testdata) => {
     }
     promise_test(async () => {
         const el = generate_role_element(role);
-        const computedRole = await test_driver.get_computed_role(el);
-        assert_equals(computedRole, roleName, el);
+        const computed_role = await test_driver.get_computed_role(el);
+		const computed_label = await test_driver.get_computed_label(el);
+        assert_equals(computed_role, roleName, el);
+		assert_equals(computed_label, `Test ${role} label`, el);
         el.remove();
     }, `Applies "${role}" via Element Internals`);
 });
@@ -128,23 +130,24 @@ const child_test_roles = [
 
 child_test_roles.map((roles) => {
     promise_test(async () => {
-        const els = roles.reduce((acc, role) => {
-            const previous = acc.at(-1);
-            if (previous) {
-                acc.push(generate_child_role_element(role, previous))
-            } else {
-                acc.push(generate_role_element(role));
-            }
-            return acc;
-        }, []);
-        const computedRoles = [];
-        for(let i=0; i < els.length; i++) {
-            computedRoles.push(await test_driver.get_computed_role(els[i]));
-        }
-        computedRoles.map((role, i) => {
-            assert_equals(role, roles[i], els[i]);
-        })
-        els[0].remove();
+		// Build the DOM tree by appending each role applied element as a child of the last.
+		const el = generate_role_element(roles[0]);
+		let currentElement = el;
+		for (let i = 1; i < roles.length; i++) {
+			currentElement = generate_child_role_element(roles[i], currentElement);
+		}
+		console.log(el);
+		// Test the DOM tree starting at the initial ancestor of the tree.
+		let testEl = el;
+		for (let i = 0; i < roles.length; i++) {
+			const role = roles[i];
+			const computed_role = await test_driver.get_computed_role(testEl);
+			const computed_label = await test_driver.get_computed_label(testEl);
+			assert_equals(computed_role, role, testEl);
+			assert_equals(computed_label, `Test ${role} label`, testEl);
+			testEl = testEl.children[0];
+		}
+        el.remove();
     }, `Applies parent/child relationship of "${roles.join('"/"')}" via Element Internals`);
 });
 </script>

--- a/custom-elements/ElementInternals-role.html
+++ b/custom-elements/ElementInternals-role.html
@@ -106,9 +106,9 @@ test_roles.map((testdata) => {
     promise_test(async () => {
         const el = generate_role_element(role);
         const computed_role = await test_driver.get_computed_role(el);
-		const computed_label = await test_driver.get_computed_label(el);
+        const computed_label = await test_driver.get_computed_label(el);
         assert_equals(computed_role, roleName, el);
-		assert_equals(computed_label, `Test ${role} label`, el);
+        assert_equals(computed_label, `Test ${role} label`, el);
         el.remove();
     }, `Applies "${role}" via Element Internals`);
 });
@@ -130,23 +130,22 @@ const child_test_roles = [
 
 child_test_roles.map((roles) => {
     promise_test(async () => {
-		// Build the DOM tree by appending each role applied element as a child of the last.
-		const el = generate_role_element(roles[0]);
-		let currentElement = el;
-		for (let i = 1; i < roles.length; i++) {
-			currentElement = generate_child_role_element(roles[i], currentElement);
-		}
-		console.log(el);
-		// Test the DOM tree starting at the initial ancestor of the tree.
-		let testEl = el;
-		for (let i = 0; i < roles.length; i++) {
-			const role = roles[i];
-			const computed_role = await test_driver.get_computed_role(testEl);
-			const computed_label = await test_driver.get_computed_label(testEl);
-			assert_equals(computed_role, role, testEl);
-			assert_equals(computed_label, `Test ${role} label`, testEl);
-			testEl = testEl.children[0];
-		}
+        // Build the DOM tree by appending each role applied element as a child of the last.
+        const el = generate_role_element(roles[0]);
+        let currentElement = el;
+        for (let i = 1; i < roles.length; i++) {
+            currentElement = generate_child_role_element(roles[i], currentElement);
+        }
+        // Test the DOM tree starting at the initial ancestor of the tree.
+        let testEl = el;
+        for (let i = 0; i < roles.length; i++) {
+            const role = roles[i];
+            const computed_role = await test_driver.get_computed_role(testEl);
+            const computed_label = await test_driver.get_computed_label(testEl);
+            assert_equals(computed_role, role, testEl);
+            assert_equals(computed_label, `Test ${role} label`, testEl);
+            testEl = testEl.children[0];
+        }
         el.remove();
     }, `Applies parent/child relationship of "${roles.join('"/"')}" via Element Internals`);
 });

--- a/custom-elements/ElementInternals-role.html
+++ b/custom-elements/ElementInternals-role.html
@@ -4,7 +4,50 @@
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 
-<body></body>
+<body>
+	<table-element id="table-row-columnheader-test">
+		<row-element>
+			<columnheader-element></columnheader-element>
+		</row-element>
+	</table-element>
+	<grid-element id="grid-row-gridcell-test">
+		<row-element>
+			<gridcell-element></gridcell-element>
+		</row-element>
+	</grid-element>
+	<list-element id="list-listitem-test">
+		<listitem-element></listitem-element>
+	</list-element>
+	<menu-element id="menu-menuitem-test">
+		<menuitem-element></menuitem-element>
+	</menu-element>
+	<menu-element id="menu-menuitemcheckbox-test">
+		<menuitemcheckbox-element></menuitemcheckbox-element>
+	</menu-element>
+	<menu-element id="menu-menuitemradio-test">
+		<menuitemradio-element></menuitemradio-element>
+	</menu-element>
+	<listbox-element id="listbox-option-test">
+		<option-element></option-element>
+	</listbox-element>
+	<table-element id="table-row-test">
+		<row-element></row-element>
+	</table-element>
+	<table-element id="table-rowgroup-test">
+		<rowgroup-element></rowgroup-element>
+	</table-element>
+	<table-element id="table-row-rowheader-test">
+		<row-element>
+			<rowheader-element></rowheader-element>
+		</row-element>
+	</table-element>
+	<tablist-element id="tablist-tab-test">
+		<tab-element></tab-element>
+	</tablist-element>
+	<tree-element id="tree-treeitem-test">
+		<treeitem-element></treeitem-element>
+	</tree-element>
+</body>
 
 <script>
 function conditionally_register_element(role) {
@@ -130,14 +173,12 @@ const child_test_roles = [
 
 child_test_roles.map((roles) => {
     promise_test(async () => {
-        // Build the DOM tree by appending each role applied element as a child of the last.
-        const el = generate_role_element(roles[0]);
-        let currentElement = el;
-        for (let i = 1; i < roles.length; i++) {
-            currentElement = generate_child_role_element(roles[i], currentElement);
-        }
-        // Test the DOM tree starting at the initial ancestor of the tree.
-        let testEl = el;
+		// Ensure role applied elements are registered.
+		roles.forEach((role) => {
+			conditionally_register_element(role);
+		});
+		// Gather test DOM and walk children to ensure parent/child relationships are correct.
+        let testEl = document.getElementById([...roles, 'test'].join('-'));
         for (let i = 0; i < roles.length; i++) {
             const role = roles[i];
             const computed_role = await test_driver.get_computed_role(testEl);
@@ -146,7 +187,6 @@ child_test_roles.map((roles) => {
             assert_equals(computed_label, `Test ${role} label`, testEl);
             testEl = testEl.children[0];
         }
-        el.remove();
     }, `Applies parent/child relationship of "${roles.join('"/"')}" via Element Internals`);
 });
 </script>

--- a/custom-elements/ElementInternals-role.html
+++ b/custom-elements/ElementInternals-role.html
@@ -1,0 +1,149 @@
+<!DOCTYPE HTML>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+
+<body></body>
+
+<script>
+function conditionally_register_element(role) {
+	if (!customElements.get(`${role}-element`)) {
+		customElements.define(`${role}-element`, class extends HTMLElement {
+			constructor() {
+				super();
+				this._internals = this.attachInternals();
+				this._internals.role = role;
+				this._internals.ariaLabel = "Test label";
+			}
+		});
+	}
+}
+
+function generate_role_element(role) {
+	conditionally_register_element(role);
+	const el = document.createElement(`${role}-element`);
+	document.body.append(el);
+	return el;
+}
+
+function generate_child_role_element(role, parentElement) {
+	conditionally_register_element(role);
+	const el = document.createElement(`${role}-element`);
+	parentElement.append(el);
+	return el;
+}
+
+const test_roles = [
+	'alert',
+	'alertdialog',
+	'application',
+	'article',
+	'banner',
+	'button',
+	'cell',
+	'checkbox',
+	'combobox',
+	'complementary',
+	'contentinfo',
+	'definition',
+	'dialog',
+	['directory', 'list'], // is this expected?
+	'document',
+	'figure',
+	'form',
+	'grid',
+	'group',
+	'heading',
+	['img', 'image'],
+	'feed',
+	'link',
+	'list',
+	'listbox',
+	'log',
+	'main',
+	'marquee',
+	'math',
+	'menu',
+	'menubar',
+	'meter',
+	'navigation',
+	'note',
+	'progressbar',
+	'radio',
+	'radiogroup',
+	'region',
+	'scrollbar',
+	'search',
+	'searchbox',
+	'separator',
+	'slider',
+	'spinbutton',
+	'status',
+	'switch',
+	'table',
+	'tablist',
+	'tabpanel',
+	'term',
+	'textbox',
+	'timer',
+	'toolbar',
+	'tooltip',
+	'tree',
+	'treegrid'
+];
+
+test_roles.map((testdata) => {
+	let role;
+	let roleName;
+	if (Array.isArray(testdata)) {
+		role = testdata[0];
+		roleName = testdata[1];
+	} else {
+		role = testdata;
+		roleName = testdata;
+	}
+	promise_test(async () => {
+		const el = generate_role_element(role);
+		const computedRole = await test_driver.get_computed_role(el);
+		assert_equals(computedRole, roleName, el);
+		el.remove();
+	}, `Applies "${role}" via Element Internals`);
+});
+
+const child_test_roles = [
+	['table', 'row', 'columnheader'],
+	['grid', 'row', 'gridcell'],
+	['list', 'listitem'],
+	['menu', 'menuitem'],
+	['menu', 'menuitemcheckbox'],
+	['menu', 'menuitemradio'],
+	['listbox', 'option'],
+	['table', 'row'],
+	['table', 'rowgroup'],
+	['table', 'row', 'rowheader'],
+	['tablist', 'tab'],
+	['tree', 'treeitem'],
+];
+
+child_test_roles.map((roles) => {
+	promise_test(async () => {
+		const els = roles.reduce((acc, role) => {
+			const previous = acc.at(-1);
+			if (previous) {
+				acc.push(generate_child_role_element(role, previous))
+			} else {
+				acc.push(generate_role_element(role));
+			}
+			return acc;
+		}, []);
+		const computedRoles = [];
+		for(let i=0; i < els.length; i++) {
+			computedRoles.push(await test_driver.get_computed_role(els[i]));
+		}
+		computedRoles.map((role, i) => {
+			assert_equals(role, roles[i], els[i]);
+		})
+		els[0].remove();
+	}, `Applies parent/child relationship of "${roles.join('"/"')}" via Element Internals`);
+});
+</script>


### PR DESCRIPTION
- add testing for the application of ALL roles in https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles
- included roles that require a specific parent/child relationship
- currently all test pass, except for `role="list"` and "role="menu"` in Safari which comes back as `"group"` and `"generic"` respectively

### Possible follow-up work
- [ ] is it worth testing child role without a parent in the negative? Support was quite lumpy for this, but it's unclear whether they _shouldn't_ work at all or could work is the browser chose at the spec level.