### PR TITLE
HTML: test <iframe src=javascript:...>

### DIFF
--- a/html/semantics/embedded-content/the-embed-element/embed-javascript-url.html
+++ b/html/semantics/embedded-content/the-embed-element/embed-javascript-url.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>embed - javascript: URL</title>
+<link rel="help" href="https://html.spec.whatwg.org/#the-embed-element-setup-steps">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+  // embed element setup steps fetches url, which results in a network error
+  // and thus "Display no plugin".
+  promise_test(async function (t) {
+    const embed = document.createElement('embed');
+    embed.src = 'javascript:"foo"';
+    embed.onload = t.unreached_func('No load event expected');
+    document.body.append(embed);
+    t.add_cleanup(() => { embed.remove(); });
+    await new Promise(resolve => { t.step_timeout(resolve, 100); });
+  }, "javascript: in src attribute should do nothing");
+
+  function insertEmbedNavigable(t) {
+    const embed = document.createElement('embed');
+    embed.src = '/resources/blank.html';
+    document.body.append(embed);
+    t.add_cleanup(() => { embed.remove(); });
+    return embed;
+  }
+
+  promise_test(async function (t) {
+    const embed = insertEmbedNavigable(t);
+    await new Promise(resolve => { embed.onload = resolve; });
+    const loaded = new Promise(resolve => { embed.onload = resolve; });
+    window[0].location.href = 'javascript:"test"';
+    await loaded;
+  }, 'location.href = \'javascript:"test"\' should fire a load event');
+
+  promise_test(async function (t) {
+    const embed = insertEmbedNavigable(t);
+    await new Promise(resolve => { embed.onload = resolve; });
+    embed.onload = t.unreached_func('No second load event expected');
+    window[0].location.href = 'javascript:1';
+    await new Promise(resolve => { t.step_timeout(resolve, 100); });
+  }, 'location.href = \'javascript:1\' should not fire a load event');
+</script>

--- a/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_in_src.htm
+++ b/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_in_src.htm
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<title>javascript: URL in iframe src</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#process-the-iframe-attributes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+const tests = [
+  // desc, url, expected body.textContent
+  ['string', 'javascript:"foo"', 'foo'],
+  ['empty string', 'javascript:""', ''],
+  ['String object', 'javascript:new String("foo")', ''],
+  ['undefined', 'javascript:void(0)', ''],
+  ['number', 'javascript:1', ''],
+  ['boolean', 'javascript:true', ''],
+  ['null', 'javascript:null', ''],
+  ['global', 'javascript:window', ''],
+  ['host object', 'javascript:document', ''],
+  ['function', 'javascript:(() => { return function() {}; })()', ''],
+  ['regexp', 'javascript:/foo/', ''],
+  ['array', 'javascript:["foo"]', ''],
+  ['object', 'javascript:{"foo": "bar"}', ''],
+  ['ArrayBuffer', 'javascript:new ArrayBuffer(8)', ''],
+  ['TypeError', 'javascript:new TypeError("foo")', ''],
+];
+for (const [desc, url, expected_textContent] of tests) {
+  async_test(t => {
+    const iframe = document.createElement('iframe');
+    iframe.src = url;
+    iframe.hidden = true;
+    let load_events = 0;
+    iframe.onload = t.step_func(() => {
+      load_events++;
+      assert_equals(iframe.contentDocument.URL, 'about:blank');
+      assert_equals(iframe.contentDocument.body.textContent, expected_textContent);
+      if (load_events === 1) {
+        t.step_timeout(() => {
+          assert_equals(load_events, 1);
+          t.done();
+        }, 100);
+      }
+    });
+    document.body.append(iframe);
+  }, `${desc}: ${url}`);
+}
+</script>

--- a/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_in_src.htm
+++ b/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_in_src.htm
@@ -6,7 +6,7 @@
 <body>
 <script>
 const tests = [
-  // desc, url, expected body.textContent
+  // desc, url, expected_textContent
   ['string', 'javascript:"foo"', 'foo'],
   ['empty string', 'javascript:""', ''],
   ['String object', 'javascript:new String("foo")', ''],
@@ -33,9 +33,9 @@ for (const [desc, url, expected_textContent] of tests) {
       load_events++;
       assert_equals(iframe.contentDocument.URL, 'about:blank');
       assert_equals(iframe.contentDocument.body.textContent, expected_textContent);
+      assert_equals(load_events, 1);
       if (load_events === 1) {
         t.step_timeout(() => {
-          assert_equals(load_events, 1);
           t.done();
         }, 100);
       }

--- a/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_initial_insertion.html
+++ b/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_initial_insertion.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>javascript: URL in iframe src, initial insertion check</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#process-the-iframe-attributes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+setup({single_test: true});
+let iframeLoaded = false;
+window.javascriptUrlRan = 0;
+</script>
+<iframe src="javascript:(() => { parent.javascriptUrlRan++; })()" onload="iframeLoaded = true; this.onload = assert_unreached;"></iframe>
+<script>
+onload = () => {
+  const iframe = document.querySelector('iframe');
+  assert_true(iframeLoaded, "iframeLoaded");
+  iframe.src = iframe.src + ";";
+  assert_equals(javascriptUrlRan, 1, "javascriptUrlRan");
+  step_timeout(() => {
+    assert_equals(javascriptUrlRan, 2, "javascriptUrlRan");
+    done();
+  }, 100); // Verify only one load event is fired on iframe
+};
+</script>

--- a/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_loading_lazy.htm
+++ b/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_loading_lazy.htm
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>javascript: URL in iframe src and loading="lazy"</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#process-the-iframe-attributes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+async_test(t => {
+  const iframe = document.createElement('iframe');
+  iframe.src = 'javascript:"test"';
+  iframe.hidden = true;
+  iframe.loading = 'lazy';
+  iframe.onload = t.step_func_done(() => {
+    assert_false(iframe.hidden, 'Got unexpected load event on iframe while still hidden');
+    assert_equals(iframe.contentDocument.body.textContent, 'test', 'Expected the document created from the javascript: URL');
+  });
+  document.body.append(iframe);
+  window.onload = t.step_func(() => {
+    assert_equals(iframe.contentDocument.body.textContent, '', 'Expected initial about:blank');
+    iframe.hidden = false; // run the lazy load resumption steps, which navigates
+  });
+});
+</script>

