### PR TITLE
Enable wdspec and crashtest tests in servodriver.

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -10,8 +10,10 @@ from .base import (WebDriverBrowser,
                    get_free_port)
 from .base import get_timeout_multiplier   # noqa: F401
 from ..executors import executor_kwargs as base_executor_kwargs
+from ..executors.base import WdspecExecutor  # noqa: F401
 from ..executors.executorservodriver import (ServoWebDriverTestharnessExecutor,  # noqa: F401
-                                             ServoWebDriverRefTestExecutor)  # noqa: F401
+                                             ServoWebDriverRefTestExecutor,  # noqa: F401
+                                             ServoWebDriverCrashtestExecutor)  # noqa: F401
 
 here = os.path.dirname(__file__)
 
@@ -22,6 +24,8 @@ __wptrunner__ = {
     "executor": {
         "testharness": "ServoWebDriverTestharnessExecutor",
         "reftest": "ServoWebDriverRefTestExecutor",
+        "crashtest": "ServoWebDriverCrashtestExecutor",
+        "wdspec": "WdspecExecutor",
     },
     "browser_kwargs": "browser_kwargs",
     "executor_kwargs": "executor_kwargs",

--- a/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -2,7 +2,7 @@
 
 import os
 
-from .executorwebdriver import WebDriverProtocol, WebDriverTestharnessExecutor, WebDriverRefTestExecutor
+from .executorwebdriver import WebDriverProtocol, WebDriverTestharnessExecutor, WebDriverRefTestExecutor, WebDriverCrashtestExecutor
 
 webdriver = None
 ServoCommandExtensions = None
@@ -102,6 +102,24 @@ class ServoWebDriverRefTestExecutor(WebDriverRefTestExecutor):
                                           timeout_multiplier, screenshot_cache,
                                           capabilities=capabilities,
                                           debug_info=debug_info)
+
+    def on_environment_change(self, new_environment):
+        self.protocol.webdriver.extension.change_prefs(
+            self.last_environment.get("prefs", {}),
+            new_environment.get("prefs", {})
+        )
+
+
+class ServoWebDriverCrashtestExecutor(WebDriverCrashtestExecutor):
+    protocol_cls = ServoWebDriverProtocol
+
+    def __init__(self, logger, browser, server_config, timeout_multiplier=1,
+                 screenshot_cache=None, capabilities={}, debug_info=None,
+                 **kwargs):
+        WebDriverCrashtestExecutor.__init__(self, logger, browser, server_config,
+                                            timeout_multiplier, screenshot_cache,
+                                            capabilities=capabilities,
+                                            debug_info=debug_info)
 
     def on_environment_change(self, new_environment):
         self.protocol.webdriver.extension.change_prefs(


### PR DESCRIPTION
This gives us parity with the tests that are supported in the non-webdriver testharness, and makes it easier to work on closing remaining functionality gaps.

Reviewed in servo/servo#34955