### PR TITLE
Check certificate expiry time

### DIFF
--- a/.github/workflows/check_certs.yml
+++ b/.github/workflows/check_certs.yml
@@ -1,0 +1,34 @@
+name: certificates
+on:
+  # Our certificates are good for ~1 year, but we regenerate them every
+  # month to be sure. Also support manually triggering the workflow.
+  schedule:
+    - cron: 0 0 * * 1
+  workflow_dispatch:
+jobs:
+  update:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Check certificates
+      id: checkCerts
+      # Use a conditional step instead of a conditional job to work around #20700.
+      if: github.repository == 'web-platform-tests/wpt'
+      run: |
+        python wpt make-hosts-file | sudo tee -a /etc/hosts
+        python wpt check-certs --days=120
+      continue-on-error: true
+    - name: Create an issue
+      # Use a conditional step instead of a conditional job to work around #20700.
+      if: github.repository == 'web-platform-tests/wpt' && steps.checkCerts.outcome == 'failure'
+      uses: peter-evans/create-issue-from-file@v5
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        title: WPT Certificates Must Be Updated
+        content-filepath: ./tools/ci/cert_update.md
+        labels: infra,priority:urgent

--- a/.github/workflows/regen_certs.yml
+++ b/.github/workflows/regen_certs.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Commit and create pull request
       # Use a conditional step instead of a conditional job to work around #20700.
       if: github.repository == 'web-platform-tests/wpt'
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@v7
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         author: wpt-pr-bot <wpt-pr-bot@users.noreply.github.com>

--- a/tools/ci/cert_update.md
+++ b/tools/ci/cert_update.md
@@ -1,0 +1,11 @@
+# WPT Certificates Update Required
+
+@web-platform-tests/wpt-core-team
+
+The wpt certificates are nearing their expiration date and must be regenerated.
+
+There should be an open PR from github-actions with the title
+[Regenerate WPT Certificates](https://github.com/web-platform-tests/wpt/pulls?q=is%3Apr+is%3Aopen+%22Regenerate+WPT+certificates%22+)
+to be merged. Please ensure this is merged ASAP to avoid problems from certificates expiring.
+
+If this PR is missing you can run `wpt regen-certs` locally to create new certificates.

--- a/tools/ci/commands.json
+++ b/tools/ci/commands.json
@@ -24,8 +24,8 @@
   },
   "regen-certs": {
     "path": "regen_certs.py",
-    "script": "run",
-    "parser": "get_parser",
+    "script": "run_regen",
+    "parser": "get_parser_regen",
     "help": "Regenerate the WPT certificates",
     "virtualenv": false
   },


### PR DESCRIPTION
This is to avoid a repeat of the recent issue where the PR to update the certificates didn't get merged until one week before expiry, which caused some downstream pain (and narrowly avoided more downstream pain).
