### PR TITLE
add a webkitwin_minibrowser product/browser

### DIFF
--- a/docs/running-tests/webkitwin_minibrowser.md
+++ b/docs/running-tests/webkitwin_minibrowser.md
@@ -1,0 +1,16 @@
+# WebKitWin MiniBrowser
+
+The option `webkitwin_minibrowser` runs the wpt tests using the WebDriver and MiniBrowser of the WebKit on Windows.
+
+This option does not have the feature of downloading the WebDriver externally or finding it on your device.<br>
+You must first build WebKit on Windows and specify the path of binary by the arguments of `wpt run`.
+
+To build WebKit on Windows, the following documentation may be helpful:<br>
+https://webkit.org/building-webkit-on-windows/
+
+After the binaries are ready, you can run tests with the following command.<br>
+Note: The MiniBrowser.exe must be in the same path as WebDriver.exe.
+
+```bash
+./wpt run --channel dev --webdriver-binary (path of WebDriver.exe) webkitwin_minibrowser TEST
+```

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -2567,3 +2567,21 @@ class Epiphany(Browser):
             # Tech Preview output looks like "Web 3.31.3-88-g97db4f40f"
             return output.split()[1]
         return None
+
+class WebKitWinMiniBrowser(WebKit):
+
+    def download(self, dest=None, channel=None, rename=None):
+        raise NotImplementedError
+
+    def install(self, dest=None, channel=None, prompt=True):
+        raise NotImplementedError
+
+    def find_binary(self, venv_path=None, channel=None):
+        raise NotImplementedError
+
+    def find_webdriver(self, venv_path=None, channel=None):
+        # use the command line option "--webdriver-binary"
+        raise NotImplementedError
+
+    def version(self, binary=None, webdriver_binary=None):
+        return None

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -877,6 +877,18 @@ class Epiphany(BrowserSetup):
             kwargs["webdriver_binary"] = webdriver_binary
 
 
+class WebKitWinMiniBrowser(BrowserSetup):
+    name = "webkitwin_minibrowser"
+    browser_cls = browser.WebKitWinMiniBrowser
+
+    def install(self, channel=None):
+        raise NotImplementedError
+
+    def setup_kwargs(self, kwargs):
+        if kwargs["webdriver_binary"] is None:
+            raise WptrunError("Missing required argument --webdriver-binary")
+
+
 product_setup = {
     "android_webview": AndroidWebview,
     "firefox": Firefox,
@@ -898,6 +910,7 @@ product_setup = {
     "wpewebkit_minibrowser": WPEWebKitMiniBrowser,
     "epiphany": Epiphany,
     "ladybird": Ladybird,
+    "webkitwin_minibrowser": WebKitWinMiniBrowser,
 }
 
 

--- a/tools/wptrunner/wptrunner/browsers/__init__.py
+++ b/tools/wptrunner/wptrunner/browsers/__init__.py
@@ -41,4 +41,5 @@ product_list = ["android_webview",
                 "wpewebkit_minibrowser",
                 "wktr",
                 "epiphany",
-                "ladybird"]
+                "ladybird",
+                "webkitwin_minibrowser"]

--- a/tools/wptrunner/wptrunner/browsers/webkitwin_minibrowser.py
+++ b/tools/wptrunner/wptrunner/browsers/webkitwin_minibrowser.py
@@ -1,0 +1,69 @@
+# mypy: allow-untyped-defs
+
+from .base import (NullBrowser,  # noqa: F401
+                   certificate_domain_list,
+                   get_timeout_multiplier,  # noqa: F401
+                   maybe_add_args)
+from .webkit import WebKitBrowser
+from ..executors import executor_kwargs as base_executor_kwargs
+from ..executors.base import WdspecExecutor  # noqa: F401
+from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
+                                           WebDriverRefTestExecutor,  # noqa: F401
+                                           WebDriverCrashtestExecutor)  # noqa: F401
+
+__wptrunner__ = {"product": "webkitwin_minibrowser",
+                 "check_args": "check_args",
+                 "browser": "WebKitWinMiniBrowser",
+                 "browser_kwargs": "browser_kwargs",
+                 "executor": {"testharness": "WebDriverTestharnessExecutor",
+                              "reftest": "WebDriverRefTestExecutor",
+                              "wdspec": "WdspecExecutor",
+                              "crashtest": "WebDriverCrashtestExecutor"},
+                 "executor_kwargs": "executor_kwargs",
+                 "env_extras": "env_extras",
+                 "env_options": "env_options",
+                 "run_info_extras": "run_info_extras",
+                 "timeout_multiplier": "get_timeout_multiplier"}
+
+
+def check_args(**kwargs):
+    pass
+
+
+def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
+    # Workaround for https://gitlab.gnome.org/GNOME/libsoup/issues/172
+    webdriver_required_args = []
+    webdriver_args = maybe_add_args(webdriver_required_args, kwargs.get("webdriver_args"))
+    return {"binary": kwargs["binary"],
+            "webdriver_binary": kwargs["webdriver_binary"],
+            "webdriver_args": webdriver_args}
+
+
+def capabilities(server_config, **kwargs):
+    return {
+        "browserName": "MiniBrowser",
+        "acceptInsecureCerts": True
+    }
+
+def executor_kwargs(logger, test_type, test_environment, run_info_data,
+                    **kwargs):
+    executor_kwargs = base_executor_kwargs(test_type, test_environment, run_info_data, **kwargs)
+    executor_kwargs["close_after_done"] = True
+    executor_kwargs["capabilities"] = capabilities(test_environment.config, **kwargs)
+    return executor_kwargs
+
+
+def env_extras(**kwargs):
+    return []
+
+
+def env_options():
+    return {}
+
+
+def run_info_extras(logger, **kwargs):
+    return {"webkit_port": "win"}
+
+
+class WebKitWinMiniBrowser(WebKitBrowser):
+    pass


### PR DESCRIPTION
The change https://commits.webkit.org/287053@main enables WebKitWebDriver on Windows to launch the browser independently, allowing the `wpt` script to run tests.
This adds the necessary changes to wpt and wptrunner.

How to run the commands is described in webkitwin_minibrowser.md.
I have confirmed that some tests in /webdriver/tests/classic work with this option.
