### PR TITLE
Add name from content tests for CSS text-transform:full-size-kana

### DIFF
--- a/accname/name/comp_name_from_content.html
+++ b/accname/name/comp_name_from_content.html
@@ -254,12 +254,6 @@
 <a href="#" data-expectedlabel="one two three" data-testname="link name from content for each child (no space, display:inline-block)" class="ex iblock"><span>one</span><span>two</span><span>three</span></a><br>
 <br>
 
-
-<!-- TODO: Add clarification to the Name from Content section of accname. -->
-<!--       If an element’s text node is transformed with CSS text-transform, -->
-<!--       what should be exposed to the a11y tree? The original text or the -->
-<!--       transformed text? These tests assume the *original* text. -->
-
 <h1 data-expectedlabel="Call us" data-testname="heading name from content with text-transform:none" class="ex" style="text-transform:none;">Call us</h1>
 <h1 data-expectedlabel="CALL US" data-testname="heading name from content with text-transform:uppercase" class="ex" style="text-transform:uppercase;">Call us</h1>
 <h1 data-expectedlabel="Call Us" data-testname="heading name from content with text-transform:capitalize" class="ex" style="text-transform:capitalize;">Call us</h1>

--- a/accname/name/comp_name_from_content.tentative.html
+++ b/accname/name/comp_name_from_content.tentative.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <title>Name Comp: Name From Content (Tentative)</title>
   <meta charset="utf-8">
@@ -36,6 +36,17 @@
   <!-- but it's picked up again (after the self-referencial image alt) in inverse order b/c of cross-referencial aria-labelledby edge case -->
   <img id="nested_image_label4" alt="image" aria-labelledby="nested_image_label4 crossref_link2" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 </h3>
+
+<h1>heading which visually transforms <span lang="ja">びょういん</span> (hospital) to <span lang="ja">びよういん</span> (beauty parlor) using CSS <code>text-transform:full-size-kana</code></h1>
+<h3 lang="ja" data-expectedlabel="びょういん" data-testname="heading name from content with text-transform:full-size-kana" class="ex" style="text-transform:full-size-kana;">びょういん</h3>
+
+<h1><code>ruby > rt</code> element which visually transforms <span lang="ja">りゅう</span> (dragon) to <span lang="ja">りゆう</span> (reason) using CSS <code>text-transform:full-size-kana</code></h1>
+<ruby lang="ja">
+  竜
+  <rp>(</rp>
+  <rt data-expectedlabel="りゅう" data-testname="ruby > rt name from content with text-transform:full-size-kana" class="ex" style="text-transform:full-size-kana;">りゅう</rt>
+  <rp>)</rp>
+</ruby>
 
 <script>
 AriaUtils.verifyLabelsBySelector(".ex");

--- a/accname/name/comp_name_from_content.tentative.html
+++ b/accname/name/comp_name_from_content.tentative.html
@@ -49,10 +49,14 @@
 <!-- “竜の背に乗る” means “Ride the dragon’s back” -->
 <!-- text-transform:full-size-kana visually changes the <rt> furigana for 竜 -->
 <!-- from りゅう (ryū = dragon) to りゆう (riyuu = reason) -->
+<!-- TODO: Restore this subtest when ruby’s accname computation and -->
+<!-- text-to-speech requirements are settled. -->
+<!--
 <h1>link containing a <code>ruby > rt</code> element which visually transforms <span lang="ja">りゅう</span> (dragon) to <span lang="ja">りゆう</span> (reason) using CSS <code>text-transform:full-size-kana</code></h1>
 <button lang="ja" data-expectedlabel="竜の背に乗る" data-testname="ruby > rt name from content with text-transform:full-size-kana" class="ex" >
   <ruby>竜<rp>(</rp><rt style="text-transform:full-size-kana;">りゅう</rt><rp>)</rp>の背<rp>(</rp><rt>せ</rt><rp>)</rp>に乗<rp>(</rp><rt>の</rt><rp>)</rp>る</ruby>
 </button>
+-->
 
 <script>
 AriaUtils.verifyLabelsBySelector(".ex");

