### PR TITLE
[wptrunner] Work around WebView bugs in ChromeDriver runner

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/android_webview.py
+++ b/tools/wptrunner/wptrunner/browsers/android_webview.py
@@ -6,16 +6,16 @@ from .base import get_timeout_multiplier   # noqa: F401
 from .chrome import executor_kwargs as chrome_executor_kwargs
 from .chrome_android import ChromeAndroidBrowserBase
 from ..executors.base import WdspecExecutor  # noqa: F401
-from ..executors.executorchrome import ChromeDriverPrintRefTestExecutor  # noqa: F401
+from ..executors.executorchrome import (ChromeDriverPrintRefTestExecutor,  # noqa: F401
+                                        ChromeDriverTestharnessExecutor)  # noqa: F401
 from ..executors.executorwebdriver import (WebDriverCrashtestExecutor,  # noqa: F401
-                                           WebDriverTestharnessExecutor,  # noqa: F401
                                            WebDriverRefTestExecutor)  # noqa: F401
 
 
 __wptrunner__ = {"product": "android_webview",
                  "check_args": "check_args",
                  "browser": "SystemWebViewShell",
-                 "executor": {"testharness": "WebDriverTestharnessExecutor",
+                 "executor": {"testharness": "ChromeDriverTestharnessExecutor",
                               "reftest": "WebDriverRefTestExecutor",
                               "print-reftest": "ChromeDriverPrintRefTestExecutor",
                               "wdspec": "WdspecExecutor",


### PR DESCRIPTION
* Restore the window-creation logic prior to #48610 for WebView, which turns out to not support the "new window" command (https://crbug.com/375275185).
* Catch all `WebDriverException`s when issuing CDP commands, since WebView fails on `Browser.resetPermissions` with `Browser context management is not supported.`. Resetting state is now best-effort.