### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=279677

### DIFF
--- a/css/css-fonts/parsing/font-size-adjust-computed.html
+++ b/css/css-fonts/parsing/font-size-adjust-computed.html
@@ -19,10 +19,16 @@
     font-family: ahem-ex-500 !important;
     font-size: 1000px;
 }
+#container {
+    container-type: inline-size;
+    width: 10px;
+}
 </style>
 </head>
 <body>
-<div id="target"></div>
+<div id="container">
+  <div id="target"></div>
+</div>
 <script>
 function compareFontSizeAdjustFromFont(actual, expected) {
   // Depending on font configurations, the retrieved aspect_value may slightly
@@ -60,6 +66,13 @@ promise_test(async (t) => {
   test_computed_value('font-size-adjust', 'ch-width from-font', 'ch-width 1', undefined, {comparisonFunction: compareFontSizeAdjustFromFont});
   test_computed_value('font-size-adjust', 'ic-width from-font', 'ic-width 1', undefined, {comparisonFunction: compareFontSizeAdjustFromFont});
   test_computed_value('font-size-adjust', 'ic-height from-font', 'ic-height 1');
+
+  test_computed_value('font-size-adjust', 'calc(0.5)', '0.5');
+  test_computed_value('font-size-adjust', 'ex-height calc(0.5)', '0.5');  // default basis 'ex' omitted from serialization
+  test_computed_value('font-size-adjust', 'cap-height calc(0.5)', 'cap-height 0.5');
+  test_computed_value('font-size-adjust', 'cap-height calc(0.5 + 1)', 'cap-height 1.5');
+  test_computed_value('font-size-adjust', 'cap-height calc(-0.5)', 'cap-height 0');
+  test_computed_value('font-size-adjust', 'cap-height calc(10 + (sign(20cqw - 10px) * 5))', 'cap-height 5');
 })
 </script>
 </body>

--- a/css/css-fonts/parsing/font-size-adjust-valid.html
+++ b/css/css-fonts/parsing/font-size-adjust-valid.html
@@ -26,6 +26,13 @@ test_valid_value('font-size-adjust', 'cap-height from-font');
 test_valid_value('font-size-adjust', 'ch-width from-font');
 test_valid_value('font-size-adjust', 'ic-width from-font');
 test_valid_value('font-size-adjust', 'ic-height from-font');
+
+test_valid_value('font-size-adjust', 'calc(0.5)');
+test_valid_value('font-size-adjust', 'ex-height calc(0.5)', 'calc(0.5)');  // default basis 'ex' omitted from serialization
+test_valid_value('font-size-adjust', 'cap-height calc(0.5)');
+test_valid_value('font-size-adjust', 'cap-height calc(0.5 + 1)', 'cap-height calc(1.5)');
+test_valid_value('font-size-adjust', 'cap-height calc(-0.5)', 'cap-height calc(-0.5)');
+test_valid_value('font-size-adjust', 'cap-height calc(10 + (sign(20cqw - 10px) * 5))', 'cap-height calc(10 + (5 * sign(20cqw - 10px)))');
 </script>
 </body>
 </html>

--- a/css/css-fonts/parsing/font-stretch-computed.html
+++ b/css/css-fonts/parsing/font-stretch-computed.html
@@ -8,9 +8,17 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/computed-testcommon.js"></script>
+<style>
+  #container {
+    container-type: inline-size;
+    width: 10px;
+  }
+</style>
 </head>
 <body>
-<div id="target"></div>
+<div id="container">
+  <div id="target"></div>
+</div>
 <script>
 test_computed_value('font-stretch', 'ultra-condensed', '50%');
 test_computed_value('font-stretch', 'extra-condensed', '62.5%');
@@ -23,6 +31,11 @@ test_computed_value('font-stretch', 'extra-expanded', '150%');
 test_computed_value('font-stretch', 'ultra-expanded', '200%');
 
 test_computed_value('font-stretch', '234.5%');
