### PR TITLE
Fix css/css-view-transitions/view-transition-types-matches.html

### DIFF
--- a/css/css-view-transitions/view-transition-types-matches.html
+++ b/css/css-view-transitions/view-transition-types-matches.html
@@ -30,7 +30,7 @@ html:active-view-transition(foo) #negative4 { background: red; }
 html:active-view-transition-type(foo,) #negative5 { background: red; }
 html:active-view-transition-type() #negative6 { background: red; }
 html:active-view-transition-type(,) #negative7 { background: red; }
-html:has(:active-view-transition-type(bar)) #negative8 { background: green; }
+html:has(:active-view-transition-type(bar)) #negative8 { background: red; }
 
 .test {
   width: 100px;


### PR DESCRIPTION
One of the negative rules should make the square red if it matches (which is wrong). Instead the rule makes the square green instead.