### PR TITLE
 `DataTransferItem`: improve spec compliance

### DIFF
--- a/html/editing/dnd/datastore/datatransferitemlist-remove.html
+++ b/html/editing/dnd/datastore/datatransferitemlist-remove.html
@@ -20,4 +20,20 @@ test(() => {
   // Must not throw
   dt.items.remove(1);
 }, "remove()ing an out-of-bounds index does nothing");
+
+test(() => {
+  const file = new File(["🕺💃"], "test.png", {
+        type: "image/png"
+  });
+
+  const dt = new DataTransfer();
+  dt.items.add(file);
+
+  let item = dt.items[0];
+  dt.items.remove(0);
+
+  assert_equals(item.kind, "");
+  assert_equals(item.type, "");
+  assert_equals(item.getAsFile(), null);
+}, "remove()ing an item will put the associated DataTransferItem object in the disabled mode");
 </script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Avoid copying the kind enum inside DataTransferItem when constructing it; fetch it through drag_data_store instead.
According to spec if an item is removed from the drag data store item list, the corresponding `DataTransferItem` will be in a disabled mode.

I decided to use IndexMap since it was already a dependency and access by both index and a key was required.
For key i simply used a u16, maybe use a newtype for clarity?

Reviewed in servo/servo#35418