### PR TITLE
Fix runtime errors with MathML tokens-rendering-from-in-flow test

### DIFF
--- a/mathml/presentation-markup/tokens/tokens-rendering-from-in-flow.html
+++ b/mathml/presentation-markup/tokens/tokens-rendering-from-in-flow.html
@@ -47,7 +47,7 @@
     <div id="log"></div>
     <div id="container">
       <math id="mo">
-        <mo><span class="box" style="background: lightblue"></span><span class="oof1 box"><span class="oof2 box"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span><span class="oof1 box"></span><span class="oof2 box"></span></mo>
+        <mo><span class="box" style="background: lightblue"></span><span class="oof1 box"></span><span class="oof2 box"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span><span class="oof1 box"></span><span class="oof2 box"></span></mo>
         <mo><span class="box" style="background: lightblue"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span></mo>
       </math>
 
@@ -56,14 +56,14 @@
         <mi><span class="box" style="background: lightblue"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span></mi>
       </math>
 
-      <math id="mi">
+      <math id="mn">
         <mn><span class="box" style="background: lightblue"></span><span class="oof1 box"></span><span class="oof2 box"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span><span class="oof1 box"></span><span class="oof2 box"></span></mn>
         <mn><span class="box" style="background: lightblue"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span></mn>
       </math>
 
-      <math id="mo">
-        <mo><span class="box" style="background: lightblue"></span><span class="oof1 box"></span><span class="oof2 box"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span><span class="oof1 box"></span><span class="oof2 box"></span></mo>
-        <mo><span class="box" style="background: lightblue"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span></mo>
+      <math id="ms">
+        <ms><span class="box" style="background: lightblue"></span><span class="oof1 box"></span><span class="oof2 box"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span><span class="oof1 box"></span><span class="oof2 box"></span></ms>
+        <ms><span class="box" style="background: lightblue"></span><span class="box" style="background: pink"></span><span class="box" style="background: yellow"></span></ms>
       </math>
 
       <math id="mtext">


### PR DESCRIPTION
There is a missing closing span tag which causes the test to error, and some of the test cases are incorrect, so fix those.