### PR TITLE
Enable ShadowRealm testing for atob/btoa

### DIFF
--- a/html/webappapis/atob/base64.any.js
+++ b/html/webappapis/atob/base64.any.js
@@ -1,3 +1,5 @@
+// META: global=window,dedicatedworker,shadowrealm
+
 /**
  * btoa() as defined by the HTML5 spec, which mostly just references RFC4648.
  */
@@ -125,7 +127,7 @@ tests.push(["btoa(first 256 code points concatenated)", everything]);
 
 generate_tests(testBtoa, tests);
 
-promise_test(() => fetch("../../../fetch/data-urls/resources/base64.json").then(res => res.json()).then(runAtobTests), "atob() setup.");
+promise_test(() => fetch_json("../../../fetch/data-urls/resources/base64.json").then(runAtobTests), "atob() setup.");
 
 const idlTests = [
   [undefined, null],


### PR DESCRIPTION
Adds the appropriate metadata for the existing tests for the functionality of atob() and btoa() to additionally be run in a ShadowRealm.

We also have to use the test harness's fetch_json() to fetch the test data instead of fetch(), which is not exposed in ShadowRealm.