### PR TITLE
Reinitialize BrowserManager's command queue after it is recreated

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -205,7 +205,7 @@ def update_properties():
 
 class ChromeBrowser(WebDriverBrowser):
 
-    # Chrome browser's default startup time is 60 seconds. Use 65 seconds here
+    # Chrome browser's default startup timeout is 60 seconds. Use 65 seconds here
     # to allow error message be displayed if that happens.
     init_timeout: float = 65
 

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -204,6 +204,11 @@ def update_properties():
     return (["debug", "os", "processor"], {"os": ["version"], "processor": ["bits"]})
 
 class ChromeBrowser(WebDriverBrowser):
+
+    # Chrome browser's default startup time is 60 seconds. Use 65 seconds here
+    # to allow error message be displayed if that happens.
+    init_timeout: float = 65
+
     def __init__(self,
                  logger: StructuredLogger,
                  leak_check: bool = False,

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -994,6 +994,8 @@ class TestRunnerManager(threading.Thread):
             self.logger.debug("Recreating command queue")
             self.command_queue.cancel_join_thread()
             self.command_queue.close()
+            # Reset the command queue for BrowserManager also as that won't
+            # be set again during retry.
             self.browser.command_queue = self.command_queue = mp.Queue()
             self.logger.debug("Recreating remote queue")
             self.remote_queue.cancel_join_thread()

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -994,7 +994,7 @@ class TestRunnerManager(threading.Thread):
             self.logger.debug("Recreating command queue")
             self.command_queue.cancel_join_thread()
             self.command_queue.close()
-            self.command_queue = mp.Queue()
+            self.browser.command_queue = self.command_queue = mp.Queue()
             self.logger.debug("Recreating remote queue")
             self.remote_queue.cancel_join_thread()
             self.remote_queue.close()


### PR DESCRIPTION
This will allow init_failed message be sent back to TestRunnerManager if timeout happens when start the browser. Previously when init retry happens, as the subsuite and test type did not change, the init process will not recreate the BrowserManager instance, causing a stale command queue be used and init_failed message won't be able to send to TestRunnerManager.

Also set the start browser timeout value to 65 seconds to align with the default browser startup timeout value.

Bug: 381944656