### PR TITLE
[WebDriver BiDi] `browsingContext.traverseHistory` only for top-level navigables

### DIFF
--- a/webdriver/tests/bidi/browsing_context/traverse_history/context.py
+++ b/webdriver/tests/bidi/browsing_context/traverse_history/context.py
@@ -26,30 +26,3 @@ async def test_top_level_contexts(
 
     await wait_for_url(top_context["context"], pages[1])
     await wait_for_url(new_tab["context"], pages[0])
-
-
-@pytest.mark.parametrize("domain", ["", "alt"], ids=["same_origin", "cross_origin"])
-async def test_iframe(bidi_session, current_url, wait_for_url, new_tab, inline, domain):
-    iframe_url_1 = inline("page 1")
-    page_url = inline(f"<iframe src='{iframe_url_1}'></iframe>", domain=domain)
-
-    await bidi_session.browsing_context.navigate(
-        context=new_tab["context"], url=page_url, wait="complete"
-    )
-    assert await current_url(new_tab["context"]) == page_url
-
-    contexts = await bidi_session.browsing_context.get_tree(root=new_tab["context"])
-    iframe_context = contexts[0]["children"][0]
-
-    iframe_url_2 = inline("page 2")
-    await bidi_session.browsing_context.navigate(
-        context=iframe_context["context"], url=iframe_url_2, wait="complete"
-    )
-    assert await current_url(iframe_context["context"]) == iframe_url_2
-
-    await bidi_session.browsing_context.traverse_history(
-        context=iframe_context["context"], delta=-1
-    )
-
-    await wait_for_url(new_tab["context"], page_url)
-    await wait_for_url(iframe_context["context"], iframe_url_1)

--- a/webdriver/tests/bidi/browsing_context/traverse_history/invalid.py
+++ b/webdriver/tests/bidi/browsing_context/traverse_history/invalid.py
@@ -44,12 +44,9 @@ async def test_delta_invalid_value(bidi_session, current_url, new_tab, inline, v
         )
 
 
-@pytest.mark.parametrize("domain", ["", "alt"],
-                         ids=["same_origin", "cross_origin"])
-async def test_iframe(bidi_session, current_url, wait_for_url, new_tab, inline,
-      domain):
+async def test_iframe(bidi_session, current_url, wait_for_url, new_tab, inline):
     iframe_url_1 = inline("page 1")
-    page_url = inline(f"<iframe src='{iframe_url_1}'></iframe>", domain=domain)
+    page_url = inline(f"<iframe src='{iframe_url_1}'></iframe>")
 
     await bidi_session.browsing_context.navigate(
         context=new_tab["context"], url=page_url, wait="complete"

--- a/webdriver/tests/bidi/browsing_context/traverse_history/invalid.py
+++ b/webdriver/tests/bidi/browsing_context/traverse_history/invalid.py
@@ -42,3 +42,31 @@ async def test_delta_invalid_value(bidi_session, current_url, new_tab, inline, v
         await bidi_session.browsing_context.traverse_history(
             context=new_tab["context"], delta=value
         )
+
+
+@pytest.mark.parametrize("domain", ["", "alt"],
+                         ids=["same_origin", "cross_origin"])
+async def test_iframe(bidi_session, current_url, wait_for_url, new_tab, inline,
+      domain):
+    iframe_url_1 = inline("page 1")
+    page_url = inline(f"<iframe src='{iframe_url_1}'></iframe>", domain=domain)
+
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"], url=page_url, wait="complete"
+    )
+    assert await current_url(new_tab["context"]) == page_url
+
+    contexts = await bidi_session.browsing_context.get_tree(
+        root=new_tab["context"])
+    iframe_context = contexts[0]["children"][0]
+
+    iframe_url_2 = inline("page 2")
+    await bidi_session.browsing_context.navigate(
+        context=iframe_context["context"], url=iframe_url_2, wait="complete"
+    )
+    assert await current_url(iframe_context["context"]) == iframe_url_2
+
+    with pytest.raises(error.InvalidArgumentException):
+        await bidi_session.browsing_context.traverse_history(
+            context=iframe_context["context"], delta=-1
+        )

--- a/webdriver/tests/bidi/browsing_context/traverse_history/invalid.py
+++ b/webdriver/tests/bidi/browsing_context/traverse_history/invalid.py
@@ -54,17 +54,10 @@ async def test_iframe(bidi_session, current_url, wait_for_url, new_tab, inline,
     await bidi_session.browsing_context.navigate(
         context=new_tab["context"], url=page_url, wait="complete"
     )
-    assert await current_url(new_tab["context"]) == page_url
 
     contexts = await bidi_session.browsing_context.get_tree(
         root=new_tab["context"])
     iframe_context = contexts[0]["children"][0]
-
-    iframe_url_2 = inline("page 2")
-    await bidi_session.browsing_context.navigate(
-        context=iframe_context["context"], url=iframe_url_2, wait="complete"
-    )
-    assert await current_url(iframe_context["context"]) == iframe_url_2
 
     with pytest.raises(error.InvalidArgumentException):
         await bidi_session.browsing_context.traverse_history(


### PR DESCRIPTION
Align with spec changes introduced in https://github.com/w3c/webdriver-bidi/pull/770