### PR TITLE
Test removing a sibling element when both are fullscreen

### DIFF
--- a/fullscreen/model/remove-first-sibling.html
+++ b/fullscreen/model/remove-first-sibling.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<title>Remove the first of two sibling elements in the fullscreen stack</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="../trusted-click.js"></script>
+<div id="log"></div>
+<div id="a"></div>
+<div id="b"></div>
+<script>
+  promise_test(async (t) => {
+    t.add_cleanup(() => {
+      if (document.fullscreenElement) {
+        return document.exitFullscreen();
+      }
+    });
+
+    const a = document.getElementById("a");
+    const b = document.getElementById("b");
+    await Promise.all([trusted_request(a), fullScreenChange()]);
+
+    assert_equals(document.fullscreenElement, a, "fullscreen element after first request");
+    assert_true(a.matches(":fullscreen"), "a matches :fullscreen after first request");
+
+    await Promise.all([trusted_request(b, a), fullScreenChange()]);
+    assert_equals(document.fullscreenElement, b, "fullscreen element after second request");
+    assert_true(a.matches(":fullscreen"), "a matches :fullscreen after second request");
+    assert_true(b.matches(":fullscreen"), "b matches :fullscreen after second request");
+
+    // Removing /a/ now shouldn't do anything except remove it from the top
+    // layer, which causes it to no longer match :fullscreen.
+    a.remove();
+    assert_equals(document.fullscreenElement, b, "fullscreen element immediately after removal");
+    assert_false(a.matches(":fullscreen"), "a matches :fullscreen immediately after removal");
+    assert_true(b.matches(":fullscreen"), "b matches :fullscreen immediately after removal");
+
+    // No fullscreenchange event should fire. If the removal triggered exiting
+    // fullscreen the event would be fired after an async section and an
+    // animation frame task, so wait until after that.
+    document.onfullscreenchange = t.unreached_func("fullscreenchange event");
+    await new Promise((resolve) => {
+      requestAnimationFrame(resolve);
+    });
+  });
+</script>

--- a/fullscreen/model/remove-first-sibling.html
+++ b/fullscreen/model/remove-first-sibling.html
@@ -31,9 +31,9 @@
     // Removing /a/ now shouldn't do anything except remove it from the top
     // layer, which causes it to no longer match :fullscreen.
     a.remove();
-    assert_equals(document.fullscreenElement, b, "fullscreen element immediately after removal");
-    assert_false(a.matches(":fullscreen"), "a matches :fullscreen immediately after removal");
-    assert_true(b.matches(":fullscreen"), "b matches :fullscreen immediately after removal");
+    assert_equals(document.fullscreenElement, b, "fullscreen element immediately after removal of a");
+    assert_false(a.matches(":fullscreen"), "a should no longer match :fullscreen immediately after removal");
+    assert_true(b.matches(":fullscreen"), "b matches :fullscreen immediately after removal of a");
 
     // No fullscreenchange event should fire. If the removal triggered exiting
     // fullscreen the event would be fired after an async section and an

--- a/fullscreen/model/remove-last-sibling.html
+++ b/fullscreen/model/remove-last-sibling.html
@@ -31,14 +31,14 @@
     // Removing the fullscreen element (b) triggers exiting fullscreen. Some changes are
     // visible synchronously and the others come when the event fires.
     b.remove();
-    assert_equals(document.fullscreenElement, a, "fullscreen element immediately after removal");
-    assert_true(a.matches(":fullscreen"), "a matches :fullscreen immediately after removal");
-    assert_false(b.matches(":fullscreen"), "b matches :fullscreen immediately after removal");
+    assert_equals(document.fullscreenElement, a, "fullscreen element immediately after removal of b");
+    assert_true(a.matches(":fullscreen"), "a matches :fullscreen immediately after removal of b");
+    assert_false(b.matches(":fullscreen"), "b no longer matches :fullscreen immediately after removal");
 
     // A fullscreenchange event should fire and all state should be cleared.
     await fullScreenChange();
     assert_equals(document.fullscreenElement, null, "fullscreen element after event");
-    assert_false(a.matches(":fullscreen"), "a matches :fullscreen after event");
-    assert_false(b.matches(":fullscreen"), "b matches :fullscreen after event");
+    assert_false(a.matches(":fullscreen"), "a no longer matches :fullscreen after event");
+    assert_false(b.matches(":fullscreen"), "b no longer matches :fullscreen after event");
   });
 </script>

--- a/fullscreen/model/remove-last-sibling.html
+++ b/fullscreen/model/remove-last-sibling.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<title>Remove the last of two sibling elements in the fullscreen stack</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="../trusted-click.js"></script>
+<div id="log"></div>
+<div id="a"></div>
+<div id="b"></div>
+<script>
+  promise_test(async (t) => {
+    t.add_cleanup(() => {
+      if (document.fullscreenElement) {
+        return document.exitFullscreen();
+      }
+    });
+
+    const a = document.getElementById("a");
+    const b = document.getElementById("b");
+    await Promise.all([trusted_request(a), fullScreenChange()]);
+
+    assert_equals(document.fullscreenElement, a, "fullscreen element after first request");
+    assert_true(a.matches(":fullscreen"), "a matches :fullscreen after first request");
+
+    await Promise.all([trusted_request(b, a), fullScreenChange()]);
+    assert_equals(document.fullscreenElement, b, "fullscreen element after second request");
+    assert_true(a.matches(":fullscreen"), "a matches :fullscreen after second request");
+    assert_true(b.matches(":fullscreen"), "b matches :fullscreen after second request");
+
+    // Removing the fullscreen element (b) triggers exiting fullscreen. Some changes are
+    // visible synchronously and the others come when the event fires.
+    b.remove();
+    assert_equals(document.fullscreenElement, a, "fullscreen element immediately after removal");
+    assert_true(a.matches(":fullscreen"), "a matches :fullscreen immediately after removal");
+    assert_false(b.matches(":fullscreen"), "b matches :fullscreen immediately after removal");
+
+    // A fullscreenchange event should fire and all state should be cleared.
+    await fullScreenChange();
+    assert_equals(document.fullscreenElement, null, "fullscreen element after event");
+    assert_false(a.matches(":fullscreen"), "a matches :fullscreen after event");
+    assert_false(b.matches(":fullscreen"), "b matches :fullscreen after event");
+  });
+</script>


### PR DESCRIPTION
These tests complements the existing remove-first.html and remove-last.html
tests where the two elements in top layer have a parent-child
relationship. These test instead have two sibling elements, and removes
one of them. This is important because remove-first.html actually
removes both elements. The remove-last-sibling.html isn't as novel but
is tested for completeness sake.
