### PR TITLE
Fix WebDriverAsyncCallbackHandler not expecting all WebDriver exceptions

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -60,8 +60,8 @@ class WebDriverCallbackHandler(CallbackHandler):
 
 
 class WebDriverAsyncCallbackHandler(AsyncCallbackHandler):
-    unimplemented_exc = (NotImplementedError, webdriver_bidi_error.UnknownCommandException)
-    expected_exc = (webdriver_bidi_error.BidiException,)
+    unimplemented_exc = (NotImplementedError, webdriver_error.UnknownCommandException, webdriver_bidi_error.UnknownCommandException)
+    expected_exc = (webdriver_error.WebDriverException, webdriver_bidi_error.BidiException)
 
 
 class WebDriverBaseProtocolPart(BaseProtocolPart):


### PR DESCRIPTION
WebDriverAsyncCallbackHandler also handles WebDriver Classic actions and, thus, needs to declare same unimplemented_exc and expected_exc as WebDriverCallbackHandler.