### PR TITLE
[wptrunner] Implement `--leak-check` for Blink-based browsers

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -1,9 +1,10 @@
 # mypy: allow-untyped-defs
 
+import collections
 import os
 import time
 import traceback
-from typing import Type
+from typing import Mapping, MutableMapping, Type
 from urllib.parse import urljoin
 
 from webdriver import error
@@ -22,7 +23,7 @@ from .executorwebdriver import (
     WebDriverTestharnessExecutor,
     WebDriverTestharnessProtocolPart,
 )
-from .protocol import PrintProtocolPart, ProtocolPart
+from .protocol import LeakProtocolPart, PrintProtocolPart, ProtocolPart
 
 here = os.path.dirname(__file__)
 
@@ -60,6 +61,19 @@ def make_sanitizer_mixin(crashtest_executor_cls: Type[CrashtestExecutor]):  # ty
 
 
 _SanitizerMixin = make_sanitizer_mixin(WebDriverCrashtestExecutor)
+
+
+class ChromeDriverLeakProtocolPart(LeakProtocolPart):
+    def get_counters(self) -> Mapping[str, int]:
+        response = self.parent.cdp.execute_cdp_command("Memory.getDOMCountersForLeakDetection")
+        counters: MutableMapping[str, int] = collections.Counter({
+            counter["name"]: counter["count"]
+            for counter in response["counters"]
+        })
+        # Exclude resources associated with User Agent CSS from leak detection,
+        # since they are persisted through page navigation.
+        counters["live_resources"] -= counters.pop("live_ua_css_resources", 0)
+        return counters
 
 
 class ChromeDriverTestharnessProtocolPart(WebDriverTestharnessProtocolPart):
@@ -206,23 +220,54 @@ class ChromeDriverProtocol(WebDriverProtocol):
         ChromeDriverFedCMProtocolPart,
         ChromeDriverPrintProtocolPart,
         ChromeDriverTestharnessProtocolPart,
-        *(part for part in WebDriverProtocol.implements
-          if part.name != ChromeDriverTestharnessProtocolPart.name and
-            part.name != ChromeDriverFedCMProtocolPart.name)
     ]
+    for base_part in WebDriverProtocol.implements:
+        if base_part.name not in {part.name for part in implements}:
+            implements.append(base_part)
+
     reuse_window = False
     # Prefix to apply to vendor-specific WebDriver extension commands.
     vendor_prefix = "goog"
 
+    def __init__(self, executor, browser, capabilities, **kwargs):
+        self.implements = list(ChromeDriverProtocol.implements)
+        if browser.leak_check:
+            self.implements.append(ChromeDriverLeakProtocolPart)
+        super().__init__(executor, browser, capabilities, **kwargs)
 
+
+def _evaluate_leaks(executor_cls):
+    if hasattr(executor_cls, "base_convert_result"):
+        # Don't wrap more than once, which can cause unbounded recursion.
+        return executor_cls
+    executor_cls.base_convert_result = executor_cls.convert_result
+
+    def convert_result(self, test, result, **kwargs):
+        test_result, subtest_results = self.base_convert_result(test, result, **kwargs)
+        if test_result.extra.get("leak_counters"):
+            test_result = test.make_result("CRASH",
+                                           test_result.message,
+                                           test_result.expected,
+                                           test_result.extra,
+                                           test_result.stack,
+                                           test_result.known_intermittent)
+        return test_result, subtest_results
+
+    executor_cls.convert_result = convert_result
+    return executor_cls
+
+
+@_evaluate_leaks
 class ChromeDriverCrashTestExecutor(WebDriverCrashtestExecutor):
     protocol_cls = ChromeDriverProtocol
 
 
+@_evaluate_leaks
 class ChromeDriverRefTestExecutor(WebDriverRefTestExecutor, _SanitizerMixin):  # type: ignore
     protocol_cls = ChromeDriverProtocol
 
 
+@_evaluate_leaks
 class ChromeDriverTestharnessExecutor(WebDriverTestharnessExecutor, _SanitizerMixin):  # type: ignore
     protocol_cls = ChromeDriverProtocol
 
