### PR TITLE
HTML: Set focus in ElementInternals-reportValidity-bubble-notref.html

### DIFF
--- a/custom-elements/form-associated/ElementInternals-reportValidity-bubble-notref.html
+++ b/custom-elements/form-associated/ElementInternals-reportValidity-bubble-notref.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>Both focusable and unfocusable custom elements can show validation bubbles</title>
 <link rel=help href=https://html.spec.whatwg.org/C/#report-validity-steps>
-<focusable-custom-element tabindex="0"></focusable-custom-element>
+<focusable-custom-element></focusable-custom-element>
 <script>
 class FocusableCustomElement extends HTMLElement {
   constructor() {
@@ -11,6 +11,7 @@ class FocusableCustomElement extends HTMLElement {
     this.elementInternals = this.attachInternals();
     const validationAnchor = this.shadowRoot.querySelector('input');
     this.elementInternals.setValidity({valueMissing: true}, 'value missing', validationAnchor);
+    this.shadowRoot.firstChild.focus();
   }
 
   static get formAssociated() {
@@ -23,6 +24,4 @@ class FocusableCustomElement extends HTMLElement {
 }
 
 customElements.define('focusable-custom-element', FocusableCustomElement);
-
-document.querySelector('unfocusable-custom-element').focus();
 </script>

--- a/custom-elements/form-associated/ElementInternals-reportValidity-bubble-notref.html
+++ b/custom-elements/form-associated/ElementInternals-reportValidity-bubble-notref.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <title>Both focusable and unfocusable custom elements can show validation bubbles</title>
 <link rel=help href=https://html.spec.whatwg.org/C/#report-validity-steps>
+<style>
+body { margin-top: 50px; }
+</style>
 <focusable-custom-element></focusable-custom-element>
 <script>
 class FocusableCustomElement extends HTMLElement {

--- a/custom-elements/form-associated/ElementInternals-reportValidity-bubble-notref.html
+++ b/custom-elements/form-associated/ElementInternals-reportValidity-bubble-notref.html
@@ -23,4 +23,6 @@ class FocusableCustomElement extends HTMLElement {
 }
 
 customElements.define('focusable-custom-element', FocusableCustomElement);
+
+document.querySelector('unfocusable-custom-element').focus();
 </script>

--- a/custom-elements/form-associated/ElementInternals-reportValidity-bubble.html
+++ b/custom-elements/form-associated/ElementInternals-reportValidity-bubble.html
@@ -1,7 +1,13 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
 <title>Both focusable and unfocusable custom elements can show validation bubbles</title>
 <link rel=mismatch href=ElementInternals-reportValidity-bubble-notref.html>
 <link rel=help href=https://html.spec.whatwg.org/C/#report-validity-steps>
+<script src="/common/reftest-wait.js"></script>
+<style>
+/* Make space for the validation message if it's above */
+body { margin-top: 50px; }
+</style>
 <unfocusable-custom-element></unfocusable-custom-element>
 <script>
 class UnfocusableCustomElement extends HTMLElement {
@@ -26,4 +32,9 @@ class UnfocusableCustomElement extends HTMLElement {
 customElements.define('unfocusable-custom-element', UnfocusableCustomElement);
 
 document.querySelector('unfocusable-custom-element').reportValidity();
+
+// Wait a bit to let the validation message show up
+onload = () => {
+  takeScreenshotDelayed(10);
+};
 </script>


### PR DESCRIPTION
The test currently passes in Firefox and Safari despite not showing a validation message because `reportValidity()` sets focus, and the element in notref did not have focus.