### PR TITLE
Add an idlharness test for the Eyedropper API

### DIFF
--- a/eyedropper/idlharness.https.window.js
+++ b/eyedropper/idlharness.https.window.js
@@ -1,0 +1,7 @@
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+idl_test(
+  ['eyedropper-api'],
+  [],
+);


### PR DESCRIPTION
This is very uninteresting, but provides a test that makes it obvious what browsers have support.

(@mfreed7: you seem to have reviewed everything else in this directory before?)