### PR TITLE
Specify cwd when getting chrome version and running webdriver.

### DIFF
--- a/tools/wpt/utils.py
+++ b/tools/wpt/utils.py
@@ -24,7 +24,11 @@ def call(*args):
     """
     logger.debug(" ".join(args))
     try:
-        return subprocess.check_output(args).decode('utf8')
+        # Since the ELF interpreter path of the webdriver binary may be
+        # relative, we need to use `cwd` to specify the same directory
+        # of the binary.
+        return subprocess.check_output(args, cwd=os.path.dirname(
+            args[0])).decode('utf8')
     except subprocess.CalledProcessError as e:
         logger.critical("%s exited with return code %i" %
                         (e.cmd, e.returncode))

--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -356,6 +356,10 @@ class WebDriverBrowser(Browser):
         self._proc = mozprocess.ProcessHandler(
             cmd,
             processOutputLine=self._output_handler,
+            # Since the ELF interpreter path of the webdriver binary may be
+            # relative, we need to use `cwd` to specify the same directory
+            # of the binary.
+            cwd=os.path.dirname(cmd[0]),
             env=self.env,
             storeOutput=False)
 


### PR DESCRIPTION
The webdriver binary's elf interpreter's path may be relative. In the case, if the current working directory is different from the binary's, exec system call will fail because of ENOENT (No such file or directory).
To avoid the issue, specify cwd=os.path.dirname(the binary's path) when calling subprocess.
(The chromium issue is crbug/360008882)
