### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=277313

### DIFF
--- a/css/css-masking/animations/mask-border-outset-composition.html
+++ b/css/css-masking/animations/mask-border-outset-composition.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>mask-border-outset composition</title>
+<link rel="help" href="https://drafts.fxtf.org/css-masking/#propdef-mask-border-outset">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<meta name="assert" content="mask-border-outset supports animation by computed value">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/interpolation-testcommon.js"></script>
+
+<body>
+<script>
+test_composition({
+  property: 'mask-border-outset',
+  underlying: '1 2 3 4',
+  addFrom: '1 2 3 4',
+  addTo: '101 102 103 104',
+}, [
+  {at: -0.25, expect: '0'}, // Non-negative.
+  {at: 0, expect: '2 4 6 8'},
+  {at: 0.25, expect: '27 29 31 33'},
+  {at: 0.5, expect: '52 54 56 58'},
+  {at: 0.75, expect: '77 79 81 83'},
+  {at: 1, expect: '102 104 106 108'},
+  {at: 1.25, expect: '127 129 131 133'},
+]);
+
+test_composition({
+  property: 'mask-border-outset',
+  underlying: '100 200 300 400',
+  addFrom: '100',
+  addTo: '200 300 500',
+}, [
+  {at: -0.25, expect: '175 250 300 450'},
+  {at: 0, expect: '200 300 400 500'},
+  {at: 0.25, expect: '225 350 500 550'},
+  {at: 0.5, expect: '250 400 600 600'},
+  {at: 0.75, expect: '275 450 700 650'},
+  {at: 1, expect: '300 500 800 700'},
+  {at: 1.25, expect: '325 550 900 750'},
+]);
+
+test_composition({
+  property: 'mask-border-outset',
+  underlying: '1 2 3px 4px',
+  addFrom: '1 2 3px 4px',
+  addTo: '101 102 103px 104px',
+}, [
+  {at: -0.25, expect: '0 0 0px 0px'}, // Non-negative.
+  {at: 0, expect: '2 4 6px 8px'},
+  {at: 0.25, expect: '27 29 31px 33px'},
+  {at: 0.5, expect: '52 54 56px 58px'},
+  {at: 0.75, expect: '77 79 81px 83px'},
+  {at: 1, expect: '102 104 106px 108px'},
+  {at: 1.25, expect: '127 129 131px 133px'},
+]);
+
+test_composition({
+  property: 'mask-border-outset',
+  underlying: '10px 20px',
+  addFrom: '190px 180px 290px 280px',
+  addTo: '90px 80px',
+}, [
+  {at: -0.25, expect: '225px 225px 350px 350px'},
+  {at: 0, expect: '200px 200px 300px 300px'},
+  {at: 0.25, expect: '175px 175px 250px 250px'},
+  {at: 0.5, expect: '150px 150px 200px 200px'},
+  {at: 0.75, expect: '125px 125px 150px 150px'},
+  {at: 1, expect: '100px'},
+  {at: 1.25, expect: '75px 75px 50px 50px'},
+]);
+
+test_composition({
+  property: 'mask-border-outset',
+  underlying: '10 20px',
+  replaceFrom: '100 100px',
+  addTo: '190 180px',
+}, [
+  {at: -0.25, expect: '75 75px'},
+  {at: 0, expect: '100 100px'},
+  {at: 0.25, expect: '125 125px'},
+  {at: 0.5, expect: '150 150px'},
+  {at: 0.75, expect: '175 175px'},
+  {at: 1, expect: '200 200px'},
+  {at: 1.25, expect: '225 225px'},
+]);
+
+test_composition({
+  property: 'mask-border-outset',
+  underlying: '10px 20',
+  addFrom: '90px 80',
+  replaceTo: '0px 0 0px 0',
+}, [
+  {at: -0.25, expect: '125px 125'},
+  {at: 0, expect: '100px 100'},
+  {at: 0.25, expect: '75px 75'},
+  {at: 0.5, expect: '50px 50'},
+  {at: 0.75, expect: '25px 25'},
+  {at: 1, expect: '0px 0'},
+  {at: 1.25, expect: '0px 0'}, // Non-negative.
+]);
+
+test_composition({
+  property: 'mask-border-outset',
+  underlying: '10 20',
+  addFrom: '100px 150px',
+  addTo: '200px 250px',
+}, [
+  {at: -0.25, expect: '75px 125px'},
+  {at: 0, expect: '100px 150px'},
+  {at: 0.25, expect: '125px 175px'},
+  {at: 0.5, expect: '150px 200px'},
+  {at: 0.75, expect: '175px 225px'},
+  {at: 1, expect: '200px 250px'},
+  {at: 1.25, expect: '225px 275px'},
+]);
+
+test_composition({
+  property: 'mask-border-outset',
+  underlying: '10 20',
+  addFrom: '100 150px',
+  addTo: '200px 250',
+}, [
+  {at: -0.25, expect: '100 150px'},
+  {at: 0, expect: '100 150px'},
+  {at: 0.25, expect: '100 150px'},
+  {at: 0.5, expect: '200px 250'},
+  {at: 0.75, expect: '200px 250'},
+  {at: 1, expect: '200px 250'},
+  {at: 1.25, expect: '200px 250'},
+]);
+</script>
+</body>

