### PR TITLE
Accessibility - Acc name - Include a term role test when calculating the accessible name for name-from-content elements

### DIFF
--- a/accname/name/comp_name_from_content.html
+++ b/accname/name/comp_name_from_content.html
@@ -259,6 +259,29 @@
 <h1 data-expectedlabel="Call Us" data-testname="heading name from content with text-transform:capitalize" class="ex" style="text-transform:capitalize;">Call us</h1>
 <h1 data-expectedlabel="call us" data-testname="heading name from content with text-transform:lowercase" class="ex" style="text-transform:lowercase;">Call us</h1>
 
+<!-- Tests `Name from Each Child` edge case failures with an embedded `term` as a child element role. -->
+<!-- https://w3c.github.io/accname/#comp_name_from_content_for_each_child -->
+
+<h2>Elements with implicit button, heading, link roles containing element with implicit term role</h2>
+<button data-expectedlabel="this is an example" data-testname="implicit button name from content containing a dfn element" class="ex iblock"><span>this is an </span><dfn>example</dfn></button>
+<h3 data-expectedlabel="this is an example" data-testname="implicit heading name from content containing a dfn element" class="ex iblock"><span>this is an </span><dfn>example</dfn></h3>
+<a href="#" data-expectedlabel="this is an example" data-testname="implicit link name from content containing a dfn element" class="ex iblock"><span>this is an </span><dfn>example</dfn></a>
+
+<h2>Elements with implicit button, heading, link roles containing element with explicit term role</h2>
+<button data-expectedlabel="this is an example" data-testname="implicit button name from content containing an element with explicit term role" class="ex iblock"><span>this is an </span><span role="term">example</span></button>
+<h3 data-expectedlabel="this is an example" data-testname="implicit heading name from content containing an element with explicit term role" class="ex iblock"><span>this is an </span><span role="term">example</span></h3>
+<a href="#" data-expectedlabel="this is an example" data-testname="implicit link name from content containing an element explicit with term role" class="ex iblock"><span>this is an </span><span role="term">example</span></a>
+
+<h2>Elements with explicit button, heading, link roles containing element with implicit term role</h2>
+<div role="button" tabindex="0" data-expectedlabel="this is an example" data-testname="explicit button name from content containing a dfn element" class="ex iblock"><span>this is an </span><dfn>example</dfn></div>
+<div role="heading" data-expectedlabel="this is an example" data-testname="explicit heading name from content containing a dfn element" class="ex iblock"><span>this is an </span><dfn>example</dfn></div>
+<div role="link" tabindex="0" data-expectedlabel="this is an example" data-testname="explicit link name from content containing a dfn element" class="ex iblock"><span>this is an </span><dfn>example</dfn></div>
+
+<h2>Elements with explicit button, heading, link roles containing element with explicit term role</h2>
+<div role="button" tabindex="0" data-expectedlabel="this is an example" data-testname="explicit button name from content containing an element explicit with term role" class="ex iblock"><span>this is an </span><span role="term">example</span></div>
+<div role="heading" data-expectedlabel="this is an example" data-testname="explicit heading name from content containing an element explicit with term role" class="ex iblock"><span>this is an </span><span role="term">example</span></div>
+<div role="link" tabindex="0" data-expectedlabel="this is an example" data-testname="explicit link name from content containing an element explicit with term role" class="ex iblock"><span>this is an </span><span role="term">example</span></div>
+
 <script>
 AriaUtils.verifyLabelsBySelector(".ex");
 </script>


### PR DESCRIPTION
Closes: https://github.com/web-platform-tests/interop-accessibility/issues/157

This PR adds embedded term role tests when calculating the accessible name for name-from-content elements

This test covers:
- Elements with implicit button, heading, link roles containing element with implicit term role
- Elements with implicit button, heading, link roles containing element with explicit term role
- Elements with explicit button, heading, link roles containing element with implicit term role
- Elements with explicit button, heading, link roles containing element with explicit term role

(thanks @cookiecrook for the support on this).