### PR TITLE
Make `wpt test-jobs` able to output JSON

### DIFF
--- a/tools/ci/jobs.py
+++ b/tools/ci/jobs.py
@@ -1,8 +1,10 @@
 # mypy: allow-untyped-defs
 
 import argparse
+import json
 import os
 import re
+import sys
 from ..wpt.testfiles import branch_point, files_changed
 
 from tools import localpaths  # noqa: F401
@@ -138,6 +140,7 @@ def create_parser():
     parser.add_argument("revish", default=None, help="Commits to consider. Defaults to the commits on the current branch", nargs="?")
     parser.add_argument("--all", help="List all jobs unconditionally.", action="store_true")
     parser.add_argument("--includes", default=None, help="Jobs to check for. Return code is 0 if all jobs are found, otherwise 1", nargs="*")
+    parser.add_argument("--json", action="store_true", help="Output jobs as JSON, instead of one per line")
     return parser
 
 
@@ -145,7 +148,11 @@ def run(**kwargs):
     paths = get_paths(**kwargs)
     jobs = get_jobs(paths, **kwargs)
     if not kwargs["includes"]:
-        for item in sorted(jobs):
-            print(item)
+        if kwargs["json"]:
+            json.dump(sorted(jobs), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+        else:
+            for item in sorted(jobs):
+                print(item)
     else:
         return 0 if set(kwargs["includes"]).issubset(jobs) else 1


### PR DESCRIPTION
This allows us to leverage GitHub Actions built-in support for JSON rather than trying to declare all the possible jobs as output variables.