### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=281773

### DIFF
--- a/css/css-inline/text-box-trim/text-box-trim-accumulation-002-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-accumulation-002-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+@import "support/TestMetricsFont.css";
+
+.spacer {
+  background: lightgray;
+  block-size: 100px;
+}
+.target {
+  font: 100px/1 MetricsTestFont;
+  margin-block: -60px -20px;
+}
+</style>
+<div class="spacer"></div>
+<div class="target">ApÉx</div>
+<div class="spacer"></div>

--- a/css/css-inline/text-box-trim/text-box-trim-accumulation-002.html
+++ b/css/css-inline/text-box-trim/text-box-trim-accumulation-002.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>Test trimming both sides of the inline content</title>
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#text-box-trim">
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#text-box-edge">
+<meta name="assert"
+      content="text-box-trim values set by multiple ancestors accumulate instead
+               of overwrite each other."
+>
+<link rel="match" href="text-box-trim-accumulation-002-ref.html">
+<style>
+@import "support/TestMetricsFont.css";
+
+.spacer {
+  block-size: 100px;
+  background: lightgray;
+}
+
+.outer {
+  text-box-trim: trim-start;
+}
+
+.middle {
+  text-box-trim: trim-end;
+  text-box-edge: ex alphabetic;
+}
+
+.inner {
+  font: 100px/1 MetricsTestFont;
+}
+</style>
+<div class="spacer"></div>
+<div class="outer">
+  <div class="middle">
+    <div class="inner">ApÉx</div>
+  </div>
+</div>
+<div class="spacer"></div>

--- a/css/css-inline/text-box-trim/text-box-trim-accumulation-003-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-accumulation-003-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+@import "support/TestMetricsFont.css";
+
+.spacer {
+  background: lightgray;
+  block-size: 100px;
+}
+.target {
+  font: 100px/1 MetricsTestFont;
+  margin-block: -60px -20px;
+}
+</style>
+<div class="spacer"></div>
+<div class="target">ApÉx</div>
+<div class="spacer"></div>

--- a/css/css-inline/text-box-trim/text-box-trim-accumulation-003.html
+++ b/css/css-inline/text-box-trim/text-box-trim-accumulation-003.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>Test trimming both sides of the inline content</title>
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#text-box-trim">
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#text-box-edge">
+<meta name="assert"
+      content="text-box-trim values set by multiple ancestors accumulate instead
+               of overwrite each other."
+>
+<link rel="match" href="text-box-trim-accumulation-003-ref.html">
+<style>
+@import "support/TestMetricsFont.css";
+
+.spacer {
+  block-size: 100px;
+  background: lightgray;
+}
+
+.outer {
+  text-box-trim: trim-end;
+}
+
+.middle {
+  text-box-trim: trim-start;
+  text-box-edge: ex alphabetic;
+}
+
+.inner {
+  font: 100px/1 MetricsTestFont;
+}
+</style>
+<div class="spacer"></div>
+<div class="outer">
+  <div class="middle">
+    <div class="inner">ApÉx</div>
+  </div>
+</div>
+<div class="spacer"></div>

--- a/css/css-inline/text-box-trim/text-box-trim-accumulation-004-ref.html
+++ b/css/css-inline/text-box-trim/text-box-trim-accumulation-004-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<style>
+@import "support/TestMetricsFont.css";
+
+body {
+  font: 100px/1 MetricsTestFont;
+}
+.spacer {
+  background: lightgray;
+  block-size: 100px;
+}
+.target-first {
+  margin-block: -60px 0px;
+}
+.target-second {
+  margin-block: 0px -20px;
+}
+</style>
+<div class="spacer"></div>
+<div class="target-first">ApÉx</div>
+<div class="spacer"></div>
+<div class="target-second">ApÉx</div>
+<div class="spacer"></div>

--- a/css/css-inline/text-box-trim/text-box-trim-accumulation-004.html
+++ b/css/css-inline/text-box-trim/text-box-trim-accumulation-004.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<title>Test trimming both sides of the inline content</title>
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#text-box-trim">
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#text-box-edge">
+<meta name="assert"
+      content="text-box-trim values set by multiple ancestors accumulate instead
+               of overwrite each other. Note that the first inner box is not the last
+               formatted line for trim-end."
+>
+<link rel="match" href="text-box-trim-accumulation-004-ref.html">
+<style>
+@import "support/TestMetricsFont.css";
+
+.spacer {
+  block-size: 100px;
+  background: lightgray;
+}
+
+.outer {
+  text-box-trim: trim-end;
+  text-box-edge: ex alphabetic;
+}
+
+.middle {
+  text-box-trim: trim-start;
+  text-box-edge: ex alphabetic;
+}
+
+.inner {
+  font: 100px/1 MetricsTestFont;
+}
+</style>
+<div class="spacer"></div>
+<div class="outer">
+  <div class="middle">
+    <div class="inner">ApÉx</div>
+  </div>
+  <div class="spacer"></div>
+  <div class="inner">ApÉx</div>
+</div>
+<div class="spacer"></div>


### PR DESCRIPTION
WebKit export from bug: [\[text-box-trim\] Do not override propagated text-box-trim values](https://bugs.webkit.org/show_bug.cgi?id=281773)