### PR TITLE
script: fix spurious animation checks to correctly invoke rAF callbacks

### DIFF
--- a/html/webappapis/animation-frames/spurious-frame-callbacks-optimization.html
+++ b/html/webappapis/animation-frames/spurious-frame-callbacks-optimization.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<head>
+  <title>Optimization of requestAnimationFrame callbacks that don't modify the DOM shouldn't break animations</title>
+  <link rel="author" title="Mukilan Thiyagarajan" href="mailto:mukilan@igalia.com">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+    <div id="target">0</div>
+</body>
+<script>
+"use strict";
+async_test(function(test) {
+  let frame = 0;
+  const draw = (t) => {
+    frame += 1;
+    if (frame < 11) {
+      // Don't mutate the DOM for 10 frames to meet the threshold for Servo's
+      // spurious frame optimization to kick in.
+      requestAnimationFrame(draw);
+    } else if (frame == 11) {
+      // Don't schedule next rAF so the compositor's tick is disabled.
+      // This is specific to Servo as the spurious frame detection at the
+      // time of this test was broken.
+      test.step_timeout(() => {
+        requestAnimationFrame(draw);
+      }, 0);
+    } else {
+      // Normal frames.
+      document.getElementById('target').innerText = t;
+      requestAnimationFrame(draw);
+    }
+  };
+
+  let target = document.getElementById('target');
+  test.step_timeout(test.step_func_done(() => {
+    assert_greater_than(parseInt(target.innerText), 500);
+  }), 550);
+  requestAnimationFrame(draw);
+});
+</script>


### PR DESCRIPTION
After running an `rAF` callback, if no new callbacks were registered, we send a `NoAnimationFramesCallback` to the compositor to stop ticking animations using video refresh callbacks. This interacts badly with the mechanism to track spurious animations frames i.e. rAF callbacks that don't mutate the DOM. Such 'faked' rAF callbacks are triggered by registering a oneshot timer instead of the compositor callback.

The compositor's refresh callback is never enabled back again once a non-spurious rAF callback runs and registers a new rAF callback. If the former callback resets the `spurious_animations_frames` counter, then when the latter rAF callback runs, it will not schedule a OneShotTimer timer for any rAF callback that itself registers, since the counter was reset previously. Hence that third rAF callback that never runs as it relies on the compsitor's refresh callback, which was disabled previously.

The current logic also doesn't actually recognize spurious animation frames because the `spurious_animations_frames` counter is updated at the end of the `run_the_animation_frame_callbacks`, effectively meaning `was_faking_animation_frames` and `self.is_faking_animation_frames` will always be the same value but the logic effectively only runs when `(!was_faking && is_faking)` is true.

This patch fixes the logic to detect spurious animations frames by moving logic to update the counter to be before the check for spurious frames. It also ensures that the compositor's refesh callbacks is re-enabled once we see a non-spurious callback.


Fixes #<!-- nolink -->35386

Reviewed in servo/servo#35387