+test_computed_value('font-stretch', 'calc(100%)', '100%');
+test_computed_value('font-stretch', 'calc(0%)', '0%');
+test_computed_value('font-stretch', 'calc(-100%)', '0%');
+test_computed_value('font-stretch', 'calc(100% + 100%)', '200%');
+test_computed_value('font-stretch', 'calc(100% + (sign(20cqw - 10px) * 5%))', '95%');
 </script>
 </body>
 </html>

--- a/css/css-fonts/parsing/font-stretch-invalid.html
+++ b/css/css-fonts/parsing/font-stretch-invalid.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Fonts Module Level 4: parsing font-stretch with invalid values</title>
 <link rel="help" href="https://www.w3.org/TR/css-fonts-4/#font-stretch-prop">
-<meta name="assert" content="font-stretch supports only the grammar 'normal | <percentage> | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded'.">
+<meta name="assert" content="font-stretch supports only the grammar 'normal | <percentage [0,∞]> | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded'.">
 <meta name="assert" content="Values less than 0% are invalid.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/css/css-fonts/parsing/font-stretch-valid.html
+++ b/css/css-fonts/parsing/font-stretch-valid.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Fonts Module Level 4: parsing font-stretch with valid values</title>
 <link rel="help" href="https://www.w3.org/TR/css-fonts-4/#font-stretch-prop">
-<meta name="assert" content="font-stretch supports the full grammar 'normal | <percentage> | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded'.">
+<meta name="assert" content="font-stretch supports the full grammar 'normal | <percentage [0,∞]> | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded'.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
@@ -22,6 +22,11 @@ test_valid_value('font-stretch', 'extra-expanded');
 test_valid_value('font-stretch', 'ultra-expanded');
 
 test_valid_value('font-stretch', '234.5%');
+test_valid_value('font-stretch', 'calc(100%)');
+test_valid_value('font-stretch', 'calc(0%)');
+test_valid_value('font-stretch', 'calc(-100%)');
+test_valid_value('font-stretch', 'calc(100% + 100%)', 'calc(200%)');
+test_valid_value('font-stretch', 'calc(100% + (sign(20cqw - 10px) * 5%))', 'calc(100% + (5% * sign(20cqw - 10px)))');
 </script>
 </body>
 </html>

--- a/css/css-fonts/parsing/font-style-computed.html
+++ b/css/css-fonts/parsing/font-style-computed.html
@@ -3,24 +3,42 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Fonts Module Level 3: getComputedStyle().fontStyle</title>
-<link rel="help" href="https://www.w3.org/TR/css-fonts-3/#font-style-prop">
+<link rel="help" href="https://www.w3.org/TR/css-fonts-4/#font-style-prop">
 <meta name="assert" content="font-style computed value is as specified.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/computed-testcommon.js"></script>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
+  #container {
+    container-type: inline-size;
+    width: 10px;
+  }
   #target {
     font-family: Ahem;
   }
 </style>
 </head>
 <body>
-<div id="target"></div>
+<div id="container">
+  <div id="target"></div>
+</div>
 <script>
 test_computed_value('font-style', 'normal');
 test_computed_value('font-style', 'italic');
 test_computed_value('font-style', 'oblique');
+
+test_computed_value('font-style', 'oblique 10deg');
+test_computed_value('font-style', 'oblique -10deg');
+test_computed_value('font-style', 'oblique 0deg');
+test_computed_value('font-style', 'oblique -90deg');
+test_computed_value('font-style', 'oblique 90deg');
+test_computed_value('font-style', 'oblique 10grad', 'oblique 9deg');
+test_computed_value('font-style', 'oblique calc(90deg)', 'oblique 90deg');
+test_computed_value('font-style', 'oblique calc(100deg)', 'oblique 90deg');
+test_computed_value('font-style', 'oblique calc(-100deg)', 'oblique -90deg');
+test_computed_value('font-style', 'oblique calc(30deg * 2)', 'oblique 60deg');
+test_computed_value('font-style', 'oblique calc(30deg + (sign(20cqw - 10px) * 5deg))', 'oblique 25deg');
 </script>
 </body>
 </html>

