### PR TITLE
[wdspec] change test_..._closes_browsing_context

### DIFF
--- a/webdriver/tests/classic/perform_actions/key.py
+++ b/webdriver/tests/classic/perform_actions/key.py
@@ -24,13 +24,21 @@ def test_no_browsing_context(session, closed_frame, key_chain):
 def test_key_down_closes_browsing_context(
     session, configuration, http_new_tab, inline, key_chain
 ):
-    session.url = inline("""
+    url = inline("""
         <input onkeydown="window.close()">close</input>
         <script>document.querySelector("input").focus();</script>
         """)
+
+    # Open a new window.
+    resp = session.execute_script(f"return window.open('{url}')")
+    new_window_handle = resp.id
+
+    # Switch to the new window.
+    session.window_handle = new_window_handle
+
     with pytest.raises(NoSuchWindowException):
         key_chain.key_down("w") \
-            .pause(100 * configuration["timeout_multiplier"]) \
+            .pause(250 * configuration["timeout_multiplier"]) \
             .key_up("w") \
             .perform()
 

--- a/webdriver/tests/classic/perform_actions/key.py
+++ b/webdriver/tests/classic/perform_actions/key.py
@@ -30,15 +30,16 @@ def test_key_down_closes_browsing_context(
         """)
 
     # Open a new window.
-    resp = session.execute_script(f"return window.open('{url}')")
-    new_window_handle = resp.id
+    new_window = session.execute_script(f"return window.open('{url}')")
+
+    new_window_handle = new_window.id
 
     # Switch to the new window.
     session.window_handle = new_window_handle
 
     with pytest.raises(NoSuchWindowException):
         key_chain.key_down("w") \
-            .pause(250 * configuration["timeout_multiplier"]) \
+            .pause(100 * configuration["timeout_multiplier"]) \
             .key_up("w") \
             .perform()
 

