### PR TITLE
prefs: Move some `DebugOptions` to `Preferences` and clean up

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -231,7 +231,7 @@ class ServoRefTestExecutor(ServoExecutor):
             extra_args = ["--exit",
                           "--output=%s" % output_path,
                           "--window-size", viewport_size or "800x600"]
-            debug_opts = "disable-text-aa,replace-surrogates"
+            debug_opts = "replace-surrogates"
 
             if dpi:
                 extra_args += ["--device-pixel-ratio", dpi]


### PR DESCRIPTION
- Move options configuring antialiasing and WebRender shader precache to
  the `Preferences` to group them with other related WebRender and DOM
  settings.
- Remove the option to disable antialiasing for canvases. This was
 unused.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#34998