### PR TITLE
Remove onmove and onmousewheel from window properties test

### DIFF
--- a/html/browsers/the-window-object/window-properties.https.html
+++ b/html/browsers/the-window-object/window-properties.https.html
@@ -178,8 +178,6 @@ var writableAttributes = [
   "onmouseout",
   "onmouseover",
   "onmouseup",
-  "onmousewheel",
-  "onmove",
   "onoffline",
   "ononline",
   "onpause",


### PR DESCRIPTION
Neither have any support in specifications: see https://dontcallmedom.github.io/webidlpedia/members.html.

onmove does not appear in any browser. onmousewheel appears in Chromium and WebKit; see some discussion in https://github.com/w3c/pointerevents/issues/595. Until that is resolved though it isn't good to test for its presence.