### PR TITLE
[wdspec] add wait_for_events helper fixture

### DIFF
--- a/webdriver/tests/bidi/session/subscribe/user_contexts.py
+++ b/webdriver/tests/bidi/session/subscribe/user_contexts.py
@@ -5,7 +5,7 @@ from ... import create_console_api_message, recursive_compare
 
 
 @pytest.mark.asyncio
-async def test_subscribe_one_user_context(bidi_session, subscribe_events, create_user_context):
+async def test_subscribe_one_user_context(bidi_session, subscribe_events, create_user_context, wait_for_events):
     user_context = await create_user_context()
 
     default_context = await bidi_session.browsing_context.create(
@@ -20,35 +20,22 @@ async def test_subscribe_one_user_context(bidi_session, subscribe_events, create
 
     await subscribe_events(events=["log.entryAdded"], user_contexts=[user_context])
 
-    # Track all received log.entryAdded events in the events array
-    events = []
+    with wait_for_events(["log.entryAdded"]) as waiter:
+        await create_console_api_message(bidi_session, default_context, "text1")
+        await create_console_api_message(bidi_session, other_context, "text2")
+        events = await waiter.get_events(lambda events : len(events) >= 1)
+        assert len(events) == 1
 
-    async def on_event(method, data):
-        events.append(data)
-
-    remove_listener = bidi_session.add_event_listener("log.entryAdded", on_event)
-
-    await create_console_api_message(bidi_session, default_context, "text1")
-    await create_console_api_message(bidi_session, other_context, "text2")
-
-    wait = AsyncPoll(
-        bidi_session, message="Didn't receive expected log events"
-    )
-    await wait.until(lambda _: len(events) >= 1)
-
-    assert len(events) == 1
-    recursive_compare(
-        {
-            "text": "text2",
-        },
-        events[0],
-    )
-
-    remove_listener()
+        recursive_compare(
+            {
+                "text": "text2",
+            },
+            events[0][1],
+        )
 
 
 @pytest.mark.asyncio
-async def test_subscribe_multiple_user_contexts(bidi_session, subscribe_events, create_user_context):
+async def test_subscribe_multiple_user_contexts(bidi_session, subscribe_events, wait_for_events, create_user_context):
     user_context = await create_user_context()
 
     default_context = await bidi_session.browsing_context.create(
@@ -63,22 +50,8 @@ async def test_subscribe_multiple_user_contexts(bidi_session, subscribe_events, 
 
     await subscribe_events(events=["log.entryAdded"], user_contexts=[user_context, "default"])
 
-    # Track all received log.entryAdded events in the events array
-    events = []
-
-    async def on_event(method, data):
-        events.append(data)
-
-    remove_listener = bidi_session.add_event_listener("log.entryAdded", on_event)
-
-    await create_console_api_message(bidi_session, default_context, "text1")
-    await create_console_api_message(bidi_session, other_context, "text2")
-
-    wait = AsyncPoll(
-        bidi_session, message="Didn't receive expected log events"
-    )
-    await wait.until(lambda _: len(events) >= 2)
-
-    assert len(events) == 2
-
-    remove_listener()
+    with wait_for_events(["log.entryAdded"]) as waiter:
+        await create_console_api_message(bidi_session, default_context, "text1")
+        await create_console_api_message(bidi_session, other_context, "text2")
+        events = await waiter.get_events(lambda events : len(events) >= 2)
+        assert len(events) == 2

--- a/webdriver/tests/bidi/session/subscribe/user_contexts.py
+++ b/webdriver/tests/bidi/session/subscribe/user_contexts.py
@@ -1,6 +1,5 @@
 import pytest
 
-from tests.support.sync import AsyncPoll
 from ... import create_console_api_message, recursive_compare
 
 

--- a/webdriver/tests/support/fixtures_bidi.py
+++ b/webdriver/tests/support/fixtures_bidi.py
@@ -155,7 +155,7 @@ def wait_for_event(bidi_session, event_loop):
 
 
 @pytest.fixture
-def wait_for_events(bidi_session):
+def wait_for_events(bidi_session, configuration):
     """Wait until the BiDi session emits events."""
 
     class Waiter:
@@ -164,10 +164,10 @@ def wait_for_events(bidi_session):
             self.remove_listeners = []
             self.events = []
 
-        async def get_events(self, predicate):
+        async def get_events(self, predicate, timeout: float = 2.0):
             wait = AsyncPoll(
                 bidi_session,
-                timeout=2,
+                timeout=timeout * configuration["timeout_multiplier"],
                 message="Didn't receive expected events"
             )
             await wait.until(lambda _: predicate(self.events))

--- a/webdriver/tests/support/fixtures_bidi.py
+++ b/webdriver/tests/support/fixtures_bidi.py
@@ -155,6 +155,47 @@ def wait_for_event(bidi_session, event_loop):
 
 
 @pytest.fixture
+def wait_for_events(bidi_session):
+    """Wait until the BiDi session emits events."""
+
+    class Waiter:
+        def __init__(self, event_names):
+            self.event_names = event_names
+            self.remove_listeners = []
+            self.events = []
+
+        async def get_events(self, predicate):
+            wait = AsyncPoll(
+                bidi_session,
+                timeout=2,
+                message="Didn't receive expected events"
+            )
+            await wait.until(lambda _: predicate(self.events))
+            return self.events
+
+        def __enter__(self):
+            async def on_event(method, data):
+                self.events.append((method, data))
+
+            for event_name in self.event_names:
+                remove_listener = bidi_session.add_event_listener(event_name, on_event)
+                self.remove_listeners.append(remove_listener)
+
+            return self
+
+
+        def __exit__(self, *args):
+            for remove_listener in self.remove_listeners:
+                remove_listener()
+
+
+    def wait_for_events(event_names):
+        return Waiter(event_names)
+
+    yield wait_for_events
+
+
+@pytest.fixture
 def wait_for_future_safe(configuration):
     """Wait for the given future for a given amount of time.
     Fails gracefully if the future does not resolve within the given timeout."""


### PR DESCRIPTION
This helper allows replacing manual collection of relevant events and reducing the amount of boilerplate in a test. 