### PR TITLE
Fix strings within GitHub Actions workflow expressions

### DIFF
--- a/.github/workflows/safari-wptrunner.yml
+++ b/.github/workflows/safari-wptrunner.yml
@@ -22,7 +22,7 @@ permissions: {}
 
 jobs:
   safari-results:
-    name: ${{ inputs.safari-technology-preview && "Safari Technology Preview" || "Safari" }}
+    name: ${{ inputs.safari-technology-preview && 'Safari Technology Preview' || 'Safari' }}
     runs-on:
       - self-hosted
       - webkit-ews
@@ -75,7 +75,7 @@ jobs:
             --log-wptscreenshot ${{ runner.temp }}/wpt_screenshot_${{ matrix.current-chunk }}.txt \
             --log-mach - \
             --log-mach-level info \
-            --channel ${{ inputs.safari-technology-preview && "preview" || "stable" }} \
+            --channel ${{ inputs.safari-technology-preview && 'preview' || 'stable' }} \
             --kill-safari \
             --max-restarts 100 \
             safari


### PR DESCRIPTION
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#literals:

> You don't need to enclose strings in ${{ and }}. However, if you do,
> you must use single quotes (') around the string. To use a literal
> single quote, escape the literal single quote using an additional
> single quote (''). Wrapping with double quotes (") will throw an
> error.

And in a shocking turn of events, using double quotes did in fact throw an error.