### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=287327

### DIFF
--- a/scroll-animations/css/view-timeline-lookup.html
+++ b/scroll-animations/css/view-timeline-lookup.html
@@ -217,7 +217,7 @@
 <script>
   promise_test(async (t) => {
     await inflate(t, timeline_ancestor_closer_timeline_wins);
-    assert_equals(getComputedStyle(target).zIndex, 'auto');
+    assert_equals(getComputedStyle(target).zIndex, '0');
   }, 'timeline-scope on ancestor sibling, closer timeline wins');
 </script>
 


### PR DESCRIPTION
WebKit export from bug: [\[web-animations\] animations without an associated timeline should have their effects in the effect stack](https://bugs.webkit.org/show_bug.cgi?id=287327)