--- a/css/css-masking/animations/mask-border-outset-interpolation.html
+++ b/css/css-masking/animations/mask-border-outset-interpolation.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>mask-border-outset interpolation</title>
+<link rel="help" href="https://drafts.fxtf.org/css-masking/#propdef-mask-border-outset">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<meta name="assert" content="mask-border-outset supports animation by computed value">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/interpolation-testcommon.js"></script>
+
+<style>
+.parent {
+  mask-border-outset: 10px;
+}
+.target {
+  width: 50px;
+  height: 50px;
+  background-color: black;
+  display: inline-block;
+  border: 25px;
+  margin-right: 50px;
+  mask-border-slice: 30%;
+  background-clip: content-box;
+  mask-border-source: linear-gradient(45deg, pink, blue, white, black, green);
+  mask-border-outset: 1px;
+}
+.expected {
+  background-color: green;
+}
+</style>
+
+<body></body>
+
+<script>
+test_interpolation({
+  property: 'mask-border-outset',
+  from: neutralKeyframe,
+  to: '2px',
+}, [
+  {at: -0.3, expect: '0.7px'},
+  {at: 0, expect: '1px'},
+  {at: 0.3, expect: '1.3px'},
+  {at: 0.6, expect: '1.6px'},
+  {at: 1, expect: '2px'},
+  {at: 1.5, expect: '2.5px'},
+]);
+
+test_interpolation({
+  property: 'mask-border-outset',
+  from: 'initial',
+  to: '2',
+}, [
+  {at: -0.3, expect: '0'}, // Non-negative
+  {at: 0, expect: '0'},
+  {at: 0.3, expect: '0.6'},
+  {at: 0.6, expect: '1.2'},
+  {at: 1, expect: '2'},
+  {at: 1.5, expect: '3'},
+]);
+
+test_interpolation({
+  property: 'mask-border-outset',
+  from: 'inherit',
+  to: '2px',
+}, [
+  {at: -0.3, expect: '12.4px'},
+  {at: 0, expect: '10px'},
+  {at: 0.3, expect: '7.6px'},
+  {at: 0.6, expect: '5.2px'},
+  {at: 1, expect: '2px'},
+  {at: 1.5, expect: '0px'},
+]);
+
+test_interpolation({
+  property: 'mask-border-outset',
+  from: 'unset',
+  to: '2',
+}, [
+  {at: -0.3, expect: '0'}, // Non-negative
+  {at: 0, expect: '0'},
+  {at: 0.3, expect: '0.6'},
+  {at: 0.6, expect: '1.2'},
+  {at: 1, expect: '2'},
+  {at: 1.5, expect: '3'},
+]);
+
+test_interpolation({
+  property: 'mask-border-outset',
+  from: '0px',
+  to: '5px',
+}, [
+  {at: -0.3, expect: '0px'}, // Non-negative
+  {at: 0, expect: '0px'},
+  {at: 0.3, expect: '1.5px'},
+  {at: 0.6, expect: '3px'},
+  {at: 1, expect: '5px'},
+  {at: 1.5, expect: '7.5px'},
+]);
+
+test_interpolation({
+  property: 'mask-border-outset',
+  from: '0',
+  to: '1',
+}, [
+  {at: -0.3, expect: '0'}, // Non-negative
+  {at: 0, expect: '0'},
+  {at: 0.3, expect: '0.3'},
+  {at: 0.6, expect: '0.6'},
+  {at: 1, expect: '1'},
+  {at: 1.5, expect: '1.5'},
+]);
+
+test_interpolation({
+  property: 'mask-border-outset',
+  from: '1 2 3px 4px',
+  to: '101 102 103px 104px',
+}, [
+  {at: -0.3, expect: '0 0 0px 0px'}, // Non-negative
+  {at: 0, expect: '1 2 3px 4px'},
+  {at: 0.3, expect: '31 32 33px 34px'},
+  {at: 0.6, expect: '61 62 63px 64px'},
+  {at: 1, expect: '101 102 103px 104px'},
+  {at: 1.5, expect: '151 152 153px 154px'},
+]);
+</script>

