### PR TITLE
Shadow trees: more involved dispatch tests

### DIFF
--- a/shadow-dom/event-post-dispatch.html
+++ b/shadow-dom/event-post-dispatch.html
@@ -223,4 +223,60 @@ test(() => {
   assert_equals(log.event.composedPath().length, 0);
 }, 'Event properties post dispatch with relatedTarget in the different shadow trees. (composed: false)');
 document.body.removeChild(n7.test7);
+
+test(t => {
+  let host = document.createElement("div");
+  let shadow = host.attachShadow({ mode: "open" });
+  let target = shadow.appendChild(document.createElement("trala"));
+
+  let eventListenerCalled = false;
+  target.addEventListener("my-event", t.step_func(e => {
+    eventListenerCalled = true;
+    assert_equals(window.event, undefined);
+
+    // Move target node out of shadow tree.
+    host.appendChild(target);
+  }));
+
+  let event = new MouseEvent('my-event', {composed: false, relatedTarget: host});
+  target.dispatchEvent(event);
+  assert_true(eventListenerCalled);
+
+  assert_equals(event.target, null, "target should have been cleared");
+  assert_equals(event.relatedTarget, null, "relatedTarget should have been cleared");
+  assert_equals(event.eventPhase, 0);
+  assert_equals(event.currentTarget, null);
+  assert_equals(event.composedPath().length, 0);
+}, 'Event properties post dispatch when target get moved out of the shadow tree by event listener');
+
+test(t => {
+  let host = document.createElement("div");
+  let shadow = host.attachShadow({ mode: "open" });
+  let target = host.appendChild(document.createElement("trala"));
+
+  let eventListenerCalled = false;
+  target.addEventListener("my-event", t.step_func(e => {
+      assert_equals(window.event, e);
+  }));
+  target.addEventListener("my-event", t.step_func(e => {
+    eventListenerCalled = true;
+    assert_equals(window.event, e);
+    // Move target node into the shadow tree.
+    shadow.append(target);
+  }));
+  target.addEventListener("my-event", t.step_func(e => {
+      assert_equals(window.event, e);
+  }));
+
+  let event = new MouseEvent('my-event', {composed: false, relatedTarget: host});
+  target.dispatchEvent(event);
+  assert_true(eventListenerCalled);
+
+  // targets should not have been cleared since the node was not in the shadow tree when the event was initially dispatched.
+  assert_equals(event.target, target, "Target should not have been cleared");
+  assert_equals(event.relatedTarget, host, "relatedTarget should not have been cleared");
+  assert_equals(event.eventPhase, 0);
+  assert_equals(event.currentTarget, null);
+  assert_equals(event.composedPath().length, 0);
+}, 'Event properties post dispatch when target get moved into the the shadow tree by event listener');
 </script>


### PR DESCRIPTION
In particular, this adds tests for when the target get moved out of the shadow tree or into a shadow tree by an event listener.