### PR TITLE
[WebDriver BiDi] Fix issue with memory cache in Chrome

### DIFF
--- a/webdriver/tests/bidi/network/before_request_sent/before_request_sent_cached.py
+++ b/webdriver/tests/bidi/network/before_request_sent/before_request_sent_cached.py
@@ -370,7 +370,7 @@ async def test_page_with_cached_script_javascript(
         wait="complete",
     )
 
-    # Expect two or three events, one for the document and the reset for javascript files.
+    # Expect two or three events, one for the document and the rest for javascript files.
     # If the browser uses memory caching there may be only single request for the javascript files,
     # see issue https://github.com/whatwg/html/issues/6110.
     wait = AsyncPoll(bidi_session, timeout=2)

--- a/webdriver/tests/bidi/network/before_request_sent/before_request_sent_cached.py
+++ b/webdriver/tests/bidi/network/before_request_sent/before_request_sent_cached.py
@@ -370,10 +370,10 @@ async def test_page_with_cached_script_javascript(
         wait="complete",
     )
 
-    # Expect three events, one for the document and two for script javascript files.
+    # Expect three events, one for the document and one or two for script javascript files.
     wait = AsyncPoll(bidi_session, timeout=2)
-    await wait.until(lambda _: len(events) >= 7)
-    assert len(events) == 7
+    await wait.until(lambda _: len(events) >= 6)
+    assert len(events) >= 6
 
     # Assert only cached events after reload.
     cached_events = events[4:]
@@ -386,10 +386,11 @@ async def test_page_with_cached_script_javascript(
         cached_events[1],
         expected_request={"method": "GET", "url": cached_script_js_url},
     )
-    assert_before_request_sent_event(
-        cached_events[2],
-        expected_request={"method": "GET", "url": cached_script_js_url},
-    )
+    if len(events) > 6:
+        assert_before_request_sent_event(
+            cached_events[2],
+            expected_request={"method": "GET", "url": cached_script_js_url},
+        )
 
 
 @pytest.mark.asyncio

--- a/webdriver/tests/bidi/network/before_request_sent/before_request_sent_cached.py
+++ b/webdriver/tests/bidi/network/before_request_sent/before_request_sent_cached.py
@@ -370,7 +370,9 @@ async def test_page_with_cached_script_javascript(
         wait="complete",
     )
 
-    # Expect three events, one for the document and one or two for script javascript files.
+    # Expect two or three events, one for the document and the reset for javascript files.
+    # If the browser uses memory caching there may be only single request for the javascript files,
+    # see issue https://github.com/whatwg/html/issues/6110.
     wait = AsyncPoll(bidi_session, timeout=2)
     await wait.until(lambda _: len(events) >= 6)
     assert len(events) >= 6

--- a/webdriver/tests/bidi/network/response_completed/response_completed_cached.py
+++ b/webdriver/tests/bidi/network/response_completed/response_completed_cached.py
@@ -530,7 +530,7 @@ async def test_page_with_cached_script_javascript(
         wait="complete",
     )
 
-    # Expect two or three events, one for the document and the reset for javascript files.
+    # Expect two or three events, one for the document and the rest for javascript files.
     # If the browser uses memory caching there may be only single request for the javascript files,
     # see issue https://github.com/whatwg/html/issues/6110.
     wait = AsyncPoll(bidi_session, timeout=2)

