### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=279012

### DIFF
--- a/css/css-transitions/custom-property-and-allow-discrete.html
+++ b/css/css-transitions/custom-property-and-allow-discrete.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+<head>
+<meta charset=utf-8>
+<title>CSS Transitions Test: transition of a custom property with "transition-behavior: allows-discrete"</title>
+<meta name="assert" content="Checks that transitioning a custom property with 'transition-behavior: allows-discrete' works as expected">
+<link rel="help" href="https://drafts.csswg.org/css-transitions-2/#transition-behavior-property">
+<script src="/resources/testharness.js" type="text/javascript"></script>
+<script src="/resources/testharnessreport.js" type="text/javascript"></script>
+<script src="./support/helper.js" type="text/javascript"></script>
+<style>
+  .target {
+    transition: --foo 10s step-start;
+    transition-behavior: allow-discrete;
+    --foo: bar;
+  }
+</style>
+</head>
+<body>
+<div id="log"></div>
+<script>
+promise_test(async t => {
+  const div = addDiv(t, { class: 'target' });
+
+  let transitionCount = 0;
+  div.addEventListener("transitionstart", () => transitionCount++);
+
+  // Trigger a transition on the custom property.
+  getComputedStyle(div).getPropertyValue('--foo');
+  div.style.setProperty('--foo', 'baz');
+  getComputedStyle(div).getPropertyValue('--foo');
+
+  // Wait two more frames to ensure only a single transition was started.
+  await waitForFrame();
+  await waitForFrame();
+
+  assert_equals(transitionCount, 1, 'A single "transitionstart" event was dispatched');
+}, 'It is possible to transition an unregistered custom property using "transition-behavior: allows-discrete"');
+</script>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [Transitioning Unregistered Custom Properties cause a transition loop](https://bugs.webkit.org/show_bug.cgi?id=279012)