### PR TITLE
Add TrustedType tests for iframe.srcdoc.

### DIFF
--- a/trusted-types/block-string-assignment-to-HTMLIFrameElement-srcdoc.html
+++ b/trusted-types/block-string-assignment-to-HTMLIFrameElement-srcdoc.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/helper.sub.js"></script>
+
+<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script';">
+<body>
+<script>
+  // TrustedHTML assignments do not throw.
+  test(t => {
+    let p = createHTML_policy(window, 1);
+    let html = p.createHTML(INPUTS.HTML);
+    let iframe = document.createElement("iframe");
+    iframe.srcdoc = html;
+    assert_equals(result.textContent, RESULTS.HTML);
+  }, "iframe.srcdoc assigned via policy (successful HTML transformation).");
+
+  // String assignments throw.
+  test(t => {
+    let iframe = document.createElement("iframe");
+    iframe.srcdoc = createHTML_policy(window, 1);
+    assert_throws_js(TypeError, _ => {
+      iframe.srcdoc = "A string";
+    });
+  }, "`iframe.srcdoc = string` throws.");
+
+  // Null assignment throws.
+  test(t => {
+    let iframe = document.createElement("iframe");
+    assert_throws_js(TypeError, _ => {
+      iframe.srcdoc = null;
+    });
+  }, "`iframe.srcdoc = null` throws.");
+
+  // After default policy creation string assignment implicitly calls createHTML
+  test(t => {
+    let p = window.trustedTypes.createPolicy("default", { createHTML:
+      (value, _, sink) => {
+        assert_equals(sink, "iframe srcdoc");
+        return createHTMLJS(value);
+      }
+    });
+
+    let iframe = document.createElement("iframe");
+    iframe.srcdoc = INPUTS.HTML;
+    assert_equals(iframe.srcdoc, RESULTS.HTML);
+  }, "`iframe.srcdoc = string` assigned via default policy (successful HTML transformation).");
+
+  // After default policy creation null assignment implicitly calls createHTML.
+  test(t => {
+    let iframe = document.createElement("iframe");
+    iframe.srcdoc = null;
+    assert_equals(container.innerText, "null");
+  }, "`iframe.srcdoc = null` assigned via default policy does not throw");
+</script>

--- a/trusted-types/block-string-assignment-to-HTMLIFrameElement-srcdoc.html
+++ b/trusted-types/block-string-assignment-to-HTMLIFrameElement-srcdoc.html
@@ -12,13 +12,12 @@
     let html = p.createHTML(INPUTS.HTML);
     let iframe = document.createElement("iframe");
     iframe.srcdoc = html;
-    assert_equals(result.textContent, RESULTS.HTML);
+    assert_equals(iframe.srcdoc, RESULTS.HTML);
   }, "iframe.srcdoc assigned via policy (successful HTML transformation).");
 
   // String assignments throw.
   test(t => {
     let iframe = document.createElement("iframe");
-    iframe.srcdoc = createHTML_policy(window, 1);
     assert_throws_js(TypeError, _ => {
       iframe.srcdoc = "A string";
     });
@@ -36,7 +35,7 @@
   test(t => {
     let p = window.trustedTypes.createPolicy("default", { createHTML:
       (value, _, sink) => {
-        assert_equals(sink, "iframe srcdoc");
+        assert_equals(sink, "HTMLIFrameElement srcdoc");
         return createHTMLJS(value);
       }
     });
@@ -50,6 +49,6 @@
   test(t => {
     let iframe = document.createElement("iframe");
     iframe.srcdoc = null;
-    assert_equals(container.innerText, "null");
+    assert_equals(iframe.srcdoc, "null");
   }, "`iframe.srcdoc = null` assigned via default policy does not throw");
 </script>


### PR DESCRIPTION
It seems we already have some tests for iframe.srcdoc but things are a bit messy so it's unclear whether we cover blocking, conversion check and sink names (#494) and null string edge case. Add a simple test doing that, similar to other `block-string-assignment-to-*` tests.