### PR TITLE
Rename Animation.progress to Animation.overallProgress

### DIFF
--- a/web-animations/interfaces/Animation/overallProgress.tentative.html
+++ b/web-animations/interfaces/Animation/overallProgress.tentative.html
@@ -16,16 +16,20 @@ test(t => {
   const animation = new Animation(null);
   animation.startTime = document.timeline.currentTime;
   assert_time_equals_literal(animation.currentTime, 0, 'currentTime is zero');
-  assert_equals(animation.overallProgress, null, 'overallProgress is unresolved');
-}, 'overallProgress of a newly created animation without an effect is unresolved');
+  assert_equals(animation.overallProgress, null,
+    'overallProgress is unresolved');
+}, 'overallProgress of a newly created animation without an effect is ' +
+   'unresolved');
 
 test(t => {
   // currentTime should be unresolved because the animation has no associated
   // timeline.
   const animation = new Animation(new KeyframeEffect(createDiv(t), null), null);
   assert_equals(animation.currentTime, null, 'currentTime is unresolved');
-  assert_equals(animation.overallProgress, null, 'overallProgress is unresolved');
-}, 'overallProgress of an animation whose currentTime is unresolved is unresolved.');
+  assert_equals(animation.overallProgress, null,
+    'overallProgress is unresolved');
+}, 'overallProgress of an animation whose currentTime is unresolved is ' +
+   'unresolved.');
 
 test(t => {
   const animation = new Animation(new KeyframeEffect(createDiv(t), null,
@@ -33,22 +37,25 @@ test(t => {
   // Set the startTime to 20 seconds into the future.
   animation.startTime = document.timeline.currentTime + 20 * MS_PER_SEC;
   assert_less_than(animation.currentTime, 0, 'currentTime is negative');
-  assert_approx_equals(animation.overallProgress, 0, 0.01, 'overallProgress is zero');
-}, "overallProgress of an animation whose effect's endTime is zero is zero if its " +
-   "currentTime is negative.");
+  assert_approx_equals(animation.overallProgress, 0, 0.01, 'overallProgress ' +
+    'is zero');
+}, "overallProgress of an animation whose effect's endTime is zero is zero " +
+   "if its currentTime is negative.");
 
 test(t => {
   const animation = new Animation(new KeyframeEffect(createDiv(t), null,
     { duration: 0 }), document.timeline);
   animation.startTime = document.timeline.currentTime;
   assert_time_equals_literal(animation.currentTime, 0, 'currentTime is zero');
-  assert_approx_equals(animation.overallProgress, 1, 0.01, 'overallProgress is one');
+  assert_approx_equals(animation.overallProgress, 1, 0.01,
+    'overallProgress is one');
 
   animation.startTime = document.timeline.currentTime - 20 * MS_PER_SEC;
   assert_greater_than(animation.currentTime, 0, 'currentTime greater than zero');
-  assert_approx_equals(animation.overallProgress, 1, 0.01, 'overallProgress is one');
-}, "overallProgress of an animation whose effect's endTime is zero is one if its " +
-   "currentTime is non-negative.");
+  assert_approx_equals(animation.overallProgress, 1, 0.01,
+    'overallProgress is one');
+}, "overallProgress of an animation whose effect's endTime is zero is one if " +
+   "its currentTime is non-negative.");
 
 test(t => {
   const animation = new Animation(new KeyframeEffect(createDiv(t), null,
@@ -56,7 +63,8 @@ test(t => {
 
   animation.startTime = document.timeline.currentTime - 20 * MS_PER_SEC;
   assert_greater_than(animation.currentTime, 0, 'currentTime is positive');
-  assert_approx_equals(animation.overallProgress, 0, 0.01, 'overallProgress is zero');
+  assert_approx_equals(animation.overallProgress, 0, 0.01,
+    'overallProgress is zero');
 }, "overallProgress of an animation whose effect's endTime is infinity is zero.");
 
 test(t => {
@@ -66,16 +74,20 @@ test(t => {
 
   animation.startTime = document.timeline.currentTime - 50 * MS_PER_SEC;
   assert_time_equals_literal(animation.currentTime, 100 * MS_PER_SEC, 'currentTime is 100s');
-  assert_approx_equals(animation.overallProgress, 0.5, 0.01, 'overallProgress is zero');
+  assert_approx_equals(animation.overallProgress, 0.5, 0.01,
+    'overallProgress is zero');
 
   animation.startTime = document.timeline.currentTime - 100 * MS_PER_SEC;
   assert_time_equals_literal(animation.currentTime, 200 * MS_PER_SEC, 'currentTime is 200s');
-  assert_approx_equals(animation.overallProgress, 1, 0.01, 'overallProgress is one');
+  assert_approx_equals(animation.overallProgress, 1, 0.01,
+    'overallProgress is one');
 
   animation.startTime = document.timeline.currentTime - 150 * MS_PER_SEC;
   assert_time_equals_literal(animation.currentTime, 300 * MS_PER_SEC, 'currentTime is 300s');
-  assert_approx_equals(animation.overallProgress, 1, 0.01, 'overallProgress is still one');
-}, "overallProgress of an animation is calculated by currentTime / effect endTime.");
+  assert_approx_equals(animation.overallProgress, 1, 0.01,
+    'overallProgress is still one');
+}, "overallProgress of an animation is calculated by " +
+   "currentTime / effect endTime.");
 
 </script>
 </body>

--- a/web-animations/interfaces/Animation/scroll-timeline-overallProgress.tentative.html
+++ b/web-animations/interfaces/Animation/scroll-timeline-overallProgress.tentative.html
@@ -52,17 +52,18 @@ promise_test(async t => {
   // Verify initial start and current times once ready.
   assert_percents_equal(animation.currentTime, 0,
       "The current time is resolved when ready.");
-  assert_equals(animation.overallProgress, 0, "The overallProgress should be zero.");
+  assert_equals(animation.overallProgress, 0,
+    "The overallProgress should be zero.");
 
   scroller.scrollTop = 0.4 * maxScroll;
 
   await waitForNextFrame();
   assert_percents_equal(animation.currentTime, 40,
-      "currentTime reflects progress as a percentage");
+      "currentTime reflects overallProgress as a percentage");
   assert_approx_equals(animation.overallProgress, 0.4, 0.01,
       "The overallProgress should match the scroll progress.");
-}, "animation.overallProgress reflects the progress of a scroll animation as a "+
-   "number between 0 and 1");
+}, "animation.overallProgress reflects the progress of a scroll animation as " +
+   "a number between 0 and 1");
 
 promise_test(async t => {
   const animation = createScrollLinkedAnimation(t);
@@ -74,13 +75,14 @@ promise_test(async t => {
   // Verify initial start and current times once ready.
   assert_percents_equal(animation.currentTime, 0,
       "The current time is resolved when ready.");
-  assert_equals(animation.overallProgress, 0, "The overallProgress should be zero.");
+  assert_equals(animation.overallProgress, 0,
+    "The overallProgress should be zero.");
 
   scroller.scrollTop = 0.4 * maxScroll;
   await waitForNextFrame();
 
   let timing = animation.effect.getComputedTiming();
-  // iteration duration should be 100%, progress should reflect 40%.
+  // iteration duration should be 100%, overallProgress should reflect 40%.
   assert_percents_equal(timing.duration, 100);
   assert_percents_equal(animation.currentTime, 40,
       "currentTime reflects progress as a percentage");
@@ -91,14 +93,14 @@ promise_test(async t => {
   animation.effect.updateTiming({ iterations: 2 });
 
   timing = animation.effect.getComputedTiming();
-  // iteration duration should be 50%, progress should still reflect 40%
+  // iteration duration should be 50%, overallProgress should still reflect 40%
   // as it measures currentTime / effect endTime.
   assert_percents_equal(timing.duration, 50);
   assert_percents_equal(animation.currentTime, 40,
       "currentTime reflects progress as a percentage");
   assert_approx_equals(animation.overallProgress, 0.4, 0.01,
-      "The overallProgress should match the scroll progress.");
-}, "animation.overallProgress reflects the overall progress of a scroll animation " +
+      "The overallProgress is should match the scroll progress.");
+}, "animation.overallProgress reflects the overall progress of a scroll " +
    "with multiple iterations.");
 
 promise_test(async t => {
@@ -127,9 +129,10 @@ promise_test(async t => {
   assert_percents_equal(animation.currentTime, expected_current_time,
       "currentTime reflects progress as a percentage");
   assert_approx_equals(animation.overallProgress, target_pct / 100, 0.01,
-    "overallProgress should reflect fraction of view timeline range scroll through.");
-}, "animation.overallProgress reflects the overall progress of a scroll animation " +
-   "that uses a view-timeline.");
+    "overallProgress should reflect fraction of view timeline range scroll "
+    + "through.");
+}, "animation.overallProgress reflects the overall progress of a scroll "
+   + "that uses a view-timeline.");
 
 promise_test(async t => {
   const scroller = createScroller(t);
@@ -151,16 +154,16 @@ promise_test(async t => {
   await waitForNextFrame();
   let timing = animation.effect.getComputedTiming();
   assert_less_than(animation.currentTime.value, 0, "currentTime is negative");
-  assert_approx_equals(animation.overallProgress, 0, 0.01, "overallProgress is zero when " +
-    "scroll offset is less than range start.");
+  assert_approx_equals(animation.overallProgress, 0, 0.01, "overallProgress " +
+    "is zero when scroll offset is less than range start.");
 
   scroller.scrollTop = 200;
   await waitForNextFrame();
   assert_approx_equals(animation.currentTime.value, timing.endTime.value, 0.01,
     "currentTime has reached endTime");
-  assert_approx_equals(animation.overallProgress, 1, 0.01, "overallProgress is one when " +
-    "scroll offset goes past than range end.");
-}, "overallProgresss of a view-timeline is bounded between 0 and 1.");
+  assert_approx_equals(animation.overallProgress, 1, 0.01, "overallProgress " +
+    "is one when scroll offset goes past than range end.");
+}, "overallProgress of a view-timeline is bounded between 0 and 1.");
 
 </script>
 </body>


### PR DESCRIPTION
In line with the CSS working group resolution in #8799[1], this patch renames Animation.progress in to Animation.overallProgress in Blink.

[1] https://github.com/w3c/csswg-drafts/issues/8799#issuecomment-2461097047

Bug: 40914396
Change-Id: Ie7605f59d99314158b77e9672dbe98a564d2d1e6
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6049834
Commit-Queue: David Awogbemila <awogbemila@chromium.org>
Reviewed-by: Robert Flack <flackr@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1387916}