### PR TITLE
[css-flexbox] incorrect layout with max-height and flex-direction col…

### DIFF
--- a/css/css-flexbox/nested-flexbox-max-height.html
+++ b/css/css-flexbox/nested-flexbox-max-height.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="author" title="Przemyslaw Gorszkowski" href="mailto:pgorszkowski@igalia.com">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=282036">
+
+<link href="support/flexbox.css" rel="stylesheet">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+
+Test passes if only the green square is visible.
+
+<div id="container" class="flexbox column" style="max-height: 100px; height: 100px; width: 100px;">
+    <div class="flexbox column justify-content-center" style="height: 400px; background: green" data-expected-height="100"><div></div></div>
+</div>
+<script>
+checkLayout('#container');
+</script>


### PR DESCRIPTION
…umn and justify-content center

Safarii/WebKitGTK currently makes this flex item 200px tall. Firefox and Chrome give it the correct height of 100px.

WebKit does not adjust the inner flex size to the max size specified in the outer flex container.

After calculation of the flex item size and adjusting it to min/max size of the flex item WebKit should also check how the calculated size corresponds to specified max size of the whole container. In case the adjusted flex item size is bigger than the max size of the whole container WebKit should use the flex item size calculated before adjusting to flex item min/max size.