### PR TITLE
[wptrunner] Add an --exclude-file, similar to --include-file

### DIFF
--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -168,7 +168,7 @@ class Subsuite:
                                                            str(self.run_info))
 
 
-def read_include_from_file(file):
+def read_test_prefixes_from_file(file):
     new_include = []
     with open(file) as f:
         for line in f:

--- a/tools/wptrunner/wptrunner/tests/test_testloader.py
+++ b/tools/wptrunner/wptrunner/tests/test_testloader.py
@@ -15,7 +15,7 @@ from ..testloader import (
     TestFilter,
     TestLoader,
     TagFilter,
-    read_include_from_file,
+    read_test_prefixes_from_file,
 )
 from .test_wpttest import make_mock_manifest
 
@@ -113,7 +113,7 @@ def test_include_file():
         f.write(test_cases)
         f.flush()
 
-        include = read_include_from_file(f.name)
+        include = read_test_prefixes_from_file(f.name)
 
         assert len(include) == 4
         assert "/foo/bar-error.https.html" in include

--- a/tools/wptrunner/wptrunner/tests/test_wptrunner.py
+++ b/tools/wptrunner/wptrunner/tests/test_wptrunner.py
@@ -1,7 +1,19 @@
-from ..wptrunner import get_pause_after_test
+# mypy: allow-untyped-calls
+
+from pathlib import Path
+from typing import List, Optional, Tuple
+from unittest.mock import Mock
+
+from ..testloader import TestQueueBuilder
+from ..wptcommandline import TestRoot
+from ..wptrunner import get_loader, get_pause_after_test
 from .test_testloader import Subsuite, TestFilter, TestLoader, WPTManifest
 
