### PR TITLE
Fix always failing assertion due to using incorrect element name

### DIFF
--- a/html/dom/documents/dom-tree-accessors/nameditem-names.html
+++ b/html/dom/documents/dom-tree-accessors/nameditem-names.html
@@ -52,7 +52,7 @@ test(function() {
 }, "An img name appears in a document's property names when the img has no id.");
 
 test(function() {
-  assert_true(names.includes("exposed_object"))
+  assert_true(names.includes("exposed_object_with_name"))
 }, "An object name appears in a document's property names if the object is exposed.");
 
 test(function() {


### PR DESCRIPTION
The object element in the document has "exposed_object_with_name" as the name, but the assertion was checking for name "exposed_object". This meant that this assertion would never ever be successful.

---

Aside: except for servo, all browsers fail on this test:

https://github.com/web-platform-tests/wpt/blob/59751055ef506c581da667594a2da8dac0c599b3/html/dom/documents/dom-tree-accessors/nameditem-names.html#L38-L40

The spec says (https://html.spec.whatwg.org/multipage/dom.html#exposed):

_"An embed or object element is said to be exposed if it has no exposed **object** ancestor, ..."_

I am not sure but it is explicitly only talking about embed/object inside object. Embed inside of an embed element should be exposed (?)