### PR TITLE
Add test to verify that document.currentScript.src should not get clobbered by a DOM element with name='currentScript'.

### DIFF
--- a/html/dom/documents/dom-tree-accessors/Document.currentScript-not-clobbered.html
+++ b/html/dom/documents/dom-tree-accessors/Document.currentScript-not-clobbered.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<meta charset=utf-8>
+<title>Test that document.currentScript should not be possible to get clobbered via a DOM element with name='currentScript'</title>
+<link rel=help href="https://html.spec.whatwg.org/multipage/#dom-document-currentscript">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<img name='currentScript' src='http://some_possibly_malevolent_address_that_clobbers_document_currentScript.com/foo.js'>
+<script>
+test(function() {
+  assert_true(document.currentScript.tagName === 'SCRIPT'); // In particular, should not be "IMG" from the DOM element
+  assert_true(!document.currentScript.src.includes('malevolent_address')); // Should not have gotten the URL address from IMG element
+  assert_true(document.currentScript.src == ''); // In fact, since this is an inline <script> element, .src should be empty.
+}, "Document.currentScript should not get clobbered by a DOM element with name='currentScript' attribute");
+</script>


### PR DESCRIPTION
Add test to verify that document.currentScript.src should not get clobbered by a DOM element with name='currentScript'. See https://github.com/whatwg/html/issues/10687 for details.

This is still pending browser vendor discussion, adding a test early to illustrate what it would look like.