### PR TITLE
[wdspec] align navigation tests with spec

### DIFF
--- a/webdriver/tests/bidi/browsing_context/navigate/navigate.py
+++ b/webdriver/tests/bidi/browsing_context/navigate/navigate.py
@@ -1,12 +1,15 @@
 import asyncio
 
 import pytest
+import webdriver.bidi.error as error
 from webdriver.bidi.modules.script import ContextTarget
 
 from . import navigate_and_assert
 from ... import any_string
 
 pytestmark = pytest.mark.asyncio
+
+USER_PROMPT_OPENED_EVENT = "browsingContext.userPromptOpened"
 
 
 async def test_payload(bidi_session, inline, new_tab):
@@ -81,12 +84,10 @@ async def test_relative_url(bidi_session, new_tab, url):
         "/webdriver/tests/bidi/browsing_context/support/empty.html"
     )
 
-    # Navigate to page1 with wait=interactive to make sure the document's base URI
-    # was updated.
-    await navigate_and_assert(bidi_session, new_tab, url_before, "interactive")
+    await navigate_and_assert(bidi_session, new_tab, url_before, "none")
 
     url_after = url_before.replace("empty.html", "other.html")
-    await navigate_and_assert(bidi_session, new_tab, url_after, "interactive")
+    await navigate_and_assert(bidi_session, new_tab, url_after, "none")
 
 
 async def test_same_document_navigation_in_before_unload(bidi_session, new_tab, url):
