### PR TITLE
[wptrunner] Generalize WebDriver-based print-reftest implementation

### DIFF
--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -740,6 +740,29 @@ class Session:
     def screenshot(self):
         return self.send_session_command("GET", "screenshot")
 
+    @command
+    def print(self,
+              background=None,
+              margin=None,
+              orientation=None,
+              page=None,
+              page_ranges=None,
+              scale=None,
+              shrink_to_fit=None):
+        body = {}
+        for prop, value in {
+            "background": background,
+            "margin": margin,
+            "orientation": orientation,
+            "page": page,
+            "pageRanges": page_ranges,
+            "scale": scale,
+            "shrinkToFit": shrink_to_fit,
+        }.items():
+            if value is not None:
+                body[prop] = value
+        return self.send_session_command("POST", "print", body)
+
 
 class ShadowRoot:
     identifier = "shadow-6066-11e4-a52e-4f735466cecf"
@@ -884,6 +907,7 @@ class WebElement:
     @command
     def property(self, name):
         return self.send_element_command("GET", "property/%s" % name)
+
 
 class WebFrame:
     identifier = "frame-075b-4da1-b6ba-e579c2d3230a"

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -3,27 +3,24 @@
 import collections
 import os
 import time
-import traceback
 from typing import Mapping, MutableMapping, Type
-from urllib.parse import urljoin
 
 from webdriver import error
 
 from .base import (
     CrashtestExecutor,
     TestharnessExecutor,
-    get_pages,
 )
 from .executorwebdriver import (
     WebDriverCrashtestExecutor,
     WebDriverFedCMProtocolPart,
+    WebDriverPrintRefTestExecutor,
     WebDriverProtocol,
     WebDriverRefTestExecutor,
-    WebDriverRun,
     WebDriverTestharnessExecutor,
     WebDriverTestharnessProtocolPart,
 )
-from .protocol import LeakProtocolPart, PrintProtocolPart, ProtocolPart
+from .protocol import LeakProtocolPart, ProtocolPart
 
 here = os.path.dirname(__file__)
 
@@ -144,54 +141,6 @@ class ChromeDriverTestharnessProtocolPart(WebDriverTestharnessProtocolPart):
         raise Exception("unable to find test window")
 
 
