### PR TITLE
Add background-clip: text animated text test

### DIFF
--- a/css/css-backgrounds/background-clip/clip-text-animated-text-ref.html
+++ b/css/css-backgrounds/background-clip/clip-text-animated-text-ref.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>CSS Test Reference</title>
+<style>
+  .text {
+    background-color: DeepPink;
+    background-clip: text;
+    font-size: 50px;
+    font-family: sans-serif;
+    font-weight: 600;
+    color: transparent;
+  }
+</style>
+<div class="text">
+  <p>Text</p>
+</div>

--- a/css/css-backgrounds/background-clip/clip-text-animated-text.html
+++ b/css/css-backgrounds/background-clip/clip-text-animated-text.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html class="reftest-wait">
+<title>CSS Test: background-clip: text animated text</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#valdef-background-clip-text">
+<link rel="author" href="mailto:nathan@knowler.dev" title="Nathan Knowler">
+<link rel="match" href="clip-text-animated-text-ref.html">
+<style>
+  .text {
+    background-color: DeepPink;
+    background-clip: text;
+    font-size: 50px;
+    font-family: sans-serif;
+    font-weight: 600;
+    color: transparent;
+  }
+
+  .text p {
+    animation: fade-in 0.1s both;
+  }
+
+  @keyframes fade-in {
+    from { opacity: 0; }
+  }
+</style>
+<div class="text">
+  <p>Text</p>
+</div>
+<script>
+  const [animation] = document.querySelector(".text p").getAnimations();
+  animation.finished.then(() => {
+    document.documentElement.classList.remove("reftest-wait");
+  });
+</script>


### PR DESCRIPTION
This adds a ref test for `background-clip: text` and animated inner text. In Chrome and Safari, the inner text will be transparent as they seem to composite it separately due to the animation. In Firefox, the animated inner text picks up the clipped background color.

Leaving this as a draft until I figure out if I’m doing this ref test correctly (this is my first of this sort).