### PR TITLE
WebCrypto: HDKF and PBKDF2 return an empty ArrayBuffer when length is zero

### DIFF
--- a/WebCryptoAPI/derive_bits_keys/derived_bits_length_testcases.js
+++ b/WebCryptoAPI/derive_bits_keys/derived_bits_length_testcases.js
@@ -3,7 +3,7 @@ var testCases = {
         {length: 256, expected: algorithms["HKDF"].derivation},
         {length: 384, expected: algorithms["HKDF"].derivation384},
         {length: 230, expected: undefined}, // should throw an exception, not multiple of 8
-        {length: 0, expected: undefined}, // explicitly disallowed, so should throw
+        {length: 0, expected: emptyArray},
         {length: null, expected: undefined }, // should throw an exception
         {length: undefined, expected: undefined }, // should throw an exception
         {length: "omitted", expected: undefined }, // default value is null, so should throw
@@ -12,7 +12,7 @@ var testCases = {
         {length: 256, expected: algorithms["PBKDF2"].derivation},
         {length: 384, expected: algorithms["PBKDF2"].derivation384},
         {length: 230, expected: undefined}, // should throw an exception, not multiple of 8
-        {length: 0, expected: undefined}, // explicitly disallowed, so should throw
+        {length: 0, expected: emptyArray},
         {length: null, expected: undefined }, // should throw an exception
         {length: undefined, expected: undefined }, // should throw an exception
         {length: "omitted", expected: undefined }, // default value is null, so should throw

--- a/WebCryptoAPI/derive_bits_keys/hkdf.js
+++ b/WebCryptoAPI/derive_bits_keys/hkdf.js
@@ -45,13 +45,13 @@ function define_tests() {
                             });
                         }, testName);
 
-                        // 0 length (OperationError)
+                        // 0 length
                         subsetTest(promise_test, function(test) {
                             return subtle.deriveBits(algorithm, baseKeys[derivedKeySize], 0)
                             .then(function(derivation) {
                                 assert_equals(derivation.byteLength, 0, "Derived correctly empty key");
                             }, function(err) {
-                                assert_equals(err.name, "OperationError", "deriveBits with 0 length correctly threw OperationError: " + err.message);
+                                assert_unreached("deriveBits failed with error " + err.name + ": " + err.message);
                             });
                         }, testName + " with 0 length");
 

--- a/WebCryptoAPI/derive_bits_keys/pbkdf2.js
+++ b/WebCryptoAPI/derive_bits_keys/pbkdf2.js
@@ -42,6 +42,16 @@ function define_tests() {
                             });
                         }, testName);
 
+                        // 0 length
+                        subsetTest(promise_test, function(test) {
+                            return subtle.deriveBits({name: "PBKDF2", salt: salts[saltSize], hash: hashName, iterations: parseInt(iterations)}, baseKeys[passwordSize], 0)
+                            .then(function(derivation) {
+                                assert_true(equalBuffers(derivation.byteLength, 0, "Derived correctly empty key"));
+                            }, function(err) {
+                                assert_unreached("deriveBits failed with error " + err.name + ": " + err.message);
+                            });
+                        }, testName + " with 0 length");
+
                         // Check for correct deriveKey results for every kind of
                         // key that can be created by the deriveKeys operation.
                         derivedKeyTypes.forEach(function(derivedKeyType) {
@@ -102,16 +112,6 @@ function define_tests() {
                             }, testName + " with wrong (ECDH) key");
 
                         });
-
-                        // 0 length (OperationError)
-                        subsetTest(promise_test, function(test) {
-                            return subtle.deriveBits({name: "PBKDF2", salt: salts[saltSize], hash: hashName, iterations: parseInt(iterations)}, baseKeys[passwordSize], 0)
-                            .then(function(derivation) {
-                                assert_unreached("0 length should have thrown an OperationError");
-                            }, function(err) {
-                                assert_equals(err.name, "OperationError", "deriveBits with 0 length correctly threw OperationError: " + err.message);
-                            });
-                        }, testName + " with 0 length");
 
                         // length not multiple of 8 (OperationError)
                         subsetTest(promise_test, function(test) {


### PR DESCRIPTION
The PR#380 [1] changed the PBKDF2 deriveBits operation to allow zero length and introduced an additional step to return an empty string in that case. It also reversted the PR#275 [2] so that HKDF also handles the zero length in the same way.

This PR updates the tests cases affecting this 2 algorithms on the cases where zero was passed in the length parameter.

[1] https://github.com/w3c/webcrypto/pull/380
[2] https://github.com/w3c/webcrypto/pull/275