### PR TITLE
Run ShadowRealm tests in multiple scopes

### DIFF
--- a/compression/idlharness-shadowrealm.window.js
+++ b/compression/idlharness-shadowrealm.window.js
@@ -1,2 +1,3 @@
+// META: script=/resources/testharness-shadowrealm-outer.js
 // META: script=/resources/idlharness-shadowrealm.js
 idl_test_shadowrealm(["compression"], ["streams"]);

--- a/console/idlharness-shadowrealm.window.js
+++ b/console/idlharness-shadowrealm.window.js
@@ -1,3 +1,4 @@
+// META: script=/resources/testharness-shadowrealm-outer.js
 // META: script=/resources/idlharness-shadowrealm.js
 
 // https://console.spec.whatwg.org/

--- a/docs/writing-tests/testharness.md
+++ b/docs/writing-tests/testharness.md
@@ -179,6 +179,9 @@ are:
 * `shadowrealm-in-sharedworker`: runs the test code in a ShadowRealm context
   hosted in a shared worker; to be run at
   <code><var>x</var>.any.shadowrealm-in-sharedworker.html</code>
+* `shadowrealm-in-serviceworker`: runs the test code in a ShadowRealm context
+  hosted in a service worker; to be run at
+  <code><var>x</var>.https.any.shadowrealm-in-serviceworker.html</code>
 * `shadowrealm`: shorthand for all of the ShadowRealm scopes
 
 To check what scope your test is run from, you can use the following methods that will

--- a/docs/writing-tests/testharness.md
+++ b/docs/writing-tests/testharness.md
@@ -167,9 +167,10 @@ are:
 * `jsshell`: to be run in a JavaScript shell, without access to the DOM
   (currently only supported in SpiderMonkey, and skipped in wptrunner)
 * `worker`: shorthand for the dedicated, shared, and service worker scopes
