### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=280648

### DIFF
--- a/css/css-anchor-position/anchor-parse-invalid.html
+++ b/css/css-anchor-position/anchor-parse-invalid.html
@@ -18,6 +18,8 @@ test_invalid_value('top', 'anchor(--foo top,)');
 test_invalid_value('top', 'anchor(--foo top bottom)');
 test_invalid_value('top', 'anchor(--foo top, 10px 20%)');
 test_invalid_value('top', 'anchor(--foo top, 10px, 20%)');
+test_invalid_value('top', 'anchor(2 * 20%)');
+test_invalid_value('top', 'anchor((2 * 20%))');
 
 // Anchor name must be a dashed ident
 test_invalid_value('top', 'anchor(foo top)');

--- a/css/css-anchor-position/anchor-parse-valid.html
+++ b/css/css-anchor-position/anchor-parse-valid.html
@@ -36,6 +36,8 @@ const anchorSides = [
   'self-end',
   'center',
   '50%',
+  'calc(50%)',
+  'min(50%, 100%)',
 ];
 
 const fallbacks = [


### PR DESCRIPTION
WebKit export from bug: [\[css-anchor-position-1\] Parse anchor argument as `<percent>` instead of `<percent-token>`](https://bugs.webkit.org/show_bug.cgi?id=280648)