### PR TITLE
[wptrunner] Always signal TestRunnerManager thread exit

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -475,6 +475,10 @@ class TestRunnerManager(threading.Thread):
             self.logger.critical(message)
             raise
         finally:
+            self._cleanup_run_loop()
+
+    def _cleanup_run_loop(self):
+        try:
             self.logger.debug("TestRunnerManager main loop terminating, starting cleanup")
 
             skipped_tests = []
@@ -499,6 +503,10 @@ class TestRunnerManager(threading.Thread):
                 assert self.browser.browser is not None
                 self.browser.browser.cleanup()
             self.logger.debug("TestRunnerManager main loop terminated")
+        finally:
+            # Even if the cleanup fails, signal that this thread is ready to
+            # exit. Otherwise, the barrier backing `parent_stop_flag` will never
+            # get enough watiers, causing wptrunner to hang.
             self.parent_stop_flag.wait_for_all_managers_done()
 
     def wait_event(self):


### PR DESCRIPTION
Starting from #45593, a barrier synchronizes the exit of all TestRunnerManager threads to ensure the browser processes they own are terminated. However, if [the cleanup itself for a thread fails][0], that thread won't wait on the barrier, causing a hang. This PR mitigates this by ensuring threads always wait on the barrier.

[0]: https://crbug.com/355076599