### PR TITLE
Add more tests for trusted-types-sink violation reports.

### DIFF
--- a/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none.html
+++ b/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none.html
@@ -4,7 +4,7 @@
 <script src="support/helper.sub.js"></script>
 <script src="./support/csp-violations.js"></script>
 <meta http-equiv="Content-Security-Policy" content="trusted-types 'none'">
-<meta http-equiv="Content-Security-Policy" content="object-src 'none'">
+<meta http-equiv="Content-Security-Policy" content="connect-src 'none'">
 <body>
 <script>
   promise_test(async t => {

--- a/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests.html
+++ b/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests.html
@@ -5,7 +5,7 @@
 <script src="./support/csp-violations.js"></script>
 
 <meta http-equiv="Content-Security-Policy" content="trusted-types SomeName JustOneMoreName AnotherName">
-<meta http-equiv="Content-Security-Policy" content="object-src 'none'">
+<meta http-equiv="Content-Security-Policy" content="connect-src 'none'">
 <body>
 <script>
   // Allowed name test

--- a/trusted-types/require-trusted-types-for-report-only.html.headers
+++ b/trusted-types/require-trusted-types-for-report-only.html.headers
@@ -1,2 +1,2 @@
 Content-Security-Policy-Report-Only: require-trusted-types-for 'script'
-Content-Security-Policy: object-src 'none'
+Content-Security-Policy: connect-src 'none'

--- a/trusted-types/require-trusted-types-for.html
+++ b/trusted-types/require-trusted-types-for.html
@@ -4,7 +4,7 @@
   <script src="/resources/testharnessreport.js"></script>
   <script src="./support/csp-violations.js"></script>
   <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">
-  <meta http-equiv="Content-Security-Policy" content="object-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="connect-src 'none'">
 </head>
 <body>
 <script>

--- a/trusted-types/support/csp-violations.js
+++ b/trusted-types/support/csp-violations.js
@@ -38,12 +38,12 @@ function trusted_type_violations_and_exception_for(fn) {
       result.exception = e;
     }
     // Force a connect-src violation. WebKit additionally throws a SecurityError
-    // so ignore that.
+    // so ignore that. See https://bugs.webkit.org/show_bug.cgi?id=286744
     try {
       new EventSource("/common/blank.html");
     } catch(e) {
       if (!e instanceof DOMException || e.name !== "SecurityError") {
-	throw e;
+        throw e;
       }
     }
   });

--- a/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html
+++ b/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html
@@ -11,13 +11,13 @@
   // headers are set in the .headers file:
   //
   //   Content-Security-Policy: script-src 'unsafe-inline'; report-uri ...
-  //   Content-Security-Policy: object-src 'none'
+  //   Content-Security-Policy: connect-src 'none'
   //   Content-Security-Policy: require-trusted-types-for 'script'
   //
   // The second rule is there so we can provoke a CSP violation report at will.
   // The intent is that in order to test that a violation has *not* been thrown
   // (and without resorting to abominations like timeouts), we force a *another*
-  // CSP violation (by violating the object-src rule) and when that event is
+  // CSP violation (by violating the connect-src rule) and when that event is
   // processed we can we sure that an earlier event - if it indeed occurred -
   // must have already been processed.
 

--- a/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html.headers
+++ b/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html.headers
@@ -1,3 +1,3 @@
 Content-Security-Policy: script-src http: https: 'nonce-123' 'report-sample'
-Content-Security-Policy: object-src 'none'
+Content-Security-Policy: connect-src 'none'
 Content-Security-Policy: require-trusted-types-for 'script'

--- a/trusted-types/trusted-types-eval-reporting-report-only.html
+++ b/trusted-types/trusted-types-eval-reporting-report-only.html
@@ -11,7 +11,7 @@
   // headers are set in the .headers file:
   //
   //   Content-Security-Policy: script-src 'unsafe-inline' 'unsafe-eval'; report-uri ...
-  //   Content-Security-Policy: object-src 'none'
+  //   Content-Security-Policy: connect-src 'none'
   //   Content-Security-Policy-Report-Only: require-trusted-types-for 'script'
   //
   // The last rule is there so we can provoke a CSP violation report at will.

