### PR TITLE
[WebDriver BiDi] Remove obsolete test pointerMove test

### DIFF
--- a/webdriver/tests/bidi/input/perform_actions/invalid.py
+++ b/webdriver/tests/bidi/input/perform_actions/invalid.py
@@ -432,7 +432,7 @@ async def test_params_pointer_action_move_coordinate_missing(
 
 
 @pytest.mark.parametrize("coordinate", ["x", "y"])
-@pytest.mark.parametrize("value", [None, "foo", True, 0.1, [], {}])
+@pytest.mark.parametrize("value", [None, "foo", True, [], {}])
 async def test_params_pointer_action_move_coordinate_invalid_type(
         perform_actions, coordinate, value):
     action = create_pointer_action(


### PR DESCRIPTION
https://github.com/w3c/webdriver-bidi/pull/874

Remove the now obsolete test pointerMove test 