### PR TITLE
The title of css/css-color/system-color-consistency.html was referencing something completely different than what is being tested.

### DIFF
--- a/css/css-color/system-color-consistency.html
+++ b/css/css-color/system-color-consistency.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>CSS Color 4: Computed value of color-contrast()</title>
+  <title>CSS Color 4: System color consistency</title>
   <link rel="author" title="Jan Keitel" href="mailto:jkeitel@google.com">
   <link rel="help" href="https://www.w3.org/TR/css-color-4/#css-system-colors">
   <meta name="assert" content="computed style of form elements is consistent with definition of system colors">


### PR DESCRIPTION
Fixed to correct title. 

(Upstreams part of https://bugs.webkit.org/show_bug.cgi?id=278864)