### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=285413

### DIFF
--- a/css/css-images/gradient/gradient-single-stop-001.html
+++ b/css/css-images/gradient/gradient-single-stop-001.html
@@ -8,6 +8,7 @@
     <link rel="help" href="https://drafts.csswg.org/css-images-3/#color-stop-syntax">
     <link rel="help" href="https://drafts.csswg.org/css-images-3/#coloring-gradient-line">
     <meta name="assert" content="Tests that gradient with a single color stop renders the expected solid color">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4500">
     <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
     <style>
         body {

--- a/css/css-images/gradient/gradient-single-stop-002.html
+++ b/css/css-images/gradient/gradient-single-stop-002.html
@@ -8,6 +8,7 @@
     <link rel="help" href="https://drafts.csswg.org/css-images-3/#color-stop-syntax">
     <link rel="help" href="https://drafts.csswg.org/css-images-3/#coloring-gradient-line">
     <meta name="assert" content="Tests that gradient with a single color stop renders the expected solid color">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4500">
     <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
     <style>
         body {

--- a/css/css-images/gradient/gradient-single-stop-003.html
+++ b/css/css-images/gradient/gradient-single-stop-003.html
@@ -8,6 +8,7 @@
     <link rel="help" href="https://drafts.csswg.org/css-images-3/#color-stop-syntax">
     <link rel="help" href="https://drafts.csswg.org/css-images-3/#coloring-gradient-line">
     <meta name="assert" content="Tests that gradient with a single color stop renders the expected solid color">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4500">
     <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
     <style>
         body {

--- a/css/css-images/gradient/gradient-single-stop-004.html
+++ b/css/css-images/gradient/gradient-single-stop-004.html
@@ -8,6 +8,7 @@
     <link rel="help" href="https://drafts.csswg.org/css-images-3/#color-stop-syntax">
     <link rel="help" href="https://drafts.csswg.org/css-images-3/#coloring-gradient-line">
     <meta name="assert" content="Tests that gradient with a single color stop renders the expected solid color">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4500">
     <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
     <style>
         body {

--- a/css/css-images/gradient/gradient-single-stop-005.html
+++ b/css/css-images/gradient/gradient-single-stop-005.html
@@ -8,6 +8,7 @@
     <link rel="help" href="https://drafts.csswg.org/css-images-3/#color-stop-syntax">
     <link rel="help" href="https://drafts.csswg.org/css-images-3/#coloring-gradient-line">
     <meta name="assert" content="Tests that gradient with a single color stop renders the expected solid color">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4500">
     <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
     <style>
         body {

--- a/css/css-images/gradient/gradient-single-stop-006.html
+++ b/css/css-images/gradient/gradient-single-stop-006.html
@@ -8,6 +8,7 @@
     <link rel="help" href="https://drafts.csswg.org/css-images-4/#color-stop-syntax">
     <link rel="help" href="https://drafts.csswg.org/css-images-4/#coloring-gradient-line">
     <meta name="assert" content="Tests that gradient with a single color stop renders the expected solid color">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-10000">
     <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
     <style>
         body {

--- a/css/css-images/gradient/gradient-single-stop-007.html
+++ b/css/css-images/gradient/gradient-single-stop-007.html
@@ -8,6 +8,7 @@
     <link rel="help" href="https://drafts.csswg.org/css-images-4/#color-stop-syntax">
     <link rel="help" href="https://drafts.csswg.org/css-images-4/#coloring-gradient-line">
     <meta name="assert" content="Tests that gradient with a single color stop renders the expected solid color">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-10000">
     <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
     <style>
         body {

--- a/css/css-images/gradient/gradient-single-stop-008.html
+++ b/css/css-images/gradient/gradient-single-stop-008.html
@@ -8,6 +8,7 @@
     <link rel="help" href="https://drafts.csswg.org/css-images-4/#color-stop-syntax">
     <link rel="help" href="https://drafts.csswg.org/css-images-4/#coloring-gradient-line">
     <meta name="assert" content="Tests that gradient with a single color stop renders the expected solid color">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-10000">
     <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
     <style>
         body {


### PR DESCRIPTION
WebKit export from bug: [\[css-images-4\] Gradients with only one stop should be supported](https://bugs.webkit.org/show_bug.cgi?id=285413)