### PR TITLE
Remove unrelated checks from trusted-types-svg-script-set-href.html

### DIFF
--- a/trusted-types/trusted-types-svg-script-set-href.html
+++ b/trusted-types/trusted-types-svg-script-set-href.html
@@ -12,7 +12,7 @@
   <svg id="svg"><script id="script">"some script text";</script></svg>
   <script>
     const policy = trustedTypes.createPolicy("policy", {
-        createScript: x => x, createHTML: x => x, createScriptURL: x => x });
+      createScriptURL: script_url => script_url });
 
     promise_test(t => {
       const elem = document.createElementNS(NSURI_SVG, "script");
@@ -104,26 +104,13 @@
     // but now expect all assignments to succeed.
     promise_test(t => {
       trustedTypes.createPolicy("default", {
-        createScript: (x, _, sink) => {
-          assert_equals(sink, 'SVGScriptElement text');
-          return x;
-        },
-        createHTML: (x, _, sink) => {
-          assert_equals(sink, 'Element innerHTML');
-          return x;
-        },
-        createScriptURL: (x, _, sink) => {
+        createScriptURL: (script_url, _, sink) => {
           assert_equals(sink, 'SVGScriptElement href');
-          return x;
+          return script_url;
         }});
 
       return Promise.resolve();
     }, "Setup default policy");
-
-    promise_test(t => {
-      document.getElementById("script").innerHTML = "'modified via innerHTML';";
-      return Promise.resolve();
-    }, "Assign String to SVGScriptElement.innerHTML w/ default policy.");
 
     promise_test(t => {
       const elem = document.createElementNS(NSURI_SVG, "script");

--- a/trusted-types/trusted-types-svg-script.html
+++ b/trusted-types/trusted-types-svg-script.html
@@ -40,5 +40,24 @@
       document.getElementById("svg").appendChild(elem);
       return promise_spv();
     }, "Modify SVGScriptElement via DOM manipulation.");
+
+    promise_test(t => {
+      trustedTypes.createPolicy("default", {
+        createScript: (x, _, sink) => {
+          assert_equals(sink, 'SVGScriptElement text');
+          return x;
+        },
+        createHTML: (x, _, sink) => {
+          assert_equals(sink, 'Element innerHTML');
+          return x;
+        },
+      });
+      return Promise.resolve();
+    }, "Setup default policy");
+
+    promise_test(t => {
+      document.getElementById("script").innerHTML = "'modified via innerHTML';";
+      return Promise.resolve();
+    }, "Assign String to SVGScriptElement.innerHTML w/ default policy.");
   </script>
 </body>

--- a/trusted-types/trusted-types-svg-script.html
+++ b/trusted-types/trusted-types-svg-script.html
@@ -43,19 +43,15 @@
 
     promise_test(t => {
       trustedTypes.createPolicy("default", {
-        createScript: (x, _, sink) => {
+        createScript: (input, _, sink) => {
           assert_equals(sink, 'SVGScriptElement text');
-          return x;
+          return input;
         },
-        createHTML: (x, _, sink) => {
+        createHTML: (input, _, sink) => {
           assert_equals(sink, 'Element innerHTML');
-          return x;
+          return input;
         },
       });
-      return Promise.resolve();
-    }, "Setup default policy");
-
-    promise_test(t => {
       document.getElementById("script").innerHTML = "'modified via innerHTML';";
       return Promise.resolve();
     }, "Assign String to SVGScriptElement.innerHTML w/ default policy.");


### PR DESCRIPTION
This test is intended to cover setting href [1] [2] but it also currently verifies some (currently not specified) unrelated behavior when setting the text of the script via innerHTML. A similar test exist in block-text-node-insertion-into-svg-script-element.html, but for a disconnected script. This PR just move the unrelated test to trusted-types-svg-script.html instead.

[1] https://github.com/w3c/svgwg/pull/934
[2] https://github.com/whatwg/dom/pull/1268