### PR TITLE
Accessibility: Input with multiple explicit label elements associated

### DIFF
--- a/accname/name/comp_host_language_label.html
+++ b/accname/name/comp_host_language_label.html
@@ -176,6 +176,14 @@
 </table>
 
 
+<!-- HTML-AAM: https://www.w3.org/TR/html-aam-1.0/#input-type-text-input-type-password-input-type-number-input-type-search-input-type-tel-input-type-email-input-type-url-and-textarea-element-accessible-name-computation -->
+<h2>HTML input with multiple label/for</h2>
+<label for="multi-label">textfield label 1</label>
+<label for="multi-label">textfield label 2</label>
+<input id="multi-label" type="text" data-expectedlabel="textfield label 1 textfield label 2" data-testname="html: multiple label elements[for]" class="ex">
+
+
+
 <!-- SVG: -> /svg-aam/name/ -->
 
 


### PR DESCRIPTION
Closes: https://github.com/web-platform-tests/wpt/issues/49825

This PR adds an input with multiple explicit label elements associated.