### PR TITLE
script: Added missing spec step in `Location::SetHash`

### DIFF
--- a/html/browsers/history/the-location-interface/location_hash_set_empty_string.html
+++ b/html/browsers/history/the-location-interface/location_hash_set_empty_string.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Set window.location.hash to an empty string</title>
+<link rel="author" href="mailto:cristianb@gmail.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-location-hash">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const orig_location = window.location.href;
+
+window.location.hash = '';
+
+test(() => {
+    assert_true(window.location.hash === '');
+    assert_true(window.location.href === orig_location + '#');
+}, 'window.location.hash is an empty string');
+</script>

--- a/html/browsers/history/the-location-interface/location_hashchange_infinite_loop.html
+++ b/html/browsers/history/the-location-interface/location_hashchange_infinite_loop.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Set window.location.hash to same value while handling event hashchange</title>
+<link rel="author" href="mailto:cristianb@gmail.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-location-hash">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+let count = 0;
+
+window.onhashchange = () => {
+    count += 1;
+    window.location.hash = 'running';
+}
+
+promise_test(async t => {
+    window.location.hash = 'running';
+
+    await t.step_wait(() => count === 1);
+}, 'Setting window.location.hash to same value while handling hashchange event shouldn\'t cause an infinite loop.');
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Added check if the new fragment is different when updating location hash. Also, fixes wrong location hash (it was set to #) when `window.location.hash` was set to an empty string.

Reviewed in servo/servo#33380