### PR TITLE
Prefer MP4 videos over WebM videos

### DIFF
--- a/common/media.js
+++ b/common/media.js
@@ -11,7 +11,7 @@ function getVideoURI(base)
 
     if ( videotag.canPlayType )
     {
-      if ( videotag.canPlayType('video/mp4; codecs="avc1, mp4a.40.2"') )
+      if ( videotag.canPlayType('video/mp4') )
       {
           extension = '.mp4';
       } else if ( videotag.canPlayType('video/webm; codecs="vp9, opus"') )

--- a/common/media.js
+++ b/common/media.js
@@ -11,7 +11,10 @@ function getVideoURI(base)
 
     if ( videotag.canPlayType )
     {
-      if (videotag.canPlayType('video/webm; codecs="vp9, opus"') )
+      if (videotag.canPlayType('video/mp4')
+      {
+          extension = '.mp4';
+      } else if (videotag.canPlayType('video/webm; codecs="vp9, opus"') )
       {
           extension = '.webm';
       }

--- a/common/media.js
+++ b/common/media.js
@@ -11,10 +11,10 @@ function getVideoURI(base)
 
     if ( videotag.canPlayType )
     {
-      if (videotag.canPlayType('video/mp4')
+      if ( videotag.canPlayType('video/mp4; codecs="avc1, mp4a.40.2"') )
       {
           extension = '.mp4';
-      } else if (videotag.canPlayType('video/webm; codecs="vp9, opus"') )
+      } else if ( videotag.canPlayType('video/webm; codecs="vp9, opus"') )
       {
           extension = '.webm';
       }


### PR DESCRIPTION
MP4 videos are more common on the web and affect more users, so testing those is more valuable than WebM which is a newer format.