### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=262014

### DIFF
--- a/css/motion/offset-path-shape-circle-008.html
+++ b/css/motion/offset-path-shape-circle-008.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test: &lt;basic-shape&gt; circle() path offset-position</title>
+<meta name="fuzzy" content="maxDifference=0-150; totalPixels=0-300">
+<link rel="match" href="offset-path-shape-circle-001-ref.html">
+<link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-basic-shape">
+
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  width: 600px;
+  height: 400px;
+}
+#box {
+  top: 100px;
+  left: 200px;
+  background-color: green;
+  position: relative;
+  offset-path: circle();
+  offset-position: 300px 200px;
+  offset-distance: 25%;
+  border-radius: 50% 50% 0 0;
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="box"></div>
+</div>

--- a/css/motion/offset-path-shape-ellipse-007.html
+++ b/css/motion/offset-path-shape-ellipse-007.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test: &lt;basic-shape&gt; ellipse() path offset-position</title>
+<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-401">
+<link rel="match" href="offset-path-shape-ellipse-001-ref.html">
+<link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-basic-shape">
+
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  width: 600px;
+  height: 400px;
+}
+#box {
+  top: 100px;
+  left: 200px;
+  background-color: green;
+  position: relative;
+  offset-path: ellipse();
+  offset-distance: 25%;
+  border-radius: 50% 50% 0 0;
+  offset-position: 300px 200px;
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="box"></div>
+</div>


### PR DESCRIPTION
WebKit export from bug: [\[motion-path\] circle() and ellipse() should use non-offset starting position](https://bugs.webkit.org/show_bug.cgi?id=262014)