### PR TITLE
[Accessibility] - Test for elements not in viewport contained within content-visibility: auto CSS property

### DIFF
--- a/accname/name/comp_content_visibility.tentative.html
+++ b/accname/name/comp_content_visibility.tentative.html
@@ -1,38 +1,33 @@
 <!doctype html>
 <html>
-	<head>
-		<title>Name Comp: content visibility (Tentative)</title>
-		<script src="/resources/testharness.js"></script>
-		<script src="/resources/testharnessreport.js"></script>
-		<script src="/resources/testdriver.js"></script>
-		<script src="/resources/testdriver-vendor.js"></script>
-		<script src="/resources/testdriver-actions.js"></script>
-		<script src="/wai-aria/scripts/aria-utils.js"></script>
-	</head>
-	<body>
-
-		<h1>Testing accessibility of content-visibility: auto</h1>
-
-		<h2>Accname</h2>
-
-		<div style="height:5px; overflow:scroll;">
-			<div>
-				<p>Some content</p>
-				<p>Some content</p>
-				<p>Some content</p>
-				<p>Some content</p>
-				<p>Some content</p>
-			</div>
-			<div style="content-visibility:auto"> 
-				<h2 class="ex" data-expectedlabel="SPEC_AMBIGUOUS_LOG_VALUE" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="HTML heading element under content-visibility auto condition">test heading</h2>
-				<button class="ex" data-expectedlabel="SPEC_AMBIGUOUS_LOG_VALUE" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="HTML button element under content-visibility auto condition">test button</button>
-				<a class="ex" href="#" data-expectedlabel="SPEC_AMBIGUOUS_LOG_VALUE" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="HTML link element under content-visibility auto condition">test link</a>
-			</div>
-		</div>
-		
-		<script>
-			AriaUtils.verifyRolesAndLabelsBySelector(".ex");
-		</script>
-	
-	</body>
+    <head>
+        <title>Name Comp: content visibility (Tentative)</title>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="/resources/testdriver.js"></script>
+        <script src="/resources/testdriver-vendor.js"></script>
+        <script src="/resources/testdriver-actions.js"></script>
+        <script src="/wai-aria/scripts/aria-utils.js"></script>
+    </head>
+    <body>
+        <h1>Testing accessibility of content-visibility: auto</h1>
+        <h2>Accname</h2>
+            <div style="height:5px; overflow:scroll;">
+            <div>
+                <p>Some content</p>
+                <p>Some content</p>
+                <p>Some content</p>
+                <p>Some content</p>
+                <p>Some content</p>
+            </div>
+            <div style="content-visibility:auto"> 
+                <h2 class="ex" data-expectedlabel="SPEC_AMBIGUOUS_LOG_VALUE" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="HTML heading element under content-visibility auto condition">test heading</h2>
+                <button class="ex" data-expectedlabel="SPEC_AMBIGUOUS_LOG_VALUE" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="HTML button element under content-visibility auto condition">test button</button>
+                <a class="ex" href="#" data-expectedlabel="SPEC_AMBIGUOUS_LOG_VALUE" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="HTML link element under content-visibility auto condition">test link</a>
+            </div>
+        </div>	
+        <script>
+            AriaUtils.verifyRolesAndLabelsBySelector(".ex");
+        </script>
+    </body>
 </html>

--- a/accname/name/comp_content_visibility.tentative.html
+++ b/accname/name/comp_content_visibility.tentative.html
@@ -1,49 +1,39 @@
 <!doctype html>
 <html>
 	<head>