--- a/css/css-fonts/parsing/font-style-valid.html
+++ b/css/css-fonts/parsing/font-style-valid.html
@@ -2,9 +2,9 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Fonts Module Level 3: parsing font-style with valid values</title>
-<link rel="help" href="https://www.w3.org/TR/css-fonts-3/#font-style-prop">
-<meta name="assert" content="font-style supports the full grammar 'normal | italic | oblique'.">
+<title>CSS Fonts Module Level 4: parsing font-style with valid values</title>
+<link rel="help" href="https://www.w3.org/TR/css-fonts-4/#font-style-prop">
+<meta name="assert" content="font-style supports the full grammar 'normal | italic | oblique <angle [-90deg,90deg]>?'.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
@@ -14,6 +14,18 @@
 test_valid_value('font-style', 'normal');
 test_valid_value('font-style', 'italic');
 test_valid_value('font-style', 'oblique');
+
+test_valid_value('font-style', 'oblique 10deg');
+test_valid_value('font-style', 'oblique -10deg');
+test_valid_value('font-style', 'oblique 0deg');
+test_valid_value('font-style', 'oblique -90deg');
+test_valid_value('font-style', 'oblique 90deg');
+test_valid_value('font-style', 'oblique 10grad');
+test_valid_value('font-style', 'oblique calc(90deg)');
+test_valid_value('font-style', 'oblique calc(100deg)');
+test_valid_value('font-style', 'oblique calc(-100deg)');
+test_valid_value('font-style', 'oblique calc(30deg * 2)', 'oblique calc(60deg)');
+test_valid_value('font-style', 'oblique calc(30deg + (sign(2cqw - 10px) * 5deg))', 'oblique calc(30deg + (5deg * sign(2cqw - 10px)))');
 </script>
 </body>
 </html>

--- a/css/css-fonts/parsing/font-weight-computed.html
+++ b/css/css-fonts/parsing/font-weight-computed.html
@@ -3,11 +3,17 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Fonts Module Level 3: getComputedStyle().fontWeight</title>
-<link rel="help" href="https://www.w3.org/TR/css-fonts-3/#font-weight-prop">
+<link rel="help" href="https://www.w3.org/TR/css-fonts-4/#font-weight-prop">
 <meta name="assert" content="font-weight computed value is a number.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/computed-testcommon.js"></script>
+<style>
+  #container {
+    container-type: inline-size;
+    width: 10px;
+  }
+</style>
 </head>
 <body>
 <div id="container">
@@ -17,6 +23,7 @@
 'use strict';
 test_computed_value('font-weight', 'normal', '400');
 test_computed_value('font-weight', 'bold', '700');
+test_computed_value('font-weight', '1');
 test_computed_value('font-weight', '100');
 test_computed_value('font-weight', '200');
 test_computed_value('font-weight', '300');
@@ -26,6 +33,14 @@ test_computed_value('font-weight', '600');
 test_computed_value('font-weight', '700');
 test_computed_value('font-weight', '800');
 test_computed_value('font-weight', '900');
