### PR TITLE
Functions in testfiles.py should honor --repo-root

### DIFF
--- a/tools/ci/jobs.py
+++ b/tools/ci/jobs.py
@@ -96,7 +96,7 @@ def get_paths(**kwargs):
     else:
         revish = kwargs["revish"]
 
-    changed, _ = files_changed(revish, ignore_rules=[])
+    changed, _ = files_changed(wpt_root, revish, ignore_rules=[])
     all_changed = {os.path.relpath(item, wpt_root) for item in set(changed)}
     return all_changed
 

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -825,35 +825,35 @@ def output_error_count(error_count: Dict[Text, int]) -> None:
         logger.info("There were %d errors (%s)" % (count, by_type))
 
 
-def changed_files(wpt_root: Text) -> List[Text]:
+def changed_files(repo_root: Text) -> List[Text]:
     revish = testfiles.get_revish(revish=None)
-    changed, _ = testfiles.files_changed(revish, None, include_uncommitted=True, include_new=True)
-    return [os.path.relpath(item, wpt_root) for item in changed]
+    changed, _ = testfiles.files_changed(repo_root, revish, None, include_uncommitted=True, include_new=True)
+    return [os.path.relpath(item, repo_root) for item in changed]
 
 
-def lint_paths(kwargs: Dict[Text, Any], wpt_root: Text) -> List[Text]:
+def lint_paths(kwargs: Dict[Text, Any], repo_root: Text) -> List[Text]:
     if kwargs.get("paths"):
         paths = []
         for path in kwargs.get("paths", []):
             if os.path.isdir(path):
-                path_dir = list(all_filesystem_paths(wpt_root, path))
+                path_dir = list(all_filesystem_paths(repo_root, path))
                 paths.extend(path_dir)
             elif os.path.isfile(path):
-                paths.append(os.path.relpath(os.path.abspath(path), wpt_root))
+                paths.append(os.path.relpath(os.path.abspath(path), repo_root))
     elif kwargs["all"]:
-        paths = list(all_filesystem_paths(wpt_root))
+        paths = list(all_filesystem_paths(repo_root))
     elif kwargs["paths_file"]:
         paths = []
         with open(kwargs["paths_file"], 'r', newline='') as f:
             for line in f.readlines():
                 path = line.strip()
                 if os.path.isdir(path):
-                    path_dir = list(all_filesystem_paths(wpt_root, path))
+                    path_dir = list(all_filesystem_paths(repo_root, path))
                     paths.extend(path_dir)
                 elif os.path.isfile(path):
-                    paths.append(os.path.relpath(os.path.abspath(path), wpt_root))
+                    paths.append(os.path.relpath(os.path.abspath(path), repo_root))
     else:
-        changed_paths = changed_files(wpt_root)
+        changed_paths = changed_files(repo_root)
         force_all = False
         for path in changed_paths:
             path = path.replace(os.path.sep, "/")
@@ -861,7 +861,7 @@ def lint_paths(kwargs: Dict[Text, Any], wpt_root: Text) -> List[Text]:
                 force_all = True
                 break
         paths = (list(changed_paths) if not force_all
-                 else list(all_filesystem_paths(wpt_root)))
+                 else list(all_filesystem_paths(repo_root)))
 
     return paths
 

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -930,8 +930,10 @@ def setup_wptrunner(venv, **kwargs):
 
     affected_revish = kwargs.get("affected")
     if affected_revish is not None:
+        # TODO: wpt run should support --repo-root as wpt tooling and the tests
+        # can be put into different directory.
         files_changed, _ = testfiles.files_changed(
-            affected_revish, include_uncommitted=True, include_new=True)
+            None, affected_revish, include_uncommitted=True, include_new=True)
         # TODO: Perhaps use wptrunner.testloader.ManifestLoader here
         # and remove the manifest-related code from testfiles.
         # https://github.com/web-platform-tests/wpt/issues/14421

--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -133,7 +133,10 @@ def compile_ignore_rule(rule: Text) -> Pattern[Text]:
     return re.compile("^%s$" % "/".join(re_parts))
 
 
-def repo_files_changed(revish: Text, include_uncommitted: bool = False, include_new: bool = False) -> Set[Text]:
+def repo_files_changed(wpt_root: Text,
+                       revish: Text,
+                       include_uncommitted: bool = False,
+                       include_new: bool = False) -> Set[Text]:
     git = get_git_cmd(wpt_root)
     if git is None:
         raise Exception("git not found")
@@ -190,7 +193,8 @@ def exclude_ignored(files: Iterable[Text], ignore_rules: Optional[Sequence[Text]
     return changed, ignored
 
 
-def files_changed(revish: Text,
+def files_changed(repo_root: Text,
+                  revish: Text,
                   ignore_rules: Optional[Sequence[Text]] = None,
                   include_uncommitted: bool = False,
                   include_new: bool = False
@@ -201,7 +205,8 @@ def files_changed(revish: Text,
     variety of forms; see `git diff --help` for details. Files in the diff that
     are matched by `ignore_rules` are excluded.
     """
-    files = repo_files_changed(revish,
+    files = repo_files_changed(repo_root or wpt_root,
+                               revish,
                                include_uncommitted=include_uncommitted,
                                include_new=include_new)
     if not files:
@@ -370,7 +375,8 @@ def get_revish(**kwargs: Any) -> Text:
 
 def run_changed_files(**kwargs: Any) -> None:
     revish = get_revish(**kwargs)
-    changed, _ = files_changed(revish,
+    changed, _ = files_changed(wpt_root,
+                               revish,
                                kwargs["ignore_rule"],
                                include_uncommitted=kwargs["modified"],
                                include_new=kwargs["new"])
@@ -384,7 +390,8 @@ def run_changed_files(**kwargs: Any) -> None:
 
 def run_tests_affected(**kwargs: Any) -> None:
     revish = get_revish(**kwargs)
-    changed, _ = files_changed(revish,
+    changed, _ = files_changed(wpt_root,
+                               revish,
                                kwargs["ignore_rule"],
                                include_uncommitted=kwargs["modified"],
                                include_new=kwargs["new"])


### PR DESCRIPTION
--repo-root is a parameter for wpt lint. As wpt tooling and tests are sitting in different dictories in Chromium, files_changed should accept repo_root as an arg to be consistent.