--- a/css/css-masking/animations/mask-border-slice-composition.html
+++ b/css/css-masking/animations/mask-border-slice-composition.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>mask-border-slice composition</title>
+<link rel="help" href="https://drafts.fxtf.org/css-masking/#propdef-mask-border-slice">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<meta name="assert" content="mask-border-slice supports animation by computed value">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/interpolation-testcommon.js"></script>
+
+<body>
+<script>
+test_composition({
+  property: 'mask-border-slice',
+  underlying: '1 2 3 4',
+  addFrom: '1 2 3 4',
+  addTo: '101 102 103 104',
+}, [
+  {at: -0.25, expect: '0'}, // Non-negative.
+  {at: 0, expect: '2 4 6 8'},
+  {at: 0.25, expect: '27 29 31 33'},
+  {at: 0.5, expect: '52 54 56 58'},
+  {at: 0.75, expect: '77 79 81 83'},
+  {at: 1, expect: '102 104 106 108'},
+  {at: 1.25, expect: '127 129 131 133'},
+]);
+
+test_composition({
+  property: 'mask-border-slice',
+  underlying: '100 200 300 400 fill',
+  addFrom: '100 fill',
+  addTo: '200 300 500 fill',
+}, [
+  {at: -0.25, expect: '175 250 300 450 fill'},
+  {at: 0, expect: '200 300 400 500 fill'},
+  {at: 0.25, expect: '225 350 500 550 fill'},
+  {at: 0.5, expect: '250 400 600 600 fill'},
+  {at: 0.75, expect: '275 450 700 650 fill'},
+  {at: 1, expect: '300 500 800 700 fill'},
+  {at: 1.25, expect: '325 550 900 750 fill'},
+]);
+
+test_composition({
+  property: 'mask-border-slice',
+  underlying: '1 2 3% 4%',
+  addFrom: '1 2 3% 4%',
+  addTo: '101 102 103% 104%',
+}, [
+  {at: -0.25, expect: '0 0 0% 0%'}, // Non-negative.
+  {at: 0, expect: '2 4 6% 8%'},
+  {at: 0.25, expect: '27 29 31% 33%'},
+  {at: 0.5, expect: '52 54 56% 58%'},
+  {at: 0.75, expect: '77 79 81% 83%'},
+  {at: 1, expect: '102 104 106% 108%'},
+  {at: 1.25, expect: '127 129 131% 133%'},
+]);
+
+test_composition({
+  property: 'mask-border-slice',
+  underlying: '10% 20%',
+  addFrom: '190% 180% 290% 280%',
+  addTo: '90% 80%',
+}, [
+  {at: -0.25, expect: '225% 225% 350% 350%'},
+  {at: 0, expect: '200% 200% 300% 300%'},
+  {at: 0.25, expect: '175% 175% 250% 250%'},
+  {at: 0.5, expect: '150% 150% 200% 200%'},
+  {at: 0.75, expect: '125% 125% 150% 150%'},
+  {at: 1, expect: '100%'},
+  {at: 1.25, expect: '75% 75% 50% 50%'},
+]);
+
+test_composition({
+  property: 'mask-border-slice',
+  underlying: '10 20%',
+  replaceFrom: '100 100%',
+  addTo: '190 180%',
+}, [
+  {at: -0.25, expect: '75 75%'},
+  {at: 0, expect: '100 100%'},
+  {at: 0.25, expect: '125 125%'},
+  {at: 0.5, expect: '150 150%'},
+  {at: 0.75, expect: '175 175%'},
+  {at: 1, expect: '200 200%'},
+  {at: 1.25, expect: '225 225%'},
+]);
+
+test_composition({
+  property: 'mask-border-slice',
+  underlying: '10% 20',
+  addFrom: '90% 80',
+  replaceTo: '0% 0 0% 0',
+}, [
+  {at: -0.25, expect: '125% 125'},
+  {at: 0, expect: '100% 100'},
+  {at: 0.25, expect: '75% 75'},
+  {at: 0.5, expect: '50% 50'},
+  {at: 0.75, expect: '25% 25'},
+  {at: 1, expect: '0% 0'},
+  {at: 1.25, expect: '0% 0'}, // Non-negative.
+]);
+
+test_composition({
+  property: 'mask-border-slice',
+  underlying: '10 20',
+  addFrom: '100% 150%',
+  addTo: '200% 250% fill',
+}, [
+  {at: -0.25, expect: '100% 150%'},
+  {at: 0, expect: '100% 150%'},
+  {at: 0.25, expect: '100% 150%'},
+  {at: 0.5, expect: '200% 250% fill'},
+  {at: 0.75, expect: '200% 250% fill'},
+  {at: 1, expect: '200% 250% fill'},
+  {at: 1.25, expect: '200% 250% fill'},
+]);
+
+test_composition({
+  property: 'mask-border-slice',
+  underlying: '10 20',
+  addFrom: '100 150%',
+  addTo: '200% 250',
+}, [
+  {at: -0.25, expect: '100 150%'},
+  {at: 0, expect: '100 150%'},
+  {at: 0.25, expect: '100 150%'},
+  {at: 0.5, expect: '200% 250'},
+  {at: 0.75, expect: '200% 250'},
+  {at: 1, expect: '200% 250'},
+  {at: 1.25, expect: '200% 250'},
+]);
+</script>
+</body>

