### PR TITLE
Set descendant's attribute's owner document in Node::adopt

### DIFF
--- a/dom/nodes/Node-mutation-adoptNode.html
+++ b/dom/nodes/Node-mutation-adoptNode.html
@@ -20,4 +20,18 @@ test(() => {
   assert_equals(div.firstChild.ownerDocument, document);
 }, "simple append of foreign div with text");
 
+test(function() {
+  var div = document.createElement("div");
+  div.id = "foobar";
+
+  assert_equals(div.ownerDocument, document);
+  assert_equals(div.attributes[0].ownerDocument, document);
+
+  var other_doc = document.implementation.createHTMLDocument();
+  other_doc.body.appendChild(div);
+
+  assert_equals(div.ownerDocument, other_doc);
+  assert_equals(div.attributes[0].ownerDocument, other_doc);
+}, "Adopting an element into a different document update's the element's owner doc as well as the owner docs of it's attributes")
+
 </script>


### PR DESCRIPTION
Draft because I still need to write a web platform test for this.

[try run](https://github.com/simonwuelker/servo/actions/runs/12855864288)

Reviewed in servo/servo#35076