### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=280889

### DIFF
--- a/scroll-animations/scroll-timelines/duration.html
+++ b/scroll-animations/scroll-timelines/duration.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>ScrollTimeline.duration</title>
+<link rel="help" href="https://drafts.csswg.org/web-animations-2/#dom-animationtimeline-duration">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+
+test(t => {
+  const timeline = new ScrollTimeline();
+  assert_equals(timeline.duration.toString(), '100%');
+}, 'The duration of a scroll timeline is 100%');
+
+</script>

--- a/scroll-animations/view-timelines/duration.html
+++ b/scroll-animations/view-timelines/duration.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>ViewTimeline.duration</title>
+<link rel="help" href="https://drafts.csswg.org/web-animations-2/#dom-animationtimeline-duration">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+
+test(t => {
+  const timeline = new ViewTimeline();
+  assert_equals(timeline.duration.toString(), '100%');
+}, 'The duration of a view timeline is 100%');
+
+</script>

--- a/web-animations/interfaces/DocumentTimeline/duration.tentative.html
+++ b/web-animations/interfaces/DocumentTimeline/duration.tentative.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>DocumentTimeline.duration</title>
+<link rel="help" href="https://drafts.csswg.org/web-animations-2/#dom-animationtimeline-duration">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../testcommon.js"></script>
+<script src="../../resources/timing-override.js"></script>
+<body>
+<div id="log"></div>
+<script>
+'use strict';
+
+test(t => {
+  const timeline = new DocumentTimeline();
+  assert_equals(timeline.duration, null);
+}, 'A document timeline does not have a duration');
+
+</script>
+</body>


### PR DESCRIPTION
WebKit export from bug: [\[scroll-animations\] implement `AnimationTimeline.duration`](https://bugs.webkit.org/show_bug.cgi?id=280889)