--- a/trusted-types/trusted-types-eval-reporting-report-only.html.headers
+++ b/trusted-types/trusted-types-eval-reporting-report-only.html.headers
@@ -1,4 +1,4 @@
 Content-Security-Policy: script-src http: https: 'nonce-123' 'unsafe-eval'
-Content-Security-Policy: object-src 'none'
+Content-Security-Policy: connect-src 'none'
 Content-Security-Policy-Report-Only: require-trusted-types-for 'script'
 

--- a/trusted-types/trusted-types-eval-reporting.html
+++ b/trusted-types/trusted-types-eval-reporting.html
@@ -11,7 +11,7 @@
   // headers are set in the .headers file:
   //
   //   Content-Security-Policy: script-src 'unsafe-inline' 'unsafe-eval'; report-uri ...
-  //   Content-Security-Policy: object-src 'none'
+  //   Content-Security-Policy: connect-src 'none'
   //   Content-Security-Policy: require-trusted-types-for 'script'
   //
   // The last rule is there so we can provoke a CSP violation report at will.

--- a/trusted-types/trusted-types-eval-reporting.html.headers
+++ b/trusted-types/trusted-types-eval-reporting.html.headers
@@ -1,4 +1,4 @@
 Content-Security-Policy: script-src http: https: 'nonce-123' 'unsafe-eval'
-Content-Security-Policy: object-src 'none'
+Content-Security-Policy: connect-src 'none'
 Content-Security-Policy: require-trusted-types-for 'script'
 

--- a/trusted-types/trusted-types-report-only.html.headers
+++ b/trusted-types/trusted-types-report-only.html.headers
@@ -1,2 +1,2 @@
 Content-Security-Policy-Report-Only: trusted-types two; report-uri /content-security-policy/resources/dummy-report.php; require-trusted-types-for 'script';
-Content-Security-Policy: object-src 'none'
+Content-Security-Policy: connect-src 'none'

--- a/trusted-types/trusted-types-reporting-for-DOMParser-parseFromString.html
+++ b/trusted-types/trusted-types-reporting-for-DOMParser-parseFromString.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/csp-violations.js"></script>
+<meta http-equiv="Content-Security-Policy"
+      content="require-trusted-types-for 'script'; connect-src 'none';">
+<body>
+  <script>
+    const policy = trustedTypes.createPolicy("dummy", { createHTML: x => x });
+    const input = `<p>${'A'.repeat(100)}</p>`;
+
+    promise_test(async t => {
+      await no_trusted_type_violation_for(_ =>
+        (new DOMParser()).parseFromString(policy.createHTML(input), "text/html")
+      );
+    }, "No violation reported for TrustedHTML.");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        (new DOMParser()).parseFromString(input, "text/html")
+      );
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `DOMParser parseFromString|${clipSampleIfNeeded(input)}`);
+    }, "Violation report for plain string.");
+  </script>
+</body>

--- a/trusted-types/trusted-types-reporting-for-Document-execCommand.html
+++ b/trusted-types/trusted-types-reporting-for-Document-execCommand.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/csp-violations.js"></script>
+<meta http-equiv="Content-Security-Policy"
+      content="require-trusted-types-for 'script'; connect-src 'none';">
+<body>
+  <script>
+    const policy = trustedTypes.createPolicy("dummy", { createHTML: x => x });
+    const input = `<p>${'A'.repeat(100)}</p>`;
+
+    promise_test(async t => {
+      await no_trusted_type_violation_for(_ => {
+        ["insertHTML", "paste"].forEach(command => {
+          document.execCommand(command, false, policy.createHTML(input));
+        });
+      });
+    }, "No violation reported for TrustedHTML.");
+
+    promise_test(async t => {
+      await no_trusted_type_violation_for(_ =>
+        document.execCommand("paste", false, input)
+      );
+    }, "No violation reported (paste command).");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        document.execCommand("insertHTML", false, input)
+      );
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `Document execCommand|${clipSampleIfNeeded(input)}`);
+    }, "Violation report for plain string (insertHTML command).");
+  </script>
+</body>

