### PR TITLE
Fix #7169: rewrite assert_readonly to check property descriptors

### DIFF
--- a/css/cssom/cssimportrule.html
+++ b/css/cssom/cssimportrule.html
@@ -84,7 +84,6 @@
             assert_idl_attribute(rule, "styleSheet");
 
             assert_readonly(rule, "href");
-            assert_readonly(rule, "media");
             assert_readonly(rule, "styleSheet");
         }, "Existence and writability of CSSImportRule attributes");
 


### PR DESCRIPTION
This changes the implementation to only check that the property descriptor makes the property readonly; it doesn't actually check its behaviour. As detailed in the above issue, there's too many ways for this test to be otherwise bogus, thus we should go for the simple implementation.

This also fixes /css/cssom/cssimportrule.html, which previously asserted that CSSImportRule#media was readonly, which was a meaningless test, as even after the `[PutForwards]` `[[Set]]` call had occurred, the attribute being tested still returned the same object, because it is defined with `[SameObject]`.

Fixes #7169.