### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=277653

### DIFF
--- a/css/css-text-decor/invalidation/text-decoration-thickness-ref.html
+++ b/css/css-text-decor/invalidation/text-decoration-thickness-ref.html
@@ -8,7 +8,8 @@
             text-decoration-thickness: 3px;
         }
     </style>
+    <p>The link below should increase its underline thickness when hovered:</p>
     <div style="font-size: 28px;">
-        <a href="#" id="link">Hover over this link, and check if the text-decoration-thickness increases.</a>
+        <a href="#" id="link">Hover me</a>
     </div>
 </html>

--- a/css/css-text-decor/invalidation/text-decoration-thickness.html
+++ b/css/css-text-decor/invalidation/text-decoration-thickness.html
@@ -15,8 +15,9 @@
             text-decoration-thickness: 3px;
         }
     </style>
+    <p>The link below should increase its underline thickness when hovered:</p>
     <div style="font-size: 28px;">
-        <a href="#" id="link">Hover over this link, and check if the text-decoration-thickness increases.</a>
+        <a href="#" id="link">Hover me</a>
     </div>
     <script src="/resources/testdriver.js"></script>
     <script src="/resources/testdriver-actions.js"></script>


### PR DESCRIPTION
WebKit export from bug: [Make `css-text-decor/invalidation/text-decoration-thickness.html` independent of viewport size](https://bugs.webkit.org/show_bug.cgi?id=277653)