### PR TITLE
ShadowRealm tests for WASM ESM integration

### DIFF
--- a/wasm/webapi/esm-integration/dynamic-import.tentative.any.js
+++ b/wasm/webapi/esm-integration/dynamic-import.tentative.any.js
@@ -1,0 +1,129 @@
+// META: title=WebAssembly ESM integration with dynamic import
+// META: global=window,dedicatedworker,shadowrealm-in-window,shadowrealm-in-shadowrealm,shadowrealm-in-dedicatedworker,shadowrealm-in-sharedworker
+
+// Tests the same things as the *.tentative.html tests in this folder (excluding
+// CSP and source phase imports), but with dynamic import and in multiple
+// globals
+
+"use strict";
+
+promise_test(async () => {
+  globalThis.log = [];
+  await import("./resources/execute-start.wasm");
+  assert_array_equals(globalThis.log, ["executed"],
+    "Imported array should be written to");
+}, "Check execution of WebAssembly start function");
+
+promise_test(async () => {
+  const mod = await import("./resources/exported-names.wasm");
+  assert_array_equals(Object.getOwnPropertyNames(mod).sort(),
+    ["func", "glob", "mem", "tab"],
+    "Exports should be correct");
+  assert_true(mod.func instanceof Function, "func export should be a Function");
+  assert_true(mod.mem instanceof WebAssembly.Memory,
+    "mem export should be a WebAssembly.Memory");
+  assert_true(mod.glob instanceof WebAssembly.Global,
+    "glob export should be a WebAssembly.Global");
+  assert_true(mod.tab instanceof WebAssembly.Table,
+    "tab export should be a WebAssembly.Table");
+  assert_throws_js(TypeError, () => { mod.func = 2; },
+    "Export should be non-writable (throws in strict mode)");
+}, "Exported names from a WebAssembly module");
+
+promise_test(async t => {
+  await promise_rejects_js(t, WebAssembly.CompileError,
+    import("./resources/invalid-bytecode.wasm"),
+    "Importing module with invalid bytecode should throw CompileError");
+}, "Handling of importing a WebAssembly module with invalid bytecode");
+
+promise_test(async t => {
+  await promise_rejects_js(t, WebAssembly.LinkError,
+    import("./resources/js-wasm-cycle-value.js"),
+    "value");
+  await promise_rejects_js(t, WebAssembly.LinkError,
+    import("./resources/js-wasm-cycle-global.js"),
+    "global");
+  await promise_rejects_js(t, WebAssembly.LinkError,
+    import("./resources/js-wasm-cycle-memory.js"),
+    "memory");
+  await promise_rejects_js(t, WebAssembly.LinkError,
+    import("./resources/js-wasm-cycle-table.js"),
+    "table");
+  await promise_rejects_js(t, WebAssembly.LinkError,
+    import("./resources/js-wasm-cycle-function-error.js"),
+    "function error");
+}, "Cyclic linking between JavaScript and WebAssembly (JS higher)");
+
+promise_test(async () => {
+  const { f } = await import("./resources/js-wasm-cycle.js");
+  assert_equals(f(), 24, "exported function f");
+}, "Check bindings in JavaScript and WebAssembly cycle (JS higher)");
+
+promise_test(async t => {
+  await promise_rejects_js(t, WebAssembly.CompileError,
+    import("./resources/invalid-module.wasm"),
+    "Importing invalid module should throw CompileError");
+}, "Handling of importing an invalid WebAssembly module");
+
+promise_test(async t => {
+  await promise_rejects_js(t, SyntaxError,
+    import("./resolve-export.js"),
+    "Re-export of missing Wasm export should result in SyntaxError.");
+}, "Check ResolveExport on invalid re-export from WebAssembly");
+
+promise_test(async () => {
+  globalThis.log = [];
+  const { logExec } = await import("./resources/wasm-import-from-wasm.wasm");
+  logExec();
+  assert_array_equals(globalThis.log, ["executed"],
+    "Imported array should be written to");
+}, "Check import and export between WebAssembly modules");
+
+promise_test(async t => {
+  await promise_rejects_js(t, WebAssembly.LinkError,
+    import("./resources/wasm-import-func.wasm"),
+    "func");
+  await promise_rejects_js(t, WebAssembly.LinkError,
+    import("./resources/wasm-import-memory.wasm"),
+    "memory");
+  await promise_rejects_js(t, WebAssembly.LinkError,
+    import("./resources/wasm-import-table.wasm"),
+    "table");
+  await promise_rejects_js(t, WebAssembly.LinkError,
+    import("./resources/wasm-import-global.wasm"),
+    "global");
+}, "Errors for imports of WebAssembly modules");
+
+promise_test(async () => {
+  const wasm = await import("./resources/wasm-js-cycle.wasm");
+  const js = await import("./resources/wasm-js-cycle.js");
+
+  js.mutateBindings();
+
+  assert_true(wasm.wasmGlob instanceof WebAssembly.Global,
+    "wasmGlob should be a WebAssembly.Global");
+  assert_equals(wasm.wasmGlob.valueOf(), 24, "wasmGlob valueOf()");
+
+  assert_true(wasm.wasmFunc instanceof Function,
+    "wasmFunc should be a Function");
+  assert_equals(wasm.wasmFunc(), 43, "wasmFunc return value");
+
+  assert_equals(wasm.incrementGlob(), 43, "incrementGlob return value");
+
+  const buf = new Int32Array(wasm.wasmMem.buffer);
+  assert_equals(buf[0], 0, "wasmMem buffer first element");
+  assert_equals(wasm.mutateMem(), 42, "mutateMem return value");
+  assert_equals(buf[0], 42, "wasmMem buffer mutated first element");
+
+  assert_equals(wasm.wasmTab.get(0), null, "wasmTab 0");
+  const ref = wasm.mutateTab();
+  assert_true(ref instanceof Function,
+    "mutateTab return value should be a Function");
+  assert_equals(wasm.wasmTab.get(0), ref, "wasmTab mutated 0");
+}, "Check bindings in JavaScript and WebAssembly cycle (Wasm higher)");
+
+promise_test(async t => {
+  await promise_rejects_js(t, WebAssembly.LinkError,
+    import("./resources/wasm-import-error-from-wasm.wasm"),
+    "should throw LinkError");
+}, "Errors for linking WebAssembly module scripts");

