### PR TITLE
[css] Add tests for `justify-self` on block-level elements

### DIFF
--- a/css/css-align/self-alignment/block-justify-self-ref.html
+++ b/css/css-align/self-alignment/block-justify-self-ref.html
@@ -27,6 +27,10 @@ body {
 <div class="stack" style="float: left;">
   <article class="grid-container" style="display: grid; grid-template-columns: 1fr; width: 300px">
     <div style="justify-self: auto;">auto</div>
+    <div style="justify-self: normal;">normal</div>
+    <div style="justify-self: stretch; width: auto; margin: 0;">stretch</div>
+    <div style="justify-self: stretch; margin: 0;">stretch</div>
+    <div style="justify-self: stretch; width: auto; margin: auto;">stretch</div>
     <div style="justify-self: left;">left</div>
     <div style="justify-self: right;">right</div>
     <div style="justify-self: start;">start</div>
@@ -45,14 +49,16 @@ body {
     <div style="justify-self: end">end parent
       <div style="position: absolute;">absolute child</div>
     </div>
-    <div style="justify-self: end; position: absolute;">absolute parent
-      <div>child</div>
-    </div>
+    <div style="justify-self: end; position: absolute;">absolute parent</div>
   </article>
 </div>
 <div class="stack" style="float: right; direction: rtl">
   <article class="grid-container" style="display: grid; grid-template-columns: 1fr; width: 300px">
     <div style="justify-self: auto;">auto</div>
+    <div style="justify-self: normal;">normal</div>
+    <div style="justify-self: stretch; width: auto; margin: 0;">stretch</div>
+    <div style="justify-self: stretch; margin: 0;">stretch</div>
+    <div style="justify-self: stretch; width: auto; margin: auto;">stretch</div>
     <div style="justify-self: left;">left</div>
     <div style="justify-self: right;">right</div>
     <div style="justify-self: start;">start</div>
@@ -71,8 +77,6 @@ body {
     <div style="justify-self: end">end parent
       <div style="position: absolute;">absolute child</div>
     </div>
-    <div style="justify-self: end; position: absolute;">absolute parent
-      <div>child</div>
-    </div>
+    <div style="justify-self: end; position: absolute;">absolute parent</div>
   </article>
 </div>

--- a/css/css-align/self-alignment/block-justify-self-ref.html
+++ b/css/css-align/self-alignment/block-justify-self-ref.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<meta charset="UTF-8">
+<title>Self-Alignment: justify-self - block-level elements reference</title>
+<link rel="author" title="David Tran" href="mailto:davidtranhq+wpt@gmail.com" />
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#justify-block" />
+<style>
+.grid-container div {
+    width: 100px;
+    background-color: green;
+}
+
+.stack {
+    display: grid;
+}
+
+.stack > * {
+    grid-row: 1;
+    grid-column: 1;
+}
+
+</style>
+</head>
+<p>Test passes if <strong>no red</strong> is visible</p>
+
+<div class="stack">
+<article class="grid-container" style="display: grid; grid-template-columns: 1fr; width: 300px">
+  <div style="justify-self: auto;">auto</div>
+  <div style="justify-self: left;">left</div>
+  <div style="justify-self: right;">right</div>
+  <div style="justify-self: start;">start</div>
+  <div style="justify-self: center;">center</div>
+  <div style="justify-self: end;">end</div>
+  <div style="justify-self: self-start;">self-start</div>
+  <div style="justify-self: self-end;">self-end</div>
+  <div style="justify-self: flex-start;">flex-start</div>
+  <div style="justify-self: flex-end;">flex-end</div>
+  <!-- justify self has no effect on floats -->
+  <div style="display: float;">float</div>
+  <div style="justify-self: self-start; direction: rtl">self-start (rtl)</div>
+  <div style="justify-self: self-end; direction: rtl">self-end (rtl)</div>
+  <div style="justify-self: start; direction: rtl">start (rtl)</div>
+  <div style="justify-self: end; direction: rtl">end (rtl)</div>
+  <div style="justify-self: end">end parent
+    <div style="position: absolute;">absolute child</div>
+  </div>
+</article>
+
+</div>

--- a/css/css-align/self-alignment/block-justify-self-ref.html
+++ b/css/css-align/self-alignment/block-justify-self-ref.html
@@ -2,47 +2,77 @@
 <meta charset="UTF-8">
 <title>Self-Alignment: justify-self - block-level elements reference</title>
 <link rel="author" title="David Tran" href="mailto:davidtranhq+wpt@gmail.com" />
-<link rel="help" href="https://www.w3.org/TR/css-align-3/#justify-block" />
 <style>
 .grid-container div {
-    width: 100px;
-    background-color: green;
+  width: 100px;
+  background-color: green;
 }
 
 .stack {
-    display: grid;
+  display: grid;
 }
 
 .stack > * {
-    grid-row: 1;
-    grid-column: 1;
+  grid-row: 1;
+  grid-column: 1;
+}
+
+body {
+  width: 700px;
 }
 
 </style>
-</head>
 <p>Test passes if <strong>no red</strong> is visible</p>
 
-<div class="stack">
-<article class="grid-container" style="display: grid; grid-template-columns: 1fr; width: 300px">
-  <div style="justify-self: auto;">auto</div>
-  <div style="justify-self: left;">left</div>
-  <div style="justify-self: right;">right</div>
-  <div style="justify-self: start;">start</div>
-  <div style="justify-self: center;">center</div>
-  <div style="justify-self: end;">end</div>
-  <div style="justify-self: self-start;">self-start</div>
-  <div style="justify-self: self-end;">self-end</div>
-  <div style="justify-self: flex-start;">flex-start</div>
-  <div style="justify-self: flex-end;">flex-end</div>
-  <!-- justify self has no effect on floats -->
-  <div style="display: float;">float</div>
-  <div style="justify-self: self-start; direction: rtl">self-start (rtl)</div>
-  <div style="justify-self: self-end; direction: rtl">self-end (rtl)</div>
-  <div style="justify-self: start; direction: rtl">start (rtl)</div>
-  <div style="justify-self: end; direction: rtl">end (rtl)</div>
-  <div style="justify-self: end">end parent
-    <div style="position: absolute;">absolute child</div>
-  </div>
-</article>
-
+<div class="stack" style="float: left;">
+  <article class="grid-container" style="display: grid; grid-template-columns: 1fr; width: 300px">
+    <div style="justify-self: auto;">auto</div>
+    <div style="justify-self: left;">left</div>
+    <div style="justify-self: right;">right</div>
+    <div style="justify-self: start;">start</div>
+    <div style="justify-self: center;">center</div>
+    <div style="justify-self: end;">end</div>
+    <div style="justify-self: self-start;">self-start</div>
+    <div style="justify-self: self-end;">self-end</div>
+    <div style="justify-self: flex-start;">flex-start</div>
+    <div style="justify-self: flex-end;">flex-end</div>
+    <div style="float: left; justify-self: center;">float left</div>
+    <div style="float: right; justify-self: center;">float right</div>
+    <div style="justify-self: self-start; direction: rtl">self-start (rtl)</div>
+    <div style="justify-self: self-end; direction: rtl">self-end (rtl)</div>
+    <div style="justify-self: start; direction: rtl">start (rtl)</div>
+    <div style="justify-self: end; direction: rtl">end (rtl)</div>
+    <div style="justify-self: end">end parent
+      <div style="position: absolute;">absolute child</div>
+    </div>
+    <div style="justify-self: end; position: absolute;">absolute parent
+      <div>child</div>
+    </div>
+  </article>
+</div>
+<div class="stack" style="float: right; direction: rtl">
+  <article class="grid-container" style="display: grid; grid-template-columns: 1fr; width: 300px">
+    <div style="justify-self: auto;">auto</div>
+    <div style="justify-self: left;">left</div>
+    <div style="justify-self: right;">right</div>
+    <div style="justify-self: start;">start</div>
+    <div style="justify-self: center;">center</div>
+    <div style="justify-self: end;">end</div>
+    <div style="justify-self: self-start;">self-start</div>
+    <div style="justify-self: self-end;">self-end</div>
+    <div style="justify-self: flex-start;">flex-start</div>
+    <div style="justify-self: flex-end;">flex-end</div>
+    <div style="float: left; justify-self: center;">float left</div>
+    <div style="float: right; justify-self: center;">float right</div>
+    <div style="justify-self: self-start; direction: ltr">self-start (ltr)</div>
+    <div style="justify-self: self-end; direction: ltr">self-end (ltr)</div>
+    <div style="justify-self: start; direction: ltr">start (ltr)</div>
+    <div style="justify-self: end; direction: ltr">end (ltr)</div>
+    <div style="justify-self: end">end parent
+      <div style="position: absolute;">absolute child</div>
+    </div>
+    <div style="justify-self: end; position: absolute;">absolute parent
+      <div>child</div>
+    </div>
+  </article>
 </div>

--- a/css/css-align/self-alignment/block-justify-self.html
+++ b/css/css-align/self-alignment/block-justify-self.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Self-Alignment: justify-self - block-level elements</title>
+<link rel="author" title="David Tran" href="mailto:davidtranhq+wpt@gmail.com">
+<link rel="match" href="block-justify-self-ref.html">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#justify-block" />
+<meta name="assert" content="justify-self applies to block-level boxes">
+<style>
+.grid-container div {
+    width: 100px;
+    background-color: green;
+}
+
+.block-container div, .block-container-with-table-items div {
+    width: 100px;
+    background-color: red;
+}
+
+
+.stack {
+    display: grid;
+}
+
+.stack > * {
+    grid-row: 1;
+    grid-column: 1;
+}
+
+</style>
+</head>
+<p>Test passes if <strong>no red</strong> is visible</p>
+
+<div class="stack">
+<article class="block-container" style="display: block; width: 300px">
+  <div style="justify-self: auto;">auto</div>
+  <div style="justify-self: left;">left</div>
+  <div style="justify-self: right;">right</div>
+  <div style="justify-self: start;">start</div>
+  <div style="justify-self: center;">center</div>
+  <div style="justify-self: end;">end</div>
+  <div style="justify-self: self-start;">self-start</div>
+  <div style="justify-self: self-end;">self-end</div>
+  <div style="justify-self: flex-start;">flex-start</div>
+  <div style="justify-self: flex-end;">flex-end</div>
+  <div style="display: float; justify-self: center;">float</div>
+    <div style="justify-self: self-start; direction: rtl">self-start (rtl)</div>
+  <div style="justify-self: self-end; direction: rtl">self-end (rtl)</div>
+  <div style="justify-self: start; direction: rtl">start (rtl)</div>
+  <div style="justify-self: end; direction: rtl">end (rtl)</div>
+  <div style="justify-self: end">end parent
+    <div style="position: absolute;">absolute child</div>
+  </div>
+</article>
+
+<article class="block-container-with-table-items" style="display: block; width: 300px">
+  <div>default</div>
+  <div style="justify-self: left;">left</div>
+  <div style="justify-self: right;">right</div>
+  <div style="justify-self: start;">start</div>
+  <div style="justify-self: center;">center</div>
+  <div style="justify-self: end;">end</div>
+  <div style="justify-self: self-start;">self-start</div>
+  <div style="justify-self: self-end;">self-end</div>
+  <div style="justify-self: flex-start;">flex-start</div>
+  <div style="justify-self: flex-end;">flex-end</div>
+  <div style="display: float; justify-self: center;">float</div>
+    <div style="justify-self: self-start; direction: rtl">self-start (rtl)</div>
+  <div style="justify-self: self-end; direction: rtl">self-end (rtl)</div>
+  <div style="justify-self: start; direction: rtl">start (rtl)</div>
+  <div style="justify-self: end; direction: rtl">end (rtl)</div>
+  <div style="justify-self: end">end parent
+    <div style="position: absolute;">absolute child</div>
+  </div>
+</article>
+
+<article class="grid-container" style="display: grid; grid-template-columns: 1fr; width: 300px">
+  <div>default</div>
+  <div style="justify-self: left;">left</div>
+  <div style="justify-self: right;">right</div>
+  <div style="justify-self: start;">start</div>
+  <div style="justify-self: center;">center</div>
+  <div style="justify-self: end;">end</div>
+  <div style="justify-self: self-start;">self-start</div>
+  <div style="justify-self: self-end;">self-end</div>
+  <div style="justify-self: flex-start;">flex-start</div>
+  <div style="justify-self: flex-end;">flex-end</div>
+  <!-- justify self has no effect on floats -->
+  <div style="display: float;">float</div>
+  <div style="justify-self: self-start; direction: rtl">self-start (rtl)</div>
+  <div style="justify-self: self-end; direction: rtl">self-end (rtl)</div>
+  <div style="justify-self: start; direction: rtl">start (rtl)</div>
+  <div style="justify-self: end; direction: rtl">end (rtl)</div>
+  <div style="justify-self: end">end parent
+    <div style="position: absolute;">absolute child</div>
+  </div>
+</article>
+</div>

--- a/css/css-align/self-alignment/block-justify-self.html
+++ b/css/css-align/self-alignment/block-justify-self.html
@@ -35,6 +35,10 @@ body {
 <div class="stack" style="float: left;">
   <article class="block-container" style="display: block; width: 300px">
     <div style="justify-self: auto;">auto</div>
+    <div style="justify-self: normal;">normal</div>
+    <div style="justify-self: stretch; width: auto; margin: 0;">stretch</div>
+    <div style="justify-self: stretch; margin: 0;">stretch</div>
+    <div style="justify-self: stretch; width: auto; margin: auto;">stretch</div>
     <div style="justify-self: left;">left</div>
     <div style="justify-self: right;">right</div>
     <div style="justify-self: start;">start</div>
@@ -53,13 +57,15 @@ body {
     <div style="justify-self: end">end parent
       <div style="position: absolute;">absolute child</div>
     </div>
-    <div style="justify-self: end; position: absolute;">absolute parent
-      <div>child</div>
-    </div>
+    <div style="justify-self: end; position: absolute;">absolute parent</div>
   </article>
 
   <article class="block-container-with-table-items" style="display: block; width: 300px">
     <div style="justify-self: auto;">auto</div>
+    <div style="justify-self: normal;">normal</div>
+    <div style="justify-self: stretch; width: auto; margin: 0;">stretch</div>
+    <div style="justify-self: stretch; margin: 0;">stretch</div>
+    <div style="justify-self: stretch; width: auto; margin: auto;">stretch</div>
     <div style="justify-self: left;">left</div>
     <div style="justify-self: right;">right</div>
     <div style="justify-self: start;">start</div>
@@ -78,13 +84,15 @@ body {
     <div style="justify-self: end">end parent
       <div style="position: absolute;">absolute child</div>
     </div>
-    <div style="justify-self: end; position: absolute;">absolute parent
-      <div>child</div>
-    </div>
+    <div style="justify-self: end; position: absolute;">absolute parent</div>
   </article>
 
   <article class="grid-container" style="display: grid; grid-template-columns: 1fr; width: 300px">
     <div style="justify-self: auto;">auto</div>
+    <div style="justify-self: normal;">normal</div>
+    <div style="justify-self: stretch; width: auto; margin: 0;">stretch</div>
+    <div style="justify-self: stretch; margin: 0;">stretch</div>
+    <div style="justify-self: stretch; width: auto; margin: auto;">stretch</div>
     <div style="justify-self: left;">left</div>
     <div style="justify-self: right;">right</div>
     <div style="justify-self: start;">start</div>
@@ -103,15 +111,17 @@ body {
     <div style="justify-self: end">end parent
       <div style="position: absolute;">absolute child</div>
     </div>
-    <div style="justify-self: end; position: absolute;">absolute parent
-      <div>child</div>
-    </div>
+    <div style="justify-self: end; position: absolute;">absolute parent</div>
   </article>
 </div>
 
 <div class="stack" style="direction: rtl; float: right;">
   <article class="block-container" style="display: block; width: 300px">
     <div style="justify-self: auto;">auto</div>
+    <div style="justify-self: normal;">normal</div>
+    <div style="justify-self: stretch; width: auto; margin: 0;">stretch</div>
+    <div style="justify-self: stretch; margin: 0;">stretch</div>
+    <div style="justify-self: stretch; width: auto; margin: auto;">stretch</div>
     <div style="justify-self: left;">left</div>
     <div style="justify-self: right;">right</div>
     <div style="justify-self: start;">start</div>
@@ -130,13 +140,15 @@ body {
     <div style="justify-self: end">end parent
       <div style="position: absolute;">absolute child</div>
     </div>
-    <div style="justify-self: end; position: absolute;">absolute parent
-      <div>child</div>
-    </div>
+    <div style="justify-self: end; position: absolute;">absolute parent</div>
   </article>
 
   <article class="block-container-with-table-items" style="display: block; width: 300px">
     <div style="justify-self: auto;">auto</div>
+    <div style="justify-self: normal;">normal</div>
+    <div style="justify-self: stretch; width: auto; margin: 0;">stretch</div>
+    <div style="justify-self: stretch; margin: 0;">stretch</div>
+    <div style="justify-self: stretch; width: auto; margin: auto;">stretch</div>
     <div style="justify-self: left;">left</div>
     <div style="justify-self: right;">right</div>
     <div style="justify-self: start;">start</div>
@@ -155,13 +167,15 @@ body {
     <div style="justify-self: end">end parent
       <div style="position: absolute;">absolute child</div>
     </div>
-    <div style="justify-self: end; position: absolute;">absolute parent
-      <div>child</div>
-    </div>
+    <div style="justify-self: end; position: absolute;">absolute parent</div>
   </article>
 
   <article class="grid-container" style="display: grid; grid-template-columns: 1fr; width: 300px">
     <div style="justify-self: auto;">auto</div>
+    <div style="justify-self: normal;">normal</div>
+    <div style="justify-self: stretch; width: auto; margin: 0;">stretch</div>
+    <div style="justify-self: stretch; margin: 0;">stretch</div>
+    <div style="justify-self: stretch; width: auto; margin: auto;">stretch</div>
     <div style="justify-self: left;">left</div>
     <div style="justify-self: right;">right</div>
     <div style="justify-self: start;">start</div>
@@ -180,8 +194,6 @@ body {
     <div style="justify-self: end">end parent
       <div style="position: absolute;">absolute child</div>
     </div>
-    <div style="justify-self: end; position: absolute;">absolute parent
-      <div>child</div>
-    </div>
+    <div style="justify-self: end; position: absolute;">absolute parent</div>
   </article>
 </div>

--- a/css/css-align/self-alignment/block-justify-self.html
+++ b/css/css-align/self-alignment/block-justify-self.html
@@ -7,91 +7,181 @@
 <meta name="assert" content="justify-self applies to block-level boxes">
 <style>
 .grid-container div {
-    width: 100px;
-    background-color: green;
+  width: 100px;
+  background-color: green;
 }
 
 .block-container div, .block-container-with-table-items div {
-    width: 100px;
-    background-color: red;
+  width: 100px;
+  background-color: red;
 }
 
-
 .stack {
-    display: grid;
+  display: grid;
 }
 
 .stack > * {
-    grid-row: 1;
-    grid-column: 1;
+  grid-row: 1;
+  grid-column: 1;
+}
+
+body {
+  width: 700px;
 }
 
 </style>
-</head>
 <p>Test passes if <strong>no red</strong> is visible</p>
 
-<div class="stack">
-<article class="block-container" style="display: block; width: 300px">
-  <div style="justify-self: auto;">auto</div>
-  <div style="justify-self: left;">left</div>
-  <div style="justify-self: right;">right</div>
-  <div style="justify-self: start;">start</div>
-  <div style="justify-self: center;">center</div>
-  <div style="justify-self: end;">end</div>
-  <div style="justify-self: self-start;">self-start</div>
-  <div style="justify-self: self-end;">self-end</div>
-  <div style="justify-self: flex-start;">flex-start</div>
-  <div style="justify-self: flex-end;">flex-end</div>
-  <div style="display: float; justify-self: center;">float</div>
+<div class="stack" style="float: left;">
+  <article class="block-container" style="display: block; width: 300px">
+    <div style="justify-self: auto;">auto</div>
+    <div style="justify-self: left;">left</div>
+    <div style="justify-self: right;">right</div>
+    <div style="justify-self: start;">start</div>
+    <div style="justify-self: center;">center</div>
+    <div style="justify-self: end;">end</div>
+    <div style="justify-self: self-start;">self-start</div>
+    <div style="justify-self: self-end;">self-end</div>
+    <div style="justify-self: flex-start;">flex-start</div>
+    <div style="justify-self: flex-end;">flex-end</div>
+    <div style="float: left; justify-self: center;">float left</div>
+    <div style="float: right; justify-self: center;">float right</div>
     <div style="justify-self: self-start; direction: rtl">self-start (rtl)</div>
-  <div style="justify-self: self-end; direction: rtl">self-end (rtl)</div>
-  <div style="justify-self: start; direction: rtl">start (rtl)</div>
-  <div style="justify-self: end; direction: rtl">end (rtl)</div>
-  <div style="justify-self: end">end parent
-    <div style="position: absolute;">absolute child</div>
-  </div>
-</article>
+    <div style="justify-self: self-end; direction: rtl">self-end (rtl)</div>
+    <div style="justify-self: start; direction: rtl">start (rtl)</div>
+    <div style="justify-self: end; direction: rtl">end (rtl)</div>
+    <div style="justify-self: end">end parent
+      <div style="position: absolute;">absolute child</div>
+    </div>
+    <div style="justify-self: end; position: absolute;">absolute parent
+      <div>child</div>
+    </div>
+  </article>
 
-<article class="block-container-with-table-items" style="display: block; width: 300px">
-  <div>default</div>
-  <div style="justify-self: left;">left</div>
-  <div style="justify-self: right;">right</div>
-  <div style="justify-self: start;">start</div>
-  <div style="justify-self: center;">center</div>
-  <div style="justify-self: end;">end</div>
-  <div style="justify-self: self-start;">self-start</div>
-  <div style="justify-self: self-end;">self-end</div>
-  <div style="justify-self: flex-start;">flex-start</div>
-  <div style="justify-self: flex-end;">flex-end</div>
-  <div style="display: float; justify-self: center;">float</div>
+  <article class="block-container-with-table-items" style="display: block; width: 300px">
+    <div style="justify-self: auto;">auto</div>
+    <div style="justify-self: left;">left</div>
+    <div style="justify-self: right;">right</div>
+    <div style="justify-self: start;">start</div>
+    <div style="justify-self: center;">center</div>
+    <div style="justify-self: end;">end</div>
+    <div style="justify-self: self-start;">self-start</div>
+    <div style="justify-self: self-end;">self-end</div>
+    <div style="justify-self: flex-start;">flex-start</div>
+    <div style="justify-self: flex-end;">flex-end</div>
+    <div style="float: left; justify-self: center;">float left</div>
+    <div style="float: right; justify-self: center;">float right</div>
     <div style="justify-self: self-start; direction: rtl">self-start (rtl)</div>
-  <div style="justify-self: self-end; direction: rtl">self-end (rtl)</div>
-  <div style="justify-self: start; direction: rtl">start (rtl)</div>
-  <div style="justify-self: end; direction: rtl">end (rtl)</div>
-  <div style="justify-self: end">end parent
-    <div style="position: absolute;">absolute child</div>
-  </div>
-</article>
+    <div style="justify-self: self-end; direction: rtl">self-end (rtl)</div>
+    <div style="justify-self: start; direction: rtl">start (rtl)</div>
+    <div style="justify-self: end; direction: rtl">end (rtl)</div>
+    <div style="justify-self: end">end parent
+      <div style="position: absolute;">absolute child</div>
+    </div>
+    <div style="justify-self: end; position: absolute;">absolute parent
+      <div>child</div>
+    </div>
+  </article>
 
-<article class="grid-container" style="display: grid; grid-template-columns: 1fr; width: 300px">
-  <div>default</div>
-  <div style="justify-self: left;">left</div>
-  <div style="justify-self: right;">right</div>
-  <div style="justify-self: start;">start</div>
-  <div style="justify-self: center;">center</div>
-  <div style="justify-self: end;">end</div>
-  <div style="justify-self: self-start;">self-start</div>
-  <div style="justify-self: self-end;">self-end</div>
-  <div style="justify-self: flex-start;">flex-start</div>
-  <div style="justify-self: flex-end;">flex-end</div>
-  <!-- justify self has no effect on floats -->
-  <div style="display: float;">float</div>
-  <div style="justify-self: self-start; direction: rtl">self-start (rtl)</div>
-  <div style="justify-self: self-end; direction: rtl">self-end (rtl)</div>
-  <div style="justify-self: start; direction: rtl">start (rtl)</div>
-  <div style="justify-self: end; direction: rtl">end (rtl)</div>
-  <div style="justify-self: end">end parent
-    <div style="position: absolute;">absolute child</div>
-  </div>
-</article>
+  <article class="grid-container" style="display: grid; grid-template-columns: 1fr; width: 300px">
+    <div style="justify-self: auto;">auto</div>
+    <div style="justify-self: left;">left</div>
+    <div style="justify-self: right;">right</div>
+    <div style="justify-self: start;">start</div>
+    <div style="justify-self: center;">center</div>
+    <div style="justify-self: end;">end</div>
+    <div style="justify-self: self-start;">self-start</div>
+    <div style="justify-self: self-end;">self-end</div>
+    <div style="justify-self: flex-start;">flex-start</div>
+    <div style="justify-self: flex-end;">flex-end</div>
+    <div style="float: left; justify-self: center;">float left</div>
+    <div style="float: right; justify-self: center;">float right</div>
+    <div style="justify-self: self-start; direction: rtl">self-start (rtl)</div>
+    <div style="justify-self: self-end; direction: rtl">self-end (rtl)</div>
+    <div style="justify-self: start; direction: rtl">start (rtl)</div>
+    <div style="justify-self: end; direction: rtl">end (rtl)</div>
+    <div style="justify-self: end">end parent
+      <div style="position: absolute;">absolute child</div>
+    </div>
+    <div style="justify-self: end; position: absolute;">absolute parent
+      <div>child</div>
+    </div>
+  </article>
+</div>
+
+<div class="stack" style="direction: rtl; float: right;">
+  <article class="block-container" style="display: block; width: 300px">
+    <div style="justify-self: auto;">auto</div>
+    <div style="justify-self: left;">left</div>
+    <div style="justify-self: right;">right</div>
+    <div style="justify-self: start;">start</div>
+    <div style="justify-self: center;">center</div>
+    <div style="justify-self: end;">end</div>
+    <div style="justify-self: self-start;">self-start</div>
+    <div style="justify-self: self-end;">self-end</div>
+    <div style="justify-self: flex-start;">flex-start</div>
+    <div style="justify-self: flex-end;">flex-end</div>
+    <div style="float: left; justify-self: center;">float left</div>
+    <div style="float: right; justify-self: center;">float right</div>
+    <div style="justify-self: self-start; direction: ltr">self-start (ltr)</div>
+    <div style="justify-self: self-end; direction: ltr">self-end (ltr)</div>
+    <div style="justify-self: start; direction: ltr">start (ltr)</div>
+    <div style="justify-self: end; direction: ltr">end (ltr)</div>
+    <div style="justify-self: end">end parent
+      <div style="position: absolute;">absolute child</div>
+    </div>
+    <div style="justify-self: end; position: absolute;">absolute parent
+      <div>child</div>
+    </div>
+  </article>
+
+  <article class="block-container-with-table-items" style="display: block; width: 300px">
+    <div style="justify-self: auto;">auto</div>
+    <div style="justify-self: left;">left</div>
+    <div style="justify-self: right;">right</div>
+    <div style="justify-self: start;">start</div>
+    <div style="justify-self: center;">center</div>
+    <div style="justify-self: end;">end</div>
+    <div style="justify-self: self-start;">self-start</div>
+    <div style="justify-self: self-end;">self-end</div>
+    <div style="justify-self: flex-start;">flex-start</div>
+    <div style="justify-self: flex-end;">flex-end</div>
+    <div style="float: left; justify-self: center;">float left</div>
+    <div style="float: right; justify-self: center;">float right</div>
+    <div style="justify-self: self-start; direction: ltr">self-start (ltr)</div>
+    <div style="justify-self: self-end; direction: ltr">self-end (ltr)</div>
+    <div style="justify-self: start; direction: ltr">start (ltr)</div>
+    <div style="justify-self: end; direction: ltr">end (ltr)</div>
+    <div style="justify-self: end">end parent
+      <div style="position: absolute;">absolute child</div>
+    </div>
+    <div style="justify-self: end; position: absolute;">absolute parent
+      <div>child</div>
+    </div>
+  </article>
+
+  <article class="grid-container" style="display: grid; grid-template-columns: 1fr; width: 300px">
+    <div style="justify-self: auto;">auto</div>
+    <div style="justify-self: left;">left</div>
+    <div style="justify-self: right;">right</div>
+    <div style="justify-self: start;">start</div>
+    <div style="justify-self: center;">center</div>
+    <div style="justify-self: end;">end</div>
+    <div style="justify-self: self-start;">self-start</div>
+    <div style="justify-self: self-end;">self-end</div>
+    <div style="justify-self: flex-start;">flex-start</div>
+    <div style="justify-self: flex-end;">flex-end</div>
+    <div style="float: left; justify-self: center;">float left</div>
+    <div style="float: right; justify-self: center;">float right</div>
+    <div style="justify-self: self-start; direction: ltr">self-start (ltr)</div>
+    <div style="justify-self: self-end; direction: ltr">self-end (ltr)</div>
+    <div style="justify-self: start; direction: ltr">start (ltr)</div>
+    <div style="justify-self: end; direction: ltr">end (ltr)</div>
+    <div style="justify-self: end">end parent
+      <div style="position: absolute;">absolute child</div>
+    </div>
+    <div style="justify-self: end; position: absolute;">absolute parent
+      <div>child</div>
+    </div>
+  </article>
 </div>


### PR DESCRIPTION
As per https://www.w3.org/TR/css-align-3/#justify-self-property , the `justify-self` property should apply to block-level elements.

The following tests cover:
* `justify-self: auto | left | right | center | start | end | self-start | self-end | flex-start | flex-end`
* functionality is disabled on `display: float`
* `justify-self: self-[start|end]` respects the direction of the item
* `justify-self: [start|end]` respects the direction of the container
* absolutely positioned items are positioned properly relative to `justify-self` items

See also the following WebKit issue: https://bugs.webkit.org/show_bug.cgi?id=277022