### PR TITLE
[wptrunner] Guard against no browser during `TestRunnerManager` cleanup

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -957,7 +957,8 @@ class TestRunnerManager(threading.Thread):
             self._ensure_runner_stopped()
             # TODO(web-platform-tests/wpt#48030): Consider removing the
             # `stop(force=...)` argument.
-            self.browser.stop(force=True)
+            if self.browser:
+                self.browser.stop(force=True)
         except (OSError, PermissionError):
             self.logger.error("Failed to stop either the runner or the browser process",
                               exc_info=True)


### PR DESCRIPTION
Even with no browser, `stop_runner()` should still call `cleanup()` in case there are other resources to clean up.

Fixes #48263