### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=280549

### DIFF
--- a/css/css-sizing/shrink-to-fit-sizing-max-width-min-content.html
+++ b/css/css-sizing/shrink-to-fit-sizing-max-width-min-content.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="help" href="https://drafts.csswg.org/css2/#float-width">
+<meta name="assert" content="shrink-to-fit sizing should respect max-width: min-content">
+<style>
+.container {
+  font: 100px/1 Ahem;
+  color: green;
+  width: 100px;
+}
+.float {
+  float: right;
+}
+.max-content {
+  max-width: min-content;
+  width: 600px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <div class=float>
+      <div class=max-content>x</div>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[Shrink-to-fit\] Incorrect inline size with max-width: min-content child](https://bugs.webkit.org/show_bug.cgi?id=280549)