--- a/wasm/webapi/esm-integration/dynamic-source-phase-imports.tentative.any.js
+++ b/wasm/webapi/esm-integration/dynamic-source-phase-imports.tentative.any.js
@@ -1,0 +1,38 @@
+// META: title=WebAssembly ESM integration with dynamic source phase imports
+// META: global=window,dedicatedworker,shadowrealm-in-window,shadowrealm-in-shadowrealm,shadowrealm-in-dedicatedworker,shadowrealm-in-sharedworker
+
+// Tests the same things as source-phase.tentative.html in this folder, but with
+// dynamic import and in multiple globals
+
+promise_test(async () => {
+  const exportedNamesSource = await import.source("./resources/exported-names.wasm");
+  assert_true(exportedNamesSource instanceof WebAssembly.Module,
+    "Source import should be a WebAssembly.Module");
+
+  const AbstractModuleSource = Object.getPrototypeOf(WebAssembly.Module);
+  assert_equals(AbstractModuleSource.name, "AbstractModuleSource",
+    "AbstractModuleSource name property");
+  assert_true(exportedNamesSource instanceof AbstractModuleSource,
+    "Source import should be an AbstractModuleSource");
+
+  assert_array_equals(WebAssembly.Module.exports(exportedNamesSource).map(({ name }) => name).sort(),
+    ["func", "glob", "mem", "tab"],
+    "Exports should be correct");
+}, "Exported names");
+
+promise_test(async () => {
+  const wasmImportFromWasmSource = await import.source("./resources/wasm-import-from-wasm.wasm");
+  assert_true(wasmImportFromWasmSource instanceof WebAssembly.Module,
+    "Source import should be a WebAssembly.Module");
+
+  let logged = false;
+  const instance = await WebAssembly.instantiate(wasmImportFromWasmSource, {
+    "./wasm-export-to-wasm.wasm": {
+      log() {
+        logged = true;
+      }
+    }
+  });
+  instance.exports.logExec();
+  assert_true(logged, "Calls into JS import");
+}, "Instantiated module");

--- a/wasm/webapi/esm-integration/execute-start.tentative.html
+++ b/wasm/webapi/esm-integration/execute-start.tentative.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <title>Check execution of WebAssembly start function</title>
+<!-- See dynamic-import.tentative.any.js for the dynamic version of this -->
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/wasm/webapi/esm-integration/exported-names.tentative.html
+++ b/wasm/webapi/esm-integration/exported-names.tentative.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <title>Exported names from a WebAssembly module</title>
+<!-- See dynamic-import.tentative.any.js for the dynamic version of this -->
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/wasm/webapi/esm-integration/invalid-bytecode.tentative.html
+++ b/wasm/webapi/esm-integration/invalid-bytecode.tentative.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <title>Handling of importing WebAssembly module with invalid bytecode</title>
+<!-- See dynamic-import.tentative.any.js for the dynamic version of this -->
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/wasm/webapi/esm-integration/invalid-bytecode.tentative.html
+++ b/wasm/webapi/esm-integration/invalid-bytecode.tentative.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Handling of importing invalid WebAssembly modules</title>
+<title>Handling of importing WebAssembly module with invalid bytecode</title>
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -11,14 +11,12 @@
     window.addEventListener("error", ev => log.push(ev.error));
 
     const test_load = async_test(
-        "Test that imports of invalid WebAssembly modules leads to WebAssembly.CompileError on window.");
+        "Test that import of WebAssembly module with invalid bytecode leads to WebAssembly.CompileError on window.");
     window.addEventListener("load", test_load.step_func_done(ev => {
-      assert_equals(log.length, 2);
+      assert_equals(log.length, 1);
       assert_equals(log[0].constructor, WebAssembly.CompileError);
-      assert_equals(log[1].constructor, WebAssembly.CompileError);
     }));
 
     function unreachable() { log.push("unexpected"); }
 </script>
 <script type="module" src="./resources/invalid-bytecode.wasm" onerror="unreachable()"></script>
