### PR TITLE
Fix Safari artifact names

### DIFF
--- a/.github/workflows/safari_stable.yml
+++ b/.github/workflows/safari_stable.yml
@@ -31,6 +31,6 @@ jobs:
       github.event_name != 'workflow_run' || fromJSON(needs.check-workflow-run.outputs.updated-refs)[0] != null
     uses: ./.github/workflows/safari-wptrunner.yml
     with:
-      artifact-name: "safari-results-*"
+      artifact-name: "safari-results"
       safari-technology-preview: false
       safaridriver-diagnose: false

--- a/.github/workflows/safari_technology_preview.yml
+++ b/.github/workflows/safari_technology_preview.yml
@@ -31,6 +31,6 @@ jobs:
       github.event_name != 'workflow_run' || fromJSON(needs.check-workflow-run.outputs.updated-refs)[0] != null
     uses: ./.github/workflows/safari-wptrunner.yml
     with:
-      artifact-name: "safari-technology-preview-results-*"
+      artifact-name: "safari-technology-preview-results"
       safari-technology-preview: true
       safaridriver-diagnose: false


### PR DESCRIPTION
With the unified workflow, we don't actually need to specify the wildcard, as this will just lead to errors like:

> Error: The artifact name is not valid: safari-technology-preview-results-*-6. Contains the following character: Asterisk *

e.g., in https://github.com/web-platform-tests/wpt/actions/runs/11410328782/job/31752427266