### PR TITLE
from-cross-realm.https.html: don't timeout in Chromium

### DIFF
--- a/streams/readable-streams/crashtests/from-cross-realm.https.html
+++ b/streams/readable-streams/crashtests/from-cross-realm.https.html
@@ -2,13 +2,17 @@
 <meta charset="utf-8">
 <script type="module">
   let a = window.open()
-  let dir = await a.navigator.storage.getDirectory()
-  let hdl = await dir.getFileHandle("7399d8cf-9ff9-494d-89eb-d3045f229c27", {"create": true})
-  let map = new Map([[]])
-  let b = ReadableStream.from(map)
-  let c = await hdl.createWritable({ })
-  await b.pipeTo(c, { }).catch(() => {
-    // Error expected as we are not piping the right form of chunk to FileHandle
-  })
-  document.documentElement.classList.remove("test-wait");
+  try {
+    let dir = await a.navigator.storage.getDirectory()
+    let hdl = await dir.getFileHandle("7399d8cf-9ff9-494d-89eb-d3045f229c27", {"create": true})
+    let map = new Map([[]])
+    let b = ReadableStream.from(map)
+    let c = await hdl.createWritable({ })
+    await b.pipeTo(c, { }).catch(() => {
+      // Error expected as we are not piping the right form of chunk to FileHandle
+    })
+  } finally {
+    document.documentElement.classList.remove("test-wait")
+    a.close()
+  }
 </script>


### PR DESCRIPTION
Test streams/readable-streams/crashtests/from-cross-realm.https.html was timing out in Chromium because ReadableStream.from() is not yet supported there.

Catch exceptions in the JavaScript to ensure that class "test-wait" is always removed from the html tag. Also close the opened window as that seems to be necessary for test completion to be detected in Chrome.

Fixes http://crbug.com/361146527