### PR TITLE
layout: Fix intrinsic contributions of anonymous blocks

### DIFF
--- a/css/CSS2/normal-flow/intrinsic-size-with-anonymous-block.html
+++ b/css/CSS2/normal-flow/intrinsic-size-with-anonymous-block.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<title>Intrinsic size of an atomic inline with an anonymous block</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#inlineblock-width">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#inline-replaced-width">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#anonymous-block-level">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  #test contains both inline-level contents (the canvas) and block-level (the <p>).
+  Then the canvas is wrapped inside an anonymous block, but it still resolves its percentage against #test.
+  So the canvas is 100px tall, and thus 100px wide because of its aspect ratio.
+  Therefore #test is 100px wide too.
+">
+<style>
+#test {
+  display: inline-block;
+  height: 100px;
+  background: green;
+}
+#test > canvas {
+  height: 100%;
+  background: red;
+  position: relative;
+  z-index: -1;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div id="test">
+  <canvas width="10" height="10"></canvas>
+  <p></p>
+</div>


### PR DESCRIPTION
In order to compute the inline min-content and max-content contributions of an anonymous block, we were finding its min-content and max-content inline size with a SizeConstraint coming from the block size of the box.

However, anonymous blocks do not establish a containing block for their contents, so this patch uses a SizeConstraint from the block size of the containing block.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#34719