### PR TITLE
[Azure Pipelines] use Ubuntu 24.04 instead of 20.04

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -71,7 +71,7 @@ jobs:
   displayName: './wpt test-jobs'
   condition: eq(variables['Build.Reason'], 'PullRequest')
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-24.04'
   steps:
   - task: UsePythonVersion@0
     inputs:

--- a/tools/ci/azure/fyi_hook.yml
+++ b/tools/ci/azure/fyi_hook.yml
@@ -10,7 +10,7 @@ jobs:
   displayName: 'wpt.fyi hook: ${{ parameters.artifactName }}'
   dependsOn: ${{ parameters.dependsOn }}
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-24.04'
   steps:
   - checkout: none
   - script: |


### PR DESCRIPTION
These jobs could probably run on any OS, but upgrade to stay in sync
with GitHub Actions and avoid breakage if 20.04 is turned down:
https://github.com/web-platform-tests/wpt/pull/50649
