### PR TITLE
Update a test for suspending import returning non-Promise value

### DIFF
--- a/wasm/jsapi/jspi/js-promise-integration.any.js
+++ b/wasm/jsapi/jspi/js-promise-integration.any.js
@@ -237,10 +237,10 @@ promise_test(async () => {
 
   let exported_promise = wrapped_export();
   AbeforeB.setB();
-  assert_true(AbeforeB.isAbeforeB());
 
   assert_equals(await exported_promise, 42);
-}, "Do not suspend if the import's return value is not a Promise");
+  assert_true(AbeforeB.isBbeforeA());
+}, "Do suspend even if the import's return value is not a Promise by wrapping it with Promise.resolve");
 
 promise_test(async (t) => {
   let tag = new WebAssembly.Tag({


### PR DESCRIPTION
The JSPI proposal was updated recently to always suspend if suspending import was called by wrapping result with Promise.resolve

https://github.com/WebAssembly/js-promise-integration/pull/57