### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=241177

### DIFF
--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -1373,6 +1373,12 @@ const gCSSProperties2 = {
       { type: 'discrete', options: [ [ 'capitalize', 'uppercase' ] ] }
     ]
   },
+  'text-underline-position': {
+    // https://drafts.csswg.org/css-text-decor-4/#text-underline-position-property
+    types: [
+      { type: 'discrete', options: [ [ 'auto', 'under' ] ] }
+    ]
+  },
   'text-wrap': {
     // https://drafts.csswg.org/css-text-4/#propdef-text-wrap
     types: [


### PR DESCRIPTION
WebKit export from bug: [\[web-animations\] Support discrete animations on `text-underline-position`](https://bugs.webkit.org/show_bug.cgi?id=241177)