### PR TITLE
Add a warning to the any.js variants table

### DIFF
--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -74,6 +74,9 @@ class VariantData(TypedDict, total=False):
     longhand: Set[str]
 
 
+# Warning: changes to this table that cause changes in the tests that end up in the manifest,
+# without changes to the corresponding `.any.js` source files. In this case, an RFC and a bump of
+# the manifest version are required.
 _any_variants: Dict[Text, VariantData] = {
     "window": {"suffix": ".any.html"},
     "window-module": {},


### PR DESCRIPTION
Is this clear enough?