### PR TITLE
[wptrunner] Support testdriver.js in {ref,print-ref,crash}tests

### DIFF
--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -13,8 +13,12 @@ written purely using web platform APIs. Outside of automation
 contexts, it allows human operators to provide expected input
 manually (for operations which may be described in simple terms).
 
-It is currently supported only for [testharness.js](testharness)
-tests.
+testdriver.js supports the following test types:
+* [testharness.js](testharness) tests
+* [reftests](reftests) and [print-reftests](print-reftests) that use the
+  `class=reftest-wait` attribute on the root element to control completion
+* [crashtests](crashtest) that use the `class=test-wait` attribute to control
+  completion
 
 ## Markup ##
 

--- a/infrastructure/crashtests/testdriver.html
+++ b/infrastructure/crashtests/testdriver.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<title>crashtests support testdriver.js</title>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<button>Complete the test</button>
+<script>
+  const button = document.querySelector("button");
+  button.addEventListener("click", () => {
+    document.documentElement.classList.remove("test-wait");
+  });
+  test_driver.click(button);
+</script>

--- a/infrastructure/metadata/infrastructure/reftest/testdriver-in-ref.html.ini
+++ b/infrastructure/metadata/infrastructure/reftest/testdriver-in-ref.html.ini
@@ -1,0 +1,5 @@
+[testdriver-in-ref.html]
+  disabled:
+    # https://github.com/web-platform-tests/wpt/issues/13183
+    if product == "firefox" or product == "firefox_android":
+      "marionette executor doesn't currently implement testdriver for reftests"

--- a/infrastructure/reftest/testdriver-child.html
+++ b/infrastructure/reftest/testdriver-child.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+  :root {
+    background-color: red;
+  }
+</style>
+<button>Turn green</button>
+<script>
+  test_driver.set_test_context(parent);
+  const button = document.querySelector("button");
+  button.addEventListener("click", () => {
+    button.remove();
+    document.documentElement.style.backgroundColor = "green";
+    test_driver.message_test("done");
+  });
+  test_driver.click(button);
+</script>

--- a/infrastructure/reftest/testdriver-iframe.sub.html
+++ b/infrastructure/reftest/testdriver-iframe.sub.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>reftests support testdriver.js in iframes</title>
+<link rel="match" href="green.html">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+  body {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+  }
+  iframe {
+    position: absolute;
+    border: none;
+    width: inherit;
+    height: inherit;
+  }
+</style>
+<script>
+  // Attach the handler that completes the test before loading the calling iframe.
+  window.addEventListener("message", (evt) => {
+    if (evt.data === "done") {
+      document.documentElement.classList.remove("reftest-wait");
+    }
+  });
+</script>
+<iframe src="https://{{host}}:{{ports[https][1]}}/infrastructure/reftest/testdriver-child.html"></iframe>

--- a/infrastructure/reftest/testdriver-in-ref.html
+++ b/infrastructure/reftest/testdriver-in-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<title>references support testdriver.js</title>
+<link rel="match" href="testdriver.html">
+<style>
+  :root {background-color:green}
+</style>

--- a/infrastructure/reftest/testdriver-print.html
+++ b/infrastructure/reftest/testdriver-print.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>print-reftests support testdriver.js</title>
+<link rel="match" href="reftest_match-print-ref.html">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+  * { margin: 0; padding: 0; }
+  div { page-break-after: always; }
+</style>
+<button>Add a page</button>
+<div>page 1</div>
+<script>
+  const button = document.querySelector("button");
+  button.addEventListener("click", () => {
+    button.remove();
+    const page2 = document.createElement("div");
+    page2.innerText = "page 2";
+    document.body.appendChild(page2);
+    document.documentElement.classList.remove("reftest-wait");
+  });
+  test_driver.click(button);
+</script>

--- a/infrastructure/reftest/testdriver.html
+++ b/infrastructure/reftest/testdriver.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>reftests support testdriver.js</title>
+<link rel="match" href="green.html">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+  :root {
+    background-color: red;
+  }
+</style>
+<button>Turn green</button>
+<script>
+  const button = document.querySelector("button");
+  button.addEventListener("click", () => {
+    button.remove();
+    document.documentElement.style.backgroundColor = "green";
+    document.documentElement.classList.remove("reftest-wait");
+  });
+  test_driver.click(button);
+</script>

