### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=285142

### DIFF
--- a/css/css-fonts/animations/font-style-interpolation.html
+++ b/css/css-fonts/animations/font-style-interpolation.html
@@ -46,7 +46,7 @@ test_interpolation({
 }, [
   {at: -2, expect: 'oblique -20deg'},
   {at: -0.25, expect: 'oblique -2.5deg'},
-  {at: 0, expect: 'normal'},
+  {at: 0, expect: 'oblique 0deg'},
   {at: 0.3, expect: 'oblique 3deg'},
   {at: 0.6, expect: 'oblique 6deg'},
   {at: 1, expect: 'oblique 10deg'},
@@ -74,7 +74,7 @@ test_interpolation({
 }, [
   { at: -2, expect: 'oblique -40deg' },
   { at: -0.25, expect: 'oblique -5deg' },
-  { at: 0, expect: 'normal' },
+  { at: 0, expect: 'oblique 0deg' },
   { at: 0.3, expect: 'oblique 6deg' },
   { at: 0.6, expect: 'oblique 12deg' },
   { at: 1, expect: 'oblique 20deg' },
@@ -89,7 +89,7 @@ test_interpolation({
   { at: -1, expect: 'oblique 40deg' },
   { at: 0, expect: 'oblique 20deg' },
   { at: 0.5, expect: 'oblique 10deg' },
-  { at: 1, expect: 'normal' },
+  { at: 1, expect: 'oblique 0deg' },
   { at: 1.5, expect: 'oblique -10deg' },
 ]);
 
@@ -101,7 +101,7 @@ test_interpolation({
   { at: -2, expect: 'oblique -90deg' },
   { at: -1, expect: 'oblique -90deg' },
   { at: 0, expect: 'oblique -90deg' },
-  { at: 0.5, expect: 'normal' },
+  { at: 0.5, expect: 'oblique 0deg' },
   { at: 1, expect: 'oblique 90deg' },
   { at: 1.5, expect: 'oblique 90deg' },
 ]);


### PR DESCRIPTION
WebKit export from bug: [Fix font-style-interpolation.html WPT to expect `oblique 0deg` instead of `normal`](https://bugs.webkit.org/show_bug.cgi?id=285142)