### PR TITLE
[WebDriver BiDi] Fix file test

### DIFF
--- a/webdriver/tests/bidi/input/set_files/files.py
+++ b/webdriver/tests/bidi/input/set_files/files.py
@@ -266,16 +266,18 @@ async def test_set_files_twice_same(
 
     element = await get_element("#input")
 
+    files = create_files(["path/to/noop.txt"])
+
     await bidi_session.input.set_files(
         context=top_context["context"],
         element=element,
-        files=create_files(["path/to/noop.txt"]),
+        files=files,
     )
 
     await bidi_session.input.set_files(
         context=top_context["context"],
         element=element,
-        files=create_files(["path/to/noop.txt"]),
+        files=files,
     )
 
     events = await get_events(bidi_session, top_context["context"])


### PR DESCRIPTION
I took a look at this failing test and it seems that the test itself is the issue:
From the long we sent two different files:
Files in the first `input.setFiles` command:
```
"files": [ "/tmp/wdspec-t_9y6_4n/pytest/wdspec-0/path/to/noop.txt" ]
```
Files in second `input.setFiles` command:
```
 "files": [ "/tmp/wdspec-t_9y6_4n/pytest/wdspec-1/path/to/noop.txt" ]
 ```
This means that they will be treated as separate files. 

This is happening because https://github.com/web-platform-tests/wpt/blob/fix-file-test/webdriver/tests/bidi/input/set_files/conftest.py#L18 we create a new temp folder in each invocation of the fixture.