### PR TITLE
wpt: Fix references for `/css/CSS2/tables/table-anonymous-objects-*`

### DIFF
--- a/css/CSS2/tables/reference/no_red_3x3_monospace_colored_table-ref.xht
+++ b/css/CSS2/tables/reference/no_red_3x3_monospace_colored_table-ref.xht
@@ -1,0 +1,73 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+          "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <title>Reference rendering - no red, 3x3 monospace table</title>
+      <link rel="author" title="Opera" href="https://www.opera.com/" />
+      <style>
+         body {
+            font-family: monospace;
+         }
+         div {
+            position: relative;
+         }
+         table {
+            font-size: 2em;
+            border-spacing: 0;
+            position: absolute;
+            top: 1px;
+            left: 1px;
+            right: 1px;
+         }
+         td {
+            padding: 0;
+         }
+         #red {
+            color: red;
+         }
+         #green {
+            color: green;
+         }
+      </style>
+   </head>
+   <body>
+      There should be no red below, except for antialiasing issues.
+      <div>
+         <table id="red">
+            <colgroup><col style="background: yellow"/><col style="background: cyan"/><col style="background: lime"/></colgroup>
+            <tr>
+               <td>Row 1, Col 1</td>
+               <td>Row 1, Col 2</td>
+               <td>Row 1, Col 3</td>
+            </tr>
+            <tr>
+               <td>Row 22, Col 1</td>
+               <td>Row 22, Col 2</td>
+               <td>Row 22, Col 3</td>
+            </tr>
+            <tr>
+               <td>Row 333, Col 1</td>
+               <td>Row 333, Col 2</td>
+               <td>Row 333, Col 3</td>
+            </tr>
+         </table>
+         <table id="green">
+            <tr>
+               <td>Row 1, Col 1</td>
+               <td>Row 1, Col 2</td>
+               <td>Row 1, Col 3</td>
+            </tr>
+            <tr>
+               <td>Row 22, Col 1</td>
+               <td>Row 22, Col 2</td>
+               <td>Row 22, Col 3</td>
+            </tr>
+            <tr>
+               <td>Row 333, Col 1</td>
+               <td>Row 333, Col 2</td>
+               <td>Row 333, Col 3</td>
+            </tr>
+         </table>
+      </div>
+   </body>
+</html>

--- a/css/CSS2/tables/reference/no_red_3x3_monospace_multi_table-ref.xht
+++ b/css/CSS2/tables/reference/no_red_3x3_monospace_multi_table-ref.xht
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+          "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <title>Reference rendering - no red, 3x3 monospace multi table</title>
+      <link rel="author" title="Opera" href="https://www.opera.com/" />
+      <style>
+         body {
+            font-family: monospace;
+         }
+         table {
+            font-size: 2em;
+            border-spacing: 0;
+         }
+         td {
+            padding: 0;
+         }
+         #red, #green {
+            position: absolute;
+            padding: 1px;
+         }
+         #red {
+            color: red;
+         }
+         #green {
+            color: green;
+         }
+      </style>
+   </head>
+   <body>
+      <p>There should be no red below, except for antialiasing issues.</p>
+      <div id="red" class="abspos">
+         <table>
+            <tr>
+               <td>Row 1, Col 1</td>
+               <td>Row 1, Col 2</td>
+               <td>Row 1, Col 3</td>
+            </tr>
+         </table>
+         <table>
+            <tr>
+               <td>Row 22, Col 1</td>
+               <td>Row 22, Col 2</td>
+               <td>Row 22, Col 3</td>
+            </tr>
+         </table>
+         <table>
+            <tr>
+               <td>Row 333, Col 1</td>
+               <td>Row 333, Col 2</td>
+               <td>Row 333, Col 3</td>
+            </tr>
+         </table>
+      </div>
+      <div id="green" class="abspos">
+         <table>
+            <tr>
+               <td>Row 1, Col 1</td>
+               <td>Row 1, Col 2</td>
+               <td>Row 1, Col 3</td>
+            </tr>
+         </table>
+         <table>
+            <tr>
+               <td>Row 22, Col 1</td>
+               <td>Row 22, Col 2</td>
+               <td>Row 22, Col 3</td>
+            </tr>
+         </table>
+         <table>
+            <tr>
+               <td>Row 333, Col 1</td>
+               <td>Row 333, Col 2</td>
+               <td>Row 333, Col 3</td>
+            </tr>
+         </table>
+      </div>
+   </body>
+</html>

--- a/css/CSS2/tables/table-anonymous-objects-079.xht
+++ b/css/CSS2/tables/table-anonymous-objects-079.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test 3-tables-ref.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_multi_table-ref.xht"/>
 </head>
 <body style="font-family: monospace; white-space: nowrap;">
 <p>There should be no red below, except for antialiasing issues.</p>

