### PR TITLE
fix viewport test

### DIFF
--- a/webdriver/tests/bidi/__init__.py
+++ b/webdriver/tests/bidi/__init__.py
@@ -141,8 +141,9 @@ async def get_element_dimensions(bidi_session, context, element):
     return remote_mapping_to_dict(result["value"])
 
 
-async def get_viewport_dimensions(bidi_session, context: str, with_scrollbar: bool = True):
-    if with_scrollbar == True:
+async def get_viewport_dimensions(bidi_session, context: str,
+      with_scrollbar: bool = True, quirk_mode: bool = False):
+    if with_scrollbar:
         expression = """
             ({
                 height: window.innerHeight,
@@ -150,11 +151,17 @@ async def get_viewport_dimensions(bidi_session, context: str, with_scrollbar: bo
             });
         """
     else:
-        expression = """
-            ({
-                height: document.documentElement.clientHeight,
-                width: document.documentElement.clientWidth,
-            });
+        # The way the viewport height without the scrollbar can be calculated
+        # is different in quirks mode. In quirks mode, the viewport height is
+        # the height of the body element, while in standard mode it is the
+        # height of the document element.
+        element_expression = \
+            "document.body" if quirk_mode else "document.documentElement"
+        expression = f"""
+            ({{
+                height: {element_expression}.clientHeight,
+                width: {element_expression}.clientWidth,
+            }});
         """
     result = await bidi_session.script.evaluate(
         expression=expression,

--- a/webdriver/tests/bidi/browsing_context/set_viewport/viewport.py
+++ b/webdriver/tests/bidi/browsing_context/set_viewport/viewport.py
@@ -197,8 +197,8 @@ async def test_persists_on_reload(bidi_session, inline, new_tab):
     ids=["horizontal", "vertical", "both"],
 )
 @pytest.mark.parametrize(
-    "doctype",
-    ["html", "html_quirks"],
+    "quirk_mode",
+    [False, True],
     ids=["standard", "quirks"],
 )
 async def test_with_scrollbars(
@@ -207,9 +207,11 @@ async def test_with_scrollbars(
     new_tab,
     use_horizontal_scrollbar,
     use_vertical_scrollbar,
-    doctype,
+    quirk_mode,
 ):
-    viewport_dimensions = await get_viewport_dimensions(bidi_session, new_tab)
+    doctype = "html_quirks" if quirk_mode else "html"
+    viewport_dimensions = await get_viewport_dimensions(bidi_session, new_tab,
+                                                        quirk_mode=quirk_mode)
 
     width = 100
     if use_horizontal_scrollbar:
@@ -228,16 +230,18 @@ async def test_with_scrollbars(
 
     test_viewport = {"width": 499, "height": 599}
 
-    assert await get_viewport_dimensions(bidi_session, new_tab) != test_viewport
+    assert await get_viewport_dimensions(bidi_session, new_tab,
+                                         quirk_mode=quirk_mode) != test_viewport
 
     await bidi_session.browsing_context.set_viewport(
         context=new_tab["context"], viewport=test_viewport
     )
 
-    assert await get_viewport_dimensions(bidi_session, new_tab) == test_viewport
+    assert await get_viewport_dimensions(bidi_session, new_tab,
+                                         quirk_mode=quirk_mode) == test_viewport
 
     viewport_without_scrollbar = await get_viewport_dimensions(
-        bidi_session, new_tab, with_scrollbar=False
+        bidi_session, new_tab, with_scrollbar=False, quirk_mode=quirk_mode
     )
 
     # The side which has scrollbar takes up space on the other side


### PR DESCRIPTION
Fix getting `clientHeight` without scrollbars in quirks mode:
> [Element: clientHeight property](https://developer.mozilla.org/en-US/docs/Web/API/Element/clientHeight): When clientHeight is used on the root element (the \<html\> element), (or on \<body\> if the document is in quirks mode), the viewport's height (excluding any scrollbar) is returned. This is a special case of clientHeight.