### PR TITLE
Test :host(:has(...)) and :host:has(...) selectors

### DIFF
--- a/css/css-scoping/host-has-001.html
+++ b/css/css-scoping/host-has-001.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host(:has(...)) direct descendent</title>
+<link rel="help" href="https://drafts.csswg.org/css-scoping/#host-selector">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id="host">
+    <template shadowrootmode="open">
+      <style>
+        :host(:has(section)) div {
+          width: 100px;
+          height: 100px;
+          background-color: green;
+        }
+      </style>
+      <div></div>
+      <slot></slot>
+    </template>
+    <section></section>
+</div>

--- a/css/css-scoping/host-has-001.html
+++ b/css/css-scoping/host-has-001.html
@@ -7,9 +7,12 @@
 <div id="host">
     <template shadowrootmode="open">
       <style>
-        :host(:has(section)) div {
+        div {
           width: 100px;
           height: 100px;
+          background-color: red;
+        }
+        :host(:has(section)) div {
           background-color: green;
         }
       </style>

--- a/css/css-scoping/host-has-002.html
+++ b/css/css-scoping/host-has-002.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host(:has(...)) complex descendent</title>
+<link rel="help" href="https://drafts.csswg.org/css-scoping/#host-selector">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id="host">
+    <template shadowrootmode="open">
+      <style>
+        :host(:has(section h1)) div {
+          width: 100px;
+          height: 100px;
+          background-color: green;
+        }
+      </style>
+      <div></div>
+      <slot></slot>
+    </template>
+    <section>
+        <h1></h1>
+    </section>
+</div>

--- a/css/css-scoping/host-has-002.html
+++ b/css/css-scoping/host-has-002.html
@@ -7,9 +7,12 @@
 <div id="host">
     <template shadowrootmode="open">
       <style>
-        :host(:has(section h1)) div {
+        div {
           width: 100px;
           height: 100px;
+          background-color: red;
+        }
+        :host(:has(section h1)) div {
           background-color: green;
         }
       </style>

--- a/css/css-scoping/host-has-003.html
+++ b/css/css-scoping/host-has-003.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host(:has(...)) deep descendent</title>
+<link rel="help" href="https://drafts.csswg.org/css-scoping/#host-selector">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id="host">
+    <template shadowrootmode="open">
+      <style>
+        :host(:has(h1)) div {
+          width: 100px;
+          height: 100px;
+          background-color: green;
+        }
+      </style>
+      <div></div>
+      <slot></slot>
+    </template>
+    <section>
+        <h1></h1>
+    </section>
+</div>

--- a/css/css-scoping/host-has-003.html
+++ b/css/css-scoping/host-has-003.html
@@ -7,9 +7,12 @@
 <div id="host">
     <template shadowrootmode="open">
       <style>
-        :host(:has(h1)) div {
+        div {
           width: 100px;
           height: 100px;
+          background-color: red;
+        }
+        :host(:has(h1)) div {
           background-color: green;
         }
       </style>

--- a/css/css-scoping/host-has-internal-001.tentative.html
+++ b/css/css-scoping/host-has-internal-001.tentative.html
@@ -7,9 +7,12 @@
 <div id="host">
     <template shadowrootmode="open">
       <style>
-        :host:has(section) div {
+        div {
           width: 100px;
           height: 100px;
+          background-color: red;
+        }
+        :host:has(section) div {
           background-color: green;
         }
       </style>

--- a/css/css-scoping/host-has-internal-001.tentative.html
+++ b/css/css-scoping/host-has-internal-001.tentative.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host(:has(...)) internal descendent</title>
+<link rel="help" href="https://drafts.csswg.org/css-scoping/#host-selector">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id="host">
+    <template shadowrootmode="open">
+      <style>
+        :host:has(section) div {
+          width: 100px;
+          height: 100px;
+          background-color: green;
+        }
+      </style>
+      <div></div>
+      <section></section>
+    </template>
+</div>

--- a/css/css-scoping/host-has-internal-002.tentative.html
+++ b/css/css-scoping/host-has-internal-002.tentative.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host(:has(...)) complex internal descendent</title>
+<link rel="help" href="https://drafts.csswg.org/css-scoping/#host-selector">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id="host">
+    <template shadowrootmode="open">
+      <style>
+        :host:has(section h1) div {
+          width: 100px;
+          height: 100px;
+          background-color: green;
+        }
+      </style>
+      <div></div>
+      <section>
+        <h1></h1>
+      </section>
+    </template>
+</div>

--- a/css/css-scoping/host-has-internal-002.tentative.html
+++ b/css/css-scoping/host-has-internal-002.tentative.html
@@ -7,9 +7,12 @@
 <div id="host">
     <template shadowrootmode="open">
       <style>
-        :host:has(section h1) div {
+        div {
           width: 100px;
           height: 100px;
+          background-color: red;
+        }
+        :host:has(section h1) div {
           background-color: green;
         }
       </style>

--- a/css/css-scoping/host-has-internal-003.tentative.html
+++ b/css/css-scoping/host-has-internal-003.tentative.html
@@ -7,9 +7,12 @@
 <div id="host">
     <template shadowrootmode="open">
       <style>
-        :host:has(h1) div {
+        div {
           width: 100px;
           height: 100px;
+          background-color: red;
+        }
+        :host:has(h1) div {
           background-color: green;
         }
       </style>

--- a/css/css-scoping/host-has-internal-003.tentative.html
+++ b/css/css-scoping/host-has-internal-003.tentative.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host(:has(...)) deep internal descendent</title>
+<link rel="help" href="https://drafts.csswg.org/css-scoping/#host-selector">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id="host">
+    <template shadowrootmode="open">
+      <style>
+        :host:has(h1) div {
+          width: 100px;
+          height: 100px;
+          background-color: green;
+        }
+      </style>
+      <div></div>
+      <section>
+        <h1></h1>
+      </section>
+    </template>
+</div>


### PR DESCRIPTION
- `:host(:has(...))` works really well is Safari, sort of well in Firefox and not at all in Chrome. It's not _really_ spec'd (IIUC) but normalizing on the output expected by developers and provided by Safari already seems like a good destination to work towards
- `:host:has(...)` doesn't work anywhere and isn't spec'd anywhere (IIUC) but this is how I would tentatively expect it to work, similar to that way the `:host(.class)` references a class "outside" of the shadow root and `:host:after` references a pseudo element inside of the shadow root.

Both of these types of selectors would likely benefit from various combinator tests and 