### PR TITLE
Add missing headers file to worker eval TT test

### DIFF
--- a/trusted-types/support/block-eval-function-constructor-worker.js.headers
+++ b/trusted-types/support/block-eval-function-constructor-worker.js.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: require-trusted-types-for 'script'


### PR DESCRIPTION
Currently, this test will fail in all browsers because trusted types isn't enforced without the headers file.