### PR TITLE
layout: Make non-`normal` `align-content` establish a block formatting context

### DIFF
--- a/css/css-align/blocks/align-content-block-006.html
+++ b/css/css-align/blocks/align-content-block-006.html
@@ -21,7 +21,7 @@
   function doTest()
   {
     document.body.offsetHeight; // trigger layout
-    document.getElementById('initial').type = 'text/plain'; // invalidate stylesheet
+    document.getElementById('initial').disabled = true;
     checkLayout('.test');
   }
   window.onload = () => {

--- a/css/css-align/blocks/align-content-block-007.html
+++ b/css/css-align/blocks/align-content-block-007.html
@@ -21,7 +21,7 @@
   function doTest()
   {
     document.body.offsetHeight; // trigger layout
-    document.getElementById('initial').type = 'text/plain'; // invalidate stylesheet
+    document.getElementById('initial').disabled = true;
     checkLayout('.test');
   }
   window.onload = () => {

--- a/css/css-align/blocks/align-content-block-008.html
+++ b/css/css-align/blocks/align-content-block-008.html
@@ -38,7 +38,7 @@
   function doTest()
   {
     document.body.offsetHeight; // trigger layout
-    document.getElementById('initial').type = 'text/plain'; // invalidate stylesheet
+    document.getElementById('initial').disabled = true;
     checkLayout('.test');
   }
   window.onload = () => {

--- a/css/css-align/blocks/align-content-block-009.html
+++ b/css/css-align/blocks/align-content-block-009.html
@@ -38,7 +38,7 @@
   function doTest()
   {
     document.body.offsetHeight; // trigger layout
-    document.getElementById('initial').type = 'text/plain'; // invalidate stylesheet
+    document.getElementById('initial').disabled = true;
     checkLayout('.test');
   }
   window.onload = () => {

--- a/css/css-align/blocks/align-content-block-010.html
+++ b/css/css-align/blocks/align-content-block-010.html
@@ -21,7 +21,7 @@
   function doTest()
   {
     document.body.offsetHeight; // trigger layout
-    document.getElementById('initial').type = 'text/plain'; // invalidate stylesheet
+    document.getElementById('initial').disabled = true;
     checkLayout('.test');
   }
   window.onload = () => {

--- a/css/css-align/blocks/align-content-block-011.html
+++ b/css/css-align/blocks/align-content-block-011.html
@@ -21,7 +21,7 @@
   function doTest()
   {
     document.body.offsetHeight; // trigger layout
-    document.getElementById('initial').type = 'text/plain'; // invalidate stylesheet
+    document.getElementById('initial').disabled = true;
     checkLayout('.test');
   }
   window.onload = () => {


### PR DESCRIPTION
Following the [spec of align-content](https://drafts.csswg.org/css-align/#distribution-block), when a element have style attribute: align-content with value other than normal, this element should have an independent block formatting context. So here i add code along side  the detection of [overflow:hidden] and other css style that can cause an element to have independent block formatting context. 

Reviewed in servo/servo#34984