### PR TITLE
Mark tests failed with 500 disconnected error as crash

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -696,7 +696,6 @@ class WebDriverRun(TimedRunner):
             self.logger.error(msg)
             return ("INTERNAL-ERROR", msg)
 
-
     def run_func(self):
         try:
             self.result = True, self.func(self.protocol, self.url, self.timeout)
@@ -709,12 +708,12 @@ class WebDriverRun(TimedRunner):
                 # so mark it as a CRASH unconditionally.
                 status = "CRASH"
             elif isinstance(e, webdriver_error.WebDriverException):
-                if e.http_status == 408 and e.status_code == "asynchronous script timeout":
-                    # workaround for https://bugs.chromium.org/p/chromedriver/issues/detail?id=2001
-                    status = "EXTERNAL-TIMEOUT"
-                elif e.http_status == 500 and e.status_code == "disconnected":
-                    # In a multiple processes architecture, the browser process
-                    # might be alive even when the renderer process has crashed.
+                # In a multiple processes architecture, the browser process might be
+                # alive even when the renderer process has crashed.
+                # TODO(https://github.com/w3c/webdriver/issues/1308): The http
+                # status and status code below are chromium specific. Replace
+                # that with a standarded code once the issue is resolved.
+                if e.http_status == 500 and e.status_code == "disconnected":
                     status = "CRASH"
             if status is None:
                 status = "INTERNAL-ERROR" if self.protocol.is_alive() else "CRASH"

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -696,28 +696,35 @@ class WebDriverRun(TimedRunner):
             self.logger.error(msg)
             return ("INTERNAL-ERROR", msg)
 
+
     def run_func(self):
         try:
             self.result = True, self.func(self.protocol, self.url, self.timeout)
         except (webdriver_error.TimeoutException, webdriver_error.ScriptTimeoutException):
             self.result = False, ("EXTERNAL-TIMEOUT", None)
-        except socket.timeout:
-            # Checking if the browser is alive below is likely to hang, so mark
-            # this case as a CRASH unconditionally.
-            self.result = False, ("CRASH", None)
         except Exception as e:
-            if (isinstance(e, webdriver_error.WebDriverException) and
-                    e.http_status == 408 and
-                    e.status_code == "asynchronous script timeout"):
-                # workaround for https://bugs.chromium.org/p/chromedriver/issues/detail?id=2001
-                self.result = False, ("EXTERNAL-TIMEOUT", None)
-            else:
+            status, message = None, None
+            if isinstance(e, socket.timeout):
+                # Checking if the browser is alive in this case is likely to hang,
+                # so mark it as a CRASH unconditionally.
+                status = "CRASH"
+            elif isinstance(e, webdriver_error.WebDriverException):
+                if e.http_status == 408 and e.status_code == "asynchronous script timeout":
+                    # workaround for https://bugs.chromium.org/p/chromedriver/issues/detail?id=2001
+                    status = "EXTERNAL-TIMEOUT"
+                elif e.http_status == 500 and e.status_code == "disconnected":
+                    # In a multiple processes architecture, the browser process
+                    # might be alive even when the renderer process has crashed.
+                    status = "CRASH"
+            if status is None:
                 status = "INTERNAL-ERROR" if self.protocol.is_alive() else "CRASH"
+
+            if status != "EXTERNAL-TIMEOUT":
                 message = str(getattr(e, "message", ""))
                 if message:
                     message += "\n"
                 message += traceback.format_exc()
-                self.result = False, (status, message)
+            self.result = False, (status, message)
         finally:
             self.result_flag.set()
 


### PR DESCRIPTION
In a multiple processes architecture, when the renderer processes crashed, the liveness check won't necessary fail as the browser process is still running. One common error we see in Chromium is that webdriver will report 500 disconnected, with an error message "Unable to receive message from renderer". Previously the test result is Internal Error instead of Crash.

Bug: 362506646