### PR TITLE
[Accessibility] Nested ARIA and HTML buttons - Presentational Roles Conflict Resolution

### DIFF
--- a/wai-aria/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role_none_conflict_resolution.tentative.html
@@ -59,7 +59,6 @@
       document.getElementById("inner-button-container").appendChild(innerButton);
 
       AriaUtils.verifyRolesBySelector(".ex-role");
-      AriaUtils.verifyGenericRolesBySelector(".ex-generic");
     </script>
 
   </body>

--- a/wai-aria/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role_none_conflict_resolution.tentative.html
@@ -13,7 +13,7 @@
     
     <!-- ARIA specs: https://w3c.github.io/aria/#tree_exclusion -->
     <!-- no conflict, since not focusable; inner button should be exposed as generic - children presentational - //https://github.com/web-platform-tests/interop-accessibility/issues/161 -->
-    <h2>ARIA role="button" nesting ARIA role="button" (no presentational roles conflict resolution, since inner button is not focusable)</h2>
+    <h2>Non-focusable ARIA role="button" nesting non-focusable ARIA role="button" (no presentational roles conflict resolution, since inner button is not focusable)</h2>
     <div role="button">
       <span>outer button</span>
       <span role="button" class="ex-role" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="non-focusable ARIA[role=button] nesting non-focusable ARIA[role=button]">Inner button</span>

--- a/wai-aria/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role_none_conflict_resolution.tentative.html
@@ -13,10 +13,31 @@
     
     <!-- ARIA specs: https://w3c.github.io/aria/#tree_exclusion -->
     <!-- no conflict, since not focusable; inner button should be exposed as generic - children presentational - //https://github.com/web-platform-tests/interop-accessibility/issues/161 -->
-    <h2>ARIA role="button" nesting ARIA role="button" (no presentational roles conflict resolution, since not focusable)</h2>
+    <h2>ARIA role="button" nesting ARIA role="button" (no presentational roles conflict resolution, since inner button is not focusable)</h2>
     <div role="button">
       <span>outer button</span>
-      <span role="button" class="ex-role" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="non-focusable ARIA[role button] nesting non-focusable ARIA[role button]">Inner button</span>
+      <span role="button" class="ex-role" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="non-focusable ARIA[role=button] nesting non-focusable ARIA[role=button]">Inner button</span>
+    </div>
+
+    <!-- no conflict, since nested button is not focusable; inner button should be exposed as generic - children presentational - //https://github.com/web-platform-tests/interop-accessibility/issues/161 -->
+    <h2>Focusable ARIA role="button" nesting non-focusable ARIA role="button" (no presentational roles conflict resolution, since inner button is not focusable)</h2>
+    <div role="button" tabindex="0">
+      <span>outer button</span>
+      <span role="button" class="ex-role" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="focusable ARIA[role=button] nesting non-focusable ARIA[role=button]">Inner button</span>
+    </div>
+
+    <!-- conflict arise, since inner button is focusable - //https://github.com/web-platform-tests/interop-accessibility/issues/161-->
+    <h2>Non-focusable ARIA role="button" nesting focusable ARIA role="button" (presentational roles conflict resolution arise, since inner button is focusable)</h2>
+    <div role="button">
+      <span>outer button</span>
+      <span role="button" class="ex-role" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="non-focusable ARIA[role=button] nesting focusable ARIA[role=button]" tabindex="0">Inner button</span>
+    </div>
+
+    <!-- conflict arise, since inner button is focusable - //https://github.com/web-platform-tests/interop-accessibility/issues/161-->
+    <h2>Focusable ARIA role="button" nesting focusable ARIA role="button" (presentational roles conflict resolution arise, since inner button is focusable)</h2>
+    <div role="button" tabindex="0">
+      <span>outer button</span>
+      <span role="button" class="ex-role" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="focusable ARIA[role=button] nesting focusable ARIA[role=button]" tabindex="0">Inner button</span>
     </div>
 
     <!-- conflict arise, since inner button is focusable - //https://github.com/web-platform-tests/interop-accessibility/issues/161-->

--- a/wai-aria/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role_none_conflict_resolution.tentative.html
@@ -11,12 +11,12 @@
   </head>
   <body>
     
