### PR TITLE
Add tests for rendering from in-flow children for MathML scripts, mpadded

### DIFF
--- a/mathml/presentation-markup/mpadded/mpadded-rendering-from-in-flow.html
+++ b/mathml/presentation-markup/mpadded/mpadded-rendering-from-in-flow.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>mpadded rendering from in-flow children</title>
+    <link rel="help" href="https://w3c.github.io/mathml-core/#adjust-space-around-content-mpadded">
+    <meta name="assert" content="Verify rendering of mpadded is only affected by in-flow children.">
+    <style>
+      .oof1 {
+          position: absolute;
+      }
+      .oof2 {
+          position: fixed;
+      }
+      .nobox {
+          display: none;
+      }
+    </style>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script>
+      setup({ explicit_done: true });
+      window.addEventListener("load", runTests);
+
+      function runTests() {
+        let math = document.querySelector("#mpadded");
+        let element = math.firstElementChild;
+        let reference = element.nextElementSibling;
+        const epsilon = 1;
+
+        test(function() {
+          compareLayout(element, reference, epsilon);
+        }, "Rendering of mpadded should only be affected by in-flow children");
+
+        done();
+      }
+    </script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <div>
+      <math id="mpadded">
+        <mpadded lspace="3em" voffset="-1em" height="1em" depth="2em" width="8em" style="background: lightblue">
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="64px" height="8px" style="background: lightgreen"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+        </mpadded>
+
+        <mpadded lspace="3em" voffset="-1em" height="1em" depth="2em" width="8em" style="background: lightblue">
+          <mspace width="64px" height="8px" style="background: lightgreen"/>
+        </mpadded>
+      </math>
+    </div>
+  </body>
+</html>

--- a/mathml/presentation-markup/scripts/scripts-rendering-from-in-flow.html
+++ b/mathml/presentation-markup/scripts/scripts-rendering-from-in-flow.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>scripts rendering from in-flow children</title>
+    <link rel="help" href="https://w3c.github.io/mathml-core/#script-and-limit-schemata">
+    <meta name="assert" content="Verify rendering of scripts and limits is only affected by in-flow children.">
+    <style>
+      .oof1 {
+          position: absolute;
+      }
+      .oof2 {
+          position: fixed;
+      }
+      .nobox {
+          display: none;
+      }
+    </style>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script>
+      setup({ explicit_done: true });
+      window.addEventListener("load", runTests);
+
+      function runTests() {
+        let container = document.querySelector("#container");
+        const epsilon = 1;
+
+        for (let math of container.children) {
+          let tagName = el.id;
+          let element = math.firstElementChild;
+          let reference = element.nextElementSibling;
+
+          test(function() {
+            compareLayout(element, reference, epsilon);
+          }, `Rendering of ${tagName} should only be affected by in-flow children`);
+        }
+
+        done();
+      }
+    </script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <div id="container">
+      <math id="mmultiscripts">
+        <mmultiscripts>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="128px" height="24px" style="background: lightblue"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="64px" height="8px" style="background: lightgreen"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="32px" height="16px" style="background: lightgreen"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="96px" height="48px" style="background: lightgreen"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="48px" height="32px" style="background: lightgreen"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mprescripts/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="32px" height="16px" style="background: lightsalmon"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="16px" height="48px" style="background: lightsalmon"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+        </mmultiscripts>
+
+        <mmultiscripts>
+          <mspace width="128px" height="24px" style="background: lightblue"/>
+          <mspace width="64px" height="8px" style="background: lightgreen"/>
+          <mspace width="32px" height="16px" style="background: lightgreen"/>
+          <mspace width="96px" height="48px" style="background: lightgreen"/>
+          <mspace width="48px" height="32px" style="background: lightgreen"/>
+          <mprescripts/>
+          <mspace width="32px" height="16px" style="background: lightsalmon"/>
+          <mspace width="16px" height="48px" style="background: lightsalmon"/>
+        </mmultiscripts>
+      </math>
+
+      <math id="munder">
+        <munder>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="128px" height="24px" style="background: lightblue"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="64px" height="8px" style="background: lightgreen"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+        </munder>
+
+        <munder>
+          <mspace width="128px" height="24px" style="background: lightblue"/>
+          <mspace width="64px" height="8px" style="background: lightgreen"/>
+        </munder>
+      </math>
+
+      <math id="mover">
+        <mover>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="128px" height="24px" style="background: lightblue"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="32px" height="16px" style="background: lightsalmon"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+        </mover>
+
+        <mover>
+          <mspace width="128px" height="24px" style="background: lightblue"/>
+          <mspace width="32px" height="16px" style="background: lightsalmon"/>
+        </mover>
+      </math>
+
+      <math id="munderover">
+        <munderover>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="128px" height="24px" style="background: lightblue"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="64px" height="8px" style="background: lightgreen"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="32px" height="16px" style="background: lightsalmon"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+        </munderover>
+
+        <munderover>
+          <mspace width="128px" height="24px" style="background: lightblue"/>
+          <mspace width="64px" height="8px" style="background: lightgreen"/>
+          <mspace width="32px" height="16px" style="background: lightsalmon"/>
+        </munderover>
+      </math>
+
+      <math id="msub">
+        <msub>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="128px" height="24px" style="background: lightblue"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="64px" height="8px" style="background: lightgreen"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+        </msub>
+
+        <msub>
+          <mspace width="128px" height="24px" style="background: lightblue"/>
+          <mspace width="64px" height="8px" style="background: lightgreen"/>
+        </msub>
+      </math>
+
+      <math id="msup">
+        <msup>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="128px" height="24px" style="background: lightblue"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="32px" height="16px" style="background: lightsalmon"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+        </msup>
+
+        <msup>
+          <mspace width="128px" height="24px" style="background: lightblue"/>
+          <mspace width="32px" height="16px" style="background: lightsalmon"/>
+        </msup>
+      </math>
+
+      <math id="msubsup">
+        <msubsup>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="128px" height="24px" style="background: lightblue"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="64px" height="8px" style="background: lightgreen"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+          <mspace width="32px" height="16px" style="background: lightsalmon"/>
+          <mspace width="32px" class="oof1"/>
+          <mspace width="16px" class="oof2"/>
+          <mspace width="8px" class="nobox"/>
+        </msubsup>
+
+        <msubsup>
+          <mspace width="128px" height="24px" style="background: lightblue"/>
+          <mspace width="64px" height="8px" style="background: lightgreen"/>
+          <mspace width="32px" height="16px" style="background: lightsalmon"/>
+        </msubsup>
+      </math>
+    </div>
+  </body>
+</html>