--- a/webdriver/tests/classic/perform_actions/key.py
+++ b/webdriver/tests/classic/perform_actions/key.py
@@ -32,10 +32,8 @@ def test_key_down_closes_browsing_context(
     # Open a new window.
     new_window = session.execute_script(f"return window.open('{url}')")
 
-    new_window_handle = new_window.id
-
     # Switch to the new window.
-    session.window_handle = new_window_handle
+    session.window_handle = new_window.id
 
     with pytest.raises(NoSuchWindowException):
         key_chain.key_down("w") \

--- a/webdriver/tests/classic/perform_actions/pointer_mouse.py
+++ b/webdriver/tests/classic/perform_actions/pointer_mouse.py
@@ -40,10 +40,9 @@ def test_pointer_down_closes_browsing_context(
 
     # Open a new window.
     new_window = session.execute_script(f"return window.open('{url}')")
-    new_window_handle = new_window.id
 
     # Switch to the new window.
-    session.window_handle = new_window_handle
+    session.window_handle = new_window.id
 
     # Get the input element.
     origin = session.find.css("input", all=False)

--- a/webdriver/tests/classic/perform_actions/pointer_mouse.py
+++ b/webdriver/tests/classic/perform_actions/pointer_mouse.py
@@ -39,8 +39,8 @@ def test_pointer_down_closes_browsing_context(
     url = inline("""<input onpointerdown="window.close()">close</input>""")
 
     # Open a new window.
-    resp = session.execute_script(f"return window.open('{url}')")
-    new_window_handle = resp.id
+    new_window = session.execute_script(f"return window.open('{url}')")
+    new_window_handle = new_window.id
 
     # Switch to the new window.
     session.window_handle = new_window_handle
@@ -51,7 +51,7 @@ def test_pointer_down_closes_browsing_context(
     with pytest.raises(NoSuchWindowException):
         mouse_chain.pointer_move(0, 0, origin=origin) \
             .pointer_down(button=0) \
-            .pause(250 * configuration["timeout_multiplier"]) \
+            .pause(100 * configuration["timeout_multiplier"]) \
             .pointer_up(button=0) \
             .perform()
 

--- a/webdriver/tests/classic/perform_actions/pointer_mouse.py
+++ b/webdriver/tests/classic/perform_actions/pointer_mouse.py
@@ -36,14 +36,22 @@ def test_no_browsing_context(session, closed_frame, mouse_chain):
 def test_pointer_down_closes_browsing_context(
     session, configuration, http_new_tab, inline, mouse_chain
 ):
-    session.url = inline(
-        """<input onpointerdown="window.close()">close</input>""")
+    url = inline("""<input onpointerdown="window.close()">close</input>""")
+
+    # Open a new window.
+    resp = session.execute_script(f"return window.open('{url}')")
+    new_window_handle = resp.id
+
+    # Switch to the new window.
+    session.window_handle = new_window_handle
+
+    # Get the input element.
     origin = session.find.css("input", all=False)
 
     with pytest.raises(NoSuchWindowException):
         mouse_chain.pointer_move(0, 0, origin=origin) \
             .pointer_down(button=0) \
-            .pause(100 * configuration["timeout_multiplier"]) \
+            .pause(250 * configuration["timeout_multiplier"]) \
             .pointer_up(button=0) \
             .perform()
 

--- a/webdriver/tests/classic/perform_actions/pointer_pen.py
+++ b/webdriver/tests/classic/perform_actions/pointer_pen.py
@@ -33,14 +33,22 @@ def test_no_browsing_context(session, closed_frame, pen_chain):
 def test_pointer_down_closes_browsing_context(
     session, configuration, http_new_tab, inline, pen_chain
 ):
-    session.url = inline(
-        """<input onpointerdown="window.close()">close</input>""")
+    url = inline("""<input onpointerdown="window.close()">close</input>""")
+
+    # Open a new window.
+    resp = session.execute_script(f"return window.open('{url}')")
+    new_window_handle = resp.id
+
+    # Switch to the new window.
+    session.window_handle = new_window_handle
+
+    # Get the input element.
     origin = session.find.css("input", all=False)
 
     with pytest.raises(NoSuchWindowException):
         pen_chain.pointer_move(0, 0, origin=origin) \
             .pointer_down(button=0) \
-            .pause(100 * configuration["timeout_multiplier"]) \
+            .pause(250 * configuration["timeout_multiplier"]) \
             .pointer_up(button=0) \
             .perform()
 

--- a/webdriver/tests/classic/perform_actions/pointer_pen.py
+++ b/webdriver/tests/classic/perform_actions/pointer_pen.py
@@ -36,8 +36,8 @@ def test_pointer_down_closes_browsing_context(
     url = inline("""<input onpointerdown="window.close()">close</input>""")
 
     # Open a new window.
-    resp = session.execute_script(f"return window.open('{url}')")
-    new_window_handle = resp.id
+    new_window = session.execute_script(f"return window.open('{url}')")
+    new_window_handle = new_window.id
 
     # Switch to the new window.
     session.window_handle = new_window_handle
@@ -48,7 +48,7 @@ def test_pointer_down_closes_browsing_context(
     with pytest.raises(NoSuchWindowException):
         pen_chain.pointer_move(0, 0, origin=origin) \
             .pointer_down(button=0) \
-            .pause(250 * configuration["timeout_multiplier"]) \
+            .pause(100 * configuration["timeout_multiplier"]) \
             .pointer_up(button=0) \
             .perform()
 

--- a/webdriver/tests/classic/perform_actions/pointer_pen.py
+++ b/webdriver/tests/classic/perform_actions/pointer_pen.py
@@ -37,10 +37,9 @@ def test_pointer_down_closes_browsing_context(
 
     # Open a new window.
     new_window = session.execute_script(f"return window.open('{url}')")
-    new_window_handle = new_window.id
 
     # Switch to the new window.
-    session.window_handle = new_window_handle
+    session.window_handle = new_window.id
 
     # Get the input element.
     origin = session.find.css("input", all=False)

--- a/webdriver/tests/classic/perform_actions/pointer_touch.py
+++ b/webdriver/tests/classic/perform_actions/pointer_touch.py
@@ -32,14 +32,22 @@ def test_no_browsing_context(session, closed_frame, touch_chain):
 def test_pointer_down_closes_browsing_context(
     session, configuration, http_new_tab, inline, touch_chain
 ):
-    session.url = inline(
-        """<input onpointerdown="window.close()">close</input>""")
+    url = inline("""<input onpointerdown="window.close()">close</input>""")
+
+    # Open a new window.
+    resp = session.execute_script(f"return window.open('{url}')")
+    new_window_handle = resp.id
+
+    # Switch to the new window.
+    session.window_handle = new_window_handle
+
+    # Get the input element.
     origin = session.find.css("input", all=False)
 
     with pytest.raises(NoSuchWindowException):
         touch_chain.pointer_move(0, 0, origin=origin) \
             .pointer_down(button=0) \
-            .pause(100 * configuration["timeout_multiplier"]) \
+            .pause(250 * configuration["timeout_multiplier"]) \
             .pointer_up(button=0) \
             .perform()
 

--- a/webdriver/tests/classic/perform_actions/pointer_touch.py
+++ b/webdriver/tests/classic/perform_actions/pointer_touch.py
@@ -36,10 +36,9 @@ def test_pointer_down_closes_browsing_context(
 
     # Open a new window.
     new_window = session.execute_script(f"return window.open('{url}')")
-    new_window_handle = new_window.id
 
     # Switch to the new window.
-    session.window_handle = new_window_handle
+    session.window_handle = new_window.id
 
     # Get the input element.
     origin = session.find.css("input", all=False)

--- a/webdriver/tests/classic/perform_actions/pointer_touch.py
+++ b/webdriver/tests/classic/perform_actions/pointer_touch.py
@@ -35,8 +35,8 @@ def test_pointer_down_closes_browsing_context(
     url = inline("""<input onpointerdown="window.close()">close</input>""")
 
     # Open a new window.
-    resp = session.execute_script(f"return window.open('{url}')")
-    new_window_handle = resp.id
+    new_window = session.execute_script(f"return window.open('{url}')")
+    new_window_handle = new_window.id
 
     # Switch to the new window.
     session.window_handle = new_window_handle
@@ -47,7 +47,7 @@ def test_pointer_down_closes_browsing_context(
     with pytest.raises(NoSuchWindowException):
         touch_chain.pointer_move(0, 0, origin=origin) \
             .pointer_down(button=0) \
-            .pause(250 * configuration["timeout_multiplier"]) \
+            .pause(100 * configuration["timeout_multiplier"]) \
             .pointer_up(button=0) \
             .perform()
 


### PR DESCRIPTION
Classic tests. Open context with `window.open` to allow it to be closed by script.