--- a/webdriver/tests/bidi/network/response_completed/response_completed_cached.py
+++ b/webdriver/tests/bidi/network/response_completed/response_completed_cached.py
@@ -532,8 +532,8 @@ async def test_page_with_cached_script_javascript(
 
     # Expect three events, one for the document and two for script javascript files.
     wait = AsyncPoll(bidi_session, timeout=2)
-    await wait.until(lambda _: len(events) >= 7)
-    assert len(events) == 7
+    await wait.until(lambda _: len(events) >= 6)
+    assert len(events) >= 6
 
     # Assert only cached events after reload.
     cached_events = events[4:]
@@ -548,11 +548,12 @@ async def test_page_with_cached_script_javascript(
         expected_request={"method": "GET", "url": cached_script_js_url},
         expected_response={"url": cached_script_js_url, "fromCache": True},
     )
-    assert_response_event(
-        cached_events[2],
-        expected_request={"method": "GET", "url": cached_script_js_url},
-        expected_response={"url": cached_script_js_url, "fromCache": True},
-    )
+    if len(events) > 6:
+        assert_response_event(
+            cached_events[2],
+            expected_request={"method": "GET", "url": cached_script_js_url},
+            expected_response={"url": cached_script_js_url, "fromCache": True},
+        )
 
 
 @pytest.mark.asyncio

--- a/webdriver/tests/bidi/network/response_completed/response_completed_cached.py
+++ b/webdriver/tests/bidi/network/response_completed/response_completed_cached.py
@@ -530,7 +530,9 @@ async def test_page_with_cached_script_javascript(
         wait="complete",
     )
 
-    # Expect three events, one for the document and two for script javascript files.
+    # Expect two or three events, one for the document and the reset for javascript files.
+    # If the browser uses memory caching there may be only single request for the javascript files,
+    # see issue https://github.com/whatwg/html/issues/6110.
     wait = AsyncPoll(bidi_session, timeout=2)
     await wait.until(lambda _: len(events) >= 6)
     assert len(events) >= 6

--- a/webdriver/tests/bidi/network/response_started/response_started_cached.py
+++ b/webdriver/tests/bidi/network/response_started/response_started_cached.py
@@ -540,7 +540,7 @@ async def test_page_with_cached_script_javascript(
         wait="complete",
     )
 
-    # Expect two or three events, one for the document and the reset for javascript files.
+    # Expect two or three events, one for the document and the rest for javascript files.
     # If the browser uses memory caching there may be only single request for the javascript files,
     # see issue https://github.com/whatwg/html/issues/6110.
     wait = AsyncPoll(bidi_session, timeout=2)

--- a/webdriver/tests/bidi/network/response_started/response_started_cached.py
+++ b/webdriver/tests/bidi/network/response_started/response_started_cached.py
@@ -212,8 +212,6 @@ async def test_cached_revalidate(
     )
 
 
-
-
 @pytest.mark.asyncio
 async def test_page_with_cached_link_stylesheet(
     bidi_session,
@@ -542,7 +540,9 @@ async def test_page_with_cached_script_javascript(
         wait="complete",
     )
 
-    # Expect three events, one for the document and one or two for script javascript files.
+    # Expect two or three events, one for the document and the reset for javascript files.
+    # If the browser uses memory caching there may be only single request for the javascript files,
+    # see issue https://github.com/whatwg/html/issues/6110.
     wait = AsyncPoll(bidi_session, timeout=2)
     await wait.until(lambda _: len(events) >= 6)
     assert len(events) >= 6

--- a/webdriver/tests/bidi/network/response_started/response_started_cached.py
+++ b/webdriver/tests/bidi/network/response_started/response_started_cached.py
@@ -542,10 +542,10 @@ async def test_page_with_cached_script_javascript(
         wait="complete",
     )
 
-    # Expect three events, one for the document and two for script javascript files.
+    # Expect three events, one for the document and one or two for script javascript files.
     wait = AsyncPoll(bidi_session, timeout=2)
-    await wait.until(lambda _: len(events) >= 7)
-    assert len(events) == 7
+    await wait.until(lambda _: len(events) >= 6)
+    assert len(events) >= 6
 
     # Assert only cached events after reload.
     cached_events = events[4:]
@@ -560,11 +560,12 @@ async def test_page_with_cached_script_javascript(
         expected_request={"method": "GET", "url": cached_script_js_url},
         expected_response={"url": cached_script_js_url, "fromCache": True},
     )
-    assert_response_event(
-        cached_events[2],
-        expected_request={"method": "GET", "url": cached_script_js_url},
-        expected_response={"url": cached_script_js_url, "fromCache": True},
-    )
+    if len(events) > 6:
+        assert_response_event(
+            cached_events[2],
+            expected_request={"method": "GET", "url": cached_script_js_url},
+            expected_response={"url": cached_script_js_url, "fromCache": True},
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
It seem that Chrome sends only 1 request when the there are multiple scripts with the same URL, this look like optimization on our end.

Tested locally with HTML:
```html
<!doctype html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Document</title>
    <script src="./console.js"></script>
    <script src="./console.js"></script>
  </head>
  <body></body>
</html>
```
And JS:
```js console.js
console.log(2);
```