### PR TITLE
Don't pass x, y to test_driver_internal.click

### DIFF
--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -211,11 +211,7 @@
                 return Promise.reject(new Error("element click intercepted error"));
             }
 
-            var rect = element.getClientRects()[0];
-            var centerPoint = getInViewCenterPoint(rect);
-            return window.test_driver_internal.click(element,
-                                                     {x: centerPoint[0],
-                                                      y: centerPoint[1]});
+            return window.test_driver_internal.click(element);
         },
 
         /**


### PR DESCRIPTION
This is because the semantics are supposed to be defined by WebDriver, and that doesn't allow setting the x,y coordinates for the click command (you have to use Actions for that instead). Therefore implementations are expected to compute the coordinates rather than use passed-in values.

By the same argument we could remove the scrollIntoView and initial check, since those just replicate checks WebDriver already does. Since that comes with the possibility of timing changes it isn't included in this change.