### PR TITLE
Fix #49301 - NotAllowedError instead of TypeError to align with the spec

### DIFF
--- a/clipboard-apis/async-navigator-clipboard-basics.https.html
+++ b/clipboard-apis/async-navigator-clipboard-basics.https.html
@@ -156,7 +156,7 @@ promise_test(async() => {
 promise_test(async t => {
   await getPermissions();
   const item = new ClipboardItem({'image/png': 'not an image'});
-  await promise_rejects_js(t, TypeError, navigator.clipboard.write([item]));
+  await promise_rejects_dom(t, "NotAllowedError", navigator.clipboard.write([item]));
 }, 'navigator.clipboard.write(image/png DOMString) fails');
 
 promise_test(async () => {


### PR DESCRIPTION
This is an attempt to fix #49301. The spec seems to require NotAllowedError in this circumstance.