### PR TITLE
Fix and enable additional streams tests in ShadowRealm

### DIFF
--- a/streams/readable-streams/owning-type-message-port.any.js
+++ b/streams/readable-streams/owning-type-message-port.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker,shadowrealm
+// META: global=window,worker
 // META: script=../resources/test-utils.js
 // META: script=../resources/rs-utils.js
 'use strict';

--- a/streams/transferable/readable-stream.any.js
+++ b/streams/transferable/readable-stream.any.js
@@ -1,3 +1,4 @@
+// META: global=window,dedicatedworker,shadowrealm
 // META: script=resources/helpers.js
 // META: script=../resources/recording-streams.js
 // META: script=../resources/test-utils.js
@@ -90,11 +91,15 @@ promise_test(async () => {
   const rs = recordingReadableStream({}, { highWaterMark: 0 });
   await delay(0);
   assert_array_equals(rs.events, [], 'pull() should not have been called');
-  // Eat the message so it can't interfere with other tests.
-  addEventListener('message', () => {}, {once: true});
-  // The transfer is done manually to verify that it is posting the stream that
-  // relieves backpressure, not receiving it.
-  postMessage(rs, '*', [rs]);
+  if (GLOBAL.isShadowRealm()) {
+    structuredClone(rs, { transfer: [rs] });
+  } else {
+    // Eat the message so it can't interfere with other tests.
+    addEventListener('message', () => {}, {once: true});
+    // The transfer is done manually to verify that it is posting the stream that
+    // relieves backpressure, not receiving it.
+    postMessage(rs, '*', [rs]);
+  }
   await delay(0);
   assert_array_equals(rs.events, ['pull'], 'pull() should have been called');
 }, 'transferring a stream should relieve backpressure');

--- a/streams/transferable/readable-stream.any.js
+++ b/streams/transferable/readable-stream.any.js
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="resources/helpers.js"></script>
-<script src="../resources/recording-streams.js"></script>
-<script src="../resources/test-utils.js"></script>
-<script>
+// META: script=resources/helpers.js
+// META: script=../resources/recording-streams.js
+// META: script=../resources/test-utils.js
+
 'use strict';
 
 promise_test(async () => {
@@ -256,5 +252,3 @@ promise_test(async () => {
   const {done} = await reader.read();
   assert_true(done, 'should be done');
 }, 'race between cancel() and enqueue() should be benign');
-
-</script>

--- a/streams/transferable/resources/helpers.js
+++ b/streams/transferable/resources/helpers.js
@@ -98,7 +98,11 @@
         }
       }, {once: true});
     });
-    postMessage(original, '*', [original]);
+    if (GLOBAL.isShadowRealm()) {
+      structuredClone(original, {transfer: [original]});
+    } else {
+      postMessage(original, '*', [original]);
+    }
     return promise;
   }
 
@@ -117,7 +121,11 @@
         }
       }, {once: true});
     });
-    postMessage(original, '*', [original]);
+    if (GLOBAL.isShadowRealm()) {
+      structuredClone(original, {transfer: [original]});
+    } else {
+      postMessage(original, '*', [original]);
+    }
     return promise;
   }
 

--- a/streams/transferable/transform-stream.any.js
+++ b/streams/transferable/transform-stream.any.js
@@ -1,9 +1,5 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="../resources/test-utils.js"></script>
-<script>
+// META: script=../resources/test-utils.js
+
 'use strict';
 
 promise_test(t => {
@@ -104,5 +100,3 @@ promise_test(t => {
                     'transforms should have been applied');
     });
 }, 'piping through transferred transforms should work');
-
-</script>

--- a/streams/transferable/transform-stream.any.js
+++ b/streams/transferable/transform-stream.any.js
@@ -1,48 +1,66 @@
+// META: global=window,dedicatedworker,shadowrealm
 // META: script=../resources/test-utils.js
 
 'use strict';
 
