### PR TITLE
Test color inheritance on the hr element

### DIFF
--- a/html/rendering/non-replaced-elements/the-hr-element-0/color-inheritance-ref.html
+++ b/html/rendering/non-replaced-elements/the-hr-element-0/color-inheritance-ref.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<title>The hr element: color inheritance reference</title>
+<body>
+<!-- Should inherit color via inherit -->
+<style>
+  #parent-inherit hr.color {
+    color: green;
+    border-color: green;
+  }
+  #parent-inherit hr.border-color {
+    border-color: green;
+  }
+</style>
+<div id="parent-inherit">
+  <hr class="color">
+  <hr class="border-color">
+</div>
+<!-- Should inherit color via currentColor -->
+<style>
+   #parent-currentcolor hr {
+    color: green;
+    border-color: green;
+  }
+</style>
+<div id="parent-currentcolor">
+  <hr>
+</div>
+</body>

--- a/html/rendering/non-replaced-elements/the-hr-element-0/color-inheritance.html
+++ b/html/rendering/non-replaced-elements/the-hr-element-0/color-inheritance.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<title>The hr element: color inheritance</title>
+<link rel="match" href="color-inheritance-ref.html">
+<body>
+<!-- Should inherit color via inherit -->
+<style>
+  #parent-inherit {
+    color: green;
+    border-color: green;
+  }
+  #parent-inherit hr.color {
+    color: inherit;
+  }
+  #parent-inherit hr.border-color {
+    border-color: inherit;
+  }
+</style>
+<div id="parent-inherit">
+  <hr class="color">
+  <hr class="border-color">
+</div>
+<!-- Should inherit color via currentColor -->
+<style>
+   #parent-currentcolor {
+    color: green;
+  }
+  #parent-currentcolor hr {
+    color: currentColor;
+  }
+</style>
+<div id="parent-currentcolor">
+  <hr>
+</div>
+</body>


### PR DESCRIPTION
It should be possible to make the hr element inherit the color of its parent, but this behavior is not supported in Chromium. 

This PR adds a test for that specific behavior. It passes in Firefox and Webkit while failing in Chromium.

Specification: https://html.spec.whatwg.org/multipage/rendering.html#the-hr-element-2