### PR TITLE
We really should be using `promise_rejects_*` instead

### DIFF
--- a/dom/observable/tentative/observable-first.any.js
+++ b/dom/observable/tentative/observable-first.any.js
@@ -19,41 +19,25 @@ promise_test(async () => {
       "Promise resolves with the first value from the source Observable");
 }, "first(): Promise resolves with the first value from the source Observable");
 
-promise_test(async () => {
+promise_test(async (t) => {
   const error = new Error("error from source");
   const source = new Observable(subscriber => {
     subscriber.error(error);
   });
 
-  let rejection;
-  try {
-    await source.first();
-  } catch (e) {
-    rejection = e;
-  }
-
-  assert_equals(rejection, error, "Promise rejects with source Observable error");
+  return promise_rejects_exactly(t, error, source.first(), "Promise rejects with source Observable error");
 }, "first(): Promise rejects with the error emitted from the source Observable");
 
-promise_test(async () => {
+promise_test(async (t) => {
   const source = new Observable(subscriber => {
     subscriber.complete();
   });
 
-  let rejection;
-  try {
-    await source.first();
-  } catch (e) {
-    rejection = e;
-  }
-
-  assert_true(rejection instanceof RangeError,
-      "Upon complete(), first() Promise rejects with RangeError");
-  assert_true(typeof rejection.message === "string", "Rejection message must be a string");
+  return promise_rejects_js(t, RangeError, source.first(), "Upon complete(), first() Promise rejects with RangeError");
 }, "first(): Promise rejects with RangeError when source Observable " +
    "completes without emitting any values");
 
-promise_test(async () => {
+promise_test(async (t) => {
   const source = new Observable(subscriber => {});
 
   const controller = new AbortController();
@@ -61,18 +45,7 @@ promise_test(async () => {
 
   controller.abort();
 
-  let rejection;
-  try {
-    await promise;
-  } catch (e) {
-    rejection = e;
-  }
-
-  assert_true(rejection instanceof DOMException,
-      "Promise rejects with a DOMException for abortion");
-  assert_equals(rejection.name, "AbortError",
-      "Rejected with 'AbortError' DOMException");
-  assert_true(typeof rejection.message === "string", "Rejection message must be a string");
+  return promise_rejects_dom(t, "AbortError", promise, "Promise rejects with a DOMException for abortion");
 }, "first(): Aborting a signal rejects the Promise with an AbortError DOMException");
 
 promise_test(async () => {

--- a/dom/observable/tentative/observable-last.any.js
+++ b/dom/observable/tentative/observable-last.any.js
@@ -12,41 +12,25 @@ promise_test(async () => {
   assert_equals(value, 2);
 }, "last(): Promise resolves to last value");
 
-promise_test(async () => {
+promise_test(async (t) => {
   const error = new Error("error from source");
   const source = new Observable(subscriber => {
     subscriber.error(error);
   });
 
-  let rejection = null;
-  try {
-    await source.last();
-  } catch (e) {
-    rejection = e;
-  }
-
-  assert_equals(rejection, error);
+  return promise_rejects_exactly(t, error, source.last());
 }, "last(): Promise rejects with emitted error");
 
-promise_test(async () => {
+promise_test(async (t) => {
   const source = new Observable(subscriber => {
     subscriber.complete();
   });
 
-  let rejection = null;
-  try {
-    await source.last();
-  } catch (e) {
-    rejection = e;
-  }
-
-  assert_true(rejection instanceof RangeError,
-      "Promise rejects with RangeError");
-  assert_true(typeof rejection.message === "string", "Rejection message must be a string");
+  return promise_rejects_js(t, RangeError, source.last());
 }, "last(): Promise rejects with RangeError when source Observable " +
    "completes without emitting any values");
 
-promise_test(async () => {
+promise_test(async (t) => {
   const source = new Observable(subscriber => {});
 
   const controller = new AbortController();
@@ -54,18 +38,7 @@ promise_test(async () => {
 
   controller.abort();
 
-  let rejection = null;
-  try {
-    await promise;
-  } catch (e) {
-    rejection = e;
-  }
-
-  assert_true(rejection instanceof DOMException,
-      "Promise rejects with a DOMException for abortion");
-  assert_equals(rejection.name, "AbortError",
-      "Rejected with 'AbortError' DOMException");
-  assert_equals(rejection.message, "signal is aborted without reason");
+  return promise_rejects_dom(t, "AbortError", promise, "Promise rejects with a DOMException for abortion");
 }, "last(): Aborting a signal rejects the Promise with an AbortError DOMException");
 
 promise_test(async () => {


### PR DESCRIPTION
A piece of feedback raised by @annevk though only after https://github.com/web-platform-tests/wpt/pull/48717 landed.