### PR TITLE
Enable URLPattern tests in ShadowRealm

### DIFF
--- a/urlpattern/resources/urlpattern-compare-tests.tentative.js
+++ b/urlpattern/resources/urlpattern-compare-tests.tentative.js
@@ -20,7 +20,6 @@ function runTests(data) {
 }
 
 promise_test(async function() {
-  const response = await fetch('resources/urlpattern-compare-test-data.json');
-  const data = await response.json();
+  const data = await fetch_json('resources/urlpattern-compare-test-data.json');
   runTests(data);
 }, 'Loading data...');

--- a/urlpattern/resources/urlpatterntests.js
+++ b/urlpattern/resources/urlpatterntests.js
@@ -182,7 +182,6 @@ function runTests(data) {
 }
 
 promise_test(async function() {
-  const response = await fetch('resources/urlpatterntestdata.json');
-  const data = await response.json();
+  const data = await fetch_json('resources/urlpatterntestdata.json');
   runTests(data);
 }, 'Loading data...');

--- a/urlpattern/urlpattern-compare.tentative.any.js
+++ b/urlpattern/urlpattern-compare.tentative.any.js
@@ -1,2 +1,2 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm-in-window,shadowrealm-in-shadowrealm,shadowrealm-in-dedicatedworker,shadowrealm-in-sharedworker
 // META: script=resources/urlpattern-compare-tests.tentative.js

--- a/urlpattern/urlpattern-compare.tentative.https.any.js
+++ b/urlpattern/urlpattern-compare.tentative.https.any.js
@@ -1,2 +1,2 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 // META: script=resources/urlpattern-compare-tests.tentative.js

--- a/urlpattern/urlpattern-hasregexpgroups.any.js
+++ b/urlpattern/urlpattern-hasregexpgroups.any.js
@@ -1,2 +1,2 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 // META: script=resources/urlpattern-hasregexpgroups-tests.js

--- a/urlpattern/urlpattern.any.js
+++ b/urlpattern/urlpattern.any.js
@@ -1,2 +1,2 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm-in-window,shadowrealm-in-shadowrealm,shadowrealm-in-dedicatedworker,shadowrealm-in-sharedworker
 // META: script=resources/urlpatterntests.js

--- a/urlpattern/urlpattern.https.any.js
+++ b/urlpattern/urlpattern.https.any.js
@@ -1,2 +1,2 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 // META: script=resources/urlpatterntests.js


### PR DESCRIPTION
Requires using fetch_json to download the test data.

See https://github.com/whatwg/urlpattern/pull/236 for spec decision.