### PR TITLE
[wdspec] fix the beforeunload + history event order test

### DIFF
--- a/webdriver/tests/bidi/integration/navigation.py
+++ b/webdriver/tests/bidi/integration/navigation.py
@@ -8,7 +8,7 @@ from webdriver.bidi.modules.script import ContextTarget
 pytestmark = pytest.mark.asyncio
 
 NAVIGATION_STARTED_EVENT = "browsingContext.navigationStarted"
-FRAGMENT_NAVIGATED_EVENT = "browsingContext.fragmentNavigated"
+HISTORY_UPDATED_EVENT = "browsingContext.historyUpdated"
 BEFORE_REQUEST_SENT_EVENT = "network.beforeRequestSent"
 
 async def test_navigate_history_replacestate_beforeunload(
@@ -38,32 +38,32 @@ async def test_navigate_history_replacestate_beforeunload(
         NAVIGATION_STARTED_EVENT, on_event
     )
 
-    remove_fragment_navigated_listener = bidi_session.add_event_listener(
-        FRAGMENT_NAVIGATED_EVENT, on_event
+    remove_history_updated_listener = bidi_session.add_event_listener(
+        HISTORY_UPDATED_EVENT, on_event
     )
 
     remove_before_request_sent_listener = bidi_session.add_event_listener(
         BEFORE_REQUEST_SENT_EVENT, on_event
     )
 
-    await subscribe_events([NAVIGATION_STARTED_EVENT, FRAGMENT_NAVIGATED_EVENT, BEFORE_REQUEST_SENT_EVENT])
+    await subscribe_events([NAVIGATION_STARTED_EVENT, HISTORY_UPDATED_EVENT, BEFORE_REQUEST_SENT_EVENT])
 
     result = await bidi_session.browsing_context.navigate(
         context=new_tab["context"], url=url, wait="interactive"
     )
 
-    # Navigation caused by browsing_context.navigate call should happen first:
-    # https://html.spec.whatwg.org/#beginning-navigation
+    # navigationStarted caused by browsing_context.navigate call should happen
+    # first: https://html.spec.whatwg.org/#beginning-navigation
     # network.beforeRequestSent should arrive before the page becomes
     # interactive.
     assert events == [
         NAVIGATION_STARTED_EVENT,
-        FRAGMENT_NAVIGATED_EVENT,
+        HISTORY_UPDATED_EVENT,
         BEFORE_REQUEST_SENT_EVENT
     ]
 
     remove_navigation_started_listener()
-    remove_fragment_navigated_listener()
+    remove_history_updated_listener()
     remove_before_request_sent_listener()
 
 


### PR DESCRIPTION
`history.replaceState` is only supposed to trigger the history updated event not the fragment navigation.