### PR TITLE
Fix incorrect view-transition-name tests

### DIFF
--- a/css/css-view-transitions/parsing/view-transition-name-invalid.html
+++ b/css/css-view-transitions/parsing/view-transition-name-invalid.html
@@ -13,6 +13,7 @@
 <body>
 <script>
 test_invalid_value("view-transition-name", "default"); // `default` isn't allowed by the `<custom-ident>` syntax.
+test_invalid_value("view-transition-name", "auto");
 test_invalid_value("view-transition-name", "none none");
 test_invalid_value("view-transition-name", `"none"`);
 test_invalid_value("view-transition-name", `"foo"`);

--- a/css/css-view-transitions/parsing/view-transition-name-valid.html
+++ b/css/css-view-transitions/parsing/view-transition-name-valid.html
@@ -13,7 +13,6 @@
 <body>
 <script>
 test_valid_value("view-transition-name", "none");
-test_valid_value("view-transition-name", "auto");
 test_valid_value("view-transition-name", "match-element");
 test_valid_value("view-transition-name", "foo");
 test_valid_value("view-transition-name", "bar");


### PR DESCRIPTION
This went out-of-sync with the spec about a year ago.
See https://github.com/w3c/csswg-drafts/pull/9895

No browser currently implements it like this, so they'll all get a new failure here.