@@ -110,25 +111,44 @@ async def test_same_document_navigation_in_before_unload(bidi_session, new_tab, 
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": {'beforeUnload': 'ignore'}})
-async def test_wait_none_with_beforeunload_prompt(
-    bidi_session, new_tab, setup_beforeunload_page, inline
-):
+@pytest.mark.parametrize("value", ["none", "interactive", "complete"])
+@pytest.mark.parametrize("accept", [True, False])
+async def test_navigate_with_beforeunload_prompt(bidi_session, new_tab,
+        setup_beforeunload_page, inline, subscribe_events, wait_for_event,
+        wait_for_future_safe, value, accept):
     await setup_beforeunload_page(new_tab)
 
+    await subscribe_events(events=[USER_PROMPT_OPENED_EVENT])
+    on_prompt_opened = wait_for_event(USER_PROMPT_OPENED_EVENT)
+
     url_after = inline("<div>foo</div>")
 
-    result = await bidi_session.browsing_context.navigate(
-        context=new_tab["context"], url=url_after, wait="none"
+    navigated_future = asyncio.create_task(
+        bidi_session.browsing_context.navigate(context=new_tab["context"],
+                                               url=url_after, wait=value))
+
+    # Wait for the prompt to open.
+    await wait_for_future_safe(on_prompt_opened)
+    # Make sure the navigation is not finished.
+    assert not navigated_future.done()
+
+    await bidi_session.browsing_context.handle_user_prompt(
+        context=new_tab["context"], accept=accept
     )
 
-    assert result["url"] == url_after
-    any_string(result["navigation"])
+    if accept:
+        await navigated_future
+    else:
+        with pytest.raises(error.UnknownErrorException):
+            await wait_for_future_safe(navigated_future)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": {'beforeUnload': 'ignore'}})
-async def test_wait_none_with_beforeunload_prompt_in_iframe(
-    bidi_session, new_tab, setup_beforeunload_page, inline
-):
+@pytest.mark.parametrize("value", ["none", "interactive", "complete"])
+@pytest.mark.parametrize("accept", [True, False])
+async def test_navigate_with_beforeunload_prompt_in_iframe(bidi_session,
+        new_tab, setup_beforeunload_page, inline, subscribe_events,
+        wait_for_event, wait_for_future_safe, value, accept):
     page = inline(f"""<iframe src={inline("foo")}></iframe>""")
     await bidi_session.browsing_context.navigate(
         context=new_tab["context"], url=page, wait="complete"
@@ -139,35 +159,69 @@ async def test_wait_none_with_beforeunload_prompt_in_iframe(
 
     await setup_beforeunload_page(iframe_context)
 
+    await subscribe_events(events=[USER_PROMPT_OPENED_EVENT])
+    on_prompt_opened = wait_for_event(USER_PROMPT_OPENED_EVENT)
+
     url_after = inline("<div>foo</div>")
 
-    result = await bidi_session.browsing_context.navigate(
-        context=iframe_context["context"], url=url_after, wait="none"
+    navigated_future = asyncio.create_task(
+        bidi_session.browsing_context.navigate(
+            context=iframe_context["context"], url=url_after, wait=value))
+
+    # Wait for the prompt to open.
+    await wait_for_future_safe(on_prompt_opened)
+    # Make sure the navigation is not finished.
+    assert not navigated_future.done()
+
+    await bidi_session.browsing_context.handle_user_prompt(
+        context=new_tab["context"], accept=accept
     )
 
-    assert result["url"] == url_after
-    any_string(result["navigation"])
+    if accept:
+        await navigated_future
+    else:
+        with pytest.raises(error.UnknownErrorException):
+            await wait_for_future_safe(navigated_future)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": {'beforeUnload': 'ignore'}})
-async def test_wait_none_with_beforeunload_prompt_in_iframe_navigate_in_top_context(
-    bidi_session, new_tab, setup_beforeunload_page, inline
-):
+@pytest.mark.parametrize("value", ["none", "interactive", "complete"])
+@pytest.mark.parametrize("accept", [True, False])
+async def test_navigate_with_beforeunload_prompt_in_iframe_navigate_in_top_context(
+        bidi_session, new_tab, setup_beforeunload_page, inline,
+        subscribe_events, wait_for_event, wait_for_future_safe, value, accept):
     page = inline(f"""<iframe src={inline("foo")}></iframe>""")
     await bidi_session.browsing_context.navigate(
         context=new_tab["context"], url=page, wait="complete"
     )
 
-    contexts = await bidi_session.browsing_context.get_tree(root=new_tab["context"])
+    contexts = await bidi_session.browsing_context.get_tree(
+        root=new_tab["context"])
     iframe_context = contexts[0]["children"][0]
 
     await setup_beforeunload_page(iframe_context)
 
+    await subscribe_events(events=[USER_PROMPT_OPENED_EVENT])
+    on_prompt_opened = wait_for_event(USER_PROMPT_OPENED_EVENT)
+
     url_after = inline("<div>foo</div>")
 
-    result = await bidi_session.browsing_context.navigate(
-        context=new_tab["context"], url=url_after, wait="none"
+    navigated_future = asyncio.create_task(
+        bidi_session.browsing_context.navigate(
+            context=new_tab["context"], url=url_after, wait=value
+        ))
+
+    # Wait for the prompt to open.
+    await wait_for_future_safe(on_prompt_opened)
+    # Make sure the navigation is not finished.
+    assert not navigated_future.done()
+
+    await bidi_session.browsing_context.handle_user_prompt(
+        context=new_tab["context"], accept=accept
     )
 
-    assert result["url"] == url_after
-    any_string(result["navigation"])
+    if accept:
+        await navigated_future
+    else:
+        with pytest.raises(error.UnknownErrorException):
+            await wait_for_future_safe(navigated_future)

--- a/webdriver/tests/bidi/browsing_context/navigate/navigate.py
+++ b/webdriver/tests/bidi/browsing_context/navigate/navigate.py
@@ -130,7 +130,7 @@ async def test_navigate_with_beforeunload_prompt(bidi_session, new_tab,
     # Wait for the prompt to open.
     await wait_for_future_safe(on_prompt_opened)
     # Make sure the navigation is not finished.
-    assert not navigated_future.done()
+    assert not navigated_future.done(), "Navigation should not be finished before prompt is handled."
 
     await bidi_session.browsing_context.handle_user_prompt(
         context=new_tab["context"], accept=accept
@@ -171,7 +171,7 @@ async def test_navigate_with_beforeunload_prompt_in_iframe(bidi_session,
     # Wait for the prompt to open.
     await wait_for_future_safe(on_prompt_opened)
     # Make sure the navigation is not finished.
-    assert not navigated_future.done()
+    assert not navigated_future.done(), "Navigation should not be finished before prompt is handled."
 
     await bidi_session.browsing_context.handle_user_prompt(
         context=new_tab["context"], accept=accept
@@ -214,7 +214,7 @@ async def test_navigate_with_beforeunload_prompt_in_iframe_navigate_in_top_conte
     # Wait for the prompt to open.
     await wait_for_future_safe(on_prompt_opened)
     # Make sure the navigation is not finished.
-    assert not navigated_future.done()
+    assert not navigated_future.done(), "Navigation should not be finished before prompt is handled."
 
     await bidi_session.browsing_context.handle_user_prompt(
         context=new_tab["context"], accept=accept

--- a/webdriver/tests/bidi/browsing_context/navigate/wait.py
+++ b/webdriver/tests/bidi/browsing_context/navigate/wait.py
@@ -28,11 +28,9 @@ async def test_expected_url(bidi_session, inline, new_tab, value):
         context=new_tab["context"], url=url, wait=value
     )
     assert result["url"] == url
-    if value != "none":
-        contexts = await bidi_session.browsing_context.get_tree(
-            root=new_tab["context"], max_depth=0
-        )
-        assert contexts[0]["url"] == url
+    contexts = await bidi_session.browsing_context.get_tree(
+        root=new_tab["context"], max_depth=0)
+    assert contexts[0]["url"] == url
 
 
 @pytest.mark.parametrize(
@@ -49,10 +47,10 @@ async def test_slow_image_blocks_load(bidi_session, inline, new_tab, wait, expec
 
     await wait_for_navigation(bidi_session, new_tab["context"], url, wait, expect_timeout)
 
-    # We cannot assert the URL for "none" by definition, and for "complete", since
-    # we expect a timeout. For the timeout case, the wait_for_navigation helper will
-    # resume  after 1 second, there is no guarantee that the URL has been updated.
-    if wait == "interactive":
+    # We cannot assert the URL for "complete", since we expect a timeout. For
+    # this case, the wait_for_navigation helper will resume  after 1 second,
+    # there is no guarantee that the URL has been updated.
+    if wait != "complete":
         contexts = await bidi_session.browsing_context.get_tree(
             root=new_tab["context"], max_depth=0
         )

--- a/webdriver/tests/bidi/browsing_context/navigation_started/navigation_started.py
+++ b/webdriver/tests/bidi/browsing_context/navigation_started/navigation_started.py
@@ -440,14 +440,15 @@ async def test_with_beforeunload_prompt(
     target_url = url("/webdriver/tests/support/html/default.html", domain="alt")
 
     on_navigation_started = wait_for_event(NAVIGATION_STARTED_EVENT)
-    result = await bidi_session.browsing_context.navigate(
+
+    # Trigger navigation, but don't wait for it to be finished.
+    asyncio.create_task(bidi_session.browsing_context.navigate(
         context=new_tab["context"], url=target_url, wait="none"
-    )
+    ))
 
     event = await wait_for_future_safe(on_navigation_started)
 
     assert event["context"] == new_tab["context"]
-    assert event["navigation"] == result["navigation"]
     assert event["url"] == target_url
 
 

--- a/webdriver/tests/bidi/browsing_context/reload/wait.py
+++ b/webdriver/tests/bidi/browsing_context/reload/wait.py
@@ -7,6 +7,8 @@ from ... import any_string
 
 pytestmark = pytest.mark.asyncio
 
+USER_PROMPT_OPENED_EVENT = "browsingContext.userPromptOpened"
+
 
 async def wait_for_reload(bidi_session, context, wait, expect_timeout):
     # Ultimately, "interactive" and "complete" should support a timeout argument.
@@ -174,16 +176,29 @@ async def test_slow_script_blocks_domContentLoaded(bidi_session, inline,
     remove_listener_1()
 
 
-@pytest.mark.capabilities({"unhandledPromptBehavior": {"beforeUnload": "ignore"}})
-async def test_wait_none_with_beforeunload_prompt(
-    bidi_session, new_tab, setup_beforeunload_page, url
-):
+@pytest.mark.parametrize("wait", ["none", "interactive", "complete"], )
+@pytest.mark.capabilities(
+    {"unhandledPromptBehavior": {"beforeUnload": "ignore"}})
+async def test_beforeunload_prompt(bidi_session, new_tab,
+        setup_beforeunload_page, url, subscribe_events, wait, wait_for_event):
     page_url = url("/webdriver/tests/support/html/beforeunload.html")
     await setup_beforeunload_page(new_tab)
 
-    result = await bidi_session.browsing_context.reload(
-        context=new_tab["context"], wait="none"
-    )
+    await subscribe_events(events=[USER_PROMPT_OPENED_EVENT])
+    on_prompt_opened = wait_for_event(USER_PROMPT_OPENED_EVENT)
 
-    assert result["url"] == page_url
-    any_string(result["navigation"])
+    reloaded_future = asyncio.create_task(
+        bidi_session.browsing_context.reload(context=new_tab["context"],
+                                             wait=wait))
+
+    await on_prompt_opened
+    # Make sure the navigation is not finished.
+    assert not reloaded_future.done(), "Reload should not be finished before prompt is handled."
+
+    await bidi_session.browsing_context.handle_user_prompt(
+        context=new_tab["context"], accept=True)
+
+    reloaded_result = await reloaded_future
+
+    assert reloaded_result["url"] == page_url
+    any_string(reloaded_result["navigation"])

--- a/webdriver/tests/bidi/browsing_context/reload/wait.py
+++ b/webdriver/tests/bidi/browsing_context/reload/wait.py
@@ -38,13 +38,12 @@ async def test_expected_url(bidi_session, inline, new_tab, wait):
         wait=wait
     )
 
-    if wait != "none":
-        assert reload_result["navigation"] != navigate_result["navigation"]
-        assert reload_result["url"] == url
+    assert reload_result["navigation"] != navigate_result["navigation"]
+    assert reload_result["url"] == url
 
-        contexts = await bidi_session.browsing_context.get_tree(
-            root=new_tab["context"], max_depth=0)
-        assert contexts[0]["url"] == url
+    contexts = await bidi_session.browsing_context.get_tree(
+        root=new_tab["context"], max_depth=0)
+    assert contexts[0]["url"] == url
 
 
 @pytest.mark.parametrize(
@@ -68,10 +67,10 @@ async def test_slow_image_blocks_load(bidi_session, inline, new_tab, wait,
     await wait_for_reload(bidi_session, new_tab["context"], wait,
                           expect_timeout)
 
-    # We cannot assert the URL for "none" by definition, and for "complete", since
-    # we expect a timeout. For the timeout case, the wait_for_navigation helper will
-    # resume after 1 second, there is no guarantee that the URL has been updated.
-    if wait == "interactive":
+    # We cannot assert the URL for "complete", since we expect a timeout. For
+    # this case, the wait_for_navigation helper will resume after 1 second,
+    # there is no guarantee that the URL has been updated.
+    if wait != "complete":
         contexts = await bidi_session.browsing_context.get_tree(
             root=new_tab["context"], max_depth=0)
         assert contexts[0]["url"] == url

--- a/webdriver/tests/bidi/network/fetch_error/fetch_error.py
+++ b/webdriver/tests/bidi/network/fetch_error/fetch_error.py
@@ -152,19 +152,16 @@ async def test_navigation_id(
     assert fetch_error_event["navigation"] is None
 
     on_fetch_error = wait_for_event(FETCH_ERROR_EVENT)
-    result = await bidi_session.browsing_context.navigate(
+    asyncio.ensure_future(bidi_session.browsing_context.navigate(
         context=new_tab["context"],
-        url=PAGE_INVALID_URL,
-    )
+        url=PAGE_INVALID_URL))
     fetch_error_event = await wait_for_future_safe(on_fetch_error)
 
     expected_request = {"method": "GET", "url": PAGE_INVALID_URL}
     assert_fetch_error_event(
         fetch_error_event,
         expected_request=expected_request,
-        navigation=result["navigation"],
     )
-    assert fetch_error_event["navigation"] == result["navigation"]
 
 
 @pytest.mark.parametrize(
@@ -320,10 +317,10 @@ async def test_redirect_navigation(
     on_fetch_error = wait_for_event(FETCH_ERROR_EVENT)
     on_response_completed = wait_for_event(RESPONSE_COMPLETED_EVENT)
 
-    result = await bidi_session.browsing_context.navigate(
+    asyncio.ensure_future(bidi_session.browsing_context.navigate(
         context=new_tab["context"],
         url=redirect_url,
-    )
+    ))
 
     wait = AsyncPoll(bidi_session, timeout=2)
     fetch_error_event = await on_fetch_error
@@ -333,14 +330,12 @@ async def test_redirect_navigation(
     assert_response_event(
         response_completed_event,
         expected_request=expected_request,
-        navigation=result["navigation"],
         redirect_count=0,
     )
     expected_request = {"method": "GET", "url": PAGE_INVALID_URL}
     assert_fetch_error_event(
         fetch_error_event,
         expected_request=expected_request,
-        navigation=result["navigation"],
         redirect_count=1,
     )
 


### PR DESCRIPTION
Align WebDriver BiDi spec tests with the breaking change in navigation wait logic: https://github.com/w3c/webdriver-bidi/pull/855.