### PR TITLE
Fix race in WebXR WPT test setup

### DIFF
--- a/webxr/resources/webxr_util.js
+++ b/webxr/resources/webxr_util.js
@@ -161,19 +161,22 @@ function xr_session_promise_test(
         }));
   }
 
-  xr_promise_test(
-    name + ' - webgl',
-    runTest,
-    properties,
-    'webgl',
-    {alpha: false, antialias: false, ...glcontextProperties}
+  document.addEventListener('DOMContentLoaded', () => {
+    xr_promise_test(
+      name + ' - webgl',
+      runTest,
+      properties,
+      'webgl',
+      {alpha: false, antialias: false, ...glcontextProperties}
     );
-  xr_promise_test(
-    name + ' - webgl2',
-    runTest,
-    properties,
-    'webgl2',
-    {alpha: false, antialias: false, ...glcontextProperties});
+    xr_promise_test(
+      name + ' - webgl2',
+      runTest,
+      properties,
+      'webgl2',
+      {alpha: false, antialias: false, ...glcontextProperties}
+    );
+  });
 }
 
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The WebXR WPT tests use a `webxr_util.js` file that handles running the tests, part of which involves appending a canvas element to the document body. Many of the webxr test pages, however, are written without explicit body elements, which in turn can cause tests to error out early from document.body being null. Wrapping the calls to `xr_promise_test` inside a listener for DOMContentLoaded ensures that these tests will now run properly, regardless of explicit body element being present.

With this, Servo's WebXR WPT results should now fully reflect the actual state of its support for the various WebXR APIs, including the WebXR Test API.

Reviewed in servo/servo#33112