### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=278441

### DIFF
--- a/css/css-backgrounds/background-clip/clip-border-area-on-body-not-propagated-to-root.html
+++ b/css/css-backgrounds/background-clip/clip-border-area-on-body-not-propagated-to-root.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>background-clip:border-area on the root</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip">
+<link rel="match" href="clip-text-on-body-not-propagated-to-root-ref.html">
+<style>
+html, body {
+  box-sizing: border-box;
+  height: 100%;
+  margin: 0;
+}
+html {
+  background-color: white;
+}
+body {
+  border: 20px solid transparent;
+  background-color: green;
+  background-clip: border-area;
+  padding: 10px;
+}
+</style>
+
+There should be a 20px green border around the edge of the viewport. This text should be black on a white background.

--- a/css/css-backgrounds/background-clip/clip-border-area-on-body-propagated-to-root.html
+++ b/css/css-backgrounds/background-clip/clip-border-area-on-body-propagated-to-root.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>background-clip:border-area on the root</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip">
+<link rel="match" href="../reference/green-root-background.html">
+<style>
+html, body {
+  box-sizing: border-box;
+  height: 100%;
+  margin: 0;
+}
+html {
+  color: transparent;
+  border: 20px solid transparent;
+}
+body {
+  background-color: green;
+  background-clip: border-area;
+}
+</style>
+
+The border should not be visible; the page should be entirely green.

--- a/css/css-backgrounds/background-clip/clip-border-area-on-root.html
+++ b/css/css-backgrounds/background-clip/clip-border-area-on-root.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>background-clip:border-area on the root</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip">
+<link rel="match" href="../reference/green-root-background.html">
+<style>
+html, body {
+  box-sizing: border-box;
+  height: 100%;
+  margin: 0;
+}
+html {
+  height: 100%;
+  color: transparent;
+  border: 20px solid transparent;
+  background-color: green;
+  background-clip: border-area;
+}
+</style>
+
+The border should not be visible; the page should be entirely green.

--- a/css/css-backgrounds/background-clip/clip-text-on-body-not-propagated-to-root-ref.html
+++ b/css/css-backgrounds/background-clip/clip-text-on-body-not-propagated-to-root-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+html {
+    font-size: 24px;
+    background-color: white;
+    color: green;
+    font-family: Ahem;
+}
+</style>
+
+This text should be green<br>
+on a white background.

--- a/css/css-backgrounds/background-clip/clip-text-on-body-not-propagated-to-root.html
+++ b/css/css-backgrounds/background-clip/clip-text-on-body-not-propagated-to-root.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>background-clip:text on the root</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#valdef-background-clip-text">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="match" href="clip-text-on-body-not-propagated-to-root-ref.html">
+<style>
+html {
+  background-color: white;
+  font-size: 24px;
+  color: transparent;
+  font-family: Ahem;
+}
+body {
+  background-color: green;
+  background-clip: text;
+}
+</style>
+
+This text should be green<br>
+on a white background.

--- a/css/css-backgrounds/background-clip/clip-text-on-body-propagated-to-root.html
+++ b/css/css-backgrounds/background-clip/clip-text-on-body-propagated-to-root.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>background-clip:text on the root</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#valdef-background-clip-text">
+<link rel="match" href="../reference/green-root-background.html">
+<style>
+html {
+  font-size: 80px;
+  color: transparent;
+  background-color: green;
+}
+body {
+  background-clip: text;
+}
+</style>
+
+This text should not be visible; the page should be entirely green.

--- a/css/css-backgrounds/background-clip/clip-text-on-root.html
+++ b/css/css-backgrounds/background-clip/clip-text-on-root.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>background-clip:text on the root</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#valdef-background-clip-text">
+<link rel="match" href="../reference/green-root-background.html">
+<style>
+html {
+  font-size: 80px;
+  color: transparent;
+  background-color: green;
+  background-clip: text;
+}
+</style>
+
+This text should not be visible; the page should be entirely green.

--- a/css/css-backgrounds/reference/green-root-background.html
+++ b/css/css-backgrounds/reference/green-root-background.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<style>
+:root {
+  background-color: green;
+}
+</style>


### PR DESCRIPTION
WebKit export from bug: [`background-clip: border-area` should do nothing on the root](https://bugs.webkit.org/show_bug.cgi?id=278441)