### PR TITLE
Fix runtime errors with MathML rendering-from-in-flow tests

### DIFF
--- a/mathml/presentation-markup/mpadded/mpadded-rendering-from-in-flow.html
+++ b/mathml/presentation-markup/mpadded/mpadded-rendering-from-in-flow.html
@@ -18,6 +18,7 @@
     </style>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
+    <script src="/mathml/support/layout-comparison.js"></script>
     <script>
       setup({ explicit_done: true });
       window.addEventListener("load", runTests);

--- a/mathml/presentation-markup/scripts/scripts-rendering-from-in-flow.html
+++ b/mathml/presentation-markup/scripts/scripts-rendering-from-in-flow.html
@@ -18,6 +18,7 @@
     </style>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
+    <script src="/mathml/support/layout-comparison.js"></script>
     <script>
       setup({ explicit_done: true });
       window.addEventListener("load", runTests);
@@ -27,7 +28,7 @@
         const epsilon = 1;
 
         for (let math of container.children) {
-          let tagName = el.id;
+          let tagName = math.id;
           let element = math.firstElementChild;
           let reference = element.nextElementSibling;
 

--- a/mathml/presentation-markup/tokens/tokens-rendering-from-in-flow.html
+++ b/mathml/presentation-markup/tokens/tokens-rendering-from-in-flow.html
@@ -20,6 +20,7 @@
     </style>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
+    <script src="/mathml/support/layout-comparison.js"></script>
     <script>
       setup({ explicit_done: true });
       window.addEventListener("load", runTests);
@@ -29,7 +30,7 @@
         const epsilon = 1;
 
         for (let math of container.children) {
-          let tagName = el.id;
+          let tagName = math.id;
           let element = math.firstElementChild;
           let reference = element.nextElementSibling;
 


### PR DESCRIPTION
Ensure that these tests collectively import the layout-comparison.js helper script and remove the remnants from an older version which causes them to error.

See: https://github.com/web-platform-tests/wpt/pull/47351#issuecomment-2270206857