### PR TITLE
Rewrite listeners in block-text-node-insertion-into*script-element.html

### DIFF
--- a/trusted-types/block-text-node-insertion-into-script-element.html
+++ b/trusted-types/block-text-node-insertion-into-script-element.html
@@ -4,12 +4,13 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="resources/block-text-node-insertion.js"></script>
+  <script src="support/csp-violations.js"></script>
   <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script';">
+  <meta http-equiv="Content-Security-Policy" content="connect-src 'none'">
 </head>
 <body>
 <div id="container"></div>
 <script id="script1">"hello world!";</script>
-<script id="trigger"></script>
 <script>
   var container = document.querySelector("#container");
   const policy_dict = {
@@ -33,7 +34,7 @@
   };
 
   // Original report:
-  promise_test(t => {
+  promise_test(async t => {
     // Setup: Create a <script> element with a <p> child.
     let s = document.createElement("script");
 
@@ -45,13 +46,16 @@
     assert_equals(s.text, "");
 
     // Try to insertAdjacentText into the <script>, starting from the <p>
-    p.insertAdjacentText("beforebegin",
-                         "postMessage('beforebegin should be blocked', '*');");
+    await checkMessage(_ =>
+      p.insertAdjacentText("beforebegin",
+                           "postMessage('beforebegin should be blocked', '*');")
+    );
     assert_true(s.text.includes("postMessage"));
-    p.insertAdjacentText("afterend",
-                         "postMessage('afterend should be blocked', '*');");
+    await checkMessage(_ =>
+      p.insertAdjacentText("afterend",
+                           "postMessage('afterend should be blocked', '*');")
+    );
     assert_true(s.text.includes("after"));
-    return checkMessage();
   }, "Regression test: Bypass via insertAdjacentText, initial comment.");
 
   const script_elements = {
@@ -61,7 +65,7 @@
   for (let [element, create_element] of Object.entries(script_elements)) {
     // Like the "Original Report" test case above, but avoids use of the "text"
     // accessor that <svg:script> doesn't support.
-    promise_test(t => {
+    promise_test(async t => {
       let s = create_element(document);
 
       // Sanity check: Element child content (<p>) doesn't count as source text.
@@ -71,72 +75,68 @@
       container.appendChild(s);
 
       // Try to insertAdjacentText into the <script>, starting from the <p>
-      p.insertAdjacentText("beforebegin",
-                           "postMessage('beforebegin should be blocked', '*');");
+      await checkMessage(_ =>
+        p.insertAdjacentText("beforebegin",
+                             "postMessage('beforebegin should be blocked', '*');")
+      );
       assert_true(s.textContent.includes("postMessage"));
-      p.insertAdjacentText("afterend",
-                           "postMessage('afterend should be blocked', '*');");
+      await checkMessage(_ =>
+        p.insertAdjacentText("afterend",
+                             "postMessage('afterend should be blocked', '*');")
+      );
       assert_true(s.textContent.includes("after"));
-      return checkMessage();
     }, "Regression test: Bypass via insertAdjacentText, initial comment. " + element);
 
     // Variant: Create a <script> element and create & insert a text node. Then
     // insert it into the document container to make it live.
-    promise_test(t => {
+    promise_test(async t => {
       // Setup: Create a <script> element, and insert text via a text node.
       let s = create_element(document);
       let text = document.createTextNode("postMessage('appendChild with a " +
                                          "text node should be blocked', '*');");
       s.appendChild(text);
-      container.appendChild(s);
-      return checkMessage();
+      await checkMessage(_ => container.appendChild(s));
     }, "Regression test: Bypass via appendChild into off-document script element" + element);
 
     // Variant: Create a <script> element and insert it into the document. Then
     // create a text node and insert it into the live <script> element.
-    promise_test(t => {
+    promise_test(async t => {
       // Setup: Create a <script> element, insert it into the doc, and then create
       // and insert text via a text node.
       let s = create_element(document);
       container.appendChild(s);
       let text = document.createTextNode("postMessage('appendChild with a live " +
                                          "text node should be blocked', '*');");
-      s.appendChild(text);
-      return checkMessage();
+      await checkMessage(_ => s.appendChild(text));
     }, "Regression test: Bypass via appendChild into live script element " + element);
   }
 
-  promise_test(t => {
-    return checkSecurityPolicyViolationEvent();
-  }, "Prep for subsequent tests: Clear SPV event queue.");
-
-  promise_test(t => {
+  promise_test(async t => {
     const inserted_script = document.getElementById("script1");
-    assert_throws_js(TypeError, _ => {
-        inserted_script.innerHTML = "2+2";
-    });
+    await trusted_type_violation_for(TypeError, _ =>
+      inserted_script.innerHTML = "2+2"
+    );
 
     let new_script = document.createElement("script");
-    assert_throws_js(TypeError, _ => {
-      new_script.innerHTML = "2+2";
-      container.appendChild(new_script);
-    });
+    await trusted_type_violation_for(TypeError, _ =>
+      new_script.innerHTML = "2+2"
+    );
+    container.appendChild(new_script);
 
     const trusted_html = policy.createHTML("2*4");
     assert_equals("" + trusted_html, "3*4");
-    inserted_script.innerHTML = trusted_html;
+    await no_trusted_type_violation_for(_ =>
+      inserted_script.innerHTML = trusted_html
+    );
     assert_equals(inserted_script.textContent, "3*4");
 
     new_script = document.createElement("script");
     new_script.innerHTML = trusted_html;
-    container.appendChild(new_script);
+    await trusted_type_violation_without_exception_for(_ =>
+      container.appendChild(new_script)
+    );
     assert_equals(inserted_script.textContent, "3*4");
-
-    // We expect 3 SPV events: two for the two assert_throws_js cases, and one
-    // for script element, which will be rejected at the time of execution.
-    return checkSecurityPolicyViolationEvent(3);
   }, "Spot tests around script + innerHTML interaction.");
-
 
   // Create default policy. Wrapped in a promise_test to ensure it runs only
   // after the other tests.
@@ -147,49 +147,53 @@
   }, "Prep for subsequent tests: Create default policy.");
 
   for (let [element, create_element] of Object.entries(script_elements)) {
-    promise_test(t => {
+    promise_test(async t => {
       let s = create_element(document);
       let text = document.createTextNode("postMessage('default', '*');");
       s.appendChild(text);
-      container.appendChild(s);
-
-      return Promise.all([checkMessage(1),
-                            checkSecurityPolicyViolationEvent(0)]);
+      await no_trusted_type_violation_for(async _ =>
+        await checkMessage(_ => container.appendChild(s), 1)
+      );
     }, "Test that default policy applies. " + element);
 
-    promise_test(t => {
+    promise_test(async t => {
       let s = create_element(document);
       let text = document.createTextNode("fail");
       s.appendChild(text);
-      container.appendChild(s);
-      return Promise.all([checkMessage(0),
-                          checkSecurityPolicyViolationEvent(1)]);
+      await trusted_type_violation_without_exception_for(async _ =>
+        await checkMessage(_ => container.appendChild(s), 0)
+      );
     }, "Test a failing default policy. " + element);
   }
 
-  promise_test(t => {
+  promise_test(async t => {
     const inserted_script = document.getElementById("script1");
-    inserted_script.innerHTML = "2+2";
+    await no_trusted_type_violation_for(_ =>
+      inserted_script.innerHTML = "2+2"
+    );
     assert_equals(inserted_script.textContent, "3+3");
 
     let new_script = document.createElement("script");
-    new_script.innerHTML = "2+2";
-    container.appendChild(new_script);
+    await no_trusted_type_violation_for(_ => {
+      new_script.innerHTML = "2+2";
+      container.appendChild(new_script);
+    });
     assert_equals(inserted_script.textContent, "3+3");
 
     const trusted_html = default_policy.createHTML("2*4");
     assert_equals("" + trusted_html, "3*4");
-    inserted_script.innerHTML = trusted_html;
+    await no_trusted_type_violation_for(_ =>
+      inserted_script.innerHTML = trusted_html
+    );
     assert_equals(inserted_script.textContent, "3*4");
 
     new_script = document.createElement("script");
-    new_script.innerHTML = trusted_html;
-    container.appendChild(new_script);
+    await no_trusted_type_violation_for(_ => {
+      new_script.innerHTML = trusted_html;
+      container.appendChild(new_script);
+    });
     assert_equals(inserted_script.textContent, "3*4");
-
-    return checkSecurityPolicyViolationEvent(0);
   }, "Spot tests around script + innerHTML interaction with default policy.");
 </script>
 </body>
 </html>
-

--- a/trusted-types/block-text-node-insertion-into-svg-script-element.html
+++ b/trusted-types/block-text-node-insertion-into-svg-script-element.html
@@ -4,12 +4,13 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="resources/block-text-node-insertion.js"></script>
+  <script src="support/csp-violations.js"></script>
   <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script';">
+  <meta http-equiv="Content-Security-Policy" content="connect-src 'none'">
 </head>
 <body>
 <div id="container"></div>
 <script id="script1">"hello world!";</script>
-<script id="trigger"></script>
 <script>
   var container = document.querySelector("#container");
   const policy_dict = {
@@ -36,7 +37,7 @@
   };
 
   // Original report:
-  promise_test(t => {
+  promise_test(async t => {
     // Setup: Create a <script> element with a <p> child.
     let s = document.createElement("script");
 
@@ -48,19 +49,22 @@
     assert_equals(s.text, "");
 
     // Try to insertAdjacentText into the <script>, starting from the <p>
-    p.insertAdjacentText("beforebegin",
-                         "postMessage('beforebegin should be blocked', '*');");
+    await checkMessage(_ =>
+      p.insertAdjacentText("beforebegin",
+                           "postMessage('beforebegin should be blocked', '*');")
+    );
     assert_true(s.text.includes("postMessage"));
-    p.insertAdjacentText("afterend",
-                         "postMessage('afterend should be blocked', '*');");
+    await checkMessage(_ =>
+      p.insertAdjacentText("afterend",
+                           "postMessage('afterend should be blocked', '*');")
+    );
     assert_true(s.text.includes("after"));
-    return checkMessage();
   }, "Regression test: Bypass via insertAdjacentText, initial comment.");
 
   for (let [element, create_element] of Object.entries(script_elements)) {
     // Like the "Original Report" test case above, but avoids use of the "text"
     // accessor that <svg:script> doesn't support.
-    promise_test(t => {
+    promise_test(async t => {
       let s = create_element(document);
 
       // Sanity check: Element child content (<p>) doesn't count as source text.
@@ -70,70 +74,67 @@
       container.appendChild(s);
 
       // Try to insertAdjacentText into the <script>, starting from the <p>
-      p.insertAdjacentText("beforebegin",
-                           "postMessage('beforebegin should be blocked', '*');");
+      await checkMessage(_ =>
+        p.insertAdjacentText("beforebegin",
+                             "postMessage('beforebegin should be blocked', '*');")
+      );
       assert_true(s.textContent.includes("postMessage"));
-      p.insertAdjacentText("afterend",
-                           "postMessage('afterend should be blocked', '*');");
+      await checkMessage(_ =>
+        p.insertAdjacentText("afterend",
+                             "postMessage('afterend should be blocked', '*');")
+      );
       assert_true(s.textContent.includes("after"));
-      return checkMessage();
     }, "Regression test: Bypass via insertAdjacentText, initial comment. " + element);
 
     // Variant: Create a <script> element and create & insert a text node. Then
     // insert it into the document container to make it live.
-    promise_test(t => {
+    promise_test(async t => {
       // Setup: Create a <script> element, and insert text via a text node.
       let s = create_element(document);
       let text = document.createTextNode("postMessage('appendChild with a " +
                                          "text node should be blocked', '*');");
       s.appendChild(text);
-      container.appendChild(s);
-      return checkMessage();
+      await checkMessage(_ => container.appendChild(s));
     }, "Regression test: Bypass via appendChild into off-document script element" + element);
 
     // Variant: Create a <script> element and insert it into the document. Then
     // create a text node and insert it into the live <script> element.
-    promise_test(t => {
+    promise_test(async t => {
       // Setup: Create a <script> element, insert it into the doc, and then create
       // and insert text via a text node.
       let s = create_element(document);
       container.appendChild(s);
       let text = document.createTextNode("postMessage('appendChild with a live " +
                                          "text node should be blocked', '*');");
-      s.appendChild(text);
-      return checkMessage();
+      await checkMessage(_ => s.appendChild(text));
     }, "Regression test: Bypass via appendChild into live script element " + element);
   }
 
-  promise_test(t => {
-    return checkSecurityPolicyViolationEvent();
-  }, "Prep for subsequent tests: Clear SPV event queue.");
-
-  promise_test(t => {
+  promise_test(async t => {
     const inserted_script = document.getElementById("script1");
-    assert_throws_js(TypeError, _ => {
-        inserted_script.innerHTML = "2+2";
-    });
+    await trusted_type_violation_for(TypeError, _ =>
+      inserted_script.innerHTML = "2+2"
+    );
 
     let new_script = document.createElement("script");
-    assert_throws_js(TypeError, _ => {
-      new_script.innerHTML = "2+2";
-      container.appendChild(new_script);
-    });
+    await trusted_type_violation_for(TypeError, _ =>
+      new_script.innerHTML = "2+2"
+    );
+    container.appendChild(new_script);
 
     const trusted_html = policy.createHTML("2*4");
     assert_equals("" + trusted_html, "3*4");
-    inserted_script.innerHTML = trusted_html;
+    await no_trusted_type_violation_for(_ =>
+      inserted_script.innerHTML = trusted_html
+    );
     assert_equals(inserted_script.textContent, "3*4");
 
     new_script = document.createElement("script");
     new_script.innerHTML = trusted_html;
-    container.appendChild(new_script);
+    await trusted_type_violation_without_exception_for(_ =>
+      container.appendChild(new_script)
+    );
     assert_equals(inserted_script.textContent, "3*4");
-
-    // We expect 3 SPV events: two for the two assert_throws_js cases, and one
-    // for script element, which will be rejected at the time of execution.
-    return checkSecurityPolicyViolationEvent(3);
   }, "Spot tests around script + innerHTML interaction.");
 
   // Create default policy. Wrapped in a promise_test to ensure it runs only
@@ -145,47 +146,52 @@
   }, "Prep for subsequent tests: Create default policy.");
 
   for (let [element, create_element] of Object.entries(script_elements)) {
-    promise_test(t => {
+    promise_test(async t => {
       let s = create_element(document);
       let text = document.createTextNode("postMessage('default', '*');");
       s.appendChild(text);
-      container.appendChild(s);
-
-      return Promise.all([checkMessage(1),
-                            checkSecurityPolicyViolationEvent(0)]);
+      await no_trusted_type_violation_for(async _ =>
+        await checkMessage(_ => container.appendChild(s), 1)
+      );
     }, "Test that default policy applies. " + element);
 
-    promise_test(t => {
+    promise_test(async t => {
       let s = create_element(document);
       let text = document.createTextNode("fail");
       s.appendChild(text);
-      container.appendChild(s);
-      return Promise.all([checkMessage(0),
-                          checkSecurityPolicyViolationEvent(1)]);
+      await trusted_type_violation_without_exception_for(async _ =>
+        await checkMessage(_ => container.appendChild(s), 0)
+      );
     }, "Test a failing default policy. " + element);
   }
 
-  promise_test(t => {
+  promise_test(async t => {
     const inserted_script = document.getElementById("script1");
-    inserted_script.innerHTML = "2+2";
+    await no_trusted_type_violation_for(_ =>
+      inserted_script.innerHTML = "2+2"
+    );
     assert_equals(inserted_script.textContent, "3+3");
 
     let new_script = document.createElement("script");
-    new_script.innerHTML = "2+2";
-    container.appendChild(new_script);
+    await no_trusted_type_violation_for(_ => {
+      new_script.innerHTML = "2+2";
+      container.appendChild(new_script);
+    });
     assert_equals(inserted_script.textContent, "3+3");
 
     const trusted_html = default_policy.createHTML("2*4");
     assert_equals("" + trusted_html, "3*4");
-    inserted_script.innerHTML = trusted_html;
+    await no_trusted_type_violation_for(_ =>
+      inserted_script.innerHTML = trusted_html
+    );
     assert_equals(inserted_script.textContent, "3*4");
 
     new_script = document.createElement("script");
-    new_script.innerHTML = trusted_html;
-    container.appendChild(new_script);
+    await no_trusted_type_violation_for(_ => {
+      new_script.innerHTML = trusted_html;
+      container.appendChild(new_script);
+    });
     assert_equals(inserted_script.textContent, "3*4");
-
-    return checkSecurityPolicyViolationEvent(0);
   }, "Spot tests around script + innerHTML interaction with default policy.");
 </script>
 </body>

--- a/trusted-types/resources/block-text-node-insertion.js
+++ b/trusted-types/resources/block-text-node-insertion.js
@@ -14,8 +14,7 @@
   // - includes "count": Count these, and later check against expect_count.
   // - includes "done": Unregister the event handler and finish the test.
   // - all else: Reject, as this is probably an error in the test.
-  function checkMessage(expect_count) {
-    postMessage("done", "*");
+  function checkMessage(fn, expect_count) {
     return new Promise((resolve, reject) => {
       let count = 0;
       globalThis.addEventListener("message", function handler(e) {
@@ -35,26 +34,7 @@
           reject("unexpected message received: " + e.data);
         }
       });
-    });
-  }
-
-  function checkSecurityPolicyViolationEvent(expect_count) {
-    return new Promise((resolve, reject) => {
-      let count = 0;
-      document.addEventListener("securitypolicyviolation", e => {
-        if (e.sample.includes("trigger")) {
-          if (expect_count && count != expect_count) {
-            reject(
-                `'trigger' received, but unexpected counts: expected ${expect_count} != actual ${count}`);
-          } else {
-            resolve();
-          }
-        } else {
-          count = count + 1;
-        }
-      });
-      try {
-        document.getElementById("trigger").text = "trigger fail";
-      } catch(e) { }
+      fn();
+      postMessage("done", "*");
     });
   }


### PR DESCRIPTION
   
    These tests rely on checkSecurityPolicyViolationEvent() and
    checkMessage() to register listeners for "securitypolicyviolation" and
    "message" events but they are actually called after the DOM mutations
    that triggering these events, so that makes the test less readable and
    possibly flaky. Instead:
    
    - We rely on existing async APIs from `support/csp-violations.js` to
      listen for the violation events. The finaly "trigger fail" only
      seems to be used to force a final message, so we remove it.
    
    - We tweak checkMessage() so it accepts a function to execute after
      event registration, similarly to what `support/csp-violations.js`
      APIs do.
    
    See https://github.com/w3c/trusted-types/issues/576
    
    Note: some SVG tests are just copies of the HTML tests and look wrong since
    the default policy expects to see "SVGScriptElement text" sinks. We rewrite
    this a bit in follow-up PRs.