--- a/accname/name/comp_name_from_content.tentative.html
+++ b/accname/name/comp_name_from_content.tentative.html
@@ -47,8 +47,9 @@
 <h3 lang="ja" data-expectedlabel="びょういんのかんじゃサービス" data-testname="heading name from content with text-transform:full-size-kana" class="ex" style="text-transform:full-size-kana;">びょういんのかんじゃサービス</h3>
 
 <!-- “竜の背に乗る” means “Ride the dragon’s back” -->
-<!-- text-transform:full-size-kana visually changes the <rt> furigana for 竜 -->
+<!-- text-transform:full-size-kana visually changes the furigana for 竜 -->
 <!-- from りゅう (ryū = dragon) to りゆう (riyuu = reason) -->
+<!-- but the computed accessibility label should retain the original meaning. -->
 <button lang="ja" data-expectedlabel="りゅう" data-testname="button with text-transform: full-size-kana on contents" class="ex" style="text-transform: full-size-kana;">りゅう</button>
 
 <script>

--- a/accname/name/comp_name_from_content.tentative.html
+++ b/accname/name/comp_name_from_content.tentative.html
@@ -37,7 +37,6 @@
   <img id="nested_image_label4" alt="image" aria-labelledby="nested_image_label4 crossref_link2" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 </h3>
 
-
 <!-- “びょういんのかんじゃサービス” means “Hospital patient services” -->
 <!-- text-transform:full-size-kana visually changes: -->
 <!--   1. びょういん (byōin = hospital) into びよういん (biyōin = beauty parlor) -->
@@ -45,12 +44,6 @@
 <!-- ...causing the whole heading to become nonsensical. -->
 <h1>heading which visually transforms <span lang="ja">びょういん</span> (hospital) to <span lang="ja">びよういん</span> (beauty parlor) using CSS <code>text-transform:full-size-kana</code></h1>
 <h3 lang="ja" data-expectedlabel="びょういんのかんじゃサービス" data-testname="heading name from content with text-transform:full-size-kana" class="ex" style="text-transform:full-size-kana;">びょういんのかんじゃサービス</h3>
-
-<!-- text-transform:full-size-kana visually changes -->
-<!-- りゅう (ryū = dragon) into りゆう (riyuu = reason) -->
-<!-- but the computed accessibility label should retain the original meaning. -->
-<h1>button which visually transforms <span lang="ja">りゅう</span> (dragon) to <span lang="ja">りゆう</span> (reason) using CSS <code>text-transform:full-size-kana</code></h1>
-<button lang="ja" data-expectedlabel="りゅう" data-testname="button with text-transform: full-size-kana on contents" class="ex" style="text-transform: full-size-kana;">りゅう</button>
 
 <script>
 AriaUtils.verifyLabelsBySelector(".ex");

--- a/accname/name/comp_name_from_content.tentative.html
+++ b/accname/name/comp_name_from_content.tentative.html
@@ -51,12 +51,7 @@
 <!-- from りゅう (ryū = dragon) to りゆう (riyuu = reason) -->
 <!-- TODO: Restore this subtest when ruby’s accname computation and -->
 <!-- text-to-speech requirements are settled. -->
-<!--
-<h1>link containing a <code>ruby > rt</code> element which visually transforms <span lang="ja">りゅう</span> (dragon) to <span lang="ja">りゆう</span> (reason) using CSS <code>text-transform:full-size-kana</code></h1>
-<button lang="ja" data-expectedlabel="竜の背に乗る" data-testname="ruby > rt name from content with text-transform:full-size-kana" class="ex" >
-  <ruby>竜<rp>(</rp><rt style="text-transform:full-size-kana;">りゅう</rt><rp>)</rp>の背<rp>(</rp><rt>せ</rt><rp>)</rp>に乗<rp>(</rp><rt>の</rt><rp>)</rp>る</ruby>
-</button>
--->
+<button lang="ja" data-expectedlabel="りゅう" data-testname="button with text-transform: full-size-kana on contents" class="ex" style="text-transform: full-size-kana;">りゅう</button>
 
 <script>
 AriaUtils.verifyLabelsBySelector(".ex");

--- a/accname/name/comp_name_from_content.tentative.html
+++ b/accname/name/comp_name_from_content.tentative.html
@@ -37,16 +37,22 @@
   <img id="nested_image_label4" alt="image" aria-labelledby="nested_image_label4 crossref_link2" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 </h3>
 