-    <!-- ARIA specs: https://www.w3.org/TR/wai-aria-1.3/#tree_exclusion -->
+    <!-- ARIA specs: https://w3c.github.io/aria/#tree_exclusion -->
     <!-- no conflict, since not focusable; inner button should be exposed as generic - children presentational - //https://github.com/web-platform-tests/interop-accessibility/issues/161 -->
     <h2>ARIA role="button" nesting ARIA role="button" (no presentational roles conflict resolution, since not focusable)</h2>
     <div role="button">
       <span>outer button</span>
-      <span role="button" class="ex-generic" data-testname="non-focusable ARIA[role button] nesting non-focusable ARIA[role button]">Inner button</span>
+      <span role="button" class="ex-role" data-expectedrole="SPEC_AMBIGUOUS_LOG_VALUE" data-testname="non-focusable ARIA[role button] nesting non-focusable ARIA[role button]">Inner button</span>
     </div>
 
     <!-- conflict arise, since inner button is focusable - //https://github.com/web-platform-tests/interop-accessibility/issues/161-->
@@ -33,12 +33,12 @@
       const innerButton = document.createElement("button");
       innerButton.textContent = " (inner button)";
       innerButton.id = "inner-button";
-      innerButton.classList.add("ex");
+      innerButton.classList.add("ex-role");
       innerButton.setAttribute('data-expectedrole','button');
       innerButton.setAttribute('data-testname','JS injected HTML button within another HTML button');
       document.getElementById("inner-button-container").appendChild(innerButton);
 
-      AriaUtils.verifyRolesBySelector(".ex");
+      AriaUtils.verifyRolesBySelector(".ex-role");
       AriaUtils.verifyGenericRolesBySelector(".ex-generic");
     </script>
 

--- a/wai-aria/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role_none_conflict_resolution.tentative.html
@@ -10,6 +10,8 @@
     <script src="/wai-aria/scripts/aria-utils.js"></script>
   </head>
   <body>
+    
+    <!-- ARIA specs: https://www.w3.org/TR/wai-aria-1.3/#tree_exclusion -->
     <!-- no conflict, since not focusable; inner button should be exposed as generic - children presentational - //https://github.com/web-platform-tests/interop-accessibility/issues/161 -->
     <h2>ARIA role="button" nesting ARIA role="button" (no presentational roles conflict resolution, since not focusable)</h2>
     <div role="button">

--- a/wai-aria/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role_none_conflict_resolution.tentative.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Role None Conflict Resolution Verification Tests</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <script src="/resources/testdriver-actions.js"></script>
+    <script src="/wai-aria/scripts/aria-utils.js"></script>
+  </head>
+  <body>
+    
+    <!-- no conflict, since not focusable; inner button should be exposed as generic - children presentational - //https://github.com/web-platform-tests/interop-accessibility/issues/161 -->
+    <h2>ARIA role="button" nesting ARIA role="button" (no presentational roles conflict resolution, since not focusable)</h2>
+    <div role="button">
+      <span>outer button</span>
+      <span role="button" class="ex-generic" data-testname="non-focusable ARIA[role button] nesting non-focusable ARIA[role button]">Inner button</span>
+    </div>
+
+    <!-- conflict arise, since inner button is focusable - //https://github.com/web-platform-tests/interop-accessibility/issues/161-->
+    <h2>HTML button nesting HTML button</h2>
+    <div id="button-container">
+      <button id="outer-button">
+        <span>outer button</span>
+        <span id="inner-button-container"></span>
+      </button>
+    </div>
+
+    <script>
+      AriaUtils.verifyRolesBySelector(".ex");
+      AriaUtils.verifyGenericRolesBySelector(".ex-generic");
+
+      //https://github.com/web-platform-tests/interop-accessibility/issues/161 starts
+      const innerButton = document.createElement("button");
+      innerButton.textContent = " (inner button)";
+      innerButton.id = "inner-button";
+      document.getElementById("inner-button-container").appendChild(innerButton);
+
+      promise_test(async t => {
+        const role = await test_driver.get_computed_role(document.getElementById('inner-button'));
+        assert_equals(role, "button");
+      }, "test nested HTML button within HTML button");
+      //https://github.com/web-platform-tests/interop-accessibility/issues/161 ends
+    </script>
+
+  </body>
+</html>

