### PR TITLE
[testharness.js] Fix issue caused when path contains full stop characters (.)

### DIFF
--- a/infrastructure/testharness/full.stop/full-stop.html
+++ b/infrastructure/testharness/full.stop/full-stop.html
@@ -1,0 +1,8 @@
+<!DOCTYPE HTML>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  test(function () {
+      assert_equals(this.name, 'full-stop', 'Check that test name does not contain part of the path (.stop)');
+  });
+</script>

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -4788,7 +4788,8 @@
             return META_TITLE;
         }
         if ('location' in global_scope && 'pathname' in location) {
-            return location.pathname.substring(location.pathname.lastIndexOf('/') + 1, location.pathname.indexOf('.'));
+            var filename = location.pathname.substring(location.pathname.lastIndexOf('/') + 1);
+            return filename.substring(0, filename.indexOf('.'));
         }
         return "Untitled";
     }


### PR DESCRIPTION
https://github.com/web-platform-tests/wpt/issues/50693

The current implementation of `get_title()` assumes that the path does not contain a full stop character. If it does, `get_title()` would return parts of the path, in stead of the filename. The pathname `/a.path/filename.html` would cause `get_title()` to return `.path` instead of the expected `filename`.

This change fixes the issue by trimming the path away before searching for the extension. It maintains the current behavior, where it only keeps the first part of the filename if the filename contains multiple full stop characters. `/path/filename.foo.html` still causes `filename` to be returned.