### PR TITLE
Rewrite Trusted types tests for CSP violations

### DIFF
--- a/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none.html
+++ b/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none.html
@@ -2,44 +2,22 @@
 <script src="/resources/testharness.js" ></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/helper.sub.js"></script>
+<script src="./support/csp-violations.js"></script>
 <meta http-equiv="Content-Security-Policy" content="trusted-types 'none'">
+<meta http-equiv="Content-Security-Policy" content="object-src 'none'">
 <body>
 <script>
-  function promise_violation(t, filter_arg) {
-    return _ => new Promise((resolve) => {
-      function handler(e) {
-        let matches = e.originalPolicy.includes(filter_arg);
-        if (matches) {
-          document.removeEventListener("securitypolicyviolation", handler);
-          e.stopPropagation();
-          resolve(e);
-        }
-      }
-
-      document.addEventListener("securitypolicyviolation", handler);
-      t.add_cleanup(() => {
-          document.removeEventListener("securitypolicyviolation", handler);
-      });
-    });
-  }
-
-  promise_test(t => {
-    let p = Promise.resolve()
-      .then(promise_violation(t, "trusted-types 'none'"));
-
-    assert_throws_js(TypeError, _ => {
-      window.trustedTypes.createPolicy('SomeName', { createHTML: s => s } );
-    });
-    return p;
+  promise_test(async t => {
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+      window.trustedTypes.createPolicy('SomeName', { createHTML: s => s } )
+    );
+    assert_true(violation.originalPolicy.includes("trusted-types 'none'"));
   }, "Cannot create policy with name 'SomeName' - policy creation throws");
 
-  promise_test(t => {
-    let p = Promise.resolve()
-      .then(promise_violation(t, "trusted-types 'none'"));
-
-    assert_throws_js(TypeError, _ => {
-      window.trustedTypes.createPolicy('default', { createHTML: s => s } );
-    });
-    return p;
+  promise_test(async t => {
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+      window.trustedTypes.createPolicy('default', { createHTML: s => s } )
+    );
+    assert_true(violation.originalPolicy.includes("trusted-types 'none'"));
   }, "Cannot create policy with name 'default' - policy creation throws");
 </script>

--- a/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests.html
+++ b/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests.html
@@ -2,8 +2,10 @@
 <script src="/resources/testharness.js" ></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/helper.sub.js"></script>
+<script src="./support/csp-violations.js"></script>
 
 <meta http-equiv="Content-Security-Policy" content="trusted-types SomeName JustOneMoreName AnotherName">
+<meta http-equiv="Content-Security-Policy" content="object-src 'none'">
 <body>
 <script>
   // Allowed name test
@@ -20,46 +22,22 @@
     assert_equals(policy.name, 'JustOneMoreName');
   }, "Another allowed-name policy creation works.");
 
-  function promise_violation(t, filter_arg) {
-    return _ => new Promise((resolve) => {
-      function handler(e) {
-        let matches = e.originalPolicy.includes(filter_arg);
-        if (matches) {
-          document.removeEventListener("securitypolicyviolation", handler);
-          e.stopPropagation();
-          resolve(e);
-        }
-      }
-
-      document.addEventListener("securitypolicyviolation", handler);
-      t.add_cleanup(() => {
-        document.removeEventListener("securitypolicyviolation", handler);
-      });
-    });
-  }
-
   // Non-allowed names test