-	  <title>Name Comp: content visibility (Tentative)</title>
-	  <script src="/resources/testharness.js"></script>
-	  <script src="/resources/testharnessreport.js"></script>
-	  <script src="/resources/testdriver.js"></script>
-	  <script src="/resources/testdriver-vendor.js"></script>
-	  <script src="/resources/testdriver-actions.js"></script>
-	  <script src="/wai-aria/scripts/aria-utils.js"></script>
+		<title>Name Comp: content visibility (Tentative)</title>
+		<script src="/resources/testharness.js"></script>
+		<script src="/resources/testharnessreport.js"></script>
+		<script src="/resources/testdriver.js"></script>
+		<script src="/resources/testdriver-vendor.js"></script>
+		<script src="/resources/testdriver-actions.js"></script>
+		<script src="/wai-aria/scripts/aria-utils.js"></script>
 	</head>
 	<body>
 
 		<h1>Testing accessibility of content-visibility: auto</h1>
 
-	  <h2>Accname</h2>
-	  
-	  <div style="height:5px; overflow:scroll;">
-		  <div>
-		  	<p>Some content</p>
-		  	<p>Some content</p>
-		  	<p>Some content</p>
-		  	<p>Some content</p>
-		  	<p>Some content</p>
-		  </div>
-		  <div style="content-visibility:auto"> 
-		  	<h2 class="el">test heading</h2>
-		    <button class="el">test button</button>
-		    <a class="el" href="#">test link</a>
-		  </div>
-	  </div>
+		<h2>Accname</h2>
+
+		<div style="height:5px; overflow:scroll;">
+			<div>
+				<p>Some content</p>
+				<p>Some content</p>
+				<p>Some content</p>
+				<p>Some content</p>
+				<p>Some content</p>
+			</div>
+			<div style="content-visibility:auto"> 
+				<h2 class="ex" data-expectedlabel="SPEC_AMBIGUOUS_LOG_VALUE" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="HTML heading element under content-visibility auto condition">test heading</h2>
+				<button class="ex" data-expectedlabel="SPEC_AMBIGUOUS_LOG_VALUE" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="HTML button element under content-visibility auto condition">test button</button>
+				<a class="ex" href="#" data-expectedlabel="SPEC_AMBIGUOUS_LOG_VALUE" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="HTML link element under content-visibility auto condition">test link</a>
+			</div>
+		</div>
 		
 		<script>
-		  const els = document.querySelectorAll('.el');
-		  if (!els.length) {
-		    throw `No`;
-		  }
-		  for (const el of els) {
-		    promise_test(async t => {
-		      let computedLabel = await test_driver.get_computed_label(el);
-		      let computedRole = await test_driver.get_computed_role(el);
-
-		      console.log('el-text-content: '+el.textContent+'; comp-role-f: '+computedRole+'; comp-label-f: '+computedLabel);
-		    })
-		  }
+			AriaUtils.verifyRolesBySelector(".ex");
+			AriaUtils.verifyLabelsBySelector(".ex");
 		</script>
-
+	
 	</body>
 </html>

--- a/accname/name/comp_content_visibility.tentative.html
+++ b/accname/name/comp_content_visibility.tentative.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html>
+	<head>
+	  <title>Name Comp: content visibility (Tentative)</title>
+	  <script src="/resources/testharness.js"></script>
+	  <script src="/resources/testharnessreport.js"></script>
+	  <script src="/resources/testdriver.js"></script>
+	  <script src="/resources/testdriver-vendor.js"></script>
+	  <script src="/resources/testdriver-actions.js"></script>
+	  <script src="/wai-aria/scripts/aria-utils.js"></script>
+	</head>
+	<body>
+
+		<h1>Testing accessibility of content-visibility: auto</h1>
+
+	  <h2>Accname</h2>
+	  
+	  <div style="height:5px; overflow:scroll;">
+		  <div>
+		  	<p>Some content</p>
+		  	<p>Some content</p>
+		  	<p>Some content</p>
+		  	<p>Some content</p>
+		  	<p>Some content</p>
+		  </div>
+		  <div style="content-visibility:auto"> 
+		  	<h2 class="el">test heading</h2>
+		    <button class="el">test button</button>
+		    <a class="el" href="#">test link</a>
+		  </div>
+	  </div>
+		
+		<script>
+		  const els = document.querySelectorAll('.el');
+		  if (!els.length) {
+		    throw `No`;
+		  }
+		  for (const el of els) {
+		    promise_test(async t => {
+		      let computedLabel = await test_driver.get_computed_label(el);
+		      let computedRole = await test_driver.get_computed_role(el);
+
+		      console.log('el-text-content: '+el.textContent+'; comp-role-f: '+computedRole+'; comp-label-f: '+computedLabel);
+		    })
+		  }
+		</script>
+
+	</body>
+</html>

