### PR TITLE
Add more TrustedType tests for eval and function constructor.

### DIFF
--- a/trusted-types/block-eval-function-constructor.html
+++ b/trusted-types/block-eval-function-constructor.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="help" href="https://w3c.github.io/webappsec-csp/#can-compile-strings">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/helper.sub.js"></script>
+<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">
+<script src="support/block-eval-function-constructor.js"></script>
+<script>
+  const testSetupPolicy = trustedTypes.createPolicy("p",
+    { createScriptURL: s => s }
+  );
+
+  fetch_tests_from_worker(new Worker(
+    testSetupPolicy.createScriptURL("support/block-eval-function-constructor-worker.js")
+  ));
+
+  fetch_tests_from_worker(new SharedWorker(
+    testSetupPolicy.createScriptURL("support/block-eval-function-constructor-worker.js")
+  ));
+</script>

--- a/trusted-types/support/block-eval-function-constructor-worker.js
+++ b/trusted-types/support/block-eval-function-constructor-worker.js
@@ -1,0 +1,10 @@
+const testSetupPolicy = trustedTypes.createPolicy("p", { createScriptURL: s => s });
+
+importScripts(testSetupPolicy.createScriptURL("/resources/testharness.js"));
+importScripts(testSetupPolicy.createScriptURL("helper.sub.js"));
+
+importScripts(testSetupPolicy.createScriptURL(
+    "block-eval-function-constructor.js"
+));
+
+done();

--- a/trusted-types/support/block-eval-function-constructor.js
+++ b/trusted-types/support/block-eval-function-constructor.js
@@ -16,6 +16,18 @@ test(t => {
 
 test(t => {
   t.add_cleanup(resetSinkName);
-  assert_throws_js(EvalError, _ => new Function("return;"));
-  assert_equals(compilationSink, "Function");
-}, `Blocked function constructor in ${globalThisStr}.`);
+  assert_throws_js(EvalError, _ => eval?.("'42'"));
+  assert_equals(compilationSink, "eval");
+}, `Blocked indirect eval in ${globalThisStr}.`);
+
+const AsyncFunction = async function() {}.constructor;
+const GeneratorFunction = function*() {}.constructor;
+const AsyncGeneratorFunction = async function*() {}.constructor;
+
+[Function, AsyncFunction, GeneratorFunction, AsyncGeneratorFunction].forEach(functionConstructor => {
+  test(t => {
+    t.add_cleanup(resetSinkName);
+    assert_throws_js(EvalError, _ => new functionConstructor("return;"));
+    assert_equals(compilationSink, "Function");
+  }, `Blocked ${functionConstructor.name} constructor in ${globalThisStr}.`);
+});

--- a/trusted-types/support/block-eval-function-constructor.js
+++ b/trusted-types/support/block-eval-function-constructor.js
@@ -1,0 +1,21 @@
+const globalThisStr = getGlobalThisStr();
+
+let compilationSink = null;
+function resetSinkName() { compilationSink = null; }
+
+trustedTypes.createPolicy("default", { createScript: (s, _, sink) => {
+  compilationSink = sink;
+  return `modified '${s}'`;
+}});
+
+test(t => {
+  t.add_cleanup(resetSinkName);
+  assert_throws_js(EvalError, _ => eval("'42'"));
+  assert_equals(compilationSink, "eval");
+}, `Blocked eval in ${globalThisStr}.`);
+
+test(t => {
+  t.add_cleanup(resetSinkName);
+  assert_throws_js(EvalError, _ => new Function("return;"));
+  assert_equals(compilationSink, "Function");
+}, `Blocked function constructor in ${globalThisStr}.`);


### PR DESCRIPTION
We already have many tests for eval and function constructor but things are a bit messy and it's difficult to figure out what we are covering. Write a simple test to test blocking, compilationSink and execution in workers.