### PR TITLE
Add serverCertificateHashes test server

### DIFF
--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -503,7 +503,7 @@ class SessionTicketStore:
     def pop(self, label: bytes) -> Optional[SessionTicket]:
         return self.tickets.pop(label, None)
 
-class WebTransportCertificateGeneration(Enum):
+class WebTransportCertificateGeneration(IntEnum):
     """
     Specify, if the server should generate a certificate or use an existing certificate
      USEPREGENERATED: use existing certificate
@@ -521,7 +521,7 @@ class WebTransportH3Server:
     :param host: Host from which to serve.
     :param port: Port from which to serve.
     :param doc_root: Document root for serving handlers.
-    :paran cert_mode: The used certificate mode can be
+    :param cert_mode: The used certificate mode can be
        USEPREGENERATED or GENERATEDVALIDSERVERCERTIFICATEHASHCERT
     :param cert_path: Path to certificate file to use.
     :param key_path: Path to key file to use.
@@ -543,7 +543,7 @@ class WebTransportH3Server:
         self.cert_mode = cert_mode
         if (cert_path is None or key_path is None) and cert_mode == WebTransportCertificateGeneration.USEPREGENERATED:
             raise ValueError("Both cert_path and key_path must be provided, if cert_mode is USEPREGENERATED")
-        if (cert_hash_info is None and cert_mode == WebTransportCertificateGeneration.GENERATEDVALIDSERVERCERTIFICATEHASHCERT):
+        if cert_hash_info is None and cert_mode == WebTransportCertificateGeneration.GENERATEDVALIDSERVERCERTIFICATEHASHCERT:
             raise ValueError("cert_hash_info  must be provided, if cert_mode is GENERATEDVALIDSERVERCERTIFICATEHASHCERT")
 
         self.started = False

--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -8,9 +8,12 @@ import ssl
 import sys
 import threading
 import traceback
-from enum import IntEnum
+from enum import IntEnum, Enum
 from urllib.parse import urlparse
 from typing import Any, Dict, List, Optional, Tuple, cast
+
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
 
 # TODO(bashi): Remove import check suppressions once aioquic dependency is resolved.
 from aioquic.buffer import Buffer  # type: ignore
@@ -31,6 +34,7 @@ from aioquic.tls import SessionTicket  # type: ignore
 from tools import localpaths  # noqa: F401
 from wptserve import stash
 from .capsule import H3Capsule, H3CapsuleDecoder, CapsuleType
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 """
 A WebTransport over HTTP/3 server for testing.
@@ -499,6 +503,16 @@ class SessionTicketStore:
     def pop(self, label: bytes) -> Optional[SessionTicket]:
         return self.tickets.pop(label, None)
 
+class WebTransportCertificateGeneration(Enum):
+    """
+    Specify, if the server should generate a certificate or use an existing certificate
+     USEPREGENERATED: use existing certificate
+     GENERATEDVALIDSERVERCERTIFICATEHASHCERT: generate a certificate compatible to server cert hashes
+    """
+    USEPREGENERATED = 1,
+    GENERATEDVALIDSERVERCERTIFICATEHASHCERT = 2
+# TODO add cases for invalid certificates
+
 
 class WebTransportH3Server:
     """
@@ -507,18 +521,31 @@ class WebTransportH3Server:
     :param host: Host from which to serve.
     :param port: Port from which to serve.
     :param doc_root: Document root for serving handlers.
+    :paran cert_mode: The used certificate mode can be
+       USEPREGENERATED or GENERATEDVALIDSERVERCERTIFICATEHASHCERT
     :param cert_path: Path to certificate file to use.
     :param key_path: Path to key file to use.
     :param logger: a Logger object for this server.
     """
 
-    def __init__(self, host: str, port: int, doc_root: str, cert_path: str,
-                 key_path: str, logger: Optional[logging.Logger]) -> None:
+    def __init__(self, host: str, port: int, doc_root: str, cert_mode: WebTransportCertificateGeneration,
+                 cert_path: Optional[str], key_path: Optional[str], logger: Optional[logging.Logger],
+                 cert_hash_info: Optional[Dict]) -> None:
         self.host = host
         self.port = port
         self.doc_root = doc_root