--- a/wai-aria/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role_none_conflict_resolution.tentative.html
@@ -10,7 +10,6 @@
     <script src="/wai-aria/scripts/aria-utils.js"></script>
   </head>
   <body>
-    
     <!-- ARIA specs: https://w3c.github.io/aria/#tree_exclusion -->
     <!-- no conflict, since not focusable; inner button should be exposed as generic - children presentational - //https://github.com/web-platform-tests/interop-accessibility/issues/161 -->
     <h2>Non-focusable ARIA role="button" nesting non-focusable ARIA role="button" (no presentational roles conflict resolution, since inner button is not focusable)</h2>
@@ -55,7 +54,7 @@
       innerButton.textContent = " (inner button)";
       innerButton.id = "inner-button";
       innerButton.classList.add("ex-role");
-      innerButton.setAttribute('data-expectedrole','button');
+      innerButton.setAttribute('data-expectedrole','SPEC_AMBIGUOUS_LOG_VALUE');
       innerButton.setAttribute('data-testname','JS injected HTML button within another HTML button');
       document.getElementById("inner-button-container").appendChild(innerButton);
 

--- a/wai-aria/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role_none_conflict_resolution.tentative.html
@@ -27,15 +27,17 @@
     </div>
 
     <script>
-      AriaUtils.verifyRolesBySelector(".ex");
-      AriaUtils.verifyGenericRolesBySelector(".ex-generic");
-
       //https://github.com/web-platform-tests/interop-accessibility/issues/161 starts
       const innerButton = document.createElement("button");
       innerButton.textContent = " (inner button)";
       innerButton.id = "inner-button";
+      innerButton.classList.add("ex");
+      innerButton.setAttribute('data-expectedrole','button');
+      innerButton.setAttribute('data-testname','JS injected HTML button within another HTML button');
       document.getElementById("inner-button-container").appendChild(innerButton);
 
+      AriaUtils.verifyRolesBySelector(".ex");
+      AriaUtils.verifyGenericRolesBySelector(".ex-generic");
     </script>
 
   </body>

--- a/wai-aria/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role_none_conflict_resolution.tentative.html
@@ -36,11 +36,6 @@
       innerButton.id = "inner-button";
       document.getElementById("inner-button-container").appendChild(innerButton);
 
-      promise_test(async t => {
-        const role = await test_driver.get_computed_role(document.getElementById('inner-button'));
-        assert_equals(role, "button");
-      }, "test nested HTML button within HTML button");
-      //https://github.com/web-platform-tests/interop-accessibility/issues/161 ends
     </script>
 
   </body>

--- a/wai-aria/role/role_none_conflict_resolution.tentative.html
+++ b/wai-aria/role/role_none_conflict_resolution.tentative.html
@@ -10,7 +10,6 @@
     <script src="/wai-aria/scripts/aria-utils.js"></script>
   </head>
   <body>
-    
     <!-- no conflict, since not focusable; inner button should be exposed as generic - children presentational - //https://github.com/web-platform-tests/interop-accessibility/issues/161 -->
     <h2>ARIA role="button" nesting ARIA role="button" (no presentational roles conflict resolution, since not focusable)</h2>
     <div role="button">


### PR DESCRIPTION
Closes: https://github.com/web-platform-tests/interop-accessibility/issues/161

Relates: https://github.com/w3c/aria/issues/1174

Description:
This WPT is designed to evaluate how browsers expose ARIA (non-focusable) vs HTML (focusable) buttons and assess their consistency.

Note:
I’ve set the expectation for the ARIA button nesting a non-focusable ARIA button to "generic" because, as of now (pending resolution of https://github.com/w3c/aria/issues/1174), the [ARIA specification](https://www.w3.org/TR/wai-aria-1.3/#button) states that button children are presentational. This means it does not trigger [Presentational Roles Conflict Resolution](https://www.w3.org/TR/wai-aria-1.3/#conflict_resolution_presentation_none). However, WebKit, Chromium, and Gecko currently ignore this specification.