### PR TITLE
Remove mentions of script inclusion that does not exist

### DIFF
--- a/console/idlharness.any.js
+++ b/console/idlharness.any.js
@@ -1,4 +1,3 @@
-// META: script=/resources/WebIDLParser.js
 // META: script=/resources/idlharness.js
 
 // https://console.spec.whatwg.org/

--- a/encoding/idlharness.any.js
+++ b/encoding/idlharness.any.js
@@ -1,5 +1,4 @@
 // META: global=window,worker
-// META: script=/resources/WebIDLParser.js
 // META: script=/resources/idlharness.js
 
 idl_test(


### PR DESCRIPTION
I am currently working on running the WPT on a JavaScript engine ([Boa](https://boajs.dev)). Loading scripts that don't exist results in a test failure, and I'd like to avoid that.

I cannot find the `WebIDLParser.js` file anywhere.