### PR TITLE
Disable chrome overlay scrollbar animations

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -158,6 +158,9 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite
         chrome_options["args"].append(
             "--ip-address-space-overrides=" + address_space_overrides_arg)
 
+    # Disable overlay scrollbar animations to prevent flaky wpt screenshots based on timing.
+    chrome_options["args"].append("--disable-features=ScrollbarAnimations")
+
     # Always disable antialiasing on the Ahem font.
     blink_features = ['DisableAhemAntialias']
 


### PR DESCRIPTION
Overlay scrollbar animations are time delayed and not web visible or testable. Disable timed animation delays to ensure ref tests do not fail based on how long it takes to capture the screenshot. In particular, this flag ensures that the overlay scrollbar remains visible indefinitely after a scroll allowing the scrollbar position / appearance to be reliably tested even when overlay scrollbars are in use.