### PR TITLE
[css-grid-3] Add Masonry Tests to cover simple 1ch and auto scenario

### DIFF
--- a/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-007-ref.html
+++ b/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-007-ref.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+  <meta charset="utf-8">
+  <title>CSS Grid Test: Masonry layout column sizing - intrinsic</title>
+  <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+  <style>
+
+@import "support/masonry-intrinsic-sizing-visual.css";
+
+grid {
+  display: inline-grid;
+  gap: 1px 2px;
+  border: 1px solid;
+  padding: 0 1px 0 2px;
+  vertical-align: top;
+}
+
+.mix grid {
+  grid-template-columns: 1ch auto;
+}
+
+.mix2 grid {
+  grid-template-columns: 1ch auto 1ch;
+}
+</style>
+
+<body>
+
+<section class="mix">
+<grid title="Auto Last Track">
+  <item style="width:5ch; grid-column: span 2;">1</item>
+</grid>
+</section>
+
+<section class="mix2">
+<grid title="Auto Middle Track">
+    <item style="width:5ch; grid-column: span 3;">1</item>
+</grid>
+</section>

--- a/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-007.html
+++ b/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-007.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+  <meta charset="utf-8">
+  <title>CSS Grid Test: Masonry layout column sizing - intrinsic</title>
+  <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
+  <link rel="match" href="masonry-intrinsic-sizing-cols-007-ref.html">
+  <style>
+
+@import "support/masonry-intrinsic-sizing-visual.css";
+
+grid {
+  display: inline-grid;
+  gap: 1px 2px;
+  grid-template-rows: masonry;
+  border: 1px solid;
+  padding: 0 1px 0 2px;
+  vertical-align: top;
+}
+
+.mix grid {
+  grid-template-columns: 1ch auto;
+}
+
+.mix2 grid {
+  grid-template-columns: 1ch auto 1ch;
+}
+</style>
+
+<body>
+
+<section class="mix">
+<grid title="Auto Last Track">
+  <item style="width:5ch; grid-column: span 2;">1</item>
+</grid>
+</section>
+
+<section class="mix2">
+<grid title="Auto Middle Track">
+    <item style="width:5ch; grid-column: span 3;">1</item>
+</grid>
+</section>


### PR DESCRIPTION
Export from WebKit https://github.com/WebKit/WebKit/pull/31504

This adds support for basic cases of 1ch and auto scenarios. This is needed to verify that the auto is correctly sized when a span goes past the end of the tracks during sizing.