### PR TITLE
[wptrunner] Decouple testdriver infrastructure from testharness

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -111,10 +111,10 @@ class ChromeDriverTestDriverProtocolPart(WebDriverTestDriverProtocolPart):
         else:
             self.webdriver.execute_script(message_script)
 
-    def _get_next_message_classic(self, url):
+    def _get_next_message_classic(self, url, script_resume):
         try:
             message_script, self._pending_message = self._pending_message, ""
-            return self.parent.base.execute_script(message_script + self.script_resume,
+            return self.parent.base.execute_script(message_script + script_resume,
                                                    asynchronous=True,
                                                    args=[strip_server(url)])
         except error.JavascriptErrorException as js_error:

--- a/tools/wptrunner/wptrunner/executors/message-queue.js
+++ b/tools/wptrunner/wptrunner/executors/message-queue.js
@@ -1,0 +1,77 @@
+(function() {
+  if (window.__wptrunner_message_queue && window.__wptrunner_process_next_event) {
+    // Another script already set up the testdriver infrastructure.
+    return;
+  }
+
+  class MessageQueue {
+    constructor() {
+      this.item_id = 0;
+      this._queue = [];
+    }
+
+    push(item) {
+      let cmd_id = this.item_id++;
+      item.id = cmd_id;
+      this._queue.push(item);
+      __wptrunner_process_next_event();
+      return cmd_id;
+    }
+
+    shift() {
+      return this._queue.shift();
+    }
+  }
+
+  window.__wptrunner_testdriver_callback = null;
+  window.__wptrunner_message_queue = new MessageQueue();
+  window.__wptrunner_url = null;
+
+  window.__wptrunner_process_next_event = function() {
+    /* This function handles the next testdriver event. The presence of
+       window.testdriver_callback is used as a switch; when that function
+       is present we are able to handle the next event and when is is not
+       present we must wait. Therefore to drive the event processing, this
+       function must be called in two circumstances:
+         * Every time there is a new event that we may be able to handle
+         * Every time we set the callback function
+       This function unsets the callback, so no further testdriver actions
+       will be run until it is reset, which wptrunner does after it has
+       completed handling the current action.
+     */
+
+    if (!window.__wptrunner_testdriver_callback) {
+      return;
+    }
+    var data = window.__wptrunner_message_queue.shift();
+    if (!data) {
+      return;
+    }
+
+    var payload = undefined;
+
+    switch(data.type) {
+    case "complete":
+      var tests = data.tests;
+      var status = data.status;
+
+      var subtest_results = tests.map(function(x) {
+        return [x.name, x.status, x.message, x.stack];
+      });
+      payload = [status.status,
+                 status.message,
+                 status.stack,
+                 subtest_results];
+      clearTimeout(window.__wptrunner_timer);
+      break;
+    case "action":
+      payload = data;
+      break;
+    default:
+      return;
+    }
+    var callback = window.__wptrunner_testdriver_callback;
+    window.__wptrunner_testdriver_callback = null;
+    callback([__wptrunner_url, data.type, payload]);
+  };
+})();

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -59,7 +59,7 @@
     });
 
     function is_test_context() {
-      return window.__wptrunner_message_queue !== undefined;
+      return !!window.__wptrunner_is_test_context;
     }
 
     // Code copied from /common/utils.js
@@ -242,7 +242,7 @@
     };
 
     window.test_driver_internal.set_test_context = function(context) {
-        if (window.__wptrunner_message_queue) {
+        if (is_test_context()) {
             throw new Error("Tried to set testharness context in a window containing testharness.js");
         }
         testharness_context = context;

--- a/tools/wptrunner/wptrunner/testharnessreport.js
+++ b/tools/wptrunner/wptrunner/testharnessreport.js
@@ -1,75 +1,9 @@
-class MessageQueue {
-  constructor() {
-    this.item_id = 0;
-    this._queue = [];
-  }
-
-  push(item) {
-    let cmd_id = this.item_id++;
-    item.id = cmd_id;
-    this._queue.push(item);
-    __wptrunner_process_next_event();
-    return cmd_id;
-  }
-
-  shift() {
-    return this._queue.shift();
-  }
-}
-
-window.__wptrunner_testdriver_callback = null;
-window.__wptrunner_message_queue = new MessageQueue();
-window.__wptrunner_url = null;
-
-window.__wptrunner_process_next_event = function() {
-  /* This function handles the next testdriver event. The presence of
-     window.testdriver_callback is used as a switch; when that function
-     is present we are able to handle the next event and when is is not
-     present we must wait. Therefore to drive the event processing, this
-     function must be called in two circumstances:
-       * Every time there is a new event that we may be able to handle
-       * Every time we set the callback function
-     This function unsets the callback, so no further testdriver actions
-     will be run until it is reset, which wptrunner does after it has
-     completed handling the current action.
-   */
-
-  if (!window.__wptrunner_testdriver_callback) {
-    return;
-  }
-  var data = window.__wptrunner_message_queue.shift();
-  if (!data) {
-    return;
-  }
-
-  var payload = undefined;
-
-  switch(data.type) {
-  case "complete":
-    var tests = data.tests;
-    var status = data.status;
-
-    var subtest_results = tests.map(function(x) {
-      return [x.name, x.status, x.message, x.stack];
-    });
-    payload = [status.status,
-               status.message,
-               status.stack,
-               subtest_results];
-    clearTimeout(window.__wptrunner_timer);
-    break;
-  case "action":
-    payload = data;
-    break;
-  default:
-    return;
-  }
-  var callback = window.__wptrunner_testdriver_callback;
-  window.__wptrunner_testdriver_callback = null;
-  callback([__wptrunner_url, data.type, payload]);
-};
-
 (function() {
+  // Signal to `testdriver.js` that this is the "main" test browsing context,
+  // meaning testdriver actions should be queued for retrieval instead of
+  // `postMessage()`d elsewhere.
+  window.__wptrunner_is_test_context = true;
+
   var props = {output: %(output)d,
                timeout_multiplier: %(timeout_multiplier)s,
                explicit_timeout: %(explicit_timeout)s,
@@ -85,4 +19,3 @@ window.__wptrunner_process_next_event = function() {
   });
   setup(props);
 })();
-


### PR DESCRIPTION
Split off from #48486 in preparation for #13183. This PR itself should be a no-op, so it need not block on https://github.com/web-platform-tests/rfcs/pull/211.