### PR TITLE
Fix `stretch` sizes on replaced abspos

### DIFF
--- a/css/css-sizing/stretch/positioned-replaced-2.html
+++ b/css/css-sizing/stretch/positioned-replaced-2.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<link rel="help" href="https://github.com/servo/servo/pull/34430">
+<p>Test passes if there is a filled green square.</p>
+<style>
+canvas {
+  position: absolute;
+  background: green;
+  width: stretch;
+  height: stretch;
+  top: 50px;
+  left: 50px;
+}
+</style>
+<div style="display: flow-root; position: relative; width: 150px; height: 150px; margin-top: -50px; margin-left: -50px;">
+  <canvas width="50" height="25"></canvas>
+</div>

--- a/css/css-sizing/stretch/positioned-replaced-3.html
+++ b/css/css-sizing/stretch/positioned-replaced-3.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<link rel="help" href="https://github.com/servo/servo/pull/34430">
+<p>Test passes if there is a filled green square.</p>
+<style>
+canvas {
+  position: absolute;
+  background: green;
+  width: stretch;
+  height: stretch;
+  inset: 50px;
+}
+</style>
+<div style="display: flow-root; position: relative; width: 200px; height: 200px; margin-top: -50px; margin-left: -50px;">
+  <canvas width="50" height="25"></canvas>
+</div>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
We were sizing absolutely positioned replaced elements within their actual containing block instead of the inset-modified containing block. Then the `stretch` keyword would result in a wrong size.

Reviewed in servo/servo#34430