### PR TITLE
Create figure-name-no-figcaption.tentative.html

### DIFF
--- a/html-aam/figure-name-no-figcaption.tentative.html
+++ b/html-aam/figure-name-no-figcaption.tentative.html
@@ -40,7 +40,7 @@ The following test can be added to names.html along with the other figure naming
   x
   <figcaption id=fctest>figcaption text</figcaption>
 </figure>
-  
+
 <figure data-testname="figure with figcaption and title" title="title" data-expectedlabel="title" class="ex">
   x
   <figcaption>y</figcaption>

--- a/html-aam/figure-name-no-figcaption.tentative.html
+++ b/html-aam/figure-name-no-figcaption.tentative.html
@@ -23,7 +23,7 @@ The following test can be added to names.html along with the other figure naming
 <h2>figure element</h2>
 <figure data-testname="figure with figcaption - no name" data-expectedlabel="" class="ex">
   x
-  <figcaption>y</figcaption>  
+  <figcaption>y</figcaption>
 </figure>
 
 <figure data-testname="figure with figcaption and aria-label" aria-label="label" data-expectedlabel="label" class="ex">

--- a/html-aam/figure-name-no-figcaption.tentative.html
+++ b/html-aam/figure-name-no-figcaption.tentative.html
@@ -30,9 +30,15 @@ The following test can be added to names.html along with the other figure naming
   x
   <figcaption>y</figcaption>
 </figure>
-<figure data-testname="figure with figcaption and aria-labelledby" aria-labelledby="labelledby" data-expectedlabel="labelledby" class="ex">
+
+<figure data-testname="figure with figcaption and aria-labelledby pointing to another element" aria-labelledby="labelledby" data-expectedlabel="labelledby" class="ex">
   x
   <figcaption>y</figcaption>
+</figure>
+
+<figure data-testname="figure with aria-labelledby pointing to figcaption" aria-labelledby="fctest" data-expectedlabel="figcaption text" class="ex">
+  x
+  <figcaption id=fctest>figcaption text</figcaption>
 </figure>
   
 <figure data-testname="figure with figcaption and title" title="title" data-expectedlabel="title" class="ex">

--- a/html-aam/figure-name-no-figcaption.tentative.html
+++ b/html-aam/figure-name-no-figcaption.tentative.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html>
+<head>
+  <title>HTML-AAM Figure Element Accessible Name From Author Tests</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+
+<p>Tests the accName for elements defined in <a href="https://w3c.github.io/html-aam/#accessible-name-and-description-computation">HTML-AAM: Accessible Name Computations By HTML Element</a>.
+  These tests are meant to show whether an element returns a name per the naming mechanism used. See <a href="https://wpt.fyi/results/accname">wpt: accname</a> for expanded accName testing.</p>
+
+
+<!--
+The following test can be added to names.html along with the other figure naming tests when the file is no longer considered tentative.
+-->
+
+<h2>figure element</h2>
+<figure data-testname="figure with figcaption - no name" data-expectedlabel="" class="ex">
+  x
+  <figcaption>y</figcaption>  
+</figure>
+
+<figure data-testname="figure with figcaption and aria-label" aria-label="label" data-expectedlabel="label" class="ex">
+  x
+  <figcaption>y</figcaption>
+</figure>
+<figure data-testname="figure with figcaption and aria-labelledby" aria-labelledby="labelledby" data-expectedlabel="labelledby" class="ex">
+  x
+  <figcaption>y</figcaption>
+</figure>
+  
+<figure data-testname="figure with figcaption and title" title="title" data-expectedlabel="title" class="ex">
+  x
+  <figcaption>y</figcaption>
+</figure>
+
+
+<!-- element to reference for aria-labelledby tests -->
+<div id="labelledby">labelledby</div>
+
+<script>
+AriaUtils.verifyLabelsBySelector(".ex");
+</script>
+
+</body>
+</html>

--- a/html-aam/figure-name-no-figcaption.tentative.html
+++ b/html-aam/figure-name-no-figcaption.tentative.html
@@ -46,6 +46,23 @@ The following test can be added to names.html along with the other figure naming
   <figcaption>y</figcaption>
 </figure>
 
+<figure data-testname="figure with figcaption and img without alt" data-expectedlabel="" class="ex">
+  <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-testname="img without alt within a figure with figcaption" data-expectedlabel="figcaption" class="ex">
+  <figcaption>figcaption</figcaption>
+</figure>
+
+<figure>
+  <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-testname="img without alt but with title within a figure with figcaption" title="title" data-expectedlabel="title" class="ex">
+  <figcaption>figcaption</figcaption>
+</figure>
+
+<!-- as there is content in the figure beyond just the img without alt and whitespace, then the figcaption applies to all content and not just the img, so it does not become the img's accname -->
+<figure>
+  <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-testname="img without alt within a figure with figcaption, and with other flow content within the figure" data-expectedlabel="" class="ex">
+  other content
+  <figcaption>figcaption</figcaption>
+</figure>
+
 
 <!-- element to reference for aria-labelledby tests -->
 <div id="labelledby">labelledby</div>


### PR DESCRIPTION
a figcaption should not provide a name to a figure element per https://github.com/w3c/aria/pull/2224