### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=279160

### DIFF
--- a/css/css-view-transitions/navigation/root-element-transition-iframe-with-startVT-on-main.html
+++ b/css/css-view-transitions/navigation/root-element-transition-iframe-with-startVT-on-main.html
@@ -29,6 +29,9 @@
   ::view-transition-new(inner) {
     opacity: 1;
   }
+  ::view-transition-group(inner) {
+    animation-duration: 0s;
+  }
 </style>
 
 <iframe id="inner" src="resources/root-element-transition-iframe.html?blue"></iframe>


### PR DESCRIPTION
WebKit export from bug: [\[css-view-transitions-2\] root-element-transition-iframe-with-startVT-on-main.html fails](https://bugs.webkit.org/show_bug.cgi?id=279160)