### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=235755

### DIFF
--- a/css/css-fonts/synthetic-bold-space-width-ref.html
+++ b/css/css-fonts/synthetic-bold-space-width-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<link rel="author" title="Myles C. Maxfield" href="mmaxfield@apple.com">
+<style>
+pre {
+    font: bold 12px 'Monaco';
+}
+</style>
+<body>
+<p>This test passes if space characters' advances are expanded by the synthetic bold offset.</p>
+<pre style="font-feature-settings: 'ABCD';"><strong>hi asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf</strong></pre>
+</body>
+</html>

--- a/css/css-fonts/synthetic-bold-space-width.html
+++ b/css/css-fonts/synthetic-bold-space-width.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<link rel="author" title="Myles C. Maxfield" href="mmaxfield@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#missing-weights">
+<link rel="match" href="synthetic-bold-space-width-ref.html">
+<style>
+pre {
+    font: bold 12px 'Monaco';
+}
+</style>
+<body>
+<p>This test passes if space characters' advances are expanded by the synthetic bold offset.</p>
+<pre><strong>hi asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf</strong></pre>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [REGRESSION(r281687): Space widths have synthetic bold applied to them in the fast text codepath but not the complex text codepath](https://bugs.webkit.org/show_bug.cgi?id=235755)