### PR TITLE
Make the Safari workflows not be invalid workflow files

### DIFF
--- a/.github/workflows/safari_stable.yml
+++ b/.github/workflows/safari_stable.yml
@@ -33,10 +33,10 @@ jobs:
   safari-stable-results:
     name: "All Tests: Safari (stable)"
     needs: check-workflow-run
+    # We need always() here to then check for success/skipped from the
+    # dependency, as otherwise the skip cascades. See
+    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-jobs-in-a-workflow#defining-prerequisite-jobs.
     if: |
-      # We need always() here to then check for success/skipped from the dependency, as otherwise
-      # the skip cascades. See
-      # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-jobs-in-a-workflow#defining-prerequisite-jobs.
       always() &&
       (needs.check-workflow-run.result == 'success' || needs.check-workflow-run.result == 'skipped') &&
       (github.event_name != 'workflow_run' || fromJSON(needs.check-workflow-run.outputs.updated-refs)[0] != null)

--- a/.github/workflows/safari_technology_preview.yml
+++ b/.github/workflows/safari_technology_preview.yml
@@ -29,10 +29,10 @@ jobs:
   safari-technology-preview-results:
     name: "All Tests: Safari Technology Preview"
     needs: check-workflow-run
+    # We need always() here to then check for success/skipped from the
+    # dependency, as otherwise the skip cascades. See
+    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-jobs-in-a-workflow#defining-prerequisite-jobs.
     if: |
-      # We need always() here to then check for success/skipped from the dependency, as otherwise
-      # the skip cascades. See
-      # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-jobs-in-a-workflow#defining-prerequisite-jobs.
       always() &&
       (needs.check-workflow-run.result == 'success' || needs.check-workflow-run.result == 'skipped') &&
       (github.event_name != 'workflow_run' || fromJSON(needs.check-workflow-run.outputs.updated-refs)[0] != null)


### PR DESCRIPTION
We can't put a YAML comment within a string, it needs to be actual YAML syntax.

Fixup from #48087.