### PR TITLE
Clear `self.pending_whitespace.max_content` in `forced_line_break()`

### DIFF
--- a/css/css-text/white-space/white-space-intrinsic-size-021.html
+++ b/css/css-text/white-space/white-space-intrinsic-size-021.html
@@ -26,6 +26,10 @@
 hr {
   clear: both;
 }
+x-br::before {
+  content: "\a";
+  white-space: preserve-breaks;
+}
 .collapse.wrap {
   white-space: normal;
 }
@@ -152,6 +156,16 @@ hr {
   <div class="break-spaces wrap"      data-expected-client-width="20" data-expected-client-height="20">X  É</div>
   <div class="break-spaces nowrap"    data-expected-client-width="40" data-expected-client-height="10">X  É</div>
 </div>
+<div class="container narrow">
+  <div class="collapse wrap"          data-expected-client-width="10" data-expected-client-height="20">X <x-br></x-br>É</div>
+  <div class="collapse nowrap"        data-expected-client-width="10" data-expected-client-height="20">X <x-br></x-br>É</div>
+  <div class="preserve wrap"          data-expected-client-width="10" data-expected-client-height="20">X <x-br></x-br>É</div>
+  <div class="preserve nowrap"        data-expected-client-width="20" data-expected-client-height="20">X <x-br></x-br>É</div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="10" data-expected-client-height="20">X <x-br></x-br>É</div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="10" data-expected-client-height="20">X <x-br></x-br>É</div>
+  <div class="break-spaces wrap"      data-expected-client-width="20" data-expected-client-height="20">X <x-br></x-br>É</div>
+  <div class="break-spaces nowrap"    data-expected-client-width="20" data-expected-client-height="20">X <x-br></x-br>É</div>
+</div>
 
 <hr>
 
@@ -254,6 +268,16 @@ hr {
   <div class="preserve-breaks nowrap" data-expected-client-width="30" data-expected-client-height="10">X  É</div>
   <div class="break-spaces wrap"      data-expected-client-width="40" data-expected-client-height="10">X  É</div>
   <div class="break-spaces nowrap"    data-expected-client-width="40" data-expected-client-height="10">X  É</div>
+</div>
+<div class="container wide">
+  <div class="collapse wrap"          data-expected-client-width="10" data-expected-client-height="20">X <x-br></x-br>É</div>
+  <div class="collapse nowrap"        data-expected-client-width="10" data-expected-client-height="20">X <x-br></x-br>É</div>
+  <div class="preserve wrap"          data-expected-client-width="20" data-expected-client-height="20">X <x-br></x-br>É</div>
+  <div class="preserve nowrap"        data-expected-client-width="20" data-expected-client-height="20">X <x-br></x-br>É</div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="10" data-expected-client-height="20">X <x-br></x-br>É</div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="10" data-expected-client-height="20">X <x-br></x-br>É</div>
+  <div class="break-spaces wrap"      data-expected-client-width="20" data-expected-client-height="20">X <x-br></x-br>É</div>
+  <div class="break-spaces nowrap"    data-expected-client-width="20" data-expected-client-height="20">X <x-br></x-br>É</div>
 </div>
 
 <hr>


### PR DESCRIPTION
If we encountered a preserved line break after some whitespace, we were including the space in the max-content size of the following line.

So just like `line_break_opportunity()` was already clearing `self.pending_whitespace.min_content`, `forced_line_break()` needs to clear `self.pending_whitespace.max_content` too.

Also some cosmetic refactoring.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#33469