### PR TITLE
Add test case for DOM XPath behavior with root element adjacent nodes

### DIFF
--- a/domxpath/domxpath-root-element-adjacent-nodes.html
+++ b/domxpath/domxpath-root-element-adjacent-nodes.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Test DOM XPath Behavior with Root Element Adjacent Nodes</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+  <div id="root1">Root Element 1</div>
+  <div id="root2">Root Element 2</div>
+
+  <script>
+    test(function() {
+      // XPath expression to find the adjacent node of the first root element
+      var xpathExpression = "/html/body/div[1]/following-sibling::div[1]";
+
+      // Evaluate the XPath expression
+      var result = document.evaluate(xpathExpression, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+
+      // Get the matched node
+      var adjacentNode = result.singleNodeValue;
+
+      // Assert that the matched node is the second root element
+      assert_equals(adjacentNode.id, "root2", "Adjacent node should be the second root element");
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This pull request adds a new test case to verify the correct behavior of DOM XPath when evaluating expressions on root elements and their adjacent nodes. The test case covers the following scenarios:

    Creates two root elements (divs) in the document.
    Uses XPath to find the adjacent node of the first root element.
    Asserts that the found node is the second root element.

This test case helps ensure that the DOM XPath implementation correctly handles adjacent nodes of root elements, which is an important aspect of XPath functionality.