### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=278579

### DIFF
--- a/css/css-overflow/overflow-auto-scrollbar-gutter-intrinsic-003.html
+++ b/css/css-overflow/overflow-auto-scrollbar-gutter-intrinsic-003.html
@@ -6,6 +6,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#scrollbar-gutter-property">
   <link rel="help" href="https://drafts.csswg.org/css-scrollbars/#scrollbar-width">
   <link rel="match" href="overflow-auto-scrollbar-gutter-intrinsic-003-ref.html">
+  <meta name="fuzzy" content="maxDifference=0-40; totalPixels=0-5" />
 
   <style>
   .line {


### PR DESCRIPTION
WebKit export from bug: [Add pixel tolerance to css/css-overflow/overflow-auto-scrollbar-gutter-intrinsic-003.html](https://bugs.webkit.org/show_bug.cgi?id=278579)