### PR TITLE
wptrunner: update to pillow 10.4.0 module to fix breakage in macos

### DIFF
--- a/tools/wptrunner/requirements.txt
+++ b/tools/wptrunner/requirements.txt
@@ -4,7 +4,7 @@ mozinfo==1.2.3  # https://bugzilla.mozilla.org/show_bug.cgi?id=1621226
 mozlog==8.0.0
 mozprocess==1.3.1
 packaging==24.0
-pillow==10.3.0
+pillow==10.4.0
 requests==2.32.3
 six==1.16.0
 urllib3==2.2.2


### PR DESCRIPTION
The wptrunner depends on the python module pillow which it currently
pins to 10.3.0. This version has a known [bug][1]  that breaks when used
with python 3.13 and above. This change updates wptrunners's
requirments.txt to use pillow 10.4.0 which contains a fix for this bug.

[bug]: https://github.com/python-pillow/Pillow/issues/8075

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>

Reviewed in servo/servo#34021