### PR TITLE
[css-fonts] font-style: oblique 0deg should serialize as font-style: normal

### DIFF
--- a/css/css-fonts/animations/font-style-interpolation.html
+++ b/css/css-fonts/animations/font-style-interpolation.html
@@ -46,7 +46,7 @@ test_interpolation({
 }, [
   {at: -2, expect: 'oblique -20deg'},
   {at: -0.25, expect: 'oblique -2.5deg'},
-  {at: 0, expect: 'oblique 0deg'},
+  {at: 0, expect: 'normal'},
   {at: 0.3, expect: 'oblique 3deg'},
   {at: 0.6, expect: 'oblique 6deg'},
   {at: 1, expect: 'oblique 10deg'},
@@ -74,7 +74,7 @@ test_interpolation({
 }, [
   { at: -2, expect: 'oblique -40deg' },
   { at: -0.25, expect: 'oblique -5deg' },
-  { at: 0, expect: 'oblique 0deg' },
+  { at: 0, expect: 'normal' },
   { at: 0.3, expect: 'oblique 6deg' },
   { at: 0.6, expect: 'oblique 12deg' },
   { at: 1, expect: 'oblique 20deg' },
@@ -89,7 +89,7 @@ test_interpolation({
   { at: -1, expect: 'oblique 40deg' },
   { at: 0, expect: 'oblique 20deg' },
   { at: 0.5, expect: 'oblique 10deg' },
-  { at: 1, expect: 'oblique 0deg' },
+  { at: 1, expect: 'normal' },
   { at: 1.5, expect: 'oblique -10deg' },
 ]);
 
@@ -101,7 +101,7 @@ test_interpolation({
   { at: -2, expect: 'oblique -90deg' },
   { at: -1, expect: 'oblique -90deg' },
   { at: 0, expect: 'oblique -90deg' },
-  { at: 0.5, expect: 'oblique 0deg' },
+  { at: 0.5, expect: 'normal' },
   { at: 1, expect: 'oblique 90deg' },
   { at: 1.5, expect: 'oblique 90deg' },
 ]);

--- a/css/css-fonts/parsing/font-style-computed.html
+++ b/css/css-fonts/parsing/font-style-computed.html
@@ -28,9 +28,11 @@ test_computed_value('font-style', 'normal');
 test_computed_value('font-style', 'italic');
 test_computed_value('font-style', 'oblique');
 
+test_computed_value('font-style', 'oblique 0deg', 'normal');
+test_computed_value('font-style', 'oblique calc(10deg - 10deg)', 'normal');
+
 test_computed_value('font-style', 'oblique 10deg');
 test_computed_value('font-style', 'oblique -10deg');
-test_computed_value('font-style', 'oblique 0deg');
 test_computed_value('font-style', 'oblique -90deg');
 test_computed_value('font-style', 'oblique 90deg');
 test_computed_value('font-style', 'oblique 10grad', 'oblique 9deg');

--- a/css/css-fonts/parsing/font-style-valid.html
+++ b/css/css-fonts/parsing/font-style-valid.html
@@ -15,9 +15,11 @@ test_valid_value('font-style', 'normal');
 test_valid_value('font-style', 'italic');
 test_valid_value('font-style', 'oblique');
 
+test_valid_value('font-style', 'oblique 0deg', 'normal');
+test_valid_value('font-style', 'oblique calc(10deg - 10deg)', 'oblique calc(0deg)');
+
 test_valid_value('font-style', 'oblique 10deg');
 test_valid_value('font-style', 'oblique -10deg');
-test_valid_value('font-style', 'oblique 0deg');
 test_valid_value('font-style', 'oblique -90deg');
 test_valid_value('font-style', 'oblique 90deg');
 test_valid_value('font-style', 'oblique 10grad');

--- a/css/css-fonts/variations/font-style-parsing.html
+++ b/css/css-fonts/variations/font-style-parsing.html
@@ -14,7 +14,7 @@
             { style: "italic 20deg",                expectedResult: false,  message: "'italic' followed by angle is invalid" },
             { style: "italic a",                    expectedResult: false,  message: "'italic' followed by non-number is invalid" },
             { style: "oblique",                     expectedResult: true,   message: "'oblique' is valid" },
-            { style: "oblique 0deg",                expectedResult: true,   message: "'oblique' followed by zero degrees is valid" },
+            { style: "oblique 0deg",                expectedResult: true,   message: "'oblique' followed by zero degrees is valid",                 expectedValue: "normal" },
             { style: "oblique 20deg",               expectedResult: true,   message: "'oblique' followed by positive angle in degrees is valid" },
             { style: "oblique 0.5rad",              expectedResult: true,   message: "'oblique' followed by positive angle in radians is valid",    expectedValue: /^oblique 28\.\d*deg$/ },
             { style: "oblique 20grad",              expectedResult: true,   message: "'oblique' followed by positive angle in gradians is valid",   expectedValue: "oblique 18deg" },


### PR DESCRIPTION
Updates font-style tests to match the CSS WG resolution on "font-style: oblique 0deg" serialization. (https://github.com/w3c/csswg-drafts/issues/11430)

Export made from a WebKit repository (2f2b93f7).