### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=279569

### DIFF
--- a/css/css-flexbox/flexbox-vert-lr-with-img.html
+++ b/css/css-flexbox/flexbox-vert-lr-with-img.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#algo-main-item">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Main size is computed from 9.2.3E using max content size.">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="writing-mode: vertical-lr; display: flex;">
+  <img src="support/100x100-green.png" />
+</div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [Stretched image in vertical flexbox disappears](https://bugs.webkit.org/show_bug.cgi?id=279569)