### PR TITLE
WIP: Add Python 3.13 support

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.12'
+      versionSpec: '3.13'
   - template: tools/ci/azure/affected_tests.yml
     parameters:
       artifactName: 'safari-preview-affected-tests'
@@ -54,7 +54,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.12'
+      versionSpec: '3.13'
   - template: tools/ci/azure/affected_tests.yml
     parameters:
       checkoutCommit: 'HEAD^1'
@@ -75,7 +75,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.12'
+      versionSpec: '3.13'
   - template: tools/ci/azure/checkout.yml
   - script: |
       set -eux -o pipefail
@@ -96,7 +96,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.12'
+      versionSpec: '3.13'
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/install_fonts.yml
   - template: tools/ci/azure/install_certs.yml
@@ -118,8 +118,8 @@ jobs:
   - template: tools/ci/azure/publish_logs.yml
   - template: tools/ci/azure/sysdiagnose.yml
 
-- job: tools_unittest_mac_py38
-  displayName: 'tools/ unittests: macOS + Python 3.8'
+- job: tools_unittest_mac_py310
+  displayName: 'tools/ unittests: macOS + Python 3.10'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.tools_unittest']
   pool:
@@ -127,15 +127,15 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.8'
+      versionSpec: '3.10'
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
       directory: tools/
-      toxenv: py38
+      toxenv: py310
 
-- job: tools_unittest_mac_py311
-  displayName: 'tools/ unittests: macOS + Python 3.12'
+- job: tools_unittest_mac_py313
+  displayName: 'tools/ unittests: macOS + Python 3.13'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.tools_unittest']
   pool:
@@ -143,15 +143,15 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.12'
+      versionSpec: '3.13'
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
       directory: tools/
-      toxenv: py311
+      toxenv: py313
 
-- job: wptrunner_unittest_mac_py38
-  displayName: 'tools/wptrunner/ unittests: macOS + Python 3.8'
+- job: wptrunner_unittest_mac_py310
+  displayName: 'tools/wptrunner/ unittests: macOS + Python 3.10'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_unittest']
   pool:
@@ -159,15 +159,15 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.8'
+      versionSpec: '3.10'
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
       directory: tools/wptrunner/
-      toxenv: py38
+      toxenv: py310
 
-- job: wptrunner_unittest_mac_py311
-  displayName: 'tools/wptrunner/ unittests: macOS + Python 3.12'
+- job: wptrunner_unittest_mac_py313
+  displayName: 'tools/wptrunner/ unittests: macOS + Python 3.13'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_unittest']
   pool:
@@ -175,15 +175,15 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.12'
+      versionSpec: '3.13'
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
       directory: tools/wptrunner/
-      toxenv: py311
+      toxenv: py313
 
-- job: wpt_integration_mac_py38
-  displayName: 'tools/wpt/ tests: macOS + Python 3.8'
+- job: wpt_integration_mac_py310
+  displayName: 'tools/wpt/ tests: macOS + Python 3.10'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wpt_integration']
   pool:
@@ -192,7 +192,7 @@ jobs:
   # full checkout required
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.8'
+      versionSpec: '3.10'
   - template: tools/ci/azure/install_chrome.yml
   - template: tools/ci/azure/install_firefox.yml
   - template: tools/ci/azure/update_hosts.yml
@@ -200,10 +200,10 @@ jobs:
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
       directory: tools/wpt/
-      toxenv: py38
+      toxenv: py310
 
-- job: wpt_integration_mac_py311
-  displayName: 'tools/wpt/ tests: macOS + Python 3.12'
+- job: wpt_integration_mac_py313
+  displayName: 'tools/wpt/ tests: macOS + Python 3.13'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wpt_integration']
   pool:
@@ -212,7 +212,7 @@ jobs:
   # full checkout required
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.12'
+      versionSpec: '3.13'
   - template: tools/ci/azure/install_chrome.yml
   - template: tools/ci/azure/install_firefox.yml
   - template: tools/ci/azure/update_hosts.yml
@@ -220,10 +220,10 @@ jobs:
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
       directory: tools/wpt/
-      toxenv: py311
+      toxenv: py313
 
-- job: tools_unittest_win_py38
-  displayName: 'tools/ unittests: Windows + Python 3.8'
+- job: tools_unittest_win_py310
+  displayName: 'tools/ unittests: Windows + Python 3.10'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.tools_unittest']
   pool:
