### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=241174

### DIFF
--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -752,6 +752,12 @@ const gCSSProperties1 = {
     types: [
     ]
   },
+  'hanging-punctuation': {
+    // https://drafts.csswg.org/css-text/#hanging-punctuation-property
+    types: [
+      { type: 'discrete', options: [ [ 'none', 'first last'] ] }
+    ]
+  },
   'hyphens': {
     // https://drafts.csswg.org/css-text-3/#propdef-hyphens
     types: [


### PR DESCRIPTION
WebKit export from bug: [\[web-animations\] hanging-punctuation should support discrete animation](https://bugs.webkit.org/show_bug.cgi?id=241174)