### PR TITLE
Don't pass --enable-xss-auditor to webkitgtk_minibrowser

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
+++ b/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
@@ -42,7 +42,6 @@ def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
 def capabilities(server_config, **kwargs):
     browser_required_args = ["--automation",
                              "--javascript-can-open-windows-automatically=true",
-                             "--enable-xss-auditor=false",
                              "--enable-media-capabilities=true",
                              "--enable-encrypted-media=true",
                              "--enable-media-stream=true",


### PR DESCRIPTION
This option was deprecated and has now been removed from recent versions of webkitgtk_minibrowser (which will cause the browser to not start if the option is given.)