--- a/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_not_about_blank.html
+++ b/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_not_about_blank.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>javascript: URL in iframe src, initial src is not about:blank</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#process-the-iframe-attributes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+setup({single_test: true});
+let iframeLoaded = false;
+window.javascriptUrlRan = false;
+</script>
+<iframe src="/resources/blank.html" onload="iframeLoaded = true; this.onload = assert_unreached;"></iframe>
+<script>
+onload = () => {
+  const iframe = document.querySelector('iframe');
+  assert_true(iframeLoaded, "iframeLoaded");
+  iframe.src = "javascript:(() => { parent.javascriptUrlRan = true; })()";
+  assert_false(javascriptUrlRan, "javascriptUrlRan");
+  step_timeout(() => {
+    assert_true(javascriptUrlRan, "javascriptUrlRan");
+    done();
+  }, 100); // Verify only one load event is fired on iframe
+};
+</script>

--- a/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_remove_srcdoc.html
+++ b/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_remove_srcdoc.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>javascript: URL in iframe src, removing srcdoc</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#process-the-iframe-attributes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+setup({single_test: true});
+let iframeLoaded = false;
+window.javascriptUrlRan = false;
+</script>
+<iframe srcdoc="srcdoc" src="javascript:(() => { parent.javascriptUrlRan = true; })()" onload="iframeLoaded = true; this.onload = assert_unreached;"></iframe>
+<script>
+onload = () => {
+  document.querySelector('iframe').removeAttribute('srcdoc');
+  assert_true(iframeLoaded, "iframeLoaded");
+  assert_false(javascriptUrlRan, "javascriptUrlRan");
+  step_timeout(() => {
+    assert_true(javascriptUrlRan, "javascriptUrlRan");
+    done();
+  }, 100); // Verify only one load event is fired on iframe
+};
+</script>

--- a/html/semantics/embedded-content/the-iframe-element/iframe_navigate_javascript_url.htm
+++ b/html/semantics/embedded-content/the-iframe-element/iframe_navigate_javascript_url.htm
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<title>Navigate an iframe to a javascript: URL</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#process-the-iframe-attributes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+const tests = [
+  // url, expected_load_event
+  ['javascript:"foo"', true],
+  ['javascript:1', false],
+];
+for (const [url, expected_load_event] of tests) {
+  promise_test(async t => {
+    const iframe = document.createElement('iframe');
+    const loaded = new Promise(resolve => { iframe.onload = resolve; });
+    document.body.append(iframe);
+    await loaded;
+    const secondLoad = new Promise((resolve, reject) => {
+      iframe.onload = () => {
+        expected_load_event ? resolve() : reject();
+      };
+    });
+    const timeout = new Promise((resolve, reject) => {
+      t.step_timeout(() => {
+        expected_load_event ? reject() : resolve();
+      }, 100);
+    });
+    iframe.contentWindow.location.href = url;
+    await Promise.race([secondLoad, timeout]);
+  }, `location.href = '${url}' should ${expected_load_event ? '' : 'not '}fire a load event`);
+}
+</script>

--- a/html/semantics/embedded-content/the-object-element/object-javascript-url.html
+++ b/html/semantics/embedded-content/the-object-element/object-javascript-url.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>object - javascript: URL</title>
+<link rel="help" href="https://html.spec.whatwg.org/#the-object-element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+  // the steps to (re)determine what the object element represents
+  // fetches url, which results in a network error
+  // and thus "fallback".
+  promise_test(async function (t) {
+    const object = document.createElement('object');
+    object.data = 'javascript:"foo"';
+    object.onload = t.unreached_func('No load event expected');
+    document.body.append(object);
+    t.add_cleanup(() => { object.remove(); });
+    await new Promise(resolve => { t.step_timeout(resolve, 100); });
+  }, "javascript: in data attribute should do nothing");
+
+  function insertObjectNavigable(t) {
+    const object = document.createElement('object');
+    object.data = '/resources/blank.html';
+    document.body.append(object);
+    t.add_cleanup(() => { object.remove(); });
+    return object;
+  }
+
+  promise_test(async function (t) {
+    const object = insertObjectNavigable(t);
+    await new Promise(resolve => { object.onload = resolve; });
+    const loaded = new Promise(resolve => { object.onload = resolve; });
+    window[0].location.href = 'javascript:"test"';
+    await loaded;
+  }, 'location.href = \'javascript:"test"\' should fire a load event');
+
+  promise_test(async function (t) {
+    const object = insertObjectNavigable(t);
+    await new Promise(resolve => { object.onload = resolve; });
+    object.onload = t.unreached_func('No second load event expected');
+    window[0].location.href = 'javascript:1';
+    await new Promise(resolve => { t.step_timeout(resolve, 100); });
+  }, 'location.href = \'javascript:1\' should not fire a load event');
+</script>


### PR DESCRIPTION
Test different return types, whether it is stringified and parsed and how many load events are fired.

Also test navigation with `location.href` and `embed`, `object`.

See https://github.com/whatwg/html/pull/10957