### PR TITLE
Do not wait for events to be dispatched to IDBRequest

### DIFF
--- a/IndexedDB/ready-state-destroyed-execution-context.html
+++ b/IndexedDB/ready-state-destroyed-execution-context.html
@@ -21,11 +21,7 @@ promise_test(async t => {
     const openRequest = iframe.contentWindow.indexedDB.open(dbname);
     assert_equals(openRequest.readyState, 'pending');
     iframe.remove();
-    await new Promise(resolve => {
-      openRequest.onerror = resolve;
-      openRequest.onsuccess = resolve;
-    });
-    assert_equals(openRequest.readyState, 'done');
+    assert_equals(typeof openRequest.readyState, 'string');
 }, 'readyState accessor is valid after execution context is destroyed');
 
 </script>


### PR DESCRIPTION
The test expects event to be dispatched to IDBRequest after its execution context is stopped, but this is not standard behavior. WebKit and Blink can stop dispatching event as soon as iframe is detached (iframe.remove() is invoked),
which leads to test timeout. Since the goal of the test is to verify the accessor is still valid after execution context is destroyed (no exception is thrown), we can just check readyState without wait. 