### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=278221

### DIFF
--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -1592,6 +1592,12 @@ const gCSSProperties2 = {
     types: [
     ]
   },
+  'view-transition-class': {
+    // https://drafts.csswg.org/css-view-transitions/#propdef-view-transition-name
+    types: [
+      { type: 'discrete', options: [ [ 'none', 'card scale-animation' ] ] },
+    ]
+  },
   'view-transition-name': {
     // https://drafts.csswg.org/css-view-transitions/#propdef-view-transition-name
     types: [


### PR DESCRIPTION
WebKit export from bug: [\[view-transitions\] Parse view-transition-class CSS property](https://bugs.webkit.org/show_bug.cgi?id=278221)