### PR TITLE
Test reference target usage via the options argument of attachShadow()

### DIFF
--- a/shadow-dom/reference-target/tentative/anchor.html
+++ b/shadow-dom/reference-target/tentative/anchor.html
@@ -74,8 +74,8 @@ background-color: yellow;
         popover.showPopover();
         assert_equals(popover.offsetLeft, 100, "popover.offsetLeft");
         assert_equals(popover.offsetTop, 100, "popover.offsetTop");
-		// Clean up the test context for future tests.
-		popover.parentElement.remove();
+        // Clean up the test context for future tests.
+        popover.parentElement.remove();
       }, name);
     }
     testPopoverAnchor('popover-1', "ShadowRoot ReferenceTarget works with anchor attribute.");

--- a/shadow-dom/reference-target/tentative/anchor.html
+++ b/shadow-dom/reference-target/tentative/anchor.html
@@ -44,13 +44,44 @@
     <div id="popover-1" popover anchor="x-anchor-1">Popover content</div>
   </div>
 
+  <div>
+    <x-anchor-2 id="x-anchor-2"></x-anchor-2>
+    <div id="popover-2" popover anchor="x-anchor-2">Popover content</div>
+  </div>
+
   <script>
-    test(function () {
-      const popover = document.getElementById("popover-1");
+    customElements.define('x-anchor-2', class extends HTMLElement {
+    constructor() {
+      super();
+      this.attachShadow({ mode: 'open', referencetarget: 'anchor' });
+      this.shadowRoot.innerHTML =`
+  <style>
+  div {
+    width: 100px;
+    height: 100px;
+  }
+
+  #anchor {
+    background-color: yellow;
+  }
+  </style>
+
+  <div></div>
+  <div id="anchor"></div>`;
+    }
+    });
+  </script>
+  <script>
+    function testPopoverAnchor(id) {
+      test(function () {
+      const popover = document.getElementById(id);
       popover.showPopover();
       assert_equals(popover.offsetLeft, 100, "popover.offsetLeft");
       assert_equals(popover.offsetTop, 100, "popover.offsetTop");
-    }, "ShadowRoot ReferenceTarget works with anchor attribute.");
+      }, "ShadowRoot ReferenceTarget works with anchor attribute.");
+    }
+    testPopoverAnchor('popover-1');
+    testPopoverAnchor('popover-2');
   </script>
 </body>
 

--- a/shadow-dom/reference-target/tentative/anchor.html
+++ b/shadow-dom/reference-target/tentative/anchor.html
@@ -51,7 +51,7 @@
 
   <script>
     const customAnchor = document.querySelector('x-anchor-2');
