### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=241176

### DIFF
--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -1249,6 +1249,24 @@ const gCSSProperties2 = {
       { type: 'discrete', options: [ [ 'auto', 'smooth' ] ] }
     ]
   },
+  'scroll-snap-align': {
+    // https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-snap-align
+    types: [
+      { type: 'discrete', options: [ [ 'none', 'start' ]] }
+    ]
+  },
+  'scroll-snap-stop': {
+    // https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-snap-stop
+    types: [
+      { type: 'discrete', options: [ [ 'normal', 'always' ]] }
+    ]
+  },
+  'scroll-snap-type': {
+    // https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-snap-type
+    types: [
+      { type: 'discrete', options: [ [ 'none', 'x mandatory' ]] }
+    ]
+  },
   'scrollbar-color': {
     // https://drafts.csswg.org/css-scrollbars/#propdef-scrollbar-color
     types: [ 'colorPair' ]


### PR DESCRIPTION
WebKit export from bug: [\[web-animations\] scroll-snap-* properties should support discrete animation](https://bugs.webkit.org/show_bug.cgi?id=241176)