### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=252207

### DIFF
--- a/css/css-rhythm/parsing/block-step-align-computed.html
+++ b/css/css-rhythm/parsing/block-step-align-computed.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-align computed values</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-align">
+<meta name="assert" content="Checking computed values for block-step-align">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+    test_computed_value("block-step-align", "auto");
+    test_computed_value("block-step-align", "center");
+    test_computed_value("block-step-align", "start");
+    test_computed_value("block-step-align", "end");
+</script>
+</body>
+</html>

--- a/css/css-rhythm/parsing/block-step-align-invalid.html
+++ b/css/css-rhythm/parsing/block-step-align-invalid.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-align invalid values</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-align">
+<meta name="assert" content="Invalid values for block-step-align should not be parsed">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+    test_invalid_value("block-step-align", "auto auto");
+    test_invalid_value("block-step-align", "start end");
+    test_invalid_value("block-step-align", "center start");
+    test_invalid_value("block-step-align", "end auto");
+    test_invalid_value("block-step-align", "-1px");
+    test_invalid_value("block-step-align", "min-content");
+    test_invalid_value("block-step-align", "10%");
+    test_invalid_value("block-step-align", "20");
+    test_invalid_value("block-step-align", "none");
+    test_invalid_value("block-step-align", "border-box");
+    test_invalid_value('block-step-align', "margin");
+    test_invalid_value("block-step-align", "padding")
+    test_invalid_value("block-step-align", "content")
+</script>
+</body>
+</html>

--- a/css/css-rhythm/parsing/block-step-align-valid.html
+++ b/css/css-rhythm/parsing/block-step-align-valid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-align valid values</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-align">
+<meta name="assert" content="Parsing valid values for block-step-align property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+    test_valid_value("block-step-align", "auto");
+    test_valid_value("block-step-align", "center");
+    test_valid_value("block-step-align", "start");
+    test_valid_value("block-step-align", "end");
+</script>
+</body>
+</html>

--- a/css/css-rhythm/parsing/block-step-insert-computed.html
+++ b/css/css-rhythm/parsing/block-step-insert-computed.html
@@ -8,7 +8,6 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/computed-testcommon.js"></script>
-<script src="/css/support/parsing-testcommon.js"></script>
 <style>
     #target {
       font-size: 40px;

--- a/css/css-rhythm/parsing/block-step-insert-invalid.html
+++ b/css/css-rhythm/parsing/block-step-insert-invalid.html
@@ -7,16 +7,9 @@
 <meta name="assert" content="Invalid values for block-step-insert should not be parsed">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css/support/computed-testcommon.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
-<style>
-    #target {
-      font-size: 40px;
-    }
-</style>
 </head>
 <body>
-<div id="target"></div>
 <script>
     test_invalid_value("block-step-insert", "auto");
     test_invalid_value("block-step-insert", "-1px");

--- a/css/css-rhythm/parsing/block-step-insert-valid.html
+++ b/css/css-rhythm/parsing/block-step-insert-valid.html
@@ -7,16 +7,9 @@
 <meta name="assert" content="Parsing valid values for block-step-insert property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css/support/computed-testcommon.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
-<style>
-    #target {
-      font-size: 40px;
-    }
-</style>
 </head>
 <body>
-<div id="target"></div>
 <script>
     test_valid_value("block-step-insert", "margin-box");
     test_valid_value("block-step-insert", "padding-box");

--- a/css/css-rhythm/parsing/block-step-size-computed.html
+++ b/css/css-rhythm/parsing/block-step-size-computed.html
@@ -8,7 +8,6 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/computed-testcommon.js"></script>
-<script src="/css/support/parsing-testcommon.js"></script>
 <style>
     #target {
       font-size: 40px;

--- a/css/css-rhythm/parsing/block-step-size-invalid.html
+++ b/css/css-rhythm/parsing/block-step-size-invalid.html
@@ -7,16 +7,9 @@
 <meta name="assert" content="Invalid values for block-step-size should not be parsed">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css/support/computed-testcommon.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
-<style>
-    #target {
-      font-size: 40px;
-    }
-</style>
 </head>
 <body>
-<div id="target"></div>
 <script>
     test_invalid_value("block-step-size", "auto");
     test_invalid_value("block-step-size", "-1px");

--- a/css/css-rhythm/parsing/block-step-size-valid.html
+++ b/css/css-rhythm/parsing/block-step-size-valid.html
@@ -7,16 +7,9 @@
 <meta name="assert" content="Parsing valid values for block-step-size properties">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/css/support/computed-testcommon.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
-<style>
-    #target {
-      font-size: 40px;
-    }
-</style>
 </head>
 <body>
-<div id="target"></div>
 <script>
     test_valid_value("block-step-size", "1px");
     test_valid_value("block-step-size", "2em");

--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -104,6 +104,12 @@ const gCSSProperties1 = {
     types: [
     ]
   },
+  'block-step-align': {
+    // https://drafts.csswg.org/css-rhythm/#block-step-align
+    types: [
+      { type: 'discrete', options: [ [ 'auto', 'center'], ['end', 'start'], ['start', 'center'] ] }
+    ]
+  },
   'block-step-insert': {
     // https://drafts.csswg.org/css-rhythm/#block-step-insert
     types: [


### PR DESCRIPTION
WebKit export from bug: [\[rhythmic-sizing\] Add block-step-align to CSS parser](https://bugs.webkit.org/show_bug.cgi?id=252207)