### PR TITLE
[wdspec] introduce assert_partition_key helper for storage

### DIFF
--- a/webdriver/tests/bidi/storage/__init__.py
+++ b/webdriver/tests/bidi/storage/__init__.py
@@ -96,3 +96,11 @@ async def get_default_partition_key(bidi_session, context=None):
     else:
         result = await bidi_session.storage.get_cookies(partition=BrowsingContextPartitionDescriptor(context))
     return result['partitionKey']
+
+
+async def assert_partition_key(bidi_session, actual, expected = {}, context=None):
+    expected = {
+        **(await get_default_partition_key(bidi_session, context)),
+        **expected
+    }
+    recursive_compare(expected, actual)

--- a/webdriver/tests/bidi/storage/delete_cookies/filter.py
+++ b/webdriver/tests/bidi/storage/delete_cookies/filter.py
@@ -5,9 +5,9 @@ from webdriver.bidi.modules.storage import CookieFilter
 from . import assert_cookies_are_not_present
 from .. import (
     assert_cookie_is_set,
+    assert_partition_key,
     create_cookie,
     format_expiry_string,
-    get_default_partition_key,
     generate_expiry_date,
 )
 
@@ -52,9 +52,7 @@ async def test_filter(
     result = await bidi_session.storage.delete_cookies(
         filter=filter,
     )
-    assert result == {
-        "partitionKey": (await get_default_partition_key(bidi_session))
-    }
+    await assert_partition_key(bidi_session, actual=result["partitionKey"])
 
     # Make sure that deleted cookies are not present.
     await assert_cookies_are_not_present(bidi_session, filter)
@@ -103,9 +101,7 @@ async def test_filter_domain(
     result = await bidi_session.storage.delete_cookies(
         filter=filter,
     )
-    assert result == {
-        "partitionKey": (await get_default_partition_key(bidi_session))
-    }
+    await assert_partition_key(bidi_session, actual=result["partitionKey"])
 
     # Make sure that deleted cookies are not present.
     await assert_cookies_are_not_present(bidi_session, filter)
@@ -179,9 +175,7 @@ async def test_filter_expiry(
     result = await bidi_session.storage.delete_cookies(
         filter=CookieFilter(expiry=expiry_to_delete),
     )
-    assert result == {
-        "partitionKey": (await get_default_partition_key(bidi_session))
-    }
+    await assert_partition_key(bidi_session, actual=result["partitionKey"])
 
     # Make sure that deleted cookies are not present.
     await assert_cookies_are_not_present(bidi_session, filter)
@@ -225,9 +219,7 @@ async def test_filter_name(bidi_session, new_tab, test_page, add_cookie, domain_
     result = await bidi_session.storage.delete_cookies(
         filter=filter,
     )
-    assert result == {
-        "partitionKey": (await get_default_partition_key(bidi_session))
-    }
+    await assert_partition_key(bidi_session, actual=result["partitionKey"])
 
     # Make sure that deleted cookies are not present.
     await assert_cookies_are_not_present(bidi_session, filter)
@@ -294,9 +286,7 @@ async def test_filter_same_site(
     result = await bidi_session.storage.delete_cookies(
         filter=filter,
     )
-    assert result == {
-        "partitionKey": (await get_default_partition_key(bidi_session))
-    }
+    await assert_partition_key(bidi_session, actual=result["partitionKey"])
 
     # Make sure that deleted cookies are not present.
     await assert_cookies_are_not_present(bidi_session, filter)
@@ -358,9 +348,7 @@ async def test_filter_secure(
     result = await bidi_session.storage.delete_cookies(
         filter=filter,
     )
-    assert result == {
-        "partitionKey": (await get_default_partition_key(bidi_session))
-    }
+    await assert_partition_key(bidi_session, actual=result["partitionKey"])
 
     # Make sure that deleted cookies are not present.
     await assert_cookies_are_not_present(bidi_session, filter)
@@ -425,9 +413,7 @@ async def test_filter_path(
     result = await bidi_session.storage.delete_cookies(
         filter=filter,
     )
-    assert result == {
-        "partitionKey": (await get_default_partition_key(bidi_session))
-    }
+    await assert_partition_key(bidi_session, actual=result["partitionKey"])
 
     # Make sure that deleted cookies are not present.
     await assert_cookies_are_not_present(bidi_session, filter)
@@ -497,9 +483,7 @@ async def test_filter_http_only(
     result = await bidi_session.storage.delete_cookies(
         filter=filter,
     )
-    assert result == {
-        "partitionKey": (await get_default_partition_key(bidi_session))
-    }
+    await assert_partition_key(bidi_session, actual=result["partitionKey"])
 
     # Make sure that deleted cookies are not present.
     await assert_cookies_are_not_present(bidi_session, filter)

--- a/webdriver/tests/bidi/storage/delete_cookies/partition.py
+++ b/webdriver/tests/bidi/storage/delete_cookies/partition.py
@@ -8,8 +8,7 @@ from webdriver.bidi.modules.storage import (
 )
 
 from . import assert_cookies_are_not_present
-from .. import assert_cookie_is_set, create_cookie, get_default_partition_key
-from ... import recursive_compare
+from .. import assert_cookie_is_set, create_cookie, assert_partition_key
 
 pytestmark = pytest.mark.asyncio
 
@@ -63,9 +62,7 @@ async def test_default_partition(
         )
 
     result = await bidi_session.storage.delete_cookies()
-    assert result == {
-        "partitionKey": (await get_default_partition_key(bidi_session))
-    }
+    await assert_partition_key(bidi_session, actual=result["partitionKey"])
 
     await assert_cookies_are_not_present(bidi_session)
 
@@ -104,7 +101,7 @@ async def test_partition_context(
         )
 
     result = await bidi_session.storage.delete_cookies(partition=partition)
-    assert result == {"partitionKey": (await get_default_partition_key(bidi_session, new_tab["context"]))}
+    await assert_partition_key(bidi_session, actual=result["partitionKey"], context=new_tab["context"])
 
     await assert_cookies_are_not_present(bidi_session, partition)
 
@@ -135,7 +132,7 @@ async def test_partition_context_iframe(
     )
 
     result = await bidi_session.storage.delete_cookies(partition=frame_partition)
-    assert result == {"partitionKey": (await get_default_partition_key(bidi_session, new_tab["context"]))}
+    await assert_partition_key(bidi_session, actual=result["partitionKey"], context=new_tab["context"])
 
     await assert_cookies_are_not_present(bidi_session, frame_partition)
 
@@ -199,12 +196,10 @@ async def test_partition_source_origin(
     )
 
     result = await bidi_session.storage.delete_cookies(partition=cookie1_partition)
-    assert result == {
-        "partitionKey": {
-            **(await get_default_partition_key(bidi_session)),
-            "sourceOrigin": cookie1_source_origin
-        }
-    }
+
+    await assert_partition_key(bidi_session, actual=result["partitionKey"], expected={
+        "sourceOrigin": cookie1_source_origin
+    }, context=new_tab["context"])
 
     await assert_cookies_are_not_present(bidi_session, partition=cookie1_partition)
 
@@ -287,12 +282,10 @@ async def test_partition_user_context(
     result = await bidi_session.storage.delete_cookies(
         partition=StorageKeyPartitionDescriptor(user_context=user_context_1)
     )
-    assert result == {
-        "partitionKey": {
-            **(await get_default_partition_key(bidi_session)),
-            "userContext": user_context_1
-        }
-    }
+
+    await assert_partition_key(bidi_session, actual=result["partitionKey"], expected={
+        "userContext": user_context_1
+    })
 
     # Make sure that deleted cookies are not present.
     await assert_cookies_are_not_present(bidi_session, partition=cookie1_partition)

--- a/webdriver/tests/bidi/storage/get_cookies/filter.py
+++ b/webdriver/tests/bidi/storage/get_cookies/filter.py
@@ -2,7 +2,7 @@ import pytest
 from webdriver.bidi.modules.network import NetworkBase64Value, NetworkStringValue
 from webdriver.bidi.modules.storage import CookieFilter
 
-from .. import create_cookie, format_expiry_string, get_default_partition_key, generate_expiry_date
+from .. import assert_partition_key, create_cookie, format_expiry_string, generate_expiry_date
 from ... import recursive_compare
 
 pytestmark = pytest.mark.asyncio
@@ -37,9 +37,7 @@ async def test_filter(
         filter=filter,
     )
 
-    assert cookies["partitionKey"] == {
-        **(await get_default_partition_key(bidi_session)),
-    }
+    await assert_partition_key(bidi_session, actual=cookies["partitionKey"])
     assert len(cookies["cookies"]) == 2
     # Provide consistent cookies order.
     (cookie_1, cookie_2) = sorted(cookies["cookies"], key=lambda c: c["name"])
@@ -104,9 +102,7 @@ async def test_filter_domain(
         filter=CookieFilter(domain=domain),
     )
 
-    assert cookies["partitionKey"] == {
-        **(await get_default_partition_key(bidi_session)),
-    }
+    await assert_partition_key(bidi_session, actual=cookies["partitionKey"])
     assert len(cookies["cookies"]) == 2
     # Provide consistent cookies order.
     (cookie_1, cookie_2) = sorted(cookies["cookies"], key=lambda c: c["name"])
@@ -195,9 +191,7 @@ async def test_filter_expiry(
         filter=CookieFilter(expiry=cookie1_expiry),
     )
 
-    assert cookies["partitionKey"] == {
-        **(await get_default_partition_key(bidi_session)),
-    }
+    await assert_partition_key(bidi_session, actual=cookies["partitionKey"])
     assert len(cookies["cookies"]) == 2
     # Provide consistent cookies order.
     (cookie_1, cookie_2) = sorted(cookies["cookies"], key=lambda c: c["name"])
@@ -309,9 +303,7 @@ async def test_filter_same_site(
         filter=CookieFilter(same_site=same_site_1),
     )
 
-    assert cookies["partitionKey"] == {
-        **(await get_default_partition_key(bidi_session)),
-    }
+    await assert_partition_key(bidi_session, actual=cookies["partitionKey"])
     assert len(cookies["cookies"]) == 2
     # Provide consistent cookies order.
     (cookie_1, cookie_2) = sorted(cookies["cookies"], key=lambda c: c["name"])
@@ -379,9 +371,7 @@ async def test_filter_secure(
         filter=CookieFilter(secure=secure_1),
     )
 
-    assert cookies["partitionKey"] == {
-        **(await get_default_partition_key(bidi_session)),
-    }
+    await assert_partition_key(bidi_session, actual=cookies["partitionKey"])
     assert len(cookies["cookies"]) == 2
     # Provide consistent cookies order.
     (cookie_1, cookie_2) = sorted(cookies["cookies"], key=lambda c: c["name"])
@@ -459,9 +449,7 @@ async def test_filter_path(
         filter=CookieFilter(path=path_1),
     )
 
-    assert cookies["partitionKey"] == {
-        **(await get_default_partition_key(bidi_session)),
-    }
+    await assert_partition_key(bidi_session, actual=cookies["partitionKey"])
     assert len(cookies["cookies"]) == 2
     (cookie_1, cookie_2) = sorted(cookies["cookies"], key=lambda c: c["name"])
     recursive_compare(
@@ -540,9 +528,7 @@ async def test_filter_http_only(
         filter=CookieFilter(http_only=http_only_1),
     )
 
-    assert cookies["partitionKey"] == {
-        **(await get_default_partition_key(bidi_session)),
-    }
+    await assert_partition_key(bidi_session, actual=cookies["partitionKey"])
     assert len(cookies["cookies"]) == 2
     (cookie_1, cookie_2) = sorted(cookies["cookies"], key=lambda c: c["name"])
     recursive_compare(

--- a/webdriver/tests/bidi/storage/get_cookies/partition.py
+++ b/webdriver/tests/bidi/storage/get_cookies/partition.py
@@ -6,7 +6,7 @@ from webdriver.bidi.modules.storage import (
     StorageKeyPartitionDescriptor,
 )
 
-from .. import create_cookie, get_default_partition_key
+from .. import assert_partition_key, create_cookie
 from ... import recursive_compare
 
 pytestmark = pytest.mark.asyncio
@@ -38,9 +38,7 @@ async def test_default_partition(
 
     cookies = await bidi_session.storage.get_cookies()
 
-    assert cookies["partitionKey"] == {
-        **(await get_default_partition_key(bidi_session)),
-    }
+    await assert_partition_key(bidi_session, actual=cookies["partitionKey"])
     assert len(cookies["cookies"]) == 2
     # Provide consistent cookies order.
     (cookie_1, cookie_2) = sorted(cookies["cookies"], key=lambda c: c["domain"])
@@ -103,10 +101,9 @@ async def test_partition_context(
         partition=BrowsingContextPartitionDescriptor(new_tab["context"])
     )
 
-    assert cookies["partitionKey"] == {
-        **(await get_default_partition_key(bidi_session, new_tab["context"])),
+    await assert_partition_key(bidi_session, actual=cookies["partitionKey"], expected={
         "userContext": "default"
-    }
+    }, context=new_tab["context"])
     assert len(cookies["cookies"]) == 1
     recursive_compare(
         {
@@ -127,10 +124,9 @@ async def test_partition_context(
         partition=BrowsingContextPartitionDescriptor(new_context["context"])
     )
 
-    assert cookies["partitionKey"] == {
-        **(await get_default_partition_key(bidi_session, new_context["context"])),
+    await assert_partition_key(bidi_session, actual=cookies["partitionKey"], expected={
         "userContext": user_context
-    }
+    }, context=new_context["context"])
     assert len(cookies["cookies"]) == 0
 
 

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_expiry.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_expiry.py
@@ -1,25 +1,23 @@
 import pytest
-from .. import assert_cookie_is_not_set, assert_cookie_is_set, create_cookie, get_default_partition_key
+from .. import assert_cookie_is_not_set, assert_partition_key, assert_cookie_is_set, create_cookie
 from datetime import datetime, timedelta
 import time
 
 pytestmark = pytest.mark.asyncio
 
 
-async def test_cookie_expiry_unset(bidi_session, set_cookie, test_page, domain_value):
+async def test_cookie_expiry_unset(bidi_session, set_cookie, domain_value):
     set_cookie_result = await set_cookie(
         cookie=create_cookie(
             domain=domain_value(),
             expiry=None))
 
-    assert set_cookie_result == {
-        'partitionKey': (await get_default_partition_key(bidi_session)),
-    }
+    await assert_partition_key(bidi_session, actual=set_cookie_result["partitionKey"])
 
     await assert_cookie_is_set(bidi_session, expiry=None, domain=domain_value())
 
 
-async def test_cookie_expiry_future(bidi_session, set_cookie, test_page, domain_value):
+async def test_cookie_expiry_future(bidi_session, set_cookie, domain_value):
     tomorrow = datetime.now() + timedelta(1)
     tomorrow_timestamp = time.mktime(tomorrow.timetuple())
 
@@ -28,14 +26,12 @@ async def test_cookie_expiry_future(bidi_session, set_cookie, test_page, domain_
             domain=domain_value(),
             expiry=tomorrow_timestamp))
 
-    assert set_cookie_result == {
-        'partitionKey': (await get_default_partition_key(bidi_session)),
-    }
+    await assert_partition_key(bidi_session, actual=set_cookie_result["partitionKey"])
 
     await assert_cookie_is_set(bidi_session, expiry=tomorrow_timestamp, domain=domain_value())
 
 
-async def test_cookie_expiry_past(bidi_session, set_cookie, test_page, domain_value):
+async def test_cookie_expiry_past(bidi_session, set_cookie, domain_value):
     yesterday = datetime.now() - timedelta(1)
     yesterday_timestamp = time.mktime(yesterday.timetuple())
 
@@ -44,8 +40,6 @@ async def test_cookie_expiry_past(bidi_session, set_cookie, test_page, domain_va
             domain=domain_value(),
             expiry=yesterday_timestamp))
 
-    assert set_cookie_result == {
-        'partitionKey': (await get_default_partition_key(bidi_session)),
-    }
+    await assert_partition_key(bidi_session, actual=set_cookie_result["partitionKey"])
 
     await assert_cookie_is_not_set(bidi_session)

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_http_only.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_http_only.py
@@ -1,5 +1,5 @@
 import pytest
-from .. import assert_cookie_is_set, create_cookie, get_default_partition_key
+from .. import assert_cookie_is_set, assert_partition_key, create_cookie
 
 pytestmark = pytest.mark.asyncio
 
@@ -15,9 +15,7 @@ async def test_cookie_http_only(bidi_session, set_cookie, test_page, domain_valu
     set_cookie_result = await set_cookie(
         cookie=create_cookie(domain=domain_value(), http_only=http_only))
 
-    assert set_cookie_result == {
-        'partitionKey': (await get_default_partition_key(bidi_session)),
-    }
+    await assert_partition_key(bidi_session, actual=set_cookie_result["partitionKey"])
 
     # `httpOnly` defaults to `false`.
     expected_http_only = http_only if http_only is not None else False

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_path.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_path.py
@@ -1,5 +1,5 @@
 import pytest
-from .. import assert_cookie_is_set, create_cookie, get_default_partition_key
+from .. import assert_cookie_is_set, assert_partition_key, create_cookie
 
 pytestmark = pytest.mark.asyncio
 
@@ -16,9 +16,7 @@ pytestmark = pytest.mark.asyncio
 async def test_cookie_path(bidi_session, test_page, set_cookie, domain_value, path):
     set_cookie_result = await set_cookie(cookie=create_cookie(domain=domain_value(), path=path))
 
-    assert set_cookie_result == {
-        'partitionKey': (await get_default_partition_key(bidi_session)),
-    }
+    await assert_partition_key(bidi_session, actual=set_cookie_result["partitionKey"])
 
     # `path` defaults to "/".
     expected_path = path if path is not None else "/"

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_same_site.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_same_site.py
@@ -1,5 +1,5 @@
 import pytest
-from .. import assert_cookie_is_set, create_cookie, get_default_partition_key
+from .. import assert_cookie_is_set, assert_partition_key, create_cookie
 
 pytestmark = pytest.mark.asyncio
 
@@ -17,9 +17,7 @@ async def test_cookie_secure(bidi_session, set_cookie, test_page, domain_value, 
     set_cookie_result = await set_cookie(
         cookie=create_cookie(domain=domain_value(), same_site=same_site))
 
-    assert set_cookie_result == {
-        'partitionKey': (await get_default_partition_key(bidi_session)),
-    }
+    await assert_partition_key(bidi_session, actual=set_cookie_result["partitionKey"])
 
     # `same_site` defaults to "none".
     expected_same_site = same_site if same_site is not None else 'none'

--- a/webdriver/tests/bidi/storage/set_cookie/cookie_secure.py
+++ b/webdriver/tests/bidi/storage/set_cookie/cookie_secure.py
@@ -1,5 +1,5 @@
 import pytest
-from .. import assert_cookie_is_set, create_cookie, get_default_partition_key
+from .. import assert_cookie_is_set, assert_partition_key, create_cookie
 
 pytestmark = pytest.mark.asyncio
 
@@ -16,9 +16,7 @@ async def test_cookie_secure(bidi_session, set_cookie, test_page, domain_value, 
     set_cookie_result = await set_cookie(
         cookie=create_cookie(domain=domain_value(), secure=secure))
 
-    assert set_cookie_result == {
-        'partitionKey': (await get_default_partition_key(bidi_session)),
-    }
+    await assert_partition_key(bidi_session, actual=set_cookie_result["partitionKey"])
 
     # `secure` defaults to `false`.
     expected_secure = secure if secure is not None else False

--- a/webdriver/tests/bidi/storage/set_cookie/page_protocols.py
+++ b/webdriver/tests/bidi/storage/set_cookie/page_protocols.py
@@ -1,6 +1,6 @@
 import pytest
 from urllib.parse import urlparse
-from .. import assert_cookie_is_set, create_cookie, get_default_partition_key
+from .. import assert_cookie_is_set, assert_partition_key, create_cookie
 
 pytestmark = pytest.mark.asyncio
 
@@ -17,9 +17,7 @@ async def test_page_protocols(bidi_session, set_cookie, get_test_page, protocol)
     domain = urlparse(url).hostname
     set_cookie_result = await set_cookie(cookie=create_cookie(domain=domain))
 
-    assert set_cookie_result == {
-        'partitionKey': (await get_default_partition_key(bidi_session)),
-    }
+    await assert_partition_key(bidi_session, actual=set_cookie_result["partitionKey"])
 
     # Assert the cookie is actually set.
     await assert_cookie_is_set(bidi_session, domain=domain)


### PR DESCRIPTION
It hides the complexity of getting the default context and checks the data using recursive_compare rather than direct assertion.