### PR TITLE
Fix inclusion of fetch_tests_from_{window,worker} into docs

### DIFF
--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -352,7 +352,7 @@ preferable if the entire test is optional.
 ### Consolidating tests from other documents ###
 
 ```eval_rst
-.. js::autofunction fetch_tests_from_window
+.. js:autofunction:: fetch_tests_from_window
 ```
 
 **Note:** By default any markup file referencing `testharness.js` will
@@ -408,7 +408,7 @@ Here's an example that uses `window.open`.
 ### Web Workers ###
 
 ```eval_rst
-.. js:autofunction fetch_tests_from_worker
+.. js:autofunction:: fetch_tests_from_worker
 ```
 
 The `testharness.js` script can be used from within [dedicated workers, shared


### PR DESCRIPTION
This fixes a couple of bits of #48314, but leaves the rest still be to fixed.