--- a/accname/name/comp_content_visibility.tentative.html
+++ b/accname/name/comp_content_visibility.tentative.html
@@ -20,12 +20,12 @@
                 <p>Some content</p>
                 <p>Some content</p>
             </div>
-            <div style="content-visibility:auto"> 
+            <div style="content-visibility:auto">
                 <h2 class="ex" data-expectedlabel="SPEC_AMBIGUOUS_LOG_VALUE" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="HTML heading element under content-visibility auto condition">test heading</h2>
                 <button class="ex" data-expectedlabel="SPEC_AMBIGUOUS_LOG_VALUE" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="HTML button element under content-visibility auto condition">test button</button>
                 <a class="ex" href="#" data-expectedlabel="SPEC_AMBIGUOUS_LOG_VALUE" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="HTML link element under content-visibility auto condition">test link</a>
             </div>
-        </div>	
+        </div>
         <script>
             AriaUtils.verifyRolesAndLabelsBySelector(".ex");
         </script>

--- a/accname/name/comp_content_visibility.tentative.html
+++ b/accname/name/comp_content_visibility.tentative.html
@@ -31,8 +31,7 @@
 		</div>
 		
 		<script>
-			AriaUtils.verifyRolesBySelector(".ex");
-			AriaUtils.verifyLabelsBySelector(".ex");
+			AriaUtils.verifyRolesAndLabelsBySelector(".ex");
 		</script>
 	
 	</body>

--- a/accname/name/comp_content_visibility.tentative.html
+++ b/accname/name/comp_content_visibility.tentative.html
@@ -21,9 +21,9 @@
                 <p>Some content</p>
             </div>
             <div style="content-visibility:auto">
-                <h2 class="ex" data-expectedlabel="SPEC_AMBIGUOUS_LOG_VALUE" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="HTML heading element under content-visibility auto condition">test heading</h2>
-                <button class="ex" data-expectedlabel="SPEC_AMBIGUOUS_LOG_VALUE" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="HTML button element under content-visibility auto condition">test button</button>
-                <a class="ex" href="#" data-expectedlabel="SPEC_AMBIGUOUS_LOG_VALUE" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="HTML link element under content-visibility auto condition">test link</a>
+                <h2 class="ex" data-expectedlabel="SPEC_AMBIGUOUS_LOG_VALUE" data-expectedrole="heading" data-testname="HTML heading element under content-visibility auto condition">test heading</h2>
+                <button class="ex" data-expectedlabel="SPEC_AMBIGUOUS_LOG_VALUE" data-expectedrole="button" data-testname="HTML button element under content-visibility auto condition">test button</button>
+                <a class="ex" href="#" data-expectedlabel="SPEC_AMBIGUOUS_LOG_VALUE" data-expectedrole="link" data-testname="HTML link element under content-visibility auto condition">test link</a>
             </div>
         </div>
         <script>


### PR DESCRIPTION
Closes: https://github.com/web-platform-tests/interop-accessibility/issues/168

Relates: https://github.com/w3c/css-aam/issues/24

This PR introduces tests for elements outside the viewport that are contained within another element with the content-visibility: auto CSS property. The console log output includes:
- el.textContent
- computedRole
- computedLabel

Note: The test outcomes are simply logs to observe browser behavior. There are no set expectations at this point, as these will be discussed in relation to https://github.com/w3c/css-aam/issues/24.