### PR TITLE
Move the Safari GitHub Actions runs to be using sRGB color space

### DIFF
--- a/.github/workflows/safari-wptrunner.yml
+++ b/.github/workflows/safari-wptrunner.yml
@@ -36,6 +36,9 @@ jobs:
         uses: actions/checkout@v4.1.0
         with:
           fetch-depth: 1
+      - name: Set display color profile
+        run: |-
+          ./wpt macos-color-profile
       - name: Enable safaridriver diagnostics
         if: inputs.safaridriver-diagnose
         run: |-


### PR DESCRIPTION
See also https://github.com/web-platform-tests/wpt/commit/04e0a9b7f7e77d1279e7fb375ed3ec250f8f072d

(This is currently only the second commit, as this is built on top of #48688)