--- a/lint.ignore
+++ b/lint.ignore
@@ -769,6 +769,12 @@ HTML INVALID SYNTAX: quirks/percentage-height-calculation.html
 HTML INVALID SYNTAX: trusted-types/TrustedTypePolicyFactory-getAttributeType-namespace.html
 
 # Tests which include testdriver.js but aren't testharness.js tests
+# TODO(web-platform-tests/wpt#13183): Remove this rule once support is added.
+TESTDRIVER-IN-UNSUPPORTED-TYPE: infrastructure/crashtests/testdriver.html
+TESTDRIVER-IN-UNSUPPORTED-TYPE: infrastructure/reftest/testdriver.html
+TESTDRIVER-IN-UNSUPPORTED-TYPE: infrastructure/reftest/testdriver-child.html
+TESTDRIVER-IN-UNSUPPORTED-TYPE: infrastructure/reftest/testdriver-iframe.sub.html
+TESTDRIVER-IN-UNSUPPORTED-TYPE: infrastructure/reftest/testdriver-print.html
 TESTDRIVER-IN-UNSUPPORTED-TYPE: css/css-grid/grid-model/grid-layout-stale-001.html
 TESTDRIVER-IN-UNSUPPORTED-TYPE: css/css-grid/grid-model/grid-layout-stale-002.html
 TESTDRIVER-IN-UNSUPPORTED-TYPE: css/css-scroll-anchoring/fullscreen-crash.html

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -166,7 +166,7 @@ class TestharnessTest(URLManifestItem):
         return self._extras.get("pac")
 
     @property
-    def testdriver(self) -> Optional[Text]:
+    def testdriver(self) -> Optional[bool]:
         return self._extras.get("testdriver")
 
     @property
@@ -240,6 +240,10 @@ class RefTest(URLManifestItem):
             rv[key] = v
         return rv
 
+    @property
+    def testdriver(self) -> Optional[bool]:
+        return self._extras.get("testdriver")
+
     def to_json(self) -> Tuple[Optional[Text], List[Tuple[Text, Text]], Dict[Text, Any]]:  # type: ignore
         rel_url = None if self._url == self.path else self._url
         rv: Tuple[Optional[Text], List[Tuple[Text, Text]], Dict[Text, Any]] = (rel_url, self.references, {})
@@ -252,6 +256,8 @@ class RefTest(URLManifestItem):
             extras["dpi"] = self.dpi
         if self.fuzzy:
             extras["fuzzy"] = list(self.fuzzy.items())
+        if self.testdriver:
+            extras["testdriver"] = self.testdriver
         return rv
 
     @classmethod
@@ -314,6 +320,16 @@ class CrashTest(URLManifestItem):
     @property
     def timeout(self) -> Optional[Text]:
         return None
+
+    @property
+    def testdriver(self) -> Optional[bool]:
+        return self._extras.get("testdriver")
+
+    def to_json(self):  # type: ignore
+        rel_url, extras = super().to_json()
+        if self.testdriver:
+            extras["testdriver"] = self.testdriver
+        return rel_url, extras
 
 
 class WebDriverSpecTest(URLManifestItem):

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -946,7 +946,8 @@ class SourceFile:
                     self.tests_root,
                     self.rel_path,
                     self.url_base,
-                    self.rel_url
+                    self.rel_url,
+                    testdriver=self.has_testdriver,
                 )]
 
         elif self.name_is_print_reftest:
@@ -965,6 +966,7 @@ class SourceFile:
                     viewport_size=self.viewport_size,
                     fuzzy=self.fuzzy,
                     page_ranges=self.page_ranges,
+                    testdriver=self.has_testdriver,
                 )]
 
         elif self.name_is_multi_global:
@@ -1065,7 +1067,8 @@ class SourceFile:
                     timeout=self.timeout,
                     viewport_size=self.viewport_size,
                     dpi=self.dpi,
-                    fuzzy=self.fuzzy
+                    fuzzy=self.fuzzy,
+                    testdriver=self.has_testdriver,
                 ))
 
         elif self.content_is_css_visual and not self.name_is_reference:

--- a/tools/manifest/tests/test_manifest.py
+++ b/tools/manifest/tests/test_manifest.py
@@ -335,3 +335,29 @@ def test_manifest_spec_to_json():
             ]}},
         }
     }
