### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=277351

### DIFF
--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -98,6 +98,16 @@ const gCSSProperties1 = {
     types: [
     ]
   },
+  'block-step-insert': {
+    // https://drafts.csswg.org/css-rhythm/#block-step-insert
+    types: [
+      { type: 'discrete', options: [ [ 'margin', 'padding' ] ] }
+    ]
+  },
+  'block-step-size': {
+    // https://drafts.csswg.org/css-rhythm/#block-step-size
+    types: [ 'length' ]
+  },
   'border-block-end-color': {
     // https://drafts.csswg.org/css-logical-props/#propdef-border-block-end-color
     types: [


### PR DESCRIPTION
WebKit export from bug: [\[web-animations\] block-step-insert and block-step-size should be animatable](https://bugs.webkit.org/show_bug.cgi?id=277351)