### PR TITLE
[wptrunner] Check we actually manage to close the window

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -252,7 +252,9 @@ class WebDriverTestharnessProtocolPart(TestharnessProtocolPart):
         for window_handle in window_handles:
             try:
                 self.webdriver.window_handle = window_handle
-                self.webdriver.window.close()
+                remaining_windows = self.webdriver.window.close()
+                if window_handle in remaining_windows:
+                    raise Exception("the window remained open after sending the window close command")
             except webdriver_error.NoSuchWindowException:
                 pass
 


### PR DESCRIPTION
After https://github.com/web-platform-tests/wpt/commit/bef892c48976038b207f3aedf4088a5552cbae67 (from https://github.com/web-platform-tests/wpt/pull/48610), Safari had a number of tests change behaviour: https://wpt.fyi/results/?diff&filter=ADC&run_id=5195649314455552&run_id=5132128627195904.

Ultimately, this is because we practically checked windows closed before, because the "Hope the first one here is the test window" comment turned out to be false hope in Safari, so we'd later fail.

This actually leaves us somewhere better than that, as it makes the check explicit, and as long as close_after_done is True (which it typically is), it makes the test that left us in the broken state come back as ERROR, rather than some following test.

Before https://github.com/web-platform-tests/wpt/commit/bef892c48976038b207f3aedf4088a5552cbae67:

```
 0:03.05 SUITE_START: web-platform-test - running 4 tests
 0:04.67 TEST_START: /permissions-policy/reporting/geolocation-report-only.https.html
 0:14.90 TEST_END: Test TIMEOUT, expected OK. Subtests passed 0/1. Unexpected 1
TIMEOUT Geolocation report only mode - Test timed outTIMEOUT /permissions-policy/reporting/geolocation-report-only.https.html
 0:14.91 TEST_START: /permissions-policy/reporting/geolocation-reporting.https.html
 0:25.10 TEST_END: Test TIMEOUT, expected OK. Subtests passed 0/1. Unexpected 1
NOTRUN Geolocation Report FormatTIMEOUT /permissions-policy/reporting/geolocation-reporting.https.html
 0:25.10 TEST_START: /permissions-policy/reporting/serial-report-only.https.html
 0:30.27 TEST_END: ERROR, expected OK - Traceback (most recent call last):
  File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorwebdriver.py", line 776, in run_func
    self.result = True, self.func(self.protocol, self.url, self.timeout)
  File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorwebdriver.py", line 869, in do_testharness
    test_window = protocol.testharness.get_test_window(self.window_id,
  File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorwebdriver.py", line 296, in get_test_window
    raise Exception("unable to find test window")
Exception: unable to find test window

 0:32.26 TEST_START: /pointerevents/pointerevent_boundary_events_at_implicit_release_hoverable_pointers.html
 0:32.72 TEST_END: Test OK. Subtests passed 1/1. Unexpected 0
 0:32.93 SUITE_END
```

After https://github.com/web-platform-tests/wpt/commit/bef892c48976038b207f3aedf4088a5552cbae67:

