### PR TITLE
Do not assert page is evicted from back forward cache

### DIFF
--- a/IndexedDB/back-forward-cache-open-connection.window.js
+++ b/IndexedDB/back-forward-cache-open-connection.window.js
@@ -15,21 +15,21 @@ promise_test(async t => {
   const rc1 = await rcHelper.addWindow(
       /*config=*/ null, /*options=*/ {features: 'noopener'});
 
-  await createIndexedDBForTesting(rc1, 'test_idb', 1);
+  const prefix = t.name + Math.random();
+  const dbname1 = prefix + "_1";
+  const dbname2 = prefix + "_2";
+  await waitUntilIndexedDBOpenForTesting(rc1, dbname1, 1);
   await assertBFCacheEligibility(rc1, /*shouldRestoreFromBFCache=*/ true);
 
   // The page is ensured to be eligible for BFCache even with open connection,
   // otherwise the previous assertion will fail with PRECONDITION_FAILED.
   // Now we can test if the versionchange event will evict the BFCache.
-  await createIndexedDBForTesting(rc1, 'test_idb_2', 1);
+  await waitUntilIndexedDBOpenForTesting(rc1, dbname2, 1);
 
   const rc2 = await rc1.navigateToNew();
   // Create an IndexedDB database with higher version.
-  await createIndexedDBForTesting(rc2, 'test_idb_2', 2);
-  await rc2.historyBack();
-  // The previous page receiving versionchange event should be evicted with the
-  // correct reason.
-  // `kIgnoreEventAndEvict` will be reported as "masked".
-  // See `NotRestoredReasonToReportString()`.
-  await assertNotRestoredFromBFCache(rc1, ['masked']);
+  // This will fire a version change event on existing connection with the
+  // same database name.  The new database will only be opened if the existing
+  // connection is closed on receiving the event.
+  await waitUntilIndexedDBOpenForTesting(rc2, dbname2, 2);
 });

--- a/IndexedDB/back-forward-cache-open-transaction.window.js
+++ b/IndexedDB/back-forward-cache-open-transaction.window.js
@@ -14,11 +14,12 @@ promise_test(async t => {
   const rc1 = await rcHelper.addWindow(
       /*config=*/ null, /*options=*/ {features: 'noopener'});
 
-  await rc1.executeScript(() => {
+  const dbname = t.name + Math.random();
+  await rc1.executeScript((dbname) => {
     return new Promise(resolve => {
       // Create an IndexedDB database and the object store named `store` as the
       // test scope for the transaction later on.
-      const db = indexedDB.open(/*name=*/ 'test_idb', /*version=*/ 1);
+      const db = indexedDB.open(/*name=*/ dbname, /*version=*/ 1);
       db.onupgradeneeded = () => {
         db.result.createObjectStore('store');
         addEventListener('pagehide', () => {
@@ -36,7 +37,7 @@ promise_test(async t => {
         resolve();
       };
     });
-  });
+  }, [dbname]);
 
   await assertBFCacheEligibility(rc1, /*shouldRestoreFromBFCache=*/ true);
 });

--- a/IndexedDB/resources/support.js
+++ b/IndexedDB/resources/support.js
@@ -226,3 +226,15 @@ async function createIndexedDBForTesting(rc, dbName, version) {
     }
   }, [dbName, version]);
 }
+
+// Create an IndexedDB by executing script on the given remote context
+// with |dbName| and |version|, and wait for the reuslt.
+async function waitUntilIndexedDBOpenForTesting(rc, dbName, version) {
+  await rc.executeScript(async (dbName, version) => {
+    await new Promise((resolve, reject) => {
+        let request = indexedDB.open(dbName, version);
+        request.onsuccess = resolve;
+        request.onerror = reject;
+    });
+  }, [dbName, version]);
+}


### PR DESCRIPTION
The test aims to verify that a page with open database connection can enter back forward cache, and new open database request from an active page does not get blocked by open connection of cached page. This is the behavior implemented in Chrome, Firefox and Safari. However, the test also asserts the cached page is removed from back forward cache. The eviction is unnecessary because request can be unblocked as long as the connection on cached page is closed. Currently Chrome and Firefox evict page from cache but Safari does not. Since this behavior is implementation-defined, we should drop the assertion from the test.

Also, update the tests to use different database names so they don't affect each other.