### PR TITLE
Expand tests with deprecated values `reset` and `invalid` to validate

### DIFF
--- a/css/css-viewport/zoom/parsing/zoom-valid.html
+++ b/css/css-viewport/zoom/parsing/zoom-valid.html
@@ -20,6 +20,8 @@ test_valid_value("zoom", "75%");
 test_valid_value("zoom", "0.5");
 
 test_invalid_value("zoom", "auto");
+test_invalid_value("zoom", "reset");
+test_invalid_value("zoom", "document");
 test_invalid_value("zoom", "-100%");
 test_invalid_value("zoom", "-200%");
 test_invalid_value("zoom", "-1");


### PR DESCRIPTION
Hi Team,

In non-standard `zoom` implementation, these used to be two values and also supported currently by WebKit, these were removed by Blink in 2017.

It is good to expand test, so adding them here.

I am tackling to remove them from WebKit in PR - https://github.com/WebKit/WebKit/pull/34402

Just doing PR to add these addition upstream.

Thanks!