### PR TITLE
Enable site isolation for headless shell

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/headless_shell.py
+++ b/tools/wptrunner/wptrunner/browsers/headless_shell.py
@@ -3,6 +3,7 @@
 from .base import require_arg
 from .base import get_timeout_multiplier   # noqa: F401
 from .chrome import ChromeBrowser, debug_args, executor_kwargs  # noqa: F401
+from .chrome import executor_kwargs as chrome_executor_kwargs
 from ..executors.base import WdspecExecutor  # noqa: F401
 from ..executors.executorchrome import (  # noqa: F401
     ChromeDriverCrashTestExecutor,
@@ -39,6 +40,18 @@ def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
             "webdriver_binary": kwargs["webdriver_binary"],
             "webdriver_args": kwargs.get("webdriver_args"),
             "debug_info": kwargs["debug_info"]}
+
+
+def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite,
+                    **kwargs):
+    executor_kwargs = chrome_executor_kwargs(test_type, test_environment, run_info_data,
+                                             subsuite, **kwargs)
+    capabilities = executor_kwargs["capabilities"]
+    chrome_options = capabilities["goog:chromeOptions"]
+    # Defaultly enable SiteIsolation in headless shell
+    if "--disable-site-isolation-trials" not in chrome_options["args"]:
+        chrome_options["args"].append("--site-per-process")
+    return executor_kwargs
 
 
 def env_extras(**kwargs):

--- a/tools/wptrunner/wptrunner/browsers/headless_shell.py
+++ b/tools/wptrunner/wptrunner/browsers/headless_shell.py
@@ -2,7 +2,7 @@
 
 from .base import require_arg
 from .base import get_timeout_multiplier   # noqa: F401
-from .chrome import ChromeBrowser, debug_args, executor_kwargs  # noqa: F401
+from .chrome import ChromeBrowser, debug_args  # noqa: F401
 from .chrome import executor_kwargs as chrome_executor_kwargs
 from ..executors.base import WdspecExecutor  # noqa: F401
 from ..executors.executorchrome import (  # noqa: F401

--- a/tools/wptrunner/wptrunner/browsers/headless_shell.py
+++ b/tools/wptrunner/wptrunner/browsers/headless_shell.py
@@ -44,10 +44,9 @@ def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
 
 def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite,
                     **kwargs):
-    executor_kwargs = chrome_executor_kwargs(test_type, test_environment, run_info_data,
+    executor_kwargs = chrome_executor_kwargs(logger, test_type, test_environment, run_info_data,
                                              subsuite, **kwargs)
-    capabilities = executor_kwargs["capabilities"]
-    chrome_options = capabilities["goog:chromeOptions"]
+    chrome_options = executor_kwargs["capabilities"]["goog:chromeOptions"]
     # Defaultly enable SiteIsolation in headless shell
     if "--disable-site-isolation-trials" not in chrome_options["args"]:
         chrome_options["args"].append("--site-per-process")


### PR DESCRIPTION
Site isolation is disabled by default in headless shell. Enable that through testrunner unless that is explicitly disabled.