-    customAnchor.attachShadow({ mode: 'open', referencetarget: 'anchor' });
+    customAnchor.attachShadow({ mode: 'open', referenceTarget: 'anchor' });
     customAnchor.shadowRoot.innerHTML =`
 <style>
 div {
@@ -70,10 +70,12 @@ background-color: yellow;
   <script>
     function testPopoverAnchor(id, name) {
       test(function () {
-      const popover = document.getElementById(id);
-      popover.showPopover();
-      assert_equals(popover.offsetLeft, 100, "popover.offsetLeft");
-      assert_equals(popover.offsetTop, 100, "popover.offsetTop");
+        const popover = document.getElementById(id);
+        popover.showPopover();
+        assert_equals(popover.offsetLeft, 100, "popover.offsetLeft");
+        assert_equals(popover.offsetTop, 100, "popover.offsetTop");
+		// Clean up the test context for future tests.
+		popover.parentElement.remove();
       }, name);
     }
     testPopoverAnchor('popover-1', "ShadowRoot ReferenceTarget works with anchor attribute.");

--- a/shadow-dom/reference-target/tentative/anchor.html
+++ b/shadow-dom/reference-target/tentative/anchor.html
@@ -50,38 +50,34 @@
   </div>
 
   <script>
-    customElements.define('x-anchor-2', class extends HTMLElement {
-    constructor() {
-      super();
-      this.attachShadow({ mode: 'open', referencetarget: 'anchor' });
-      this.shadowRoot.innerHTML =`
-  <style>
-  div {
-    width: 100px;
-    height: 100px;
-  }
+    const customAnchor = document.querySelector('x-anchor-2');
+    customAnchor.attachShadow({ mode: 'open', referencetarget: 'anchor' });
+    customAnchor.shadowRoot.innerHTML =`
+<style>
+div {
+width: 100px;
+height: 100px;
+}
 
-  #anchor {
-    background-color: yellow;
-  }
-  </style>
+#anchor {
+background-color: yellow;
+}
+</style>
 
-  <div></div>
-  <div id="anchor"></div>`;
-    }
-    });
+<div></div>
+<div id="anchor"></div>`;
   </script>
   <script>
-    function testPopoverAnchor(id) {
+    function testPopoverAnchor(id, name) {
       test(function () {
       const popover = document.getElementById(id);
       popover.showPopover();
       assert_equals(popover.offsetLeft, 100, "popover.offsetLeft");
       assert_equals(popover.offsetTop, 100, "popover.offsetTop");
-      }, "ShadowRoot ReferenceTarget works with anchor attribute.");
+      }, name);
     }
-    testPopoverAnchor('popover-1');
-    testPopoverAnchor('popover-2');
+    testPopoverAnchor('popover-1', "ShadowRoot ReferenceTarget works with anchor attribute.");
+    testPopoverAnchor('popover-2', "ShadowRoot ReferenceTarget works with anchor attribute via options.");
   </script>
 </body>
 

--- a/shadow-dom/reference-target/tentative/label-descendant.html
+++ b/shadow-dom/reference-target/tentative/label-descendant.html
@@ -32,13 +32,9 @@
 </label>
 
 <script>
-  customElements.define('x-input1', class extends HTMLElement {
-    constructor() {
-    super();
-    this.attachShadow({ mode: 'open', referenceTarget: 'input1' });
-    this.shadowRoot.innerHTML = `<input id="input1">`;
-    }
-  });
+  const customInput1 = document.querySelector('x-input1');
+  customInput1.attachShadow({ mode: 'open', referenceTarget: 'input1' });
+  customInput1.shadowRoot.innerHTML = `<input id="input1">`;
 </script>
 
 <script>
@@ -77,20 +73,12 @@
 </label>
 
 <script>
-  customElements.define('x-outer2', class extends HTMLElement {
-    constructor() {
-      super();
-      this.attachShadow({ mode: 'open', referenceTarget: 'x-inner2' });
-      this.shadowRoot.innerHTML = `<x-inner2 id="x-inner2"></x-inner2>`;
-    }
-  });
-  customElements.define('x-inner2', class extends HTMLElement {
-    constructor() {
-      super();
-      this.attachShadow({ mode: 'open', referenceTarget: 'input2' });
-      this.shadowRoot.innerHTML = `<input id="input2">`;
-    }
-  });
+  const customOuter2 = document.querySelector('x-outer2');
+  customOuter2.attachShadow({ mode: 'open', referenceTarget: 'x-inner2' });
+  customOuter2.shadowRoot.innerHTML = `<x-inner2 id="x-inner2"></x-inner2>`;
+  const customInner2 = document.querySelector('x-inner2');
+  customInner2.attachShadow({ mode: 'open', referenceTarget: 'input2' });
+  customInner2.shadowRoot.innerHTML = `<input id="input2">`;
 </script>
 
 <script>

--- a/shadow-dom/reference-target/tentative/label-descendant.html
+++ b/shadow-dom/reference-target/tentative/label-descendant.html
@@ -24,15 +24,36 @@
   </div>
 </label>
 
-<script>
-  promise_test(async t => {
-    const x_input = document.getElementById('x-input1');
-    const input = x_input.shadowRoot.getElementById('input1');
+<label>
+  Input 1 via Options
+  <div>
+    <x-input1 id="x-input1-a"></x-input1>
+  </div>
+</label>
 
-    // The label should apply to the input element and not the host.
-    assert_equals(await test_driver.get_computed_label(x_input), "");
-    assert_equals(await test_driver.get_computed_label(input), "Input 1");
-  }, "Label applies to descendant custom element that uses shadowrootreferencetarget");
+<script>
+  customElements.define('x-input1', class extends HTMLElement {
+    constructor() {
+    super();
+    this.attachShadow({ mode: 'open', referenceTarget: 'input1' });
+    this.shadowRoot.innerHTML = `<input id="input1">`;
+    }
+  });
+</script>
+
+<script>
+  function testImplicitLabelAssociation(id, label) {
+    promise_test(async t => {
+      const x_input = document.getElementById(id);
+      const input = x_input.shadowRoot.getElementById('input1');
+
+      // The label should apply to the input element and not the host.
+      assert_equals(await test_driver.get_computed_label(x_input), "");
+      assert_equals(await test_driver.get_computed_label(input), label);
+    }, "Label applies to descendant custom element that uses shadowrootreferencetarget");
+  }
+  testImplicitLabelAssociation('x-input1', 'Input 1');
+  testImplicitLabelAssociation('x-input1-a', 'Input 1 via Options');
 </script>
 
 <!-- 2. Label applies to multiple layers of descendant custom elements that use shadowrootreferencetarget -->
@@ -50,17 +71,43 @@
   </x-outer2>
 </label>
 
-<script>
-  promise_test(async t => {
-    const outer = document.getElementById('x-outer2');
-    const inner = outer.shadowRoot.getElementById('x-inner2');
-    const input = inner.shadowRoot.getElementById('input2');
+<label>
+  Input 2 via Options
+  <x-outer2 id="x-outer2-a"></x-outer2>
+</label>
 
-    // The label should apply to the input element and not any of the hosts.
-    assert_equals(await test_driver.get_computed_label(outer), "");
-    assert_equals(await test_driver.get_computed_label(inner), "");
-    assert_equals(await test_driver.get_computed_label(input), "Input 2");
-  }, "Label applies to multiple layers of descendant custom elements that use shadowrootreferencetarget");
+<script>
+  customElements.define('x-outer2', class extends HTMLElement {
+    constructor() {
+      super();
+      this.attachShadow({ mode: 'open', referenceTarget: 'x-inner2' });
+      this.shadowRoot.innerHTML = `<x-inner2 id="x-inner2"></x-inner2>`;
+    }
+  });
+  customElements.define('x-inner2', class extends HTMLElement {
+    constructor() {
+      super();
+      this.attachShadow({ mode: 'open', referenceTarget: 'input2' });
+      this.shadowRoot.innerHTML = `<input id="input2">`;
+    }
+  });
+</script>
+
+<script>
+  function testDeepImplicitLabelAssociation(id, label) {
+    promise_test(async t => {
+      const outer = document.getElementById(id);
+      const inner = outer.shadowRoot.getElementById('x-inner2');
+      const input = inner.shadowRoot.getElementById('input2');
+
+      // The label should apply to the input element and not any of the hosts.
+      assert_equals(await test_driver.get_computed_label(outer), "");
+      assert_equals(await test_driver.get_computed_label(inner), "");
+      assert_equals(await test_driver.get_computed_label(input), label);
+    }, "Label applies to multiple layers of descendant custom elements that use shadowrootreferencetarget");
+  }
+  testDeepImplicitLabelAssociation('x-outer2', 'Label 2');
+  testDeepImplicitLabelAssociation('x-outer2-a', 'Label 2 via Options');
 </script>
 
 </body>

--- a/shadow-dom/reference-target/tentative/label-descendant.html
+++ b/shadow-dom/reference-target/tentative/label-descendant.html
@@ -17,8 +17,8 @@
   Input 1
   <div>
     <x-input1 id="x-input1">
-      <template shadowrootmode="open" shadowrootreferencetarget="input1">
-        <input id="input1">
+      <template shadowrootmode="open" shadowrootreferencetarget="input">
+        <input id="input">
       </template>
     </x-input1>
   </div>
@@ -32,16 +32,16 @@
 </label>
 
 <script>
-  const customInput1 = document.querySelector('x-input1');
-  customInput1.attachShadow({ mode: 'open', referenceTarget: 'input1' });
-  customInput1.shadowRoot.innerHTML = `<input id="input1">`;
+  const customInput1 = document.querySelector('#x-input1-a');
+  customInput1.attachShadow({ mode: 'open', referenceTarget: 'input' });
+  customInput1.shadowRoot.innerHTML = `<input id="input">`;
 </script>
 
 <script>
   function testImplicitLabelAssociation(id, label) {
     promise_test(async t => {
       const x_input = document.getElementById(id);
-      const input = x_input.shadowRoot.getElementById('input1');
+      const input = x_input.shadowRoot.getElementById('input');
 
       // The label should apply to the input element and not the host.
       assert_equals(await test_driver.get_computed_label(x_input), "");
@@ -59,8 +59,8 @@
   <x-outer2 id="x-outer2">
     <template shadowrootmode="open" shadowrootreferencetarget="x-inner2">
       <x-inner2 id="x-inner2">
-        <template shadowrootmode="open" shadowrootreferencetarget="input2">
-          <input id="input2">
+        <template shadowrootmode="open" shadowrootreferencetarget="input">
+          <input id="input">
         </template>
       </x-inner2>
     </template>
@@ -73,12 +73,12 @@
 </label>
 
 <script>
-  const customOuter2 = document.querySelector('x-outer2');
+  const customOuter2 = document.querySelector('#x-outer2-a');
   customOuter2.attachShadow({ mode: 'open', referenceTarget: 'x-inner2' });
   customOuter2.shadowRoot.innerHTML = `<x-inner2 id="x-inner2"></x-inner2>`;
-  const customInner2 = document.querySelector('x-inner2');
-  customInner2.attachShadow({ mode: 'open', referenceTarget: 'input2' });
-  customInner2.shadowRoot.innerHTML = `<input id="input2">`;
+  const customInner2 = customOuter2.shadowRoot.querySelector('x-inner2');
+  customInner2.attachShadow({ mode: 'open', referenceTarget: 'input' });
+  customInner2.shadowRoot.innerHTML = `<input id="input">`;
 </script>
 
 <script>
@@ -86,7 +86,7 @@
     promise_test(async t => {
       const outer = document.getElementById(id);
       const inner = outer.shadowRoot.getElementById('x-inner2');
-      const input = inner.shadowRoot.getElementById('input2');
+      const input = inner.shadowRoot.getElementById('input');
 
       // The label should apply to the input element and not any of the hosts.
       assert_equals(await test_driver.get_computed_label(outer), "");

--- a/shadow-dom/reference-target/tentative/label-for.html
+++ b/shadow-dom/reference-target/tentative/label-for.html
@@ -33,7 +33,7 @@
 
 <!-- 2. Label for attribute targets a custom element using shadowrootreferencetarget inside multiple layers of shadow roots -->
 
-<label for="x-outer2">Input 2</label>
+<!-- <label for="x-outer2">Input 2</label>
 <x-outer2 id="x-outer2">
   <template shadowrootmode="open" shadowrootreferencetarget="x-inner2">
     <x-inner2 id="x-inner2">
@@ -55,12 +55,12 @@
     assert_equals(await test_driver.get_computed_label(inner), "");
     assert_equals(await test_driver.get_computed_label(input), "Input 2");
   }, "Label for attribute targets a custom element using shadowrootreferencetarget inside multiple layers of shadow roots");
-</script>
+</script> -->
 
 
 <!-- 3. Multiple labels targeting a custom element using shadowrootreferencetarget inside multiple layers of shadow roots -->
 
-<label for="x-outer3">A</label>
+<!-- <label for="x-outer3">A</label>
 <x-outer3 id="x-outer3">
   <template shadowrootmode="open" shadowrootreferencetarget="x-inner3">
     <label for="x-inner3">B</label>
@@ -84,7 +84,7 @@
       const computed_label = await test_driver.get_computed_label(input);
       assert_equals(computed_label, "A B C D E F");
     }, "Multiple labels targeting a custom element using shadowrootreferencetarget inside multiple layers of shadow roots");
-  </script>
+  </script> -->
 
 </body>
 

--- a/shadow-dom/reference-target/tentative/label-for.html
+++ b/shadow-dom/reference-target/tentative/label-for.html
@@ -33,7 +33,7 @@
 
 <!-- 2. Label for attribute targets a custom element using shadowrootreferencetarget inside multiple layers of shadow roots -->
 
-<!-- <label for="x-outer2">Input 2</label>
+<label for="x-outer2">Input 2</label>
 <x-outer2 id="x-outer2">
   <template shadowrootmode="open" shadowrootreferencetarget="x-inner2">
     <x-inner2 id="x-inner2">
@@ -55,12 +55,12 @@
     assert_equals(await test_driver.get_computed_label(inner), "");
     assert_equals(await test_driver.get_computed_label(input), "Input 2");
   }, "Label for attribute targets a custom element using shadowrootreferencetarget inside multiple layers of shadow roots");
-</script> -->
+</script>
 
 
 <!-- 3. Multiple labels targeting a custom element using shadowrootreferencetarget inside multiple layers of shadow roots -->
 
-<!-- <label for="x-outer3">A</label>
+<label for="x-outer3">A</label>
 <x-outer3 id="x-outer3">
   <template shadowrootmode="open" shadowrootreferencetarget="x-inner3">
     <label for="x-inner3">B</label>
@@ -84,7 +84,7 @@
       const computed_label = await test_driver.get_computed_label(input);
       assert_equals(computed_label, "A B C D E F");
     }, "Multiple labels targeting a custom element using shadowrootreferencetarget inside multiple layers of shadow roots");
-  </script> -->
+  </script>
 
 </body>
 

--- a/shadow-dom/reference-target/tentative/popovertarget.html
+++ b/shadow-dom/reference-target/tentative/popovertarget.html
@@ -11,29 +11,46 @@
 </head>
 
 <body>
-  <button id="toggle-button" popovertarget="x-popover-1">Toggle the popover</button>
+  <button id="toggle-button-1" popovertarget="x-popover-1">Toggle the popover</button>
   <x-popover-1 id="x-popover-1">
     <template shadowrootmode="open" shadowrootreferencetarget="popover-1">
       <div id="popover-1" popover>Popover content inside shadow root</div>
     </template>
   </x-popover-1>
 
+  <button id="toggle-button-2" popovertarget="x-popover-2">Toggle the popover</button>
+  <x-popover-1 id="x-popover-2"></x-popover-1>
+
   <script>
-    test(function () {
-      const xPopover = document.getElementById("x-popover-1");
-      const popover = xPopover.shadowRoot.getElementById("popover-1");
+    customElements.define('x-popover-1', class extends HTMLElement {
+      constructor() {
+        super();
+        this.attachShadow({ mode: 'open', referenceTarget: 'popover-1' });
+        this.shadowRoot.innerHTML = '<div id="popover-1" popover>Popover content inside shadow root</div>';
+      }
+    });
+  </script>
 
-      let showCount = 0;
-      popover.addEventListener('beforetoggle', (e) => {
-        if (e.newState === "open")
-          ++showCount;
-      });
+  <script>
+    function testPopoverTarget(popoverId, buttonId) {
+      test(function () {
+        const xPopover = document.getElementById("x-popover-1");
+        const popover = xPopover.shadowRoot.getElementById("popover-1");
 
-      const toggleButton = document.getElementById("toggle-button");
-      toggleButton.click();
+        let showCount = 0;
+        popover.addEventListener('beforetoggle', (e) => {
+          if (e.newState === "open")
+            ++showCount;
+        });
 
-      assert_equals(showCount, 1, "showCount");
-    }, "Shadow root reference target works with popovertarget attribute.");
+        const toggleButton = document.getElementById("toggle-button");
+        toggleButton.click();
+
+        assert_equals(showCount, 1, "showCount");
+      }, "Shadow root reference target works with popovertarget attribute.");
+    }
+    testPopoverTarget('x-popover-1', 'toggle-button-1');
+    testPopoverTarget('x-popover-2', 'toggle-button-2');
   </script>
 </body>
 

--- a/shadow-dom/reference-target/tentative/popovertarget.html
+++ b/shadow-dom/reference-target/tentative/popovertarget.html
@@ -19,22 +19,18 @@
   </x-popover-1>
 
   <button id="toggle-button-2" popovertarget="x-popover-2">Toggle the popover</button>
-  <x-popover-1 id="x-popover-2"></x-popover-1>
+  <x-popover-2 id="x-popover-2"></x-popover-2>
 
   <script>
-    customElements.define('x-popover-1', class extends HTMLElement {
-      constructor() {
-        super();
-        this.attachShadow({ mode: 'open', referenceTarget: 'popover-1' });
-        this.shadowRoot.innerHTML = '<div id="popover-1" popover>Popover content inside shadow root</div>';
-      }
-    });
+    const customPopover2 = document.querySelector('x-popover-2');
+    customPopover2.attachShadow({ mode: 'open', referenceTarget: 'popover-2' });
+    customPopover2.shadowRoot.innerHTML = '<div id="popover-1" popover>Popover content inside shadow root</div>';
   </script>
 
   <script>
-    function testPopoverTarget(popoverId, buttonId) {
+    function testPopoverTarget(popoverId, buttonId, name) {
       test(function () {
-        const xPopover = document.getElementById("x-popover-1");
+        const xPopover = document.getElementById(popoverId);
         const popover = xPopover.shadowRoot.getElementById("popover-1");
 
         let showCount = 0;
@@ -43,14 +39,14 @@
             ++showCount;
         });
 
-        const toggleButton = document.getElementById("toggle-button");
+        const toggleButton = document.getElementById(buttonId);
         toggleButton.click();
 
         assert_equals(showCount, 1, "showCount");
-      }, "Shadow root reference target works with popovertarget attribute.");
+      }, name);
     }
-    testPopoverTarget('x-popover-1', 'toggle-button-1');
-    testPopoverTarget('x-popover-2', 'toggle-button-2');
+    testPopoverTarget('x-popover-1', 'toggle-button-1', "Shadow root reference target works with popovertarget attribute.");
+    testPopoverTarget('x-popover-2', 'toggle-button-2', "Shadow root reference target works with popovertarget attribute via options.");
   </script>
 </body>
 

--- a/shadow-dom/reference-target/tentative/popovertarget.html
+++ b/shadow-dom/reference-target/tentative/popovertarget.html
@@ -13,8 +13,8 @@
 <body>
   <button id="toggle-button-1" popovertarget="x-popover-1">Toggle the popover</button>
   <x-popover-1 id="x-popover-1">
-    <template shadowrootmode="open" shadowrootreferencetarget="popover-1">
-      <div id="popover-1" popover>Popover content inside shadow root</div>
+    <template shadowrootmode="open" shadowrootreferencetarget="popover">
+      <div id="popover" popover>Popover content inside shadow root</div>
     </template>
   </x-popover-1>
 
@@ -23,15 +23,15 @@
 
   <script>
     const customPopover2 = document.querySelector('x-popover-2');
-    customPopover2.attachShadow({ mode: 'open', referenceTarget: 'popover-2' });
-    customPopover2.shadowRoot.innerHTML = '<div id="popover-1" popover>Popover content inside shadow root</div>';
+    customPopover2.attachShadow({ mode: 'open', referenceTarget: 'popover' });
+    customPopover2.shadowRoot.innerHTML = '<div id="popover" popover>Popover content inside shadow root</div>';
   </script>
 
   <script>
     function testPopoverTarget(popoverId, buttonId, name) {
       test(function () {
         const xPopover = document.getElementById(popoverId);
-        const popover = xPopover.shadowRoot.getElementById("popover-1");
+        const popover = xPopover.shadowRoot.getElementById("popover");
 
         let showCount = 0;
         popover.addEventListener('beforetoggle', (e) => {

--- a/shadow-dom/reference-target/tentative/property-reflection.html
+++ b/shadow-dom/reference-target/tentative/property-reflection.html
@@ -20,7 +20,7 @@
       ReflectsHostIDInDOMTokenList: 'ReflectsHostIDInDOMTokenList',
     });
 
-    function test_property_reflection(referencing_element_type, referenced_element_type, attribute, reflected_property, expected_behavior) {
+    function test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, attribute, reflected_property, expected_behavior) {
       // There's nothing to test if the referencing element type doesn't have the reflecting
       // property.
       if (!(reflected_property in document.createElement(referencing_element_type))) {
@@ -32,13 +32,7 @@
         document.body.appendChild(referencing_element);
         referencing_element.setAttribute(attribute, "host-id");
         const host_container = document.querySelector("#host-container");
-        host_container.setHTMLUnsafe(`
-        <div id="host-id">
-          <template shadowrootmode="open" shadowrootreferencetarget="target">
-            <${referenced_element_type} id="target"></${referenced_element_type}>
-          </template>
-        </div>`);
-        const host = host_container.firstElementChild;
+        const host = element_creation_path(host_container, referenced_element_type);
         if (expected_behavior === Behavior.ReflectsHost) {
           assert_equals(referencing_element[reflected_property], host);
         } else if (expected_behavior === Behavior.ReflectsHostInArray) {
@@ -56,6 +50,25 @@
       }, `${referencing_element_type}.${reflected_property} has reflection behavior ${expected_behavior} when pointing to ${referenced_element_type} with reference target`);
     }
 
+    const element_creation_paths = [
+      function appendTestDeclaratively(host_container, referenced_element_type) {
+        host_container.setHTMLUnsafe(`
+        <div id="host-id">
+          <template shadowrootmode="open" shadowrootreferencetarget="target">
+            <${referenced_element_type} id="target"></${referenced_element_type}>
+          </template>
+        </div>`);
+        const host = host_container.firstElementChild;
+        return host;
+      },
+      function appendTestWithOptions(host_container, referenced_element_type) {
+        const host = host_container.firstElementChild;
+        host.attachShadow({ mode: 'open', referenceTarget: 'target' });
+        host.shadowRoot.innerHTML = `<${referenced_element_type} id="target"></${referenced_element_type}>`;
+        host_container.innerHTML = '<div id="host-id"></div>';
+        return host;
+      }
+    ]
     // We want to test types of elements that are associated with properties that can reflect other
     // elements and can therefore interact with reference target in interesting ways.
     // The HTML5_LABELABLE_ELEMENTS are defined in https://html.spec.whatwg.org/#category-label,
@@ -67,35 +80,37 @@
     const non_labelable_element_types = ["div", "object", "label", "fieldset", "legend", "option", "datalist", "form"];
     const element_types = HTML5_LABELABLE_ELEMENTS.concat(non_labelable_element_types);
 
-    for(let referencing_element_type of element_types) {
-      for(let referenced_element_type of element_types) {
-        test_property_reflection(referencing_element_type, referenced_element_type, "aria-controls", "ariaControlsElements", Behavior.ReflectsHostInArray);
-        test_property_reflection(referencing_element_type, referenced_element_type, "aria-activedescendant", "ariaActiveDescendantElement", Behavior.ReflectsHost);
-        test_property_reflection(referencing_element_type, referenced_element_type, "aria-describedby", "ariaDescribedByElements", Behavior.ReflectsHostInArray);
-        test_property_reflection(referencing_element_type, referenced_element_type, "aria-details", "ariaDetailsElements", Behavior.ReflectsHostInArray);
-        test_property_reflection(referencing_element_type, referenced_element_type, "aria-errormessage", "ariaErrorMessageElements", Behavior.ReflectsHostInArray);
-        test_property_reflection(referencing_element_type, referenced_element_type, "aria-flowto", "ariaFlowToElements", Behavior.ReflectsHostInArray);
-        test_property_reflection(referencing_element_type, referenced_element_type, "aria-labelledby", "ariaLabelledByElements", Behavior.ReflectsHostInArray);
-        test_property_reflection(referencing_element_type, referenced_element_type, "aria-owns", "ariaOwnsElements", Behavior.ReflectsHostInArray);
+    for(let element_creation_path of element_creation_paths) {
+      for(let referencing_element_type of element_types) {
+        for(let referenced_element_type of element_types) {
+          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "aria-controls", "ariaControlsElements", Behavior.ReflectsHostInArray);
+          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "aria-activedescendant", "ariaActiveDescendantElement", Behavior.ReflectsHost);
+          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "aria-describedby", "ariaDescribedByElements", Behavior.ReflectsHostInArray);
+          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "aria-details", "ariaDetailsElements", Behavior.ReflectsHostInArray);
+          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "aria-errormessage", "ariaErrorMessageElements", Behavior.ReflectsHostInArray);
+          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "aria-flowto", "ariaFlowToElements", Behavior.ReflectsHostInArray);
+          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "aria-labelledby", "ariaLabelledByElements", Behavior.ReflectsHostInArray);
+          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "aria-owns", "ariaOwnsElements", Behavior.ReflectsHostInArray);
 
-        test_property_reflection(referencing_element_type, referenced_element_type, "anchor", "anchorElement", Behavior.ReflectsHost);
-        test_property_reflection(referencing_element_type, referenced_element_type, "commandfor", "commandForElement", Behavior.ReflectsHost);
-        test_property_reflection(referencing_element_type, referenced_element_type, "popovertarget", "popoverTargetElement", Behavior.ReflectsHost);
-        test_property_reflection(referencing_element_type, referenced_element_type, "interesttarget", "interestTargetElement", Behavior.ReflectsHost);
+          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "anchor", "anchorElement", Behavior.ReflectsHost);
+          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "commandfor", "commandForElement", Behavior.ReflectsHost);
+          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "popovertarget", "popoverTargetElement", Behavior.ReflectsHost);
+          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "interesttarget", "interestTargetElement", Behavior.ReflectsHost);
 
-        const expected_htmlFor_property_behavior = (referencing_element_type == "output") ? Behavior.ReflectsHostIDInDOMTokenList : Behavior.ReflectsHostID;
-        test_property_reflection(referencing_element_type, referenced_element_type, "for", "htmlFor", expected_htmlFor_property_behavior);
+          const expected_htmlFor_property_behavior = (referencing_element_type == "output") ? Behavior.ReflectsHostIDInDOMTokenList : Behavior.ReflectsHostID;
+          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "for", "htmlFor", expected_htmlFor_property_behavior);
 
-        // It's unclear whether `form` and `list` should return null or should return the
-        // shadow host. See https://github.com/WICG/webcomponents/issues/1072.
-        test_property_reflection(referencing_element_type, referenced_element_type, "form", "form", Behavior.IsNull);
-        test_property_reflection(referencing_element_type, referenced_element_type, "list", "list", Behavior.IsNull);
+          // It's unclear whether `form` and `list` should return null or should return the
+          // shadow host. See https://github.com/WICG/webcomponents/issues/1072.
+          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "form", "form", Behavior.IsNull);
+          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "list", "list", Behavior.IsNull);
 
-        // It's unclear whether this should always reflect the host even if the underlying
-        // referenced element isn't labelable. See
-        // https://github.com/WICG/webcomponents/issues/1072#issuecomment-2305875929
-        const expected_control_property_behavior = HTML5_LABELABLE_ELEMENTS.includes(referenced_element_type) ? Behavior.ReflectsHost : Behavior.IsNull;
-        test_property_reflection(referencing_element_type, referenced_element_type, "for", "control", expected_control_property_behavior);
+          // It's unclear whether this should always reflect the host even if the underlying
+          // referenced element isn't labelable. See
+          // https://github.com/WICG/webcomponents/issues/1072#issuecomment-2305875929
+          const expected_control_property_behavior = HTML5_LABELABLE_ELEMENTS.includes(referenced_element_type) ? Behavior.ReflectsHost : Behavior.IsNull;
+          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "for", "control", expected_control_property_behavior);
+        }
       }
     }
   </script>

--- a/shadow-dom/reference-target/tentative/property-reflection.html
+++ b/shadow-dom/reference-target/tentative/property-reflection.html
@@ -62,15 +62,15 @@
         return host;
       },
       function appendTestWithOptions(host_container, referenced_element_type) {
-		host_container.setHTMLUnsafe('<div id="host-id"></div>');
+        host_container.setHTMLUnsafe('<div id="host-id"></div>');
         const host = host_container.firstElementChild;
         host.attachShadow({ mode: 'open', referenceTarget: 'target' });
         host.shadowRoot.innerHTML = `<${referenced_element_type} id="target"></${referenced_element_type}>`;
         return host;
       }
     ];
-	element_creation_methods[0].name = '';
-	element_creation_methods[1].name = ' via options';
+    element_creation_methods[0].name = '';
+    element_creation_methods[1].name = ' via options';
     // We want to test types of elements that are associated with properties that can reflect other
     // elements and can therefore interact with reference target in interesting ways.
     // The HTML5_LABELABLE_ELEMENTS are defined in https://html.spec.whatwg.org/#category-label,

--- a/shadow-dom/reference-target/tentative/property-reflection.html
+++ b/shadow-dom/reference-target/tentative/property-reflection.html
@@ -20,7 +20,7 @@
       ReflectsHostIDInDOMTokenList: 'ReflectsHostIDInDOMTokenList',
     });
 
-    function test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, attribute, reflected_property, expected_behavior) {
+    function test_property_reflection(element_creation_method, referencing_element_type, referenced_element_type, attribute, reflected_property, expected_behavior) {
       // There's nothing to test if the referencing element type doesn't have the reflecting
       // property.
       if (!(reflected_property in document.createElement(referencing_element_type))) {
@@ -32,7 +32,7 @@
         document.body.appendChild(referencing_element);
         referencing_element.setAttribute(attribute, "host-id");
         const host_container = document.querySelector("#host-container");
-        const host = element_creation_path(host_container, referenced_element_type);
+        const host = element_creation_method(host_container, referenced_element_type);
         if (expected_behavior === Behavior.ReflectsHost) {
           assert_equals(referencing_element[reflected_property], host);
         } else if (expected_behavior === Behavior.ReflectsHostInArray) {
@@ -47,10 +47,10 @@
         }
         referencing_element.remove();
         host_container.setHTMLUnsafe("");
-      }, `${referencing_element_type}.${reflected_property} has reflection behavior ${expected_behavior} when pointing to ${referenced_element_type} with reference target`);
+      }, `${referencing_element_type}.${reflected_property} has reflection behavior ${expected_behavior} when pointing to ${referenced_element_type} with reference target${element_creation_method.name}`);
     }
 
-    const element_creation_paths = [
+    const element_creation_methods = [
       function appendTestDeclaratively(host_container, referenced_element_type) {
         host_container.setHTMLUnsafe(`
         <div id="host-id">
