### PR TITLE
Remove (for now) tentative accname tests conflicting with current spec

### DIFF
--- a/accname/name/comp_name_from_content.tentative.html
+++ b/accname/name/comp_name_from_content.tentative.html
@@ -12,31 +12,6 @@
 </head>
 <body>
 
-<!--
-  These aria-labelledby tests may not be valid, pending spec discussion.
-  See https://github.com/w3c/accname/issues/209
--->
-
-<!-- cross-referencial edge case-->
-<h1>heading with link referencing image using aria-labelledby, that in turn references text element via aria-labelledby</h1>
-<h3 data-expectedlabel="image link" data-testname="heading with link referencing image using aria-labelledby, that in turn references text element via aria-labelledby" class="ex">
-  <a href="#" aria-labelledby="nested_image_label3">
-    <span class="note" id="crossref_link">link</span><!-- this text is skipped the first time around because of aria-labelledby on parent element -->
-  </a>
-  <!-- but it's picked up again in inverse order b/c of cross-referencial aria-labelledby edge case -->
-  <img id="nested_image_label3" alt="image" aria-labelledby="crossref_link" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
-</h3>
-
-<!-- self-referencial edge case-->
-<h1>heading with link referencing image using aria-labelledby, that in turn references itself and another element via aria-labelledby</h1>
-<h3 data-expectedlabel="image link" data-testname="heading with link referencing image using aria-labelledby, that in turn references itself and another element via aria-labelledby" class="ex">
-  <a href="#" aria-labelledby="nested_image_label4">
-    <span class="note" id="crossref_link2">link</span><!-- this text is skipped the first time around because of aria-labelledby on parent element -->
-  </a>
-  <!-- but it's picked up again (after the self-referencial image alt) in inverse order b/c of cross-referencial aria-labelledby edge case -->
-  <img id="nested_image_label4" alt="image" aria-labelledby="nested_image_label4 crossref_link2" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
-</h3>
-
 <!-- “びょういんのかんじゃサービス” means “Hospital patient services” -->
 <!-- text-transform:full-size-kana visually changes: -->
 <!--   1. びょういん (byōin = hospital) into びよういん (biyōin = beauty parlor) -->


### PR DESCRIPTION
This change drops two subtests from the test at `accname/name/comp_name_from_content.tentative.html`.

Gecko, WebKit, and Chromium all fail those, and the tests don’t conform to the current spec requirements, nor to any WIP PR for changing the spec requirements. And there seems to have been no indication so far from Gecko, WebKit, or Chromium that they’re interested in implementing the change that’d be required to get their implementations passing.

So let’s remove them for now. If circumstances change, we can add them back later.

> [!NOTE]
> I’m implementing accname support in Ladybird, and I don’t have any strong opinion at all about whether the spec should be updated to require the behavior that these tests expect.
>
> If any of Gecko, WebKit, and Chromium showed some interest in implementing the behavior expected by these tests, then I’d also happily implement it. But in the mean time, rather than keeping those tests (and the failures for them) hanging around indefinitely, it seems better at this point to remove them for now.
>
> I’m aware of the issue at https://github.com/w3c/accname/issues/209 that discusses whether the spec requirements should be changed to match the behavior expected by these tests — but I notice that there hasn’t been any resolution on that issue, and there hasn’t even been any discussion in that issue for more than a year now.
>
> So again — given all that — rather than keeping the tests and the failures for them hanging around indefinitely, it seems better at this point to remove them for now.