### PR TITLE
Unify sizing logic for replaced elements

### DIFF
--- a/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-intrinsic-width-height.html
+++ b/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-intrinsic-width-height.html
@@ -25,7 +25,7 @@
         <!-- A width:height ratio other than 2:1 and overriding the specified style must be used to
              verify that width/height does not influence intrinsic ratio -->
         <video title="both width/height attributes and style"
-               data-expected-width="300" data-expected-height="300"
+               data-expected-width="300" data-expected-height="150"
                width="100" height="100" style="width: auto; height: auto"></video>
         <script>
             Array.prototype.forEach.call(document.querySelectorAll('video'), function(video)


### PR DESCRIPTION
The logic varied quite a bit depending on the case, now it's unified.

This also fixes the following case where the iframe was 150px tall instead of 50px:
```html
<iframe style="min-width: 400px; max-height: 50px"></iframe>
```

This also modifies video-intrinsic-width-height.html to expect the new behavior that we share with Blink and WebKit. In fact WebKit already modified this test but forgot to export the change upstream. Firefox is different but it was already failing anyways.
<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#34076