### PR TITLE
Enable ShadowRealm testing for ErrorEvent and queueMicrotask

### DIFF
--- a/html/semantics/scripting-1/the-script-element/microtasks/checkpoint-after-shadowrealmglobalscope-onerror.any.js
+++ b/html/semantics/scripting-1/the-script-element/microtasks/checkpoint-after-shadowrealmglobalscope-onerror.any.js
@@ -1,0 +1,32 @@
+// META: title=Microtask checkpoint after ShadowRealm onerror events
+// META: global=shadowrealm
+
+// Adapted from first part of ./resources/checkpoint-after-error-event.js.
+
+setup({allow_uncaught_exception: true});
+
+var log = [];
+
+addEventListener('error', () => {
+  log.push('handler 1');
+  Promise.resolve().then(() => log.push('handler 1 promise'));
+});
+addEventListener('error', () => {
+  log.push('handler 2');
+  Promise.resolve().then(() => log.push('handler 2 promise'));
+});
+
+async_test(t => {
+  t.step_timeout(() => {
+      assert_array_equals(log, [
+          'handler 1',
+          'handler 2',
+          'handler 1 promise',
+          'handler 2 promise'
+        ]);
+      t.done();
+    },
+    0);
+}, "Promise resolved during #report-the-error");
+
+queueMicrotask(() => thisFunctionDoesNotExist());

--- a/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-1-nothrow-static-import.any.js
+++ b/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-1-nothrow-static-import.any.js
@@ -1,4 +1,4 @@
-// META: global=dedicatedworker-module,sharedworker-module
+// META: global=dedicatedworker-module,sharedworker-module,shadowrealm-in-window,shadowrealm-in-shadowrealm,shadowrealm-in-dedicatedworker,shadowrealm-in-sharedworker
 // META: script=./resources/evaluation-order-setup.js
 
 import './resources/evaluation-order-1-nothrow-setup.js';

--- a/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-1-throw-static-import.any.js
+++ b/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-1-throw-static-import.any.js
@@ -1,4 +1,4 @@
-// META: global=dedicatedworker-module,sharedworker-module
+// META: global=dedicatedworker-module,sharedworker-module,shadowrealm-in-window,shadowrealm-in-shadowrealm,shadowrealm-in-dedicatedworker,shadowrealm-in-sharedworker
 // META: script=./resources/evaluation-order-setup.js
 
 import './resources/evaluation-order-1-throw-setup.js';

--- a/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-2.any.js
+++ b/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-2.any.js
@@ -1,4 +1,4 @@
-// META: global=dedicatedworker-module,sharedworker-module
+// META: global=dedicatedworker-module,sharedworker-module,shadowrealm-in-window,shadowrealm-in-shadowrealm,shadowrealm-in-dedicatedworker,shadowrealm-in-sharedworker
 // META: script=./resources/evaluation-order-setup.js
 
 import './resources/evaluation-order-2-setup.js';

--- a/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-3.any.js
+++ b/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-3.any.js
@@ -1,4 +1,4 @@
-// META: global=dedicatedworker-module,sharedworker-module
+// META: global=dedicatedworker-module,sharedworker-module,shadowrealm-in-window,shadowrealm-in-shadowrealm,shadowrealm-in-dedicatedworker,shadowrealm-in-sharedworker
 // META: script=./resources/evaluation-order-setup.js
 
 import './resources/evaluation-order-3-setup.js';

