### PR TITLE
Relax value precision for converting rad to deg for CSS fonts variations

### DIFF
--- a/css/css-fonts/variations/font-style-parsing.html
+++ b/css/css-fonts/variations/font-style-parsing.html
@@ -16,7 +16,7 @@
             { style: "oblique",                     expectedResult: true,   message: "'oblique' is valid" },
             { style: "oblique 0deg",                expectedResult: true,   message: "'oblique' followed by zero degrees is valid" },
             { style: "oblique 20deg",               expectedResult: true,   message: "'oblique' followed by positive angle in degrees is valid" },
-            { style: "oblique 0.5rad",              expectedResult: true,   message: "'oblique' followed by positive angle in radians is valid",    expectedValue: /^oblique 28\.64\d*deg$/ },
+            { style: "oblique 0.5rad",              expectedResult: true,   message: "'oblique' followed by positive angle in radians is valid",    expectedValue: /^oblique 28\.\d*deg$/ },
             { style: "oblique 20grad",              expectedResult: true,   message: "'oblique' followed by positive angle in gradians is valid",   expectedValue: "oblique 18deg" },
             { style: "oblique 0.1turn",             expectedResult: true,   message: "'oblique' followed by positive angle in turns is valid",      expectedValue: "oblique 36deg" },
             { style: "oblique 20px",                expectedResult: false,  message: "'oblique' followed by number with invalid unit type is in valid" },


### PR DESCRIPTION
The current difference in between browsers results is the way they compute and round the conversion from radian angle to degrees for fonts.

The test is about making sure that the conversion is giving a positive number in degree, which is the case.

This was dicussed with @dholbert on 
https://bugs.webkit.org/show_bug.cgi?id=285141