+
+
+@pytest.mark.parametrize("testdriver,expected_extra", [
+    (True, {"testdriver": True}),
+    # Don't bloat the manifest with the `testdriver=False` default.
+    (False, {}),
+])
+def test_dump_testdriver(testdriver, expected_extra):
+    m = manifest.Manifest("")
+    source_file = SourceFileWithTest("a" + os.path.sep + "b", "0"*40, item.RefTest,
+                                     testdriver=testdriver)
+
+    tree, sourcefile_mock = tree_and_sourcefile_mocks([(source_file, None, True)])
+    with mock.patch("tools.manifest.manifest.SourceFile", side_effect=sourcefile_mock):
+        assert m.update(tree) is True
+
+    assert m.to_json() == {
+        'version': 9,
+        'url_base': '/',
+        'items': {
+            'reftest': {'a': {'b': [
+                '0000000000000000000000000000000000000000',
+                (mock.ANY, [], expected_extra)
+            ]}},
+        }
+    }

--- a/tools/wptrunner/wptrunner/executors/message-queue.js
+++ b/tools/wptrunner/wptrunner/executors/message-queue.js
@@ -54,15 +54,19 @@
     case "complete":
       var tests = data.tests;
       var status = data.status;
-
-      var subtest_results = tests.map(function(x) {
-        return [x.name, x.status, x.message, x.stack];
-      });
-      payload = [status.status,
-                 status.message,
-                 status.stack,
-                 subtest_results];
-      clearTimeout(window.__wptrunner_timer);
+      if (tests && status) {
+        var subtest_results = tests.map(function(x) {
+          return [x.name, x.status, x.message, x.stack];
+        });
+        payload = [status.status,
+                   status.message,
+                   status.stack,
+                   subtest_results];
+        clearTimeout(window.__wptrunner_timer);
+      } else {
+        // Non-testharness test.
+        payload = [];
+      }
       break;
     case "action":
       payload = data;

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -58,6 +58,15 @@
         event.stopImmediatePropagation();
     });
 
+    const root_classes = document.documentElement.classList;
+    // For non-testharness tests, the presence of `(ref)test-wait` indicates
+    // it's the "main" browsing context through which testdriver actions are
+    // routed. Evaluate this eagerly before the test starts and removes these
+    // classes.
+    if (root_classes.contains("reftest-wait") || root_classes.contains("test-wait")) {
+      window.__wptrunner_is_test_context = true;
+    }
+
     function is_test_context() {
       return !!window.__wptrunner_is_test_context;
     }

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -258,24 +258,21 @@ def run_test_iteration(test_status, test_loader, test_queue_builder,
                 logger.test_end(test.id, status="SKIP", subsuite=subsuite_name)
                 test_status.skipped += 1
 
-            if test_type == "testharness":
-                for test in test_loader.tests[subsuite_name][test_type]:
-                    skip_reason = None
-                    if test.testdriver and not executor_cls.supports_testdriver:
-                        skip_reason = "Executor does not support testdriver.js"
-                    elif test.jsshell and not executor_cls.supports_jsshell:
-                        skip_reason = "Executor does not support jsshell"
-                    if skip_reason:
-                        logger.test_start(test.id, subsuite=subsuite_name)
-                        logger.test_end(test.id,
-                                        status="SKIP",
-                                        subsuite=subsuite_name,
-                                        message=skip_reason)
-                        test_status.skipped += 1
-                    else:
-                        tests_to_run[(subsuite_name, test_type)].append(test)
-            else:
-                tests_to_run[(subsuite_name, test_type)] = test_loader.tests[subsuite_name][test_type]
+            for test in test_loader.tests[subsuite_name][test_type]:
+                skip_reason = None
+                if getattr(test, "testdriver", False) and not executor_cls.supports_testdriver:
+                    skip_reason = "Executor does not support testdriver.js"
+                elif test_type == "testharness" and test.jsshell and not executor_cls.supports_jsshell:
+                    skip_reason = "Executor does not support jsshell"
+                if skip_reason:
+                    logger.test_start(test.id, subsuite=subsuite_name)
+                    logger.test_end(test.id,
+                                    status="SKIP",
+                                    subsuite=subsuite_name,
+                                    message=skip_reason)
+                    test_status.skipped += 1
+                else:
+                    tests_to_run[(subsuite_name, test_type)].append(test)
 
     unexpected_fail_tests = defaultdict(list)
     unexpected_pass_tests = defaultdict(list)


### PR DESCRIPTION
Implements the `wpt {manifest,run}` changes proposed in https://github.com/web-platform-tests/rfcs/pull/211.