### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=279516

### DIFF
--- a/css/css-transitions/custom-property-and-allow-discrete.html
+++ b/css/css-transitions/custom-property-and-allow-discrete.html
@@ -36,6 +36,19 @@ promise_test(async t => {
 
   assert_equals(transitionCount, 1, 'A single "transitionstart" event was dispatched');
 }, 'It is possible to transition an unregistered custom property using "transition-behavior: allows-discrete"');
+
+promise_test(async t => {
+  const div = addDiv(t);
+  div.style.setProperty('--foo', 'bar');
+
+  // Trigger a transition on the custom property.
+  getComputedStyle(div).getPropertyValue('--foo');
+  div.style.transition = "--foo 10s allow-discrete";
+  div.style.setProperty('--foo', 'baz');
+
+  assert_equals(div.getAnimations()[0].transitionProperty, '--foo', 'A transition was started for the custom property');
+}, 'It is possible to transition an unregistered custom property using "transition-behavior: allows-discrete" when setting "transition-property" in the style change that yields the transition');
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
WebKit export from bug: [\[css-transitions\] `transition-behavior: allow-discrete` may not start a transition for a custom property](https://bugs.webkit.org/show_bug.cgi?id=279516)