### PR TITLE
ARIA, HTML-AAM: Update tests for new sectionheader and sectionfooter roles

### DIFF
--- a/html-aam/roles-contextual.html
+++ b/html-aam/roles-contextual.html
@@ -53,19 +53,10 @@
 </section>
 
 <!-- el-footer -->
-<nav>
-  <footer data-testname="el-footer" aria-label="x" class="ex-generic">x</aside>
-</nav>
 <footer data-testname="el-footer-ancestorbody" data-expectedrole="contentinfo" class="ex">x</footer>
 
 <!-- el-header -->
-<nav>
-  <header data-testname="el-header" aria-label="x" class="ex-generic">x</header>
-</nav>
 <header data-testname="el-header-ancestorbody" data-expectedrole="banner" class="ex">x</header>
-<main>
-  <header data-testname="el-header-ancestormain" data-expectedrole="generic" class="ex-generic">x</header>
-</main>
 
 <!-- el-section -->
 <section data-testname="el-section" aria-label="x" data-expectedrole="region" class="ex">x</section>

--- a/html-aam/roles-contextual.html
+++ b/html-aam/roles-contextual.html
@@ -53,10 +53,14 @@
 </section>
 
 <!-- el-footer -->
+<!-- nav>footer -> ./roles-contextual.tentative.html -->
 <footer data-testname="el-footer-ancestorbody" data-expectedrole="contentinfo" class="ex">x</footer>
+<!-- main>footer -> ./roles-contextual.tentative.html -->
 
 <!-- el-header -->
+<!-- nav>header -> ./roles-contextual.tentative.html -->
 <header data-testname="el-header-ancestorbody" data-expectedrole="banner" class="ex">x</header>
+<!-- main>header -> ./roles-contextual.tentative.html -->
 
 <!-- el-section -->
 <section data-testname="el-section" aria-label="x" data-expectedrole="region" class="ex">x</section>

--- a/html-aam/roles-contextual.tentative.html
+++ b/html-aam/roles-contextual.tentative.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+<head>
+  <title>Tentative: HTML-AAM Contextual-Specific Role Verification Tests</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<!--
+  New sectionheader and sectionfooter roles.
+  See https://github.com/w3c/aria/pull/1931
+-->
+<nav>
+  <footer data-testname="el-footer" aria-label="x" data-expectedrole="sectionfooter" class="ex">x</aside>
+</nav>
+<nav>
+  <header data-testname="el-header" aria-label="x" data-expectedrole="sectionheader" class="ex">x</header>
+</nav>
+<main>
+  <header data-testname="el-header-ancestormain" data-expectedrole="sectionheader" class="ex">x</header>
+</main>
+
+<script>
+AriaUtils.verifyRolesBySelector(".ex");
+</script>
+
+</body>
+</html>

--- a/html-aam/roles-contextual.tentative.html
+++ b/html-aam/roles-contextual.tentative.html
@@ -18,6 +18,9 @@
 <nav>
   <footer data-testname="el-footer" aria-label="x" data-expectedrole="sectionfooter" class="ex">x</aside>
 </nav>
+<main>
+  <footer data-testname="el-footer-ancestormain" data-expectedrole="sectionfooter" class="ex">x</footer>
+</main>
 <nav>
   <header data-testname="el-header" aria-label="x" data-expectedrole="sectionheader" class="ex">x</header>
 </nav>

--- a/wai-aria/role/contextual-roles.html
+++ b/wai-aria/role/contextual-roles.html
@@ -74,10 +74,6 @@
     2. If <footer> is scoped to <body>, it should be 'contentinfo' as expected
 
     see: https://w3c.github.io/html-aam/#el-footer-ancestorbody -->
-    <main>
-        <footer data-testname="footer element scoped to main element is generic" class="ex-generic">x</footer>
-    </main>
-
     <footer data-testname="footer scoped to body element is contentinfo" data-expectedrole="contentinfo" class="ex">x</footer>
     <div role="contentinfo" data-testname="contentinfo region scoped to body element is contentinfo" data-expectedrole="contentinfo" class="ex">x</div>
 

--- a/wai-aria/role/contextual-roles.html
+++ b/wai-aria/role/contextual-roles.html
@@ -74,6 +74,8 @@
     2. If <footer> is scoped to <body>, it should be 'contentinfo' as expected
 
     see: https://w3c.github.io/html-aam/#el-footer-ancestorbody -->
+    <!-- main>footer -> ./roles-contextual.tentative.html -->
+
     <footer data-testname="footer scoped to body element is contentinfo" data-expectedrole="contentinfo" class="ex">x</footer>
     <div role="contentinfo" data-testname="contentinfo region scoped to body element is contentinfo" data-expectedrole="contentinfo" class="ex">x</div>
 

--- a/wai-aria/role/contextual-roles.tentative.html
+++ b/wai-aria/role/contextual-roles.tentative.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+<head>
+  <title>Tentative: Contextual Role Verification Tests</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<!--
+  New sectionheader and sectionfooter roles.
+  See https://github.com/w3c/aria/pull/1931
+-->
+<main>
+    <footer data-testname="footer element scoped to main element is sectionfooter" data-expectedrole="sectionfooter" class="ex">x</footer>
+</main>
+
+<script>
+    AriaUtils.verifyRolesBySelector(".ex");
+</script>
+
+</body>
+</html>

--- a/wai-aria/role/contextual-roles.tentative.html
+++ b/wai-aria/role/contextual-roles.tentative.html
@@ -16,7 +16,10 @@
   See https://github.com/w3c/aria/pull/1931
 -->
 <main>
-    <footer data-testname="footer element scoped to main element is sectionfooter" data-expectedrole="sectionfooter" class="ex">x</footer>
+    <div role="sectionfooter" data-testname="role is sectionfooter (in main)" data-expectedrole="sectionfooter" class="ex">x</div>
+</main>
+<main>
+    <div role="sectionheader" data-testname="role is sectionheader (in main)" data-expectedrole="sectionheader" class="ex">x</div>
 </main>
 
 <script>


### PR DESCRIPTION
Change in ARIA: https://github.com/w3c/aria/pull/1931

Closes web-platform-tests/interop-accessibility#136.