--- a/trusted-types/trusted-types-reporting-for-Document-parseHTMLUnsafe.html
+++ b/trusted-types/trusted-types-reporting-for-Document-parseHTMLUnsafe.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/csp-violations.js"></script>
+<meta http-equiv="Content-Security-Policy"
+      content="require-trusted-types-for 'script'; connect-src 'none';">
+<body>
+  <script>
+    const policy = trustedTypes.createPolicy("dummy", { createHTML: x => x });
+    const input = `<p>${'A'.repeat(100)}</p>`;
+
+    promise_test(async t => {
+      await no_trusted_type_violation_for(_ =>
+        Document.parseHTMLUnsafe(policy.createHTML(input))
+      );
+    }, "No violation reported for TrustedHTML.");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        Document.parseHTMLUnsafe(input)
+      );
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `Document parseHTMLUnsafe|${clipSampleIfNeeded(input)}`);
+    }, "Violation report for plain string.");
+  </script>
+</body>

--- a/trusted-types/trusted-types-reporting-for-Document-write.html
+++ b/trusted-types/trusted-types-reporting-for-Document-write.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/csp-violations.js"></script>
+<meta http-equiv="Content-Security-Policy"
+      content="require-trusted-types-for 'script'; connect-src 'none';">
+<body>
+  <div id="log"></div>
+  <script>
+    const policy = trustedTypes.createPolicy("dummy", { createHTML: x => x });
+    const input = [`<p>${'A'.repeat(50)}</p>`,
+                   `<p>${'B'.repeat(30)}</p>`,
+                   `<p>${'C'.repeat(20)}</p>`];
+    const joinedInput = input.join('');
+    const trustedInput = input.map(x => policy.createHTML(input));
+
+    // Create a separate document for testing, so write calls don't mess up with
+    // how testharness writes its output in the main document.
+    const doc = (new DOMParser()).
+          parseFromString(policy.createHTML("<body></body>"), "text/html");
+
+    ["write", "writeln"].forEach(methodName => {
+      promise_test(async t => {
+        await no_trusted_type_violation_for(_ =>
+          doc[methodName](...trustedInput)
+        );
+      }, `No violation reported for ${methodName}() with TrustedHTML arguments.`);
+
+      promise_test(async t => {
+        let violation = await trusted_type_violation_for(TypeError, _ =>
+          doc[methodName](trustedInput[0], input[1], trustedInput[2])
+        );
+        assert_equals(violation.blockedURI, "trusted-types-sink");
+        assert_equals(violation.sample, `Document ${methodName}|${clipSampleIfNeeded(joinedInput)}`);
+      }, `Violation report for plain string for ${methodName}() with at least one plain string argument.`);
+    });
+  </script>
+</body>

--- a/trusted-types/trusted-types-reporting-for-Element-innerHTML.html
+++ b/trusted-types/trusted-types-reporting-for-Element-innerHTML.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/csp-violations.js"></script>
+<meta http-equiv="Content-Security-Policy"
+      content="require-trusted-types-for 'script'; connect-src 'none';">
+<body>
+  <script>
+    const policy = trustedTypes.createPolicy("dummy", { createHTML: x => x });
+    const input = `<p>${'A'.repeat(100)}</p>`;
+
+    promise_test(async t => {
+      await no_trusted_type_violation_for(_ =>
+        document.createElement("div").innerHTML = policy.createHTML(input)
+      );
+    }, "No violation reported for TrustedHTML.");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        document.createElement("div").innerHTML = input
+      );
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `Element innerHTML|${clipSampleIfNeeded(input)}`);
+    }, "Violation report for plain string.");
+  </script>
+</body>