-<h1>heading which visually transforms <span lang="ja">びょういん</span> (hospital) to <span lang="ja">びよういん</span> (beauty parlor) using CSS <code>text-transform:full-size-kana</code></h1>
-<h3 lang="ja" data-expectedlabel="びょういん" data-testname="heading name from content with text-transform:full-size-kana" class="ex" style="text-transform:full-size-kana;">びょういん</h3>
 
-<h1><code>ruby > rt</code> element which visually transforms <span lang="ja">りゅう</span> (dragon) to <span lang="ja">りゆう</span> (reason) using CSS <code>text-transform:full-size-kana</code></h1>
-<ruby lang="ja">
-  竜
-  <rp>(</rp>
-  <rt data-expectedlabel="りゅう" data-testname="ruby > rt name from content with text-transform:full-size-kana" class="ex" style="text-transform:full-size-kana;">りゅう</rt>
-  <rp>)</rp>
-</ruby>
+<!-- びょういんのかんじゃサービス means “Hospital patient services -->
+<!-- text-transform:full-size-kana incorrectlys change: -->
+<!--   1. びょういん (byōin = hospital) into びよういん (biyōin = beauty parlor) -->
+<!--   2. かんじゃ (kanja = patient) into かんじや (kanjiya = [no meaning]) -->
+<!-- ...causing the whole heading to become nonsensical. -->
+<h1>heading which visually transforms <span lang="ja">びょういん</span> (hospital) to <span lang="ja">びよういん</span> (beauty parlor) using CSS <code>text-transform:full-size-kana</code></h1>
+<h3 lang="ja" data-expectedlabel="びょういんのかんじゃサービス" data-testname="heading name from content with text-transform:full-size-kana" class="ex" style="text-transform:full-size-kana;">びょういんのかんじゃサービス</h3>
+
+<!-- “竜の背に乗る” means “Ride the dragon’s back” -->
+<!-- text-transform:full-size-kana incorrectly changes the <rp> furigana: -->
+<!-- from りゅう (ryū = dragon) to りゆう (riyuu = reason) -->
+<h1>link containing a <code>ruby > rt</code> element which visually transforms <span lang="ja">りゅう</span> (dragon) to <span lang="ja">りゆう</span> (reason) using CSS <code>text-transform:full-size-kana</code></h1>
+<button lang="ja" data-expectedlabel="竜の背に乗る" data-testname="ruby > rt name from content with text-transform:full-size-kana" class="ex" >
+  <ruby>竜<rp>(</rp><rt style="text-transform:full-size-kana;">りゅう</rt><rp>)</rp>の背<rp>(</rp><rt>せ</rt><rp>)</rp>に乗<rp>(</rp><rt>の</rt><rp>)</rp>る</ruby>
+</button>
 
 <script>
 AriaUtils.verifyLabelsBySelector(".ex");

--- a/accname/name/comp_name_from_content.tentative.html
+++ b/accname/name/comp_name_from_content.tentative.html
@@ -38,8 +38,8 @@
 </h3>
 
 
-<!-- びょういんのかんじゃサービス means “Hospital patient services -->
-<!-- text-transform:full-size-kana incorrectlys change: -->
+<!-- “びょういんのかんじゃサービス” means “Hospital patient services” -->
+<!-- text-transform:full-size-kana incorrectly changes: -->
 <!--   1. びょういん (byōin = hospital) into びよういん (biyōin = beauty parlor) -->
 <!--   2. かんじゃ (kanja = patient) into かんじや (kanjiya = [no meaning]) -->
 <!-- ...causing the whole heading to become nonsensical. -->
@@ -47,7 +47,7 @@
 <h3 lang="ja" data-expectedlabel="びょういんのかんじゃサービス" data-testname="heading name from content with text-transform:full-size-kana" class="ex" style="text-transform:full-size-kana;">びょういんのかんじゃサービス</h3>
 
 <!-- “竜の背に乗る” means “Ride the dragon’s back” -->
-<!-- text-transform:full-size-kana incorrectly changes the <rp> furigana: -->
+<!-- text-transform:full-size-kana incorrectly changes 竜’s <rt> furigana: -->
 <!-- from りゅう (ryū = dragon) to りゆう (riyuu = reason) -->
 <h1>link containing a <code>ruby > rt</code> element which visually transforms <span lang="ja">りゅう</span> (dragon) to <span lang="ja">りゆう</span> (reason) using CSS <code>text-transform:full-size-kana</code></h1>
 <button lang="ja" data-expectedlabel="竜の背に乗る" data-testname="ruby > rt name from content with text-transform:full-size-kana" class="ex" >

