### PR TITLE
feColorMatrix on Display P3 canvas

### DIFF
--- a/css/filter-effects/fecolormatrix-display-p3-ref.html
+++ b/css/filter-effects/fecolormatrix-display-p3-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Filter Effects: Test feColorMatrix with type matrix on a Display P3 canvas</title>
+    <link rel="author" title="Hans Otto Wirtz" href="mailto:hansottowirtz@gmail.com">
+</head>
+<body>
+	<p>You should see three yellow squares.</p>
+	<svg width="300" height="100">
+		<rect width="80" height="80" fill="#ffff89" />
+		<rect x="100" width="80" height="80" fill="#ffff89" />
+		<rect x="200" width="80" height="80" fill="#ffff89" />
+	</svg>
+</body>
+</html>

--- a/css/filter-effects/fecolormatrix-display-p3.html
+++ b/css/filter-effects/fecolormatrix-display-p3.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+	<title>Filter Effects: Test feColorMatrix with type matrix on a Display P3 canvas</title>
+	<link rel="author" title="Hans Otto Wirtz" href="mailto:hansottowirtz@gmail.com">
+	<link rel="help" href="http://www.w3.org/TR/filter-effects-1/#feColorMatrixElement">
+	<link rel="help" href="http://www.w3.org/TR/filter-effects-1/#element-attrdef-fecolormatrix-type">
+	<link rel="match" href="fecolormatrix-display-p3-ref.html">
+	<meta name="assert" content="If the test runs, you should see three yellow squares.">
+	<meta name=fuzzy content="maxDifference=0-2;totalPixels=0-19200">
+	<style type="text/css">
+		svg {
+			vertical-align: top;
+		}
+		div {
+			font-size: 0;
+		}
+	</style>
+</head>
+<body>
+	<p>You should see three yellow squares.</p>
+	<div>
+		<svg width="100" height="100">
+			<defs>
+				<filter id="filter" color-interpolation-filters="sRGB">
+					<feColorMatrix
+						type="matrix"
+						values="-1.0986 -0.2556 1.5646 0.0146 0 -0.3103 -1.8658 2.6509 0.0109 0 -0.3976 1.8096 -0.734 0.0035 0 0 0 0 1 0"
+					></feColorMatrix>
+				</filter>
+			</defs>
+			<rect width="80" height="80" fill="#0ca7da" filter="url(#filter)"/>
+		</svg>
+		<img width="100" height="100"/>
+		<canvas width="100" height="100"></canvas>
+	</div>
+	<script>
+		const canvas = document.querySelector('canvas');
+		const svg = document.querySelector('svg');
+		const img = document.querySelector('img');
+		const svgString = new XMLSerializer().serializeToString(svg);
+		const ctx = canvas.getContext('2d', { colorSpace: 'display-p3' });
+		img.src = "data:image/svg+xml," + encodeURIComponent(svgString);
+		img.onload = () => {
+			ctx.drawImage(img, 0, 0);
+			document.documentElement.classList.remove('reftest-wait');
+		};
+	</script>
+</body>
+</html>


### PR DESCRIPTION
Add a test for SVG feColorMatrix on Display P3 canvas, as it's not possible to test Display P3 screens directly.

The SVG filter operations should be done in sRGB space and not in display space (Safari and Firefox use sRGB space, Chromium uses display space)

Questions:
- is this test is in the right place?
- is there a better way to test Display P3 and Rec. 2020 rendering? this test tests if feColorMatrix on Display P3 canvas is valid, but not that feColorMatrix on Display P3 screens is valid.

Chromium issue: https://issues.chromium.org/issues/41483538
Skia issue: https://issues.skia.org/issues/362116527