### PR TITLE
script: Properly handle removed iframes in `GlobalScope::get_referrer`

### DIFF
--- a/html/semantics/embedded-content/the-iframe-element/srcdoc-removed-iframe-crash.html
+++ b/html/semantics/embedded-content/the-iframe-element/srcdoc-removed-iframe-crash.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <title>iframe with srcdoc content that loads after iframe is removed from the document</title>
+        <link rel="author" title="Martin Robinson" href="mrobinson@igalia.com">
+        <link rel="help" href="https://github.com/servo/servo/issues/32432">
+        <iframe srcdoc="contents"></iframe>
+        <script>
+            document.querySelector('iframe').remove();
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
This change, modifies the `GlobalScope::get_referrer` to handle
the case where it cannot get the parent document when dealing
with srcdoc. This can happen when the iframe has been removed
from the parent document before reading htis line of code. In this
case `Referrer::NoReferrer` is returned.

In addition, in order to make the crash test work, changes were
made to the panic hook to trigger a segfault when doing a hard
exit rather than exiting with a non-zero return value. This allows
the WPT test harness to interpret the exit as a crash rather than
a non-crash error exit.

Reviewed in servo/servo#32782