--- a/trusted-types/trusted-types-reporting-for-Element-insertAdjacentHTML.html
+++ b/trusted-types/trusted-types-reporting-for-Element-insertAdjacentHTML.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/csp-violations.js"></script>
+<meta http-equiv="Content-Security-Policy"
+      content="require-trusted-types-for 'script'; connect-src 'none';">
+<body>
+  <script>
+    const policy = trustedTypes.createPolicy("dummy", { createHTML: x => x });
+    const input = `<p>${'A'.repeat(100)}</p>`;
+
+    promise_test(async t => {
+      await no_trusted_type_violation_for(_ =>
+        document.createElement("div").
+          insertAdjacentHTML("beforeend", policy.createHTML(input))
+      );
+    }, "No violation reported for TrustedHTML.");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        document.createElement("div").insertAdjacentHTML("beforeend", input)
+      );
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `Element insertAdjacentHTML|${clipSampleIfNeeded(input)}`);
+    }, "Violation report for plain string.");
+  </script>
+</body>

--- a/trusted-types/trusted-types-reporting-for-Element-outerHTML.html
+++ b/trusted-types/trusted-types-reporting-for-Element-outerHTML.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/csp-violations.js"></script>
+<meta http-equiv="Content-Security-Policy"
+      content="require-trusted-types-for 'script'; connect-src 'none';">
+<body>
+  <script>
+    const policy = trustedTypes.createPolicy("dummy", { createHTML: x => x });
+    const input = `<p>${'A'.repeat(100)}</p>`;
+
+    promise_test(async t => {
+      await no_trusted_type_violation_for(_ =>
+        document.createElement("div").outerHTML = policy.createHTML(input)
+      );
+    }, "No violation reported for TrustedHTML.");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        document.createElement("div").outerHTML = input
+      );
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `Element outerHTML|${clipSampleIfNeeded(input)}`);
+    }, "Violation report for plain string.");
+  </script>
+</body>

--- a/trusted-types/trusted-types-reporting-for-Element-setAttribute.html
+++ b/trusted-types/trusted-types-reporting-for-Element-setAttribute.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/csp-violations.js"></script>
+<script src="support/namespaces.js"></script>
+<meta http-equiv="Content-Security-Policy"
+      content="require-trusted-types-for 'script'; connect-src 'none';">
+<body>
+  <script>
+    const policy = trustedTypes.createPolicy("dummy", {
+      createHTML: x => x, createScript: x => x, createScriptURL: x => x });
+    const input = 'A'.repeat(100);
+    const trustedHTML = policy.createHTML(input);
+    const trustedScript = policy.createScript(input);
+    const trustedScriptURL = policy.createScriptURL(input);
+    function createIFrame() { return document.createElement("iframe"); }
+    function createScript() { return document.createElement("script"); }
+    function createSVGScript() { return document.createElementNS(NSURI_SVG, "script"); }
+
+    promise_test(async t => {
+      await no_trusted_type_violation_for(_ => {
+        createIFrame().setAttribute("srcdoc", trustedHTML);
+        createIFrame().setAttributeNS(null, "srcdoc", trustedHTML);
+        createIFrame().setAttribute("onclick", trustedScript);
+        createIFrame().setAttributeNS(null, "onclick", trustedScript);
+        createScript().setAttribute("src", trustedScriptURL);
+        createScript().setAttributeNS(null, "src", trustedScriptURL);
+        createSVGScript().setAttribute("href", trustedScriptURL);
+        createSVGScript().setAttributeNS(null, "href", trustedScriptURL);
+        createSVGScript().setAttributeNS(NSURI_XLINK, "href", trustedScriptURL);
+      });
+    }, "No violation reported for trusted types.");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ => {
+        createIFrame().setAttribute("srcdoc", input);
+      });
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `HTMLIFrameElement srcdoc|${clipSampleIfNeeded(input)}`);
+    }, "Violation report for HTMLIFrameElement.setAttribute('srcdoc', plain_string)");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ => {
+        createIFrame().setAttributeNS(null, "srcdoc", input);
+      });
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `HTMLIFrameElement srcdoc|${clipSampleIfNeeded(input)}`);
+    }, "Violation report for HTMLIFrameElement.setAttributeNS(null, 'srcdoc', plain_string)");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ => {
+        createIFrame().setAttribute("onclick", input);
+      });
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `Element onclick|${clipSampleIfNeeded(input)}`);
+    }, "Violation report for Element.setAttribute('onclick', plain_string)");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ => {
+        createIFrame().setAttributeNS(null, "onclick", input);
+      });
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `Element onclick|${clipSampleIfNeeded(input)}`);
+    }, "Violation report for Element.setAttributeNS(null, 'onclick', plain_string)");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ => {
+        createScript().setAttribute("src", input);
+      });
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `HTMLScriptElement src|${clipSampleIfNeeded(input)}`);
+    }, "Violation report for HTMLScriptElement.setAttribute('src', plain_string)");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ => {
+        createScript().setAttributeNS(null, "src", input);
+      });
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `HTMLScriptElement src|${clipSampleIfNeeded(input)}`);
+    }, "Violation report for HTMLScriptElement.setAttributeNS(null, 'src', plain_string)");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ => {
+        createSVGScript().setAttribute("href", input);
+      });
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `SVGScriptElement href|${clipSampleIfNeeded(input)}`);
+    }, "Violation report for SVGScriptElement.setAttribute('href', plain_string)");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ => {
+        createSVGScript().setAttributeNS(null, "href", input);
+      });
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `SVGScriptElement href|${clipSampleIfNeeded(input)}`);
+    }, `Violation report for SVGScriptElement.setAttributeNS(null, 'href', plain_string)`);
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ => {
+        createSVGScript().setAttributeNS(NSURI_XLINK, "href", input);
+      });
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `SVGScriptElement href|${clipSampleIfNeeded(input)}`);
+    }, `Violation report for SVGScriptElement.setAttributeNS(${NSURI_XLINK}, 'href', plain_string)`);
+
+  </script>
+</body>

