### PR TITLE
Improve reporting of harness errors in ShadowRealm tests

### DIFF
--- a/resources/testharness-shadowrealm-outer.js
+++ b/resources/testharness-shadowrealm-outer.js
@@ -125,3 +125,22 @@ globalThis.setupFakeFetchOverMessagePort = function (port) {
   });
   port.start();
 }
+
+/**
+ * Returns a message suitable for posting with postMessage() that will signal to
+ * the test harness that the tests are finished and there was an error in the
+ * setup code.
+ *
+ * @param {message} string - error message
+ */
+globalThis.createSetupErrorResult = function (message) {
+  return {
+    type: "complete",
+    tests: [],
+    asserts: [],
+    status: {
+      status: 1, // TestsStatus.ERROR,
+      message,
+    },
+  };
+};

--- a/resources/testharness-shadowrealm-outer.js
+++ b/resources/testharness-shadowrealm-outer.js
@@ -5,6 +5,9 @@
  * Convenience function for evaluating some async code in the ShadowRealm and
  * waiting for the result.
  *
+ * In case of error, this function intentionally exposes the stack trace (if it
+ * is available) to the hosting realm, for debugging purposes.
+ *
  * @param {ShadowRealm} realm - the ShadowRealm to evaluate the code in
  * @param {string} asyncBody - the code to evaluate; will be put in the body of
  *   an async function, and must return a value explicitly if a value is to be
@@ -15,7 +18,7 @@ globalThis.shadowRealmEvalAsync = function (realm, asyncBody) {
     (resolve, reject) => {
       (async () => {
         ${asyncBody}
-      })().then(resolve, (e) => reject(e.toString()));
+      })().then(resolve, (e) => reject(e.toString() + "\\n" + (e.stack || "")));
     }
   `));
 };

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -452,7 +452,7 @@ class ShadowRealmInWindowHandler(HtmlWrapperHandler):
 
   await fetch_tests_from_shadow_realm(r);
   done();
-})();
+})().catch(e => setup(() => { throw e; }));
 </script>
 """
 
@@ -504,7 +504,7 @@ class ShadowRealmInShadowRealmHandler(HtmlWrapperHandler):
   `);
   await fetch_tests_from_shadow_realm(outer);
   done();
