### PR TITLE
[doc] describe extending testdriver with bidi

### DIFF
--- a/docs/writing-tests/testdriver-extension-tutorial.md
+++ b/docs/writing-tests/testdriver-extension-tutorial.md
@@ -4,8 +4,8 @@ Adding new commands to testdriver.js
 ## Assumptions
 We assume the following in this writeup:
  - You know what web-platform-tests is and you have a working checkout and can run tests
- - You know what [WebDriver Classic](https://w3c.github.io/webdriver/) and 
-   [WebDriver BiDi](https://w3c.github.io/webdriver-bidi) protocols are
+ - You know what [WebDriver Classic](https://w3c.github.io/webdriver/) and
+  [WebDriver BiDi](https://w3c.github.io/webdriver-bidi) protocols are
  - Familiarity with JavaScript and Python
 
 ## Introduction!
@@ -90,7 +90,7 @@ We will leave this unimplemented and override it in another file. Lets do that n
 
 #### WebDriver BiDi
 
-For commands using WebDriver BiDi, add the methods to `window.test_driver.bidi`. Parameters are passed as a single object `params`. 
+For commands using WebDriver BiDi, add the methods to `window.test_driver.bidi`. Parameters are passed as a single object `params`.
 <!-- TODO: add an example link once a first bidi command (probably `test_driver.bidi.permissions.set_permission`) is implemented.-->
 
 ### [tools/wptrunner/wptrunner/testdriver-extra.js](https://github.com/web-platform-tests/wpt/blob/master/tools/wptrunner/wptrunner/testdriver-extra.js)
@@ -103,7 +103,7 @@ window.test_driver_internal.set_element_rect = function(x, y, width, height) {
 };
 ```
 
-The `create_action` helper function does the heavy lifting of setting up a postMessage to the wptrunner internals as well as returning a promise that will resolve once the call is complete. 
+The `create_action` helper function does the heavy lifting of setting up a postMessage to the wptrunner internals as well as returning a promise that will resolve once the call is complete.
 
 The action's `name` is important and will be used later when defining the corresponding Python action representation. Keep this name in mind for the next steps.
 
@@ -162,7 +162,7 @@ class SetWindowRectAction:
 
 The `name` property should match the `name` used in [tools/wptrunner/wptrunner/testdriver-extra.js](#tools-wptrunner-wptrunner-testdriver-extra-js). This name acts as the key that connects the testdriver function in JavaScript with its corresponding Python action.
 
-You can access the `SetWindowRectProtocolPart` using its name `set_window_rect_protocol_part` we defined earlier: 
+You can access the `SetWindowRectProtocolPart` using its name `set_window_rect_protocol_part` we defined earlier:
 ```python
 self.protocol.set_window_rect_protocol_part.set_window_rect(x, y, width, height)
 ```
@@ -349,7 +349,7 @@ The WebDriver command will return a [WindowRect object](https://w3c.github.io/we
 class WebDriverGetWindowRectProtocolPart(GetWindowRectProtocolPart):
     def get_window_rect(self):
         # The communication channel between testharness and backend is blocked until the end of the action.
-        return self.webdriver.get_window_rect() 
+        return self.webdriver.get_window_rect()
 ```
 
 Then a test can access the return value as follows:

--- a/docs/writing-tests/testdriver-extension-tutorial.md
+++ b/docs/writing-tests/testdriver-extension-tutorial.md
@@ -12,7 +12,7 @@ We assume the following in this writeup:
 
 Let's implement window resizing. We can do this via the [Set Window Rect](https://w3c.github.io/webdriver/#set-window-rect) command in WebDriver.
 
-For extensions to `testdriver.js` that use a [WebDriver BiDi](https://w3c.github.io/webdriver-bidi) command, the process is similar, with any differences noted in this document.
+The process of extending `testdriver.js` is similar for [WebDriver Classic](https://w3c.github.io/webdriver/) and [WebDriver BiDi](https://w3c.github.io/webdriver-bidi) commands. This tutorial highlights the differences inline.
 
 First, we need to think of what the API will look like a little. We will be using WebDriver and Marionette for this, so we can look and see that they take in x, y coordinates, width and height integers.
 

--- a/docs/writing-tests/testdriver-extension-tutorial.md
+++ b/docs/writing-tests/testdriver-extension-tutorial.md
@@ -43,7 +43,7 @@ Members of the community will then have the opportunity to comment on our propos
 
 With that said, developing a prototype implementation may help others evaluate the proposal during the RFC process, so let's move on to writing some code.
 
-Note that for extensions to testdriver.js that directly reflect a [WebDriver Classic](https://w3c.github.io/webdriver/) command, [WebDriver BiDi](https://w3c.github.io/webdriver-bidi) command, or event, a formal RFC process isn't strictly required.
+Note that for extensions to testdriver.js that directly reflect a [WebDriver Classic](https://w3c.github.io/webdriver/) command, [WebDriver BiDi](https://w3c.github.io/webdriver-bidi) command, or event, the [RFC](https://github.com/web-platform-tests/rfcs) process isn't required.
 
 ## Code!
 


### PR DESCRIPTION
Extend [Testdriver extension tutorial](https://web-platform-tests.org/writing-tests/testdriver-extension-tutorial.html) with description of adding new methods matching WebDriver BiDi commands.

Addressing https://github.com/web-platform-tests/wpt/issues/47565.

Apparently, the current version is outdated, as it refers to the non-existing `SetWindowRectProtocolPart`. I updated the protocol part name to avoid confusion with the action name, but leave `SetWindowRectProtocolPart` out of scope for this PR.

BiDi events are out of scope as well.