### PR TITLE
Fix Trusted Type sink test changes from https://github.com/WebKit/Web…

### DIFF
--- a/trusted-types/support/block-string-assignment-to-DOMWindowTimers-setTimeout-setInterval.js
+++ b/trusted-types/support/block-string-assignment-to-DOMWindowTimers-setTimeout-setInterval.js
@@ -52,10 +52,13 @@ const kTimeoutTestString = "timeoutTestString";
 const kIntervalTestString = "intervalTestString";
 
 let policy = globalThis.trustedTypes.createPolicy("default", { createScript: (x, _, sink) => {
+   // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timer-initialisation-steps,
+  // step 9.6.1.1.
+  const expectedSink = globalThisStr.includes("Window") ? "Window" : "Worker";
   if (x === kTimeoutTestString) {
-    assert_equals(sink, `${globalThisStr} setTimeout`);
+    assert_equals(sink, `${expectedSink} setTimeout`);
   } else if (x === kIntervalTestString) {
-    assert_equals(sink, `${globalThisStr} setInterval`);
+    assert_equals(sink, `${expectedSink} setInterval`);
   }
   return "0";
 }});

--- a/trusted-types/trusted-types-duplicate-names-without-enforcement.html
+++ b/trusted-types/trusted-types-duplicate-names-without-enforcement.html
@@ -6,10 +6,6 @@
 <body>
 <script>
 const policy = { createHTML: a => a };
-const policy_default = { createHTML: (a, _, sink) => {
-  assert_equals(sink, 'Element innerHTML');
-  return a;
-}};
 
 test(t => {
   // The spec demands that duplicate policies are allowed when TT is not
@@ -24,11 +20,11 @@ test(t => {
 test(t => {
   // The spec demands that duplicate "default" policy creation fails, even
   // when TT is not enforced.
-  let p = trustedTypes.createPolicy("default", policy_default);
+  let p = trustedTypes.createPolicy("default", policy);
   assert_true(p instanceof TrustedTypePolicy);
 
   // The second instance should throw:
-  assert_throws_js(TypeError, _ => trustedTypes.createPolicy("default", policy_default));
+  assert_throws_js(TypeError, _ => trustedTypes.createPolicy("default", policy));
 }, "createPolicy - duplicate \"default\" policy is never allowed.");
 </script>
 </body>

--- a/trusted-types/worker-constructor.https.html
+++ b/trusted-types/worker-constructor.https.html
@@ -62,33 +62,44 @@ promise_test(t => {
 }, "Block ServiceWorker creation via String");
 
 // Tests with default policy.
+let seenTrustedTypeName;
+let seenSinkName;
+function resetSeenArguments() {
+  seenTrustedTypeName = undefined;
+  seenSinkName = undefined;
+}
+
 promise_test(t => {
   trustedTypes.createPolicy("default", {
-    createScriptURL: (s, _, sink) => {
-      if (s === "Worker") {
-        assert_equals(sink, 'Worker constructor');
-      } else if (s === "SharedWorker") {
-        assert_equals(sink, 'SharedWorker constructor');
-      } else if (s == "service_worker") {
-        assert_equals(sink, 'ServiceWorkerContainer register');
-      }
-      return s.replace("potato", "https");
+    createScriptURL: (input, trustedTypeName, sinkName) => {
+      seenTrustedTypeName = trustedTypeName;
+      seenSinkName = sinkName;
+      return input.replace("potato", "https");
     }});
   return Promise.resolve();
 }, "Setup default policy.");
 
 promise_test(t => {
+  t.add_cleanup(resetSeenArguments);
   new Worker(default_url);
+  assert_equals(seenTrustedTypeName, "TrustedScriptURL");
+  assert_equals(seenSinkName, "Worker constructor");
   return Promise.resolve();
 }, "Create Worker via string with default policy.");
 
 promise_test(t => {
+  t.add_cleanup(resetSeenArguments);
   new SharedWorker(default_url);
+  assert_equals(seenTrustedTypeName, "TrustedScriptURL");
+  assert_equals(seenSinkName, "SharedWorker constructor");
   return Promise.resolve();
 }, "Create SharedWorker via string with default policy.");
 
-promise_test(t => {
-  return service_worker(default_url);
+promise_test(async t => {
+  t.add_cleanup(resetSeenArguments);
+  await service_worker(default_url);
+  assert_equals(seenTrustedTypeName, "TrustedScriptURL");
+  assert_equals(seenSinkName, "ServiceWorkerContainer register");
 }, "Create ServiceWorker via string with default policy.");
 
 </script>


### PR DESCRIPTION
…Kit/pull/28165

    * trusted-types-duplicate-names-without-enforcement.html: this test is
      about createPolicy(), it actually never executes the default policy
      so we cannot check the sink value.
    
    * worker-constructor.https.html: This checks a sink value, conditioning
      the expectations on the input string but that one is always a URL.
      Fix that by actually saving the seen parameters and testing them
      in the promise tests.
    
    * block-string-assignment-to-DOMWindowTimers-setTimeout-setInterval.html:
      some fixes were made in https://phabricator.services.mozilla.com/D232984
      but it wrongly uses globalThisStr. We need to something similar to what
      DOMWindowTimers-setTimeout-setInterval.js does instead.