--- a/mathml/presentation-markup/tokens/tokens-rendering-from-in-flow.html
+++ b/mathml/presentation-markup/tokens/tokens-rendering-from-in-flow.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>tokens rendering from in-flow children</title>
+    <link rel="help" href="https://w3c.github.io/mathml-core/#token-elements">
+    <meta name="assert" content="Verify rendering of tokens is only affected by in-flow children.">
+    <style>
+      .oof1 {
+          position: absolute;
+      }
+      .oof2 {
+          position: fixed;
+      }
+      .box {
+          display: inline-block;
+          width: 10px;
+          height: 10px;
+      }
+    </style>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script>
+      setup({ explicit_done: true });
+      window.addEventListener("load", runTests);
+
+      function runTests() {
+        let container = document.querySelector("#container");
+        const epsilon = 1;
+
+        for (let math of container.children) {
+          let tagName = el.id;
+          let element = math.firstElementChild;
+          let reference = element.nextElementSibling;
+
+          test(function() {
+            compareLayout(element, reference, epsilon);
+          }, `Rendering of ${tagName} should only be affected by in-flow children`);
+        }
+
+        done();
+      }
+    </script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <div id="container">
+      <math id="mo">
+        <mo><span class="box" style="background: lightblue"></span><span class="oof1 box"><span class="oof2 box"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span><span class="oof1 box"></span><span class="oof2 box"></span></mo>
+        <mo><span class="box" style="background: lightblue"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span></mo>
+      </math>
+
+      <math id="mi">
+        <mi><span class="box" style="background: lightblue"></span><span class="oof1 box"></span><span class="oof2 box"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span><span class="oof1 box"></span><span class="oof2 box"></span></mi>
+        <mi><span class="box" style="background: lightblue"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span></mi>
+      </math>
+
+      <math id="mi">
+        <mn><span class="box" style="background: lightblue"></span><span class="oof1 box"></span><span class="oof2 box"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span><span class="oof1 box"></span><span class="oof2 box"></span></mn>
+        <mn><span class="box" style="background: lightblue"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span></mn>
+      </math>
+
+      <math id="mo">
+        <mo><span class="box" style="background: lightblue"></span><span class="oof1 box"></span><span class="oof2 box"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span><span class="oof1 box"></span><span class="oof2 box"></span></mo>
+        <mo><span class="box" style="background: lightblue"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span></mo>
+      </math>
+
+      <math id="mtext">
+        <mtext><span class="box" style="background: lightblue"></span><span class="oof1 box"></span><span class="oof2 box"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span><span class="oof1 box"></span><span class="oof2 box"></span></mtext>
+        <mtext><span class="box" style="background: lightblue"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span></mtext>
+      </math>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Currently, we already test that we render from in-flow children only for radicals [1] and fractions [2].

For more coverage, this adds analogous tests for scripts (msub, msup, msubsup, mover, munder, munderover, mmultiscripts) and mpadded.

[1] https://github.com/web-platform-tests/wpt/blob/ad7e196b12/mathml/presentation-markup/radicals/radical-rendering-from-in-flow.html
[2] https://github.com/web-platform-tests/wpt/blob/ad7e196b122827421b84dca83cda6d69e64eef41/mathml/presentation-markup/fractions/frac-rendering-from-in-flow.html