### PR TITLE
Add some Media Capabilities API tests

### DIFF
--- a/media-capabilities/decodingInfo.any.js
+++ b/media-capabilities/decodingInfo.any.js
@@ -233,7 +233,7 @@ promise_test(t => {
       width: 800,
       height: 600,
       bitrate: 3000,
-      framerate: 24,
+      framerate: '24000/1001',
     }
   }));
 }, "Test that decodingInfo rejects framerate in the form of x/y");

--- a/media-capabilities/decodingInfo.any.js
+++ b/media-capabilities/decodingInfo.any.js
@@ -110,6 +110,20 @@ promise_test(t => {
   }));
 }, "Test that decodingInfo rejects if the video configuration contentType doesn't parse");
 
+// See https://mimesniff.spec.whatwg.org/#example-valid-mime-type-string
+promise_test(t => {
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
+    type: 'file',
+    video: {
+      contentType: 'video/webm;',
+      width: 800,
+      height: 600,
+      bitrate: 3000,
+      framerate: 24,
+    },
+  }));
+}, "Test that decodingInfo rejects if the video configuration contentType is not a valid MIME type string");
+
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
     type: 'file',
@@ -171,6 +185,45 @@ promise_test(t => {
     },
   }));
 }, "Test that decodingInfo rejects if the video configuration contentType has one parameter that isn't codecs");
+
+promise_test(t => {
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
+    type: 'file',
+    video: {
+      contentType: 'video/webm',
+      width: 800,
+      height: 600,
+      bitrate: 3000,
+      framerate: 24,
+    },
+  }));
+}, "Test that decodingInfo rejects if the video configuration contentType does not imply a single media codec but has no codecs parameter");
+
+promise_test(t => {
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
+    type: 'file',
+    video: {
+      contentType: 'video/webm; codecs="vp09.00.10.08, vp8"',
+      width: 800,
+      height: 600,
+      bitrate: 3000,
+      framerate: '24000/1001',
+    }
+  }));
+}, "Test that decodingInfo() rejects if the video configuration contentType has a codecs parameter that indicates multiple video codecs");
+
+promise_test(t => {
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
+    type: 'file',
+    video: {
+      contentType: 'video/webm; codecs="vp09.00.10.08, opus"',
+      width: 800,
+      height: 600,
+      bitrate: 3000,
+      framerate: '24000/1001',
+    }
+  }));
+}, "Test that decodingInfo() rejects if the video configuration contentType has a codecs parameter that indicates both an audio and a video codec");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
@@ -268,7 +321,15 @@ promise_test(t => {
     type: 'file',
     audio: { contentType: 'fgeoa' },
   }));
-}, "Test that decodingInfo rejects if the audio configuration contenType doesn't parse");
+}, "Test that decodingInfo rejects if the audio configuration contentType doesn't parse");
+
+// See https://mimesniff.spec.whatwg.org/#example-valid-mime-type-string
+promise_test(t => {
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
+    type: 'file',
+    audio: { contentType: 'audio/mpeg;' },
+  }));
+}, "Test that decodingInfo rejects if the audio configuration contentType is not a valid MIME type string");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
@@ -282,7 +343,7 @@ promise_test(t => {
     type: 'file',
     audio: { contentType: 'audio/webm; codecs="opus"; foo="bar"' },
   }));
-}, "Test that decodingInfo rejects if the audio configuration contentType has more than one parameters");
+}, "Test that decodingInfo rejects if the audio configuration contentType has more than one parameter");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
@@ -290,6 +351,27 @@ promise_test(t => {
     audio: { contentType: 'audio/webm; foo="bar"' },
   }));
 }, "Test that decodingInfo rejects if the audio configuration contentType has one parameter that isn't codecs");
+
+promise_test(t => {
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
+    type: 'file',
+    audio: { contentType: 'audio/webm' },
+  }));
+}, "Test that decodingInfo rejects if the audio configuration contentType does not imply a single media codec but has no codecs parameter");
+
+promise_test(t => {
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
+    type: 'file',
+    audio: { contentType: 'audio/webm; codecs="vorbis, opus"' },
+  }));
+}, "Test that decodingInfo() rejects if the audio configuration contentType has a codecs parameter that indicates multiple audio codecs");
+
+promise_test(t => {
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
+    type: 'file',
+    audio: { contentType: 'audio/webm; codecs="vp09.00.10.08, opus"' },
+  }));
+}, "Test that decodingInfo() rejects if the audio configuration contentType has a codecs parameter that indicates both an audio and a video codec");
 
 promise_test(t => {
   return navigator.mediaCapabilities.decodingInfo({

--- a/media-capabilities/decodingInfo.any.js
+++ b/media-capabilities/decodingInfo.any.js
@@ -207,10 +207,10 @@ promise_test(t => {
       width: 800,
       height: 600,
       bitrate: 3000,
-      framerate: '24000/1001',
+      framerate: 24,
     }
   }));
-}, "Test that decodingInfo() rejects if the video configuration contentType has a codecs parameter that indicates multiple video codecs");
+}, "Test that decodingInfo rejects if the video configuration contentType has a codecs parameter that indicates multiple video codecs");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
@@ -220,10 +220,10 @@ promise_test(t => {
       width: 800,
       height: 600,
       bitrate: 3000,
-      framerate: '24000/1001',
+      framerate: 24,
     }
   }));
