### PR TITLE
Tentative: match new PR about 2E "unless the element is marked as presentational"

### DIFF
--- a/accname/name/comp_host_language_label.tentative.html
+++ b/accname/name/comp_host_language_label.tentative.html
@@ -25,55 +25,55 @@
     <h2>HTML input with role="none" and label associated (presentational roles conflict resolution)</h2>
     <h3>HTML input label/for</h3>
     <label for="irn">input label</label>
-    <input id="irn" type="text" data-expectedlabel="input label" data-testname="html: label[for]input[role=none]" class="ex-label" role="none">
+    <input id="irn" type="text" data-expectedlabel="input label" data-testname="html:label[for]+input[role=none] (role invalidated due to focusability)" class="ex-label" role="none">
     <h3>HTML label encapsulation</h3>
     <label>
       <span>input label</span>
-      <input type="text" data-expectedlabel="input label" data-testname="html: input[role=none] with label encapsulation" class="ex-label" role="none">
+      <input type="text" data-expectedlabel="input label" data-testname="html: label>input[role=none] (with label encapsulation, role invalidated due to focusability)" class="ex-label" role="none">
     </label>
 
     <h2>HTML input with role="none" and label with role none (presentational roles conflict resolution)</h2>
     <h3>HTML input label/for</h3>
     <label role="none" for="lirp">input label</label>
-    <input id="lirp" type="text" data-expectedlabel="input label" data-testname="html: label[for][role=none] input[role=none]" class="ex-label" role="none">
+    <input id="lirp" type="text" data-expectedlabel="input label" data-testname="html: label[for][role=none]+input[role=none] (role invalidated due to focusability)" class="ex-label" role="none">
     <h3>HTML label encapsulation</h3>
     <label role="none">
       <span>input label</span>
-      <input type="text" data-expectedlabel="input label" data-testname="html: input[role=none] with label[role=none] encapsulation" class="ex-label" role="none">
+      <input type="text" data-expectedlabel="input label" data-testname="html: label[role=none]>input[role=none] (with label encapsulation, role invalidated due to focusability)" class="ex-label" role="none">
     </label>
 
     <!-- This test case is specifically designed to check the accessible name, but a separate test case has been created in wai-aria/role/role_none_conflict_resolution.tentative.html to check the role -->
     <h2>HTML input with role="none" and disabled with label associated</h2>
     <h3>HTML input label/for</h3>
     <label for="irpd">input label</label>
-    <input id="irpd" type="text" data-expectedlabel="" data-testname="html: label[for]input[role=none][disabled]" class="ex-label" role="none" disabled>
+    <input id="irpd" type="text" data-expectedlabel="" data-testname="html: label[for]+input[role=none][disabled] (role none applied due to disabled input)" class="ex-label" role="none" disabled>
     <h3>HTML label encapsulation</h3>
     <label>
       <span>input label</span>
-      <input type="text" data-expectedlabel="" data-testname="html: input[role=none][disabled] with label encapsulation" class="ex-label" role="none" disabled>
+      <input type="text" data-expectedlabel="" data-testname="html: label>input[role=none][disabled] (with label encapsulation, role none applied due to disabled input)" class="ex-label" role="none" disabled>
     </label>
 
     <h2>HTML img with role="none" and non empty alt</h2>
-    <img src="https://www.w3.org/assets/logos/w3c/w3c-no-bars.svg" role="none" alt="w3c logo" data-expectedlabel="" data-testname="html: img[role=none][non-empty alt]" class="ex-label">
+    <img src="https://www.w3.org/assets/logos/w3c/w3c-no-bars.svg" role="none" alt="w3c logo" data-expectedlabel="" data-testname="html: img[role=none][alt]:not([alt='']) (role none takes precedence over empty alt)" class="ex-label">
 
     <h2>SVG wrapping title with role="none"</h2>
     <svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg">
-      <circle cx="5" cy="5" r="4" data-expectedlabel="circle" data-testname="svg: svg circle title[role=none]" class="ex-label">
+      <circle cx="5" cy="5" r="4" data-expectedlabel="circle" data-testname="svg: svg>circle>title[role=none] (role none set on title doesn't affect circle acc name)" class="ex-label">
         <title role="none">circle</title>
       </circle>
     </svg>
 
     <h2>HTML fieldset wrapping legend with role="none"</h2>
-    <fieldset data-expectedlabel="legend" data-testname="html: fieldset wrapping legend[role=none]" class="ex-label"><legend role="none">legend</legend></fieldset>
+    <fieldset data-expectedlabel="legend" data-testname="html: fieldset>legend[role=none] (role none set on legend doesn't affect fieldset acc name)" class="ex-label"><legend role="none">legend</legend></fieldset>
 
     <h2>HTML fieldset with role="none" wrapping legend</h2>
-    <fieldset role="none" data-expectedlabel="" data-testname="html: fieldset[role=none] wrapping legend" class="ex-label"><legend>legend</legend></fieldset>
+    <fieldset role="none" data-expectedlabel="" data-testname="html: fieldset[role=none]>legend (role none set on fieldset affects fieldset acc name)" class="ex-label"><legend>legend</legend></fieldset>
 
     <h2>HTML fieldset role="none" wrapping legend with role="none"</h2>
-    <fieldset role="none" data-expectedlabel="" data-testname="html: fieldset[role=none] wrapping legend[role=none]" class="ex-label"><legend role="none">legend</legend></fieldset>
+    <fieldset role="none" data-expectedlabel="" data-testname="html: fieldset[role=none]>legend[role=none] (role none set on fieldset affects fieldset acc name)" class="ex-label"><legend role="none">legend</legend></fieldset>
 
     <h2>HTML table wrapping caption with role="none"</h2>
