### PR TITLE
Add Protected Audiences real time reporting routes to RoutesBuilder

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -602,6 +602,7 @@ class RoutesBuilder:
             ("*", "/.well-known/attribution-reporting/debug/report-aggregate-debug", handlers.PythonScriptHandler),
             ("*", "/.well-known/attribution-reporting/debug/verbose", handlers.PythonScriptHandler),
             ("GET", "/.well-known/interest-group/permissions/", handlers.PythonScriptHandler),
+            ("*", "/.well-known/interest-group/real-time-report", handlers.PythonScriptHandler),
             ("*", "/.well-known/private-aggregation/*", handlers.PythonScriptHandler),
             ("*", "/.well-known/web-identity", handlers.PythonScriptHandler),
             ("*", "*.py", handlers.PythonScriptHandler),


### PR DESCRIPTION
Protected Audience's Real Time Reporting (RTR) API supports sending auction monitoring data to the buyer and seller as quickly as possible (e.g. < 5 mins). Adding RTR routes as a well-known route to the RoutesBuilder so that the WPT server can receive and return RTR reports.

Explainer: https://github.com/WICG/turtledove/blob/main/PA_real_time_monitoring.md#sending-reports-after-an-auction