### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=278837

### DIFF
--- a/css/css-view-transitions/navigation/no-view-transition-with-cross-origin-redirect.sub.html
+++ b/css/css-view-transitions/navigation/no-view-transition-with-cross-origin-redirect.sub.html
@@ -24,7 +24,7 @@
 </style>
 <script>
   function runTest() {
-    let crossOriginPath = "http://{{hosts[][www]}}:{{ports[http][1]}}";
+    let crossOriginPath = "http://{{hosts[alt][]}}:{{ports[http][1]}}";
     let newUrl = crossOriginPath + "/common/redirect.py?location=" + location.href.split('?')[0] + "?new";
     location.href = newUrl;
   }


### PR DESCRIPTION
WebKit export from bug: [\[css-view-transitions-2\] no-view-transition-with-cross-origin-redirect.sub.html fails](https://bugs.webkit.org/show_bug.cgi?id=278837)