@@ -62,13 +62,15 @@
         return host;
       },
       function appendTestWithOptions(host_container, referenced_element_type) {
+		host_container.setHTMLUnsafe('<div id="host-id"></div>');
         const host = host_container.firstElementChild;
         host.attachShadow({ mode: 'open', referenceTarget: 'target' });
         host.shadowRoot.innerHTML = `<${referenced_element_type} id="target"></${referenced_element_type}>`;
-        host_container.innerHTML = '<div id="host-id"></div>';
         return host;
       }
-    ]
+    ];
+	element_creation_methods[0].name = '';
+	element_creation_methods[1].name = ' via options';
     // We want to test types of elements that are associated with properties that can reflect other
     // elements and can therefore interact with reference target in interesting ways.
     // The HTML5_LABELABLE_ELEMENTS are defined in https://html.spec.whatwg.org/#category-label,
@@ -80,36 +82,36 @@
     const non_labelable_element_types = ["div", "object", "label", "fieldset", "legend", "option", "datalist", "form"];
     const element_types = HTML5_LABELABLE_ELEMENTS.concat(non_labelable_element_types);
 
-    for(let element_creation_path of element_creation_paths) {
+    for(let element_creation_method of element_creation_methods) {
       for(let referencing_element_type of element_types) {
         for(let referenced_element_type of element_types) {
-          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "aria-controls", "ariaControlsElements", Behavior.ReflectsHostInArray);
-          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "aria-activedescendant", "ariaActiveDescendantElement", Behavior.ReflectsHost);
-          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "aria-describedby", "ariaDescribedByElements", Behavior.ReflectsHostInArray);
-          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "aria-details", "ariaDetailsElements", Behavior.ReflectsHostInArray);
-          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "aria-errormessage", "ariaErrorMessageElements", Behavior.ReflectsHostInArray);
-          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "aria-flowto", "ariaFlowToElements", Behavior.ReflectsHostInArray);
-          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "aria-labelledby", "ariaLabelledByElements", Behavior.ReflectsHostInArray);
-          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "aria-owns", "ariaOwnsElements", Behavior.ReflectsHostInArray);
+          test_property_reflection(element_creation_method, referencing_element_type, referenced_element_type, "aria-controls", "ariaControlsElements", Behavior.ReflectsHostInArray);
+          test_property_reflection(element_creation_method, referencing_element_type, referenced_element_type, "aria-activedescendant", "ariaActiveDescendantElement", Behavior.ReflectsHost);
+          test_property_reflection(element_creation_method, referencing_element_type, referenced_element_type, "aria-describedby", "ariaDescribedByElements", Behavior.ReflectsHostInArray);
+          test_property_reflection(element_creation_method, referencing_element_type, referenced_element_type, "aria-details", "ariaDetailsElements", Behavior.ReflectsHostInArray);
+          test_property_reflection(element_creation_method, referencing_element_type, referenced_element_type, "aria-errormessage", "ariaErrorMessageElements", Behavior.ReflectsHostInArray);
+          test_property_reflection(element_creation_method, referencing_element_type, referenced_element_type, "aria-flowto", "ariaFlowToElements", Behavior.ReflectsHostInArray);
+          test_property_reflection(element_creation_method, referencing_element_type, referenced_element_type, "aria-labeledby", "ariaLabelledByElements", Behavior.ReflectsHostInArray);
+          test_property_reflection(element_creation_method, referencing_element_type, referenced_element_type, "aria-owns", "ariaOwnsElements", Behavior.ReflectsHostInArray);
 
