### PR TITLE
Add test for Window scroll offsets with fractional zoom

### DIFF
--- a/css/cssom-view/scroll-offsets-fractional-zoom-window.html
+++ b/css/cssom-view/scroll-offsets-fractional-zoom-window.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#extension-to-the-element-interface">
+<meta name="assert" content="This test checks that the scroll offsets for the Window element behave as expected on fractional zoom situations.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  .content {
+    width: 5000px;
+    height: 5000px;
+    background: lightgrey;
+  }
+</style>
+<div id="log"></div>
+<div class="content"></div>
+<script>
+  function runTest(zoom, x, y) {
+    window.scrollTo(x, y);
+    test(() => {
+      assert_equals(window.scrollX, x, `scrollX should be ${x}`);
+    }, `scrollX after scrollTo(${x}, ${y}) with 'zoom: ${zoom}'`);
+    test(() => {
+      assert_equals(window.scrollY, y, `scrollY should be ${y}`);
+    }, `scrollY after scrollTo(${x}, ${y}) with 'zoom: ${zoom}'`);
+  }
+
+  function runTests(zoom) {
+    document.body.style.zoom = zoom;
+
+    runTest(zoom, 0, 0);
+    runTest(zoom, 1, 2);
+    runTest(zoom, 13, 61);
+    runTest(zoom, 75, 100);
+  }
+
+  runTests(0.75);
+  runTests(0.9);
+  runTests(1);
+  runTests(1.13);
+  runTests(1.25);
+  runTests(1.5);
+  runTests(1.9);
+  runTests(2);
+  runTests(3.33);
+
+  // Reset zoom.
+  document.body.style.zoom = 1;
+</script>


### PR DESCRIPTION
Similar to the test added in #50406 but for the Window object, as it looks browsers are doing things differently for it.