### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=278925 (CSS timing functions should not eagerly evaluate calc())

### DIFF
--- a/css/css-easing/linear-timing-functions-syntax.html
+++ b/css/css-easing/linear-timing-functions-syntax.html
@@ -15,9 +15,17 @@
 <script>
 test_valid_value("animation-timing-function", "linear(0 0%, 1 100%)");
 test_valid_value("animation-timing-function", "linear( 0 0%, 1 100% )", "linear(0 0%, 1 100%)");
-test_valid_value("animation-timing-function", "linear(0 0% 50%, 1 50% 100%)", "linear(0 0%, 0 50%, 1 50%, 1 100%)");
-test_valid_value("animation-timing-function", "linear(0, 0.5 25% 75%, 1 100% 100%)", "linear(0 0%, 0.5 25%, 0.5 75%, 1 100%, 1 100%)");
-test_valid_value("animation-timing-function", "linear(0, 1.3, 1, 0.92, 1, 0.99, 1, 1.004, 0.998, 1 100% 100%)", "linear(0 0%, 1.3 11.1111%, 1 22.2222%, 0.92 33.3333%, 1 44.4444%, 0.99 55.5556%, 1 66.6667%, 1.004 77.7778%, 0.998 88.8889%, 1 100%, 1 100%)");
+test_valid_value("animation-timing-function", "linear(0, 1)");
+test_valid_value("animation-timing-function", "linear(-10, -5, 0, 5, 10)");
+test_valid_value("animation-timing-function", "linear(-10 -10%, -5 -5%, 0, 5, 10)");
+test_valid_value("animation-timing-function", "linear(0 calc(0%), 0 calc(100%))");
+test_valid_value("animation-timing-function", "linear(0 calc(50% - 50%), 0 calc(50% + 50%))", "linear(0 calc(0%), 0 calc(100%))");
+test_valid_value("animation-timing-function", "linear(0 calc(50%), 0 100%)");
+test_valid_value("animation-timing-function", "linear(0 0% 50%, 1 50% 100%)");
+test_valid_value("animation-timing-function", "linear(0, 0.5 25% 75%, 1 100% 100%)");
+test_valid_value("animation-timing-function", "linear(0, 1.3, 1, 0.92, 1, 0.99, 1, 0.998, 1 100% 100%)");
+test_valid_value("animation-timing-function", "linear(0, 0 40%, 1, 0.5, 1)");
+test_valid_value("animation-timing-function", "linear(0, 1.3, 1, 0.92, 1, 0.99, 1, 1.004, 0.998, 1 100% 100%)");
 
 test_invalid_value("animation-timing-function", "linear()");
 test_invalid_value("animation-timing-function", "linear(0)");
@@ -28,16 +36,19 @@ test_invalid_value("animation-timing-function", "linear(0% 100% 0)");
 test_invalid_value("animation-timing-function", "linear(0 calc(50px - 50%), 0 calc(50em + 50em))");
 test_invalid_value("animation-timing-function", "linear(0 calc(50%, 50%), 0 calc(50% + 50%))");
 
+test_computed_value("animation-timing-function", "linear(0 0%, 1 100%)");
+test_computed_value("animation-timing-function", "linear( 0 0%, 1 100% )", "linear(0 0%, 1 100%)");
 test_computed_value("animation-timing-function", "linear(0, 1)", "linear(0 0%, 1 100%)");
+test_computed_value("animation-timing-function", "linear(-10, -5, 0, 5, 10)", "linear(-10 0%, -5 25%, 0 50%, 5 75%, 10 100%)");
+test_computed_value("animation-timing-function", "linear(-10 -10%, -5 -5%, 0, 5, 10)", "linear(-10 -10%, -5 -5%, 0 30%, 5 65%, 10 100%)");
 test_computed_value("animation-timing-function", "linear(0 calc(0%), 0 calc(100%))", "linear(0 0%, 0 100%)");
 test_computed_value("animation-timing-function", "linear(0 calc(50% - 50%), 0 calc(50% + 50%))", "linear(0 0%, 0 100%)");
 test_computed_value("animation-timing-function", "linear(0 calc(min(50%, 60%)), 0 100%)", "linear(0 50%, 0 100%)");
 test_computed_value("animation-timing-function", "linear(0 0% 50%, 1 50% 100%)", "linear(0 0%, 0 50%, 1 50%, 1 100%)");
 test_computed_value("animation-timing-function", "linear(0, 0.5 25% 75%, 1 100% 100%)", "linear(0 0%, 0.5 25%, 0.5 75%, 1 100%, 1 100%)");
 test_computed_value("animation-timing-function", "linear(0, 1.3, 1, 0.92, 1, 0.99, 1, 0.998, 1 100% 100%)", "linear(0 0%, 1.3 12.5%, 1 25%, 0.92 37.5%, 1 50%, 0.99 62.5%, 1 75%, 0.998 87.5%, 1 100%, 1 100%)");
-
 test_computed_value("animation-timing-function", "linear(0, 0 40%, 1, 0.5, 1)", "linear(0 0%, 0 40%, 1 60%, 0.5 80%, 1 100%)");
