### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=282962

### DIFF
--- a/css/css-typed-om/the-stylepropertymap/computed/get.html
+++ b/css/css-typed-om/the-stylepropertymap/computed/get.html
@@ -13,8 +13,8 @@
 
 test(t => {
   const styleMap = createComputedStyleMap(t, '--foo: auto');
-  assert_equals(styleMap.get('--Foo'), null);
-}, 'Getting a custom property not in the computed style returns null');
+  assert_equals(styleMap.get('--Foo'), undefined);
+}, 'Getting a custom property not in the computed style returns undefined');
 
 test(t => {
   const styleMap = createComputedStyleMap(t, 'width: 10px; height: 20px');

--- a/css/css-typed-om/the-stylepropertymap/declared/clear.html
+++ b/css/css-typed-om/the-stylepropertymap/declared/clear.html
@@ -21,11 +21,11 @@ test(t => {
   let styleMap = createInlineStyleMap(t, '--foo: auto; width: 10px; transition-duration: 1s, 2s');
 
   styleMap.clear();
-  assert_equals(styleMap.get('--foo'), null,
+  assert_equals(styleMap.get('--foo'), undefined,
     'Custom properties should be cleared');
-  assert_equals(styleMap.get('width'), null,
+  assert_equals(styleMap.get('width'), undefined,
     'CSS properties should be cleared');
-  assert_equals(styleMap.get('transition-duration'), null,
+  assert_equals(styleMap.get('transition-duration'), undefined,
     'List-valued properties should be cleared');
   assert_array_equals([...styleMap], []);
 }, 'Can clear a CSS rule containing properties');

--- a/css/css-typed-om/the-stylepropertymap/declared/declared.tentative.html
+++ b/css/css-typed-om/the-stylepropertymap/declared/declared.tentative.html
@@ -40,8 +40,8 @@ test(() => {
 }, 'Declared StylePropertyMap contains CSS property declarations in style rules');
 
 test(() => {
-  assert_equals(styleMap.get('top'), null);
-  assert_equals(styleMap.get('--bar'), null);
+  assert_equals(styleMap.get('top'), undefined);
+  assert_equals(styleMap.get('--bar'), undefined);
 }, 'Declared StylePropertyMap does not contain inline styles');
 
 test(() => {
@@ -49,7 +49,7 @@ test(() => {
 }, 'Declared StylePropertyMap contains custom property declarations');
 
 test(() => {
-  assert_equals(styleMap.get('color'), null);
+  assert_equals(styleMap.get('color'), undefined);
 }, 'Declared StylePropertyMap does not contain properties with invalid values');
 
 test(() => {

--- a/css/css-typed-om/the-stylepropertymap/declared/get-shorthand.html
+++ b/css/css-typed-om/the-stylepropertymap/declared/get-shorthand.html
@@ -13,7 +13,7 @@
 test(t => {
   const styleMap = createDeclaredStyleMap(t, 'margin: 1px 2px 3px 4px');
   const result = styleMap.get('margin');
-  assert_not_equals(result, null, 'Shorthand value must not be null');
+  assert_not_equals(result, undefined, 'Shorthand value must not be undefined');
   assert_class_string(result, 'CSSStyleValue',
     'Shorthand value must be a base CSSStyleValue');
 }, 'Getting a shorthand property set explicitly in css rule returns ' +
@@ -22,9 +22,9 @@ test(t => {
 test(t => {
   const styleMap = createDeclaredStyleMap(t, 'margin-top: 1px');
   const result = styleMap.get('margin');
-  assert_equals(result, null,
-    'Shorthand value must be null as it is not explicitly set');
+  assert_equals(result, undefined,
+    'Shorthand value must be undefined as it is not explicitly set');
 }, 'Getting a shorthand property that is partially set in css rule ' +
-   'returns null');
+   'returns undefined');
 
 </script>

--- a/css/css-typed-om/the-stylepropertymap/declared/get.html
+++ b/css/css-typed-om/the-stylepropertymap/declared/get.html
@@ -13,13 +13,13 @@
 
 test(t => {
   const styleMap = createDeclaredStyleMap(t, '--foo: auto');
-  assert_equals(styleMap.get('--Foo'), null);
-}, 'Getting a custom property not in the CSS rule returns null');
+  assert_equals(styleMap.get('--Foo'), undefined);
+}, 'Getting a custom property not in the CSS rule returns undefined');
 
 test(t => {
   const styleMap = createDeclaredStyleMap(t, '');
-  assert_equals(styleMap.get('width'), null);
-}, 'Getting a valid property not in the CSS rule returns null');
+  assert_equals(styleMap.get('width'), undefined);
+}, 'Getting a valid property not in the CSS rule returns undefined');
 
 test(t => {
   const styleMap = createDeclaredStyleMap(t, 'width: 10px; height: 20px');

--- a/css/css-typed-om/the-stylepropertymap/inline/clear.html
+++ b/css/css-typed-om/the-stylepropertymap/inline/clear.html
@@ -21,11 +21,11 @@ test(t => {
   let styleMap = createInlineStyleMap(t, '--foo: auto; width: 10px; transition-duration: 1s, 2s');
 
   styleMap.clear();
-  assert_equals(styleMap.get('--foo'), null,
+  assert_equals(styleMap.get('--foo'), undefined,
     'Custom properties should be cleared');
-  assert_equals(styleMap.get('width'), null,
+  assert_equals(styleMap.get('width'), undefined,
     'CSS properties should be cleared');
-  assert_equals(styleMap.get('transition-duration'), null,
+  assert_equals(styleMap.get('transition-duration'), undefined,
     'List-valued properties should be cleared');
   assert_array_equals([...styleMap], []);
 }, 'Can clear an inline style containing properties');

--- a/css/css-typed-om/the-stylepropertymap/inline/get-shorthand.html
+++ b/css/css-typed-om/the-stylepropertymap/inline/get-shorthand.html
@@ -22,15 +22,15 @@ test(t => {
 test(t => {
   const styleMap = createInlineStyleMap(t, 'margin-top: 1px');
   const result = styleMap.get('margin');
-  assert_equals(result, null,
-    'Shorthand value must be null as it is not explicitly set');
+  assert_equals(result, undefined,
+    'Shorthand value must be undefined as it is not explicitly set');
 }, 'Getting a shorthand property that is partially set in inline style ' +
    'returns null');
 
 test(t => {
   const styleMap = createDivWithoutStyle(t).attributeStyleMap;
-  assert_equals(styleMap.get('margin'), null,
-    'Shorthand value must be null for element without style');
+  assert_equals(styleMap.get('margin'), undefined,
+    'Shorthand value must be undefined for element without style');
 }, 'Getting an attributeStyleMap shorthand property from an element without ' +
    'a style attribute');
 </script>

--- a/css/css-typed-om/the-stylepropertymap/inline/get.html
+++ b/css/css-typed-om/the-stylepropertymap/inline/get.html
@@ -13,13 +13,13 @@
 
 test(t => {
   const styleMap = createInlineStyleMap(t, '--foo: auto');
-  assert_equals(styleMap.get('--Foo'), null);
-}, 'Getting a custom property not in the inline style returns null');
+  assert_equals(styleMap.get('--Foo'), undefined);
+}, 'Getting a custom property not in the inline style returns undefined');
 
 test(t => {
   const styleMap = createInlineStyleMap(t, '');
-  assert_equals(styleMap.get('width'), null);
-}, 'Getting a valid property not in the inline style returns null');
+  assert_equals(styleMap.get('width'), undefined);
+}, 'Getting a valid property not in the inline style returns undefined');
 
 test(t => {
   const styleMap = createInlineStyleMap(t, 'width: 10px; height: 20px');


### PR DESCRIPTION
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=282962

Update typed CSSOM StylePropertyMap get function result from null to undefined to match spec.