-    <table data-expectedlabel="caption" data-testname="html: table wrapping caption[role=none]" class="ex-label">
+    <table data-expectedlabel="caption" data-testname="html: table>caption[role=none] (role none set on caption doesn't affect table acc name)" class="ex-label">
       <caption role="none">caption</caption>
       <tr>
         <th>th1</th>
@@ -86,7 +86,7 @@
     </table>
 
     <h2>HTML table with role="none" wrapping caption</h2>
-    <table role="none" data-expectedlabel="" data-testname="html: table[role=none] wrapping caption" class="ex-label">
+    <table role="none" data-expectedlabel="" data-testname="html: table[role=none]>caption (role none set on table affects fieldset acc name)" class="ex-label">
       <caption>caption</caption>
       <tr>
         <th>th1</th>
@@ -99,7 +99,7 @@
     </table>
 
     <h2>HTML table role="none" wrapping caption with role="none"</h2>
-    <table role="none" data-expectedlabel="" data-testname="html: table[role=none] wrapping caption[role=none]" class="ex-label">
+    <table role="none" data-expectedlabel="" data-testname="html: table[role=none]>caption[role=none] (role none set on table affects fieldset acc name)" class="ex-label">
       <caption role="none">caption</caption>
       <tr>
         <th>th1</th>

--- a/accname/name/comp_host_language_label.tentative.html
+++ b/accname/name/comp_host_language_label.tentative.html
@@ -21,7 +21,7 @@
       <input type="text" data-expectedlabel="input label" data-testname="html: label[role presentation] encapsulation" class="ex">
     </label>
 
-    <h2>HTML input with role="none" and label associated (presentational roles conflict resolution)</h2>
+    <h2>HTML input with role="presentation" and label associated (presentational roles conflict resolution)</h2>
     <h3>HTML input label/for</h3>
     <label for="irn">input label</label>
     <input id="irn" type="text" data-expectedlabel="input label" data-testname="html: label[for]input[role presentation]" class="ex" role="presentation">
@@ -31,7 +31,7 @@
       <input type="text" data-expectedlabel="input label" data-testname="html: input[role presentation] with label encapsulation" class="ex" role="presentation">
     </label>
     
-    <h2>HTML input with role="none" and label with role presentation (presentational roles conflict resolution)</h2>
+    <h2>HTML input with role="presentation" and label with role presentation (presentational roles conflict resolution)</h2>
     <h3>HTML input label/for</h3>
     <label role="presentation" for="lirp">input label</label>
     <input id="lirp" type="text" data-expectedlabel="input label" data-testname="html: label[for][role presentation] input[role presentation]" class="ex" role="presentation">
@@ -41,7 +41,7 @@
       <input type="text" data-expectedlabel="input label" data-testname="html: input[role presentation] with label[role presentation] encapsulation" class="ex" role="presentation">
     </label>
 
-    <h2>HTML input with role="none" and disabled with label associated</h2>
+    <h2>HTML input with role="presentation" and disabled with label associated</h2>
     <h3>HTML input label/for</h3>
     <label for="irpd">input label</label>
     <input id="irpd" type="text" data-expectedlabel="" data-testname="html: label[for]input[role presentation][disabled]" class="ex" role="presentation" disabled>
@@ -57,7 +57,7 @@
     <h2>SVG wrapping title with role="presentation"</h2>
     <svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg" data-expectedlabel="circle" data-testname="svg: svg wrapping title[role presentation]">
       <circle cx="5" cy="5" r="4">
-        <title role="none">circle</title>
+        <title role="presentation">circle</title>
       </circle>
     </svg>
 

--- a/accname/name/comp_host_language_label.tentative.html
+++ b/accname/name/comp_host_language_label.tentative.html
@@ -73,13 +73,43 @@
     <fieldset role="none" data-expectedlabel="" data-testname="html: fieldset[role=none] wrapping legend[role=none]" class="ex-label"><legend role="none">legend</legend></fieldset>
 
     <h2>HTML table wrapping caption with role="none"</h2>
-    <table data-expectedlabel="caption" data-testname="html: table wrapping caption[role=none]" class="ex-label"><caption role="none">caption</caption></table>
+    <table data-expectedlabel="caption" data-testname="html: table wrapping caption[role=none]" class="ex-label">
+      <caption role="none">caption</caption>
+      <tr>
+        <th>th1</th>
+        <th>th2</th>
+      </tr>
+      <tr>
+        <td>td1</td>
+        <td>td2</td>
+      </tr>
+    </table>
 
     <h2>HTML table with role="none" wrapping caption</h2>
-    <table role="none" data-expectedlabel="" data-testname="html: table[role=none] wrapping caption" class="ex-label"><caption>caption</caption></table>
+    <table role="none" data-expectedlabel="" data-testname="html: table[role=none] wrapping caption" class="ex-label">
+      <caption>caption</caption>
+      <tr>
+        <th>th1</th>
+        <th>th2</th>
+      </tr>
+      <tr>
+        <td>td1</td>
+        <td>td2</td>
+      </tr>
+    </table>
 
     <h2>HTML table role="none" wrapping caption with role="none"</h2>
-    <table role="none" data-expectedlabel="" data-testname="html: table[role=none] wrapping caption[role=none]" class="ex-label"><caption role="none">caption</caption></table>
+    <table role="none" data-expectedlabel="" data-testname="html: table[role=none] wrapping caption[role=none]" class="ex-label">
+      <caption role="none">caption</caption>
+      <tr>
+        <th>th1</th>
+        <th>th2</th>
+      </tr>
+      <tr>
+        <td>td1</td>
+        <td>td2</td>
+      </tr>
+    </table>
 
     <script>
       AriaUtils.verifyLabelsBySelector(".ex-label");

