### PR TITLE
WebKit export: Fix css/css-overflow/line-clamp/reference/webkit-line-clamp-025-ref.html

### DIFF
--- a/css/css-overflow/line-clamp/reference/webkit-line-clamp-025-ref.html
+++ b/css/css-overflow/line-clamp/reference/webkit-line-clamp-025-ref.html
@@ -16,4 +16,4 @@
   color: orange;
 }
 </style>
-<div class="clamp"><div><div class="float">[f]</div>A B C D…</div>
+<div class="clamp"><div><div class="float">[f]</div>A B C D…</div></div>


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=279743