-  promise_test(t => {
-    let p = Promise.resolve()
-      .then(promise_violation(t, "trusted-types SomeName JustOneMoreName AnotherName"));
-
-    assert_throws_js(TypeError, _ => {
-     window.trustedTypes.createPolicy('SomeOtherName', { createHTML: s => s } );
-    });
-    return p;
+  promise_test(async t => {
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+     window.trustedTypes.createPolicy('SomeOtherName', { createHTML: s => s } )
+    );
+    assert_true(violation.originalPolicy.includes("trusted-types SomeName JustOneMoreName AnotherName"));
   }, "Non-allowed name policy creation throws.");
 
   // Duplicate names test
-  promise_test(t => {
-    let p = Promise.resolve()
-      .then(promise_violation(t, "trusted-types SomeName JustOneMoreName AnotherName"));
-
+  promise_test(async t => {
     let policy = window.trustedTypes.createPolicy('AnotherName', { createHTML: s => s } );
     assert_equals(policy.name, 'AnotherName');
 
-    assert_throws_js(TypeError, _ => {
-      window.trustedTypes.createPolicy('AnotherName', { createHTML: s => s } );
-    });
-    return p;
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+      window.trustedTypes.createPolicy('AnotherName', { createHTML: s => s } )
+    );
+    assert_true(violation.originalPolicy.includes("trusted-types SomeName JustOneMoreName AnotherName"));
   }, "Duplicate name policy creation throws.");
 </script>

--- a/trusted-types/require-trusted-types-for-report-only.html
+++ b/trusted-types/require-trusted-types-for-report-only.html
@@ -2,55 +2,35 @@
 <head>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
+  <script src="./support/csp-violations.js"></script>
 </head>
 <body>
 <script>
-
-  function promise_violation(filter_arg) {
-    return _ => new Promise((resolve, reject) => {
-      function handler(e) {
-        let matches = (filter_arg instanceof Function)
-            ? filter_arg(e)
-            : (e.originalPolicy.includes(filter_arg));
-        if (matches) {
-          document.removeEventListener("securitypolicyviolation", handler);
-          e.stopPropagation();
-          resolve(e);
-        }
-      }
-
-      document.addEventListener("securitypolicyviolation", handler);
-    });
-  }
-
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"));
-
+  promise_test(async t => {
     d = document.createElement("div");
-    d.innerHTML = "a";
+    let violation = await trusted_type_violation_without_exception_for(_ =>
+      d.innerHTML = "a"
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
     assert_equals("a", d.innerHTML);
-    return p;
   }, "Require trusted types for 'script' block create HTML.");
 
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"));
-
+  promise_test(async t => {
     d = document.createElement("script");
-    d.innerText = "a";
+    let violation = await trusted_type_violation_without_exception_for(_ =>
+      d.innerText = "a"
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
     assert_equals("a", d.innerText);
-    return p;
   }, "Require trusted types for 'script' block create script.");
 
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"));
-
+  promise_test(async t => {
     s = document.createElement("script");
-    s.src = "a";
+    let violation = await trusted_type_violation_without_exception_for(_ =>
+      s.src = "a"
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
     assert_true(s.src.includes("/trusted-types/a"));
-    return p;
   }, "Require trusted types for 'script' block create script URL.");
 
   promise_test(t => {

--- a/trusted-types/require-trusted-types-for-report-only.html.headers
+++ b/trusted-types/require-trusted-types-for-report-only.html.headers
@@ -1,1 +1,2 @@
 Content-Security-Policy-Report-Only: require-trusted-types-for 'script'
+Content-Security-Policy: object-src 'none'

--- a/trusted-types/require-trusted-types-for.html
+++ b/trusted-types/require-trusted-types-for.html
@@ -2,62 +2,37 @@
 <head>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
+  <script src="./support/csp-violations.js"></script>
   <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">
+  <meta http-equiv="Content-Security-Policy" content="object-src 'none'">
 </head>
 <body>
 <script>
-
-  function promise_violation(filter_arg) {
-    return _ => new Promise((resolve, reject) => {
-      function handler(e) {
-        let matches = (filter_arg instanceof Function)
-            ? filter_arg(e)
-            : (e.originalPolicy.includes(filter_arg));
-        if (matches) {
-          document.removeEventListener("securitypolicyviolation", handler);
-          e.stopPropagation();
-          resolve(e);
-        }
-      }
-
-      document.addEventListener("securitypolicyviolation", handler);
-    });
-  }
-
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"));
+  promise_test(async t => {
     d = document.createElement("div");
-    assert_throws_js(TypeError,
-        _ => {
-          d.innerHTML = "a";
-        });
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+      d.innerHTML = "a"
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
     assert_equals("", d.innerHTML);
-    return p;
   }, "Require trusted types for 'script' block create HTML.");
 
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"));
+  promise_test(async t => {
     d = document.createElement("script");
-    assert_throws_js(TypeError,
-        _ => {
-          d.innerText = "a";
-        });
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+      d.innerText = "a"
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
     assert_equals("", d.innerText);
-    return p;
   }, "Require trusted types for 'script' block create script.");
 
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"));
+  promise_test(async t => {
     s = document.createElement("script");
-    assert_throws_js(TypeError,
-        _ => {
-          s.src = "a";
-        });
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+      s.src = "a"
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
     assert_equals("", s.src);
-    return p;
   }, "Require trusted types for 'script' block create script URL.");
 
   promise_test(t => {

--- a/trusted-types/support/csp-violations.js
+++ b/trusted-types/support/csp-violations.js
@@ -20,7 +20,7 @@ function trusted_type_violations_and_exception_for(fn) {
         e.stopPropagation();
         resolve(result);
       } else {
-	reject("Unexpected violation for directive ${e.effectiveDirective}");
+        reject(`Unexpected violation for directive ${e.effectiveDirective}`);
       }
     }
     document.addEventListener("securitypolicyviolation", handler);

--- a/trusted-types/support/csp-violations.js
+++ b/trusted-types/support/csp-violations.js
@@ -49,7 +49,7 @@ async function trusted_type_violation_for(expectedException, fn) {
   let {violations, exception} =
       await trusted_type_violations_and_exception_for(fn);
   assert_equals(violations.length, 1, "a single violation reported");
-  assert_true(exception instanceof expectedException, "TypeError exception reported");
+  assert_true(exception instanceof expectedException, `${expectedException.prototype} exception reported`);
   return violations[0];
 }
 

--- a/trusted-types/support/csp-violations.js
+++ b/trusted-types/support/csp-violations.js
@@ -1,8 +1,10 @@
-const trustedTypeDirectives = [
+const cspDirectives = [
   // https://w3c.github.io/trusted-types/dist/spec/#require-trusted-types-for-csp-directive
   "require-trusted-types-for",
   // https://w3c.github.io/trusted-types/dist/spec/#trusted-types-csp-directive
   "trusted-types",
+  // https://w3c.github.io/webappsec-csp/#script-src
+  "script-src",
 ];
 
 // A generic helper that runs function fn and return a promise resolving with
@@ -13,7 +15,7 @@ function trusted_type_violations_and_exception_for(fn) {
     // Listen for security policy violations.
     let result = { violations: [], exception: null };
     let handler = e => {
-      if (trustedTypeDirectives.includes(e.effectiveDirective)) {
+      if (cspDirectives.includes(e.effectiveDirective)) {
         result.violations.push(e);
       } else if (e.effectiveDirective === "object-src") {
         document.removeEventListener("securitypolicyviolation", handler);

--- a/trusted-types/support/csp-violations.js
+++ b/trusted-types/support/csp-violations.js
@@ -54,9 +54,17 @@ async function trusted_type_violation_for(expectedException, fn) {
 }
 
 // Helper function when we expect no violation or exception.
-async function no_trusted_type_violation_report_for(fn) {
+async function no_trusted_type_violation_for(fn) {
   let {violations, exception} =
       await trusted_type_violations_and_exception_for(fn);
   assert_equals(violations.length, 0, "no violation reported");
   assert_equals(exception, null, "no exception thrown");
+}
+
+async function trusted_type_violation_without_exception_for(fn) {
+  let {violations, exception} =
+      await trusted_type_violations_and_exception_for(fn);
+  assert_equals(violations.length, 1, "a single violation reported");
+  assert_equals(exception, null, "no exception thrown");
+  return violations[0];
 }

--- a/trusted-types/support/csp-violations.js
+++ b/trusted-types/support/csp-violations.js
@@ -1,0 +1,60 @@
+const trustedTypeDirectives = [
+  // https://w3c.github.io/trusted-types/dist/spec/#require-trusted-types-for-csp-directive
+  "require-trusted-types-for",
+  // https://w3c.github.io/trusted-types/dist/spec/#trusted-types-csp-directive
+  "trusted-types",
+];
+
+// A generic helper that runs function fn and return a promise resolving with
+// an array of reported violations for trusted type directives and a possible
+// exception thrown.
+function trusted_type_violations_and_exception_for(fn) {
+  return new Promise((resolve, reject) => {
+    // Listen for security policy violations.
+    let result = { violations: [], exception: null };
+    let handler = e => {
+      if (trustedTypeDirectives.includes(e.effectiveDirective)) {
+        result.violations.push(e);
+      } else if (e.effectiveDirective === "object-src") {
+        document.removeEventListener("securitypolicyviolation", handler);
+        e.stopPropagation();
+        resolve(result);
+      } else {
+	reject("Unexpected violation for directive ${e.effectiveDirective}");
+      }
+    }
+    document.addEventListener("securitypolicyviolation", handler);
+
+    // Run the specified function and record any exception.
+    try {
+      fn();
+    } catch(e) {
+      result.exception = e;
+    }
+
+    // Force an "object-src" violation, to make sure all the previous violations
+    // have been delivered. This assumes the test file's associated .headers
+    // file contains Content-Security-Policy: object-src 'none'.
+    var o = document.createElement('object');
+    o.type = "video/mp4";
+    o.data = "dummy.webm";
+    document.body.appendChild(o);
+  });
+}
+
+// Helper function when we expect one violation and exception.
+async function trusted_type_violation_for(expectedException, fn) {
+  let {violations, exception} =
+      await trusted_type_violations_and_exception_for(fn);
+  assert_equals(violations.length, 1, "a single violation reported");
+  assert_true(exception instanceof expectedException, "TypeError exception reported");
+  return violations[0];
+}
+
+// Helper function when we expect no violation or exception.
+async function no_trusted_type_violation_report_for(fn) {
+  let {violations, exception} =
+      await trusted_type_violations_and_exception_for(fn);
+  assert_equals(violations.length, 0, "no violation reported");
+  assert_equals(exception, null, "no exception thrown");
+}

--- a/trusted-types/support/resolve-spv.js
+++ b/trusted-types/support/resolve-spv.js
@@ -1,9 +1,0 @@
-// Returns a promise that resolves with a Security Policy Violation (spv)
-    // even when it is received.
-function promise_spv() {
-  return new Promise((resolve, reject) => {
-    window.addEventListener("securitypolicyviolation", e => {
-      resolve(e);
-    }, { once: true });
-  });
-}

--- a/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html
+++ b/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html
@@ -2,7 +2,7 @@
 <head>
   <script nonce="123" src="/resources/testharness.js"></script>
   <script nonce="123"src="/resources/testharnessreport.js"></script>
-  <script nonce="123"src="/content-security-policy/support/testharness-helper.js"></script>
+  <script src="./support/csp-violations.js"></script>
 </head>
 <body>
   <script nonce="123">
@@ -21,34 +21,6 @@
   // processed we can we sure that an earlier event - if it indeed occurred -
   // must have already been processed.
 
-  // Return function that returns a promise that resolves on the given
-  // violation report.
-  // how_many - how many violation events are expected.
-  // filter_arg - iff function, call it with the event object.
-  //              Else, string-ify and compare against event.originalPolicy.
-  function promise_violation(filter_arg) {
-    return _ => new Promise((resolve, reject) => {
-      function handler(e) {
-        let matches = (filter_arg instanceof Function)
-            ? filter_arg(e)
-            : (e.originalPolicy.includes(filter_arg));
-        if (matches) {
-          document.removeEventListener("securitypolicyviolation", handler);
-          e.stopPropagation();
-          resolve(e);
-        }
-      }
-      document.addEventListener("securitypolicyviolation", handler);
-    });
-  }
-
-  // Like assert_throws_*, but we don't care about the exact error. We just want
-  // to run the code and continue.
-  function expect_throws(fn) {
-    try { fn(); } catch (err) { return; /* ignore */ }
-    assert_unreached();
-  }
-
   // A sample policy we use to test trustedTypes.createPolicy behaviour.
   const id = x => x;
   const a_policy = {
@@ -59,56 +31,35 @@
 
   const scriptyPolicy = trustedTypes.createPolicy('allowEval', a_policy);
 
-  // Provoke/wait for a CSP violation, in order to be sure that all previous
-  // CSP violations have been delivered.
-  function promise_flush() {
-    return promise_violation("object-src 'none'");
-  }
-  function flush() {
-   expect_throws(_ => {
-      var o = document.createElement('object');
-      o.type = "application/x-shockwave-flash";
-      document.body.appendChild(o);
-    });
-  }
-
   window.script_run_beacon = 'never_overwritten';
 
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"))
-        .then(promise_flush());
-    expect_throws(_ => eval('script_run_beacon="should not run"'));
+  promise_test(async t => {
+    let violation = await trusted_type_violation_for(EvalError, _ =>
+      eval('script_run_beacon="should not run"')
+    );
     assert_equals(script_run_beacon, 'never_overwritten');
-    flush();
-    return p;
   }, "Trusted Type violation report: evaluating a string violates both script-src and trusted-types.");
 
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("script-src"))
-        .then(promise_flush());
-    expect_throws(_ => eval(scriptyPolicy.createScript('script_run_beacon="i ran"')));
-    flush();
+  promise_test(async t => {
+    let violation = await trusted_type_violation_for(EvalError, _ =>
+      eval(scriptyPolicy.createScript('script_run_beacon="i ran"'))
+    );
+    assert_equals(violation.effectiveDirective, "script-src");
     assert_not_equals(script_run_beacon, 'i ran'); // Code did not run.
     assert_equals(script_run_beacon, 'never_overwritten');
-    return p;
   }, "Trusted Type violation report: evaluating a Trusted Script violates script-src.");
 
-  promise_test(t => {
+  promise_test(async t => {
     trustedTypes.createPolicy('default', {
       createScript: s => s,
     }, true);
-    let p = Promise.resolve()
-        .then(promise_violation((e) =>
-           e.effectiveDirective.includes('script-src') &&
-           e.sample.includes("should not run")))
-        .then(promise_flush());
-    expect_throws(_ => eval('script_run_beacon="should not run"')); // script-src will block.
+    let violation = await trusted_type_violation_for(EvalError, _ =>
+      eval('script_run_beacon="should not run"') // script-src will block.
+    );
+    assert_equals(violation.effectiveDirective, "script-src");
+    assert_true(violation.sample.includes("should not run"));
     assert_not_equals(script_run_beacon, 'should not run'); // Code did not run.
     assert_equals(script_run_beacon, 'never_overwritten');
-    flush();
-    return p;
   }, "Trusted Type violation report: script-src restrictions apply after the default policy runs.");
 
   </script>

--- a/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html
+++ b/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html
@@ -37,6 +37,7 @@
     let violation = await trusted_type_violation_for(EvalError, _ =>
       eval('script_run_beacon="should not run"')
     );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
     assert_equals(script_run_beacon, 'never_overwritten');
   }, "Trusted Type violation report: evaluating a string violates both script-src and trusted-types.");
 

--- a/trusted-types/trusted-types-eval-reporting-report-only.html
+++ b/trusted-types/trusted-types-eval-reporting-report-only.html
@@ -34,18 +34,15 @@
   window.script_run_beacon = 'vanilla';
 
   promise_test(async t => {
-    let {violations, exception} =
-      await trusted_type_violations_and_exception_for(_ =>
-        eval('script_run_beacon="report-only-does-not-stop"')
-      );
-    assert_equals(violations.length, 1);
-    assert_equals(exception, null);
-    assert_true(violations[0].originalPolicy.includes("require-trusted-types-for 'script'"));
+    let violation = await trusted_type_violation_without_exception_for(_ =>
+      eval('script_run_beacon="report-only-does-not-stop"')
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
     assert_equals(script_run_beacon, 'report-only-does-not-stop');
   }, "Trusted Type violation report: evaluating a string.");
 
   promise_test(async t => {
-    await no_trusted_type_violation_report_for(_ =>
+    await no_trusted_type_violation_for(_ =>
       eval(scriptyPolicy.createScript('script_run_beacon="trusted-script-ok"'))
     );
     assert_equals(script_run_beacon, 'trusted-script-ok');
@@ -55,7 +52,7 @@
     trustedTypes.createPolicy('default', {
       createScript: s => s,
     }, true);
-    await no_trusted_type_violation_report_for(_ =>
+    await no_trusted_type_violation_for(_ =>
       eval('script_run_beacon="payload"')
     );
     assert_equals(script_run_beacon, 'payload');

--- a/trusted-types/trusted-types-eval-reporting-report-only.html
+++ b/trusted-types/trusted-types-eval-reporting-report-only.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <head>
   <script nonce="123" src="/resources/testharness.js"></script>
-  <script nonce="123"src="/resources/testharnessreport.js"></script>
-  <script nonce="123"src="/content-security-policy/support/testharness-helper.js"></script>
+  <script nonce="123" src="/resources/testharnessreport.js"></script>
+  <script nonce="123" src="./support/csp-violations.js"></script>
 </head>
 <body>
   <script nonce="123">
-  // CSP insists the "trusted-types: ..." directives are deliverd as headers
+  // CSP insists the "trusted-types: ..." directives are delivered as headers
   // (rather than as "<meta http-equiv" tags). This test assumes the following
   // headers are set in the .headers file:
   //
@@ -21,34 +21,6 @@
   // processed we can we sure that an earlier event - if it indeed occurred -
   // must have already been processed.
 
-  // Return function that returns a promise that resolves on the given
-  // violation report.
-  //
-  // filter_arg - iff function, call it with the event object.
-  //              Else, string-ify and compare against event.originalPolicy.
-  function promise_violation(filter_arg) {
-    return _ => new Promise((resolve, reject) => {
-      function handler(e) {
-        let matches = (filter_arg instanceof Function)
-            ? filter_arg(e)
-            : (e.originalPolicy.includes(filter_arg));
-        if (matches) {
-          document.removeEventListener("securitypolicyviolation", handler);
-          e.stopPropagation();
-          resolve(e);
-        }
-      }
-      document.addEventListener("securitypolicyviolation", handler);
-    });
-  }
-
-  // Like assert_throws_*, but we don't care about the exact error. We just want
-  // to run the code and continue.
-  function expect_throws(fn) {
-    try { fn(); } catch (err) { return; /* ignore */ }
-    assert_unreached();
-  }
-
   // A sample policy we use to test trustedTypes.createPolicy behaviour.
   const id = x => x;
   const a_policy = {
@@ -59,48 +31,34 @@
 
   const scriptyPolicy = trustedTypes.createPolicy('allowEval', a_policy);
 
-  // Provoke/wait for a CSP violation, in order to be sure that all previous
-  // CSP violations have been delivered.
-  function promise_flush() {
-    return promise_violation("object-src 'none'");
-  }
-  function flush() {
-   expect_throws(_ => {
-      var o = document.createElement('object');
-      o.type = "application/x-shockwave-flash";
-      document.body.appendChild(o);
-    });
-  }
-
   window.script_run_beacon = 'vanilla';
 
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"))
-        .then(promise_flush());
-    eval('script_run_beacon="report-only-does-not-stop"');
+  promise_test(async t => {
+    let {violations, exception} =
+      await trusted_type_violations_and_exception_for(_ =>
+        eval('script_run_beacon="report-only-does-not-stop"')
+      );
+    assert_equals(violations.length, 1);
+    assert_equals(exception, null);
+    assert_true(violations[0].originalPolicy.includes("require-trusted-types-for 'script'"));
     assert_equals(script_run_beacon, 'report-only-does-not-stop');
-    flush();
-    return p;
   }, "Trusted Type violation report: evaluating a string.");
 
-  promise_test(t => {
-    let p = promise_flush()();
-    eval(scriptyPolicy.createScript('script_run_beacon="trusted-script-ok"'));
-    flush();
+  promise_test(async t => {
+    await no_trusted_type_violation_report_for(_ =>
+      eval(scriptyPolicy.createScript('script_run_beacon="trusted-script-ok"'))
+    );
     assert_equals(script_run_beacon, 'trusted-script-ok');
-    return p;
   }, "Trusted Type violation report: evaluating a Trusted Script.");
 
-  promise_test(t => {
+  promise_test(async t => {
     trustedTypes.createPolicy('default', {
       createScript: s => s,
     }, true);
-    let p = promise_flush()();
-    eval('script_run_beacon="payload"');
+    await no_trusted_type_violation_report_for(_ =>
+      eval('script_run_beacon="payload"')
+    );
     assert_equals(script_run_beacon, 'payload');
-    flush();
-    return p;
   }, "Trusted Type violation report: default policy runs in report-only mode.");
 
   </script>

--- a/trusted-types/trusted-types-eval-reporting.html
+++ b/trusted-types/trusted-types-eval-reporting.html
@@ -41,7 +41,7 @@
 
   promise_test(async t => {
     let beacon = 'never_overwritten2';
-    await no_trusted_type_violation_report_for(_ =>
+    await no_trusted_type_violation_for(_ =>
       eval(scriptyPolicy.createScript('beacon="i ran"'))
     );
     assert_equals(beacon, 'i ran');

--- a/trusted-types/trusted-types-eval-reporting.html
+++ b/trusted-types/trusted-types-eval-reporting.html
@@ -2,10 +2,11 @@
 <head>
   <script nonce="123" src="/resources/testharness.js"></script>
   <script nonce="123" src="/resources/testharnessreport.js"></script>
+  <script nonce="123" src="./support/csp-violations.js"></script>
 </head>
 <body>
   <script nonce="123">
-  // CSP insists the "trusted-types: ..." directives are deliverd as headers
+  // CSP insists the "trusted-types: ..." directives are delivered as headers
   // (rather than as "<meta http-equiv" tags). This test assumes the following
   // headers are set in the .headers file:
   //
@@ -20,29 +21,6 @@
   // processed we can we sure that an earlier event - if it indeed occurred -
   // must have already been processed.
 
-  // Return function that returns a promise that resolves on the given
-  // violation report.
-  function promise_violation(filter_arg) {
-    return _ => new Promise((resolve, reject) => {
-      function handler(e) {
-        let matches = e.originalPolicy.includes(filter_arg);
-        if (matches) {
-          document.removeEventListener("securitypolicyviolation", handler);
-          e.stopPropagation();
-          resolve(e);
-        }
-      }
-      document.addEventListener("securitypolicyviolation", handler);
-    });
-  }
-
-  // Like assert_throws_*, but we don't care about the exact error. We just want
-  // to run the code and continue.
-  function expect_throws(fn) {
-    try { fn(); } catch (err) { return; /* ignore */ }
-    assert_unreached();
-  }
-
   // A sample policy we use to test trustedTypes.createPolicy behaviour.
   const id = x => x;
   const a_policy = {
@@ -52,38 +30,21 @@
   };
   const scriptyPolicy = trustedTypes.createPolicy('allowEval', a_policy);
 
-  // Provoke/wait for a CSP violation, in order to be sure that all previous
-  // CSP violations have been delivered.
-  function promise_flush() {
-    return promise_violation("object-src 'none'");
-  }
-  function flush() {
-   expect_throws(_ => {
-      var o = document.createElement('object');
-      o.type = "application/x-shockwave-flash";
-      document.body.appendChild(o);
-    });
-  }
-
-  promise_test(t => {
+  promise_test(async t => {
     let beacon = 'never_overwritten';
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"))
-        .then(promise_flush());
-    assert_throws_js(EvalError,
-                     _ => eval('beacon="should not run"'));
+    let violation = await trusted_type_violation_for(EvalError, _ =>
+      eval('beacon="should not run"')
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
     assert_equals(beacon, 'never_overwritten');
-    flush();
-    return p;
   }, "Trusted Type violation report: evaluating a string.");
 
-  promise_test(t => {
+  promise_test(async t => {
     let beacon = 'never_overwritten2';
-    let p = promise_flush()();
-    eval(scriptyPolicy.createScript('beacon="i ran"'));
+    await no_trusted_type_violation_report_for(_ =>
+      eval(scriptyPolicy.createScript('beacon="i ran"'))
+    );
     assert_equals(beacon, 'i ran');
-    flush();
-    return p;
   }, "Trusted Type violation report: evaluating a Trusted Script.");
 
   </script>

--- a/trusted-types/trusted-types-report-only.html
+++ b/trusted-types/trusted-types-report-only.html
@@ -3,6 +3,7 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="/content-security-policy/support/testharness-helper.js"></script>
+<script src="./support/csp-violations.js"></script>
 </head>
 <body>
 
@@ -13,26 +14,11 @@
   <script id="script2"></script>
 
   <script>
-  // CSP insists the "trusted-types: ..." directives are deliverd as headers
+  // CSP insists the "trusted-types: ..." directives are delivered as headers
   // (rather than as "meta http-equiv" tags). This test assumes the following
   // headers are set in the .headers file:
   //
   //   Content-Security-Policy-Report-Only: trusted-types ...; report-uri ...
-
-  // Return function that returns a promise that resolves on the given
-  // violation report.
-  function expect_violation(filter) {
-    return new Promise((resolve, reject) => {
-      function handler(e) {
-        if (e.originalPolicy.includes(filter)) {
-          document.removeEventListener("securitypolicyviolation", handler);
-          e.stopPropagation();
-          resolve(e);
-        }
-      }
-      document.addEventListener("securitypolicyviolation", handler);
-    });
-  }
 
   // A sample policy we use to test trustedTypes.createPolicy behaviour.
   const id = x => x;
@@ -41,46 +27,48 @@
     createScriptURL: id,
     createScript: id,
   });
-/*
-  promise_test(t => {
-    let p = expect_violation("trusted-types two");
-    document.getElementById("script").src = "#abc";
-    assert_true(document.getElementById("script").src.endsWith("#abc"));
-    return p;
-  }, "Trusted Type violation report-only: assign string to script url");
-*/
 
-  promise_test(t => {
-    let p = expect_violation("trusted-types two");
-    document.getElementById("div").innerHTML = "abc";
+  promise_test(async t => {
+    let violation = await trusted_type_violation_without_exception_for(_ =>
+      document.getElementById("script").src = "// #abc"
+    );
+    assert_true(violation.originalPolicy.includes("trusted-types two"));
+    assert_true(document.getElementById("script").src.endsWith("// #abc"));
+  }, "Trusted Type violation report-only: assign string to script url");
+
+  promise_test(async t => {
+    let violation = await trusted_type_violation_without_exception_for(_ =>
+      document.getElementById("div").innerHTML = "abc"
+    );
+    assert_true(violation.originalPolicy.includes("trusted-types two"));
     assert_equals(document.getElementById("div").textContent, "abc");
-    return p;
   }, "Trusted Type violation report-only: assign string to html");
 
-  promise_test(t => {
-    let p = expect_violation("trusted-types two");
-    document.getElementById("script-src").src = "#";
+  promise_test(async t => {
+    let violation = await trusted_type_violation_without_exception_for(_ =>
+      document.getElementById("script-src").src = "#"
+    );
+    assert_true(violation.originalPolicy.includes("trusted-types two"));
     assert_true(document.getElementById("script-src").src.endsWith("#"));
-    return p;
   }, "Trusted Type violation report-only: assign string to script.src");
 
-  promise_test(t => {
-    let p = expect_violation("trusted-types two");
-    document.getElementById("script").innerHTML = "con" + "sole.log('Hello');";
+  promise_test(async t => {
+    let violation = await trusted_type_violation_without_exception_for(_ =>
+      document.getElementById("script").innerHTML = "con" + "sole.log('Hello');"
+    );
+    assert_true(violation.originalPolicy.includes("trusted-types two"));
     assert_true(document.getElementById("script").textContent.startsWith("consol"));
-    return p;
   }, "Trusted Type violation report-only: assign string to script content");
 
-  promise_test(t => {
-    let p = expect_violation("trusted-types two");
-    document.getElementById("script").src = "#def";
-    return p.then(report => {
-      assert_equals(report.documentURI, "" + window.location);
-      assert_equals(report.disposition, "report");
-      assert_equals(report.effectiveDirective, "require-trusted-types-for");
-      assert_equals(report.violatedDirective, "require-trusted-types-for");
-      assert_true(report.originalPolicy.startsWith("trusted-types two;"));
-    });
+  promise_test(async t => {
+    let report = await trusted_type_violation_without_exception_for(_ =>
+      document.getElementById("script").src = "#def"
+    );
+    assert_equals(report.documentURI, "" + window.location);
+    assert_equals(report.disposition, "report");
+    assert_equals(report.effectiveDirective, "require-trusted-types-for");
+    assert_equals(report.violatedDirective, "require-trusted-types-for");
+    assert_true(report.originalPolicy.startsWith("trusted-types two;"));
   }, "Trusted Type violation report: check report contents");
   </script>
 </body>

--- a/trusted-types/trusted-types-report-only.html.headers
+++ b/trusted-types/trusted-types-report-only.html.headers
@@ -1,1 +1,2 @@
 Content-Security-Policy-Report-Only: trusted-types two; report-uri /content-security-policy/resources/dummy-report.php; require-trusted-types-for 'script';
+Content-Security-Policy: object-src 'none'

--- a/trusted-types/trusted-types-reporting.html
+++ b/trusted-types/trusted-types-reporting.html
@@ -76,7 +76,7 @@
 
   promise_test(async t => {
     let {violations, exception} =
-        await trusted_type_violations_and_exception_for(_ =>
+        await trusted_type_violation_without_exception_for(_ =>
           policy_one = trustedTypes.createPolicy("one", a_policy)
         );
     assert_equals(violations.length, 1);
@@ -109,13 +109,13 @@
   }, "Trusted Type violation report: assign string to html");
 
   promise_test(async t => {
-    await no_trusted_type_violation_report_for(_ =>
+    await no_trusted_type_violation_for(_ =>
       document.getElementById("script").text = policy_one.createScript("2+2;")
     );
   }, "Trusted Type violation report: assign trusted script to script; no report");
 
   promise_test(async t => {
-    await no_trusted_type_violation_report_for(_ =>
+    await no_trusted_type_violation_for(_ =>
       document.getElementById("div").innerHTML = policy_one.createHTML("abc")
     );
   }, "Trusted Type violation report: assign trusted HTML to html; no report");

--- a/trusted-types/trusted-types-reporting.html
+++ b/trusted-types/trusted-types-reporting.html
@@ -3,7 +3,7 @@
   <meta name="timeout" content="long">
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
-  <script src="/content-security-policy/support/testharness-helper.js"></script>
+  <script src="./support/csp-violations.js"></script>
 </head>
 <body>
   <!-- Some elements for the tests to act on. -->
@@ -33,51 +33,10 @@
 
   const url = "" + document.location;
 
-  // Return function that returns a promise that resolves on the given
-  // violation report.
-  //
-  // filter_arg - iff function, call it with the event object.
-  //              Else, string-ify and compare against event.originalPolicy.
-  function promise_violation(filter_arg) {
-    return _ => new Promise((resolve, reject) => {
-      function handler(e) {
-        let matches = (filter_arg instanceof Function)
-            ? filter_arg(e)
-            : (e.originalPolicy.includes(filter_arg));
-        if (matches) {
-          document.removeEventListener("securitypolicyviolation", handler);
-          e.stopPropagation();
-          resolve(e);
-        }
-      }
-      document.addEventListener("securitypolicyviolation", handler);
-    });
-  }
-
-  // Like assert_throws_*, but we don't care about the exact error. We just want
-  // to run the code and continue.
-  function expect_throws(fn) {
-    try { fn(); } catch (err) { return; /* ignore */ }
-    assert_unreached();
-  }
-
-  // Test the "sample" field of the event.
   // TODO(vogelheim): The current set of tests allows for more variance in the
   //     sample reports than the current spec draft does. Once the spec has
   //     been finalized, we should clamp this down to check byte-for-byte
   //     against the values mandated by the spec.
-
-  function expect_sample(s) { return e => {
-    assert_true(e.sample.includes(s),
-                `expected "${e.sample}" to include "${s}".`);
-    return e;
-  } }
-
-  function expect_blocked_uri(s) { return e => {
-    assert_equals(e.blockedURI, s,
-                `expected "${e.blockedURI}" to be "${s}".`);
-    return e;
-  } }
 
   // A sample policy we use to test trustedTypes.createPolicy behaviour.
   const id = x => x;
@@ -87,172 +46,163 @@
     createScript: id,
   };
 
-  // Provoke/wait for a CSP violation, in order to be sure that all previous
-  // CSP violations have been delivered.
-  function promise_flush() {
-    return promise_violation("object-src 'none'");
-  }
-  function flush() {
-   expect_throws(_ => {
-      var o = document.createElement('object');
-      o.type = "video/mp4";
-      o.data = "dummy.webm";
-      document.body.appendChild(o);
-    });
-  }
-
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("trusted-types one"))
-        .then(promise_violation("trusted-types two"))
-        .then(expect_sample("three"))
-        .then(expect_blocked_uri("trusted-types-policy"))
-        .then(promise_flush());
-    expect_throws(_ => trustedTypes.createPolicy("three", a_policy));
-    flush();
-    return p;
+  promise_test(async t => {
+    let {violations, exception} =
+        await trusted_type_violations_and_exception_for(_ =>
+          trustedTypes.createPolicy("three", a_policy)
+        );
+    assert_equals(violations.length, 2);
+    assert_true(violations[0].originalPolicy.includes("trusted-types one"));
+    assert_true(violations[1].originalPolicy.includes("trusted-types two"));
+    assert_true(violations[1].sample.includes("three"));
+    assert_equals(violations[1].blockedURI, "trusted-types-policy");
+    assert_true(exception instanceof TypeError);
   }, "Trusted Type violation report: creating a forbidden policy.");
 
-  promise_test(t => {
-    let p = promise_flush()();
-    expect_throws(_ => trustedTypes.createPolicy("two", a_policy));
-    flush();
-    return p;
+  promise_test(async t => {
+    let {violations, exception} =
+        await trusted_type_violations_and_exception_for(_ =>
+          trustedTypes.createPolicy("two", a_policy)
+        );
+    assert_equals(violations.length, 1);
+    assert_true(violations[0].originalPolicy.includes("trusted-types one"));
+    assert_true(violations[0].sample.includes("two"));
+    assert_equals(violations[0].blockedURI, "trusted-types-policy");
+    assert_true(exception instanceof TypeError);
   }, "Trusted Type violation report: creating a report-only-forbidden policy.");
 
   // policy_one is set below, and used in several tests further down.
   let policy_one = null;
 
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("trusted-types two"))
-        .then(promise_flush());
-    policy_one = trustedTypes.createPolicy("one", a_policy);
-    flush();
-    return p;
+  promise_test(async t => {
+    let {violations, exception} =
+        await trusted_type_violations_and_exception_for(_ =>
+          policy_one = trustedTypes.createPolicy("one", a_policy)
+        );
+    assert_equals(violations.length, 1);
+    assert_true(violations[0].originalPolicy.includes("trusted-types two"));
+    assert_true(violations[0].sample.includes("one"));
+    assert_equals(violations[0].blockedURI, "trusted-types-policy");
+    assert_equals(exception, null);
   }, "Trusted Type violation report: creating a forbidden-but-not-reported policy.");
 
-  promise_test(t => {
-    let p = promise_violation("require-trusted-types-for 'script")()
-         .then(expect_blocked_uri("trusted-types-sink"))
-         .then(expect_sample("Element insertAdjacentHTML|x"));
-    expect_throws(() => {
-      document.getElementById("div").insertAdjacentHTML("beforebegin", "x");
-    });
-    return p;
+  promise_test(async t => {
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+      document.getElementById("div").insertAdjacentHTML("beforebegin", "x")
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
+    assert_equals(violation.blockedURI, "trusted-types-sink");
   }, "Trusted Type violation report: blocked URI and sample for insertAdjacentHTML");
 
-  promise_test(t => {
-    let p = promise_violation("require-trusted-types-for 'script'")();
-    expect_throws(_ => document.getElementById("script").src = url);
-    return p;
+  promise_test(async t => {
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+      document.getElementById("script").src = url
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
   }, "Trusted Type violation report: assign string to script url");
 
-  promise_test(t => {
-    let p = promise_violation("require-trusted-types-for 'script'")();
-    expect_throws(_ => document.getElementById("div").innerHTML = "abc");
-    return p;
+  promise_test(async t => {
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+      document.getElementById("div").innerHTML = "abc"
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
   }, "Trusted Type violation report: assign string to html");
 
-  promise_test(t => {
-    let p = promise_flush()();
-    document.getElementById("script").text = policy_one.createScript("2+2;");
-    flush();
-    return p;
+  promise_test(async t => {
+    await no_trusted_type_violation_report_for(_ =>
+      document.getElementById("script").text = policy_one.createScript("2+2;")
+    );
   }, "Trusted Type violation report: assign trusted script to script; no report");
 
-  promise_test(t => {
-    let p = promise_flush()();
-    document.getElementById("div").innerHTML = policy_one.createHTML("abc");
-    flush();
-    return p;
+  promise_test(async t => {
+    await no_trusted_type_violation_report_for(_ =>
+      document.getElementById("div").innerHTML = policy_one.createHTML("abc")
+    );
   }, "Trusted Type violation report: assign trusted HTML to html; no report");
 
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"))
-        .then(expect_blocked_uri("trusted-types-sink"))
-        .then(expect_sample("Element innerHTML|abc"));
-    expect_throws(_ => { document.getElementById("div").innerHTML = "abc" });
-    return p;
+  promise_test(async t => {
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+      document.getElementById("div").innerHTML = "abc"
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
+    assert_equals(violation.blockedURI, "trusted-types-sink");
+    assert_true(violation.sample.includes("Element innerHTML|abc"));
   }, "Trusted Type violation report: sample for innerHTML assignment");
 
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"))
-        .then(expect_blocked_uri("trusted-types-sink"))
-        .then(expect_sample("HTMLScriptElement text|abc"));
-    expect_throws(_ => { document.getElementById("script").text = "abc" });
-    return p;
+  promise_test(async t => {
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+      document.getElementById("script").text = "abc"
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
+    assert_equals(violation.blockedURI, "trusted-types-sink");
+    assert_true(violation.sample.includes("HTMLScriptElement text|abc"));
   }, "Trusted Type violation report: sample for text assignment");
 
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"))
-        .then(expect_blocked_uri("trusted-types-sink"))
-        .then(expect_sample("HTMLScriptElement src"));
-      expect_throws(_ => { document.getElementById("script").src = "" });
-    return p;
+  promise_test(async t => {
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+      document.getElementById("script").src = ""
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
+    assert_equals(violation.blockedURI, "trusted-types-sink");
+    assert_true(violation.sample.includes("HTMLScriptElement src"));
   }, "Trusted Type violation report: sample for script.src assignment");
 
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"))
-        .then(expect_blocked_uri("trusted-types-sink"))
-        .then(expect_sample("HTMLScriptElement innerText|2+2;"));
-    expect_throws(_ => document.getElementById("script").innerText = "2+2;");
-    return p;
+  promise_test(async t => {
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+      document.getElementById("script").innerText = "2+2;"
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
+    assert_equals(violation.blockedURI, "trusted-types-sink");
+    assert_true(violation.sample.includes("Element innerText|2+2"));
   }, "Trusted Type violation report: sample for script innerText assignment");
 
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"))
-        .then(expect_blocked_uri("trusted-types-sink"))
-        .then(expect_sample("SVGScriptElement href"));
-      expect_throws(_ => { document.getElementById("svgscript").href.baseVal = "" });
-    return p;
+  promise_test(async t => {
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+      document.getElementById("svgscript").href.baseVal = ""
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
+    assert_equals(violation.blockedURI, "trusted-types-sink");
+    assert_true(violation.sample.includes("SVGScriptElement href"));
   }, "Trusted Type violation report: sample for SVGScriptElement href assignment");
 
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"))
-        .then(expect_blocked_uri("trusted-types-sink"))
-        .then(expect_sample("SVGScriptElement href"));
-      expect_throws(_ => { document.getElementById("svgscript").setAttribute('href', "test"); });
-    return p;
+  promise_test(async t => {
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+      document.getElementById("svgscript").setAttribute('href', "test")
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
+    assert_equals(violation.blockedURI, "trusted-types-sink");
+    assert_true(violation.sample.includes("SVGScriptElement href"));
   }, "Trusted Type violation report: sample for SVGScriptElement href assignment by setAttribute");
 
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"))
-        .then(expect_blocked_uri("trusted-types-sink"))
-        .then(expect_sample("SVGScriptElement text"));
-      expect_throws(_ => { document.getElementById("svgscript").insertBefore(document.createTextNode("Hello"), null) });
-    return p;
+  promise_test(async t => {
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+      document.getElementById("svgscript").insertBefore(document.createTextNode("Hello"), null)
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
+    assert_equals(violation.blockedURI, "trusted-types-sink");
+    assert_true(violation.sample.includes("SVGScriptElement text"));
   }, "Trusted Type violation report: sample for SVGScriptElement text assignment");
 
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"))
-        .then(expect_blocked_uri("trusted-types-sink"))
-        .then(expect_sample("eval|2+2"))
-        .then(promise_flush());
-    expect_throws(_ => eval("2+2"));
-    flush();
-    return p;
+  promise_test(async t => {
+    let violation = await trusted_type_violation_for(EvalError, _ =>
+      eval("2+2")
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
+    assert_equals(violation.blockedURI, "trusted-types-sink");
+    assert_true(violation.sample.includes("eval|2+2"));
   }, "Trusted Type violation report: sample for eval");
 
-  promise_test(t => {
+  promise_test(async t => {
     // We expect the sample string to always contain the name, and at least the
     // start of the value, but it should not be excessively long.
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"))
-        .then(expect_blocked_uri("trusted-types-sink"))
-        .then(expect_sample("HTMLScriptElement innerText|abbb"))
-        .then(e => assert_less_than(e.sample.length, 150));
     const value = "a" + "b".repeat(50000);
-    expect_throws(_ => document.getElementById("script").innerText = value);
-    return p;
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+      document.getElementById("script").innerText = value
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
+    assert_equals(violation.blockedURI, "trusted-types-sink");
+    assert_true(violation.sample.includes("HTMLScriptElement innerText|abbb"));
+    assert_less_than(violation.sample.length, 150);
   }, "Trusted Type violation report: large values should be handled sanely.");
 
   // Test reporting for Custom Elements (where supported). The report should
@@ -262,25 +212,23 @@
     class CustomScript extends HTMLScriptElement {};
     customElements.define("custom-script", CustomScript, { extends: "script" });
 
-    promise_test(t => {
-      let p = Promise.resolve()
-          .then(promise_violation("require-trusted-types-for 'script'"))
-          .then(expect_blocked_uri("trusted-types-sink"))
-          .then(expect_sample("HTMLScriptElement src|abc"));
-      expect_throws(_ => document.getElementById("customscript").src = "abc");
-      return p;
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        document.getElementById("customscript").src = "abc"
+      );
+      assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_true(violation.sample.includes("HTMLScriptElement src|abc"));
     }, "Trusted Type violation report: sample for custom element assignment");
   }
 
-  promise_test(t => {
-    let p = Promise.resolve()
-        .then(promise_violation("require-trusted-types-for 'script'"))
-        .then(expect_blocked_uri("trusted-types-sink"))
-        .then(expect_sample("Worker constructor|"))
-        .then(promise_flush());
-    expect_throws(_ => new Worker("blabla"));
-    flush();
-    return p;
+  promise_test(async t => {
+    let violation = await trusted_type_violation_for(TypeError, _ =>
+      new Worker("blabla")
+    );
+    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
+    assert_equals(violation.blockedURI, "trusted-types-sink");
+    assert_true(violation.sample.includes("Worker constructor|"));
   }, "Trusted Type violation report: Worker constructor");
 
   </script>

--- a/trusted-types/trusted-types-source-file-path.html
+++ b/trusted-types/trusted-types-source-file-path.html
@@ -6,8 +6,10 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="/common/get-host-info.sub.js"></script>
+  <script src="./support/csp-violations.js"></script>
   <meta http-equiv="Content-Security-Policy"
         content="require-trusted-types-for 'script'; trusted-types id">
+  <meta http-equiv="Content-Security-Policy" content="object-src 'none'">
   </head>
 <body>
 
@@ -21,12 +23,6 @@ let id_policy = trustedTypes.createPolicy("id", {
   createScript: x => x,
 });
 
-function futureViolation() {
-  return new Promise(r => addEventListener("securitypolicyviolation", r), {
-    once: true
-  });
-}
-
 function futureScript(url) {
   return new Promise(r => {
     let script = document.createElement("script");
@@ -37,11 +33,9 @@ function futureScript(url) {
 }
 
 promise_test(async t => {
-  let future_violation = futureViolation();
-  assert_throws_js(TypeError, _ => {
-    document.getElementById("to-be-modified").innerHTML = "'test'";
-  });
-  let violation = await future_violation;
+  let violation = await trusted_type_violation_for(TypeError, _ =>
+    document.getElementById("to-be-modified").innerHTML = "'test'"
+  );
   assert_equals(violation.sourceFile, location.href)
 }, "same-document script")
 
@@ -50,9 +44,9 @@ promise_test(async t => {
   let script_src = script_origin +
     "/trusted-types/support/set-inner-html.js";
   let script = await futureScript(script_src);
-  let future_violation = futureViolation();
-  assert_throws_js(TypeError, () => setInnerHtml(toBeModified, "'test'"));
-  let violation = await future_violation;
+  let violation = await trusted_type_violation_for(TypeError, _ =>
+    setInnerHtml(toBeModified, "'test'")
+  );
   assert_equals(violation.sourceFile, script_src);
 }, "same-origin script")
 
@@ -61,9 +55,9 @@ promise_test(async t => {
   let script_src = script_origin +
     "/trusted-types/support/set-inner-html.js";
   let script = await futureScript(script_src);
-  let future_violation = futureViolation();
-  assert_throws_js(TypeError, () => setInnerHtml(toBeModified, "'test'"));
-  let violation = await future_violation;
+  let violation = await trusted_type_violation_for(TypeError, _ =>
+    setInnerHtml(toBeModified, "'test'")
+  );
   assert_equals(violation.sourceFile, script_src);
 }, "cross-origin script")
 

--- a/trusted-types/trusted-types-svg-script-set-href.html
+++ b/trusted-types/trusted-types-svg-script-set-href.html
@@ -2,10 +2,11 @@
 <head>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
-  <script src="./support/resolve-spv.js"></script>
+  <script src="./support/csp-violations.js"></script>
   <script src="./support/namespaces.js"></script>
   <meta http-equiv="Content-Security-Policy"
         content="require-trusted-types-for 'script'">
+  <meta http-equiv="Content-Security-Policy" content="object-src 'none'">
 </head>
 <body>
   <div id="log"></div>
@@ -14,13 +15,13 @@
     const policy = trustedTypes.createPolicy("policy", {
       createScriptURL: script_url => script_url });
 
-    promise_test(t => {
+    promise_test(async t => {
       const elem = document.createElementNS(NSURI_SVG, "script");
-      assert_throws_js(TypeError, _ => {
-        elem.href.baseVal = "about:blank";
-      });
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        elem.href.baseVal = "about:blank"
+      );
+      assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
       document.getElementById("svg").appendChild(elem);
-      return promise_spv();
     }, "Assign string to SVGScriptElement.href.baseVal.");
 
     promise_test(t => {
@@ -32,13 +33,13 @@
       return Promise.resolve();
     }, "Assign TrustedScriptURL to SVGScriptElement.href.baseVal.");
 
-    promise_test(t => {
+    promise_test(async t => {
       const elem = document.createElementNS(NSURI_SVG, "script");
-      assert_throws_js(TypeError, _ => {
-        elem.setAttribute("href", "about:blank");
-      });
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        elem.setAttribute("href", "about:blank")
+      );
+      assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
       document.getElementById("svg").appendChild(elem);
-      return promise_spv();
     }, "Assign string to non-attached SVGScriptElement.href via setAttribute.");
 
     promise_test(t => {
@@ -50,13 +51,13 @@
       return Promise.resolve();
     }, "Assign TrustedScriptURL to non-attached SVGScriptElement.href via setAttribute.");
 
-    promise_test(t => {
+    promise_test(async t => {
       const elem = document.createElementNS(NSURI_SVG, "script");
       document.getElementById("svg").appendChild(elem);
-      assert_throws_js(TypeError, _ => {
-        elem.setAttribute("href", "about:blank");
-      });
-      return promise_spv();
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        elem.setAttribute("href", "about:blank")
+      );
+      assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
     }, "Assign string to attached SVGScriptElement.href via setAttribute.");
 
     promise_test(t => {

--- a/trusted-types/trusted-types-svg-script.html
+++ b/trusted-types/trusted-types-svg-script.html
@@ -2,9 +2,10 @@
 <head>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
-  <script src="./support/resolve-spv.js"></script>
+  <script src="./support/csp-violations.js"></script>
   <meta http-equiv="Content-Security-Policy"
         content="require-trusted-types-for 'script'">
+  <meta http-equiv="Content-Security-Policy" content="object-src 'none'">
 </head>
 <body>
   <div id="log"></div>
@@ -13,32 +14,38 @@
     const policy = trustedTypes.createPolicy("policy", {
         createScript: x => x, createHTML: x => x, createScriptURL: x => x });
 
-    promise_test(t => {
-      assert_throws_js(TypeError, _ => {
-        document.getElementById("script").innerHTML = "'modified via innerHTML';";
-      });
-      return promise_spv();
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        document.getElementById("script").innerHTML = "'modified via innerHTML';"
+      );
+      assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
     }, "Assign String to SVGScriptElement.innerHTML.");
 
-    promise_test(t => {
-      document.getElementById("script").innerHTML = policy.createHTML("'modified via innerHTML';");
-      return Promise.resolve();
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        document.getElementById("script").innerHTML = policy.createHTML("'modified via innerHTML';")
+      );
+      assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
     }, "Assign TrustedHTML to SVGScriptElement.innerHTML.");
 
-    promise_test(t => {
+    promise_test(async t => {
       const elem = document.createElementNS(
           "http://www.w3.org/2000/svg", "script");
-      elem.innerHTML = policy.createHTML("'modified via innerHTML';");
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        elem.innerHTML = policy.createHTML("'modified via innerHTML';")
+      );
+      assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
       document.getElementById("svg").appendChild(elem);
-      return promise_spv();
     }, "Assign TrustedHTML to SVGScriptElement.innerHTML and execute it.");
 
-    promise_test(t => {
+    promise_test(async t => {
       const elem = document.createElementNS(
           "http://www.w3.org/2000/svg", "script");
-      elem.insertBefore(document.createTextNode("modified via DOM"), null);
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        elem.insertBefore(document.createTextNode("modified via DOM"), null)
+      );
+      assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
       document.getElementById("svg").appendChild(elem);
-      return promise_spv();
     }, "Modify SVGScriptElement via DOM manipulation.");
 
     promise_test(t => {


### PR DESCRIPTION
Currently the listener to "securitypolicyviolation" is added before actually running the statement that triggers violations, so it could be possible that some violations are not caught. This bad pattern is duplicated in several `trusted-types*reporting*` tests.

This patch adds a new helper file to properly wrap the listener registration and statement execution in a promise, and reuses it in existing tests.

https://github.com/w3c/trusted-types/issues/576