@@ -233,16 +233,16 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.8'
+      versionSpec: '3.10'
       addToPath: false
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
       directory: tools/
-      toxenv: py38
+      toxenv: py310
 
-- job: tools_unittest_win_py311
-  displayName: 'tools/ unittests: Windows + Python 3.12'
+- job: tools_unittest_win_py313
+  displayName: 'tools/ unittests: Windows + Python 3.13'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.tools_unittest']
   pool:
@@ -250,16 +250,16 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.12'
+      versionSpec: '3.13'
       addToPath: false
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
       directory: tools/
-      toxenv: py311
+      toxenv: py313
 
-- job: wptrunner_unittest_win_py38
-  displayName: 'tools/wptrunner/ unittests: Windows + Python 3.8'
+- job: wptrunner_unittest_win_py310
+  displayName: 'tools/wptrunner/ unittests: Windows + Python 3.10'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_unittest']
   pool:
@@ -267,16 +267,16 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.8'
+      versionSpec: '3.10'
       addToPath: false
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
       directory: tools/wptrunner/
-      toxenv: py38
+      toxenv: py310
 
-- job: wptrunner_unittest_win_py311
-  displayName: 'tools/wptrunner/ unittests: Windows + Python 3.12'
+- job: wptrunner_unittest_win_py313
+  displayName: 'tools/wptrunner/ unittests: Windows + Python 3.13'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_unittest']
   pool:
@@ -284,16 +284,16 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.12'
+      versionSpec: '3.13'
       addToPath: false
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
       directory: tools/wptrunner/
-      toxenv: py311
+      toxenv: py313
 
-- job: wpt_integration_win_py38
-  displayName: 'tools/wpt/ tests: Windows + Python 3.8'
+- job: wpt_integration_win_py310
+  displayName: 'tools/wpt/ tests: Windows + Python 3.10'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wpt_integration']
   pool:
@@ -302,7 +302,7 @@ jobs:
   # full checkout required
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.8'
+      versionSpec: '3.10'
   # currently just using the outdated Chrome/Firefox on the VM rather than
   # figuring out how to install Chrome Dev channel on Windows
   # - template: tools/ci/azure/install_chrome.yml
@@ -312,10 +312,10 @@ jobs:
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
       directory: tools/wpt/
-      toxenv: py38
+      toxenv: py310
 
-- job: wpt_integration_win_py311
-  displayName: 'tools/wpt/ tests: Windows + Python 3.12'
+- job: wpt_integration_win_py313
+  displayName: 'tools/wpt/ tests: Windows + Python 3.13'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wpt_integration']
   pool:
@@ -324,7 +324,7 @@ jobs:
   # full checkout required
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.12'
+      versionSpec: '3.13'
   # currently just using the outdated Chrome/Firefox on the VM rather than
   # figuring out how to install Chrome Dev channel on Windows
   # - template: tools/ci/azure/install_chrome.yml
@@ -334,7 +334,7 @@ jobs:
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
       directory: tools/wpt/
-      toxenv: py311
+      toxenv: py313
 
 - job: results_edge_stable
   displayName: 'all tests: Edge Stable'
@@ -350,7 +350,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.12'
+      versionSpec: '3.13'
   - template: tools/ci/azure/system_info.yml
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/install_certs.yml
@@ -386,7 +386,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.12'
+      versionSpec: '3.13'
   - template: tools/ci/azure/system_info.yml
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/install_certs.yml
@@ -422,7 +422,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.12'
+      versionSpec: '3.13'
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/install_certs.yml
   - template: tools/ci/azure/install_edge.yml
@@ -456,7 +456,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.12'
+      versionSpec: '3.13'
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/install_certs.yml
   - template: tools/ci/azure/color_profile.yml

--- a/resources/test/tox.ini
+++ b/resources/test/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311
+envlist = py310,py311,py312,py313
 skipsdist=True
 
 [testenv]

