### PR TITLE
[wpt][webassembly][jspi] Correct WPT tests for JSPI

### DIFF
--- a/wasm/jsapi/jspi/js-promise-integration.any.js
+++ b/wasm/jsapi/jspi/js-promise-integration.any.js
@@ -334,9 +334,7 @@ test(() => {
   builder.addFunction("export", kSig_v_v).addBody([]).exportFunc();
   let instance = builder.instantiate();
   let export_wrapper = WebAssembly.promising(instance.exports.export);
-  let export_sig = export_wrapper.type();
-  assert_array_equals(export_sig.parameters, []);
-  assert_array_equals(export_sig.results, ['externref']);
+  assert_true(export_wrapper instanceof Function);
 },"Promising with no return");
 
 promise_test(async () => {

--- a/wasm/jsapi/jspi/rejects.any.js
+++ b/wasm/jsapi/jspi/rejects.any.js
@@ -98,7 +98,14 @@ promise_test(async (t) => {
   let instance = builder.instantiate();
   let wrapper = WebAssembly.promising(instance.exports.test);
 
-  promise_rejects_js(t, RangeError, wrapper(), "Maximum call stack size exceeded");
+  // Stack overflow has undefined behavior -- check if an exception was thrown.
+  let thrown = false;
+  try {
+    await wrapper();
+  } catch (e) {
+    thrown = true;
+  }
+  assert_true(thrown);
 }, "Stack overflow");
 
 promise_test(async (t) => {


### PR DESCRIPTION
Corrections that are made by https://github.com/WebAssembly/js-promise-integration/pull/52

- Assert that WebAssembly.promising returns a Function (not WebAssembly.Function)
- Don't assert exact error message for stack overflow.
