### PR TITLE
Add test for calling worker constructor from a shared worker.

### DIFF
--- a/trusted-types/WorkerGlobalScope-worker-constructor.html
+++ b/trusted-types/WorkerGlobalScope-worker-constructor.html
@@ -9,6 +9,9 @@
   <script>
     fetch_tests_from_worker(new Worker(
       "support/WorkerGlobalScope-worker-constructor.js"));
+
+    fetch_tests_from_worker(new SharedWorker(
+      "support/WorkerGlobalScope-worker-constructor.js"));
   </script>
 </body>
 </html>

--- a/trusted-types/support/WorkerGlobalScope-worker-constructor.js
+++ b/trusted-types/support/WorkerGlobalScope-worker-constructor.js
@@ -4,20 +4,28 @@ const test_setup_policy = trustedTypes.createPolicy("p",
 
 importScripts(test_setup_policy.createScriptURL("/resources/testharness.js"));
 
+// Determine worker type (for better logging)
+let worker_type = "unknown";
+if (this.DedicatedWorkerGlobalScope !== undefined) {
+  worker_type = "dedicated worker";
+} else if (this.SharedWorkerGlobalScope !== undefined) {
+  worker_type = "shared worker";
+}
+
 test(() => {
   assert_throws_js(TypeError, () => { new Worker("w"); },
     "Creating a Worker threw");
-}, "Creating a Worker from a string should throw");
+}, `Creating a Worker from a string should throw (${worker_type} scope)`);
 
 test(() => {
   new Worker(test_setup_policy.createScriptURL("u"));
-}, "Creating a Worker from a TrustedScriptURL should not throw");
+}, `Creating a Worker from a TrustedScriptURL should not throw (${worker_type} scope)`);
 
 test(() => {
   trustedTypes.createPolicy("default",
     { createScriptURL: s => "defaultValue" });
 
   new Worker("s");
-}, "Creating a Worker from a string with a default policy should not throw");
+}, `Creating a Worker from a string with a default policy should not throw (${worker_type} scope)`);
 
 done();

--- a/trusted-types/support/WorkerGlobalScope-worker-constructor.js
+++ b/trusted-types/support/WorkerGlobalScope-worker-constructor.js
@@ -23,7 +23,12 @@ test(() => {
 
 test(() => {
   trustedTypes.createPolicy("default",
-    { createScriptURL: s => "defaultValue" });
+    { createScriptURL: (s, _, sink) => {
+        assert_equals(sink, 'Worker constructor');
+        return "defaultValue";
+      }
+    }
+  );
 
   new Worker("s");
 }, `Creating a Worker from a string with a default policy should not throw (${worker_type} scope)`);


### PR DESCRIPTION
See https://html.spec.whatwg.org/multipage/workers.html#dedicated-workers-and-the-worker-interface

- Calling the Worker constructor from Window is covered by worker-constructor.html
- Calling the Worker constructor from a DedicatedWorker is covered by WorkerGlobalScope-worker-constructor.html
- This patch extends the previous test to also cover the case when the Worker constructor is called from a SharedWorker.

https://github.com/w3c/trusted-types/issues/567