### PR TITLE
Checkout tools/ before running a script in tools/ci

### DIFF
--- a/.github/workflows/check-workflow-run.yml
+++ b/.github/workflows/check-workflow-run.yml
@@ -23,6 +23,12 @@ jobs:
     outputs:
       output: ${{ steps.check.outputs.test }}
     steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+        sparse-checkout: |
+          tools
       - uses: actions/download-artifact@v4
         with:
           name: git-push-output


### PR DESCRIPTION
In a shocking turn of events, running scripts without first checking out anything doesn't work well.