### PR TITLE
Add fuzzy metadata for conic gradient tests

### DIFF
--- a/css/css-images/conic-gradient-angle-negative.html
+++ b/css/css-images/conic-gradient-angle-negative.html
@@ -3,6 +3,7 @@
 <title>Conic gradient with negative angle parameter</title>
 <link rel="help" href="https://drafts.csswg.org/css-images-4/#conic-gradients">
 <meta name="assert" content="Rendering of conic-gradient with negative center parameter">
+<meta name="fuzzy" content="maxDifference=1;totalPixels=40000">
 <link rel="match" href="reference/200x200-blue-black-green-red.html">
 <style>
   #gradient {

--- a/css/css-images/conic-gradient-angle.html
+++ b/css/css-images/conic-gradient-angle.html
@@ -3,6 +3,7 @@
 <title>Conic gradient with custom angle parameter</title>
 <link rel="help" href="https://drafts.csswg.org/css-images-4/#conic-gradients">
 <meta name="assert" content="Rendering of conic-gradient with custom center parameter">
+<meta name="fuzzy" content="maxDifference=1;totalPixels=40000">
 <link rel="match" href="reference/200x200-blue-black-green-red.html">
 <style>
   #gradient {

--- a/css/css-images/conic-gradient-center.html
+++ b/css/css-images/conic-gradient-center.html
@@ -3,6 +3,7 @@
 <title>Conic gradient with custom center parameter</title>
 <link rel="help" href="https://drafts.csswg.org/css-images-4/#conic-gradients">
 <meta name="assert" content="Rendering of conic-gradient with custom center parameter">
+<meta name="fuzzy" content="maxDifference=1;totalPixels=40000">
 <link rel="match" href="conic-gradient-center-ref.html">
 <style>
   #gradient {

--- a/css/css-images/multiple-position-color-stop-conic.html
+++ b/css/css-images/multiple-position-color-stop-conic.html
@@ -2,6 +2,7 @@
 <title>Conic gradient with a two position color stop</title>
 <link rel="help" href="https://drafts.csswg.org/css-images-4/#color-stop-syntax">
 <meta name="assert" content="A color stop with two positions create a hard transition">
+<meta name="fuzzy" content="maxDifference=1;totalPixels=10000">
 <link rel="match" href="reference/100x100-blue-green.html">
 <style>
 #target {

--- a/css/css-images/normalization-conic-2.html
+++ b/css/css-images/normalization-conic-2.html
@@ -3,6 +3,7 @@
 <title>Conic gradient stop normalization</title>
 <link rel="help" href="https://drafts.csswg.org/css-images-4/#conic-gradients">
 <meta name="assert" content="Rendering of conic-gradient with normalized color stops">
+<meta name="fuzzy" content="maxDifference=1;totalPixels=10000">
 <link rel="match" href="reference/100x100-blue.html">
 <style>
   #gradient {

--- a/css/css-images/normalization-conic-degenerate.html
+++ b/css/css-images/normalization-conic-degenerate.html
@@ -3,6 +3,7 @@
 <title>Conic gradient stop normalization</title>
 <link rel="help" href="https://www.w3.org/TR/css-images-3/#repeating-gradients">
 <meta name="assert" content="Rendering of repeating-conic-gradient w/ stops at the same place">
+<meta name="fuzzy" content="maxDifference=1;totalPixels=10000">
 <link rel="match" href="reference/100x100-blue.html">
 <style>
   #gradient {

--- a/css/css-images/normalization-conic.html
+++ b/css/css-images/normalization-conic.html
@@ -3,6 +3,7 @@
 <title>Conic gradient stop normalization</title>
 <link rel="help" href="https://drafts.csswg.org/css-images-4/#conic-gradients">
 <meta name="assert" content="Rendering of conic-gradient with normalized color stops">
+<meta name="fuzzy" content="maxDifference=1;totalPixels=10000">
 <link rel="match" href="reference/100x100-blue.html">
 <style>
   #gradient {

--- a/css/css-images/out-of-range-color-stop-conic.html
+++ b/css/css-images/out-of-range-color-stop-conic.html
@@ -3,6 +3,7 @@
 <title>Conic gradient with out-of-range stops</title>
 <link rel="help" href="https://drafts.csswg.org/css-images-4/#conic-gradients">
 <meta name="assert" content="Rendering of conic-gradient with stops positioned outside of [0, 1]">
+<meta name="fuzzy" content="maxDifference=1;totalPixels=40000">
 <link rel="match" href="reference/200x200-blue-black-green-red.html">
 <style>
   #gradient {

--- a/css/css-images/tiled-conic-gradients.html
+++ b/css/css-images/tiled-conic-gradients.html
@@ -3,6 +3,7 @@
 <title>Checkerboard using conic gradients</title>
 <link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size">
 <meta name="assert" content="Gradients are correctly repeated.">
+<meta name="fuzzy" content="maxDifference=1;totalPixels=40000">
 <link rel="match" href="tiled-conic-gradients-ref.html">
 <style>
   #gradient {


### PR DESCRIPTION
There are 9 tests that fail in Safari:
https://wpt.fyi/results/css/css-images?label=master&label=stable&aligned&q=feature%3Aconic-gradients

These all fail with a maxDifference of 1, and varying number of total
pixels. To not overfit on Safari's current behavior, totalPixels was set
to the area of the test element, which is either 100x100 or 200x200.
