### PR TITLE
view-transition-types tests: make grid column width fixed at 100px

### DIFF
--- a/css/css-view-transitions/view-transition-types-matches-ref.html
+++ b/css/css-view-transitions/view-transition-types-matches-ref.html
@@ -11,7 +11,7 @@
 }
 #container {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, 100px);
   grid-gap: 10px;
 }
 body { background: lightpink; }

--- a/css/css-view-transitions/view-transition-types-matches.html
+++ b/css/css-view-transitions/view-transition-types-matches.html
@@ -54,7 +54,7 @@ html:has(:active-view-transition-type(bar)) #negative8 { background: green; }
 
 #container {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, 100px);
   grid-gap: 10px;
 }
 

--- a/css/css-view-transitions/view-transition-types-reserved-mutation.html
+++ b/css/css-view-transitions/view-transition-types-reserved-mutation.html
@@ -41,7 +41,7 @@
 
   #container {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(3, 100px);
     grid-gap: 10px;
   }
 

--- a/css/css-view-transitions/view-transition-types-reserved-ref.html
+++ b/css/css-view-transitions/view-transition-types-reserved-ref.html
@@ -11,7 +11,7 @@
 }
 #container {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, 100px);
   grid-gap: 10px;
 }
 body { background: lightpink; }

--- a/css/css-view-transitions/view-transition-types-reserved.html
+++ b/css/css-view-transitions/view-transition-types-reserved.html
@@ -22,7 +22,7 @@ html:active-view-transition-type(-ua-foo, -UA-foo) #negative2 { background: red;
 
 #container {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, 100px);
   grid-gap: 10px;
 }
 


### PR DESCRIPTION
The grid column width was 1fr, which caused issues in WebKit where the columns in the test case were rendered a few pixels off compared to the reference. Make the grid column width fixed at 100px so the columns would match up.