### PR TITLE
subtlecrypto: Don't throw exceptions twice when converting to Algorithm object

### DIFF
--- a/WebCryptoAPI/digest/digest.https.any.js
+++ b/WebCryptoAPI/digest/digest.https.any.js
@@ -118,6 +118,20 @@
         });
     });
 
+    // Call digest() with empty algorithm object
+    Object.keys(sourceData).forEach(function(size) {
+        promise_test(function(test) {
+            var promise = subtle.digest({}, sourceData[size])
+            .then(function(result) {
+                assert_unreached("digest() with missing algorithm name should have thrown a TypeError");
+            }, function(err) {
+                assert_equals(err.name, "TypeError", "Missing algorithm name should cause TypeError")
+            });
+
+            return promise;
+        }, "empty algorithm object with " + size);
+    });
+
 
     done();
 

--- a/WebCryptoAPI/generateKey/failures.js
+++ b/WebCryptoAPI/generateKey/failures.js
@@ -166,6 +166,14 @@ function run_test(algorithmNames) {
         });
     });
 
+    // Empty algorithm should fail with TypeError
+    allValidUsages(["decrypt", "sign", "deriveBits"], true, []) // Small search space, shouldn't matter because should fail before used
+        .forEach(function(usages) {
+            [false, true, "RED", 7].forEach(function(extractable){
+                testError({}, extractable, usages, "TypeError", "Empty algorithm");
+            });
+        });
+
 
     // Algorithms normalize okay, but usages bad (though not empty).
     // It shouldn't matter what other extractable is. Should fail

--- a/WebCryptoAPI/import_export/importKey_failures.js
+++ b/WebCryptoAPI/import_export/importKey_failures.js
@@ -192,4 +192,19 @@ function run_test(algorithmNames) {
             });
         });
     });
+
+    // Missing mandatory "name" field on algorithm
+    testVectors.forEach(function(vector) {
+        var name = vector.name;
+        // We just need *some* valid keydata, so pick the first available algorithm.
+        var algorithm = allAlgorithmSpecifiersFor(name)[0];
+        getValidKeyData(algorithm).forEach(function(test) {
+            validUsages(vector, test.format, test.data).forEach(function(usages) {
+                [true, false].forEach(function(extractable) {
+                    testError(test.format, {}, test.data, name, usages, extractable, "TypeError", "Missing algorithm name");
+                });
+            });
+        });
+    });
+
 }


### PR DESCRIPTION
Removes match statements like
```rust
let Ok(ConversionResult::Success(algorithm)) = Algorithm::new(cx, value.handle())
else {
    return Err(Error::Syntax);
};
```
These don't cause issues if `Algorithm::new` returns `Ok(ConversionResult::Failure`, but in the case of `Err(())` the implementation already called `throw_type_error` and we must not throw an additional Syntax error, otherwise we'll crash.

Luckily, this case is already handled elsewhere by the `value_from_js_object` macro.



Reviewed in servo/servo#34239