### PR TITLE
[css-inline-3] actually test end-edge

### DIFF
--- a/css/css-inline/text-box-trim/text-box-trim-height-002-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-height-002-ref.html
@@ -5,6 +5,9 @@
   background: lightgray;
   block-size: 20px;
 }
+.max-height > .spacer:first-child {
+  margin-top: 80px; /* avoid overlap */
+}
 
 .target {
   font: 100px/1 Ahem;
@@ -17,7 +20,8 @@
 }
 
 .max-height > .target {
-  height: 10px;
+  margin-top: -70px;
+  height: 80px;
 }
 </style>
 

--- a/css/css-inline/text-box-trim/text-box-trim-height-002.html
+++ b/css/css-inline/text-box-trim/text-box-trim-height-002.html
@@ -10,12 +10,15 @@
   background: lightgray;
   block-size: 20px;
 }
+.max-height > .spacer:first-child {
+  margin-top: 80px; /* avoid overlap */
+}
 
 .target {
   font: 100px/2 Ahem;
   text-box-trim: trim-both;
   text-box-edge: text alphabetic;
-  align-content: end;
+  align-content: unsafe end;
 }
 
 .height > .target {


### PR DESCRIPTION
This reverts the reference adjustments in e6e8541 and instead applies `unsafe end` to force end alignment in the last testcase.