### PR TITLE
Use outline-offset instead of letter-spacing in hypot-pow-sqrt-invalid.html

### DIFF
--- a/css/css-values/hypot-pow-sqrt-invalid.html
+++ b/css/css-values/hypot-pow-sqrt-invalid.html
@@ -11,8 +11,8 @@ function test_invalid_number(value) {
   test_invalid_value('opacity', value);
 }
 function test_invalid_length(value) {
-  // 'letter-spacing' accepts <length> only, not <percentage> or any mixes.
-  test_invalid_value('letter-spacing', value);
+  // 'outline-offset' accepts <length> only, not <percentage> or any mixes.
+  test_invalid_value('outline-offset', value);
 }
 
 // Syntax checking
@@ -54,7 +54,6 @@ test_invalid_number('pow(1, , 2)');
 test_invalid_length('calc(1px * pow(1))');
 test_invalid_length('calc(1px * pow(2px, 3px))');
 test_invalid_length('calc(sqrt(100px)');
-test_invalid_length('hypot(2px, 40%)');
 test_invalid_length('hypot(2px, 3)');
 test_invalid_length('hypot(3, ,4)');
 test_invalid_length('hypot(1, 2)');

--- a/css/css-values/hypot-pow-sqrt-serialize.html
+++ b/css/css-values/hypot-pow-sqrt-serialize.html
@@ -40,4 +40,7 @@ test_serialization(
     'calc(sqrt(1) - 1)',
     'calc(0)',
     '0');
+
+test_specified_serialization('letter-spacing', 'hypot(2px, 40%)', 'hypot(2px, 40%)');
+test_computed_serialization('letter-spacing', 'hypot(2px, 40%)', 'hypot(2px, 40%)');
 </script>

--- a/css/css-values/hypot-pow-sqrt-serialize.html
+++ b/css/css-values/hypot-pow-sqrt-serialize.html
@@ -42,5 +42,4 @@ test_serialization(
     '0');
 
 test_specified_serialization('letter-spacing', 'hypot(2px, 40%)', 'hypot(2px, 40%)');
-test_computed_serialization('letter-spacing', 'hypot(2px, 40%)', 'hypot(2px, 40%)');
 </script>


### PR DESCRIPTION
`test_invalid_length('hypot(2px, 40%)');` fails in latest WebKit because the test assumes `letter-spacing` can't take in a percentage.