### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=278910

### DIFF
--- a/css/css-logical/animation-001.html
+++ b/css/css-logical/animation-001.html
@@ -105,23 +105,6 @@ test(t => {
   const div = addDiv(t);
   const anim = div.animate(
     {
-      marginInlineStart: '100px',
-      marginInline: '200px',
-      margin: 'logical 300px',
-    },
-    { duration: 1, easing: 'step-start' }
-  );
-  assert_equals(getComputedStyle(div).marginLeft, '100px');
-  assert_equals(getComputedStyle(div).marginRight, '200px');
-  assert_equals(getComputedStyle(div).marginTop, '300px');
-  assert_equals(getComputedStyle(div).marginBottom, '300px');
-}, 'Logical shorthands follow the usual prioritization based on number of'
-   + ' component longhands');
-
-test(t => {
-  const div = addDiv(t);
-  const anim = div.animate(
-    {
       marginInline: '100px',
       marginLeft: '200px',
     },

--- a/css/css-logical/animations/logical-shorthand-relative-prioritization-by-number-of-components.tentative.html
+++ b/css/css-logical/animations/logical-shorthand-relative-prioritization-by-number-of-components.tentative.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Logical shorthands follow the usual prioritization based on number of component longhands</title>
+<link rel="help" href="https://drafts.csswg.org/web-animations-1/#calculating-computed-keyframes">
+<meta name="assert" content="Shorthand properties with fewer longhand components override those with more longhand components (e.g. border-top overrides border-color).">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../css-animations/support/testcommon.js"></script>
+
+<div id="log"></div>
+<script>
+'use strict';
+
+test(t => {
+  const div = addDiv(t);
+  const anim = div.animate(
+    {
+      marginInlineStart: '100px',
+      marginInline: '200px',
+      margin: 'logical 300px',
+    },
+    { duration: 1, easing: 'step-start' }
+  );
+  assert_equals(getComputedStyle(div).marginLeft, '100px');
+  assert_equals(getComputedStyle(div).marginRight, '200px');
+  assert_equals(getComputedStyle(div).marginTop, '300px');
+  assert_equals(getComputedStyle(div).marginBottom, '300px');
+}, 'Logical shorthands follow the usual prioritization based on number of'
+   + ' component longhands');
+
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[css-logical\] split logical shorthand relative prioritization animation test off from css/css-logical/animation-001.html as a dedicated tentative test](https://bugs.webkit.org/show_bug.cgi?id=278910)