### PR TITLE
[wdspec] verify internal ids for deeply nested objects

### DIFF
--- a/webdriver/tests/bidi/script/evaluate/internal_id.py
+++ b/webdriver/tests/bidi/script/evaluate/internal_id.py
@@ -63,3 +63,25 @@ async def test_different_remote_values_have_unique_internal_ids(evaluate):
 
     # Make sure that different duplicated objects have different internal ids
     assert internalId1 != internalId2
+
+
+@pytest.mark.asyncio
+async def test_nested_remote_values_have_same_internal_ids(evaluate):
+    result = await evaluate(
+        "{const obj1 = document; const obj2 = {}; ({key1:obj1, key2:obj2, nested:{key3:obj1, key4:obj2}}) }"
+    )
+
+    assert len(result["value"]) == 3
+
+    # key1
+    internalIdKey1 = result["value"][0][1]["internalId"]
+    # key2
+    internalIdKey2 = result["value"][1][1]["internalId"]
+    # nested.key3
+    internalIdKey3 = result["value"][2][1]["value"][0][1]["internalId"]
+    # nested.key4
+    internalIdKey4 = result["value"][2][1]["value"][1][1]["internalId"]
+
+    assert internalIdKey1 != internalIdKey2
+    assert internalIdKey1 == internalIdKey3
+    assert internalIdKey2 == internalIdKey4

--- a/webdriver/tests/bidi/script/evaluate/internal_id.py
+++ b/webdriver/tests/bidi/script/evaluate/internal_id.py
@@ -73,13 +73,9 @@ async def test_nested_remote_values_have_same_internal_ids(evaluate):
 
     assert len(result["value"]) == 3
 
-    # key1
     internalIdKey1 = result["value"][0][1]["internalId"]
-    # key2
     internalIdKey2 = result["value"][1][1]["internalId"]
-    # nested.key3
     internalIdKey3 = result["value"][2][1]["value"][0][1]["internalId"]
-    # nested.key4
     internalIdKey4 = result["value"][2][1]["value"][1][1]["internalId"]
 
     assert internalIdKey1 != internalIdKey2


### PR DESCRIPTION
Currently tests never verify that serialization of deeply (more than 1 level) objects actually works.