### PR TITLE
WebKit export: Support CSS color values that use calc() with non-absolute lengths

### DIFF
--- a/css/css-color/parsing/color-computed-color-function.html
+++ b/css/css-color/parsing/color-computed-color-function.html
@@ -13,6 +13,7 @@
 </div>
 <style>
   #container {
+    container-type: inline-size;
     color: rgb(255, 0, 0);
   }
 </style>
@@ -49,6 +50,10 @@ for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophot
 
     test_computed_value("color", `color(${colorSpace} calc(NaN) 0 0)`, `color(${colorSpace} 0 0 0)`);
     test_computed_value("color", `color(${colorSpace} calc(0 / 0) 0 0)`, `color(${colorSpace} 0 0 0)`);
+
+    // calc(50% + (sign(1em - 10px) * 10%)), with its font relative units, must be evaluatated for computed value.
+    test_computed_value("color", `color(${colorSpace} calc(50% + (sign(1em - 10px) * 10%)) 0 0 / 0.5)`, `color(${colorSpace} 0.6 0 0 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} 0.5 0 0 / calc(50% + (sign(1em - 10px) * 10%)))`, `color(${colorSpace} 0.5 0 0 / 0.6)`);
 }
 
 for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
@@ -78,6 +83,10 @@ for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
 
     test_computed_value("color", `color(${colorSpace} calc(NaN) 0 0)`, `color(${resultColorSpace} 0 0 0)`);
     test_computed_value("color", `color(${colorSpace} calc(0 / 0) 0 0)`, `color(${resultColorSpace} 0 0 0)`);
+
+    // calc(50% + (sign(1em - 10px) * 10%)), with its font relative units, must be evaluatated for computed value.
+    test_computed_value("color", `color(${colorSpace} calc(0.5 + (sign(1em - 10px) * 0.1)) 0 0 / 0.5)`, `color(${resultColorSpace} 0.6 0 0 / 0.5)`);
+    test_computed_value("color", `color(${colorSpace} 0.5 0 0 / calc(0.5 + (sign(1em - 10px) * 0.1)))`, `color(${resultColorSpace} 0.5 0 0 / 0.6)`);
 }
 
 // Opaque sRGB in color()
@@ -279,4 +288,11 @@ test_computed_value("color", "color(display-p3 0.5 -199 0.75)", "color(display-p
 test_computed_value("color", "color(display-p3 184 1.00001 1103)", "color(display-p3 184 1.00001 1103)", "[Display P3 color with component > 1 should not clamp]");
 test_computed_value("color", "color(srgb 0.1 0.2 0.3 / 1.9)", "color(srgb 0.1 0.2 0.3)", "[Alpha > 1 should clamp]");
 test_computed_value("color", "color(srgb 1 1 1 / -0.2)", "color(srgb 1 1 1 / 0)", "[Negative alpha should clamp]");
+
+
+// Ensure that `calc` values work with dynamically changing relative units (slighly different alpha values to make test harness not complain about duplicate tests).
+document.getElementById("container").style.width = "1000px";
+test_computed_value("color", `color(srgb calc(0.5 + (sign(2cqw - 10px) * 0.1)) 0 0 / 0.51)`, `color(srgb 0.6 0 0 / 0.51)`);
+document.getElementById("container").style.width = "100px";
+test_computed_value("color", `color(srgb calc(0.5 + (sign(2cqw - 10px) * 0.1)) 0 0 / 0.52)`, `color(srgb 0.4 0 0 / 0.52)`);
 </script>

--- a/css/css-color/parsing/color-computed-color-mix-function.html
+++ b/css/css-color/parsing/color-computed-color-mix-function.html
@@ -493,6 +493,30 @@
         fuzzy_test_computed_color(`color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / 25%) 0%, color(${colorSpace} none none none / 50%))`, `color(${resultColorSpace} 0.1 0.2 0.3 / 0.5)`);
         fuzzy_test_computed_color(`color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / 25%) 0%, color(${colorSpace} 0.5 none none / 50%))`, `color(${resultColorSpace} 0.5 0.2 0.3 / 0.5)`);
     }
+
+    // Test percent normalization
+    fuzzy_test_computed_color(`color-mix(in srgb, red 50%,       blue 50%)`,          `color(srgb 0.5 0 0.5)`);                 // `color-mix(in srgb, red, blue)`            both 50%
+    fuzzy_test_computed_color(`color-mix(in srgb, red 10%,       blue 90%)`,          `color(srgb 0.1 0 0.9)`);                 // `color-mix(in srgb, red 10%, blue)`        sum to 100%
+    fuzzy_test_computed_color(`color-mix(in srgb, red 50%,       blue 40%)`,          `color(srgb 0.555556 0 0.444444 / 0.9)`); // `color-mix(in srgb, red 50%, blue 40%)`    only one is 50% (p1)
+    fuzzy_test_computed_color(`color-mix(in srgb, red 40%,       blue 50%)`,          `color(srgb 0.444444 0 0.555556 / 0.9)`); // `color-mix(in srgb, red 40%, blue 50%)`    only one is 50% (p2)
+    fuzzy_test_computed_color(`color-mix(in srgb, red 30%,       blue 40%)`,          `color(srgb 0.428571 0 0.571429 / 0.7)`); // `color-mix(in srgb, red 30%, blue 40%)`    sum to less than 100
+    fuzzy_test_computed_color(`color-mix(in srgb, red 75%,       blue 75%)`,          `color(srgb 0.5 0 0.5)`);                 // `color-mix(in srgb, red 75%, blue 75%)`    sum to more than 100
+    fuzzy_test_computed_color(`color-mix(in srgb, red calc(10%), blue 50%)`,          `color(srgb 0.166667 0 0.833333 / 0.6)`); // `color-mix(in srgb, red 10%, blue 50%)`    one is `calc()` (p1)
+    fuzzy_test_computed_color(`color-mix(in srgb, red 50%,       blue calc(10%))`,    `color(srgb 0.833333 0 0.166667 / 0.6)`); // `color-mix(in srgb, red 50%, blue 10%))`   one is `calc()` (p2)
+    fuzzy_test_computed_color(`color-mix(in srgb, red calc(10%), blue calc(90%))`,    `color(srgb 0.1 0 0.9)`);                 // `color-mix(in srgb, red, blue)`            both are `calc()`, sum to 100%
+    fuzzy_test_computed_color(`color-mix(in srgb, red calc(10%), blue calc(80%))`,    `color(srgb 0.111111 0 0.888889 / 0.9)`); // `color-mix(in srgb, red 10%, blue 80%)`    both are `calc()`,
+    fuzzy_test_computed_color(`color-mix(in srgb, red 50%,       blue)`,              `color(srgb 0.5 0 0.5)`);                 // `color-mix(in srgb, red, blue)`            only p1 specified, is 50%
+    fuzzy_test_computed_color(`color-mix(in srgb, red 10%,       blue)`,              `color(srgb 0.1 0 0.9)`);                 // `color-mix(in srgb, red 10%, blue)`        only p1 specified
+    fuzzy_test_computed_color(`color-mix(in srgb, red calc(50%), blue)`,              `color(srgb 0.5 0 0.5)`);                 // `color-mix(in srgb, red, blue)`            only p1 specified, is `calc()` is 50%
+    fuzzy_test_computed_color(`color-mix(in srgb, red calc(10%), blue)`,              `color(srgb 0.1 0 0.9)`);                 // `color-mix(in srgb, red 10%, blue)`        only p1 specified, is `calc()`
+    fuzzy_test_computed_color(`color-mix(in srgb, red,           blue 50%)`,          `color(srgb 0.5 0 0.5)`);                 // `color-mix(in srgb, red, blue)`            only p2 specified, is 50%
+    fuzzy_test_computed_color(`color-mix(in srgb, red,           blue 90%)`,          `color(srgb 0.1 0 0.9)`);                 // `color-mix(in srgb, red 10%, blue)`        only p2 specified
+    fuzzy_test_computed_color(`color-mix(in srgb, red,           blue calc(50%))`,    `color(srgb 0.5 0 0.5)`);                 // `color-mix(in srgb, red, blue)`            only p2 specified, is `calc()`, is 50%
+    fuzzy_test_computed_color(`color-mix(in srgb, red,           blue calc(90%))`,    `color(srgb 0.1 0 0.9)`);                 // `color-mix(in srgb, red 10%, blue)`        only p2 specified, is `calc()`
+    fuzzy_test_computed_color(`color-mix(in srgb, red,           blue)`,              `color(srgb 0.5 0 0.5)`);                 // `color-mix(in srgb, red, blue)`            neither is specified
+
+    // Percent with calc that uses font-relative length.
+    fuzzy_test_computed_color(`color-mix(in srgb, red calc(50% + (sign(100em - 1px) * 10%)), blue)`, `color(srgb 0.6 0 0.4)`);
 </script>
 </body>
 </html>

--- a/css/css-color/parsing/color-computed-hsl.html
+++ b/css/css-color/parsing/color-computed-hsl.html
@@ -17,6 +17,7 @@
 </div>
 <style>
   #container {
+    container-type: inline-size;
     color: rgb(255, 0, 0);
   }
 </style>
@@ -3759,11 +3760,37 @@ tests = [
     ["hsla(360, 37.5%, 62.5%, 1)", "rgb(195, 124, 124)", "HSL/HSLA value should parse and round correctly"],
     ["hsl(360, 37.5%, 75%)", "rgb(215, 167, 167)", "HSL/HSLA value should parse and round correctly"],
     ["hsla(360, 37.5%, 75%, 0)", "rgba(215, 167, 167, 0)", "HSL/HSLA value should parse and round correctly"],
+
+    // calc(50% + (sign(1em - 10px) * 10%)), with its font relative units, must be evaluatated for computed value.
+    ["hsl(calc(50deg + (sign(1em - 10px) * 10deg)), 100%, 37.5%, 50%)", "rgba(191, 191, 0, 0.5)"],
+    ["hsla(calc(50deg + (sign(1em - 10px) * 10deg)), 100%, 37.5%, 50%)", "rgba(191, 191, 0, 0.5)"],
+    ["hsl(calc(50 + (sign(1em - 10px) * 10)), 100%, 37.5%, 50%)", "rgba(191, 191, 0, 0.5)"],
+    ["hsla(calc(50 + (sign(1em - 10px) * 10)), 100%, 37.5%, 50%)", "rgba(191, 191, 0, 0.5)"],
+    ["hsl(60deg, 100%, 37.5%, calc(50% + (sign(1em - 10px) * 10%)))", "rgba(191, 191, 0, 0.6)"],
+    ["hsla(60deg, 100%, 37.5%, calc(50% + (sign(1em - 10px) * 10%)))", "rgba(191, 191, 0, 0.6)"],
+    ["hsl(60, 100%, 37.5%, calc(50% + (sign(1em - 10px) * 10%)))", "rgba(191, 191, 0, 0.6)"],
+    ["hsla(60, 100%, 37.5%, calc(50% + (sign(1em - 10px) * 10%)))", "rgba(191, 191, 0, 0.6)"],
+
+    ["hsl(calc(50deg + (sign(1em - 10px) * 10deg)) 100% 37.5% / 50%)", "rgba(191, 191, 0, 0.5)"],
+    ["hsla(calc(50deg + (sign(1em - 10px) * 10deg)) 100% 37.5% / 50%)", "rgba(191, 191, 0, 0.5)"],
+    ["hsl(calc(50 + (sign(1em - 10px) * 10)) 100 37.5 / 0.5)", "rgba(191, 191, 0, 0.5)"],
+    ["hsla(calc(50 + (sign(1em - 10px) * 10)) 100 37.5 / 0.5)", "rgba(191, 191, 0, 0.5)"],
+    ["hsl(60deg 100% 37.5% / calc(50% + (sign(1em - 10px) * 10%)))", "rgba(191, 191, 0, 0.6)"],
+    ["hsla(60deg 100% 37.5% / calc(50% + (sign(1em - 10px) * 10%)))", "rgba(191, 191, 0, 0.6)"],
+    ["hsl(60 100 37.5 / calc(0.75 + (sign(1em - 10px) * 0.1)))", "rgba(191, 191, 0, 0.85)"],
+    ["hsla(60 100 37.5 / calc(0.75 + (sign(1em - 10px) * 0.1)))", "rgba(191, 191, 0, 0.85)"],
 ];
 
 for (const test of tests) {
     test_computed_value("color", test[0], test[1], test[2] ? `[${test[2]}]` : undefined);
 }
+
+// Ensure that `calc` values work with dynamically changing relative units (slighly different alpha values to make test harness not complain about duplicate tests).
+document.getElementById("container").style.width = "1000px";
+test_computed_value("color", "hsla(calc(50deg + (sign(2cqw - 10px) * 10deg)), 100%, 37.5%, 51%)", "rgba(191, 191, 0, 0.51)");
+document.getElementById("container").style.width = "100px";
+test_computed_value("color", "hsla(calc(50deg + (sign(2cqw - 10px) * 10deg)), 100%, 37.5%, 52%)", "rgba(191, 127, 0, 0.52)");
+
 </script>
 </body>
 </html>

--- a/css/css-color/parsing/color-computed-hwb.html
+++ b/css/css-color/parsing/color-computed-hwb.html
@@ -17,6 +17,7 @@
 </div>
 <style>
   #container {
+    container-type: inline-size;
     color: rgb(255, 0, 0);
   }
 </style>
@@ -73,11 +74,24 @@ tests = [
     ["hwb(90 50% 50% / 0)", "rgba(128, 128, 128, 0)", "HWB value should parse and round correctly"],
     ["hwb(90 50% 50% / 0.2)", "rgba(128, 128, 128, 0.2)", "HWB value should parse and round correctly"],
     ["hwb(90 50% 50% / 1)", "rgb(128, 128, 128)", "HWB value should parse and round correctly"],
+
+    // calc(50% + (sign(1em - 10px) * 10%)), with its font relative units, must be evaluatated for computed value.
+    ["hwb(calc(110deg + (sign(1em - 10px) * 10deg)) 30% 50% / 50%)", "rgba(77, 128, 77, 0.5)"],
+    ["hwb(calc(110 + (sign(1em - 10px) * 10)) 30 50 / 0.5)", "rgba(77, 128, 77, 0.5)"],
+    ["hwb(120deg 30% 50% / calc(50% + (sign(1em - 10px) * 10%)))", "rgba(77, 128, 77, 0.6)"],
+    ["hwb(120 30 50 / calc(0.75 + (sign(1em - 10px) * 0.1)))", "rgba(77, 128, 77, 0.85)"],
 ];
 
 for (const test of tests) {
     test_computed_value("color", test[0], test[1], test[2] ? `[${test[2]}]` : undefined);
 }
+
+// Ensure that `calc` values work with dynamically changing relative units (slighly different alpha values to make test harness not complain about duplicate tests).
+document.getElementById("container").style.width = "1000px";
+test_computed_value("color", "hwb(calc(110deg + (sign(2cqw - 10px) * 10deg)) 30 50 / 51%)", "rgba(77, 128, 77, 0.51)");
+document.getElementById("container").style.width = "100px";
+test_computed_value("color", "hwb(calc(110deg + (sign(2cqw - 10px) * 10deg)) 30 50 / 52%)", "rgba(94, 128, 77, 0.52)");
+
 </script>
 </body>
 </html>

--- a/css/css-color/parsing/color-computed-lab.html
+++ b/css/css-color/parsing/color-computed-lab.html
@@ -18,134 +18,163 @@
 </div>
 <style>
   #container {
-    color: rgb(255, 0, 0);
+    container-type: inline-size;
+    color: rgb(255, 0, 0]);
   }
 </style>
 <script>
