### PR TITLE
Ensure versionchange event is not fired to a cached page

### DIFF
--- a/IndexedDB/back-forward-cache-open-connection.window.js
+++ b/IndexedDB/back-forward-cache-open-connection.window.js
@@ -1,4 +1,4 @@
-// META: title=Testing BFCache support for page with open IndexedDB connection, and eviction behavior when receiving versionchange event.
+// META: title=Testing BFCache support for page with open IndexedDB connection, and cached page will not block open request from active page.
 // META: script=/common/dispatcher/dispatcher.js
 // META: script=/common/utils.js
 // META: script=resources/support.js
@@ -18,18 +18,27 @@ promise_test(async t => {
   const prefix = t.name + Math.random();
   const dbname1 = prefix + "_1";
   const dbname2 = prefix + "_2";
+  // Ensure the page can enter back forward cache with open connection.
   await waitUntilIndexedDBOpenForTesting(rc1, dbname1, 1);
   await assertBFCacheEligibility(rc1, /*shouldRestoreFromBFCache=*/ true);
 
-  // The page is ensured to be eligible for BFCache even with open connection,
-  // otherwise the previous assertion will fail with PRECONDITION_FAILED.
-  // Now we can test if the versionchange event will evict the BFCache.
+  // Create a new database connection for testing.
   await waitUntilIndexedDBOpenForTesting(rc1, dbname2, 1);
 
+  // Navigate to a new page; the old page should be put in cache.
   const rc2 = await rc1.navigateToNew();
-  // Create an IndexedDB database with higher version.
-  // This will fire a version change event on existing connection with the
-  // same database name.  The new database will only be opened if the existing
-  // connection is closed on receiving the event.
+
+  // Opening a new database connection with higher version should succeed 
+  // because page with open connection is in cache. The open connection 
+  // should be closed to unblock requests from active page.
   await waitUntilIndexedDBOpenForTesting(rc2, dbname2, 2);
+
+  // Navigate back to old page and ensure versionchange event is
+  // not fired because versionchange event handler is not
+  // expected to run after database version has been upgraded.
+  await rc2.historyBack();
+  assert_false(await rc1.executeScript(() => {
+    // This should be unset or false.
+    return !!window.versionChangedEventFired;
+  }));
 });


### PR DESCRIPTION
If an open IndexedDB connection on a cached page blocks requests from an active page, the connection should be closed automatically to unblock the requests. In this case, we don't want to queue versionchange event to the connection on the cached page, because when the cached page is resumed and handles the event, the handler may suggest the database version has not changed, while the database version may already be changed by requests from active page.