### PR TITLE
Remove ex-generic selector in wai-aria/roles/contextual-roles.html

### DIFF
--- a/wai-aria/role/contextual-roles.html
+++ b/wai-aria/role/contextual-roles.html
@@ -83,7 +83,6 @@
 
 <script>
     AriaUtils.verifyRolesBySelector(".ex");
-    AriaUtils.verifyGenericRolesBySelector(".ex-generic");
 </script>
 
 </body>


### PR DESCRIPTION
The only subtest with the `ex-generic` class in `wai-aria/role/contextual-roles.html` was removed in [this pr](https://github.com/web-platform-tests/wpt/pull/47420/files#diff-c81c5900f03bb7215b953d8a1a5871025f2953ba803923d183fe5af170a1f317).

The line `AriaUtils.verifyGenericRolesBySelector(".ex-generic");` must also be removed, otherwise it will cause the following error: 
```
Harness Error. harness_status.status = 1 , harness_status.message = Uncaught Selector ".ex-generic" should match at least one element.
```