### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=238985

### DIFF
--- a/css/cssom-view/scrollintoview-zero-height-item.html
+++ b/css/cssom-view/scrollintoview-zero-height-item.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<title>CSSOM View - scrollIntoView does not scroll to zero height item</title>
+<meta charset="UTF-8">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<div style="border: 1px solid black; height: 300px; width: 200px; overflow-y: auto;visibility: hidden" id="box">
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div id="text">--- Clicking here should NOT scroll to top ---</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+    <div>text</div>
+</div>
+<script>
+test(() => {
+box.scrollTop = 40;
+
+let div = document.createElement("div");
+div.textContent = "div";
+text.parentNode.insertBefore(div, text);
+
+let span = document.createElement("span");
+span.tabIndex = 0;
+div.append(span);
+
+span.scrollIntoViewIfNeeded();
+
+assert_equals(box.scrollTop, 40, 'box.scrollTop');
+}, `scrollIntoView on zero height item`);
+
+</script>
+</body>


### PR DESCRIPTION
WebKit export from bug: [REGRESSION(r290770): element.scrollIntoViewIfNeeded() scrolls to top even when element is already in viewport](https://bugs.webkit.org/show_bug.cgi?id=238985)