### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=278893

### DIFF
--- a/css/css-ruby/ruby-overhang-ref.html
+++ b/css/css-ruby/ruby-overhang-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Tests for ruby-overhang: none</title>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  div {
+    font: 16px/5 Ahem;
+  }
+  span {
+    color: transparent;
+    font-size: 8px; /* annotation -> 50% */
+  }
+</style>
+<div>X<span>XXX</span>X</div>
+<div>X<span>XXXX</span>X</div>
+<div>X<span>XXXX</span>X</div>

--- a/css/css-ruby/ruby-overhang.html
+++ b/css/css-ruby/ruby-overhang.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Tests for ruby-overhang: none</title>
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#ruby-overhang">
+<link rel="match" href="ruby-overhang-ref.html">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  div {
+    font: 16px/5 Ahem;
+  }
+  ruby, rt {
+    color: transparent;
+  }
+</style>
+<div>X<ruby>X<rt>XXXX</rt></ruby>X</div>
+<div>X<ruby style="ruby-overhang: none">X<rt>XXXX</rt></ruby>X</div>
+<div style="ruby-overhang: none">X<ruby>X<rt>XXXX</rt></ruby>X</div>


### PR DESCRIPTION
WebKit export from bug: [\[Ruby\] Do not apply annotation overhang when ruby-overhang is none](https://bugs.webkit.org/show_bug.cgi?id=278893)