### PR TITLE
Sync with SVG2 for removed properties

### DIFF
--- a/css/css-variables/variable-presentation-attribute.html
+++ b/css/css-variables/variable-presentation-attribute.html
@@ -51,8 +51,8 @@
         });
 
         let testproperties = [
-            { property: "alignment-baseline", valuesToTest:["baseline", "before-edge", "text-before-edge", "middle", "central", "after-edge", "text-after-edge", "ideographic", "alphabetic", "hanging", "mathematical"], default: "baseline" },
-            { property: "baseline-shift", valuesToTest:["baseline", "sub", "super", "13%", "28px"], default: "baseline" },
+            { property: "alignment-baseline", valuesToTest:["baseline", "before-edge", "text-before-edge", "middle", "central", "after-edge", "text-after-edge", "ideographic", "alphabetic", "hanging", "mathematical"], default: "" },
+            { property: "baseline-shift", valuesToTest:["baseline", "sub", "super", "13%", "28px"], default: "" },
             { property: "clip-rule", valuesToTest:["nonzero", "evenodd"], default: "nonzero" },
             { property: "color", valuesToTest:["rgb(128, 0, 128)"], default: "rgb(0, 0, 0)" },
             { property: "color-interpolation-filters", valuesToTest:["auto", "sRGB", "linearRGB"], default: "" },
@@ -72,9 +72,9 @@
             { property: "font-stretch", valuesToTest:["100%", "50%", "62.5%", "75%", "87.5%", "112.5%", "125%", "150%", "200%"], default: "100%" },
             { property: "font-style", valuesToTest:["normal", "italic"], default: "normal" },
             { property: "font-weight", valuesToTest:["100", "200", "300", "400", "500", "600", "700", "800", "900"], default: "400" },
-            { property: "glyph-orientation-horizontal", valuesToTest:["13deg"], default: "0deg" },
-            { property: "glyph-orientation-vertical", valuesToTest:["auto", "19deg"], default: "auto" },
-            { property: "kerning", valuesToTest:["auto", "15"], default: "auto" },
+            { property: "glyph-orientation-horizontal", valuesToTest:["13deg"], default: "" },
+            { property: "glyph-orientation-vertical", valuesToTest:["auto", "19deg"], default: "" },
+            { property: "kerning", valuesToTest:["auto", "15"], default: "" },
             { property: "letter-spacing", valuesToTest:["normal", "21px"], default: "normal" },
             { property: "lighting-color", valuesToTest:["currentColor", "pink"], default: "" },
             { property: "opacity", valuesToTest:["0.11"], default: "1" },


### PR DESCRIPTION
Hi Team,

This is an update to test for few bits:

`alignment-baseline` - removed from Firefox and SVG2 [1]

[1] https://svgwg.org/svg2-draft/text.html#AlignmentBaselineProperty

So this updates it to return `empty` instead of default.

`baseline-shift` - removed from Firefox and SVG2 [2]

[2] https://svgwg.org/svg2-draft/text.html#BaselineShiftProperty

So this updates it to return `empty` instead of default.

`glyph-orientation-horizontal` and `glyph-orientation-vertical` - removed from Chrome, Firefox and SVG2 [3]

[3] https://svgwg.org/svg2-draft/text.html#GlyphOrientationHorizontalProperty and https://svgwg.org/svg2-draft/text.html#GlyphOrientationVerticalProperty

`kerning` - removed from Chrome, Firefox, Safari and SVG2 [4]

[4] https://svgwg.org/svg2-draft/text.html#KerningProperty

___

We can also remove them completely but I think still showing-up them as failure for browser engines, which haven't removed, is better for tracking.

Thanks!