+tests = [
+    // lab()
+    ["lab(0 0 0)", "lab(0 0 0)"],
+    ["lab(0 0 0 / 1)", "lab(0 0 0)"],
+    ["lab(0 0 0 / 0.5)", "lab(0 0 0 / 0.5)"],
+    ["lab(20 0 10/0.5)", "lab(20 0 10 / 0.5)"],
+    ["lab(20 0 10/50%)", "lab(20 0 10 / 0.5)"],
+    ["lab(400 0 10/50%)", "lab(100 0 10 / 0.5)"],
+    ["lab(50 -160 160)", "lab(50 -160 160)"],
+    ["lab(50 -200 200)", "lab(50 -200 200)"],
+    ["lab(0 0 0 / -10%)", "lab(0 0 0 / 0)"],
+    ["lab(0 0 0 / 110%)", "lab(0 0 0)"],
+    ["lab(0 0 0 / 300%)", "lab(0 0 0)"],
+    ["lab(-40 0 0)", "lab(0 0 0)"],
+    ["lab(50 -20 0)", "lab(50 -20 0)"],
+    ["lab(50 0 -20)", "lab(50 0 -20)"],
+    ["lab(calc(50 * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))", "lab(100 -0.5 1.5 / 0.5)"],
+    ["lab(calc(-50 * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))", "lab(0 1.5 -1.5 / 0)"],
 
-// lab()
-test_computed_value("color", "lab(0 0 0)", "lab(0 0 0)");
-test_computed_value("color", "lab(0 0 0 / 1)", "lab(0 0 0)");
-test_computed_value("color", "lab(0 0 0 / 0.5)", "lab(0 0 0 / 0.5)");
-test_computed_value("color", "lab(20 0 10/0.5)", "lab(20 0 10 / 0.5)");
-test_computed_value("color", "lab(20 0 10/50%)", "lab(20 0 10 / 0.5)");
-test_computed_value("color", "lab(400 0 10/50%)", "lab(100 0 10 / 0.5)");
-test_computed_value("color", "lab(50 -160 160)", "lab(50 -160 160)");
-test_computed_value("color", "lab(50 -200 200)", "lab(50 -200 200)");
-test_computed_value("color", "lab(0 0 0 / -10%)", "lab(0 0 0 / 0)");
-test_computed_value("color", "lab(0 0 0 / 110%)", "lab(0 0 0)");
-test_computed_value("color", "lab(0 0 0 / 300%)", "lab(0 0 0)");
-test_computed_value("color", "lab(-40 0 0)", "lab(0 0 0)");
-test_computed_value("color", "lab(50 -20 0)", "lab(50 -20 0)");
-test_computed_value("color", "lab(50 0 -20)", "lab(50 0 -20)");
-test_computed_value("color", "lab(calc(50 * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))", "lab(100 -0.5 1.5 / 0.5)");
-test_computed_value("color", "lab(calc(-50 * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))", "lab(0 1.5 -1.5 / 0)");
+    ["lab(none none none / none)", "lab(none none none / none)"],
+    ["lab(none none none)", "lab(none none none)"],
+    ["lab(20 none none / none)", "lab(20 none none / none)"],
+    ["lab(none none none / 0.5)", "lab(none none none / 0.5)"],
+    ["lab(0 0 0 / none)", "lab(0 0 0 / none)"],
 
-test_computed_value("color", "lab(none none none / none)", "lab(none none none / none)");
-test_computed_value("color", "lab(none none none)", "lab(none none none)");
-test_computed_value("color", "lab(20 none none / none)", "lab(20 none none / none)");
-test_computed_value("color", "lab(none none none / 0.5)", "lab(none none none / 0.5)");
-test_computed_value("color", "lab(0 0 0 / none)", "lab(0 0 0 / none)");
+    ["lab(calc(NaN) 0 0)", "lab(0 0 0)"],
+    ["lab(calc(0 / 0) 0 0)", "lab(0 0 0)"],
 
-test_computed_value("color", "lab(calc(NaN) 0 0)", "lab(0 0 0)");
-test_computed_value("color", "lab(calc(0 / 0) 0 0)", "lab(0 0 0)");
+    // oklab()
+    ["oklab(0 0 0)", "oklab(0 0 0)"],
+    ["oklab(0 0 0 / 1)", "oklab(0 0 0)"],
+    ["oklab(0 0 0 / 0.5)", "oklab(0 0 0 / 0.5)"],
+    ["oklab(0.2 0 0.1/0.5)", "oklab(0.2 0 0.1 / 0.5)"],
+    ["oklab(0.2 0 0.1/50%)", "oklab(0.2 0 0.1 / 0.5)"],
+    ["oklab(4 0 0.1/50%)", "oklab(1 0 0.1 / 0.5)"],
+    ["oklab(0.5 -1.6 1.6)", "oklab(0.5 -1.6 1.6)"],
+    ["oklab(0.5 -2 2)", "oklab(0.5 -2 2)"],
+    ["oklab(0 0 0 / -10%)", "oklab(0 0 0 / 0)"],
+    ["oklab(0 0 0 / 110%)", "oklab(0 0 0)"],
+    ["oklab(0 0 0 / 300%)", "oklab(0 0 0)"],
+    ["oklab(-0.4 0 0)", "oklab(0 0 0)"],
+    ["oklab(0.5 -0.2 0)", "oklab(0.5 -0.2 0)"],
+    ["oklab(0.5 0 -0.2)", "oklab(0.5 0 -0.2)"],
+    ["oklab(calc(0.5 * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))", "oklab(1 -0.5 1.5 / 0.5)"],
+    ["oklab(calc(-0.5 * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))", "oklab(0 1.5 -1.5 / 0)"],
 
-// oklab()
-test_computed_value("color", "oklab(0 0 0)", "oklab(0 0 0)");
-test_computed_value("color", "oklab(0 0 0 / 1)", "oklab(0 0 0)");
-test_computed_value("color", "oklab(0 0 0 / 0.5)", "oklab(0 0 0 / 0.5)");
-test_computed_value("color", "oklab(0.2 0 0.1/0.5)", "oklab(0.2 0 0.1 / 0.5)");
-test_computed_value("color", "oklab(0.2 0 0.1/50%)", "oklab(0.2 0 0.1 / 0.5)");
-test_computed_value("color", "oklab(4 0 0.1/50%)", "oklab(1 0 0.1 / 0.5)");
-test_computed_value("color", "oklab(0.5 -1.6 1.6)", "oklab(0.5 -1.6 1.6)");
-test_computed_value("color", "oklab(0.5 -2 2)", "oklab(0.5 -2 2)");
-test_computed_value("color", "oklab(0 0 0 / -10%)", "oklab(0 0 0 / 0)");
-test_computed_value("color", "oklab(0 0 0 / 110%)", "oklab(0 0 0)");
-test_computed_value("color", "oklab(0 0 0 / 300%)", "oklab(0 0 0)");
-test_computed_value("color", "oklab(-0.4 0 0)", "oklab(0 0 0)");
-test_computed_value("color", "oklab(0.5 -0.2 0)", "oklab(0.5 -0.2 0)");
-test_computed_value("color", "oklab(0.5 0 -0.2)", "oklab(0.5 0 -0.2)");
-test_computed_value("color", "oklab(calc(0.5 * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))", "oklab(1 -0.5 1.5 / 0.5)");
-test_computed_value("color", "oklab(calc(-0.5 * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))", "oklab(0 1.5 -1.5 / 0)");
+    ["oklab(none none none / none)", "oklab(none none none / none)"],
+    ["oklab(none none none)", "oklab(none none none)"],
+    ["oklab(0.2 none none / none)", "oklab(0.2 none none / none)"],
+    ["oklab(none none none / 0.5)", "oklab(none none none / 0.5)"],
+    ["oklab(0 0 0 / none)", "oklab(0 0 0 / none)"],
 
-test_computed_value("color", "oklab(none none none / none)", "oklab(none none none / none)");
-test_computed_value("color", "oklab(none none none)", "oklab(none none none)");
-test_computed_value("color", "oklab(0.2 none none / none)", "oklab(0.2 none none / none)");
-test_computed_value("color", "oklab(none none none / 0.5)", "oklab(none none none / 0.5)");
-test_computed_value("color", "oklab(0 0 0 / none)", "oklab(0 0 0 / none)");
+    // These tests validate the ranges of lab() vs. oklab() components
+    ["lab(20% -50% 90%/0.5)", "lab(20 -62.5 112.5 / 0.5)"],
+    ["oklab(20% 70% -80%/0.5)", "oklab(0.2 0.28 -0.32 / 0.5)"],
 
-// These tests validate the ranges of lab() vs. oklab() components
-test_computed_value("color", "lab(20% -50% 90%/0.5)", "lab(20 -62.5 112.5 / 0.5)");
-test_computed_value("color", "oklab(20% 70% -80%/0.5)", "oklab(0.2 0.28 -0.32 / 0.5)");
+    ["oklab(calc(NaN) 0 0)", "oklab(0 0 0)"],
+    ["oklab(calc(0 / 0) 0 0)", "oklab(0 0 0)"],
 
-test_computed_value("color", "oklab(calc(NaN) 0 0)", "oklab(0 0 0)");
-test_computed_value("color", "oklab(calc(0 / 0) 0 0)", "oklab(0 0 0)");
+    // lch()
+    ["lch(0 0 0deg)", "lch(0 0 0)"],
+    ["lch(0 0 0deg / 1)", "lch(0 0 0)"],
+    ["lch(0 0 0deg / 0.5)", "lch(0 0 0 / 0.5)"],
+    ["lch(100 230 0deg / 0.5)", "lch(100 230 0 / 0.5)"],
+    ["lch(20 50 20deg/0.5)", "lch(20 50 20 / 0.5)"],
+    ["lch(20 50 20deg/50%)", "lch(20 50 20 / 0.5)"],
+    ["lch(10 20 20deg / -10%)", "lch(10 20 20 / 0)"],
+    ["lch(10 20 20deg / 110%)", "lch(10 20 20)"],
+    ["lch(10 20 1.28rad)", "lch(10 20 73.3386)"],
+    ["lch(10 20 380deg)", "lch(10 20 20)"],
+    ["lch(10 20 -340deg)", "lch(10 20 20)"],
+    ["lch(10 20 740deg)", "lch(10 20 20)"],
+    ["lch(10 20 -700deg)", "lch(10 20 20)"],
+    ["lch(-40 0 0)", "lch(0 0 0)"],
+    ["lch(20 -20 0)", "lch(20 0 0)"],
+    ["lch(0 0 0 / 0.5)", "lch(0 0 0 / 0.5)"],
+    ["lch(10 20 20 / 110%)", "lch(10 20 20)"],
+    ["lch(10 20 -700)", "lch(10 20 20)"],
+    ["lch(calc(50 * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))", "lch(100 0 40 / 0.5)"],
+    ["lch(calc(-50 * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))", "lch(0 1.5 320 / 0)"],
 
-// lch()
-test_computed_value("color", "lch(0 0 0deg)", "lch(0 0 0)");
-test_computed_value("color", "lch(0 0 0deg / 1)", "lch(0 0 0)");
-test_computed_value("color", "lch(0 0 0deg / 0.5)", "lch(0 0 0 / 0.5)");
-test_computed_value("color", "lch(100 230 0deg / 0.5)", "lch(100 230 0 / 0.5)");
-test_computed_value("color", "lch(20 50 20deg/0.5)", "lch(20 50 20 / 0.5)");
-test_computed_value("color", "lch(20 50 20deg/50%)", "lch(20 50 20 / 0.5)");
-test_computed_value("color", "lch(10 20 20deg / -10%)", "lch(10 20 20 / 0)");
-test_computed_value("color", "lch(10 20 20deg / 110%)", "lch(10 20 20)");
-test_computed_value("color", "lch(10 20 1.28rad)", "lch(10 20 73.3386)");
-test_computed_value("color", "lch(10 20 380deg)", "lch(10 20 20)");
-test_computed_value("color", "lch(10 20 -340deg)", "lch(10 20 20)");
-test_computed_value("color", "lch(10 20 740deg)", "lch(10 20 20)");
-test_computed_value("color", "lch(10 20 -700deg)", "lch(10 20 20)");
-test_computed_value("color", "lch(-40 0 0)", "lch(0 0 0)");
-test_computed_value("color", "lch(20 -20 0)", "lch(20 0 0)");
-test_computed_value("color", "lch(0 0 0 / 0.5)", "lch(0 0 0 / 0.5)");
-test_computed_value("color", "lch(10 20 20 / 110%)", "lch(10 20 20)");
-test_computed_value("color", "lch(10 20 -700)", "lch(10 20 20)");
-test_computed_value("color", "lch(calc(50 * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))", "lch(100 0 40 / 0.5)");
-test_computed_value("color", "lch(calc(-50 * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))", "lch(0 1.5 320 / 0)");
+    ["lch(none none none / none)", "lch(none none none / none)"],
+    ["lch(none none none)", "lch(none none none)"],
+    ["lch(20 none none / none)", "lch(20 none none / none)"],
+    ["lch(none none none / 0.5)", "lch(none none none / 0.5)"],
+    ["lch(0 0 0 / none)", "lch(0 0 0 / none)"],
 
-test_computed_value("color", "lch(none none none / none)", "lch(none none none / none)");
-test_computed_value("color", "lch(none none none)", "lch(none none none)");
-test_computed_value("color", "lch(20 none none / none)", "lch(20 none none / none)");
-test_computed_value("color", "lch(none none none / 0.5)", "lch(none none none / 0.5)");
-test_computed_value("color", "lch(0 0 0 / none)", "lch(0 0 0 / none)");
+    ["lch(calc(NaN) 0 0)", "lch(0 0 0)"],
+    ["lch(calc(0 / 0) 0 0)", "lch(0 0 0)"],
 
-test_computed_value("color", "lch(calc(NaN) 0 0)", "lch(0 0 0)");
-test_computed_value("color", "lch(calc(0 / 0) 0 0)", "lch(0 0 0)");
+    // oklch()
+    ["oklch(0 0 0deg)", "oklch(0 0 0)"],
+    ["oklch(0 0 0deg / 1)", "oklch(0 0 0)"],
+    ["oklch(0 0 0deg / 0.5)", "oklch(0 0 0 / 0.5)"],
+    ["oklch(1 2.3 0deg / 0.5)", "oklch(1 2.3 0 / 0.5)"],
+    ["oklch(0.2 0.5 20deg/0.5)", "oklch(0.2 0.5 20 / 0.5)"],
+    ["oklch(0.2 0.5 20deg/50%)", "oklch(0.2 0.5 20 / 0.5)"],
+    ["oklch(0.1 0.2 20deg / -10%)", "oklch(0.1 0.2 20 / 0)"],
+    ["oklch(0.1 0.2 20deg / 110%)", "oklch(0.1 0.2 20)"],
+    ["oklch(0.1 0.2 1.28rad)", "oklch(0.1 0.2 73.3386)"],
+    ["oklch(0.1 0.2 380deg)", "oklch(0.1 0.2 20)"],
+    ["oklch(0.1 0.2 -340deg)", "oklch(0.1 0.2 20)"],
+    ["oklch(0.1 0.2 740deg)", "oklch(0.1 0.2 20)"],
+    ["oklch(0.1 0.2 -700deg)", "oklch(0.1 0.2 20)"],
+    ["oklch(-0.4 0 0)", "oklch(0 0 0)"],
+    ["oklch(0.2 -0.2 0)", "oklch(0.2 0 0)"],
+    ["oklch(0 0 0 / 0.5)", "oklch(0 0 0 / 0.5)"],
+    ["oklch(0.1 0.2 20 / 110%)", "oklch(0.1 0.2 20)"],
+    ["oklch(0.1 0.2 -700)", "oklch(0.1 0.2 20)"],
+    ["oklch(calc(0.5 * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))", "oklch(1 0 40 / 0.5)"],
+    ["oklch(calc(-0.5 * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))", "oklch(0 1.5 320 / 0)"],
 
-// oklch()
-test_computed_value("color", "oklch(0 0 0deg)", "oklch(0 0 0)");
-test_computed_value("color", "oklch(0 0 0deg / 1)", "oklch(0 0 0)");
-test_computed_value("color", "oklch(0 0 0deg / 0.5)", "oklch(0 0 0 / 0.5)");
-test_computed_value("color", "oklch(1 2.3 0deg / 0.5)", "oklch(1 2.3 0 / 0.5)");
-test_computed_value("color", "oklch(0.2 0.5 20deg/0.5)", "oklch(0.2 0.5 20 / 0.5)");
-test_computed_value("color", "oklch(0.2 0.5 20deg/50%)", "oklch(0.2 0.5 20 / 0.5)");
-test_computed_value("color", "oklch(0.1 0.2 20deg / -10%)", "oklch(0.1 0.2 20 / 0)");
-test_computed_value("color", "oklch(0.1 0.2 20deg / 110%)", "oklch(0.1 0.2 20)");
-test_computed_value("color", "oklch(0.1 0.2 1.28rad)", "oklch(0.1 0.2 73.3386)");
-test_computed_value("color", "oklch(0.1 0.2 380deg)", "oklch(0.1 0.2 20)");
-test_computed_value("color", "oklch(0.1 0.2 -340deg)", "oklch(0.1 0.2 20)");
-test_computed_value("color", "oklch(0.1 0.2 740deg)", "oklch(0.1 0.2 20)");
-test_computed_value("color", "oklch(0.1 0.2 -700deg)", "oklch(0.1 0.2 20)");
-test_computed_value("color", "oklch(-0.4 0 0)", "oklch(0 0 0)");
-test_computed_value("color", "oklch(0.2 -0.2 0)", "oklch(0.2 0 0)");
-test_computed_value("color", "oklch(0 0 0 / 0.5)", "oklch(0 0 0 / 0.5)");
-test_computed_value("color", "oklch(0.1 0.2 20 / 110%)", "oklch(0.1 0.2 20)");
-test_computed_value("color", "oklch(0.1 0.2 -700)", "oklch(0.1 0.2 20)");
-test_computed_value("color", "oklch(calc(0.5 * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))", "oklch(1 0 40 / 0.5)");
-test_computed_value("color", "oklch(calc(-0.5 * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))", "oklch(0 1.5 320 / 0)");
+    ["oklch(none none none / none)", "oklch(none none none / none)"],
+    ["oklch(none none none)", "oklch(none none none)"],
+    ["oklch(0.2 none none / none)", "oklch(0.2 none none / none)"],
+    ["oklch(none none none / 0.5)", "oklch(none none none / 0.5)"],
+    ["oklch(0 0 0 / none)", "oklch(0 0 0 / none)"],
 
-test_computed_value("color", "oklch(none none none / none)", "oklch(none none none / none)");
-test_computed_value("color", "oklch(none none none)", "oklch(none none none)");
-test_computed_value("color", "oklch(0.2 none none / none)", "oklch(0.2 none none / none)");
-test_computed_value("color", "oklch(none none none / 0.5)", "oklch(none none none / 0.5)");
-test_computed_value("color", "oklch(0 0 0 / none)", "oklch(0 0 0 / none)");
+    // These tests validate the ranges of lch() vs. oklch() lightness and chroma
+    ["lch(20% 80% 10/0.5)", "lch(20 120 10 / 0.5)"],
+    ["oklch(20% 60% 10/0.5)", "oklch(0.2 0.24 10 / 0.5)"],
 
-// These tests validate the ranges of lch() vs. oklch() lightness and chroma
-test_computed_value("color", "lch(20% 80% 10/0.5)", "lch(20 120 10 / 0.5)");
-test_computed_value("color", "oklch(20% 60% 10/0.5)", "oklch(0.2 0.24 10 / 0.5)");
+    ["oklch(calc(NaN) 0 0)", "oklch(0 0 0)"],
+    ["oklch(calc(0 / 0) 0 0)", "oklch(0 0 0)"],
 
-test_computed_value("color", "oklch(calc(NaN) 0 0)", "oklch(0 0 0)");
-test_computed_value("color", "oklch(calc(0 / 0) 0 0)", "oklch(0 0 0)");
+    // calc(50% + (sign(1em - 10px) * 10%)), with its font relative units, must be evaluatated for computed value.
+    ["lab(calc(50 + (sign(1em - 10px) * 10)) 30 50 / 50%)", "lab(60 30 50 / 0.5)"],
+    ["oklab(calc(0.5 + (sign(1em - 10px) * 0.1)) 0.3 0.5 / 50%)", "oklab(0.6 0.3 0.5 / 0.5)"],
+    ["lab(60 30 50 / calc(50% + (sign(1em - 10px) * 10%)))", "lab(60 30 50 / 0.6)"],
+    ["oklab(0.6 0.3 0.5 / calc(50% + (sign(1em - 10px) * 10%)))", "oklab(0.6 0.3 0.5 / 0.6)"],
+
+    ["lch(calc(50 + (sign(1em - 10px) * 10)) 30 50deg / 50%)", "lch(60 30 50 / 0.5)"],
+    ["oklch(calc(0.5 + (sign(1em - 10px) * 0.1)) 0.3 50deg / 50%)", "oklch(0.6 0.3 50 / 0.5)"],
+    ["lch(60 30 50deg / calc(50% + (sign(1em - 10px) * 10%)))", "lch(60 30 50 / 0.6)"],
+    ["oklch(0.6 0.3 50deg / calc(50% + (sign(1em - 10px) * 10%)))", "oklch(0.6 0.3 50 / 0.6)"],
+];
+
+for (const test of tests) {
+    test_computed_value("color", test[0], test[1], test[2] ? `[${test[2]}]` : undefined);
+}
+
+// Ensure that `calc` values work with dynamically changing relative units (slighly different alpha values to make test harness not complain about duplicate tests).
+document.getElementById("container").style.width = "1000px";
+test_computed_value("color", "lab(calc(50 + (sign(2cqw - 10px) * 10)) 30 50 / 0.51)", "lab(60 30 50 / 0.51)");
+test_computed_value("color", "oklab(calc(0.5 + (sign(2cqw - 10px) * 0.1)) 0.3 0.5 / 0.51)", "oklab(0.6 0.3 0.5 / 0.51)");
+test_computed_value("color", "lch(calc(50 + (sign(2cqw - 10px) * 10)) 30 50 / 0.51)", "lch(60 30 50 / 0.51)");
+test_computed_value("color", "oklch(calc(0.5 + (sign(2cqw - 10px) * 0.1)) 0.3 50 / 0.51)", "oklch(0.6 0.3 50 / 0.51)");
+document.getElementById("container").style.width = "100px";
+test_computed_value("color", "lab(calc(50 + (sign(2cqw - 10px) * 10)) 30 50 / 0.52)", "lab(40 30 50 / 0.52)");
+test_computed_value("color", "oklab(calc(0.5 + (sign(2cqw - 10px) * 0.1)) 0.3 0.5 / 0.52)", "oklab(0.4 0.3 0.5 / 0.52)");
+test_computed_value("color", "lch(calc(50 + (sign(2cqw - 10px) * 10)) 30 50 / 0.52)", "lch(40 30 50 / 0.52)");
+test_computed_value("color", "oklch(calc(0.5 + (sign(2cqw - 10px) * 0.1)) 0.3 50 / 0.52)", "oklch(0.4 0.3 50 / 0.52)");
 
 </script>
 </body>

