### PR TITLE
Navigate to about:blank after completing a crash test

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -1274,6 +1274,7 @@ class MarionetteCrashtestExecutor(CrashtestExecutor):
 
         protocol.base.load(url)
         protocol.base.execute_script(self.wait_script, asynchronous=True)
+        protocol.base.load("about:blank")
 
         if self.protocol.coverage.is_enabled:
             self.protocol.coverage.dump()

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -1139,6 +1139,7 @@ class WebDriverCrashtestExecutor(CrashtestExecutor):
     def do_crashtest(self, protocol, url, timeout):
         protocol.base.load(url)
         protocol.base.execute_script(self.wait_script, asynchronous=True)
+        protocol.base.load("about:blank")
         result = {"status": "PASS", "message": None}
         if (leak_part := getattr(protocol, "leak", None)) and (counters := leak_part.check()):
             result["extra"] = {"leak_counters": counters}


### PR DESCRIPTION
This ensures that any crash that only happens after a navigation is correctly attributed to the test.