### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=278664

### DIFF
--- a/xhr/request-content-length.any.js
+++ b/xhr/request-content-length.any.js
@@ -11,6 +11,7 @@ async_test(test => {
     assert_true(happened);
     assert_true(client.responseText.includes(`Content-Length: ${data.length}`));
   });
+  client.onerror = test.unreached_func();
   client.open("POST", "resources/echo-headers.py");
   client.send(data);
 }, "Uploads need to set the Content-Length header");


### PR DESCRIPTION
WebKit export from bug: [WPT xhr/request-content-length.any.js should error early instead of timing out if the load fails](https://bugs.webkit.org/show_bug.cgi?id=278664)