--- a/css/css-color/parsing/color-computed-rgb.html
+++ b/css/css-color/parsing/color-computed-rgb.html
@@ -21,6 +21,7 @@
     --negative: -100;
   }
   #container {
+    container-type: inline-size;
     color: rgb(255, 0, 0);
   }
 </style>
@@ -112,11 +113,40 @@ tests = [
 
     ["rgb(var(--high), 0, 0)", "rgb(255, 0, 0)", "Variables above 255 get clamped to 255."],
     ["rgb(var(--negative), 64, 128)", "rgb(0, 64, 128)", "Variables below 0 get clamped to 0."],
+
+    // calc(50% + (sign(1em - 10px) * 10%)), with its font relative units, must be evaluatated for computed value.
+    ["rgb(calc(50% + (sign(1em - 10px) * 10%)), 0%, 0%, 50%)", "rgba(153, 0, 0, 0.5)"],
+    ["rgba(calc(50% + (sign(1em - 10px) * 10%)), 0%, 0%, 50%)", "rgba(153, 0, 0, 0.5)"],
+    ["rgb(calc(50 + (sign(1em - 10px) * 10)), 0, 0, 0.5)", "rgba(60, 0, 0, 0.5)"],
+    ["rgba(calc(50 + (sign(1em - 10px) * 10)), 0, 0, 0.5)", "rgba(60, 0, 0, 0.5)"],
+    ["rgb(0%, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))", "rgba(0, 0, 0, 0.6)"],
+    ["rgba(0%, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))", "rgba(0, 0, 0, 0.6)"],
+    ["rgb(0, 0, 0, calc(0.75 + (sign(1em - 10px) * 0.1)))", "rgba(0, 0, 0, 0.85)"],
+    ["rgba(0, 0, 0, calc(0.75 + (sign(1em - 10px) * 0.1)))", "rgba(0, 0, 0, 0.85)"],
+
+    ["rgb(calc(50% + (sign(1em - 10px) * 10%)) 0% 0% / 50%)", "rgba(153, 0, 0, 0.5)"],
+    ["rgba(calc(50% + (sign(1em - 10px) * 10%)) 0% 0% / 50%)", "rgba(153, 0, 0, 0.5)"],
+    ["rgb(calc(50 + (sign(1em - 10px) * 10)) 0 0 / 0.5)", "rgba(60, 0, 0, 0.5)"],
+    ["rgba(calc(50 + (sign(1em - 10px) * 10)) 0 0 / 0.5)", "rgba(60, 0, 0, 0.5)"],
+    ["rgb(0% 0% 0% / calc(50% + (sign(1em - 10px) * 10%)))", "rgba(0, 0, 0, 0.6)"],
+    ["rgba(0% 0% 0% / calc(50% + (sign(1em - 10px) * 10%)))", "rgba(0, 0, 0, 0.6)"],
+    ["rgb(0 0 0 / calc(0.75 + (sign(1em - 10px) * 0.1)))", "rgba(0, 0, 0, 0.85)"],
+    ["rgba(0 0 0 / calc(0.75 + (sign(1em - 10px) * 0.1)))", "rgba(0, 0, 0, 0.85)"],
+
+    ["rgba(calc(50% + (sign(1em - 10px) * 10%)) 0 0% / 0.5)", "rgba(153, 0, 0, 0.5)"],
+    ["rgba(0% 0 0% / calc(0.75 + (sign(1em - 10px) * 0.1)))", "rgba(0, 0, 0, 0.85)"],
 ];
 
 for (const test of tests) {
     test_computed_value("color", test[0], test[1], test[2] ? `[${test[2]}]` : undefined);
 }
+
+// Ensure that `calc` values work with dynamically changing relative units (slighly different alpha values to make test harness not complain about duplicate tests).
+document.getElementById("container").style.width = "1000px";
+test_computed_value("color", "rgba(calc(50% + (sign(2cqw - 10px) * 10%)), 0%, 0%, 51%)", "rgba(153, 0, 0, 0.51)");
+document.getElementById("container").style.width = "100px";
+test_computed_value("color", "rgba(calc(50% + (sign(2cqw - 10px) * 10%)), 0%, 0%, 52%)", "rgba(102, 0, 0, 0.52)");
+
 </script>
 </body>
 </html>

--- a/css/css-color/parsing/color-valid-color-function.html
+++ b/css/css-color/parsing/color-valid-color-function.html
@@ -46,6 +46,10 @@ for (const colorSpace of [ "srgb", "srgb-linear", "a98-rgb", "rec2020", "prophot
     test_valid_value("color", `color(${colorSpace} 0 calc(-infinity) 0)`, `color(${colorSpace} 0 calc(-infinity) 0)`);
     test_valid_value("color", `color(${colorSpace} calc(NaN) 0 0)`, `color(${colorSpace} calc(NaN) 0 0)`);
     test_valid_value("color", `color(${colorSpace} calc(0 / 0) 0 0)`, `color(${colorSpace} calc(NaN) 0 0)`);
+
+    // calc(50% + (sign(1em - 10px) * 10%)) cannot be evaluated eagerly because font relative units are not yet known at parse time.
+    test_valid_value("color", `color(${colorSpace} calc(50% + (sign(1em - 10px) * 10%)) 0 0 / 0.5)`, `color(${colorSpace} calc(50% + (10% * sign(1em - 10px))) 0 0 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} 0.5 0 0 / calc(50% + (sign(1em - 10px) * 10%)))`, `color(${colorSpace} 0.5 0 0 / calc(50% + (10% * sign(1em - 10px))))`);
 }
 
 for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
@@ -77,6 +81,10 @@ for (const colorSpace of [ "xyz", "xyz-d50", "xyz-d65" ]) {
     test_valid_value("color", `color(${colorSpace} 0 calc(-infinity) 0)`, `color(${resultColorSpace} 0 calc(-infinity) 0)`);
     test_valid_value("color", `color(${colorSpace} calc(NaN) 0 0)`, `color(${resultColorSpace} calc(NaN) 0 0)`);
     test_valid_value("color", `color(${colorSpace} calc(0 / 0) 0 0)`, `color(${resultColorSpace} calc(NaN) 0 0)`);
+
+    // calc(50% + (sign(1em - 10px) * 10%)) cannot be evaluated eagerly because font relative units are not yet known at parse time.
+    test_valid_value("color", `color(${colorSpace} calc(0.5 + (sign(1em - 10px) * 0.1)) 0 0 / 0.5)`, `color(${resultColorSpace} calc(0.5 + (0.1 * sign(1em - 10px))) 0 0 / 0.5)`);
+    test_valid_value("color", `color(${colorSpace} 0.5 0 0 / calc(0.5 + (sign(1em - 10px) * 0.1)))`, `color(${resultColorSpace} 0.5 0 0 / calc(0.5 + (0.1 * sign(1em - 10px))))`);
 }
 </script>
 </body>

--- a/css/css-color/parsing/color-valid-color-mix-function.html
+++ b/css/css-color/parsing/color-valid-color-mix-function.html
@@ -34,152 +34,154 @@
     fuzzy_test_valid_color(`color-mix(in lch decreasing hue, red, hsl(120, 100%, 50%))`, `color-mix(in lch decreasing hue, red, rgb(0, 255, 0))`);
     fuzzy_test_valid_color(`color-mix(in hsl, red calc(50% * sign(100em - 1px)), blue)`, `color-mix(in hsl, red calc(50% * sign(100em - 1px)), blue)`);
 
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%), hsl(30deg 30% 40%))`, `color-mix(in hsl, rgb(46, 56, 46), rgb(133, 102, 71))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, 50% hsl(120deg 10% 20%), hsl(30deg 30% 40%))`, `color-mix(in hsl, rgb(46, 56, 46), rgb(133, 102, 71))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%), 50% hsl(30deg 30% 40%))`, `color-mix(in hsl, rgb(46, 56, 46), rgb(133, 102, 71))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40%))`, `color-mix(in hsl, rgb(46, 56, 46) 25%, rgb(133, 102, 71))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, 25% hsl(120deg 10% 20%), hsl(30deg 30% 40%))`, `color-mix(in hsl, rgb(46, 56, 46) 25%, rgb(133, 102, 71))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%), 25% hsl(30deg 30% 40%))`, `color-mix(in hsl, rgb(46, 56, 46) 75%, rgb(133, 102, 71))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%), hsl(30deg 30% 40%) 25%)`, `color-mix(in hsl, rgb(46, 56, 46) 75%, rgb(133, 102, 71))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40%) 75%)`, `color-mix(in hsl, rgb(46, 56, 46) 25%, rgb(133, 102, 71))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%) 30%, hsl(30deg 30% 40%) 90%)`, `color-mix(in hsl, rgb(46, 56, 46) 30%, rgb(133, 102, 71) 90%)`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%) 12.5%, hsl(30deg 30% 40%) 37.5%)`, `color-mix(in hsl, rgb(46, 56, 46) 12.5%, rgb(133, 102, 71) 37.5%)`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%) 0%, hsl(30deg 30% 40%))`, `color-mix(in hsl, rgb(46, 56, 46) 0%, rgb(133, 102, 71))`);
+    // NOTE: For the epsilon to meaningful for fuzzy_test_valid_color when used with integer rounded results like rgb(), it must be at least 1.
 
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8))`, `color-mix(in hsl, rgba(46, 56, 46, 0.4), rgba(133, 102, 71, 0.8))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40% / .8))`, `color-mix(in hsl, rgb(46, 56, 46) 25%, rgba(133, 102, 71, 0.8))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, 25% hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8))`, `color-mix(in hsl, rgba(46, 56, 46, 0.4) 25%, rgba(133, 102, 71, 0.8))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20% / .4), 25% hsl(30deg 30% 40% / .8))`, `color-mix(in hsl, rgba(46, 56, 46, 0.4) 75%, rgba(133, 102, 71, 0.8))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8) 25%)`, `color-mix(in hsl, rgba(46, 56, 46, 0.4) 75%, rgba(133, 102, 71, 0.8))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20% / .4) 25%, hsl(30deg 30% 40% / .8) 75%)`, `color-mix(in hsl, rgba(46, 56, 46, 0.4) 25%, rgba(133, 102, 71, 0.8))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20% / .4) 30%, hsl(30deg 30% 40% / .8) 90%)`, `color-mix(in hsl, rgba(46, 56, 46, 0.4) 30%, rgba(133, 102, 71, 0.8) 90%)`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20% / .4) 12.5%, hsl(30deg 30% 40% / .8) 37.5%)`, `color-mix(in hsl, rgba(46, 56, 46, 0.4) 12.5%, rgba(133, 102, 71, 0.8) 37.5%)`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20% / .4) 0%, hsl(30deg 30% 40% / .8))`, `color-mix(in hsl, rgba(46, 56, 46, 0.4) 0%, rgba(133, 102, 71, 0.8))`);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%), hsl(30deg 30% 40%))`, `color-mix(in hsl, rgb(46, 56, 46), rgb(133, 102, 71))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, 50% hsl(120deg 10% 20%), hsl(30deg 30% 40%))`, `color-mix(in hsl, rgb(46, 56, 46), rgb(133, 102, 71))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%), 50% hsl(30deg 30% 40%))`, `color-mix(in hsl, rgb(46, 56, 46), rgb(133, 102, 71))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40%))`, `color-mix(in hsl, rgb(46, 56, 46) 25%, rgb(133, 102, 71))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, 25% hsl(120deg 10% 20%), hsl(30deg 30% 40%))`, `color-mix(in hsl, rgb(46, 56, 46) 25%, rgb(133, 102, 71))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%), 25% hsl(30deg 30% 40%))`, `color-mix(in hsl, rgb(46, 56, 46) 75%, rgb(133, 102, 71))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%), hsl(30deg 30% 40%) 25%)`, `color-mix(in hsl, rgb(46, 56, 46) 75%, rgb(133, 102, 71))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40%) 75%)`, `color-mix(in hsl, rgb(46, 56, 46) 25%, rgb(133, 102, 71))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%) 30%, hsl(30deg 30% 40%) 90%)`, `color-mix(in hsl, rgb(46, 56, 46) 30%, rgb(133, 102, 71) 90%)`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%) 12.5%, hsl(30deg 30% 40%) 37.5%)`, `color-mix(in hsl, rgb(46, 56, 46) 12.5%, rgb(133, 102, 71) 37.5%)`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%) 0%, hsl(30deg 30% 40%))`, `color-mix(in hsl, rgb(46, 56, 46) 0%, rgb(133, 102, 71))`, 1);
 
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(40deg 50% 50%), hsl(60deg 50% 50%))`, `color-mix(in hsl, rgb(191, 149, 64), rgb(191, 191, 64))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(60deg 50% 50%), hsl(40deg 50% 50%))`, `color-mix(in hsl, rgb(191, 191, 64), rgb(191, 149, 64))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(50deg 50% 50%), hsl(330deg 50% 50%))`, `color-mix(in hsl, rgb(191, 170, 64), rgb(191, 64, 128))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(330deg 50% 50%), hsl(50deg 50% 50%))`, `color-mix(in hsl, rgb(191, 64, 128), rgb(191, 170, 64))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(20deg 50% 50%), hsl(320deg 50% 50%))`, `color-mix(in hsl, rgb(191, 106, 64), rgb(191, 64, 149))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(320deg 50% 50%), hsl(20deg 50% 50%))`, `color-mix(in hsl, rgb(191, 64, 149), rgb(191, 106, 64))`);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8))`, `color-mix(in hsl, rgba(46, 56, 46, 0.4), rgba(133, 102, 71, 0.8))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40% / .8))`, `color-mix(in hsl, rgb(46, 56, 46) 25%, rgba(133, 102, 71, 0.8))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, 25% hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8))`, `color-mix(in hsl, rgba(46, 56, 46, 0.4) 25%, rgba(133, 102, 71, 0.8))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20% / .4), 25% hsl(30deg 30% 40% / .8))`, `color-mix(in hsl, rgba(46, 56, 46, 0.4) 75%, rgba(133, 102, 71, 0.8))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8) 25%)`, `color-mix(in hsl, rgba(46, 56, 46, 0.4) 75%, rgba(133, 102, 71, 0.8))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20% / .4) 25%, hsl(30deg 30% 40% / .8) 75%)`, `color-mix(in hsl, rgba(46, 56, 46, 0.4) 25%, rgba(133, 102, 71, 0.8))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20% / .4) 30%, hsl(30deg 30% 40% / .8) 90%)`, `color-mix(in hsl, rgba(46, 56, 46, 0.4) 30%, rgba(133, 102, 71, 0.8) 90%)`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20% / .4) 12.5%, hsl(30deg 30% 40% / .8) 37.5%)`, `color-mix(in hsl, rgba(46, 56, 46, 0.4) 12.5%, rgba(133, 102, 71, 0.8) 37.5%)`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 10% 20% / .4) 0%, hsl(30deg 30% 40% / .8))`, `color-mix(in hsl, rgba(46, 56, 46, 0.4) 0%, rgba(133, 102, 71, 0.8))`, 1);
 
-    fuzzy_test_valid_color(`color-mix(in hsl shorter hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))`, `color-mix(in hsl, rgb(191, 149, 64), rgb(191, 191, 64))`);
-    fuzzy_test_valid_color(`color-mix(in hsl shorter hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))`, `color-mix(in hsl, rgb(191, 191, 64), rgb(191, 149, 64))`);
-    fuzzy_test_valid_color(`color-mix(in hsl shorter hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))`, `color-mix(in hsl, rgb(191, 170, 64), rgb(191, 64, 128))`);
-    fuzzy_test_valid_color(`color-mix(in hsl shorter hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))`, `color-mix(in hsl, rgb(191, 64, 128), rgb(191, 170, 64))`);
-    fuzzy_test_valid_color(`color-mix(in hsl shorter hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))`, `color-mix(in hsl, rgb(191, 106, 64), rgb(191, 64, 149))`);
-    fuzzy_test_valid_color(`color-mix(in hsl shorter hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))`, `color-mix(in hsl, rgb(191, 64, 149), rgb(191, 106, 64))`);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(40deg 50% 50%), hsl(60deg 50% 50%))`, `color-mix(in hsl, rgb(191, 149, 64), rgb(191, 191, 64))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(60deg 50% 50%), hsl(40deg 50% 50%))`, `color-mix(in hsl, rgb(191, 191, 64), rgb(191, 149, 64))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(50deg 50% 50%), hsl(330deg 50% 50%))`, `color-mix(in hsl, rgb(191, 170, 64), rgb(191, 64, 128))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(330deg 50% 50%), hsl(50deg 50% 50%))`, `color-mix(in hsl, rgb(191, 64, 128), rgb(191, 170, 64))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(20deg 50% 50%), hsl(320deg 50% 50%))`, `color-mix(in hsl, rgb(191, 106, 64), rgb(191, 64, 149))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(320deg 50% 50%), hsl(20deg 50% 50%))`, `color-mix(in hsl, rgb(191, 64, 149), rgb(191, 106, 64))`, 1);
 
