### PR TITLE
Revert "[wptrunner] Clear cookies between testharness tests for Chrome"

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -141,9 +141,6 @@ class ChromeDriverTestharnessProtocolPart(WebDriverTestharnessProtocolPart):
     """
     def reset_browser_state(self):
         for command, params in [
-            # TODO(web-platform-tests/wpt#48078): Find a cross-vendor way to
-            # clear cookies for all domains.
-            ("Network.clearBrowserCookies", None),
             # Reset default permissions that `test_driver.set_permission(...)`
             # may have altered.
             ("Browser.resetPermissions", None),


### PR DESCRIPTION
This workaround allows tests to pass without performing their own cookie cleanup when run with Chrome. Per meeting discussion, revert #48106 until there's a portable solution.