```
 0:04.29 SUITE_START: web-platform-test - running 4 tests
 0:05.94 TEST_START: /permissions-policy/reporting/geolocation-report-only.https.html
 0:16.16 TEST_END: Test TIMEOUT, expected OK. Subtests passed 0/1. Unexpected 1
TIMEOUT Geolocation report only mode - Test timed outTIMEOUT /permissions-policy/reporting/geolocation-report-only.https.html
 0:16.16 TEST_START: /permissions-policy/reporting/geolocation-reporting.https.html
 0:26.34 TEST_END: Test TIMEOUT, expected OK. Subtests passed 0/1. Unexpected 1
NOTRUN Geolocation Report FormatTIMEOUT /permissions-policy/reporting/geolocation-reporting.https.html
 0:26.34 TEST_START: /permissions-policy/reporting/serial-report-only.https.html
 0:26.52 TEST_END: Test OK. Subtests passed 0/2. Unexpected 2
FAIL requestPort in serial report only mode - assert_equals: expected (number) 8 but got (undefined) undefined
@https://web-platform.test:8443/permissions-policy/reporting/serial-report-only.https.html:30:18
FAIL getPorts in serial report only mode - promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'navigator.serial.getPorts')"
get_stack@https://web-platform.test:8443/resources/testharness.js:4551:30
AssertionError@https://web-platform.test:8443/resources/testharness.js:4544:31
assert@https://web-platform.test:8443/resources/testharness.js:4528:37
@https://web-platform.test:8443/resources/testharness.js:764:35
@https://web-platform.test:8443/resources/testharness.js:2622:30
@https://web-platform.test:8443/resources/testharness.js:2669:40

 0:26.52 TEST_START: /pointerevents/pointerevent_boundary_events_at_implicit_release_hoverable_pointers.html
 0:36.74 TEST_END: Test TIMEOUT, expected OK. Subtests passed 0/1. Unexpected 1
NOTRUN mouse Event sequence at implicit release on clickTIMEOUT /pointerevents/pointerevent_boundary_events_at_implicit_release_hoverable_pointers.html
 0:37.16 SUITE_END
```

And after this PR:

```
 0:04.57 SUITE_START: web-platform-test - running 4 tests
 0:06.15 TEST_START: /permissions-policy/reporting/geolocation-report-only.https.html
 0:16.38 TEST_END: ERROR, expected OK - Traceback (most recent call last):
  File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorwebdriver.py", line 719, in run_func
    self.result = True, self.func(self.protocol, self.url, self.timeout)
  File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorwebdriver.py", line 919, in do_testharness
    protocol.testharness.close_old_windows()
  File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorwebdriver.py", line 243, in close_old_windows
    self.close_windows(set(self.webdriver.handles) - {
  File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorwebdriver.py", line 257, in close_windows
    raise Exception("the window remained open after sending the window close command")
Exception: the window remained open after sending the window close command

 0:18.44 TEST_START: /permissions-policy/reporting/geolocation-reporting.https.html
 0:28.65 TEST_END: ERROR, expected OK - Traceback (most recent call last):
  File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorwebdriver.py", line 719, in run_func
    self.result = True, self.func(self.protocol, self.url, self.timeout)
  File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorwebdriver.py", line 919, in do_testharness
    protocol.testharness.close_old_windows()
  File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorwebdriver.py", line 243, in close_old_windows
    self.close_windows(set(self.webdriver.handles) - {
  File "/Volumes/gsnedders/projects/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorwebdriver.py", line 257, in close_windows
    raise Exception("the window remained open after sending the window close command")
Exception: the window remained open after sending the window close command

 0:30.57 TEST_START: /permissions-policy/reporting/serial-report-only.https.html
 0:30.83 TEST_END: Test OK. Subtests passed 0/2. Unexpected 2
FAIL requestPort in serial report only mode - assert_equals: expected (number) 8 but got (undefined) undefined
@https://web-platform.test:8443/permissions-policy/reporting/serial-report-only.https.html:30:18
FAIL getPorts in serial report only mode - promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'navigator.serial.getPorts')"
get_stack@https://web-platform.test:8443/resources/testharness.js:4551:30
AssertionError@https://web-platform.test:8443/resources/testharness.js:4544:31
assert@https://web-platform.test:8443/resources/testharness.js:4528:37
@https://web-platform.test:8443/resources/testharness.js:764:35
@https://web-platform.test:8443/resources/testharness.js:2622:30
@https://web-platform.test:8443/resources/testharness.js:2669:40

 0:30.83 TEST_START: /pointerevents/pointerevent_boundary_events_at_implicit_release_hoverable_pointers.html
 0:31.28 TEST_END: Test OK. Subtests passed 1/1. Unexpected 0
 0:31.56 SUITE_END
 ```