### PR TITLE
Fix check-workflow-run to run unconditionally and read the right file

### DIFF
--- a/.github/workflows/check-workflow-run.yml
+++ b/.github/workflows/check-workflow-run.yml
@@ -41,3 +41,11 @@ jobs:
         env:
           GIT_PUSH_OUTPUT: ${{ runner.temp }}/git-push-output/git-push-output.txt
           REFS: ${{ inputs.check-refs }}
+
+  check-workflow-run-noop:
+    name: "Check for appropriate epochs (noop)"
+    if: ${{ github.event_name != 'workflow_run' }}
+    runs-on:
+      - ubuntu-22.04
+    steps:
+      - run: exit 0

--- a/.github/workflows/check-workflow-run.yml
+++ b/.github/workflows/check-workflow-run.yml
@@ -32,12 +32,12 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: git-push-output
-          path: ${{ runner.temp }}/git-push-output.txt
+          path: ${{ runner.temp }}/git-push-output
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - id: check
         run: |-
           python3 tools/ci/check_for_updated_refs.py >> "$GITHUB_OUTPUT"
         env:
-          GIT_PUSH_OUTPUT: ${{ runner.temp }}/git-push-output.txt
+          GIT_PUSH_OUTPUT: ${{ runner.temp }}/git-push-output/git-push-output.txt
           REFS: ${{ inputs.check-refs }}

--- a/.github/workflows/safari_stable.yml
+++ b/.github/workflows/safari_stable.yml
@@ -33,13 +33,8 @@ jobs:
   safari-stable-results:
     name: "All Tests: Safari (stable)"
     needs: check-workflow-run
-    # We need always() here to then check for success/skipped from the
-    # dependency, as otherwise the skip cascades. See
-    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-jobs-in-a-workflow#defining-prerequisite-jobs.
     if: |
-      always() &&
-      (needs.check-workflow-run.result == 'success' || needs.check-workflow-run.result == 'skipped') &&
-      (github.event_name != 'workflow_run' || fromJSON(needs.check-workflow-run.outputs.updated-refs)[0] != null)
+      github.event_name != 'workflow_run' || fromJSON(needs.check-workflow-run.outputs.updated-refs)[0] != null
     runs-on:
       - self-hosted
       - webkit-ews

--- a/.github/workflows/safari_technology_preview.yml
+++ b/.github/workflows/safari_technology_preview.yml
@@ -33,13 +33,8 @@ jobs:
   safari-technology-preview-results:
     name: "All Tests: Safari Technology Preview"
     needs: check-workflow-run
-    # We need always() here to then check for success/skipped from the
-    # dependency, as otherwise the skip cascades. See
-    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-jobs-in-a-workflow#defining-prerequisite-jobs.
     if: |
-      always() &&
-      (needs.check-workflow-run.result == 'success' || needs.check-workflow-run.result == 'skipped') &&
-      (github.event_name != 'workflow_run' || fromJSON(needs.check-workflow-run.outputs.updated-refs)[0] != null)
+      github.event_name != 'workflow_run' || fromJSON(needs.check-workflow-run.outputs.updated-refs)[0] != null
     runs-on:
       - self-hosted
       - webkit-ews


### PR DESCRIPTION
download-artifact takes the path the contents gets extracted into, even if the ZIP contains only a single file, so this currently has been failing to read the file.

Plus:

Simplify all of the logic we have where we conditionally run jobs even after earlier jobs have been skipped.

The current behaviour doesn't actually work, because _all_ jobs are skipped following one job (i.e., check-workflow-run) being skipped. This means safari-stable-results-notify doesn't actually get run, because it also gets skipped, even if the actual test runs ran successfully.