### PR TITLE
[css-properties-values-api] : add a test for registered properties with `initial-value` only for `<url>`

### DIFF
--- a/css/css-properties-values-api/support/main/main.css
+++ b/css/css-properties-values-api/support/main/main.css
@@ -20,3 +20,15 @@
     --unreg-multi-ref-to-reg-urls: var(--reg-non-inherited-url), var(--reg-alt-non-inherited-url);
     --unreg-multi-ref-to-reg-funcs: var(--reg-non-inherited-func), var(--reg-alt-non-inherited-func);
 }
+
+@property --reg-non-inherited-initial-value-only-url {
+    syntax: '<url>';
+    inherits: true;
+    initial-value: url(foo.jpg);
+}
+
+@property --reg-non-inherited-initial-value-only-func {
+    syntax: '<url>';
+    inherits: true;
+    initial-value: url("foo.jpg");
+}

--- a/css/css-properties-values-api/url-resolution.html
+++ b/css/css-properties-values-api/url-resolution.html
@@ -9,8 +9,8 @@
 <link id="main" rel="stylesheet" type="text/css" href="support/main/main.css" />
 <link id="main_utf16be" rel="stylesheet" type="text/css" href="support/main/main.utf16be.css" />
 <link id="alt" rel="stylesheet" type="text/css" href="support/alt/alt.css" />
-<div id=target>
-    <div id=inner></div>
+<div id="target">
+    <div id="inner"></div>
 </div>
 <script>
 function parse_url(urlstr) {
@@ -133,5 +133,15 @@ test(function() {
     target.style = 'background-image: var(--reg-utf16be-func);';
     assert_base_path_equal(get_bg_url(target), main_utf16be.sheet.href);
 }, 'Registered UTF16BE-encoded var reference resolve against sheet (URL function)');
+
+test(function () {
+    target.style = 'background-image: var(--reg-non-inherited-initial-value-only-url);';
+    assert_base_path_equal(get_bg_url(target), document.baseURI);
+}, 'Registered non-inherited <url> with only an initial value resolves against document (URL token)');
+
+test(function () {
+    target.style = 'background-image: var(--reg-non-inherited-initial-value-only-func);';
+    assert_base_path_equal(get_bg_url(target), document.baseURI);
+}, 'Registered non-inherited <url>  with only an initial value resolves against document (URL function)');
 
 </script>


### PR DESCRIPTION
Chrome and Safari pass these new tests, Firefox fails it.

spec url: https://drafts.css-houdini.org/css-properties-values-api-1/#registered-custom-property