### PR TITLE
Ignore an error when unlock() throws it without allow-orientation-lock.

### DIFF
--- a/screen-orientation/resources/sandboxed-iframe-locking.html
+++ b/screen-orientation/resources/sandboxed-iframe-locking.html
@@ -5,7 +5,10 @@
 test_driver.set_test_context(parent);
 
 // At first, run simple unlock test without lock.
-screen.orientation?.unlock();
+try {
+  screen.orientation?.unlock();
+} catch (error) {
+}
 
 test_driver.bless("request full screen", async () => {
   const data = {};
@@ -19,7 +22,11 @@ test_driver.bless("request full screen", async () => {
     data.name = error.name;
   }
 
-  screen.orientation.unlock();
+  try {
+    screen.orientation.unlock();
+  } catch (error) {
+  }
+
   try {
     await document.exitFullscreen();
   } catch (error) {


### PR DESCRIPTION
According to common safety check (https://w3c.github.io/screen-orientation/#common-safety-checks), If without allow-orientation-lock, unlock() will throw SecurityError.

unlock() call in sandboxed-iframe-locking.html will throws it, then postMessage won't be reached.

So we should ignore unlock()'s error by try-catch block.