### PR TITLE
serve: Handle case where server subprocess times out

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -1280,6 +1280,11 @@ def run(config_cls=ConfigBuilder, route_builder=None, mp_context=None, log_handl
                 server.wait(timeout=1)
                 if server.proc.exitcode == 0:
                     logger.info('Status of subprocess "%s": exited correctly', server.proc.name)
+                elif server.proc.exitcode is None:
+                    logger.warning(
+                        'Status of subprocess "%s": shutdown timed out',
+                        server.proc.name)
+                    failed_subproc += 1
                 else:
                     subproc = server.proc
                     logger.warning('Status of subprocess "%s": failed. Exit with non-zero status: %d',


### PR DESCRIPTION
If `wait()` times out, the `exitcode` attribute will not be set. Instead, it'll be `None`. Handle this case and log a warning that the server process timed out, instead of throwing in the else-clause when trying to format `None` as `%d`.