### PR TITLE
Assert relative changes in `history.length` in `same-url.html`

### DIFF
--- a/html/browsers/browsing-the-web/history-traversal/same-url.html
+++ b/html/browsers/browsing-the-web/history-traversal/same-url.html
@@ -6,30 +6,31 @@
 <script>
 async_test((t) => {
   let state = "begin"
+  let initialLength = history.length
+
   self[0].frameElement.onload = t.step_func(() => {
     if(state === "b first") {
-      assert_equals(history.length, 2)
+      assert_equals(history.length, initialLength + 1, state)
 
       state = "c first"
       navigateFrameAfterDelay(t, "resources/c.html")
     } else if (state === "c first") {
-      assert_equals(history.length, 3)
+      assert_equals(history.length, initialLength + 2, state)
 
       state = "a second"
       history.back(2)
     } else if (state === "a second") {
-      assert_equals(history.length, 3)
+      assert_equals(history.length, initialLength + 2, state)
 
       state = "a third"
       navigateFrameAfterDelay(t, "resources/a.html")
     } else if (state === "a third") {
-      assert_equals(history.length, 3)
+      assert_equals(history.length, initialLength + 2, state)
       t.done()
     }
   })
   onload = t.step_func(() => {
     assert_equals(state, "begin")
-    assert_equals(history.length, 1)
 
     state = "b first"
 


### PR DESCRIPTION
All browsers except Firefox spuriously [fail the precondition in `onload`][0] because their history [includes `about:blank`][2] ([initially loaded by WebDriver][1]), followed by `same-url.html`. Avoid encoding this implementation detail in the test.

Also, add the test state to each assertion to make failure more informative.

[0]: https://wpt.fyi/results/html/browsers/browsing-the-web/history-traversal/same-url.html?run_id=5145442707046400&run_id=5078811356168192&run_id=5154571592925184&run_id=6326848455966720
[1]: https://www.w3.org/TR/webdriver/#new-window
[2]: https://github.com/web-platform-tests/wpt/blob/3939cbfd/tools/wptrunner/wptrunner/executors/executorwebdriver.py#L811-L818