### PR TITLE
[wptrunner] Reland "Implement --leak-check for Blink-based browsers"

### DIFF
--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -1,10 +1,11 @@
 # mypy: allow-untyped-defs
 
+import collections
 import traceback
 from http.client import HTTPConnection
 
 from abc import ABCMeta, abstractmethod
-from typing import Any, Awaitable, Callable, ClassVar, List, Mapping, Optional, Type
+from typing import Any, Awaitable, Callable, ClassVar, List, Mapping, Optional, Tuple, Type
 
 
 def merge_dicts(target, source):
@@ -69,6 +70,8 @@ class Protocol:
 
             msg = "Post-connection steps failed"
             self.after_connect()
+            for cls in self.implements:
+                getattr(self, cls.name).after_connect()
         except Exception:
             message = "Protocol.setup caught an exception:\n"
             message += f"{msg}\n" if msg is not None else ""
@@ -111,6 +114,11 @@ class ProtocolPart:
 
     def setup(self):
         """Run any setup steps required for the ProtocolPart."""
+        pass
+
+    def after_connect(self):
+        """Run any post-connection steps. This happens after the ProtocolParts are
+        initalized so can depend on a fully-populated object."""
         pass
 
     def teardown(self):
@@ -611,6 +619,37 @@ class AssertsProtocolPart(ProtocolPart):
     def get(self):
         """Get a count of assertions since the last browser start"""
         pass
+
+
+class LeakProtocolPart(ProtocolPart):
+    """Protocol part that checks for leaked DOM objects."""
+    __metaclass__ = ABCMeta
+
+    name = "leak"
+
+    def after_connect(self):
+        self.parent.base.load("about:blank")
+        self.expected_counters = collections.Counter(self.get_counters())
+
+    @abstractmethod
+    def get_counters(self) -> Mapping[str, int]:
+        """Get counts of types of live objects (names are browser-dependent)."""
+
+    def check(self) -> Optional[Mapping[str, Tuple[int, int]]]:
+        """Check for DOM objects that outlive the current page.
+
+        Returns:
+            A map from object type to (expected, actual) counts, if one or more
+            types leaked. Otherwise, `None`.
+        """
+        self.parent.base.load("about:blank")
+        counters = collections.Counter(self.get_counters())
+        if counters - self.expected_counters:
+            return {
+                name: (self.expected_counters[name], counters[name])
+                for name in set(counters) | set(self.expected_counters)
+            }
+        return None
 
 
 class CoverageProtocolPart(ProtocolPart):

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -221,6 +221,12 @@ scheme host and port.""")
                                  help="Path to stackwalker program used to analyse minidumps.")
     debugging_group.add_argument("--pdb", action="store_true",
                                  help="Drop into pdb on python exception")
+    debugging_group.add_argument("--leak-check", dest="leak_check", action="store_true", default=None,
+                                 help=("Enable leak checking for supported browsers "
+                                       "(Gecko: enabled by default for debug builds, "
+                                       "silently ignored for opt, mobile)"))
+    debugging_group.add_argument("--no-leak-check", dest="leak_check", action="store_false", default=None,
+                                 help="Disable leak checking")
 
     android_group = parser.add_argument_group("Android specific arguments")
     android_group.add_argument("--adb-binary", action="store",
@@ -334,11 +340,6 @@ scheme host and port.""")
     gecko_group.add_argument("--setpref", dest="extra_prefs", action='append',
                              default=[], metavar="PREF=VALUE",
                              help="Defines an extra user preference (overrides those in prefs_root)")
-    gecko_group.add_argument("--leak-check", dest="leak_check", action="store_true", default=None,
-                             help="Enable leak checking (enabled by default for debug builds, "
-                             "silently ignored for opt, mobile)")
-    gecko_group.add_argument("--no-leak-check", dest="leak_check", action="store_false", default=None,
-                             help="Disable leak checking")
     gecko_group.add_argument("--reftest-internal", dest="reftest_internal", action="store_true",
                              default=None, help="Enable reftest runner implemented inside Marionette")
     gecko_group.add_argument("--reftest-external", dest="reftest_internal", action="store_false",


### PR DESCRIPTION
This PR relands https://github.com/web-platform-tests/wpt/pull/47850 with two fixes:
* Introduce `ProtocolPart.after_connect()`, then fetch the initial leak
  counters there after the `base` protocol part is initialized. This
  avoids requiring `base` to be `setup()` before `leak`, which was true
  by happenstance.
* Tolerate `ExecutorBrowser` without `leak_check`, since some browsers
  that don't inherit from `ChromeBrowser` still use
  `ChromeDriverProtocol` sometimes (e.g., print-reftests for Chrome on
  Android). `ChromeDriverProtocol` still excludes its `leak` part
  altogether if `leak_check=False` to avoid running
  `LeakProtocolPart.after_connect()`. This precludes an alternative
  approach that passes `leak_check` to `WebDriver*Executor`s directly.