### PR TITLE
fix invalid urlpattern test(s)

### DIFF
--- a/urlpattern/resources/urlpatterntestdata.json
+++ b/urlpattern/resources/urlpatterntestdata.json
@@ -2370,15 +2370,24 @@
   },
   {
     "pattern": [{ "hostname": "bad#hostname" }],
-    "expected_obj": "error"
+    "exactly_empty_components": ["port"],
+    "expected_match": {
+      "hostname": { "input": "bad", "groups": {} }
+    }
   },
   {
     "pattern": [{ "hostname": "bad%hostname" }],
-    "expected_obj": "error"
+    "exactly_empty_components": ["port"],
+    "expected_match": {
+      "hostname": { "input": "bad%hostname", "groups": {} }
+    }
   },
   {
     "pattern": [{ "hostname": "bad/hostname" }],
-    "expected_obj": "error"
+    "exactly_empty_components": ["port"],
+    "expected_match": {
+      "hostname": { "input": "bad", "groups": {} }
+    }
   },
   {
     "pattern": [{ "hostname": "bad\\:hostname" }],
@@ -2422,15 +2431,24 @@
   },
   {
     "pattern": [{ "hostname": "bad\nhostname" }],
-    "expected_obj": "error"
+    "exactly_empty_components": ["port"],
+    "expected_match": {
+      "hostname": { "input": "badhostname", "groups": {} }
+    }
   },
   {
     "pattern": [{ "hostname": "bad\rhostname" }],
-    "expected_obj": "error"
+    "exactly_empty_components": ["port"],
+    "expected_match": {
+      "hostname": { "input": "badhostname", "groups": {} }
+    }
   },
   {
     "pattern": [{ "hostname": "bad\thostname" }],
-    "expected_obj": "error"
+    "exactly_empty_components": ["port"],
+    "expected_match": {
+      "hostname": { "input": "badhostname", "groups": {} }
+    }
   },
   {
     "pattern": [{}],

--- a/urlpattern/resources/urlpatterntestdata.json
+++ b/urlpattern/resources/urlpatterntestdata.json
@@ -1151,6 +1151,11 @@
     }
   },
   {
+    "pattern": [{ "protocol": "http", "port": "100000" }],
+    "inputs": [{ "protocol": "http", "port": "100000" }],
+    "expected_obj": "error"
+  },
+  {
     "pattern": [{ "port": "80" }],
     "inputs": [{ "protocol": "http", "port": "80" }],
     "expected_match": null

--- a/urlpattern/resources/urlpatterntestdata.json
+++ b/urlpattern/resources/urlpatterntestdata.json
@@ -1145,7 +1145,10 @@
   {
     "pattern": [{ "protocol": "http", "port": "80 " }],
     "inputs": [{ "protocol": "http", "port": "80" }],
-    "expected_obj": "error"
+    "exactly_empty_components": ["port"],
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} }
+    }
   },
   {
     "pattern": [{ "port": "80" }],


### PR DESCRIPTION
Fixes https://github.com/whatwg/urlpattern/issues/239

Port calls canonicalizePort which just calls url parser setter, which removes the leading trailing c0 whitespace characters from the input.

cc @annevk @lucacasonato @sisidovski 