### PR TITLE
[wptrunner] Pass Chrome-specific `quitGracefully` when debugging

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -44,18 +44,6 @@ __wptrunner__ = {"product": "chrome",
 from ..wpttest import Test
 
 
-def debug_args(debug_info):
-    if debug_info.interactive:
-        # Keep in sync with:
-        # https://chromium.googlesource.com/chromium/src/+/main/third_party/blink/tools/debug_renderer
-        return [
-            "--no-sandbox",
-            "--disable-hang-monitor",
-            "--wait-for-debugger-on-navigation",
-        ]
-    return []
-
-
 def check_args(**kwargs):
     require_arg(kwargs, "webdriver_binary")
 

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -186,14 +186,13 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite
     if kwargs["enable_experimental"]:
         chrome_options["args"].extend(["--enable-experimental-web-platform-features"])
 
-    # Copy over any other flags that were passed in via `--binary-arg`
-    for arg in kwargs.get("binary_args", []):
+    # Copy over any other flags that were passed in via `--binary-arg` or the
+    # subsuite config.
+    binary_args = kwargs.get("binary_args", []) + subsuite.config.get("binary_args", [])
+    for arg in binary_args:
         if arg not in chrome_options["args"]:
             chrome_options["args"].append(arg)
 
-    for arg in subsuite.config.get("binary_args", []):
-        if arg not in chrome_options["args"]:
-            chrome_options["args"].append(arg)
 
     # Pass the --headless=new flag to Chrome if WPT's own --headless flag was
     # set. '--headless' should always mean the new headless mode, as the old

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -92,6 +92,11 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite
     chrome_options = capabilities["goog:chromeOptions"]
     if kwargs["binary"] is not None:
         chrome_options["binary"] = kwargs["binary"]
+    if kwargs["debug_test"]:
+        # Give debuggers like `rr` time to terminate gracefully and dump
+        # recordings or traces. Note that older `chromedriver` versions will
+        # fail to create a session if they don't recognize this capability.
+        chrome_options["quitGracefully"] = True
 
     # Here we set a few Chrome flags that are always passed.
     # ChromeDriver's "acceptInsecureCerts" capability only controls the current

--- a/tools/wptrunner/wptrunner/browsers/headless_shell.py
+++ b/tools/wptrunner/wptrunner/browsers/headless_shell.py
@@ -2,7 +2,7 @@
 
 from .base import require_arg
 from .base import get_timeout_multiplier   # noqa: F401
-from .chrome import ChromeBrowser, debug_args  # noqa: F401
+from .chrome import ChromeBrowser  # noqa: F401
 from .chrome import executor_kwargs as chrome_executor_kwargs
 from ..executors.base import WdspecExecutor  # noqa: F401
 from ..executors.executorchrome import (  # noqa: F401


### PR DESCRIPTION
This is plumbing for the Chrome-specific `quitGracefully` capability (https://crrev.com/c/6269180), which will be used to support debugging with `rr record`. The `wpt run` option is needed (at least temporarily) to avoid passing an unrecognized capability to older `chromedriver` versions, which will fail to create a session.

Drive-by: clean up some dead/redundant code.