### PR TITLE
Streams: Fix typos and actually use advanced function

### DIFF
--- a/streams/transferable/transfer-with-messageport.window.js
+++ b/streams/transferable/transfer-with-messageport.window.js
@@ -105,7 +105,7 @@ async function transferMessagePortWith(constructor) {
   await transferMessagePortWithOrder3(new constructor());
 }
 
-async function advancedTransferMesagePortWith(constructor) {
+async function advancedTransferMessagePortWith(constructor) {
   await transferMessagePortWithOrder4(new constructor());
   await transferMessagePortWithOrder5(new constructor());
   await transferMessagePortWithOrder6(new constructor());
@@ -166,7 +166,7 @@ async function mixedTransferMessagePortWithOrder3() {
   );
 }
 
-async function mixedTransferMesagePortWith() {
+async function mixedTransferMessagePortWith() {
   await mixedTransferMessagePortWithOrder1();
   await mixedTransferMessagePortWithOrder2();
   await mixedTransferMessagePortWithOrder3();
@@ -197,7 +197,7 @@ promise_test(async t => {
 }, "Transferring a MessagePort with a TransformStream should set `.ports`, advanced");
 
 promise_test(async t => {
-  await mixedTransferMesagePortWith();
+  await mixedTransferMessagePortWith();
 }, "Transferring a MessagePort with multiple streams should set `.ports`");
 
 test(() => {

--- a/streams/transferable/transfer-with-messageport.window.js
+++ b/streams/transferable/transfer-with-messageport.window.js
@@ -185,15 +185,15 @@ promise_test(async t => {
 }, "Transferring a MessagePort with a TransformStream should set `.ports`");
 
 promise_test(async t => {
-  await transferMessagePortWith(ReadableStream);
+  await advancedTransferMessagePortWith(ReadableStream);
 }, "Transferring a MessagePort with a ReadableStream should set `.ports`, advanced");
 
 promise_test(async t => {
-  await transferMessagePortWith(WritableStream);
+  await advancedTransferMessagePortWith(WritableStream);
 }, "Transferring a MessagePort with a WritableStream should set `.ports`, advanced");
 
 promise_test(async t => {
-  await transferMessagePortWith(TransformStream);
+  await advancedTransferMessagePortWith(TransformStream);
 }, "Transferring a MessagePort with a TransformStream should set `.ports`, advanced");
 
 promise_test(async t => {


### PR DESCRIPTION
Fixes some typos.

Also I noticed that the [advancedTransferMesagePortWith](https://github.com/web-platform-tests/wpt/blob/84d708bb188b5871ec81a3b610bea89a549008ab/streams/transferable/transfer-with-messageport.window.js#L108) function is never called.  Probably it was intended to be called here: https://github.com/web-platform-tests/wpt/blob/84d708bb188b5871ec81a3b610bea89a549008ab/streams/transferable/transfer-with-messageport.window.js#L187-L197 


I can fix that as well in this PR if you agree?