### PR TITLE
[wdspec] change test_..._closes_browsing_context

### DIFF
--- a/webdriver/tests/bidi/input/perform_actions/key.py
+++ b/webdriver/tests/bidi/input/perform_actions/key.py
@@ -10,6 +10,8 @@ from . import get_shadow_root_from_test_page
 
 pytestmark = pytest.mark.asyncio
 
+CONTEXT_LOAD_EVENT = "browsingContext.load"
+
 
 async def test_invalid_browsing_context(bidi_session):
     actions = Actions()
@@ -20,18 +22,26 @@ async def test_invalid_browsing_context(bidi_session):
 
 
 async def test_key_down_closes_browsing_context(
-    bidi_session, configuration, new_tab, inline
+    bidi_session, configuration, new_tab, inline, subscribe_events,
+    wait_for_event
 ):
     url = inline("""
         <input onkeydown="window.close()">close</input>
         <script>document.querySelector("input").focus();</script>
         """)
 
-    await bidi_session.browsing_context.navigate(
-        context=new_tab["context"],
-        url=url,
-        wait="complete",
+    # Opening a new context via `window.open` is required for script to be able
+    # to close it.
+    await subscribe_events(events=[CONTEXT_LOAD_EVENT])
+    on_load = wait_for_event(CONTEXT_LOAD_EVENT)
+
+    await bidi_session.script.evaluate(
+        expression=f"window.open('{url}')",
+        target=ContextTarget(new_tab["context"]),
+        await_promise=True
     )
+    # Wait for the new context to be created and get it.
+    new_context = await on_load
 
     actions = Actions()
     (
@@ -43,7 +53,7 @@ async def test_key_down_closes_browsing_context(
 
     with pytest.raises(NoSuchFrameException):
         await bidi_session.input.perform_actions(
-            actions=actions, context=new_tab["context"]
+            actions=actions, context=new_context["context"]
         )
 
 

--- a/webdriver/tests/bidi/input/perform_actions/key.py
+++ b/webdriver/tests/bidi/input/perform_actions/key.py
@@ -19,13 +19,13 @@ async def test_invalid_browsing_context(bidi_session):
         await bidi_session.input.perform_actions(actions=actions, context="foo")
 
 
-async def test_browsing_context_closed_before_key_up(bidi_session,
-        configuration, new_tab, get_test_page):
-    """
-    If the browsing context is closed during the action chain, the action
-    command should fail with `NoSuchFrame` error code.
-    """
-    url = get_test_page()
+async def test_key_down_closes_browsing_context(
+    bidi_session, configuration, new_tab, inline
+):
+    url = inline("""
+        <input onkeydown="window.close()">close</input>
+        <script>document.querySelector("input").focus();</script>
+        """)
 
     await bidi_session.browsing_context.navigate(
         context=new_tab["context"],
@@ -41,13 +41,10 @@ async def test_browsing_context_closed_before_key_up(bidi_session,
         .key_up("w")
     )
 
-    actions_command_future = bidi_session.input.perform_actions(
-        actions=actions, context=new_tab["context"])
-
-    await bidi_session.browsing_context.close(context=new_tab["context"])
-
     with pytest.raises(NoSuchFrameException):
-        await actions_command_future
+        await bidi_session.input.perform_actions(
+            actions=actions, context=new_tab["context"]
+        )
 
 
 async def test_key_backspace(bidi_session, top_context, setup_key_test):

--- a/webdriver/tests/bidi/input/perform_actions/key.py
+++ b/webdriver/tests/bidi/input/perform_actions/key.py
@@ -19,13 +19,13 @@ async def test_invalid_browsing_context(bidi_session):
         await bidi_session.input.perform_actions(actions=actions, context="foo")
 
 
-async def test_key_down_closes_browsing_context(
-    bidi_session, configuration, new_tab, inline
-):
-    url = inline("""
-        <input onkeydown="window.close()">close</input>
-        <script>document.querySelector("input").focus();</script>
-        """)
+async def test_browsing_context_closed_before_key_up(bidi_session,
+        configuration, new_tab, get_test_page):
+    """
+    If the browsing context is closed during the action chain, the action
+    command should fail with `NoSuchFrame` error code.
+    """
+    url = get_test_page()
 
     await bidi_session.browsing_context.navigate(
         context=new_tab["context"],
@@ -41,10 +41,13 @@ async def test_key_down_closes_browsing_context(
         .key_up("w")
     )
 
+    actions_command_future = bidi_session.input.perform_actions(
+        actions=actions, context=new_tab["context"])
+
+    await bidi_session.browsing_context.close(context=new_tab["context"])
+
     with pytest.raises(NoSuchFrameException):
-        await bidi_session.input.perform_actions(
-            actions=actions, context=new_tab["context"]
-        )
+        await actions_command_future
 
 
 async def test_key_backspace(bidi_session, top_context, setup_key_test):

--- a/webdriver/tests/bidi/input/perform_actions/pointer_mouse.py
+++ b/webdriver/tests/bidi/input/perform_actions/pointer_mouse.py
@@ -2,6 +2,7 @@ import pytest
 
 from webdriver.bidi.error import MoveTargetOutOfBoundsException, NoSuchFrameException
 from webdriver.bidi.modules.input import Actions, get_element_origin
+from webdriver.bidi.modules.script import ContextTarget
 
 from tests.support.asserts import assert_move_to_coordinates
 from tests.support.helpers import filter_dict
@@ -16,18 +17,29 @@ from . import (
 
 pytestmark = pytest.mark.asyncio
 
+CONTEXT_LOAD_EVENT = "browsingContext.load"
+
 
 async def test_pointer_down_closes_browsing_context(
-    bidi_session, configuration, get_element, new_tab, inline
+    bidi_session, configuration, get_element, new_tab, inline, subscribe_events,
+    wait_for_event
 ):
     url = inline("""<input onpointerdown="window.close()">close</input>""")
-    await bidi_session.browsing_context.navigate(
-        context=new_tab["context"],
-        url=url,
-        wait="complete",
-    )
 
-    element = await get_element("input", context=new_tab)
+    # Opening a new context via `window.open` is required for script to be able
+    # to close it.
+    await subscribe_events(events=[CONTEXT_LOAD_EVENT])
+    on_load = wait_for_event(CONTEXT_LOAD_EVENT)
+
+    await bidi_session.script.evaluate(
+        expression=f"window.open('{url}')",
+        target=ContextTarget(new_tab["context"]),
+        await_promise=True
+    )
+    # Wait for the new context to be created and get it.
+    new_context = await on_load
+
+    element = await get_element("input", context=new_context)
     origin = get_element_origin(element)
 
     actions = Actions()
@@ -41,7 +53,7 @@ async def test_pointer_down_closes_browsing_context(
 
     with pytest.raises(NoSuchFrameException):
         await bidi_session.input.perform_actions(
-            actions=actions, context=new_tab["context"]
+            actions=actions, context=new_context["context"]
         )
 
 

--- a/webdriver/tests/bidi/input/perform_actions/pointer_mouse.py
+++ b/webdriver/tests/bidi/input/perform_actions/pointer_mouse.py
@@ -17,10 +17,14 @@ from . import (
 pytestmark = pytest.mark.asyncio
 
 
-async def test_pointer_down_closes_browsing_context(
-    bidi_session, configuration, get_element, new_tab, inline
+async def test_browsing_context_closed_before_pointer_up(
+    bidi_session, configuration, get_element, new_tab, get_test_page
 ):
-    url = inline("""<input onpointerdown="window.close()">close</input>""")
+    """
+    If the browsing context is closed during the action chain, the action
+    command should fail with `NoSuchFrame` error code.
+    """
+    url = get_test_page()
     await bidi_session.browsing_context.navigate(
         context=new_tab["context"],
         url=url,
@@ -39,10 +43,13 @@ async def test_pointer_down_closes_browsing_context(
         .pointer_up(button=0)
     )
 
+    actions_command_future = bidi_session.input.perform_actions(
+        actions=actions, context=new_tab["context"])
+
+    await bidi_session.browsing_context.close(context=new_tab["context"])
+
     with pytest.raises(NoSuchFrameException):
-        await bidi_session.input.perform_actions(
-            actions=actions, context=new_tab["context"]
-        )
+        await actions_command_future
 
 
 async def test_click_at_coordinates(bidi_session, top_context, load_static_test_page):

--- a/webdriver/tests/bidi/input/perform_actions/pointer_mouse.py
+++ b/webdriver/tests/bidi/input/perform_actions/pointer_mouse.py
@@ -17,14 +17,10 @@ from . import (
 pytestmark = pytest.mark.asyncio
 
 
-async def test_browsing_context_closed_before_pointer_up(
-    bidi_session, configuration, get_element, new_tab, get_test_page
+async def test_pointer_down_closes_browsing_context(
+    bidi_session, configuration, get_element, new_tab, inline
 ):
-    """
-    If the browsing context is closed during the action chain, the action
-    command should fail with `NoSuchFrame` error code.
-    """
-    url = get_test_page()
+    url = inline("""<input onpointerdown="window.close()">close</input>""")
     await bidi_session.browsing_context.navigate(
         context=new_tab["context"],
         url=url,
@@ -43,13 +39,10 @@ async def test_browsing_context_closed_before_pointer_up(
         .pointer_up(button=0)
     )
 
-    actions_command_future = bidi_session.input.perform_actions(
-        actions=actions, context=new_tab["context"])
-
-    await bidi_session.browsing_context.close(context=new_tab["context"])
-
     with pytest.raises(NoSuchFrameException):
-        await actions_command_future
+        await bidi_session.input.perform_actions(
+            actions=actions, context=new_tab["context"]
+        )
 
 
 async def test_click_at_coordinates(bidi_session, top_context, load_static_test_page):

--- a/webdriver/tests/bidi/input/perform_actions/pointer_pen.py
+++ b/webdriver/tests/bidi/input/perform_actions/pointer_pen.py
@@ -2,6 +2,7 @@ import pytest
 
 from webdriver.bidi.error import MoveTargetOutOfBoundsException, NoSuchFrameException
 from webdriver.bidi.modules.input import Actions, get_element_origin
+from webdriver.bidi.modules.script import ContextTarget
 
 from .. import get_events
 from . import (
@@ -13,18 +14,29 @@ from . import (
 
 pytestmark = pytest.mark.asyncio
 
+CONTEXT_LOAD_EVENT = "browsingContext.load"
+
 
 async def test_pointer_down_closes_browsing_context(
-    bidi_session, configuration, get_element, new_tab, inline
+    bidi_session, configuration, get_element, new_tab, inline, subscribe_events,
+    wait_for_event
 ):
     url = inline("""<input onpointerdown="window.close()">close</input>""")
-    await bidi_session.browsing_context.navigate(
-        context=new_tab["context"],
-        url=url,
-        wait="complete",
-    )
 
-    element = await get_element("input", context=new_tab)
+    # Opening a new context via `window.open` is required for script to be able
+    # to close it.
+    await subscribe_events(events=[CONTEXT_LOAD_EVENT])
+    on_load = wait_for_event(CONTEXT_LOAD_EVENT)
+
+    await bidi_session.script.evaluate(
+        expression=f"window.open('{url}')",
+        target=ContextTarget(new_tab["context"]),
+        await_promise=True
+    )
+    # Wait for the new context to be created and get it.
+    new_context = await on_load
+
+    element = await get_element("input", context=new_context)
     origin = get_element_origin(element)
 
     actions = Actions()
@@ -38,7 +50,7 @@ async def test_pointer_down_closes_browsing_context(
 
     with pytest.raises(NoSuchFrameException):
         await bidi_session.input.perform_actions(
-            actions=actions, context=new_tab["context"]
+            actions=actions, context=new_context["context"]
         )
 
 

--- a/webdriver/tests/bidi/input/perform_actions/pointer_pen.py
+++ b/webdriver/tests/bidi/input/perform_actions/pointer_pen.py
@@ -14,10 +14,14 @@ from . import (
 pytestmark = pytest.mark.asyncio
 
 
-async def test_pointer_down_closes_browsing_context(
-    bidi_session, configuration, get_element, new_tab, inline
+async def test_browsing_context_closed_before_pointer_up(
+    bidi_session, configuration, get_element, new_tab, get_test_page
 ):
-    url = inline("""<input onpointerdown="window.close()">close</input>""")
+    """
+    If the browsing context is closed during the action chain, the action
+    command should fail with `NoSuchFrame` error code.
+    """
+    url = get_test_page()
     await bidi_session.browsing_context.navigate(
         context=new_tab["context"],
         url=url,
@@ -36,10 +40,13 @@ async def test_pointer_down_closes_browsing_context(
         .pointer_up(button=0)
     )
 
+    actions_command_future = bidi_session.input.perform_actions(
+        actions=actions, context=new_tab["context"])
+
+    await bidi_session.browsing_context.close(context=new_tab["context"])
+
     with pytest.raises(NoSuchFrameException):
-        await bidi_session.input.perform_actions(
-            actions=actions, context=new_tab["context"]
-        )
+        await actions_command_future
 
 
 @pytest.mark.parametrize("origin", ["element", "pointer", "viewport"])

--- a/webdriver/tests/bidi/input/perform_actions/pointer_pen.py
+++ b/webdriver/tests/bidi/input/perform_actions/pointer_pen.py
@@ -14,14 +14,10 @@ from . import (
 pytestmark = pytest.mark.asyncio
 
 
-async def test_browsing_context_closed_before_pointer_up(
-    bidi_session, configuration, get_element, new_tab, get_test_page
+async def test_pointer_down_closes_browsing_context(
+    bidi_session, configuration, get_element, new_tab, inline
 ):
-    """
-    If the browsing context is closed during the action chain, the action
-    command should fail with `NoSuchFrame` error code.
-    """
-    url = get_test_page()
+    url = inline("""<input onpointerdown="window.close()">close</input>""")
     await bidi_session.browsing_context.navigate(
         context=new_tab["context"],
         url=url,
@@ -40,13 +36,10 @@ async def test_browsing_context_closed_before_pointer_up(
         .pointer_up(button=0)
     )
 
-    actions_command_future = bidi_session.input.perform_actions(
-        actions=actions, context=new_tab["context"])
-
-    await bidi_session.browsing_context.close(context=new_tab["context"])
-
     with pytest.raises(NoSuchFrameException):
-        await actions_command_future
+        await bidi_session.input.perform_actions(
+            actions=actions, context=new_tab["context"]
+        )
 
 
 @pytest.mark.parametrize("origin", ["element", "pointer", "viewport"])

--- a/webdriver/tests/bidi/input/perform_actions/pointer_touch.py
+++ b/webdriver/tests/bidi/input/perform_actions/pointer_touch.py
@@ -2,6 +2,7 @@ import pytest
 
 from webdriver.bidi.error import MoveTargetOutOfBoundsException, NoSuchFrameException
 from webdriver.bidi.modules.input import Actions, get_element_origin
+from webdriver.bidi.modules.script import ContextTarget
 
 from .. import get_events
 from . import (
@@ -13,18 +14,29 @@ from . import (
 
 pytestmark = pytest.mark.asyncio
 
+CONTEXT_LOAD_EVENT = "browsingContext.load"
+
 
 async def test_pointer_down_closes_browsing_context(
-    bidi_session, configuration, get_element, new_tab, inline
+    bidi_session, configuration, get_element, new_tab, inline, subscribe_events,
+    wait_for_event
 ):
     url = inline("""<input onpointerdown="window.close()">close</input>""")
-    await bidi_session.browsing_context.navigate(
-        context=new_tab["context"],
-        url=url,
-        wait="complete",
-    )
 
-    element = await get_element("input", context=new_tab)
+    # Opening a new context via `window.open` is required for script to be able
+    # to close it.
+    await subscribe_events(events=[CONTEXT_LOAD_EVENT])
+    on_load = wait_for_event(CONTEXT_LOAD_EVENT)
+
+    await bidi_session.script.evaluate(
+        expression=f"window.open('{url}')",
+        target=ContextTarget(new_tab["context"]),
+        await_promise=True
+    )
+    # Wait for the new context to be created and get it.
+    new_context = await on_load
+
+    element = await get_element("input", context=new_context)
     origin = get_element_origin(element)
 
     actions = Actions()
@@ -38,7 +50,7 @@ async def test_pointer_down_closes_browsing_context(
 
     with pytest.raises(NoSuchFrameException):
         await bidi_session.input.perform_actions(
-            actions=actions, context=new_tab["context"]
+            actions=actions, context=new_context["context"]
         )
 
 

--- a/webdriver/tests/bidi/input/perform_actions/pointer_touch.py
+++ b/webdriver/tests/bidi/input/perform_actions/pointer_touch.py
@@ -14,10 +14,14 @@ from . import (
 pytestmark = pytest.mark.asyncio
 
 
-async def test_pointer_down_closes_browsing_context(
-    bidi_session, configuration, get_element, new_tab, inline
+async def test_browsing_context_closed_before_pointer_up(
+    bidi_session, configuration, get_element, new_tab, get_test_page
 ):
-    url = inline("""<input onpointerdown="window.close()">close</input>""")
+    """
+    If the browsing context is closed during the action chain, the action
+    command should fail with `NoSuchFrame` error code.
+    """
+    url = get_test_page()
     await bidi_session.browsing_context.navigate(
         context=new_tab["context"],
         url=url,
@@ -36,10 +40,13 @@ async def test_pointer_down_closes_browsing_context(
         .pointer_up(button=0)
     )
 
+    actions_command_future = bidi_session.input.perform_actions(
+        actions=actions, context=new_tab["context"])
+
+    await bidi_session.browsing_context.close(context=new_tab["context"])
+
     with pytest.raises(NoSuchFrameException):
-        await bidi_session.input.perform_actions(
-            actions=actions, context=new_tab["context"]
-        )
+        await actions_command_future
 
 
 @pytest.mark.parametrize("origin", ["element", "pointer", "viewport"])

--- a/webdriver/tests/bidi/input/perform_actions/pointer_touch.py
+++ b/webdriver/tests/bidi/input/perform_actions/pointer_touch.py
@@ -14,14 +14,10 @@ from . import (
 pytestmark = pytest.mark.asyncio
 
 
-async def test_browsing_context_closed_before_pointer_up(
-    bidi_session, configuration, get_element, new_tab, get_test_page
+async def test_pointer_down_closes_browsing_context(
+    bidi_session, configuration, get_element, new_tab, inline
 ):
-    """
-    If the browsing context is closed during the action chain, the action
-    command should fail with `NoSuchFrame` error code.
-    """
-    url = get_test_page()
+    url = inline("""<input onpointerdown="window.close()">close</input>""")
     await bidi_session.browsing_context.navigate(
         context=new_tab["context"],
         url=url,
@@ -40,13 +36,10 @@ async def test_browsing_context_closed_before_pointer_up(
         .pointer_up(button=0)
     )
 
-    actions_command_future = bidi_session.input.perform_actions(
-        actions=actions, context=new_tab["context"])
-
-    await bidi_session.browsing_context.close(context=new_tab["context"])
-
     with pytest.raises(NoSuchFrameException):
-        await actions_command_future
+        await bidi_session.input.perform_actions(
+            actions=actions, context=new_tab["context"]
+        )
 
 
 @pytest.mark.parametrize("origin", ["element", "pointer", "viewport"])


### PR DESCRIPTION
The tests relied on the script closing browsing context which causes "Scripts may only close windows that were opened by a script".

Open context with `window.open` to allow it to be closed by script.