### PR TITLE
Fix `has-slotted-functional-changing-00*.tentative.html` subtest names

### DIFF
--- a/css/css-scoping/has-slotted-functional-changing-001.tentative.html
+++ b/css/css-scoping/has-slotted-functional-changing-001.tentative.html
@@ -56,7 +56,7 @@
       test.innerHTML = '';
       styles = getComputedStyle(target);
       assert_equals(styles.getPropertyValue('color'), green);
-    }, name);
+    });
   </script>
 </body>
 

--- a/css/css-scoping/has-slotted-functional-changing-002.tentative.html
+++ b/css/css-scoping/has-slotted-functional-changing-002.tentative.html
@@ -58,7 +58,7 @@
       test.replaceChildren();
       styles = getComputedStyle(target);
       assert_equals(styles.getPropertyValue('color'), green);
-    }, name);
+    });
   </script>
 </body>
 

--- a/css/css-scoping/has-slotted-functional-changing-003.tentative.html
+++ b/css/css-scoping/has-slotted-functional-changing-003.tentative.html
@@ -57,7 +57,7 @@
       test.textContent = '';
       styles = getComputedStyle(target);
       assert_equals(styles.getPropertyValue('color'), green);
-    }, name);
+    });
   </script>
 </body>
 

--- a/css/css-scoping/has-slotted-functional-changing-004.tentative.html
+++ b/css/css-scoping/has-slotted-functional-changing-004.tentative.html
@@ -64,7 +64,7 @@
       span.remove();
       styles = getComputedStyle(target);
       assert_equals(styles.getPropertyValue('color'), green);
-    }, name);
+    });
   </script>
 </body>
 


### PR DESCRIPTION
Using the testharness window's `name` as a subtest name is problematic because WPT doesn't prescribe any particular value. For some browsers, `wpt run` sets `name` to [an unstable UUID][0] ([wpt.fyi results][1]). Simply omit the `name` arg to [default to `document.title` instead][2].

[0]: https://github.com/web-platform-tests/wpt/blob/a08267ec/tools/wptrunner/wptrunner/executors/executorwebdriver.py#L263
[1]: https://wpt.fyi/results/css/css-scoping/has-slotted-functional-changing-001.tentative.html?run_id=5141001291431936&run_id=5160261803835392&run_id=6263739599028224&run_id=5140230613237760
[2]: https://github.com/web-platform-tests/wpt/blob/a08267ec/resources/testharness.js#L208-L212