### PR TITLE
layout: Implement a non-recursive version of CSS `quotes`

### DIFF
--- a/css/css-content/quotes-lang-dynamic-001.html
+++ b/css/css-content/quotes-lang-dynamic-001.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>CSS-content test: changing the lang attribute affects quotes</title>
+<link rel="author" title="Xiaocheng Hu" href="mailto:xiaochengh.work@gmail.com">
+<link rel="match" href="reference/quotes-lang-dynamic-001-ref.html">
+<link rel=help href="https://drafts.csswg.org/css-content/#quotes">
+
+<div id="root" lang="en"><q>First letter</q></div>
+
+<script>
+  document.body.offsetTop;
+  root.setAttribute('lang', 'fr');
+</script>

--- a/css/css-content/quotes-slot-scoping-ref.html
+++ b/css/css-content/quotes-slot-scoping-ref.html
@@ -4,15 +4,8 @@
     <title>Quote scope Shadow DOM and SLOT</title>
     <link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
     <link rel="help" href="https://www.w3.org/TR/css-content-3/#quote-values">
-    <style>
-      q {
-        quotes: '1''1''2''2''3''3';
-      }
-    </style>
   </head>
   <body>
-    <q>
-      <q>Quote</q>
-    </q>
+    1 2Quote2 1
   </body>
 </html>

--- a/css/css-content/reference/quotes-lang-dynamic-001-ref.html
+++ b/css/css-content/reference/quotes-lang-dynamic-001-ref.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>CSS-content test: changing the lang attribute affects quotes</title>
+<link rel="author" title="Xiaocheng Hu" href="mailto:xiaochengh.work@gmail.com">
+<link rel=help href="https://drafts.csswg.org/css-content/#quotes">
+
+<div>&#xab;First letter&#xbb;</div>


### PR DESCRIPTION
This PR partially implements CSS quotes (#34446):
- For non-auto `quotes` value, retrieves the quote data from the property value
- For `auto` value:
  - Hooks up the `-x-lang` internal property to track the computed `lang` attribute value
  - Uses `-x-lang` value to determine current locale
  - Finds out the correct quotes data according to the ICU CLDR data

It also removes the stale and incorrect UA sheet `quotes.css` that is not used anywhere.

Quote depth calculation is out of the scope of this PR and will be left for future.

Other caveats:
- `-x-lang` doesn't track the browser/OS-default locale
- The quotes data is copy-pasted from the [Gecko implementation](https://searchfox.org/mozilla-central/source/intl/locale/Quotes.cpp) instead of generated automatically

Reviewed in servo/servo#34770