--- a/css/css-masking/animations/mask-border-slice-interpolation-stability.html
+++ b/css/css-masking/animations/mask-border-slice-interpolation-stability.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>mask-border-slice interpolation stability</title>
+<link rel="help" href="https://drafts.fxtf.org/css-masking/#propdef-mask-border-slice">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="target"></div>
+<script>
+test(function() {
+  var player = target.animate([
+    {borderImageSlice: '50'},
+    {borderImageSlice: '50'},
+  ], {
+    duration: 1,
+    fill: 'forwards',
+    easing: 'cubic-bezier(0, 1.5, 1, 1.5)',
+  });
+  player.pause();
+  player.currentTime = 0.6345195996109396
+  assert_equals(getComputedStyle(target).borderImageSlice, '50');
+});
+</script>

--- a/css/css-masking/animations/mask-border-slice-interpolation.html
+++ b/css/css-masking/animations/mask-border-slice-interpolation.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>mask-border-slice interpolation</title>
+<link rel="help" href="https://drafts.fxtf.org/css-masking/#propdef-mask-border-slice">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<meta name="assert" content="mask-border-slice supports animation by computed value">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/interpolation-testcommon.js"></script>
+
+<style>
+.parent {
+  mask-border-slice: 50%;
+}
+.target {
+  width: 50px;
+  height: 50px;
+  background-color: black;
+  display: inline-block;
+  border: 25px;
+  mask-border-source: linear-gradient(45deg, red, blue, green);
+  mask-border-slice: 20%;
+}
+.expected {
+  background-color: green;
+  margin-right: 2px;
+}
+</style>
+
+<body></body>
+
+<script>
+test_interpolation({
+  property: 'mask-border-slice',
+  from: neutralKeyframe,
+  to: '10%',
+}, [
+  {at: -0.3, expect: '23%'},
+  {at: 0, expect: '20%'},
+  {at: 0.3, expect: '17%'},
+  {at: 0.5, expect: '15%'},
+  {at: 0.6, expect: '14%'},
+  {at: 1, expect: '10%'},
+  {at: 1.5, expect: '5%'},
+]);
+
+test_interpolation({
+  property: 'mask-border-slice',
+  from: 'initial',
+  to: '10',
+}, [
+  {at: -0.3, expect: '0'},
+  {at: 0, expect: '0'},
+  {at: 0.3, expect: '3'},
+  {at: 0.5, expect: '5'},
+  {at: 0.6, expect: '6'},
+  {at: 1, expect: '10'},
+  {at: 1.5, expect: '15'},
+]);
+
+test_interpolation({
+  property: 'mask-border-slice',
+  from: 'inherit',
+  to: '10%',
+}, [
+  {at: -0.3, expect: '62%'},
+  {at: 0, expect: '50%'},
+  {at: 0.3, expect: '38%'},
+  {at: 0.5, expect: '30%'},
+  {at: 0.6, expect: '26%'},
+  {at: 1, expect: '10%'},
+  {at: 1.5, expect: '0%'},
+]);
+
+test_interpolation({
+  property: 'mask-border-slice',
+  from: 'unset',
+  to: '10',
+}, [
+  {at: -0.3, expect: '0'},
+  {at: 0, expect: '0'},
+  {at: 0.3, expect: '3'},
+  {at: 0.5, expect: '5'},
+  {at: 0.6, expect: '6'},
+  {at: 1, expect: '10'},
+  {at: 1.5, expect: '15'},
+]);
+
+test_interpolation({
+  property: 'mask-border-slice',
+  from: '0%',
+  to: '50%',
+}, [
+  {at: -0.3, expect: '0%'}, // CSS mask-border-slice can't be negative.
+  {at: 0, expect: '0%'},
+  {at: 0.3, expect: '15%'},
+  {at: 0.5, expect: '25%'},
+  {at: 0.6, expect: '30%'},
+  {at: 1, expect: '50%'},
+  {at: 1.5, expect: '75%'},
+]);
+
+test_interpolation({
+  property: 'mask-border-slice',
+  from: '0% 10% 20% 30%',
+  to: '40% 50% 60% 70%',
+}, [
+  {at: -0.5, expect: '0% 0% 0% 10%'},
+  {at: 0, expect: '0% 10% 20% 30%'},
+  {at: 0.3, expect: '12% 22% 32% 42%'},
+  {at: 0.5, expect: '20% 30% 40% 50%'},
+  {at: 0.6, expect: '24% 34% 44% 54%'},
+  {at: 1, expect: '40% 50% 60% 70%'},
+  {at: 1.5, expect: '60% 70% 80% 90%'},
+]);
+
+test_interpolation({
+  property: 'mask-border-slice',
+  from: '0 10 20 30 fill',
+  to: '40 50 60 70 fill',
+}, [
+  {at: -0.5, expect: '0 0 0 10 fill'}, // CSS mask-border-slice can't be negative.
+  {at: 0, expect: '0 10 20 30 fill'},
+  {at: 0.3, expect: '12 22 32 42 fill'},
+  {at: 0.5, expect: '20 30 40 50 fill'},
+  {at: 0.6, expect: '24 34 44 54 fill'},
+  {at: 1, expect: '40 50 60 70 fill'},
+  {at: 1.5, expect: '60 70 80 90 fill'},
+]);
+
+test_interpolation({
+  property: 'mask-border-slice',
+  from: '0% 10 20% 30 fill',
+  to: '40% 50 60% 70 fill',
+}, [
+  {at: -0.5, expect: '0% 0 0% 10 fill'}, // CSS mask-border-slice can't be negative.
+  {at: 0, expect: '0% 10 20% 30 fill'},
+  {at: 0.3, expect: '12% 22 32% 42 fill'},
+  {at: 0.5, expect: '20% 30 40% 50 fill'},
+  {at: 0.6, expect: '24% 34 44% 54 fill'},
+  {at: 1, expect: '40% 50 60% 70 fill'},
+  {at: 1.5, expect: '60% 70 80% 90 fill'},
+]);
+
+test_no_interpolation({
+  property: 'mask-border-slice',
+  from: '0% fill',
+  to: '50%',
+});
+
+test_no_interpolation({
+  property: 'mask-border-slice',
+  from: '50%',
+  to: '100',
+});
+
+test_no_interpolation({
+  property: 'mask-border-slice',
+  from: '50% fill',
+  to: '100 fill',
+});
+
+test_no_interpolation({
+  property: 'mask-border-slice',
+  from: '0% 10 20% 30 fill',
+  to: '40% 50 60% 70',
+});
+
+test_no_interpolation({
+  property: 'mask-border-slice',
+  from: '0% 10 20 30 fill',
+  to: '40 50 60% 70',
+});
+</script>
+</body>

