### PR TITLE
Split Ed448 and Ed25519 sign / verify algorithms

### DIFF
--- a/WebCryptoAPI/sign_verify/eddsa.js
+++ b/WebCryptoAPI/sign_verify/eddsa.js
@@ -1,10 +1,10 @@
 
-function run_test() {
+function run_test(algorithmName) {
   var subtle = self.crypto.subtle; // Change to test prefixed implementations
 
   // Source file [algorithm_name]_vectors.js provides the getTestVectors method
   // for the algorithm that drives these tests.
-  var testVectors = getTestVectors();
+  var testVectors = getTestVectors(algorithmName);
 
   testVectors.forEach(function(vector) {
       var algorithm = {name: vector.algorithmName};

--- a/WebCryptoAPI/sign_verify/eddsa_curve25519.https.any.js
+++ b/WebCryptoAPI/sign_verify/eddsa_curve25519.https.any.js
@@ -3,4 +3,4 @@
 // META: script=eddsa.js
 // META: timeout=long
 
-run_test();
+run_test("Ed25519");

--- a/WebCryptoAPI/sign_verify/eddsa_curve448.https.any.js
+++ b/WebCryptoAPI/sign_verify/eddsa_curve448.https.any.js
@@ -1,0 +1,6 @@
+// META: title=WebCryptoAPI: sign() and verify() Using EdDSA
+// META: script=eddsa_vectors.js
+// META: script=eddsa.js
+// META: timeout=long
+
+run_test("Ed448");

--- a/WebCryptoAPI/sign_verify/eddsa_vectors.js
+++ b/WebCryptoAPI/sign_verify/eddsa_vectors.js
@@ -16,7 +16,7 @@
 //     algorithmName - the name of the AlgorithmIdentifier parameter to provide to sign
 //     data - the text to sign
 //     signature - the expected signature
-function getTestVectors() {
+function getTestVectors(algorithmName) {
   var pkcs8 = {
       "Ed25519": new Uint8Array([48, 46, 2, 1, 0, 48, 5, 6, 3, 43, 101, 112, 4, 34, 4, 32, 243, 200, 244, 196, 141, 248, 120, 20, 110, 140, 211, 191, 109, 244, 229, 14, 56, 155, 167, 7, 78, 21, 194, 53, 45, 205, 93, 48, 141, 76, 168, 31]),
       "Ed448": new Uint8Array([48, 71, 2, 1, 0, 48, 5, 6, 3, 43, 101, 113, 4, 59, 4, 57, 14, 255, 3, 69, 140, 40, 224, 23, 156, 82, 29, 227, 18, 201, 105, 183, 131, 67, 72, 236, 171, 153, 26, 96, 227, 178, 233, 167, 158, 76, 217, 228, 128, 239, 41, 23, 18, 210, 200, 61, 4, 114, 114, 213, 201, 244, 40, 102, 79, 105, 109, 38, 112, 69, 143, 29, 46]),
@@ -37,7 +37,7 @@ function getTestVectors() {
   }
 
   var vectors = [];
-  ["Ed25519", "Ed448"].forEach(function(algorithmName) {
+  {
     var vector = {
       name: "EdDSA " + algorithmName,
       publicKeyBuffer: spki[algorithmName],
@@ -52,7 +52,7 @@ function getTestVectors() {
     };
 
     vectors.push(vector);
-  });
+  }
   return vectors;
 }
 


### PR DESCRIPTION
The Curve448 algorithm is not implemented in any of the major browsers, so it's better to define its sign / verify tests in a separate file to avoid unnecessary noise on the tests for the Curve25519 algorithm.