--- a/html/webappapis/microtask-queuing/queue-microtask-exceptions.any.js
+++ b/html/webappapis/microtask-queuing/queue-microtask-exceptions.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 "use strict";
 
 setup({

--- a/html/webappapis/microtask-queuing/queue-microtask-shadowrealm-callback-report-exception.window.js
+++ b/html/webappapis/microtask-queuing/queue-microtask-shadowrealm-callback-report-exception.window.js
@@ -1,0 +1,33 @@
+// META: title=Errors thrown by wrapped microtask in ShadowRealm
+
+setup({ allow_uncaught_exception: true });
+
+const realm = new ShadowRealm();
+
+const onerrorCalls = [];
+window.onerror = e => {
+  onerrorCalls.push("Window");
+};
+realm.evaluate(`(push) => {
+  onerror = function (e) {
+    const assertResult = e instanceof TypeError;
+    push(assertResult);
+  };
+}`)(assertResult => {
+  onerrorCalls.push("ShadowRealm");
+  assert_true(assertResult,
+    "exception should be converted to a fresh ShadowRealm TypeError")
+});
+
+async_test(t => {
+  window.onload = t.step_func(() => {
+    const task = () => { throw new Error("will be converted to TypeError"); };
+    realm.evaluate(`queueMicrotask`)(task);
+
+    t.step_timeout(() => {
+      assert_array_equals(onerrorCalls, ["ShadowRealm"],
+        "exception should only be reported in ShadowRealm's onerror handler");
+      t.done();
+    }, 4);
+  });
+});

--- a/html/webappapis/microtask-queuing/queue-microtask.any.js
+++ b/html/webappapis/microtask-queuing/queue-microtask.any.js
@@ -1,4 +1,4 @@
-// META: global=window,worker
+// META: global=window,worker,shadowrealm
 "use strict";
 
 test(() => {

--- a/html/webappapis/scripting/events/event-handler-processing-algorithm-error/otherglobalscope-runtime-error.any.js
+++ b/html/webappapis/scripting/events/event-handler-processing-algorithm-error/otherglobalscope-runtime-error.any.js
@@ -1,5 +1,6 @@
+// META: global=worker,shadowrealm
+
 "use strict";
-importScripts("/resources/testharness.js");
 
 setup({ allow_uncaught_exception: true });
 
@@ -14,10 +15,10 @@ promise_test(t => {
     assert_equals(e.defaultPrevented, true);
   });
 
-  setTimeout(() => thisFunctionDoesNotExist(), 0);
+  queueMicrotask(() => thisFunctionDoesNotExist());
 
   return promise;
-}, "error event is weird (return true cancels; many args) on WorkerGlobalScope, with a runtime error");
+}, "error event is weird (return true cancels; many args) on non-Window global scope, with a runtime error");
 
 promise_test(t => {
   self.onerror = t.step_func(function (message, filename, lineno, colno, error) {
@@ -31,10 +32,8 @@ promise_test(t => {
     return true;
   });
 
-  setTimeout(() => thisFunctionDoesNotExist(), 0);
+  queueMicrotask(() => thisFunctionDoesNotExist());
 
   const eventWatcher = new EventWatcher(t, self, "error");
   return eventWatcher.wait_for("error");
-}, "error event has the right 5 args on WorkerGlobalScope, with a runtime error");
-
-done();
+}, "error event has the right 5 args on non-Window global scope, with a runtime error");

--- a/html/webappapis/scripting/events/event-handler-processing-algorithm-error/otherglobalscope-synthetic-errorevent.any.js
+++ b/html/webappapis/scripting/events/event-handler-processing-algorithm-error/otherglobalscope-synthetic-errorevent.any.js
@@ -1,5 +1,6 @@
+// META: global=worker,shadowrealm
+
 "use strict";
-importScripts("/resources/testharness.js");
 
 setup({ allow_uncaught_exception: true });
 
@@ -17,7 +18,7 @@ promise_test(t => {
   self.dispatchEvent(new ErrorEvent("error", { cancelable: true }));
 
   return promise;
-}, "error event is weird (return true cancels; many args) on WorkerGlobalScope, with a synthetic ErrorEvent");
+}, "error event is weird (return true cancels; many args) on non-Window global scope, with a synthetic ErrorEvent");
 
 promise_test(t => {
   const theError = { the: "error object" };
@@ -44,6 +45,4 @@ promise_test(t => {
   }));
 
   return promise;
-}, "error event has the right 5 args on WorkerGlobalScope, with a synthetic ErrorEvent");
-
-done();
+}, "error event has the right 5 args on non-Window global scope, with a synthetic ErrorEvent");

--- a/html/webappapis/scripting/events/event-handler-processing-algorithm-error/otherglobalscope-synthetic-event.any.js
+++ b/html/webappapis/scripting/events/event-handler-processing-algorithm-error/otherglobalscope-synthetic-event.any.js
@@ -1,5 +1,6 @@
+// META: global=worker,shadowrealm
+
 "use strict";
-importScripts("/resources/testharness.js");
 
 setup({ allow_uncaught_exception: true });
 
@@ -17,6 +18,4 @@ promise_test(t => {
   self.dispatchEvent(new Event("error", { cancelable: true }));
 
   return promise;
-}, "error event is normal (return true does not cancel; one arg) on WorkerGlobalScope, with a synthetic Event");
-
-done();
+}, "error event is normal (return true does not cancel; one arg) on non-Window global scope, with a synthetic Event");

