### PR TITLE
css-function tests for shadow dom

### DIFF
--- a/css/css-mixins/dashed-function-eval.html
+++ b/css/css-mixins/dashed-function-eval.html
@@ -8,6 +8,13 @@
 <div id=target></div>
 <div id=main></div>
 
+<div id=host>
+  <template shadowrootmode="open">
+    <div id=target></div>
+    <div id=main></div>
+  </template>
+</div>
+
 <!-- To pass, a test must produce matching computed values for --actual and
      --expected on #target. -->
 
@@ -681,4 +688,8 @@
 
 <script>
   test_all_templates();
+  const shadowTarget = host.shadowRoot.getElementById('target');
+  const shadowTemplateTarget = host.shadowRoot.getElementById('main');
+  test_all_templates(shadowTarget, main, 'Shadow DOM');
+  test_all_templates(shadowTarget, shadowTemplateTarget, 'Shadow DOM defined');
 </script>

--- a/css/css-mixins/resources/utils.js
+++ b/css/css-mixins/resources/utils.js
@@ -15,17 +15,20 @@
 // The test passes if the computed value of --actual matches
 // the computed value of --expected on #target.
 //
-// Elements <div id=target> and <div=main> are assumed to exist.
-function test_all_templates() {
+// Arguments:
+// * `styleTarget`, defaults to <div id=target>, which is assumed to exist.
+// * `templateTarget` defaults to <div=main>, which are assumed to exist.
+// * `descriptor` optional test descriptor
+function test_all_templates(styleTarget = target, templateTarget = main, descriptor = '') {
   let templates = document.querySelectorAll('template');
   for (let template of templates) {
     test((t) => {
-      t.add_cleanup(() => main.replaceChildren());
-      main.append(template.content.cloneNode(true));
-      let cs = getComputedStyle(target);
+      t.add_cleanup(() => templateTarget.replaceChildren());
+      templateTarget.append(template.content.cloneNode(true));
+      let cs = getComputedStyle(styleTarget);
       let actual = cs.getPropertyValue('--actual');
       let expected = cs.getPropertyValue('--expected');
       assert_equals(actual, expected);
-    }, template.getAttribute('data-name'));
+    }, `${descriptor ? `${descriptor}: `: ''}${template.getAttribute('data-name')}`);
   }
 }


### PR DESCRIPTION
Augments the css-function evaluation tests to confirm that:
1. globally defined css functions apply in Shadow DOM
2. Shadow DOM defined css functions apply in Shadow DOM