--- a/css/css-masking/animations/mask-border-source-interpolation.html
+++ b/css/css-masking/animations/mask-border-source-interpolation.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>mask-border-source interpolation</title>
+<link rel="help" href="https://drafts.fxtf.org/css-masking/#propdef-mask-border-source">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<meta name="assert" content="mask-border-source has discrete animation">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/interpolation-testcommon.js"></script>
+
+<style>
+.parent {
+  mask-border-source: url(../support/green.png);
+}
+.target {
+  width: 50px;
+  height: 50px;
+  background-color: black;
+  display: inline-block;
+  border: 5px solid aqua;
+  mask-border-source: url(../support/blue_color.png);
+  mask-border-slice: 10%;
+}
+.expected {
+  background-color: green;
+  margin-right: 2px;
+}
+</style>
+
+<body></body>
+
+<script>
+// initial
+test_no_interpolation({
+  property: 'mask-border-source',
+  from: 'initial',
+  to: 'url(../support/orange_color.png)',
+});
+
+// inherit
+test_no_interpolation({
+  property: 'mask-border-source',
+  from: 'inherit',
+  to: 'url(../support/orange_color.png)',
+});
+
+// unset
+test_no_interpolation({
+  property: 'mask-border-source',
+  from: 'unset',
+  to: 'url(../support/orange_color.png)',
+});
+
+// None to image
+test_no_interpolation({
+  property: 'mask-border-source',
+  from: 'none',
+  to: 'url(../support/orange_color.png)',
+});
+
+// Image to image
+test_no_interpolation({
+  property: 'mask-border-source',
+  from: 'url(../support/aqua_color.png)',
+  to: 'url(../support/orange_color.png)',
+});
+
+// Image to gradient
+test_no_interpolation({
+  property: 'mask-border-source',
+  from: 'url(../support/aqua_color.png)',
+  to: 'linear-gradient(45deg, blue, orange)',
+});
+
+// Gradient to gradient
+test_no_interpolation({
+  property: 'mask-border-source',
+  from: 'linear-gradient(-45deg, red, yellow)',
+  to: 'linear-gradient(45deg, blue, orange)',
+});
+</script>
+</body>

