### PR TITLE
Avoid wrapping line at the start of text run with `text-wrap-mode: nowrap`

### DIFF
--- a/css/css-text/white-space/white-space-intrinsic-size-021.html
+++ b/css/css-text/white-space/white-space-intrinsic-size-021.html
@@ -166,6 +166,16 @@ x-br::before {
   <div class="break-spaces wrap"      data-expected-client-width="20" data-expected-client-height="20">X <x-br></x-br>É</div>
   <div class="break-spaces nowrap"    data-expected-client-width="20" data-expected-client-height="20">X <x-br></x-br>É</div>
 </div>
+<div class="container narrow">
+  <div class="collapse wrap"          data-expected-client-width="10" data-expected-client-height="20">X <a>É</a></div>
+  <div class="collapse nowrap"        data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="preserve wrap"          data-expected-client-width="10" data-expected-client-height="20">X <a>É</a></div>
+  <div class="preserve nowrap"        data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="10" data-expected-client-height="20">X <a>É</a></div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="break-spaces wrap"      data-expected-client-width="20" data-expected-client-height="20">X <a>É</a></div>
+  <div class="break-spaces nowrap"    data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+</div>
 
 <hr>
 
@@ -278,6 +288,16 @@ x-br::before {
   <div class="preserve-breaks nowrap" data-expected-client-width="10" data-expected-client-height="20">X <x-br></x-br>É</div>
   <div class="break-spaces wrap"      data-expected-client-width="20" data-expected-client-height="20">X <x-br></x-br>É</div>
   <div class="break-spaces nowrap"    data-expected-client-width="20" data-expected-client-height="20">X <x-br></x-br>É</div>
+</div>
+<div class="container wide">
+  <div class="collapse wrap"          data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="collapse nowrap"        data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="preserve wrap"          data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="preserve nowrap"        data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="break-spaces wrap"      data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="break-spaces nowrap"    data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
 </div>
 
 <hr>


### PR DESCRIPTION
When computing the min-content size of an inline formatting context, we could allow a soft wrap opportunity at the start of a text run. This shouldn't happen with `text-wrap-mode: nowrap`.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#33848