### PR TITLE
Do not wait for onload events in JS modules

### DIFF
--- a/navigation-api/ordering-and-transition/anchor-download-intercept-reject.html
+++ b/navigation-api/ordering-and-transition/anchor-download-intercept-reject.html
@@ -10,7 +10,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const from = navigation.currentEntry;
   const expectedError = new Error("boo");

--- a/navigation-api/ordering-and-transition/anchor-download-intercept.html
+++ b/navigation-api/ordering-and-transition/anchor-download-intercept.html
@@ -10,7 +10,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const from = navigation.currentEntry;
 

--- a/navigation-api/ordering-and-transition/back-same-document-intercept-reject.html
+++ b/navigation-api/ordering-and-transition/back-same-document-intercept-reject.html
@@ -10,7 +10,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
   await navigation.navigate("#1").finished;
 
   const from = navigation.currentEntry;

--- a/navigation-api/ordering-and-transition/back-same-document-intercept.html
+++ b/navigation-api/ordering-and-transition/back-same-document-intercept.html
@@ -10,7 +10,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
   await navigation.navigate("#1").finished;
 
   const from = navigation.currentEntry;

--- a/navigation-api/ordering-and-transition/back-same-document.html
+++ b/navigation-api/ordering-and-transition/back-same-document.html
@@ -10,7 +10,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
   await navigation.navigate("#1").finished;
 
   const recorder = new Recorder({

--- a/navigation-api/ordering-and-transition/intercept-async.html
+++ b/navigation-api/ordering-and-transition/intercept-async.html
@@ -10,7 +10,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const from = navigation.currentEntry;
 

--- a/navigation-api/ordering-and-transition/location-href-canceled.html
+++ b/navigation-api/ordering-and-transition/location-href-canceled.html
@@ -8,7 +8,8 @@ import { Recorder } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const recorder = new Recorder({
     finalExpectedEvent: "promise microtask"

--- a/navigation-api/ordering-and-transition/location-href-double-intercept.html
+++ b/navigation-api/ordering-and-transition/location-href-double-intercept.html
@@ -9,7 +9,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const fromStart = navigation.currentEntry;
   let fromHash1;

--- a/navigation-api/ordering-and-transition/location-href-intercept-reentrant.html
+++ b/navigation-api/ordering-and-transition/location-href-intercept-reentrant.html
@@ -10,7 +10,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const from = navigation.currentEntry;
   let firstNavigate = true;

--- a/navigation-api/ordering-and-transition/location-href-intercept-reject.html
+++ b/navigation-api/ordering-and-transition/location-href-intercept-reject.html
@@ -10,7 +10,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const from = navigation.currentEntry;
   const expectedError = new Error("boo");

--- a/navigation-api/ordering-and-transition/location-href-intercept.html
+++ b/navigation-api/ordering-and-transition/location-href-intercept.html
@@ -10,7 +10,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const from = navigation.currentEntry;
 

--- a/navigation-api/ordering-and-transition/navigate-204-205-download-then-same-document.html
+++ b/navigation-api/ordering-and-transition/navigate-204-205-download-then-same-document.html
@@ -16,7 +16,8 @@ for (const [description, url] of tests) {
     const i = document.createElement("iframe");
     i.src = "/common/blank.html";
     document.body.append(i);
-    await new Promise(resolve => i.onload = () => t.step_timeout(resolve, 0));
+    if (document.readyState != 'complete')
+      await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
     const fromStart = i.contentWindow.navigation.currentEntry;
 

--- a/navigation-api/ordering-and-transition/navigate-canceled.html
+++ b/navigation-api/ordering-and-transition/navigate-canceled.html
@@ -8,7 +8,8 @@ import { Recorder } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const recorder = new Recorder({
     finalExpectedEvent: "finished rejected"

--- a/navigation-api/ordering-and-transition/navigate-commit-after-transition-intercept.html
+++ b/navigation-api/ordering-and-transition/navigate-commit-after-transition-intercept.html
@@ -10,7 +10,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const from = navigation.currentEntry;
 

--- a/navigation-api/ordering-and-transition/navigate-double-intercept.html
+++ b/navigation-api/ordering-and-transition/navigate-double-intercept.html
@@ -9,7 +9,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const fromStart = navigation.currentEntry;
   let fromHash1;

--- a/navigation-api/ordering-and-transition/navigate-in-transition-finished.html
+++ b/navigation-api/ordering-and-transition/navigate-in-transition-finished.html
@@ -9,7 +9,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const fromStart = navigation.currentEntry;
   let fromHash1;

--- a/navigation-api/ordering-and-transition/navigate-intercept-stop.html
+++ b/navigation-api/ordering-and-transition/navigate-intercept-stop.html
@@ -10,7 +10,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const from = navigation.currentEntry;
 

--- a/navigation-api/ordering-and-transition/navigate-intercept.html
+++ b/navigation-api/ordering-and-transition/navigate-intercept.html
@@ -10,7 +10,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const from = navigation.currentEntry;
 

--- a/navigation-api/ordering-and-transition/navigate-same-document-intercept-reentrant.html
+++ b/navigation-api/ordering-and-transition/navigate-same-document-intercept-reentrant.html
@@ -10,7 +10,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const from = navigation.currentEntry;
   let firstNavigate = true;

--- a/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject.html
+++ b/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject.html
@@ -10,7 +10,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const from = navigation.currentEntry;
   const expectedError = new Error("boo");

--- a/navigation-api/ordering-and-transition/navigate-same-document.html
+++ b/navigation-api/ordering-and-transition/navigate-same-document.html
@@ -10,7 +10,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const recorder = new Recorder({
     skipCurrentChange: !hasVariant("currententrychange"),

--- a/navigation-api/ordering-and-transition/reload-canceled.html
+++ b/navigation-api/ordering-and-transition/reload-canceled.html
@@ -8,7 +8,8 @@ import { Recorder } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const recorder = new Recorder({
     finalExpectedEvent: "finished rejected"

--- a/navigation-api/ordering-and-transition/reload-intercept-reject.html
+++ b/navigation-api/ordering-and-transition/reload-intercept-reject.html
@@ -10,7 +10,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const from = navigation.currentEntry;
   const expectedError = new Error("boo");

--- a/navigation-api/ordering-and-transition/reload-intercept.html
+++ b/navigation-api/ordering-and-transition/reload-intercept.html
@@ -10,7 +10,8 @@ import { Recorder, hasVariant } from "./resources/helpers.mjs";
 promise_test(async t => {
   // Wait for after the load event so that the navigation doesn't get converted
   // into a replace navigation.
-  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  if (document.readyState != 'complete')
+    await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
 
   const from = navigation.currentEntry;
 


### PR DESCRIPTION
In WebKit the subtests in the JS module already have the window load event sent, so tests waiting for it will timeout. So add a check using readystate to detect when the load event is already sent and skip this waiting operation.