### PR TITLE
Make text-decoration-underline-position-vertical-ja.html fonts consistent across test & reference

### DIFF
--- a/css/css-text-decor/reference/text-decoration-underline-position-vertical-ja-ref.html
+++ b/css/css-text-decor/reference/text-decoration-underline-position-vertical-ja-ref.html
@@ -3,14 +3,18 @@
 <head>
     <meta charset="utf-8">
     <style>
-            body { writing-mode: vertical-rl; }
-            .underline { text-decoration: underline; }
-            .overline { text-decoration: overline; }
+        @font-face {
+            font-family: halt-font;
+            src: url('/fonts/noto/cjk/NotoSansCJKjp-Regular-subset-halt-min.otf');
+        }
+        body { writing-mode: vertical-rl; font-family: Arial; }
+        .underline { text-decoration: underline; font-family: halt-font; font-language-override: "JAN"; }
+        .overline { text-decoration: overline; font-family: halt-font; font-language-override: "JAN"; }
     </style>
 </head>
 <body lang="en">
     <div>In vertical writing mode with lang=ja, default overline will be same as underline (lang=en). However, when we set text-underline-position to "under left" it should be shifted.</div>
-    <div class="underline">サンプル</div>
-    <div class="underline">サンプル</div>
+    <div class="underline">&#x56fd;&#x56fd;&#x56fd;&#x56fd;</div>
+    <div class="underline">&#x56fd;&#x56fd;&#x56fd;&#x56fd;</div>
 </body>
 </html>

--- a/css/css-text-decor/text-decoration-underline-position-vertical-ja.html
+++ b/css/css-text-decor/text-decoration-underline-position-vertical-ja.html
@@ -5,14 +5,18 @@
     <link rel="help" href="https://www.w3.org/TR/css-text-decor-3/#text-underline-position-property">
     <link rel="match" href="reference/text-decoration-underline-position-vertical-ja-ref.html">
     <style>
-        body { writing-mode: vertical-rl; }
-        .underline { text-decoration: underline; }
-        .overline { text-decoration: overline; }
+        @font-face {
+            font-family: halt-font;
+            src: url('/fonts/noto/cjk/NotoSansCJKjp-Regular-subset-halt-min.otf');
+        }
+        body { writing-mode: vertical-rl; font-family: Arial; }
+        .underline { text-decoration: underline; font-family: halt-font; font-language-override: "JAN"; }
+        .overline { text-decoration: overline; font-family: halt-font; font-language-override: "JAN"; }
     </style>
 </head>
 <body lang="ja">
     <div>In vertical writing mode with lang=ja, default overline will be same as underline (lang=en). However, when we set text-underline-position to "under left" it should be shifted.</div>
-    <div class="underline" style="text-underline-position: under left">サンプル</div>
-    <div class="overline">サンプル</div>
+    <div class="underline" style="text-underline-position: under left">&#x56fd;&#x56fd;&#x56fd;&#x56fd;</div>
+    <div class="overline">&#x56fd;&#x56fd;&#x56fd;&#x56fd;</div>
 </body>
 </html>


### PR DESCRIPTION
Different languages have different default fonts, override those default fonts to get a consistent result between the test and the ref.

Fixes #47270