### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=287806

### DIFF
--- a/scroll-animations/view-timelines/block-view-timeline-current-time-vertical-rl.tentative.html
+++ b/scroll-animations/view-timelines/block-view-timeline-current-time-vertical-rl.tentative.html
@@ -80,7 +80,7 @@
     assert_equals(getComputedStyle(target).opacity, '0.7',
                   'Opacity with fill forwards at effect end time');
     anim.effect.updateTiming({ fill: 'none' });
-    assert_equals(getComputedStyle(target).opacity, '1',
+    assert_equals(getComputedStyle(target).opacity, '0.7',
                   'Opacity with fill none at effect end time');
 
     // Advance to the scroll limit.

--- a/scroll-animations/view-timelines/block-view-timeline-current-time.tentative.html
+++ b/scroll-animations/view-timelines/block-view-timeline-current-time.tentative.html
@@ -76,7 +76,7 @@
                           "Timeline's currentTime at end offset");
     assert_percents_equal(anim.currentTime, 100,
                           "Animation's currentTime at end offset");
-    assert_equals(getComputedStyle(target).opacity, '1',
+    assert_equals(getComputedStyle(target).opacity, '0.7',
                   'Effect is in the after phase at effect end time');
 
     // Advance to the scroll limit.
@@ -133,7 +133,7 @@
                           "Timeline's current time at end offset");
     assert_percents_equal(anim.currentTime, 100,
                           "Animation's current time at end offset");
-    assert_equals(getComputedStyle(target).opacity, '1',
+    assert_equals(getComputedStyle(target).opacity, '0.7',
                   'Effect inactive at the end offset');
 
     // Advance to scroll limit.

--- a/scroll-animations/view-timelines/block-view-timeline-nested-subject.tentative.html
+++ b/scroll-animations/view-timelines/block-view-timeline-nested-subject.tentative.html
@@ -92,7 +92,7 @@
                           "Timeline's currentTime at end offset");
     assert_percents_equal(anim.currentTime, 100,
                           "Animation's currentTime at end offset");
-    assert_equals(getComputedStyle(target).opacity, '1',
+    assert_equals(getComputedStyle(target).opacity, '0.7',
                   'Effect is in the after phase at effect end time');
 
     // Advance to the scroll limit.

--- a/scroll-animations/view-timelines/inline-view-timeline-current-time.tentative.html
+++ b/scroll-animations/view-timelines/inline-view-timeline-current-time.tentative.html
@@ -91,7 +91,7 @@
                           "Timeline's currentTime at end offset");
     assert_percents_equal(anim.currentTime, 100,
                           "Animation's currentTime at end offset");
-    assert_equals(getComputedStyle(target).opacity, '1',
+    assert_equals(getComputedStyle(target).opacity, '0.7',
                   'Effect is in the after phase at effect end time');
 
     // Advance to the scroll limit.
@@ -154,7 +154,7 @@
                           "Timeline's current time at end offset");
     assert_percents_equal(anim.currentTime, 100,
                           "Animation's current time at end offset");
-    assert_equals(getComputedStyle(target).opacity, '1',
+    assert_equals(getComputedStyle(target).opacity, '0.7',
                   'Effect at the end of the active phase');
 
     // Advance to scroll limit.
@@ -282,7 +282,7 @@
                           "Timeline's currentTime at end offset");
     assert_percents_equal(anim.currentTime, 100,
                           "Animation's currentTime at end offset");
-    assert_equals(getComputedStyle(target).opacity, '1',
+    assert_equals(getComputedStyle(target).opacity, '0.7',
                   'Effect is in the after phase at effect end time');
 
     // Advance to the scroll limit.


### PR DESCRIPTION
WebKit export from bug: [\[scroll-animations\] several WPT tests under `scroll-animations/view-timelines` are incorrectly expecting an animation not to apply at the "at progress timeline boundary"](https://bugs.webkit.org/show_bug.cgi?id=287806)