### PR TITLE
[wptrunner] Remove obsolete workaround for "set timeouts" nonconformance

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -73,12 +73,7 @@ class WebDriverBaseProtocolPart(BaseProtocolPart):
         return method(script, args=args)
 
     def set_timeout(self, timeout):
-        try:
-            self.webdriver.timeouts.script = timeout
-        except webdriver_error.WebDriverException:
-            # workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2057
-            body = {"type": "script", "ms": timeout * 1000}
-            self.webdriver.send_session_command("POST", "timeouts", body)
+        self.webdriver.timeouts.script = timeout
 
     def create_window(self, type="tab", **kwargs):
         return self.webdriver.new_window(type_hint=type)


### PR DESCRIPTION
According to the bug, ChromeDriver now fully supports the standard "set timeouts" endpoint, so there's no need to fall back to the nonstandard endpoint.