-}, "Test that decodingInfo() rejects if the video configuration contentType has a codecs parameter that indicates both an audio and a video codec");
+}, "Test that decodingInfo rejects if the video configuration contentType has a codecs parameter that indicates both an audio and a video codec");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
@@ -233,10 +233,10 @@ promise_test(t => {
       width: 800,
       height: 600,
       bitrate: 3000,
-      framerate: '24000/1001',
+      framerate: 24,
     }
   }));
-}, "Test that decodingInfo() rejects framerate in the form of x/y");
+}, "Test that decodingInfo rejects framerate in the form of x/y");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
@@ -249,7 +249,7 @@ promise_test(t => {
       framerate: '24000/0',
     }
   }));
-}, "Test that decodingInfo() rejects framerate in the form of x/0");
+}, "Test that decodingInfo rejects framerate in the form of x/0");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
@@ -262,7 +262,7 @@ promise_test(t => {
       framerate: '0/10001',
     }
   }));
-}, "Test that decodingInfo() rejects framerate in the form of 0/y");
+}, "Test that decodingInfo rejects framerate in the form of 0/y");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
@@ -275,7 +275,7 @@ promise_test(t => {
       framerate: '-24000/10001',
     }
   }));
-}, "Test that decodingInfo() rejects framerate in the form of -x/y");
+}, "Test that decodingInfo rejects framerate in the form of -x/y");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
@@ -288,7 +288,7 @@ promise_test(t => {
       framerate: '24000/-10001',
     }
   }));
-}, "Test that decodingInfo() rejects framerate in the form of x/-y");
+}, "Test that decodingInfo rejects framerate in the form of x/-y");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
@@ -301,7 +301,7 @@ promise_test(t => {
       framerate: '24000/',
     }
   }));
-}, "Test that decodingInfo() rejects framerate in the form of x/");
+}, "Test that decodingInfo rejects framerate in the form of x/");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
@@ -314,7 +314,7 @@ promise_test(t => {
       framerate: '1/3x',
     }
   }));
-}, "Test that decodingInfo() rejects framerate with trailing unallowed characters");
+}, "Test that decodingInfo rejects framerate with trailing unallowed characters");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
@@ -364,14 +364,14 @@ promise_test(t => {
     type: 'file',
     audio: { contentType: 'audio/webm; codecs="vorbis, opus"' },
   }));
-}, "Test that decodingInfo() rejects if the audio configuration contentType has a codecs parameter that indicates multiple audio codecs");
+}, "Test that decodingInfo rejects if the audio configuration contentType has a codecs parameter that indicates multiple audio codecs");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
     type: 'file',
     audio: { contentType: 'audio/webm; codecs="vp09.00.10.08, opus"' },
   }));
