### PR TITLE
Ensure Element ID modifications inside disconnected shadow roots are registered

### DIFF
--- a/shadow-dom/getElementById-dynamic-002.html
+++ b/shadow-dom/getElementById-dynamic-002.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>Shadow DOM: ShadowRoot.getElementById in shadow trees keeps working after host is removed from tree</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid">
+<link rel="author" name="Simon Wülker">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="host"></div>
+<script>
+test(function() {
+  let host = document.getElementById("host");
+  host.attachShadow({ mode: "open" }).innerHTML = `<div id="test-id"></div>`;
+  let element = host.shadowRoot.getElementById("test-id");
+  assert_true(!!element);
+
+  host.remove();
+  host.shadowRoot.getElementById("test-id").id = "new-id";
+
+  assert_equals(host.shadowRoot.getElementById("new-id"), element);
+}, "ShadowRoot.getElementById works on elements whose id was modified after the root was disconnected");
+</script>

--- a/shadow-dom/getElementById-dynamic-002.html
+++ b/shadow-dom/getElementById-dynamic-002.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<title>Shadow DOM: ShadowRoot.getElementById in shadow trees keeps working after host is removed from tree</title>
+<title>Shadow DOM: Modifying an element ID inside a disconnected shadow root does not break getElementById</title>
 <link rel="help" href="https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid">
 <link rel="author" name="Simon Wülker">
 <script src="/resources/testharness.js"></script>


### PR DESCRIPTION
The previous code used `Node::is_connected` instead of `Node::is_connected_to_tree`, meaning that modifications to an element id inside a shadow root that is not connected to a document would not be registered.

Also fixes a crash with registering named elements caused by the same problem. Both of these changes are covered by the new web platform test.

We'll likely run into more of these issues as we integrate the shadow dom into the codebase.

[try](https://github.com/simonwuelker/servo/actions/runs/12605903112)

Reviewed in servo/servo#34834