### PR TITLE
Take into account the intrinsic block size when computing the main size of a column flex container

### DIFF
--- a/css/css-flexbox/flex-one-sets-flex-basis-to-zero-px.html
+++ b/css/css-flexbox/flex-one-sets-flex-basis-to-zero-px.html
@@ -2,6 +2,7 @@
 <html>
 <title>CSS Flexbox: flex-basis with zero pixel</title>
 <link rel="help" href="https://drafts.csswg.org/css-flexbox/#flex-basis-property">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#intrinsic-main-sizes">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <link href="support/flexbox.css" rel="stylesheet">
 <meta name="assert" content="This test ensures that setting 'flex-basis' property to
@@ -10,18 +11,40 @@ and 'writing-mode' value works properly.">
 <style>
 .flexbox > div {
     font: 14px/1 Ahem;
+    min-width: 0;
+    min-height: 0;
+}
+
+.flex-zero {
+    flex: 0;
+}
+
+.flex-zero-one-zero-percent {
+    flex: 0 1 0%;
+}
+
+.flex-zero-one-zero-px {
+    flex: 0 1 0px;
+}
+
+.flex-half {
+    flex: 0.5;
+}
+
+.flex-half-one-zero-percent {
+    flex: 0.5 1 0%;
+}
+
+.flex-half-one-zero-px {
+    flex: 0.5 1 0px;
 }
 
 .flex-one-one-zero-percent {
     flex: 1 1 0%;
-    min-width: 0;
-    min-height: 0;
 }
 
 .flex-one-one-zero-px {
     flex: 1 1 0px;
-    min-width: 0;
-    min-height: 0;
 }
 
 .vertical {
@@ -34,6 +57,35 @@ and 'writing-mode' value works properly.">
 <body onload="document.fonts.ready.then(() => { checkLayout('.flexbox'); })">
 <div id=log></div>
 <div class="flexbox column">
+  <div class="flex-zero" data-expected-height="14">Flex item with flex: 0</div>
+</div>
+
+<div class="flexbox column">
+  <div class="flex-zero-one-zero-percent" data-expected-height="14">Flex item with flex: 0 1 0%</div>
+</div>
+
+<div class="flexbox column">
+  <div class="flex-zero-one-zero-px" data-expected-height="0">Flex item with flex: 0 1 0px</div>
+</div>
+
+<div class="flexbox column">
+  <div class="flex-half" data-expected-height="14">Flex item with flex: 0.5</div>
+</div>
+
+<div class="flexbox column">
+  <div class="flex-half-one-zero-percent" data-expected-height="14">Flex item with flex: 0.5 1 0%</div>
+</div>
+
+<!-- A flex-grow of 0 would size the container to the flex base size of the item (0px),
+     and a flex-grow of 1 would size it to the max-content contribution of the item (14px).
+     Therefore, a flew-grow of 0.5 sizes the container to the average, 7px.
+     And then the item grows to fill half of that, 3.5px.
+     Note that Gecko, Blink and WebKit use the flex-basis instead. -->
+<div class="flexbox column">
+  <div class="flex-half-one-zero-px" data-expected-height="4">Flex item with flex: 0.5 1 0px</div>
+</div>
+
+<div class="flexbox column">
   <div class="flex-one" data-expected-height="14">Flex item with flex: 1</div>
 </div>
 
@@ -41,8 +93,39 @@ and 'writing-mode' value works properly.">
   <div class="flex-one-one-zero-percent" data-expected-height="14">Flex item with flex: 1 1 0%</div>
 </div>
 
+<!-- flex-grow is >= 1, so the flex container is sized to the max-content contribution of the item.
+     Note that Gecko, Blink and WebKit use the flex-basis instead. -->
 <div class="flexbox column">
-  <div class="flex-one-one-zero-px" data-expected-height="0">Flex item with flex: 1 1 0px</div>
+  <div class="flex-one-one-zero-px" data-expected-height="14">Flex item with flex: 1 1 0px</div>
+</div>
+
+<div class="flexbox column vertical">
+  <div class="flex-zero" data-expected-width="14">Flex item with flex: 0</div>
+</div>
+
+<div class="flexbox column vertical">
+  <div class="flex-zero-one-zero-percent" data-expected-width="14">Flex item with flex: 0 1 0%</div>
+</div>
+
+<div class="flexbox column vertical">
+  <div class="flex-zero-one-zero-px" data-expected-width="0">Flex item with flex: 0 1 0px</div>
+</div>
+
+<div class="flexbox column vertical">
+  <div class="flex-half" data-expected-width="14">Flex item with flex: 0.5</div>
+</div>
+
+<div class="flexbox column vertical">
+  <div class="flex-half-one-zero-percent" data-expected-width="14">Flex item with flex: 0.5 1 0%</div>
+</div>
+
+<!-- A flex-grow of 0 would size the container to the flex base size of the item (0px),
+     and a flex-grow of 1 would size it to the max-content contribution of the item (14px).
+     Therefore, a flew-grow of 0.5 sizes the container to the average, 7px.
+     And then the item grows to fill half of that, 3.5px.
+     Note that Gecko, Blink and WebKit use the flex-basis instead. -->
+<div class="flexbox column vertical">
+  <div class="flex-half-one-zero-px" data-expected-width="4">Flex item with flex: 0.5 1 0px</div>
 </div>
 
 <div class="flexbox column vertical">
@@ -53,8 +136,10 @@ and 'writing-mode' value works properly.">
   <div class="flex-one-one-zero-percent" data-expected-width="14">Flex item with flex: 1 1 0%</div>
 </div>
 
+<!-- flex-grow is >= 1, so the flex container is sized to the max-content contribution of the item.
+     Note that Gecko, Blink and WebKit use the flex-basis instead. -->
 <div class="flexbox column vertical">
-  <div class="flex-one-one-zero-px" data-expected-width="0">Flex item with flex: 1 1 0px</div>
+  <div class="flex-one-one-zero-px" data-expected-width="14">Flex item with flex: 1 1 0px</div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
In particular, `main_content_sizes()` now works with columns.

`layout_for_block_content_size()` is now used for both intrinsic sizes and intrinsic contributions, a IntrinsicSizingMode parameter is added to choose the behavior.

Also, we consider the main size of a flex item as indefinite if its flex basis is indefinite and the flex container has an indefinite main size.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#33135