### PR TITLE
Sandboxed origin comparison should use window.origin instead of location.origin

### DIFF
--- a/content-security-policy/sandbox/meta-element.sub.html
+++ b/content-security-policy/sandbox/meta-element.sub.html
@@ -10,7 +10,7 @@
 // https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-security-policy
 // `sandbox` directives must be ignored when delivered via `<meta>`.
 test(() => {
-  assert_equals(location.origin, "{{location[scheme]}}://{{location[host]}}");
+  assert_equals(window.origin, "{{location[scheme]}}://{{location[host]}}");
 }, "Document shouldn't be sandboxed by <meta>");
 
 // Note: sandbox directive for workers are not yet specified.


### PR DESCRIPTION
window.origin is the origin that changes based on sandboxing with/without allow-same-origin; location.origin is taken from the page's URL which remains the same.

I think this is the only place that needs to change