### PR TITLE
<details> element is tabbable via keyboard but has a computed tabIndex of -1

### DIFF
--- a/focus/details-with-no-summary-computed-negative-tabindex.html
+++ b/focus/details-with-no-summary-computed-negative-tabindex.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>details is keyboard focusable but the computed tabindex value is -1</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<!-- This details element is focusable via keyboard but its computed tabIndex value is -1 -->
+<details id="details">Test</details>
+
+<script>
+window.onload = function() {
+  test(function() {
+      assert_equals(document.getElementById('details').tabIndex, 0, 'Check result');
+  }, "Check result");
+}
+</script>


### PR DESCRIPTION
Related to: https://github.com/web-platform-tests/interop-accessibility/issues/175

The `<details>` element remains focusable and operable via keyboard even when no `<summary>` is nested. Given this behavior, I would expect its computed tabIndex value to be 0. However, none of the major browsers expose it as such (all return -1).
