### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=287410

### DIFF
--- a/css/css-color/parsing/color-computed-contrast-color-function.html
+++ b/css/css-color/parsing/color-computed-contrast-color-function.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test CSS Color Module 5 contrast-color() computed value</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-color-5/#contrast-color">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<style>
+  #container {
+    container-type: inline-size;
+    width: 10px;
+    color: pink;
+  }
+</style>
+</head>
+<body>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+
+// NOTE: As the algorithm for determining constrast is not defined, all computed values can validly be either `rgb(0, 0, 0)` or `rgb(255, 255, 255)`.
+
+// Test basic legacy colors
+test_computed_value("background-color", "contrast-color(white)", ["rgb(0, 0, 0)", "rgb(255, 255, 255)"]);
+test_computed_value("background-color", "contrast-color(black)", ["rgb(0, 0, 0)", "rgb(255, 255, 255)"]);
+test_computed_value("background-color", "contrast-color(pink)", ["rgb(0, 0, 0)", "rgb(255, 255, 255)"]);
+
+// Test non-legacy colors
+test_computed_value("background-color", "contrast-color(color(srgb 1 0 1 / 0.5))", ["rgb(0, 0, 0)", "rgb(255, 255, 255)"]);
+test_computed_value("background-color", "contrast-color(lab(0.2 0.5 0.2))", ["rgb(0, 0, 0)", "rgb(255, 255, 255)"]);
+
+// Test out-of-gamut colors
+test_computed_value("background-color", "contrast-color(color(srgb 10 10 10))", ["rgb(0, 0, 0)", "rgb(255, 255, 255)"]);
+test_computed_value("background-color", "contrast-color(color(srgb -10 -10 -10))", ["rgb(0, 0, 0)", "rgb(255, 255, 255)"]);
+
+// Test nested contrast-color
+test_computed_value("background-color", "contrast-color(contrast-color(pink))", ["rgb(0, 0, 0)", "rgb(255, 255, 255)"]);
+
+// Test currentColor
+test_computed_value("background-color", "contrast-color(currentcolor)", ["rgb(0, 0, 0)", "rgb(255, 255, 255)"]);
+
+// Test color using calc().
+test_computed_value("background-color", "contrast-color(color(srgb calc(1 + (sign(20cqw - 10px) * 1)) calc(1 + (sign(20cqw - 10px) * 1)) calc(1 + (sign(20cqw - 10px) * 1))))", ["rgb(0, 0, 0)", "rgb(255, 255, 255)"]);
+
+</script>
+</body>
+</html>

--- a/css/css-color/parsing/color-invalid-contrast-color-function.html
+++ b/css/css-color/parsing/color-invalid-contrast-color-function.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test CSS Color Module 5 contrast-color() computed value</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-color-5/#contrast-color">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+  #container {
+    container-type: inline-size;
+    width: 10px;
+    color: pink;
+  }
+</style>
+</head>
+<body>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+
+test_invalid_value("background-color", "contrast-color()");
+test_invalid_value("background-color", "contrast-color(1)");
+test_invalid_value("background-color", "contrast-color(max)");
+test_invalid_value("background-color", "contrast-color(max max)");
+test_invalid_value("background-color", "contrast-color(max white)");
+test_invalid_value("background-color", "contrast-color(white white)");
+test_invalid_value("background-color", "contrast-color(white max)");
+test_invalid_value("background-color", "contrast-color(white min)");
+test_invalid_value("background-color", "contrast-color(white max bar)");
+
+</script>
+</body>
+</html>

--- a/css/css-color/parsing/color-valid-contrast-color-function.html
+++ b/css/css-color/parsing/color-valid-contrast-color-function.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test CSS Color Module 5 contrast-color() parsing valid values</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-color-5/#contrast-color">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+  #container {
+    container-type: inline-size;
+    width: 10px;
+    color: pink;
+  }
+</style>
+</head>
+<body>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+
+// Test basic legacy colors
+test_valid_value("background-color", "contrast-color(white)");
+test_valid_value("background-color", "contrast-color(black)");
+test_valid_value("background-color", "contrast-color(pink)");
+
+// Test non-legacy colors
+test_valid_value("background-color", "contrast-color(color(srgb 1 0 1 / 0.5))");
+test_valid_value("background-color", "contrast-color(lab(0.2 0.5 0.2))");
+
+// Test out-of-gamut colors
+test_valid_value("background-color", "contrast-color(color(srgb 10 10 10))");
+test_valid_value("background-color", "contrast-color(color(srgb -10 -10 -10))");
+
+// Test nested contrast-color
+test_valid_value("background-color", "contrast-color(contrast-color(pink))");
+
+// Test currentColor
+test_valid_value("background-color", "contrast-color(currentcolor)");
+
+// Test color using calc().
+test_valid_value("background-color", "contrast-color(color(srgb calc(0.5) calc(1 + (sign(20cqw - 10px) * 0.5)) 1 / .5))", "contrast-color(color(srgb calc(0.5) calc(1 + (0.5 * sign(20cqw - 10px))) 1 / 0.5))");
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [Update contrast-color() for removal of `max` parameter](https://bugs.webkit.org/show_bug.cgi?id=287410)