### PR TITLE
Return cached object from `CryptoKey.algorithm` getter

### DIFF
--- a/WebCryptoAPI/cryptokey_algorithm_returns_cached_object.https.any.js
+++ b/WebCryptoAPI/cryptokey_algorithm_returns_cached_object.https.any.js
@@ -1,0 +1,24 @@
+// META: title=WebCryptoAPI: CryptoKey.algorithm getter returns cached object
+
+// https://w3c.github.io/webcrypto/#dom-cryptokey-algorithm
+// https://github.com/servo/servo/issues/33908
+
+promise_test(function() {
+    return self.crypto.subtle.generateKey(
+        {
+          name: "AES-CTR",
+          length: 256,
+        },
+        true,
+        ["encrypt"],
+      ).then(
+        function(key) {
+          let a = key.algorithm;
+          let b = key.algorithm;
+          assert_true(a === b);
+        },
+        function(err) {
+            assert_unreached("generateKey threw an unexpected error: " + err.toString());
+        }
+    );
+}, "CryptoKey.algorithm getter returns cached object");


### PR DESCRIPTION
Fixes the [`CryptoKey.algorithm`](https://w3c.github.io/webcrypto/#cryptokey-interface-members) getter which previously did not cache the returned object, but rather created a new one each time.

Reviewed in servo/servo#34092