### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=281570

### DIFF
--- a/css/css-contain/content-visibility/content-visibility-auto-svg-text.html
+++ b/css/css-contain/content-visibility/content-visibility-auto-svg-text.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
+<link rel="help" href="https://drafts.csswg.org/css-contain-2/#content-visibility">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<style>
+text {
+  font: 100px/1 Ahem;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="content-visibility: auto;">
+<svg>
+  <text fill="green" x="0" y="80">x</text>
+</svg>
+</div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[content-visibility\] content-visibility: auto prevents text nodes in SVG from being painted](https://bugs.webkit.org/show_bug.cgi?id=281570)