### PR TITLE
frozen array in XRInputSourcesChangeEvent, update `to_frozen_array` doc

### DIFF
--- a/webxr/events_input_sources_change.https.html
+++ b/webxr/events_input_sources_change.https.html
@@ -5,6 +5,7 @@
 <script src="resources/webxr_test_constants.js"></script>
 
 <script>
+"use strict"
 let testName = "Transient input sources fire events in the right order";
 
 let watcherDone = new Event("watcherdone");
@@ -24,6 +25,17 @@ let testFunction = function(session, fakeDeviceController, t) {
       inputChangeEvents++;
       assert_equals(event.session, session);
       validateSameObject(event);
+
+      assert_throws_js(
+          TypeError,
+          () => { event.added[0] = "test"; },
+          "added array must be frozen"
+      );
+      assert_throws_js(
+          TypeError,
+          () => { event.removed[0] = "test"; },
+          "removed array must be frozen"
+      );
 
       // The first change event should be adding our controller.
       if (inputChangeEvents === 1) {


### PR DESCRIPTION
PR Description
Issue:

1. `XRInputSourcesChangeEvent` was not using `to_frozen_array` for array conversion, leading to manual conversions inconsistent with WebXR spec requirements. 
2. `to_frozen_array` rustdoc comment needs to be updated.

Changes:
1. Replaced manual conversions with `to_frozen_array`
2. Used `JSContext::from_ptr(*cx)` for context creation
3. Changed `to_frozen_array` rustdoc comment to reflect broader usage

Reviewed in servo/servo#34100