### PR TITLE
Obey `min-block-size` and `max-block-size` in floats

### DIFF
--- a/css/CSS2/normal-flow/max-height-applies-to-018.html
+++ b/css/CSS2/normal-flow/max-height-applies-to-018.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>CSS Test: Max-Height applied to element with 'float' set to 'left'</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#min-max-heights">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="The float should be 100px tall, not 200px.">
+
+<style>
+.float {
+  float: left;
+  width: 100px;
+  height: 200px;
+  max-height: 100px;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square.</p>
+<div class="float"></div>

--- a/css/CSS2/normal-flow/max-width-applies-to-018.html
+++ b/css/CSS2/normal-flow/max-width-applies-to-018.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>CSS Test: Max-Width applied to element with 'float' set to 'left'</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#min-max-heights">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="The float should be 100px wide, not 200px.">
+
+<style>
+.float {
+  float: left;
+  height: 100px;
+  width: 200px;
+  max-width: 100px;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square.</p>
+<div class="float"></div>


### PR DESCRIPTION
We were using the unclamped `box_size.block` instead of `block_size`.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#33241