### PR TITLE
Add lint for test_driver_internal usage

### DIFF
--- a/lint.ignore
+++ b/lint.ignore
@@ -817,3 +817,6 @@ SET TIMEOUT: wasm/core/js/harness/testharness.js
 ASSERT_THROWS: wasm/core/js/harness/testharness.js
 GENERATE_TESTS: wasm/core/js/harness/testharness.js
 PROMISE_REJECTS: wasm/core/js/harness/testharness.js
+
+# Legitimate use of test_driver_internal
+TEST DRIVER INTERNAL: resources/testdriver.js

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -356,7 +356,8 @@ regexps = [item() for item in  # type: ignore
             rules.AssertThrowsRegexp,
             rules.PromiseRejectsRegexp,
             rules.AssertPreconditionRegexp,
-            rules.HTMLInvalidSyntaxRegexp]]
+            rules.HTMLInvalidSyntaxRegexp,
+            rules.TestDriverInternalRegexp]]
 
 
 def check_regexp_line(repo_root: Text, path: Text, f: IO[bytes]) -> List[rules.Error]:

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -565,3 +565,11 @@ class HTMLInvalidSyntaxRegexp(Regexp):
     file_extensions = EXTENSIONS["html"]
     description = "Test-file line has a non-void HTML tag with /> syntax"
     to_fix = """Replace with start tag and end tag"""
+
+
+class TestDriverInternalRegexp(Regexp):
+    pattern = br"test_driver_internal"
+    name = "TEST DRIVER INTERNAL"
+    file_extensions = EXTENSIONS["js_all"]
+    description = "Test-file uses test_driver_internal API"
+    to_fix = """Only use test_driver public API"""

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -379,6 +379,17 @@ class MissingTestInWebFeaturesFile(Rule):
     """)
 
 
+EXTENSIONS = {
+    "html": [".html", ".htm"],
+    "xhtml": [".xht", ".xhtml"],
+    "svg": [".svg"],
+    "js": [".js", ".mjs"],
+    "python": [".py"]
+}
+EXTENSIONS["markup"] = EXTENSIONS["html"] + EXTENSIONS["xhtml"] + EXTENSIONS["svg"]
+EXTENSIONS["js_all"] = EXTENSIONS["markup"] + EXTENSIONS["js"]
+
+
 class Regexp(metaclass=abc.ABCMeta):
     @abc.abstractproperty
     def pattern(self) -> bytes:
@@ -425,7 +436,7 @@ class CRRegexp(Regexp):
 class SetTimeoutRegexp(Regexp):
     pattern = br"setTimeout\s*\("
     name = "SET TIMEOUT"
-    file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
+    file_extensions = EXTENSIONS["js_all"]
     description = "setTimeout used"
     to_fix = """
         replace all `setTimeout(...)` calls with `step_timeout(...)` calls
@@ -462,7 +473,7 @@ class Webidl2Regexp(Regexp):
 class ConsoleRegexp(Regexp):
     pattern = br"console\.[a-zA-Z]+\s*\("
     name = "CONSOLE"
