### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=278759

### DIFF
--- a/css/css-view-transitions/navigation/mismatched-snapshot-containing-block-size-skips.html
+++ b/css/css-view-transitions/navigation/mismatched-snapshot-containing-block-size-skips.html
@@ -117,9 +117,10 @@ if (is_harness_page) {
       // This simply ensures the test only runs if render blocking was
       // successful since a fetch failure looks the same as never blocking
       // rendering.
-      Promise.all([rendering_blocked_promise, rendering_unblocked_promise]).then(() => {
+      Promise.all([rendering_blocked_promise, rendering_unblocked_promise]).then(async () => {
         window.viewTransition = e.viewTransition;
         window.opener.postMessage('pagereveal');
+        await Promise.allSettled([e.viewTransition.ready]);
       }, () => {});
     });
   }


### PR DESCRIPTION
WebKit export from bug: [\[css-view-transitions-2\] mismatched-snapshot-containing-block-size-skips fails](https://bugs.webkit.org/show_bug.cgi?id=278759)