-})();
+})().catch(e => setup(() => { throw e; }));
 </script>
 """
 

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -625,23 +625,27 @@ class ShadowRealmWorkerWrapperHandler(BaseWorkerHandler):
     wrapper = """%(meta)s
 importScripts("/resources/testharness-shadowrealm-outer.js");
 (async function() {
-  const r = new ShadowRealm();
-  await shadowRealmEvalAsync(r, `
-    await import("/resources/testharness-shadowrealm-inner.js");
-    await import("/resources/testharness.js");
-  `);
-  r.evaluate("setShadowRealmGlobalProperties")("%(query)s", fetchAdaptor);
-
-  await shadowRealmEvalAsync(r, `
-    %(script)s
-    await import("%(path)s");
-  `);
-
   const postMessageFunc = await getPostMessageFunc();
-  function forwardMessage(msgJSON) {
-    postMessageFunc(JSON.parse(msgJSON));
+  try {
+    const r = new ShadowRealm();
+    await shadowRealmEvalAsync(r, `
+      await import("/resources/testharness-shadowrealm-inner.js");
+      await import("/resources/testharness.js");
+    `);
+    r.evaluate("setShadowRealmGlobalProperties")("%(query)s", fetchAdaptor);
+
+    await shadowRealmEvalAsync(r, `
+      %(script)s
+      await import("%(path)s");
+    `);
+
+    function forwardMessage(msgJSON) {
+      postMessageFunc(JSON.parse(msgJSON));
+    }
+    r.evaluate('begin_shadow_realm_tests')(forwardMessage);
+  } catch (e) {
+    postMessageFunc(createSetupErrorResult(e));
   }
-  r.evaluate('begin_shadow_realm_tests')(forwardMessage);
 })();
 """
 
@@ -655,25 +659,29 @@ class ShadowRealmServiceWorkerWrapperHandler(BaseWorkerHandler):
 importScripts("/resources/testharness-shadowrealm-outer.js");
 
 (async function () {
-  const r = new ShadowRealm();
-  setupFakeDynamicImportInShadowRealm(r, fetchAdaptor);
-
-  await shadowRealmEvalAsync(r, `
-    await fakeDynamicImport("/resources/testharness-shadowrealm-inner.js");
-    await fakeDynamicImport("/resources/testharness.js");
-  `);
-  r.evaluate("setShadowRealmGlobalProperties")("%(query)s", fetchAdaptor);
-
-  await shadowRealmEvalAsync(r, `
-    %(script)s
-    await fakeDynamicImport("%(path)s");
-  `);
-
   const postMessageFunc = await getPostMessageFunc();
-  function forwardMessage(msgJSON) {
-    postMessageFunc(JSON.parse(msgJSON));
+  try {
+    const r = new ShadowRealm();
+    setupFakeDynamicImportInShadowRealm(r, fetchAdaptor);
+
+    await shadowRealmEvalAsync(r, `
+      await fakeDynamicImport("/resources/testharness-shadowrealm-inner.js");
+      await fakeDynamicImport("/resources/testharness.js");
+    `);
+    r.evaluate("setShadowRealmGlobalProperties")("%(query)s", fetchAdaptor);
+
+    await shadowRealmEvalAsync(r, `
+      %(script)s
+      await fakeDynamicImport("%(path)s");
+    `);
+
+    function forwardMessage(msgJSON) {
+      postMessageFunc(JSON.parse(msgJSON));
+    }
+    r.evaluate("begin_shadow_realm_tests")(forwardMessage);
+  } catch (e) {
+    postMessageFunc(createSetupErrorResult(e));
   }
-  r.evaluate("begin_shadow_realm_tests")(forwardMessage);
 })();
 """
 
@@ -685,26 +693,30 @@ class ShadowRealmAudioWorkletWrapperHandler(BaseWorkerHandler):
     path_replace = [(".any.audioworklet-shadowrealm.js", ".any.js")]
     wrapper = """%(meta)s
 TestRunner.prototype.createShadowRealmAndStartTests = async function() {
-  const queryPart = import.meta.url.split('?')[1];
-  const locationSearch = queryPart ? '?' + queryPart : '';
+  try {
+    const queryPart = import.meta.url.split('?')[1];
+    const locationSearch = queryPart ? '?' + queryPart : '';
 
-  const r = new ShadowRealm();
-  const adaptor = this.fetchOverPortExecutor.bind(this);
-  setupFakeDynamicImportInShadowRealm(r, adaptor);
+    const r = new ShadowRealm();
+    const adaptor = this.fetchOverPortExecutor.bind(this);
+    setupFakeDynamicImportInShadowRealm(r, adaptor);
 
-  await shadowRealmEvalAsync(r, `
-    await fakeDynamicImport("/resources/testharness-shadowrealm-inner.js");
-    await fakeDynamicImport("/resources/testharness.js");
-  `);
-  r.evaluate("setShadowRealmGlobalProperties")(locationSearch, adaptor);
+    await shadowRealmEvalAsync(r, `
+      await fakeDynamicImport("/resources/testharness-shadowrealm-inner.js");
+      await fakeDynamicImport("/resources/testharness.js");
+    `);
+    r.evaluate("setShadowRealmGlobalProperties")(locationSearch, adaptor);
 
-  await shadowRealmEvalAsync(r, `
-    %(script)s
-    await fakeDynamicImport("%(path)s");
-  `);
-  const forwardMessage = (msgJSON) =>
-    this.port.postMessage(JSON.parse(msgJSON));
-  r.evaluate("begin_shadow_realm_tests")(forwardMessage);
+    await shadowRealmEvalAsync(r, `
+      %(script)s
+      await fakeDynamicImport("%(path)s");
+    `);
+    const forwardMessage = (msgJSON) =>
+      this.port.postMessage(JSON.parse(msgJSON));
+    r.evaluate("begin_shadow_realm_tests")(forwardMessage);
+  } catch (e) {
+    this.port.postMessage(createSetupErrorResult(e));
+  }
 }
 """
 


### PR DESCRIPTION
- Better error reporting when setup code fails or an exception is thrown outside a test
- ShadowRealm-in-Worker/AudioWorklet tests fail immediately instead of timing out in that case