### PR TITLE
Send wptserve.server.BaseWebTestRequestHandler.log_* to the logger

### DIFF
--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 
 import errno
+import http
 import http.server
 import os
 import socket
@@ -341,6 +342,34 @@ class BaseWebTestRequestHandler(http.server.BaseHTTPRequestHandler):
                                                    server_side=True)
             self.setup()
         return
+
+    def log_request(self, code="-", size="-"):
+        if isinstance(code, http.HTTPStatus):
+            code = code.value
+
+        self.logger.debug(
+            "{} - - [{}] {!r} {!s} {!s}".format(
+                self.address_string(),
+                self.log_date_time_string(),
+                self.requestline,
+                code,
+                size,
+            )
+        )
+
+    def log_error(self, format, *args):
+        self.logger.error(
+            "{} - - [{}] {}".format(
+                self.address_string(), self.log_date_time_string(), format % args
+            )
+        )
+
+    def log_message(self, format, *args):
+        self.logger.info(
+            "{} - - [{}] {}".format(
+                self.address_string(), self.log_date_time_string(), format % args
+            )
+        )
 
 
 class Http2WebTestRequestHandler(BaseWebTestRequestHandler):


### PR DESCRIPTION
The superclass `http.server.BaseHTTPRequestHandler` implementation of its `log_*` methods sends them all to `log_message` and onto stderr.

Instead, let's re-implement all three of them to log to the logger, at appropriate logging levels.

This prevents a bunch of kinda unexpected stderr output while running tests, and ensures it is properly integrated with the rest of the logging output.

Note the behaviour still isn't perfect, because of #10512, thus something somewhere seems to be swallowing the logging from `log_request` at the DEBUG level (even with the hardcoded `LogLevelFilter` in `wptrunner/environment.py` changed).