### PR TITLE
Catch committed promise rejection

### DIFF
--- a/navigation-api/navigate-event/signal-abort-window-stop-in-onnavigate.html
+++ b/navigation-api/navigate-event/signal-abort-window-stop-in-onnavigate.html
@@ -3,7 +3,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 async_test(t => {
-  window.onload = t.step_func_done(() => {
+  window.onload = t.step_func(() => {
     let abort_signal;
     let onabort_called = false;
     let canceled_in_second_handler = false;
@@ -15,10 +15,12 @@ async_test(t => {
     navigation.addEventListener("navigate", t.step_func(e => {
       canceled_in_second_handler = e.defaultPrevented;
     }));
-    navigation.navigate("?1");
-    assert_true(abort_signal.aborted);
-    assert_true(onabort_called);
-    assert_true(canceled_in_second_handler);
+    navigation.navigate("?1").committed.catch((error) => {
+      assert_true(abort_signal.aborted);
+      assert_true(onabort_called);
+      assert_true(canceled_in_second_handler);
+      t.done();
+    });
   });
 }, "window.stop() signals event.signal inside a navigate event handler");
 </script>


### PR DESCRIPTION
Not catching promise rejection can (flakily) cause log statements in test results for WebKit.