### PR TITLE
Change expected Trusted Types sink name for WorkerGlobalScope functions

### DIFF
--- a/trusted-types/support/DOMWindowTimers-setTimeout-setInterval.js
+++ b/trusted-types/support/DOMWindowTimers-setTimeout-setInterval.js
@@ -17,7 +17,7 @@ async_test(t => {
 globalThis.trustedTypes.createPolicy("default", {createScript: (s, _, sink) => {
   // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timer-initialisation-steps,
   // step 9.6.1.1.
-  const expectedSink = globalThisStr.includes("Window") ? "Window" : "Worker";
+  const expectedSink = globalThisStr.includes("Window") ? "Window" : "WorkerGlobalScope";
 
   if (s === "timeoutStringTest") {
     assert_equals(sink, `${expectedSink} setTimeout`);

--- a/trusted-types/support/WorkerGlobalScope-importScripts.https.js
+++ b/trusted-types/support/WorkerGlobalScope-importScripts.https.js
@@ -65,7 +65,7 @@ test(t => {
 // Test default policy application:
 trustedTypes.createPolicy("default", {
   createScriptURL: (url, _, sink) => {
-    assert_equals(sink, "Worker importScripts");
+    assert_equals(sink, "WorkerGlobalScope importScripts");
     return url.replace("play", "work");
   }
 }, true);

--- a/trusted-types/support/block-string-assignment-to-DOMWindowTimers-setTimeout-setInterval.js
+++ b/trusted-types/support/block-string-assignment-to-DOMWindowTimers-setTimeout-setInterval.js
@@ -54,7 +54,7 @@ const kIntervalTestString = "intervalTestString";
 let policy = globalThis.trustedTypes.createPolicy("default", { createScript: (x, _, sink) => {
    // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timer-initialisation-steps,
   // step 9.6.1.1.
-  const expectedSink = globalThisStr.includes("Window") ? "Window" : "Worker";
+  const expectedSink = globalThisStr.includes("Window") ? "Window" : "WorkerGlobalScope";
   if (x === kTimeoutTestString) {
     assert_equals(sink, `${expectedSink} setTimeout`);
   } else if (x === kIntervalTestString) {


### PR DESCRIPTION
Previously we expected the sink name to start with Worker. We should be expecting WorkerGlobalScope.