### PR TITLE
URL: update toascii.json for Unicode 16.0

### DIFF
--- a/url/resources/toascii.json
+++ b/url/resources/toascii.json
@@ -259,7 +259,7 @@
   },
   {
     "input": "look\u180Eout.net",
-    "output": null
+    "output": "lookout.net"
   },
   {
     "input": "look\u2060out.net",
@@ -291,7 +291,7 @@
   },
   {
     "input": "look\u206Bout.net",
-    "output": null
+    "output": "lookout.net"
   },
   {
     "input": "look\uDB40\uDC01out.net",
@@ -319,7 +319,7 @@
   },
   {
     "input": "\u04C0.com",
-    "output": null
+    "output": "xn--s5a.com"
   },
   {
     "comment": "This is U+2F868 (which is mapped to U+36FC starting with Unicode 16.0)",
@@ -328,7 +328,7 @@
   },
   {
     "input": "\u2183.com",
-    "output": null
+    "output": "xn--r5g.com"
   },
   {
     "input": "look\u034Fout.net",

--- a/url/resources/toascii.json
+++ b/url/resources/toascii.json
@@ -322,7 +322,6 @@
     "output": "xn--s5a.com"
   },
   {
-    "comment": "This is U+2F868 (which is mapped to U+36FC starting with Unicode 16.0)",
     "input": "\uD87E\uDC68.com",
     "output": "xn--snl.com"
   },


### PR DESCRIPTION
Some code points not allowed in the previous Unicode version are ignored / mapped in Unicode 16.0 (according to the `IdnaMappingTable.txt` file):

* `U+180E` and `U+206B` are ignored

* `U+04C0` - mapped to `U+04CF`

* `U+2183` - mapped to `U+2184`

Related to https://github.com/web-platform-tests/wpt/pull/48301