### PR TITLE
Make text-autospace-001 platform independent

### DIFF
--- a/css/css-text/text-autospace/text-autospace-001-ref.html
+++ b/css/css-text/text-autospace/text-autospace-001-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#text-autospace-property">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<style>
+.test {
+  font-family: Ahem;
+  font-size: 40px;
+}
+.no-autospace {
+  text-autospace: no-autospace;
+}
+.normal {
+  text-autospace: normal;
+}
+.spacing {
+  margin: 5px;
+}
+.spacing-left {
+  margin-left: 5px;
+}
+</style>
+<div id="container">
+  <div class="test no-autospace">国国<span class="spacing">XX</span>国</div>
+  <div class="test no-autospace">国。XX<span class="spacing-left">国</span></div>
+  <div dir="rtl" class="test no-autospace">国国<span class="spacing">XX</span>国</div>
+  <div dir="rtl" class="test no-autospace">国。XX<span class="spacing-left">国</span></div>
+</div>

--- a/css/css-text/text-autospace/text-autospace-001.html
+++ b/css/css-text/text-autospace/text-autospace-001.html
@@ -2,9 +2,7 @@
 <meta charset="utf-8">
 <link rel="help" href="https://drafts.csswg.org/css-text-4/#text-autospace-property">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="../support/get-char-advances.js"></script>
+<link rel="match" href="text-autospace-001-ref.html">
 <style>
 .test {
   font-family: Ahem;
@@ -13,37 +11,13 @@
 .no-autospace {
   text-autospace: no-autospace;
 }
+.normal {
+  text-autospace: normal;
+}
 </style>
 <div id="container">
-  <div class="test" expect="1,3">国国XX国</div>
-  <div class="test" expect="3">国。XX国</div>
-  <div dir="rtl" class="test" expect="1,3">国国XX国</div>
-  <div dir="rtl" class="test" expect="3">国。XX国</div>
-  <div class="test" expect="1,3"><span>国国11国</span></div>
+  <div class="test normal">国国XX国</div>
+  <div class="test normal">国。XX国</div>
+  <div dir="rtl" class="test normal">国国XX国</div>
+  <div dir="rtl" class="test normal">国。XX国</div>
 </div>
-<script>
-// Compute expected advances from advances without `text-autospace` and the
-// `expect` attribute.
-const container = document.getElementById('container');
-container.classList.add('no-autospace');
-const tests = [];
-for (const element of document.getElementsByClassName('test')) {
-  const em = parseFloat(getComputedStyle(element).fontSize);
-  const spacing = em / 8;
-  const advances = getCharAdvances(element);
-  const expect = element.getAttribute('expect').split(',').map(i => parseInt(i));
-  for (const i of expect) {
-    advances[i] += spacing;
-  }
-  tests.push({element: element, advances: advances});
-}
-
-// Apply `text-autospace` and compare the actual advances.
-container.classList.remove('no-autospace');
-for (const t of tests) {
-  const advances = getCharAdvances(t.element);
-  test(() => {
-    assert_array_equals(advances, t.advances);
-  })
-}
-</script>


### PR DESCRIPTION
The current test relies on Blink's implementation detail:
- Test considers that spacing is always added as a leading space to the glyph's advance, which will influence on the results we get while calculating the advances on the test.

We can make this a ref test such that it just matters that the added space is between the relevant adjacent glyphs. It won't matter if it is added as a trailing or leading space.