--- a/tools/ci/ci_tools_unittest.sh
+++ b/tools/ci/ci_tools_unittest.sh
@@ -6,9 +6,9 @@ WPT_ROOT=$SCRIPT_DIR/../..
 cd $WPT_ROOT
 
 run_applicable_tox () {
-    # instead of just running TOXENV (e.g., py38)
+    # instead of just running TOXENV (e.g., py310)
     # run all environments that start with TOXENV
-    # (e.g., py38-firefox as well as py38)
+    # (e.g., py310-firefox as well as py310)
     local OLD_TOXENV="$TOXENV"
     unset TOXENV
     local RUN_ENVS=$(tox -l | grep "^${OLD_TOXENV}\(\-\|\$\)" | tr "\n" ",")

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -115,24 +115,24 @@ components:
     chunks-override:
       testharness: 30
 
-  tox-python3_8:
+  tox-python3_10:
     env:
-      TOXENV: py38
+      TOXENV: py310
       PY_COLORS: "0"
     install:
-      - python3.8
-      - python3.8-distutils
-      - python3.8-dev
-      - python3.8-venv
+      - python3.10
+      - python3.10-distutils
+      - python3.10-dev
+      - python3.10-venv
 
-  tox-python3_12:
+  tox-python3_13:
     env:
-      TOXENV: py312
+      TOXENV: py313
       PY_COLORS: "0"
     install:
-      - python3.12
-      - python3.12-dev
-      - python3.12-venv
+      - python3.13
+      - python3.13-dev
+      - python3.13-venv
   tests-affected:
     options:
       browser:
@@ -437,13 +437,13 @@ tasks:
           - update_built
       command: "./tools/ci/ci_built_diff.sh"
 
-  - tools/ unittests (Python 3.8):
+  - tools/ unittests (Python 3.10):
       description: >-
-        Unit tests for tools running under Python 3.8, excluding wptrunner
+        Unit tests for tools running under Python 3.10, excluding wptrunner
       use:
         - wpt-base
         - trigger-pr
-        - tox-python3_8
+        - tox-python3_10
       command: ./tools/ci/ci_tools_unittest.sh
       env:
         HYPOTHESIS_PROFILE: ci
@@ -451,13 +451,13 @@ tasks:
         run-job:
           - tools_unittest
 
-  - tools/ unittests (Python 3.12):
+  - tools/ unittests (Python 3.13):
       description: >-
-        Unit tests for tools running under Python 3.12, excluding wptrunner
+        Unit tests for tools running under Python 3.13, excluding wptrunner
       use:
         - wpt-base
         - trigger-pr
-        - tox-python3_12
+        - tox-python3_13
       command: ./tools/ci/ci_tools_unittest.sh
       env:
         HYPOTHESIS_PROFILE: ci
@@ -465,13 +465,13 @@ tasks:
         run-job:
           - tools_unittest
 
-  - tools/ integration tests (Python 3.8):
+  - tools/ integration tests (Python 3.10):
       description: >-
-        Integration tests for tools running under Python 3.8
+        Integration tests for tools running under Python 3.10
       use:
         - wpt-base
         - trigger-pr
-        - tox-python3_8
+        - tox-python3_10
       command: ./tools/ci/ci_tools_integration_test.sh
       install:
         - libnss3-tools
@@ -487,13 +487,13 @@ tasks:
         run-job:
           - wpt_integration
 
-  - tools/ integration tests (Python 3.12):
+  - tools/ integration tests (Python 3.13):
       description: >-
-        Integration tests for tools running under Python 3.12
+        Integration tests for tools running under Python 3.13
       use:
         - wpt-base
         - trigger-pr
-        - tox-python3_12
+        - tox-python3_13
       command: ./tools/ci/ci_tools_integration_test.sh
       install:
         - libnss3-tools
@@ -509,13 +509,13 @@ tasks:
         run-job:
           - wpt_integration
 
-  - resources/ tests (Python 3.8):
+  - resources/ tests (Python 3.10):
       description: >-
-        Tests for testharness.js and other files in resources/ under Python 3.8
+        Tests for testharness.js and other files in resources/ under Python 3.10
       use:
         - wpt-base
         - trigger-pr
-        - tox-python3_8
+        - tox-python3_10
       command: ./tools/ci/ci_resources_unittest.sh
       install:
         - libnss3-tools
@@ -528,13 +528,13 @@ tasks:
         run-job:
           - resources_unittest
 
-  - resources/ tests (Python 3.12):
+  - resources/ tests (Python 3.13):
       description: >-
-        Tests for testharness.js and other files in resources/ under Python 3.12
+        Tests for testharness.js and other files in resources/ under Python 3.13
       use:
         - wpt-base
         - trigger-pr
-        - tox-python3_12
+        - tox-python3_13
       command: ./tools/ci/ci_resources_unittest.sh
       install:
         - libnss3-tools

--- a/tools/manifest/requirements.txt
+++ b/tools/manifest/requirements.txt
@@ -1,1 +1,1 @@
-zstandard==0.22.0
+zstandard==0.23.0

--- a/tools/third_party/pytest/CONTRIBUTING.rst
+++ b/tools/third_party/pytest/CONTRIBUTING.rst
@@ -202,7 +202,7 @@ Short version
 #. Follow `PEP-8 <https://www.python.org/dev/peps/pep-0008/>`_ for naming.
 #. Tests are run using ``tox``::
 
-    tox -e linting,py39
+    tox -e linting,py310
 
    The test environments above are usually enough to cover most cases locally.
 
@@ -274,10 +274,10 @@ Here is a simple overview, with pytest-specific bits:
 
 #. Run all the tests
 
-   You need to have Python 3.8 or later available in your system.  Now
+   You need to have Python 3.10 or later available in your system.  Now
    running tests is as simple as issuing this command::
 
-    $ tox -e linting,py39
+    $ tox -e linting,py310
 
    This command will run tests via the "tox" tool against Python 3.9
    and also perform "lint" coding-style checks.
@@ -287,11 +287,11 @@ Here is a simple overview, with pytest-specific bits:
    You can pass different options to ``tox``. For example, to run tests on Python 3.9 and pass options to pytest
    (e.g. enter pdb on failure) to pytest you can do::
 
-    $ tox -e py39 -- --pdb
+    $ tox -e py310 -- --pdb
 
-   Or to only run tests in a particular test module on Python 3.9::
+   Or to only run tests in a particular test module on Python 3.10::
 
-    $ tox -e py39 -- testing/test_config.py
+    $ tox -e py310 -- testing/test_config.py
 
 
    When committing, ``pre-commit`` will re-format the files if necessary.

--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312,{py38,py39,py310,py311,py312}-{flake8,mypy}
+envlist = py310,py311,py312,py313{py310,py311,py312,py313}-{flake8,mypy}
 skipsdist=True
 skip_missing_interpreters=False
 

--- a/tools/wave/tox.ini
+++ b/tools/wave/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312
+envlist = py310,py311,py312,py313
 skipsdist=True
 skip_missing_interpreters = False
 

--- a/tools/wpt/tox.ini
+++ b/tools/wpt/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312
+envlist = py310,py311,py312,py313
 skipsdist=True
 skip_missing_interpreters = False
 

--- a/tools/wptrunner/requirements.txt
+++ b/tools/wptrunner/requirements.txt
@@ -1,10 +1,11 @@
 html5lib==1.1
+legacy-cgi==2.6.1
 mozdebug==0.3.1
 mozinfo==1.2.3  # https://bugzilla.mozilla.org/show_bug.cgi?id=1621226
 mozlog==8.0.0
 mozprocess==1.3.1
 packaging==24.0
-pillow==10.3.0
+pillow==11.0.0
 requests==2.32.3
 six==1.16.0
 urllib3==2.2.2

--- a/tools/wptrunner/tox.ini
+++ b/tools/wptrunner/tox.ini
@@ -2,7 +2,7 @@
 xfail_strict=true
 
 [tox]
-envlist = py312-{base,chrome,firefox,opera,safari,sauce,servo,webkit,webkitgtk_minibrowser,epiphany},{py38,py39,py310,py311}-base
+envlist = py313-{base,chrome,firefox,opera,safari,sauce,servo,webkit,webkitgtk_minibrowser,epiphany},{py310,py311,py312}-base
 skip_missing_interpreters = False
 
 [testenv]

--- a/wpt
+++ b/wpt
@@ -2,8 +2,8 @@
 
 if __name__ == "__main__":
     import sys
-    if sys.version_info < (3, 8):
-        sys.stderr.write("wpt requires Python 3.8 or higher\n")
+    if sys.version_info < (3, 10):
+        sys.stderr.write("wpt requires Python 3.10 or higher\n")
         sys.exit(1)
 
     from tools.wpt import wpt


### PR DESCRIPTION
This is a work in progress to add Python 3.13 support as requested in issue #48585. I'm trying to get help with it because it fails inside the Python logging code, and I don't know how to fix that. I suspect it might be a threading issue related to importlib.reload.

The 'cgi' module was removed in Python 3.13. The `legacy-cgi` module is a drop-in replacement for projects not ready to upgrade to a better approach. I've added that to the requirements. The newer version of the `pillow` module was also required.

I also ran into an issue with the version of `zstandard`. Some internal C functions have been removed in Python 3.13 which resulted in cffi errors.

These changes required increasing the minimum Python version from 3.8 to 3.10.

Again, help is very welcome.