### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=283412

### DIFF
--- a/scroll-animations/css/scroll-timeline-anonymous-source-quirks-mode.html
+++ b/scroll-animations/css/scroll-timeline-anonymous-source-quirks-mode.html
@@ -1,0 +1,50 @@
+<html>
+<title>The scroll() timeline source in quirks mode</title>
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#scroll-notation">
+<link rel="help" href="https://drafts.csswg.org/css-animations-2/#animation-timeline">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  @keyframes move {
+    to { margin-left: 100px }
+  }
+
+  .animated {
+    animation: move 1s linear;
+  }
+
+  #default {
+    animation-timeline: scroll();
+  }
+
+  #root {
+    animation-timeline: scroll(root);
+  }
+
+  #nearest {
+    animation-timeline: scroll(nearest);
+  }
+</style>
+
+<div class="animated" id="default"></div>
+<div class="animated" id="root"></div>
+<div class="animated" id="nearest"></div>
+
+<script>
+"use strict";
+
+const timelineSourceTest = type => {
+  test(() => {
+    const target = document.getElementById(type);
+    const animations = target.getAnimations();
+    assert_equals(animations.length, 1);
+    assert_equals(animations[0].timeline.source, document.body);
+  }, `CSS animation correctly uses the <body> element as the source for the ${type} scroll() timeline in quirks mode`);
+};
+
+timelineSourceTest("default");
+timelineSourceTest("root");
+timelineSourceTest("nearest");
+
+</script>

--- a/scroll-animations/css/scroll-timeline-anonymous-source-scrollable-body-quirks-mode.html
+++ b/scroll-animations/css/scroll-timeline-anonymous-source-scrollable-body-quirks-mode.html
@@ -1,0 +1,48 @@
+<html>
+<title>The scroll() timeline source in quirks mode with a scrollable &lt;body> in quirks mode</title>
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#scroll-notation">
+<link rel="help" href="https://drafts.csswg.org/css-animations-2/#animation-timeline">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+
+@keyframes move {
+  to { margin-left: 100px }
+}
+
+html {
+  height: 100px;
+  padding: 20px;
+}
+
+body {
+  height: 110vh;
+  overflow: auto;
+
+  animation: 1s move linear, 1s move linear, 1s move linear;
+  animation-timeline: scroll(self), scroll(nearest), scroll(root);
+}
+
+body::after {
+  content: "";
+  display: block;
+  height: 110%;
+}
+</style>
+<body>
+<script>
+"use strict";
+
+const timelineSourceTest = data => {
+  test(() => {
+    assert_equals(document.body.getAnimations()[data.index].timeline.source, document.body);
+  }, `CSS animation correctly uses the <body> element as the source for the ${data.keyword} scroll() timeline in quirks mode`);
+};
+
+timelineSourceTest({ index: 0, keyword: "self" });
+timelineSourceTest({ index: 1, keyword: "nearest" });
+timelineSourceTest({ index: 1, keyword: "root" });
+
+</script>
+</body>

--- a/scroll-animations/css/scroll-timeline-anonymous-source-scrollable-body.html
+++ b/scroll-animations/css/scroll-timeline-anonymous-source-scrollable-body.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<title>The scroll() timeline source in quirks mode with a scrollable &lt;body></title>
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#scroll-notation">
+<link rel="help" href="https://drafts.csswg.org/css-animations-2/#animation-timeline">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+
+@keyframes move {
+  to { margin-left: 100px }
+}
+
+html {
+  height: 100px;
+  padding: 20px;
+}
+
+body {
+  height: 110vh;
+  overflow: auto;
+
+  animation: 1s move linear, 1s move linear, 1s move linear;
+  animation-timeline: scroll(self), scroll(nearest), scroll(root);
+}
+
+body::after {
+  content: "";
+  display: block;
+  height: 110%;
+}
+</style>
+<body>
+<script>
+"use strict";
+
+const timelineSourceTest = data => {
+  test(() => {
+    assert_equals(document.body.getAnimations()[data.index].timeline.source, data.expectedSource);
+  }, `CSS animation correctly uses the <${data.expectedSource.localName}> element as the source for the ${data.keyword} scroll() timeline`);
+};
+
+timelineSourceTest({ index: 0, keyword: "self", expectedSource: document.body });
+timelineSourceTest({ index: 1, keyword: "nearest", expectedSource: document.documentElement });
+timelineSourceTest({ index: 1, keyword: "root", expectedSource: document.documentElement });
+
+</script>
+</body>

--- a/scroll-animations/css/scroll-timeline-anonymous-source.html
+++ b/scroll-animations/css/scroll-timeline-anonymous-source.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<title>The scroll() timeline source</title>
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#scroll-notation">
+<link rel="help" href="https://drafts.csswg.org/css-animations-2/#animation-timeline">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  @keyframes move {
+    to { margin-left: 100px }
+  }
+
+  .animated {
+    animation: move 1s linear;
+  }
+
+  #default {
+    animation-timeline: scroll();
+  }
+
+  #root {
+    animation-timeline: scroll(root);
+  }
+
+  #nearest {
+    animation-timeline: scroll(nearest);
+  }
+</style>
+
+<div class="animated" id="default"></div>
+<div class="animated" id="root"></div>
+<div class="animated" id="nearest"></div>
+
+<script>
+"use strict";
+
+const timelineSourceTest = type => {
+  test(() => {
+    const target = document.getElementById(type);
+    const animations = target.getAnimations();
+    assert_equals(animations.length, 1);
+    assert_equals(animations[0].timeline.source, document.documentElement);
+  }, `CSS animation correctly uses the <html> element as the source for the ${type} scroll() timeline`);
+};
+
+timelineSourceTest("default");
+timelineSourceTest("root");
+timelineSourceTest("nearest");
+
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[scroll-animations\] scroll timelines should use the document's scrolling element as their default and root source](https://bugs.webkit.org/show_bug.cgi?id=283412)