### PR TITLE
Emit win64 on 64bit Windows for chrome platform string

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -956,7 +956,7 @@ class Chrome(ChromeChromiumBase):
         of the Chrome for Testing downloads.
         """
         if self.platform in ("Linux", "Win"):
-            bits = "64" if uname.machine == "x86_64" else "32"
+            bits = "64" if uname.machine in ("x86_64", "AMD64") else "32"
         elif self.platform == "Mac":
             bits = "-arm64" if uname.machine == "arm64" else "-x64"
         else:

--- a/tools/wpt/tests/test_install.py
+++ b/tools/wpt/tests/test_install.py
@@ -43,7 +43,7 @@ def test_install_chrome():
     channel = "dev"
     dest = os.path.join(wpt.localpaths.repo_root, wpt.venv_dir(), "browsers", channel)
     if sys.platform == "win32":
-        chrome_path = os.path.join(dest, "chrome-win32")
+        chrome_path = os.path.join(dest, "chrome-win64")
     elif sys.platform == "darwin":
         chrome_path = os.path.join(dest, "chrome-mac-x64")
     else:


### PR DESCRIPTION
Skipping ARM64/aarch64 check as it seems it's not available yet.