### PR TITLE
Task done before test in audiobuffersource-duration-loop.html

### DIFF
--- a/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-duration-loop.html
+++ b/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-duration-loop.html
@@ -42,7 +42,7 @@
                   audioBuffer.getChannelData(0), 'audioBuffer.getChannelData')
                   .beEqualToArray(expected);
             })
-            .then(task.done());
+            .then(task.done.bind(task));
       });
 
       audit.run();


### PR DESCRIPTION
In the [audiobuffersource-duration-loop.html](https://github.com/web-platform-tests/wpt/blob/master/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-duration-loop.html#L45), `task.done()` is placed in the second `then()`, which will cause the test code in the first `then()` to be executed after `task.done()`.

If you do this test in Chrome, you can see final result message:
`[loop with duration] All assertions passed. (total 0 assertions)` 
is printed before test result:
`audioBuffer.getChannelData is identical to the array |1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1...].`.
<img width="1005" alt="done_before_test" src="https://github.com/user-attachments/assets/a028eef4-3cd1-4c09-9b70-4bd73c6ec656">

After using `.then(task.done.bind(task));`, the order of message seems correct:
<img width="1047" alt="test_before_done" src="https://github.com/user-attachments/assets/a3f61e8b-4124-47cf-84ee-10d3db7c8db5">
