### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=287415

### DIFF
--- a/scroll-animations/css/timeline-scope-computed.tentative.html
+++ b/scroll-animations/css/timeline-scope-computed.tentative.html
@@ -5,22 +5,22 @@
 <script src="/css/support/computed-testcommon.js"></script>
 </head>
 <style>
-  #outer { timeline-scope: foo; }
-  #target { timeline-scope: bar; }
+  #outer { timeline-scope: --foo; }
+  #target { timeline-scope: --bar; }
 </style>
 <div id="outer">
   <div id="target"></div>
 </div>
 <script>
 test_computed_value('timeline-scope', 'initial', 'none');
-test_computed_value('timeline-scope', 'inherit', 'foo');
+test_computed_value('timeline-scope', 'inherit', '--foo');
 test_computed_value('timeline-scope', 'unset', 'none');
 test_computed_value('timeline-scope', 'revert', 'none');
 test_computed_value('timeline-scope', 'none');
-test_computed_value('timeline-scope', 'test');
-test_computed_value('timeline-scope', 'foo, bar');
-test_computed_value('timeline-scope', 'bar, foo');
-test_computed_value('timeline-scope', 'a, b, c, D, e');
+test_computed_value('timeline-scope', '--test');
+test_computed_value('timeline-scope', '--foo, --bar');
+test_computed_value('timeline-scope', '--bar, --foo');
+test_computed_value('timeline-scope', '--a, --b, --c, --D, --e');
 
 test(() => {
   let style = getComputedStyle(document.getElementById('target'));

--- a/scroll-animations/css/timeline-scope-parsing.tentative.html
+++ b/scroll-animations/css/timeline-scope-parsing.tentative.html
@@ -12,12 +12,12 @@ test_valid_value('timeline-scope', 'unset');
 test_valid_value('timeline-scope', 'revert');
 
 test_valid_value('timeline-scope', 'none');
-test_valid_value('timeline-scope', 'abc');
-test_valid_value('timeline-scope', '  abc', 'abc');
-test_valid_value('timeline-scope', 'aBc');
-test_valid_value('timeline-scope', 'foo, bar');
-test_valid_value('timeline-scope', 'bar, foo');
-test_valid_value('timeline-scope', 'auto');
+test_valid_value('timeline-scope', '--abc');
+test_valid_value('timeline-scope', '  --abc', '--abc');
+test_valid_value('timeline-scope', '--aBc');
+test_valid_value('timeline-scope', '--foo, --bar');
+test_valid_value('timeline-scope', '--bar, --foo');
+test_valid_value('timeline-scope', '--auto');
 
 test_invalid_value('timeline-scope', 'none, abc');
 test_invalid_value('timeline-scope', '10px');
@@ -25,5 +25,11 @@ test_invalid_value('timeline-scope', 'foo bar');
 test_invalid_value('timeline-scope', '"foo" "bar"');
 test_invalid_value('timeline-scope', 'rgb(1, 2, 3)');
 test_invalid_value('timeline-scope', '#fefefe');
+test_invalid_value('timeline-scope', 'abc');
+test_invalid_value('timeline-scope', '  abc', 'abc');
+test_invalid_value('timeline-scope', 'aBc');
+test_invalid_value('timeline-scope', 'foo, bar');
+test_invalid_value('timeline-scope', 'bar, foo');
+test_invalid_value('timeline-scope', 'auto');
 
 </script>


### PR DESCRIPTION
WebKit export from bug: [\[scroll-animations\] WPT tests for `timeline-scope` parsing are failures](https://bugs.webkit.org/show_bug.cgi?id=287415)