### PR TITLE
[wptrunner] Don't override `HeadlessShellBrowser.make_command()`

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/headless_shell.py
+++ b/tools/wptrunner/wptrunner/browsers/headless_shell.py
@@ -1,6 +1,6 @@
 # mypy: allow-untyped-defs
 
-from .base import cmd_arg, require_arg
+from .base import require_arg
 from .base import get_timeout_multiplier   # noqa: F401
 from .chrome import ChromeBrowser, debug_args, executor_kwargs  # noqa: F401
 from ..executors.base import WdspecExecutor  # noqa: F401
@@ -55,8 +55,4 @@ def update_properties():
 
 
 class HeadlessShellBrowser(ChromeBrowser):
-    def make_command(self):
-        return [self.webdriver_binary,
-                cmd_arg("port", str(self.port)),
-                cmd_arg("url-base", self.base_path),
-                cmd_arg("enable-chrome-logs")] + self.webdriver_args
+    pass


### PR DESCRIPTION
web-platform-tests/wpt#47229 changed the implementation of `ChromeBrowser.port` so that it's dynamically set from a free port that `chromedriver` finds. This broke `HeadlessShellBrowser`, which tries to use the port number [before it's available][0].

As it turns out, there's no need for `HeadlessShellBrowser` to override `ChromeBrowser.make_command()`; the default implementation works fine.

[0]: https://ci.chromium.org/ui/p/chromium/builders/ci/linux-wpt-chromium-rel/9991/overview