### PR TITLE
layout: Implement keyword sizes for block layout heuristics

### DIFF
--- a/css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-001.html
+++ b/css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-001.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#fit-content-size">
+<link rel="help" href="https://drafts.csswg.org/css2/#floats">
+<link rel="help" href="https://drafts.csswg.org/css2/#clearance">
+<link rel="help" href="https://drafts.csswg.org/css2/#collapsing-margins">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The element with `width: fit-content` becomes 0px wide.
+  Therefore, the padding percentage of its child resolves to 0px.
+  Therefore, the 100px of margin collapse with the top margin of the element with `clear: both`.
+  Therefore, the element with `clear: both` is already past the float and receives no clearance.
+">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="display: inline-block; background: red">
+  <div style="width: 100px; height: 100px; float: left; background: green"></div>
+  <div style="clear: both">
+    <div style="width: fit-content">
+      <div style="padding-top: 100%; margin-bottom: 100px;"></div>
+    </div>
+  </div>
+</div>

--- a/css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-002.html
+++ b/css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-002.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#fit-content-size">
+<link rel="help" href="https://drafts.csswg.org/css2/#floats">
+<link rel="help" href="https://drafts.csswg.org/css2/#clearance">
+<link rel="help" href="https://drafts.csswg.org/css2/#collapsing-margins">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The element with `width: fit-content` becomes 0px wide.
+  Therefore, the padding percentage of its child resolves to 0px.
+  Therefore, the 75px of margin collapse with the top margin of the element with `clear: both`.
+  Therefore, the element with `clear: both` receives 25px of clearance.
+">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="display: inline-block; background: red">
+  <div style="width: 100px; height: 100px; float: left; background: green"></div>
+  <div style="clear: both">
+    <div style="width: fit-content">
+      <div style="padding-top: 100%; margin-bottom: 75px;"></div>
+    </div>
+  </div>
+</div>

--- a/css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-003.html
+++ b/css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-003.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#fit-content-size">
+<link rel="help" href="https://drafts.csswg.org/css2/#floats">
+<link rel="help" href="https://drafts.csswg.org/css2/#clearance">
+<link rel="help" href="https://drafts.csswg.org/css2/#collapsing-margins">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The element with `width: fit-content` becomes 0px wide.
+  Therefore, the padding percentage of its child resolves to 0px.
+  Therefore, the 100px of margin collapse with the top margin of the element with `clear: both`.
+  Therefore, the element with `clear: both` is already past the float and receives no clearance.
+">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="display: inline-block; background: red">
+  <div style="width: 100px; height: 100px; float: left; background: green"></div>
+  <div style="clear: both; width: fit-content">
+    <div style="padding-top: 100%; margin-bottom: 100px;"></div>
+  </div>
+</div>

--- a/css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-004.html
+++ b/css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-004.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#fit-content-size">
+<link rel="help" href="https://drafts.csswg.org/css2/#floats">
+<link rel="help" href="https://drafts.csswg.org/css2/#clearance">
+<link rel="help" href="https://drafts.csswg.org/css2/#collapsing-margins">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The element with `width: fit-content` becomes 0px wide.
+  Therefore, the padding percentage of its child resolves to 0px.
+  Therefore, the 75px of margin collapse with the top margin of the element with `clear: both`.
+  Therefore, the element with `clear: both` receives 25px of clearance.
+">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="display: inline-block; background: red">
+  <div style="width: 100px; height: 100px; float: left; background: green"></div>
+  <div style="clear: both; width: fit-content">
+    <div style="padding-top: 100%; margin-bottom: 75px;"></div>
+  </div>
+</div>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Block layout uses some heuristics to guess whether margins are separated by clearance and then don't collapse. These heuristics now take the min-content, max-content, fit-content and stretch sizing keywords into account.

Reviewed in servo/servo#34695