### PR TITLE
Credentials Container abort reason tests

### DIFF
--- a/credential-management/credentialscontainer-create-basics.https.html
+++ b/credential-management/credentialscontainer-create-basics.https.html
@@ -132,4 +132,12 @@ promise_test(function(t) {
     return promise_rejects_dom(t, "NotSupportedError",
             navigator.credentials.create({bogus_key: "bogus data"}));
 }, "navigator.credentials.create() with bogus data");
+
+promise_test(function(t) {
+    const controller = new AbortController();
+    controller.abort("custom reason");
+
+    return promise_rejects_exactly(t, "custom reason",
+        navigator.credentials.create({ signal: controller.signal }));
+}, "navigator.credentials.create() aborted with custom reason");
 </script>

--- a/credential-management/credentialscontainer-get-basics.https.html
+++ b/credential-management/credentialscontainer-get-basics.https.html
@@ -54,4 +54,12 @@
       navigator.credentials.get({ signal, mediation: "required" })
     );
   }, "Calling navigator.credentials.get() without a valid matching interface.");
+
+  promise_test(function(t) {
+      const controller = new AbortController();
+      controller.abort("custom reason");
+
+      return promise_rejects_exactly(t, "custom reason",
+          navigator.credentials.get({ signal: controller.signal }));
+  }, "navigator.credentials.get() aborted with custom reason");
 </script>


### PR DESCRIPTION
As part of https://bugs.webkit.org/show_bug.cgi?id=258911 we needed to add extra tests for the `.get` and `.create` methods, to assert the abort reason is forwarded to the rejection handler.

Given the [spec](https://w3c.github.io/webappsec-credential-management/), section 2.5.4 "Create a credential" point 10 states:
> If options.signal is aborted, then return a promise rejected with options.signal's abort reason.

This is passing in this WebKit change PR: https://github.com/WebKit/WebKit/pull/36172