### PR TITLE
[wptrunner] Add a new argument for the wpt cli to pass custom Android activity names

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/android_webview.py
+++ b/tools/wptrunner/wptrunner/browsers/android_webview.py
@@ -60,7 +60,7 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     capabilities["goog:chromeOptions"]["androidPackage"] = \
         kwargs.get("package_name", "org.chromium.webview_shell")
     capabilities["goog:chromeOptions"]["androidActivity"] = \
-        "org.chromium.webview_shell.WebPlatformTestsActivity"
+        kwargs.get("activity_name", "org.chromium.webview_shell.WebPlatformTestsActivity")
     capabilities["goog:chromeOptions"]["androidKeepAppDataDir"] = \
         kwargs.get("keep_app_data_directory")
 

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -217,6 +217,8 @@ scheme host and port.""")
     android_group.add_argument("--adb-binary", help="Path to adb binary to use")
     android_group.add_argument("--package-name",
                                help="Android package name to run tests against")
+    android_group.add_argument("--activity-name",
+                               help="Android activity to run tests against")
     android_group.add_argument("--keep-app-data-directory", action="store_true",
                         help="Don't delete the app data directory")
     android_group.add_argument("--device-serial", action="append", default=[],


### PR DESCRIPTION
**What are these changes**
This supports plumbing custom activity names for running WPT on Android applications. 

**Why make these changes**
Currently, it is only possible to run WPT for Android webviews when the activity name is exactly `org.chromium.webview_shell.WebPlatformTestsActivity`. This makes it complicated to run WPT on webviews in applications other than the [reference activity provided by Chromium](https://source.chromium.org/chromium/chromium/src/+/main:android_webview/tools/system_webview_shell/layout_tests/src/org/chromium/webview_shell/test/WebPlatformTestsActivityTest.java?q=WebPlatformTestsActivityTest&ss=chromium).

**How to use this functionality**
`./wpt run --package-name com.my.application --activity-name com.my.application.MyActivity android_webview `

**Potential modifications**
As you can see in the above example, the package name is repeated (`com.my.application`). It might be simpler to compose the `activity_name` by concatenating the `package_name` and just the final activity name (`MyActivity`). I avoided this design because it would change the existing behaviour for users who already override the package name.