### PR TITLE
Add compute pressure-related commands to testdriver

### DIFF
--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -131,6 +131,13 @@ the global scope.
 .. js:autofunction:: test_driver.run_bounce_tracking_mitigations
 ```
 
+### Compute Pressure ###
+```eval_rst
+.. js:autofunction:: test_driver.create_virtual_pressure_source
+.. js:autofunction:: test_driver.update_virtual_pressure_source
+.. js:autofunction:: test_driver.remove_virtual_pressure_source
+```
+
 ### Using test_driver in other browsing contexts ###
 
 Testdriver can be used in browsing contexts (i.e. windows or frames)

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -1141,6 +1141,82 @@
          */
         run_bounce_tracking_mitigations: function (context = null) {
             return window.test_driver_internal.run_bounce_tracking_mitigations(context);
+        },
+
+        /**
+         * Creates a virtual pressure source.
+         *
+         * Matches the `Create virtual pressure source
+         * <https://w3c.github.io/compute-pressure/#create-virtual-pressure-source>`_
+         * WebDriver command.
+         *
+         * @param {String} source_type - A `virtual pressure source type
+         *                               <https://w3c.github.io/compute-pressure/#dom-pressuresource>`_
+         *                               such as "cpu".
+         * @param {Object} [metadata={}] - Optional parameters described
+         *                                 in `Create virtual pressure source
+         *                                 <https://w3c.github.io/compute-pressure/#create-virtual-pressure-source>`_.
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         *
+         * @returns {Promise} Fulfilled when virtual pressure source is created.
+         *                    Rejected in case the WebDriver command errors out
+         *                    (including if a virtual pressure source of the
+         *                    same type already exists).
+         */
+        create_virtual_pressure_source: function(source_type, metadata={}, context=null) {
+            return window.test_driver_internal.create_virtual_pressure_source(source_type, metadata, context);
+        },
+
+        /**
+         * Causes a virtual pressure source to report a new reading.
+         *
+         * Matches the `Update virtual pressure source
+         * <https://w3c.github.io/compute-pressure/#update-virtual-pressure-source>`_
+         * WebDriver command.
+         *
+         * @param {String} source_type - A `virtual pressure source type
+         *                               <https://w3c.github.io/compute-pressure/#dom-pressuresource>`_
+         *                               such as "cpu".
+         * @param {String} sample - A `virtual pressure sample
+         *                          <https://w3c.github.io/compute-pressure/#dom-pressurestate>`_
+         *                          such as "critical".
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         *
+         * @returns {Promise} Fulfilled after the reading update reaches the
+         *                    virtual pressure source. Rejected in case the
+         *                    WebDriver command errors out (including if a
+         *                    virtual pressure source of the given type does not
+         *                    exist).
+         */
+        update_virtual_pressure_source: function(source_type, sample, context=null) {
+            return window.test_driver_internal.update_virtual_pressure_source(source_type, sample, context);
+        },
+
+        /**
+         * Removes created virtual pressure source.
+         *
+         * Matches the `Delete virtual pressure source
+         * <https://w3c.github.io/compute-pressure/#delete-virtual-pressure-source>`_
+         * WebDriver command.
+         *
+         * @param {String} source_type - A `virtual pressure source type
+         *                               <https://w3c.github.io/compute-pressure/#dom-pressuresource>`_
+         *                               such as "cpu".
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         *
+         * @returns {Promise} Fulfilled after the virtual pressure source has
+         *                    been removed or if a pressure source of the given
+         *                    type does not exist. Rejected in case the
+         *                    WebDriver command errors out.
+         */
+        remove_virtual_pressure_source: function(source_type, context=null) {
+            return window.test_driver_internal.remove_virtual_pressure_source(source_type, context);
         }
     };
 
