### PR TITLE
Improve Trusted Types test coverage over eval and Function constructor

### DIFF
--- a/content-security-policy/reporting/report-clips-sample.https.html
+++ b/content-security-policy/reporting/report-clips-sample.https.html
@@ -9,26 +9,72 @@
 </head>
 <body>
   <script>
+  const trimmedSampleLength = 40;
+  const evalSample = "evil = '1234567890123456789012345678901234567890;'";
+  const trimmedEvalSample = evalSample.substring(0, trimmedSampleLength);
   promise_test(t => {
     let evil = false;
     assert_throws_js(EvalError, _ => {
-      eval("evil = '1234567890123456789012345678901234567890';");
+      eval(evalSample);
     });
     assert_false(evil);
     return waitUntilCSPEventForTrustedTypes(t).then(t.step_func_done(e => {
-      assert_equals(e.sample, "eval|evil = '12345678901234567890123456789012");
+      assert_equals(e.sample, `eval|${trimmedEvalSample}`);
     }));
-  }, "Unsafe eval violation sample is clipped to 40 characters.");
+  }, `Unsafe eval violation sample is clipped to ${trimmedSampleLength} characters.`);
+
+  promise_test(t => {
+    let evil = false;
+    assert_throws_js(EvalError, _ => {
+      eval?.(evalSample);
+    });
+    assert_false(evil);
+    return waitUntilCSPEventForTrustedTypes(t).then(t.step_func_done(e => {
+      assert_equals(e.sample, `eval|${trimmedEvalSample}`);
+    }));
+  }, `Unsafe indirect eval violation sample is clipped to ${trimmedSampleLength} characters.`);
+
+  const functionBody = "return '1234567890123456789012345678901234567890';";
+  const sampleWithoutFunctionPrefix = `(a,b\n) {\nreturn ${functionBody}\n}`;
 
   promise_test(t => {
     assert_throws_js(EvalError, _ => {
-      new Function("a", "b", "return '1234567890123456789012345678901234567890';");
+      new Function("a", "b", functionBody);
     });
     return waitUntilCSPEventForTrustedTypes(t).then(t.step_func_done(e => {
-      assert_equals(e.sample.replace(/\n/g, ""),
-                    "Function|(a,b) {return '12345678901234567890123");
+      assert_equals(e.sample, `Function|${sampleWithoutFunctionPrefix.substring(0, trimmedSampleLength)}`);
     }));
   }, "Function constructor - the other kind of eval - is clipped.");
