### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=268743

### DIFF
--- a/html/dom/render-blocking/support/utils.js
+++ b/html/dom/render-blocking/support/utils.js
@@ -1,4 +1,5 @@
 function generateParserDelay(seconds = 1) {
+  seconds += (Math.random() / 10.0);
   document.write(`
     <script src="/loading/resources/dummy.js?pipe=trickle(d${seconds})"></script>
   `);


### PR DESCRIPTION
WebKit export from bug: [Document render-blocking with <link rel=expect>](https://bugs.webkit.org/show_bug.cgi?id=268743)