### PR TITLE
Remove third parameters passed to `TrustedTypePolicyFactory.createPol…

### DIFF
--- a/trusted-types/Document-write-exception-order.xhtml
+++ b/trusted-types/Document-write-exception-order.xhtml
@@ -28,7 +28,7 @@
   }, "`document.write(TrustedHTML)` throws InvalidStateError");
 
   let default_policy = trustedTypes.createPolicy('default',
-      { createHTML: createHTMLJS }, true );
+      { createHTML: createHTMLJS });
 
   test(t => {
     const old = document.body.innerText;

--- a/trusted-types/TrustedTypePolicy-createXXX.html
+++ b/trusted-types/TrustedTypePolicy-createXXX.html
@@ -25,7 +25,7 @@
       createScriptURL: (s) => s,
       createScript: (s) => s,
     };
-    policy = trustedTypes.createPolicy(Math.random(), noopPolicy, true);
+    policy = trustedTypes.createPolicy(Math.random(), noopPolicy);
     let el = document.createElement("div");
 
     el.title = policy.createHTML(INPUTS.SCRIPTURL);

--- a/trusted-types/block-string-assignment-to-Document-write.html
+++ b/trusted-types/block-string-assignment-to-Document-write.html
@@ -129,7 +129,7 @@
               return html.replace("Hi", "Quack")
                       .replace("transformed", "a duck")
                       .replace("defghi", "zxcvbn")
-            } }, true );
+            } });
 
   // Default policy works.
   test(t => {

--- a/trusted-types/block-string-assignment-to-Element-setAttribute.html
+++ b/trusted-types/block-string-assignment-to-Element-setAttribute.html
@@ -64,7 +64,7 @@
   }, "`Script.prototype.setAttribute.SrC = string` throws.");
 
   // After default policy creation string and null assignments implicitly call createXYZ
-  let p = window.trustedTypes.createPolicy("default", { createScriptURL: createScriptURLJS, createHTML: createHTMLJS, createScript: createScriptJS }, true);
+  let p = window.trustedTypes.createPolicy("default", { createScriptURL: createScriptURLJS, createHTML: createHTMLJS, createScript: createScriptJS });
   scriptURLTestCases.forEach(c => {
     test(t => {
       assert_element_accepts_trusted_type(c[0], c[1], c[2], c[3]);

--- a/trusted-types/block-string-assignment-to-HTMLElement-generic.html
+++ b/trusted-types/block-string-assignment-to-HTMLElement-generic.html
@@ -40,7 +40,7 @@
   });
 
   // After default policy creation string and null assignments implicitly call createHTML
-  let p = window.trustedTypes.createPolicy("default", { createScriptURL: createScriptURLJS, createHTML: createHTMLJS }, true);
+  let p = window.trustedTypes.createPolicy("default", { createScriptURL: createScriptURLJS, createHTML: createHTMLJS });
 
   scriptURLTestCases.forEach(c => {
     test(t => {

--- a/trusted-types/support/WorkerGlobalScope-importScripts.https.js
+++ b/trusted-types/support/WorkerGlobalScope-importScripts.https.js
@@ -68,7 +68,7 @@ trustedTypes.createPolicy("default", {
     assert_equals(sink, "WorkerGlobalScope importScripts");
     return url.replace("play", "work");
   }
-}, true);
+});
 test(t => {
   self.result = "Fail";
   let untrusted_url = "player.js";

--- a/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html
+++ b/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html
@@ -58,7 +58,7 @@
     const input = 'script_run_beacon="should not run"';
     trustedTypes.createPolicy('default', {
       createScript: s => s,
-    }, true);
+    });
     let violation = await trusted_type_violation_for(EvalError, _ =>
       eval(input) // script-src will block.
     );

--- a/trusted-types/trusted-types-eval-reporting-report-only.html
+++ b/trusted-types/trusted-types-eval-reporting-report-only.html
@@ -53,7 +53,7 @@
   promise_test(async t => {
     trustedTypes.createPolicy('default', {
       createScript: s => s,
-    }, true);
+    });
     await no_trusted_type_violation_for(_ =>
       eval('script_run_beacon="payload"')
     );


### PR DESCRIPTION
…icy()`

Likely a legacy feature. Current specification only accepts two parameters: https://w3c.github.io/trusted-types/dist/spec/#dom-trustedtypepolicyfactory-createpolicy