### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=277709

### DIFF
--- a/css/css-masking/animations/clip-path-interpolation-shape.html
+++ b/css/css-masking/animations/clip-path-interpolation-shape.html
@@ -97,50 +97,50 @@ test_interpolation({
 
 test_interpolation({
   property: 'clip-path',
-  from: 'shape(from 5% 5px, curve to 10% 10px via 0% 80px, curve to 30% 20px via 20% 50px 25% 70px)',
-  to: 'shape(from 15% 15px, curve to 20% 0px via 10% 60px, curve to 20% 30px via 30% 40px -5% 100px)',
+  from: 'shape(from 5% 5px, curve to 10% 10px using 0% 80px, curve to 30% 20px using 20% 50px 25% 70px)',
+  to: 'shape(from 15% 15px, curve to 20% 0px using 10% 60px, curve to 20% 30px using 30% 40px -5% 100px)',
 }, [
-  {at: -0.3, expect: 'shape(from 2% 2px, curve to 7% 13px via -3% 86px, curve to 33% 17px via 17% 53px 34% 61px)'},
-  {at: 0, expect: 'shape(from 5% 5px, curve to 10% 10px via 0% 80px, curve to 30% 20px via 20% 50px 25% 70px)'},
-  {at: 0.5, expect: 'shape(from 10% 10px, curve to 15% 5px via 5% 70px, curve to 25% 25px via 25% 45px 10% 85px)'},
-  {at: 1, expect: 'shape(from 15% 15px, curve to 20% 0px via 10% 60px, curve to 20% 30px via 30% 40px -5% 100px)'},
-  {at: 1.5, expect: 'shape(from 20% 20px, curve to 25% -5px via 15% 50px, curve to 15% 35px via 35% 35px -20% 115px)'},
+  {at: -0.3, expect: 'shape(from 2% 2px, curve to 7% 13px using -3% 86px, curve to 33% 17px using 17% 53px 34% 61px)'},
+  {at: 0, expect: 'shape(from 5% 5px, curve to 10% 10px using 0% 80px, curve to 30% 20px using 20% 50px 25% 70px)'},
+  {at: 0.5, expect: 'shape(from 10% 10px, curve to 15% 5px using 5% 70px, curve to 25% 25px using 25% 45px 10% 85px)'},
+  {at: 1, expect: 'shape(from 15% 15px, curve to 20% 0px using 10% 60px, curve to 20% 30px using 30% 40px -5% 100px)'},
+  {at: 1.5, expect: 'shape(from 20% 20px, curve to 25% -5px using 15% 50px, curve to 15% 35px using 35% 35px -20% 115px)'},
 ]);
 
 test_interpolation({
   property: 'clip-path',
-  from: 'shape(from 5% 5px, curve by 10% 10px via 0% 80px, curve by 30% 20px via 20% 50px 25% 70px)',
-  to: 'shape(from 15% 15px, curve by 20% 0px via 10% 60px, curve by 20% 30px via 30% 40px -5% 100px)',
+  from: 'shape(from 5% 5px, curve by 10% 10px using 0% 80px, curve by 30% 20px using 20% 50px 25% 70px)',
+  to: 'shape(from 15% 15px, curve by 20% 0px using 10% 60px, curve by 20% 30px using 30% 40px -5% 100px)',
 }, [
-  {at: -0.3, expect: 'shape(from 2% 2px, curve by 7% 13px via -3% 86px, curve by 33% 17px via 17% 53px 34% 61px)'},
-  {at: 0, expect: 'shape(from 5% 5px, curve by 10% 10px via 0% 80px, curve by 30% 20px via 20% 50px 25% 70px)'},
-  {at: 0.5, expect: 'shape(from 10% 10px, curve by 15% 5px via 5% 70px, curve by 25% 25px via 25% 45px 10% 85px)'},
-  {at: 1, expect: 'shape(from 15% 15px, curve by 20% 0px via 10% 60px, curve by 20% 30px via 30% 40px -5% 100px)'},
-  {at: 1.5, expect: 'shape(from 20% 20px, curve by 25% -5px via 15% 50px, curve by 15% 35px via 35% 35px -20% 115px)'},
+  {at: -0.3, expect: 'shape(from 2% 2px, curve by 7% 13px using -3% 86px, curve by 33% 17px using 17% 53px 34% 61px)'},
+  {at: 0, expect: 'shape(from 5% 5px, curve by 10% 10px using 0% 80px, curve by 30% 20px using 20% 50px 25% 70px)'},
+  {at: 0.5, expect: 'shape(from 10% 10px, curve by 15% 5px using 5% 70px, curve by 25% 25px using 25% 45px 10% 85px)'},
+  {at: 1, expect: 'shape(from 15% 15px, curve by 20% 0px using 10% 60px, curve by 20% 30px using 30% 40px -5% 100px)'},
+  {at: 1.5, expect: 'shape(from 20% 20px, curve by 25% -5px using 15% 50px, curve by 15% 35px using 35% 35px -20% 115px)'},
 ]);
 
 test_interpolation({
   property: 'clip-path',
-  from: 'shape(from 5% 5px, smooth to 10% 10px via 0% 80px, smooth to 30% 20px)',
-  to: 'shape(from 15% 15px, smooth to 20% 0px via 10% 60px, smooth to 20% 30px)',
+  from: 'shape(from 5% 5px, smooth to 10% 10px using 0% 80px, smooth to 30% 20px)',
+  to: 'shape(from 15% 15px, smooth to 20% 0px using 10% 60px, smooth to 20% 30px)',
 }, [
-  {at: -0.3, expect: 'shape(from 2% 2px, smooth to 7% 13px via -3% 86px, smooth to 33% 17px)'},
-  {at: 0, expect: 'shape(from 5% 5px, smooth to 10% 10px via 0% 80px, smooth to 30% 20px)'},
-  {at: 0.5, expect: 'shape(from 10% 10px, smooth to 15% 5px via 5% 70px, smooth to 25% 25px)'},
-  {at: 1, expect: 'shape(from 15% 15px, smooth to 20% 0px via 10% 60px, smooth to 20% 30px)'},
-  {at: 1.5, expect: 'shape(from 20% 20px, smooth to 25% -5px via 15% 50px, smooth to 15% 35px)'},
+  {at: -0.3, expect: 'shape(from 2% 2px, smooth to 7% 13px using -3% 86px, smooth to 33% 17px)'},
+  {at: 0, expect: 'shape(from 5% 5px, smooth to 10% 10px using 0% 80px, smooth to 30% 20px)'},
+  {at: 0.5, expect: 'shape(from 10% 10px, smooth to 15% 5px using 5% 70px, smooth to 25% 25px)'},
+  {at: 1, expect: 'shape(from 15% 15px, smooth to 20% 0px using 10% 60px, smooth to 20% 30px)'},
+  {at: 1.5, expect: 'shape(from 20% 20px, smooth to 25% -5px using 15% 50px, smooth to 15% 35px)'},
 ]);
 
 test_interpolation({
   property: 'clip-path',
-  from: 'shape(from 5% 5px, smooth by 10% 10px via 0% 80px, smooth by 30% 20px)',
-  to: 'shape(from 15% 15px, smooth by 20% 0px via 10% 60px, smooth by 20% 30px)',
+  from: 'shape(from 5% 5px, smooth by 10% 10px using 0% 80px, smooth by 30% 20px)',
+  to: 'shape(from 15% 15px, smooth by 20% 0px using 10% 60px, smooth by 20% 30px)',
 }, [
-  {at: -0.3, expect: 'shape(from 2% 2px, smooth by 7% 13px via -3% 86px, smooth by 33% 17px)'},
-  {at: 0, expect: 'shape(from 5% 5px, smooth by 10% 10px via 0% 80px, smooth by 30% 20px)'},
-  {at: 0.5, expect: 'shape(from 10% 10px, smooth by 15% 5px via 5% 70px, smooth by 25% 25px)'},
-  {at: 1, expect: 'shape(from 15% 15px, smooth by 20% 0px via 10% 60px, smooth by 20% 30px)'},
-  {at: 1.5, expect: 'shape(from 20% 20px, smooth by 25% -5px via 15% 50px, smooth by 15% 35px)'},
+  {at: -0.3, expect: 'shape(from 2% 2px, smooth by 7% 13px using -3% 86px, smooth by 33% 17px)'},
+  {at: 0, expect: 'shape(from 5% 5px, smooth by 10% 10px using 0% 80px, smooth by 30% 20px)'},
+  {at: 0.5, expect: 'shape(from 10% 10px, smooth by 15% 5px using 5% 70px, smooth by 25% 25px)'},
+  {at: 1, expect: 'shape(from 15% 15px, smooth by 20% 0px using 10% 60px, smooth by 20% 30px)'},
+  {at: 1.5, expect: 'shape(from 20% 20px, smooth by 25% -5px using 15% 50px, smooth by 15% 35px)'},
 ]);
 
 test_interpolation({
@@ -206,50 +206,50 @@ test_interpolation({
 
 test_interpolation({
   property: 'clip-path',
-  from: 'shape(from 5% 5px, curve to 10% 10px via 0% 80px, curve to 30% 20px via 20% 50px 25% 70px)',
+  from: 'shape(from 5% 5px, curve to 10% 10px using 0% 80px, curve to 30% 20px using 20% 50px 25% 70px)',
   to: 'path("M 15 15 Q 10 60 20 0 C 30 40 -5 100 20 30")',
 }, [
-  {at: -0.3, expect: 'shape(from calc(6.5% - 4.5px) 2px, curve to calc(13% - 6px) 13px via calc(0% - 3px) 86px, curve to calc(39% - 6px) 17px via calc(26% - 9px) 53px calc(32.5% + 1.5px) 61px)'},
-  {at: 0, expect: 'shape(from 5% 5px, curve to 10% 10px via 0% 80px, curve to 30% 20px via 20% 50px 25% 70px)'},
-  {at: 0.5, expect: 'shape(from calc(2.5% + 7.5px) 10px, curve to calc(5% + 10px) 5px via calc(0% + 5px) 70px, curve to calc(15% + 10px) 25px via calc(10% + 15px) 45px calc(12.5% - 2.5px) 85px)'},
-  {at: 1, expect: 'shape(from calc(0% + 15px) 15px, curve to calc(0% + 20px) 0px via calc(0% + 10px) 60px, curve to calc(0% + 20px) 30px via calc(0% + 30px) 40px calc(0% - 5px) 100px)'},
-  {at: 1.5, expect: 'shape(from calc(-2.5% + 22.5px) 20px, curve to calc(-5% + 30px) -5px via calc(0% + 15px) 50px, curve to calc(-15% + 30px) 35px via calc(-10% + 45px) 35px calc(-12.5% - 7.5px) 115px)'},
+  {at: -0.3, expect: 'shape(from calc(6.5% - 4.5px) 2px, curve to calc(13% - 6px) 13px using calc(0% - 3px) 86px, curve to calc(39% - 6px) 17px using calc(26% - 9px) 53px calc(32.5% + 1.5px) 61px)'},
+  {at: 0, expect: 'shape(from 5% 5px, curve to 10% 10px using 0% 80px, curve to 30% 20px using 20% 50px 25% 70px)'},
+  {at: 0.5, expect: 'shape(from calc(2.5% + 7.5px) 10px, curve to calc(5% + 10px) 5px using calc(0% + 5px) 70px, curve to calc(15% + 10px) 25px using calc(10% + 15px) 45px calc(12.5% - 2.5px) 85px)'},
+  {at: 1, expect: 'shape(from calc(0% + 15px) 15px, curve to calc(0% + 20px) 0px using calc(0% + 10px) 60px, curve to calc(0% + 20px) 30px using calc(0% + 30px) 40px calc(0% - 5px) 100px)'},
+  {at: 1.5, expect: 'shape(from calc(-2.5% + 22.5px) 20px, curve to calc(-5% + 30px) -5px using calc(0% + 15px) 50px, curve to calc(-15% + 30px) 35px using calc(-10% + 45px) 35px calc(-12.5% - 7.5px) 115px)'},
 ]);
 
 test_interpolation({
   property: 'clip-path',
   from: 'path("M 5 5 q 0 80 10 10 c 20 50 25 70 30 20")',
-  to: 'shape(from 15% 15px, curve by 20% 0px via 10% 60px, curve by 20% 30px via 30% 40px -5% 100px)',
+  to: 'shape(from 15% 15px, curve by 20% 0px using 10% 60px, curve by 20% 30px using 30% 40px -5% 100px)',
 }, [
-  {at: -0.3, expect: 'shape(from calc(-4.5% + 6.5px) 2px, curve by calc(-6% + 13px) 13px via -3% 86px, curve by calc(-6% + 39px) 17px via calc(-9% + 26px) 53px calc(1.5% + 32.5px) 61px)'},
-  {at: 0, expect: 'shape(from calc(0% + 5px) 5px, curve by calc(0% + 10px) 10px via 0% 80px, curve by calc(0% + 30px) 20px via calc(0% + 20px) 50px calc(0% + 25px) 70px)'},
-  {at: 0.5, expect: 'shape(from calc(7.5% + 2.5px) 10px, curve by calc(10% + 5px) 5px via 5% 70px, curve by calc(10% + 15px) 25px via calc(15% + 10px) 45px calc(-2.5% + 12.5px) 85px)'},
-  {at: 1, expect: 'shape(from 15% 15px, curve by 20% 0px via 10% 60px, curve by 20% 30px via 30% 40px -5% 100px)'},
-  {at: 1.5, expect: 'shape(from calc(22.5% - 2.5px) 20px, curve by calc(30% - 5px) -5px via 15% 50px, curve by calc(30% - 15px) 35px via calc(45% - 10px) 35px calc(-7.5% - 12.5px) 115px)'},
+  {at: -0.3, expect: 'shape(from calc(-4.5% + 6.5px) 2px, curve by calc(-6% + 13px) 13px using -3% 86px, curve by calc(-6% + 39px) 17px using calc(-9% + 26px) 53px calc(1.5% + 32.5px) 61px)'},
+  {at: 0, expect: 'shape(from calc(0% + 5px) 5px, curve by calc(0% + 10px) 10px using 0% 80px, curve by calc(0% + 30px) 20px using calc(0% + 20px) 50px calc(0% + 25px) 70px)'},
+  {at: 0.5, expect: 'shape(from calc(7.5% + 2.5px) 10px, curve by calc(10% + 5px) 5px using 5% 70px, curve by calc(10% + 15px) 25px using calc(15% + 10px) 45px calc(-2.5% + 12.5px) 85px)'},
+  {at: 1, expect: 'shape(from 15% 15px, curve by 20% 0px using 10% 60px, curve by 20% 30px using 30% 40px -5% 100px)'},
+  {at: 1.5, expect: 'shape(from calc(22.5% - 2.5px) 20px, curve by calc(30% - 5px) -5px using 15% 50px, curve by calc(30% - 15px) 35px using calc(45% - 10px) 35px calc(-7.5% - 12.5px) 115px)'},
 ]);
 
 test_interpolation({
   property: 'clip-path',
-  from: 'shape(from 5% 5px, smooth to 10% 10px via 0% 80px, smooth to 30% 20px)',
+  from: 'shape(from 5% 5px, smooth to 10% 10px using 0% 80px, smooth to 30% 20px)',
   to: 'path("M 15 15 S 10 60 20 0 T 20 30")',
 }, [
-  {at: -0.3, expect: 'shape(from calc(6.5% - 4.5px) 2px, smooth to calc(13% - 6px) 13px via calc(0% - 3px) 86px, smooth to calc(39% - 6px) 17px)'},
-  {at: 0, expect: 'shape(from 5% 5px, smooth to 10% 10px via 0% 80px, smooth to 30% 20px)'},
-  {at: 0.5, expect: 'shape(from calc(2.5% + 7.5px) 10px, smooth to calc(5% + 10px) 5px via calc(0% + 5px) 70px, smooth to calc(15% + 10px) 25px)'},
-  {at: 1, expect: 'shape(from calc(0% + 15px) 15px, smooth to calc(0% + 20px) 0px via calc(0% + 10px) 60px, smooth to calc(0% + 20px) 30px)'},
-  {at: 1.5, expect: 'shape(from calc(-2.5% + 22.5px) 20px, smooth to calc(-5% + 30px) -5px via calc(0% + 15px) 50px, smooth to calc(-15% + 30px) 35px)'},
+  {at: -0.3, expect: 'shape(from calc(6.5% - 4.5px) 2px, smooth to calc(13% - 6px) 13px using calc(0% - 3px) 86px, smooth to calc(39% - 6px) 17px)'},
+  {at: 0, expect: 'shape(from 5% 5px, smooth to 10% 10px using 0% 80px, smooth to 30% 20px)'},
+  {at: 0.5, expect: 'shape(from calc(2.5% + 7.5px) 10px, smooth to calc(5% + 10px) 5px using calc(0% + 5px) 70px, smooth to calc(15% + 10px) 25px)'},
+  {at: 1, expect: 'shape(from calc(0% + 15px) 15px, smooth to calc(0% + 20px) 0px using calc(0% + 10px) 60px, smooth to calc(0% + 20px) 30px)'},
+  {at: 1.5, expect: 'shape(from calc(-2.5% + 22.5px) 20px, smooth to calc(-5% + 30px) -5px using calc(0% + 15px) 50px, smooth to calc(-15% + 30px) 35px)'},
 ]);
 
 test_interpolation({
   property: 'clip-path',
   from: 'path("M 5 5 s 0 80 10 10 t 30 20")',
-  to: 'shape(from 15px 15px, smooth by 20px 0px via 10px 60px, smooth by 20px 30px)',
+  to: 'shape(from 15px 15px, smooth by 20px 0px using 10px 60px, smooth by 20px 30px)',
 }, [
-  {at: -0.3, expect: 'shape(from 2px 2px, smooth by 7px 13px via -3px 86px, smooth by 33px 17px)'},
-  {at: 0, expect: 'shape(from 5px 5px, smooth by 10px 10px via 0px 80px, smooth by 30px 20px)'},
-  {at: 0.5, expect: 'shape(from 10px 10px, smooth by 15px 5px via 5px 70px, smooth by 25px 25px)'},
-  {at: 1, expect: 'shape(from 15px 15px, smooth by 20px 0px via 10px 60px, smooth by 20px 30px)'},
-  {at: 1.5, expect: 'shape(from 20px 20px, smooth by 25px -5px via 15px 50px, smooth by 15px 35px)'},
+  {at: -0.3, expect: 'shape(from 2px 2px, smooth by 7px 13px using -3px 86px, smooth by 33px 17px)'},
+  {at: 0, expect: 'shape(from 5px 5px, smooth by 10px 10px using 0px 80px, smooth by 30px 20px)'},
+  {at: 0.5, expect: 'shape(from 10px 10px, smooth by 15px 5px using 5px 70px, smooth by 25px 25px)'},
+  {at: 1, expect: 'shape(from 15px 15px, smooth by 20px 0px using 10px 60px, smooth by 20px 30px)'},
+  {at: 1.5, expect: 'shape(from 20px 20px, smooth by 25px -5px using 15px 50px, smooth by 15px 35px)'},
 ]);
 
 test_interpolation({


### PR DESCRIPTION
WebKit export from bug: [\[CSS Shape function\] Support interpolation between path() and shape()](https://bugs.webkit.org/show_bug.cgi?id=277709)