### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=277317

### DIFF
--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -1292,6 +1292,10 @@ const gCSSProperties2 = {
     types: [
     ]
   },
+  'stroke-color': {
+    // https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-color
+    types: [ 'color' ]
+  },
   'stroke-dasharray': {
     // https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty
     types: [


### PR DESCRIPTION
WebKit export from bug: [\[web-animations\] stroke-color should be animatable](https://bugs.webkit.org/show_bug.cgi?id=277317)