### PR TITLE
Make the JPEG XL images get rendered larger

### DIFF
--- a/jpegxl/3x3_jpeg_recompression-ref.html
+++ b/jpegxl/3x3_jpeg_recompression-ref.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <title>JPEG XL test reference</title>
 
-<img src="./resources/3x3_jpeg_recompression.png">
+<img src="./resources/3x3_jpeg_recompression.png" style="height:525px">

--- a/jpegxl/3x3_jpeg_recompression.html
+++ b/jpegxl/3x3_jpeg_recompression.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <title>JPEG XL test</title>
-<meta name=fuzzy content="0-1;0-9">
+<meta name=fuzzy content="0-1;0-275625">
 <link rel="help" href="https://jpeg.org/jpegxl/">
 <link rel="match" href="3x3_jpeg_recompression-ref.html">
 <meta name="assert" content="JPEG XL image is rendered correctly">
 
-<img src="./resources/3x3_jpeg_recompression.jxl">
+<img src="./resources/3x3_jpeg_recompression.jxl" style="height:525px">

--- a/jpegxl/3x3_srgb_lossless-ref.html
+++ b/jpegxl/3x3_srgb_lossless-ref.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <title>JPEG XL test reference</title>
 
-<img src="./resources/3x3_srgb_lossless.png">
+<img src="./resources/3x3_srgb_lossless.png" style="height:525px">

--- a/jpegxl/3x3_srgb_lossless.html
+++ b/jpegxl/3x3_srgb_lossless.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <title>JPEG XL test</title>
-<meta name=fuzzy content="0-4;0-9">
+<meta name=fuzzy content="0-4;0-275625">
 <link rel="help" href="https://jpeg.org/jpegxl/">
 <link rel="match" href="3x3_srgb_lossless-ref.html">
 <meta name="assert" content="JPEG XL image is rendered correctly">
 
-<img src="./resources/3x3_srgb_lossless.jxl">
+<img src="./resources/3x3_srgb_lossless.jxl" style="height:525px">

--- a/jpegxl/3x3_srgb_lossy-ref.html
+++ b/jpegxl/3x3_srgb_lossy-ref.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <title>JPEG XL test reference</title>
 
-<img src="./resources/3x3_srgb_lossy.png">
+<img src="./resources/3x3_srgb_lossy.png" style="height:525px">

--- a/jpegxl/3x3_srgb_lossy.html
+++ b/jpegxl/3x3_srgb_lossy.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <title>JPEG XL test</title>
-<meta name=fuzzy content="0-10;0-9">
+<meta name=fuzzy content="0-10;0-275625">
 <link rel="help" href="https://jpeg.org/jpegxl/">
 <link rel="match" href="3x3_srgb_lossy-ref.html">
 <meta name="assert" content="JPEG XL image is rendered correctly">
 
-<img src="./resources/3x3_srgb_lossy.jxl">
+<img src="./resources/3x3_srgb_lossy.jxl" style="height:525px">

--- a/jpegxl/3x3a_srgb_lossless-ref.html
+++ b/jpegxl/3x3a_srgb_lossless-ref.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <title>JPEG XL test reference</title>
 
-<img src="./resources/3x3a_srgb_lossless.png">
+<img src="./resources/3x3a_srgb_lossless.png" style="height:525px">

--- a/jpegxl/3x3a_srgb_lossless.html
+++ b/jpegxl/3x3a_srgb_lossless.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <title>JPEG XL test</title>
-<meta name=fuzzy content="0-4;0-9">
+<meta name=fuzzy content="0-4;0-275625">
 <link rel="help" href="https://jpeg.org/jpegxl/">
 <link rel="match" href="3x3a_srgb_lossless-ref.html">
 <meta name="assert" content="JPEG XL image is rendered correctly">
 
-<img src="./resources/3x3a_srgb_lossless.jxl">
+<img src="./resources/3x3a_srgb_lossless.jxl" style="height:525px">

--- a/jpegxl/3x3a_srgb_lossy-ref.html
+++ b/jpegxl/3x3a_srgb_lossy-ref.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <title>JPEG XL test reference</title>
 
-<img src="./resources/3x3a_srgb_lossy.png">
+<img src="./resources/3x3a_srgb_lossy.png" style="height:525px">

--- a/jpegxl/3x3a_srgb_lossy.html
+++ b/jpegxl/3x3a_srgb_lossy.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <title>JPEG XL test</title>
-<meta name=fuzzy content="0-10;0-9">
+<meta name=fuzzy content="0-10;0-275625">
 <link rel="help" href="https://jpeg.org/jpegxl/">
 <link rel="match" href="3x3a_srgb_lossy-ref.html">
 <meta name="assert" content="JPEG XL image is rendered correctly">
 
-<img src="./resources/3x3a_srgb_lossy.jxl">
+<img src="./resources/3x3a_srgb_lossy.jxl" style="height:525px">


### PR DESCRIPTION
It's very hard to look at differences when they're very small 3x3 spots on a large screen, so we should just make these bigger.