-    fuzzy_test_valid_color(`color-mix(in hsl longer hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))`, `color-mix(in hsl longer hue, rgb(191, 149, 64), rgb(191, 191, 64))`);
-    fuzzy_test_valid_color(`color-mix(in hsl longer hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))`, `color-mix(in hsl longer hue, rgb(191, 191, 64), rgb(191, 149, 64))`);
-    fuzzy_test_valid_color(`color-mix(in hsl longer hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))`, `color-mix(in hsl longer hue, rgb(191, 170, 64), rgb(191, 64, 128))`);
-    fuzzy_test_valid_color(`color-mix(in hsl longer hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))`, `color-mix(in hsl longer hue, rgb(191, 64, 128), rgb(191, 170, 64))`);
-    fuzzy_test_valid_color(`color-mix(in hsl longer hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))`, `color-mix(in hsl longer hue, rgb(191, 106, 64), rgb(191, 64, 149))`);
-    fuzzy_test_valid_color(`color-mix(in hsl longer hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))`, `color-mix(in hsl longer hue, rgb(191, 64, 149), rgb(191, 106, 64))`);
+    fuzzy_test_valid_color(`color-mix(in hsl shorter hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))`, `color-mix(in hsl, rgb(191, 149, 64), rgb(191, 191, 64))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl shorter hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))`, `color-mix(in hsl, rgb(191, 191, 64), rgb(191, 149, 64))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl shorter hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))`, `color-mix(in hsl, rgb(191, 170, 64), rgb(191, 64, 128))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl shorter hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))`, `color-mix(in hsl, rgb(191, 64, 128), rgb(191, 170, 64))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl shorter hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))`, `color-mix(in hsl, rgb(191, 106, 64), rgb(191, 64, 149))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl shorter hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))`, `color-mix(in hsl, rgb(191, 64, 149), rgb(191, 106, 64))`, 1);
 
-    fuzzy_test_valid_color(`color-mix(in hsl increasing hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))`, `color-mix(in hsl increasing hue, rgb(191, 149, 64), rgb(191, 191, 64))`);
-    fuzzy_test_valid_color(`color-mix(in hsl increasing hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))`, `color-mix(in hsl increasing hue, rgb(191, 191, 64), rgb(191, 149, 64))`);
-    fuzzy_test_valid_color(`color-mix(in hsl increasing hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))`, `color-mix(in hsl increasing hue, rgb(191, 170, 64), rgb(191, 64, 128))`);
-    fuzzy_test_valid_color(`color-mix(in hsl increasing hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))`, `color-mix(in hsl increasing hue, rgb(191, 64, 128), rgb(191, 170, 64))`);
-    fuzzy_test_valid_color(`color-mix(in hsl increasing hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))`, `color-mix(in hsl increasing hue, rgb(191, 106, 64), rgb(191, 64, 149))`);
-    fuzzy_test_valid_color(`color-mix(in hsl increasing hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))`, `color-mix(in hsl increasing hue, rgb(191, 64, 149), rgb(191, 106, 64))`);
+    fuzzy_test_valid_color(`color-mix(in hsl longer hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))`, `color-mix(in hsl longer hue, rgb(191, 149, 64), rgb(191, 191, 64))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl longer hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))`, `color-mix(in hsl longer hue, rgb(191, 191, 64), rgb(191, 149, 64))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl longer hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))`, `color-mix(in hsl longer hue, rgb(191, 170, 64), rgb(191, 64, 128))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl longer hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))`, `color-mix(in hsl longer hue, rgb(191, 64, 128), rgb(191, 170, 64))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl longer hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))`, `color-mix(in hsl longer hue, rgb(191, 106, 64), rgb(191, 64, 149))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl longer hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))`, `color-mix(in hsl longer hue, rgb(191, 64, 149), rgb(191, 106, 64))`, 1);
 
-    fuzzy_test_valid_color(`color-mix(in hsl decreasing hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))`, `color-mix(in hsl decreasing hue, rgb(191, 149, 64), rgb(191, 191, 64))`);
-    fuzzy_test_valid_color(`color-mix(in hsl decreasing hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))`, `color-mix(in hsl decreasing hue, rgb(191, 191, 64), rgb(191, 149, 64))`);
-    fuzzy_test_valid_color(`color-mix(in hsl decreasing hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))`, `color-mix(in hsl decreasing hue, rgb(191, 170, 64), rgb(191, 64, 128))`);
-    fuzzy_test_valid_color(`color-mix(in hsl decreasing hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))`, `color-mix(in hsl decreasing hue, rgb(191, 64, 128), rgb(191, 170, 64))`);
-    fuzzy_test_valid_color(`color-mix(in hsl decreasing hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))`, `color-mix(in hsl decreasing hue, rgb(191, 106, 64), rgb(191, 64, 149))`);
-    fuzzy_test_valid_color(`color-mix(in hsl decreasing hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))`, `color-mix(in hsl decreasing hue, rgb(191, 64, 149), rgb(191, 106, 64))`);
+    fuzzy_test_valid_color(`color-mix(in hsl increasing hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))`, `color-mix(in hsl increasing hue, rgb(191, 149, 64), rgb(191, 191, 64))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl increasing hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))`, `color-mix(in hsl increasing hue, rgb(191, 191, 64), rgb(191, 149, 64))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl increasing hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))`, `color-mix(in hsl increasing hue, rgb(191, 170, 64), rgb(191, 64, 128))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl increasing hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))`, `color-mix(in hsl increasing hue, rgb(191, 64, 128), rgb(191, 170, 64))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl increasing hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))`, `color-mix(in hsl increasing hue, rgb(191, 106, 64), rgb(191, 64, 149))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl increasing hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))`, `color-mix(in hsl increasing hue, rgb(191, 64, 149), rgb(191, 106, 64))`, 1);
 
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(none none none), hsl(none none none))`, `color-mix(in hsl, rgb(0, 0, 0), rgb(0, 0, 0))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(none none none), hsl(30deg 40% 80%))`, `color-mix(in hsl, rgb(0, 0, 0), rgb(224, 204, 184))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 20% 40%), hsl(none none none))`, `color-mix(in hsl, rgb(82, 122, 82), rgb(0, 0, 0))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 20% none), hsl(30deg 40% 60%))`, `color-mix(in hsl, rgb(0, 0, 0), rgb(194, 153, 112))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 20% 40%), hsl(30deg 20% none))`, `color-mix(in hsl, rgb(82, 122, 82), rgb(0, 0, 0))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(none 20% 40%), hsl(30deg none 80%))`, `color-mix(in hsl, rgb(122, 82, 82), rgb(204, 204, 204))`);
+    fuzzy_test_valid_color(`color-mix(in hsl decreasing hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))`, `color-mix(in hsl decreasing hue, rgb(191, 149, 64), rgb(191, 191, 64))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl decreasing hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))`, `color-mix(in hsl decreasing hue, rgb(191, 191, 64), rgb(191, 149, 64))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl decreasing hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))`, `color-mix(in hsl decreasing hue, rgb(191, 170, 64), rgb(191, 64, 128))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl decreasing hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))`, `color-mix(in hsl decreasing hue, rgb(191, 64, 128), rgb(191, 170, 64))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl decreasing hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))`, `color-mix(in hsl decreasing hue, rgb(191, 106, 64), rgb(191, 64, 149))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl decreasing hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))`, `color-mix(in hsl decreasing hue, rgb(191, 64, 149), rgb(191, 106, 64))`, 1);
 
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40%))`, `color-mix(in hsl, rgba(61, 143, 61, 0), rgb(143, 61, 61))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40% / 0.5))`, `color-mix(in hsl, rgba(61, 143, 61, 0), rgba(143, 61, 61, 0.5))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40% / none))`, `color-mix(in hsl, rgba(61, 143, 61, 0), rgba(143, 61, 61, 0))`);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(none none none), hsl(none none none))`, `color-mix(in hsl, rgb(0, 0, 0), rgb(0, 0, 0))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(none none none), hsl(30deg 40% 80%))`, `color-mix(in hsl, rgb(0, 0, 0), rgb(224, 204, 184))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 20% 40%), hsl(none none none))`, `color-mix(in hsl, rgb(82, 122, 82), rgb(0, 0, 0))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 20% none), hsl(30deg 40% 60%))`, `color-mix(in hsl, rgb(0, 0, 0), rgb(194, 153, 112))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 20% 40%), hsl(30deg 20% none))`, `color-mix(in hsl, rgb(82, 122, 82), rgb(0, 0, 0))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(none 20% 40%), hsl(30deg none 80%))`, `color-mix(in hsl, rgb(122, 82, 82), rgb(204, 204, 204))`, 1);
 
-    fuzzy_test_valid_color(`color-mix(in hsl, color(display-p3 0 1 0) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, color(display-p3 0 1 0) 100%, rgb(0, 0, 0))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, lab(100 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, lab(100 104.3 -50.9) 100%, rgb(0, 0, 0))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, lab(0 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, lab(0 104.3 -50.9) 100%, rgb(0, 0, 0))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, lch(100 116 334) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, lch(100 116 334) 100%, rgb(0, 0, 0))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, lch(0 116 334) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, lch(0 116 334) 100%, rgb(0, 0, 0))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, oklab(100 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, oklab(1 0.365 -0.16) 100%, rgb(0, 0, 0))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, oklab(0 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, oklab(0 0.365 -0.16) 100%, rgb(0, 0, 0))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, oklch(100 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, oklch(1 0.399 336.3) 100%, rgb(0, 0, 0))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, oklab(1 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, oklab(1 0.365 -0.16) 100%, rgb(0, 0, 0))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, oklch(1 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, oklch(1 0.399 336.3) 100%, rgb(0, 0, 0))`);
-    fuzzy_test_valid_color(`color-mix(in hsl, oklch(0 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, oklch(0 0.399 336.3) 100%, rgb(0, 0, 0))`);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40%))`, `color-mix(in hsl, rgba(61, 143, 61, 0), rgb(143, 61, 61))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40% / 0.5))`, `color-mix(in hsl, rgba(61, 143, 61, 0), rgba(143, 61, 61, 0.5))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40% / none))`, `color-mix(in hsl, rgba(61, 143, 61, 0), rgba(143, 61, 61, 0))`, 1);
 
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%))`, `color-mix(in hwb, rgb(26, 204, 26), rgb(153, 115, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, 50% hwb(120deg 10% 20%), hwb(30deg 30% 40%))`, `color-mix(in hwb, rgb(26, 204, 26), rgb(153, 115, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%), 50% hwb(30deg 30% 40%))`, `color-mix(in hwb, rgb(26, 204, 26), rgb(153, 115, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%) 25%, hwb(30deg 30% 40%))`, `color-mix(in hwb, rgb(26, 204, 26) 25%, rgb(153, 115, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, 25% hwb(120deg 10% 20%), hwb(30deg 30% 40%))`, `color-mix(in hwb, rgb(26, 204, 26) 25%, rgb(153, 115, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%), 25% hwb(30deg 30% 40%))`, `color-mix(in hwb, rgb(26, 204, 26) 75%, rgb(153, 115, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%) 25%)`, `color-mix(in hwb, rgb(26, 204, 26) 75%, rgb(153, 115, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%) 25%, hwb(30deg 30% 40%) 75%)`, `color-mix(in hwb, rgb(26, 204, 26) 25%, rgb(153, 115, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%) 30%, hwb(30deg 30% 40%) 90%)`, `color-mix(in hwb, rgb(26, 204, 26) 30%, rgb(153, 115, 77) 90%)`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%) 12.5%, hwb(30deg 30% 40%) 37.5%)`, `color-mix(in hwb, rgb(26, 204, 26) 12.5%, rgb(153, 115, 77) 37.5%)`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%) 0%, hwb(30deg 30% 40%))`, `color-mix(in hwb, rgb(26, 204, 26) 0%, rgb(153, 115, 77))`);
+    fuzzy_test_valid_color(`color-mix(in hsl, color(display-p3 0 1 0) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, color(display-p3 0 1 0) 100%, rgb(0, 0, 0))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, lab(100 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, lab(100 104.3 -50.9) 100%, rgb(0, 0, 0))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, lab(0 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, lab(0 104.3 -50.9) 100%, rgb(0, 0, 0))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, lch(100 116 334) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, lch(100 116 334) 100%, rgb(0, 0, 0))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, lch(0 116 334) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, lch(0 116 334) 100%, rgb(0, 0, 0))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, oklab(100 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, oklab(1 0.365 -0.16) 100%, rgb(0, 0, 0))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, oklab(0 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, oklab(0 0.365 -0.16) 100%, rgb(0, 0, 0))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, oklch(100 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, oklch(1 0.399 336.3) 100%, rgb(0, 0, 0))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, oklab(1 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, oklab(1 0.365 -0.16) 100%, rgb(0, 0, 0))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, oklch(1 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, oklch(1 0.399 336.3) 100%, rgb(0, 0, 0))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hsl, oklch(0 0.399 336.3) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hsl, oklch(0 0.399 336.3) 100%, rgb(0, 0, 0))`, 1);
 
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8))`, `color-mix(in hwb, rgba(26, 204, 26, 0.4), rgba(153, 115, 77, 0.8))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / .4) 25%, hwb(30deg 30% 40% / .8))`, `color-mix(in hwb, rgba(26, 204, 26, 0.4) 25%, rgba(153, 115, 77, 0.8))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, 25% hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8))`, `color-mix(in hwb, rgba(26, 204, 26, 0.4) 25%, rgba(153, 115, 77, 0.8))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%), 25% hwb(30deg 30% 40% / .8))`, `color-mix(in hwb, rgb(26, 204, 26) 75%, rgba(153, 115, 77, 0.8))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8) 25%)`, `color-mix(in hwb, rgba(26, 204, 26, 0.4) 75%, rgba(153, 115, 77, 0.8))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / .4) 25%, hwb(30deg 30% 40% / .8) 75%)`, `color-mix(in hwb, rgba(26, 204, 26, 0.4) 25%, rgba(153, 115, 77, 0.8))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / .4) 30%, hwb(30deg 30% 40% / .8) 90%)`, `color-mix(in hwb, rgba(26, 204, 26, 0.4) 30%, rgba(153, 115, 77, 0.8) 90%)`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / .4) 12.5%, hwb(30deg 30% 40% / .8) 37.5%)`, `color-mix(in hwb, rgba(26, 204, 26, 0.4) 12.5%, rgba(153, 115, 77, 0.8) 37.5%)`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / .4) 0%, hwb(30deg 30% 40% / .8))`, `color-mix(in hwb, rgba(26, 204, 26, 0.4) 0%, rgba(153, 115, 77, 0.8))`);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%))`, `color-mix(in hwb, rgb(26, 204, 26), rgb(153, 115, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, 50% hwb(120deg 10% 20%), hwb(30deg 30% 40%))`, `color-mix(in hwb, rgb(26, 204, 26), rgb(153, 115, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%), 50% hwb(30deg 30% 40%))`, `color-mix(in hwb, rgb(26, 204, 26), rgb(153, 115, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%) 25%, hwb(30deg 30% 40%))`, `color-mix(in hwb, rgb(26, 204, 26) 25%, rgb(153, 115, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, 25% hwb(120deg 10% 20%), hwb(30deg 30% 40%))`, `color-mix(in hwb, rgb(26, 204, 26) 25%, rgb(153, 115, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%), 25% hwb(30deg 30% 40%))`, `color-mix(in hwb, rgb(26, 204, 26) 75%, rgb(153, 115, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%) 25%)`, `color-mix(in hwb, rgb(26, 204, 26) 75%, rgb(153, 115, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%) 25%, hwb(30deg 30% 40%) 75%)`, `color-mix(in hwb, rgb(26, 204, 26) 25%, rgb(153, 115, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%) 30%, hwb(30deg 30% 40%) 90%)`, `color-mix(in hwb, rgb(26, 204, 26) 30%, rgb(153, 115, 77) 90%)`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%) 12.5%, hwb(30deg 30% 40%) 37.5%)`, `color-mix(in hwb, rgb(26, 204, 26) 12.5%, rgb(153, 115, 77) 37.5%)`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%) 0%, hwb(30deg 30% 40%))`, `color-mix(in hwb, rgb(26, 204, 26) 0%, rgb(153, 115, 77))`, 1);
 
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(40deg 30% 40%), hwb(60deg 30% 40%))`, `color-mix(in hwb, rgb(153, 128, 77), rgb(153, 153, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(60deg 30% 40%), hwb(40deg 30% 40%))`, `color-mix(in hwb, rgb(153, 153, 77), rgb(153, 128, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(50deg 30% 40%), hwb(330deg 30% 40%))`, `color-mix(in hwb, rgb(153, 140, 77), rgb(153, 77, 115))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(330deg 30% 40%), hwb(50deg 30% 40%))`, `color-mix(in hwb, rgb(153, 77, 115), rgb(153, 140, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(20deg 30% 40%), hwb(320deg 30% 40%))`, `color-mix(in hwb, rgb(153, 102, 77), rgb(153, 77, 128))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(320deg 30% 40%), hwb(20deg 30% 40%))`, `color-mix(in hwb, rgb(153, 77, 128), rgb(153, 102, 77))`);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8))`, `color-mix(in hwb, rgba(26, 204, 26, 0.4), rgba(153, 115, 77, 0.8))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / .4) 25%, hwb(30deg 30% 40% / .8))`, `color-mix(in hwb, rgba(26, 204, 26, 0.4) 25%, rgba(153, 115, 77, 0.8))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, 25% hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8))`, `color-mix(in hwb, rgba(26, 204, 26, 0.4) 25%, rgba(153, 115, 77, 0.8))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%), 25% hwb(30deg 30% 40% / .8))`, `color-mix(in hwb, rgb(26, 204, 26) 75%, rgba(153, 115, 77, 0.8))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8) 25%)`, `color-mix(in hwb, rgba(26, 204, 26, 0.4) 75%, rgba(153, 115, 77, 0.8))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / .4) 25%, hwb(30deg 30% 40% / .8) 75%)`, `color-mix(in hwb, rgba(26, 204, 26, 0.4) 25%, rgba(153, 115, 77, 0.8))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / .4) 30%, hwb(30deg 30% 40% / .8) 90%)`, `color-mix(in hwb, rgba(26, 204, 26, 0.4) 30%, rgba(153, 115, 77, 0.8) 90%)`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / .4) 12.5%, hwb(30deg 30% 40% / .8) 37.5%)`, `color-mix(in hwb, rgba(26, 204, 26, 0.4) 12.5%, rgba(153, 115, 77, 0.8) 37.5%)`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / .4) 0%, hwb(30deg 30% 40% / .8))`, `color-mix(in hwb, rgba(26, 204, 26, 0.4) 0%, rgba(153, 115, 77, 0.8))`, 1);
 
-    fuzzy_test_valid_color(`color-mix(in hwb shorter hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))`, `color-mix(in hwb, rgb(153, 128, 77), rgb(153, 153, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb shorter hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))`, `color-mix(in hwb, rgb(153, 153, 77), rgb(153, 128, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb shorter hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))`, `color-mix(in hwb, rgb(153, 140, 77), rgb(153, 77, 115))`);
-    fuzzy_test_valid_color(`color-mix(in hwb shorter hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))`, `color-mix(in hwb, rgb(153, 77, 115), rgb(153, 140, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb shorter hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))`, `color-mix(in hwb, rgb(153, 102, 77), rgb(153, 77, 128))`);
-    fuzzy_test_valid_color(`color-mix(in hwb shorter hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))`, `color-mix(in hwb, rgb(153, 77, 128), rgb(153, 102, 77))`);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(40deg 30% 40%), hwb(60deg 30% 40%))`, `color-mix(in hwb, rgb(153, 128, 77), rgb(153, 153, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(60deg 30% 40%), hwb(40deg 30% 40%))`, `color-mix(in hwb, rgb(153, 153, 77), rgb(153, 128, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(50deg 30% 40%), hwb(330deg 30% 40%))`, `color-mix(in hwb, rgb(153, 140, 77), rgb(153, 77, 115))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(330deg 30% 40%), hwb(50deg 30% 40%))`, `color-mix(in hwb, rgb(153, 77, 115), rgb(153, 140, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(20deg 30% 40%), hwb(320deg 30% 40%))`, `color-mix(in hwb, rgb(153, 102, 77), rgb(153, 77, 128))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(320deg 30% 40%), hwb(20deg 30% 40%))`, `color-mix(in hwb, rgb(153, 77, 128), rgb(153, 102, 77))`, 1);
 
