### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=285347

### DIFF
--- a/css/css-animations/parsing/animation-name-computed.html
+++ b/css/css-animations/parsing/animation-name-computed.html
@@ -13,6 +13,7 @@
 <div id="target"></div>
 <script>
 test_computed_value("animation-name", 'none');
+test_computed_value("animation-name", 'NONE', 'none');
 
 test_computed_value("animation-name", 'foo');
 test_computed_value("animation-name", 'Both');
@@ -20,13 +21,28 @@ test_computed_value("animation-name", 'ease-in');
 test_computed_value("animation-name", 'infinite');
 test_computed_value("animation-name", 'paused');
 test_computed_value("animation-name", 'first, second, third');
-test_computed_value("animation-name", '"something"', ["something", '"something"']);
 
-// TODO: Test more strings, after https://github.com/w3c/csswg-drafts/issues/2435
-// is resolved.
-// Examples that need testing either here or in animation-name-invalid.html :
-// '"Initial"', '"initial"', '"None"', '"Default"', '" x "', "1", '" "', '""',
-// '"multi word string"', '"---\\22---"'
+test_computed_value("animation-name", '"something"', 'something');
+test_computed_value("animation-name", '"---\\22---"', '---\\\"---');
+test_computed_value("animation-name", '"multi word string"', 'multi\\ word\\ string');
+
+// Restricted keywords as strings
+test_computed_value("animation-name", '"none"');
+test_computed_value("animation-name", '"none", "INITIAL", "inherit"');
+test_computed_value("animation-name", '"none", both, ease-in');
+test_computed_value("animation-name", '"NoNe"');
+test_computed_value("animation-name", '"initial"');
+test_computed_value("animation-name", '"INITIAL"');
+test_computed_value("animation-name", '"inherit"');
+test_computed_value("animation-name", '"INHERIT"');
+test_computed_value("animation-name", '"revert"');
+test_computed_value("animation-name", '"REVERT"');
+test_computed_value("animation-name", '"revert-layer"');
+test_computed_value("animation-name", '"REVERT-LAYER"');
+test_computed_value("animation-name", '"unset"');
+test_computed_value("animation-name", '"UNSET"');
+test_computed_value("animation-name", '"default"');
+test_computed_value("animation-name", '"DEFAULT"');
 </script>
 </body>
 </html>

--- a/css/css-animations/parsing/animation-name-valid.html
+++ b/css/css-animations/parsing/animation-name-valid.html
@@ -11,6 +11,7 @@
 </head>
 <body>
 <script>
+test_valid_value("animation-name", 'none');
 test_valid_value("animation-name", 'NONE', 'none');
 
 test_valid_value("animation-name", 'foo');
@@ -20,10 +21,27 @@ test_valid_value("animation-name", 'infinite');
 test_valid_value("animation-name", 'paused');
 test_valid_value("animation-name", 'first, second, third');
 
-test_valid_value("animation-name", '"string"', ['"string"', "string"]);
-test_valid_value("animation-name", '"multi word string"', ['"multi word string"', "multi\\ word\\ string"]);
+test_valid_value("animation-name", '"something"', 'something');
+test_valid_value("animation-name", '"---\\22---"', '---\\\"---');
+test_valid_value("animation-name", '"multi word string"', 'multi\\ word\\ string');
+
+// Restricted keywords as strings
+test_valid_value("animation-name", '"none"');
+test_valid_value("animation-name", '"none", "INITIAL", "inherit"');
+test_valid_value("animation-name", '"none", both, ease-in');
+test_valid_value("animation-name", '"NoNe"');
 test_valid_value("animation-name", '"initial"');
-test_valid_value("animation-name", '"---\\22---"', ['\"---\\\"---\"', '---\\\"---']);
+test_valid_value("animation-name", '"INITIAL"');
+test_valid_value("animation-name", '"inherit"');
+test_valid_value("animation-name", '"INHERIT"');
+test_valid_value("animation-name", '"revert"');
+test_valid_value("animation-name", '"REVERT"');
+test_valid_value("animation-name", '"revert-layer"');
+test_valid_value("animation-name", '"REVERT-LAYER"');
+test_valid_value("animation-name", '"unset"');
+test_valid_value("animation-name", '"UNSET"');
+test_valid_value("animation-name", '"default"');
+test_valid_value("animation-name", '"DEFAULT"');
 </script>
 </body>
 </html>

--- a/css/css-typed-om/the-stylepropertymap/properties/animation-name.html
+++ b/css/css-typed-om/the-stylepropertymap/properties/animation-name.html
@@ -20,8 +20,4 @@ runListValuedPropertyTests('animation-name', [
   { syntax: 'custom-ident' },
 ]);
 
-runUnsupportedPropertyTests('animation-name', [
-  '"foo"'
-]);
-
 </script>


### PR DESCRIPTION
WebKit export from bug: [\[css-animations\] Fix serialization and parsing of `animation-name` strings](https://bugs.webkit.org/show_bug.cgi?id=285347)