### PR TITLE
layout: Add an indefinite containing block for intrinsic sizing

### DIFF
--- a/css/css-flexbox/percentage-padding-005.html
+++ b/css/css-flexbox/percentage-padding-005.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#item-margins">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#intrinsic-main-sizes">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="The flex container becomes 100px tall because the padding percentage of the item resolves against its width.">
+
+<p>Test passes if there is a filled green square.</p>
+<div style="display: flex; background: green; flex-direction: column; width: 100px;">
+  <div style="width: 100px; padding-bottom: 100%"></div>
+</div>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
When computing the min-content or max-content size of an element we
need to ignore `inline-size`, `min-inline-size` and `max-inline-size`.

However, we should take the block-axis sizing properties into account.
That's because the contents could have percentages depending on them,
which can then affect their inline size via an aspect ratio.

Therefore, this patch adds `IndefiniteContainingBlock`, which is similar
to `ContainingBlock`, but it allows an indefinite inline-size. This
struct is then passed arround during intrinsic sizing.

More refinement will be needed in follow-up patches in order to fully
address the problem.

Reviewed in servo/servo#33204