-    fuzzy_test_valid_color(`color-mix(in hwb longer hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))`, `color-mix(in hwb longer hue, rgb(153, 128, 77), rgb(153, 153, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb longer hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))`, `color-mix(in hwb longer hue, rgb(153, 153, 77), rgb(153, 128, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb longer hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))`, `color-mix(in hwb longer hue, rgb(153, 140, 77), rgb(153, 77, 115))`);
-    fuzzy_test_valid_color(`color-mix(in hwb longer hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))`, `color-mix(in hwb longer hue, rgb(153, 77, 115), rgb(153, 140, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb longer hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))`, `color-mix(in hwb longer hue, rgb(153, 102, 77), rgb(153, 77, 128))`);
-    fuzzy_test_valid_color(`color-mix(in hwb longer hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))`, `color-mix(in hwb longer hue, rgb(153, 77, 128), rgb(153, 102, 77))`);
+    fuzzy_test_valid_color(`color-mix(in hwb shorter hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))`, `color-mix(in hwb, rgb(153, 128, 77), rgb(153, 153, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb shorter hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))`, `color-mix(in hwb, rgb(153, 153, 77), rgb(153, 128, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb shorter hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))`, `color-mix(in hwb, rgb(153, 140, 77), rgb(153, 77, 115))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb shorter hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))`, `color-mix(in hwb, rgb(153, 77, 115), rgb(153, 140, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb shorter hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))`, `color-mix(in hwb, rgb(153, 102, 77), rgb(153, 77, 128))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb shorter hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))`, `color-mix(in hwb, rgb(153, 77, 128), rgb(153, 102, 77))`, 1);
 
-    fuzzy_test_valid_color(`color-mix(in hwb increasing hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))`, `color-mix(in hwb increasing hue, rgb(153, 128, 77), rgb(153, 153, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb increasing hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))`, `color-mix(in hwb increasing hue, rgb(153, 153, 77), rgb(153, 128, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb increasing hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))`, `color-mix(in hwb increasing hue, rgb(153, 140, 77), rgb(153, 77, 115))`);
-    fuzzy_test_valid_color(`color-mix(in hwb increasing hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))`, `color-mix(in hwb increasing hue, rgb(153, 77, 115), rgb(153, 140, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb increasing hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))`, `color-mix(in hwb increasing hue, rgb(153, 102, 77), rgb(153, 77, 128))`);
-    fuzzy_test_valid_color(`color-mix(in hwb increasing hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))`, `color-mix(in hwb increasing hue, rgb(153, 77, 128), rgb(153, 102, 77))`);
+    fuzzy_test_valid_color(`color-mix(in hwb longer hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))`, `color-mix(in hwb longer hue, rgb(153, 128, 77), rgb(153, 153, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb longer hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))`, `color-mix(in hwb longer hue, rgb(153, 153, 77), rgb(153, 128, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb longer hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))`, `color-mix(in hwb longer hue, rgb(153, 140, 77), rgb(153, 77, 115))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb longer hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))`, `color-mix(in hwb longer hue, rgb(153, 77, 115), rgb(153, 140, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb longer hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))`, `color-mix(in hwb longer hue, rgb(153, 102, 77), rgb(153, 77, 128))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb longer hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))`, `color-mix(in hwb longer hue, rgb(153, 77, 128), rgb(153, 102, 77))`, 1);
 
