### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=281259

### DIFF
--- a/scroll-animations/view-timelines/intermediate-transform.html
+++ b/scroll-animations/view-timelines/intermediate-transform.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html id="top">
+<meta charset="utf-8">
+<title>View timeline delay</title>
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#viewtimeline-interface">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/web-animations/testcommon.js"></script>
+<script src="/scroll-animations/scroll-timelines/testcommon.js"></script>
+<script src="/scroll-animations/view-timelines/testcommon.js"></script>
+<style>
+  #container {
+    overflow-x: scroll;
+    height:  200px;
+    width: 200px;
+  }
+  #content {
+    translate: 50px;
+    width:  1800px;
+    margin: 0;
+  }
+  .spacer {
+    width:  800px;
+    display:  inline-block;
+  }
+  #target {
+    background-color:  green;
+    height:  100px;
+    width:  100px;
+    display:  inline-block;
+    font-size: 10px;
+  }
+</style>
+<body>
+<div id="container">
+    <div id="content">
+      <div class="spacer"></div>
+      <div id="target"></div>
+      <div class="spacer"></div>
+    </div>
+  </div>
+</body>
+<script type="text/javascript">
+  promise_test(async t => {
+    const timeline = new ViewTimeline({
+      subject: target,
+      axis: "inline"
+    });
+    const anim = target.animate({ backgroundColor: ['green', 'red' ] },
+                                { timeline: timeline });
+    await new Promise(requestAnimationFrame);
+    assert_px_equals(timeline.startOffset, 654, 'startOffset');
+    assert_px_equals(timeline.endOffset, 954, 'endOffset');
+  });
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[scroll-animations\] Update view timeline progress calculation to use localToContainerPoint for subject offset calculation](https://bugs.webkit.org/show_bug.cgi?id=281259)