### PR TITLE
Add missing > to html tag

### DIFF
--- a/css/css-lists/before-after-selectors-on-code-element-crash.html
+++ b/css/css-lists/before-after-selectors-on-code-element-crash.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <link rel="help" href="http://bugs.webkit.org/show_bug.cgi?id=11197">
-<html
+<html>
 <head>
 <style>
     code:before {


### PR DESCRIPTION
This doesn't seem to be an intentional part of this test, but it was causing Ladybird's HTML parser to crash.

See https://github.com/LadybirdBrowser/ladybird/issues/891