### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=283378

### DIFF
--- a/css/css-rhythm/content-based-height-rounds-up-to-step-unit.html
+++ b/css/css-rhythm/content-based-height-rounds-up-to-step-unit.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Content based block size is rounded up to step unit.">
+<style>
+.container {
+  display: flow-root;
+  width: 100px;
+  background-color: green;
+}
+.block-step {
+  width: min-content;
+  block-step-size: 100px;
+  color: green;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <div class="block-step">
+    x x x
+  </div>
+</div>
+</body>
+</html>

--- a/css/css-rhythm/definite-height-rounds-up-to-next-multiple-of-step-unit.html
+++ b/css/css-rhythm/definite-height-rounds-up-to-next-multiple-of-step-unit.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Definite height should be rounded up to next multiple of specified step unit.">
+<style>
+.container {
+  display: flow-root;
+  width: 100px;
+  background-color: green;
+}
+.block-step {
+  block-step-size: 50px;
+  height: 51px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <div class="block-step"></div>
+</div>
+</body>
+</html>
+

--- a/css/css-rhythm/definite-height-rounds-up-to-step-unit.html
+++ b/css/css-rhythm/definite-height-rounds-up-to-step-unit.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Definite height smaller than step size should be rounded up to step size.">
+<style>
+.container {
+  display: flow-root;
+  width: 100px;
+  background-color: green;
+}
+.block-step {
+  block-step-size: 100px;
+  height: 33px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <div class="block-step"></div>
+</div>
+</body>
+</html>
+

--- a/css/css-rhythm/definite-height-same-as-step-unit.html
+++ b/css/css-rhythm/definite-height-same-as-step-unit.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Block size that is the same as the step unit should be unchanged.">
+<style>
+.container {
+  display: flow-root;
+  width: 100px;
+  background-color: green;
+}
+.block-step {
+  height: 100px;
+  block-step-size: 100px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <div class="block-step"></div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[block-step-sizing\] Support block-step-size for some simple content](https://bugs.webkit.org/show_bug.cgi?id=283378)