### PR TITLE
Make tests more strict

### DIFF
--- a/css/css-overflow/line-clamp/webkit-line-clamp-005.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-005.html
@@ -14,7 +14,6 @@
   white-space: pre;
   background-color: yellow;
   padding: 0 4px;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 </style>
 <div class="clamp">Line 1

--- a/css/css-overflow/line-clamp/webkit-line-clamp-006.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-006.html
@@ -14,7 +14,6 @@
   white-space: pre;
   padding: 0 4px;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 </style>
 <div class="clamp">Line 1

--- a/css/css-overflow/line-clamp/webkit-line-clamp-007.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-007.html
@@ -14,7 +14,6 @@
   white-space: pre;
   padding: 0 4px;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 </style>
 <div class="clamp"><div>Line 1

--- a/css/css-overflow/line-clamp/webkit-line-clamp-008.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-008.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-3/#webkit-line-clamp">
 <link rel="match" href="reference/webkit-line-clamp-008-ref.html">
-<meta name="assert" content="-webkit-line-clamp should apply to all flex items in a -webkit-box or -webkit-inline-box flex container independently.">
+<meta name="assert" content="-webkit-line-clamp should not count lines in BFC descendants of the clamping element">
 <style>
 .clamp {
   display: -webkit-box;
@@ -15,8 +15,8 @@
   padding: 0 4px;
   background-color: yellow;
 }
