### PR TITLE
add bazel config file

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,0 +1,31 @@
+name: Bazel files check
+
+permissions: read-all
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '*.bazel'
+      - '*.bzl'
+  pull_request:
+    paths:
+      - '*.bazel'
+      - '*.bzl'
+
+jobs:
+  check:
+    name: Validate formatting
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup buildifier
+      uses: jbajic/setup-buildifier@v1
+      with:
+        buildifier-version: '7.3.1'
+
+    - name: Run buildifier
+      run: |
+        buildifier -mode check -r .

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,16 @@
+# Bazel support is added to enable projects that use Bazel to easily
+# access the test suite, and file groups without having the need to float
+# a patch on top of WPT.
+#
+# In order to iterate over the files inside a subfolder of WPT, we expose
+# the globs in the `tests.bzl` file.
+#
+# In order to format and lint a bazel file, you can use the following command:
+# > buildifier -mode=check BUILD.bazel tests.bzl
+load("//:tests.bzl", "directories")
+
+[filegroup(
+    name = dir,
+    srcs = glob(["{}/**/*".format(dir)]),
+    visibility = ["//visibility:public"],
+) for dir in directories]

--- a/tests.bzl
+++ b/tests.bzl
@@ -1,0 +1,7 @@
+# This excludes all folders that start with `.` annotation to remove folders like `.github`
+directories = glob(["*"], exclude_directories = 0, exclude = glob(["*", ".*"], exclude_directories = 1))
+
+TEST_GROUPS = {
+    name: glob([name + "/**/*"])
+    for name in directories
+}


### PR DESCRIPTION
I'm currently working on adding WPT to Cloudflare workers, and it has been a little bit of pain to define filegroups and run a WPT test runner. I propose adding a BUILD.bazel file as stated in this pull-request to expose the filegroups for other projects that run Bazel. This would simplify the adoption.

Once, this pull-request has some feedback, I'll add the rest of the directories/filegroups to the build file before merging.

cc @web-platform-tests/reviewers 