--- a/css/CSS2/tables/table-anonymous-objects-080.xht
+++ b/css/CSS2/tables/table-anonymous-objects-080.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test 3-tables-ref.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_multi_table-ref.xht"/>
 </head>
 <body style="font-family: monospace; white-space: nowrap;">
 <p>There should be no red below, except for antialiasing issues.</p>

--- a/css/CSS2/tables/table-anonymous-objects-081.xht
+++ b/css/CSS2/tables/table-anonymous-objects-081.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test blocks-divide-tables-1.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_multi_table-ref.xht"/>
 </head>
 <body style="font-family: monospace; white-space: nowrap;">
 <p>There should be no red below, except for antialiasing issues.</p>

--- a/css/CSS2/tables/table-anonymous-objects-082.xht
+++ b/css/CSS2/tables/table-anonymous-objects-082.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test blocks-divide-tables-1.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_multi_table-ref.xht"/>
 </head>
 <body style="font-family: monospace; white-space: nowrap;">
 <p>There should be no red below, except for antialiasing issues.</p>

--- a/css/CSS2/tables/table-anonymous-objects-083.xht
+++ b/css/CSS2/tables/table-anonymous-objects-083.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test blocks-divide-tables-2.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_multi_table-ref.xht"/>
 </head>
 <body style="font-family: monospace; white-space: nowrap;">
 <p>There should be no red below, except for antialiasing issues.</p>

--- a/css/CSS2/tables/table-anonymous-objects-084.xht
+++ b/css/CSS2/tables/table-anonymous-objects-084.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test blocks-divide-tables-2.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_multi_table-ref.xht"/>
 </head>
 <body style="font-family: monospace; white-space: nowrap;">
 <p>There should be no red below, except for antialiasing issues.</p>

--- a/css/CSS2/tables/table-anonymous-objects-085.xht
+++ b/css/CSS2/tables/table-anonymous-objects-085.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test infer-cells-1.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_multi_table-ref.xht"/>
 </head>
 <body style="font-family: monospace; white-space: nowrap;">
 <p>There should be no red below, except for antialiasing issues.</p>

--- a/css/CSS2/tables/table-anonymous-objects-086.xht
+++ b/css/CSS2/tables/table-anonymous-objects-086.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test infer-cells-1.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_multi_table-ref.xht"/>
 </head>
 <body style="font-family: monospace; white-space: nowrap;">
 <p>There should be no red below, except for antialiasing issues.</p>

--- a/css/CSS2/tables/table-anonymous-objects-093.xht
+++ b/css/CSS2/tables/table-anonymous-objects-093.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test cols-test-1.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_colored_table-ref.xht"/>
 </head>
 <body style="font-family: monospace">
 There should be no red below, except for antialiasing issues.
@@ -36,7 +36,6 @@ There should be no red below, except for antialiasing issues.
 <div style="position: absolute; z-index: 2; top: 0; color: green; padding: 1px;">
 
     <table cellpadding="0" cellspacing="0" style="margin: 0; padding: 0; border: none">
-      <colgroup><col style="background: yellow"/><col style="background: cyan"/><col style="background: lime"/></colgroup>
       <tr>
         <td>Row 1, Col 1</td>
         <td>Row 1, Col 2</td>

--- a/css/CSS2/tables/table-anonymous-objects-094.xht
+++ b/css/CSS2/tables/table-anonymous-objects-094.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test cols-test-1.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_colored_table-ref.xht"/>
 </head>
 <body style="font-family: monospace">
 There should be no red below, except for antialiasing issues.
@@ -13,11 +13,11 @@ There should be no red below, except for antialiasing issues.
 <div style="position: absolute; z-index: 2; top: 0; color: green; padding: 1px;">
 
     <span style="display:table">
-      <span style="display: table-column; background: yellow"></span>
+      <span style="display: table-column"></span>
       <span style="display: table-cell">Row 1, Col 1</span>
       <span style="display: table-cell">Row 1, Col 2</span>
       <span style="display: table-cell">Row 1, Col 3</span>
-      <span style="display: table-column; background: cyan"></span>
+      <span style="display: table-column"></span>
       <span style="display: table-row-group">
         <span style="display: table-row">
           <span style="display: table-cell">Row 22, Col 1</span>
@@ -30,7 +30,7 @@ There should be no red below, except for antialiasing issues.
           <span style="display: table-cell">Row 333, Col 3</span>
         </span>
       </span>
-      <span style="display: table-column; background: lime"></span>
+      <span style="display: table-column"></span>
     </span>
   </div>
 <div style="position: relative; z-index: 1; color: red; padding: 1px;">

--- a/css/CSS2/tables/table-anonymous-objects-095.xht
+++ b/css/CSS2/tables/table-anonymous-objects-095.xht
@@ -5,10 +5,10 @@
   <title>CSS Test: Auto-imported from Gecko test cols-test-2.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_colored_table-ref.xht"/>
 </head>
 <body style="font-family: monospace">
