### PR TITLE
dependencies: Upgrade `cookie` and rename Servo's `Cookie` to `ServoCookie`

### DIFF
--- a/html/dom/documents/resource-metadata-management/document-cookie.html
+++ b/html/dom/documents/resource-metadata-management/document-cookie.html
@@ -26,7 +26,7 @@ for (const i in TEST_CASES) {
 
     // Cleanup
     if (document.cookie.includes("=")) {
-      document.cookie = document.cookie.split("=")[0] + "=; expires=Thu, 01 Jan 1970 00:00:00 UTC";
+      document.cookie = document.cookie.split("=")[0] + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
       assert_equals(document.cookie, "");
     }
   }, t.name);


### PR DESCRIPTION
This changes updates to the new version of the `cookie` crate in Servo
which no longer uses the old `time@0.1` data types. This requires using
a new version of `time` while we transition off of the old one. This is
the first step in that process.

In addition, the overloading of the `cookie::Cookie` name was causing a
great deal of confusion, so I've renamed the Servo wrapper to
`ServoCookie` like we do with `ServoUrl`.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#32861