### PR TITLE
Fix 'fill-fallback-invalid-uri.svg'

### DIFF
--- a/svg/pservers/reftests/fill-fallback-invalid-uri.svg
+++ b/svg/pservers/reftests/fill-fallback-invalid-uri.svg
@@ -1,4 +1,4 @@
-<svg fill="red" xmlns:h="http://www.w3.org/1999/xhtml">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" fill="red">
   <h:link rel="match" href="reference/green-100x100.svg"/>
   <rect width="100" height="100" fill="green"/>
   <rect width="100" height="100" fill="url(#nonexisting)"/>


### PR DESCRIPTION
Hi,

This test was failing earlier and so this is to fix it so it can be used as reference by all browser engines.

Thanks!