-<p>There should be no red below, except for antialiasing issues.</p>
+There should be no red below, except for antialiasing issues.
 <div style="position: relative; font-size: 2em;">
 <div style="position: relative; z-index: 1; color: red; padding: 1px;">
 
@@ -36,7 +36,6 @@
 <div style="position: absolute; z-index: 2; top: 0; color: green; padding: 1px;">
 
     <table cellpadding="0" cellspacing="0" style="margin: 0; padding: 0; border: none">
-      <colgroup><col style="background: yellow"/><col style="background: cyan"/><col style="background: lime"/></colgroup>
       <tr>
         <td>Row 1, Col 1</td>
         <td>Row 1, Col 2</td>

--- a/css/CSS2/tables/table-anonymous-objects-096.xht
+++ b/css/CSS2/tables/table-anonymous-objects-096.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test cols-test-2.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_colored_table-ref.xht"/>
 </head>
 <body style="font-family: monospace">
 There should be no red below, except for antialiasing issues.
@@ -13,9 +13,9 @@ There should be no red below, except for antialiasing issues.
 <div style="position: absolute; z-index: 2; top: 0; color: green; padding: 1px;">
 
     <span style="display:table">
-      <span style="display: table-column; background: yellow"></span>
-      <span style="display: table-column; background: cyan"></span>
-      <span style="display: table-column; background: lime"></span>
+      <span style="display: table-column"></span>
+      <span style="display: table-column"></span>
+      <span style="display: table-column"></span>
       <span style="display: table-cell">Row 1, Col 1</span>
       <span style="display: table-cell">Row 1, Col 2</span>
       <span style="display: table-cell">Row 1, Col 3</span>

--- a/css/CSS2/tables/table-anonymous-objects-097.xht
+++ b/css/CSS2/tables/table-anonymous-objects-097.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test cols-test-3.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_colored_table-ref.xht"/>
 </head>
 <body style="font-family: monospace">
 There should be no red below, except for antialiasing issues.
@@ -36,7 +36,6 @@ There should be no red below, except for antialiasing issues.
 <div style="position: absolute; z-index: 2; top: 0; color: green; padding: 1px;">
 
     <table cellpadding="0" cellspacing="0" style="margin: 0; padding: 0; border: none">
-      <colgroup><col style="background: yellow"/><col style="background: cyan"/><col style="background: lime"/></colgroup>
       <tr>
         <td>Row 1, Col 1</td>
         <td>Row 1, Col 2</td>

--- a/css/CSS2/tables/table-anonymous-objects-098.xht
+++ b/css/CSS2/tables/table-anonymous-objects-098.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test cols-test-3.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_colored_table-ref.xht"/>
 </head>
 <body style="font-family: monospace">
 There should be no red below, except for antialiasing issues.
@@ -28,9 +28,9 @@ There should be no red below, except for antialiasing issues.
           <span style="display: table-cell">Row 333, Col 3</span>
         </span>
       </span>
-      <span style="display: table-column; background: yellow"></span>
-      <span style="display: table-column; background: cyan"></span>
-      <span style="display: table-column; background: lime"></span>
+      <span style="display: table-column"></span>
+      <span style="display: table-column"></span>
+      <span style="display: table-column"></span>
     </span>
   </div>
 <div style="position: relative; z-index: 1; color: red; padding: 1px;">

--- a/css/CSS2/tables/table-anonymous-objects-155.xht
+++ b/css/CSS2/tables/table-anonymous-objects-155.xht
@@ -4,7 +4,7 @@
   <title>CSS Test: Auto-imported from Gecko test white-space-1.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_multi_table-ref.xht"/>
   <meta name="flags" content='dom'/>
 
     <script type="text/javascript"><![CDATA[

--- a/css/CSS2/tables/table-anonymous-objects-156.xht
+++ b/css/CSS2/tables/table-anonymous-objects-156.xht
@@ -4,7 +4,7 @@
   <title>CSS Test: Auto-imported from Gecko test white-space-1.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_multi_table-ref.xht"/>
   <meta name="flags" content='dom'/>
 
     <script type="text/javascript"><![CDATA[


### PR DESCRIPTION
Some of these tests were using `no_red_3x3_monospace_table-ref.xht` as a reference. However, the reference has a single 3x3 table, while the tests put each row on a different table. Thus text wasn't aligning well, and the tests were failing on all browsers. Therefore this adds a new reference for these tests.

Some other tests were instead adding a background on their columns. These also get their own reference. But additionally, these tests attempt to work as visual tests by overlapping two tables: one with green text in front of another with red text. However, this feature was broken since both tables had a background, so the underlying one was not visible at all.
Therefore, I'm also removing the background of the table at the front. Note that these tests come in pairs that just switch which one is in front, so no functionality is lost.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#35166