--- a/trusted-types/trusted-types-reporting-for-Element-setHTMLUnsafe.html
+++ b/trusted-types/trusted-types-reporting-for-Element-setHTMLUnsafe.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/csp-violations.js"></script>
+<meta http-equiv="Content-Security-Policy"
+      content="require-trusted-types-for 'script'; connect-src 'none';">
+<body>
+  <script>
+    const policy = trustedTypes.createPolicy("dummy", { createHTML: x => x });
+    const input = `<p>${'A'.repeat(100)}</p>`;
+
+    promise_test(async t => {
+      await no_trusted_type_violation_for(_ =>
+        document.createElement("div").setHTMLUnsafe(policy.createHTML(input))
+      );
+    }, "No violation reported for TrustedHTML.");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        document.createElement("div").setHTMLUnsafe(input)
+      );
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `Element setHTMLUnsafe|${clipSampleIfNeeded(input)}`);
+    }, "Violation report for plain string.");
+  </script>
+</body>

--- a/trusted-types/trusted-types-reporting-for-HTMLIFrameElement-srcdoc.html
+++ b/trusted-types/trusted-types-reporting-for-HTMLIFrameElement-srcdoc.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/csp-violations.js"></script>
+<meta http-equiv="Content-Security-Policy"
+      content="require-trusted-types-for 'script'; connect-src 'none';">
+<body>
+  <script>
+    const policy = trustedTypes.createPolicy("dummy", { createHTML: x => x });
+    const input = `<p>${'A'.repeat(100)}</p>`;
+
+    promise_test(async t => {
+      await no_trusted_type_violation_for(_ =>
+        document.createElement("iframe").srcdoc = policy.createHTML(input)
+      );
+    }, "No violation reported for TrustedHTML.");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        document.createElement("iframe").srcdoc = input
+      );
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `HTMLIFrameElement srcdoc|${clipSampleIfNeeded(input)}`);
+    }, "Violation report for plain string.");
+  </script>
+</body>

