### PR TITLE
[wptrunner] On WebKitGTK-based browsers do not open the new test window in a tab

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -77,7 +77,11 @@ class WebDriverBaseProtocolPart(BaseProtocolPart):
     def set_timeout(self, timeout):
         self.webdriver.timeouts.script = timeout
 
-    def create_window(self, type="tab", **kwargs):
+    def create_window(self, type=None, **kwargs):
+        # WebKitGTK-based browsers have issues when the test is opened in a new tab instead of a separate window
+        # See: https://github.com/web-platform-tests/wpt/issues/49262 and https://webkit.org/b/283392
+        if type is None:
+            type = 'window' if 'webkitgtk:browserOptions' in self.parent.capabilities else 'tab'
         return self.webdriver.new_window(type_hint=type)
 
     @property


### PR DESCRIPTION
WPT commit [bef892c](https://github.com/web-platform-tests/wpt/commit/bef892c48976038b207f3aedf4088a5552cbae67) changed some things on the webdriver executor, like:

1. Open the new window for the test via webdriver command "/window/new" instead of using injected javascript to open the new window.
2. Open the new window as tab by default instead as of a separate window

And in the case of WebKitGTK-based browsers there is currently a bug that when the new test window is opened in a tab instead in a standalone window it causes many timeouts and failures on the WPT tests.

This has been reported to WebKitGTK here https://webkit.org/b/283392

So this commits defaults back the new test window to be an standalone window instead of a tab for the WebkitGTK-based browsers meanwhile the issue is not fixed there.

Related issue: #49262