### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=282634

### DIFF
--- a/css/css-sizing/intrinsic-fixed-width-with-max-content-height.html
+++ b/css/css-sizing/intrinsic-fixed-width-with-max-content-height.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="help" href="https://drafts.csswg.org/css2/#inline-replaced-height">
+<meta name="assert" content="max-content height of an image with specified width is computed via aspect ratio">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<img style="width: 100px; height: max-content;" src="../support/60x60-green.png">
+</body>
+</html>

--- a/css/css-sizing/intrinsic-fixed-width-with-min-content-height.html
+++ b/css/css-sizing/intrinsic-fixed-width-with-min-content-height.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="help" href="https://drafts.csswg.org/css2/#inline-replaced-height">
+<meta name="assert" content="min-content height of an image with specified width is computed via aspect ratio">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<img style="width: 100px; height: min-content;" src="../support/60x60-green.png">
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [walzr.com: <img> element with height: min-content is vertically stretched](https://bugs.webkit.org/show_bug.cgi?id=282634)