### PR TITLE
Add Ladybird browser version detection support

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -2252,6 +2252,15 @@ class Ladybird(Browser):
         raise NotImplementedError
 
     def version(self, binary=None, webdriver_binary=None):
+        if not binary:
+            self.logger.warning("No browser binary provided.")
+            return None
+        output = call(binary, "--version")
+        if output:
+            version_string = output.strip()
+            match = re.match(r"Version (.*)", version_string)
+            if match:
+                return match.group(1)
         return None
 
 class WebKitTestRunner(Browser):


### PR DESCRIPTION
This extracts the browser version from the provided Ladybird binary.

My motivation for doing this is to ensure that the `browser_version` field is included in wptreport JSON files generated by `--log-wptreport`, as this is needed when uploading files to wpt.fyi.

cc: @ADKaster 