### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=213554

### DIFF
--- a/css/css-text-decor/reference/text-decoration-thickness-single2-notref.html
+++ b/css/css-text-decor/reference/text-decoration-thickness-single2-notref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<title>Non-reference case for text-decoration-thickness</title>
+<body>
+    <p>Test passes if the short inline content has a thick green underline.</p>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-thickness-single2.html
+++ b/css/css-text-decor/text-decoration-thickness-single2.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<title>Test case for text-decoration-thickness</title>
+<meta name="assert" content="thick underline should show on short inline content">
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#text-box-trim">
+<link rel="mismatch" href="reference/text-decoration-thickness-single2-notref.html">
+<style>
+div {
+  text-decoration: underline;
+  font: 20px/1 Monospace;
+  color: transparent;
+  text-decoration-thickness: 20px;
+  text-decoration-color: green;
+}
+</style>
+<body>
+    <p>Test passes if the short inline content has a thick green underline.</p>
+    <div>X</div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-thickness-single2.html
+++ b/css/css-text-decor/text-decoration-thickness-single2.html
@@ -6,11 +6,11 @@
 <link rel="mismatch" href="reference/text-decoration-thickness-single2-notref.html">
 <style>
 div {
-  text-decoration: underline;
-  font: 20px/1 Monospace;
-  color: transparent;
-  text-decoration-thickness: 20px;
-  text-decoration-color: green;
+    text-decoration: underline;
+    font: 20px/1 Monospace;
+    color: transparent;
+    text-decoration-thickness: 20px;
+    text-decoration-color: green;
 }
 </style>
 <body>


### PR DESCRIPTION
WebKit export from bug: [Child text-decoration-thickness and text-underline-offset override parent decorating boxes' values](https://bugs.webkit.org/show_bug.cgi?id=213554)