### PR TITLE
Make clipboard-apis tests more robust to local variations in html

### DIFF
--- a/clipboard-apis/async-html-script-removal.https.html
+++ b/clipboard-apis/async-html-script-removal.https.html
@@ -31,9 +31,10 @@ function reformatHtml(html) {
 const html_with_script =
   '<title>Title of the document</title> <script>const a = 5;</scr'
   + 'ipt> <p>Hello World</p>';
-const html_script = '<script>const a = 5;</scr'
+const html_script = 
+  '<script>const a = 5;</scr'
   + 'ipt>';
-  promise_test(async t => {
+promise_test(async t => {
   await tryGrantReadPermission();
   await tryGrantWritePermission();
   const blobInput = new Blob([html_with_script], {type: 'text/html'});

--- a/clipboard-apis/async-html-script-removal.https.html
+++ b/clipboard-apis/async-html-script-removal.https.html
@@ -31,7 +31,7 @@ function reformatHtml(html) {
 const html_with_script =
   '<title>Title of the document</title> <script>const a = 5;</scr'
   + 'ipt> <p>Hello World</p>';
-const html_script = 
+const html_script =
   '<script>const a = 5;</scr'
   + 'ipt>';
 promise_test(async t => {

--- a/clipboard-apis/async-html-script-removal.https.html
+++ b/clipboard-apis/async-html-script-removal.https.html
@@ -31,9 +31,9 @@ function reformatHtml(html) {
 const html_with_script =
   '<title>Title of the document</title> <script>const a = 5;</scr'
   + 'ipt> <p>Hello World</p>';
-const html_without_script =
-  '<title>Title of the document</title> <p>Hello World</p>';
-promise_test(async t => {
+const html_script = '<script>const a = 5;</scr'
+  + 'ipt>';
+  promise_test(async t => {
   await tryGrantReadPermission();
   await tryGrantWritePermission();
   const blobInput = new Blob([html_with_script], {type: 'text/html'});
@@ -53,8 +53,7 @@ promise_test(async t => {
   const blobText = await (new Response(blobOutput)).text();
 
   const outputHtml = reformatHtml(blobText);
-  const inputHtml = reformatHtml(html_without_script);
-  assert_equals(outputHtml, inputHtml);
-}, 'Verify write and read clipboard with scripts removed given text/html: '
-    + html_with_script);
+  const html_script_no_spaces = reformatHtml(html_script);
+  assert_true(!outputHtml.includes(html_script_no_spaces));
+}, 'Verify write and read clipboard with scripts removed given text/html. The string "' + html_script + '" has been removed.');
 </script>

--- a/clipboard-apis/async-navigator-clipboard-read-resource-load.https.html
+++ b/clipboard-apis/async-navigator-clipboard-read-resource-load.https.html
@@ -34,7 +34,7 @@ promise_test(async test => {
   const htmlBlob = await items[0].getType("text/html");
   const html = await htmlBlob.text();
 
-  assert_equals(html, '<img src="https://example.com/oops">');
+  assert_true(html.includes('<img src="https://example.com/oops">'));
 
   // Allow resource loading to start asynchronously
   await new Promise(resolve => test.step_timeout(resolve, 100));


### PR DESCRIPTION
Currently the test relies on a canonical form of html after a clipboard operations.
It goes further than the intent of the test and the spec. 
This reduces the scope of the test to just what need to be tested. 
