### PR TITLE
Add bounce tracking mitigations command to testdriver

### DIFF
--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -125,6 +125,12 @@ the global scope.
 .. js:autofunction:: test_driver.clear_device_posture
 ```
 
+### Bounce Tracking Mitigations ###
+
+```eval_rst
+.. js:autofunction:: test_driver.run_bounce_tracking_mitigations
+```
+
 ### Using test_driver in other browsing contexts ###
 
 Testdriver can be used in browsing contexts (i.e. windows or frames)

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -1067,9 +1067,30 @@
         clear_device_posture: function(context=null) {
             return window.test_driver_internal.clear_device_posture(context);
         }
+
+        /**
+         * Run the deletion algorithm for all hosts in the stateful bounce
+         * tracking map (without regard for the bounce tracking grace period),
+         * then return a list of those hosts.
+         *
+         * Matches the `Run Bounce Tracking Mitigations
+         * https://privacycg.github.io/nav-tracking-mitigations/#bounce-tracking-mitigations`_
+         * WebDriver command.
+         *
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         * @returns {Promise} Fulfilled after the deletion algorithm has
+         *                    finished running. Returns an array of all hosts
+         *                    that were in the stateful bounce tracking map
+         *                    before deletion occurred.
+         */
+        run_bounce_tracking_mitigations: function (context = null) {
+            return window.test_driver_internal.run_bounce_tracking_mitigations(context);
+        }
     };
 
-    window.test_driver_internal = {
+  window.test_driver_internal = {
         /**
          * This flag should be set to `true` by any code which implements the
          * internal methods defined below for automation purposes. Doing so
@@ -1262,6 +1283,10 @@
 
         async clear_device_posture(context=null) {
             throw new Error("clear_device_posture() is not implemented by testdriver-vendor.js");
+        },
+
+        async run_bounce_tracking_mitigations(context=null) {
+            throw new Error("run_bounce_tracking_mitigations() is not implemented by testdriver-vendor.js");
         }
-    };
+  };
 })();

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -1069,21 +1069,23 @@
         },
 
         /**
-         * Run the deletion algorithm for all hosts in the stateful bounce
-         * tracking map (without regard for the bounce tracking grace period),
-         * then return a list of those hosts.
+         * Runs the `bounce tracking timer algorithm
+         * <https://privacycg.github.io/nav-tracking-mitigations/#bounce-tracking-timer>`_,
+         * which removes all hosts from the stateful bounce tracking map, without
+         * regard for the bounce tracking grace period and returns a list of the
+         * deleted hosts.
          *
          * Matches the `Run Bounce Tracking Mitigations
-         * https://privacycg.github.io/nav-tracking-mitigations/#bounce-tracking-mitigations`_
+         * https://privacycg.github.io/nav-tracking-mitigations/#run-bounce-tracking-mitigations-command`_
          * WebDriver command.
          *
          * @param {WindowProxy} [context=null] - Browsing context in which to
          *                                       run the call, or null for the
          *                                       current browsing context.
-         * @returns {Promise} Fulfilled after the deletion algorithm has
-         *                    finished running. Returns an array of all hosts
-         *                    that were in the stateful bounce tracking map
-         *                    before deletion occurred.
+         * @returns {Promise} Fulfilled after the bounce tracking timer
+         *                    algorithm has finished running. Returns an array
+         *                    of all hosts that were in the stateful bounce
+         *                    tracking map before deletion occurred.
          */
         run_bounce_tracking_mitigations: function (context = null) {
             return window.test_driver_internal.run_bounce_tracking_mitigations(context);

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -1066,7 +1066,7 @@
          */
         clear_device_posture: function(context=null) {
             return window.test_driver_internal.clear_device_posture(context);
-        }
+        },
 
         /**
          * Run the deletion algorithm for all hosts in the stateful bounce
@@ -1090,7 +1090,7 @@
         }
     };
 
-  window.test_driver_internal = {
+    window.test_driver_internal = {
         /**
          * This flag should be set to `true` by any code which implements the
          * internal methods defined below for automation purposes. Doing so
@@ -1288,5 +1288,5 @@
         async run_bounce_tracking_mitigations(context=null) {
             throw new Error("run_bounce_tracking_mitigations() is not implemented by testdriver-vendor.js");
         }
-  };
+    };
 })();

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -464,6 +464,17 @@ class ClearDevicePostureAction:
     def __call__(self, payload):
         return self.protocol.device_posture.clear_device_posture()
 
+class RunBounceTrackingMitigationsAction:
+    name = "run_bounce_tracking_mitigations"
+
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        self.logger.debug("Running bounce tracking mitigations")
+        return self.protocol.storage.run_bounce_tracking_mitigations()
+
 actions = [ClickAction,
            DeleteAllCookiesAction,
            GetAllCookiesAction,
@@ -499,4 +510,5 @@ actions = [ClickAction,
            RemoveVirtualSensorAction,
            GetVirtualSensorInformationAction,
            SetDevicePostureAction,
-           ClearDevicePostureAction]
+           ClearDevicePostureAction,
+           RunBounceTrackingMitigationsAction]

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -36,6 +36,7 @@ from .protocol import (BaseProtocolPart,
                        FedCMProtocolPart,
                        VirtualSensorProtocolPart,
                        DevicePostureProtocolPart,
+                       StorageProtocolPart,
                        merge_dicts)
 
 from webdriver.client import Session
@@ -443,6 +444,13 @@ class WebDriverDevicePostureProtocolPart(DevicePostureProtocolPart):
     def clear_device_posture(self):
         return self.webdriver.send_session_command("DELETE", "deviceposture")
 
+class WebDriverStorageProtocolPart(StorageProtocolPart):
+    def setup(self):
+        self.webdriver = self.parent.webdriver
+
+    def run_bounce_tracking_mitigations(self):
+        return self.webdriver.send_session_command("DELETE", "storage/run_bounce_tracking_mitigations")
+
 class WebDriverProtocol(Protocol):
     implements = [WebDriverBaseProtocolPart,
                   WebDriverTestharnessProtocolPart,
@@ -462,7 +470,8 @@ class WebDriverProtocol(Protocol):
                   WebDriverFedCMProtocolPart,
                   WebDriverDebugProtocolPart,
                   WebDriverVirtualSensorPart,
-                  WebDriverDevicePostureProtocolPart]
+                  WebDriverDevicePostureProtocolPart,
+                  WebDriverStorageProtocolPart]
 
     def __init__(self, executor, browser, capabilities, **kwargs):
         super().__init__(executor, browser)

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -262,6 +262,12 @@ class StorageProtocolPart(ProtocolPart):
         :param url: A url belonging to the origin"""
         pass
 
+    @abstractmethod
+    def run_bounce_tracking_mitigations(self):
+        """Run the Bounce Tracking Mitigations deletion/enforcement algorithm
+
+        :returns: A list of sites corresponding to bounce trackers whose state was removed"""
+        pass
 
 class SelectorProtocolPart(ProtocolPart):
     """Protocol part for selecting elements on the page."""

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -335,4 +335,8 @@
     window.test_driver_internal.clear_device_posture = function(context=null) {
         return create_action("clear_device_posture", {context});
     };
+
+    window.test_driver_internal.run_bounce_tracking_mitigations = function (context = null) {
+        return create_action("run_bounce_tracking_mitigations", {context});
+    };
 })();


### PR DESCRIPTION
Spec PR: privacycg/nav-tracking-mitigations#63

This PR adds the required infrastructure to run bounce tracking mitigations from testdriver. The new command correspond to the WebDriver extension command added by the spec PR above.