### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=283672

### DIFF
--- a/web-animations/interfaces/Animation/overallProgress.tentative.html
+++ b/web-animations/interfaces/Animation/overallProgress.tentative.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Animation.progress</title>
+<title>Animation.overallProgress</title>
 <link rel="help"
-href="https://drafts.csswg.org/web-animations-2/#the-progress-of-an-animation">
+href="https://drafts.csswg.org/web-animations-2/#the-overall-progress-of-an-animation">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>
@@ -16,16 +16,16 @@ test(t => {
   const animation = new Animation(null);
   animation.startTime = document.timeline.currentTime;
   assert_time_equals_literal(animation.currentTime, 0, 'currentTime is zero');
-  assert_equals(animation.progress, null, 'progress is unresolved');
-}, 'progress of a newly created animation without an effect is unresolved');
+  assert_equals(animation.overallProgress, null, 'overallProgress is unresolved');
+}, 'overallProgress of a newly created animation without an effect is unresolved');
 
 test(t => {
   // currentTime should be unresolved because the animation has no associated
   // timeline.
   const animation = new Animation(new KeyframeEffect(createDiv(t), null), null);
   assert_equals(animation.currentTime, null, 'currentTime is unresolved');
-  assert_equals(animation.progress, null, 'progress is unresolved');
-}, 'progress of an animation whose currentTime is unresolved is unresolved.');
+  assert_equals(animation.overallProgress, null, 'overallProgress is unresolved');
+}, 'overallProgress of an animation whose currentTime is unresolved is unresolved.');
 
 test(t => {
   const animation = new Animation(new KeyframeEffect(createDiv(t), null,
@@ -33,8 +33,8 @@ test(t => {
   // Set the startTime to 20 seconds into the future.
   animation.startTime = document.timeline.currentTime + 20 * MS_PER_SEC;
   assert_less_than(animation.currentTime, 0, 'currentTime is negative');
-  assert_approx_equals(animation.progress, 0, 0.01, 'progress is zero');
-}, "progress of an animation whose effect's endTime is zero is zero if its " +
+  assert_approx_equals(animation.overallProgress, 0, 0.01, 'overallProgress is zero');
+}, "overallProgress of an animation whose effect's endTime is zero is zero if its " +
    "currentTime is negative.");
 
 test(t => {
@@ -42,12 +42,12 @@ test(t => {
     { duration: 0 }), document.timeline);
   animation.startTime = document.timeline.currentTime;
   assert_time_equals_literal(animation.currentTime, 0, 'currentTime is zero');
-  assert_approx_equals(animation.progress, 1, 0.01, 'progress is one');
+  assert_approx_equals(animation.overallProgress, 1, 0.01, 'overallProgress is one');
 
   animation.startTime = document.timeline.currentTime - 20 * MS_PER_SEC;
   assert_greater_than(animation.currentTime, 0, 'currentTime greater than zero');
-  assert_approx_equals(animation.progress, 1, 0.01, 'progress is one');
-}, "progress of an animation whose effect's endTime is zero is one if its " +
+  assert_approx_equals(animation.overallProgress, 1, 0.01, 'overallProgress is one');
+}, "overallProgress of an animation whose effect's endTime is zero is one if its " +
    "currentTime is non-negative.");
 
 test(t => {
@@ -56,8 +56,8 @@ test(t => {
 
   animation.startTime = document.timeline.currentTime - 20 * MS_PER_SEC;
   assert_greater_than(animation.currentTime, 0, 'currentTime is positive');
-  assert_approx_equals(animation.progress, 0, 0.01, 'progress is zero');
-}, "progress of an animation whose effect's endTime is infinity is zero.");
+  assert_approx_equals(animation.overallProgress, 0, 0.01, 'overallProgress is zero');
+}, "overallProgress of an animation whose effect's endTime is infinity is zero.");
 
 test(t => {
   const animation = new Animation(new KeyframeEffect(createDiv(t), null,
@@ -66,16 +66,16 @@ test(t => {
 
   animation.startTime = document.timeline.currentTime - 50 * MS_PER_SEC;
   assert_time_equals_literal(animation.currentTime, 100 * MS_PER_SEC, 'currentTime is 100s');
-  assert_approx_equals(animation.progress, 0.5, 0.01, 'progress is zero');
+  assert_approx_equals(animation.overallProgress, 0.5, 0.01, 'overallProgress is zero');
 
   animation.startTime = document.timeline.currentTime - 100 * MS_PER_SEC;
   assert_time_equals_literal(animation.currentTime, 200 * MS_PER_SEC, 'currentTime is 200s');
-  assert_approx_equals(animation.progress, 1, 0.01, 'progress is one');
+  assert_approx_equals(animation.overallProgress, 1, 0.01, 'overallProgress is one');
 
   animation.startTime = document.timeline.currentTime - 150 * MS_PER_SEC;
   assert_time_equals_literal(animation.currentTime, 300 * MS_PER_SEC, 'currentTime is 300s');
-  assert_approx_equals(animation.progress, 1, 0.01, 'progress is still one');
-}, "progress of an animation is calculated by currentTime / effect endTime.");
+  assert_approx_equals(animation.overallProgress, 1, 0.01, 'overallProgress is still one');
+}, "overallProgress of an animation is calculated by currentTime / effect endTime.");
 
 </script>
 </body>

--- a/web-animations/interfaces/Animation/scroll-timeline-overallProgress.tentative.html
+++ b/web-animations/interfaces/Animation/scroll-timeline-overallProgress.tentative.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Animation.progress</title>
+<title>Animation.overallProgress</title>
 <link rel="help"
-href="https://drafts.csswg.org/web-animations-2/#the-progress-of-an-animation">
+href="https://drafts.csswg.org/web-animations-2/#the-overall-progress-of-an-animation">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>
@@ -21,8 +21,8 @@ href="https://drafts.csswg.org/web-animations-2/#the-progress-of-an-animation">
       width: 100%;
     }
     #target {
-      height:  100px;
-      width:  100px;
+      height: 100px;
+      width: 100px;
       background-color: green;
       margin-top: -1000px;
     }
@@ -38,30 +38,30 @@ promise_test(async t => {
 
   assert_equals(animation.currentTime, null,
       "The current time is null in Idle state.");
-  assert_equals(animation.progress, null,
-      "The progress is null since the currentTime is unresolved.");
+  assert_equals(animation.overallProgress, null,
+      "The overallProgress is null since the currentTime is unresolved.");
 
   animation.play();
   assert_true(animation.pending, "Animation is in the pending state.");
   assert_equals(animation.currentTime, null,
       "The current time remains null while in the pending state.");
-  assert_equals(animation.progress, null,
-      "The progress is null since the currentTime is unresolved.");
+  assert_equals(animation.overallProgress, null,
+      "The overallProgress is null since the currentTime is unresolved.");
 
   await animation.ready;
   // Verify initial start and current times once ready.
   assert_percents_equal(animation.currentTime, 0,
       "The current time is resolved when ready.");
-  assert_equals(animation.progress, 0, "The progress is should be zero.");
+  assert_equals(animation.overallProgress, 0, "The overallProgress should be zero.");
 
   scroller.scrollTop = 0.4 * maxScroll;
 
   await waitForNextFrame();
   assert_percents_equal(animation.currentTime, 40,
       "currentTime reflects progress as a percentage");
-  assert_approx_equals(animation.progress, 0.4, 0.01,
-      "The progress is should match the scroll progress.");
-}, "animation.progress reflects the progress of a scroll animation as a "+
+  assert_approx_equals(animation.overallProgress, 0.4, 0.01,
+      "The overallProgress should match the scroll progress.");
+}, "animation.overallProgress reflects the progress of a scroll animation as a "+
    "number between 0 and 1");
 
 promise_test(async t => {
@@ -74,7 +74,7 @@ promise_test(async t => {
   // Verify initial start and current times once ready.
   assert_percents_equal(animation.currentTime, 0,
       "The current time is resolved when ready.");
-  assert_equals(animation.progress, 0, "The progress is should be zero.");
+  assert_equals(animation.overallProgress, 0, "The overallProgress should be zero.");
 
   scroller.scrollTop = 0.4 * maxScroll;
   await waitForNextFrame();
@@ -84,8 +84,8 @@ promise_test(async t => {
   assert_percents_equal(timing.duration, 100);
   assert_percents_equal(animation.currentTime, 40,
       "currentTime reflects progress as a percentage");
-  assert_approx_equals(animation.progress, 0.4, 0.01,
-      "The progress is should match the scroll progress.");
+  assert_approx_equals(animation.overallProgress, 0.4, 0.01,
+      "The overallProgress should match the scroll progress.");
       timing = animation.effect.getComputedTiming();
 
   animation.effect.updateTiming({ iterations: 2 });
@@ -96,9 +96,9 @@ promise_test(async t => {
   assert_percents_equal(timing.duration, 50);
   assert_percents_equal(animation.currentTime, 40,
       "currentTime reflects progress as a percentage");
-  assert_approx_equals(animation.progress, 0.4, 0.01,
-      "The progress is should match the scroll progress.");
-}, "animation.progress reflects the overall progress of a scroll animation " +
+  assert_approx_equals(animation.overallProgress, 0.4, 0.01,
+      "The overallProgress should match the scroll progress.");
+}, "animation.overallProgress reflects the overall progress of a scroll animation " +
    "with multiple iterations.");
 
 promise_test(async t => {
@@ -126,9 +126,9 @@ promise_test(async t => {
   const expected_current_time = timeline_time - start_time;
   assert_percents_equal(animation.currentTime, expected_current_time,
       "currentTime reflects progress as a percentage");
-  assert_approx_equals(animation.progress, target_pct / 100, 0.01,
-    "progress should reflect fraction of view timeline range scroll through.");
-}, "animation.progress reflects the overall progress of a scroll animation " +
+  assert_approx_equals(animation.overallProgress, target_pct / 100, 0.01,
+    "overallProgress should reflect fraction of view timeline range scroll through.");
+}, "animation.overallProgress reflects the overall progress of a scroll animation " +
    "that uses a view-timeline.");
 
 promise_test(async t => {
@@ -151,16 +151,16 @@ promise_test(async t => {
   await waitForNextFrame();
   let timing = animation.effect.getComputedTiming();
   assert_less_than(animation.currentTime.value, 0, "currentTime is negative");
-  assert_approx_equals(animation.progress, 0, 0.01, "progress is zero when " +
+  assert_approx_equals(animation.overallProgress, 0, 0.01, "overallProgress is zero when " +
     "scroll offset is less than range start.");
 
   scroller.scrollTop = 200;
   await waitForNextFrame();
   assert_approx_equals(animation.currentTime.value, timing.endTime.value, 0.01,
     "currentTime has reached endTime");
-  assert_approx_equals(animation.progress, 1, 0.01, "progress is one when " +
+  assert_approx_equals(animation.overallProgress, 1, 0.01, "overallProgress is one when " +
     "scroll offset goes past than range end.");
-}, "progresss of a view-timeline is bounded between 0 and 1.");
+}, "overallProgresss of a view-timeline is bounded between 0 and 1.");
 
 </script>
 </body>

--- a/web-animations/interfaces/Animation/style-change-events.html
+++ b/web-animations/interfaces/Animation/style-change-events.html
@@ -169,7 +169,7 @@ const tests = {
   // no effect.
   rangeStart: UsePropertyTest(animation => animation.rangeStart),
   rangeEnd:  UsePropertyTest(animation => animation.rangeEnd),
-  progress: UsePropertyTest(animation => animation.progress),
+  overallProgress: UsePropertyTest(animation => animation.overallProgress),
   replaceState: UsePropertyTest(animation => animation.replaceState),
   ready: UsePropertyTest(animation => animation.ready),
   finished: UsePropertyTest(animation => {


### PR DESCRIPTION
WebKit export from bug: [\[web-animations\] Rename `Animation.progress` to `Animation.overallProgress` and use a dedicated run-time flag for it](https://bugs.webkit.org/show_bug.cgi?id=283672)