### PR TITLE
Exit with useful error when using Python 3.13

### DIFF
--- a/wpt
+++ b/wpt
@@ -5,6 +5,9 @@ if __name__ == "__main__":
     if sys.version_info < (3, 8):
         sys.stderr.write("wpt requires Python 3.8 or higher\n")
         sys.exit(1)
+    elif sys.version_info >= (3, 13):
+        sys.stderr.write("wpt is not compatible with Python 3.13 or higher yet, see https://github.com/web-platform-tests/wpt/issues/48585\n");
+        sys.exit(1)
 
     from tools.wpt import wpt
     wpt.main()


### PR DESCRIPTION
As per #48585 WPT do not support Python 3.13 yet, and it looks like adding support for it is non-trivial. However, 3.13 has started to become the default Python available on some development machines. Since the produced error messages in this case are quiet poor, I've added an explicit check for Python 3.13 until support for it has been implemented.