### PR TITLE
[wptrunner] Resolve config paths relative to stable locations

### DIFF
--- a/tools/wptrunner/wptrunner/config.py
+++ b/tools/wptrunner/wptrunner/config.py
@@ -29,7 +29,8 @@ def read(config_path: str) -> Mapping[str, ConfigDict]:
     success = parser.read(config_path)
     assert config_path in success, success
 
-    subns = {"pwd": os.path.abspath(os.path.curdir)}
+    subns = {"pwd": os.path.abspath(os.path.curdir),
+             "dir": os.path.abspath(os.path.dirname(config_path))}
 
     rv = OrderedDict()
     for section in parser.sections():

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -213,6 +213,13 @@ class TestEnvironment:
         config.server_host = self.options.get("server_host", None)
         config.doc_root = serve_path(self.test_paths)
         config.inject_script = self.inject_script
+        # Resolve `local-dir` relative to the main test root instead of `wpt
+        # run`'s CWD, which can be unstable between different users. Absolute
+        # paths are passed through as-is.
+        config.aliases = [{
+            **alias,
+            "local-dir": os.path.normpath(os.path.join(config.doc_root, alias["local-dir"])),
+        } for alias in config.aliases]
 
         if self.suppress_handler_traceback is not None:
             config.logging["suppress_handler_traceback"] = self.suppress_handler_traceback


### PR DESCRIPTION
This is a more sensible default because the checked-in file structure is more stable than wherever the user happens to invoke `wpt run`.

In Chromium, developers working locally and CI bots may invoke `wpt run` from any directory. The script wrapping `wpt run` would first [`chdir()` to a known location][1] for `serve` to find Chromium's `testdriver-vendor.js`, but [this hack inevitably broke][0].

[0]: https://crbug.com/360008882
[1]: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/tools/blinkpy/wpt_tests/wpt_adapter.py;l=557-567;drc=365358d09a7a9715e8e384021f75c4413b010ad6;bpv=0;bpt=0