### PR TITLE
Add test to verify legacy sinks for TrustedScript are not supported

### DIFF
--- a/trusted-types/legacy-trusted-scripts.html
+++ b/trusted-types/legacy-trusted-scripts.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">
+<div id="log"></div>
+<script id="prependScript">;</script>
+<script id="appendScript">;</script>
+<script id="replaceChildrenScript">;</script>
+<script id="beforeScript">;</script>
+<script id="afterScript">;</script>
+<script id="replaceWithScript">;</script>
+<script>
+test(t => {
+  prependScript.prepend("1", "2", "3");
+  assert_equals(prependScript.textContent, "123;");
+
+  appendScript.append("1", "2", "3");
+  assert_equals(appendScript.textContent, ";123");
+
+  replaceChildrenScript.replaceChildren("1", "2", "3");
+  assert_equals(replaceChildrenScript.textContent, "123");
+
+  beforeScript.firstChild.before("1", "2", "3");
+  assert_equals(beforeScript.textContent, "123;");
+
+  afterScript.firstChild.after("1", "2", "3");
+  assert_equals(afterScript.textContent, ";123");
+
+  replaceWithScript.firstChild.replaceWith("1", "2", "3");
+  assert_equals(replaceWithScript.textContent, "123");
+}, "Legacy sinks for TrustedScript accept arbitrary strings.");
+</script>


### PR DESCRIPTION
This verifies some API for ParentNode/ChildNode [1] [2] don't do any check for trusted types. This might already be covered by IDL tests but we just perform a direct verification here. This test fails in Chromium, which is not aligned with the DOM spec here [3] and performs specific checks for HTML script elements. Chromium also implements similar behavior for `ChildNodePart.replaceChildren()` but that's currently not shipped [4].

[1] https://dom.spec.whatwg.org/#interface-parentnode
[2] https://dom.spec.whatwg.org/#interface-childnode
[3] https://github.com/w3c/trusted-types/issues/494#issuecomment-2572883416
[4] https://groups.google.com/a/chromium.org/g/blink-dev/c/wIADRnljZDA/m/whzEaaAADAAJ