### PR TITLE
Merge the Safari workflows into a single workflow

### DIFF
--- a/.github/workflows/safari-wptrunner.yml
+++ b/.github/workflows/safari-wptrunner.yml
@@ -1,0 +1,112 @@
+name: Run Safari Tests
+
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        description: "Prefix for the artifact uploaded"
+        required: true
+        type: string
+      safari-technology-preview:
+        description: "Run Safari Technology Preview rather than the system Safari"
+        required: true
+        type: bool
+      safaridriver-diagnose:
+        description: "Run safaridriver capturing diagnostics"
+        required: true
+        type: bool
+
+# We never interact with the GitHub API, thus we can simply disable all
+# permissions the GitHub token would have.
+permissions: {}
+
+jobs:
+  safari-results:
+    name: ${{ inputs.safari-technology-preview && "Safari Technology Preview" || "Safari" }}
+    runs-on:
+      - self-hosted
+      - webkit-ews
+    timeout-minutes: 180
+    strategy:
+      matrix:
+        current-chunk: [1, 2, 3, 4, 5, 6, 7, 8]
+        total-chunks: [8]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4.1.0
+        with:
+          fetch-depth: 1
+      - name: Enable safaridriver diagnostics
+        if: inputs.safaridriver-diagnose
+        run: |-
+          rm -rf ~/Library/Logs/com.apple.WebDriver/
+          defaults write com.apple.WebDriver DiagnosticsEnabled 1
+      - name: Enable safaridriver (Safari)
+        if: ${{ !inputs.safari-technology-preview }}
+        run: |-
+          set -eux -o pipefail
+          sudo safaridriver --enable
+      - name: Enable safaridriver (Safari Technology Preview)
+        if: ${{ inputs.safari-technology-preview }}
+        run: |-
+          set -eux -o pipefail
+          export SYSTEM_VERSION_COMPAT=0
+          ./wpt install --channel preview --download-only -d . --rename STP safari browser
+          sudo installer -pkg STP.pkg -target LocalSystem
+          sudo /Applications/Safari\ Technology\ Preview.app/Contents/MacOS/safaridriver --enable
+      - name: Update hosts
+        run: |-
+          set -eux -o pipefail
+          ./wpt make-hosts-file | sudo tee -a /etc/hosts
+      - name: Update manifest
+        run: ./wpt manifest
+      - name: Run tests
+        run: |-
+          set -eux -o pipefail
+          export SYSTEM_VERSION_COMPAT=0
+          ./wpt run \
+            --no-manifest-update \
+            --no-restart-on-unexpected \
+            --no-fail-on-unexpected \
+            --this-chunk=${{ matrix.current-chunk }} \
+            --total-chunks=${{ matrix.total-chunks }} \
+            --chunk-type hash \
+            --log-wptreport ${{ runner.temp }}/wpt_report_${{ matrix.current-chunk }}.json \
+            --log-wptscreenshot ${{ runner.temp }}/wpt_screenshot_${{ matrix.current-chunk }}.txt \
+            --log-mach - \
+            --log-mach-level info \
+            --channel ${{ inputs.safari-technology-preview && "preview" || "stable" }} \
+            --kill-safari \
+            --max-restarts 100 \
+            safari
+      - name: Publish results
+        uses: actions/upload-artifact@v4.1.0
+        with:
+          name: ${{ inputs.artifact-name }}-${{ matrix.current-chunk }}
+          path: |
+            ${{ runner.temp }}/wpt_report_*.json
+            ${{ runner.temp }}/wpt_screenshot_*.txt
+          if-no-files-found: "error"
+      - name: Publish safaridriver logs
+        if: inputs.safaridriver-diagnose
+        uses: actions/upload-artifact@v4.1.0
+        with:
+          name: ${{ inputs.artifact-name }}-safaridriver-logs-${{ matrix.current-chunk }}
+          path: ~/Library/Logs/com.apple.WebDriver/
+          if-no-files-found: warn
+      - name: Disable safaridriver diagnostics
+        if: inputs.safaridriver-diagnose
+        run: |-
+          defaults write com.apple.WebDriver DiagnosticsEnabled 0
+          rm -rf ~/Library/Logs/com.apple.WebDriver/
+      - name: Cleanup
+        if: always()
+        run: |-
+            set -ux
+            sudo sed -i '' '/^# Start web-platform-tests hosts$/,/^# End web-platform-tests hosts$/d' /etc/hosts
+
+  safari-notify:
+    needs: safari-results
+    uses: ./.github/workflows/wpt_fyi_notify.yml
+    with:
+      artifact-name: "${{ inputs.artifact-name }}-*"

