### PR TITLE
Fix assertBothRejectDOM usage

### DIFF
--- a/navigation-api/scroll-behavior/after-transition-reject.html
+++ b/navigation-api/scroll-behavior/after-transition-reject.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../navigation-methods/return-value/resources/helpers.js"></script>
 <body>
 <div style="height: 1000px; width: 1000px;"></div>
 <div id="frag"></div>
@@ -17,7 +16,7 @@ promise_test(async t => {
       e => e.intercept({ handler: () => Promise.reject(),
                          scroll: "after-transition" });
 
-  assertBothRejectDOM(t, navigation.back(), "AbortError");
+  await promise_rejects_exactly(t, undefined, navigation.back().finished);
   assert_not_equals(window.scrollY, 0);
 }, "scroll: after-transition should not scroll when the intercept() handler rejects");
 </script>

--- a/navigation-api/scroll-behavior/scroll-after-preventDefault.html
+++ b/navigation-api/scroll-behavior/scroll-after-preventDefault.html
@@ -16,7 +16,7 @@ promise_test(async t => {
     e.preventDefault();
     assert_throws_dom("InvalidStateError", () => e.scroll());
   }), { once : true });
-  assertBothRejectDOM(t, navigation.navigate("#frag"), "AbortError");
+  await assertBothRejectDOM(t, navigation.navigate("#frag"), "AbortError");
 }, "scroll: scroll() should throw after preventDefault");
 </script>
 </body>


### PR DESCRIPTION
Recent changes have replaced promise_rejects_dom with assertBothRejectDOM but mistakenly have removed the await part, this change fixes that.

Also revert the assertBothRejectDOM change to after-transition-reject.html, the problem seems to be with the unhandled promise in the handler, not the committed promise.