-    fuzzy_test_valid_color(`color-mix(in hwb decreasing hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))`, `color-mix(in hwb decreasing hue, rgb(153, 128, 77), rgb(153, 153, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb decreasing hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))`, `color-mix(in hwb decreasing hue, rgb(153, 153, 77), rgb(153, 128, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb decreasing hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))`, `color-mix(in hwb decreasing hue, rgb(153, 140, 77), rgb(153, 77, 115))`);
-    fuzzy_test_valid_color(`color-mix(in hwb decreasing hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))`, `color-mix(in hwb decreasing hue, rgb(153, 77, 115), rgb(153, 140, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb decreasing hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))`, `color-mix(in hwb decreasing hue, rgb(153, 102, 77), rgb(153, 77, 128))`);
-    fuzzy_test_valid_color(`color-mix(in hwb decreasing hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))`, `color-mix(in hwb decreasing hue, rgb(153, 77, 128), rgb(153, 102, 77))`);
+    fuzzy_test_valid_color(`color-mix(in hwb increasing hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))`, `color-mix(in hwb increasing hue, rgb(153, 128, 77), rgb(153, 153, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb increasing hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))`, `color-mix(in hwb increasing hue, rgb(153, 153, 77), rgb(153, 128, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb increasing hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))`, `color-mix(in hwb increasing hue, rgb(153, 140, 77), rgb(153, 77, 115))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb increasing hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))`, `color-mix(in hwb increasing hue, rgb(153, 77, 115), rgb(153, 140, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb increasing hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))`, `color-mix(in hwb increasing hue, rgb(153, 102, 77), rgb(153, 77, 128))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb increasing hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))`, `color-mix(in hwb increasing hue, rgb(153, 77, 128), rgb(153, 102, 77))`, 1);
 
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(none none none), hwb(none none none))`, `color-mix(in hwb, rgb(255, 0, 0), rgb(255, 0, 0))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(none none none), hwb(30deg 30% 40%))`, `color-mix(in hwb, rgb(255, 0, 0), rgb(153, 115, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%), hwb(none none none))`, `color-mix(in hwb, rgb(26, 204, 26), rgb(255, 0, 0))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% none), hwb(30deg 30% 40%))`, `color-mix(in hwb, rgb(26, 255, 26), rgb(153, 115, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% none))`, `color-mix(in hwb, rgb(26, 204, 26), rgb(255, 166, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(none 10% 20%), hwb(30deg none 40%))`, `color-mix(in hwb, rgb(204, 26, 26), rgb(153, 77, 0))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40%))`, `color-mix(in hwb, rgba(26, 204, 26, 0), rgb(153, 115, 77))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / 0.5))`, `color-mix(in hwb, rgba(26, 204, 26, 0), rgba(153, 115, 77, 0.5))`);
-    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / none))`, `color-mix(in hwb, rgba(26, 204, 26, 0), rgba(153, 115, 77, 0))`);
+    fuzzy_test_valid_color(`color-mix(in hwb decreasing hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))`, `color-mix(in hwb decreasing hue, rgb(153, 128, 77), rgb(153, 153, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb decreasing hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))`, `color-mix(in hwb decreasing hue, rgb(153, 153, 77), rgb(153, 128, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb decreasing hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))`, `color-mix(in hwb decreasing hue, rgb(153, 140, 77), rgb(153, 77, 115))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb decreasing hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))`, `color-mix(in hwb decreasing hue, rgb(153, 77, 115), rgb(153, 140, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb decreasing hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))`, `color-mix(in hwb decreasing hue, rgb(153, 102, 77), rgb(153, 77, 128))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb decreasing hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))`, `color-mix(in hwb decreasing hue, rgb(153, 77, 128), rgb(153, 102, 77))`, 1);
+
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(none none none), hwb(none none none))`, `color-mix(in hwb, rgb(255, 0, 0), rgb(255, 0, 0))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(none none none), hwb(30deg 30% 40%))`, `color-mix(in hwb, rgb(255, 0, 0), rgb(153, 115, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%), hwb(none none none))`, `color-mix(in hwb, rgb(26, 204, 26), rgb(255, 0, 0))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% none), hwb(30deg 30% 40%))`, `color-mix(in hwb, rgb(26, 255, 26), rgb(153, 115, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% none))`, `color-mix(in hwb, rgb(26, 204, 26), rgb(255, 166, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(none 10% 20%), hwb(30deg none 40%))`, `color-mix(in hwb, rgb(204, 26, 26), rgb(153, 77, 0))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40%))`, `color-mix(in hwb, rgba(26, 204, 26, 0), rgb(153, 115, 77))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / 0.5))`, `color-mix(in hwb, rgba(26, 204, 26, 0), rgba(153, 115, 77, 0.5))`, 1);
+    fuzzy_test_valid_color(`color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / none))`, `color-mix(in hwb, rgba(26, 204, 26, 0), rgba(153, 115, 77, 0))`, 1);
 
     fuzzy_test_valid_color(`color-mix(in hwb, color(display-p3 0 1 0) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hwb, color(display-p3 0 1 0) 100%, rgb(0, 0, 0))`);
     fuzzy_test_valid_color(`color-mix(in hwb, lab(100 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)`, `color-mix(in hwb, lab(100 104.3 -50.9) 100%, rgb(0, 0, 0))`);
@@ -387,7 +389,7 @@
     fuzzy_test_valid_color(`color-mix(in oklab, oklab(0.1 0.2 0.3 / none), oklab(0.5 0.6 0.7 / 0.5))`, `color-mix(in oklab, oklab(0.1 0.2 0.3 / none), oklab(0.5 0.6 0.7 / 0.5))`);
     fuzzy_test_valid_color(`color-mix(in oklab, oklab(0.1 0.2 0.3 / none), oklab(0.5 0.6 0.7 / none))`, `color-mix(in oklab, oklab(0.1 0.2 0.3 / none), oklab(0.5 0.6 0.7 / none))`);
 
-  for (const colorSpace of [ "srgb", "srgb-linear", "display-p3", "a98-rgb", "prophoto-rgb", "rec2020", "xyz", "xyz-d50", "xyz-d65" ]) {
+    for (const colorSpace of [ "srgb", "srgb-linear", "display-p3", "a98-rgb", "prophoto-rgb", "rec2020", "xyz", "xyz-d50", "xyz-d65" ]) {
       const resultColorSpace = colorSpace == "xyz" ? "xyz-d65" : colorSpace;
 
       fuzzy_test_valid_color(`color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3), color(${colorSpace} .5 .6 .7))`, `color-mix(in ${resultColorSpace}, color(${resultColorSpace} 0.1 0.2 0.3), color(${resultColorSpace} 0.5 0.6 0.7))`);
@@ -421,7 +423,25 @@
       fuzzy_test_valid_color(`color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / none), color(${colorSpace} .5 .6 .7))`, `color-mix(in ${resultColorSpace}, color(${resultColorSpace} 0.1 0.2 0.3 / none), color(${resultColorSpace} 0.5 0.6 0.7))`);
       fuzzy_test_valid_color(`color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / none), color(${colorSpace} .5 .6 .7 / 0.5))`, `color-mix(in ${resultColorSpace}, color(${resultColorSpace} 0.1 0.2 0.3 / none), color(${resultColorSpace} 0.5 0.6 0.7 / 0.5))`);
       fuzzy_test_valid_color(`color-mix(in ${colorSpace}, color(${colorSpace} .1 .2 .3 / none), color(${colorSpace} .5 .6 .7 / none))`, `color-mix(in ${resultColorSpace}, color(${resultColorSpace} 0.1 0.2 0.3 / none), color(${resultColorSpace} 0.5 0.6 0.7 / none))`);
-  }
+    }
+
+    // Test percent normalization
+    fuzzy_test_valid_color(`color-mix(in srgb, red 50%,       blue 50%)`,          `color-mix(in srgb, red, blue)`)                     // both 50%
+    fuzzy_test_valid_color(`color-mix(in srgb, red 10%,       blue 90%)`,          `color-mix(in srgb, red 10%, blue)`)                 // sum to 100%
+    fuzzy_test_valid_color(`color-mix(in srgb, red 50%,       blue 40%)`,          `color-mix(in srgb, red 50%, blue 40%)`)             // only one is 50% (p1)
+    fuzzy_test_valid_color(`color-mix(in srgb, red 40%,       blue 50%)`,          `color-mix(in srgb, red 40%, blue 50%)`)             // only one is 50% (p2)
+    fuzzy_test_valid_color(`color-mix(in srgb, red 30%,       blue 40%)`,          `color-mix(in srgb, red 30%, blue 40%)`)             // sum to less than 100
+    fuzzy_test_valid_color(`color-mix(in srgb, red 75%,       blue 75%)`,          `color-mix(in srgb, red 75%, blue 75%)`)             // sum to more than 100
+    fuzzy_test_valid_color(`color-mix(in srgb, red calc(10%), blue 50%)`,          `color-mix(in srgb, red calc(10%), blue 50%)`)       // one is `calc()` (p1)
+    fuzzy_test_valid_color(`color-mix(in srgb, red 50%,       blue calc(10%))`,    `color-mix(in srgb, red 50%, blue calc(10%))`)       // one is `calc()` (p2)
+    fuzzy_test_valid_color(`color-mix(in srgb, red calc(10%), blue calc(90%))`,    `color-mix(in srgb, red calc(10%), blue calc(90%))`) // both are `calc()`
+    fuzzy_test_valid_color(`color-mix(in srgb, red 50%,       blue)`,              `color-mix(in srgb, red, blue)`)                     // only p1 specified, is 50%
+    fuzzy_test_valid_color(`color-mix(in srgb, red 10%,       blue)`,              `color-mix(in srgb, red 10%, blue)`)                 // only p1 specified
+    fuzzy_test_valid_color(`color-mix(in srgb, red calc(50%), blue)`,              `color-mix(in srgb, red calc(50%), blue)`)           // only p1 specified, is `calc()`
+    fuzzy_test_valid_color(`color-mix(in srgb, red,           blue 50%)`,          `color-mix(in srgb, red, blue)`)                     // only p2 specified, is 50%
+    fuzzy_test_valid_color(`color-mix(in srgb, red,           blue 90%)`,          `color-mix(in srgb, red 10%, blue)`)                 // only p2 specified
+    fuzzy_test_valid_color(`color-mix(in srgb, red,           blue calc(50%))`,    `color-mix(in srgb, red, blue calc(50%))`)           // only p2 specified, is `calc()`
+    fuzzy_test_valid_color(`color-mix(in srgb, red,           blue)`,              `color-mix(in srgb, red, blue)`)                     // neither is specified
 </script>
 </body>
 </html>

--- a/css/css-color/parsing/color-valid-hsl.html
+++ b/css/css-color/parsing/color-valid-hsl.html
@@ -12,54 +12,80 @@
 </head>
 <body>
 <script>
-test_valid_value("color", "hsl(120 30% 50%)", "rgb(89, 166, 89)");
-test_valid_value("color", "hsl(120 30% 50% / 0.5)", "rgba(89, 166, 89, 0.5)");
-test_valid_value("color", "hsl(none none none)", "rgb(0, 0, 0)");
-test_valid_value("color", "hsl(0 0% 0%)", "rgb(0, 0, 0)");
-test_valid_value("color", "hsl(none none none / none)", "rgba(0, 0, 0, 0)");
-test_valid_value("color", "hsl(0 0% 0% / 0)", "rgba(0, 0, 0, 0)");
-test_valid_value("color", "hsla(none none none)", "rgb(0, 0, 0)");
-test_valid_value("color", "hsla(0 0% 0%)", "rgb(0, 0, 0)");
-test_valid_value("color", "hsla(none none none / none)", "rgba(0, 0, 0, 0)");
-test_valid_value("color", "hsla(0 0% 0% / 0)", "rgba(0, 0, 0, 0)");
-test_valid_value("color", "hsl(120 none none)", "rgb(0, 0, 0)");
-test_valid_value("color", "hsl(120 0% 0%)", "rgb(0, 0, 0)");
-test_valid_value("color", "hsl(120 80% none)", "rgb(0, 0, 0)");
-test_valid_value("color", "hsl(120 80% 0%)", "rgb(0, 0, 0)");
-test_valid_value("color", "hsl(120 none 50%)", "rgb(128, 128, 128)");
-test_valid_value("color", "hsl(120 0% 50%)", "rgb(128, 128, 128)");
-test_valid_value("color", "hsl(120 100% 50% / none)", "rgba(0, 255, 0, 0)");
-test_valid_value("color", "hsl(120 100% 50% / 0)", "rgba(0, 255, 0, 0)");
-test_valid_value("color", "hsl(none 100% 50%)", "rgb(255, 0, 0)");
-test_valid_value("color", "hsl(0 100% 50%)", "rgb(255, 0, 0)");
+tests = [
+    ["hsl(120 30% 50%)", "rgb(89, 166, 89)"],
+    ["hsl(120 30% 50% / 0.5)", "rgba(89, 166, 89, 0.5)"],
+    ["hsl(none none none)", "rgb(0, 0, 0)"],
+    ["hsl(0 0% 0%)", "rgb(0, 0, 0)"],
+    ["hsl(none none none / none)", "rgba(0, 0, 0, 0)"],
+    ["hsl(0 0% 0% / 0)", "rgba(0, 0, 0, 0)"],
+    ["hsla(none none none)", "rgb(0, 0, 0)"],
+    ["hsla(0 0% 0%)", "rgb(0, 0, 0)"],
+    ["hsla(none none none / none)", "rgba(0, 0, 0, 0)"],
+    ["hsla(0 0% 0% / 0)", "rgba(0, 0, 0, 0)"],
+    ["hsl(120 none none)", "rgb(0, 0, 0)"],
+    ["hsl(120 0% 0%)", "rgb(0, 0, 0)"],
+    ["hsl(120 80% none)", "rgb(0, 0, 0)"],
+    ["hsl(120 80% 0%)", "rgb(0, 0, 0)"],
+    ["hsl(120 none 50%)", "rgb(128, 128, 128)"],
+    ["hsl(120 0% 50%)", "rgb(128, 128, 128)"],
+    ["hsl(120 100% 50% / none)", "rgba(0, 255, 0, 0)"],
+    ["hsl(120 100% 50% / 0)", "rgba(0, 255, 0, 0)"],
+    ["hsl(none 100% 50%)", "rgb(255, 0, 0)"],
+    ["hsl(0 100% 50%)", "rgb(255, 0, 0)"],
 
-// Test with number components.
-test_valid_value("color", "hsl(120 30 50)", "rgb(89, 166, 89)");
-test_valid_value("color", "hsl(120 30 50 / 0.5)", "rgba(89, 166, 89, 0.5)");
-test_valid_value("color", "hsl(120 30% 50)", "rgb(89, 166, 89)");
-test_valid_value("color", "hsl(120 30% 50 / 0.5)", "rgba(89, 166, 89, 0.5)");
-test_valid_value("color", "hsl(120 30 50%)", "rgb(89, 166, 89)");
-test_valid_value("color", "hsl(120 30 50% / 0.5)", "rgba(89, 166, 89, 0.5)");
-test_valid_value("color", "hsl(120 none 50)", "rgb(128, 128, 128)");
-test_valid_value("color", "hsl(120 none 50 / 0.5)", "rgba(128, 128, 128, 0.5)");
-test_valid_value("color", "hsl(120 30 none)", "rgb(0, 0, 0)");
-test_valid_value("color", "hsl(120 30 none / 0.5)", "rgba(0, 0, 0, 0.5)");
-test_valid_value("color", "hsl(120 30 50 / none)", "rgba(89, 166, 89, 0)");
+    // Test with number components.
+    ["hsl(120 30 50)", "rgb(89, 166, 89)"],
+    ["hsl(120 30 50 / 0.5)", "rgba(89, 166, 89, 0.5)"],
+    ["hsl(120 30% 50)", "rgb(89, 166, 89)"],
+    ["hsl(120 30% 50 / 0.5)", "rgba(89, 166, 89, 0.5)"],
+    ["hsl(120 30 50%)", "rgb(89, 166, 89)"],
+    ["hsl(120 30 50% / 0.5)", "rgba(89, 166, 89, 0.5)"],
+    ["hsl(120 none 50)", "rgb(128, 128, 128)"],
+    ["hsl(120 none 50 / 0.5)", "rgba(128, 128, 128, 0.5)"],
+    ["hsl(120 30 none)", "rgb(0, 0, 0)"],
+    ["hsl(120 30 none / 0.5)", "rgba(0, 0, 0, 0.5)"],
+    ["hsl(120 30 50 / none)", "rgba(89, 166, 89, 0)"],
 
-// Test parse-time clamp of negative saturation to zero
-test_valid_value("color", "hsl(0 -50% 40%)", "rgb(102, 102, 102)");
-test_valid_value("color", "hsl(30 -50% 60)", "rgb(153, 153, 153)");
-test_valid_value("color", "hsl(0 -50 40%)", "rgb(102, 102, 102)");
-test_valid_value("color", "hsl(30 -50 60)", "rgb(153, 153, 153)");
+    // Test parse-time clamp of negative saturation to zero
+    ["hsl(0 -50% 40%)", "rgb(102, 102, 102)"],
+    ["hsl(30 -50% 60)", "rgb(153, 153, 153)"],
+    ["hsl(0 -50 40%)", "rgb(102, 102, 102)"],
+    ["hsl(30 -50 60)", "rgb(153, 153, 153)"],
 
-// Test non-finite values. calc(infinity) goes to upper bound while calc(-infinity) and NaN go to the lower bound.
-// See: https://github.com/w3c/csswg-drafts/issues/8629
-test_valid_value("color", "hsl(calc(infinity) 100% 50%)", "rgb(255, 0, 0)"); // hsl(360 100% 50%)
-test_valid_value("color", "hsl(calc(-infinity) 100% 50%)", "rgb(255, 0, 0)"); // hsl(0 100% 50%)
-test_valid_value("color", "hsl(calc(0 / 0) 100% 50%)", "rgb(255, 0, 0)"); // hsl(0 100% 50%)
-test_valid_value("color", "hsl(90 50% 50% / calc(infinity))", "rgb(128, 191, 64)"); // hsl(90 50% 50%)
-test_valid_value("color", "hsl(90 50% 50% / calc(-infinity))", "rgba(128, 191, 64, 0)"); // hsl(90 50% 50% / 0)
-test_valid_value("color", "hsl(90 50% 50% / calc(0 / 0))", "rgba(128, 191, 64, 0)"); // hsl(90 50% 50% / 0)
+    // Test non-finite values. calc(infinity) goes to upper bound while calc(-infinity) and NaN go to the lower bound.
+    // See: https://github.com/w3c/csswg-drafts/issues/8629
+    ["hsl(calc(infinity) 100% 50%)", "rgb(255, 0, 0)"], // hsl(360 100% 50%)
+    ["hsl(calc(-infinity) 100% 50%)", "rgb(255, 0, 0)"], // hsl(0 100% 50%)
+    ["hsl(calc(0 / 0) 100% 50%)", "rgb(255, 0, 0)"], // hsl(0 100% 50%)
+    ["hsl(90 50% 50% / calc(infinity))", "rgb(128, 191, 64)"], // hsl(90 50% 50%)
+    ["hsl(90 50% 50% / calc(-infinity))", "rgba(128, 191, 64, 0)"], // hsl(90 50% 50% / 0)
+    ["hsl(90 50% 50% / calc(0 / 0))", "rgba(128, 191, 64, 0)"], // hsl(90 50% 50% / 0)
+
+    // calc(50% + (sign(1em - 10px) * 10%)) cannot be evaluated eagerly because font relative units are not yet known at parse time.
+    ["hsl(calc(50deg + (sign(1em - 10px) * 10deg)), 0%, 0%, 50%)", "hsl(calc(50deg + (10deg * sign(1em - 10px))) 0% 0% / 50%)"],
+    ["hsla(calc(50deg + (sign(1em - 10px) * 10deg)), 0%, 0%, 50%)", "hsl(calc(50deg + (10deg * sign(1em - 10px))) 0% 0% / 50%)"],
+    ["hsl(calc(50 + (sign(1em - 10px) * 10)), 0%, 0%, 50%)", "hsl(calc(50 + (10 * sign(1em - 10px))) 0% 0% / 50%)"],
+    ["hsla(calc(50 + (sign(1em - 10px) * 10)), 0%, 0%, 50%)", "hsl(calc(50 + (10 * sign(1em - 10px))) 0% 0% / 50%)"],
+    ["hsl(0deg, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))", "hsl(0deg 0% 0% / calc(50% + (10% * sign(1em - 10px))))"],
+    ["hsla(0deg, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))", "hsl(0deg 0% 0% / calc(50% + (10% * sign(1em - 10px))))"],
+    ["hsl(0, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))", "hsl(0 0% 0% / calc(50% + (10% * sign(1em - 10px))))"],
+    ["hsla(0, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))", "hsl(0 0% 0% / calc(50% + (10% * sign(1em - 10px))))"],
+
+    ["hsl(calc(50deg + (sign(1em - 10px) * 10deg)) 0% 0% / 50%)", "hsl(calc(50deg + (10deg * sign(1em - 10px))) 0% 0% / 50%)"],
+    ["hsla(calc(50deg + (sign(1em - 10px) * 10deg)) 0% 0% / 50%)", "hsl(calc(50deg + (10deg * sign(1em - 10px))) 0% 0% / 50%)"],
+    ["hsl(calc(50 + (sign(1em - 10px) * 10)) 0 0 / 0.5)", "hsl(calc(50 + (10 * sign(1em - 10px))) 0 0 / 0.5)"],
+    ["hsla(calc(50 + (sign(1em - 10px) * 10)) 0 0 / 0.5)", "hsl(calc(50 + (10 * sign(1em - 10px))) 0 0 / 0.5)"],
+    ["hsl(0deg 0% 0% / calc(50% + (sign(1em - 10px) * 10%)))", "hsl(0deg 0% 0% / calc(50% + (10% * sign(1em - 10px))))"],
+    ["hsla(0deg 0% 0% / calc(50% + (sign(1em - 10px) * 10%)))", "hsl(0deg 0% 0% / calc(50% + (10% * sign(1em - 10px))))"],
+    ["hsl(0 0 0 / calc(0.75 + (sign(1em - 10px) * 0.1)))", "hsl(0 0 0 / calc(0.75 + (0.1 * sign(1em - 10px))))"],
+    ["hsla(0 0 0 / calc(0.75 + (sign(1em - 10px) * 0.1)))", "hsl(0 0 0 / calc(0.75 + (0.1 * sign(1em - 10px))))"],
+];
+
+for (const test of tests) {
+    test_valid_value("color", test[0], test[1], test[2] ? `[${test[2]}]` : undefined);
+}
+
 </script>
 </body>
 </html>

--- a/css/css-color/parsing/color-valid-hwb.html
+++ b/css/css-color/parsing/color-valid-hwb.html
@@ -12,49 +12,61 @@
 </head>
 <body>
 <script>
-test_valid_value("color", "hwb(120 30% 50%)", "rgb(77, 128, 77)");
-test_valid_value("color", "hwb(120 30% 50% / 0.5)", "rgba(77, 128, 77, 0.5)");
-test_valid_value("color", "hwb(none none none)", "rgb(255, 0, 0)");
-test_valid_value("color", "hwb(0 0% 0%)", "rgb(255, 0, 0)");
-test_valid_value("color", "hwb(none none none / none)", "rgba(255, 0, 0, 0)");
-test_valid_value("color", "hwb(0 0% 0% / 0)", "rgba(255, 0, 0, 0)");
-test_valid_value("color", "hwb(120 none none)", "rgb(0, 255, 0)");
-test_valid_value("color", "hwb(120 0% 0%)", "rgb(0, 255, 0)");
-test_valid_value("color", "hwb(120 80% none)", "rgb(204, 255, 204)");
-test_valid_value("color", "hwb(120 80% 0%)", "rgb(204, 255, 204)");
-test_valid_value("color", "hwb(120 none 50%)", "rgb(0, 128, 0)");
-test_valid_value("color", "hwb(120 0% 50%)", "rgb(0, 128, 0)");
-test_valid_value("color", "hwb(120 30% 50% / none)", "rgba(77, 128, 77, 0)");
-test_valid_value("color", "hwb(120 30% 50% / 0)", "rgba(77, 128, 77, 0)");
-test_valid_value("color", "hwb(none 100% 50% / none)", "rgba(170, 170, 170, 0)");
-test_valid_value("color", "hwb(0 100% 50% / 0)", "rgba(170, 170, 170, 0)");
+tests = [
+    ["hwb(120 30% 50%)", "rgb(77, 128, 77)"],
+    ["hwb(120 30% 50% / 0.5)", "rgba(77, 128, 77, 0.5)"],
+    ["hwb(none none none)", "rgb(255, 0, 0)"],
+    ["hwb(0 0% 0%)", "rgb(255, 0, 0)"],
+    ["hwb(none none none / none)", "rgba(255, 0, 0, 0)"],
+    ["hwb(0 0% 0% / 0)", "rgba(255, 0, 0, 0)"],
+    ["hwb(120 none none)", "rgb(0, 255, 0)"],
+    ["hwb(120 0% 0%)", "rgb(0, 255, 0)"],
+    ["hwb(120 80% none)", "rgb(204, 255, 204)"],
+    ["hwb(120 80% 0%)", "rgb(204, 255, 204)"],
+    ["hwb(120 none 50%)", "rgb(0, 128, 0)"],
+    ["hwb(120 0% 50%)", "rgb(0, 128, 0)"],
+    ["hwb(120 30% 50% / none)", "rgba(77, 128, 77, 0)"],
+    ["hwb(120 30% 50% / 0)", "rgba(77, 128, 77, 0)"],
+    ["hwb(none 100% 50% / none)", "rgba(170, 170, 170, 0)"],
+    ["hwb(0 100% 50% / 0)", "rgba(170, 170, 170, 0)"],
 
-// Test with number components.
-test_valid_value("color", "hwb(120 30 50)", "rgb(77, 128, 77)");
-test_valid_value("color", "hwb(120 30 50 / 0.5)", "rgba(77, 128, 77, 0.5)");
-test_valid_value("color", "hwb(120 30% 50)", "rgb(77, 128, 77)");
-test_valid_value("color", "hwb(120 30% 50 / 0.5)", "rgba(77, 128, 77, 0.5)");
-test_valid_value("color", "hwb(120 30 50%)", "rgb(77, 128, 77)");
-test_valid_value("color", "hwb(120 30 50% / 0.5)", "rgba(77, 128, 77, 0.5)");
-test_valid_value("color", "hwb(120 none 50)", "rgb(0, 128, 0)");
-test_valid_value("color", "hwb(120 none 50 / 0.5)", "rgba(0, 128, 0, 0.5)");
-test_valid_value("color", "hwb(120 30 none)", "rgb(77, 255, 77)");
-test_valid_value("color", "hwb(120 30 none / 0.5)", "rgba(77, 255, 77, 0.5)");
-test_valid_value("color", "hwb(120 30 50 / none)", "rgba(77, 128, 77, 0)");
+    // Test with number components.
+    ["hwb(120 30 50)", "rgb(77, 128, 77)"],
+    ["hwb(120 30 50 / 0.5)", "rgba(77, 128, 77, 0.5)"],
+    ["hwb(120 30% 50)", "rgb(77, 128, 77)"],
+    ["hwb(120 30% 50 / 0.5)", "rgba(77, 128, 77, 0.5)"],
+    ["hwb(120 30 50%)", "rgb(77, 128, 77)"],
+    ["hwb(120 30 50% / 0.5)", "rgba(77, 128, 77, 0.5)"],
+    ["hwb(120 none 50)", "rgb(0, 128, 0)"],
+    ["hwb(120 none 50 / 0.5)", "rgba(0, 128, 0, 0.5)"],
+    ["hwb(120 30 none)", "rgb(77, 255, 77)"],
+    ["hwb(120 30 none / 0.5)", "rgba(77, 255, 77, 0.5)"],
+    ["hwb(120 30 50 / none)", "rgba(77, 128, 77, 0)"],
 
-// Test that rounding happens properly. hwb(320deg 30% 40%) in sRGB has a blue
-// channel of exactly one-half.
-// 0.5 * 255 = 127.5. This value should be rounded UP to 128, not down to 127.
-test_valid_value("color", "hwb(320deg 30% 40%)", "rgb(153, 77, 128)");
+    // Test that rounding happens properly. hwb(320deg 30% 40%) in sRGB has a blue
+    // channel of exactly one-half.
+    // 0.5 * 255 = 127.5. This value should be rounded UP to 128, not down to 127.
+    ["hwb(320deg 30% 40%)", "rgb(153, 77, 128)"],
 
-// Test non-finite values. calc(infinity) goes to upper bound while calc(-infinity) and NaN go to the lower bound.
-// See: https://github.com/w3c/csswg-drafts/issues/8629
-test_valid_value("color", "hwb(calc(infinity) 20% 10%)", "rgb(230, 51, 51)"); // hwb(360 20% 10%)
-test_valid_value("color", "hwb(calc(-infinity) 20% 10%)", "rgb(230, 51, 51)"); // hwb(0 20% 10%)
-test_valid_value("color", "hwb(calc(0 / 0) 20% 10%)", "rgb(230, 51, 51)"); // hwb(0 20% 10%)
-test_valid_value("color", "hwb(90 20% 10% / calc(infinity))", "rgb(140, 230, 51)"); // hwb(90 20% 10%)
-test_valid_value("color", "hwb(90 20% 10% / calc(-infinity))", "rgba(140, 230, 51, 0)"); // hwb(90 20% 10% / 0)
-test_valid_value("color", "hwb(90 20% 10% / calc(0 / 0))", "rgba(140, 230, 51, 0)"); // hwb(90 20% 10% / 0)
+    // Test non-finite values. calc(infinity) goes to upper bound while calc(-infinity) and NaN go to the lower bound.
+    // See: https://github.com/w3c/csswg-drafts/issues/8629
+    ["hwb(calc(infinity) 20% 10%)", "rgb(230, 51, 51)"], // hwb(360 20% 10%)
+    ["hwb(calc(-infinity) 20% 10%)", "rgb(230, 51, 51)"], // hwb(0 20% 10%)
+    ["hwb(calc(0 / 0) 20% 10%)", "rgb(230, 51, 51)"], // hwb(0 20% 10%)
+    ["hwb(90 20% 10% / calc(infinity))", "rgb(140, 230, 51)"], // hwb(90 20% 10%)
+    ["hwb(90 20% 10% / calc(-infinity))", "rgba(140, 230, 51, 0)"], // hwb(90 20% 10% / 0)
+    ["hwb(90 20% 10% / calc(0 / 0))", "rgba(140, 230, 51, 0)"], // hwb(90 20% 10% / 0)
+
+    // calc(50% + (sign(1em - 10px) * 10%)) cannot be evaluated eagerly because font relative units are not yet known at parse time.
+    ["hwb(calc(110deg + (sign(1em - 10px) * 10deg)) 30% 50% / 50%)", "hwb(calc(110deg + (10deg * sign(1em - 10px))) 30% 50% / 50%)"],
+    ["hwb(calc(110 + (sign(1em - 10px) * 10)) 30 50 / 0.5)", "hwb(calc(110 + (10 * sign(1em - 10px))) 30 50 / 0.5)"],
+    ["hwb(120deg 30% 50% / calc(50% + (sign(1em - 10px) * 10%)))", "hwb(120deg 30% 50% / calc(50% + (10% * sign(1em - 10px))))"],
+    ["hwb(120 30 50 / calc(0.75 + (sign(1em - 10px) * 0.1)))", "hwb(120 30 50 / calc(0.75 + (0.1 * sign(1em - 10px))))"],
+];
+
+for (const test of tests) {
+    test_valid_value("color", test[0], test[1]);
+}
 
 </script>
 </body>

--- a/css/css-color/parsing/color-valid-lab.html
+++ b/css/css-color/parsing/color-valid-lab.html
@@ -14,143 +14,158 @@
 </head>
 <body>
 <script>
+tests = [
+    // lab()
+    ["lab(0 0 0)", "lab(0 0 0)"],
+    ["lab(0 0 0 / 1)", "lab(0 0 0)"],
+    ["lab(0 0 0 / 0.5)", "lab(0 0 0 / 0.5)"],
+    ["lab(20 0 10/0.5)", "lab(20 0 10 / 0.5)"],
+    ["lab(20 0 10/50%)", "lab(20 0 10 / 0.5)"],
+    ["lab(400 0 10/50%)", "lab(100 0 10 / 0.5)"],
+    ["lab(50 -160 160)", "lab(50 -160 160)"],
+    ["lab(50 -200 200)", "lab(50 -200 200)"],
+    ["lab(0 0 0 / -10%)", "lab(0 0 0 / 0)"],
+    ["lab(0 0 0 / 110%)", "lab(0 0 0)"],
+    ["lab(0 0 0 / 300%)", "lab(0 0 0)"],
+    ["lab(-40 0 0)", "lab(0 0 0)"],
+    ["lab(50 -20 0)", "lab(50 -20 0)"],
+    ["lab(50 0 -20)", "lab(50 0 -20)"],
+    ["lab(calc(50 * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))", "lab(100 -0.5 1.5 / 0.5)"],
+    ["lab(calc(-50 * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))", "lab(0 1.5 -1.5 / 0)"],
 
-// lab()
-test_valid_value("color", "lab(0 0 0)", "lab(0 0 0)");
-test_valid_value("color", "lab(0 0 0 / 1)", "lab(0 0 0)");
-test_valid_value("color", "lab(0 0 0 / 0.5)", "lab(0 0 0 / 0.5)");
-test_valid_value("color", "lab(20 0 10/0.5)", "lab(20 0 10 / 0.5)");
-test_valid_value("color", "lab(20 0 10/50%)", "lab(20 0 10 / 0.5)");
-test_valid_value("color", "lab(400 0 10/50%)", "lab(100 0 10 / 0.5)");
-test_valid_value("color", "lab(50 -160 160)", "lab(50 -160 160)");
-test_valid_value("color", "lab(50 -200 200)", "lab(50 -200 200)");
-test_valid_value("color", "lab(0 0 0 / -10%)", "lab(0 0 0 / 0)");
-test_valid_value("color", "lab(0 0 0 / 110%)", "lab(0 0 0)");
-test_valid_value("color", "lab(0 0 0 / 300%)", "lab(0 0 0)");
-test_valid_value("color", "lab(-40 0 0)", "lab(0 0 0)");
-test_valid_value("color", "lab(50 -20 0)", "lab(50 -20 0)");
-test_valid_value("color", "lab(50 0 -20)", "lab(50 0 -20)");
-test_valid_value("color", "lab(calc(50 * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))", "lab(100 -0.5 1.5 / 0.5)");
-test_valid_value("color", "lab(calc(-50 * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))", "lab(0 1.5 -1.5 / 0)");
+    ["lab(none none none / none)", "lab(none none none / none)"],
+    ["lab(none none none)", "lab(none none none)"],
+    ["lab(20 none none / none)", "lab(20 none none / none)"],
+    ["lab(none none none / 0.5)", "lab(none none none / 0.5)"],
+    ["lab(0 0 0 / none)", "lab(0 0 0 / none)"],
 
-test_valid_value("color", "lab(none none none / none)", "lab(none none none / none)");
-test_valid_value("color", "lab(none none none)", "lab(none none none)");
-test_valid_value("color", "lab(20 none none / none)", "lab(20 none none / none)");
-test_valid_value("color", "lab(none none none / 0.5)", "lab(none none none / 0.5)");
-test_valid_value("color", "lab(0 0 0 / none)", "lab(0 0 0 / none)");
+    ["lab(calc(infinity) 0 0)", "lab(100 0 0)"],
+    ["lab(50 calc(infinity) 0)", "lab(50 calc(infinity) 0)"],
+    ["lab(50 calc(-infinity) 0)", "lab(50 calc(-infinity) 0)"],
+    ["lab(calc(NaN) 0 0)", "lab(calc(NaN) 0 0)"],
+    ["lab(calc(0 / 0) 0 0)", "lab(calc(NaN) 0 0)"],
 
-test_valid_value("color", "lab(calc(infinity) 0 0)", "lab(100 0 0)");
-test_valid_value("color", "lab(50 calc(infinity) 0)", "lab(50 calc(infinity) 0)");
-test_valid_value("color", "lab(50 calc(-infinity) 0)", "lab(50 calc(-infinity) 0)");
-test_valid_value("color", "lab(calc(NaN) 0 0)", "lab(calc(NaN) 0 0)");
-test_valid_value("color", "lab(calc(0 / 0) 0 0)", "lab(calc(NaN) 0 0)");
+    // oklab()
+    ["oklab(0 0 0)", "oklab(0 0 0)"],
+    ["oklab(0 0 0 / 1)", "oklab(0 0 0)"],
+    ["oklab(0 0 0 / 0.5)", "oklab(0 0 0 / 0.5)"],
+    ["oklab(0.2 0 0.1/0.5)", "oklab(0.2 0 0.1 / 0.5)"],
+    ["oklab(0.2 0 0.1/50%)", "oklab(0.2 0 0.1 / 0.5)"],
+    ["oklab(4 0 0.1/50%)", "oklab(1 0 0.1 / 0.5)"],
+    ["oklab(0.5 -1.6 1.6)", "oklab(0.5 -1.6 1.6)"],
+    ["oklab(0.5 -2 2)", "oklab(0.5 -2 2)"],
+    ["oklab(0 0 0 / -10%)", "oklab(0 0 0 / 0)"],
+    ["oklab(0 0 0 / 110%)", "oklab(0 0 0)"],
+    ["oklab(0 0 0 / 300%)", "oklab(0 0 0)"],
+    ["oklab(-0.4 0 0)", "oklab(0 0 0)"],
+    ["oklab(0.5 -2 0)", "oklab(0.5 -2 0)"],
+    ["oklab(0.5 0 -2)", "oklab(0.5 0 -2)"],
+    ["oklab(calc(0.5 * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))", "oklab(1 -0.5 1.5 / 0.5)"],
+    ["oklab(calc(-0.5 * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))", "oklab(0 1.5 -1.5 / 0)"],
 
-// oklab()
-test_valid_value("color", "oklab(0 0 0)", "oklab(0 0 0)");
-test_valid_value("color", "oklab(0 0 0 / 1)", "oklab(0 0 0)");
-test_valid_value("color", "oklab(0 0 0 / 0.5)", "oklab(0 0 0 / 0.5)");
-test_valid_value("color", "oklab(0.2 0 0.1/0.5)", "oklab(0.2 0 0.1 / 0.5)");
-test_valid_value("color", "oklab(0.2 0 0.1/50%)", "oklab(0.2 0 0.1 / 0.5)");
-test_valid_value("color", "oklab(4 0 0.1/50%)", "oklab(1 0 0.1 / 0.5)");
-test_valid_value("color", "oklab(0.5 -1.6 1.6)", "oklab(0.5 -1.6 1.6)");
-test_valid_value("color", "oklab(0.5 -2 2)", "oklab(0.5 -2 2)");
-test_valid_value("color", "oklab(0 0 0 / -10%)", "oklab(0 0 0 / 0)");
-test_valid_value("color", "oklab(0 0 0 / 110%)", "oklab(0 0 0)");
-test_valid_value("color", "oklab(0 0 0 / 300%)", "oklab(0 0 0)");
-test_valid_value("color", "oklab(-0.4 0 0)", "oklab(0 0 0)");
-test_valid_value("color", "oklab(0.5 -2 0)", "oklab(0.5 -2 0)");
-test_valid_value("color", "oklab(0.5 0 -2)", "oklab(0.5 0 -2)");
-test_valid_value("color", "oklab(calc(0.5 * 3) calc(0.5 - 1) calc(1.5) / calc(-0.5 + 1))", "oklab(1 -0.5 1.5 / 0.5)");
-test_valid_value("color", "oklab(calc(-0.5 * 3) calc(0.5 + 1) calc(-1.5) / calc(-0.5 * 2))", "oklab(0 1.5 -1.5 / 0)");
+    ["oklab(none none none / none)", "oklab(none none none / none)"],
+    ["oklab(none none none)", "oklab(none none none)"],
+    ["oklab(0.2 none none / none)", "oklab(0.2 none none / none)"],
+    ["oklab(none none none / 0.5)", "oklab(none none none / 0.5)"],
+    ["oklab(0 0 0 / none)", "oklab(0 0 0 / none)"],
 
-test_valid_value("color", "oklab(none none none / none)", "oklab(none none none / none)");
-test_valid_value("color", "oklab(none none none)", "oklab(none none none)");
-test_valid_value("color", "oklab(0.2 none none / none)", "oklab(0.2 none none / none)");
-test_valid_value("color", "oklab(none none none / 0.5)", "oklab(none none none / 0.5)");
-test_valid_value("color", "oklab(0 0 0 / none)", "oklab(0 0 0 / none)");
+    // These tests validate the ranges of lab() vs. oklab() components
+    ["lab(20% -50% 90%/0.5)", "lab(20 -62.5 112.5 / 0.5)"],
+    ["oklab(20% 70% -80%/0.5)", "oklab(0.2 0.28 -0.32 / 0.5)"],
 
-// These tests validate the ranges of lab() vs. oklab() components
-test_valid_value("color", "lab(20% -50% 90%/0.5)", "lab(20 -62.5 112.5 / 0.5)");
-test_valid_value("color", "oklab(20% 70% -80%/0.5)", "oklab(0.2 0.28 -0.32 / 0.5)");
+    ["oklab(calc(infinity) 0 0)", "oklab(1 0 0)"],
+    ["oklab(0.5 calc(infinity) 0)", "oklab(0.5 calc(infinity) 0)"],
+    ["oklab(0.5 calc(-infinity) 0)", "oklab(0.5 calc(-infinity) 0)"],
+    ["oklab(calc(NaN) 0 0)", "oklab(calc(NaN) 0 0)"],
+    ["oklab(calc(0 / 0) 0 0)", "oklab(calc(NaN) 0 0)"],
 
-test_valid_value("color", "oklab(calc(infinity) 0 0)", "oklab(1 0 0)");
-test_valid_value("color", "oklab(0.5 calc(infinity) 0)", "oklab(0.5 calc(infinity) 0)");
-test_valid_value("color", "oklab(0.5 calc(-infinity) 0)", "oklab(0.5 calc(-infinity) 0)");
-test_valid_value("color", "oklab(calc(NaN) 0 0)", "oklab(calc(NaN) 0 0)");
-test_valid_value("color", "oklab(calc(0 / 0) 0 0)", "oklab(calc(NaN) 0 0)");
+    // lch()
+    ["lch(0 0 0deg)", "lch(0 0 0)"],
+    ["lch(0 0 0deg / 1)", "lch(0 0 0)"],
+    ["lch(0 0 0deg / 0.5)", "lch(0 0 0 / 0.5)"],
+    ["lch(100 230 0deg / 0.5)", "lch(100 230 0 / 0.5)"],
+    ["lch(20 50 20deg/0.5)", "lch(20 50 20 / 0.5)"],
+    ["lch(20 50 20deg/50%)", "lch(20 50 20 / 0.5)"],
+    ["lch(10 20 20deg / -10%)", "lch(10 20 20 / 0)"],
+    ["lch(10 20 20deg / 110%)", "lch(10 20 20)"],
+    ["lch(10 20 1.28rad)", "lch(10 20 73.3386)"],
+    ["lch(10 20 380deg)", "lch(10 20 20)"],
+    ["lch(10 20 -340deg)", "lch(10 20 20)"],
+    ["lch(10 20 740deg)", "lch(10 20 20)"],
+    ["lch(10 20 -700deg)", "lch(10 20 20)"],
+    ["lch(-40 0 0)", "lch(0 0 0)"],
+    ["lch(20 -20 0)", "lch(20 0 0)"],
+    ["lch(0 0 0 / 0.5)", "lch(0 0 0 / 0.5)"],
+    ["lch(10 20 20 / 110%)", "lch(10 20 20)"],
+    ["lch(10 20 -700)", "lch(10 20 20)"],
+    ["lch(calc(50 * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))", "lch(100 0 40 / 0.5)"],
+    ["lch(calc(-50 * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))", "lch(0 1.5 320 / 0)"],
 
-// lch()
-test_valid_value("color", "lch(0 0 0deg)", "lch(0 0 0)");
-test_valid_value("color", "lch(0 0 0deg / 1)", "lch(0 0 0)");
-test_valid_value("color", "lch(0 0 0deg / 0.5)", "lch(0 0 0 / 0.5)");
-test_valid_value("color", "lch(100 230 0deg / 0.5)", "lch(100 230 0 / 0.5)");
-test_valid_value("color", "lch(20 50 20deg/0.5)", "lch(20 50 20 / 0.5)");
-test_valid_value("color", "lch(20 50 20deg/50%)", "lch(20 50 20 / 0.5)");
-test_valid_value("color", "lch(10 20 20deg / -10%)", "lch(10 20 20 / 0)");
-test_valid_value("color", "lch(10 20 20deg / 110%)", "lch(10 20 20)");
-test_valid_value("color", "lch(10 20 1.28rad)", "lch(10 20 73.3386)");
-test_valid_value("color", "lch(10 20 380deg)", "lch(10 20 20)");
-test_valid_value("color", "lch(10 20 -340deg)", "lch(10 20 20)");
-test_valid_value("color", "lch(10 20 740deg)", "lch(10 20 20)");
-test_valid_value("color", "lch(10 20 -700deg)", "lch(10 20 20)");
-test_valid_value("color", "lch(-40 0 0)", "lch(0 0 0)");
-test_valid_value("color", "lch(20 -20 0)", "lch(20 0 0)");
-test_valid_value("color", "lch(0 0 0 / 0.5)", "lch(0 0 0 / 0.5)");
-test_valid_value("color", "lch(10 20 20 / 110%)", "lch(10 20 20)");
-test_valid_value("color", "lch(10 20 -700)", "lch(10 20 20)");
-test_valid_value("color", "lch(calc(50 * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))", "lch(100 0 40 / 0.5)");
-test_valid_value("color", "lch(calc(-50 * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))", "lch(0 1.5 320 / 0)");
+    ["lch(none none none / none)", "lch(none none none / none)"],
+    ["lch(none none none)", "lch(none none none)"],
+    ["lch(20 none none / none)", "lch(20 none none / none)"],
+    ["lch(none none none / 0.5)", "lch(none none none / 0.5)"],
+    ["lch(0 0 0 / none)", "lch(0 0 0 / none)"],
 
-test_valid_value("color", "lch(none none none / none)", "lch(none none none / none)");
-test_valid_value("color", "lch(none none none)", "lch(none none none)");
-test_valid_value("color", "lch(20 none none / none)", "lch(20 none none / none)");
-test_valid_value("color", "lch(none none none / 0.5)", "lch(none none none / 0.5)");
-test_valid_value("color", "lch(0 0 0 / none)", "lch(0 0 0 / none)");
+    ["lch(calc(infinity) 0 0)", "lch(100 0 0)"],
+    ["lch(50 calc(infinity) 0)", "lch(50 calc(infinity) 0)"],
+    ["lch(50 calc(-infinity) 0)", "lch(50 0 0)"],
+    ["lch(calc(NaN) 0 0)", "lch(calc(NaN) 0 0)"],
+    ["lch(calc(0 / 0) 0 0)", "lch(calc(NaN) 0 0)"],
 
-test_valid_value("color", "lch(calc(infinity) 0 0)", "lch(100 0 0)");
-test_valid_value("color", "lch(50 calc(infinity) 0)", "lch(50 calc(infinity) 0)");
-test_valid_value("color", "lch(50 calc(-infinity) 0)", "lch(50 0 0)");
-test_valid_value("color", "lch(calc(NaN) 0 0)", "lch(calc(NaN) 0 0)");
-test_valid_value("color", "lch(calc(0 / 0) 0 0)", "lch(calc(NaN) 0 0)");
+    // oklch()
+    ["oklch(0 0 0deg)", "oklch(0 0 0)"],
+    ["oklch(0 0 0deg / 1)", "oklch(0 0 0)"],
+    ["oklch(0 0 0deg / 0.5)", "oklch(0 0 0 / 0.5)"],
+    ["oklch(1 2.3 0deg / 0.5)", "oklch(1 2.3 0 / 0.5)"],
+    ["oklch(0.2 0.5 20deg/0.5)", "oklch(0.2 0.5 20 / 0.5)"],
+    ["oklch(0.2 0.5 20deg/50%)", "oklch(0.2 0.5 20 / 0.5)"],
+    ["oklch(0.1 0.2 20deg / -10%)", "oklch(0.1 0.2 20 / 0)"],
+    ["oklch(0.1 0.2 20deg / 110%)", "oklch(0.1 0.2 20)"],
+    ["oklch(0.1 0.2 1.28rad)", "oklch(0.1 0.2 73.3386)"],
+    ["oklch(0.1 0.2 380deg)", "oklch(0.1 0.2 20)"],
+    ["oklch(0.1 0.2 -340deg)", "oklch(0.1 0.2 20)"],
+    ["oklch(0.1 0.2 740deg)", "oklch(0.1 0.2 20)"],
+    ["oklch(0.1 0.2 -700deg)", "oklch(0.1 0.2 20)"],
+    ["oklch(-4 0 0)", "oklch(0 0 0)"],
+    ["oklch(0.2 -0.2 0)", "oklch(0.2 0 0)"],
+    ["oklch(0 0 0 / 0.5)", "oklch(0 0 0 / 0.5)"],
+    ["oklch(0.1 0.2 20 / 110%)", "oklch(0.1 0.2 20)"],
+    ["oklch(0.1 0.2 -700)", "oklch(0.1 0.2 20)"],
+    ["oklch(calc(0.5 * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))", "oklch(1 0 40 / 0.5)"],
+    ["oklch(calc(-0.5 * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))", "oklch(0 1.5 320 / 0)"],
 
-// oklch()
-test_valid_value("color", "oklch(0 0 0deg)", "oklch(0 0 0)");
-test_valid_value("color", "oklch(0 0 0deg / 1)", "oklch(0 0 0)");
-test_valid_value("color", "oklch(0 0 0deg / 0.5)", "oklch(0 0 0 / 0.5)");
-test_valid_value("color", "oklch(1 2.3 0deg / 0.5)", "oklch(1 2.3 0 / 0.5)");
-test_valid_value("color", "oklch(0.2 0.5 20deg/0.5)", "oklch(0.2 0.5 20 / 0.5)");
-test_valid_value("color", "oklch(0.2 0.5 20deg/50%)", "oklch(0.2 0.5 20 / 0.5)");
-test_valid_value("color", "oklch(0.1 0.2 20deg / -10%)", "oklch(0.1 0.2 20 / 0)");
-test_valid_value("color", "oklch(0.1 0.2 20deg / 110%)", "oklch(0.1 0.2 20)");
-test_valid_value("color", "oklch(0.1 0.2 1.28rad)", "oklch(0.1 0.2 73.3386)");
-test_valid_value("color", "oklch(0.1 0.2 380deg)", "oklch(0.1 0.2 20)");
-test_valid_value("color", "oklch(0.1 0.2 -340deg)", "oklch(0.1 0.2 20)");
-test_valid_value("color", "oklch(0.1 0.2 740deg)", "oklch(0.1 0.2 20)");
-test_valid_value("color", "oklch(0.1 0.2 -700deg)", "oklch(0.1 0.2 20)");
-test_valid_value("color", "oklch(-4 0 0)", "oklch(0 0 0)");
-test_valid_value("color", "oklch(0.2 -0.2 0)", "oklch(0.2 0 0)");
-test_valid_value("color", "oklch(0 0 0 / 0.5)", "oklch(0 0 0 / 0.5)");
-test_valid_value("color", "oklch(0.1 0.2 20 / 110%)", "oklch(0.1 0.2 20)");
-test_valid_value("color", "oklch(0.1 0.2 -700)", "oklch(0.1 0.2 20)");
-test_valid_value("color", "oklch(calc(0.5 * 3) calc(0.5 - 1) calc(20deg * 2) / calc(-0.5 + 1))", "oklch(1 0 40 / 0.5)");
-test_valid_value("color", "oklch(calc(-0.5 * 3) calc(0.5 + 1) calc(-20deg * 2) / calc(-0.5 * 2))", "oklch(0 1.5 320 / 0)");
+    ["oklch(none none none / none)", "oklch(none none none / none)"],
+    ["oklch(none none none)", "oklch(none none none)"],
+    ["oklch(0.2 none none / none)", "oklch(0.2 none none / none)"],
+    ["oklch(none none none / 0.5)", "oklch(none none none / 0.5)"],
+    ["oklch(0 0 0 / none)", "oklch(0 0 0 / none)"],
 
-test_valid_value("color", "oklch(none none none / none)", "oklch(none none none / none)");
-test_valid_value("color", "oklch(none none none)", "oklch(none none none)");
-test_valid_value("color", "oklch(0.2 none none / none)", "oklch(0.2 none none / none)");
-test_valid_value("color", "oklch(none none none / 0.5)", "oklch(none none none / 0.5)");
-test_valid_value("color", "oklch(0 0 0 / none)", "oklch(0 0 0 / none)");
+    // These tests validate the ranges of lch() vs. oklch() lightness and chroma
+    ["lch(20% 80% 10/0.5)", "lch(20 120 10 / 0.5)"],
+    ["oklch(20% 60% 10/0.5)", "oklch(0.2 0.24 10 / 0.5)"],
 
+    ["oklch(calc(infinity) 0 0)", "oklch(1 0 0)"],
+    ["oklch(0.5 calc(infinity) 0)", "oklch(0.5 calc(infinity) 0)"],
+    ["oklch(0.5 calc(-infinity) 0)", "oklch(0.5 0 0)"],
+    ["oklch(calc(NaN) 0 0)", "oklch(calc(NaN) 0 0)"],
+    ["oklch(calc(0 / 0) 0 0)", "oklch(calc(NaN) 0 0)"],
 
-// These tests validate the ranges of lch() vs. oklch() lightness and chroma
-test_valid_value("color", "lch(20% 80% 10/0.5)", "lch(20 120 10 / 0.5)");
-test_valid_value("color", "oklch(20% 60% 10/0.5)", "oklch(0.2 0.24 10 / 0.5)");
+    // calc(50% + (sign(1em - 10px) * 10%)) cannot be evaluated eagerly because font relative units are not yet known at parse time.
+    ["lab(calc(50 + (sign(1em - 10px) * 10)) 30 50 / 50%)", "lab(calc(50 + (10 * sign(1em - 10px))) 30 50 / 50%)"],
+    ["oklab(calc(0.5 + (sign(1em - 10px) * 0.1)) 0.3 0.5 / 50%)", "oklab(calc(0.5 + (0.1 * sign(1em - 10px))) 0.3 0.5 / 50%)"],
+    ["lab(60 30 50 / calc(50% + (sign(1em - 10px) * 10%)))", "lab(60 30 50 / calc(50% + (10% * sign(1em - 10px))))"],
+    ["oklab(0.6 0.3 0.5 / calc(50% + (sign(1em - 10px) * 10%)))", "oklab(0.6 0.3 0.5 / calc(50% + (10% * sign(1em - 10px))))"],
 
-test_valid_value("color", "oklch(calc(infinity) 0 0)", "oklch(1 0 0)");
-test_valid_value("color", "oklch(0.5 calc(infinity) 0)", "oklch(0.5 calc(infinity) 0)");
-test_valid_value("color", "oklch(0.5 calc(-infinity) 0)", "oklch(0.5 0 0)");
-test_valid_value("color", "oklch(calc(NaN) 0 0)", "oklch(calc(NaN) 0 0)");
-test_valid_value("color", "oklch(calc(0 / 0) 0 0)", "oklch(calc(NaN) 0 0)");
+    ["lch(calc(50 + (sign(1em - 10px) * 10)) 30 50deg / 50%)", "lch(calc(50 + (10 * sign(1em - 10px))) 30 50deg / 50%)"],
+    ["oklch(calc(0.5 + (sign(1em - 10px) * 0.1)) 0.3 50deg / 50%)", "oklch(calc(0.5 + (0.1 * sign(1em - 10px))) 0.3 50deg / 50%)"],
+    ["lch(60 30 50deg / calc(50% + (sign(1em - 10px) * 10%)))", "lch(60 30 50deg / calc(50% + (10% * sign(1em - 10px))))"],
+    ["oklch(0.6 0.3 50deg / calc(50% + (sign(1em - 10px) * 10%)))", "oklch(0.6 0.3 50deg / calc(50% + (10% * sign(1em - 10px))))"],
+];
+
+for (const test of tests) {
+    test_valid_value("color", test[0], test[1]);
+}
 
 </script>
 </body>

--- a/css/css-color/parsing/color-valid-rgb.html
+++ b/css/css-color/parsing/color-valid-rgb.html
@@ -12,62 +12,91 @@
 </head>
 <body>
 <script>
-test_valid_value("color", "rgb(none none none)", "rgb(0, 0, 0)");
-test_valid_value("color", "rgb(none none none / none)", "rgba(0, 0, 0, 0)");
-test_valid_value("color", "rgb(128 none none)", "rgb(128, 0, 0)");
-test_valid_value("color", "rgb(128 none none / none)", "rgba(128, 0, 0, 0)");
-test_valid_value("color", "rgb(none none none / .5)", "rgba(0, 0, 0, 0.5)");
-test_valid_value("color", "rgb(20% none none)", "rgb(51, 0, 0)");
-test_valid_value("color", "rgb(20% none none / none)", "rgba(51, 0, 0, 0)");
-test_valid_value("color", "rgb(none none none / 50%)", "rgba(0, 0, 0, 0.5)");
-test_valid_value("color", "rgba(none none none)", "rgb(0, 0, 0)");
-test_valid_value("color", "rgba(none none none / none)", "rgba(0, 0, 0, 0)");
-test_valid_value("color", "rgba(128 none none)", "rgb(128, 0, 0)");
-test_valid_value("color", "rgba(128 none none / none)", "rgba(128, 0, 0, 0)");
-test_valid_value("color", "rgba(none none none / .5)", "rgba(0, 0, 0, 0.5)");
-test_valid_value("color", "rgba(20% none none)", "rgb(51, 0, 0)");
-test_valid_value("color", "rgba(20% none none / none)", "rgba(51, 0, 0, 0)");
-test_valid_value("color", "rgba(none none none / 50%)", "rgba(0, 0, 0, 0.5)");
-test_valid_value("color", "rgb(-2 3 4)", "rgb(0, 3, 4)");
-test_valid_value("color", "rgb(-20% 20% 40%)", "rgb(0, 51, 102)");
-test_valid_value("color", "rgb(257 30 40)", "rgb(255, 30, 40)");
-test_valid_value("color", "rgb(250% 20% 40%)", "rgb(255, 51, 102)");
-test_valid_value("color", "rgba(-2 3 4)", "rgb(0, 3, 4)");
-test_valid_value("color", "rgba(-20% 20% 40%)", "rgb(0, 51, 102)");
-test_valid_value("color", "rgba(257 30 40)", "rgb(255, 30, 40)");
-test_valid_value("color", "rgba(250% 20% 40%)", "rgb(255, 51, 102)");
-test_valid_value("color", "rgba(-2 3 4 / .5)", "rgba(0, 3, 4, 0.5)");
-test_valid_value("color", "rgba(-20% 20% 40% / 50%)", "rgba(0, 51, 102, 0.5)");
-test_valid_value("color", "rgba(257 30 40 / 50%)", "rgba(255, 30, 40, 0.5)");
-test_valid_value("color", "rgba(250% 20% 40% / .5)", "rgba(255, 51, 102, 0.5)");
+tests = [
+    ["rgb(none none none)", "rgb(0, 0, 0)"],
+    ["rgb(none none none / none)", "rgba(0, 0, 0, 0)"],
+    ["rgb(128 none none)", "rgb(128, 0, 0)"],
+    ["rgb(128 none none / none)", "rgba(128, 0, 0, 0)"],
+    ["rgb(none none none / .5)", "rgba(0, 0, 0, 0.5)"],
+    ["rgb(20% none none)", "rgb(51, 0, 0)"],
+    ["rgb(20% none none / none)", "rgba(51, 0, 0, 0)"],
+    ["rgb(none none none / 50%)", "rgba(0, 0, 0, 0.5)"],
+    ["rgba(none none none)", "rgb(0, 0, 0)"],
+    ["rgba(none none none / none)", "rgba(0, 0, 0, 0)"],
+    ["rgba(128 none none)", "rgb(128, 0, 0)"],
+    ["rgba(128 none none / none)", "rgba(128, 0, 0, 0)"],
+    ["rgba(none none none / .5)", "rgba(0, 0, 0, 0.5)"],
+    ["rgba(20% none none)", "rgb(51, 0, 0)"],
+    ["rgba(20% none none / none)", "rgba(51, 0, 0, 0)"],
+    ["rgba(none none none / 50%)", "rgba(0, 0, 0, 0.5)"],
+    ["rgb(-2 3 4)", "rgb(0, 3, 4)"],
+    ["rgb(-20% 20% 40%)", "rgb(0, 51, 102)"],
+    ["rgb(257 30 40)", "rgb(255, 30, 40)"],
+    ["rgb(250% 20% 40%)", "rgb(255, 51, 102)"],
+    ["rgba(-2 3 4)", "rgb(0, 3, 4)"],
+    ["rgba(-20% 20% 40%)", "rgb(0, 51, 102)"],
+    ["rgba(257 30 40)", "rgb(255, 30, 40)"],
+    ["rgba(250% 20% 40%)", "rgb(255, 51, 102)"],
+    ["rgba(-2 3 4 / .5)", "rgba(0, 3, 4, 0.5)"],
+    ["rgba(-20% 20% 40% / 50%)", "rgba(0, 51, 102, 0.5)"],
+    ["rgba(257 30 40 / 50%)", "rgba(255, 30, 40, 0.5)"],
+    ["rgba(250% 20% 40% / .5)", "rgba(255, 51, 102, 0.5)"],
 
-// Test with mixed components.
-test_valid_value("color", "rgb(250% 51 40%)", "rgb(255, 51, 102)");
-test_valid_value("color", "rgb(255 20% 102)", "rgb(255, 51, 102)");
+    // Test with mixed components.
+    ["rgb(250% 51 40%)", "rgb(255, 51, 102)"],
+    ["rgb(255 20% 102)", "rgb(255, 51, 102)"],
 
-// rgb are in the range [0, 255], alpha is in the range [0, 1].
-// Values above or below these numbers should get resolved to the upper/lower bound.
-test_valid_value("color", "rgb(500, 0, 0)", "rgb(255, 0, 0)");
-test_valid_value("color", "rgb(-500, 64, 128)", "rgb(0, 64, 128)");
+    // rgb are in the range [0, 255], alpha is in the range [0, 1].
+    // Values above or below these numbers should get resolved to the upper/lower bound.
+    ["rgb(500, 0, 0)", "rgb(255, 0, 0)"],
+    ["rgb(-500, 64, 128)", "rgb(0, 64, 128)"],
 
-// calc(infinity) resolves to the upper bound while calc(-infinity) and calc(NaN) resolves the lower bound.
-// See: https://github.com/w3c/csswg-drafts/issues/8629
-test_valid_value("color", "rgb(calc(infinity), 0, 0)", "rgb(255, 0, 0)");
-test_valid_value("color", "rgb(0, calc(infinity), 0)", "rgb(0, 255, 0)");
-test_valid_value("color", "rgb(0, 0, calc(infinity))", "rgb(0, 0, 255)");
-test_valid_value("color", "rgba(0, 0, 0, calc(infinity))", "rgb(0, 0, 0)");
-test_valid_value("color", "rgb(calc(-infinity), 0, 0)", "rgb(0, 0, 0)");
-test_valid_value("color", "rgb(0, calc(-infinity), 0)", "rgb(0, 0, 0)");
-test_valid_value("color", "rgb(0, 0, calc(-infinity))", "rgb(0, 0, 0)");
-test_valid_value("color", "rgba(0, 0, 0, calc(-infinity))", "rgba(0, 0, 0, 0)");
-test_valid_value("color", "rgb(calc(NaN), 0, 0)", "rgb(0, 0, 0)");
-test_valid_value("color", "rgb(0, calc(NaN), 0)", "rgb(0, 0, 0)");
-test_valid_value("color", "rgb(0, 0, calc(NaN))", "rgb(0, 0, 0)");
-test_valid_value("color", "rgba(0, 0, 0, calc(NaN))", "rgba(0, 0, 0, 0)");
-test_valid_value("color", "rgb(calc(0 / 0), 0, 0)", "rgb(0, 0, 0)");
-test_valid_value("color", "rgb(0, calc(0 / 0), 0)", "rgb(0, 0, 0)");
-test_valid_value("color", "rgb(0, 0, calc(0 / 0))", "rgb(0, 0, 0)");
-test_valid_value("color", "rgba(0, 0, 0, calc(0 / 0))", "rgba(0, 0, 0, 0)");
+    // calc(infinity) resolves to the upper bound while calc(-infinity) and calc(NaN) resolves the lower bound.
+    // See: https://github.com/w3c/csswg-drafts/issues/8629
+    ["rgb(calc(infinity), 0, 0)", "rgb(255, 0, 0)"],
+    ["rgb(0, calc(infinity), 0)", "rgb(0, 255, 0)"],
+    ["rgb(0, 0, calc(infinity))", "rgb(0, 0, 255)"],
+    ["rgba(0, 0, 0, calc(infinity))", "rgb(0, 0, 0)"],
+    ["rgb(calc(-infinity), 0, 0)", "rgb(0, 0, 0)"],
+    ["rgb(0, calc(-infinity), 0)", "rgb(0, 0, 0)"],
+    ["rgb(0, 0, calc(-infinity))", "rgb(0, 0, 0)"],
+    ["rgba(0, 0, 0, calc(-infinity))", "rgba(0, 0, 0, 0)"],
+    ["rgb(calc(NaN), 0, 0)", "rgb(0, 0, 0)"],
+    ["rgb(0, calc(NaN), 0)", "rgb(0, 0, 0)"],
+    ["rgb(0, 0, calc(NaN))", "rgb(0, 0, 0)"],
+    ["rgba(0, 0, 0, calc(NaN))", "rgba(0, 0, 0, 0)"],
+    ["rgb(calc(0 / 0), 0, 0)", "rgb(0, 0, 0)"],
+    ["rgb(0, calc(0 / 0), 0)", "rgb(0, 0, 0)"],
+    ["rgb(0, 0, calc(0 / 0))", "rgb(0, 0, 0)"],
+    ["rgba(0, 0, 0, calc(0 / 0))", "rgba(0, 0, 0, 0)"],
+
+    // calc(50% + (sign(1em - 10px) * 10%)) cannot be evaluated eagerly because font relative units are not yet known at parse time.
+    ["rgb(calc(50% + (sign(1em - 10px) * 10%)), 0%, 0%, 50%)", "rgb(calc(50% + (10% * sign(1em - 10px))) 0% 0% / 50%)"],
+    ["rgba(calc(50% + (sign(1em - 10px) * 10%)), 0%, 0%, 50%)", "rgb(calc(50% + (10% * sign(1em - 10px))) 0% 0% / 50%)"],
+    ["rgb(calc(50 + (sign(1em - 10px) * 10)), 0, 0, 0.5)", "rgb(calc(50 + (10 * sign(1em - 10px))) 0 0 / 0.5)"],
+    ["rgba(calc(50 + (sign(1em - 10px) * 10)), 0, 0, 0.5)", "rgb(calc(50 + (10 * sign(1em - 10px))) 0 0 / 0.5)"],
+    ["rgb(0%, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))", "rgb(0% 0% 0% / calc(50% + (10% * sign(1em - 10px))))"],
+    ["rgba(0%, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))", "rgb(0% 0% 0% / calc(50% + (10% * sign(1em - 10px))))"],
+    ["rgb(0, 0, 0, calc(0.75 + (sign(1em - 10px) * 0.1)))", "rgb(0 0 0 / calc(0.75 + (0.1 * sign(1em - 10px))))"],
+    ["rgba(0, 0, 0, calc(0.75 + (sign(1em - 10px) * 0.1)))", "rgb(0 0 0 / calc(0.75 + (0.1 * sign(1em - 10px))))"],
+
+    ["rgb(calc(50% + (sign(1em - 10px) * 10%)) 0% 0% / 50%)", "rgb(calc(50% + (10% * sign(1em - 10px))) 0% 0% / 50%)"],
+    ["rgba(calc(50% + (sign(1em - 10px) * 10%)) 0% 0% / 50%)", "rgb(calc(50% + (10% * sign(1em - 10px))) 0% 0% / 50%)"],
+    ["rgb(calc(50 + (sign(1em - 10px) * 10)) 0 0 / 0.5)", "rgb(calc(50 + (10 * sign(1em - 10px))) 0 0 / 0.5)"],
+    ["rgba(calc(50 + (sign(1em - 10px) * 10)) 0 0 / 0.5)", "rgb(calc(50 + (10 * sign(1em - 10px))) 0 0 / 0.5)"],
+    ["rgb(0% 0% 0% / calc(50% + (sign(1em - 10px) * 10%)))", "rgb(0% 0% 0% / calc(50% + (10% * sign(1em - 10px))))"],
+    ["rgba(0% 0% 0% / calc(50% + (sign(1em - 10px) * 10%)))", "rgb(0% 0% 0% / calc(50% + (10% * sign(1em - 10px))))"],
+    ["rgb(0 0 0 / calc(0.75 + (sign(1em - 10px) * 0.1)))", "rgb(0 0 0 / calc(0.75 + (0.1 * sign(1em - 10px))))"],
+    ["rgba(0 0 0 / calc(0.75 + (sign(1em - 10px) * 0.1)))", "rgb(0 0 0 / calc(0.75 + (0.1 * sign(1em - 10px))))"],
+
+    ["rgba(calc(50% + (sign(1em - 10px) * 10%)) 0 0% / 0.5)", "rgb(calc(50% + (10% * sign(1em - 10px))) 0 0% / 0.5)"],
+    ["rgba(0% 0 0% / calc(0.75 + (sign(1em - 10px) * 0.1)))", "rgb(0% 0 0% / calc(0.75 + (0.1 * sign(1em - 10px))))"],
+];
+
+for (const test of tests) {
+    test_valid_value("color", test[0], test[1], test[2] ? `[${test[2]}]` : undefined);
+}
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
Export of Support CSS color values that use calc() with non-absolute lengths (https://bugs.webkit.org/show_bug.cgi?id=278547)