### PR TITLE
[WebDriver BiDi] Align initial `browsingContext` events with the spec

### DIFF
--- a/webdriver/tests/bidi/browsing_context/dom_content_loaded/dom_content_loaded.py
+++ b/webdriver/tests/bidi/browsing_context/dom_content_loaded/dom_content_loaded.py
@@ -1,5 +1,6 @@
 import pytest
 from tests.support.sync import AsyncPoll
+from webdriver.error import TimeoutException
 from webdriver.bidi.modules.script import ContextTarget
 
 from ... import int_interval
@@ -142,22 +143,33 @@ async def test_iframe(
 
 
 @pytest.mark.parametrize("type_hint", ["tab", "window"])
-async def test_new_context(bidi_session, subscribe_events, wait_for_event, wait_for_future_safe, type_hint):
+async def test_new_context_not_emitted(bidi_session, subscribe_events,
+      wait_for_event, wait_for_future_safe, type_hint):
     await subscribe_events(events=[DOM_CONTENT_LOADED_EVENT])
 
-    on_entry = wait_for_event(DOM_CONTENT_LOADED_EVENT)
-    new_context = await bidi_session.browsing_context.create(type_hint=type_hint)
-    event = await wait_for_future_safe(on_entry)
+    # Track all received browsingContext.domContentLoaded events in the events array
+    events = []
 
-    assert_navigation_info(
-        event, {"context": new_context["context"], "url": "about:blank"}
+    async def on_event(method, data):
+        events.append(data)
+
+    remove_listener = bidi_session.add_event_listener(
+        DOM_CONTENT_LOADED_EVENT, on_event
     )
-    assert event["navigation"] is not None
+
+    await bidi_session.browsing_context.create(type_hint=type_hint)
+
+    # In the future we can wait for "browsingContext.domContentLoaded" event instead.
+    wait = AsyncPoll(bidi_session, timeout=0.5)
+    with pytest.raises(TimeoutException):
+        await wait.until(lambda _: len(events) > 0)
+
+    remove_listener()
 
 
 @pytest.mark.parametrize("sandbox", [None, "sandbox_1"])
 async def test_document_write(
-    bidi_session, subscribe_events, new_tab, wait_for_event, wait_for_future_safe, sandbox
+      bidi_session, subscribe_events, new_tab, wait_for_event, wait_for_future_safe, sandbox
 ):
     await subscribe_events(events=[DOM_CONTENT_LOADED_EVENT])
 

--- a/webdriver/tests/bidi/browsing_context/dom_content_loaded/dom_content_loaded.py
+++ b/webdriver/tests/bidi/browsing_context/dom_content_loaded/dom_content_loaded.py
@@ -159,7 +159,6 @@ async def test_new_context_not_emitted(bidi_session, subscribe_events,
 
     await bidi_session.browsing_context.create(type_hint=type_hint)
 
-    # In the future we can wait for "browsingContext.domContentLoaded" event instead.
     wait = AsyncPoll(bidi_session, timeout=0.5)
     with pytest.raises(TimeoutException):
         await wait.until(lambda _: len(events) > 0)

--- a/webdriver/tests/bidi/browsing_context/load/load.py
+++ b/webdriver/tests/bidi/browsing_context/load/load.py
@@ -122,17 +122,28 @@ async def test_iframe(
 
 
 @pytest.mark.parametrize("type_hint", ["tab", "window"])
-async def test_new_context(bidi_session, subscribe_events, wait_for_event, wait_for_future_safe, type_hint):
+async def test_new_context_not_emitted(bidi_session, subscribe_events,
+      wait_for_event, wait_for_future_safe, type_hint):
     await subscribe_events(events=[CONTEXT_LOAD_EVENT])
 
-    on_entry = wait_for_event(CONTEXT_LOAD_EVENT)
-    new_context = await bidi_session.browsing_context.create(type_hint=type_hint)
-    event = await wait_for_future_safe(on_entry)
+    # Track all received "browsingContext.load" events in the events array
+    events = []
 
-    assert_navigation_info(
-        event, {"context": new_context["context"], "url": "about:blank"}
+    async def on_event(method, data):
+        events.append(data)
+
+    remove_listener = bidi_session.add_event_listener(
+        CONTEXT_LOAD_EVENT, on_event
     )
-    assert event["navigation"] is not None
+
+    await bidi_session.browsing_context.create(type_hint=type_hint)
+
+    # In the future we can wait for "browsingContext.load" event instead.
+    wait = AsyncPoll(bidi_session, timeout=0.5)
+    with pytest.raises(TimeoutException):
+        await wait.until(lambda _: len(events) > 0)
+
+    remove_listener()
 
 
 @pytest.mark.parametrize("sandbox", [None, "sandbox_1"])

--- a/webdriver/tests/bidi/browsing_context/load/load.py
+++ b/webdriver/tests/bidi/browsing_context/load/load.py
@@ -138,7 +138,6 @@ async def test_new_context_not_emitted(bidi_session, subscribe_events,
 
     await bidi_session.browsing_context.create(type_hint=type_hint)
 
-    # In the future we can wait for "browsingContext.load" event instead.
     wait = AsyncPoll(bidi_session, timeout=0.5)
     with pytest.raises(TimeoutException):
         await wait.until(lambda _: len(events) > 0)

--- a/webdriver/tests/bidi/session/unsubscribe/events.py
+++ b/webdriver/tests/bidi/session/unsubscribe/events.py
@@ -9,7 +9,7 @@ from tests.support.sync import AsyncPoll
 
 
 @pytest.mark.asyncio
-async def test_unsubscribe_from_module(bidi_session):
+async def test_unsubscribe_from_module(bidi_session, new_tab, inline):
     await bidi_session.session.subscribe(events=["browsingContext"])
     await bidi_session.session.unsubscribe(events=["browsingContext"])
 
@@ -19,9 +19,6 @@ async def test_unsubscribe_from_module(bidi_session):
     async def on_event(method, data):
         events.append(data)
 
-    remove_listener_contextCreated = bidi_session.add_event_listener(
-        "browsingContext.contextCreated", on_event
-    )
     remove_listener_domContentLoaded = bidi_session.add_event_listener(
         "browsingContext.domContentLoaded", on_event
     )
@@ -29,25 +26,27 @@ async def test_unsubscribe_from_module(bidi_session):
         "browsingContext.load", on_event
     )
 
-    await bidi_session.browsing_context.create(type_hint="tab")
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"], url=inline("")
+    )
 
     wait = AsyncPoll(bidi_session, timeout=0.5)
     with pytest.raises(TimeoutException):
         await wait.until(lambda _: len(events) > 0)
 
-    remove_listener_contextCreated()
     remove_listener_domContentLoaded()
     remove_listener_load()
 
 
 @pytest.mark.asyncio
 async def test_subscribe_to_module_unsubscribe_from_one_event(
-    bidi_session, wait_for_event, wait_for_future_safe
+      bidi_session, wait_for_event, wait_for_future_safe, new_tab, inline
 ):
     await bidi_session.session.subscribe(events=["browsingContext"])
 
     # Unsubscribe from one event
-    await bidi_session.session.unsubscribe(events=["browsingContext.domContentLoaded"])
+    await bidi_session.session.unsubscribe(
+        events=["browsingContext.domContentLoaded"])
 
     # Track all received browsing context events in the events array
     events = []
@@ -55,9 +54,6 @@ async def test_subscribe_to_module_unsubscribe_from_one_event(
     async def on_event(method, _):
         events.append(method)
 
-    remove_listener_contextCreated = bidi_session.add_event_listener(
-        "browsingContext.contextCreated", on_event
-    )
     remove_listener_domContentLoaded = bidi_session.add_event_listener(
         "browsingContext.domContentLoaded", on_event
     )
@@ -67,17 +63,17 @@ async def test_subscribe_to_module_unsubscribe_from_one_event(
 
     # Wait for the last event
     on_entry_added = wait_for_event("browsingContext.load")
-    await bidi_session.browsing_context.create(type_hint="tab")
+    await bidi_session.browsing_context.navigate(
+        context=new_tab["context"], url=inline("")
+    )
     await wait_for_future_safe(on_entry_added)
 
     # Make sure we didn't receive browsingContext.domContentLoaded event
-    assert len(events) == 2
+    assert len(events) == 1
     assert "browsingContext.domContentLoaded" not in events
 
-    remove_listener_contextCreated()
     remove_listener_domContentLoaded()
     remove_listener_load()
 
     # Unsubscribe from the rest of the events
-    await bidi_session.session.unsubscribe(events=["browsingContext.contextCreated"])
     await bidi_session.session.unsubscribe(events=["browsingContext.load"])


### PR DESCRIPTION
As discussed in https://github.com/w3c/webdriver-bidi/issues/766, and according to the HTML spec, the navigation, load and dom loaded events should not be emitted when browsing context is created.