### PR TITLE
Use assert_throws_js in content-security-policy/securitypolicyviolation/source-file.html

### DIFF
--- a/content-security-policy/securitypolicyviolation/source-file.html
+++ b/content-security-policy/securitypolicyviolation/source-file.html
@@ -22,11 +22,7 @@ const testSourceFile = (description, input, output) => {
       eval('');
       //# sourceURL=${input}
     `)
-    try {
-      eval(trusted_script);
-      assert_unreached();
-    } catch (e) {}
-
+    assert_throws_js(EvalError, _ => eval(trusted_script));
     assert_equals((await violation).sourceFile, output);
   }, description);
 };


### PR DESCRIPTION
Currently it's using the pattern

`try { ...; assert_unreached(); } catch (e) {}`

but then the assertion thrown by assert_unreached() is ignored by the catch.