@@ -1356,6 +1432,18 @@
 
         async run_bounce_tracking_mitigations(context=null) {
             throw new Error("run_bounce_tracking_mitigations() is not implemented by testdriver-vendor.js");
+        },
+
+        async create_virtual_pressure_source(source_type, metadata={}, context=null) {
+            throw new Error("create_virtual_pressure_source() is not implemented by testdriver-vendor.js");
+        },
+
+        async update_virtual_pressure_source(source_type, sample, context=null) {
+            throw new Error("update_virtual_pressure_source() is not implemented by testdriver-vendor.js");
+        },
+
+        async remove_virtual_pressure_source(source_type, context=null) {
+            throw new Error("remove_virtual_pressure_source() is not implemented by testdriver-vendor.js");
         }
     };
 })();

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -1179,7 +1179,7 @@
          * @param {String} source_type - A `virtual pressure source type
          *                               <https://w3c.github.io/compute-pressure/#dom-pressuresource>`_
          *                               such as "cpu".
-         * @param {String} sample - A `virtual pressure sample
+         * @param {String} sample - A `virtual pressure state
          *                          <https://w3c.github.io/compute-pressure/#dom-pressurestate>`_
          *                          such as "critical".
          * @param {WindowProxy} [context=null] - Browsing context in which to

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -475,6 +475,42 @@ class RunBounceTrackingMitigationsAction:
         self.logger.debug("Running bounce tracking mitigations")
         return self.protocol.storage.run_bounce_tracking_mitigations()
 
+class CreateVirtualPressureSourceAction:
+    name = "create_virtual_pressure_source"
+
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        source_type = payload["source_type"]
+        metadata = payload["metadata"]
+        self.logger.debug("Creating %s pressure source with %s values" % (source_type, metadata))
+        return self.protocol.pressure.create_virtual_pressure_source(source_type, metadata)
+
+class UpdateVirtualPressureSourceAction:
+    name = "update_virtual_pressure_source"
+
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        source_type = payload["source_type"]
+        sample = payload["sample"]
+        return self.protocol.pressure.update_virtual_pressure_source(source_type, sample)
+
+class RemoveVirtualPressureSourceAction:
+    name = "remove_virtual_pressure_source"
+
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        source_type = payload["source_type"]
+        return self.protocol.pressure.remove_virtual_pressure_source(source_type)
+
 actions = [ClickAction,
            DeleteAllCookiesAction,
            GetAllCookiesAction,
@@ -511,4 +547,7 @@ actions = [ClickAction,
            GetVirtualSensorInformationAction,
            SetDevicePostureAction,
            ClearDevicePostureAction,
-           RunBounceTrackingMitigationsAction]
+           RunBounceTrackingMitigationsAction,
+           CreateVirtualPressureSourceAction,
+           UpdateVirtualPressureSourceAction,
+           RemoveVirtualPressureSourceAction]

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -46,6 +46,7 @@ from .protocol import (AccessibilityProtocolPart,
                        DebugProtocolPart,
                        VirtualSensorProtocolPart,
                        DevicePostureProtocolPart,
+                       VirtualPressureSourceProtocolPart,
                        merge_dicts)
 
 
@@ -761,6 +762,20 @@ class MarionetteDevicePostureProtocolPart(DevicePostureProtocolPart):
         raise NotImplementedError("clear_device_posture not yet implemented")
 
 
+class MarionetteVirtualPressureSourceProtocolPart(VirtualPressureSourceProtocolPart):
+    def setup(self):
+        self.marionette = self.parent.marionette
+
+    def create_virtual_pressure_source(self, source_type, metadata):
+        raise NotImplementedError("create_virtual_pressure_source not yet implemented")
+
+    def update_virtual_pressure_source(self, source_type, sample):
+        raise NotImplementedError("update_virtual_pressure_source not yet implemented")
+
+    def remove_virtual_pressure_source(self, source_type):
+        raise NotImplementedError("remove_virtual_pressure_source not yet implemented")
+
+
 class MarionetteProtocol(Protocol):
     implements = [MarionetteBaseProtocolPart,
                   MarionetteTestharnessProtocolPart,
@@ -782,7 +797,8 @@ class MarionetteProtocol(Protocol):
                   MarionetteDebugProtocolPart,
                   MarionetteAccessibilityProtocolPart,
                   MarionetteVirtualSensorProtocolPart,
-                  MarionetteDevicePostureProtocolPart]
+                  MarionetteDevicePostureProtocolPart,
+                  MarionetteVirtualPressureSourceProtocolPart]
 
     def __init__(self, executor, browser, capabilities=None, timeout_multiplier=1, e10s=True, ccov=False):
         do_delayed_imports()

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -42,6 +42,7 @@ from .protocol import (BaseProtocolPart,
                        BidiScriptProtocolPart,
                        DevicePostureProtocolPart,
                        StorageProtocolPart,
+                       VirtualPressureSourceProtocolPart,
                        merge_dicts)
 
 from typing import List, Optional, Tuple