-* `shadowrealm`: runs the test code in a
+* `shadowrealm-in-window`: runs the test code in a
   [ShadowRealm](https://github.com/tc39/proposal-shadowrealm) context hosted in
-  an ordinary Window context; to be run at <code><var>x</var>.any.shadowrealm.html</code>
+  an ordinary Window context; to be run at <code><var>x</var>.any.shadowrealm-in-window.html</code>
+* `shadowrealm`: shorthand for all of the ShadowRealm scopes
 
 To check what scope your test is run from, you can use the following methods that will
 be made available by the framework:

--- a/docs/writing-tests/testharness.md
+++ b/docs/writing-tests/testharness.md
@@ -173,6 +173,9 @@ are:
 * `shadowrealm-in-shadowrealm`: runs the test code in a ShadowRealm context
   hosted in another ShadowRealm context; to be run at
   <code><var>x</var>.any.shadowrealm-in-shadowrealm.html</code>
+* `shadowrealm-in-dedicatedworker`: runs the test code in a ShadowRealm context
+  hosted in a dedicated worker; to be run at
+  <code><var>x</var>.any.shadowrealm-in-dedicatedworker.html</code>
 * `shadowrealm`: shorthand for all of the ShadowRealm scopes
 
 To check what scope your test is run from, you can use the following methods that will

--- a/docs/writing-tests/testharness.md
+++ b/docs/writing-tests/testharness.md
@@ -170,6 +170,9 @@ are:
 * `shadowrealm-in-window`: runs the test code in a
   [ShadowRealm](https://github.com/tc39/proposal-shadowrealm) context hosted in
   an ordinary Window context; to be run at <code><var>x</var>.any.shadowrealm-in-window.html</code>
+* `shadowrealm-in-shadowrealm`: runs the test code in a ShadowRealm context
+  hosted in another ShadowRealm context; to be run at
+  <code><var>x</var>.any.shadowrealm-in-shadowrealm.html</code>
 * `shadowrealm`: shorthand for all of the ShadowRealm scopes
 
 To check what scope your test is run from, you can use the following methods that will

--- a/docs/writing-tests/testharness.md
+++ b/docs/writing-tests/testharness.md
@@ -176,6 +176,9 @@ are:
 * `shadowrealm-in-dedicatedworker`: runs the test code in a ShadowRealm context
   hosted in a dedicated worker; to be run at
   <code><var>x</var>.any.shadowrealm-in-dedicatedworker.html</code>
+* `shadowrealm-in-sharedworker`: runs the test code in a ShadowRealm context
+  hosted in a shared worker; to be run at
+  <code><var>x</var>.any.shadowrealm-in-sharedworker.html</code>
 * `shadowrealm`: shorthand for all of the ShadowRealm scopes
 
 To check what scope your test is run from, you can use the following methods that will

--- a/docs/writing-tests/testharness.md
+++ b/docs/writing-tests/testharness.md
@@ -182,6 +182,9 @@ are:
 * `shadowrealm-in-serviceworker`: runs the test code in a ShadowRealm context
   hosted in a service worker; to be run at
   <code><var>x</var>.https.any.shadowrealm-in-serviceworker.html</code>
+* `shadowrealm-in-audioworklet`: runs the test code in a ShadowRealm context
+  hosted in an AudioWorklet processor; to be run at
+  <code><var>x</var>.https.any.shadowrealm-in-audioworklet.html</code>
 * `shadowrealm`: shorthand for all of the ShadowRealm scopes
 
 To check what scope your test is run from, you can use the following methods that will

--- a/dom/idlharness-shadowrealm.window.js
+++ b/dom/idlharness-shadowrealm.window.js
@@ -1,2 +1,3 @@
+// META: script=/resources/testharness-shadowrealm-outer.js
 // META: script=/resources/idlharness-shadowrealm.js
 idl_test_shadowrealm(["dom"], ["html"]);

--- a/encoding/idlharness-shadowrealm.window.js
+++ b/encoding/idlharness-shadowrealm.window.js
@@ -1,2 +1,3 @@
+// META: script=/resources/testharness-shadowrealm-outer.js
 // META: script=/resources/idlharness-shadowrealm.js
 idl_test_shadowrealm(["encoding"], ["streams"]);

--- a/hr-time/idlharness-shadowrealm.window.js
+++ b/hr-time/idlharness-shadowrealm.window.js
@@ -1,2 +1,3 @@
+// META: script=/resources/testharness-shadowrealm-outer.js
 // META: script=/resources/idlharness-shadowrealm.js
 idl_test_shadowrealm(["hr-time"], ["html", "dom"]);

--- a/html/dom/idlharness-shadowrealm.window.js
+++ b/html/dom/idlharness-shadowrealm.window.js
@@ -1,2 +1,3 @@
+// META: script=/resources/testharness-shadowrealm-outer.js
 // META: script=/resources/idlharness-shadowrealm.js
 idl_test_shadowrealm(["html"], ["wai-aria", "SVG", "cssom", "touch-events", "uievents", "dom", "xhr", "FileAPI", "mediacapture-streams", "performance-timeline"]);

--- a/performance-timeline/idlharness-shadowrealm.window.js
+++ b/performance-timeline/idlharness-shadowrealm.window.js
@@ -1,2 +1,3 @@
+// META: script=/resources/testharness-shadowrealm-outer.js
 // META: script=/resources/idlharness-shadowrealm.js
 idl_test_shadowrealm(["performance-timeline"], ["hr-time", "dom"]);

--- a/resources/idlharness-shadowrealm.js
+++ b/resources/idlharness-shadowrealm.js
@@ -1,3 +1,7 @@
+/* global shadowRealmEvalAsync */
+
+// requires /resources/idlharness-shadowrealm-outer.js
+
 // TODO: it would be nice to support `idl_array.add_objects`
 function fetch_text(url) {
     return fetch(url).then(function (r) {
@@ -23,35 +27,25 @@ function fetch_text(url) {
 function idl_test_shadowrealm(srcs, deps) {
     promise_setup(async t => {
         const realm = new ShadowRealm();
-        realm.evaluate(`
-            globalThis.self.GLOBAL = {
-                isWindow: function() { return false; },
-                isWorker: function() { return false; },
-                isShadowRealm: function() { return true; },
-            }; undefined;
-        `);
         const specs = await Promise.all(srcs.concat(deps).map(spec => {
             return fetch_text("/interfaces/" + spec + ".idl");
         }));
         const idls = JSON.stringify(specs);
-        await new Promise(
-            realm.evaluate(`(resolve,reject) => {
-                (async () => {
-                    await import("/resources/testharness.js");
-                    await import("/resources/WebIDLParser.js");
-                    await import("/resources/idlharness.js");
-                    const idls = ${idls};
-                    const idl_array = new IdlArray();
-                    for (let i = 0; i < ${srcs.length}; i++) {
-                        idl_array.add_idls(idls[i]);
-                    }
-                    for (let i = ${srcs.length}; i < ${srcs.length + deps.length}; i++) {
-                        idl_array.add_dependency_idls(idls[i]);
-                    }
-                    idl_array.test();
-                })().then(resolve, (e) => reject(e.toString()));
-            }`)
-        );
+        await shadowRealmEvalAsync(realm, `
+            await import("/resources/testharness-shadowrealm-inner.js");
+            await import("/resources/testharness.js");
+            await import("/resources/WebIDLParser.js");
+            await import("/resources/idlharness.js");
+            const idls = ${idls};
+            const idl_array = new IdlArray();
+            for (let i = 0; i < ${srcs.length}; i++) {
+                idl_array.add_idls(idls[i]);
+            }
+            for (let i = ${srcs.length}; i < ${srcs.length + deps.length}; i++) {
+                idl_array.add_dependency_idls(idls[i]);
+            }
+            idl_array.test();
+        `);
         await fetch_tests_from_shadow_realm(realm);
     });
 }

--- a/resources/idlharness-shadowrealm.js
+++ b/resources/idlharness-shadowrealm.js
@@ -23,9 +23,6 @@ function fetch_text(url) {
 function idl_test_shadowrealm(srcs, deps) {
     promise_setup(async t => {
         const realm = new ShadowRealm();
-        // https://github.com/web-platform-tests/wpt/issues/31996
-        realm.evaluate("globalThis.self = globalThis; undefined;");
-
         realm.evaluate(`
             globalThis.self.GLOBAL = {
                 isWindow: function() { return false; },

--- a/resources/testharness-shadowrealm-audioworkletprocessor.js
+++ b/resources/testharness-shadowrealm-audioworkletprocessor.js
@@ -1,0 +1,52 @@
+/**
+ * AudioWorkletProcessor intended for hosting a ShadowRealm and running a test
+ * inside of that ShadowRealm.
+ */
+globalThis.TestRunner = class TestRunner extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.createShadowRealmAndStartTests();
+  }
+
+  /**
+   * Fetch adaptor function intended as a drop-in replacement for fetchAdaptor()
+   * (see testharness-shadowrealm-outer.js), but it does not assume fetch() is
+   * present in the realm. Instead, it relies on setupFakeFetchOverMessagePort()
+   * having been called on the port on the other side of this.port's channel.
+   */
+  fetchOverPortExecutor(resource) {
+    return (resolve, reject) => {
+      const listener = (event) => {
+        if (typeof event.data !== "string" || !event.data.startsWith("fetchResult::")) {
+          return;
+        }
+
+        const result = event.data.slice("fetchResult::".length);
+        if (result.startsWith("success::")) {
+          resolve(result.slice("success::".length));
+        } else {
+          reject(result.slice("fail::".length));
+        }
+
+        this.port.removeEventListener("message", listener);
+      }
+      this.port.addEventListener("message", listener);
+      this.port.start();
+      this.port.postMessage(`fetchRequest::${resource}`);
+    }
+  }
+
+  /**
+   * Async method, which is patched over in
+   * (test).any.audioworklet-shadowrealm.js; see serve.py
+   */
+  async createShadowRealmAndStartTests() {
+    throw new Error("Forgot to overwrite this method!");
+  }
+
+  /** Overrides AudioWorkletProcessor.prototype.process() */
+  process() {
+    return false;
+  }
+};
+registerProcessor("test-runner", TestRunner);

--- a/resources/testharness-shadowrealm-inner.js
+++ b/resources/testharness-shadowrealm-inner.js
@@ -1,0 +1,27 @@
+// testharness file with ShadowRealm utilities to be imported inside ShadowRealm
+
+/**
+ * Set up all properties on the ShadowRealm's global object that tests will
+ * expect to be present.
+ *
+ * @param {string} queryString - string to use as value for location.search,
+ *   used for subsetting some tests
+ * @param {function} fetchAdaptor - a function that takes a resource URI and
+ *   returns a function which itself takes a (resolve, reject) pair from the
+ *   hosting realm, and calls resolve with the text result of fetching the
+ *   resource, or reject with a string indicating the error that occurred
+ */
+globalThis.setShadowRealmGlobalProperties = function (queryString, fetchAdaptor) {
+  globalThis.fetch_json = (resource) => {
+    const executor = fetchAdaptor(resource);
+    return new Promise(executor).then((s) => JSON.parse(s));
+  };
+
+  globalThis.location = { search: queryString };
+};
+
+globalThis.GLOBAL = {
+  isWindow: function() { return false; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return true; },
+};

--- a/resources/testharness-shadowrealm-outer.js
+++ b/resources/testharness-shadowrealm-outer.js
@@ -1,0 +1,33 @@
+// testharness file with ShadowRealm utilities to be imported in the realm
+// hosting the ShadowRealm
+
+/**
+ * Convenience function for evaluating some async code in the ShadowRealm and
+ * waiting for the result.
+ *
+ * @param {ShadowRealm} realm - the ShadowRealm to evaluate the code in
+ * @param {string} asyncBody - the code to evaluate; will be put in the body of
+ *   an async function, and must return a value explicitly if a value is to be
+ *   returned to the hosting realm.
+ */
+globalThis.shadowRealmEvalAsync = function (realm, asyncBody) {
+  return new Promise(realm.evaluate(`
+    (resolve, reject) => {
+      (async () => {
+        ${asyncBody}
+      })().then(resolve, (e) => reject(e.toString()));
+    }
+  `));
+};
+
+/**
+ * Convenience adaptor function for fetch() that can be passed to
+ * setShadowRealmGlobalProperties() (see testharness-shadowrealm-inner.js).
+ * Used to adapt the hosting realm's fetch(), if present, to fetch a resource
+ * and pass its text through the callable boundary to the ShadowRealm.
+ */
+globalThis.fetchAdaptor = (resource) => (resolve, reject) => {
+  fetch(resource)
+    .then(res => res.text())
+    .then(resolve, (e) => reject(e.toString()));
+};

--- a/streams/idlharness-shadowrealm.window.js
+++ b/streams/idlharness-shadowrealm.window.js
@@ -1,2 +1,3 @@
+// META: script=/resources/testharness-shadowrealm-outer.js
 // META: script=/resources/idlharness-shadowrealm.js
 idl_test_shadowrealm(["streams"], ["dom"]);

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -88,10 +88,12 @@ _any_variants: Dict[Text, VariantData] = {
     "shadowrealm-in-window": {},
     "shadowrealm-in-shadowrealm": {},
     "shadowrealm-in-dedicatedworker": {},
+    "shadowrealm-in-sharedworker": {},
     "shadowrealm": {"longhand": {
         "shadowrealm-in-window",
         "shadowrealm-in-shadowrealm",
         "shadowrealm-in-dedicatedworker",
+        "shadowrealm-in-sharedworker",
     }},
     "jsshell": {"suffix": ".any.js"},
 }

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -86,7 +86,8 @@ _any_variants: Dict[Text, VariantData] = {
     "worker": {"longhand": {"dedicatedworker", "sharedworker", "serviceworker"}},
     "worker-module": {},
     "shadowrealm-in-window": {},
-    "shadowrealm": {"longhand": {"shadowrealm-in-window"}},
+    "shadowrealm-in-shadowrealm": {},
+    "shadowrealm": {"longhand": {"shadowrealm-in-window", "shadowrealm-in-shadowrealm"}},
     "jsshell": {"suffix": ".any.js"},
 }
 

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -85,7 +85,8 @@ _any_variants: Dict[Text, VariantData] = {
     "dedicatedworker-module": {"suffix": ".any.worker-module.html"},
     "worker": {"longhand": {"dedicatedworker", "sharedworker", "serviceworker"}},
     "worker-module": {},
-    "shadowrealm": {},
+    "shadowrealm-in-window": {},
+    "shadowrealm": {"longhand": {"shadowrealm-in-window"}},
     "jsshell": {"suffix": ".any.js"},
 }
 

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -87,7 +87,12 @@ _any_variants: Dict[Text, VariantData] = {
     "worker-module": {},
     "shadowrealm-in-window": {},
     "shadowrealm-in-shadowrealm": {},
-    "shadowrealm": {"longhand": {"shadowrealm-in-window", "shadowrealm-in-shadowrealm"}},
+    "shadowrealm-in-dedicatedworker": {},
+    "shadowrealm": {"longhand": {
+        "shadowrealm-in-window",
+        "shadowrealm-in-shadowrealm",
+        "shadowrealm-in-dedicatedworker",
+    }},
     "jsshell": {"suffix": ".any.js"},
 }
 

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -93,12 +93,17 @@ _any_variants: Dict[Text, VariantData] = {
         "force_https": True,
         "suffix": ".https.any.shadowrealm-in-serviceworker.html",
     },
+    "shadowrealm-in-audioworklet": {
+        "force_https": True,
+        "suffix": ".https.any.shadowrealm-in-audioworklet.html",
+    },
     "shadowrealm": {"longhand": {
         "shadowrealm-in-window",
         "shadowrealm-in-shadowrealm",
         "shadowrealm-in-dedicatedworker",
         "shadowrealm-in-sharedworker",
         "shadowrealm-in-serviceworker",
+        "shadowrealm-in-audioworklet",
     }},
     "jsshell": {"suffix": ".any.js"},
 }

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -89,11 +89,16 @@ _any_variants: Dict[Text, VariantData] = {
     "shadowrealm-in-shadowrealm": {},
     "shadowrealm-in-dedicatedworker": {},
     "shadowrealm-in-sharedworker": {},
+    "shadowrealm-in-serviceworker": {
+        "force_https": True,
+        "suffix": ".https.any.shadowrealm-in-serviceworker.html",
+    },
     "shadowrealm": {"longhand": {
         "shadowrealm-in-window",
         "shadowrealm-in-shadowrealm",
         "shadowrealm-in-dedicatedworker",
         "shadowrealm-in-sharedworker",
+        "shadowrealm-in-serviceworker",
     }},
     "jsshell": {"suffix": ".any.js"},
 }

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -438,7 +438,6 @@ class ShadowRealmInWindowHandler(HtmlWrapperHandler):
 <script>
 (async function() {
   const r = new ShadowRealm();
-  r.evaluate("globalThis.self = globalThis; undefined;");
   r.evaluate(`func => {
     globalThis.fetch_json = (resource) => {
       const thenMethod = func(resource);

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -425,9 +425,10 @@ class ServiceWorkerModulesHandler(HtmlWrapperHandler):
 </script>
 """
 
-class ShadowRealmHandler(HtmlWrapperHandler):
-    global_type = "shadowrealm"
-    path_replace = [(".any.shadowrealm.html", ".any.js")]
+
+class ShadowRealmInWindowHandler(HtmlWrapperHandler):
+    global_type = "shadowrealm-in-window"
+    path_replace = [(".any.shadowrealm-in-window.html", ".any.js")]
 
     wrapper = """<!doctype html>
 <meta charset=utf-8>
@@ -590,7 +591,7 @@ class RoutesBuilder:
             ("GET", "*.any.sharedworker-module.html", SharedWorkerModulesHandler),
             ("GET", "*.any.serviceworker.html", ServiceWorkersHandler),
             ("GET", "*.any.serviceworker-module.html", ServiceWorkerModulesHandler),
-            ("GET", "*.any.shadowrealm.html", ShadowRealmHandler),
+            ("GET", "*.any.shadowrealm-in-window.html", ShadowRealmInWindowHandler),
             ("GET", "*.any.window-module.html", WindowModulesHandler),
             ("GET", "*.any.worker.js", ClassicWorkerHandler),
             ("GET", "*.any.worker-module.js", ModuleWorkerHandler),

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -521,6 +521,13 @@ class ShadowRealmInDedicatedWorkerHandler(WorkersHandler):
                      ".any.worker-shadowrealm.js")]
 
 
+class ShadowRealmInSharedWorkerHandler(SharedWorkersHandler):
+    global_type = "shadowrealm-in-sharedworker"
+    path_replace = [(".any.shadowrealm-in-sharedworker.html",
+                     ".any.js",
+                     ".any.worker-shadowrealm.js")]
+
+
 class BaseWorkerHandler(WrapperHandler):
     headers = [('Content-Type', 'text/javascript')]
 
@@ -596,8 +603,9 @@ importScripts("/resources/testharness-shadowrealm-outer.js");
     await import("%(path)s");
   `);
 
+  const postMessageFunc = await getPostMessageFunc();
   function forwardMessage(msgJSON) {
-    postMessage(JSON.parse(msgJSON));
+    postMessageFunc(JSON.parse(msgJSON));
   }
   r.evaluate('begin_shadow_realm_tests')(forwardMessage);
 })();
@@ -666,6 +674,7 @@ class RoutesBuilder:
             ("GET", "*.any.shadowrealm-in-window.html", ShadowRealmInWindowHandler),
             ("GET", "*.any.shadowrealm-in-shadowrealm.html", ShadowRealmInShadowRealmHandler),
             ("GET", "*.any.shadowrealm-in-dedicatedworker.html", ShadowRealmInDedicatedWorkerHandler),
+            ("GET", "*.any.shadowrealm-in-sharedworker.html", ShadowRealmInSharedWorkerHandler),
             ("GET", "*.any.window-module.html", WindowModulesHandler),
             ("GET", "*.any.worker.js", ClassicWorkerHandler),
             ("GET", "*.any.worker-module.js", ModuleWorkerHandler),

--- a/url/idlharness-shadowrealm.window.js
+++ b/url/idlharness-shadowrealm.window.js
@@ -1,2 +1,3 @@
+// META: script=/resources/testharness-shadowrealm-outer.js
 // META: script=/resources/idlharness-shadowrealm.js
 idl_test_shadowrealm(["url"], []);

--- a/user-timing/idlharness-shadowrealm.window.js
+++ b/user-timing/idlharness-shadowrealm.window.js
@@ -1,2 +1,3 @@
+// META: script=/resources/testharness-shadowrealm-outer.js
 // META: script=/resources/idlharness-shadowrealm.js
 idl_test_shadowrealm(["user-timing"], ["hr-time", "performance-timeline", "dom"]);

--- a/wasm/jsapi/idlharness-shadowrealm.window.js
+++ b/wasm/jsapi/idlharness-shadowrealm.window.js
@@ -1,2 +1,3 @@
+// META: script=/resources/testharness-shadowrealm-outer.js
 // META: script=/resources/idlharness-shadowrealm.js
 idl_test_shadowrealm(["wasm-js-api"], []);

--- a/webidl/idlharness-shadowrealm.window.js
+++ b/webidl/idlharness-shadowrealm.window.js
@@ -1,2 +1,3 @@
+// META: script=/resources/testharness-shadowrealm-outer.js
 // META: script=/resources/idlharness-shadowrealm.js
 idl_test_shadowrealm(["webidl"], []);


### PR DESCRIPTION
This adds a bunch of new global scopes to run ShadowRealm tests inside ShadowRealms hosted in multiple scopes: window, workers, AudioWorklet, and another ShadowRealm. `global=shadowrealm` is now an alias for all of these scopes. The purpose is to catch more potential bugs and exercise different codepaths in implementations, compared to the status quo of only testing in a ShadowRealm hosted in a window scope.

Closes: #48573