### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=283391

### DIFF
--- a/css/css-view-transitions/new-content-flat-transform-ancestor.html
+++ b/css/css-view-transitions/new-content-flat-transform-ancestor.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
 <link rel="match" href="new-content-flat-transform-ancestor-ref.html">
-<meta name="fuzzy" content="maxDifference=0-63; totalPixels=0-510" />
+<meta name="fuzzy" content="maxDifference=0-63; totalPixels=0-512">
 <script src="/common/rendering-utils.js"></script>
 <script src="/common/reftest-wait.js"></script>
 <script src="../../../../../resources/ui-helper.js"></script>


### PR DESCRIPTION
WebKit export from bug: [Missing style invalidation in View Transitions](https://bugs.webkit.org/show_bug.cgi?id=283391)