### PR TITLE
Implement testdriver features (RFC-214)

### DIFF
--- a/docs/writing-tests/testdriver-extension-tutorial.md
+++ b/docs/writing-tests/testdriver-extension-tutorial.md
@@ -90,8 +90,16 @@ We will leave this unimplemented and override it in another file. Lets do that n
 
 #### WebDriver BiDi
 
-For commands using WebDriver BiDi, add the methods to `window.test_driver.bidi`. Parameters are passed as a single object `params`.
-<!-- TODO: add an example link once a first bidi command (probably `test_driver.bidi.permissions.set_permission`) is implemented.-->
+For commands using WebDriver BiDi, add the methods to `test_driver.bidi`. Parameters are passed as a single object `params`. For example [`test_driver.bidi.permissions.set_permission`](https://github.com/web-platform-tests/wpt/blob/5ec8ba6d68f27d49a056cbf940e3bc9a8324c538/resources/testdriver.js#L183).
+
+Before calling `test_driver_internal` method, assert the `bidi` testdriver feature is enabled.
+```javascript
+set_permission: function (params) {
+    assertBidiIsEnabled();
+    return window.test_driver_internal.bidi.permissions.set_permission(
+        params);
+}
+```
 
 ### [tools/wptrunner/wptrunner/testdriver-extra.js](https://github.com/web-platform-tests/wpt/blob/master/tools/wptrunner/wptrunner/testdriver-extra.js)
 

--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -38,7 +38,7 @@ The api in `test_driver.bidi` provides access to the
 
 ### Markup ###
 
-To use WebDriver BiDi, enable the `bidi` feature in `testdriver.js` by adding
+To use WebDriver BiDi, enable the `bidi` feature in `testdriver.js` by adding the
 `feature=bidi` query string parameter. Details are in [RFC 214: Add testdriver features](https://github.com/web-platform-tests/rfcs/blob/master/rfcs/testdriver-features.md).
 ```html
 <script src="/resources/testdriver.js?feature=bidi"></script>

--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -36,6 +36,20 @@ document when using testdriver from a different context):
 The api in `test_driver.bidi` provides access to the
 [WebDriver BiDi](https://w3c.github.io/webdriver-bidi) protocol.
 
+### Markup ###
+
+To use WebDriver BiDi, enable the `bidi` feature in `testdriver.js` by adding
+`feature=bidi` query string parameter. Details are in [RFC 214: Add testdriver features](https://github.com/web-platform-tests/rfcs/blob/master/rfcs/testdriver-features.md).
+```html
+<script src="/resources/testdriver.js?feature=bidi"></script>
+```
+
+```javascript
+// META: script=/resources/testdriver.js?feature=bidi
+```
+
+[Example](https://github.com/web-platform-tests/wpt/blob/aae46926b1fdccd460e1c6eaaf01ca20b941fbce/infrastructure/webdriver/bidi/subscription.html#L6).
+
 ### Context ###
 
 A WebDriver BiDi "browsing context" is equivalent to an

--- a/infrastructure/metadata/infrastructure/testdriver/bidi/bluetooth/simulate_adapter.https.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/bidi/bluetooth/simulate_adapter.https.html.ini
@@ -1,1 +1,2 @@
-disabled: https://github.com/web-platform-tests/wpt/issues/47544
+disabled :
+  if product != "chrome": @True

--- a/infrastructure/metadata/infrastructure/testdriver/bidi/bluetooth/simulate_adapter.https.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/bidi/bluetooth/simulate_adapter.https.html.ini
@@ -1,2 +1,2 @@
-disabled :
+disabled:
   if product != "chrome": @True

--- a/infrastructure/metadata/infrastructure/testdriver/bidi/permissions/set_permission.https.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/bidi/permissions/set_permission.https.html.ini
@@ -1,1 +1,2 @@
-disabled: https://github.com/web-platform-tests/wpt/issues/47544
+disabled:
+  if product != "chrome": @True

--- a/infrastructure/metadata/infrastructure/webdriver/bidi/subscription.html.ini
+++ b/infrastructure/metadata/infrastructure/webdriver/bidi/subscription.html.ini
@@ -1,1 +1,2 @@
-disabled: https://github.com/web-platform-tests/wpt/issues/47544
+disabled:
+  if product != "chrome": @True

--- a/infrastructure/metadata/infrastructure/webdriver/bidi/subscription.window.js.ini
+++ b/infrastructure/metadata/infrastructure/webdriver/bidi/subscription.window.js.ini
@@ -1,0 +1,1 @@
+disabled: https://github.com/web-platform-tests/wpt/issues/47544

--- a/infrastructure/metadata/infrastructure/webdriver/bidi/subscription.window.js.ini
+++ b/infrastructure/metadata/infrastructure/webdriver/bidi/subscription.window.js.ini
@@ -1,1 +1,2 @@
-disabled: https://github.com/web-platform-tests/wpt/issues/47544
+disabled:
+  if product != "chrome": @True

--- a/infrastructure/testdriver/bidi/bluetooth/simulate_adapter.https.html
+++ b/infrastructure/testdriver/bidi/bluetooth/simulate_adapter.https.html
@@ -3,7 +3,7 @@
 <title>TestDriver bidi.bluetooth.simulate_adapter method</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 
 <script>

--- a/infrastructure/testdriver/bidi/permissions/set_permission.https.html
+++ b/infrastructure/testdriver/bidi/permissions/set_permission.https.html
@@ -3,7 +3,7 @@
 <title>TestDriver bidi.permissions.set_permission method</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 
 <script>

--- a/infrastructure/webdriver/bidi/subscription.html
+++ b/infrastructure/webdriver/bidi/subscription.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Test console log are present</title>
+<title>Can subscribe and receive WebDriver BiDi events</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script>
     promise_test(async () => {

--- a/infrastructure/webdriver/bidi/subscription.window.js
+++ b/infrastructure/webdriver/bidi/subscription.window.js
@@ -1,0 +1,22 @@
+// META: title=Can subscribe and receive WebDriver BiDi events
+// META: script=/resources/testdriver.js?feature=bidi
+
+'use strict';
+
+promise_test(async () => {
+    const some_message = "SOME MESSAGE";
+    // Subscribe to `log.entryAdded` BiDi events. This will not add a listener to the page.
+    await test_driver.bidi.log.entry_added.subscribe();
+    // Add a listener for the log.entryAdded event. This will not subscribe to the event, so the subscription is
+    // required before. The cleanup is done automatically after the test is finished.
+    const log_entry_promise = test_driver.bidi.log.entry_added.once();
+    // Emit a console.log message.
+    // Note: Lint rule is disabled in `lint.ignore` file.
+    console.log(some_message);
+    // Wait for the log.entryAdded event to be received.
+    const event = await log_entry_promise;
+    // Assert the log.entryAdded event has the expected message.
+    assert_equals(event.args.length, 1);
+    const event_message = event.args[0];
+    assert_equals(event_message.value, some_message);
+}, "Assert testdriver can subscribe and receive events");

--- a/lint.ignore
+++ b/lint.ignore
@@ -123,6 +123,7 @@ CONSOLE: webaudio/resources/audit.js:41
 
 # Intentional use of console.*
 CONSOLE: infrastructure/webdriver/bidi/subscription.html
+CONSOLE: infrastructure/webdriver/bidi/subscription.window.js
 
 # use of console in a public library - annotation-model ensures
 # it is not actually used

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -3,6 +3,26 @@
     var idCounter = 0;
     let testharness_context = null;
 
+    const features = (() => {
+        function getFeatures(scriptSrc) {
+            try {
+                const url = new URL(scriptSrc);
+                return url.searchParams.getAll('feature');
+            } catch (e) {
+                return [];
+            }
+        }
+
+        return getFeatures(document?.currentScript?.src ?? '');
+    })();
+
+    function assertBidiIsEnabled(){
+        if (!features.includes('bidi')) {
+            throw new Error(
+                "`?feature=bidi` is missing when importing testdriver.js but the test is using WebDriver BiDi APIs");
+        }
+    }
+
     function getInViewCenterPoint(rect) {
         var left = Math.max(0, rect.left);
         var right = Math.min(window.innerWidth, rect.right);
@@ -115,6 +135,7 @@
                      * is successfully done.
                      */
                     subscribe: async function (params = {}) {
+                        assertBidiIsEnabled();
                         return window.test_driver_internal.bidi.log.entry_added.subscribe(params);
                     },
                     /**
@@ -127,6 +148,7 @@
                      * added event listener when called.
                      */
                     on: function (callback) {
+                        assertBidiIsEnabled();
                         return window.test_driver_internal.bidi.log.entry_added.on(callback);
                     },
                     /**
@@ -137,6 +159,7 @@
                      * with the event object when the event is emitted.
                      */
                     once: function () {
+                        assertBidiIsEnabled();
                         return new Promise(resolve => {
                             const remove_handler = window.test_driver_internal.bidi.log.entry_added.on(
                                 event => {
@@ -181,6 +204,7 @@
                  *                    the permission fails.
                  */
                 set_permission: function (params) {
+                    assertBidiIsEnabled();
                     return window.test_driver_internal.bidi.permissions.set_permission(
                         params);
                 }

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -585,14 +585,12 @@ def check_parsed(repo_root: Text, path: Text, f: IO[bytes]) -> List[rules.Error]
                         return False
             return True
 
-        if not is_path_correct("testharness.js",
-                               src) or not is_query_string_correct(
-            "testharness.js", src, {}):
+        if (not is_path_correct("testharness.js", src) or
+                not is_query_string_correct("testharness.js", src, {})):
             errors.append(rules.TestharnessPath.error(path))
 
-        if not is_path_correct("testharnessreport.js",
-                               src) or not is_query_string_correct(
-            "testharnessreport.js", src, {}):
+        if (not is_path_correct("testharnessreport.js", src) or
+                not is_query_string_correct("testharnessreport.js", src, {})):
             errors.append(rules.TestharnessReportPath.error(path))
 
         if not is_path_correct("testdriver.js", src):
@@ -601,9 +599,8 @@ def check_parsed(repo_root: Text, path: Text, f: IO[bytes]) -> List[rules.Error]
                                        {'feature': ['bidi']}):
             errors.append(rules.TestdriverUnsupportedQueryParameter.error(path))
 
-        if not is_path_correct("testdriver-vendor.js",
-                               src) or not is_query_string_correct(
-            "testdriver-vendor.js", src, {}):
+        if (not is_path_correct("testdriver-vendor.js", src) or
+                not is_query_string_correct("testdriver-vendor.js", src, {})):
             errors.append(rules.TestdriverVendorPath.error(path))
 
         script_path = None

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -537,6 +537,25 @@ def check_parsed(repo_root: Text, path: Text, f: IO[bytes]) -> List[rules.Error]
 
         def is_query_string_correct(script: Text, src: Text,
                 allowed_query_string_params: Dict[str, List[str]]) -> bool:
+            """
+            Checks if the query string in a script tag's `src` is valid.
+
+            Specifically, it verifies that the query string parameters and their
+            values are among those allowed for the given script. It handles vendor
+            prefixes (parameters or values containing a colon) by allowing them
+            unconditionally.
+
+            :param script: the name of the script (e.g., "testharness.js"). Used
+                           to verify is the given `src` is related to the
+                           script.
+            :param src: the full `src` attribute value from the script tag.
+            :param allowed_query_string_params: A dictionary where keys are
+                                                allowed parameter names and
+                                                values are lists of allowed
+                                                values for each parameter.
+            :return: if the query string does not contain any not-allowed
+                     params.
+            """
             if not ("%s" % src).startswith("/resources/%s?" % script):
                 # The src is not related to the script.
                 return True

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from typing import (Any, Callable, Dict, IO, Iterable, List, Optional, Sequence, Set, Text, Tuple,
                     Type, TypeVar)
 
-from urllib.parse import urlsplit, urljoin
+from urllib.parse import urlsplit, urljoin, parse_qs
 
 try:
     from xml.etree import cElementTree as ElementTree
@@ -523,20 +523,68 @@ def check_parsed(repo_root: Text, path: Text, f: IO[bytes]) -> List[rules.Error]
     for element in source_file.root.findall(".//{http://www.w3.org/1999/xhtml}script[@src]"):
         src = element.attrib["src"]
 
-        def incorrect_path(script: Text, src: Text) -> bool:
-            return (script == src or
-                ("/%s" % script in src and src != "/resources/%s" % script))
+        def is_path_correct(script: Text, src: Text) -> bool:
+            if script == src:
+                # The src does not provide the full path.
+                return False
 
-        if incorrect_path("testharness.js", src):
+            if "/%s" % script not in src:
+                # The src is not related to the script.
+                return True
+
+            return src == "/resources/%s" % script or ("%s" % src).startswith(
+                "/resources/%s?" % script)
+
+        def is_query_string_correct(script: Text, src: Text,
+                allowed_query_string_params: Dict[str, List[str]]) -> bool:
+            if not ("%s" % src).startswith("/resources/%s?" % script):
+                # The src is not related to the script.
+                return True
+
+            try:
+                query_string = urlsplit(urljoin(source_file.url, src)).query
+                query_string_params = parse_qs(query_string,
+                                               keep_blank_values=True)
+            except ValueError:
+                # Parsing error means that the query string is incorrect.
+                return False
+
+            for param_name in query_string_params:
+                if ':' in param_name:
+                    # Allow for vendor-specific query parameters.
+                    continue
+
+                if param_name not in allowed_query_string_params:
+                    return False
+
+                for param_value in query_string_params[param_name]:
+                    if ':' in param_value:
+                        # Allow for vendor-specific values in query parameters.
+                        continue
+                    if param_value not in allowed_query_string_params[
+                            param_name]:
+                        return False
+            return True
+
+        if not is_path_correct("testharness.js",
+                               src) or not is_query_string_correct(
+            "testharness.js", src, {}):
             errors.append(rules.TestharnessPath.error(path))
 
-        if incorrect_path("testharnessreport.js", src):
+        if not is_path_correct("testharnessreport.js",
+                               src) or not is_query_string_correct(
+            "testharnessreport.js", src, {}):
             errors.append(rules.TestharnessReportPath.error(path))
 
-        if incorrect_path("testdriver.js", src):
+        if not is_path_correct("testdriver.js", src):
             errors.append(rules.TestdriverPath.error(path))
+        if not is_query_string_correct("testdriver.js", src,
+                                       {'feature': ['bidi']}):
+            errors.append(rules.TestdriverUnsupportedQueryParameter.error(path))
 
-        if incorrect_path("testdriver-vendor.js", src):
+        if not is_path_correct("testdriver-vendor.js",
+                               src) or not is_query_string_correct(
+            "testdriver-vendor.js", src, {}):
             errors.append(rules.TestdriverVendorPath.error(path))
 
         script_path = None

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -524,16 +524,23 @@ def check_parsed(repo_root: Text, path: Text, f: IO[bytes]) -> List[rules.Error]
         src = element.attrib["src"]
 
         def is_path_correct(script: Text, src: Text) -> bool:
+            """
+            If the `src` relevant to the `script`, check that the `src` is the
+            correct path for `script`.
+            :param script: the script name to check the `src` for.
+            :param src: the included path.
+            :return: if the `src` irrelevant to the `script`, or if the `src`
+                     path is the correct path.
+            """
             if script == src:
                 # The src does not provide the full path.
                 return False
 
             if "/%s" % script not in src:
-                # The src is not related to the script.
+                # The src is not relevant to the script.
                 return True
 
-            return src == "/resources/%s" % script or ("%s" % src).startswith(
-                "/resources/%s?" % script)
+            return ("%s" % src).startswith("/resources/%s" % script)
 
         def is_query_string_correct(script: Text, src: Text,
                 allowed_query_string_params: Dict[str, List[str]]) -> bool:
@@ -553,7 +560,7 @@ def check_parsed(repo_root: Text, path: Text, f: IO[bytes]) -> List[rules.Error]
                                                 allowed parameter names and
                                                 values are lists of allowed
                                                 values for each parameter.
-            :return: if the query string does not contain any not-allowed
+            :return: if the query string is empty or contains only allowed
                      params.
             """
             if not ("%s" % src).startswith("/resources/%s?" % script):
@@ -569,10 +576,6 @@ def check_parsed(repo_root: Text, path: Text, f: IO[bytes]) -> List[rules.Error]
                 return False
 
             for param_name in query_string_params:
-                if ':' in param_name:
-                    # Allow for vendor-specific query parameters.
-                    continue
-
                 if param_name not in allowed_query_string_params:
                     return False
 

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -274,6 +274,11 @@ class TestdriverPath(Rule):
     description = "testdriver.js script seen with incorrect path"
 
 
+class TestdriverUnsupportedQueryParameter(Rule):
+    name = "TESTDRIVER-UNSUPPORTED-QUERY-PARAMETER"
+    description = "testdriver.js script seen with incorrect query parameters"
+
+
 class TestdriverVendorPath(Rule):
     name = "TESTDRIVER-VENDOR-PATH"
     description = "testdriver-vendor.js script seen with incorrect path"

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -276,7 +276,7 @@ class TestdriverPath(Rule):
 
 class TestdriverUnsupportedQueryParameter(Rule):
     name = "TESTDRIVER-UNSUPPORTED-QUERY-PARAMETER"
-    description = "testdriver.js script seen with incorrect query parameters"
+    description = "testdriver.js script seen with unsupported query parameters"
 
 
 class TestdriverVendorPath(Rule):

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -395,6 +395,50 @@ def test_early_testdriver_vendor():
             ]
 
 
+def test_testdriver_allowed():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind in ["web-lax", "web-strict"]:
+            assert errors == []
+        elif kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 2),
+            ]
+
+
+def test_testdriver_feature_bidi():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind in ["web-lax", "web-strict"]:
+            assert errors == []
+        elif kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 2),
+            ]
+
+
 def test_multiple_testdriver():
     code = b"""
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -413,6 +457,211 @@ def test_multiple_testdriver():
         if kind in ["web-lax", "web-strict"]:
             assert errors == [
                 ("MULTIPLE-TESTDRIVER", "More than one `<script src='/resources/testdriver.js'>`", filename, None),
+            ]
+        elif kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 2),
+            ]
+
+
+def test_multiple_testdriver_with_query_param():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind in ["web-lax", "web-strict"]:
+            assert errors == [
+                ("MULTIPLE-TESTDRIVER",
+                 "More than one `<script src='/resources/testdriver.js'>`",
+                 filename, None),
+            ]
+        elif kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 2),
+            ]
+
+
+def test_testdriver_unsupported_query_param():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?foo"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind in ["web-lax", "web-strict"]:
+            assert errors == [
+                ("TESTDRIVER-UNSUPPORTED-QUERY-PARAMETER",
+                 "testdriver.js script seen with incorrect query parameters",
+                 filename, None),
+            ]
+        elif kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 2),
+            ]
+
+
+def test_testdriver_vendor_query_param():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?vendor:param=foo"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind in ["web-lax", "web-strict"]:
+            assert errors == []
+        elif kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 2),
+            ]
+
+
+def test_testdriver_unsupported_feature():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=unsupported_feature"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind in ["web-lax", "web-strict"]:
+            assert errors == [
+                ("TESTDRIVER-UNSUPPORTED-QUERY-PARAMETER",
+                 "testdriver.js script seen with incorrect query parameters",
+                 filename, None),
+            ]
+        elif kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 2),
+            ]
+
+
+def test_testdriver_multiple_unsupported_features():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=bidi&feature=unsupported_feature"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind == "web-lax":
+            assert errors == [
+                ('TESTDRIVER-UNSUPPORTED-QUERY-PARAMETER',
+                 'testdriver.js script seen with incorrect query parameters',
+                 filename, None)
+            ]
+        elif kind == "python":
+            assert errors == [
+                ('PARSE-FAILED', 'Unable to parse file', filename, 2),
+            ]
+        elif kind == "web-strict":
+            assert errors == [
+                ('PARSE-FAILED', 'Unable to parse file', filename, None),
+            ]
+
+
+def test_testdriver_multiple_vendor_features():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=bidi&feature=vendor:feature"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind == "web-lax":
+            assert errors == []
+        elif kind == "python":
+            assert errors == [
+                ('PARSE-FAILED', 'Unable to parse file', filename, 2),
+            ]
+        elif kind == "web-strict":
+            assert errors == [
+                ('PARSE-FAILED', 'Unable to parse file', filename, None),
+            ]
+
+
+def test_testdriver_vendor_feature():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=vendor:feature"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind in ["web-lax", "web-strict"]:
+            assert errors == []
+        elif kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 2),
+            ]
+
+
+def test_testdriver_unsupported_empty_feature():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature="></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind in ["web-lax", "web-strict"]:
+            assert errors == [
+                ("TESTDRIVER-UNSUPPORTED-QUERY-PARAMETER",
+                 "testdriver.js script seen with incorrect query parameters",
+                 filename, None),
             ]
         elif kind == "python":
             assert errors == [

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -508,7 +508,7 @@ def test_testdriver_unsupported_query_param():
         if kind in ["web-lax", "web-strict"]:
             assert errors == [
                 ("TESTDRIVER-UNSUPPORTED-QUERY-PARAMETER",
-                 "testdriver.js script seen with incorrect query parameters",
+                 "testdriver.js script seen with unsupported query parameters",
                  filename, None),
             ]
         elif kind == "python":
@@ -532,7 +532,11 @@ def test_testdriver_vendor_query_param():
         check_errors(errors)
 
         if kind in ["web-lax", "web-strict"]:
-            assert errors == []
+            assert errors == [
+                ('TESTDRIVER-UNSUPPORTED-QUERY-PARAMETER',
+                 'testdriver.js script seen with unsupported query parameters',
+                 filename, None)
+            ]
         elif kind == "python":
             assert errors == [
                 ("PARSE-FAILED", "Unable to parse file", filename, 2),
@@ -556,7 +560,7 @@ def test_testdriver_unsupported_feature():
         if kind in ["web-lax", "web-strict"]:
             assert errors == [
                 ("TESTDRIVER-UNSUPPORTED-QUERY-PARAMETER",
-                 "testdriver.js script seen with incorrect query parameters",
+                 "testdriver.js script seen with unsupported query parameters",
                  filename, None),
             ]
         elif kind == "python":
@@ -565,7 +569,7 @@ def test_testdriver_unsupported_feature():
             ]
 
 
-def test_testdriver_multiple_unsupported_features():
+def test_testdriver_multiple_with_unsupported_features():
     code = b"""
 <html xmlns="http://www.w3.org/1999/xhtml">
 <script src="/resources/testharness.js"></script>
@@ -582,7 +586,7 @@ def test_testdriver_multiple_unsupported_features():
         if kind == "web-lax":
             assert errors == [
                 ('TESTDRIVER-UNSUPPORTED-QUERY-PARAMETER',
-                 'testdriver.js script seen with incorrect query parameters',
+                 'testdriver.js script seen with unsupported query parameters',
                  filename, None)
             ]
         elif kind == "python":
@@ -660,7 +664,7 @@ def test_testdriver_unsupported_empty_feature():
         if kind in ["web-lax", "web-strict"]:
             assert errors == [
                 ("TESTDRIVER-UNSUPPORTED-QUERY-PARAMETER",
-                 "testdriver.js script seen with incorrect query parameters",
+                 "testdriver.js script seen with unsupported query parameters",
                  filename, None),
             ]
         elif kind == "python":

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -166,6 +166,10 @@ class TestharnessTest(URLManifestItem):
         return self._extras.get("pac")
 
     @property
+    def testdriver_features(self) -> Optional[List[Text]]:
+        return self._extras.get("testdriver_features")
+
+    @property
     def testdriver(self) -> Optional[bool]:
         return self._extras.get("testdriver")
 
@@ -183,6 +187,8 @@ class TestharnessTest(URLManifestItem):
             rv[-1]["timeout"] = self.timeout
         if self.pac is not None:
             rv[-1]["pac"] = self.pac
+        if self.testdriver_features is not None:
+            rv[-1]["testdriver_features"] = self.testdriver_features
         if self.testdriver:
             rv[-1]["testdriver"] = self.testdriver
         if self.jsshell:

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -743,8 +743,9 @@ class SourceFile:
     def ___get_testdriver_include_path(self) -> Optional[str]:
         if self.script_metadata:
             for (meta, content) in self.script_metadata:
-                if meta.strip() == 'script' and content.startswith(
-                        '/resources/testdriver.js'):
+                if meta.strip() == 'script' and (
+                        content == '/resources/testdriver.js' or content.startswith(
+                        '/resources/testdriver.js?')):
                     return content.strip()
 
         if self.root is None:

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -6,7 +6,7 @@ from fnmatch import fnmatch
 from io import BytesIO
 from typing import (Any, BinaryIO, Callable, Deque, Dict, Iterable, List,
                     Optional, Pattern, Set, Text, Tuple, TypedDict, Union, cast)
-from urllib.parse import urljoin
+from urllib.parse import parse_qs, urlparse, urljoin
 
 try:
     from xml.etree import cElementTree as ElementTree
@@ -723,7 +723,14 @@ class SourceFile:
         """List of ElementTree Elements corresponding to nodes representing a
         testdriver.js script"""
         assert self.root is not None
-        return self.root.findall(".//{http://www.w3.org/1999/xhtml}script[@src='/resources/testdriver.js']")
+        # `xml.etree.ElementTree.findall` has a limited support of xPath, so
+        # explicit filter is required.
+        return [node for node in
+                self.root.findall(".//{http://www.w3.org/1999/xhtml}script")
+                if node.attrib.get('src',
+                                   "") == '/resources/testdriver.js' or
+                node.attrib.get('src', "").startswith(
+                    '/resources/testdriver.js?')]
 
     @cached_property
     def has_testdriver(self) -> Optional[bool]:
@@ -732,6 +739,45 @@ class SourceFile:
         if self.root is None:
             return None
         return bool(self.testdriver_nodes)
+
+    def ___get_testdriver_include_path(self) -> Optional[str]:
+        if self.script_metadata:
+            for (meta, content) in self.script_metadata:
+                if meta.strip() == 'script' and content.startswith(
+                        '/resources/testdriver.js'):
+                    return content.strip()
+
+        if self.root is None:
+            return None
+
+        for node in self.testdriver_nodes:
+            if "src" in node.attrib:
+                return node.attrib.get("src")
+
+        return None
+
+    @cached_property
+    def testdriver_features(self) -> Optional[List[Text]]:
+        """
+        List of requested testdriver features.
+        """
+
+        testdriver_include_url = self.___get_testdriver_include_path()
+
+        if testdriver_include_url is None:
+            return None
+
+        # Parse the URL
+        parsed_url = urlparse(testdriver_include_url)
+        # Extract query parameters
+        query_params = parse_qs(parsed_url.query)
+        # Get the values for the 'feature' parameter
+        feature_values = query_params.get('feature', [])
+
+        if len(feature_values) > 0:
+            return feature_values
+
+        return None
 
     @cached_property
     def reftest_nodes(self) -> List[ElementTree.Element]:
@@ -986,6 +1032,7 @@ class SourceFile:
                     global_variant_url(self.rel_url, suffix) + variant,
                     timeout=self.timeout,
                     pac=self.pac,
+                    testdriver_features=self.testdriver_features,
                     jsshell=jsshell,
                     script_metadata=self.script_metadata
                 )
@@ -1004,6 +1051,7 @@ class SourceFile:
                     test_url + variant,
                     timeout=self.timeout,
                     pac=self.pac,
+                    testdriver_features=self.testdriver_features,
                     script_metadata=self.script_metadata
                 )
                 for variant in self.test_variants
@@ -1020,6 +1068,7 @@ class SourceFile:
                     test_url + variant,
                     timeout=self.timeout,
                     pac=self.pac,
+                    testdriver_features=self.testdriver_features,
                     script_metadata=self.script_metadata
                 )
                 for variant in self.test_variants
@@ -1047,6 +1096,7 @@ class SourceFile:
                     url,
                     timeout=self.timeout,
                     pac=self.pac,
+                    testdriver_features=self.testdriver_features,
                     testdriver=testdriver,
                     script_metadata=self.script_metadata
                 ))

--- a/tools/manifest/tests/test_manifest.py
+++ b/tools/manifest/tests/test_manifest.py
@@ -294,8 +294,12 @@ def test_update_from_json_modified():
     # Reload it from JSON
     m = manifest.Manifest.from_json("/", json_str)
 
-    # Update it with timeout="long"
-    s2 = SourceFileWithTest("test1", "1"*40, item.TestharnessTest, timeout="long", pac="proxy.pac")
+    testdriver_features = ['feature_1', 'feature_2']
+
+    # Update timeout, pac and testdriver_features
+    s2 = SourceFileWithTest("test1", "1" * 40, item.TestharnessTest,
+                            timeout="long", pac="proxy.pac",
+                            testdriver_features=testdriver_features)
     tree, sourcefile_mock = tree_and_sourcefile_mocks([(s2, None, True)])
     with mock.patch("tools.manifest.manifest.SourceFile", side_effect=sourcefile_mock):
         m.update(tree)
@@ -303,7 +307,8 @@ def test_update_from_json_modified():
     assert json_str == {
         'items': {'testharness': {'test1': [
             "1"*40,
-            (None, {'timeout': 'long', 'pac': 'proxy.pac'})
+            (None, {'timeout': 'long', 'pac': 'proxy.pac',
+                    'testdriver_features': testdriver_features})
         ]}},
         'url_base': '/',
         'version': 9

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -216,7 +216,8 @@ class Test(ABC):
     long_timeout = 60  # seconds
 
     def __init__(self, url_base, tests_root, url, inherit_metadata, test_metadata,
-                 timeout=None, path=None, protocol="http", subdomain=False, pac=None):
+          timeout=None, path=None, protocol="http", subdomain=False, pac=None,
+          testdriver_features=None):
         self.url_base = url_base
         self.tests_root = tests_root
         self.url = url
@@ -224,6 +225,7 @@ class Test(ABC):
         self._test_metadata = test_metadata
         self.timeout = timeout if timeout is not None else self.default_timeout
         self.path = path
+        self.testdriver_features = testdriver_features
         self.subdomain = subdomain
         self.environment = {"url_base": url_base,
                             "protocol": protocol,
@@ -482,9 +484,10 @@ class TestharnessTest(Test):
 
     def __init__(self, url_base, tests_root, url, inherit_metadata, test_metadata,
                  timeout=None, path=None, protocol="http", testdriver=False,
-                 jsshell=False, scripts=None, subdomain=False, pac=None):
+                 jsshell=False, scripts=None, subdomain=False, pac=None,
+                 testdriver_features=None):
         Test.__init__(self, url_base, tests_root, url, inherit_metadata, test_metadata, timeout,
-                      path, protocol, subdomain, pac)
+                      path, protocol, subdomain, pac, testdriver_features)
 
         self.testdriver = testdriver
         self.jsshell = jsshell
@@ -494,6 +497,7 @@ class TestharnessTest(Test):
     def from_manifest(cls, manifest_file, manifest_item, inherit_metadata, test_metadata):
         timeout = cls.long_timeout if manifest_item.timeout == "long" else cls.default_timeout
         pac = manifest_item.pac
+        testdriver_features = manifest_item.testdriver_features
         testdriver = manifest_item.testdriver if hasattr(manifest_item, "testdriver") else False
         jsshell = manifest_item.jsshell if hasattr(manifest_item, "jsshell") else False
         script_metadata = manifest_item.script_metadata or []
@@ -506,6 +510,7 @@ class TestharnessTest(Test):
                    test_metadata,
                    timeout=timeout,
                    pac=pac,
+                   testdriver_features=testdriver_features,
                    path=os.path.join(manifest_file.tests_root, manifest_item.path),
                    protocol=server_protocol(manifest_item),
                    testdriver=testdriver,


### PR DESCRIPTION
Add testdriver features and use in chrome. Implementation of [RFC 214: Add testdriver features](https://github.com/web-platform-tests/rfcs/blob/master/rfcs/testdriver-features.md).

* Add testdriver features
* Add lint rules
* Enable bidi in chrome based on `feature=bidi`
* Enable `infrastructure/webdriver/bidi/subscription.html` for chrome
* Enable `infrastructure/testdriver/bidi/permissions/set_permission.https.html` for chrome
* Enable `infrastructure/metadata/infrastructure/testdriver/bidi/bluetooth/simulate_adapter.https.html` for chrome