### PR TITLE
[testdriver.js] Fix malformed action payloads

### DIFF
--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -383,15 +383,15 @@
     };
 
     window.test_driver_internal.set_device_posture = function(posture, context=null) {
-        return create_context_action("set_device_posture", {posture, context});
+        return create_context_action("set_device_posture", context, {posture});
     };
 
     window.test_driver_internal.clear_device_posture = function(context=null) {
-        return create_context_action("clear_device_posture", {context});
+        return create_context_action("clear_device_posture", context, {});
     };
 
     window.test_driver_internal.run_bounce_tracking_mitigations = function (context = null) {
-        return create_action("run_bounce_tracking_mitigations", {context});
+        return create_context_action("run_bounce_tracking_mitigations", context, {});
     };
 
     window.test_driver_internal.create_virtual_pressure_source = function(source_type, metadata={}, context=null) {


### PR DESCRIPTION
Starting in #45823, `create_context_action()` wraps `create_action()` in `testdriver-extra.js`. Some methods still pass the old `create_action()` arguments to `create_context_action()`, which incorrectly [assigns `__wptrunner_id`][0] to the params object and not the `WindowProxy`. This causes `TestDriverProtocolPart.switch_to_window()` to [fail to find the requested window][1].

[0]: https://github.com/web-platform-tests/wpt/blob/2a471e0d/tools/wptrunner/wptrunner/testdriver-extra.js#L85
[1]: https://wpt.fyi/results/device-posture/device-posture-clear.https.html?run_id=5117148234252288&run_id=5157553306861568&run_id=5072332666437632&run_id=5173437035446272