### PR TITLE
Command updates

### DIFF
--- a/html/semantics/popovers/button-type-popovertarget.html
+++ b/html/semantics/popovers/button-type-popovertarget.html
@@ -42,8 +42,8 @@ test((t) => {
   });
   document.getElementById('reset-in-form').click();
   assert_true(formReset, 'type=reset should trigger form reset event');
-  assert_true(mypopover.matches(':popover-open'), 'type=reset should toggle the popover');
-}, 'Button type=reset in form should trigger form reset and toggle popover');
+  assert_false(mypopover.matches(':popover-open'), 'type=reset should not toggle the popover');
+}, 'Button type=reset in form should trigger form reset and not toggle popover');
 
 test((t) => {
   let formSubmit = false;
@@ -114,8 +114,8 @@ test((t) => {
   });
   document.getElementById('reset-attr-form').click();
   assert_true(formReset, 'type=reset should trigger form reset event');
-  assert_true(mypopover.matches(':popover-open'), 'type=reset should toggle the popover');
-}, 'Button type=reset with form attr should trigger form reset and toggle popover');
+  assert_false(mypopover.matches(':popover-open'), 'type=reset should not toggle the popover');
+}, 'Button type=reset with form attr should trigger form reset and not toggle popover');
 
 test((t) => {
   let formSubmit = false;

--- a/html/semantics/popovers/input-type-popovertarget.html
+++ b/html/semantics/popovers/input-type-popovertarget.html
@@ -39,8 +39,8 @@ test((t) => {
   });
   document.getElementById('reset-in-form').click();
   assert_true(formReset, 'type=reset should trigger form reset event');
-  assert_true(mypopover.matches(':popover-open'), 'type=reset should toggle the popover');
-}, 'input type=reset in form should trigger form reset and toggle popover');
+  assert_false(mypopover.matches(':popover-open'), 'type=reset should not toggle the popover');
+}, 'input type=reset in form should trigger form reset and not toggle popover');
 
 test((t) => {
   let formSubmit = false;
@@ -95,8 +95,8 @@ test((t) => {
   });
   document.getElementById('reset-attr-form').click();
   assert_true(formReset, 'type=reset should trigger form reset event');
-  assert_true(mypopover.matches(':popover-open'), 'type=reset should toggle the popover');
-}, 'input type=reset with form attr should trigger form reset and toggle popover');
+  assert_false(mypopover.matches(':popover-open'), 'type=reset should not toggle the popover');
+}, 'input type=reset with form attr should trigger form reset and not toggle popover');
 
 test((t) => {
   let formSubmit = false;

--- a/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.html
+++ b/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.html
@@ -195,8 +195,8 @@
     invokerbutton.setAttribute("form", "aform");
     invokerbutton.setAttribute("type", "reset");
     await clickOn(invokerbutton);
-    assert_true(called, "event was called");
-  }, "event does dispatch if button is form associated, with explicit type=reset");
+    assert_false(called, "event was called");
+  }, "event does NOT dispatch if button is form associated, with explicit type=reset");
 
   promise_test(async function (t) {
     svgInvokee = document.createElementNS("http://www.w3.org/2000/svg", "svg");

--- a/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.html
+++ b/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.html
@@ -163,6 +163,16 @@
 
   promise_test(async function (t) {
     t.add_cleanup(resetState);
+    let called = false;
+    invokee.addEventListener("command", (e) => (called = true), { once: true });
+    invokerbutton.setAttribute("form", "aform");
+    invokerbutton.setAttribute("type", "invalid");
+    await clickOn(invokerbutton);
+    assert_false(called, "event was not called");
+  }, "event does NOT dispatch if button is form associated, with explicit type=invalid");
+
+  promise_test(async function (t) {
+    t.add_cleanup(resetState);
     let event;
     invokee.addEventListener("command", (e) => (event = e), { once: true });
     invokerbutton.setAttribute("form", "aform");

--- a/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.html
+++ b/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.html
@@ -44,8 +44,8 @@ test((t) => {
   });
   document.getElementById('reset-in-form').click();
   assert_true(formReset, 'type=reset should trigger form reset event');
-  assert_true(mypopover.matches(':popover-open'), 'type=reset should toggle the popover');
-}, 'Button type=reset in form should trigger form reset and toggle popover');
+  assert_false(mypopover.matches(':popover-open'), 'type=reset should not toggle the popover');
+}, 'Button type=reset in form should trigger form reset and not toggle popover');
 
 test((t) => {
   let formSubmit = false;
@@ -148,8 +148,8 @@ test((t) => {
   });
   document.getElementById('reset-attr-form').click();
   assert_true(formReset, 'type=reset should trigger form reset event');
-  assert_true(mypopover.matches(':popover-open'), 'type=reset should toggle the popover');
-}, 'Button type=reset with form attr should trigger form reset and toggle popover');
+  assert_false(mypopover.matches(':popover-open'), 'type=reset should not toggle the popover');
+}, 'Button type=reset with form attr should trigger form reset and not toggle popover');
 
 test((t) => {
   let formSubmit = false;

--- a/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.html
+++ b/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.html
@@ -11,6 +11,8 @@
   <button id=submit-in-form type=submit commandfor=mypopover command=toggle-popover>submit</button>
   <button id=button-in-form type=button commandfor=mypopover command=toggle-popover>type=button</button>
   <button id=invalid-in-form type=invalid commandfor=mypopover command=toggle-popover>invalid</button>
+  <button id=invalid-in-form-command-only type=invalid command=toggle-popover>invalid with command only</button>
+  <button id=invalid-in-form-commandfor-only type=invalid commandfor=mypopover >invalid with commandfor only</button>
   <button id=missing-in-form commandfor=mypopover command=toggle-popover>missing</button>
   <button id=missing-in-form-command-only command=toggle-popover>missing with command only</button>
   <button id=missing-in-form-commandfor-only commandfor=mypopover >missing with commandfor only</button>
@@ -20,6 +22,8 @@
 <button id=submit-attr-form type=submit commandfor=mypopover command=toggle-popover form=form>submit</button>
 <button id=button-attr-form type=button commandfor=mypopover command=toggle-popover form=form>type=button</button>
 <button id=invalid-attr-form type=invalid commandfor=mypopover command=toggle-popover form=form>invalid</button>
+<button id=invalid-attr-form-command-only type=invalid command=toggle-popover form=form>invalid with command only</button>
+<button id=invalid-attr-form-commandfor-only type=invalid commandfor=mypopover form=form>invalid with commandfor only</button>
 <button id=missing-attr-form commandfor=mypopover command=toggle-popover form=form>missing</button>
 <button id=missing-attr-form-command-only command=toggle-popover form=form>missing with command only</button>
 <button id=missing-attr-form-commandfor-only commandfor=mypopover form=form>missing with commandfor only</button>
@@ -83,9 +87,41 @@ test((t) => {
     form.removeEventListener('submit', onSubmit);
   });
   document.getElementById('invalid-in-form').click();
-  assert_true(formSubmit, 'type=invalid should trigger form submit event');
+  assert_false(formSubmit, 'invalid type should not trigger form submit event');
   assert_false(mypopover.matches(':popover-open'), 'type=invalid should not toggle the popover');
-}, 'Button type=invalid in form should trigger form submit and not toggle popover');
+}, 'Button type=invalid in form should not trigger form submit and not toggle popover');
+
+test((t) => {
+  let formSubmit = false;
+  function onSubmit(e) {
+    e.preventDefault();
+    formSubmit = true;
+  }
+  form.addEventListener('submit', onSubmit);
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+    form.removeEventListener('submit', onSubmit);
+  });
+  document.getElementById('invalid-in-form-command-only').click();
+  assert_false(formSubmit, 'type=invalid should not trigger form submit event');
+  assert_false(mypopover.matches(':popover-open'), 'type=invalid should not toggle the popover');
+}, 'Button type=invalid in form with only command should not trigger form submit and not toggle popover');
+
+test((t) => {
+  let formSubmit = false;
+  function onSubmit(e) {
+    e.preventDefault();
+    formSubmit = true;
+  }
+  form.addEventListener('submit', onSubmit);
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+    form.removeEventListener('submit', onSubmit);
+  });
+  document.getElementById('invalid-in-form-commandfor-only').click();
+  assert_false(formSubmit, 'type=invalid should not trigger form submit event');
+  assert_false(mypopover.matches(':popover-open'), 'type=invalid should not toggle the popover');
+}, 'Button type=invalid in form with only commandfor should not trigger form submit and not toggle popover');
 
 test((t) => {
   let formSubmit = false;
@@ -100,7 +136,7 @@ test((t) => {
   });
   document.getElementById('missing-in-form').click();
   assert_false(formSubmit, 'missing type should not trigger form submit event');
-  assert_false(mypopover.matches(':popover-open'), 'type=invalid should not toggle the popover');
+  assert_false(mypopover.matches(':popover-open'), 'missing type should not toggle the popover');
 }, 'Button missing type in form should not trigger form submit and not toggle popover');
 
 test((t) => {
@@ -187,9 +223,57 @@ test((t) => {
     form.removeEventListener('submit', onSubmit);
   });
   document.getElementById('invalid-attr-form').click();
-  assert_true(formSubmit, 'type=invalid should trigger form submit event');
+  assert_false(formSubmit, 'type=invalid should not trigger form submit event');
   assert_false(mypopover.matches(':popover-open'), 'type=invalid should not toggle the popover');
-}, 'Button type=invalid with form attr should trigger form submit and not toggle popover');
+}, 'Button type=invalid with form attr should not trigger form submit and not toggle popover');
+
+test((t) => {
+  let formSubmit = false;
+  function onSubmit(e) {
+    e.preventDefault();
+    formSubmit = true;
+  }
+  form.addEventListener('submit', onSubmit);
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+    form.removeEventListener('submit', onSubmit);
+  });
+  document.getElementById('invalid-attr-form-command-only').click();
+  assert_false(formSubmit, 'type=invalid should not trigger form submit event');
+  assert_false(mypopover.matches(':popover-open'), 'type=invalid should not toggle the popover');
+}, 'Button type=invalid with form attr and only command should not trigger form submit and not toggle popover');
+
+test((t) => {
+  let formSubmit = false;
+  function onSubmit(e) {
+    e.preventDefault();
+    formSubmit = true;
+  }
+  form.addEventListener('submit', onSubmit);
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+    form.removeEventListener('submit', onSubmit);
+  });
+  document.getElementById('invalid-attr-form-commandfor-only').click();
+  assert_false(formSubmit, 'type=invalid should not trigger form submit event');
+  assert_false(mypopover.matches(':popover-open'), 'type=invalid should not toggle the popover');
+}, 'Button type=invalid with form attr and only commandfor should not trigger form submit and not toggle popover');
+
+test((t) => {
+  let formSubmit = false;
+  function onSubmit(e) {
+    e.preventDefault();
+    formSubmit = true;
+  }
+  form.addEventListener('submit', onSubmit);
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+    form.removeEventListener('submit', onSubmit);
+  });
+  document.getElementById('missing-attr-form').click();
+  assert_false(formSubmit, 'missing type should not trigger form submit event');
+  assert_false(mypopover.matches(':popover-open'), 'missing type should not toggle the popover');
+}, 'Button missing type with form attr should not trigger form submit and not toggle popover');
 
 test((t) => {
   let formSubmit = false;

--- a/html/semantics/the-button-element/command-and-commandfor/button-type-reflection.html
+++ b/html/semantics/the-button-element/command-and-commandfor/button-type-reflection.html
@@ -9,6 +9,8 @@
   <button id=submit-in-form type=submit commandfor=mypopover command=toggle-popover>submit</button>
   <button id=button-in-form type=button commandfor=mypopover command=toggle-popover>type=button</button>
   <button id=invalid-in-form type=invalid commandfor=mypopover command=toggle-popover>invalid</button>
+  <button id=invalid-in-form-command-only type=invalid command=toggle-popover>invalid with command only</button>
+  <button id=invalid-in-form-commandfor-only type=invalid commandfor=mypopover >invalid with commandfor only</button>
   <button id=missing-in-form commandfor=mypopover command=toggle-popover>missing</button>
   <button id=missing-in-form-command-only command=toggle-popover>missing with command only</button>
   <button id=missing-in-form-commandfor-only commandfor=mypopover >missing with commandfor only</button>
@@ -18,6 +20,8 @@
 <button id=submit-attr-form type=submit commandfor=mypopover command=toggle-popover form=form>submit</button>
 <button id=button-attr-form type=button commandfor=mypopover command=toggle-popover form=form>type=button</button>
 <button id=invalid-attr-form type=invalid commandfor=mypopover command=toggle-popover form=form>invalid</button>
+<button id=invalid-attr-form-command-only type=invalid command=toggle-popover form=form>invalid with command only</button>
+<button id=invalid-attr-form-commandfor-only type=invalid commandfor=mypopover form=form>invalid with commandfor only</button>
 <button id=missing-attr-form commandfor=mypopover command=toggle-popover form=form>missing</button>
 <button id=missing-attr-form-command-only command=toggle-popover form=form>missing with command only</button>
 <button id=missing-attr-form-commandfor-only commandfor=mypopover form=form>missing with commandfor only</button>
@@ -26,6 +30,8 @@
 <button id=submit-outside-form type=submit commandfor=mypopover command=toggle-popover>submit</button>
 <button id=button-outside-form type=button commandfor=mypopover command=toggle-popover>type=button</button>
 <button id=invalid-outside-form type=invalid commandfor=mypopover command=toggle-popover>invalid</button>
+<button id=invalid-outside-form-command-only type=invalid command=toggle-popover>invalid with command only</button>
+<button id=invalid-outside-form-commandfor-only type=invalid commandfor=mypopover>invalid with commandfor only</button>
 <button id=missing-outside-form commandfor=mypopover command=toggle-popover>missing</button>
 <button id=missing-outside-form-command-only command=toggle-popover>missing with command only</button>
 <button id=missing-outside-form-commandfor-only commandfor=mypopover>missing with commandfor only</button>
@@ -35,21 +41,27 @@ const data = {
   'reset-in-form': 'reset',
   'submit-in-form': 'submit',
   'button-in-form': 'button',
-  'invalid-in-form': 'submit',
+  'invalid-in-form': 'button',
+  'invalid-in-form-command-only': 'button',
+  'invalid-in-form-commandfor-only': 'button',
   'missing-in-form': 'button',
   'missing-in-form-command-only': 'button',
   'missing-in-form-commandfor-only': 'button',
   'reset-attr-form': 'reset',
   'submit-attr-form': 'submit',
   'button-attr-form': 'button',
-  'invalid-attr-form': 'submit',
+  'invalid-attr-form': 'button',
+  'invalid-attr-form-command-only': 'button',
+  'invalid-attr-form-commandfor-only': 'button',
   'missing-attr-form': 'button',
   'missing-attr-form-command-only': 'button',
   'missing-attr-form-commandfor-only': 'button',
   'reset-outside-form': 'reset',
   'submit-outside-form': 'submit',
   'button-outside-form': 'button',
-  'invalid-outside-form': 'submit',
+  'invalid-outside-form': 'button',
+  'invalid-outside-form-command-only': 'button',
+  'invalid-outside-form-commandfor-only': 'button',
   'missing-outside-form': 'button',
   'missing-outside-form-command-only': 'button',
   'missing-outside-form-commandfor-only': 'button',


### PR DESCRIPTION
Update popovertarget and commandfor reset button tests 

Reset buttons should no longer trigger popovertarget or commandfor behaviour

Update commandfor invalid button tests 

Invalid type buttons should no longer trigger commandfor behaviour