### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=179334

### DIFF
--- a/css/css-backgrounds/background-clip/clip-text-text-decorations-ref.html
+++ b/css/css-backgrounds/background-clip/clip-text-text-decorations-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+    .test {
+        line-height: 2em;
+        font-size: 40px;
+        color: green;
+        text-decoration-thickness: 20px;
+    }
+</style>
+<body>
+    <div class="test" style="text-decoration: underline">AAAA</div>
+    <div class="test" style="text-decoration: line-through">AAAA</div>
+    <div class="test" style="text-decoration: overline">AAAA</div>
+</body>

--- a/css/css-backgrounds/background-clip/clip-text-text-decorations.html
+++ b/css/css-backgrounds/background-clip/clip-text-text-decorations.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>background-clip: text shows text decorations</title>
+<link rel="match" href="clip-rounded-corner-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#corner-clipping">
+<style>
+    .test {
+        line-height: 2em;
+        font-size: 40px;
+        color: transparent;
+        background-color: green;
+        background-clip: text;
+        text-decoration-thickness: 20px;
+    }
+</style>
+<body>
+    <div class="test" style="text-decoration: underline">AAAA</div>
+    <div class="test" style="text-decoration: line-through">AAAA</div>
+    <div class="test" style="text-decoration: overline">AAAA</div>
+</body>


### PR DESCRIPTION
WebKit export from bug: [background-clip: text fails to paint text decorations](https://bugs.webkit.org/show_bug.cgi?id=179334)