### PR TITLE
Fix #48684: stop Actions from running (and failing) on forks

### DIFF
--- a/.github/workflows/check-workflow-run.yml
+++ b/.github/workflows/check-workflow-run.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   check-workflow-run:
     name: "Check for appropriate epochs"
-    if: ${{ github.event_name == 'workflow_run' }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
     runs-on:
       - ubuntu-22.04
     permissions:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-20.04
+    if: github.repository == 'web-platform-tests/wpt'
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -31,8 +32,6 @@ jobs:
         with:
           fetch-depth: 50
       - name: Run website_build.sh
-        # Use a conditional step instead of a conditional job to work around #20700.
-        if: github.repository == 'web-platform-tests/wpt'
         run: ./tools/ci/website_build.sh
         env:
           DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}

--- a/.github/workflows/epochs.yml
+++ b/.github/workflows/epochs.yml
@@ -7,14 +7,13 @@ on:
 jobs:
   update:
     runs-on: ubuntu-20.04
+    if: github.repository == 'web-platform-tests/wpt'
     steps:
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Run epochs_update.sh
-      # Use a conditional step instead of a conditional job to work around #20700.
-      if: github.repository == 'web-platform-tests/wpt'
       run: ./tools/ci/epochs_update.sh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/interfaces.yml
+++ b/.github/workflows/interfaces.yml
@@ -7,14 +7,13 @@ on:
 jobs:
   update:
     runs-on: ubuntu-20.04
+    if: github.repository == 'web-platform-tests/wpt'
     steps:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Run interfaces_update.sh
       run: ./tools/ci/interfaces_update.sh
     - name: Create pull request
-      # Use a conditional step instead of a conditional job to work around #20700.
-      if: github.repository == 'web-platform-tests/wpt'
       uses: peter-evans/create-pull-request@v6
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-and-tag:
     runs-on: ubuntu-20.04
+    if: github.repository == 'web-platform-tests/wpt'
     steps:
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -23,8 +24,6 @@ jobs:
         sudo apt-get -qqy install zstd
         pip install -r tools/wpt/requirements.txt
     - name: Run manifest_build.py
-      # Use a conditional step instead of a conditional job to work around #20700.
-      if: github.repository == 'web-platform-tests/wpt'
       run: tools/docker/retry.py --delay 60 python tools/ci/manifest_build.py
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/regen_certs.yml
+++ b/.github/workflows/regen_certs.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   update:
     runs-on: ubuntu-20.04
+    if: github.repository == 'web-platform-tests/wpt'
     steps:
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -16,14 +17,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Regenerate certs
-      # Use a conditional step instead of a conditional job to work around #20700.
-      if: github.repository == 'web-platform-tests/wpt'
       run: |
         python wpt make-hosts-file | sudo tee -a /etc/hosts
         python wpt regen-certs --force
     - name: Commit and create pull request
-      # Use a conditional step instead of a conditional job to work around #20700.
-      if: github.repository == 'web-platform-tests/wpt'
       uses: peter-evans/create-pull-request@v6
       with:
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This undoes the workaround from #20700, as GitHub Actions now handles a workflow run in which everything is skipped more gracefully.

Fixes #48684.