--- a/.github/workflows/safari_stable.yml
+++ b/.github/workflows/safari_stable.yml
@@ -15,12 +15,6 @@ on:
       - epochs/daily
       - triggers/safari_stable
 
-env:
-  # Set SAFARIDRIVER_DIAGNOSE to true to enable safaridriver diagnostics. The
-  # logs won't appear in `./wpt run` output but will be uploaded as an
-  # artifact.
-  SAFARIDRIVER_DIAGNOSE: false
-
 jobs:
   check-workflow-run:
     name: "Check for appropriate epochs"
@@ -35,81 +29,8 @@ jobs:
     needs: check-workflow-run
     if: |
       github.event_name != 'workflow_run' || fromJSON(needs.check-workflow-run.outputs.updated-refs)[0] != null
-    runs-on:
-      - self-hosted
-      - webkit-ews
-    timeout-minutes: 180
-    strategy:
-      matrix:
-        current-chunk: [1, 2, 3, 4, 5, 6, 7, 8]
-        total-chunks: [8]
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4.1.0
-        with:
-          fetch-depth: 1
-      - name: Enable safaridriver diagnostics
-        if: env.SAFARIDRIVER_DIAGNOSE == true
-        run: |-
-          rm -rf ~/Library/Logs/com.apple.WebDriver/
-          defaults write com.apple.WebDriver DiagnosticsEnabled 1
-      - name: Enable safaridriver
-        run: |-
-          set -eux -o pipefail
-          sudo safaridriver --enable
-      - name: Update hosts
-        run: |-
-          set -eux -o pipefail
-          ./wpt make-hosts-file | sudo tee -a /etc/hosts
-      - name: Update manifest
-        run: ./wpt manifest
-      - name: Run tests
-        run: |-
-          set -eux -o pipefail
-          export SYSTEM_VERSION_COMPAT=0
-          ./wpt run \
-            --no-manifest-update \
-            --no-restart-on-unexpected \
-            --no-fail-on-unexpected \
-            --this-chunk=${{ matrix.current-chunk }} \
-            --total-chunks=${{ matrix.total-chunks }} \
-            --chunk-type hash \
-            --log-wptreport ${{ runner.temp }}/wpt_report_${{ matrix.current-chunk }}.json \
-            --log-wptscreenshot ${{ runner.temp }}/wpt_screenshot_${{ matrix.current-chunk }}.txt \
-            --log-mach - \
-            --log-mach-level info \
-            --channel stable \
-            --kill-safari \
-            --max-restarts 100 \
-            safari
-      - name: Publish results
-        uses: actions/upload-artifact@v4.1.0
-        with:
-          name: safari-results-${{ matrix.current-chunk }}
-          path: |
-            ${{ runner.temp }}/wpt_report_*.json
-            ${{ runner.temp }}/wpt_screenshot_*.txt
-          if-no-files-found: "error"
-      - name: Publish safaridriver logs
-        if: env.SAFARIDRIVER_DIAGNOSE == true
-        uses: actions/upload-artifact@v4.1.0
-        with:
-          name: safaridriver-logs-${{ matrix.current-chunk }}
-          path: ~/Library/Logs/com.apple.WebDriver/
-          if-no-files-found: warn
-      - name: Disable safaridriver diagnostics
-        if: env.SAFARIDRIVER_DIAGNOSE == true
-        run: |-
-          defaults write com.apple.WebDriver DiagnosticsEnabled 0
-          rm -rf ~/Library/Logs/com.apple.WebDriver/
-      - name: Cleanup
-        if: always()
-        run: |-
-            set -ux
-            sudo sed -i '' '/^# Start web-platform-tests hosts$/,/^# End web-platform-tests hosts$/d' /etc/hosts
-
-  safari-stable-results-notify:
-    needs: safari-stable-results
-    uses: ./.github/workflows/wpt_fyi_notify.yml
+    uses: ./.github/workflows/safari-wptrunner.yml
     with:
-      artifact-name: 'safari-results-*'
+      artifact-name: "safari-results-*"
+      safari-technology-preview: false
+      safaridriver-diagnose: false

--- a/.github/workflows/safari_technology_preview.yml
+++ b/.github/workflows/safari_technology_preview.yml
@@ -15,12 +15,6 @@ on:
       - epochs/three_hourly
       - triggers/safari_preview
 
