### PR TITLE
Enable ShadowRealm testing for DOMException

### DIFF
--- a/webidl/ecmascript-binding/es-exceptions/DOMException-constants.any.js
+++ b/webidl/ecmascript-binding/es-exceptions/DOMException-constants.any.js
@@ -1,3 +1,5 @@
+// META: global=window,dedicatedworker,shadowrealm
+
 'use strict';
 
 test(function() {

--- a/webidl/ecmascript-binding/es-exceptions/DOMException-constructor-and-prototype.any.js
+++ b/webidl/ecmascript-binding/es-exceptions/DOMException-constructor-and-prototype.any.js
@@ -1,3 +1,5 @@
+// META: global=window,dedicatedworker,shadowrealm
+
 test(function() {
     assert_own_property(self, "DOMException", "property of global");
 

--- a/webidl/ecmascript-binding/es-exceptions/DOMException-constructor-behavior.any.js
+++ b/webidl/ecmascript-binding/es-exceptions/DOMException-constructor-behavior.any.js
@@ -1,3 +1,5 @@
+// META: global=window,dedicatedworker,shadowrealm
+
 'use strict';
 
 test(function() {

--- a/webidl/ecmascript-binding/es-exceptions/DOMException-custom-bindings.any.js
+++ b/webidl/ecmascript-binding/es-exceptions/DOMException-custom-bindings.any.js
@@ -1,3 +1,5 @@
+// META: global=window,dedicatedworker,shadowrealm
+
 "use strict";
 
 test(() => {

--- a/webidl/idlharness-shadowrealm.window.js
+++ b/webidl/idlharness-shadowrealm.window.js
@@ -1,2 +1,12 @@
 // META: script=/resources/idlharness-shadowrealm.js
-idl_test_shadowrealm(["webidl"], []);
+idl_test_shadowrealm(
+  ["webidl"],
+  [],
+  idl_array => {
+    idl_array.add_objects({
+      DOMException: ["new DOMException()",
+                     'new DOMException("my message")',
+                     'new DOMException("my message", "myName")']
+    });
+  }
+);


### PR DESCRIPTION
Adds the appropriate metadata for the existing tests for the functionality of DOMException to additionally be tested in a ShadowRealm.

Adds the same IDL array to the IDL tests for DOMExceptions in ShadowRealm as for DOMExceptions in other realms.