### PR TITLE
Fix overflow:hidden test with incorrect synthetic bolding

### DIFF
--- a/css/CSS2/ui/overflow-applies-to-009.xht
+++ b/css/CSS2/ui/overflow-applies-to-009.xht
@@ -12,7 +12,7 @@
         <meta name="assert" content="The 'overflow' property applies to elements with 'display' set to 'block'." />
         <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
         <style type="text/css">
-            span
+            #blockoverflow
             {
                 border: 5px solid transparent;
                 color: white;
@@ -30,7 +30,7 @@
     <body>
         <p>Test passes if there is <strong>no red</strong>.</p>
         <div>
-            <span><b>XXXXX</b><b id="test">XXXXX</b></span>
+            <span id="blockoverflow"><span>XXXXX</span><span id="test">XXXXX</span></span>
         </div>
     </body>
 </html>


### PR DESCRIPTION
This test expects the first Ahem blocked to be clipped and not showing any red from the second block, but uses `<b>` tags as a shortcut for spans. The second block's emboldened first glyph becomes - correctly - visible and overpaints the last bit of the first block.

Fix by using a named id for the main style and switching from `<b>` tags to spans.