### PR TITLE
Get rid of remote_queue from browsers

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/android_webview.py
+++ b/tools/wptrunner/wptrunner/browsers/android_webview.py
@@ -88,7 +88,6 @@ class SystemWebViewShell(ChromeAndroidBrowserBase):
 
     def __init__(self, logger, binary, webdriver_binary="chromedriver",
                  adb_binary=None,
-                 remote_queue=None,
                  device_serial=None,
                  webdriver_args=None,
                  stackwalk_binary=None,
@@ -96,7 +95,7 @@ class SystemWebViewShell(ChromeAndroidBrowserBase):
         """Creates a new representation of Chrome.  The `binary` argument gives
         the browser binary to use for testing."""
         super().__init__(logger,
-                         webdriver_binary, adb_binary, remote_queue,
+                         webdriver_binary, adb_binary,
                          device_serial, webdriver_args, stackwalk_binary,
                          symbols_path)
         self.binary = binary

--- a/tools/wptrunner/wptrunner/browsers/chrome_android.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_android.py
@@ -3,7 +3,7 @@
 import mozprocess
 import subprocess
 
-from .base import cmd_arg, require_arg
+from .base import OutputHandler, cmd_arg, require_arg
 from .base import get_timeout_multiplier   # noqa: F401
 from .base import WebDriverBrowser  # noqa: F401
 from .chrome import executor_kwargs as chrome_executor_kwargs
@@ -79,10 +79,9 @@ def env_options():
 
 
 class LogcatRunner:
-    def __init__(self, logger, browser, remote_queue):
+    def __init__(self, logger, browser):
         self.logger = logger
         self.browser = browser
-        self.remote_queue = remote_queue
 
     def start(self):
         try:
@@ -99,35 +98,24 @@ class LogcatRunner:
             self.logger.error("Failed to clear logcat buffer")
 
         self._cmd = self.browser.logcat_cmd()
+        self._output_handler = OutputHandler(self.logger, self._cmd)
         self._proc = mozprocess.ProcessHandler(
             self._cmd,
-            processOutputLine=self.on_output,
+            processOutputLine=self._output_handler,
             storeOutput=False)
         self._proc.run()
-
-    def _send_message(self, command, *args):
-        try:
-            self.remote_queue.put((command, args))
-        except AssertionError:
-            self.logger.warning("Error when send to remote queue")
+        self._output_handler.after_process_start(self._proc.pid)
+        self._output_handler.start()
 
     def stop(self, force=False):
         if self.is_alive():
             kill_result = self._proc.kill()
             if force and kill_result != 0:
                 self._proc.kill(9)
+        self._output_handler.after_process_stop()
 
     def is_alive(self):
         return hasattr(self._proc, "proc") and self._proc.poll() is None
-
-    def on_output(self, line):
-        data = {
-            "action": "process_output",
-            "process": "LOGCAT",
-            "command": "logcat",
-            "data": line
-        }
-        self._send_message("log", data)
 
 
 class ChromeAndroidBrowserBase(WebDriverBrowser):
@@ -135,7 +123,6 @@ class ChromeAndroidBrowserBase(WebDriverBrowser):
                  logger,
                  webdriver_binary="chromedriver",
                  adb_binary=None,
-                 remote_queue=None,
                  device_serial=None,
                  webdriver_args=None,
                  stackwalk_binary=None,
@@ -148,15 +135,11 @@ class ChromeAndroidBrowserBase(WebDriverBrowser):
         self.device_serial = device_serial
         self.stackwalk_binary = stackwalk_binary
         self.symbols_path = symbols_path
-        self.remote_queue = remote_queue
-
-        if self.remote_queue is not None:
-            self.logcat_runner = LogcatRunner(self.logger, self, self.remote_queue)
+        self.logcat_runner = LogcatRunner(self.logger)
 
     def setup(self):
         self.setup_adb_reverse()
-        if self.remote_queue is not None:
-            self.logcat_runner.start()
+        self.logcat_runner.start()
 
     def _adb_run(self, args):
         cmd = [self.adb_binary]
@@ -176,8 +159,7 @@ class ChromeAndroidBrowserBase(WebDriverBrowser):
         super().cleanup()
         self._adb_run(['forward', '--remove-all'])
         self._adb_run(['reverse', '--remove-all'])
-        if self.remote_queue is not None:
-            self.logcat_runner.stop(force=True)
+        self.logcat_runner.stop(force=True)
 
     def executor_browser(self):
         cls, kwargs = super().executor_browser()
@@ -231,13 +213,12 @@ class ChromeAndroidBrowser(ChromeAndroidBrowserBase):
     def __init__(self, logger, package_name,
                  webdriver_binary="chromedriver",
                  adb_binary=None,
-                 remote_queue = None,
                  device_serial=None,
                  webdriver_args=None,
                  stackwalk_binary=None,
                  symbols_path=None):
         super().__init__(logger,
-                         webdriver_binary, adb_binary, remote_queue,
+                         webdriver_binary, adb_binary,
                          device_serial, webdriver_args, stackwalk_binary,
                          symbols_path)
         self.package_name = package_name

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -601,7 +601,7 @@ class TestRunnerManager(threading.Thread):
                 assert self.browser.browser is not None
                 self.browser.browser.cleanup()
             impl = self.test_implementations[(self.state.subsuite, self.state.test_type)]
-            browser = impl.browser_cls(self.logger, remote_queue=self.command_queue,
+            browser = impl.browser_cls(self.logger,
                                        **impl.browser_kwargs)
             browser.setup()
             self.browser = BrowserManager(self.logger,


### PR DESCRIPTION
This doesn't belong here, especially given it was only ever used to
send "log" commands (which there's no need for: we're within the same
process, we can just invoke the logger directly).

While we're at it, migrate LogcatRunner over to using the same
OutputHandler as used elsewhere (e.g., for WebDriver), thus hopefully
avoiding further duplication.