--- a/accname/name/comp_name_from_content.tentative.html
+++ b/accname/name/comp_name_from_content.tentative.html
@@ -39,7 +39,7 @@
 
 
 <!-- “びょういんのかんじゃサービス” means “Hospital patient services” -->
-<!-- text-transform:full-size-kana incorrectly changes: -->
+<!-- text-transform:full-size-kana visually changes: -->
 <!--   1. びょういん (byōin = hospital) into びよういん (biyōin = beauty parlor) -->
 <!--   2. かんじゃ (kanja = patient) into かんじや (kanjiya = [no meaning]) -->
 <!-- ...causing the whole heading to become nonsensical. -->
@@ -47,7 +47,7 @@
 <h3 lang="ja" data-expectedlabel="びょういんのかんじゃサービス" data-testname="heading name from content with text-transform:full-size-kana" class="ex" style="text-transform:full-size-kana;">びょういんのかんじゃサービス</h3>
 
 <!-- “竜の背に乗る” means “Ride the dragon’s back” -->
-<!-- text-transform:full-size-kana incorrectly changes 竜’s <rt> furigana: -->
+<!-- text-transform:full-size-kana visually changes the <rt> furigana for 竜 -->
 <!-- from りゅう (ryū = dragon) to りゆう (riyuu = reason) -->
 <h1>link containing a <code>ruby > rt</code> element which visually transforms <span lang="ja">りゅう</span> (dragon) to <span lang="ja">りゆう</span> (reason) using CSS <code>text-transform:full-size-kana</code></h1>
 <button lang="ja" data-expectedlabel="竜の背に乗る" data-testname="ruby > rt name from content with text-transform:full-size-kana" class="ex" >

--- a/accname/name/comp_name_from_content.tentative.html
+++ b/accname/name/comp_name_from_content.tentative.html
@@ -49,8 +49,6 @@
 <!-- “竜の背に乗る” means “Ride the dragon’s back” -->
 <!-- text-transform:full-size-kana visually changes the <rt> furigana for 竜 -->
 <!-- from りゅう (ryū = dragon) to りゆう (riyuu = reason) -->
-<!-- TODO: Restore this subtest when ruby’s accname computation and -->
-<!-- text-to-speech requirements are settled. -->
 <button lang="ja" data-expectedlabel="りゅう" data-testname="button with text-transform: full-size-kana on contents" class="ex" style="text-transform: full-size-kana;">りゅう</button>
 
 <script>

--- a/accname/name/comp_name_from_content.tentative.html
+++ b/accname/name/comp_name_from_content.tentative.html
@@ -46,10 +46,10 @@
 <h1>heading which visually transforms <span lang="ja">びょういん</span> (hospital) to <span lang="ja">びよういん</span> (beauty parlor) using CSS <code>text-transform:full-size-kana</code></h1>
 <h3 lang="ja" data-expectedlabel="びょういんのかんじゃサービス" data-testname="heading name from content with text-transform:full-size-kana" class="ex" style="text-transform:full-size-kana;">びょういんのかんじゃサービス</h3>
 
-<!-- “竜の背に乗る” means “Ride the dragon’s back” -->
-<!-- text-transform:full-size-kana visually changes the furigana for 竜 -->
-<!-- from りゅう (ryū = dragon) to りゆう (riyuu = reason) -->
+<!-- text-transform:full-size-kana visually changes -->
+<!-- りゅう (ryū = dragon) into りゆう (riyuu = reason) -->
 <!-- but the computed accessibility label should retain the original meaning. -->
+<h1>button which visually transforms <span lang="ja">りゅう</span> (dragon) to <span lang="ja">りゆう</span> (reason) using CSS <code>text-transform:full-size-kana</code></h1>
 <button lang="ja" data-expectedlabel="りゅう" data-testname="button with text-transform: full-size-kana on contents" class="ex" style="text-transform: full-size-kana;">りゅう</button>
 
 <script>


### PR DESCRIPTION
Closes web-platform-tests/interop-accessibility#137.