### PR TITLE
Update background-image-table-cells-straddling-no-repeat.html

### DIFF
--- a/css/css-backgrounds/background-image-table-cells-straddling-no-repeat.html
+++ b/css/css-backgrounds/background-image-table-cells-straddling-no-repeat.html
@@ -3,6 +3,7 @@
 <link rel="help" href="https://www.w3.org/TR/CSS21/tables.html#table-layers">
 <link rel="help" href="https://drafts.csswg.org/css-tables/#drawing-cell-backgrounds">
 <link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4500">
 <style>
 .green {
   background-image: linear-gradient(green, green);


### PR DESCRIPTION
This test currently fails in Safari while giving the right result, because of fuzzy issues. This add a fuzzy meta.

See https://wpt.fyi/results/css/css-backgrounds/background-image-table-cells-straddling-no-repeat.html
and http://wpt.live/css/css-backgrounds/background-image-table-cells-straddling-no-repeat.html
and https://wpt.fyi/analyzer?screenshot=sha1%3Aa7ba45e24caf2ec47178cd923c6bc13f1e0d57e3&screenshot=sha1%3A5288597415ee79459c8de9c8e0308a8a510a4688

maxDifference: 1
totalPixels: 3954