-promise_test(t => {
-  const orig = new TransformStream();
-  const promise = new Promise(resolve => {
+function transfer(t, obj, transfers) {
+  if (GLOBAL.isShadowRealm()) {
+    const transferred = structuredClone(obj, {transfer: transfers});
+    return Promise.resolve(transferred);
+  }
+  return new Promise(resolve => {
     addEventListener('message', t.step_func(evt => {
       const transferred = evt.data;
-      assert_equals(transferred.constructor, TransformStream,
-                    'transferred should be a TransformStream in this realm');
-      assert_true(transferred instanceof TransformStream,
-                  'instanceof check should pass');
-
-      // Perform a brand-check on |transferred|.
-      const readableGetter = Object.getOwnPropertyDescriptor(
-        TransformStream.prototype, 'readable').get;
-      assert_true(readableGetter.call(transferred) instanceof ReadableStream,
-                 'brand check should pass and readable stream should result');
-      const writableGetter = Object.getOwnPropertyDescriptor(
-        TransformStream.prototype, 'writable').get;
-      assert_true(writableGetter.call(transferred) instanceof WritableStream,
-                 'brand check should pass and writable stream should result');
-      resolve();
+      resolve(transferred);
     }), {once: true});
+    postMessage(obj, '*', transfers);
   });
-  postMessage(orig, '*', [orig]);
+}
+
+function failToTransfer(obj) {
+  if (GLOBAL.isShadowRealm()) {
+    structuredClone(obj, {transfer: [obj]});
+  } else {
+    postMessage(obj, '*', [obj]);
+  }
+}
+
+promise_test(t => {
+  const orig = new TransformStream();
+  const promise = transfer(t, orig, [orig]);
   assert_true(orig.readable.locked, 'the readable side should be locked');
   assert_true(orig.writable.locked, 'the writable side should be locked');
-  return promise;
-}, 'window.postMessage should be able to transfer a TransformStream');
+  return promise.then(transferred => {
+    assert_equals(transferred.constructor, TransformStream,
+      'transferred should be a TransformStream in this realm');
+    assert_true(transferred instanceof TransformStream,
+        'instanceof check should pass');
+
+    // Perform a brand-check on |transferred|.
+    const readableGetter = Object.getOwnPropertyDescriptor(
+    TransformStream.prototype, 'readable').get;
+    assert_true(readableGetter.call(transferred) instanceof ReadableStream,
+      'brand check should pass and readable stream should result');
+    const writableGetter = Object.getOwnPropertyDescriptor(
+    TransformStream.prototype, 'writable').get;
+    assert_true(writableGetter.call(transferred) instanceof WritableStream,
+      'brand check should pass and writable stream should result');
+  });
+}, `should be able to transfer a TransformStream`);
 
 test(() => {
   const ts = new TransformStream();
   const writer = ts.writable.getWriter();
-  assert_throws_dom('DataCloneError', () => postMessage(ts, '*', [ts]),
-                    'postMessage should throw');
+  assert_throws_dom('DataCloneError', () => failToTransfer(ts),
+                    'transferring should throw');
   assert_false(ts.readable.locked, 'readable side should not get locked');
 }, 'a TransformStream with a locked writable should not be transferable');
 
 test(() => {
   const ts = new TransformStream();
   const reader = ts.readable.getReader();
-  assert_throws_dom('DataCloneError', () => postMessage(ts, '*', [ts]),
-                    'postMessage should throw');
+  assert_throws_dom('DataCloneError', () => failToTransfer(ts),
+                    'transferring should throw');
   assert_false(ts.writable.locked, 'writable side should not get locked');
 }, 'a TransformStream with a locked readable should not be transferable');
 
@@ -50,8 +68,8 @@ test(() => {
   const ts = new TransformStream();
   const reader = ts.readable.getReader();
   const writer = ts.writable.getWriter();
-  assert_throws_dom('DataCloneError', () => postMessage(ts, '*', [ts]),
-                    'postMessage should throw');
+  assert_throws_dom('DataCloneError', () => failToTransfer(ts),
+                    'transferring should throw');
 }, 'a TransformStream with both sides locked should not be transferable');
 
 promise_test(t => {
@@ -83,18 +101,15 @@ promise_test(t => {
       controller.enqueue(chunk + chunk);
     }
   });
-  const promise = new Promise(resolve => {
-    addEventListener('message', t.step_func(evt => {
-      const data = evt.data;
+  return transfer(t, {source, sink, transform1, transform2},
+    [source, transform1, sink, transform2])
+    .then(data => {
       resolve(data.source
-                .pipeThrough(data.transform1)
-                .pipeThrough(data.transform2)
-                .pipeTo(data.sink));
-    }));
-  });
-  postMessage({source, sink, transform1, transform2}, '*',
-              [source, transform1, sink, transform2]);
-  return ready
+        .pipeThrough(data.transform1)
+        .pipeThrough(data.transform2)
+        .pipeTo(data.sink));
+    })
+    .then(() => ready)
     .then(() => {
       assert_equals(result, 'HELLO HELLO THERE THERE ',
                     'transforms should have been applied');

--- a/streams/transferable/writable-stream.any.js
+++ b/streams/transferable/writable-stream.any.js
@@ -1,61 +1,78 @@
+// META: global=window,dedicatedworker,shadowrealm
 // META: script=resources/helpers.js
 // META: script=../resources/test-utils.js
 // META: script=../resources/recording-streams.js
 
 'use strict';
 
-promise_test(t => {
-  const orig = new WritableStream();
-  const promise = new Promise(resolve => {
+function transfer(t, obj, transfers) {
+  if (GLOBAL.isShadowRealm()) {
+    const transferred = structuredClone(obj, {transfer: transfers});
+    return Promise.resolve(transferred);
+  }
+  return new Promise(resolve => {
     addEventListener('message', t.step_func(evt => {
       const transferred = evt.data;
-      assert_equals(transferred.constructor, WritableStream,
-                    'transferred should be a WritableStream in this realm');
-      assert_true(transferred instanceof WritableStream,
-                  'instanceof check should pass');
-
-      // Perform a brand-check on |transferred|.
-      const writer = WritableStream.prototype.getWriter.call(transferred);
-      resolve();
+      resolve(transferred);
     }), {once: true});
+    postMessage(obj, '*', transfers);
   });
-  postMessage(orig, '*', [orig]);
+}
+
+function failToTransfer(obj) {
+  if (GLOBAL.isShadowRealm()) {
+    structuredClone(obj, {transfer: [obj]});
+  } else {
+    postMessage(obj, '*', [obj]);
+  }
+}
+
+promise_test(t => {
+  const orig = new WritableStream();
+  const promise = transfer(t, orig, [orig]);
   assert_true(orig.locked, 'the original stream should be locked');
-  return promise;
-}, 'window.postMessage should be able to transfer a WritableStream');
+  return promise.then(transferred => {
+    assert_equals(transferred.constructor, WritableStream,
+      'transferred should be a WritableStream in this realm');
+    assert_true(transferred instanceof WritableStream,
+      'instanceof check should pass');
+
+    // Perform a brand-check on |transferred|.
+    const writer = WritableStream.prototype.getWriter.call(transferred);
+  });
+}, 'should be able to transfer a WritableStream');
 
 test(() => {
   const ws = new WritableStream();
   const writer = ws.getWriter();
-  assert_throws_dom('DataCloneError', () => postMessage(ws, '*', [ws]),
-                    'postMessage should throw');
+  assert_throws_dom('DataCloneError', () => failToTransfer(ws),
+                    'transferring should throw');
 }, 'a locked WritableStream should not be transferable');
 
 promise_test(t => {
   const {writable, readable} = new TransformStream();
-  const promise = new Promise(resolve => {
-    addEventListener('message', t.step_func(async evt => {
-      const {writable, readable} = evt.data;
-      const reader = readable.getReader();
-      const writer = writable.getWriter();
-      const writerPromises = Promise.all([
-        writer.write('hi'),
-        writer.close(),
-      ]);
-      const {value, done} = await reader.read();
-      assert_false(done, 'we should not be done');
-      assert_equals(value, 'hi', 'chunk should have been delivered');
-      const readResult = await reader.read();
-      assert_true(readResult.done, 'readable should be closed');
-      await writerPromises;
-      resolve();
-    }), {once: true});
+  const promise = transfer(t, {writable, readable}, [writable, readable]);
+  return promise.then(async ({writable, readable}) => {
+    const reader = readable.getReader();
+    const writer = writable.getWriter();
+    const writerPromises = Promise.all([
+      writer.write('hi'),
+      writer.close(),
+    ]);
+    const {value, done} = await reader.read();
+    assert_false(done, 'we should not be done');
+    assert_equals(value, 'hi', 'chunk should have been delivered');
+    const readResult = await reader.read();
+    assert_true(readResult.done, 'readable should be closed');
+    await writerPromises;
   });
-  postMessage({writable, readable}, '*', [writable, readable]);
-  return promise;
-}, 'window.postMessage should be able to transfer a {readable, writable} pair');
+}, 'should be able to transfer a {readable, writable} pair');
 
-function transfer(stream) {
+function transferSimple(stream) {
+  if (GLOBAL.isShadowRealm()) {
+    const transferred = structuredClone(stream, {transfer: [stream]});
+    return Promise.resolve(transferred);
+  }
   return new Promise(resolve => {
     addEventListener('message', evt => resolve(evt.data), { once: true });
     postMessage(stream, '*', [stream]);
@@ -65,7 +82,7 @@ function transfer(stream) {
 promise_test(async () => {
   const orig = new WritableStream(
     {}, new ByteLengthQueuingStrategy({ highWaterMark: 65536 }));
-  const transferred = await transfer(orig);
+  const transferred = await transferSimple(orig);
   const writer = transferred.getWriter();
   assert_equals(writer.desiredSize, 1, 'desiredSize should be 1');
 }, 'desiredSize for a newly-transferred stream should be 1');
@@ -76,7 +93,7 @@ promise_test(async () => {
       return new Promise(() => {});
     }
   });
-  const transferred = await transfer(orig);
+  const transferred = await transferSimple(orig);
   const writer = transferred.getWriter();
   await writer.write('a');
   assert_equals(writer.desiredSize, 1, 'desiredSize should be 1');
@@ -93,7 +110,7 @@ promise_test(async () => {
       });
     }
   });
-  const transferred = await transfer(orig);
+  const transferred = await transferSimple(orig);
   const writer = transferred.getWriter();
   await writer.write('a');
   let writeDone = false;
@@ -113,7 +130,7 @@ async function transferredWritableStreamWithAbortPromise() {
       resolveAbortCalled();
     }
   });
-  const transferred = await transfer(orig);
+  const transferred = await transferSimple(orig);
   return { orig, transferred, abortCalled };
 }
 

--- a/streams/transferable/writable-stream.any.js
+++ b/streams/transferable/writable-stream.any.js
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="resources/helpers.js"></script>
-<script src="../resources/test-utils.js"></script>
-<script src="../resources/recording-streams.js"></script>
-<script>
+// META: script=resources/helpers.js
+// META: script=../resources/test-utils.js
+// META: script=../resources/recording-streams.js
+
 'use strict';
 
 promise_test(t => {
@@ -143,4 +139,3 @@ promise_test(async t => {
   assert_equals(orig.events[1].name, 'DataCloneError',
                 'reason should be a DataCloneError');
 }, 'writing a unclonable object should error the stream');
-</script>


### PR DESCRIPTION
Follow up with some things that were missed in #42005.

- Convert a few additional tests from .html to .any.js format so they can be run in multiple scopes
- ~~Give absolute paths in meta script tags~~
- Use structuredClone to transfer a stream if postMessage is not available
