### PR TITLE
WebDriverTestharnessExecutor bidi/classic decision

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -436,8 +436,15 @@ class WebDriverBrowser(Browser):
                                  "env": self.env}
 
     def settings(self, test: Test) -> BrowserSettings:
-        self._pac = test.environment.get("pac", None) if self._supports_pac else None
-        return {"pac": self._pac}
+        self._pac = test.environment.get("pac",
+                                         None) if self._supports_pac else None
+        return {
+            "pac": self._pac,
+            "require_webdriver_bidi": (
+                    test.testdriver_features is not None
+                    and 'bidi' in test.testdriver_features
+            )
+        }
 
     @property
     def pac(self) -> Optional[str]:

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -6,7 +6,7 @@ import time
 from mozlog.structuredlog import StructuredLogger
 
 from . import chrome_spki_certs
-from .base import BrowserError, BrowserSettings
+from .base import BrowserError
 from .base import WebDriverBrowser, require_arg
 from .base import NullBrowser  # noqa: F401
 from .base import OutputHandler
@@ -40,8 +40,6 @@ __wptrunner__ = {"product": "chrome",
                  "env_options": "env_options",
                  "update_properties": "update_properties",
                  "timeout_multiplier": "get_timeout_multiplier",}
-
-from ..wpttest import Test
 
 
 def debug_args(debug_info):
@@ -225,7 +223,6 @@ class ChromeBrowser(WebDriverBrowser):
         super().__init__(logger, **kwargs)
         self._leak_check = leak_check
         self._actual_port = None
-        self._require_webdriver_bidi: Optional[bool] = None
 
     def restart_on_test_type_change(self, new_test_type: str, old_test_type: str) -> bool:
         # Restart the test runner when switch from/to wdspec tests. Wdspec test
@@ -273,20 +270,6 @@ class ChromeBrowser(WebDriverBrowser):
     def executor_browser(self):
         browser_cls, browser_kwargs = super().executor_browser()
         return browser_cls, {**browser_kwargs, "leak_check": self._leak_check}
-
-    @property
-    def require_webdriver_bidi(self) -> Optional[bool]:
-        return self._require_webdriver_bidi
-
-    def settings(self, test: Test) -> BrowserSettings:
-        """ Required to store `require_webdriver_bidi` in browser settings."""
-        settings = super().settings(test)
-        self._require_webdriver_bidi = test.testdriver_features is not None and 'bidi' in test.testdriver_features
-
-        return {
-            **settings,
-            "require_webdriver_bidi": self._require_webdriver_bidi
-        }
 
 
 class ChromeDriverOutputHandler(OutputHandler):

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -276,16 +276,15 @@ class ChromeDriverRefTestExecutor(WebDriverRefTestExecutor):
 class ChromeDriverTestharnessExecutor(WebDriverTestharnessExecutor):
 
     def __init__(self, *args, sanitizer_enabled=False, reuse_window=False, **kwargs):
-        require_webdriver_bidi = kwargs.get("browser_settings", {}).get(
-            "require_webdriver_bidi", None)
-        if require_webdriver_bidi:
-            self.protocol_cls = ChromeDriverBidiProtocol
-        else:
-            self.protocol_cls = ChromeDriverProtocol
-
         super().__init__(*args, **kwargs)
         self.sanitizer_enabled = sanitizer_enabled
         self.reuse_window = reuse_window
+
+    def protocol_cls(self, require_webdriver_bidi):
+        if require_webdriver_bidi:
+            return ChromeDriverBidiProtocol
+        else:
+            return ChromeDriverProtocol
 
     def get_or_create_test_window(self, protocol):
         test_window = self.protocol.testharness.persistent_test_window

--- a/tools/wptrunner/wptrunner/executors/executoredge.py
+++ b/tools/wptrunner/wptrunner/executors/executoredge.py
@@ -22,7 +22,8 @@ class EdgeDriverRefTestExecutor(WebDriverRefTestExecutor):
 
 
 class EdgeDriverTestharnessExecutor(WebDriverTestharnessExecutor):
-    protocol_cls = EdgeDriverProtocol
+    def protocol_cls(self, require_webdriver_bidi):
+        return EdgeDriverProtocol
 
 
 class EdgeDriverPrintRefTestExecutor(EdgeDriverRefTestExecutor):

--- a/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -75,7 +75,6 @@ class ServoWebDriverProtocol(WebDriverProtocol):
 
 class ServoWebDriverTestharnessExecutor(WebDriverTestharnessExecutor):
     supports_testdriver = True
-    protocol_cls = ServoWebDriverProtocol
 
     def __init__(self, logger, browser, server_config, timeout_multiplier=1,
                  close_after_done=True, capabilities={}, debug_info=None,
@@ -84,6 +83,10 @@ class ServoWebDriverTestharnessExecutor(WebDriverTestharnessExecutor):
                                               timeout_multiplier, capabilities=capabilities,
                                               debug_info=debug_info, close_after_done=close_after_done,
                                               cleanup_after_test=False)
+
+    def protocol_cls(self, require_webdriver_bidi):
+        return ServoWebDriverProtocol
+
 
     def on_environment_change(self, new_environment):
         self.protocol.webdriver.extension.change_prefs(


### PR DESCRIPTION
Addressing https://github.com/web-platform-tests/wpt/issues/50546.
Move decision on whether enable or not WebDriver BiDi to WebDriverTestharnessExecutor. Executors can specify the protocol by overriding `protocol_cls`. If the protocol instance do not implement WebDriver BiDi, fail with an error.