### PR TITLE
[css-fonts] Add a test that src:local matches a single face, not a whole family.

### DIFF
--- a/css/css-fonts/font-face-local-not-family-ref.html
+++ b/css/css-fonts/font-face-local-not-family-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>@font-face src:local() reference</title>
+
+<style>
+@font-face {
+  /* Load the regular face of Arial, or if not present, harmlessly fall back to Ahem
+     (but the test will then be pointless). */
+  font-family: "LocalArial";
+  src: local("Arial"),
+       local("ArialMT"),
+       local(Ahem),
+       url(/fonts/Ahem.ttf);
+}
+</style>
+
+<p style="font: 24px LocalArial">These two lines should look the same</p>
+
+<p style="font: 24px LocalArial">These two lines should look the same</p>

--- a/css/css-fonts/font-face-local-not-family.html
+++ b/css/css-fonts/font-face-local-not-family.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>@font-face src:local() test</title>
+<meta name="assert" content="src:local() loads an individual face, not an entire font family">
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#local-font-fallback">
+<link rel="match" href="font-face-local-not-family-ref.html">
+
+<style>
+@font-face {
+  /* Load the regular face of Arial, or if not present, harmlessly fall back to Ahem
+     (but the test will then be pointless). */
+  font-family: "LocalArial";
+  src: local("Arial"),
+       local("ArialMT"),
+       local(Ahem),
+       url(/fonts/Ahem.ttf);
+}
+</style>
+
+<p style="font: 24px LocalArial">These two lines should look the same</p>
+
+<!-- Because we only defined a single face in the LocalArial family, and disabled any synthesis,
+     the 'bold' here must have no effect; in particular, it does NOT access any installed
+     Arial-Bold face. -->
+<p style="font: bold 24px LocalArial; font-synthesis: none">These two lines should look the same</p>


### PR DESCRIPTION
This was discussed at some length several years ago in https://github.com/web-platform-tests/wpt/pull/28990, but the test there never got merged.

Given the time that has passed, it seemed cleanest to rewrite this as a new PR that simply adds the test we concluded was missing.

This test depends on having a locally-installed Arial font family, which is true across all current macOS and Windows versions, but may not be the case on other platforms; in that case it falls back to Ahem and should harmlessly "pass" without really testing anything.