### PR TITLE
layout: Take percentage columns into account when sizing table grid min and max

### DIFF
--- a/css/css-flexbox/table-as-item-percent-width-cell-001-ref.html
+++ b/css/css-flexbox/table-as-item-percent-width-cell-001-ref.html
@@ -8,7 +8,7 @@
     width: 200px;
     border: 1px solid black;
   }
-  table { width: max-content; }
+  table { width: min-content; }
   td {
     background-color: cyan;
     width: 100%;


### PR DESCRIPTION
The specification doesn't say how to deal with percentages when
determining the minimum and maximum size of a table grid, so follow the
approach that Chromium uses.

Essentially, figure out the "missing" percentage from the non-percentage
columns and then use that to work backwards to fine the size of the
percentage ones.

This change is larger than one might expect, because this percentage
approach shouldn't happen for tables that are descendants of a flex,
grid or table container (except when there is an interceding absolute).
We have to pass this information down when building the box tree. This
will also make it easier to improve propagated text decorations in the
future.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->

Fix #<!-- nolink -->33671.

Reviewed in servo/servo#35167