--- a/trusted-types/trusted-types-reporting-for-HTMLScriptElement.html
+++ b/trusted-types/trusted-types-reporting-for-HTMLScriptElement.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/csp-violations.js"></script>
+<meta http-equiv="Content-Security-Policy"
+      content="require-trusted-types-for 'script'; connect-src 'none';">
+<body>
+  <script>
+    function createScript() { return document.createElement("script"); }
+    const policy = trustedTypes.createPolicy("dummy", {
+      createScript: x => x,
+      createScriptURL: x => x,
+    });
+    const properties = {
+      innerText: "script",
+      textContent: "script",
+      src: "scriptURL",
+      text: "script",
+    };
+    const input = {
+      script: `${';'.repeat(100)}`,
+      scriptURL: `about:blank?${'A'.repeat(100)}`,
+    };
+    const trustedInput = {
+      script: policy.createScript(input.script),
+      scriptURL: policy.createScriptURL(input.scriptURL),
+    };
+    for (let [property, type] of Object.entries(properties)) {
+      promise_test(async t => {
+        await no_trusted_type_violation_for(_ =>
+          createScript()[property] = trustedInput[type]
+        );
+      }, `No violation reported for trusted input (${property}).`);
+
+      promise_test(async t => {
+        let violation = await trusted_type_violation_for(TypeError, _ =>
+          createScript()[property] = input[type]
+        );
+        assert_equals(violation.blockedURI, "trusted-types-sink");
+        assert_equals(violation.sample, `HTMLScriptElement ${property}|${clipSampleIfNeeded(input[type])}`);
+      }, `Violation report for plain string (${property})`);
+    }
+  </script>
+</body>

--- a/trusted-types/trusted-types-reporting-for-Range-createContextualFragment.html
+++ b/trusted-types/trusted-types-reporting-for-Range-createContextualFragment.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/csp-violations.js"></script>
+<meta http-equiv="Content-Security-Policy"
+      content="require-trusted-types-for 'script'; connect-src 'none';">
+<body>
+  <div id="element"></div>
+  <script>
+    const policy = trustedTypes.createPolicy("dummy", { createHTML: x => x });
+    const input = `<p>${'A'.repeat(100)}</p>`;
+    function createRange() {
+      let range = document.createRange();
+      range.selectNodeContents(document.getElementById("element"));
+      return range;
+    }
+
+    promise_test(async t => {
+      await no_trusted_type_violation_for(_ =>
+        createRange().createContextualFragment(policy.createHTML(input))
+      );
+    }, "No violation reported for TrustedHTML.");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        createRange().createContextualFragment(input)
+      );
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `Range createContextualFragment|${clipSampleIfNeeded(input)}`);
+    }, "Violation report for plain string.");
+  </script>
+</body>

--- a/trusted-types/trusted-types-reporting-for-ShadowRoot-innerHTML.html
+++ b/trusted-types/trusted-types-reporting-for-ShadowRoot-innerHTML.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/csp-violations.js"></script>
+<meta http-equiv="Content-Security-Policy"
+      content="require-trusted-types-for 'script'; connect-src 'none';">
+<body>
+  <script>
+    const policy = trustedTypes.createPolicy("dummy", { createHTML: x => x });
+    const input = `<p>${'A'.repeat(100)}</p>`;
+    function createShadowRoot() {
+      return document.createElement('div').attachShadow({mode: 'open'});
+    }
+
+    promise_test(async t => {
+      await no_trusted_type_violation_for(_ =>
+        createShadowRoot().innerHTML = policy.createHTML(input)
+      );
+    }, "No violation reported for TrustedHTML.");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        createShadowRoot().innerHTML = input
+      );
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `ShadowRoot innerHTML|${clipSampleIfNeeded(input)}`);
+    }, "Violation report for plain string.");
+  </script>
+</body>

--- a/trusted-types/trusted-types-reporting-for-ShadowRoot-setHTMLUnsafe.html
+++ b/trusted-types/trusted-types-reporting-for-ShadowRoot-setHTMLUnsafe.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/csp-violations.js"></script>
+<meta http-equiv="Content-Security-Policy"
+      content="require-trusted-types-for 'script'; connect-src 'none';">
+<body>
+  <script>
+    const policy = trustedTypes.createPolicy("dummy", { createHTML: x => x });
+    const input = `<p>${'A'.repeat(100)}</p>`;
+    function createShadowRoot() {
+      return document.createElement('div').attachShadow({mode: 'open'});
+    }
+
+    promise_test(async t => {
+      await no_trusted_type_violation_for(_ =>
+        createShadowRoot().setHTMLUnsafe(policy.createHTML(input))
+      );
+    }, "No violation reported for TrustedHTML.");
+
+    promise_test(async t => {
+      let violation = await trusted_type_violation_for(TypeError, _ =>
+        createShadowRoot().setHTMLUnsafe(input)
+      );
+      assert_equals(violation.blockedURI, "trusted-types-sink");
+      assert_equals(violation.sample, `ShadowRoot setHTMLUnsafe|${clipSampleIfNeeded(input)}`);
+    }, "Violation report for plain string.");
+  </script>
+</body>

