### PR TITLE
Update infrastructure/metadata based on recent PR results

### DIFF
--- a/infrastructure/metadata/infrastructure/server/webtransport-h3.https.sub.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/webtransport-h3.https.sub.any.js.ini
@@ -4,6 +4,7 @@
       if (product == "chrome") or (product == "firefox"): PASS
       FAIL
 
+
 [webtransport-h3.https.sub.any.worker.html]
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
@@ -17,11 +18,12 @@
       if (product == "chrome") or (product == "firefox"): PASS
       FAIL
 
+
 [webtransport-h3.https.sub.any.serviceworker.html]
   expected:
-    if product == "firefox_android": TIMEOUT
+    if product == "firefox_android": [TIMEOUT, OK]
   [WebTransport server should be running and should handle a bidirectional stream]
     expected:
       if (product == "chrome") or (product == "firefox"): PASS
-      if product == "firefox_android": TIMEOUT
+      if product == "firefox_android": [TIMEOUT, FAIL]
       FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/generate_test_report.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/generate_test_report.html.ini
@@ -1,4 +1,6 @@
 [generate_test_report.html]
+  expected:
+    if product == "firefox_android": [OK, TIMEOUT]
   [TestDriver generate_test_report method]
     expected:
       if (product == "firefox") or (product == "epiphany") or (product == "webkit"): FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/get_all_cookies.sub.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/get_all_cookies.sub.html.ini
@@ -1,0 +1,3 @@
+[get_all_cookies.sub.html]
+  expected:
+    if product == "firefox_android": [OK, TIMEOUT]


### PR DESCRIPTION
This is from running update-epxectations --update-intermittent with a bunch of recent wptreport.json files from recent infrastructure/ runs on recent infra PRs. This is basically just adding Firefox-for-Android intermittents, but it would be very nice to actually have Taskcluster succeeding for infra changes.