### PR TITLE
Fix safari-wptrunner.yml to match the schema

### DIFF
--- a/.github/workflows/safari-wptrunner.yml
+++ b/.github/workflows/safari-wptrunner.yml
@@ -10,11 +10,11 @@ on:
       safari-technology-preview:
         description: "Run Safari Technology Preview rather than the system Safari"
         required: true
-        type: bool
+        type: boolean
       safaridriver-diagnose:
         description: "Run safaridriver capturing diagnostics"
         required: true
-        type: bool
+        type: boolean
 
 # We never interact with the GitHub API, thus we can simply disable all
 # permissions the GitHub token would have.


### PR DESCRIPTION
(whoops)

```
(venv) gsnedders@gsnedders-milk workflows % check-jsonschema --builtin-schema vendor.github-workflows *.yml 
Schema validation errors were encountered.
  safari-wptrunner.yml::$.on: {'workflow_call': {'inputs': {'artifact-name': {'description': 'Prefix for the artifact uploaded', 'required': True, 'type': 'string'}, 'safari-technology-preview': {'description': 'Run Safari Technology Preview rather than the system Safari', 'required': True, 'type': 'bool'}, 'safaridriver-diagnose': {'description': 'Run safaridriver capturing diagnostics', 'required': True, 'type': 'bool'}}}} is not valid under any of the given schemas
  Underlying errors caused this.

  Best Match:
    $.on: {'workflow_call': {'inputs': {'artifact-name': {'description': 'Prefix for the artifact uploaded', 'required': True, 'type': 'string'}, 'safari-technology-preview': {'description': 'Run Safari Technology Preview rather than the system Safari', 'required': True, 'type': 'bool'}, 'safaridriver-diagnose': {'description': 'Run safaridriver capturing diagnostics', 'required': True, 'type': 'bool'}}}} is not of type 'string'
  Best Deep Match:
    $.on.workflow_call.inputs.safari-technology-preview.type: 'bool' is not one of ['boolean', 'number', 'string']

  3 other errors were produced. Use '--verbose' to see all errors.
```

v.

```
(venv) gsnedders@gsnedders-milk workflows % check-jsonschema --builtin-schema vendor.github-workflows *.yml
ok -- validation done
```