--- a/html/webappapis/scripting/processing-model-2/globalthis-onerror-shadowrealm.window.js
+++ b/html/webappapis/scripting/processing-model-2/globalthis-onerror-shadowrealm.window.js
@@ -1,0 +1,71 @@
+// META: title=globalThis.onerror: runtime script errors in ShadowRealm
+
+// https://html.spec.whatwg.org/multipage/#runtime-script-errors says what to do
+// for uncaught runtime script errors, and just below describes what to do when
+// onerror is a Function.
+
+async_test(t => {
+  onerror = t.unreached_func("Window onerror should not be triggered");
+
+  const realm = new ShadowRealm();
+
+  realm.evaluate("var errorCount = 0;");
+  realm.evaluate(`(doAsserts) => {
+    globalThis.onerror = function(msg, url, lineno, colno, thrownValue) {
+      ++errorCount;
+      doAsserts(url, lineno, colno, typeof thrownValue, String(thrownValue));
+    };
+  }`)(t.step_func((url, lineno, typeofThrownValue, stringifiedThrownValue) => {
+    assert_equals(url, "eval code", "correct url passed to onerror");
+    assert_equals(lineno, 8, "correct line number passed to onerror");
+    assert_equals(typeofThrownValue, "string", "thrown string passed directly to onerror");
+    assert_equals(stringifiedThrownValue, "bar", "correct thrown value passed to onerror");
+  }));
+
+  assert_throws_js(TypeError, () => realm.evaluate(`
+    try {
+      // This error is caught, so it should NOT trigger onerror.
+      throw "foo";
+    } catch (ex) {
+    }
+    // This error is NOT caught, so it should trigger onerror.
+    throw "bar";
+  `), "thrown error is wrapped in a TypeError object from the surrounding realm");
+
+  t.step_timeout(() => {
+    assert_equals(realm.evaluate("errorCount"), 1, "onerror should be called once");
+  }, 1000);
+}, "onerror triggered by uncaught thrown exception in realm.evaluate");
+
+async_test(t => {
+  onerror = t.unreached_func("Window onerror should not be triggered");
+
+  const realm = new ShadowRealm();
+
+  realm.evaluate("var errorCount = 0;");
+  realm.evaluate(`(doAsserts) => {
+    globalThis.onerror = function(msg, url, lineno, colno, thrownValue) {
+      ++errorCount;
+      doAsserts(url, lineno, typeof thrownValue, thrownValue instanceof TypeError);
+    };
+  }`)(t.step_func((url, lineno, typeofThrownValue, isTypeError) => {
+    assert_equals(url, "eval code", "correct url passed to onerror");
+    assert_equals(lineno, 8, "correct line number passed to onerror");
+    assert_equals(typeofThrownValue, "object", "thrown error instance passed to onerror");
+    assert_true(isShadowRealmTypeError, "correct thrown value passed to onerror");
+  }));
+
+  assert_throws_js(TypeError, () => realm.evaluate(`
+    try {
+      // This error is caught, so it should NOT trigger onerror.
+      window.nonexistentproperty.oops();
+    } catch (ex) {
+    }
+    // This error is NOT caught, so it should trigger onerror.
+    window.nonexistentproperty.oops();
+  `), "thrown error is wrapped in a TypeError object from the surrounding realm");
+
+  t.step_timeout(() => {
+    assert_equals(realm.evaluate("errorCount"), 1, "onerror should be called once");
+  }, 1000);
+}, "onerror triggered by uncaught runtime error in realm.evaluate");

--- a/html/webappapis/scripting/reporterror.any.js
+++ b/html/webappapis/scripting/reporterror.any.js
@@ -1,3 +1,5 @@
+// META: global=window,dedicatedworker,shadowrealm
+
 setup({ allow_uncaught_exception:true });
 
 [
@@ -9,7 +11,7 @@ setup({ allow_uncaught_exception:true });
     let happened = false;
     self.addEventListener("error", t.step_func(e => {
       assert_true(e.message !== "");
-      assert_equals(e.filename, new URL("reporterror.any.js", location.href).href);
+      assert_equals(e.filename, location ? new URL("reporterror.any.js", location.href).href : "");
       assert_greater_than(e.lineno, 0);
       assert_greater_than(e.colno, 0);
       assert_equals(e.error, throwable);


### PR DESCRIPTION
Adapt the tests for the onerror event on Worker global scopes to cover ShadowRealm global scopes as well.

One of the tests uses setTimeout() directly to fire the global onerror event. Use queueMicrotask() instead, since that is [Exposed=*]. We cannot use t.step_timeout() because that wraps the callback in a t.step_func() which catches the error and fails the test.

Run the microtask evaluation order tests in ShadowRealm scopes.

Add a new test ensuring that the behaviour of wrapping exceptions thrown from outer realm functions in a fresh TypeError extends to the onerror event as well.

(This PR was originally for just ErrorEvent and onerror. I added my queueMicrotask coverage as well, because most of the tests are quite related. EDIT: added reportError coverage as well, pending https://github.com/whatwg/html/pull/9893#discussion_r1857463381)