### PR TITLE
Move 'valid codec with spaces' to validButUnsupportedConfigs configs

### DIFF
--- a/webcodecs/video-decoder.https.any.js
+++ b/webcodecs/video-decoder.https.any.js
@@ -97,7 +97,7 @@ const validButUnsupportedConfigs = [
   {
     comment: 'codec with spaces',
     config: {codec: '  vp09.00.10.08  '},
-  },  
+  },
 ];  //  validButUnsupportedConfigs
 
 validButUnsupportedConfigs.forEach(entry => {

--- a/webcodecs/video-decoder.https.any.js
+++ b/webcodecs/video-decoder.https.any.js
@@ -94,6 +94,10 @@ const validButUnsupportedConfigs = [
     comment: 'Possible future AV1 codec string',
     config: {codec: 'av01.9.99M.08'},
   },
+  {
+    comment: 'codec with spaces',
+    config: {codec: '  vp09.00.10.08  '},
+  },  
 ];  //  validButUnsupportedConfigs
 
 validButUnsupportedConfigs.forEach(entry => {
@@ -151,10 +155,6 @@ promise_test(t => {
 }, 'Test VideoDecoder construction');
 
 const validConfigs = [
-  {
-    comment: 'valid codec with spaces',
-    config: {codec: '  vp09.00.10.08  '},
-  },
   {
     comment: 'variant 1 of h264 codec string',
     config: {codec: 'avc3.42001E'},


### PR DESCRIPTION
UA is not expected to support codec strings with whitespaces around it, even though it's a valid config.

Originally when this test was introduced by https://github.com/web-platform-tests/wpt/commit/10ae57963ebb479471d0b6b1c4d66af3ad4f354a , it tested that spaces around codec string don't make it invalid. Later on this https://github.com/web-platform-tests/wpt/commit/3939cbfd5454fcecc7ad20798af01116dfb5442e change started to check that `'  vp09.00.10.08  '` is a correct way to refer to a VP9 codec and `VideoDecoder.configure()` should be succeed. The spec does not support this point of view and I see no reason to allow it. 