### PR TITLE
Use default object size as fallback for intrinsic size of replaced element

### DIFF
--- a/css/css-sizing/intrinsic-size-fallback-video.html
+++ b/css/css-sizing/intrinsic-size-fallback-video.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<title>CSS Sizing Test: intrinsic contribution of videos with fallback size</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-contribution">
+<meta name="assert" content="
+    These <video>s have no natural size nor natural aspect ratio,
+    but fall back to default size of 300x150 and ratio of 300/150.
+    Their intrinsic contributions should take these fallbacks into account.">
+<style>
+.wrapper {
+  float: left;
+  clear: both;
+  border: solid;
+}
+video {
+  background: cyan;
+}
+</style>
+<div id="log"></div>
+<div class="wrapper" data-expected-client-width="300">
+  <video></video>
+</div>
+<div class="wrapper" data-expected-client-width="200">
+  <video style="height: 100px"></video>
+</div>
+<div class="wrapper" data-expected-client-width="100">
+  <video style="max-height: 50px"></video>
+</div>
+<div class="wrapper" data-expected-client-width="400">
+  <video style="min-height: 200px"></video>
+</div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script>
+checkLayout(".wrapper");
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Instead of falling back to zero.

Reviewed in servo/servo#34084