### PR TITLE
HTML: test more body/frameset event handler reflection scenarios

### DIFF
--- a/html/webappapis/scripting/events/event-handler-all-global-events.html
+++ b/html/webappapis/scripting/events/event-handler-all-global-events.html
@@ -30,7 +30,10 @@ fetch("/interfaces/html.idl").then(res => res.text()).then(htmlIDL => {
   const names = globalEventHandlers.members.map(member => member.name).filter(name => name !== "onerror");
 
   for (const name of names) {
-    const withoutOn = name.substring(2);
+    let withoutOn = name.substring(2);
+    if (prefixedAnimationAttributeToEventType.has(withoutOn)) {
+      withoutOn = prefixedAnimationAttributeToEventType.get(withoutOn);
+    }
 
     test(() => {
       for (const location of [window, HTMLElement.prototype, SVGElement.prototype, Document.prototype]) {
@@ -64,11 +67,7 @@ fetch("/interfaces/html.idl").then(res => res.text()).then(htmlIDL => {
       const el = document.createElement("div");
       el.setAttribute(name, `window.${name}Happened2 = true;`);
 
-      let eventType = withoutOn;
-      if (prefixedAnimationAttributeToEventType.has(eventType)) {
-        eventType = prefixedAnimationAttributeToEventType.get(eventType);
-      }
-      el.dispatchEvent(new Event(eventType));
+      el.dispatchEvent(new Event(withoutOn));
 
       assert_true(window[name + "Happened2"], "Dispatching an event must run the code");
     }, `${name}: the content attribute must execute when an event is dispatched`);

--- a/html/webappapis/scripting/events/event-handler-all-global-events.html
+++ b/html/webappapis/scripting/events/event-handler-all-global-events.html
@@ -75,11 +75,14 @@ fetch("/interfaces/html.idl").then(res => res.text()).then(htmlIDL => {
 
     test(() => {
       const element = document.createElement("meta");
+      let fired = false;
       element[name] = e => {
         assert_equals(e.currentTarget, element, "The event must be fired at the <meta> element");
+        fired = true;
       };
 
       element.dispatchEvent(new Event(withoutOn));
+      assert_true(fired);
     }, `${name}: dispatching an Event at a <meta> element must trigger element.${name}`);
   }
 

--- a/html/webappapis/scripting/events/resources/event-handler-body.js
+++ b/html/webappapis/scripting/events/resources/event-handler-body.js
@@ -57,5 +57,21 @@ function eventHandlerTest(shadowedHandlers, notShadowedHandlers, element) {
         assert_equals(obj3['on' + handler], null, `${des3} should reflect`);
       }, `shadowed ${handler} removal (${des})`);
     });
+
+    shadowedHandlers.forEach(handler => {
+      // Cannot test the error and unhandledrejection events as the test harness listens for those.
+      if (des != "document.body" || handler == "error" || handler == "unhandledrejection") {
+        return;
+      }
+      test(t => {
+        t.add_cleanup(() => {
+          obj1.removeAttribute('on' + handler);
+          window[`on${handler}Happened`] = undefined;
+        });
+        obj1.setAttribute('on' + handler, `window.on${handler}Happened = true`);
+        obj3.dispatchEvent(new Event(handler));
+        assert_true(window[`on${handler}Happened`]);
+      }, `shadowed ${handler} on body fires when event dispatched on window`);
+    });
   }
 }


### PR DESCRIPTION
Also make sure that for global events we actually fail a test if the listener doesn't run.