-          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "anchor", "anchorElement", Behavior.ReflectsHost);
-          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "commandfor", "commandForElement", Behavior.ReflectsHost);
-          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "popovertarget", "popoverTargetElement", Behavior.ReflectsHost);
-          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "interesttarget", "interestTargetElement", Behavior.ReflectsHost);
+          test_property_reflection(element_creation_method, referencing_element_type, referenced_element_type, "anchor", "anchorElement", Behavior.ReflectsHost);
+          test_property_reflection(element_creation_method, referencing_element_type, referenced_element_type, "commandfor", "commandForElement", Behavior.ReflectsHost);
+          test_property_reflection(element_creation_method, referencing_element_type, referenced_element_type, "popovertarget", "popoverTargetElement", Behavior.ReflectsHost);
+          test_property_reflection(element_creation_method, referencing_element_type, referenced_element_type, "interesttarget", "interestTargetElement", Behavior.ReflectsHost);
 
           const expected_htmlFor_property_behavior = (referencing_element_type == "output") ? Behavior.ReflectsHostIDInDOMTokenList : Behavior.ReflectsHostID;
-          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "for", "htmlFor", expected_htmlFor_property_behavior);
+          test_property_reflection(element_creation_method, referencing_element_type, referenced_element_type, "for", "htmlFor", expected_htmlFor_property_behavior);
 
           // It's unclear whether `form` and `list` should return null or should return the
           // shadow host. See https://github.com/WICG/webcomponents/issues/1072.
