### PR TITLE
Remove obsolete checks for testdriver-internal messages

### DIFF
--- a/event-timing/crossiframe.html
+++ b/event-timing/crossiframe.html
@@ -76,13 +76,10 @@
 
     const childFrameEntriesPromise = new Promise(resolve => {
       window.addEventListener("message", (event) => {
-        // testdriver-complete is a webdriver internal event
-        if (event.data.type != "testdriver-complete") {
-          t.step(() => {
-            validateChildFrameEntries(event.data);
-          });
-          resolve();
-        }
+        t.step(() => {
+          validateChildFrameEntries(event.data);
+        });
+        resolve();
       }, false);
     });
 

--- a/serial/requestPort/sandboxed_iframe.https.window.js
+++ b/serial/requestPort/sandboxed_iframe.https.window.js
@@ -15,10 +15,6 @@ promise_test(async (t) => {
 
   await new Promise(resolve => {
     window.addEventListener('message', t.step_func(messageEvent => {
-      // Ignore internal testdriver.js messages (web-platform-tests/wpt#48326)
-      if ((messageEvent.data.type || '').startsWith('testdriver-')) {
-        return;
-      }
       // The failure message of no device chosen is expected. The point here is
       // to validate not failing because of a sandboxed iframe.
       assert_true(messageEvent.data.includes('NotFoundError'));

--- a/serial/resources/open-in-iframe.html
+++ b/serial/resources/open-in-iframe.html
@@ -13,10 +13,6 @@
   test_driver.set_test_context(parent);
 
   window.onmessage = messageEvent => {
-    // Ignore internal testdriver.js messages (web-platform-tests/wpt#48326)
-    if ((messageEvent.data.type || '').startsWith('testdriver-')) {
-      return;
-    }
     switch (messageEvent.data.type) {
       case 'GetPorts':
         navigator.serial.getPorts()


### PR DESCRIPTION
No longer necessary after fixing #48326.