--- a/css/css-masking/animations/mask-border-width-composition.html
+++ b/css/css-masking/animations/mask-border-width-composition.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>mask-border-width composition</title>
+<link rel="help" href="https://drafts.fxtf.org/css-masking/#propdef-mask-border-width">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<meta name="assert" content="mask-border-width supports animation by computed value">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/interpolation-testcommon.js"></script>
+
+<body>
+<script>
+test_composition({
+  property: 'mask-border-width',
+  underlying: '1 2 3 4',
+  addFrom: '1 2 3 4',
+  addTo: '101 102 103 104',
+}, [
+  {at: -0.25, expect: '0'}, // Non-negative.
+  {at: 0, expect: '2 4 6 8'},
+  {at: 0.25, expect: '27 29 31 33'},
+  {at: 0.5, expect: '52 54 56 58'},
+  {at: 0.75, expect: '77 79 81 83'},
+  {at: 1, expect: '102 104 106 108'},
+  {at: 1.25, expect: '127 129 131 133'},
+]);
+
+test_composition({
+  property: 'mask-border-width',
+  underlying: '100 200 300 400',
+  addFrom: '100',
+  addTo: '200 300 500',
+}, [
+  {at: -0.25, expect: '175 250 300 450'},
+  {at: 0, expect: '200 300 400 500'},
+  {at: 0.25, expect: '225 350 500 550'},
+  {at: 0.5, expect: '250 400 600 600'},
+  {at: 0.75, expect: '275 450 700 650'},
+  {at: 1, expect: '300 500 800 700'},
+  {at: 1.25, expect: '325 550 900 750'},
+]);
+
+test_composition({
+  property: 'mask-border-width',
+  underlying: '1 2 3px 4%',
+  addFrom: '1 2 3px 4%',
+  addTo: '101 102 103px 104%',
+}, [
+  {at: -0.25, expect: '0 0 0px 0%'}, // Non-negative.
+  {at: 0, expect: '2 4 6px 8%'},
+  {at: 0.25, expect: '27 29 31px 33%'},
+  {at: 0.5, expect: '52 54 56px 58%'},
+  {at: 0.75, expect: '77 79 81px 83%'},
+  {at: 1, expect: '102 104 106px 108%'},
+  {at: 1.25, expect: '127 129 131px 133%'},
+]);
+
+test_composition({
+  property: 'mask-border-width',
+  underlying: '10px 20px',
+  addFrom: '190px 180px 290px 280px',
+  addTo: '90px 80px',
+}, [
+  {at: -0.25, expect: '225px 225px 350px 350px'},
+  {at: 0, expect: '200px 200px 300px 300px'},
+  {at: 0.25, expect: '175px 175px 250px 250px'},
+  {at: 0.5, expect: '150px 150px 200px 200px'},
+  {at: 0.75, expect: '125px 125px 150px 150px'},
+  {at: 1, expect: '100px'},
+  {at: 1.25, expect: '75px 75px 50px 50px'},
+]);
+
+test_composition({
+  property: 'mask-border-width',
+  underlying: '10 20px',
+  replaceFrom: '100 100px',
+  addTo: '190 180px',
+}, [
+  {at: -0.25, expect: '75 75px'},
+  {at: 0, expect: '100 100px'},
+  {at: 0.25, expect: '125 125px'},
+  {at: 0.5, expect: '150 150px'},
+  {at: 0.75, expect: '175 175px'},
+  {at: 1, expect: '200 200px'},
+  {at: 1.25, expect: '225 225px'},
+]);
+
+test_composition({
+  property: 'mask-border-width',
+  underlying: '10px 20',
+  addFrom: '90px 80',
+  replaceTo: '0px 0 0px 0',
+}, [
+  {at: -0.25, expect: '125px 125'},
+  {at: 0, expect: '100px 100'},
+  {at: 0.25, expect: '75px 75'},
+  {at: 0.5, expect: '50px 50'},
+  {at: 0.75, expect: '25px 25'},
+  {at: 1, expect: '0px 0'},
+  {at: 1.25, expect: '0px 0'}, // Non-negative.
+]);
+
+test_composition({
+  property: 'mask-border-width',
+  underlying: '10 20',
+  addFrom: '100px 150px',
+  addTo: '200px 250px',
+}, [
+  {at: -0.25, expect: '75px 125px'},
+  {at: 0, expect: '100px 150px'},
+  {at: 0.25, expect: '125px 175px'},
+  {at: 0.5, expect: '150px 200px'},
+  {at: 0.75, expect: '175px 225px'},
+  {at: 1, expect: '200px 250px'},
+  {at: 1.25, expect: '225px 275px'},
+]);
+
+test_composition({
+  property: 'mask-border-width',
+  underlying: '10 20',
+  addFrom: '100 150px',
+  addTo: '200% 250',
+}, [
+  {at: -0.25, expect: '100 150px'},
+  {at: 0, expect: '100 150px'},
+  {at: 0.25, expect: '100 150px'},
+  {at: 0.5, expect: '200% 250'},
+  {at: 0.75, expect: '200% 250'},
+  {at: 1, expect: '200% 250'},
+  {at: 1.25, expect: '200% 250'},
+]);
+</script>
+</body>

