### PR TITLE
WebVTT parser.py: collect_timestamp(), fix limit for minutes, seconds

### DIFF
--- a/webvtt/parsing/file-parsing/tools/parser.py
+++ b/webvtt/parsing/file-parsing/tools/parser.py
@@ -678,7 +678,7 @@ class VTTCueParser(W3CParser):
         value_4 = int(string)
 
         # 17.
-        if value_2 >= 59 or value_3 >= 59:
+        if value_2 > 59 or value_3 > 59:
             return None
 
         # 18.


### PR DESCRIPTION
`VTTCueParser.collect_timestamp()` does not allow for value of 59 for minutes / seconds.

https://github.com/web-platform-tests/wpt/blob/203d2ac45900139633d4f3f29750ea4b5e06d6f5/webvtt/parsing/file-parsing/tools/parser.py#L680-L682
