### PR TITLE
fonts: Remove synchronous web font loading functionality

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -231,7 +231,7 @@ class ServoRefTestExecutor(ServoExecutor):
             extra_args = ["--exit",
                           "--output=%s" % output_path,
                           "--window-size", viewport_size or "800x600"]
-            debug_opts = "disable-text-aa,load-webfonts-synchronously,replace-surrogates"
+            debug_opts = "disable-text-aa,replace-surrogates"
 
             if dpi:
                 extra_args += ["--device-pixel-ratio", dpi]


### PR DESCRIPTION
Synchronous web font loading is not specification compliant and was
added in #<!-- nolink -->8341 to work around issues that do not exist any longer. This
change removes the functionality and ensures that WPT tests are run with
the spec compliant loader.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#35000