### PR TITLE
[CredentialContainer] Test more scenarios around the abort reason's

### DIFF
--- a/credential-management/credentialscontainer-create-basics.https.html
+++ b/credential-management/credentialscontainer-create-basics.https.html
@@ -140,4 +140,23 @@ promise_test(function(t) {
     return promise_rejects_exactly(t, "custom reason",
         navigator.credentials.create({ signal: controller.signal }));
 }, "navigator.credentials.create() aborted with custom reason");
+
+promise_test(async function(t) {
+    const reasons = [{}, [], new Error("custom error")];
+
+    for (let reason of reasons) {
+        const result = navigator.credentials.create({ signal: AbortSignal.abort(reason) });
+        await promise_rejects_exactly(t, reason, result);
+  }
+}, "navigator.credentials.create() aborted with different objects");
+
+promise_test(function(t) {
+    const error = new Error("custom error");
+    const controller = new AbortController();
+
+    const result = navigator.credentials.create({ signal: controller.signal });
+    controller.abort(error); // aborted after the promise is created
+
+    return promise_rejects_exactly(t, error, result);
+}, "navigator.credentials.create() rejects when aborted after the promise creation");
 </script>

--- a/credential-management/credentialscontainer-get-basics.https.html
+++ b/credential-management/credentialscontainer-get-basics.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Credential Management API: create() basics.</title>
+<title>Credential Management API: get() basics.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
@@ -56,10 +56,29 @@
   }, "Calling navigator.credentials.get() without a valid matching interface.");
 
   promise_test(function(t) {
-      const controller = new AbortController();
-      controller.abort("custom reason");
+    const controller = new AbortController();
+    controller.abort("custom reason");
 
-      return promise_rejects_exactly(t, "custom reason",
-          navigator.credentials.get({ signal: controller.signal }));
+    return promise_rejects_exactly(t, "custom reason",
+        navigator.credentials.get({ signal: controller.signal }));
   }, "navigator.credentials.get() aborted with custom reason");
+
+  promise_test(async function(t) {
+    const reasons = [{}, [], new Error("custom error")];
+
+    for (let reason of reasons) {
+        const result = navigator.credentials.get({ signal: AbortSignal.abort(reason) });
+        await promise_rejects_exactly(t, reason, result);
+    }
+  }, "navigator.credentials.get() aborted with different objects");
+
+  promise_test(function(t) {
+    const error = new Error("custom error");
+    const controller = new AbortController();
+
+    const result = navigator.credentials.get({ signal: controller.signal });
+    controller.abort(error); // aborted after the promise is created
+
+    return promise_rejects_exactly(t, error, result);
+  }, "navigator.credentials.get() rejects when aborted after the promise creation");
 </script>


### PR DESCRIPTION
We need more tests I feel around the AbortSignal reason forwarding, seeing as we accept and return an "any" — we should assert those things.

I also added a test for when the signal is aborted a tick after the promise is created. Tests for things like "add algorithm", than for a synchronous check in browser's for if the signal is aborted. 