### PR TITLE
Check the processed capabilities of always supported capabilities

### DIFF
--- a/webdriver/tests/classic/new_session/create_alwaysMatch.py
+++ b/webdriver/tests/classic/new_session/create_alwaysMatch.py
@@ -13,3 +13,10 @@ def test_valid(new_session, add_browser_capabilities, key, value):
     response, _ = new_session({"capabilities": {
         "alwaysMatch": add_browser_capabilities({key: value})}})
     assert_success(response)
+    response_capabilities = response.body["value"]["capabilities"]
+    if ":" not in key and value is not None:
+        if key == "timeouts":
+            for timeout_key, timeout_value in value.items():
+                assert response_capabilities[key][timeout_key] == timeout_value
+        else:
+            assert response_capabilities[key] == value

--- a/webdriver/tests/classic/new_session/create_firstMatch.py
+++ b/webdriver/tests/classic/new_session/create_firstMatch.py
@@ -14,3 +14,10 @@ def test_valid(new_session, add_browser_capabilities, key, value):
     response, _ = new_session({"capabilities": {
         "firstMatch": [add_browser_capabilities({key: value})]}})
     assert_success(response)
+    response_capabilities = response.body["value"]["capabilities"]
+    if ":" not in key and value is not None:
+        if key == "timeouts":
+            for timeout_key, timeout_value in value.items():
+                assert response_capabilities[key][timeout_key] == timeout_value
+        else:
+            assert response_capabilities[key] == value


### PR DESCRIPTION
I do vaguely wonder if we should split out this into a separate test, rather than adding this to the existing one? We mostly validate the processed (returned) capabilities in individual tests, but we mostly can't do this in such a generic way.