### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=227704

### DIFF
--- a/css/css-masking/clip-path/clip-path-marginBox-1d.html
+++ b/css/css-masking/clip-path/clip-path-marginBox-1d.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-clip-path">
 <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#valdef-shape-box-margin-box">
 <link rel="match" href="clip-path-marginBox-1d-ref.html">
-<meta name="fuzzy" content="maxDifference=0-146; totalPixels=0-500">
+<meta name="fuzzy" content="maxDifference=0-224; totalPixels=0-500">
 <meta name="assert" content="Check that the 'clip-path' property supports margin-box with border-radius.">
 
 <style>


### PR DESCRIPTION
WebKit export from bug: [\[LegacySVG\] clip-path inset is incorrectly applied to the svg element.](https://bugs.webkit.org/show_bug.cgi?id=227704)