-<script type="module" src="./resources/invalid-module.wasm" onerror="unreachable()"></script>

--- a/wasm/webapi/esm-integration/js-wasm-cycle-errors.tentative.html
+++ b/wasm/webapi/esm-integration/js-wasm-cycle-errors.tentative.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <title>Cyclic linking between JavaScript and WebAssembly (JS higher)</title>
+<!-- See dynamic-import.tentative.any.js for the dynamic version of this -->
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/wasm/webapi/esm-integration/js-wasm-cycle.tentative.html
+++ b/wasm/webapi/esm-integration/js-wasm-cycle.tentative.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <title>Check bindings in JavaScript and WebAssembly cycle (JS higher)</title>
+<!-- See dynamic-import.tentative.any.js for the dynamic version of this -->
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/wasm/webapi/esm-integration/module-parse-error.tentative.html
+++ b/wasm/webapi/esm-integration/module-parse-error.tentative.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <title>Handling of importing invalid WebAssembly module</title>
+<!-- See dynamic-import.tentative.any.js for the dynamic version of this -->
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/wasm/webapi/esm-integration/module-parse-error.tentative.html
+++ b/wasm/webapi/esm-integration/module-parse-error.tentative.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Handling of importing invalid WebAssembly modules</title>
+<title>Handling of importing invalid WebAssembly module</title>
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -11,14 +11,12 @@
     window.addEventListener("error", ev => log.push(ev.error));
 
     const test_load = async_test(
-        "Test that imports of invalid WebAssembly modules leads to WebAssembly.CompileError on window.");
+        "Test that import of invalid WebAssembly module leads to WebAssembly.CompileError on window.");
     window.addEventListener("load", test_load.step_func_done(ev => {
-      assert_equals(log.length, 2);
+      assert_equals(log.length, 1);
       assert_equals(log[0].constructor, WebAssembly.CompileError);
-      assert_equals(log[1].constructor, WebAssembly.CompileError);
     }));
 
     function unreachable() { log.push("unexpected"); }
 </script>
-<script type="module" src="./resources/invalid-bytecode.wasm" onerror="unreachable()"></script>
 <script type="module" src="./resources/invalid-module.wasm" onerror="unreachable()"></script>

--- a/wasm/webapi/esm-integration/resolve-export.tentative.html
+++ b/wasm/webapi/esm-integration/resolve-export.tentative.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <title>Check ResolveExport on invalid re-export from WebAssembly</title>
+<!-- See dynamic-import.tentative.any.js for the dynamic version of this -->
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/wasm/webapi/esm-integration/source-phase.tentative.html
+++ b/wasm/webapi/esm-integration/source-phase.tentative.html
@@ -1,5 +1,7 @@
 <!doctype html>
 <title>Source phase imports</title>
+<!-- See dynamic-source-phase-imports.tentative.any.js for the dynamic version
+ of this -->
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/wasm/webapi/esm-integration/wasm-import-wasm-export.tentative.html
+++ b/wasm/webapi/esm-integration/wasm-import-wasm-export.tentative.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <title>Check import and export between WebAssembly modules</title>
+<!-- See dynamic-import.tentative.any.js for the dynamic version of this -->
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/wasm/webapi/esm-integration/wasm-import.tentative.html
+++ b/wasm/webapi/esm-integration/wasm-import.tentative.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <title>Errors for imports of WebAssembly modules</title>
+<!-- See dynamic-import.tentative.any.js for the dynamic version of this -->
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/wasm/webapi/esm-integration/wasm-js-cycle.tentative.html
+++ b/wasm/webapi/esm-integration/wasm-js-cycle.tentative.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <title>Check bindings in JavaScript and WebAssembly cycle (Wasm higher)</title>
+<!-- See dynamic-import.tentative.any.js for the dynamic version of this -->
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/wasm/webapi/esm-integration/wasm-to-wasm-link-error.tentative.html
+++ b/wasm/webapi/esm-integration/wasm-to-wasm-link-error.tentative.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <title>Errors for linking WebAssembly module scripts</title>
+<!-- See dynamic-import.tentative.any.js for the dynamic version of this -->
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>


### PR DESCRIPTION
Adds dynamic import versions of the existing ESM integration tests, as `.any.js` tests so they can be tested in ShadowRealm scopes.

Also fixes an existing duplicate test that probably wasn't supposed to be duplicate.