-        self.cert_path = cert_path
-        self.key_path = key_path
+        if cert_path is not None:
+            self.cert_path = cert_path
+        if key_path is not None:
+            self.key_path = key_path
+        if cert_hash_info is not None:
+            self.cert_hash_info = cert_hash_info
+        self.cert_mode = cert_mode
+        if (cert_path is None or key_path is None) and cert_mode == WebTransportCertificateGeneration.USEPREGENERATED:
+            raise ValueError("Both cert_path and key_path must be provided, if cert_mode is USEPREGENERATED")
+        if (cert_hash_info is None and cert_mode == WebTransportCertificateGeneration.GENERATEDVALIDSERVERCERTIFICATEHASHCERT):
+            raise ValueError("cert_hash_info  must be provided, if cert_mode is GENERATEDVALIDSERVERCERTIFICATEHASHCERT")
+
         self.started = False
         global _doc_root
         _doc_root = self.doc_root
@@ -551,7 +578,16 @@ class WebTransportH3Server:
         _logger.info("Starting WebTransport over HTTP/3 server on %s:%s",
                      self.host, self.port)
 
-        configuration.load_cert_chain(self.cert_path, self.key_path)
+        if self.cert_mode == WebTransportCertificateGeneration.USEPREGENERATED:
+            configuration.load_cert_chain(self.cert_path, self.key_path)
+        else: # GENERATEDVALIDSERVERCERTIFICATEHASHCERT case
+            configuration.private_key =  serialization.load_pem_private_key(self.cert_hash_info["private_key"],
+                                                                            password=None
+                                                                            )
+            configuration.certificate = x509.load_pem_x509_certificate(self.cert_hash_info["certificate"])
+            configuration.certificate_chain = []
+
+
 
         ticket_store = SessionTicketStore()
 

--- a/tools/webtransport/requirements.txt
+++ b/tools/webtransport/requirements.txt
@@ -1,1 +1,2 @@
 aioquic==1.2.0
+cryptography

--- a/tools/wptserve/wptserve/config.py
+++ b/tools/wptserve/wptserve/config.py
@@ -128,6 +128,7 @@ class ConfigBuilder:
 
     _default = {
         "browser_host": "localhost",
+        "certificate_hash": {},
         "alternate_hosts": {},
         "doc_root": os.path.dirname("__file__"),
         "server_host": None,

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -478,6 +478,8 @@ def template(request, content, escape_type="html"):
             value = variables[field]
         elif hasattr(SubFunctions, field):
             value = getattr(SubFunctions, field)
+        elif field == "server_certificate_hash":
+            value = request.server.config["cert_hash_info"]["hash"]
         elif field == "headers":
             value = request.headers
         elif field == "GET":

--- a/webtransport/resources/webtransport-test-helpers.sub.js
+++ b/webtransport/resources/webtransport-test-helpers.sub.js
@@ -3,16 +3,23 @@
 
 const HOST = get_host_info().ORIGINAL_HOST;
 const PORT = '{{ports[webtransport-h3][0]}}';
+const PORT_CERT_HASH = '{{ports[webtransport-h3-cert-hash][0]}}';
 const BASE = `https://${HOST}:${PORT}`;
+const BASE_CERT_HASH = `https://${HOST}:${PORT_CERT_HASH}`;
 
 // Wait for the given number of milliseconds (ms).
 function wait(ms) { return new Promise(res => step_timeout(res, ms)); }
 
 // Create URL for WebTransport session.
-function webtransport_url(handler) {
+function webtransport_url(handler, options) {
+  if (options?.cert_hashes) {
+    return `${BASE_CERT_HASH}/webtransport/handlers/${handler}`;
+  }
   return `${BASE}/webtransport/handlers/${handler}`;
 }
 
+const cert_hash = new Uint8Array('{{server_certificate_hash}}'.split(':').map((el) => parseInt(el, 16)));
+const cert_hash_str = '{{server_certificate_hash}}'
 // Converts WebTransport stream error code to HTTP/3 error code.
 // https://ietf-wg-webtrans.github.io/draft-ietf-webtrans-http3/draft-ietf-webtrans-http3.html#section-4.3
 function webtransport_code_to_http_code(n) {


### PR DESCRIPTION
Add a second webtransport server, in order to test connection with a server, that has a self-signed certificate together with serverCertificateHashes.

See https://github.com/web-platform-tests/rfcs/pull/216