### PR TITLE
Avoid reliance on async module timing in import-map test

### DIFF
--- a/import-maps/multiple-import-maps/resolution-consistency-in-module-tree.html
+++ b/import-maps/multiple-import-maps/resolution-consistency-in-module-tree.html
@@ -5,7 +5,7 @@
   <script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
-<script type="module" async>
+<script>
 step_timeout(() => {
   const importMapScript = document.createElement('script');
   importMapScript.type = 'importmap';


### PR DESCRIPTION
While implementing https://github.com/WebKit/WebKit/pull/37896 in WebKit, I realized that async inline module scripts run at different times there compared to Chromium.

Looking at the [spec](https://html.spec.whatwg.org/multipage/scripting.html#the-script-element:~:text=Queue%20an%20element%20task%20on%20the%20networking%20task%20source%20given%20el%20to%20perform%20the%20following%20steps%3A), the timing for them doesn't seem well defined, and in any case is not the subject of the test in question.

This PR modifies the test to avoid that reliance. It might be worthwhile to consider further testing for async inline module timings if interop on that front is desired, but that seems orthogonal. 