### PR TITLE
[wdspec] fix `browsingContext.navigationFailed` test

### DIFF
--- a/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py
+++ b/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py
@@ -9,6 +9,7 @@ from .. import assert_navigation_info
 
 pytestmark = pytest.mark.asyncio
 
+NAVIGATION_ABORTED_EVENT = "browsingContext.navigationAborted"
 NAVIGATION_FAILED_EVENT = "browsingContext.navigationFailed"
 NAVIGATION_STARTED_EVENT = "browsingContext.navigationStarted"
 USER_PROMPT_OPENED_EVENT = "browsingContext.userPromptOpened"
@@ -233,12 +234,26 @@ async def test_with_new_navigation(
     slow_page_url = url(
         "/webdriver/tests/bidi/browsing_context/support/empty.html?pipe=trickle(d10)"
     )
-    await subscribe_events(events=[NAVIGATION_FAILED_EVENT])
+    # Depending on implementation, the `trickle(d10)` page can or can not yet
+    # create a new document. Depending on this, `aborted` or `failed` event
+    # should be emitted.
+    await subscribe_events(
+        events=[NAVIGATION_ABORTED_EVENT, NAVIGATION_FAILED_EVENT])
 
     result = await bidi_session.browsing_context.navigate(
         context=new_tab["context"], url=slow_page_url, wait="none"
     )
-    on_navigation_failed = wait_for_event(NAVIGATION_FAILED_EVENT)
+
+    events = []
+
+    async def on_event(method, data):
+        events.append(data)
+
+    remove_listener_1 = bidi_session.add_event_listener(
+        NAVIGATION_ABORTED_EVENT, on_event)
+    remove_listener_2 = bidi_session.add_event_listener(NAVIGATION_FAILED_EVENT,
+                                                        on_event)
+
     second_url = inline("<div>foo</div>")
 
     # Trigger the second navigation which should fail the first one.
@@ -246,17 +261,22 @@ async def test_with_new_navigation(
         context=new_tab["context"], url=second_url, wait="none"
     )
 
-    event = await wait_for_future_safe(on_navigation_failed)
+    wait = AsyncPoll(bidi_session, timeout=1)
+    await wait.until(lambda _: len(events) > 0)
+    assert len(events) == 1
 
-    # Make sure that the first navigation failed.
+    # Make sure that the first navigation failed or aborted.
     assert_navigation_info(
-        event,
+        events[0],
         {
             "context": new_tab["context"],
             "navigation": result["navigation"],
             "url": slow_page_url,
         },
     )
+
+    remove_listener_1()
+    remove_listener_2()
 
 
 async def test_with_new_navigation_inside_page(
@@ -282,24 +302,43 @@ async def test_with_new_navigation_inside_page(
 </html>
 """
     )
-    await subscribe_events(events=[NAVIGATION_FAILED_EVENT])
-    on_navigation_failed = wait_for_event(NAVIGATION_FAILED_EVENT)
+
+    # Depending on implementation, the `trickle(d10)` page can or can not yet
+    # create a new document. Depending on this, `aborted` or `failed` event
+    # should be emitted.
+    await subscribe_events(
+        events=[NAVIGATION_ABORTED_EVENT, NAVIGATION_FAILED_EVENT])
+
+    events = []
+
+    async def on_event(method, data):
+        events.append(data)
+
+    remove_listener_1 = bidi_session.add_event_listener(
+        NAVIGATION_ABORTED_EVENT, on_event)
+    remove_listener_2 = bidi_session.add_event_listener(NAVIGATION_FAILED_EVENT,
+                                                        on_event)
 
     result = await bidi_session.browsing_context.navigate(
         context=new_tab["context"], url=slow_page_url, wait="none"
     )
 
-    event = await wait_for_future_safe(on_navigation_failed)
+    wait = AsyncPoll(bidi_session, timeout=1)
+    await wait.until(lambda _: len(events) > 0)
+    assert len(events) == 1
 
     # Make sure that the first navigation failed.
     assert_navigation_info(
-        event,
+        events[0],
         {
             "context": new_tab["context"],
             "navigation": result["navigation"],
             "url": slow_page_url,
         },
     )
+
+    remove_listener_1()
+    remove_listener_2()
 
 
 @pytest.mark.parametrize("type_hint", ["tab", "window"])
@@ -315,25 +354,44 @@ async def test_close_context(
     slow_page_url = url(
         "/webdriver/tests/bidi/browsing_context/support/empty.html?pipe=trickle(d10)"
     )
-    await subscribe_events(events=[NAVIGATION_FAILED_EVENT])
+    # Depending on implementation, the `trickle(d10)` page can or can not yet
+    # create a new document. Depending on this, `aborted` or `failed` event
+    # should be emitted.
+    await subscribe_events(
+        events=[NAVIGATION_ABORTED_EVENT, NAVIGATION_FAILED_EVENT])
 
     result = await bidi_session.browsing_context.navigate(
         context=new_context["context"], url=slow_page_url, wait="none"
     )
 
-    on_navigation_failed = wait_for_event(NAVIGATION_FAILED_EVENT)
+    events = []
+
+    async def on_event(method, data):
+        events.append(data)
+
+    remove_listener_1 = bidi_session.add_event_listener(
+        NAVIGATION_ABORTED_EVENT, on_event)
+    remove_listener_2 = bidi_session.add_event_listener(NAVIGATION_FAILED_EVENT,
+                                                        on_event)
+
     await bidi_session.browsing_context.close(context=new_context["context"])
-    event = await wait_for_future_safe(on_navigation_failed)
+
+    wait = AsyncPoll(bidi_session, timeout=1)
+    await wait.until(lambda _: len(events) > 0)
+    assert len(events) == 1
 
     # Make sure that the navigation failed.
     assert_navigation_info(
-        event,
+        events[0],
         {
             "context": new_context["context"],
             "navigation": result["navigation"],
             "url": slow_page_url,
         },
     )
+
+    remove_listener_1()
+    remove_listener_2()
 
 
 async def test_close_iframe(
@@ -348,9 +406,13 @@ async def test_close_iframe(
     iframe_url = inline("<div>foo</div>")
     page_url = inline(f"<iframe src={iframe_url}></iframe")
 
-    await subscribe_events(events=[NAVIGATION_FAILED_EVENT])
+    # Depending on implementation, the `trickle(d10)` page can or can not yet
+    # create a new document. Depending on this, `aborted` or `failed` event
+    # should be emitted.
+    await subscribe_events(
+        events=[NAVIGATION_ABORTED_EVENT, NAVIGATION_FAILED_EVENT])
 
-    result = await bidi_session.browsing_context.navigate(
+    await bidi_session.browsing_context.navigate(
         context=new_tab["context"], url=page_url, wait="complete"
     )
 
@@ -365,20 +427,35 @@ async def test_close_iframe(
         context=iframe_context, url=slow_page_url, wait="none"
     )
 
-    on_navigation_failed = wait_for_event(NAVIGATION_FAILED_EVENT)
+    events = []
+
+    async def on_event(method, data):
+        events.append(data)
+
+    remove_listener_1 = bidi_session.add_event_listener(
+        NAVIGATION_ABORTED_EVENT, on_event)
+    remove_listener_2 = bidi_session.add_event_listener(NAVIGATION_FAILED_EVENT,
+                                                        on_event)
+
     # Reload the top context to destroy the iframe.
     await bidi_session.browsing_context.reload(context=new_tab["context"], wait="none")
-    event = await wait_for_future_safe(on_navigation_failed)
+
+    wait = AsyncPoll(bidi_session, timeout=1)
+    await wait.until(lambda _: len(events) > 0)
+    assert len(events) == 1
 
     # Make sure that the iframe navigation failed.
     assert_navigation_info(
-        event,
+        events[0],
         {
             "context": iframe_context,
             "navigation": result["navigation"],
             "url": slow_page_url,
         },
     )
+
+    remove_listener_1()
+    remove_listener_2()
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": {"beforeUnload": "ignore"}})


### PR DESCRIPTION
Align `webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py:test_with_new_navigation_inside_page` and `test_with_new_navigation` with the spec. Currently, the test are not fully aligned with the spec, as the specific event depends on the document creation step, which in order depends on the fetch status.

When WPT trickles response, it sends headers and adds timeouts before sending the body. However, this does not guarantee the new document will not be created and activated:

* [Navigate](https://html.spec.whatwg.org/#navigate), step 22.9.
* [Attempt to populate the history entry's document](https://html.spec.whatwg.org/#attempt-to-populate-the-history-entry's-document)
    * step 5.2
        * [Create navigation params by fetching](https://html.spec.whatwg.org/#create-navigation-params-by-fetching), step 19.5.
        * [Fetch request](https://fetch.spec.whatwg.org/#concept-fetch), step 15.
        * Run [main fetch](https://fetch.spec.whatwg.org/#concept-main-fetch) given fetchParams.
    * step 6.6.
        * [load a document](https://html.spec.whatwg.org/#loading-a-document), step 2, case "[HTML MIME type](https://mimesniff.spec.whatwg.org/#html-mime-type)".
        * [load an HTML document](https://html.spec.whatwg.org/#navigate-html),  step 1.
        * [create and initialize a Document object](https://html.spec.whatwg.org/#initialise-the-document-object), step 9.
        * Set [during-loading navigation ID for WebDriver BiDi](https://html.spec.whatwg.org/#concept-document-navigation-id).

E.g. in case of Chromium, the document is created after the headers are received. This makes the discrepancy in the events have to be emitted. If the new document is created, it should be the "browsingContext.navigationAborted" event. If not, it should be "browsingContext.navigationFailed".