### PR TITLE
Fix test timing for all tests using xr_promise_test

### DIFF
--- a/webxr/resources/webxr_util.js
+++ b/webxr/resources/webxr_util.js
@@ -13,6 +13,8 @@
 // override this.
 var xr_debug = function(name, msg) {};
 
+let loaded = new Promise(resolve => document.addEventListener('DOMContentLoaded', resolve));
+
 function xr_promise_test(name, func, properties, glContextType, glContextProperties) {
   promise_test(async (t) => {
     if (glContextType === 'webgl2') {
@@ -60,6 +62,7 @@ function xr_promise_test(name, func, properties, glContextType, glContextPropert
     let canvas = null;
     if (glContextType) {
       canvas = document.createElement('canvas');
+      await loaded;
       document.body.appendChild(canvas);
       gl = canvas.getContext(glContextType, glContextProperties);
     }
@@ -161,22 +164,20 @@ function xr_session_promise_test(
         }));
   }
 
-  document.addEventListener('DOMContentLoaded', () => {
-    xr_promise_test(
-      name + ' - webgl',
-      runTest,
-      properties,
-      'webgl',
-      {alpha: false, antialias: false, ...glcontextProperties}
-    );
-    xr_promise_test(
-      name + ' - webgl2',
-      runTest,
-      properties,
-      'webgl2',
-      {alpha: false, antialias: false, ...glcontextProperties}
-    );
-  });
+  xr_promise_test(
+    name + ' - webgl',
+    runTest,
+    properties,
+    'webgl',
+    {alpha: false, antialias: false, ...glcontextProperties}
+  );
+  xr_promise_test(
+    name + ' - webgl2',
+    runTest,
+    properties,
+    'webgl2',
+    {alpha: false, antialias: false, ...glcontextProperties}
+  );
 }
 
 


### PR DESCRIPTION
#<!-- nolink -->33112 addressed all tests that used xr_session_promise_test, but the actual timing issue resides in xr_promise_test and there are a bunch of files that call that instead. These changes ensure that xr_promise_test waits for the DOMContentLoaded event to be fired before attempting to access the document's body element.

Reviewed in servo/servo#33715