### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=263431

### DIFF
--- a/css/css-text-decor/animations/text-underline-offset-interpolation.html
+++ b/css/css-text-decor/animations/text-underline-offset-interpolation.html
@@ -9,7 +9,7 @@
 
 <style>
 .target {
-  font: 10px sans-serif;
+  font: 16px sans-serif;
 }
 </style>
 
@@ -29,4 +29,212 @@ test_interpolation({
   {at: 1, expect: '0px'},
 ]);
 
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '16px',
+  to: '0px',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '11.2px'},
+  {at: 0.6, expect: '6.4px'},
+  {at: 1, expect: '0px'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '16px',
+  to: '32px',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '20.8px'},
+  {at: 0.6, expect: '25.6px'},
+  {at: 1, expect: '32px'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '1em',
+  to: '0em',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '11.2px'},
+  {at: 0.6, expect: '6.4px'},
+  {at: 1, expect: '0px'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '1em',
+  to: '2em',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '20.8px'},
+  {at: 0.6, expect: '25.6px'},
+  {at: 1, expect: '32px'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '100%',
+  to: '0%',
+}, [
+  {at: 0, expect: '100%'},
+  {at: 0.3, expect: '70%'},
+  {at: 0.6, expect: '40%'},
+  {at: 1, expect: '0%'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '100%',
+  to: '200%',
+}, [
+  {at: 0, expect: '100%'},
+  {at: 0.3, expect: '130%'},
+  {at: 0.6, expect: '160%'},
+  {at: 1, expect: '200%'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '16px',
+  to: '0em',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '11.2px'},
+  {at: 0.6, expect: '6.4px'},
+  {at: 1, expect: '0px'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '16px',
+  to: '2em',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '20.8px'},
+  {at: 0.6, expect: '25.6px'},
+  {at: 1, expect: '32px'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '16px',
+  to: '0%',
+}, [
+  {at: 0, expect: 'calc(0% + 16px)'},
+  {at: 0.3, expect: 'calc(0% + 11.2px)'},
+  {at: 0.6, expect: 'calc(0% + 6.4px)'},
+  {at: 1, expect: '0%'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '16px',
+  to: '200%',
+}, [
+  {at: 0, expect: 'calc(0% + 16px)'},
+  {at: 0.3, expect: 'calc(120% + 11.2px)'},
+  {at: 0.6, expect: 'calc(120% + 6.4px)'},
+  {at: 1, expect: '200%'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '1em',
+  to: '0px',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '11.2px'},
+  {at: 0.6, expect: '6.4px'},
+  {at: 1, expect: '0px'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '1em',
+  to: '32px',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '20.8px'},
+  {at: 0.6, expect: '25.6px'},
+  {at: 1, expect: '32px'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '1em',
+  to: '0%',
+}, [
+  {at: 0, expect: 'calc(0% + 16px)'},
+  {at: 0.3, expect: 'calc(0% + 11.2px)'},
+  {at: 0.6, expect: 'calc(0% + 6.4px)'},
+  {at: 1, expect: '0%'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '1em',
+  to: '200%',
+}, [
+  {at: 0, expect: 'calc(0% + 16px)'},
+  {at: 0.3, expect: 'calc(60% + 11.2px)'},
+  {at: 0.6, expect: 'calc(120% + 6.4px)'},
+  {at: 1, expect: '200%'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '100%',
+  to: '0px',
+}, [
+  {at: 0, expect: '100%'},
+  {at: 0.3, expect: '70%'},
+  {at: 0.6, expect: '40%'},
+  {at: 1, expect: '0%'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '100%',
+  to: '32px',
+}, [
+  {at: 0, expect: 'calc(100% + 0px)'},
+  {at: 0.3, expect: 'calc(100% + 9.6px)'},
+  {at: 0.6, expect: 'calc(100% + 19.2px)'},
+  {at: 1, expect: 'calc(100% + 32px)'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '100%',
+  to: '0em',
+}, [
+  {at: 0, expect: 'calc(100% + 0em)'},
+  {at: 0.3, expect: 'calc(70% + 0em)'},
+  {at: 0.6, expect: 'calc(40% + 0em)'},
+  {at: 1, expect: 'calc(0% + 0em)'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '100%',
+  to: '2em',
+}, [
+  {at: 0, expect: '100%'},
+  {at: 0.3, expect: 'calc(70% + 9.6px)'},
+  {at: 0.6, expect: 'calc(40% + 19.2px)'},
+  {at: 1, expect: 'calc(0% + 32px)'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '0%',
+  to: '100%',
+}, [
+  {at: 0, expect: '0%'},
+  {at: 0.3, expect: '30%'},
+  {at: 0.6, expect: '60%'},
+  {at: 1, expect: '100%'},
+]);
 </script>

--- a/css/css-text-decor/text-underline-offset-calc-ref.html
+++ b/css/css-text-decor/text-underline-offset-calc-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>text-underline-offset calc() support</title>
+<link rel="author" title="Zak Ridouh" href="mailto:zakr@apple.com" />
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#underline-offset" />
+<style>
+div {
+  display: flex;
+  font-size: 22px;
+}
+.underline {
+  text-decoration-color: green;
+  text-decoration-line: underline;
+  text-decoration-thickness: 15px;
+  text-decoration-skip-ink: none;
+}
+.ref {
+  text-underline-offset: 1em;
+}
+</style>
+<p>Test passes if black and green bar pairs are the same shape and size.</p>
+<div>
+  <span class="underline ref">XXXXXX</span>
+</div>

--- a/css/css-text-decor/text-underline-offset-calc.html
+++ b/css/css-text-decor/text-underline-offset-calc.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>text-underline-offset calc() support</title>
+<link rel="author" title="Zak Ridouh" href="mailto:zakr@apple.com" />
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#underline-offset" />
+<meta name="assert" content="Test checks whether text-underline-offset supports calc() values.">
+<link rel="match" href="text-underline-offset-calc-ref.html">
+<style>
+div {
+  display: flex;
+  font-size: 22px;
+}
+.underline {
+  text-decoration-color: green;
+  text-decoration-line: underline;
+  text-decoration-thickness: 15px;
+  text-decoration-skip-ink: none;
+}
+.ref {
+  text-underline-offset: 1em;
+}
+.test1 {
+  text-underline-offset: calc(1em);
+}
+.test2 {
+  text-underline-offset: calc(100%);
+}
+.test3 {
+  text-underline-offset: calc(50% + 11px);
+}
+.test4 {
+  text-underline-offset: calc(50% + 0.5em);
+}
+.test5 {
+  text-underline-offset: calc(0.5em + 11px);
+}
+</style>
+<p>Test passes if black and green bar pairs are the same shape and size.</p>
+<div>
+  <span class="underline ref">X</span>
+  <span class="underline test1">X</span>
+  <span class="underline test2">X</span>
+  <span class="underline test3">X</span>
+  <span class="underline test4">X</span>
+  <span class="underline test5">X</span>
+</div>

--- a/css/css-text-decor/text-underline-offset-computed.html
+++ b/css/css-text-decor/text-underline-offset-computed.html
@@ -14,6 +14,23 @@
 <script>
 test_computed_value("text-underline-offset", "auto");
 test_computed_value("text-underline-offset", "calc(10px - 8px)", "2px");
+
+test_computed_value("text-underline-offset", "32px", "32px");
+test_computed_value("text-underline-offset", "2em", "32px");
+test_computed_value("text-underline-offset", "200%", "200%");
+
+test_computed_value("text-underline-offset", "calc(2em - 0px)", "32px");
+test_computed_value("text-underline-offset", "calc(200% - 0px)", "200%");
+test_computed_value("text-underline-offset", "calc(0.5em - 0px)", "8px");
+test_computed_value("text-underline-offset", "calc(50% - 0px)", "50%");
+
+test_computed_value("text-underline-offset", "calc(2em - 8px)", "24px");
+test_computed_value("text-underline-offset", "calc(2em - 0.5em)", "24px");
+test_computed_value("text-underline-offset", "calc(2em - 50%)", "calc(-50% + 32px)");
+
+test_computed_value("text-underline-offset", "calc(200% - 8px)");
+test_computed_value("text-underline-offset", "calc(200% - 0.5em)", "calc(200% - 8px)");
+test_computed_value("text-underline-offset", "calc(200% - 50%)", "150%");
 </script>
 </body>
 </html>

--- a/css/css-text-decor/text-underline-offset-percentage-ref.html
+++ b/css/css-text-decor/text-underline-offset-percentage-ref.html
@@ -2,33 +2,29 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>Test case for text-underline-offset</title>
-    <link rel="author" title="Charlie Marlow" href="mailto:cmarlow@mozilla.com">
-    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <title>Reference case for text-underline-offset</title>
+    <link rel="author" title="Zak Ridouh" href="mailto:zakr@apple.com">
+    <link rel="author" title="Apple" href="https://www.apple.com">
     <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#underline-offset">
-    <link rel="match" href="reference/text-underline-offset-002-ref.html">
-    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style>
-        #main{
-            border-bottom: 1px solid cyan;
+        #main {
+            border-bottom: 2px solid purple;
             display: flex;
         }
-        #text, #norm{
+        #text, #norm {
             text-decoration-color: green;
             text-decoration-line: underline;
-            text-decoration-skip-ink: none;
-            font: 20px/1 Ahem;
+            text-decoration-thickness: 15px;
+            font: 20px/2 Arial;
             color: transparent;
             position: relative;
             margin-right: 10px;
         }
-        #text{
-            top: 10px;
-            text-underline-offset: 11px;
+        #text {
+            text-underline-offset: 5px;
         }
-        #norm{
-            top: 21px;
-            text-underline-offset: 0px;
+        #norm {
+            text-underline-offset: 5px;
         }
     </style>
 </head>

--- a/css/css-text-decor/text-underline-offset-percentage.html
+++ b/css/css-text-decor/text-underline-offset-percentage.html
@@ -2,33 +2,30 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>Test case for text-underline-offset</title>
-    <link rel="author" title="Charlie Marlow" href="mailto:cmarlow@mozilla.com">
-    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <title>Test case for text-underline-offset percentage support</title>
+    <link rel="author" title="Zak Ridouh" href="mailto:zakr@apple.com">
+    <link rel="author" title="Apple" href="https://www.apple.com">
     <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#underline-offset">
-    <link rel="match" href="reference/text-underline-offset-002-ref.html">
-    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+    <link rel="match" href="text-underline-offset-percentage-ref.html">
     <style>
-        #main{
-            border-bottom: 1px solid cyan;
+        #main {
+            border-bottom: 2px solid purple;
             display: flex;
         }
-        #text, #norm{
+        #text, #norm {
             text-decoration-color: green;
             text-decoration-line: underline;
-            text-decoration-skip-ink: none;
-            font: 20px/1 Ahem;
+            text-decoration-thickness: 15px;
+            font: 20px/2 Arial;
             color: transparent;
             position: relative;
             margin-right: 10px;
         }
-        #text{
-            top: 10px;
-            text-underline-offset: 11px;
+        #text {
+            text-underline-offset: 25%;
         }
-        #norm{
-            top: 21px;
-            text-underline-offset: 0px;
+        #norm {
+            text-underline-offset: 25%;
         }
     </style>
 </head>

--- a/css/css-text-decor/text-underline-offset-valid.html
+++ b/css/css-text-decor/text-underline-offset-valid.html
@@ -16,6 +16,11 @@ test_valid_value("text-underline-offset", "-10px");
 test_valid_value("text-underline-offset", "2001em");
 test_valid_value("text-underline-offset", "-49em");
 test_valid_value("text-underline-offset", "53px");
+test_valid_value("text-underline-offset", "5%");
+test_valid_value("text-underline-offset", "89%");
+test_valid_value("text-underline-offset", "-30%");
+test_valid_value("text-underline-offset", "187%");
+test_valid_value("text-underline-offset", "calc(45% - 0.3em)");
 test_valid_value("text-underline-offset", "calc(40em - 10px)");
 test_valid_value("text-underline-offset", "calc(-13em + 50px)");
 </script>


### PR DESCRIPTION
WebKit export from bug: [text-underline-offset should support percentages](https://bugs.webkit.org/show_bug.cgi?id=263431)