--- a/trusted-types/trusted-types-reporting.html
+++ b/trusted-types/trusted-types-reporting.html
@@ -7,8 +7,6 @@
 </head>
 <body>
   <!-- Some elements for the tests to act on. -->
-  <div id="div"></div>
-  <script id="script"></script>
   <script id="customscript" is="custom-script" src="a"></script>
   <svg><script id="svgscript"></script></svg>
   <script>
@@ -18,13 +16,13 @@
   //
   //   Content-Security-Policy: trusted-types one
   //   Content-Security-Policy-Report-Only: trusted-types two; report-uri ...
-  //   Content-Security-Policy: object-src 'none'
+  //   Content-Security-Policy: connect-src 'none'
   //   Content-Security-Policy: default-src * 'unsafe-inline'
   //
   // The third rule is there so we can provoke a CSP violation report at will.
   // The intent is that in order to test that a violation has *not* been thrown
   // (and without resorting to abominations like timeouts), we force a *another*
-  // CSP violation (by violating the object-src rule) and when that event is
+  // CSP violation (by violating the connect-src rule) and when that event is
   // processed we can we sure that an earlier event - if it indeed occurred -
   // must have already been processed.
   //
@@ -85,80 +83,6 @@
   }, "Trusted Type violation report: creating a forbidden-but-not-reported policy.");
 
   promise_test(async t => {
-    let violation = await trusted_type_violation_for(TypeError, _ =>
-      document.getElementById("div").insertAdjacentHTML("beforebegin", "x")
-    );
-    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
-    assert_equals(violation.blockedURI, "trusted-types-sink");
-  }, "Trusted Type violation report: blocked URI and sample for insertAdjacentHTML");
-
-  promise_test(async t => {
-    let violation = await trusted_type_violation_for(TypeError, _ =>
-      document.getElementById("script").src = url
-    );
-    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
-  }, "Trusted Type violation report: assign string to script url");
-
-  promise_test(async t => {
-    let violation = await trusted_type_violation_for(TypeError, _ =>
-      document.getElementById("div").innerHTML = "abc"
-    );
-    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
-  }, "Trusted Type violation report: assign string to html");
-
-  promise_test(async t => {
-    await no_trusted_type_violation_for(_ =>
-      document.getElementById("script").text = policy_one.createScript("2+2;")
-    );
-  }, "Trusted Type violation report: assign trusted script to script; no report");
-
-  promise_test(async t => {
-    await no_trusted_type_violation_for(_ =>
-      document.getElementById("div").innerHTML = policy_one.createHTML("abc")
-    );
-  }, "Trusted Type violation report: assign trusted HTML to html; no report");
-
-  promise_test(async t => {
-    const input = "abc";
-    let violation = await trusted_type_violation_for(TypeError, _ =>
-      document.getElementById("div").innerHTML = input
-    );
-    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
-    assert_equals(violation.blockedURI, "trusted-types-sink");
-    assert_equals(violation.sample, `Element innerHTML|${clipSampleIfNeeded(input)}`);
-  }, "Trusted Type violation report: sample for innerHTML assignment");
-
-  promise_test(async t => {
-    const input = "1+2;";
-    let violation = await trusted_type_violation_for(TypeError, _ =>
-      document.getElementById("script").text = input
-    );
-    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
-    assert_equals(violation.blockedURI, "trusted-types-sink");
-    assert_equals(violation.sample, `HTMLScriptElement text|${clipSampleIfNeeded(input)}`);
-  }, "Trusted Type violation report: sample for text assignment");
-
-  promise_test(async t => {
-    const input = "about:blank";
-    let violation = await trusted_type_violation_for(TypeError, _ =>
-      document.getElementById("script").src = input
-    );
-    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
-    assert_equals(violation.blockedURI, "trusted-types-sink");
-    assert_equals(violation.sample, `HTMLScriptElement src|${clipSampleIfNeeded(input)}`);
-  }, "Trusted Type violation report: sample for script.src assignment");
-
-  promise_test(async t => {
-    const input = "2+2;";
-    let violation = await trusted_type_violation_for(TypeError, _ =>
-      document.getElementById("script").innerText = "2+2;"
-    );
-    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
-    assert_equals(violation.blockedURI, "trusted-types-sink");
-    assert_equals(violation.sample, `HTMLScriptElement innerText|${clipSampleIfNeeded(input)}`);
-  }, "Trusted Type violation report: sample for script innerText assignment");
-
-  promise_test(async t => {
     const input = "about:blank";
     let violation = await trusted_type_violation_for(TypeError, _ =>
       document.getElementById("svgscript").href.baseVal = input
@@ -197,18 +121,6 @@
     assert_equals(violation.blockedURI, "trusted-types-sink");
     assert_equals(violation.sample, `eval|${clipSampleIfNeeded(input)}`);
   }, "Trusted Type violation report: sample for eval");
-
-  promise_test(async t => {
-    // We expect the sample string to always contain the name, and at least the
-    // start of the value, but it should not be excessively long.
-    const value = "a" + "b".repeat(50000);
-    let violation = await trusted_type_violation_for(TypeError, _ =>
-      document.getElementById("script").innerText = value
-    );
-    assert_true(violation.originalPolicy.includes("require-trusted-types-for 'script'"));
-    assert_equals(violation.blockedURI, "trusted-types-sink");
-    assert_equals(violation.sample, `HTMLScriptElement innerText|${clipSampleIfNeeded(value)}`);
-  }, "Trusted Type violation report: large values should be handled sanely.");
 
   // Test reporting for Custom Elements (where supported). The report should
   // refer to the DOM elements being modified, so that Custom Elements cannot

--- a/trusted-types/trusted-types-reporting.html.headers
+++ b/trusted-types/trusted-types-reporting.html.headers
@@ -1,6 +1,6 @@
 Content-Security-Policy: trusted-types one
 Content-Security-Policy-Report-Only: trusted-types two; report-uri /content-security-policy/resources/dummy-report.php
-Content-Security-Policy: object-src 'none'
+Content-Security-Policy: connect-src 'none'
 Content-Security-Policy: default-src * 'unsafe-inline'
 Content-Security-Policy: require-trusted-types-for 'script'
 

--- a/trusted-types/trusted-types-source-file-path.html
+++ b/trusted-types/trusted-types-source-file-path.html
@@ -9,7 +9,7 @@
   <script src="./support/csp-violations.js"></script>
   <meta http-equiv="Content-Security-Policy"
         content="require-trusted-types-for 'script'; trusted-types id">
-  <meta http-equiv="Content-Security-Policy" content="object-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="connect-src 'none'">
   </head>
 <body>
 

--- a/trusted-types/trusted-types-svg-script-set-href.html
+++ b/trusted-types/trusted-types-svg-script-set-href.html
@@ -6,7 +6,7 @@
   <script src="./support/namespaces.js"></script>
   <meta http-equiv="Content-Security-Policy"
         content="require-trusted-types-for 'script'">
-  <meta http-equiv="Content-Security-Policy" content="object-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="connect-src 'none'">
 </head>
 <body>
   <div id="log"></div>

--- a/trusted-types/trusted-types-svg-script.html
+++ b/trusted-types/trusted-types-svg-script.html
@@ -5,7 +5,7 @@
   <script src="./support/csp-violations.js"></script>
   <meta http-equiv="Content-Security-Policy"
         content="require-trusted-types-for 'script'">
-  <meta http-equiv="Content-Security-Policy" content="object-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="connect-src 'none'">
 </head>
 <body>
   <div id="log"></div>


### PR DESCRIPTION
This covers all Window-only sinks listed in
https://github.com/w3c/trusted-types/issues/494#issuecomment-2572763334

This also relies on connect-src / EventSource / self.add/removeEventListner, so
that the file could be usable in Workers in the future.
