### PR TITLE
Obey min and max cross sizes of flex items

### DIFF
--- a/css/css-flexbox/percentage-max-height-005.html
+++ b/css/css-flexbox/percentage-max-height-005.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<title>CSS Flexbox Test: flex item with max cross size</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#algo-stretch">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#max-size-properties">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="The content of the flex item should resolve the percentage against 100px, not against 200px">
+
+<style>
+.flex {
+  display: flex;
+}
+.item {
+  height: 200px;
+  max-height: 100px;
+  align-self: flex-start;
+  background: red;
+}
+.content {
+  height: 100%;
+  width: 100px;
+  background: green;
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class="flex">
+  <div class="item">
+    <div class="content"></div>
+  </div>
+</div>


### PR DESCRIPTION
When laying out the contents of a flex item, we used to resolve their cross-axis percentages against the preferred cross size of the item. Now we will take the min and max cross sizes into account.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#33242