### PR TITLE
[wptrunner] Add a wpewebkit_minibrowser product/browser.

### DIFF
--- a/docs/running-tests/from-local-system.md
+++ b/docs/running-tests/from-local-system.md
@@ -173,6 +173,7 @@ here](command-line-arguments.html#run).
   android_webview
   safari
   webkitgtk_minibrowser
+  wpewebkit_minibrowser
 ```
 
 ### Running in parallel

--- a/docs/running-tests/webkitgtk_minibrowser.md
+++ b/docs/running-tests/webkitgtk_minibrowser.md
@@ -1,22 +1,71 @@
 # WebKitGTK MiniBrowser
 
+To be able to run tests with the [WebKitGTK](https://webkitgtk.org/)
+MiniBrowser you need the following packages installed:
 
-To be able to run tests with the WebKitGTK MiniBrowser you need the
-following packages installed:
-
-* Fedora: `webkit2gtk3-devel`
-* Debian or Ubuntu: `webkit2gtk-driver`
-
+* Fedora: `webkitgtk6.0`
+* Debian or Ubuntu: `webkitgtk-driver` or `webkit2gtk-driver`
+* Arch: `webkitgtk-6.0`
 
 The WebKitGTK MiniBrowser is not installed on the default binary path.
 The `wpt` script will try to automatically locate it, but if you need
 to run it manually you can find it on any of this paths:
 
-* Fedora: `/usr/libexec/webkit2gtk-${VERSION}/MiniBrowser`
-* Debian or Ubuntu: `/usr/lib/x86_64-linux-gnu/webkit2gtk-${VERSION}/MiniBrowser`
-* Note:
-     * `VERSION` is `4.0` or `4.1`.
-     * If not Fedora and the machine architecture is not `x86_64`, then it will
-      be located inside:
-      `/usr/lib/${TRIPLET}/webkit2gtk-${VERSION}/MiniBrowser`
-      where `TRIPLET=$(gcc -dumpmachine)`
+* Fedora: `/usr/libexec/webkitgtk-${APIVERSION}/MiniBrowser`
+* Arch: `/usr/lib/webkitgtk-${APIVERSION}/MiniBrowser`
+* Debian or Ubuntu: `/usr/lib/${TRIPLET}/webkitgtk-${APIVERSION}/MiniBrowser`
+  * Note: `${TRIPLET}` is the output of the command `gcc -dumpmachine`
+
+# Nightly universal bundle
+
+Alternatively you can pass to `wpt` the flags `--install-browser --channel=nightly`
+and then `wpt` will automatically download the last bundle and unpack it on the
+default `wpt` working directory (usually subdir `_venv3/browsers` in your `wpt` checkout)
+Then it will use the unpacked `MiniBrowser` and `WebKitWebDriver` binaries to run the tests.
+
+This universal bundles should work on any Linux distribution as they include inside
+the tarball all the system libraries and resources needed to run WebKitGTK, from libc
+up to the Mesa graphics drivers without requiring the usage of containers.
+
+If you are not using open source graphics drivers (Mesa) and you experience issues
+with this bundle then a possible workaround is to try to run the tests headless
+inside a virtualized display like `Xvfb` (see command `xvfb-run -a` on Debian/Ubuntu).
+You can do this also from inside a virtual machine or docker container.
+
+# Headless mode
+
+WebKitGTK does not have a native headless mode, but you can workaround that
+by running the tests inside a virtualized display. For example you can use
+`weston` with the headless backend for a virtualized `Wayland` display,
+or you can use `Xvfb` for a virtualized `X11` display.
+
+Example:
+   ```
+   xvfb-run -a ./wpt run [more-options] webkitgtk_minibrowser [tests-to-run]
+   ```
+
+# Using a custom WebKitGTK build
+
+If you want to test with a custom WebKitGTK build the easiest way is that you
+install this build in a temporary directory and then tell wpt to run it from there.
+
+Steps:
+
+  1. Build WebKitGTK passing the arguments `-DENABLE_MINIBROWSER=ON -DCMAKE_INSTALL_PREFIX=/home/user/testdir_install`
+  2. Install it: `ninja install` (or `make install`)
+  3. Locate the `MiniBrowser` and `WebKitWebDriver` binaries under `/home/user/testdir_install`
+  4. Run `wpt` passing this two paths like this:
+  ```
+      ./wpt run --webdriver-binary=/home/user/testdir_install/bin/WebKitWebDriver \
+                --binary=/home/user/testdir_install/libexec/MiniBrowser \
+                [more-options] webkitgtk_minibrowser [tests-to-run]
+  ```
+
+ * Note: It is important that you build WebKitGTK against the libraries of your system.
+Do not build WebKitGTK inside Flatpak or other container unless you run `wpt` also
+from inside this container.
+
+# Running tests locally
+
+Is a good idea that you increase the verbosity of `wpt` by passing to it the flag `--log-mach=-`
+Also, please check the documentation about [Running Tests from the Local System](from-local-system).

--- a/docs/running-tests/wpewebkit_minibrowser.md
+++ b/docs/running-tests/wpewebkit_minibrowser.md
@@ -1,0 +1,67 @@
+# WPE WebKit MiniBrowser
+
+To be able to run tests with the [WPE WebKit](https://wpewebkit.org)
+MiniBrowser you need the following packages installed:
+
+* Fedora: N/A (build your own or use the nighly bundle)
+* Debian or Ubuntu: `wpewebkit-driver` and `libwpewebkit`
+* Arch:  `wpewebkit`
+
+The WPE WebKit MiniBrowser is not installed on the default binary path.
+The `wpt` script will try to automatically locate it, but if you need
+to run it manually you can find it on any of this paths:
+
+* Arch: `/usr/lib/wpe-webkit-${APIVERSION}/MiniBrowser`
+* Debian or Ubuntu: `/usr/lib/${TRIPLET}/wpe-webkit-${APIVERSION}/MiniBrowser`
+  * Note: `${TRIPLET}` is the output of the command `gcc -dumpmachine`
+
+# Nightly universal bundle
+
+Alternatively you can pass to `wpt` the flags `--install-browser --channel=nightly`
+and then `wpt` will automatically download the last bundle and unpack it on the
+default `wpt` working directory (usually subdir `_venv3/browsers` in your `wpt` checkout)
+Then it will use the unpacked `MiniBrowser` and `WPEWebDriver` binaries to run the tests.
+
+This universal bundles should work on any Linux distribution as they include inside
+the tarball all the system libraries and resources needed to run WebKitGTK, from libc
+up to the Mesa graphics drivers without requiring the usage of containers.
+
+If you are not using open source graphics drivers (Mesa) and you experience issues
+with this bundle then a possible workaround is to try to run the tests in headless
+mode, for that pass the flag `--headless` to `wpt`
+
+# Headless mode
+
+The WPE MiniBrowser needs a Wayland display to run, but if you don't have one
+or you want to enable headless mode you can pass the flag `--headless` to `wpt`.
+
+Example:
+   ```
+   ./wpt run [more-options] --headless wpewebkit_minibrowser [tests-to-run]
+   ```
+
+# Using a custom WPE WebKit build
+
+If you want to test with a custom WPE WebKit build the easiest way is that you
+install this build in a temporary directory and then tell wpt to run it from there.
+
+Steps:
+
+  1. Build WPE WebKit passing the arguments `-DENABLE_MINIBROWSER=ON -DCMAKE_INSTALL_PREFIX=/home/user/testdir_install'
+  2. Install it: `ninja install` (or `make install`)
+  3. Locate the `MiniBrowser` and `WPEWebDriver` binaries under /home/user/testdir_install`
+  4. Run `wpt` passing this two paths like this:
+  ```
+      ./wpt run --webdriver-binary=/home/user/testdir_install/bin/WPEWebDriver \
+                --binary=/home/user/testdir_install/libexec/MiniBrowser \
+                [more-options] webkitgtk_minibrowser [tests-to-run]
+  ```
+
+Note: It is important that you build WPE WebKit against the libraries of your system.
+Do not build WPE WebKit inside Flatpak or other container unless you run `wpt` also
+from inside this container.
+
+# Running tests locally
+
+Is a good idea that you increase the verbosity of `wpt` by passing to it the flag `--log-mach=-`
+Also, please check the documentation about [Running Tests from the Local System](from-local-system).

--- a/tools/wpt/install.py
+++ b/tools/wpt/install.py
@@ -14,6 +14,7 @@ latest_channels = {
     'safari': 'preview',
     'servo': 'nightly',
     'webkitgtk_minibrowser': 'nightly',
+    'wpewebkit_minibrowser': 'nightly',
     'wktr': 'main',
 }
 

--- a/tools/wptrunner/wptrunner/browsers/__init__.py
+++ b/tools/wptrunner/wptrunner/browsers/__init__.py
@@ -38,6 +38,7 @@ product_list = ["android_webview",
                 "opera",
                 "webkit",
                 "webkitgtk_minibrowser",
+                "wpewebkit_minibrowser",
                 "wktr",
                 "epiphany",
                 "ladybird"]

--- a/tools/wptrunner/wptrunner/browsers/wpewebkit_minibrowser.py
+++ b/tools/wptrunner/wptrunner/browsers/wpewebkit_minibrowser.py
@@ -1,0 +1,77 @@
+# mypy: allow-untyped-defs
+
+from .base import (NullBrowser,  # noqa: F401
+                   certificate_domain_list,
+                   get_timeout_multiplier,  # noqa: F401
+                   maybe_add_args)
+from .webkit import WebKitBrowser
+from ..executors import executor_kwargs as base_executor_kwargs
+from ..executors.base import WdspecExecutor  # noqa: F401
+from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
+                                           WebDriverRefTestExecutor,  # noqa: F401
+                                           WebDriverCrashtestExecutor)  # noqa: F401
+
+__wptrunner__ = {"product": "wpewebkit_minibrowser",
+                 "check_args": "check_args",
+                 "browser": "WPEWebKitMiniBrowser",
+                 "browser_kwargs": "browser_kwargs",
+                 "executor": {"testharness": "WebDriverTestharnessExecutor",
+                              "reftest": "WebDriverRefTestExecutor",
+                              "wdspec": "WdspecExecutor",
+                              "crashtest": "WebDriverCrashtestExecutor"},
+                 "executor_kwargs": "executor_kwargs",
+                 "env_extras": "env_extras",
+                 "env_options": "env_options",
+                 "run_info_extras": "run_info_extras",
+                 "timeout_multiplier": "get_timeout_multiplier"}
+
+
+def check_args(**kwargs):
+    pass
+
+
+def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
+    # Workaround for https://gitlab.gnome.org/GNOME/libsoup/issues/172
+    webdriver_required_args = ["--host=127.0.0.1"]
+    webdriver_args = maybe_add_args(webdriver_required_args, kwargs.get("webdriver_args"))
+    return {"binary": kwargs["binary"],
+            "webdriver_binary": kwargs["webdriver_binary"],
+            "webdriver_args": webdriver_args}
+
+
+def capabilities(server_config, **kwargs):
+    browser_required_args = ["--automation"]
+    args = kwargs.get("binary_args", [])
+    args = maybe_add_args(browser_required_args, args)
+    return {
+        "browserName": "MiniBrowser",
+        "wpe:browserOptions": {
+            "binary": kwargs["binary"],
+            "args": args,
+            "certificates": certificate_domain_list(server_config.domains_set, kwargs["host_cert_path"])}}
+
+
+def executor_kwargs(logger, test_type, test_environment, run_info_data,
+                    **kwargs):
+    executor_kwargs = base_executor_kwargs(test_type, test_environment, run_info_data, **kwargs)
+    executor_kwargs["close_after_done"] = True
+    executor_kwargs["capabilities"] = capabilities(test_environment.config, **kwargs)
+    if test_type == "wdspec":
+        executor_kwargs["binary_args"] = executor_kwargs["capabilities"]["wpe:browserOptions"]["args"]
+    return executor_kwargs
+
+
+def env_extras(**kwargs):
+    return []
+
+
+def env_options():
+    return {}
+
+
+def run_info_extras(logger, **kwargs):
+    return {"webkit_port": "wpe"}
+
+
+class WPEWebKitMiniBrowser(WebKitBrowser):
+    pass


### PR DESCRIPTION
This adds a new browser type to run tests with the WPE WebKit port. It can be passed an optional `--headless` parameter to enable headless testing with WPT. Otherwise wayland is required.

A pre-built nightly bundle can be also automatically downloaded and installed by passing `--install-browser` to the WPT runner. It shares with webkitgtk_minibrowser most of the logic to download and install the built product.

Documentation is also added and the webkitgtk_minibrowser one updated accordingly.

Unit tests are added and updated.