### PR TITLE
Add three dialog crash tests

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-crash.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-crash.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+
+<!-- This test passes if it does not crash. -->
+
+<dialog id="dialog" open closedby="closerequest">Dialog</dialog>

--- a/html/semantics/interactive-elements/the-dialog-element/dialog-open-add-closedby-crash.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-open-add-closedby-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+
+<!-- This test passes if it does not crash. -->
+
+<dialog id="dialog" open>Dialog</dialog>
+
+<script>
+  window.onload = () => {
+      dialog.setAttribute('closedby', 'closerequest');
+  }
+</script>

--- a/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-crash.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+
+<!-- This test passes if it does not crash. -->
+
+<dialog id="dialog" open>Dialog</dialog>
+
+<script>
+    window.onload = () => {
+        dialog.requestClose();
+    }
+</script>


### PR DESCRIPTION
- Test calling requestClose() on an initially open dialog. (Spec issue: https://github.com/whatwg/html/issues/10982)

- Test having closedby="closerequest" on an initially open dialog.

- Test adding closedby="closerequest" attribute to an initially open dialog.