### PR TITLE
Cookie Store API - Add tests for creation url, control characters, default secure

### DIFF
--- a/cookie-store/cookieListItem_attributes.https.any.js
+++ b/cookie-store/cookieListItem_attributes.https.any.js
@@ -195,3 +195,15 @@ promise_test(async testCase => {
   }, `CookieListItem - cookieStore.set with sameSite set to ${sameSiteValue}`);
 
 });
+
+promise_test(async testCase => {
+  await cookieStore.delete('cookie-name');
+
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie.secure, true);
+}, 'CookieListItem - secure defaults to true');

--- a/cookie-store/cookieStore_delete_arguments.https.any.js
+++ b/cookie-store/cookieStore_delete_arguments.https.any.js
@@ -143,7 +143,7 @@ promise_test(async testCase => {
   assert_equals(cookie_attributes.name, 'cookie-name');
   assert_equals(cookie_attributes.value, 'cookie-value');
 
-  await cookieStore.delete(cookie_attributes);
+  await cookieStore.delete(cookie_attributes.name);
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);
 }, 'cookieStore.delete with get result');

--- a/cookie-store/cookieStore_getAll_set_creation_url.https.any.js
+++ b/cookie-store/cookieStore_getAll_set_creation_url.https.any.js
@@ -1,0 +1,33 @@
+// META: title=Cookie Store API: cookieStore.set()/getAll() with Document URL changing
+// META: global=window
+
+'use strict';
+
+promise_test(async testCase => {
+  const currentUrl = new URL(self.location.href);
+  const currentPath = currentUrl.pathname;
+  const currentDirectory =
+      currentPath.substr(0, currentPath.lastIndexOf('/') + 1);
+
+  await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+
+  await cookieStore.set(
+    { name: 'cookie-name', value: 'cookie-value', path: currentDirectory });
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+  });
+
+  // This changes the Document's current URL to this different URL.
+  // The Document's creation URL does not change.
+  // If set() and getAll() use Document's current URL, the cookie will be set
+  // using the original URL above, and the get below will fail since it looks
+  // for cookies with this different URL. If they both use the creation URL,
+  // the get will succeed since it won't use this different URL to search.
+  let different_url = `${self.location.protocol}//${self.location.host}/different/path`;
+  history.pushState({}, "", different_url);
+
+  const cookies = await cookieStore.getAll();
+  assert_equals(cookies.length, 1);
+  assert_equals(cookies[0].name, 'cookie-name');
+  assert_equals(cookies[0].value, 'cookie-value');
+}, 'cookieStore.set and cookieStore.getAll use the creation url');

--- a/cookie-store/cookieStore_get_set_creation_url.https.any.js
+++ b/cookie-store/cookieStore_get_set_creation_url.https.any.js
@@ -1,0 +1,32 @@
+// META: title=Cookie Store API: cookieStore.set()/get() with Document URL changing
+// META: global=window
+
+'use strict';
+
+promise_test(async testCase => {
+  const currentUrl = new URL(self.location.href);
+  const currentPath = currentUrl.pathname;
+  const currentDirectory =
+      currentPath.substr(0, currentPath.lastIndexOf('/') + 1);
+
+  await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+
+  await cookieStore.set(
+      { name: 'cookie-name', value: 'cookie-value', path: currentDirectory });
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+  });
+
+  // This changes the Document's current URL to this different URL.
+  // The Document's creation URL does not change.
+  // If set() and get() use Document's current URL, the cookie will be set
+  // using the original URL above, and the get below will fail since it looks
+  // for cookies with this different URL. If they both use the creation URL,
+  // the get will succeed since it won't use this different URL to search.
+  let different_url = `${self.location.protocol}//${self.location.host}/different/path`;
+  history.pushState({}, "", different_url);
+
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie.name, 'cookie-name');
+  assert_equals(cookie.value, 'cookie-value');
+}, 'cookieStore.set and cookieStore.get use the creation url');


### PR DESCRIPTION
Added tests:
1. Check that set/get/getAll are using the context's creation URL
2. Check that set fails if certain control characters are present in the name or value
3. Check that CookieListItem is secure by default (we want to test this property individually since the other tests in set_arguments check other properties first--so failing one of the earlier properties means we never check the secure property)

Changed tests:
1. There are two tests in set_arguments and delete_arguments that pass in the result of get() to delete(). These tests indirectly depend on the domain property. But Safari/Mozilla don't support domain being returned by get(). So we change these tests to not rely on domain. The test still passes for Chrome.