-}, "Test that decodingInfo() rejects if the audio configuration contentType has a codecs parameter that indicates both an audio and a video codec");
+}, "Test that decodingInfo rejects if the audio configuration contentType has a codecs parameter that indicates both an audio and a video codec");
 
 promise_test(t => {
   return navigator.mediaCapabilities.decodingInfo({

--- a/media-capabilities/encodingInfo.any.js
+++ b/media-capabilities/encodingInfo.any.js
@@ -103,6 +103,20 @@ promise_test(t => {
   }));
 }, "Test that encodingInfo rejects if the video configuration contentType doesn't parse");
 
+// See https://mimesniff.spec.whatwg.org/#example-valid-mime-type-string
+promise_test(t => {
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
+    type: 'record',
+    video: {
+      contentType: 'video/webm;',
+      width: 800,
+      height: 600,
+      bitrate: 3000,
+      framerate: 24,
+    },
+  }));
+}, "Test that encodingInfo rejects if the video configuration contentType is not a valid MIME type string");
+
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
@@ -146,6 +160,45 @@ promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     video: {
+      contentType: 'video/webm',
+      width: 800,
+      height: 600,
+      bitrate: 3000,
+      framerate: 24,
+    },
+  }));
+}, "Test that encodingInfo rejects if the video configuration contentType does not imply a single media codec but has no codecs parameter");
+
+promise_test(t => {
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
+    type: 'record',
+    video: {
+      contentType: 'video/webm; codecs="vp09.00.10.08, vp8"',
+      width: 800,
+      height: 600,
+      bitrate: 3000,
+      framerate: 24,
+    }
+  }));
+}, "Test that encodingInfo rejects if the video configuration contentType has a codecs parameter that indicates multiple video codecs");
+
+promise_test(t => {
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
+    type: 'record',
+    video: {
+      contentType: 'video/webm; codecs="vp09.00.10.08, opus"',
+      width: 800,
+      height: 600,
+      bitrate: 3000,
+      framerate: 24,
+    }
+  }));
+}, "Test that encodingInfo rejects if the video configuration contentType has a codecs parameter that indicates both an audio and a video codec");
+
+promise_test(t => {
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
+    type: 'record',
+    video: {
       contentType: 'video/webm; codecs="vp09.00.10.08"',
       width: 800,
       height: 600,
@@ -153,7 +206,7 @@ promise_test(t => {
       framerate: '24000/1001',
     }
   }));
-}, "Test that encodingInfo() rejects framerate in the form of x/y");
+}, "Test that encodingInfo rejects framerate in the form of x/y");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
@@ -166,7 +219,7 @@ promise_test(t => {
       framerate: '24000/0',
     }
   }));
-}, "Test that encodingInfo() rejects framerate in the form of x/0");
+}, "Test that encodingInfo rejects framerate in the form of x/0");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
@@ -179,7 +232,7 @@ promise_test(t => {
       framerate: '0/10001',
     }
   }));
-}, "Test that encodingInfo() rejects framerate in the form of 0/y");
+}, "Test that encodingInfo rejects framerate in the form of 0/y");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
@@ -192,7 +245,7 @@ promise_test(t => {
       framerate: '-24000/10001',
     }
   }));
-}, "Test that encodingInfo() rejects framerate in the form of -x/y");
+}, "Test that encodingInfo rejects framerate in the form of -x/y");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
@@ -205,7 +258,7 @@ promise_test(t => {
       framerate: '24000/-10001',
     }
   }));
-}, "Test that encodingInfo() rejects framerate in the form of x/-y");
+}, "Test that encodingInfo rejects framerate in the form of x/-y");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
@@ -218,7 +271,7 @@ promise_test(t => {
       framerate: '24000/',
     }
   }));
-}, "Test that encodingInfo() rejects framerate in the form of x/");
+}, "Test that encodingInfo rejects framerate in the form of x/");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
@@ -231,7 +284,7 @@ promise_test(t => {
       framerate: '1/3x',
     }
   }));
-}, "Test that encodingInfo() rejects framerate with trailing unallowed characters");
+}, "Test that encodingInfo rejects framerate with trailing unallowed characters");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
@@ -262,6 +315,27 @@ promise_test(t => {
 }, "Test that encodingInfo rejects if the audio configuration contentType has one parameter that isn't codecs");
 
 promise_test(t => {
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
+    type: 'record',
+    audio: { contentType: 'audio/webm' },
+  }));
+}, "Test that encodingInfo rejects if the audio configuration contentType does not imply a single media codec but has no codecs parameter");
+
+promise_test(t => {
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
+    type: 'record',
+    audio: { contentType: 'audio/webm; codecs="vorbis, opus"' },
+  }));
+}, "Test that encodingInfo rejects if the audio configuration contentType has a codecs parameter that indicates multiple audio codecs");
+
+promise_test(t => {
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
+    type: 'record',
+    audio: { contentType: 'audio/webm; codecs="vp09.00.10.08, opus"' },
+  }));
+}, "Test that encodingInfo rejects if the audio configuration contentType has a codecs parameter that indicates both an audio and a video codec");
+
+promise_test(t => {
   return navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     video: minimalVideoConfiguration,
@@ -271,7 +345,7 @@ promise_test(t => {
     assert_equals(typeof ability.smooth, "boolean");
     assert_equals(typeof ability.powerEfficient, "boolean");
   });
-}, "Test that encodingInfo returns a valid MediaCapabilitiesInfo objects for record type");
+}, "Test that encodingInfo returns a valid MediaCapabilitiesInfo object for record type");
 
 async_test(t => {
   var validTypes = [ 'record', 'webrtc' ];


### PR DESCRIPTION
Per spec draft at https://www.w3.org/TR/2024/WD-media-capabilities-20241007/

- Add tests for 'does not imply a codec'
- Add tests for 'valid MIME type string'
- Add tests for 'single media codec'

PTAL @markafoltz 