-div {
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
+.clamp div {
+  overflow: hidden;
 }
 </style>
 <div class="clamp"><div>Line 1

--- a/css/css-overflow/line-clamp/webkit-line-clamp-010.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-010.html
@@ -14,7 +14,6 @@
   white-space: pre;
   padding: 0 4px;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 .child {
   font: 24px / 48px serif;

--- a/css/css-overflow/line-clamp/webkit-line-clamp-011.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-011.html
@@ -14,7 +14,6 @@
   white-space: pre;
   padding: 0 4px;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 .child {
   overflow: auto;

--- a/css/css-overflow/line-clamp/webkit-line-clamp-012.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-012.html
@@ -14,7 +14,6 @@
   white-space: pre;
   padding: 0 4px;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 .child {
   display: flex;

--- a/css/css-overflow/line-clamp/webkit-line-clamp-013.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-013.html
@@ -14,7 +14,6 @@
   white-space: pre;
   padding: 0 4px;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 .child {
   font: 24px / 48px serif;

--- a/css/css-overflow/line-clamp/webkit-line-clamp-014.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-014.html
@@ -14,7 +14,6 @@
   white-space: pre;
   padding: 0 4px;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
   direction: rtl;
 }
 </style>

--- a/css/css-overflow/line-clamp/webkit-line-clamp-015.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-015.html
@@ -14,7 +14,6 @@
   white-space: pre;
   padding: 4px 0;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
   writing-mode: vertical-rl;
 }
 </style>

--- a/css/css-overflow/line-clamp/webkit-line-clamp-016.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-016.html
@@ -14,7 +14,6 @@
   white-space: pre;
   padding: 0 4px;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 .child {
   -webkit-line-clamp: 3;

--- a/css/css-overflow/line-clamp/webkit-line-clamp-017.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-017.html
@@ -14,7 +14,6 @@
   white-space: pre;
   padding: 0 4px;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 </style>
 <div class="clamp">Line 1

--- a/css/css-overflow/line-clamp/webkit-line-clamp-018.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-018.html
@@ -15,7 +15,6 @@
   white-space: pre;
   padding: 0 4px;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 </style>
 <div class="clamp">Line 1

--- a/css/css-overflow/line-clamp/webkit-line-clamp-019.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-019.html
@@ -15,7 +15,6 @@
   white-space: pre;
   padding: 0 4px;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 </style>
 <div class="clamp">Line 1

--- a/css/css-overflow/line-clamp/webkit-line-clamp-020.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-020.html
@@ -15,7 +15,6 @@
   white-space: pre;
   padding: 0 4px;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 </style>
 <div class="clamp">Line 1

--- a/css/css-overflow/line-clamp/webkit-line-clamp-021.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-021.html
@@ -15,7 +15,6 @@
   white-space: pre;
   padding: 0 4px;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 </style>
 <div class="clamp">Line 1

--- a/css/css-overflow/line-clamp/webkit-line-clamp-022.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-022.html
@@ -15,7 +15,6 @@
   white-space: pre;
   padding: 0 4px;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 </style>
 <div class="clamp">Line 1

--- a/css/css-overflow/line-clamp/webkit-line-clamp-024.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-024.html
@@ -14,7 +14,6 @@
   white-space: pre;
   padding: 0 4px;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 </style>
 Before <div class="clamp">Line 1

--- a/css/css-overflow/line-clamp/webkit-line-clamp-025.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-025.html
@@ -15,7 +15,6 @@
   padding: 0 4px;
   background-color: yellow;
   width: 11ch;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 .float {
   float: right;

--- a/css/css-overflow/line-clamp/webkit-line-clamp-026.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-026.html
@@ -13,7 +13,6 @@
   font: 16px / 32px monospace;
   white-space: pre;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 </style>
 <div class="clamp">Line 1

--- a/css/css-overflow/line-clamp/webkit-line-clamp-027.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-027.html
@@ -13,7 +13,6 @@
   font: 16px / 32px monospace;
   white-space: pre;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 </style>
 <div class="clamp"><div>Line 1

--- a/css/css-overflow/line-clamp/webkit-line-clamp-029.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-029.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="https://drafts.csswg.org/css-overflow-3/#webkit-line-clamp">
 <link rel="match" href="reference/webkit-line-clamp-029-ref.html">
-<meta name="assert" content="-webkit-line-clamp should apply to flex items that are scrollable.">
+<meta name="assert" content="-webkit-line-clamp should not apply to descendant items that are BFCs due to being scrollable.">
 <style>
 .clamp {
   display: -webkit-box;
@@ -13,7 +13,6 @@
   font: 16px / 32px monospace;
   white-space: pre;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 .child {
   overflow: hidden;

--- a/css/css-overflow/line-clamp/webkit-line-clamp-031.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-031.html
@@ -14,7 +14,6 @@
   white-space: pre;
   padding: 0 4px;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 .big {
   font-weight: bold;

--- a/css/css-overflow/line-clamp/webkit-line-clamp-032.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-032.html
@@ -14,7 +14,6 @@
   white-space: pre;
   padding: 0 4px;
   background-color: yellow;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 </style>
 <div class="clamp">Line 1

--- a/css/css-overflow/line-clamp/webkit-line-clamp-033.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-033.html
@@ -13,7 +13,6 @@
   white-space: pre;
   background-color: yellow;
   padding: 0 4px;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 </style>
 <div class="clamp"><div><span></span></div></div>

--- a/css/css-overflow/line-clamp/webkit-line-clamp-034.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-034.html
@@ -10,7 +10,6 @@
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 </style>
 <div id="clamp">

--- a/css/css-overflow/line-clamp/webkit-line-clamp-035.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-035.html
@@ -17,7 +17,6 @@
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
   width: 4ch;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 }
 </style>
 <div id="parent">

--- a/css/css-overflow/line-clamp/webkit-line-clamp-038.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-038.html
@@ -9,7 +9,6 @@
   -webkit-line-clamp: 3;
   font: 16px / 32px serif;
   background-color: yellow;
-  overflow: hidden;
 }
 </style>
 <div class="clamp">

--- a/css/css-overflow/line-clamp/webkit-line-clamp-039.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-039.html
@@ -9,7 +9,6 @@
   -webkit-line-clamp: 5;
   font: 16px / 32px serif;
   background-color: yellow;
-  overflow: hidden;
 }
 </style>
 <div class="clamp">

--- a/css/css-overflow/line-clamp/webkit-line-clamp-043.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-043.html
@@ -4,7 +4,7 @@
 <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 <div style="columns:3; column-fill:auto; gap:0; width:300px; height:250px;">
-  <div style="display:-webkit-box; -webkit-box-orient:vertical; -webkit-line-clamp:2; overflow:clip; line-height:50px; color:transparent; background:green;">
+  <div style="display:-webkit-box; -webkit-box-orient:vertical; -webkit-line-clamp:2; line-height:50px; color:transparent; background:green;">
     <br>
     <br>
     <span style="color:red;">

--- a/css/css-overflow/line-clamp/webkit-line-clamp-045.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-045.html
@@ -14,7 +14,6 @@
   white-space: pre;
   background-color: yellow;
   padding: 0 4px;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
 
   /* If display: -webkit-box behaves the same as without -webkit-line-clamp,
    * these properties would cause the anonymous inline box to be centered. */

--- a/css/css-overflow/line-clamp/webkit-line-clamp-048.html
+++ b/css/css-overflow/line-clamp/webkit-line-clamp-048.html
@@ -12,7 +12,6 @@
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 4;
-  overflow: hidden; /* can be removed once implementations update their old -webkit-line-clamp implementations */
   font: 16px / 32px serif;
   white-space: pre;
   background-color: yellow;


### PR DESCRIPTION
@andreubotella, as you noted in a comment in the test, this line isn't needed for the test to pass in the spec-based version of `-webkit-line-clamp`. It is only needed to help legacy implementations pass.

I wonder if we really do need to help them pass. Sure, they correctly do what the test is testing, and fail for some other reason, but still, that other reason also isn't spec compliant, so it seems fine to me to let them fail. what do you think?