-    file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
+    file_extensions = EXTENSIONS["js_all"]
     description = "Test-file line has a `console.*(...)` call"
     to_fix = """
         remove the `console.*(...)` call (and in some cases, consider adding an
@@ -473,7 +484,7 @@ class ConsoleRegexp(Regexp):
 class GenerateTestsRegexp(Regexp):
     pattern = br"generate_tests\s*\("
     name = "GENERATE_TESTS"
-    file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
+    file_extensions = EXTENSIONS["js_all"]
     description = "Test file line has a generate_tests call"
     to_fix = "remove the call and call `test()` a number of times instead"
 
@@ -481,7 +492,7 @@ class GenerateTestsRegexp(Regexp):
 class PrintRegexp(Regexp):
     pattern = br"print(?:\s|\s*\()"
     name = "PRINT STATEMENT"
-    file_extensions = [".py"]
+    file_extensions = EXTENSIONS["python"]
     description = collapse("""
         A server-side python support file contains a `print` statement
     """)
@@ -494,14 +505,14 @@ class PrintRegexp(Regexp):
 class LayoutTestsRegexp(Regexp):
     pattern = br"(eventSender|testRunner|internals)\."
     name = "LAYOUTTESTS APIS"
-    file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
+    file_extensions = EXTENSIONS["js_all"]
     description = "eventSender/testRunner/internals used; these are LayoutTests-specific APIs (WebKit/Blink)"
 
 
 class MissingDepsRegexp(Regexp):
     pattern = br"[^\w]/gen/"
     name = "MISSING DEPENDENCY"
-    file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
+    file_extensions = EXTENSIONS["js_all"]
     description = "Chromium-specific content referenced"
     to_fix = "Reimplement the test to use well-documented testing interfaces"
 
@@ -509,7 +520,7 @@ class MissingDepsRegexp(Regexp):
 class SpecialPowersRegexp(Regexp):
     pattern = b"SpecialPowers"
     name = "SPECIALPOWERS API"
-    file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
+    file_extensions = EXTENSIONS["js_all"]
     description = "SpecialPowers used; this is gecko-specific and not supported in wpt"
 
 
@@ -523,7 +534,7 @@ class TrailingWhitespaceRegexp(Regexp):
 class AssertThrowsRegexp(Regexp):
     pattern = br"[^.]assert_throws\("
     name = "ASSERT_THROWS"
-    file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
+    file_extensions = EXTENSIONS["js_all"]
     description = "Test-file line has an `assert_throws(...)` call"
     to_fix = """Replace with `assert_throws_dom` or `assert_throws_js` or `assert_throws_exactly`"""
 
@@ -531,7 +542,7 @@ class AssertThrowsRegexp(Regexp):
 class PromiseRejectsRegexp(Regexp):
     pattern = br"promise_rejects\("
     name = "PROMISE_REJECTS"
-    file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
+    file_extensions = EXTENSIONS["js_all"]
     description = "Test-file line has a `promise_rejects(...)` call"
     to_fix = """Replace with promise_rejects_dom or promise_rejects_js or `promise_rejects_exactly`"""
 
@@ -539,7 +550,7 @@ class PromiseRejectsRegexp(Regexp):
 class AssertPreconditionRegexp(Regexp):
     pattern = br"[^.]assert_precondition\("
     name = "ASSERT-PRECONDITION"
-    file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
+    file_extensions = EXTENSIONS["js_all"]
     description = "Test-file line has an `assert_precondition(...)` call"
     to_fix = """Replace with `assert_implements` or `assert_implements_optional`"""
 
@@ -551,6 +562,6 @@ class HTMLInvalidSyntaxRegexp(Regexp):
                br"search|section|select|slot|small|span|strong|style|sub|summary|sup|table|tbody|td|template|textarea|tfoot|th|thead|time|"
                br"title|tr|u|ul|var|video)(\s+[^>]+)?\s*/>")
     name = "HTML INVALID SYNTAX"
-    file_extensions = [".html", ".htm"]
+    file_extensions = EXTENSIONS["html"]
     description = "Test-file line has a non-void HTML tag with /> syntax"
     to_fix = """Replace with start tag and end tag"""

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -243,6 +243,16 @@ def test_html_invalid_syntax():
             assert errors == [("HTML INVALID SYNTAX", "Test-file line has a non-void HTML tag with /> syntax", filename, 1)]
 
 
+def test_testdriver_internal():
+    error_map = check_with_files(b"  test_driver_internal.foo()")
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind not in {"web-strict", "python"}:
+            assert errors == [("TEST DRIVER INTERNAL", "Test-file uses test_driver_internal API", filename, 1)]
+
+
 def test_meta_timeout():
     code = b"""
 <html xmlns="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
We currently have a few tests that try to use `test_driver_internal` in a way that is unsurprisingly broken:
```
input-events/input-events-spin-button-click-on-number-input-delete-document.html
input-events/input-events-spin-button-click-on-number-input.html
input-events/input-events-spin-button-click-on-number-input-prevent-default.html
```

As a result all of these tests are failing on wpt.fyi (although they presumably pass on Chromium infrastructure, due to an incorrect implementation of the test_driver API).

This adds a lint to avoid this happening again in the future (@whimboo is going to actually fix those tests, so this will need to land after that).
