### PR TITLE
Allow prefs to be overridden from a file and set WPT-specific prefs from file

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -78,6 +78,7 @@ class ServoExecutor(ProcessTestExecutor):
             args += ["--user-stylesheet", stylesheet]
         for pref, value in self.environment.get('prefs', {}).items():
             args += ["--pref", f"{pref}={value}"]
+        args += ["--prefs-file", "resources/wpt-prefs.json"]
         if self.browser.ca_certificate_path:
             args += ["--certificate-path", self.browser.ca_certificate_path]
         if extra_args:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This adds the ability to pass in a separate prefs file to override prefs.json. It also adds a new `wpt-prefs.json` file in the resources, designed to designate any prefs that should be overridden in Servo's wpt.fyi runs. 

Reviewed in servo/servo#33163