### PR TITLE
Fix link in run_bounce_tracking_mitigations docs

### DIFF
--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -1128,7 +1128,7 @@
          * deleted hosts.
          *
          * Matches the `Run Bounce Tracking Mitigations
-         * https://privacycg.github.io/nav-tracking-mitigations/#run-bounce-tracking-mitigations-command`_
+         * <https://privacycg.github.io/nav-tracking-mitigations/#run-bounce-tracking-mitigations-command>`_
          * WebDriver command.
          *
          * @param {WindowProxy} [context=null] - Browsing context in which to


### PR DESCRIPTION
The link was missing `<>` so the full URL was visible.