### PR TITLE
Streams: Fix assertion for invalid min for ReadableStreamBYOBReader read

### DIFF
--- a/streams/readable-byte-streams/read-min.any.js
+++ b/streams/readable-byte-streams/read-min.any.js
@@ -28,8 +28,8 @@ promise_test(async t => {
     pull: t.unreached_func('pull() should not be called'),
   });
   const reader = rs.getReader({ mode: 'byob' });
-  await promise_rejects_js(t, TypeError, reader.read(new Uint8Array(1), { min: -1 }));
-}, 'ReadableStream with byte source: read({ min }) rejects if min is negative');
+  assert_throws_js(TypeError, () => reader.read(new Uint8Array(1), { min: -1 }));
+}, 'ReadableStream with byte source: read({ min }) throws if min is negative');
 
 promise_test(async t => {
   const rs = new ReadableStream({


### PR DESCRIPTION
The IDL for ReadableStreamBYOBReaderReadOptions defines min with [EnforceRange].

https://streams.spec.whatwg.org/#dom-readablestreambyobreaderreadoptions-min