-class ChromeDriverPrintProtocolPart(PrintProtocolPart):
-    def setup(self):
-        self.webdriver = self.parent.webdriver
-        self.runner_handle = None
-
-    def load_runner(self):
-        url = urljoin(self.parent.executor.server_url("http"), "/print_pdf_runner.html")
-        self.logger.debug("Loading %s" % url)
-        try:
-            self.webdriver.url = url
-        except Exception as e:
-            self.logger.critical(
-                "Loading initial page %s failed. Ensure that the "
-                "there are no other programs bound to this port and "
-                "that your firewall rules or network setup does not "
-                "prevent access.\n%s" % (url, traceback.format_exc(e)))
-            raise
-        self.runner_handle = self.webdriver.window_handle
-
-    def render_as_pdf(self, width, height):
-        margin = 0.5
-        params = {
-            # Chrome accepts dimensions in inches; we are using cm
-            "paperWidth": width / 2.54,
-            "paperHeight": height / 2.54,
-            "marginLeft": margin,
-            "marginRight": margin,
-            "marginTop": margin,
-            "marginBottom": margin,
-            "shrinkToFit": False,
-            "printBackground": True,
-        }
-        return self.parent.cdp.execute_cdp_command("Page.printToPDF", params)["data"]
-
-    def pdf_to_png(self, pdf_base64, ranges):
-        handle = self.webdriver.window_handle
-        self.webdriver.window_handle = self.runner_handle
-        try:
-            rv = self.webdriver.execute_async_script("""
-let callback = arguments[arguments.length - 1];
-render('%s').then(result => callback(result))""" % pdf_base64)
-            page_numbers = get_pages(ranges, len(rv))
-            rv = [item for i, item in enumerate(rv) if i + 1 in page_numbers]
-            return rv
-        finally:
-            self.webdriver.window_handle = handle
-
-
 class ChromeDriverFedCMProtocolPart(WebDriverFedCMProtocolPart):
     def confirm_idp_login(self):
         return self.webdriver.send_session_command("POST",
@@ -221,7 +170,6 @@ class ChromeDriverProtocol(WebDriverProtocol):
     implements = [
         ChromeDriverDevToolsProtocolPart,
         ChromeDriverFedCMProtocolPart,
-        ChromeDriverPrintProtocolPart,
         ChromeDriverTestharnessProtocolPart,
     ]
     for base_part in WebDriverProtocol.implements:
@@ -298,49 +246,6 @@ class ChromeDriverTestharnessExecutor(WebDriverTestharnessExecutor, _SanitizerMi
 
 
 @_evaluate_leaks
-class ChromeDriverPrintRefTestExecutor(ChromeDriverRefTestExecutor):
+class ChromeDriverPrintRefTestExecutor(WebDriverPrintRefTestExecutor,
+                                       _SanitizerMixin):  # type: ignore
     protocol_cls = ChromeDriverProtocol
-    is_print = True
-
-    def setup(self, runner, protocol=None):
-        super().setup(runner, protocol)
-        self.protocol.pdf_print.load_runner()
-        self.has_window = False
-        with open(os.path.join(here, "reftest.js")) as f:
-            self.script = f.read()
-
-    def screenshot(self, test, viewport_size, dpi, page_ranges):
-        # https://github.com/web-platform-tests/wpt/issues/7140
-        assert dpi is None
-
-        if not self.has_window:
-            self.protocol.base.execute_script(self.script)
-            self.protocol.base.set_window(self.protocol.webdriver.handles[-1])
-            self.has_window = True
-
-        self.viewport_size = viewport_size
-        self.page_ranges = page_ranges.get(test.url)
-        timeout = self.timeout_multiplier * test.timeout if self.debug_info is None else None
-
-        test_url = self.test_url(test)
-
-        return WebDriverRun(self.logger,
-                            self._render,
-                            self.protocol,
-                            test_url,
-                            timeout,
-                            self.extra_timeout).run()
-
-    def _render(self, protocol, url, timeout):
-        protocol.webdriver.url = url
-
-        protocol.base.execute_script(self.wait_script, asynchronous=True)
-
-        pdf = protocol.pdf_print.render_as_pdf(*self.viewport_size)
-        screenshots = protocol.pdf_print.pdf_to_png(pdf, self.page_ranges)
-        for i, screenshot in enumerate(screenshots):
-            # strip off the data:img/png, part of the url
-            if screenshot.startswith("data:image/png;base64,"):
-                screenshots[i] = screenshot.split(",", 1)[1]
-
-        return screenshots

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -17,8 +17,10 @@ from .base import (AsyncCallbackHandler,
                    RefTestImplementation,
                    TestharnessExecutor,
                    TimedRunner,
+                   get_pages,
                    strip_server)
 from .protocol import (BaseProtocolPart,
+                       PrintProtocolPart,
                        TestharnessProtocolPart,
                        Protocol,
                        SelectorProtocolPart,
@@ -317,6 +319,53 @@ class WebDriverTestharnessProtocolPart(TestharnessProtocolPart):
                 pass
 
 
+class WebDriverPrintProtocolPart(PrintProtocolPart):
+    CM_PER_INCH = 2.54
+
+    def setup(self):
+        self.webdriver = self.parent.webdriver
+        self.runner_handle = None
+
+    def load_runner(self):
+        url = urljoin(self.parent.executor.server_url("http"), "/print_pdf_runner.html")
+        self.logger.debug("Loading %s" % url)
+        try:
+            self.webdriver.url = url
+        except Exception as e:
+            self.logger.critical(
+                "Loading initial page %s failed. Ensure that the "
+                "there are no other programs bound to this port and "
+                "that your firewall rules or network setup does not "
+                "prevent access.\n%s" % (url, traceback.format_exc(e)))
+            raise
+        self.runner_handle = self.webdriver.window_handle
+
+    def render_as_pdf(self, width, height):
+        # All units passed to `print()` are in cm. See [0] for testing specifications.
+        #
+        # [0]: https://web-platform-tests.org/writing-tests/print-reftests.html
+        margin = 0.5 * self.CM_PER_INCH
+        pdf_base64 = self.webdriver.print(page={"width": width, "height": height},
+                                          margin={"top": margin, "right": margin, "bottom": margin,
+                                                  "left": margin},
+                                          background=True,
+                                          shrink_to_fit=False)
+        return pdf_base64
+
+    def pdf_to_png(self, pdf_base64, ranges):
+        handle = self.webdriver.window_handle
+        self.webdriver.window_handle = self.runner_handle
+        try:
+            rv = self.webdriver.execute_async_script("""
+let callback = arguments[arguments.length - 1];
+render('%s').then(result => callback(result))""" % pdf_base64)
+            page_numbers = get_pages(ranges, len(rv))
+            rv = [item for i, item in enumerate(rv) if i + 1 in page_numbers]
+            return rv
+        finally:
+            self.webdriver.window_handle = handle
+
+
 class WebDriverSelectorProtocolPart(SelectorProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
@@ -380,6 +429,7 @@ class WebDriverWindowProtocolPart(WindowProtocolPart):
     def get_rect(self):
         self.logger.info("Getting rect")
         return self.webdriver.window.rect
+
 
 class WebDriverSendKeysProtocolPart(SendKeysProtocolPart):
     def setup(self):
@@ -487,6 +537,7 @@ class WebDriverSPCTransactionsProtocolPart(SPCTransactionsProtocolPart):
         body = {"mode": mode}
         return self.webdriver.send_session_command("POST", "secure-payment-confirmation/set-mode", body)
 
+
 class WebDriverRPHRegistrationsProtocolPart(RPHRegistrationsProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
@@ -494,6 +545,7 @@ class WebDriverRPHRegistrationsProtocolPart(RPHRegistrationsProtocolPart):
     def set_rph_registration_mode(self, mode):
         body = {"mode": mode}
         return self.webdriver.send_session_command("POST", "custom-handlers/set-mode", body)
+
 
 class WebDriverFedCMProtocolPart(FedCMProtocolPart):
     def setup(self):
@@ -551,6 +603,7 @@ class WebDriverVirtualSensorPart(VirtualSensorProtocolPart):
     def get_virtual_sensor_information(self, sensor_type):
         return self.webdriver.send_session_command("GET", "sensor/%s" % sensor_type)
 
+
 class WebDriverDevicePostureProtocolPart(DevicePostureProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
@@ -562,12 +615,14 @@ class WebDriverDevicePostureProtocolPart(DevicePostureProtocolPart):
     def clear_device_posture(self):
         return self.webdriver.send_session_command("DELETE", "deviceposture")
 
+
 class WebDriverStorageProtocolPart(StorageProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
 
     def run_bounce_tracking_mitigations(self):
         return self.webdriver.send_session_command("DELETE", "storage/run_bounce_tracking_mitigations")
+
 
 class WebDriverVirtualPressureSourceProtocolPart(VirtualPressureSourceProtocolPart):
     def setup(self):
@@ -585,9 +640,11 @@ class WebDriverVirtualPressureSourceProtocolPart(VirtualPressureSourceProtocolPa
     def remove_virtual_pressure_source(self, source_type):
         return self.webdriver.send_session_command("DELETE", "pressuresource/%s" % source_type)
 
+
 class WebDriverProtocol(Protocol):
     enable_bidi = False
     implements = [WebDriverBaseProtocolPart,
+                  WebDriverPrintProtocolPart,
                   WebDriverTestharnessProtocolPart,
                   WebDriverSelectorProtocolPart,
                   WebDriverAccessibilityProtocolPart,
@@ -1043,6 +1100,51 @@ class WebDriverRefTestExecutor(RefTestExecutor):
             screenshot = screenshot.split(",", 1)[1]
 
         return screenshot
+
+
+class WebDriverPrintRefTestExecutor(WebDriverRefTestExecutor):
+    is_print = True
+
+    def setup(self, runner, protocol=None):
+        super().setup(runner, protocol)
+        self.protocol.pdf_print.load_runner()
+        self.has_window = False
+        with open(os.path.join(here, "reftest.js")) as f:
+            self.script = f.read()
+
+    def screenshot(self, test, viewport_size, dpi, page_ranges):
+        # https://github.com/web-platform-tests/wpt/issues/7140
+        assert dpi is None
+
+        if not self.has_window:
+            self.protocol.base.execute_script(self.script)
+            self.protocol.base.set_window(self.protocol.webdriver.handles[-1])
+            self.has_window = True
+
+        self.viewport_size = viewport_size
+        self.page_ranges = page_ranges.get(test.url)
+        timeout = self.timeout_multiplier * test.timeout if self.debug_info is None else None
+        test_url = self.test_url(test)
+
+        return WebDriverRun(self.logger,
+                            self._render,
+                            self.protocol,
+                            test_url,
+                            timeout,
+                            self.extra_timeout).run()
+
+    def _render(self, protocol, url, timeout):
+        protocol.webdriver.url = url
+        protocol.base.execute_script(self.wait_script, asynchronous=True)
+
+        pdf = protocol.pdf_print.render_as_pdf(*self.viewport_size)
+        screenshots = protocol.pdf_print.pdf_to_png(pdf, self.page_ranges)
+        for i, screenshot in enumerate(screenshots):
+            # strip off the data:img/png, part of the url
+            if screenshot.startswith("data:image/png;base64,"):
+                screenshots[i] = screenshot.split(",", 1)[1]
+
+        return screenshots
 
 
 class WebDriverCrashtestExecutor(CrashtestExecutor):


### PR DESCRIPTION
Most of the implementation is lifted verbatim from an existing `chromedriver` one, except the nonstandard CDP call in `render_as_pdf()` is replaced by an equivalent one to [WebDriver's "print page"][0].

`shrinkToFit` is actually a WebDriver parameter, not a CDP one, so this PR also fixes [some incorrectly scaled screenshots][1].

Fixes #48237

[0]: https://www.w3.org/TR/webdriver/#print-page
[1]: https://crbug.com/366293137