### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=281731

### DIFF
--- a/scroll-animations/scroll-timelines/setting-current-time.html
+++ b/scroll-animations/scroll-timelines/setting-current-time.html
@@ -42,13 +42,13 @@ promise_test(async t => {
 
 promise_test(async t => {
   const animation = createScrollLinkedAnimation(t);
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.currentTime = CSSNumericValue.parse("300");
   });
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.currentTime = CSSNumericValue.parse("300ms");
   });
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.currentTime = CSSNumericValue.parse("0.3s");
   });
 }, 'Setting the current time to an absolute time value throws exception');

--- a/scroll-animations/scroll-timelines/setting-start-time.html
+++ b/scroll-animations/scroll-timelines/setting-start-time.html
@@ -26,13 +26,13 @@
 
 promise_test(async t => {
   const animation = createScrollLinkedAnimation(t);
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.startTime = CSSNumericValue.parse("300");
   });
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.startTime = CSSNumericValue.parse("300ms");
   });
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.startTime = CSSNumericValue.parse("0.3s");
   });
 }, 'Setting the start time to an absolute time value throws exception');


### PR DESCRIPTION
WebKit export from bug: [\[scroll-animations\] WPT tests `scroll-timelines/setting-start-time.html` and `scroll-timelines/setting-current-time.html` under `scroll-animations` are crashes](https://bugs.webkit.org/show_bug.cgi?id=281731)