### PR TITLE
Fix timeout in `cross-origin-top-navigation-with-user-activation...`

### DIFF
--- a/html/browsers/browsing-the-web/navigating-across-documents/cross-origin-top-navigation-denied.window.js
+++ b/html/browsers/browsing-the-web/navigating-across-documents/cross-origin-top-navigation-denied.window.js
@@ -1,0 +1,19 @@
+// META: script=/resources/testdriver.js
+// META: script=/resources/testdriver-vendor.js
+// META: variant=?parent_user_gesture=true
+// META: variant=?parent_user_gesture=false
+
+let description = 'Cross-origin top navigation is blocked without user activation';
+const urlParams = new URLSearchParams(location.search);
+const parentUserGesture = urlParams.get('parent_user_gesture') || 'false';
+if (parentUserGesture === 'true') {
+  description += ', even if the parent has user activation';
+}
+
+async_test(t => {
+  addEventListener('message', t.step_func_done(e => {
+    assert_equals(e.data, 'Denied');
+  }));
+  const w = open(`resources/page-with-top-navigating-iframe.html?parent_user_gesture=${parentUserGesture}`);
+  t.add_cleanup(() => {w.close()});
+}, description);

--- a/html/browsers/browsing-the-web/navigating-across-documents/cross-origin-top-navigation-with-user-activation-in-parent.window.js
+++ b/html/browsers/browsing-the-web/navigating-across-documents/cross-origin-top-navigation-with-user-activation-in-parent.window.js
@@ -1,8 +1,0 @@
-async_test(t => {
-  addEventListener('message', t.step_func_done(e => {
-    assert_equals(e.data, 'Denied');
-  }));
-  const w = open("resources/page-with-top-navigating-iframe.html?parent_user_gesture=true");
-  t.add_cleanup(() => {w.close()});
-
-}, "Cross-origin top navigation is blocked without user activation, even if the parent has user activation");

--- a/html/browsers/browsing-the-web/navigating-across-documents/cross-origin-top-navigation-without-user-activation.window.js
+++ b/html/browsers/browsing-the-web/navigating-across-documents/cross-origin-top-navigation-without-user-activation.window.js
@@ -1,8 +1,0 @@
-async_test(t => {
-  addEventListener('message', t.step_func_done(e => {
-    assert_equals(e.data, 'Denied');
-  }));
-  const w = open("resources/page-with-top-navigating-iframe.html");
-  t.add_cleanup(() => {w.close()});
-
-}, "Cross-origin top navigation is blocked without user activation");

--- a/html/browsers/browsing-the-web/navigating-across-documents/resources/page-with-top-navigating-iframe.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/resources/page-with-top-navigating-iframe.html
@@ -15,6 +15,7 @@ function addIframe() {
 addEventListener('load', () => {
   const urlParams = new URLSearchParams(location.search);
   const parentUserGesture = urlParams.get('parent_user_gesture') === 'true';
+  test_driver.set_test_context(opener);
   if (parentUserGesture)
     test_driver.bless("Giving parent frame user activation").then(addIframe);
   else


### PR DESCRIPTION
The test drops testdriver commands and [times out in all browsers][0] because:
1. The top document doesn't [embed `testharness*.js`][1].
2. The opened document needs to [`set_test_context()`][2] to send testdriver commands to its parent.

Also, [use variants][3] to merge the test file with the very similar "without activation" case.

[0]: https://wpt.fyi/results/html/browsers/browsing-the-web/navigating-across-documents/cross-origin-top-navigation-with-user-activation-in-parent.window.html?run_id=5141001291431936&run_id=5160261803835392&run_id=6263739599028224&run_id=5140230613237760
[1]: https://web-platform-tests.org/writing-tests/testdriver.html#markup
[2]: https://web-platform-tests.org/writing-tests/testdriver.html#test_driver.set_test_context
[3]: https://web-platform-tests.org/writing-tests/testharness.html#variants