### PR TITLE
wpt: fix the path to wpt-prefs.json on WPT runner

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -69,10 +69,11 @@ class ServoExecutor(ProcessTestExecutor):
     def find_wpt_prefs(self):
         default_path = os.path.join("resources", "wpt-prefs.json")
         # The cwd is the servo repo for `./mach test-wpt`, but on WPT runners
-        # it is the virtual environment where the nightly is extracted. In the
-        # latter case, the cwd has the `servo` folder inside which we find the
+        # it is the WPT repo. The nightly tar is extracted inside the python
+        # virtual environment within the repo. This means that on WPT runners,
+        # the cwd has the `_venv/servo` directory inside which we find the
         # binary and the 'resources' directory.
-        for dir in [".", "./servo"]:
+        for dir in [".", "./_venv/servo"]:
             candidate = os.path.abspath(os.path.join(dir, default_path))
             if os.path.isfile(candidate):
                 return candidate


### PR DESCRIPTION
The path added in #<!-- nolink -->33202 turned out to be incorrect. The logic had a [fallback to pwd](https://github.com/servo/servo/blob/6de7848aff46920e1f8235ed3bd57aae7f350c26/tests/wpt/tests/tools/wpt/browser.py#L2151), but that is not the one that WPT runner uses. Instead, the path to the venv sub-directory is [passed in from the caller](https://github.com/servo/servo/blob/6de7848aff46920e1f8235ed3bd57aae7f350c26/tests/wpt/tests/tools/wpt/browser.py#L2151).

The logs from WPT runner also show that the ./wpt run command is executed with the wpt repo as the CWD
```
2024-08-28 01:51:32,158 - tc-run - INFO - Executing command: python3 ./wpt run --channel=nightly --log-wptreport=../artifacts/wpt_report.json --log-wptscreenshot=../artifacts/wpt_screenshot.txt --no-fail-on-unexpected --this-chunk=4 --total-chunks=16 --test-type=testharness --log-mach-level=info --log-mach=- -y --no-pause --no-restart-on-unexpected --install-fonts --no-headless --verify-log-full --install-browser --processes=12 servo
```

Reviewed in servo/servo#33220