### PR TITLE
Configure docker image to autospawn pulseaudio on demand

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -77,6 +77,11 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
+# Setup on-demand pulseaudio with a "Dummy Output" audio sink.
+# This simply creates a file containing autospawn=yes at
+# /run/pulseaudio-enable-autospawn, linked from /etc/pulse/client.conf.d/
+RUN /etc/init.d/pulseaudio-enable-autospawn start
+
 RUN useradd test \
          --shell /bin/bash  \
          --create-home \


### PR DESCRIPTION
Many webaudio tests expect an audio output device.  Chrome renders Web Audio to a silent sink if the platform provides none [1], but Firefox does not.

Some audio-output tests also expect an audio output device.

Having an audio output device present is representative of the majority of desktop systems.

autospawn is used because systemd does not run inside the docker container.

[1]
https://chromium-review.googlesource.com/c/chromium/src/+/5937369/4#message-0a2737d58de0ab8bd8acf4a245adbd045cdbc75d