### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=277093

### DIFF
--- a/css/css-grid/img-src-changes.html
+++ b/css/css-grid/img-src-changes.html
@@ -2,6 +2,7 @@
 <html>
 <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
 <link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<link rel="help" href="https://drafts.csswg.org/css-grid/">
 <meta name="assert" content="Grid goes through layout when image src changes">
 <style>
 div {

--- a/css/css-grid/img-src-changes.html
+++ b/css/css-grid/img-src-changes.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Grid goes through layout when image src changes">
+<style>
+div {
+  display: grid;
+}
+img {
+  width: 100px;
+  height: 100%;
+}
+</style>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div>
+<img src="">
+</div>
+</body>
+<script>
+document.body.offsetHeight;
+document.querySelector("img").src = "grid-items/support/100x100-green.png";
+</script>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[Grid\]\[Replaced\] Grid item which is an image with specified sizes fails to update when src changes](https://bugs.webkit.org/show_bug.cgi?id=277093)