### PR TITLE
Reverse the computed label expectation for an img with a title and an empty alt

### DIFF
--- a/accname/name/comp_tooltip.html
+++ b/accname/name/comp_tooltip.html
@@ -18,7 +18,6 @@
 <a href="#" title="title" data-expectedlabel="contents" data-testname="link with text with tooltip label and contents" class="ex">contents</a>
 <div title="title" role="group" data-expectedlabel="title" data-testname="div with text with tooltip label" class="ex">contents</div><!-- Note: group role disallows nameFrom:contents -->
 <img title="title" data-expectedlabel="title" data-testname="img with tooltip label without alt" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
-<img title="title" data-expectedlabel="title" alt="" data-testname="img with tooltip label with empty alt" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 <img title="title" data-expectedlabel="alt" alt="alt" data-testname="img with tooltip label with alt" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 <img data-expectedlabel="alt" alt="alt" data-testname="img with tooltip label without title" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 

--- a/accname/name/comp_tooltip.tentative.html
+++ b/accname/name/comp_tooltip.tentative.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+<head>
+  <title>Name Comp: Tooltip (Tentative)</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<p>Tests the <a href="https://w3c.github.io/accname/#comp_tooltip">#comp_tooltip</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
+
+<img title="title" data-expectedlabel="" alt="" data-testname="img with tooltip label with empty alt" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+
+<script>
+AriaUtils.verifyLabelsBySelector(".ex");
+</script>
+</body>
+</html>

--- a/accname/name/comp_tooltip.tentative.html
+++ b/accname/name/comp_tooltip.tentative.html
@@ -13,6 +13,7 @@
 
 <p>Tests the tentative <a href="https://w3c.github.io/accname/#comp_tooltip">#comp_tooltip</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
 
+<!-- Explanation in https://github.com/w3c/aria/pull/2378#issuecomment-2493635126 -->
 <img title="title" data-expectedlabel="" alt="" data-testname="img with tooltip label with empty alt" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 
 <script>

--- a/accname/name/comp_tooltip.tentative.html
+++ b/accname/name/comp_tooltip.tentative.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 
-<p>Tests the <a href="https://w3c.github.io/accname/#comp_tooltip">#comp_tooltip</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
+<p>Tests the tentative <a href="https://w3c.github.io/accname/#comp_tooltip">#comp_tooltip</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
 
 <img title="title" data-expectedlabel="" alt="" data-testname="img with tooltip label with empty alt" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 


### PR DESCRIPTION
Relocates the “_img with tooltip label with empty alt_” subtest out of `accname/name/comp_tooltip.html` into `accname/name/comp_tooltip.tentative.html` and reverses its computed label expectation to match [the accname spec](https://w3c.github.io/accname/#comp_host_language_label:~:text=Host%20Language%20Label,role%3D%22none%22).

re: w3c/aria#2378