-          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "form", "form", Behavior.IsNull);
-          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "list", "list", Behavior.IsNull);
+          test_property_reflection(element_creation_method, referencing_element_type, referenced_element_type, "form", "form", Behavior.IsNull);
+          test_property_reflection(element_creation_method, referencing_element_type, referenced_element_type, "list", "list", Behavior.IsNull);
 
           // It's unclear whether this should always reflect the host even if the underlying
           // referenced element isn't labelable. See
           // https://github.com/WICG/webcomponents/issues/1072#issuecomment-2305875929
           const expected_control_property_behavior = HTML5_LABELABLE_ELEMENTS.includes(referenced_element_type) ? Behavior.ReflectsHost : Behavior.IsNull;
-          test_property_reflection(element_creation_path, referencing_element_type, referenced_element_type, "for", "control", expected_control_property_behavior);
+          test_property_reflection(element_creation_method, referencing_element_type, referenced_element_type, "for", "control", expected_control_property_behavior);
         }
       }
     }


### PR DESCRIPTION
@dandclark and @behowell this seems appropriate as per https://github.com/WICG/webcomponents/blob/gh-pages/proposals/reference-target-explainer.md#:~:text=%3Ctemplate%3E%20element.-,JavaScript%20example%3A,-%3Cscript%3E, but if something has changed in the interim let me know how we can work together to catch up the proposal for others.

If this does look right, and it is useful, I'm happy to expand my efforts to the rest of the baseline test yall have already submitted. Let me know what's best for supporting this awesome new feature moving forward!