### PR TITLE
[WebDriver BiDi] realmCreated emitted after session.subscribe

### DIFF
--- a/webdriver/tests/bidi/script/realm_created/realm_created.py
+++ b/webdriver/tests/bidi/script/realm_created/realm_created.py
@@ -21,7 +21,8 @@ async def test_unsubscribe(bidi_session):
     async def on_event(method, data):
         events.append(data)
 
-    remove_listener = bidi_session.add_event_listener(REALM_CREATED_EVENT, on_event)
+    remove_listener = bidi_session.add_event_listener(
+        REALM_CREATED_EVENT, on_event)
 
     await bidi_session.browsing_context.create(type_hint="tab")
 
@@ -39,11 +40,13 @@ async def test_create_context(bidi_session, subscribe_events, type_hint):
     async def on_event(method, data):
         events.append(data)
 
-    remove_listener = bidi_session.add_event_listener(REALM_CREATED_EVENT, on_event)
+    remove_listener = bidi_session.add_event_listener(
+        REALM_CREATED_EVENT, on_event)
 
     new_context = await bidi_session.browsing_context.create(type_hint=type_hint)
 
-    wait = AsyncPoll(bidi_session, message="Didn't receive realm created events")
+    wait = AsyncPoll(
+        bidi_session, message="Didn't receive realm created events")
     await wait.until(lambda _: len(events) >= 1)
 
     result = await bidi_session.script.get_realms(context=new_context["context"])
@@ -61,7 +64,8 @@ async def test_navigate(bidi_session, subscribe_events, inline, new_tab):
     async def on_event(method, data):
         events.append(data)
 
-    remove_listener = bidi_session.add_event_listener(REALM_CREATED_EVENT, on_event)
+    remove_listener = bidi_session.add_event_listener(
+        REALM_CREATED_EVENT, on_event)
 
     await bidi_session.browsing_context.navigate(
         context=new_tab["context"], url=inline("<div>foo</div>"), wait="complete"
@@ -86,7 +90,8 @@ async def test_reload(bidi_session, subscribe_events, new_tab, inline):
     async def on_event(method, data):
         events.append(data)
 
-    remove_listener = bidi_session.add_event_listener(REALM_CREATED_EVENT, on_event)
+    remove_listener = bidi_session.add_event_listener(
+        REALM_CREATED_EVENT, on_event)
 
     await bidi_session.browsing_context.reload(
         context=new_tab["context"], wait="complete"
@@ -135,7 +140,8 @@ async def test_iframe(bidi_session, subscribe_events, top_context, inline, domai
     async def on_event(method, data):
         events.append(data)
 
-    remove_listener = bidi_session.add_event_listener(REALM_CREATED_EVENT, on_event)
+    remove_listener = bidi_session.add_event_listener(
+        REALM_CREATED_EVENT, on_event)
 
     frame_url = inline("<div>foo</div>")
     url = inline(f"<iframe src='{frame_url}'></iframe>", domain=domain)
@@ -168,7 +174,8 @@ async def test_subscribe_to_one_context(
     async def on_event(method, data):
         events.append(data)
 
-    remove_listener = bidi_session.add_event_listener(REALM_CREATED_EVENT, on_event)
+    remove_listener = bidi_session.add_event_listener(
+        REALM_CREATED_EVENT, on_event)
 
     await bidi_session.browsing_context.navigate(
         context=top_context["context"], url=inline("<div>foo</div>"), wait="complete"
@@ -246,10 +253,12 @@ async def test_dedicated_worker(
             nonlocal window_realm
             window_realm = data
 
-    remove_listener = bidi_session.add_event_listener(REALM_CREATED_EVENT, on_event)
+    remove_listener = bidi_session.add_event_listener(
+        REALM_CREATED_EVENT, on_event)
 
     worker_url = inline("while(true){}", doctype="js")
-    url = inline(f"<script>const worker = new Worker('{worker_url}');</script>")
+    url = inline(
+        f"<script>const worker = new Worker('{worker_url}');</script>")
     await bidi_session.browsing_context.navigate(
         url=url, context=top_context["context"], wait="complete"
     )
@@ -291,7 +300,8 @@ async def test_shared_worker(
             nonlocal window_realm
             window_realm = data
 
-    remove_listener = bidi_session.add_event_listener(REALM_CREATED_EVENT, on_event)
+    remove_listener = bidi_session.add_event_listener(
+        REALM_CREATED_EVENT, on_event)
 
     worker_url = inline("while(true){}", doctype="js")
     url = inline(
@@ -339,7 +349,8 @@ async def test_service_worker(
             nonlocal window_realm
             window_realm = data
 
-    remove_listener = bidi_session.add_event_listener(REALM_CREATED_EVENT, on_event)
+    remove_listener = bidi_session.add_event_listener(
+        REALM_CREATED_EVENT, on_event)
 
     worker_url = inline("while(true){}", doctype="js")
     url = inline(
@@ -366,8 +377,9 @@ async def test_service_worker(
 
 
 @pytest.mark.parametrize("type_hint", ["tab", "window"])
-async def test_existing_context(bidi_session, wait_for_event, wait_for_future_safe, subscribe_events, test_origin, type_hint):
-    # See https://w3c.github.io/webdriver-bidi/#ref-for-remote-end-subscribe-steps%E2%91%A1.
+async def test_existing_realm(bidi_session, wait_for_event, wait_for_future_safe, subscribe_events, test_origin, type_hint):
+    # See https://w3c.github.io/webdriver-bidi/#event-script-realmCreated
+    # "The remote end subscribe steps with subscribe priority 2"
     top_level_context = await bidi_session.browsing_context.create(type_hint=type_hint)
 
     await bidi_session.browsing_context.navigate(

--- a/webdriver/tests/bidi/script/realm_created/realm_created.py
+++ b/webdriver/tests/bidi/script/realm_created/realm_created.py
@@ -1,3 +1,5 @@
+# META: timeout=long
+
 import pytest
 from tests.support.sync import AsyncPoll
 


### PR DESCRIPTION
As per the spec:
https://w3c.github.io/webdriver-bidi/#event-script-realmCreated:~:text=The%20remote%20end%20subscribe%20steps%20with%20subscribe%20priority%202%2C

