### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=284005

### DIFF
--- a/css/css-rhythm/zero-outer-size-rounded-up-to-block-step-size.html
+++ b/css/css-rhythm/zero-outer-size-rounded-up-to-block-step-size.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Box with an outer size of 0 is rounded up to the specified block-step-size">
+<style>
+.container {
+  display: flow-root;
+  width: 100px;
+  background-color: green;
+}
+.block-step {
+  display: block;
+  block-step-size: 100px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <div class="block-step"></div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[block-step-sizing\] Boxes with outer size of 0 should be rounded up to specified block-step-size](https://bugs.webkit.org/show_bug.cgi?id=284005)