### PR TITLE
navigation-api/navigation-history-entry/entries-after-blob-navigation…

### DIFF
--- a/navigation-api/navigation-history-entry/entries-after-blob-navigation.html
+++ b/navigation-api/navigation-history-entry/entries-after-blob-navigation.html
@@ -19,7 +19,7 @@ async_test(t => {
       assert_true(isUUID(entries[1].key));
       assert_true(isUUID(entries[1].id));
     });
-    i.src = URL.createObjectURL(new Blob(["<body></body>"]));
+    i.src = URL.createObjectURL(new Blob(["<body></body>"], { type: "text/html" }));
   });
 }, "entries() after navigation to a blob: URL");
 </script>


### PR DESCRIPTION
….html doesn't run in WebKit

Pass the content type when constructing the Blob so that it is guaranteed to be rendered inside the iframe. Without specifying the content type, Gecko was treating treating the blob as HTML, Blink was treating it as text and WebKit was treating it as binary and downloading it instead of rendering it inside the iframe.