### PR TITLE
Remove domain from report-hash tests

### DIFF
--- a/content-security-policy/report-hash/default-src.https.window.js.sub.headers
+++ b/content-security-policy/report-hash/default-src.https.window.js.sub.headers
@@ -1,3 +1,3 @@
 Reporting-Endpoints: csp-endpoint="/reporting/resources/report.py?reportID={{$id:uuid()}}"
-Content-Security-Policy: default-src 'self' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
+Content-Security-Policy: default-src 'self' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
 Server-Timing: uuid;desc="{{$id}}",hash;desc="sha256-1XF/E08XndkoxwN6eIa5J89hYn3OVZ/UyB8BrU5jgzk="

--- a/content-security-policy/report-hash/multiple-policies.https.sub.html.sub.headers
+++ b/content-security-policy/report-hash/multiple-policies.https.sub.html.sub.headers
@@ -1,7 +1,7 @@
 Reporting-Endpoints: csp-endpoint="/reporting/resources/report.py?reportID={{$id:uuid()}}"
-Content-Security-Policy: script-src-elem 'self' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
+Content-Security-Policy: script-src-elem 'self' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
 Reporting-Endpoints: csp-endpoint2="/reporting/resources/report.py?reportID={{$id2:uuid()}}"
-Content-Security-Policy: script-src-elem 'self' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha512'; report-to csp-endpoint2
+Content-Security-Policy: script-src-elem 'self' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha512'; report-to csp-endpoint2
 Server-Timing: uuid;desc="{{$id}}",hash;desc="sha256-1XF/E08XndkoxwN6eIa5J89hYn3OVZ/UyB8BrU5jgzk="
 Server-Timing: uuid2;desc="{{$id2}}",hash2;desc="sha512-hG4x56V5IhUUepZdYU/lX7UOQJ2M7f6ud2EI7os4JV3OwXSZ002P3zkb9tXQkjpOO8UbtjuEufvdcU67Qt2tlw=="
 

--- a/content-security-policy/report-hash/reportonly-default-src.https.window.js.sub.headers
+++ b/content-security-policy/report-hash/reportonly-default-src.https.window.js.sub.headers
@@ -1,3 +1,3 @@
 Reporting-Endpoints: csp-endpoint="/reporting/resources/report.py?reportID={{$id:uuid()}}"
-Content-Security-Policy-Report-Only: default-src 'self' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
+Content-Security-Policy-Report-Only: default-src 'self' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
 Server-Timing: uuid;desc="{{$id}}",hash;desc="sha256-1XF/E08XndkoxwN6eIa5J89hYn3OVZ/UyB8BrU5jgzk="

--- a/content-security-policy/report-hash/reportonly-script-src-elem.https.window.js.sub.headers
+++ b/content-security-policy/report-hash/reportonly-script-src-elem.https.window.js.sub.headers
@@ -1,3 +1,3 @@
 Reporting-Endpoints: csp-endpoint="/reporting/resources/report.py?reportID={{$id:uuid()}}"
-Content-Security-Policy-Report-Only: script-src-elem 'self' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
+Content-Security-Policy-Report-Only: script-src-elem 'self' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
 Server-Timing: uuid;desc="{{$id}}",hash;desc="sha256-1XF/E08XndkoxwN6eIa5J89hYn3OVZ/UyB8BrU5jgzk="

--- a/content-security-policy/report-hash/reportonly-script-src-none.https.window.js.sub.headers
+++ b/content-security-policy/report-hash/reportonly-script-src-none.https.window.js.sub.headers
@@ -1,4 +1,4 @@
 Reporting-Endpoints: csp-endpoint="/reporting/resources/report.py?reportID={{$id:uuid()}}"
-Content-Security-Policy-Report-Only: script-src 'none' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
+Content-Security-Policy-Report-Only: script-src 'none' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
 Server-Timing: uuid;desc="{{$id}}",hash;desc="sha256-1XF/E08XndkoxwN6eIa5J89hYn3OVZ/UyB8BrU5jgzk="
 

