### PR TITLE
Update Trusted Types content attributes test

### DIFF
--- a/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html
+++ b/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html
@@ -10,7 +10,7 @@
 <script src="support/namespaces.js"></script>
 <script>
 promise_setup(async function() {
-  let attributeNames = [];
+  let attributeNamesWithInterfaceName = [];
   function addOnAttributes(IDL, interfaceName) {
     // Parsing the whole IDL file is slow, so use a small regexp to extract only
     // the part that is relevant for this test.
@@ -20,29 +20,47 @@ promise_setup(async function() {
       .members.map(member => member.name)
       .filter(name => name.length >= 3 && name.startsWith("on") &&
               !name.startsWith("onwebkit"))
-      .forEach(name => attributeNames.push(name));
+      .forEach(name => attributeNamesWithInterfaceName.push({name, interfaceName}));
   }
 
   const htmlIDL = await (await fetch("/interfaces/html.idl")).text();
+  // GlobalEventHandlers exist on HTMLElement, SVGElement, and MathMLElement.
+  // WindowEventHandlers exist on HTMLBodyElement, and HTMLFrameSetElement.
   ["GlobalEventHandlers", "WindowEventHandlers"].forEach(interfaceName => {
     addOnAttributes(htmlIDL, interfaceName);
   });
 
-  const entrypedMediaIDL = await (await fetch("/interfaces/encrypted-media.idl")).text();
-  addOnAttributes(entrypedMediaIDL, "HTMLMediaElement");
+  const encryptedMediaIDL = await (await fetch("/interfaces/encrypted-media.idl")).text();
+  // HTMLMediaElement (the parent for <audio> and <video>) has extra event handlers.
+  addOnAttributes(encryptedMediaIDL, "HTMLMediaElement");
 
   const svgAnimationsIDL = await (await fetch("/interfaces/svg-animations.idl")).text();
+  // SVGAnimationElement has extra event handlers.
   addOnAttributes(svgAnimationsIDL, "SVGAnimationElement");
 
-  for (const attributeName of attributeNames) {
+  for (const attributeNameWithInterfaceName of attributeNamesWithInterfaceName) {
+    // Skip attributes that are not implemented in the browser.
+    if (attributeNameWithInterfaceName.interfaceName === 'GlobalEventHandlers' && !(attributeNameWithInterfaceName.name in HTMLElement.prototype)) {
+      continue;
+    }
+    if (attributeNameWithInterfaceName.interfaceName === 'WindowEventHandlers' && !(attributeNameWithInterfaceName.name in HTMLBodyElement.prototype)) {
+      continue;
+    }
+    if (attributeNameWithInterfaceName.interfaceName === 'HTMLMediaElement' && !(attributeNameWithInterfaceName.name in HTMLMediaElement.prototype)) {
+      continue;
+    }
+    if (attributeNameWithInterfaceName.interfaceName === 'SVGAnimationElement' && !(attributeNameWithInterfaceName.name in SVGAnimationElement.prototype)) {
+      continue;
+    }
+
     promise_test(async () => {
       NSURI_ARRAY.forEach(attrNs => {
         assert_equals(trustedTypes.getAttributeType(
-          "dummy", attributeName, "dummyNs", attrNs),
+          "dummy", attributeNameWithInterfaceName.name, "dummyNs", attrNs),
           attrNs === NSURI_EMPTY ? "TrustedScript" : null,
           `for attrNs='${attrNs}'`);
       });
-    }, `getAttributeType("dummy", "${attributeName}", "dummyNs", attrNs)`);
+    }, `getAttributeType("dummy", "${attributeNameWithInterfaceName.name}", "dummyNs", attrNs)`);
   }
 });
 </script>


### PR DESCRIPTION
- Remove WindowEventHandlers from IDL as they're not TT sinks.

- Skip attributes that are in WPT IDL but are not implemented in browser IDL.

encrypted-media event listeners are an interesting case, they're only a TT sink in Firefox currently but as specced they should be in all browsers so I've kept the tests for them.

encrypted-media tests might need a follow up test change, or addition (to actually check they're enforced if need be).