### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=277910

### DIFF
--- a/css/css-backgrounds/background-clip/clip-border-area-background-geometry-ref.html
+++ b/css/css-backgrounds/background-clip/clip-border-area-background-geometry-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .test {
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px solid transparent;
+        background-image: url(../resources/stripes-100.png);
+        background-size: 100px 100px;
+        background-position: 15px 20px;
+    }
+
+    .test > div {
+        width: 100%;
+        height: 100%;
+        background-color: white;
+    }
+</style>
+</head>
+<body>
+
+<div class="test"><div></div></div>
+
+</body>
+</html>

--- a/css/css-backgrounds/background-clip/clip-border-area-background-geometry.html
+++ b/css/css-backgrounds/background-clip/clip-border-area-background-geometry.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Backgrounds Test:  background-clip:border-area</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#background-clip" >
+<link rel="match" href="clip-border-area-background-geometry-ref.html">
+<meta name="assert" content="The border-area fill respects background i geometry">
+<style>
+    .test {
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px solid transparent;
+        background-clip: border-area;
+        background-image: url(../resources/stripes-100.png);
+        background-size: 100px 100px;
+        background-position: 15px 20px;
+    }
+</style>
+</head>
+<body>
+
+<div class="test"></div>
+
+</body>
+</html>

--- a/css/css-backgrounds/background-clip/clip-border-area-border-image-ref.html
+++ b/css/css-backgrounds/background-clip/clip-border-area-border-image-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .test {
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px solid transparent;
+        background-image: url(../resources/green-100.png);
+        background-size: 100px 100px;
+        background-position: 15px 20px;
+        border-image: url(../resources/stripes-100.png);
+    }
+    .test > div {
+        width: 100%;
+        height: 100%;
+        background-color: white;
+    }
+</style>
+</head>
+<body>
+
+<div class="test"><div></div></div>
+
+</body>
+</html>

--- a/css/css-backgrounds/background-clip/clip-border-area-border-image.html
+++ b/css/css-backgrounds/background-clip/clip-border-area-border-image.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Backgrounds Test:  background-clip:border-area</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#background-clip" >
+<link rel="match" href="clip-border-area-border-image-ref.html">
+<meta name="assert" content="The border-area fill respects background i geometry">
+<style>
+    .test {
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px solid transparent;
+        background-clip: border-area;
+        background-image: url(../resources/green-100.png);
+        background-size: 100px 100px;
+        background-position: 15px 20px;
+        border-image: url(../resources/stripes-100.png);
+    }
+</style>
+</head>
+<body>
+
+<div class="test"></div>
+
+</body>
+</html>

--- a/css/css-backgrounds/background-clip/clip-border-area-border-on-top-ref.html
+++ b/css/css-backgrounds/background-clip/clip-border-area-border-on-top-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .test {
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px solid rgba(0, 128, 0, 0.75);
+        background-image: url(../resources/green-100.png);
+    }
+
+    .test > div {
+        width: 100%;
+        height: 100%;
+        background-color: orange;
+    }
+</style>
+</head>
+<body>
+<div class="test"><div></div></div>
+</body>
+</html>

--- a/css/css-backgrounds/background-clip/clip-border-area-border-on-top.html
+++ b/css/css-backgrounds/background-clip/clip-border-area-border-on-top.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Backgrounds Test:  background-clip:border-area</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#background-clip">
+<link rel="match" href="clip-border-area-border-on-top-ref.html">
+<meta name="assert" content="A non-transparent border is painted on top of the filled border-area">
+<style>
+    .test {
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px solid rgba(0, 128, 0, 0.75);
+        background-clip: border-area, border-box;
+        background-color: orange;
+        background-image: url(../resources/green-100.png), none;
+    }
+</style>
+</head>
+<body>
+<div class="test"></div>
+</body>
+</html>

--- a/css/css-backgrounds/background-clip/clip-border-area-multiple-backgrounds-ref.html
+++ b/css/css-backgrounds/background-clip/clip-border-area-multiple-backgrounds-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .test {
+        display: inline-block;
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px dotted blue;
+        background-clip: border-box;
+        background-color: red;
+        background-image: url(../resources/green-100.png);
+    }
+</style>
+</head>
+<body>
+
+<div class="test"></div>
+
+</body>
+</html>

--- a/css/css-backgrounds/background-clip/clip-border-area-multiple-backgrounds.html
+++ b/css/css-backgrounds/background-clip/clip-border-area-multiple-backgrounds.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Backgrounds Test:  background-clip:border-area</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#background-clip">
+<link rel="match" href="clip-border-area-multiple-backgrounds-ref.html">
+<meta name="assert" content="Multiple backgrounds, some using border-area, are layered correctly.">
+<style>
+    .test {
+        display: inline-block;
+        margin: 20px;
+        width: 300px;
+        height: 200px;
+        box-sizing: border-box;
+        border: 50px dotted transparent;
+        background-clip: border-area, border-box, content-box;
+        background-color: red;
+        background-image: url(../resources/blue-100.png), url(../resources/green-100.png), none;
+    }
+</style>
+</head>
+<body>
+
+<div class="test"></div>
+
+</body>
+</html>

--- a/css/css-backgrounds/background-clip/clip-border-area-ref.html
+++ b/css/css-backgrounds/background-clip/clip-border-area-ref.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .test {
+        display: inline-block;
+        margin: 20px;
+        width: 300px;
+        height: 150px;
+        box-sizing: border-box;
+        border: 50px solid blue;
+    }
+
+    .rounded {
+        border-radius: 40%;
+    }
+
+    .missing-border {
+        border-right-style: hidden;
+    }
+
+    .double {
+        border-style: double;
+    }
+
+    .inset {
+        border-style: solid;
+    }
+
+    .complex {
+        border-right-style: double;
+        border-bottom-style: dashed;
+        border-left-style: dotted;
+    }
+</style>
+</head>
+<body>
+
+<div class="test"></div>
+<div class="test rounded"></div>
+<div class="test missing-border"></div>
+<div class="test double"></div>
+<div class="test inset"></div>
+<div class="test complex"></div>
+
+</body>
+</html>

--- a/css/css-backgrounds/background-clip/clip-border-area.html
+++ b/css/css-backgrounds/background-clip/clip-border-area.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Backgrounds Test:  background-clip:border-area</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#background-clip">
+<link rel="match" href="clip-border-area-ref.html">
+<meta name="assert" content="border-area: The border area is filled with the background image">
+<meta name="fuzzy" content="maxDifference=0-130; totalPixels=0-1100">
+<style>
+    .test {
+        display: inline-block;
+        margin: 20px;
+        width: 300px;
+        height: 150px;
+        box-sizing: border-box;
+        border: 50px solid transparent;
+        background-clip: border-area;
+        background-image: url(../resources/blue-100.png);
+    }
+
+    .rounded {
+        border-radius: 40%;
+    }
+
+    .missing-border {
+        border-right-style: hidden;
+    }
+
+    .double {
+        border-style: double;
+    }
+
+    .inset {
+        border-style: inset;
+    }
+
+    .complex {
+        border-right-style: double;
+        border-bottom-style: dashed;
+        border-left-style: dotted;
+    }
+</style>
+</head>
+<body>
+
+<div class="test"></div>
+<div class="test rounded"></div>
+<div class="test missing-border"></div>
+<div class="test double"></div>
+<div class="test inset"></div>
+<div class="test complex"></div>
+
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [Implement rendering for `background-clip: border-area` and flip to preview](https://bugs.webkit.org/show_bug.cgi?id=277910)