### PR TITLE
Remove inconsistent subtests from color-valid-relative-color.html

### DIFF
--- a/css/css-color/parsing/color-valid-relative-color.html
+++ b/css/css-color/parsing/color-valid-relative-color.html
@@ -755,10 +755,6 @@
     fuzzy_test_valid_color(`lch(from var(--mycolor) l 0 h)`);
     fuzzy_test_valid_color(`var(--mygray)`);
     fuzzy_test_valid_color(`lch(from var(--mygray) l 30 h)`);
-
-    // Ensure that converting between legacy and modern sRGB color spaces work as expected.
-    fuzzy_test_valid_color(`color(from rebeccapurple srgb r g b)`, `color(srgb 0.4 0.2 0.6)`, 0.01);
-    fuzzy_test_valid_color(`rgb(from color(srgb 0.4 0.2 0.6) r g b)`, `color(srgb 0.4 0.2 0.6)`, 0.01);
 </script>
 </body>
 </html>


### PR DESCRIPTION
As discussed in #48203:

These two cases expect relative colors to be resolved at parse time when it's possible to do so. However, the rest of the cases in this test have been updated per [w3c/csswg-drafts#10328](https://github.com/w3c/csswg-drafts/issues/10328) to expect declared values of relative colors to preserve their original forms.

The cases tested that both rgb and color(srgb both result in color(srgb, but this is not valid any more for specified colors. We already have coverage of the same scenario for computed colors in color-computed-relative-color.html, so these subtests can be removed.