### PR TITLE
[PROTOTYPE] RFC-212 Enable testdriver BiDi on-demand in Chrome

### DIFF
--- a/infrastructure/metadata/infrastructure/webdriver/bidi/subscription.html.ini
+++ b/infrastructure/metadata/infrastructure/webdriver/bidi/subscription.html.ini
@@ -1,1 +1,2 @@
-disabled: https://github.com/web-platform-tests/wpt/issues/47544
+disabled:
+  if product != "chrome": @True

--- a/infrastructure/metadata/infrastructure/webdriver/bidi/subscription.window.js.ini
+++ b/infrastructure/metadata/infrastructure/webdriver/bidi/subscription.window.js.ini
@@ -1,1 +1,2 @@
-disabled: https://github.com/web-platform-tests/wpt/issues/47544
+disabled:
+  if product != "chrome": @True

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -6,7 +6,7 @@ import time
 from mozlog.structuredlog import StructuredLogger
 
 from . import chrome_spki_certs
-from .base import BrowserError
+from .base import BrowserError, BrowserSettings
 from .base import WebDriverBrowser, require_arg
 from .base import NullBrowser  # noqa: F401
 from .base import OutputHandler
@@ -40,6 +40,8 @@ __wptrunner__ = {"product": "chrome",
                  "env_options": "env_options",
                  "update_properties": "update_properties",
                  "timeout_multiplier": "get_timeout_multiplier",}
+
+from ..wpttest import Test
 
 
 def debug_args(debug_info):
@@ -214,6 +216,7 @@ class ChromeBrowser(WebDriverBrowser):
         super().__init__(logger, **kwargs)
         self._leak_check = leak_check
         self._actual_port = None
+        self._require_webdriver_bidi = None
 
     def restart_on_test_type_change(self, new_test_type: str, old_test_type: str) -> bool:
         # Restart the test runner when switch from/to wdspec tests. Wdspec test
@@ -261,6 +264,19 @@ class ChromeBrowser(WebDriverBrowser):
     def executor_browser(self):
         browser_cls, browser_kwargs = super().executor_browser()
         return browser_cls, {**browser_kwargs, "leak_check": self._leak_check}
+
+    @property
+    def require_webdriver_bidi(self) -> Optional[bool]:
+        return self._require_webdriver_bidi
+
+    def settings(self, test: Test) -> BrowserSettings:
+        """ Required to store `require_webdriver_bidi` in browser settings."""
+        settings = super().settings(test)
+        self._require_webdriver_bidi = test.require_webdriver_bidi
+        return {
+            **settings,
+            "require_webdriver_bidi": self._require_webdriver_bidi
+        }
 
 
 class ChromeDriverOutputHandler(OutputHandler):

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -20,6 +20,7 @@ from .executorwebdriver import (
     WebDriverFedCMProtocolPart,
     WebDriverPrintRefTestExecutor,
     WebDriverProtocol,
+    WebDriverBidiProtocol,
     WebDriverRefTestExecutor,
     WebDriverTestharnessExecutor,
     WebDriverTestharnessProtocolPart,
@@ -211,6 +212,28 @@ class ChromeDriverProtocol(WebDriverProtocol):
         super().__init__(executor, browser, capabilities, **kwargs)
 
 
+# TODO: simplify
+class ChromeDriverBidiProtocol(WebDriverBidiProtocol):
+    implements = [
+        ChromeDriverBaseProtocolPart,
+        ChromeDriverDevToolsProtocolPart,
+        ChromeDriverFedCMProtocolPart,
+        ChromeDriverTestharnessProtocolPart,
+    ]
+    for base_part in WebDriverBidiProtocol.implements:
+        if base_part.name not in {part.name for part in implements}:
+            implements.append(base_part)
+
+    # Prefix to apply to vendor-specific WebDriver extension commands.
+    vendor_prefix = "goog"
+
+    def __init__(self, executor, browser, capabilities, **kwargs):
+        self.implements = list(ChromeDriverBidiProtocol.implements)
+        if getattr(browser, "leak_check", False):
+            self.implements.append(ChromeDriverLeakProtocolPart)
+        super().__init__(executor, browser, capabilities, **kwargs)
+
+
 def _evaluate_leaks(executor_cls):
     if hasattr(executor_cls, "base_convert_result"):
         # Don't wrap more than once, which can cause unbounded recursion.
@@ -244,9 +267,14 @@ class ChromeDriverRefTestExecutor(WebDriverRefTestExecutor, _SanitizerMixin):  #
 
 @_evaluate_leaks
 class ChromeDriverTestharnessExecutor(WebDriverTestharnessExecutor, _SanitizerMixin):  # type: ignore
-    protocol_cls = ChromeDriverProtocol
-
     def __init__(self, *args, reuse_window=False, **kwargs):
+        require_webdriver_bidi = kwargs.get("browser_settings", {}).get("require_webdriver_bidi",
+                                                              None)
+        if require_webdriver_bidi == 'true':
+            self.protocol_cls = ChromeDriverBidiProtocol
+        else:
+            self.protocol_cls = ChromeDriverProtocol
+
         super().__init__(*args, **kwargs)
         self.reuse_window = reuse_window
 


### PR DESCRIPTION
# This prototype is not intended to be merged

Prototype of using [RFC 212](https://github.com/web-platform-tests/rfcs/pull/212) in Chrome implementation.

Choose chome transport based on `require_webdriver_bidi` setting introduced in https://github.com/web-platform-tests/wpt/pull/48622