### PR TITLE
Use `a.href = ...;` instead of `a.setAttribute('href', ...);`

### DIFF
--- a/url/resources/a-element.js
+++ b/url/resources/a-element.js
@@ -10,7 +10,7 @@ function setBase(base) {
 function bURL(url, base) {
   setBase(base);
   const a = document.createElement("a");
-  a.setAttribute("href", url);
+  a.href = url;
   return a;
 }
 


### PR DESCRIPTION
Browsers disagree on what `a.setAttribute('href', '<malformed UTF-16>');` should set `a.href` to, and the spec is ambiguous about it as well.

The second argument to `setAttribute` is a `DOMString` [^1], which accepts malformed UTF-16, while most attributes, including `href`, are explicitly defined as `USVString` [^2], which replaces malformed UTF-16 code units with
U+FFFD "REPLACEMENT CHARACTER".

The malformed `DOMString` value that was set should be retrievable with `a.getAttribute('...')` because `Attr.value` is a `DOMString` [^3], and yet a `USVString` value should also be retrievable with `a.href` [^4].

`a.href` must still return a well-formed UTF-16 string in this case, of course, but the exact string that should be returned in this case is unspecified.

Using `a.href = ...;` [^5] solves this by always performing the U+FFFD replacements, making all browsers return the expected result for the test in `url/resources/urltestdata-javascript-only.json`.

[^1]: https://dom.spec.whatwg.org/#dom-element-setattribute
[^2]: https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-href
[^3]: https://dom.spec.whatwg.org/#attr
[^4]: https://dom.spec.whatwg.org/#concept-element-attributes-get-value
[^5]: https://dom.spec.whatwg.org/#concept-element-attributes-set-value