### PR TITLE
Add Shared Storage trusted origins route to RoutesBuilder

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -604,6 +604,7 @@ class RoutesBuilder:
             ("GET", "/.well-known/interest-group/permissions/", handlers.PythonScriptHandler),
             ("*", "/.well-known/interest-group/real-time-report", handlers.PythonScriptHandler),
             ("*", "/.well-known/private-aggregation/*", handlers.PythonScriptHandler),
+            ("GET", "/.well-known/shared-storage/trusted-origins", handlers.PythonScriptHandler),
             ("*", "/.well-known/web-identity", handlers.PythonScriptHandler),
             ("*", "*.py", handlers.PythonScriptHandler),
             ("GET", "*", handlers.FileHandler)


### PR DESCRIPTION
We add a route for /.well-known/shared-storage/trusted-origins to RoutesBuilder in order to test custom data origins for shared storage.

See the explainer update: https://github.com/WICG/shared-storage/pull/198.