### PR TITLE
[lint] Allow {ref,print-ref,crash}tests to use `testdriver.js`

### DIFF
--- a/lint.ignore
+++ b/lint.ignore
@@ -768,21 +768,8 @@ HTML INVALID SYNTAX: mathml/crashtests/mozilla/411603-1.html
 HTML INVALID SYNTAX: quirks/percentage-height-calculation.html
 HTML INVALID SYNTAX: trusted-types/TrustedTypePolicyFactory-getAttributeType-namespace.html
 
-# Tests which include testdriver.js but aren't testharness.js tests
-# TODO(web-platform-tests/wpt#13183): Remove this rule once support is added.
-TESTDRIVER-IN-UNSUPPORTED-TYPE: infrastructure/crashtests/testdriver.html
-TESTDRIVER-IN-UNSUPPORTED-TYPE: infrastructure/reftest/testdriver.html
-TESTDRIVER-IN-UNSUPPORTED-TYPE: infrastructure/reftest/testdriver-child.html
-TESTDRIVER-IN-UNSUPPORTED-TYPE: infrastructure/reftest/testdriver-iframe.sub.html
-TESTDRIVER-IN-UNSUPPORTED-TYPE: infrastructure/reftest/testdriver-print.html
-TESTDRIVER-IN-UNSUPPORTED-TYPE: css/css-grid/grid-model/grid-layout-stale-001.html
-TESTDRIVER-IN-UNSUPPORTED-TYPE: css/css-grid/grid-model/grid-layout-stale-002.html
-TESTDRIVER-IN-UNSUPPORTED-TYPE: css/css-scroll-anchoring/fullscreen-crash.html
-TESTDRIVER-IN-UNSUPPORTED-TYPE: css/css-shadow-parts/interaction-with-nested-pseudo-class.html
-TESTDRIVER-IN-UNSUPPORTED-TYPE: css/css-text-decor/invalidation/text-decoration-thickness.html
-TESTDRIVER-IN-UNSUPPORTED-TYPE: css/css-view-transitions/hit-test-unpainted-element.html
-TESTDRIVER-IN-UNSUPPORTED-TYPE: css/css-view-transitions/hit-test-unrelated-element.html
-TESTDRIVER-IN-UNSUPPORTED-TYPE: css/selectors/remove-hovered-element.html
+# Tests that incorrectly include `testdriver.js`, which isn't supported for some
+# test types.
 TESTDRIVER-IN-UNSUPPORTED-TYPE: file-system-access/local_FileSystemBaseHandle-IndexedDB-manual.https.html
 TESTDRIVER-IN-UNSUPPORTED-TYPE: file-system-access/local_FileSystemBaseHandle-getUniqueId-manual.https.html
 TESTDRIVER-IN-UNSUPPORTED-TYPE: file-system-access/local_FileSystemBaseHandle-isSameEntry-manual.https.html
@@ -812,13 +799,9 @@ TESTDRIVER-IN-UNSUPPORTED-TYPE: file-system-access/local_FileSystemWritableFileS
 TESTDRIVER-IN-UNSUPPORTED-TYPE: file-system-access/showDirectoryPicker-manual.https.html
 TESTDRIVER-IN-UNSUPPORTED-TYPE: file-system-access/showOpenFilePicker-manual.https.html
 TESTDRIVER-IN-UNSUPPORTED-TYPE: file-system-access/showSaveFilePicker-manual.https.html
-TESTDRIVER-IN-UNSUPPORTED-TYPE: html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/crashtests/fieldset-middleclick.html
-TESTDRIVER-IN-UNSUPPORTED-TYPE: infrastructure/testdriver/click_child_crossorigin.html
-TESTDRIVER-IN-UNSUPPORTED-TYPE: infrastructure/testdriver/click_child_testdriver.html
 TESTDRIVER-IN-UNSUPPORTED-TYPE: mediacapture-streams/MediaStreamTrack-end-manual.https.html
 TESTDRIVER-IN-UNSUPPORTED-TYPE: payment-handler/change-payment-method-manual.https.html
 TESTDRIVER-IN-UNSUPPORTED-TYPE: payment-handler/change-shipping-address-manual.https.html
 TESTDRIVER-IN-UNSUPPORTED-TYPE: payment-handler/change-shipping-option-manual.https.html
 TESTDRIVER-IN-UNSUPPORTED-TYPE: payment-handler/payment-request-event-manual.https.html
 TESTDRIVER-IN-UNSUPPORTED-TYPE: payment-handler/supports-shipping-contact-delegation-manual.https.html
-TESTDRIVER-IN-UNSUPPORTED-TYPE: shadow-dom/crashtests/move-to-new-tree-1343016.html

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -475,7 +475,7 @@ def check_parsed(repo_root: Text, path: Text, f: IO[bytes]) -> List[rules.Error]
 
     testdriver_vendor_nodes: List[ElementTree.Element] = []
     if source_file.testdriver_nodes:
-        if test_type != "testharness":
+        if test_type not in {"testharness", "reftest", "print-reftest", "crashtest", "support"}:
             errors.append(rules.TestdriverInUnsupportedType.error(path, (test_type,)))
 
         if len(source_file.testdriver_nodes) > 1:

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -350,37 +350,20 @@ def test_multiple_testharnessreport():
 def test_testdriver_in_unsupported():
     code = b"""
 <html xmlns="http://www.w3.org/1999/xhtml">
-<link rel="match" href="test-ref.html"/>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 </html>
 """
-    error_map = check_with_files(code)
 
-    for (filename, (errors, kind)) in error_map.items():
-        check_errors(errors)
-
-        if kind in ["web-lax", "web-strict"]:
-            assert errors == [
-                (
-                    "NON-EXISTENT-REF",
-                    "Reference test with a non-existent 'match' relationship reference: "
-                    "'test-ref.html'",
-                    filename,
-                    None,
-                ),
-                (
-                    "TESTDRIVER-IN-UNSUPPORTED-TYPE",
-                    "testdriver.js included in a reftest test, which doesn't support "
-                    "testdriver.js",
-                    filename,
-                    None,
-                ),
-            ]
-        elif kind == "python":
-            assert errors == [
-                ("PARSE-FAILED", "Unable to parse file", filename, 2),
-            ]
+    filename = os.path.join("html", "test-manual.html")
+    errors = check_file_contents("", filename, io.BytesIO(code))
+    check_errors(errors)
+    assert errors == [(
+        "TESTDRIVER-IN-UNSUPPORTED-TYPE",
+        "testdriver.js included in a manual test, which doesn't support testdriver.js",
+        filename,
+        None,
+    )]
 
 
 def test_early_testdriver_vendor():


### PR DESCRIPTION
Relax the `TESTDRIVER-IN-UNSUPPORTED-TYPE` rule now that #48486 has landed. `wpt lint` still bans `testdriver.js` in manual tests, since there's no external WebDriver program to drive testdriver.