### PR TITLE
Fix a bug in test_driver.bless()

### DIFF
--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -250,7 +250,7 @@
             let wait_click = new Promise(resolve => button.addEventListener("click", resolve));
 
             return test_driver.click(button)
-                .then(wait_click)
+                .then(() => wait_click)
                 .then(function() {
                     button.remove();
 


### PR DESCRIPTION
The code was previously doing this:

```
  let wait_click = new Promise(resolve => {
    button.addEventListener("click", resolve));
  };
  return test_driver.click(button)
    .then(wait_click)
    .then(...
```

but the argument to `.then(wait_click)` isn't a function, it's the promise to return. Therefore .then() ignores its argument (see step #3 at https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-performpromisethen) and proceeds immediately to the next `.then()` block.

Since the code wasn't actually waiting for the `click` event to finish getting fired, subsequent steps could happen out of order.