@@ -249,8 +294,10 @@ class ChromeDriverTestharnessExecutor(WebDriverTestharnessExecutor, _SanitizerMi
         self.protocol.cdp.execute_cdp_command("Browser.setPermission", params)
 
 
+@_evaluate_leaks
 class ChromeDriverPrintRefTestExecutor(ChromeDriverRefTestExecutor):
     protocol_cls = ChromeDriverProtocol
+    is_print = True
 
     def setup(self, runner, protocol=None):
         super().setup(runner, protocol)

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -1,10 +1,11 @@
 # mypy: allow-untyped-defs
 
+import collections
 import traceback
 from http.client import HTTPConnection
 
 from abc import ABCMeta, abstractmethod
-from typing import Any, Awaitable, Callable, ClassVar, List, Mapping, Optional, Type
+from typing import Any, Awaitable, Callable, ClassVar, List, Mapping, Optional, Tuple, Type
 
 
 def merge_dicts(target, source):
@@ -611,6 +612,37 @@ class AssertsProtocolPart(ProtocolPart):
     def get(self):
         """Get a count of assertions since the last browser start"""
         pass
+
+
+class LeakProtocolPart(ProtocolPart):
+    """Protocol part that checks for leaked DOM objects."""
+    __metaclass__ = ABCMeta
+
+    name = "leak"
+
+    def setup(self):
+        self.parent.base.load("about:blank")
+        self.expected_counters = collections.Counter(self.get_counters())
+
+    @abstractmethod
+    def get_counters(self) -> Mapping[str, int]:
+        """Get counts of types of live objects (names are browser-dependent)."""
+
+    def check(self) -> Optional[Mapping[str, Tuple[int, int]]]:
+        """Check for DOM objects that outlive the current page.
+
+        Returns:
+            A map from object type to (expected, actual) counts, if one or more
+            types leaked. Otherwise, `None`.
+        """
+        self.parent.base.load("about:blank")
+        counters = collections.Counter(self.get_counters())
+        if counters - self.expected_counters:
+            return {
+                name: (self.expected_counters[name], counters[name])
+                for name in set(counters) | set(self.expected_counters)
+            }
+        return None
 
 
 class CoverageProtocolPart(ProtocolPart):

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -221,6 +221,12 @@ scheme host and port.""")
                                  help="Path to stackwalker program used to analyse minidumps.")
     debugging_group.add_argument("--pdb", action="store_true",
                                  help="Drop into pdb on python exception")
+    debugging_group.add_argument("--leak-check", dest="leak_check", action="store_true", default=None,
+                                 help=("Enable leak checking for supported browsers "
+                                       "(Gecko: enabled by default for debug builds, "
+                                       "silently ignored for opt, mobile)"))
+    debugging_group.add_argument("--no-leak-check", dest="leak_check", action="store_false", default=None,
+                                 help="Disable leak checking")
 
     android_group = parser.add_argument_group("Android specific arguments")
     android_group.add_argument("--adb-binary", action="store",
@@ -334,11 +340,6 @@ scheme host and port.""")
     gecko_group.add_argument("--setpref", dest="extra_prefs", action='append',
                              default=[], metavar="PREF=VALUE",
                              help="Defines an extra user preference (overrides those in prefs_root)")
-    gecko_group.add_argument("--leak-check", dest="leak_check", action="store_true", default=None,
-                             help="Enable leak checking (enabled by default for debug builds, "
-                             "silently ignored for opt, mobile)")
-    gecko_group.add_argument("--no-leak-check", dest="leak_check", action="store_false", default=None,
-                             help="Disable leak checking")
     gecko_group.add_argument("--reftest-internal", dest="reftest_internal", action="store_true",
                              default=None, help="Enable reftest runner implemented inside Marionette")
     gecko_group.add_argument("--reftest-external", dest="reftest_internal", action="store_false",


### PR DESCRIPTION
... to support Chromium CI testing needs.

* Introduce `LeakProtocolPart`, an optional API that lets wptrunner check for leaks programmatically. The default implementation checks that navigating to `about:blank` after a test cleans up the DOM objects it created.
* For browsers that implement `LeakProtocolPart`, the base WebDriver executors run the leak check after each test and report the results as an extra test result field named `leak_counters`.
* Currently, the only implementers of `LeakProtocolPart` are ChromeDriver-based browsers, which use [a nonstandard Chrome DevTools Protocol method][0] to count DOM objects. For those browsers, a leak is coerced to CRASH to report the result appropriately and induce a browser restart.

[0]: https://chromedevtools.github.io/devtools-protocol/tot/Memory/#method-getDOMCountersForLeakDetection

See Also: https://crbug.com/40887057