--- a/content-security-policy/report-hash/reportonly-script-src.https.window.js.sub.headers
+++ b/content-security-policy/report-hash/reportonly-script-src.https.window.js.sub.headers
@@ -1,3 +1,3 @@
 Reporting-Endpoints: csp-endpoint="/reporting/resources/report.py?reportID={{$id:uuid()}}"
-Content-Security-Policy-Report-Only: script-src 'self' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
+Content-Security-Policy-Report-Only: script-src 'self' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
 Server-Timing: uuid;desc="{{$id}}",hash;desc="sha256-1XF/E08XndkoxwN6eIa5J89hYn3OVZ/UyB8BrU5jgzk="

--- a/content-security-policy/report-hash/resources/report-hash-test-runner.sub.js
+++ b/content-security-policy/report-hash/resources/report-hash-test-runner.sub.js
@@ -9,7 +9,7 @@ function find_server_timing(name) {
 }
 
 const ORIGIN = "https://{{host}}:{{ports[https][0]}}";
-const REMOTE_ORIGIN = "https://{{hosts[alt][www]}}:{{ports[https][0]}}";
+const REMOTE_ORIGIN = "https://{{hosts[alt][]}}:{{ports[https][0]}}";
 const endpoint = `${ORIGIN}/reporting/resources/report.py`;
 const id = find_server_timing("uuid");
 const id2 = find_server_timing("uuid2");

--- a/content-security-policy/report-hash/script-src-elem.https.window.js.sub.headers
+++ b/content-security-policy/report-hash/script-src-elem.https.window.js.sub.headers
@@ -1,3 +1,3 @@
 Reporting-Endpoints: csp-endpoint="/reporting/resources/report.py?reportID={{$id:uuid()}}"
-Content-Security-Policy: script-src-elem 'self' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
+Content-Security-Policy: script-src-elem 'self' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
 Server-Timing: uuid;desc="{{$id}}",hash;desc="sha256-1XF/E08XndkoxwN6eIa5J89hYn3OVZ/UyB8BrU5jgzk="

--- a/content-security-policy/report-hash/script-src-sha512.https.window.js.sub.headers
+++ b/content-security-policy/report-hash/script-src-sha512.https.window.js.sub.headers
@@ -1,3 +1,3 @@
 Reporting-Endpoints: csp-endpoint="/reporting/resources/report.py?reportID={{$id:uuid()}}"
-Content-Security-Policy: script-src 'self' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha512' 'report-sha384' 'report-sha256'; report-to csp-endpoint
+Content-Security-Policy: script-src 'self' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha512' 'report-sha384' 'report-sha256'; report-to csp-endpoint
 Server-Timing: uuid;desc="{{$id}}",hash;desc="sha512-hG4x56V5IhUUepZdYU/lX7UOQJ2M7f6ud2EI7os4JV3OwXSZ002P3zkb9tXQkjpOO8UbtjuEufvdcU67Qt2tlw=="

--- a/content-security-policy/report-hash/script-src.https.window.js.sub.headers
+++ b/content-security-policy/report-hash/script-src.https.window.js.sub.headers
@@ -1,3 +1,3 @@
 Reporting-Endpoints: csp-endpoint="/reporting/resources/report.py?reportID={{$id:uuid()}}"
-Content-Security-Policy: script-src 'self' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
+Content-Security-Policy: script-src 'self' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
 Server-Timing: uuid;desc="{{$id}}",hash;desc="sha256-1XF/E08XndkoxwN6eIa5J89hYn3OVZ/UyB8BrU5jgzk="


### PR DESCRIPTION
The CSP report-hash tests have a domain in them, which made them [fail](https://github.com/WebKit/WebKit/pull/38282/files) in WebKit. This removes that domain dependency, without affecting the tested functionality.