### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=286920

### DIFF
--- a/scroll-animations/css/timeline-offset-keyframes-hidden-subject.html
+++ b/scroll-animations/css/timeline-offset-keyframes-hidden-subject.html
@@ -94,11 +94,11 @@
       // ignored.
       frames = anim.effect.getKeyframes();
       let expected_unresolved_offsets = [
-        { offset: 0, computedOffset: 0, opacity: "1", easing: "linear",
+        { offset: 0, computedOffset: 0, marginRight: "10px", opacity: "1", easing: "linear",
           composite: "replace" },
         { offset: 0.5, computedOffset: 0.5, opacity: "0.5", easing: "linear",
           composite: "auto", },
-        { offset: 1, computedOffset: 1, opacity: "1", easing: "linear",
+        { offset: 1, computedOffset: 1, marginLeft: "10px", opacity: "1", easing: "linear",
           composite: "replace" },
         { offset: { rangeName: 'cover', offset: CSS.percent(0) },
           computedOffset: null, easing: "linear",

--- a/scroll-animations/css/view-timeline-keyframe-boundary-interpolation.html
+++ b/scroll-animations/css/view-timeline-keyframe-boundary-interpolation.html
@@ -51,15 +51,18 @@
 </body>
 <script type="text/javascript">
   async function runTest() {
+
+    const epsilon = 1e-5;
+
     function assert_progress_equals(anim, expected, errorMessage) {
       assert_approx_equals(
           anim.effect.getComputedTiming().progress,
-          expected, 1e-6, errorMessage);
+          expected, epsilon, errorMessage);
     }
 
     function assert_opacity_equals(expected, errorMessage) {
       assert_approx_equals(
-          parseFloat(getComputedStyle(target).opacity), expected, 1e-6,
+          parseFloat(getComputedStyle(target).opacity), expected, epsilon,
                      errorMessage);
     }
 
@@ -70,12 +73,12 @@
       const translateIndex = 4;
       const match = style.match(regex)[captureGroupIndex];
       const translateX = parseFloat(match.split(',')[translateIndex].trim());
-      assert_approx_equals(translateX, expected, 1e-6, errorMessage);
+      assert_approx_equals(translateX, expected, epsilon, errorMessage);
     }
 
     function assert_property_equals(property, expected, errorMessage) {
       const value = parseFloat(getComputedStyle(target)[property]);
-      assert_approx_equals(value, expected, 1e-6, errorMessage);
+      assert_approx_equals(value, expected, epsilon, errorMessage);
     }
 
     promise_test(async t => {


### PR DESCRIPTION
WebKit export from bug: [\[scroll-animations\] allow timeline ranges to be used when specifying keyframes](https://bugs.webkit.org/show_bug.cgi?id=286920)