### PR TITLE
Enable structuredClone testing in ShadowRealm

### DIFF
--- a/common/sab.js
+++ b/common/sab.js
@@ -1,4 +1,4 @@
-const createBuffer = (() => {
+globalThis.createBuffer = (() => {
   // See https://github.com/whatwg/html/issues/5380 for why not `new SharedArrayBuffer()`
   let sabConstructor;
   try {

--- a/html/webappapis/structured-clone/structured-clone-battery-of-tests-harness.js
+++ b/html/webappapis/structured-clone/structured-clone-battery-of-tests-harness.js
@@ -19,14 +19,16 @@ function runStructuredCloneBatteryOfTests(runner) {
     preTest() {},
     postTest() {},
     teardown() {},
-    hasDocument: true
+    hasDocument: true,
+    hasBlob: true,
   };
   runner = Object.assign({}, defaultRunner, runner);
 
   let setupPromise = runner.setup();
   const allTests = structuredCloneBatteryOfTests.map(test => {
 
-    if (!runner.hasDocument && test.requiresDocument) {
+    if ((!runner.hasDocument && test.requiresDocument) ||
+        (!runner.hasBlob && test.requiresBlob)) {
       return;
     }
 

--- a/html/webappapis/structured-clone/structured-clone-battery-of-tests-harness.js
+++ b/html/webappapis/structured-clone/structured-clone-battery-of-tests-harness.js
@@ -45,3 +45,4 @@ function runStructuredCloneBatteryOfTests(runner) {
   });
   Promise.all(allTests).then(_ => runner.teardown());
 }
+globalThis.runStructuredCloneBatteryOfTests = runStructuredCloneBatteryOfTests;

--- a/html/webappapis/structured-clone/structured-clone-battery-of-tests.js
+++ b/html/webappapis/structured-clone/structured-clone-battery-of-tests.js
@@ -2,7 +2,7 @@
 
 structuredCloneBatteryOfTests = [];
 
-function check(description, input, callback, requiresDocument = false) {
+function check(description, input, callback, requiresDocument = false, requiresBlob = false) {
   structuredCloneBatteryOfTests.push({
     description,
     async f(runner) {
@@ -13,7 +13,8 @@ function check(description, input, callback, requiresDocument = false) {
       const copy = await runner.structuredClone(newInput);
       await callback(copy, newInput);
     },
-    requiresDocument
+    requiresDocument,
+    requiresBlob,
   });
 }
 
@@ -296,7 +297,7 @@ async function compare_Blob(actual, input, expect_File) {
 function func_Blob_basic() {
   return new Blob(['foo'], {type:'text/x-bar'});
 }
-check('Blob basic', func_Blob_basic, compare_Blob);
+check('Blob basic', func_Blob_basic, compare_Blob, false, true);
 
 function b(str) {
   return parseInt(str, 2);
@@ -322,33 +323,33 @@ function func_Blob_bytes(arr) {
     return new Blob([view]);
   };
 }
-check('Blob unpaired high surrogate (invalid utf-8)', func_Blob_bytes(encode_cesu8([0xD800])), compare_Blob);
-check('Blob unpaired low surrogate (invalid utf-8)', func_Blob_bytes(encode_cesu8([0xDC00])), compare_Blob);
-check('Blob paired surrogates (invalid utf-8)', func_Blob_bytes(encode_cesu8([0xD800, 0xDC00])), compare_Blob);
+check('Blob unpaired high surrogate (invalid utf-8)', func_Blob_bytes(encode_cesu8([0xD800])), compare_Blob, false, true);
+check('Blob unpaired low surrogate (invalid utf-8)', func_Blob_bytes(encode_cesu8([0xDC00])), compare_Blob, false, true);
+check('Blob paired surrogates (invalid utf-8)', func_Blob_bytes(encode_cesu8([0xD800, 0xDC00])), compare_Blob, false, true);
 
 function func_Blob_empty() {
   return new Blob(['']);
 }
-check('Blob empty', func_Blob_empty , compare_Blob);
+check('Blob empty', func_Blob_empty , compare_Blob, false, true);
 function func_Blob_NUL() {
   return new Blob(['\u0000']);
 }
-check('Blob NUL', func_Blob_NUL, compare_Blob);
+check('Blob NUL', func_Blob_NUL, compare_Blob, false, true);
 
-check('Array Blob object, Blob basic', [func_Blob_basic()], compare_Array(enumerate_props(compare_Blob)));
-check('Array Blob object, Blob unpaired high surrogate (invalid utf-8)', [func_Blob_bytes([0xD800])()], compare_Array(enumerate_props(compare_Blob)));
-check('Array Blob object, Blob unpaired low surrogate (invalid utf-8)', [func_Blob_bytes([0xDC00])()], compare_Array(enumerate_props(compare_Blob)));
-check('Array Blob object, Blob paired surrogates (invalid utf-8)', [func_Blob_bytes([0xD800, 0xDC00])()], compare_Array(enumerate_props(compare_Blob)));
-check('Array Blob object, Blob empty', [func_Blob_empty()], compare_Array(enumerate_props(compare_Blob)));
-check('Array Blob object, Blob NUL', [func_Blob_NUL()], compare_Array(enumerate_props(compare_Blob)));
-check('Array Blob object, two Blobs', [func_Blob_basic(), func_Blob_empty()], compare_Array(enumerate_props(compare_Blob)));
+check('Array Blob object, Blob basic', () => [func_Blob_basic()], compare_Array(enumerate_props(compare_Blob)), false, true);
+check('Array Blob object, Blob unpaired high surrogate (invalid utf-8)', () => [func_Blob_bytes([0xD800])()], compare_Array(enumerate_props(compare_Blob)), false, true);
+check('Array Blob object, Blob unpaired low surrogate (invalid utf-8)', () => [func_Blob_bytes([0xDC00])()], compare_Array(enumerate_props(compare_Blob)), false, true);
+check('Array Blob object, Blob paired surrogates (invalid utf-8)', () => [func_Blob_bytes([0xD800, 0xDC00])()], compare_Array(enumerate_props(compare_Blob)), false, true);
+check('Array Blob object, Blob empty', () => [func_Blob_empty()], compare_Array(enumerate_props(compare_Blob)), false, true);
+check('Array Blob object, Blob NUL', () => [func_Blob_NUL()], compare_Array(enumerate_props(compare_Blob)), false, true);
+check('Array Blob object, two Blobs', () => [func_Blob_basic(), func_Blob_empty()], compare_Array(enumerate_props(compare_Blob)), false, true);
 
-check('Object Blob object, Blob basic', {'x':func_Blob_basic()}, compare_Object(enumerate_props(compare_Blob)));
-check('Object Blob object, Blob unpaired high surrogate (invalid utf-8)', {'x':func_Blob_bytes([0xD800])()}, compare_Object(enumerate_props(compare_Blob)));
-check('Object Blob object, Blob unpaired low surrogate (invalid utf-8)', {'x':func_Blob_bytes([0xDC00])()}, compare_Object(enumerate_props(compare_Blob)));
-check('Object Blob object, Blob paired surrogates (invalid utf-8)', {'x':func_Blob_bytes([0xD800, 0xDC00])()  }, compare_Object(enumerate_props(compare_Blob)));
-check('Object Blob object, Blob empty', {'x':func_Blob_empty()}, compare_Object(enumerate_props(compare_Blob)));
-check('Object Blob object, Blob NUL', {'x':func_Blob_NUL()}, compare_Object(enumerate_props(compare_Blob)));
+check('Object Blob object, Blob basic', () => ({'x':func_Blob_basic()}), compare_Object(enumerate_props(compare_Blob)), false, true);
+check('Object Blob object, Blob unpaired high surrogate (invalid utf-8)', () => ({'x':func_Blob_bytes([0xD800])()}), compare_Object(enumerate_props(compare_Blob)), false, true);
+check('Object Blob object, Blob unpaired low surrogate (invalid utf-8)', () => ({'x':func_Blob_bytes([0xDC00])()}), compare_Object(enumerate_props(compare_Blob)), false, true);
+check('Object Blob object, Blob paired surrogates (invalid utf-8)', () => ({'x':func_Blob_bytes([0xD800, 0xDC00])()}), compare_Object(enumerate_props(compare_Blob)), false, true);
+check('Object Blob object, Blob empty', () => ({'x':func_Blob_empty()}), compare_Object(enumerate_props(compare_Blob)), false, true);
+check('Object Blob object, Blob NUL', () => ({'x':func_Blob_NUL()}), compare_Object(enumerate_props(compare_Blob)), false, true);
 
 async function compare_File(actual, input) {
   assert_true(actual instanceof File, 'instanceof File');
@@ -359,7 +360,7 @@ async function compare_File(actual, input) {
 function func_File_basic() {
   return new File(['foo'], 'bar', {type:'text/x-bar', lastModified:42});
 }
-check('File basic', func_File_basic, compare_File);
+check('File basic', func_File_basic, compare_File, false, true);
 
 function compare_FileList(actual, input) {
   if (typeof actual === 'string')
@@ -686,7 +687,9 @@ check(
   },
   (copy) => {
     assert_equals(Object.getPrototypeOf(copy), File.prototype, "Prototype is File, not Blob");
-  }
+  },
+  false,
+  true
 );
 
 check(

--- a/html/webappapis/structured-clone/structured-clone-battery-of-tests.js
+++ b/html/webappapis/structured-clone/structured-clone-battery-of-tests.js
@@ -1,6 +1,6 @@
 /* This file is mostly a remix of @zcorpan’s web worker test suite */
 
-structuredCloneBatteryOfTests = [];
+globalThis.structuredCloneBatteryOfTests = [];
 
 function check(description, input, callback, requiresDocument = false, requiresBlob = false) {
   structuredCloneBatteryOfTests.push({

--- a/html/webappapis/structured-clone/structured-clone.any.js
+++ b/html/webappapis/structured-clone/structured-clone.any.js
@@ -1,4 +1,5 @@
 // META: title=structuredClone() tests
+// META: global=window,dedicatedworker,shadowrealm
 // META: script=/common/sab.js
 // META: script=/html/webappapis/structured-clone/structured-clone-battery-of-tests.js
 // META: script=/html/webappapis/structured-clone/structured-clone-battery-of-tests-with-transferables.js

--- a/html/webappapis/structured-clone/structured-clone.any.js
+++ b/html/webappapis/structured-clone/structured-clone.any.js
@@ -11,4 +11,5 @@ runStructuredCloneBatteryOfTests({
     });
   },
   hasDocument: typeof document !== "undefined",
+  hasBlob: typeof Blob !== "undefined",
 });


### PR DESCRIPTION
Run the "structuredClone battery of tests" in the various ShadowRealm scopes. This requires using different objects in some cases where an example of a transferable or serializable object is needed. It also requires adding a mechanism to skip the `Blob`-specific tests.