### PR TITLE
[css-flexbox] Improve sizing in column layout

### DIFF
--- a/css/css-flexbox/column-flex-child-with-max-width.html
+++ b/css/css-flexbox/column-flex-child-with-max-width.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Item in column flex container with max-width</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#flex-direction-property">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#flex-items">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#align-items-property">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="Contents of a flex item with max-width should be laid out within the decreased containing block.">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="width: 100px; height: 100px; background: red">
+  <div style="display: flex; flex-direction: column; width: 200px; height: 100px">
+    <div style="align-self: start; max-width: 100px">
+      <div style="display: flow-root; background: green">
+        <div style="float: left; width: 100px; height: 50px"></div>
+        <div style="float: left; width: 100px; height: 50px"></div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This patch implements intrinsic sizing for column flex containers.

It also removes inline_content_sizes() from FlexItemBox, in favour of outer_inline_content_sizes() from IndependentFormattingContext, which now accepts a new parameter to resolve automatic minimum sizes.

Also some fixes during the layout of flex items in a column layout.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#33022