### PR TITLE
parseHTMLUnsafe has only one parameter

### DIFF
--- a/trusted-types/block-string-assignment-to-Document-parseHTMLUnsafe.html
+++ b/trusted-types/block-string-assignment-to-Document-parseHTMLUnsafe.html
@@ -34,13 +34,13 @@
   // After default policy creation string assignment implicitly calls createHTML.
   test(t => {
     let p = window.trustedTypes.createPolicy("default", { createHTML: createHTMLJS }, true);
-    let doc = Document.parseHTMLUnsafe(INPUTS.HTML, "text/html");
+    let doc = Document.parseHTMLUnsafe(INPUTS.HTML);
     assert_equals(doc.body.innerText, RESULTS.HTML);
   }, "'Document.parseHTMLUnsafe(string)' assigned via default policy (successful HTML transformation).");
 
   // After default policy creation null assignment implicitly calls createHTML.
   test(t => {
-    var doc = Document.parseHTMLUnsafe(null, "text/html");
+    var doc = Document.parseHTMLUnsafe(null);
     assert_equals(doc.body.innerText, "null");
   }, "'Document.parseHTMLUnsafe(null)' assigned via default policy does not throw");
 </script>


### PR DESCRIPTION
Document.parseHTMLUnsafe has only one parameter. A future extension wants to add an options bag to parseHTMLUnsafe, which conflicts with this usage.

Note the references below, which are all consistent in parseHTMLUnsafe not having a second parameter.
This is probably a left-over from adapting the test from DOMParser.parseFromString, which does have a second string
parameter, because parseFromString supports different document types.

References:
- Spec: https://dom.spec.whatwg.org/#interface-document
- MDN: https://developer.mozilla.org/en-US/docs/Web/API/Document/parseHTMLUnsafe_static
- Blink IDL: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/document.idl;l=84
- Firefox IDL: https://searchfox.org/mozilla-central/source/dom/webidl/Document.webidl#154
- WebKit IDL: https://github.com/WebKit/WebKit/blob/main/Source/WebCore/dom/Document.idl#L44