--- a/accname/name/comp_host_language_label.tentative.html
+++ b/accname/name/comp_host_language_label.tentative.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Name Comp: Host Language Label</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <script src="/resources/testdriver-actions.js"></script>
+    <script src="/wai-aria/scripts/aria-utils.js"></script>
+  </head>
+  <body>
+  
+    <!-- Ambiguity coming from Host Language Label in accname specs (https://www.w3.org/TR/accname-1.2/#comp_host_language_label) - PR that tries to solve it https://github.com/w3c/aria/pull/2405 -->
+    <h2>HTML input with label with role presentation</h2>
+    <h3>HTML input label/for</h3>
+    <label role="presentation" for="lrp">input label</label>
+    <input id="lrp" type="text" data-expectedlabel="input label" data-testname="html: label[for][role presentation]" class="ex">
+    <h3>HTML label encapsulation</h3>
+    <label role="presentation">
+      <span>input label</span>
+      <input type="text" data-expectedlabel="input label" data-testname="html: label[role presentation] encapsulation" class="ex">
+    </label>
+    
+    <script>
+    AriaUtils.verifyLabelsBySelector(".ex");
+    </script>
+  </body>
+</html>

--- a/accname/name/comp_host_language_label.tentative.html
+++ b/accname/name/comp_host_language_label.tentative.html
@@ -10,7 +10,6 @@
     <script src="/wai-aria/scripts/aria-utils.js"></script>
   </head>
   <body>
-  
     <!-- Ambiguity coming from Host Language Label in accname specs (https://www.w3.org/TR/accname-1.2/#comp_host_language_label) - PR that tries to solve it https://github.com/w3c/aria/pull/2405 -->
     <h2>HTML input with label with role presentation</h2>
     <h3>HTML input label/for</h3>
@@ -21,9 +20,67 @@
       <span>input label</span>
       <input type="text" data-expectedlabel="input label" data-testname="html: label[role presentation] encapsulation" class="ex">
     </label>
+
+    <h2>HTML input with role="none" and label associated (presentational roles conflict resolution)</h2>
+    <h3>HTML input label/for</h3>
+    <label for="irn">input label</label>
+    <input id="irn" type="text" data-expectedlabel="input label" data-testname="html: label[for]input[role presentation]" class="ex" role="presentation">
+    <h3>HTML label encapsulation</h3>
+    <label>
+      <span>input label</span>
+      <input type="text" data-expectedlabel="input label" data-testname="html: input[role presentation] with label encapsulation" class="ex" role="presentation">
+    </label>
     
+    <h2>HTML input with role="none" and label with role presentation (presentational roles conflict resolution)</h2>
+    <h3>HTML input label/for</h3>
+    <label role="presentation" for="lirp">input label</label>
+    <input id="lirp" type="text" data-expectedlabel="input label" data-testname="html: label[for][role presentation] input[role presentation]" class="ex" role="presentation">
+    <h3>HTML label encapsulation</h3>
+    <label role="presentation">
+      <span>input label</span>
+      <input type="text" data-expectedlabel="input label" data-testname="html: input[role presentation] with label[role presentation] encapsulation" class="ex" role="presentation">
+    </label>
+
+    <h2>HTML input with role="none" and disabled with label associated</h2>
+    <h3>HTML input label/for</h3>
+    <label for="irpd">input label</label>
+    <input id="irpd" type="text" data-expectedlabel="" data-testname="html: label[for]input[role presentation][disabled]" class="ex" role="presentation" disabled>
+    <h3>HTML label encapsulation</h3>
+    <label>
+      <span>input label</span>
+      <input type="text" data-expectedlabel="" data-testname="html: input[role presentation][disabled] with label encapsulation" class="ex" role="presentation" disabled>
+    </label>
+
+    <h2>HTML img with role="presentation" and non empty alt</h2>
+    <img src="https://www.w3.org/assets/logos/w3c/w3c-no-bars.svg" role="presentation" alt="w3c logo" data-expectedlabel="" data-testname="html: img[role presentation][non-empty alt]">
+
+    <h2>SVG wrapping title with role="presentation"</h2>
+    <svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg" data-expectedlabel="circle" data-testname="svg: svg wrapping title[role presentation]">
+      <circle cx="5" cy="5" r="4">
+        <title role="none">circle</title>
+      </circle>
+    </svg>
+
+    <h2>HTML fieldset wrapping legend with role="presentation"</h2>
+    <fieldset data-expectedlabel="legend" data-testname="html: fieldset wrapping legend[role presentation]"><legend role="presentation">legend</legend></fieldset>
+
+    <h2>HTML fieldset with role="presentation" wrapping legend</h2>
+    <fieldset role="presentation" data-expectedlabel="" data-testname="html: fieldset[role presentation] wrapping legend"><legend>legend</legend></fieldset>
+
+    <h2>HTML fieldset role="presentation" wrapping legend with role="presentation"</h2>
+    <fieldset role="presentation" data-expectedlabel="" data-testname="html: fieldset[role presentation] wrapping legend[role presentation]"><legend role="presentation">legend</legend></fieldset>
+
+    <h2>HTML table wrapping caption with role="presentation"</h2>
+    <table data-expectedlabel="caption" data-testname="html: table wrapping caption[role presentation]"><caption role="presentation">caption</caption></table>
+
+    <h2>HTML table with role="presentation" wrapping caption</h2>
+    <table role="presentation" data-expectedlabel="" data-testname="html: table[role presentation] wrapping caption"><caption>caption</caption></table>
+
+    <h2>HTML table role="presentation" wrapping caption with role="presentation"</h2>
+    <table role="presentation" data-expectedlabel="" data-testname="html: table[role presentation] wrapping caption[role presentation]"><caption role="presentation">caption</caption></table>
+
     <script>
-    AriaUtils.verifyLabelsBySelector(".ex");
+      AriaUtils.verifyLabelsBySelector(".ex");
     </script>
   </body>
 </html>

--- a/accname/name/comp_host_language_label.tentative.html
+++ b/accname/name/comp_host_language_label.tentative.html
@@ -57,8 +57,8 @@
     <img src="https://www.w3.org/assets/logos/w3c/w3c-no-bars.svg" role="none" alt="w3c logo" data-expectedlabel="" data-testname="html: img[role=none][non-empty alt]" class="ex-label">
 
     <h2>SVG wrapping title with role="none"</h2>
-    <svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg" data-expectedlabel="circle" data-testname="svg: svg wrapping title[role=none]" class="ex-label">
-      <circle cx="5" cy="5" r="4">
+    <svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="5" cy="5" r="4" data-expectedlabel="circle" data-testname="svg: svg circle title[role=none]" class="ex-label">
         <title role="none">circle</title>
       </circle>
     </svg>

--- a/accname/name/comp_host_language_label.tentative.html
+++ b/accname/name/comp_host_language_label.tentative.html
@@ -42,20 +42,6 @@
       <input type="text" data-expectedlabel="input label" data-testname="html: label[role=none]>input[role=none] (with label encapsulation, role invalidated due to focusability)" class="ex-label" role="none">
     </label>
 
-    <!-- This test case is specifically designed to check the accessible name, but a separate test case has been created in wai-aria/role/role_none_conflict_resolution.tentative.html to check the role -->
-    <h2>HTML input with role="none" and disabled with label associated</h2>
-    <h3>HTML input label/for</h3>
-    <label for="irpd">input label</label>
-    <input id="irpd" type="text" data-expectedlabel="" data-testname="html: label[for]+input[role=none][disabled] (role none applied due to disabled input)" class="ex-label" role="none" disabled>
-    <h3>HTML label encapsulation</h3>
-    <label>
-      <span>input label</span>
-      <input type="text" data-expectedlabel="" data-testname="html: label>input[role=none][disabled] (with label encapsulation, role none applied due to disabled input)" class="ex-label" role="none" disabled>
-    </label>
-
-    <h2>HTML img with role="none" and non empty alt</h2>
-    <img src="https://www.w3.org/assets/logos/w3c/w3c-no-bars.svg" role="none" alt="w3c logo" data-expectedlabel="" data-testname="html: img[role=none][alt]:not([alt='']) (role none takes precedence over empty alt)" class="ex-label">
-
     <h2>SVG wrapping title with role="none"</h2>
     <svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg">
       <circle cx="5" cy="5" r="4" data-expectedlabel="circle" data-testname="svg: svg>circle>title[role=none] (role none set on title doesn't affect circle acc name)" class="ex-label">
@@ -66,40 +52,8 @@
     <h2>HTML fieldset wrapping legend with role="none"</h2>
     <fieldset data-expectedlabel="legend" data-testname="html: fieldset>legend[role=none] (role none set on legend doesn't affect fieldset acc name)" class="ex-label"><legend role="none">legend</legend></fieldset>
 
-    <h2>HTML fieldset with role="none" wrapping legend</h2>
-    <fieldset role="none" data-expectedlabel="" data-testname="html: fieldset[role=none]>legend (role none set on fieldset affects fieldset acc name)" class="ex-label"><legend>legend</legend></fieldset>
-
-    <h2>HTML fieldset role="none" wrapping legend with role="none"</h2>
-    <fieldset role="none" data-expectedlabel="" data-testname="html: fieldset[role=none]>legend[role=none] (role none set on fieldset affects fieldset acc name)" class="ex-label"><legend role="none">legend</legend></fieldset>
-
     <h2>HTML table wrapping caption with role="none"</h2>
     <table data-expectedlabel="caption" data-testname="html: table>caption[role=none] (role none set on caption doesn't affect table acc name)" class="ex-label">
-      <caption role="none">caption</caption>
-      <tr>
-        <th>th1</th>
-        <th>th2</th>
-      </tr>
-      <tr>
-        <td>td1</td>
-        <td>td2</td>
-      </tr>
-    </table>
-
-    <h2>HTML table with role="none" wrapping caption</h2>
-    <table role="none" data-expectedlabel="" data-testname="html: table[role=none]>caption (role none set on table affects fieldset acc name)" class="ex-label">
-      <caption>caption</caption>
-      <tr>
-        <th>th1</th>
-        <th>th2</th>
-      </tr>
-      <tr>
-        <td>td1</td>
-        <td>td2</td>
-      </tr>
-    </table>
-
-    <h2>HTML table role="none" wrapping caption with role="none"</h2>
-    <table role="none" data-expectedlabel="" data-testname="html: table[role=none]>caption[role=none] (role none set on table affects fieldset acc name)" class="ex-label">
       <caption role="none">caption</caption>
       <tr>
         <th>th1</th>

--- a/accname/name/comp_host_language_label.tentative.html
+++ b/accname/name/comp_host_language_label.tentative.html
@@ -18,66 +18,66 @@
     <h3>HTML label encapsulation</h3>
     <label role="none">
       <span>input label</span>
-      <input type="text" data-expectedlabel="input label" data-testname="html: label[role none] encapsulation" class="ex-label">
+      <input type="text" data-expectedlabel="input label" data-testname="html: label[role=none] encapsulation" class="ex-label">
     </label>
 
     <h2>HTML input with role="none" and label associated (presentational roles conflict resolution)</h2>
     <h3>HTML input label/for</h3>
     <label for="irn">input label</label>
-    <input id="irn" type="text" data-expectedlabel="input label" data-testname="html: label[for]input[role none]" class="ex-label" role="none">
+    <input id="irn" type="text" data-expectedlabel="input label" data-testname="html: label[for]input[role=none]" class="ex-label" role="none">
     <h3>HTML label encapsulation</h3>
     <label>
       <span>input label</span>
-      <input type="text" data-expectedlabel="input label" data-testname="html: input[role none] with label encapsulation" class="ex-label" role="none">
+      <input type="text" data-expectedlabel="input label" data-testname="html: input[role=none] with label encapsulation" class="ex-label" role="none">
     </label>
     
     <h2>HTML input with role="none" and label with role none (presentational roles conflict resolution)</h2>
     <h3>HTML input label/for</h3>
     <label role="none" for="lirp">input label</label>
-    <input id="lirp" type="text" data-expectedlabel="input label" data-testname="html: label[for][role none] input[role none]" class="ex-label" role="none">
+    <input id="lirp" type="text" data-expectedlabel="input label" data-testname="html: label[for][role=none] input[role=none]" class="ex-label" role="none">
     <h3>HTML label encapsulation</h3>
     <label role="none">
       <span>input label</span>
-      <input type="text" data-expectedlabel="input label" data-testname="html: input[role none] with label[role none] encapsulation" class="ex-label" role="none">
+      <input type="text" data-expectedlabel="input label" data-testname="html: input[role=none] with label[role=none] encapsulation" class="ex-label" role="none">
     </label>
 
     <h2>HTML input with role="none" and disabled with label associated</h2>
     <h3>HTML input label/for</h3>
     <label for="irpd">input label</label>
-    <input id="irpd" type="text" data-expectedlabel="" data-testname="html: label[for]input[role none][disabled]" class="ex-label" role="none" disabled>
+    <input id="irpd" type="text" data-expectedlabel="" data-testname="html: label[for]input[role=none][disabled]" class="ex-label" role="none" disabled>
     <h3>HTML label encapsulation</h3>
     <label>
       <span>input label</span>
-      <input type="text" data-expectedlabel="" data-testname="html: input[role none][disabled] with label encapsulation" class="ex-label" role="none" disabled>
+      <input type="text" data-expectedlabel="" data-testname="html: input[role=none][disabled] with label encapsulation" class="ex-label" role="none" disabled>
     </label>
 
     <h2>HTML img with role="none" and non empty alt</h2>
-    <img src="https://www.w3.org/assets/logos/w3c/w3c-no-bars.svg" role="none" alt="w3c logo" data-expectedlabel="" data-testname="html: img[role none][non-empty alt]" class="ex-label">
+    <img src="https://www.w3.org/assets/logos/w3c/w3c-no-bars.svg" role="none" alt="w3c logo" data-expectedlabel="" data-testname="html: img[role=none][non-empty alt]" class="ex-label">
 
     <h2>SVG wrapping title with role="none"</h2>
-    <svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg" data-expectedlabel="circle" data-testname="svg: svg wrapping title[role none]" class="ex-label">
+    <svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg" data-expectedlabel="circle" data-testname="svg: svg wrapping title[role=none]" class="ex-label">
       <circle cx="5" cy="5" r="4">
         <title role="none">circle</title>
       </circle>
     </svg>
 
     <h2>HTML fieldset wrapping legend with role="none"</h2>
-    <fieldset data-expectedlabel="legend" data-testname="html: fieldset wrapping legend[role none]" class="ex-label"><legend role="none">legend</legend></fieldset>
+    <fieldset data-expectedlabel="legend" data-testname="html: fieldset wrapping legend[role=none]" class="ex-label"><legend role="none">legend</legend></fieldset>
 
     <h2>HTML fieldset with role="none" wrapping legend</h2>
-    <fieldset role="none" data-expectedlabel="" data-testname="html: fieldset[role none] wrapping legend" class="ex-label"><legend>legend</legend></fieldset>
+    <fieldset role="none" data-expectedlabel="" data-testname="html: fieldset[role=none] wrapping legend" class="ex-label"><legend>legend</legend></fieldset>
 
     <h2>HTML fieldset role="none" wrapping legend with role="none"</h2>
-    <fieldset role="none" data-expectedlabel="" data-testname="html: fieldset[role none] wrapping legend[role none]" class="ex-label"><legend role="none">legend</legend></fieldset>
+    <fieldset role="none" data-expectedlabel="" data-testname="html: fieldset[role=none] wrapping legend[role=none]" class="ex-label"><legend role="none">legend</legend></fieldset>
 
     <h2>HTML table wrapping caption with role="none"</h2>
-    <table data-expectedlabel="caption" data-testname="html: table wrapping caption[role none]" class="ex-label"><caption role="none">caption</caption></table>
+    <table data-expectedlabel="caption" data-testname="html: table wrapping caption[role=none]" class="ex-label"><caption role="none">caption</caption></table>
 
     <h2>HTML table with role="none" wrapping caption</h2>
-    <table role="none" data-expectedlabel="" data-testname="html: table[role none] wrapping caption" class="ex-label"><caption>caption</caption></table>
+    <table role="none" data-expectedlabel="" data-testname="html: table[role=none] wrapping caption" class="ex-label"><caption>caption</caption></table>
 
     <h2>HTML table role="none" wrapping caption with role="none"</h2>
-    <table role="none" data-expectedlabel="" data-testname="html: table[role none] wrapping caption[role none]" class="ex-label"><caption role="none">caption</caption></table>
+    <table role="none" data-expectedlabel="" data-testname="html: table[role=none] wrapping caption[role=none]" class="ex-label"><caption role="none">caption</caption></table>
 
     <script>
       AriaUtils.verifyLabelsBySelector(".ex-label");

--- a/accname/name/comp_host_language_label.tentative.html
+++ b/accname/name/comp_host_language_label.tentative.html
@@ -21,6 +21,7 @@
       <input type="text" data-expectedlabel="input label" data-testname="html: label[role=none] encapsulation" class="ex-label">
     </label>
 
+    <!-- This test case is specifically designed to check the accessible name, but a separate test case has been created in wai-aria/role/role_none_conflict_resolution.tentative.html to check the role -->
     <h2>HTML input with role="none" and label associated (presentational roles conflict resolution)</h2>
     <h3>HTML input label/for</h3>
     <label for="irn">input label</label>
@@ -41,6 +42,7 @@
       <input type="text" data-expectedlabel="input label" data-testname="html: input[role=none] with label[role=none] encapsulation" class="ex-label" role="none">
     </label>
 
+    <!-- This test case is specifically designed to check the accessible name, but a separate test case has been created in wai-aria/role/role_none_conflict_resolution.tentative.html to check the role -->
     <h2>HTML input with role="none" and disabled with label associated</h2>
     <h3>HTML input label/for</h3>
     <label for="irpd">input label</label>

--- a/accname/name/comp_host_language_label.tentative.html
+++ b/accname/name/comp_host_language_label.tentative.html
@@ -31,7 +31,7 @@
       <span>input label</span>
       <input type="text" data-expectedlabel="input label" data-testname="html: input[role=none] with label encapsulation" class="ex-label" role="none">
     </label>
-    
+
     <h2>HTML input with role="none" and label with role none (presentational roles conflict resolution)</h2>
     <h3>HTML input label/for</h3>
     <label role="none" for="lirp">input label</label>

--- a/accname/name/comp_host_language_label.tentative.html
+++ b/accname/name/comp_host_language_label.tentative.html
@@ -14,7 +14,7 @@
     <h2>HTML input with label with role none</h2>
     <h3>HTML input label/for</h3>
     <label role="none" for="lrp">input label</label>
-    <input id="lrp" type="text" data-expectedlabel="input label" data-testname="html: label[for][role none]" class="ex-label">
+    <input id="lrp" type="text" data-expectedlabel="input label" data-testname="html: label[for][role=none]" class="ex-label">
     <h3>HTML label encapsulation</h3>
     <label role="none">
       <span>input label</span>

--- a/accname/name/comp_host_language_label.tentative.html
+++ b/accname/name/comp_host_language_label.tentative.html
@@ -11,76 +11,76 @@
   </head>
   <body>
     <!-- Ambiguity coming from Host Language Label in accname specs (https://www.w3.org/TR/accname-1.2/#comp_host_language_label) - PR that tries to solve it https://github.com/w3c/aria/pull/2405 -->
-    <h2>HTML input with label with role presentation</h2>
+    <h2>HTML input with label with role none</h2>
     <h3>HTML input label/for</h3>
-    <label role="presentation" for="lrp">input label</label>
-    <input id="lrp" type="text" data-expectedlabel="input label" data-testname="html: label[for][role presentation]" class="ex">
+    <label role="none" for="lrp">input label</label>
+    <input id="lrp" type="text" data-expectedlabel="input label" data-testname="html: label[for][role none]" class="ex-label">
     <h3>HTML label encapsulation</h3>
-    <label role="presentation">
+    <label role="none">
       <span>input label</span>
-      <input type="text" data-expectedlabel="input label" data-testname="html: label[role presentation] encapsulation" class="ex">
+      <input type="text" data-expectedlabel="input label" data-testname="html: label[role none] encapsulation" class="ex-label">
     </label>
 
-    <h2>HTML input with role="presentation" and label associated (presentational roles conflict resolution)</h2>
+    <h2>HTML input with role="none" and label associated (presentational roles conflict resolution)</h2>
     <h3>HTML input label/for</h3>
     <label for="irn">input label</label>
-    <input id="irn" type="text" data-expectedlabel="input label" data-testname="html: label[for]input[role presentation]" class="ex" role="presentation">
+    <input id="irn" type="text" data-expectedlabel="input label" data-testname="html: label[for]input[role none]" class="ex-label" role="none">
     <h3>HTML label encapsulation</h3>
     <label>
       <span>input label</span>
-      <input type="text" data-expectedlabel="input label" data-testname="html: input[role presentation] with label encapsulation" class="ex" role="presentation">
+      <input type="text" data-expectedlabel="input label" data-testname="html: input[role none] with label encapsulation" class="ex-label" role="none">
     </label>
     
-    <h2>HTML input with role="presentation" and label with role presentation (presentational roles conflict resolution)</h2>
+    <h2>HTML input with role="none" and label with role none (presentational roles conflict resolution)</h2>
     <h3>HTML input label/for</h3>
-    <label role="presentation" for="lirp">input label</label>
-    <input id="lirp" type="text" data-expectedlabel="input label" data-testname="html: label[for][role presentation] input[role presentation]" class="ex" role="presentation">
+    <label role="none" for="lirp">input label</label>
+    <input id="lirp" type="text" data-expectedlabel="input label" data-testname="html: label[for][role none] input[role none]" class="ex-label" role="none">
     <h3>HTML label encapsulation</h3>
-    <label role="presentation">
+    <label role="none">
       <span>input label</span>
-      <input type="text" data-expectedlabel="input label" data-testname="html: input[role presentation] with label[role presentation] encapsulation" class="ex" role="presentation">
+      <input type="text" data-expectedlabel="input label" data-testname="html: input[role none] with label[role none] encapsulation" class="ex-label" role="none">
     </label>
 
-    <h2>HTML input with role="presentation" and disabled with label associated</h2>
+    <h2>HTML input with role="none" and disabled with label associated</h2>
     <h3>HTML input label/for</h3>
     <label for="irpd">input label</label>
-    <input id="irpd" type="text" data-expectedlabel="" data-testname="html: label[for]input[role presentation][disabled]" class="ex" role="presentation" disabled>
+    <input id="irpd" type="text" data-expectedlabel="" data-testname="html: label[for]input[role none][disabled]" class="ex-label" role="none" disabled>
     <h3>HTML label encapsulation</h3>
     <label>
       <span>input label</span>
-      <input type="text" data-expectedlabel="" data-testname="html: input[role presentation][disabled] with label encapsulation" class="ex" role="presentation" disabled>
+      <input type="text" data-expectedlabel="" data-testname="html: input[role none][disabled] with label encapsulation" class="ex-label" role="none" disabled>
     </label>
 
-    <h2>HTML img with role="presentation" and non empty alt</h2>
-    <img src="https://www.w3.org/assets/logos/w3c/w3c-no-bars.svg" role="presentation" alt="w3c logo" data-expectedlabel="" data-testname="html: img[role presentation][non-empty alt]">
+    <h2>HTML img with role="none" and non empty alt</h2>
+    <img src="https://www.w3.org/assets/logos/w3c/w3c-no-bars.svg" role="none" alt="w3c logo" data-expectedlabel="" data-testname="html: img[role none][non-empty alt]" class="ex-label">
 
-    <h2>SVG wrapping title with role="presentation"</h2>
-    <svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg" data-expectedlabel="circle" data-testname="svg: svg wrapping title[role presentation]">
+    <h2>SVG wrapping title with role="none"</h2>
+    <svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg" data-expectedlabel="circle" data-testname="svg: svg wrapping title[role none]" class="ex-label">
       <circle cx="5" cy="5" r="4">
-        <title role="presentation">circle</title>
+        <title role="none">circle</title>
       </circle>
     </svg>
 
-    <h2>HTML fieldset wrapping legend with role="presentation"</h2>
-    <fieldset data-expectedlabel="legend" data-testname="html: fieldset wrapping legend[role presentation]"><legend role="presentation">legend</legend></fieldset>
+    <h2>HTML fieldset wrapping legend with role="none"</h2>
+    <fieldset data-expectedlabel="legend" data-testname="html: fieldset wrapping legend[role none]" class="ex-label"><legend role="none">legend</legend></fieldset>
 
-    <h2>HTML fieldset with role="presentation" wrapping legend</h2>
-    <fieldset role="presentation" data-expectedlabel="" data-testname="html: fieldset[role presentation] wrapping legend"><legend>legend</legend></fieldset>
+    <h2>HTML fieldset with role="none" wrapping legend</h2>
+    <fieldset role="none" data-expectedlabel="" data-testname="html: fieldset[role none] wrapping legend" class="ex-label"><legend>legend</legend></fieldset>
 
-    <h2>HTML fieldset role="presentation" wrapping legend with role="presentation"</h2>
-    <fieldset role="presentation" data-expectedlabel="" data-testname="html: fieldset[role presentation] wrapping legend[role presentation]"><legend role="presentation">legend</legend></fieldset>
+    <h2>HTML fieldset role="none" wrapping legend with role="none"</h2>
+    <fieldset role="none" data-expectedlabel="" data-testname="html: fieldset[role none] wrapping legend[role none]" class="ex-label"><legend role="none">legend</legend></fieldset>
 
-    <h2>HTML table wrapping caption with role="presentation"</h2>
-    <table data-expectedlabel="caption" data-testname="html: table wrapping caption[role presentation]"><caption role="presentation">caption</caption></table>
+    <h2>HTML table wrapping caption with role="none"</h2>
+    <table data-expectedlabel="caption" data-testname="html: table wrapping caption[role none]" class="ex-label"><caption role="none">caption</caption></table>
 
-    <h2>HTML table with role="presentation" wrapping caption</h2>
-    <table role="presentation" data-expectedlabel="" data-testname="html: table[role presentation] wrapping caption"><caption>caption</caption></table>
+    <h2>HTML table with role="none" wrapping caption</h2>
+    <table role="none" data-expectedlabel="" data-testname="html: table[role none] wrapping caption" class="ex-label"><caption>caption</caption></table>
 
-    <h2>HTML table role="presentation" wrapping caption with role="presentation"</h2>
-    <table role="presentation" data-expectedlabel="" data-testname="html: table[role presentation] wrapping caption[role presentation]"><caption role="presentation">caption</caption></table>
+    <h2>HTML table role="none" wrapping caption with role="none"</h2>
+    <table role="none" data-expectedlabel="" data-testname="html: table[role none] wrapping caption[role none]" class="ex-label"><caption role="none">caption</caption></table>
 
     <script>
-      AriaUtils.verifyLabelsBySelector(".ex");
+      AriaUtils.verifyLabelsBySelector(".ex-label");
     </script>
   </body>
 </html>

--- a/wai-aria/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role_none_conflict_resolution.tentative.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Role None Conflict Resolution Verification Tests</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <script src="/resources/testdriver-actions.js"></script>
+    <script src="/wai-aria/scripts/aria-utils.js"></script>
+  </head>
+  <body>
+
+    <h2>HTML input with role="none" (presentational roles conflict resolution)</h2>
+    <label for="irn">input label</label>
+    <input id="irn" type="text" data-expectedrole="textbox" data-testname="HTML input[role presentation] but focusable" class="ex" role="presentation">
+
+    <h2>HTML input with role="none" and disabled (presentational roles conflict resolution does not apply due to disabled attr)</h2>
+    <label for="irpd">input label</label>
+    <input id="irpd" type="text" data-testname="HTML input[role presentation][disabled]" class="ex-generic" role="presentation" disabled>
+
+    <script>
+      AriaUtils.verifyRolesBySelector(".ex");
+      AriaUtils.verifyGenericRolesBySelector(".ex-generic");
+    </script>
+
+  </body>
+</html>

--- a/wai-aria/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role_none_conflict_resolution.tentative.html
@@ -13,14 +13,14 @@
 
     <h2>HTML input with role="none" (presentational roles conflict resolution)</h2>
     <label for="irn">input label</label>
-    <input id="irn" type="text" data-expectedrole="textbox" data-testname="HTML input[role none] but focusable" class="ex" role="none">
+    <input id="irn" type="text" data-expectedrole="textbox" data-testname="HTML input[role none] but focusable" class="ex-role" role="none">
 
     <h2>HTML input with role="none" and disabled (presentational roles conflict resolution does not apply due to disabled attr)</h2>
     <label for="irpd">input label</label>
     <input id="irpd" type="text" data-testname="HTML input[role none][disabled]" class="ex-generic" role="none" disabled>
 
     <script>
-      AriaUtils.verifyRolesBySelector(".ex");
+      AriaUtils.verifyRolesBySelector(".ex-role");
       AriaUtils.verifyGenericRolesBySelector(".ex-generic");
     </script>
 

--- a/wai-aria/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role_none_conflict_resolution.tentative.html
@@ -11,10 +11,12 @@
   </head>
   <body>
 
+    <!-- This test case is specifically designed to check the role, but a separate test case has been created in accname/name/comp_host_language_label.tentative.html to check the acc name -->
     <h2>HTML input with role="none" (presentational roles conflict resolution)</h2>
     <label for="irn">input label</label>
     <input id="irn" type="text" data-expectedrole="textbox" data-testname="HTML input[role=none] but focusable" class="ex-role" role="none">
 
+    <!-- This test case is specifically designed to check the role, but a separate test case has been created in accname/name/comp_host_language_label.tentative.html to check the acc name -->
     <h2>HTML input with role="none" and disabled (presentational roles conflict resolution does not apply due to disabled attr)</h2>
     <label for="irpd">input label</label>
     <input id="irpd" type="text" data-testname="HTML input[role=none][disabled]" class="ex-generic" role="none" disabled>

--- a/wai-aria/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role_none_conflict_resolution.tentative.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>Role None Conflict Resolution Verification Tests</title>
+    <title>Role None/Presentation Conflict Resolution Verification Tests</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/resources/testdriver.js"></script>
@@ -11,11 +11,11 @@
   </head>
   <body>
 
-    <h2>HTML input with role="none" (presentational roles conflict resolution)</h2>
+    <h2>HTML input with role="presentation" (presentational roles conflict resolution)</h2>
     <label for="irn">input label</label>
     <input id="irn" type="text" data-expectedrole="textbox" data-testname="HTML input[role presentation] but focusable" class="ex" role="presentation">
 
-    <h2>HTML input with role="none" and disabled (presentational roles conflict resolution does not apply due to disabled attr)</h2>
+    <h2>HTML input with role="presentation" and disabled (presentational roles conflict resolution does not apply due to disabled attr)</h2>
     <label for="irpd">input label</label>
     <input id="irpd" type="text" data-testname="HTML input[role presentation][disabled]" class="ex-generic" role="presentation" disabled>
 

--- a/wai-aria/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role_none_conflict_resolution.tentative.html
@@ -13,11 +13,19 @@
 
     <h2>HTML input with role="none" (presentational roles conflict resolution)</h2>
     <label for="irn">input label</label>
-    <input id="irn" type="text" data-expectedrole="textbox" data-testname="HTML input[role none] but focusable" class="ex-role" role="none">
+    <input id="irn" type="text" data-expectedrole="textbox" data-testname="HTML input[role=none] but focusable" class="ex-role" role="none">
 
     <h2>HTML input with role="none" and disabled (presentational roles conflict resolution does not apply due to disabled attr)</h2>
     <label for="irpd">input label</label>
-    <input id="irpd" type="text" data-testname="HTML input[role none][disabled]" class="ex-generic" role="none" disabled>
+    <input id="irpd" type="text" data-testname="HTML input[role=none][disabled]" class="ex-generic" role="none" disabled>
+
+    <h2>HTML input with role="none" and readonly (presentational roles conflict resolution)</h2>
+    <label for="irnro">input label</label>
+    <input id="irnro" type="text" data-expectedrole="textbox" data-testname="HTML input[role=none][readonly] but focusable" class="ex-role" role="none" readonly>
+
+    <h2>HTML input with role="none", disabled and readonly (presentational roles conflict resolution does not apply due to disabled attr)</h2>
+    <label for="irpdro">input label</label>
+    <input id="irpdro" type="text" data-testname="HTML input[role=none][disabled][readonly]" class="ex-generic" role="none" disabled readonly>
 
     <script>
       AriaUtils.verifyRolesBySelector(".ex-role");

--- a/wai-aria/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role_none_conflict_resolution.tentative.html
@@ -11,13 +11,13 @@
   </head>
   <body>
 
-    <h2>HTML input with role="presentation" (presentational roles conflict resolution)</h2>
+    <h2>HTML input with role="none" (presentational roles conflict resolution)</h2>
     <label for="irn">input label</label>
-    <input id="irn" type="text" data-expectedrole="textbox" data-testname="HTML input[role presentation] but focusable" class="ex" role="presentation">
+    <input id="irn" type="text" data-expectedrole="textbox" data-testname="HTML input[role none] but focusable" class="ex" role="none">
 
-    <h2>HTML input with role="presentation" and disabled (presentational roles conflict resolution does not apply due to disabled attr)</h2>
+    <h2>HTML input with role="none" and disabled (presentational roles conflict resolution does not apply due to disabled attr)</h2>
     <label for="irpd">input label</label>
-    <input id="irpd" type="text" data-testname="HTML input[role presentation][disabled]" class="ex-generic" role="presentation" disabled>
+    <input id="irpd" type="text" data-testname="HTML input[role none][disabled]" class="ex-generic" role="none" disabled>
 
     <script>
       AriaUtils.verifyRolesBySelector(".ex");


### PR DESCRIPTION
Closes: https://github.com/web-platform-tests/interop-accessibility/issues/167

Relates and match: https://github.com/w3c/aria/pull/2405

Ambiguity: https://www.w3.org/TR/accname-1.2/#comp_host_language_label

This PR adds tests for:
- elements receiving the accessible name from host language label elements (both explicit and implicit) with role="presentation";
- elements with role=presentation that do not receive the accessible name from host language label elements (both explicit and implicit) 
- elements with role=presentation that receives the accessible name from host language label elements (both explicit and implicit) due to presentational roles conflict resolution

Note: since I created tests for acc name related to presentational roles conflict resolution, I have also included tests to verify that the computed role aligns with the expected result.