### PR TITLE
Add tests of duplicate PublicKeyCredentialHint values

### DIFF
--- a/webauthn/createcredential-hints.https.html
+++ b/webauthn/createcredential-hints.https.html
@@ -23,7 +23,7 @@ function testCreateWithHints() {
       return createCredential({
         options: {
           publicKey: {
-            hints: ["not-a-defined-value"],
+            hints: ["duplicated-value", "not-a-defined-value", "duplicated-value"],
           },
         },
       });

--- a/webauthn/getcredential-hints.https.html
+++ b/webauthn/getcredential-hints.https.html
@@ -17,7 +17,7 @@ standardSetup(async function() {
   // The 'hints' parameter affects UI, which cannot be tested with WPTs.
   // However, we can check that unknown values are ignored, as they
   // should be, and don't trigger an error.
-  new GetCredentialsTest("options.publicKey.hints", ["not-a-defined-value"])
+  new GetCredentialsTest("options.publicKey.hints", ["duplicated-value", "not-a-defined-value", "duplicated-value"])
       .addCredential(credPromise)
       .runTest("navigator.credentials.get with hints");
 }, {});

--- a/webauthn/public-key-credential-creation-options-from-json.https.window.js
+++ b/webauthn/public-key-credential-creation-options-from-json.https.window.js
@@ -277,7 +277,6 @@ test(() => {
         alg: -7,
       },
     ],
-    // The spec defaults the following fields:
     attestation: "none",
     hints: ["duplicated-value", "duplicated-value"]
   };

--- a/webauthn/public-key-credential-creation-options-from-json.https.window.js
+++ b/webauthn/public-key-credential-creation-options-from-json.https.window.js
@@ -25,7 +25,6 @@ test(() => {
         alg: -7,
       },
     ],
-    hints: ["duplicated-value", "duplicated-value"]
   });
   let expected = {
     rp: {
@@ -46,7 +45,7 @@ test(() => {
     ],
     // The spec defaults the following fields:
     attestation: "none",
-    hints: ["duplicated-value", "duplicated-value"]
+    hints: [],
   };
 
   assertJsonEquals(actual.rp, expected.rp);
@@ -240,3 +239,52 @@ test(() => {
         'prf ebc');
   }
 }, "parseCreationOptionsFromJSON() with extensions");
+
+test(() => {
+  let actual = PublicKeyCredential.parseCreationOptionsFromJSON({
+    rp: {
+      id: "example.com",
+      name: "Example Inc",
+    },
+    user: {
+      id: test_b64,
+      name: "test@example.com",
+      displayName: "test user"
+    },
+    challenge: test_b64,
+    pubKeyCredParams: [
+      {
+        type: "public-key",
+        alg: -7,
+      },
+    ],
+    hints: ["duplicated-value", "duplicated-value"]
+  });
+  let expected = {
+    rp: {
+      id: "example.com",
+      name: "Example Inc",
+    },
+    user: {
+      id: test_bytes,
+      name: "test@example.com",
+      displayName: "test user"
+    },
+    challenge: test_bytes,
+    pubKeyCredParams: [
+      {
+        type: "public-key",
+        alg: -7,
+      },
+    ],
+    // The spec defaults the following fields:
+    attestation: "none",
+    hints: ["duplicated-value", "duplicated-value"]
+  };
+
+  assert_equals(actual.attestation, expected.attestation);
+  if (actual.hasOwnProperty('hints')) {
+    // Not all implementations support hints yet.
+    assertJsonEquals(actual.hints, expected.hints);
+  }
+}, "parseCreationOptionsFromJSON() with duplicated hints");

--- a/webauthn/public-key-credential-creation-options-from-json.https.window.js
+++ b/webauthn/public-key-credential-creation-options-from-json.https.window.js
@@ -25,6 +25,7 @@ test(() => {
         alg: -7,
       },
     ],
+    hints: ["duplicated-value", "duplicated-value"]
   });
   let expected = {
     rp: {
@@ -45,7 +46,7 @@ test(() => {
     ],
     // The spec defaults the following fields:
     attestation: "none",
-    hints: [],
+    hints: ["duplicated-value", "duplicated-value"]
   };
 
   assertJsonEquals(actual.rp, expected.rp);

--- a/webauthn/public-key-credential-request-options-from-json.https.window.js
+++ b/webauthn/public-key-credential-request-options-from-json.https.window.js
@@ -16,7 +16,7 @@ test(() => {
       { type: "public-key", id: test_b64 },
     ],
     userVerification: "required",
-    hints: ["hybrid", "security-key"],
+    hints: ["hybrid", "security-key", "hybrid"],
   });
   let expected = {
     challenge: test_bytes,
@@ -26,7 +26,7 @@ test(() => {
       { type: "public-key", id: test_bytes },
     ],
     userVerification: "required",
-    hints: ["hybrid", "security-key"],
+    hints: ["hybrid", "security-key", "hybrid"],
   };
 
   assert_equals(actual.rpId, expected.rpId);


### PR DESCRIPTION
This relates to WebAuthn PR #2145:
- https://github.com/w3c/webauthn/pull/2145

And in turn WebAuthn issue #2134: "Clarify behaviour of duplicate hints"
- https://github.com/w3c/webauthn/issues/2135