### PR TITLE
Various servodriver fixes

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -87,7 +87,7 @@ class ServoWebDriverBrowser(WebDriverBrowser):
         args = [
             "--hard-fail",
             "--webdriver=%s" % port,
-            "about:blank",
+            "data:,",
         ]
 
         ca_cert_path = server_config.ssl_config["ca_cert_path"]


### PR DESCRIPTION
This is a grab-bag of fixes for failures that occur when running `./mach test-wpt tests/wpt/mozilla/tests/mozilla/ --product=servodriver --processes=1`. They get us incrementally closer to being able to use servodriver as the primary test harness.

Reviewed in servo/servo#34871