-def test_get_pause_after_test():  # type: ignore
+TestQueueBuilder.__test__ = None  # type: ignore[attr-defined]
+TestRoot.__test__ = None  # type: ignore[attr-defined]
+
+
+def test_get_pause_after_test() -> None:
     manifest_json = {
         "items": {
             "testharness": {
@@ -77,3 +89,183 @@ def test_get_pause_after_test():  # type: ignore
                         manifest_filters=manifest_filters)
     print(loader.tests)
     assert get_pause_after_test(loader, **kwargs) is False
+
+
+def get_loader_with_fakes(
+    tmp_path: Path,
+    include: Optional[List[str]] = None,
+    include_file: Optional[str] = None,
+    exclude: Optional[List[str]] = None,
+    exclude_file: Optional[str] = None,
+) -> Tuple[TestQueueBuilder, TestLoader]:
+    repo_root = tmp_path / "wpt"
+    repo_root.mkdir()
+
+    test_paths = {
+        "/": TestRoot(str(repo_root), str(repo_root), str(repo_root / "MANIFEST.json"))
+    }
+
+    spec_dir = repo_root / "fake-spec"
+    spec_dir.mkdir()
+    test_filenames = [f"test-{i:03d}.html" for i in range(10)]
+    for test_filename in test_filenames:
+        with (spec_dir / test_filename).open("wb") as f:
+            f.write(b"<script src=/resources/testharness.js></script>")
+
+    product = Mock(spec=["name", "run_info_extras"], name="fake-product")
+    product.run_info_extras = Mock(spec=[], return_value={})
+
+    # Unfortunately this requires quite a lot of kwargs
+    return get_loader(
+        test_paths,
+        product,
+        chunk_type="none",
+        debug=None,
+        default_exclude=False,
+        enable_webtransport_h3=True,
+        exclude=exclude,
+        exclude_file=exclude_file,
+        exclude_tags=None,
+        fully_parallel=False,
+        include=include,
+        include_file=include_file,
+        include_manifest=None,
+        manifest_download=False,
+        manifest_update=True,
+        processes=1,
+        run_by_dir=False,
+        run_info=str(repo_root / "tools/wptrunner/wptrunner.default.ini"),
+        skip_crash=False,
+        skip_implementation_status=None,
+        skip_timeout=False,
+        ssl_type="pregenerated",
+        subsuite_file=None,
+        subsuites=None,
+        tags=None,
+        test_groups_file=None,
+        test_types={"crashtest", "print-reftest", "reftest", "testharness", "wdspec"},
+        this_chunk=1,
+        total_chunks=1,
+    )
+
+
+def test_get_loader(tmp_path: Path) -> None:
+    _, test_loader = get_loader_with_fakes(tmp_path)
+
+    assert test_loader.test_ids == [
+        "/fake-spec/test-000.html",
+        "/fake-spec/test-001.html",
+        "/fake-spec/test-002.html",
+        "/fake-spec/test-003.html",
+        "/fake-spec/test-004.html",
+        "/fake-spec/test-005.html",
+        "/fake-spec/test-006.html",
+        "/fake-spec/test-007.html",
+        "/fake-spec/test-008.html",
+        "/fake-spec/test-009.html",
+    ]
+
+
+def test_get_loader_include(tmp_path: Path) -> None:
+    _, test_loader = get_loader_with_fakes(
+        tmp_path,
+        include=["/fake-spec/test-007.html", "/fake-spec/test-008.html"],
+    )
+
+    assert test_loader.test_ids == [
+        "/fake-spec/test-007.html",
+        "/fake-spec/test-008.html",
+    ]
+
+
+def test_get_loader_exclude(tmp_path: Path) -> None:
+    _, test_loader = get_loader_with_fakes(
+        tmp_path,
+        exclude=["/fake-spec/test-007.html"],
+    )
+
+    assert test_loader.test_ids == [
+        "/fake-spec/test-000.html",
+        "/fake-spec/test-001.html",
+        "/fake-spec/test-002.html",
+        "/fake-spec/test-003.html",
+        "/fake-spec/test-004.html",
+        "/fake-spec/test-005.html",
+        "/fake-spec/test-006.html",
+        "/fake-spec/test-008.html",
+        "/fake-spec/test-009.html",
+    ]
+
+
+def test_get_loader_include_exclude(tmp_path: Path) -> None:
+    _, test_loader = get_loader_with_fakes(
+        tmp_path,
+        include=["/fake-spec/test-007.html", "/fake-spec/test-008.html"],
+        exclude=["/fake-spec/test-007.html"],
+    )
+
+    assert test_loader.test_ids == [
+        "/fake-spec/test-008.html",
+    ]
+
+
+def test_get_loader_include_file(tmp_path: Path) -> None:
+    include = ["/fake-spec/test-007.html", "/fake-spec/test-008.html"]
+
+    with (tmp_path / "include.txt").open("w") as f:
+        f.writelines([f"{t}\n" for t in include])
+
+    _, test_loader = get_loader_with_fakes(
+        tmp_path,
+        include_file=str(tmp_path / "include.txt"),
+    )
+
+    assert test_loader.test_ids == [
+        "/fake-spec/test-007.html",
+        "/fake-spec/test-008.html",
+    ]
+
+
+def test_get_loader_exclude_file(tmp_path: Path) -> None:
+    exclude = ["/fake-spec/test-007.html"]
+
+    with (tmp_path / "exclude.txt").open("w") as f:
+        f.writelines([f"{t}\n" for t in exclude])
+
+    _, test_loader = get_loader_with_fakes(
+        tmp_path,
+        exclude_file=str(tmp_path / "exclude.txt"),
+    )
+
+    assert test_loader.test_ids == [
+        "/fake-spec/test-000.html",
+        "/fake-spec/test-001.html",
+        "/fake-spec/test-002.html",
+        "/fake-spec/test-003.html",
+        "/fake-spec/test-004.html",
+        "/fake-spec/test-005.html",
+        "/fake-spec/test-006.html",
+        "/fake-spec/test-008.html",
+        "/fake-spec/test-009.html",
+    ]
+
+
+def test_get_loader_include_exclude_file(tmp_path: Path) -> None:
+    include = ["/fake-spec/test-007.html", "/fake-spec/test-008.html"]
+    exclude = ["/fake-spec/test-007.html"]
+
+    with (tmp_path / "include.txt").open("w") as f:
+        f.writelines([f"{t}\n" for t in include])
+
+    with (tmp_path / "exclude.txt").open("w") as f:
+        f.writelines([f"{t}\n" for t in exclude])
+
+    _, test_loader = get_loader_with_fakes(
+        tmp_path,
+        include_file=str(tmp_path / "include.txt"),
+        exclude_file=str(tmp_path / "exclude.txt"),
+    )
+
+    assert test_loader.test_ids == [
+        "/fake-spec/test-008.html",
+    ]

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -159,6 +159,8 @@ scheme host and port.""")
                                       help="A file listing URL prefix for tests")
     test_selection_group.add_argument("--exclude", action="append",
                                       help="URL prefix to exclude")
+    test_selection_group.add_argument("--exclude-file", action="store",
+                                      help="A file listing URL prefix for tests")
     test_selection_group.add_argument("--include-manifest", type=abs_path,
                                       help="Path to manifest listing tests to include")
     test_selection_group.add_argument("--test-groups", dest="test_groups_file", type=abs_path,

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -85,16 +85,20 @@ def get_loader(test_paths: wptcommandline.TestPaths,
     include = kwargs["include"]
     if kwargs["include_file"]:
         include = include or []
-        include.extend(testloader.read_include_from_file(kwargs["include_file"]))
+        include.extend(testloader.read_test_prefixes_from_file(kwargs["include_file"]))
+    exclude = kwargs["exclude"]
+    if kwargs["exclude_file"]:
+        exclude = exclude or []
+        exclude.extend(testloader.read_test_prefixes_from_file(kwargs["exclude_file"]))
     if test_groups:
         include = testloader.update_include_for_groups(test_groups, include)
 
     if kwargs["tags"] or kwargs["exclude_tags"]:
         test_filters.append(testloader.TagFilter(kwargs["tags"], kwargs["exclude_tags"]))
 
-    if include or kwargs["exclude"] or kwargs["include_manifest"] or kwargs["default_exclude"]:
+    if include or exclude or kwargs["include_manifest"] or kwargs["default_exclude"]:
         manifest_filters.append(testloader.TestFilter(include=include,
-                                                      exclude=kwargs["exclude"],
+                                                      exclude=exclude,
                                                       manifest_path=kwargs["include_manifest"],
                                                       test_manifests=test_manifests,
                                                       explicit=kwargs["default_exclude"]))


### PR DESCRIPTION
It would at times be nice to be able to use files for larger numbers of exclusions; it's somewhat surprising that we support `--include-file` but not `--exclude-file`, so let's just support both.