-env:
-  # Set SAFARIDRIVER_DIAGNOSE to true to enable safaridriver diagnostics. The
-  # logs won't appear in `./wpt run` output but will be uploaded as an
-  # artifact.
-  SAFARIDRIVER_DIAGNOSE: false
-
 jobs:
   check-workflow-run:
     name: "Check for appropriate epochs"
@@ -35,84 +29,8 @@ jobs:
     needs: check-workflow-run
     if: |
       github.event_name != 'workflow_run' || fromJSON(needs.check-workflow-run.outputs.updated-refs)[0] != null
-    runs-on:
-      - self-hosted
-      - webkit-ews
-    timeout-minutes: 180
-    strategy:
-      matrix:
-        current-chunk: [1, 2, 3, 4, 5, 6, 7, 8]
-        total-chunks: [8]
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4.1.0
-        with:
-          fetch-depth: 1
-      - name: Enable safaridriver diagnostics
-        if: env.SAFARIDRIVER_DIAGNOSE == true
-        run: |-
-          rm -rf ~/Library/Logs/com.apple.WebDriver/
-          defaults write com.apple.WebDriver DiagnosticsEnabled 1
-      - name: Enable safaridriver
-        run: |-
-          set -eux -o pipefail
-          export SYSTEM_VERSION_COMPAT=0
-          ./wpt install --channel preview --download-only -d . --rename STP safari browser
-          sudo installer -pkg STP.pkg -target LocalSystem
-          sudo /Applications/Safari\ Technology\ Preview.app/Contents/MacOS/safaridriver --enable
-      - name: Update hosts
-        run: |-
-          set -eux -o pipefail
-          ./wpt make-hosts-file | sudo tee -a /etc/hosts
-      - name: Update manifest
-        run: ./wpt manifest
-      - name: Run tests
-        run: |-
-          set -eux -o pipefail
-          export SYSTEM_VERSION_COMPAT=0
-          ./wpt run \
-            --no-manifest-update \
-            --no-restart-on-unexpected \
-            --no-fail-on-unexpected \
-            --this-chunk=${{ matrix.current-chunk }} \
-            --total-chunks=${{ matrix.total-chunks }} \
-            --chunk-type hash \
-            --log-wptreport ${{ runner.temp }}/wpt_report_${{ matrix.current-chunk }}.json \
-            --log-wptscreenshot ${{ runner.temp }}/wpt_screenshot_${{ matrix.current-chunk }}.txt \
-            --log-mach - \
-            --log-mach-level info \
-            --channel experimental \
-            --kill-safari \
-            --max-restarts 100 \
-            safari
-      - name: Publish results
-        uses: actions/upload-artifact@v4.1.0
-        with:
-          name: safari-technology-preview-results-${{ matrix.current-chunk }}
-          path: |
-            ${{ runner.temp }}/wpt_report_*.json
-            ${{ runner.temp }}/wpt_screenshot_*.txt
-          if-no-files-found: "error"
-      - name: Publish safaridriver logs
-        if: env.SAFARIDRIVER_DIAGNOSE == true
-        uses: actions/upload-artifact@v4.1.0
-        with:
-          name: safaridriver-logs-${{ matrix.current-chunk }}
-          path: ~/Library/Logs/com.apple.WebDriver/
-          if-no-files-found: warn
-      - name: Disable safaridriver diagnostics
-        if: env.SAFARIDRIVER_DIAGNOSE == true
-        run: |-
-          defaults write com.apple.WebDriver DiagnosticsEnabled 0
-          rm -rf ~/Library/Logs/com.apple.WebDriver/
-      - name: Cleanup
-        if: always()
-        run: |-
-            set -ux
-            sudo sed -i '' '/^# Start web-platform-tests hosts$/,/^# End web-platform-tests hosts$/d' /etc/hosts
-
-  safari-technology-preview-results-notify:
-    needs: safari-technology-preview-results
-    uses: ./.github/workflows/wpt_fyi_notify.yml
+    uses: ./.github/workflows/safari-wptrunner.yml
     with:
-      artifact-name: 'safari-technology-preview-results-*'
+      artifact-name: "safari-technology-preview-results-*"
+      safari-technology-preview: true
+      safaridriver-diagnose: false


### PR DESCRIPTION
This gets rid of a lot of duplication and makes this much simpler. This might be hard to use for PRs where we want to do different chunking (given the matrix definition), but that is a future challenge (one possibility is to just pass in a blob of JSON as an input and use matrix: fromJSON()).