### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=282332

### DIFF
--- a/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-034.html
+++ b/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-034.html
@@ -10,6 +10,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-circle-034-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the right float shape defined by the basic shape circle(50% at right top) value.">
+  <meta name="fuzzy" content="maxDifference=1-3; totalPixels=0-4" />
   <style>
   .container {
     direction: rtl;

--- a/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-034.html
+++ b/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-034.html
@@ -10,7 +10,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-circle-034-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the right float shape defined by the basic shape circle(50% at right top) value.">
-  <meta name="fuzzy" content="maxDifference=1-3; totalPixels=0-4" />
+  <meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-4" />
   <style>
   .container {
     direction: rtl;

--- a/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-049.html
+++ b/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-049.html
@@ -10,6 +10,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-circle-049-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the right float shape defined by circle(50% at left 40px bottom 40px) value under vertical-rl writing-mode.">
+  <meta name="fuzzy" content="maxDifference=2-3; totalPixels=3" />
   <style>
   .container {
     writing-mode: vertical-rl;

--- a/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-049.html
+++ b/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-049.html
@@ -10,7 +10,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-circle-049-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the right float shape defined by circle(50% at left 40px bottom 40px) value under vertical-rl writing-mode.">
-  <meta name="fuzzy" content="maxDifference=2-3; totalPixels=3" />
+  <meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-3" />
   <style>
   .container {
     writing-mode: vertical-rl;

--- a/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-051.html
+++ b/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-051.html
@@ -10,6 +10,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-circle-051-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the right float shape defined by circle(50% at right 40px bottom 40px) value under vertical-lr writing-mode.">
+  <meta name="fuzzy" content="maxDifference=2-3; totalPixels=3" />
   <style>
   .container {
     writing-mode: vertical-lr;

--- a/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-051.html
+++ b/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-051.html
@@ -10,7 +10,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-circle-051-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the right float shape defined by circle(50% at right 40px bottom 40px) value under vertical-lr writing-mode.">
-  <meta name="fuzzy" content="maxDifference=2-3; totalPixels=3" />
+  <meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-3" />
   <style>
   .container {
     writing-mode: vertical-lr;

--- a/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-055.html
+++ b/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-055.html
@@ -10,6 +10,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-circle-055-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the right float shape defined by circle(50% at right 40px bottom 40px) value under horizontal-tb writing-mode.">
+  <meta name="fuzzy" content="maxDifference=2-3; totalPixels=3" />
   <style>
   .container {
     writing-mode: horizontal-tb;

--- a/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-055.html
+++ b/css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-055.html
@@ -10,7 +10,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-circle-055-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the right float shape defined by circle(50% at right 40px bottom 40px) value under horizontal-tb writing-mode.">
-  <meta name="fuzzy" content="maxDifference=2-3; totalPixels=3" />
+  <meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-3" />
   <style>
   .container {
     writing-mode: horizontal-tb;

--- a/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-034.html
+++ b/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-034.html
@@ -10,6 +10,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-ellipse-034-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the right float shape defined by the basic shape ellipse(40px 60px at right top)">
+  <meta name="fuzzy" content="maxDifference=1-3; totalPixels=2" />
   <style>
   .container {
     direction: rtl;

--- a/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-034.html
+++ b/css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-034.html
@@ -10,7 +10,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes">
   <link rel="match" href="reference/shape-outside-ellipse-034-ref.html">
   <meta name="assert" content="Test the boxes are wrapping around the right float shape defined by the basic shape ellipse(40px 60px at right top)">
-  <meta name="fuzzy" content="maxDifference=1-3; totalPixels=2" />
+  <meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-2" />
   <style>
   .container {
     direction: rtl;


### PR DESCRIPTION
WebKit export from bug: [\[IFC\]\[shape-outside\] RTL content fails with shape-outside float](https://bugs.webkit.org/show_bug.cgi?id=282332)