### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=283358

### DIFF
--- a/css/css-contain/content-visibility/content-visibility-on-ruby-ref.html
+++ b/css/css-contain/content-visibility/content-visibility-on-ruby-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<style>
+    ruby {
+        font: 25px/1 Ahem;
+    }
+</style>
+<body>
+<p>Test passes if both base and annotation are visible</p>
+<ruby>base<rt>annotation</rt></ruby>
+</body>
+</html>
+

--- a/css/css-contain/content-visibility/content-visibility-on-ruby.html
+++ b/css/css-contain/content-visibility/content-visibility-on-ruby.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<link rel="help" href="https://drafts.csswg.org/css-contain-2/#content-visibility">
+<meta name="assert" content="content-visibility does not apply when the principal box is an internal ruby box since size containment does not apply to it">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<style>
+    ruby {
+        font: 25px/1 Ahem;
+    }
+</style>
+<body>
+<p>Test passes if both base and annotation are visible</p>
+<ruby style="content-visibility: hidden;">base<rt>annotation</rt></ruby>
+</body>
+</html>
+

--- a/css/css-contain/content-visibility/content-visibility-on-ruby.html
+++ b/css/css-contain/content-visibility/content-visibility-on-ruby.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<link rel="match" href="content-visibility-on-ruby-ref.html">
 <link rel="help" href="https://drafts.csswg.org/css-contain-2/#content-visibility">
 <meta name="assert" content="content-visibility does not apply when the principal box is an internal ruby box since size containment does not apply to it">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />


### PR DESCRIPTION
WebKit export from bug: [\[content-visibility\] Property should not apply to ruby](https://bugs.webkit.org/show_bug.cgi?id=283358)