### PR TITLE
[wdspec] fix `browsingContext.navigationCommitted` test

### DIFF
--- a/webdriver/tests/bidi/browsing_context/navigation_committed/navigation_committed.py
+++ b/webdriver/tests/bidi/browsing_context/navigation_committed/navigation_committed.py
@@ -368,9 +368,8 @@ async def test_redirect_navigation(
         events[0],
         {
             "context": top_context["context"],
-            "url": redirect_url,
-        },
-    )
+            "url": html_url,
+        })
 
     remove_listener()
 


### PR DESCRIPTION
The test used a wrong assertion. It used to pass due to a bug in chrome implementation, which is fixed now.