+
+  promise_test(t => {
+    assert_throws_js(EvalError, _ => {
+      const AsyncFunction = async function() {}.constructor
+      new AsyncFunction("a", "b", functionBody);
+    });
+    return waitUntilCSPEventForTrustedTypes(t).then(t.step_func_done(e => {
+      assert_equals(e.sample, `Function|${sampleWithoutFunctionPrefix.substring(0, trimmedSampleLength)}`);
+    }));
+  }, "Async Function constructor is also clipped.");
+
+  promise_test(t => {
+    assert_throws_js(EvalError, _ => {
+      const GeneratorFunction = function*() {}.constructor
+      new GeneratorFunction("a", "b", functionBody);
+    });
+    return waitUntilCSPEventForTrustedTypes(t).then(t.step_func_done(e => {
+        assert_equals(e.sample, `Function|${sampleWithoutFunctionPrefix.substring(0, trimmedSampleLength)}`);
+    }));
+  }, "Generator Function constructor is also clipped.");
+
+  promise_test(t => {
+    assert_throws_js(EvalError, _ => {
+      const AsyncGeneratorFunction = async function*() {}.constructor
+      new AsyncGeneratorFunction("a", "b", functionBody);
+    });
+    return waitUntilCSPEventForTrustedTypes(t).then(t.step_func_done(e => {
+        assert_equals(e.sample, `Function|${sampleWithoutFunctionPrefix.substring(0, trimmedSampleLength)}`);
+    }));
+  }, "AsyncGenerator Function constructor is also clipped.");
 
   promise_test(t => {
     const a = document.createElement("a");

--- a/trusted-types/default-policy-callback-arguments.html
+++ b/trusted-types/default-policy-callback-arguments.html
@@ -47,7 +47,7 @@
       [ "about:blank", "TrustedScriptURL", "HTMLScriptElement src",
           _ => script.src = "about:blank" ],
       [ "2+2", "TrustedScript", "eval", _ => eval("2+2") ],
-      [ "(function anonymous(\n) {\nreturn 2+2\n})", "TrustedScript",
+      [ "function anonymous(\n) {\nreturn 2+2\n}", "TrustedScript",
         "Function", _ => new Function("return 2+2") ],
     ];
     for (var tc of cases) {

--- a/trusted-types/eval-csp-tt-default-policy-mutate.html
+++ b/trusted-types/eval-csp-tt-default-policy-mutate.html
@@ -21,4 +21,20 @@
   test(t => {
     assert_throws_js(EvalError, _ => new Function('return 1+1'));
   }, "Function constructor with string where default policy mutates value throws.");
+
+  const AsyncFunction = async function() {}.constructor;
+  const GeneratorFunction = function*() {}.constructor;
+  const AsyncGeneratorFunction = async function*() {}.constructor;
+
+  test(t => {
+    assert_throws_js(EvalError, _ => new AsyncFunction('return 1+1'));
+  }, "AsyncFunction constructor with string where default policy mutates value throws.");
+
+  test(t => {
+    assert_throws_js(EvalError, _ => new GeneratorFunction('return 1+1'));
+  }, "GeneratorFunction constructor with string where default policy mutates value throws.");
+
+  test(t => {
+    assert_throws_js(EvalError, _ => new AsyncGeneratorFunction('return 1+1'));
+  }, "AsyncGeneratorFunction constructor with string where default policy mutates value throws.");
 </script>

--- a/trusted-types/eval-csp-tt-default-policy.html
+++ b/trusted-types/eval-csp-tt-default-policy.html
@@ -8,7 +8,18 @@
 </head>
 <body>
 <script>
-  trustedTypes.createPolicy("default", {createScript: s => s});
+  trustedTypes.createPolicy("default", {
+    createScript: ((s, _, sink) => {
+      // eval's source string is "1+1", the Function constructor's source string is "return 1+1"
+      // so we can distinguish between the two.
+      if (s === "1+1") {
+        assert_equals(sink, "eval");
+      } else {
+        assert_equals(sink, "Function");
+      }
+      return s
+    })
+  });
   const p = trustedTypes.createPolicy("p", {createScript: s => s});
 
   test(t => {
@@ -37,5 +48,80 @@
   test(t => {
     assert_equals(new Function('return 1+1')(), 2);
   }, "Function constructor of string works.");
+
+  test(t => {
+    assert_equals(new Function(p.createScript('val'),p.createScript('return val+1'))(1), 2);
+  }, "Function constructor of all TrustedScripts works.");
+
+  test(t => {
+    assert_equals(new Function('val', 'return val+1')(1), 2);
+  }, "Function constructor of all strings works.");
+
+  test(t => {
+    assert_equals(new Function('val', p.createScript('return val+1'))(1), 2);
+  }, "Function constructor of string and TrustedScript works.");
+
+  const AsyncFunction = async function() {}.constructor;
+  test(t => {
+    new AsyncFunction(p.createScript('return 1+1'))
+  }, "Async Function constructor of TrustedScript works.");
+
+  test(t => {
+    new AsyncFunction('return 1+1')
+  }, "AsyncFunction constructor of string works.");
+
+  test(t => {
+    new AsyncFunction(p.createScript('val'),p.createScript('return val+1'))
+  }, "AsyncFunction constructor of all TrustedScripts works.");
+
+  test(t => {
+    new AsyncFunction('val', 'return val+1')
+  }, "AsyncFunction constructor of all strings works.");
+
+  test(t => {
+    new AsyncFunction('val', p.createScript('return val+1'))
+  }, "AsyncFunction constructor of string and TrustedScript works.");
+
+  const GeneratorFunction = function*() {}.constructor;
+  test(t => {
+    new GeneratorFunction(p.createScript('return 1+1'))
+  }, "GeneratorFunction constructor of TrustedScript works.");
+
+  test(t => {
+    new GeneratorFunction('return 1+1')
+  }, "GeneratorFunction constructor of string works.");
+
+  test(t => {
+    new GeneratorFunction(p.createScript('val'),p.createScript('return val+1'))
+  }, "GeneratorFunction constructor of all TrustedScripts works.");
+
+  test(t => {
+    new GeneratorFunction('val', 'return val+1')
+  }, "GeneratorFunction constructor of all strings works.");
+
+  test(t => {
+    new GeneratorFunction('val', p.createScript('return val+1'))
+  }, "GeneratorFunction constructor of string and TrustedScript works.");
+
+  const AsyncGeneratorFunction = async function*() {}.constructor;
+  test(t => {
+    new AsyncGeneratorFunction(p.createScript('return 1+1'));
+  }, "AsyncGeneratorFunction constructor of TrustedScript works.");
+
+  test(t => {
+    new AsyncGeneratorFunction('return 1+1');
+  }, "AsyncGeneratorFunction constructor of string works.");
+
+  test(t => {
+    new AsyncGeneratorFunction(p.createScript('val'),p.createScript('return val+1'));
+  }, "AsyncGeneratorFunction constructor of all TrustedScripts works.");
+
+  test(t => {
+    new AsyncGeneratorFunction('val', 'return val+1');
+  }, "AsyncGeneratorFunction constructor of all strings works.");
+
+  test(t => {
+    new AsyncGeneratorFunction('val', p.createScript('return val+1'));
+  }, "AsyncGeneratorFunction constructor of string and TrustedScript works.");
 </script>
 

--- a/trusted-types/eval-csp-tt-no-default-policy.html
+++ b/trusted-types/eval-csp-tt-no-default-policy.html
@@ -40,5 +40,33 @@
   test(t => {
     assert_throws_js(EvalError, _ => new Function('return 1+1')());
   }, "Function constructor of string fails.");
+
+  test(t => {
+    assert_equals(new Function(p.createScript('val'),p.createScript('return val+1'))(1), 2);
+  }, "Function constructor of all TrustedScripts works.");
+
+  test(t => {
+    assert_throws_js(EvalError, _ => new Function('val', 'return val+1')(1));
+  }, "Function constructor of all strings fails.");
+
+  test(t => {
+    assert_throws_js(EvalError, _ => new Function('val', p.createScript('return val+1'))(1));
+  }, "Function constructor of string and TrustedScript fails.");;
+
+  const AsyncFunction = async function() {}.constructor;
+  const GeneratorFunction = function*() {}.constructor;
+  const AsyncGeneratorFunction = async function*() {}.constructor;
+
+  test(t => {
+    assert_throws_js(EvalError, _ => new AsyncFunction('return 1+1')());
+  }, "AsyncFunction constructor of string fails.");
+
+  test(t => {
+    assert_throws_js(EvalError, _ => new GeneratorFunction('return 1+1')());
+  }, "GeneratorFunction constructor of string fails.");
+
+  test(t => {
+    assert_throws_js(EvalError, _ => new AsyncGeneratorFunction('return 1+1')());
+  }, "AsyncGeneratorFunction constructor of string fails.");
 </script>
 

--- a/trusted-types/eval-function-constructor.html
+++ b/trusted-types/eval-function-constructor.html
@@ -15,14 +15,27 @@
   const args = ["a", "b", "c = 5", "return (a+b)*c;"];
   const arg_max = 2 ** args.length -1;
 
+  const AsyncFunction = async function() {}.constructor;
+  const GeneratorFunction = function*() {}.constructor;
+  const AsyncGeneratorFunction = async function*() {}.constructor;
+
   // Call 'new Function(...args)', but with a subset of args being Strings,
   // and a subset being TrustedScript. We use a bitmask to determine which
   // argument gets to be trusted or not.
-  function new_function_with_maybe_trusted_args(mask) {
+  function new_function_with_maybe_trusted_args(mask, type) {
     let maybe_trusted_args = args.map((value, arg_nr) => {
       return (mask & (2**arg_nr)) ? policy.createScript(value) : value;
     });
-    return new Function(...maybe_trusted_args);
+    switch (type) {
+      case "Function":
+        return new Function(...maybe_trusted_args);
+      case "AsyncFunction":
+        return new AsyncFunction(...maybe_trusted_args);
+      case "GeneratorFunction":
+        return new GeneratorFunction(...maybe_trusted_args);
+      case "AsyncGeneratorFunction":
+        return new AsyncGeneratorFunction(...maybe_trusted_args);
+    }
   }
 
   // Generate all combinations of String/TrustedScript, except for the one
@@ -32,18 +45,30 @@
   for (let mask = 0; mask < arg_max; mask++) {
     test(t => {
       assert_throws_js(EvalError,
-                       _ => new_function_with_maybe_trusted_args(mask));
+                       _ => new_function_with_maybe_trusted_args(mask, "Function"));
     }, "Function constructor with mixed plain and trusted strings, mask #" + mask);
+    test(t => {
+      assert_throws_js(EvalError,
+                       _ => new_function_with_maybe_trusted_args(mask, "AsyncFunction"));
+    }, "AsyncFunction constructor with mixed plain and trusted strings, mask #" + mask);
+    test(t => {
+      assert_throws_js(EvalError,
+                       _ => new_function_with_maybe_trusted_args(mask, "GeneratorFunction"));
+    }, "GeneratorFunction constructor with mixed plain and trusted strings, mask #" + mask);
+    test(t => {
+      assert_throws_js(EvalError,
+                       _ => new_function_with_maybe_trusted_args(mask, "AsyncGeneratorFunction"));
+    }, "AsyncGeneratorFunction constructor with mixed plain and trusted strings, mask #" + mask);
   }
 
   // Now do one with all trusted arguments. In that case, isTrusted=true in
   // EnsureCSPDoesNotBlockStringCompilation and the function is built without
   // error.
   test(t => {
-    const f = new_function_with_maybe_trusted_args(arg_max);
+    const f = new_function_with_maybe_trusted_args(arg_max, "Function");
     assert_equals(f(1,2,3), 9);
     assert_equals(f(1,2), 15);
-  }, "Function constructor with mixed plain and trusted strings, mask #" + arg_max);
+  }, `Function constructor with mixed plain and trusted strings, mask #${arg_max}`);
 
   // Similarly wrap all args in TrustedScript objects, but forges the toString()
   // method at one index so that it adds extra leading/trailing space compared

--- a/trusted-types/eval-no-csp-no-tt.html
+++ b/trusted-types/eval-no-csp-no-tt.html
@@ -38,7 +38,19 @@
   }, "Function constructor of TrustedScript works.");
 
   test(t => {
+    assert_equals(new Function(p.createScript('val'),p.createScript('return val+1'))(1), 2);
+  }, "Function constructor of all TrustedScripts works.");
+
+  test(t => {
     assert_equals(new Function('return 1+1')(), 2);
   }, "Function constructor of string works.");
+
+  test(t => {
+    assert_equals(new Function('val', 'return val+1')(1), 2);
+  }, "Function constructor of all strings works.");
+
+  test(t => {
+    assert_equals(new Function('val', p.createScript('return val+1'))(1), 2);
+  }, "Function constructor of string and TrustedScript works.");
 </script>
 


### PR DESCRIPTION
- Add tests for multi-argument function constructor calls

- Add tests for exotic Function types (e.g. generators)

- Add more tests for the CSP sample prefix-stripping behaviour

- Fixed default policy sample test for Function constructor to match spec. (Chromium is non-spec compliant currently).