### PR TITLE
Add missing tabindex="0" to focus-reset tests

### DIFF
--- a/navigation-api/focus-reset/resources/helpers.mjs
+++ b/navigation-api/focus-reset/resources/helpers.mjs
@@ -10,6 +10,7 @@ export function testFocusWasReset(setupFunc, description) {
 
     const button = document.body.appendChild(document.createElement("button"));
     const button2 = document.body.appendChild(document.createElement("button"));
+    button.tabIndex = 0;
     button2.tabIndex = 0;
     t.add_cleanup(() => {
       button.remove();


### PR DESCRIPTION
On Safari, buttons are not focusable by default unless a setting is enabled, or if the button has tabindex="0". Add missing tabindex="0" so the buttons can be focus delegates.