### PR TITLE
Fix timeout in position-absolute-replaced-minmax.html

### DIFF
--- a/css/css-position/position-absolute-replaced-minmax.html
+++ b/css/css-position/position-absolute-replaced-minmax.html
@@ -336,6 +336,7 @@
 
   function testAfterImageLoads(img, test) {
     let asyncTest = async_test(getTestName(img));
+    img.addEventListener("error", asyncTest.unreached_func("Load shouldn't fail"));
     img.addEventListener("load", _ => {
       asyncTest.step(test);
       asyncTest.done();


### PR DESCRIPTION
Some images don't load because we don't support SVG.
In that case this makes the test fail rather than timing out.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#34075