### PR TITLE
servoshell: Allow overriding screen resolution with a command-line argument

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -230,7 +230,7 @@ class ServoRefTestExecutor(ServoExecutor):
         with TempFilename(self.tempdir) as output_path:
             extra_args = ["--exit",
                           "--output=%s" % output_path,
-                          "--resolution", viewport_size or "800x600"]
+                          "--window-size", viewport_size or "800x600"]
             debug_opts = "disable-text-aa,load-webfonts-synchronously,replace-surrogates"
 
             if dpi:


### PR DESCRIPTION
There is a command-line argument to override the default window size,
but not one for overriding the default screen resolution. This is
important for testing pages that use screen size to have different
behavior.

In addition to adding the new option this change:

 - Renames the `--resolution` command-line argument to `--window-size`
   to remove ambiguity with the `--screen-size` argument.
 - Passes the screen size as device independent (device pixels scaled by
   HiDPI factor) to Servo internals. Not only it make it simpler to pass
   the `--window-size` override, it makes more sense. Different screens
   can have different HiDPI factors and these can be different from the
   scale of the window. This makes the screen HiDPI factor totally
   independent of the one that Servo uses for the window.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#34038