### PR TITLE
Merge Blink's test case for fallback handling of paint servers to WPT

### DIFF
--- a/svg/pservers/reftests/fill-fallback-currentcolor-1.svg
+++ b/svg/pservers/reftests/fill-fallback-currentcolor-1.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
+  <h:link rel="match" href="reference/green-100x100.svg"/>
+  <linearGradient id="lg">
+    <stop stop-color="#008000"/>
+  </linearGradient>
+  <!-- Test that 'fill' on the 'rect' uses the gradient 'lg'. -->
+  <g color="#ff0000" fill="#ff0000">
+    <rect width="100" height="100" fill="url(#lg) currentColor"/>
+  </g>
+</svg>

--- a/svg/pservers/reftests/fill-fallback-currentcolor-2.svg
+++ b/svg/pservers/reftests/fill-fallback-currentcolor-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
+  <h:link rel="match" href="reference/green-100x100.svg"/>
+  <!-- Test that 'fill' on the 'rect' falls back to currentColor (green). -->
+  <g color="#008000" fill="#ff0000">
+    <rect width="100" height="100" fill="url(#notfound) currentColor"/>
+  </g>
+</svg>

--- a/svg/pservers/reftests/fill-fallback-invalid-uri.svg
+++ b/svg/pservers/reftests/fill-fallback-invalid-uri.svg
@@ -1,0 +1,5 @@
+<svg fill="red" xmlns:h="http://www.w3.org/1999/xhtml">
+  <h:link rel="match" href="reference/green-100x100.svg"/>
+  <rect width="100" height="100" fill="green"/>
+  <rect width="100" height="100" fill="url(#nonexisting)"/>
+</svg>

--- a/svg/pservers/reftests/fill-fallback-none-1.svg
+++ b/svg/pservers/reftests/fill-fallback-none-1.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
+  <h:link rel="match" href="reference/green-100x100.svg"/>
+  <linearGradient id="lg">
+    <stop stop-color="#008000"/>
+  </linearGradient>
+  <!-- Test that 'fill' on the 'rect' uses the gradient 'lg'. -->
+  <rect width="100" height="100" fill="url(#lg) none"/>
+</svg>

--- a/svg/pservers/reftests/fill-fallback-none-2.svg
+++ b/svg/pservers/reftests/fill-fallback-none-2.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
+  <h:link rel="match" href="reference/green-100x100.svg"/>
+  <rect width="100" height="100" fill="#008000"/>
+  <!-- Test that 'fill' on the 'rect' falls back to 'none'. -->
+  <g fill="#ff0000">
+    <rect width="100" height="100" fill="url(#notfound) none"/>
+  </g>
+</svg>

--- a/svg/pservers/reftests/fill-fallback-none-3.svg
+++ b/svg/pservers/reftests/fill-fallback-none-3.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" fill="red">
+  <h:link rel="match" href="reference/green-100x100.svg"/>
+  <linearGradient id="working">
+    <stop stop-color="green"/>
+  </linearGradient>
+  <rect width="100" height="100" fill="green"/>
+  <rect width="100" height="100" fill="url(#broken) none" stroke="url(#working)" stroke-width="0"/>
+</svg>

--- a/svg/pservers/reftests/stroke-fallback-invalid-uri.svg
+++ b/svg/pservers/reftests/stroke-fallback-invalid-uri.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" stroke="red" stroke-width="50">
+  <h:link rel="match" href="reference/green-100x100.svg"/>
+  <rect x="25" y="25" width="50" height="50" fill="none" stroke="green"/>
+  <rect x="25" y="25" width="50" height="50" fill="none" stroke="url(#nonexisting)"/>
+</svg>


### PR DESCRIPTION
Hi Team,

While looking into SVG failures in WebKit, I noticed following tests, which could benefit from being on WPT. I asked for explicit approval from Fredrik Söderqvist (author of these tests) and now uploading them on WPT.

These are in relation to following Blink / Chromium PRs:

Commits:
https://source.chromium.org/chromium/chromium/src/+/a06aaf2d26a09493ed64b542baa29278a671425e , https://source.chromium.org/chromium/chromium/src/+/9ba199165cab706b90519a681f67ecce92241d5d and https://source.chromium.org/chromium/chromium/src/+/8a0b30e1432898d243c79bab84b373243edb97f2

Happy to fix any issue or error with guidance.

Thanks!