### PR TITLE
Tidy up WebDriver errors (mostly via `__str__`)

### DIFF
--- a/tools/webdriver/webdriver/error.py
+++ b/tools/webdriver/webdriver/error.py
@@ -2,6 +2,7 @@
 
 import collections
 import json
+import string
 
 from typing import ClassVar, DefaultDict, Type
 
@@ -32,11 +33,10 @@ class WebDriverException(Exception):
         message = f"{self.status_code} ({self.http_status})"
 
         if self.message is not None:
-            message += ": %s" % self.message
-        message += "\n"
+            message += ": %s" % self.message.strip(string.whitespace)
 
-        if self.stacktrace:
-            message += ("\nRemote-end stacktrace:\n\n%s" % self.stacktrace)
+        if self.stacktrace is not None:
+            message += ("\n\nRemote-end stacktrace:\n\n%s" % self.stacktrace.strip("\n"))
 
         return message
 
@@ -209,9 +209,10 @@ def from_response(response):
             "Expected 'value' key in response body:\n"
             "%s" % json.dumps(response.body))
 
-    # all fields must exist, but stacktrace can be an empty string
+    # all fields must exist, but both message and stacktrace are
+    # implementation-defined and could be empty
     code = value["error"]
-    message = value["message"]
+    message = value["message"] or None
     stack = value["stacktrace"] or None
 
     cls = get(code)


### PR DESCRIPTION
This avoids `__str__` having a trailing new line (as this makes it odd to include in a typically single-line error message), and remove excess whitespace (all ASCII from the message, new lines from the stacktrace).

Additionally, make the message match the stacktrace: set it to None unless we have a non-empty string. Both are implementation defined, and in both cases they are sometimes empty. This makes the `if self.message is not None` work as intended within `__str__`.