### PR TITLE
Split pointerevent_sequence_at_implicit_release_on_click.html into 2 subtests

### DIFF
--- a/pointerevents/pointerevent_sequence_at_implicit_release_on_click.html
+++ b/pointerevents/pointerevent_sequence_at_implicit_release_on_click.html
@@ -32,11 +32,14 @@
         var test_pointer_event = setup_pointerevent_test("Event sequence at implicit release on click", [inputSource]);
 
         on_event(document.getElementById("done"), "click", function() {
+          var expected_events = "pointerup, lostpointercapture, pointerout, pointerleave";
           test_pointer_event.step(function () {
-            var expected_events = "pointerup, lostpointercapture, pointerout, pointerleave";
             assert_true(event_log.join(", ").startsWith(expected_events), "Boundary events are emitted after lostpointercapture");
+          });
+          test_pointer_event.step(function () {
             assert_equals(event_log.join(", "), expected_events, "No extra events are emitted");
           });
+
           // Make sure the test finishes after all the input actions are completed.
           actions_promise.then( () => {
             test_pointer_event.done();

--- a/pointerevents/pointerevent_sequence_at_implicit_release_on_click.html
+++ b/pointerevents/pointerevent_sequence_at_implicit_release_on_click.html
@@ -40,10 +40,11 @@
 
           // Make sure the test finishes after all the input actions are completed.
           actions_promise.then( () => {
+            let extra_events = event_log.join(", ").replace(new RegExp(`^${expected_events}(, )?`), "");
             test_pointer_event.done();
 
             no_extra_event_test.step(() => {
-              assert_equals(event_log.join(", "), expected_events);
+              assert_equals(extra_events, "");
             });
             no_extra_event_test.done();
           });

--- a/pointerevents/pointerevent_sequence_at_implicit_release_on_click.html
+++ b/pointerevents/pointerevent_sequence_at_implicit_release_on_click.html
@@ -29,20 +29,22 @@
       }
 
       function run() {
-        var test_pointer_event = setup_pointerevent_test("Event sequence at implicit release on click", [inputSource]);
+        var test_pointer_event = setup_pointerevent_test("Boundary events are emitted after lostpointercapture", [inputSource]);
 
         on_event(document.getElementById("done"), "click", function() {
           var expected_events = "pointerup, lostpointercapture, pointerout, pointerleave";
           test_pointer_event.step(function () {
             assert_true(event_log.join(", ").startsWith(expected_events), "Boundary events are emitted after lostpointercapture");
           });
-          test_pointer_event.step(function () {
-            assert_equals(event_log.join(", "), expected_events, "No extra events are emitted");
-          });
 
           // Make sure the test finishes after all the input actions are completed.
           actions_promise.then( () => {
             test_pointer_event.done();
+
+            // Run the next subtest.
+            test(function () {
+              assert_equals(event_log.join(", "), expected_events);
+            }, "No extra events are emitted");
           });
         });
 

--- a/pointerevents/pointerevent_sequence_at_implicit_release_on_click.html
+++ b/pointerevents/pointerevent_sequence_at_implicit_release_on_click.html
@@ -30,21 +30,22 @@
 
       function run() {
         var test_pointer_event = setup_pointerevent_test("Boundary events are emitted after lostpointercapture", [inputSource]);
+        var no_extra_event_test = async_test("No extra events are emitted");
 
         on_event(document.getElementById("done"), "click", function() {
           var expected_events = "pointerup, lostpointercapture, pointerout, pointerleave";
           test_pointer_event.step(function () {
-            assert_true(event_log.join(", ").startsWith(expected_events), "Boundary events are emitted after lostpointercapture");
+            assert_true(event_log.join(", ").startsWith(expected_events));
           });
 
           // Make sure the test finishes after all the input actions are completed.
           actions_promise.then( () => {
             test_pointer_event.done();
 
-            // Run the next subtest.
-            test(function () {
+            no_extra_event_test.step(() => {
               assert_equals(event_log.join(", "), expected_events);
-            }, "No extra events are emitted");
+            });
+            no_extra_event_test.done();
           });
         });
 


### PR DESCRIPTION
#48862 didn't turn out as expected, let's try to split this into 2 different subtests.