@@ -568,6 +569,22 @@ class WebDriverStorageProtocolPart(StorageProtocolPart):
     def run_bounce_tracking_mitigations(self):
         return self.webdriver.send_session_command("DELETE", "storage/run_bounce_tracking_mitigations")
 
+class WebDriverVirtualPressureSourceProtocolPart(VirtualPressureSourceProtocolPart):
+    def setup(self):
+        self.webdriver = self.parent.webdriver
+
+    def create_virtual_pressure_source(self, source_type, metadata):
+        body = {"type": source_type}
+        body.update(metadata)
+        return self.webdriver.send_session_command("POST", "pressuresource", body)
+
+    def update_virtual_pressure_source(self, source_type, sample):
+        body = {"sample": sample}
+        return self.webdriver.send_session_command("POST", "pressuresource/%s" % source_type, body)
+
+    def remove_virtual_pressure_source(self, source_type):
+        return self.webdriver.send_session_command("DELETE", "pressuresource/%s" % source_type)
+
 class WebDriverProtocol(Protocol):
     enable_bidi = False
     implements = [WebDriverBaseProtocolPart,
@@ -589,7 +606,8 @@ class WebDriverProtocol(Protocol):
                   WebDriverDebugProtocolPart,
                   WebDriverVirtualSensorPart,
                   WebDriverDevicePostureProtocolPart,
-                  WebDriverStorageProtocolPart]
+                  WebDriverStorageProtocolPart,
+                  WebDriverVirtualPressureSourceProtocolPart]
 
     def __init__(self, executor, browser, capabilities, **kwargs):
         super().__init__(executor, browser)

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -940,3 +940,21 @@ class DevicePostureProtocolPart(ProtocolPart):
     @abstractmethod
     def clear_device_posture(self):
         pass
+
+class VirtualPressureSourceProtocolPart(ProtocolPart):
+    """Protocol part for Virtual Pressure Source"""
+    __metaclass__ = ABCMeta
+
+    name = "pressure"
+
+    @abstractmethod
+    def create_virtual_pressure_source(self, source_type, metadata):
+        pass
+
+    @abstractmethod
+    def update_virtual_pressure_source(self, source_type, sample):
+        pass
+
+    @abstractmethod
+    def remove_virtual_pressure_source(self, source_type):
+        pass

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -393,4 +393,16 @@
     window.test_driver_internal.run_bounce_tracking_mitigations = function (context = null) {
         return create_action("run_bounce_tracking_mitigations", {context});
     };
+
+    window.test_driver_internal.create_virtual_pressure_source = function(source_type, metadata={}, context=null) {
+        return create_context_action("create_virtual_pressure_source", context, {source_type, metadata});
+    };
+
+    window.test_driver_internal.update_virtual_pressure_source = function(source_type, sample, context=null) {
+        return create_context_action("update_virtual_pressure_source", context, {source_type, sample});
+    };
+
+    window.test_driver_internal.remove_virtual_pressure_source = function(source_type, context=null) {
+        return create_context_action("remove_virtual_pressure_source", context, {source_type});
+    };
 })();


### PR DESCRIPTION
Spec PR: w3c/compute-pressure#284

This PR adds the required infrastructure to manipulate compute pressure from testdriver. The three new commands correspond to the three WebDriver extension commands added by the spec PR above.