### PR TITLE
Revert invalid computedlabel test for unrendered element.

### DIFF
--- a/accname/name/comp_label.html
+++ b/accname/name/comp_label.html
@@ -179,12 +179,6 @@ x
   x
 </button>
 
-<span style="display: none">
-<button data-expectedlabel="" data-testname="Hidden button's label should be the empty string" class="ex">
-x
-</button>
-</span>
-
 <!-- Step 2B: LabelledBy supercedes 2D: AriaLabel, also see wpt/accname/name/comp_labelledby.html -->
 <a href="#" aria-labelledby="span7" aria-label="foo" data-expectedlabel="label" data-testname="link's aria-labelledby name supercedes aria-label" class="ex">x</a>
 <span id="span7">label</span>


### PR DESCRIPTION
This reverts commit 2a5fc85b0613ad24f9b98dea72f9494a9a1ae9f5.

Closes https://github.com/web-platform-tests/interop-accessibility/issues/141