### PR TITLE
Refactor AbsoluteAxisSolver

### DIFF
--- a/css/css-sizing/stretch/positioned-replaced-2.html
+++ b/css/css-sizing/stretch/positioned-replaced-2.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<link rel="help" href="https://github.com/servo/servo/pull/34430">
+<p>Test passes if there is a filled green square.</p>
+<style>
+canvas {
+  position: absolute;
+  background: green;
+  width: stretch;
+  height: stretch;
+  top: 50px;
+  left: 50px;
+}
+</style>
+<div style="display: flow-root; position: relative; width: 150px; height: 150px; margin-top: -50px; margin-left: -50px;">
+  <canvas width="50" height="25"></canvas>
+</div>

--- a/css/css-sizing/stretch/positioned-replaced-3.html
+++ b/css/css-sizing/stretch/positioned-replaced-3.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<link rel="help" href="https://github.com/servo/servo/pull/34430">
+<p>Test passes if there is a filled green square.</p>
+<style>
+canvas {
+  position: absolute;
+  background: green;
+  width: stretch;
+  height: stretch;
+  inset: 50px;
+}
+</style>
+<div style="display: flow-root; position: relative; width: 200px; height: 200px; margin-top: -50px; margin-left: -50px;">
+  <canvas width="50" height="25"></canvas>
+</div>


### PR DESCRIPTION
`AbsoluteAxisSolver::solve()` would compute, among other things, the position of the absolute positioned element if it had start alignment. Then, `AbsoluteAxisSolver::origin_for_alignment_or_justification()` could optionally opt into modifying that alignment if needed.

This was quite convoluted and not easy to follow. It's simpler to not compute the position in `AbsoluteAxisSolver::solve()`, and instead do it always in `AbsoluteAxisSolver::origin_for_alignment_or_justification()`, which I'm renaming to `AbsoluteAxisSolver::origin_for_margin_box()` because it aligns the margin box of the abspos within its alignment container.

Then the `Anchor` struct becomes useless and can be removed.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#34443