### PR TITLE
[fullscreen] Make sure assertions run in element-request-fullscreen-timing.html

### DIFF
--- a/fullscreen/api/element-request-fullscreen-timing.html
+++ b/fullscreen/api/element-request-fullscreen-timing.html
@@ -14,19 +14,24 @@ promise_test(async t => {
   // callbacks should be run after it is fired, before the timer callback.
   // The resize event should fire before the fullscreenchange event.
   const events = [];
-  const callback = t.step_func(event => {
-    // fullscreenElement should have changed before either event is fired.
-    assert_equals(document.fullscreenElement, div, `fullscreenElement in {event.type} event`);
-    events.push(event.type);
-    if (event.type == 'fullscreenchange') {
-      step_timeout(t.unreached_func('timer callback'));
-      requestAnimationFrame(t.step_func_done(() => {
-        assert_array_equals(events, ['resize', 'fullscreenchange'], 'event order');
-      }));
-    }
-  });
-  document.onfullscreenchange = window.onresize = callback;
+  const p = new Promise(res => {
+    const callback = t.step_func(event => {
+      // fullscreenElement should have changed before either event is fired.
+      assert_equals(document.fullscreenElement, div, `fullscreenElement in {event.type} event`);
+      events.push(event.type);
+      if (event.type == 'fullscreenchange') {
+        step_timeout(t.unreached_func('timer callback'));
+        requestAnimationFrame(t.step_func_done(() => {
+          assert_array_equals(events, ['resize', 'fullscreenchange'], 'event order');
+        }));
+      }
+    });
+    document.onfullscreenchange = window.onresize = callback;
+  })
   await trusted_request(div);
+  await p
+  // so the user doesn't have to exit for themselves
+  document.exitFullscreen()
 }, 'Timing of fullscreenchange and resize events');
 
 async_test(t => {

--- a/fullscreen/api/element-request-fullscreen-timing.html
+++ b/fullscreen/api/element-request-fullscreen-timing.html
@@ -28,11 +28,11 @@ promise_test(async t => {
       }
     });
     document.onfullscreenchange = window.onresize = callback;
-  })
+  });
   await trusted_request(div);
-  await p
+  await p;
   // so the user doesn't have to exit for themselves
-  document.exitFullscreen()
+  document.exitFullscreen();
 }, 'Timing of fullscreenchange and resize events');
 
 async_test(t => {

--- a/fullscreen/api/element-request-fullscreen-timing.html
+++ b/fullscreen/api/element-request-fullscreen-timing.html
@@ -14,7 +14,7 @@ promise_test(async t => {
   // callbacks should be run after it is fired, before the timer callback.
   // The resize event should fire before the fullscreenchange event.
   const events = [];
-  const p = new Promise(res => {
+  const p = new Promise(resolve => {
     const callback = t.step_func(event => {
       // fullscreenElement should have changed before either event is fired.
       assert_equals(document.fullscreenElement, div, `fullscreenElement in {event.type} event`);
@@ -23,6 +23,7 @@ promise_test(async t => {
         step_timeout(t.unreached_func('timer callback'));
         requestAnimationFrame(t.step_func_done(() => {
           assert_array_equals(events, ['resize', 'fullscreenchange'], 'event order');
+          resolve();
         }));
       }
     });


### PR DESCRIPTION
This PR fixes a faulty fullscreen/api test that previously did not have it's asserts execute due to not waiting for them.

Fixes #47837.