### PR TITLE
[wptrunner] Delete all cookies after navigating to testharness runner page

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -775,6 +775,10 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
         # The previous test may not have closed its old windows (if something
         # went wrong or if cleanup_after_test was False), so clean up here.
         parent_window = protocol.testharness.close_old_windows()
+        # At this point, the runner window should be focused with the runner
+        # page loaded over the same origin as `url`. Clear cookies to isolate
+        # state between tests.
+        protocol.cookies.delete_all_cookies()
 
         # If protocol implements `bidi_events`, remove all the existing subscriptions.
         if hasattr(protocol, 'bidi_events'):


### PR DESCRIPTION
... for WebDriver-based browsers. This should fix [some flakiness][1] when [an unrelated test leaks cookies][2] and the browser is not restarted.

Many tests already delete cookies during setup, but this new callsite:
1. Guarantees a clean slate enforced by the harness
2. Works for non-`window` scopes that don't have access to `test_driver.delete_all_cookies()`

[1]: https://ci.chromium.org/ui/p/chromium/builders/ci/linux-wpt-chromium-rel/11454/test-results?q=ExactID%3Aninja%3A%2F%2F%3Aheadless_shell_wpt%2Fexternal%2Fwpt%2Ffetch%2Fapi%2Fcredentials%2Fcookies.any.serviceworker.html+VHash%3A0c0dfda1bb530016
[2]: https://github.com/web-platform-tests/wpt/blob/4af0c1ce/fedcm/support/set_cookie.headers