### PR TITLE
Use image-rendering: crisp-edges for all the resized image tests

### DIFF
--- a/avif/animated-avif-timeout-ref.html
+++ b/avif/animated-avif-timeout-ref.html
@@ -1,1 +1,1 @@
-<img src=../images/green.avif style="height:500px">
+<img src=../images/green.avif style="height:500px;image-rendering:crisp-edges;">

--- a/avif/animated-avif-timeout.html
+++ b/avif/animated-avif-timeout.html
@@ -1,7 +1,7 @@
 <html class="reftest-wait">
 <title>Animated AVIF: Second frame displays quickly, replacing red with green.</title>
 <link rel="match" href="animated-avif-timeout-ref.html"/>
-<img src=../images/animated-avif.avif onload="loaded()" style="height:500px"/>
+<img src=../images/animated-avif.avif onload="loaded()" style="height:500px;image-rendering:crisp-edges;"/>
 <script>
   function loaded() {
     setTimeout(function() {

--- a/jpegxl/3x3_jpeg_recompression-ref.html
+++ b/jpegxl/3x3_jpeg_recompression-ref.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <title>JPEG XL test reference</title>
 
-<img src="./resources/3x3_jpeg_recompression.png" style="height:525px">
+<img src="./resources/3x3_jpeg_recompression.png" style="height:525px;image-rendering:crisp-edges;">

--- a/jpegxl/3x3_jpeg_recompression.html
+++ b/jpegxl/3x3_jpeg_recompression.html
@@ -5,4 +5,4 @@
 <link rel="match" href="3x3_jpeg_recompression-ref.html">
 <meta name="assert" content="JPEG XL image is rendered correctly">
 
-<img src="./resources/3x3_jpeg_recompression.jxl" style="height:525px">
+<img src="./resources/3x3_jpeg_recompression.jxl" style="height:525px;image-rendering:crisp-edges;">

--- a/jpegxl/3x3_srgb_lossless-ref.html
+++ b/jpegxl/3x3_srgb_lossless-ref.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <title>JPEG XL test reference</title>
 
-<img src="./resources/3x3_srgb_lossless.png" style="height:525px">
+<img src="./resources/3x3_srgb_lossless.png" style="height:525px;image-rendering:crisp-edges;">

--- a/jpegxl/3x3_srgb_lossless.html
+++ b/jpegxl/3x3_srgb_lossless.html
@@ -5,4 +5,4 @@
 <link rel="match" href="3x3_srgb_lossless-ref.html">
 <meta name="assert" content="JPEG XL image is rendered correctly">
 
-<img src="./resources/3x3_srgb_lossless.jxl" style="height:525px">
+<img src="./resources/3x3_srgb_lossless.jxl" style="height:525px;image-rendering:crisp-edges;">

--- a/jpegxl/3x3_srgb_lossy-ref.html
+++ b/jpegxl/3x3_srgb_lossy-ref.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <title>JPEG XL test reference</title>
 
-<img src="./resources/3x3_srgb_lossy.png" style="height:525px">
+<img src="./resources/3x3_srgb_lossy.png" style="height:525px;image-rendering:crisp-edges;">

--- a/jpegxl/3x3_srgb_lossy.html
+++ b/jpegxl/3x3_srgb_lossy.html
@@ -5,4 +5,4 @@
 <link rel="match" href="3x3_srgb_lossy-ref.html">
 <meta name="assert" content="JPEG XL image is rendered correctly">
 
-<img src="./resources/3x3_srgb_lossy.jxl" style="height:525px">
+<img src="./resources/3x3_srgb_lossy.jxl" style="height:525px;image-rendering:crisp-edges;">

--- a/jpegxl/3x3a_srgb_lossless-ref.html
+++ b/jpegxl/3x3a_srgb_lossless-ref.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <title>JPEG XL test reference</title>
 
-<img src="./resources/3x3a_srgb_lossless.png" style="height:525px">
+<img src="./resources/3x3a_srgb_lossless.png" style="height:525px;image-rendering:crisp-edges;">

--- a/jpegxl/3x3a_srgb_lossless.html
+++ b/jpegxl/3x3a_srgb_lossless.html
@@ -5,4 +5,4 @@
 <link rel="match" href="3x3a_srgb_lossless-ref.html">
 <meta name="assert" content="JPEG XL image is rendered correctly">
 
-<img src="./resources/3x3a_srgb_lossless.jxl" style="height:525px">
+<img src="./resources/3x3a_srgb_lossless.jxl" style="height:525px;image-rendering:crisp-edges;">

--- a/jpegxl/3x3a_srgb_lossy-ref.html
+++ b/jpegxl/3x3a_srgb_lossy-ref.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <title>JPEG XL test reference</title>
 
-<img src="./resources/3x3a_srgb_lossy.png" style="height:525px">
+<img src="./resources/3x3a_srgb_lossy.png" style="height:525px;image-rendering:crisp-edges;">

--- a/jpegxl/3x3a_srgb_lossy.html
+++ b/jpegxl/3x3a_srgb_lossy.html
@@ -5,4 +5,4 @@
 <link rel="match" href="3x3a_srgb_lossy-ref.html">
 <meta name="assert" content="JPEG XL image is rendered correctly">
 
-<img src="./resources/3x3a_srgb_lossy.jxl" style="height:525px">
+<img src="./resources/3x3a_srgb_lossy.jxl" style="height:525px;image-rendering:crisp-edges;">


### PR DESCRIPTION
We've slowly added explicit sizing to a number of image rendering tests to make it easier to see the actual test element; however, we should probably keep the often sharp edges (of individual test blocks) within the test images clear.

This is a follow-on from #41949 and #48859.