### PR TITLE
fixes background-size tests for two values serialization

### DIFF
--- a/css/css-backgrounds/background-332.html
+++ b/css/css-backgrounds/background-332.html
@@ -32,7 +32,7 @@
 
         test(function() {
             assert_equals(cs.getPropertyValue("background-size"),
-                "160px", "background specified value for background-size");
+                "160px auto", "background specified value for background-size");
         }, "background_specified_size");
 
         test(function() {

--- a/css/css-backgrounds/background-size-001.html
+++ b/css/css-backgrounds/background-size-001.html
@@ -39,43 +39,43 @@
         document.getElementById("test").style.backgroundSize = "0px";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "0px", "background-size supporting value");
+                "0px auto", "background-size supporting value");
         }, "background-size_length_zero");
 
         document.getElementById("test").style.backgroundSize = "-0px";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "0px", "background-size supporting value");
+                "0px auto", "background-size supporting value");
         }, "background-size_length_negative_zero");
 
         document.getElementById("test").style.backgroundSize = "+0px";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "0px", "background-size supporting value");
+                "0px auto", "background-size supporting value");
         }, "background-size_length_positive_zero");
 
         document.getElementById("test").style.backgroundSize = "15px";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "15px", "background-size supporting value");
+                "15px auto", "background-size supporting value");
         }, "background-size_length_normal");
 
         document.getElementById("test").style.backgroundSize = "0%";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "0%", "background-size supporting value");
+                "0% auto", "background-size supporting value");
         }, "background-size_percentage_min");
 
         document.getElementById("test").style.backgroundSize = "50%";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "50%", "background-size supporting value");
+                "50% auto", "background-size supporting value");
         }, "background-size_percentage_normal");
 
         document.getElementById("test").style.backgroundSize = "100%";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "100%", "background-size supporting value");
+                "100% auto", "background-size supporting value");
         }, "background-size_percentage_max");
 
         document.getElementById("test").style.backgroundSize = "auto auto";
@@ -99,7 +99,7 @@
         document.getElementById("test").style.backgroundSize = "15px auto";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "15px", "background-size supporting value");
+                "15px auto", "background-size supporting value");
         }, "background-size_length_auto");
 
         document.getElementById("test").style.backgroundSize = "15px 15px";
@@ -117,7 +117,7 @@
         document.getElementById("test").style.backgroundSize = "50% auto";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "50%", "background-size supporting value");
+                "50% auto", "background-size supporting value");
         }, "background-size_percentage_auto");
 
         document.getElementById("test").style.backgroundSize = "50% 15px";


### PR DESCRIPTION
This is fixing some WPT tests related to background-size results being serialized as two values, which is the new behavior of WebKit.
    Some tests currently contradict themselves on WPT.
    http://wpt.live/css/css-backgrounds/background-size-001.html
    https://wpt.live/css/css-backgrounds/parsing/background-size-computed.html
    
So this PR makes it uniform and changes the expectation files.
    
This is dependent on a resolution from the CSS WG about the two values system. https://github.com/w3c/csswg-drafts/issues/7802