### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=282498

### DIFF
--- a/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-046.html
+++ b/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-046.html
@@ -10,6 +10,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-ellipse-046-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the left float shape defined by the basic shape ellipse(closest-side farthest-side at top 40px right 60px) border-box">
+  <meta name="fuzzy" content="maxDifference=2-5; totalPixels=2" />
   <style>
   .container {
     writing-mode: vertical-rl;

--- a/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-046.html
+++ b/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-046.html
@@ -10,7 +10,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-ellipse-046-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the left float shape defined by the basic shape ellipse(closest-side farthest-side at top 40px right 60px) border-box">
-  <meta name="fuzzy" content="maxDifference=2-5; totalPixels=2" />
+  <meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-2" />
   <style>
   .container {
     writing-mode: vertical-rl;

--- a/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-047.html
+++ b/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-047.html
@@ -10,6 +10,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-ellipse-047-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the right float shape defined by the basic shape ellipse(closest-side farthest-side at top 40px right 60px) border-box">
+  <meta name="fuzzy" content="maxDifference=2-5; totalPixels=2" />
   <style>
   .container {
     writing-mode: vertical-rl;

--- a/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-047.html
+++ b/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-047.html
@@ -10,7 +10,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-ellipse-047-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the right float shape defined by the basic shape ellipse(closest-side farthest-side at top 40px right 60px) border-box">
-  <meta name="fuzzy" content="maxDifference=2-5; totalPixels=2" />
+  <meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-2" />
   <style>
   .container {
     writing-mode: vertical-rl;

--- a/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-048.html
+++ b/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-048.html
@@ -10,6 +10,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-ellipse-048-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the left float shape defined by the basic shape ellipse(closest-side farthest-side at left 40px top 60px) border-box">
+  <meta name="fuzzy" content="maxDifference=2-5; totalPixels=2" />
   <style>
   .container {
     writing-mode: vertical-lr;

--- a/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-048.html
+++ b/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-048.html
@@ -10,7 +10,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-ellipse-048-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the left float shape defined by the basic shape ellipse(closest-side farthest-side at left 40px top 60px) border-box">
-  <meta name="fuzzy" content="maxDifference=2-5; totalPixels=2" />
+  <meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-2" />
   <style>
   .container {
     writing-mode: vertical-lr;

--- a/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-049.html
+++ b/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-049.html
@@ -10,6 +10,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-ellipse-049-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the right float shape defined by the basic shape ellipse(closest-side farthest-side at left 40px top 60px) border-box">
+  <meta name="fuzzy" content="maxDifference=2-5; totalPixels=2" />
   <style>
   .container {
     writing-mode: vertical-lr;

--- a/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-049.html
+++ b/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-049.html
@@ -10,7 +10,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-ellipse-049-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the right float shape defined by the basic shape ellipse(closest-side farthest-side at left 40px top 60px) border-box">
-  <meta name="fuzzy" content="maxDifference=2-5; totalPixels=2" />
+  <meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-2" />
   <style>
   .container {
     writing-mode: vertical-lr;


### PR DESCRIPTION
WebKit export from bug: [\[shape-outside\] Incorrect (overlapping) rendering when float has shape-outside: ellipse in vertical mode](https://bugs.webkit.org/show_bug.cgi?id=282498)