--- a/css/css-masking/animations/mask-border-width-interpolation.html
+++ b/css/css-masking/animations/mask-border-width-interpolation.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>mask-border-width interpolation</title>
+<link rel="help" href="https://drafts.fxtf.org/css-masking/#propdef-mask-border-width">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<meta name="assert" content="mask-border-width supports animation by computed value">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/interpolation-testcommon.js"></script>
+
+<style>
+.parent {
+  mask-border-width: 100px;
+}
+.target {
+  width: 80px;
+  height: 80px;
+  background-color: black;
+  display: inline-block;
+  border: 10px;
+  mask-border-source: linear-gradient(45deg, red, blue, green);
+  mask-border-width: 10px;
+}
+.expected {
+  background-color: green;
+  margin-right: 2px;
+}
+</style>
+
+<body></body>
+
+<script>
+test_interpolation({
+  property: 'mask-border-width',
+  from: neutralKeyframe,
+  to: '20px',
+}, [
+  {at: -0.3, expect:   '7px'},
+  {at: 0,    expect:  '10px'},
+  {at: 0.3,  expect:  '13px'},
+  {at: 0.6,  expect:  '16px'},
+  {at: 1,    expect:  '20px'},
+  {at: 1.5,  expect:  '25px'},
+  {at: 5,    expect:  '60px'},
+  {at: 10,   expect: '110px'},
+]);
+test_no_interpolation({
+  property: 'mask-border-width',
+  from: 'initial',
+  to: '20px',
+});
+test_interpolation({
+  property: 'mask-border-width',
+  from: 'inherit',
+  to: '20px',
+}, [
+  {at: -0.3, expect: '124px'},
+  {at: 0,    expect: '100px'},
+  {at: 0.3,  expect:  '76px'},
+  {at: 0.6,  expect:  '52px'},
+  {at: 1,    expect:  '20px'},
+  {at: 1.5,  expect:   '0px'},
+  {at: 5,    expect:   '0px'},
+  {at: 10,   expect:   '0px'},
+]);
+test_no_interpolation({
+  property: 'mask-border-width',
+  from: 'unset',
+  to: '20px',
+});
+test_interpolation({
+  property: 'mask-border-width',
+  from: '0px',
+  to: '20px'
+}, [
+  {at: -0.3, expect:   '0px'}, // CSS mask-border-width can't be negative.
+  {at: 0,    expect:   '0px'},
+  {at: 0.3,  expect:   '6px'},
+  {at: 0.6,  expect:  '12px'},
+  {at: 1,    expect:  '20px'},
+  {at: 1.5,  expect:  '30px'},
+  {at: 5,    expect: '100px'},
+  {at: 10,   expect: '200px'}
+]);
+test_interpolation({
+  property: 'mask-border-width',
+  from: '0%',
+  to: '20%'
+}, [
+  {at: -0.3, expect:   '0%'}, // CSS mask-border-width can't be negative.
+  {at: 0,    expect:   '0%'},
+  {at: 0.3,  expect:   '6%'},
+  {at: 0.6,  expect:  '12%'},
+  {at: 1,    expect:  '20%'},
+  {at: 1.5,  expect:  '30%'},
+  {at: 5,    expect: '100%'},
+  {at: 10,   expect: '200%'}
+]);
+test_interpolation({
+  property: 'mask-border-width',
+  from: '0',
+  to: '20'
+}, [
+  {at: -0.3, expect:   '0'}, // CSS mask-border-width can't be negative.
+  {at: 0,    expect:   '0'},
+  {at: 0.3,  expect:   '6'},
+  {at: 0.6,  expect:  '12'},
+  {at: 1,    expect:  '20'},
+  {at: 1.5,  expect:  '30'},
+  {at: 5,    expect: '100'},
+  {at: 10,   expect: '200'}
+]);
+test_interpolation({
+  property: 'mask-border-width',
+  from: '10px 20% 30 40px',
+  to: '80px 70% 60 50px'
+}, [
+  {at: -0.3, expect:   '0px   5%  21  37px'}, // CSS mask-border-width can't be negative.
+  {at: 0,    expect:  '10px  20%  30  40px'},
+  {at: 0.3,  expect:  '31px  35%  39  43px'},
+  {at: 0.6,  expect:  '52px  50%  48  46px'},
+  {at: 1,    expect:  '80px  70%  60  50px'},
+  {at: 1.5,  expect: '115px  95%  75  55px'},
+  {at: 5,    expect: '360px 270% 180  90px'},
+  {at: 10,   expect: '710px 520% 330 140px'}
+]);
+test_interpolation({
+  property: 'mask-border-width',
+  from: '10%',
+  to: '20px'
+}, [
+  // Percentages are relative to the size of the border image area, which is 120px.
+  {at: -0.3, expect: 'calc(13% + -6px)'}, // Should be parsed as 16px - 6px = 10px
+  {at: 0,    expect: '10%'},              // Should be parsed as 12px
+  {at: 0.3,  expect: 'calc(7% + 6px)'},   // Should be parsed as 8px + 6px = 14px
+  {at: 0.6,  expect: 'calc(4% + 12px)'},  // Should be parsed as 5px + 12px = 17px
+  {at: 1,    expect: 'calc(0% + 20px)'},
+  {at: 1.5,  expect: 'calc(-5% + 30px)'}, // Should be parsed as -6px + 30px = 24px
+]);
+test_interpolation({
+  property: 'mask-border-width',
+  from: '10px',
+  to: '20%'
+}, [
+  // Percentages are relative to the size of the border image area, which is 120px.
+  {at: -0.3, expect: 'calc(13px + -6%)'}, // Should be parsed as 13px - 7px = 6px
+  {at: 0,    expect: 'calc(0% + 10px)'},
+  {at: 0.3,  expect: 'calc(7px + 6%)'},   // Should be parsed as 7px + 7px = 14px
+  {at: 0.6,  expect: 'calc(4px + 12%)'},  // Should be parsed as 4px + 14px = 18px
+  {at: 1,    expect: '20%'},              // Should be parsed as 24px
+  {at: 1.5,  expect: 'calc(-5px + 30%)'}, // Should be parsed as -5px + 36px = 31px
+]);
+
+test_interpolation({
+  property: 'mask-border-width',
+  from: '10px auto auto 20',
+  to: '110px auto auto 120'
+}, [
+  {at: -0.3, expect: '  0px auto auto   0'},
+  {at: 0,    expect: ' 10px auto auto  20'},
+  {at: 0.3,  expect: ' 40px auto auto  50'},
+  {at: 0.6,  expect: ' 70px auto auto  80'},
+  {at: 1,    expect: '110px auto auto 120'},
+  {at: 1.5,  expect: '160px auto auto 170'},
+]);
+
+test_no_interpolation({
+  property: 'mask-border-width',
+  from: '10px auto auto 20',
+  to: '110px auto 120 auto'
+});
+test_no_interpolation({
+  property: 'mask-border-width',
+  from: '10px',
+  to: '20'
+});
+test_no_interpolation({
+  property: 'mask-border-width',
+  from: '10',
+  to: '20px'
+});
+test_no_interpolation({
+  property: 'mask-border-width',
+  from: '10%',
+  to: '20'
+});
+test_no_interpolation({
+  property: 'mask-border-width',
+  from: '10',
+  to: '20%'
+});
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[web-animations\] mask-border-* properties should be animatable](https://bugs.webkit.org/show_bug.cgi?id=277313)