+test_computed_value('font-weight', '1000');
+test_computed_value('font-weight', '101');
+test_computed_value('font-weight', '150.25');
+test_computed_value('font-weight', 'calc(100)', '100');
+test_computed_value('font-weight', 'calc(0)', '1');
+test_computed_value('font-weight', 'calc(-100)', '1');
+test_computed_value('font-weight', 'calc(100 + 100)', '200');
+test_computed_value('font-weight', 'calc(100 + (sign(20cqw - 10px) * 5))', '95');
 
 function test_relative(specified, inherited, computed) {
   test(() => {
@@ -37,25 +52,45 @@ function test_relative(specified, inherited, computed) {
   }, inherited + ' made ' + specified + ' computes to ' + computed);
 }
 
+test_relative('bolder', '1', '400');
+test_relative('bolder', '50', '400');
 test_relative('bolder', '100', '400');
 test_relative('bolder', '200', '400');
 test_relative('bolder', '300', '400');
+test_relative('bolder', '349', '400');
+test_relative('bolder', '350', '700');
 test_relative('bolder', '400', '700');
 test_relative('bolder', '500', '700');
+test_relative('bolder', '549', '700');
+test_relative('bolder', '550', '900');
 test_relative('bolder', '600', '900');
 test_relative('bolder', '700', '900');
+test_relative('bolder', '749', '900');
+test_relative('bolder', '750', '900');
 test_relative('bolder', '800', '900');
 test_relative('bolder', '900', '900');
+test_relative('bolder', '950', '950');
+test_relative('bolder', '1000', '1000');
 
+test_relative('lighter', '1', '1');
+test_relative('lighter', '50', '50');
 test_relative('lighter', '100', '100');
 test_relative('lighter', '200', '100');
 test_relative('lighter', '300', '100');
+test_relative('lighter', '349', '100');
+test_relative('lighter', '350', '100');
 test_relative('lighter', '400', '100');
 test_relative('lighter', '500', '100');
+test_relative('lighter', '549', '100');
+test_relative('lighter', '550', '400');
 test_relative('lighter', '600', '400');
 test_relative('lighter', '700', '400');
+test_relative('lighter', '749', '400');
+test_relative('lighter', '750', '700');
 test_relative('lighter', '800', '700');
 test_relative('lighter', '900', '700');
+test_relative('lighter', '950', '700');
+test_relative('lighter', '1000', '700');
 </script>
 </body>
 </html>

--- a/css/css-fonts/parsing/font-weight-valid.html
+++ b/css/css-fonts/parsing/font-weight-valid.html
@@ -2,9 +2,9 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Fonts Module Level 3: parsing font-weight with valid values</title>
-<link rel="help" href="https://www.w3.org/TR/css-fonts-3/#font-weight-prop">
-<meta name="assert" content="font-weight supports the full grammar 'normal | bold | bolder | lighter | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900'.">
+<title>CSS Fonts Module Level 4: parsing font-weight with valid values</title>
+<link rel="help" href="https://www.w3.org/TR/css-fonts-4/#font-weight-prop">
+<meta name="assert" content="font-weight supports the full grammar 'normal | bold | bolder | lighter | <number [1,1000]>'.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
@@ -15,6 +15,7 @@ test_valid_value('font-weight', 'normal');
 test_valid_value('font-weight', 'bold');
 test_valid_value('font-weight', 'bolder');
 test_valid_value('font-weight', 'lighter');
+test_valid_value('font-weight', '1');
 test_valid_value('font-weight', '100');
 test_valid_value('font-weight', '200');
 test_valid_value('font-weight', '300');
@@ -24,6 +25,14 @@ test_valid_value('font-weight', '600');
 test_valid_value('font-weight', '700');
 test_valid_value('font-weight', '800');
 test_valid_value('font-weight', '900');
+test_valid_value('font-weight', '1000');
+test_valid_value('font-weight', '101');
+test_valid_value('font-weight', '150.25');
+test_valid_value('font-weight', 'calc(100)');
+test_valid_value('font-weight', 'calc(0)');
+test_valid_value('font-weight', 'calc(-100)');
+test_valid_value('font-weight', 'calc(100 + 100)', 'calc(200)');
+test_valid_value('font-weight', 'calc(100 + (sign(20cqw - 10px) * 5))', 'calc(100 + (5 * sign(20cqw - 10px)))');
 </script>
 </body>
 </html>


### PR DESCRIPTION
WebKit export from bug: [\[Part 5\] All numeric CSSPrimitiveValue resolvers need to take CSSToLengthConversionData: font](https://bugs.webkit.org/show_bug.cgi?id=279677)