### PR TITLE
Add tests to ensure generator teardown in converted observables

### DIFF
--- a/dom/observable/tentative/observable-from.any.js
+++ b/dom/observable/tentative/observable-from.any.js
@@ -425,8 +425,6 @@ test(() => {
         yield n;
       }
       throw new Error('from the generator');
-    } catch (e) {
-      assert_equals(e.message, 'from the generator', "from(): generator errors are propagated to the observable");
     } finally {
       generatorFinalized = true;
     }
@@ -525,8 +523,6 @@ promise_test(async t => {
         yield n;
       }
       throw new Error('from the async generator');
-    } catch (e) {
-      assert_equals(e.message, 'from the async generator', "from(): async generator errors are propagated to the observable");
     } finally {
       generatorFinalized = true;
     }

--- a/dom/observable/tentative/observable-from.any.js
+++ b/dom/observable/tentative/observable-from.any.js
@@ -434,7 +434,7 @@ test(() => {
 
   const observable = Observable.from(generator());
 
-  observable.subscribe({ 
+  observable.subscribe({
     next: (n) => results.push(n),
     error: (e) => results.push(e.message)
   });
@@ -535,7 +535,7 @@ promise_test(async t => {
   const observable = Observable.from(asyncGenerator());
 
   await new Promise((resolve) => {
-    observable.subscribe({ 
+    observable.subscribe({
       next: (n) => results.push(n),
       error: (e) => {
         results.push(e.message);


### PR DESCRIPTION
Related to https://github.com/WICG/observable/pull/160 and other offline discussions with @domfarolino, we need to make sure this works properly. :) 