### PR TITLE
Fix mistakes in trusted-types*reporting tests.

### DIFF
--- a/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html
+++ b/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html
@@ -45,7 +45,8 @@
   // Like assert_throws_*, but we don't care about the exact error. We just want
   // to run the code and continue.
   function expect_throws(fn) {
-    try { fn(); assert_unreached(); } catch (err) { /* ignore */ }
+    try { fn(); } catch (err) { return; /* ignore */ }
+    assert_unreached();
   }
 
   // A sample policy we use to test trustedTypes.createPolicy behaviour.

--- a/trusted-types/trusted-types-eval-reporting-report-only.html
+++ b/trusted-types/trusted-types-eval-reporting-report-only.html
@@ -45,7 +45,8 @@
   // Like assert_throws_*, but we don't care about the exact error. We just want
   // to run the code and continue.
   function expect_throws(fn) {
-    try { fn(); assert_unreached(); } catch (err) { /* ignore */ }
+    try { fn(); } catch (err) { return; /* ignore */ }
+    assert_unreached();
   }
 
   // A sample policy we use to test trustedTypes.createPolicy behaviour.

--- a/trusted-types/trusted-types-eval-reporting.html
+++ b/trusted-types/trusted-types-eval-reporting.html
@@ -39,7 +39,8 @@
   // Like assert_throws_*, but we don't care about the exact error. We just want
   // to run the code and continue.
   function expect_throws(fn) {
-    try { fn(); assert_unreached(); } catch (err) { /* ignore */ }
+    try { fn(); } catch (err) { return; /* ignore */ }
+    assert_unreached();
   }
 
   // A sample policy we use to test trustedTypes.createPolicy behaviour.

--- a/trusted-types/trusted-types-reporting.html
+++ b/trusted-types/trusted-types-reporting.html
@@ -204,9 +204,6 @@
     return p;
   }, "Trusted Type violation report: sample for script innerText assignment");
 
-  // TODO(lyf): https://crbug.com/1066791 Following tests which related to svg
-  // script element cause a flaky timeout in `linux-blink-rel`, following tests
-  // should be added back after the bug fix.
   promise_test(t => {
     let p = Promise.resolve()
         .then(promise_violation("require-trusted-types-for 'script'"))

--- a/trusted-types/trusted-types-reporting.html
+++ b/trusted-types/trusted-types-reporting.html
@@ -6,6 +6,11 @@
   <script src="/content-security-policy/support/testharness-helper.js"></script>
 </head>
 <body>
+  <!-- Some elements for the tests to act on. -->
+  <div id="div"></div>
+  <script id="script"></script>
+  <script id="customscript" is="custom-script" src="a"></script>
+  <svg><script id="svgscript"></script></svg>
   <script>
   // CSP insists the "trusted-types: ..." directives are delivered as headers
   // (rather than as "<meta http-equiv" tags). This test assumes the following
@@ -52,7 +57,8 @@
   // Like assert_throws_*, but we don't care about the exact error. We just want
   // to run the code and continue.
   function expect_throws(fn) {
-    try { fn(); assert_unreached(); } catch (err) { /* ignore */ }
+    try { fn(); } catch (err) { return; /* ignore */ }
+    assert_unreached();
   }
 
   // Test the "sample" field of the event.
@@ -281,10 +287,4 @@
   }, "Trusted Type violation report: Worker constructor");
 
   </script>
-
-  <!-- Some elements for the tests to act on. -->
-  <div id="div"></div>
-  <script id="script"></script>
-  <script id="customscript" is="custom-script" src="a"></script>
-  <svg><script id="svgscript"></script></svg>
 </body>


### PR DESCRIPTION
* expect_throws(): move out assert_unreached() out of the try scope. assert_unreached() throws [1] [2] so expect_throws() will not throw in case of failure.

* trusted-types-reporting.html: Move the elements before the script to make sure they are already in the DOM when the tests are run.

[1] https://github.com/web-platform-tests/wpt/blob/070a67f19da0b454068bc38ef40904403e5edca0/resources/testharness.js#L2391
[2] https://github.com/web-platform-tests/wpt/blob/070a67f19da0b454068bc38ef40904403e5edca0/resources/testharness.js#L4544