### PR TITLE
[GitHub Actions] use Ubuntu 24.04 for all workflows

### DIFF
--- a/.github/workflows/check-workflow-run.yml
+++ b/.github/workflows/check-workflow-run.yml
@@ -16,8 +16,7 @@ jobs:
   check-workflow-run:
     name: "Check for appropriate epochs"
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
-    runs-on:
-      - ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
     outputs:
@@ -49,7 +48,6 @@ jobs:
   check-workflow-run-noop:
     name: "Check for appropriate epochs (noop)"
     if: ${{ github.event_name != 'workflow_run' }}
-    runs-on:
-      - ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - run: exit 0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   docker-publish:
     name: Publish Docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,7 +14,7 @@ on:
       - 'tools/**'
 jobs:
   build-and-publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.repository == 'web-platform-tests/wpt'
     steps:
       - name: Set up Python

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,11 +2,7 @@ name: documentation
 on:
   push:
     branches:
-      - master
-    paths:
-      - 'docs/**'
-      - 'resources/**'
-      - 'tools/**'
+      - ubuntu-24.04
   pull_request:
     paths:
       - 'docs/**'
@@ -34,4 +30,4 @@ jobs:
       - name: Run website_build.sh
         run: ./tools/ci/website_build.sh
         env:
-          DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+          DEPLOY_TOKEN: dummy

--- a/.github/workflows/epochs.yml
+++ b/.github/workflows/epochs.yml
@@ -6,7 +6,7 @@ on:
     - cron: 10 */3 * * *
 jobs:
   update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.repository == 'web-platform-tests/wpt'
     steps:
     - name: Checkout

--- a/.github/workflows/interfaces.yml
+++ b/.github/workflows/interfaces.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.repository == 'web-platform-tests/wpt'
     steps:
     - name: Checkout

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -8,7 +8,7 @@ on:
       - 'tools/**'
 jobs:
   build-and-tag:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.repository == 'web-platform-tests/wpt'
     steps:
     - name: Set up Python

--- a/.github/workflows/regen_certs.yml
+++ b/.github/workflows/regen_certs.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.repository == 'web-platform-tests/wpt'
     steps:
     - name: Set up Python

--- a/.github/workflows/update-wasm-tests.yml
+++ b/.github/workflows/update-wasm-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-wpt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout WPT repo
         uses: actions/checkout@v4

--- a/.github/workflows/wpt_fyi_notify.yml
+++ b/.github/workflows/wpt_fyi_notify.yml
@@ -8,8 +8,7 @@ on:
 jobs:
   wpt-fyi-notify:
     name: "Notify wpt.fyi"
-    runs-on:
-      - ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: "wpt.fyi"
         uses: fjogeleit/http-request-action@v1


### PR DESCRIPTION
Per a GitHub email, Ubuntu 20.04 will be fully unsupported by April 1,
2025 and there are brownout periods starting March 4.

Make all workflows use 24.04 instead.

----

Checklist to confirm still working before landing this:

- [ ] check-workflow-run.yml
- [x] [docker.yml](https://github.com/web-platform-tests/wpt/actions/runs/13283638488/job/37087313268)
- [x] [documentation.yml](https://github.com/web-platform-tests/wpt/actions/runs/13284191189/job/37089062478?pr=50649)
- [x] [epochs.yml](https://github.com/web-platform-tests/wpt/actions/runs/13284079079/job/37088726492?pr=50649)
- [x] [interfaces.yml](https://github.com/web-platform-tests/wpt/actions/runs/13281438473/job/37080486246)
- [x] [manifest.yml](https://github.com/web-platform-tests/wpt/actions/runs/13283916320/job/37088218960?pr=50649#step:5:234)
- [x] [regen_certs.yml](https://github.com/web-platform-tests/wpt/actions/runs/13283195283/job/37085929900)
- [x] [update-wasm-tests.yml](https://github.com/web-platform-tests/wpt/actions/runs/13283781764/job/37087788848)
- [ ] wpt_fyi_notify.yml