### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=277842

### DIFF
--- a/css/css-backgrounds/parsing/background-clip-computed.html
+++ b/css/css-backgrounds/parsing/background-clip-computed.html
@@ -15,9 +15,10 @@
 test_computed_value("background-clip", "border-box");
 test_computed_value("background-clip", "padding-box");
 test_computed_value("background-clip", "content-box");
+test_computed_value("background-clip", "border-area");
 
 // See background-computed.html for a test with multiple background images.
-test_computed_value("background-clip", "border-box, padding-box, content-box", "border-box");
+test_computed_value("background-clip", "border-box, padding-box, content-box, border-area", "border-box");
 </script>
 </body>
 </html>

--- a/css/css-backgrounds/parsing/background-clip-invalid.html
+++ b/css/css-backgrounds/parsing/background-clip-invalid.html
@@ -16,6 +16,7 @@ test_invalid_value("background-clip", "fill-box");
 test_invalid_value("background-clip", "margin-box");
 test_invalid_value("background-clip", "stroke-box");
 test_invalid_value("background-clip", "view-box");
+test_invalid_value("background-clip", "border");
 </script>
 </body>
 </html>

--- a/css/css-backgrounds/parsing/background-clip-valid.html
+++ b/css/css-backgrounds/parsing/background-clip-valid.html
@@ -15,8 +15,9 @@
 test_valid_value("background-clip", "border-box");
 test_valid_value("background-clip", "padding-box");
 test_valid_value("background-clip", "content-box");
+test_valid_value("background-clip", "border-area");
 
-test_valid_value("background-clip", "border-box, padding-box, content-box");
+test_valid_value("background-clip", "border-box, padding-box, content-box, border-area");
 </script>
 </body>
 </html>

--- a/css/css-backgrounds/parsing/background-computed.html
+++ b/css/css-backgrounds/parsing/background-computed.html
@@ -27,6 +27,8 @@ test_computed_value("background-clip", "border-box", "border-box, border-box, bo
 test_computed_value("background-clip", "content-box, border-box", "content-box, border-box, content-box");
 test_computed_value("background-clip", "border-box, padding-box, content-box");
 test_computed_value("background-clip", "content-box, border-box, padding-box, content-box", "content-box, border-box, padding-box");
+test_computed_value("background-clip", "content-box, border-box, padding-box", "content-box, border-box, padding-box");
+test_computed_value("background-clip", "content-box, border-box, border-area", "content-box, border-box, border-area");
 
 // background-color always computes as a single color.
 test_computed_value("background-color", "rgb(255, 0, 0)");


### PR DESCRIPTION
WebKit export from bug: [Add parsing support for `background-clip: border-area`](https://bugs.webkit.org/show_bug.cgi?id=277842)