### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=282015

### DIFF
--- a/css/css-masking/clip-path/clip-path-shape-hline-vline-keywords.tentative.html
+++ b/css/css-masking/clip-path/clip-path-shape-hline-vline-keywords.tentative.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Masking: Test clip-path property and shape function hline/vline keywords</title>
+  <link rel="help" href="https://drafts.csswg.org/css-shapes-2/#funcdef-shape">
+  <link rel="match" href="reference/green-100x100.html">
+  <meta name="assert" content="Test that center and edge keywords work in hline and vline">
+</head>
+<style>
+  #shape {
+    width: 200px;
+    height: 200px;
+    background-color: green;
+    clip-path: shape(from top left,
+                    hline to center,
+                    vline to center,
+                    hline to left,
+                    close);
+  }
+</style>
+<body>
+  <div id="shape"></div>
+</body>
+</html>

--- a/css/css-shapes/shape-functions/shape-function-invalid.tentative.html
+++ b/css/css-shapes/shape-functions/shape-function-invalid.tentative.html
@@ -15,6 +15,24 @@ test_invalid_value("clip-path", "shape(from 20px 40px line to 20px 30px)");
 test_invalid_value("clip-path", "shape(from 20px 40px line to 20px 30px,)");
 test_invalid_value("clip-path", "shape(from 20px, 40px, line to 20px, 30px)");
 
+test_invalid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, hline to top)");
+test_invalid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, hline to bottom)");
+test_invalid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, hline to y-start)");
+test_invalid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, hline to y-end)");
+test_invalid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, vline to left)");
+test_invalid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, vline to right)");
+test_invalid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, vline to x-start)");
+test_invalid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, vline to x-end)");
+
+test_invalid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, hline to top 20px)");
+test_invalid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, hline to right, vline to bottom left, close)");
+
+test_invalid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, hline by left)");
+test_invalid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, hline by right)");
+
+test_invalid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, vline by top)");
+test_invalid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, vline by bottom)");
+
 // Control points start after "with"
 test_invalid_value("clip-path", "shape(from 20px 40px, curve to 20px 20px, using 10px 30px)");
 test_invalid_value("clip-path", "shape(from 20px 40px, curve to 20px 20px using 10px 30px, 12px 32px)");

--- a/css/css-shapes/shape-functions/shape-function-valid.tentative.html
+++ b/css/css-shapes/shape-functions/shape-function-valid.tentative.html
@@ -21,6 +21,11 @@ test_valid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, hline by
 test_valid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, vline to 100px)");
 test_valid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, vline by 100%)");
 
+test_valid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, hline to left, hline to center, hline to right)");
+test_valid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, hline to x-start, hline to y-start)");
+test_valid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, vline to top, vline to center, vline to bottom)");
+test_valid_value("clip-path", "shape(from 20px 40px, move to 20px 30px, vline to y-start, vline to y-end)");
+
 test_valid_value("clip-path", "shape(from 20px 40px, curve to 20px 20px with 10px 30px)");
 test_valid_value("clip-path", "shape(from 20px 40px, curve to 20em 20pt with 10vw 30vh)");
 test_valid_value("clip-path", "shape(from 20px 40px, curve to 10% 20% with 10px 30px / 12px 32px)");


### PR DESCRIPTION
WebKit export from bug: [shape(): support the edge keywords for hline and vline.](https://bugs.webkit.org/show_bug.cgi?id=282015)