### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=278143

### DIFF
--- a/css/css-masking/clip-path/clip-path-xywh-003.html
+++ b/css/css-masking/clip-path/clip-path-xywh-003.html
@@ -4,7 +4,7 @@
   <title>CSS Masking: Test clip-path property and xywh function</title>
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-xywh">
   <link rel="match" href="reference/clip-path-xywh-003-ref.html">
-  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-32">
+  <meta name=fuzzy content="maxDifference=0-62;totalPixels=0-250">
   <meta name="assert" content="The clip-path property takes the basic shape
 	'xywh()' for clipping. On pass you should see a green rect with round.">
 </head>


### PR DESCRIPTION
WebKit export from bug: [Mark some more xywh() tests as passing](https://bugs.webkit.org/show_bug.cgi?id=278143)