### PR TITLE
 Add tests for setAttribute/setAttributeNS and content event handler attributes

### DIFF
--- a/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html
+++ b/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html
@@ -11,6 +11,20 @@
 <script>
 promise_setup(async function() {
   let attributeNamesWithInterfaceName = [];
+  function isAttributeImplemented(interfaceName, name) {
+    switch (interfaceName) {
+      case 'GlobalEventHandlers':
+        return name in HTMLElement.prototype;
+      case 'WindowEventHandlers':
+        return name in HTMLBodyElement.prototype;
+      case 'HTMLMediaElement':
+        return name in HTMLMediaElement.prototype;
+      case 'SVGAnimationElement':
+        return name in SVGAnimationElement.prototype;
+      default:
+       throw "Unknown interface";
+    }
+  }
   function addOnAttributes(IDL, interfaceName) {
     // Parsing the whole IDL file is slow, so use a small regexp to extract only
     // the part that is relevant for this test.
@@ -19,7 +33,8 @@ promise_setup(async function() {
     parsedIDL.find(idl => idl.name === interfaceName)
       .members.map(member => member.name)
       .filter(name => name.length >= 3 && name.startsWith("on") &&
-              !name.startsWith("onwebkit"))
+              !name.startsWith("onwebkit") &&
+              isAttributeImplemented(interfaceName, name))
       .forEach(name => attributeNamesWithInterfaceName.push({name, interfaceName}));
   }
 
@@ -39,20 +54,6 @@ promise_setup(async function() {
   addOnAttributes(svgAnimationsIDL, "SVGAnimationElement");
 
   for (const attributeNameWithInterfaceName of attributeNamesWithInterfaceName) {
-    // Skip attributes that are not implemented in the browser.
-    if (attributeNameWithInterfaceName.interfaceName === 'GlobalEventHandlers' && !(attributeNameWithInterfaceName.name in HTMLElement.prototype)) {
-      continue;
-    }
-    if (attributeNameWithInterfaceName.interfaceName === 'WindowEventHandlers' && !(attributeNameWithInterfaceName.name in HTMLBodyElement.prototype)) {
-      continue;
-    }
-    if (attributeNameWithInterfaceName.interfaceName === 'HTMLMediaElement' && !(attributeNameWithInterfaceName.name in HTMLMediaElement.prototype)) {
-      continue;
-    }
-    if (attributeNameWithInterfaceName.interfaceName === 'SVGAnimationElement' && !(attributeNameWithInterfaceName.name in SVGAnimationElement.prototype)) {
-      continue;
-    }
-
     promise_test(async () => {
       NSURI_ARRAY.forEach(attrNs => {
         assert_equals(trustedTypes.getAttributeType(

--- a/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html
+++ b/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html
@@ -6,62 +6,19 @@
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/WebIDLParser.js"></script>
 <script src="support/namespaces.js"></script>
-<script>
-promise_setup(async function() {
-  let attributeNamesWithInterfaceName = [];
-  function isAttributeImplemented(interfaceName, name) {
-    switch (interfaceName) {
-      case 'GlobalEventHandlers':
-        return name in HTMLElement.prototype;
-      case 'WindowEventHandlers':
-        return name in HTMLBodyElement.prototype;
-      case 'HTMLMediaElement':
-        return name in HTMLMediaElement.prototype;
-      case 'SVGAnimationElement':
-        return name in SVGAnimationElement.prototype;
-      default:
-       throw "Unknown interface";
+<script type="module">
+  import { getEventHandlerAttributeWithInterfaceNames } from './support/event-handler-attributes.mjs';
+  promise_setup(async function() {
+    for (const attr of await getEventHandlerAttributeWithInterfaceNames()) {
+      promise_test(async () => {
+        NSURI_ARRAY.forEach(attrNs => {
+          assert_equals(trustedTypes.getAttributeType(
+            "dummy", attr.name, "dummyNs", attrNs),
+            attrNs === NSURI_EMPTY ? "TrustedScript" : null,
+            `for attrNs='${attrNs}'`);
+        });
+      }, `getAttributeType("dummy", "${attr.name}", "dummyNs", attrNs)`);
     }
-  }
-  function addOnAttributes(IDL, interfaceName) {
-    // Parsing the whole IDL file is slow, so use a small regexp to extract only
-    // the part that is relevant for this test.
-    let regexp = new RegExp(`^.*\(partial \)?interface \(mixin \)?${interfaceName}[^{]*{[^{}]*};$`, "m");
-    let parsedIDL = WebIDL2.parse(IDL.match(regexp)[0]);
-    parsedIDL.find(idl => idl.name === interfaceName)
-      .members.map(member => member.name)
-      .filter(name => name.length >= 3 && name.startsWith("on") &&
-              !name.startsWith("onwebkit") &&
-              isAttributeImplemented(interfaceName, name))
-      .forEach(name => attributeNamesWithInterfaceName.push({name, interfaceName}));
-  }
-
-  const htmlIDL = await (await fetch("/interfaces/html.idl")).text();
-  // GlobalEventHandlers exist on HTMLElement, SVGElement, and MathMLElement.
-  // WindowEventHandlers exist on HTMLBodyElement, and HTMLFrameSetElement.
-  ["GlobalEventHandlers", "WindowEventHandlers"].forEach(interfaceName => {
-    addOnAttributes(htmlIDL, interfaceName);
   });
-
-  const encryptedMediaIDL = await (await fetch("/interfaces/encrypted-media.idl")).text();
-  // HTMLMediaElement (the parent for <audio> and <video>) has extra event handlers.
-  addOnAttributes(encryptedMediaIDL, "HTMLMediaElement");
-
-  const svgAnimationsIDL = await (await fetch("/interfaces/svg-animations.idl")).text();
-  // SVGAnimationElement has extra event handlers.
-  addOnAttributes(svgAnimationsIDL, "SVGAnimationElement");
-
-  for (const attributeNameWithInterfaceName of attributeNamesWithInterfaceName) {
-    promise_test(async () => {
-      NSURI_ARRAY.forEach(attrNs => {
-        assert_equals(trustedTypes.getAttributeType(
-          "dummy", attributeNameWithInterfaceName.name, "dummyNs", attrNs),
-          attrNs === NSURI_EMPTY ? "TrustedScript" : null,
-          `for attrNs='${attrNs}'`);
-      });
-    }, `getAttributeType("dummy", "${attributeNameWithInterfaceName.name}", "dummyNs", attrNs)`);
-  }
-});
 </script>

--- a/trusted-types/set-event-handlers-content-attributes.tentative.html
+++ b/trusted-types/set-event-handlers-content-attributes.tentative.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="support/namespaces.js"></script>
+  <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">
+</head>
+<body>
+<script type="module">
+  import { getEventHandlerAttributeWithInterfaceNames } from './support/event-handler-attributes.mjs';
+
+  promise_setup(async function() {
+    const input_string = "unsafe_handler()";
+    const output_string = "safe_handler()";
+    let seenSinkName;
+    function resetSeenSinkName() { seenSinkName = undefined; }
+    trustedTypes.createPolicy("default", {
+      createScript: (input, trustedTypeName, sinkName) => {
+        assert_equals(input, input_string);
+        assert_equals(trustedTypeName, "TrustedScript");
+        seenSinkName = sinkName;
+        return output_string;
+      }
+    });
+    function elementsImplementingInterface(interfaceName) {
+      switch (interfaceName) {
+      case 'GlobalEventHandlers':
+          return [document.createElement("div"),
+                  document.createElementNS(NSURI_SVG, "g"),
+                  document.createElementNS(NSURI_MATHML, "mrow")];
+      case 'WindowEventHandlers':
+          return [document.createElement("body"),
+                  document.createElement("frameset")];
+      case 'HTMLMediaElement':
+          return [document.createElement("audio"),
+                  document.createElement("video")];
+      case 'SVGAnimationElement':
+         return [document.createElementNS(NSURI_SVG, "animation")];
+      default:
+        throw "Unknown interface";
+      }
+    }
+
+    for (const attr of await getEventHandlerAttributeWithInterfaceNames()) {
+      elementsImplementingInterface(attr.interfaceName).forEach(element => {
+         function cleanup() {
+           resetSeenSinkName();
+           element.removeAttribute(attr.name);
+         }
+         promise_test(async t => {
+           t.add_cleanup(cleanup);
+           element.setAttribute(attr.name, input_string);
+           assert_equals(seenSinkName, `Element ${attr.name}`);
+           assert_equals(element.getAttribute(attr.name),output_string);
+         }, `${element.tagName}.setAttribute(${attr.name}, "${input_string}") calls default policy`);
+         promise_test(async t => {
+           t.add_cleanup(cleanup);
+           element.setAttributeNS(null, attr.name, input_string);
+           assert_equals(seenSinkName, `Element ${attr.name}`);
+           assert_equals(element.getAttribute(attr.name),output_string);
+         }, `${element.tagName}.setAttributeNS(${attr.name}, "${input_string}") calls default policy`);
+      });
+    }
+  });
+</script>
+</body>

--- a/trusted-types/set-event-handlers-content-attributes.tentative.html
+++ b/trusted-types/set-event-handlers-content-attributes.tentative.html
@@ -18,6 +18,7 @@
       createScript: (input, trustedTypeName, sinkName) => {
         assert_equals(input, input_string);
         assert_equals(trustedTypeName, "TrustedScript");
+        assert_equals(seenSinkName, undefined);
         seenSinkName = sinkName;
         return output_string;
       }

--- a/trusted-types/support/event-handler-attributes.mjs
+++ b/trusted-types/support/event-handler-attributes.mjs
@@ -1,0 +1,47 @@
+import '/resources/WebIDLParser.js';
+
+export async function getEventHandlerAttributeWithInterfaceNames() {
+  let attributeNamesWithInterfaceName = [];
+  function isAttributeImplemented(interfaceName, name) {
+    switch (interfaceName) {
+      case 'GlobalEventHandlers':
+        return name in HTMLElement.prototype;
+      case 'WindowEventHandlers':
+        return name in HTMLBodyElement.prototype;
+      case 'HTMLMediaElement':
+        return name in HTMLMediaElement.prototype;
+      case 'SVGAnimationElement':
+        return name in SVGAnimationElement.prototype;
+      default:
+       throw "Unknown interface";
+    }
+  }
+  function addOnAttributes(IDL, interfaceName) {
+    // Parsing the whole IDL file is slow, so use a small regexp to extract only
+    // the part that is relevant for this test.
+    let regexp = new RegExp(`^.*\(partial \)?interface \(mixin \)?${interfaceName}[^{]*{[^{}]*};$`, "m");
+    let parsedIDL = WebIDL2.parse(IDL.match(regexp)[0]);
+    parsedIDL.find(idl => idl.name === interfaceName)
+      .members.map(member => member.name)
+      .filter(name => name.length >= 3 && name.startsWith("on") &&
+              !name.startsWith("onwebkit") &&
+              isAttributeImplemented(interfaceName, name))
+      .forEach(name => attributeNamesWithInterfaceName.push({name, interfaceName}));
+  }
+  const htmlIDL = await (await fetch("/interfaces/html.idl")).text();
+  // GlobalEventHandlers exist on HTMLElement, SVGElement, and MathMLElement.
+  // WindowEventHandlers exist on HTMLBodyElement, and HTMLFrameSetElement.
+  ["GlobalEventHandlers", "WindowEventHandlers"].forEach(interfaceName => {
+    addOnAttributes(htmlIDL, interfaceName);
+  });
+
+  const encryptedMediaIDL = await (await fetch("/interfaces/encrypted-media.idl")).text();
+  // HTMLMediaElement (the parent for <audio> and <video>) has extra event handlers.
+  addOnAttributes(encryptedMediaIDL, "HTMLMediaElement");
+
+  const svgAnimationsIDL = await (await fetch("/interfaces/svg-animations.idl")).text();
+  // SVGAnimationElement has extra event handlers.
+  addOnAttributes(svgAnimationsIDL, "SVGAnimationElement");
+
+  return attributeNamesWithInterfaceName;
+}


### PR DESCRIPTION
```
    Never include unsupported event attributes into attributeNamesWithInterfaceName
    
    This is a small refactoring of https://github.com/web-platform-tests/wpt/pull/49473
    
    Instead of skipping unsupported attributes in the for loop, we filter
    them out when building the list.
    
    Technically, interfaceName is no longer used in the for loop, but we
    keep it in case that's needed for future setAttribute/setAttributeNS
    tests.
```

```
    Add tests for setAttribute/setAttributeNS and content event handler attributes
    
    * Factor out the code generating the list of event handler attribute from TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html into a event-handler-attributes.mjs module.
    * Use this to write tests for setAttribute/setAttributeNS for all event handler attributes.
```