-
+test_computed_value("animation-timing-function", "linear(0, 1.3, 1, 0.92, 1, 0.99, 1, 1.004, 0.998, 1 100% 100%)", "linear(0 0%, 1.3 11.111111%, 1 22.222222%, 0.92 33.333333%, 1 44.444444%, 0.99 55.555556%, 1 66.666667%, 1.004 77.777778%, 0.998 88.888889%, 1 100%, 1 100%)");
 </script>
 </body>
 </html>

--- a/css/css-easing/timing-functions-syntax-computed.html
+++ b/css/css-easing/timing-functions-syntax-computed.html
@@ -21,14 +21,18 @@ test_computed_value("animation-timing-function", "ease-in-out");
 test_computed_value("animation-timing-function", "cubic-bezier(0.1, 0.2, 0.8, 0.9)");
 test_computed_value("animation-timing-function", "cubic-bezier(0, -2, 1, 3)");
 test_computed_value("animation-timing-function", "cubic-bezier(0, 0.7, 1, 1.3)");
-
+test_computed_value("animation-timing-function", "cubic-bezier(calc(-2), calc(0.7 / 2), calc(1.5), calc(0))", "cubic-bezier(0, 0.35, 1, 0)",);
 
 test_computed_value("animation-timing-function", "steps(4, start)");
 test_computed_value("animation-timing-function", "steps(2, end)", "steps(2)");
+test_computed_value("animation-timing-function", "steps( 2, end )", "steps(2)");
 test_computed_value("animation-timing-function", "steps(2, jump-start)");
 test_computed_value("animation-timing-function", "steps(2, jump-end)", "steps(2)");
 test_computed_value("animation-timing-function", "steps(2, jump-both)");
 test_computed_value("animation-timing-function", "steps(2, jump-none)");
+test_computed_value("animation-timing-function", "steps(calc(-10), start)", "steps(1, start)");
+test_computed_value("animation-timing-function", "steps(calc(5 / 2), start)", "steps(3, start)");
+test_computed_value("animation-timing-function", "steps(calc(1), jump-none)", "steps(2, jump-none)");
 
 test_computed_value("animation-timing-function", "linear, ease, linear");
 

--- a/css/css-easing/timing-functions-syntax-invalid.html
+++ b/css/css-easing/timing-functions-syntax-invalid.html
@@ -18,9 +18,12 @@ test_invalid_value("animation-timing-function", "cubic-bezier(1, 2, 3, infinite)
 test_invalid_value("animation-timing-function", "cubic-bezier(1, 2, 3, 4, 5)");
 test_invalid_value("animation-timing-function", "cubic-bezier(-0.1, 0.1, 0.5, 0.9)");
 test_invalid_value("animation-timing-function", "cubic-bezier(0.5, 0.1, 1.1, 0.9)");
-
 test_invalid_value("animation-timing-function", "initial, cubic-bezier(0, -2, 1, 3)");
 test_invalid_value("animation-timing-function", "cubic-bezier(0, -2, 1, 3), initial");
+test_invalid_value("animation-timing-function", "steps(1, jump-none)");
+test_invalid_value("animation-timing-function", "steps(-100, jump-none)");
+test_invalid_value("animation-timing-function", "steps(0, start)");
+test_invalid_value("animation-timing-function", "steps(-100, start)");
 </script>
 </body>
 </html>

--- a/css/css-easing/timing-functions-syntax-valid.html
+++ b/css/css-easing/timing-functions-syntax-valid.html
@@ -20,7 +20,7 @@ test_valid_value("animation-timing-function", "ease-in-out");
 test_valid_value("animation-timing-function", "cubic-bezier(0.1, 0.2, 0.8, 0.9)");
 test_valid_value("animation-timing-function", "cubic-bezier(0, -2, 1, 3)");
 test_valid_value("animation-timing-function", "cubic-bezier(0, 0.7, 1, 1.3)");
-
+test_valid_value("animation-timing-function", "cubic-bezier(calc(-2), calc(0.7 / 2), calc(1.5), calc(0))", "cubic-bezier(calc(-2), calc(0.35), calc(1.5), calc(0))");
 
 test_valid_value("animation-timing-function", "steps(4, start)");
 test_valid_value("animation-timing-function", "steps(2, end)", "steps(2)");
@@ -29,6 +29,9 @@ test_valid_value("animation-timing-function", "steps(2, jump-start)");
 test_valid_value("animation-timing-function", "steps(2, jump-end)", "steps(2)");
 test_valid_value("animation-timing-function", "steps(2, jump-both)");
 test_valid_value("animation-timing-function", "steps(2, jump-none)");
+test_valid_value("animation-timing-function", "steps(calc(-10), start)");
+test_valid_value("animation-timing-function", "steps(calc(5 / 2), start)", "steps(calc(2.5), start)");
+test_valid_value("animation-timing-function", "steps(calc(1), jump-none)");
 
 test_valid_value("animation-timing-function", "linear, ease, linear");
 


### PR DESCRIPTION
Updates easing function tests to better account for calc().