### PR TITLE
[wptrunner] Run `--enable-sanitizer` tests with their own executors

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -67,13 +67,10 @@ def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
 
 def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite,
                     **kwargs):
-    sanitizer_enabled = kwargs.get("sanitizer_enabled")
-    if sanitizer_enabled:
-        test_type = "crashtest"
     executor_kwargs = base_executor_kwargs(test_type, test_environment, run_info_data,
                                            subsuite, **kwargs)
     executor_kwargs["close_after_done"] = True
-    executor_kwargs["sanitizer_enabled"] = sanitizer_enabled
+    executor_kwargs["sanitizer_enabled"] = kwargs.get("sanitizer_enabled", False)
     executor_kwargs["reuse_window"] = kwargs.get("reuse_window", False)
 
     capabilities = {

--- a/tools/wptrunner/wptrunner/executors/executoredge.py
+++ b/tools/wptrunner/wptrunner/executors/executoredge.py
@@ -3,31 +3,25 @@
 import os
 
 from .executorwebdriver import (
-    WebDriverCrashtestExecutor,
     WebDriverRefTestExecutor,
     WebDriverRun,
     WebDriverTestharnessExecutor,
 )
 
-from .executorchrome import (
-    ChromeDriverProtocol,
-    make_sanitizer_mixin,
-)
+from .executorchrome import ChromeDriverProtocol
 
 here = os.path.dirname(__file__)
-
-_SanitizerMixin = make_sanitizer_mixin(WebDriverCrashtestExecutor)
 
 
 class EdgeDriverProtocol(ChromeDriverProtocol):
     vendor_prefix = "ms"
 
 
-class EdgeDriverRefTestExecutor(WebDriverRefTestExecutor, _SanitizerMixin):  # type: ignore
+class EdgeDriverRefTestExecutor(WebDriverRefTestExecutor):
     protocol_cls = EdgeDriverProtocol
 
 
-class EdgeDriverTestharnessExecutor(WebDriverTestharnessExecutor, _SanitizerMixin):  # type: ignore
+class EdgeDriverTestharnessExecutor(WebDriverTestharnessExecutor):
     protocol_cls = EdgeDriverProtocol
 
 


### PR DESCRIPTION
Running non-crashtests with the crashtest executor likely doesn't provide high-fidelity coverage because the test completes on the `load` event by default. This means that code paths normally exercised after the `load` event aren't actually run under sanitization. Also, some tests require testdriver, which the crashtest executor doesn't implement yet, to progress.

Now, simply run each test with its corresponding type's executor and suppress functional failures (i.e., not timeout or crash) at the end. This also simplifies the result coercion, which didn't interact correctly with #47903.

Tested locally:

```sh
./wpt run -y chrome infrastructure --metadata infrastructure/metadata --enable-sanitizer
```