### PR TITLE
Protect wasm/core from accidental manual changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,3 +8,6 @@
 # Require a review for Dockerfile
 tools/docker/Dockerfile @web-platform-tests/wpt-core-team @web-platform-tests/admins
 .taskcluster.yml @web-platform-tests/wpt-core-team @web-platform-tests/admins
+
+# Prevent accidentally touching wasm/core which is updated by a workflow
+wasm/core/ @web-platform-tests/wpt-core-team


### PR DESCRIPTION
Wasm/core is updated from a GitHub workflow and should not be getting manual updates. As discussed at https://github.com/web-platform-tests/wpt/pull/49277#issuecomment-2573510239.