### PR TITLE
Allow breaking line after space with `white-space: break-spaces`

### DIFF
--- a/css/css-text/white-space/break-spaces-with-word-break-001.html
+++ b/css/css-text/white-space/break-spaces-with-word-break-001.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: white-space:break-spaces + word-break:keep-all</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#valdef-white-space-collapse-break-spaces">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#valdef-word-break-keep-all">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="break-spaces + keep-all does allow a break after space.">
+
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+div {
+  font: 50px/1 Ahem;
+  white-space: break-spaces;
+  word-break: keep-all;
+  width: 100px;
+  height: 100px;
+  background: red;
+  color: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div>XX XX</div>


### PR DESCRIPTION
`white-space: break-spaces` should allow a soft wrap opportunity *after* every preserved white space. Then, to avoid breaking before the first white space, `TextRunSegment::shape_text()` has some logic to separate it from the following spaces and put it with the preceding text instead.

The problem was that, when combined with `word-break: keep-all`, we were then only checking whether there were more white spaces afterwards, ignoring the soft wrap opportunity after the first one.

Also removing a duplicated `can_break_anywhere` variable.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#33376