### PR TITLE
Permissions: add missing tests

### DIFF
--- a/permissions/edge-cases.https.html
+++ b/permissions/edge-cases.https.html
@@ -11,30 +11,44 @@
 <script>
 'use strict';
 
+/**
+ * 1. Setting the same state ("prompt" -> "prompt") won't fire "change"
+ */
 promise_test(async t => {
-  // Forcing the same state: "prompt" -> "prompt" again
+  // Start in "prompt"
   await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
   const status = await navigator.permissions.query({ name: 'geolocation' });
-  
-  let changes = 0;
-  status.addEventListener('change', () => { changes++; });
 
-  // Force the same state again
+  // We'll watch for a "change" event
+  const p = new Promise((resolve, reject) => {
+    status.addEventListener('change', () => {
+      reject('A "change" event fired despite forcing the same state');
+    });
+  });
+
+  // Force the same state
   await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
-  await new Promise(resolve => t.step_timeout(resolve, 100));
 
-  assert_equals(changes, 0, 'No change event if state remains "prompt"');
-}, 'Reapplying the same permission state should not fire a "change" event');
+  // Wait a microtask to see if any event triggers
+  await Promise.resolve();
 
+  // If we got no event, pass
+  // Cleanup
+  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
+}, 'Reapplying the same permission state does not fire a "change" event');
+
+
+/**
+ * 2. Querying an invalid permission name
+ */
 promise_test(async t => {
-  // Unsupported permission name
   await promise_rejects_js(
     t,
     TypeError,
     navigator.permissions.query({ name: 'not-a-real-permission' }),
-    'Querying an unsupported permission must throw TypeError'
+    'Unsupported permission name should reject with TypeError'
   );
-}, 'Unsupported permission name should reject with a TypeError');
+}, 'Query with an unsupported name rejects with TypeError');
 </script>
 </body>
 </html>

--- a/permissions/edge-cases.https.html
+++ b/permissions/edge-cases.https.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Permissions API - Edge Cases</title>
+<link rel="help" href="https://www.w3.org/TR/permissions/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<body>
+<script>
+'use strict';
+
+promise_test(async t => {
+  // Forcing the same state: "prompt" -> "prompt" again
+  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
+  const status = await navigator.permissions.query({ name: 'geolocation' });
+  
+  let changes = 0;
+  status.addEventListener('change', () => { changes++; });
+
+  // Force the same state again
+  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
+  await new Promise(resolve => t.step_timeout(resolve, 100));
+
+  assert_equals(changes, 0, 'No change event if state remains "prompt"');
+}, 'Reapplying the same permission state should not fire a "change" event');
+
+promise_test(async t => {
+  // Unsupported permission name
+  await promise_rejects_js(
+    t,
+    TypeError,
+    navigator.permissions.query({ name: 'not-a-real-permission' }),
+    'Querying an unsupported permission must throw TypeError'
+  );
+}, 'Unsupported permission name should reject with a TypeError');
+</script>
+</body>
+</html>

--- a/permissions/edge-cases.https.html
+++ b/permissions/edge-cases.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <title>Permissions API - Test invalid permission name</title>
 <link rel="help" href="https://www.w3.org/TR/permissions/" />
 <script src="/resources/testharness.js"></script>
@@ -8,17 +8,16 @@
 <script src="/resources/testdriver-vendor.js"></script>
 
 <body>
-<script>
-"use strict";
+    <script>
+        "use strict";
 
-promise_test(async t => {
-  await promise_rejects_js(
-    t,
-    TypeError,
-    navigator.permissions.query({ name: 'not-a-real-permission' }),
-    'Unsupported permission name should reject with TypeError'
-  );
-}, 'Query with an unsupported name rejects with TypeError');
-</script>
+        promise_test(async (t) => {
+            await promise_rejects_js(
+                t,
+                TypeError,
+                navigator.permissions.query({ name: "not-a-real-permission" }),
+                "Unsupported permission name should reject with TypeError"
+            );
+        }, "Query with an unsupported name rejects with TypeError");
+    </script>
 </body>
-</html>

--- a/permissions/edge-cases.https.html
+++ b/permissions/edge-cases.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Permissions API - Edge Cases</title>
+<title>Permissions API - Test invalid permission name</title>
 <link rel="help" href="https://www.w3.org/TR/permissions/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -9,38 +9,8 @@
 
 <body>
 <script>
-'use strict';
+"use strict";
 
-/**
- * 1. Setting the same state ("prompt" -> "prompt") won't fire "change"
- */
-promise_test(async t => {
-  // Start in "prompt"
-  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
-  const status = await navigator.permissions.query({ name: 'geolocation' });
-
-  // We'll watch for a "change" event
-  const p = new Promise((resolve, reject) => {
-    status.addEventListener('change', () => {
-      reject('A "change" event fired despite forcing the same state');
-    });
-  });
-
-  // Force the same state
-  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
-
-  // Wait a microtask to see if any event triggers
-  await Promise.resolve();
-
-  // If we got no event, pass
-  // Cleanup
-  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
-}, 'Reapplying the same permission state does not fire a "change" event');
-
-
-/**
- * 2. Querying an invalid permission name
- */
 promise_test(async t => {
   await promise_rejects_js(
     t,

--- a/permissions/event-model.https.html
+++ b/permissions/event-model.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Permissions API - Event Model Tests (Simplified)</title>
+<title>Permissions API - Event Model Tests</title>
 <link rel="help" href="https://www.w3.org/TR/permissions/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -21,49 +21,48 @@ promise_test(async t => {
   assert_equals(status.state, 'prompt', 'Initial state is "prompt"');
 
   // We'll create two promises, one for each listener
-  const changePromise1 = new Promise(resolve => {
-    status.addEventListener('change', () => {
-      resolve('listener1-fired');
-    });
+  const promise1 = new Promise(resolve => {
+    status.addEventListener('change', () => resolve('addEventListener-fired'));
   });
-  const changePromise2 = new Promise(resolve => {
-    status.onchange = () => {
-      resolve('onchange-fired');
-    };
+  const promise2 = new Promise(resolve => {
+    status.onchange = () => resolve('.onchange-fired');
   });
 
   // Trigger a single transition -> "granted"
   await test_driver.set_permission({ name: 'geolocation' }, 'granted');
 
-  // Wait for both listeners to fire
-  const results = await Promise.all([changePromise1, changePromise2]);
+  // Wait for both listeners
+  const results = await Promise.all([promise1, promise2]);
+  results.sort();
 
-  // At this point, both listeners must have fired exactly once
   assert_equals(status.state, 'granted', 'State should now be "granted"');
-  assert_array_equals(results.sort(), ['listener1-fired', 'onchange-fired'].sort(),
-    'Both addEventListener and .onchange promises resolved');
+  assert_array_equals(
+    results,
+    ['.onchange-fired', 'addEventListener-fired'].sort(),
+    'Both listeners fired exactly once'
+  );
 
   // Cleanup
   status.onchange = null;
   await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
-}, 'Multiple listeners on a single PermissionStatus should both fire on change');
+}, 'Multiple listeners on a single PermissionStatus should all fire on change');
 
 
 /**
- * 2. Multiple transitions (prompt -> granted -> denied) in sequence
+ * 2. Multiple transitions (prompt -> granted -> denied)
  */
 promise_test(async t => {
-  // Start from "prompt"
   await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
   const status = await navigator.permissions.query({ name: 'geolocation' });
   assert_equals(status.state, 'prompt', 'Initial state is "prompt"');
 
   // Step 1: prompt -> granted
   const grantedPromise = new Promise(resolve => {
-    status.addEventListener('change', function onChange() {
-      status.removeEventListener('change', onChange);
+    const listener = () => {
+      status.removeEventListener('change', listener);
       resolve();
-    });
+    };
+    status.addEventListener('change', listener);
   });
   await test_driver.set_permission({ name: 'geolocation' }, 'granted');
   await grantedPromise;
@@ -71,10 +70,11 @@ promise_test(async t => {
 
   // Step 2: granted -> denied
   const deniedPromise = new Promise(resolve => {
-    status.addEventListener('change', function onChange() {
-      status.removeEventListener('change', onChange);
+    const listener = () => {
+      status.removeEventListener('change', listener);
       resolve();
-    });
+    };
+    status.addEventListener('change', listener);
   });
   await test_driver.set_permission({ name: 'geolocation' }, 'denied');
   await deniedPromise;
@@ -94,25 +94,24 @@ promise_test(async t => {
   const statusA = await navigator.permissions.query({ name: 'geolocation' });
   const statusB = await navigator.permissions.query({ name: 'geolocation' });
 
-  // Each watcher resolves its own promise when it sees "change"
-  const pA = new Promise(resolve => {
-    statusA.addEventListener('change', () => resolve('statusA-changed'));
+  const watchA = new Promise(resolve => {
+    statusA.addEventListener('change', () => resolve('A'));
   });
-  const pB = new Promise(resolve => {
-    statusB.addEventListener('change', () => resolve('statusB-changed'));
+  const watchB = new Promise(resolve => {
+    statusB.addEventListener('change', () => resolve('B'));
   });
 
   // Now transition -> "granted"
   await test_driver.set_permission({ name: 'geolocation' }, 'granted');
 
   // Wait for both watchers
-  const results = await Promise.all([pA, pB]);
-  assert_array_equals(results.sort(), ['statusA-changed','statusB-changed'].sort(),
-    'Both watchers observed the transition');
+  const results = await Promise.all([watchA, watchB]);
+  results.sort();
+  assert_array_equals(results, ['A', 'B'], 'Both watchers observed the transition');
 
   // Cleanup
   await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
-}, 'Multiple PermissionStatus objects observe the same permission transition');
+}, 'Multiple PermissionStatus objects observe the same transition');
 
 
 /**
@@ -122,30 +121,31 @@ promise_test(async t => {
   // Start from "prompt"
   await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
 
-  let changeFired = false;
+  let eventFired = false;
   const ephemeralPromise = new Promise(resolve => {
+    // We immediately create and then lose the reference to `status`
     (async () => {
       const status = await navigator.permissions.query({ name: 'geolocation' });
       status.addEventListener('change', () => {
-        changeFired = true;
+        eventFired = true;
         resolve();
       });
     })();
-    // We do NOT retain 'status' – it goes out of scope here
+    // No returned reference, so it goes out of scope
   });
 
   // Transition -> "granted"
   await test_driver.set_permission({ name: 'geolocation' }, 'granted');
-
-  // Wait for the ephemeral object's event
   await ephemeralPromise;
 
-  assert_true(changeFired,
-    'PermissionStatus "change" event fired even after status went out of scope');
+  assert_true(
+    eventFired,
+    'PermissionStatus "change" fired even after going out of scope'
+  );
 
   // Cleanup
   await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
-}, 'PermissionStatus out of scope still fires "change" event');
+}, 'PermissionStatus out of scope should still fire "change" event');
 </script>
 </body>
 </html>

--- a/permissions/event-model.https.html
+++ b/permissions/event-model.https.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Permissions API - Event Model Tests (Simplified)</title>
+<link rel="help" href="https://www.w3.org/TR/permissions/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<body>
+<script>
+'use strict';
+
+/**
+ * 1. Multiple listeners on one PermissionStatus
+ */
+promise_test(async t => {
+  // Start from "prompt"
+  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
+  const status = await navigator.permissions.query({ name: 'geolocation' });
+  assert_equals(status.state, 'prompt', 'Initial state is "prompt"');
+
+  // We'll create two promises, one for each listener
+  const changePromise1 = new Promise(resolve => {
+    status.addEventListener('change', () => {
+      resolve('listener1-fired');
+    });
+  });
+  const changePromise2 = new Promise(resolve => {
+    status.onchange = () => {
+      resolve('onchange-fired');
+    };
+  });
+
+  // Trigger a single transition -> "granted"
+  await test_driver.set_permission({ name: 'geolocation' }, 'granted');
+
+  // Wait for both listeners to fire
+  const results = await Promise.all([changePromise1, changePromise2]);
+
+  // At this point, both listeners must have fired exactly once
+  assert_equals(status.state, 'granted', 'State should now be "granted"');
+  assert_array_equals(results.sort(), ['listener1-fired', 'onchange-fired'].sort(),
+    'Both addEventListener and .onchange promises resolved');
+
+  // Cleanup
+  status.onchange = null;
+  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
+}, 'Multiple listeners on a single PermissionStatus should both fire on change');
+
+
+/**
+ * 2. Multiple transitions (prompt -> granted -> denied) in sequence
+ */
+promise_test(async t => {
+  // Start from "prompt"
+  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
+  const status = await navigator.permissions.query({ name: 'geolocation' });
+  assert_equals(status.state, 'prompt', 'Initial state is "prompt"');
+
+  // Step 1: prompt -> granted
+  const grantedPromise = new Promise(resolve => {
+    status.addEventListener('change', function onChange() {
+      status.removeEventListener('change', onChange);
+      resolve();
+    });
+  });
+  await test_driver.set_permission({ name: 'geolocation' }, 'granted');
+  await grantedPromise;
+  assert_equals(status.state, 'granted', 'Now in "granted" state');
+
+  // Step 2: granted -> denied
+  const deniedPromise = new Promise(resolve => {
+    status.addEventListener('change', function onChange() {
+      status.removeEventListener('change', onChange);
+      resolve();
+    });
+  });
+  await test_driver.set_permission({ name: 'geolocation' }, 'denied');
+  await deniedPromise;
+  assert_equals(status.state, 'denied', 'Now in "denied" state');
+
+  // Cleanup
+  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
+}, 'Multiple transitions generate multiple "change" events');
+
+
+/**
+ * 3. Multiple watchers (two PermissionStatus objects for the same permission)
+ */
+promise_test(async t => {
+  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
+
+  const statusA = await navigator.permissions.query({ name: 'geolocation' });
+  const statusB = await navigator.permissions.query({ name: 'geolocation' });
+
+  // Each watcher resolves its own promise when it sees "change"
+  const pA = new Promise(resolve => {
+    statusA.addEventListener('change', () => resolve('statusA-changed'));
+  });
+  const pB = new Promise(resolve => {
+    statusB.addEventListener('change', () => resolve('statusB-changed'));
+  });
+
+  // Now transition -> "granted"
+  await test_driver.set_permission({ name: 'geolocation' }, 'granted');
+
+  // Wait for both watchers
+  const results = await Promise.all([pA, pB]);
+  assert_array_equals(results.sort(), ['statusA-changed','statusB-changed'].sort(),
+    'Both watchers observed the transition');
+
+  // Cleanup
+  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
+}, 'Multiple PermissionStatus objects observe the same permission transition');
+
+
+/**
+ * 4. Ephemeral scope: "out of scope" object must still receive the event
+ */
+promise_test(async t => {
+  // Start from "prompt"
+  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
+
+  let changeFired = false;
+  const ephemeralPromise = new Promise(resolve => {
+    (async () => {
+      const status = await navigator.permissions.query({ name: 'geolocation' });
+      status.addEventListener('change', () => {
+        changeFired = true;
+        resolve();
+      });
+    })();
+    // We do NOT retain 'status' – it goes out of scope here
+  });
+
+  // Transition -> "granted"
+  await test_driver.set_permission({ name: 'geolocation' }, 'granted');
+
+  // Wait for the ephemeral object's event
+  await ephemeralPromise;
+
+  assert_true(changeFired,
+    'PermissionStatus "change" event fired even after status went out of scope');
+
+  // Cleanup
+  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
+}, 'PermissionStatus out of scope still fires "change" event');
+</script>
+</body>
+</html>

--- a/permissions/event-model.https.html
+++ b/permissions/event-model.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <title>Permissions API - Event Model Tests</title>
 <link rel="help" href="https://www.w3.org/TR/permissions/" />
 <script src="/resources/testharness.js"></script>
@@ -8,135 +8,108 @@
 <script src="/resources/testdriver-vendor.js"></script>
 
 <body>
-<script>
-promise_test(async t => {
-  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
-  const status = await navigator.permissions.query({ name: 'geolocation' });
-  assert_equals(status.state, 'prompt', 'Initial state is "prompt"');
+    <script>
+        promise_test(async (t) => {
+            await test_driver.set_permission({ name: "geolocation" }, "prompt");
+            const status = await navigator.permissions.query({
+                name: "geolocation",
+            });
+            assert_equals(status.state, "prompt", 'Initial state is "prompt"');
 
-  const promise1 = new Promise(resolve => {
-    status.addEventListener('change', () => resolve('addEventListener-fired'));
-  });
-  const promise2 = new Promise(resolve => {
-    status.onchange = () => resolve('.onchange-fired');
-  });
+            let count = 0;
+            const promise1 = new Promise((resolve) => {
+                status.addEventListener("change", () => resolve(count++), {
+                    once: true,
+                });
+            });
 
-  await test_driver.set_permission({ name: 'geolocation' }, 'granted');
+            const promise2 = new Promise((resolve) => {
+                status.onchange = () => resolve(count++);
+            });
 
-  const results = await Promise.all([promise1, promise2]);
-  results.sort();
+            await test_driver.set_permission(
+                { name: "geolocation" },
+                "granted"
+            );
 
-  assert_equals(status.state, 'granted', 'State should now be "granted"');
-  assert_array_equals(
-    results,
-    ['.onchange-fired', 'addEventListener-fired'].sort(),
-    'Both listeners fired exactly once'
-  );
+            const results = await Promise.all([promise1, promise2]);
 
-  // Cleanup
-  status.onchange = null;
-  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
-}, 'Multiple listeners on a single PermissionStatus should all fire on change');
+            assert_equals(
+                status.state,
+                "granted",
+                'State should now be "granted"'
+            );
+            assert_array_equals(results, [0, 1], "Both listeners fired once");
 
+            status.onchange = null;
+        }, "Multiple listeners on a single PermissionStatus should all fire on change");
 
-/**
- * 2. Multiple transitions (prompt -> granted -> denied)
- */
-promise_test(async t => {
-  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
-  const status = await navigator.permissions.query({ name: 'geolocation' });
-  assert_equals(status.state, 'prompt', 'Initial state is "prompt"');
+        promise_test(async (t) => {
+            await test_driver.set_permission({ name: "geolocation" }, "prompt");
+            const status = await navigator.permissions.query({
+                name: "geolocation",
+            });
+            assert_equals(status.state, "prompt", 'Initial state is "prompt"');
 
-  // Step 1: prompt -> granted
-  const grantedPromise = new Promise(resolve => {
-    const listener = () => {
-      status.removeEventListener('change', listener);
-      resolve();
-    };
-    status.addEventListener('change', listener);
-  });
-  await test_driver.set_permission({ name: 'geolocation' }, 'granted');
-  await grantedPromise;
-  assert_equals(status.state, 'granted', 'Now in "granted" state');
+            const grantedPromise = new Promise((resolve) => {
+                status.addEventListener("change", resolve, { once: true });
+            });
+            await test_driver.set_permission(
+                { name: "geolocation" },
+                "granted"
+            );
+            await grantedPromise;
+            assert_equals(status.state, "granted", 'Now in "granted" state');
 
-  // Step 2: granted -> denied
-  const deniedPromise = new Promise(resolve => {
-    const listener = () => {
-      status.removeEventListener('change', listener);
-      resolve();
-    };
-    status.addEventListener('change', listener);
-  });
-  await test_driver.set_permission({ name: 'geolocation' }, 'denied');
-  await deniedPromise;
-  assert_equals(status.state, 'denied', 'Now in "denied" state');
+            const deniedPromise = new Promise((resolve) => {
+                status.addEventListener("change", resolve, { once: true });
+            });
+            await test_driver.set_permission({ name: "geolocation" }, "denied");
+            await deniedPromise;
+            assert_equals(status.state, "denied", 'Now in "denied" state');
+        }, 'Multiple transitions generate multiple "change" events');
 
-  // Cleanup
-  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
-}, 'Multiple transitions generate multiple "change" events');
+        promise_test(async (t) => {
+            await test_driver.set_permission({ name: "geolocation" }, "prompt");
 
+            const statusA = await navigator.permissions.query({
+                name: "geolocation",
+            });
+            const statusB = await navigator.permissions.query({
+                name: "geolocation",
+            });
 
-/**
- * 3. Multiple watchers (two PermissionStatus objects for the same permission)
- */
-promise_test(async t => {
-  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
+            const watchA = new Promise((resolve) => {
+                statusA.addEventListener("change", resolve, { once: true });
+            });
+            const watchB = new Promise((resolve) => {
+                statusB.addEventListener("change", resolve, { once: true });
+            });
 
-  const statusA = await navigator.permissions.query({ name: 'geolocation' });
-  const statusB = await navigator.permissions.query({ name: 'geolocation' });
+            await test_driver.set_permission(
+                { name: "geolocation" },
+                "granted"
+            );
+            const results = await Promise.all([watchA, watchB]);
+        }, "Multiple PermissionStatus objects observe the same transition");
 
-  const watchA = new Promise(resolve => {
-    statusA.addEventListener('change', () => resolve('A'));
-  });
-  const watchB = new Promise(resolve => {
-    statusB.addEventListener('change', () => resolve('B'));
-  });
+        promise_test(async (t) => {
+            await test_driver.set_permission({ name: "geolocation" }, "prompt");
 
-  // Now transition -> "granted"
-  await test_driver.set_permission({ name: 'geolocation' }, 'granted');
+            const ephemeralPromise = new Promise((resolve) => {
+                (async () => {
+                    const status = await navigator.permissions.query({
+                        name: "geolocation",
+                    });
+                    status.addEventListener("change", resolve, { once: true });
+                })();
+            });
 
-  // Wait for both watchers
-  const results = await Promise.all([watchA, watchB]);
-  results.sort();
-  assert_array_equals(results, ['A', 'B'], 'Both watchers observed the transition');
-
-  // Cleanup
-  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
-}, 'Multiple PermissionStatus objects observe the same transition');
-
-
-/**
- * 4. Ephemeral scope: "out of scope" object must still receive the event
- */
-promise_test(async t => {
-  // Start from "prompt"
-  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
-
-  let eventFired = false;
-  const ephemeralPromise = new Promise(resolve => {
-    // We immediately create and then lose the reference to `status`
-    (async () => {
-      const status = await navigator.permissions.query({ name: 'geolocation' });
-      status.addEventListener('change', () => {
-        eventFired = true;
-        resolve();
-      });
-    })();
-    // No returned reference, so it goes out of scope
-  });
-
-  // Transition -> "granted"
-  await test_driver.set_permission({ name: 'geolocation' }, 'granted');
-  await ephemeralPromise;
-
-  assert_true(
-    eventFired,
-    'PermissionStatus "change" fired even after going out of scope'
-  );
-
-  // Cleanup
-  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
-}, 'PermissionStatus out of scope should still fire "change" event');
-</script>
+            await test_driver.set_permission(
+                { name: "geolocation" },
+                "granted"
+            );
+            await ephemeralPromise;
+        }, 'PermissionStatus out of scope should still fire "change" event');
+    </script>
 </body>
-</html>

--- a/permissions/event-model.https.html
+++ b/permissions/event-model.https.html
@@ -9,18 +9,11 @@
 
 <body>
 <script>
-'use strict';
-
-/**
- * 1. Multiple listeners on one PermissionStatus
- */
 promise_test(async t => {
-  // Start from "prompt"
   await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
   const status = await navigator.permissions.query({ name: 'geolocation' });
   assert_equals(status.state, 'prompt', 'Initial state is "prompt"');
 
-  // We'll create two promises, one for each listener
   const promise1 = new Promise(resolve => {
     status.addEventListener('change', () => resolve('addEventListener-fired'));
   });
@@ -28,10 +21,8 @@ promise_test(async t => {
     status.onchange = () => resolve('.onchange-fired');
   });
 
-  // Trigger a single transition -> "granted"
   await test_driver.set_permission({ name: 'geolocation' }, 'granted');
 
-  // Wait for both listeners
   const results = await Promise.all([promise1, promise2]);
   results.sort();
 

--- a/permissions/revocation.https.html
+++ b/permissions/revocation.https.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Permissions API - Revocation Tests</title>
+<link rel="help" href="https://www.w3.org/TR/permissions/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<body>
+<script>
+'use strict';
+
+async function setPermission(state) {
+  return test_driver.set_permission({ name: 'geolocation' }, state);
+}
+
+promise_test(async t => {
+  // "granted" -> "prompt"
+  await setPermission('granted');
+  const status = await navigator.permissions.query({ name: 'geolocation' });
+  assert_equals(status.state, 'granted', 'Started at "granted"');
+
+  let changeCount = 0;
+  status.addEventListener('change', () => changeCount++);
+
+  await setPermission('prompt');
+  await new Promise(r => t.step_timeout(r, 50));
+
+  assert_equals(changeCount, 1, 'Should have exactly one change event');
+  assert_equals(status.state, 'prompt', 'Permission is now "prompt"');
+
+  // Cleanup
+  await setPermission('prompt');
+}, 'Transition from "granted" to "prompt" fires a "change"');
+
+promise_test(async t => {
+  // "granted" -> "denied"
+  await setPermission('granted');
+  const status = await navigator.permissions.query({ name: 'geolocation' });
+  assert_equals(status.state, 'granted', 'Confirm "granted" start');
+
+  let changed = false;
+  status.addEventListener('change', () => { changed = true; });
+
+  await setPermission('denied');
+  await new Promise(r => t.step_timeout(r, 50));
+
+  assert_true(changed, 'Should have fired change event');
+  assert_equals(status.state, 'denied', 'Now "denied"');
+
+  // Cleanup
+  await setPermission('prompt');
+}, 'Transition from "granted" to "denied" fires a "change"');
+</script>
+</body>
+</html>

--- a/permissions/revocation.https.html
+++ b/permissions/revocation.https.html
@@ -11,47 +11,51 @@
 <script>
 'use strict';
 
-async function setPermission(state) {
-  return test_driver.set_permission({ name: 'geolocation' }, state);
-}
-
+// 1. "granted" -> "prompt"
 promise_test(async t => {
-  // "granted" -> "prompt"
-  await setPermission('granted');
+  await test_driver.set_permission({ name: 'geolocation' }, 'granted');
   const status = await navigator.permissions.query({ name: 'geolocation' });
-  assert_equals(status.state, 'granted', 'Started at "granted"');
+  assert_equals(status.state, 'granted', 'Initial state is "granted"');
 
-  let changeCount = 0;
-  status.addEventListener('change', () => changeCount++);
+  const p = new Promise(resolve => {
+    const listener = () => {
+      status.removeEventListener('change', listener);
+      resolve();
+    };
+    status.addEventListener('change', listener);
+  });
 
-  await setPermission('prompt');
-  await new Promise(r => t.step_timeout(r, 50));
+  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
+  await p;
 
-  assert_equals(changeCount, 1, 'Should have exactly one change event');
-  assert_equals(status.state, 'prompt', 'Permission is now "prompt"');
+  assert_equals(status.state, 'prompt', 'Now in "prompt" state');
+  
+  // Cleanup
+  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
+}, 'Transition "granted" -> "prompt" fires a "change" event');
+
+// 2. "granted" -> "denied"
+promise_test(async t => {
+  await test_driver.set_permission({ name: 'geolocation' }, 'granted');
+  const status = await navigator.permissions.query({ name: 'geolocation' });
+  assert_equals(status.state, 'granted', 'Initial state is "granted"');
+
+  const p = new Promise(resolve => {
+    const listener = () => {
+      status.removeEventListener('change', listener);
+      resolve();
+    };
+    status.addEventListener('change', listener);
+  });
+
+  await test_driver.set_permission({ name: 'geolocation' }, 'denied');
+  await p;
+
+  assert_equals(status.state, 'denied', 'Now in "denied" state');
 
   // Cleanup
-  await setPermission('prompt');
-}, 'Transition from "granted" to "prompt" fires a "change"');
-
-promise_test(async t => {
-  // "granted" -> "denied"
-  await setPermission('granted');
-  const status = await navigator.permissions.query({ name: 'geolocation' });
-  assert_equals(status.state, 'granted', 'Confirm "granted" start');
-
-  let changed = false;
-  status.addEventListener('change', () => { changed = true; });
-
-  await setPermission('denied');
-  await new Promise(r => t.step_timeout(r, 50));
-
-  assert_true(changed, 'Should have fired change event');
-  assert_equals(status.state, 'denied', 'Now "denied"');
-
-  // Cleanup
-  await setPermission('prompt');
-}, 'Transition from "granted" to "denied" fires a "change"');
+  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
+}, 'Transition "granted" -> "denied" fires a "change" event');
 </script>
 </body>
 </html>

--- a/permissions/revocation.https.html
+++ b/permissions/revocation.https.html
@@ -31,7 +31,6 @@
             await p;
 
             assert_equals(status.state, "prompt", 'Now in "prompt" state');
-
         }, 'Transition "granted" -> "prompt" fires a "change" event');
 
         promise_test(async (t) => {

--- a/permissions/revocation.https.html
+++ b/permissions/revocation.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <title>Permissions API - Revocation Tests</title>
 <link rel="help" href="https://www.w3.org/TR/permissions/" />
 <script src="/resources/testharness.js"></script>
@@ -8,54 +8,53 @@
 <script src="/resources/testdriver-vendor.js"></script>
 
 <body>
-<script>
-'use strict';
+    <script>
+        promise_test(async (t) => {
+            await test_driver.set_permission(
+                { name: "geolocation" },
+                "granted"
+            );
+            const status = await navigator.permissions.query({
+                name: "geolocation",
+            });
+            assert_equals(
+                status.state,
+                "granted",
+                'Initial state is "granted"'
+            );
 
-// 1. "granted" -> "prompt"
-promise_test(async t => {
-  await test_driver.set_permission({ name: 'geolocation' }, 'granted');
-  const status = await navigator.permissions.query({ name: 'geolocation' });
-  assert_equals(status.state, 'granted', 'Initial state is "granted"');
+            const p = new Promise((resolve) => {
+                status.addEventListener("change", resolve, { once: true });
+            });
 
-  const p = new Promise(resolve => {
-    const listener = () => {
-      status.removeEventListener('change', listener);
-      resolve();
-    };
-    status.addEventListener('change', listener);
-  });
+            await test_driver.set_permission({ name: "geolocation" }, "prompt");
+            await p;
 
-  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
-  await p;
+            assert_equals(status.state, "prompt", 'Now in "prompt" state');
 
-  assert_equals(status.state, 'prompt', 'Now in "prompt" state');
-  
-  // Cleanup
-  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
-}, 'Transition "granted" -> "prompt" fires a "change" event');
+        }, 'Transition "granted" -> "prompt" fires a "change" event');
 
-// 2. "granted" -> "denied"
-promise_test(async t => {
-  await test_driver.set_permission({ name: 'geolocation' }, 'granted');
-  const status = await navigator.permissions.query({ name: 'geolocation' });
-  assert_equals(status.state, 'granted', 'Initial state is "granted"');
+        promise_test(async (t) => {
+            await test_driver.set_permission(
+                { name: "geolocation" },
+                "granted"
+            );
+            const status = await navigator.permissions.query({
+                name: "geolocation",
+            });
+            assert_equals(
+                status.state,
+                "granted",
+                'Initial state is "granted"'
+            );
 
-  const p = new Promise(resolve => {
-    const listener = () => {
-      status.removeEventListener('change', listener);
-      resolve();
-    };
-    status.addEventListener('change', listener);
-  });
+            const p = new Promise((resolve) => {
+                status.addEventListener("change", resolve, { once: true });
+            });
 
-  await test_driver.set_permission({ name: 'geolocation' }, 'denied');
-  await p;
-
-  assert_equals(status.state, 'denied', 'Now in "denied" state');
-
-  // Cleanup
-  await test_driver.set_permission({ name: 'geolocation' }, 'prompt');
-}, 'Transition "granted" -> "denied" fires a "change" event');
-</script>
+            await test_driver.set_permission({ name: "geolocation" }, "denied");
+            await p;
+            assert_equals(status.state, "denied", 'Now in "denied" state');
+        }, 'Transition "granted" -> "denied" fires a "change" event');
+    </script>
 </body>
-</html>

--- a/permissions/worker.https.html
+++ b/permissions/worker.https.html
@@ -10,14 +10,21 @@
 <script>
 'use strict';
 
-// Inline the Worker script
+/*
+  We'll assume test_driver.set_permission({ name: 'notifications' }, 'prompt')
+  is supported. If not, adapt accordingly.
+
+  The Worker script:
+    1. queries { name: 'notifications' }
+    2. posts back initialState
+    3. sets an 'onchange' to post changedState
+*/
+
 const workerScript = `
   onmessage = async () => {
     try {
       const status = await self.navigator.permissions.query({ name: 'notifications' });
-      // Send back the initial state
       postMessage({ initialState: status.state });
-      // Listen for changes
       status.onchange = () => {
         postMessage({ changedState: status.state });
       };
@@ -28,65 +35,62 @@ const workerScript = `
 `;
 
 promise_test(async t => {
-  // 1. Force the initial Notifications permission to "prompt".
-  //    We assume this is supported in the test environment.
+  // Start from "prompt"
   await test_driver.set_permission({ name: 'notifications' }, 'prompt');
 
-  // 2. Create a Blob-based Worker
+  // Create a Blob worker
   const blobUrl = URL.createObjectURL(new Blob([workerScript], { type: 'text/javascript' }));
   const worker = new Worker(blobUrl);
 
   const messages = [];
   worker.onmessage = evt => messages.push(evt.data);
 
-  // 3. Start the Worker’s logic
+  // Start the worker
   worker.postMessage({});
 
-  // 4. Wait for the Worker’s initial response
-  await new Promise(resolve => t.step_timeout(resolve, 300));
+  // Wait for the initial message
+  // Typically it should arrive almost immediately
+  await new Promise(resolve => {
+    const observer = setInterval(() => {
+      if (messages.length > 0) {
+        clearInterval(observer);
+        resolve();
+      }
+    }, 10);
+  });
 
-  // Check we got something back
-  assert_greater_than(
-    messages.length,
-    0,
-    'Worker should have sent at least one message by now'
-  );
-
+  // Check first message
   const firstMsg = messages[0];
-  // If there's an error, the Worker likely doesn't support notifications
-  if (firstMsg.error) {
-    assert_unreached(`Worker query for notifications threw error: ${firstMsg.error}`);
-  } else {
-    assert_true(
-      'initialState' in firstMsg,
-      'Expected an `initialState` in the Worker’s first message'
-    );
-    assert_equals(
-      firstMsg.initialState, 
-      'prompt',
-      'Worker should see the permission as "prompt" initially'
-    );
+  if (firstMsg && firstMsg.error) {
+    assert_unreached(`Worker got error: ${firstMsg.error}`);
   }
+  assert_true(
+    firstMsg && 'initialState' in firstMsg,
+    'Expected an "initialState" from the Worker'
+  );
+  assert_equals(
+    firstMsg.initialState,
+    'prompt',
+    'Worker sees the initial "prompt" state'
+  );
 
-  // 5. Transition from "prompt" to "granted"
+  // Now we transition to "granted"
+  const changedPromise = new Promise(resolve => {
+    const observer = setInterval(() => {
+      // If we get a second message with changedState, resolve
+      if (messages.length > 1 && 'changedState' in messages[1]) {
+        clearInterval(observer);
+        resolve(messages[1]);
+      }
+    }, 10);
+  });
+
   await test_driver.set_permission({ name: 'notifications' }, 'granted');
+  const secondMsg = await changedPromise;
+  assert_equals(secondMsg.changedState, 'granted',
+    'Worker sees the permission changed to "granted"');
 
-  // Wait again for the Worker to detect the "change"
-  await new Promise(resolve => t.step_timeout(resolve, 300));
-
-  assert_equals(
-    messages.length,
-    2,
-    'A second message should arrive after changing permission to "granted"'
-  );
-  const secondMsg = messages[1];
-  assert_equals(
-    secondMsg.changedState,
-    'granted',
-    'Worker should see the permission changed to "granted"'
-  );
-
-  // 6. Cleanup - set back to "prompt" if desired
+  // Cleanup
   await test_driver.set_permission({ name: 'notifications' }, 'prompt');
-}, 'Worker can query {name: "notifications"} permission, see initial "prompt," and detect "granted" transition');
+}, 'Worker can query the "notifications" permission and detect a transition to "granted"');
 </script>

--- a/permissions/worker.https.html
+++ b/permissions/worker.https.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Permissions API in Worker - Notifications</title>
+<link rel="help" href="https://www.w3.org/TR/permissions/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<script>
+'use strict';
+
+// Inline the Worker script
+const workerScript = `
+  onmessage = async () => {
+    try {
+      const status = await self.navigator.permissions.query({ name: 'notifications' });
+      // Send back the initial state
+      postMessage({ initialState: status.state });
+      // Listen for changes
+      status.onchange = () => {
+        postMessage({ changedState: status.state });
+      };
+    } catch (err) {
+      postMessage({ error: String(err) });
+    }
+  };
+`;
+
+promise_test(async t => {
+  // 1. Force the initial Notifications permission to "prompt".
+  //    We assume this is supported in the test environment.
+  await test_driver.set_permission({ name: 'notifications' }, 'prompt');
+
+  // 2. Create a Blob-based Worker
+  const blobUrl = URL.createObjectURL(new Blob([workerScript], { type: 'text/javascript' }));
+  const worker = new Worker(blobUrl);
+
+  const messages = [];
+  worker.onmessage = evt => messages.push(evt.data);
+
+  // 3. Start the Worker’s logic
+  worker.postMessage({});
+
+  // 4. Wait for the Worker’s initial response
+  await new Promise(resolve => t.step_timeout(resolve, 300));
+
+  // Check we got something back
+  assert_greater_than(
+    messages.length,
+    0,
+    'Worker should have sent at least one message by now'
+  );
+
+  const firstMsg = messages[0];
+  // If there's an error, the Worker likely doesn't support notifications
+  if (firstMsg.error) {
+    assert_unreached(`Worker query for notifications threw error: ${firstMsg.error}`);
+  } else {
+    assert_true(
+      'initialState' in firstMsg,
+      'Expected an `initialState` in the Worker’s first message'
+    );
+    assert_equals(
+      firstMsg.initialState, 
+      'prompt',
+      'Worker should see the permission as "prompt" initially'
+    );
+  }
+
+  // 5. Transition from "prompt" to "granted"
+  await test_driver.set_permission({ name: 'notifications' }, 'granted');
+
+  // Wait again for the Worker to detect the "change"
+  await new Promise(resolve => t.step_timeout(resolve, 300));
+
+  assert_equals(
+    messages.length,
+    2,
+    'A second message should arrive after changing permission to "granted"'
+  );
+  const secondMsg = messages[1];
+  assert_equals(
+    secondMsg.changedState,
+    'granted',
+    'Worker should see the permission changed to "granted"'
+  );
+
+  // 6. Cleanup - set back to "prompt" if desired
+  await test_driver.set_permission({ name: 'notifications' }, 'prompt');
+}, 'Worker can query {name: "notifications"} permission, see initial "prompt," and detect "granted" transition');
+</script>

--- a/permissions/worker.https.html
+++ b/permissions/worker.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
-<title>Permissions API in Worker - Notifications</title>
+<meta charset="utf-8" />
+<title>Permissions API in Worker</title>
 <link rel="help" href="https://www.w3.org/TR/permissions/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -8,89 +8,52 @@
 <script src="/resources/testdriver-vendor.js"></script>
 
 <script>
-'use strict';
+    const workerScript = `
+      async function setup() {
+          const status = await self.navigator.permissions.query({
+              name: "geolocation",
+          });
+          status.addEventListener("change", () => {
+              postMessage({ event: "change", state: status.state });
+          });
+          self.postMessage({ event: "ready", state: status.state });
+      }
 
-/*
-  We'll assume test_driver.set_permission({ name: 'notifications' }, 'prompt')
-  is supported. If not, adapt accordingly.
+      setup();
+    `;
 
-  The Worker script:
-    1. queries { name: 'notifications' }
-    2. posts back initialState
-    3. sets an 'onchange' to post changedState
-*/
-
-const workerScript = `
-  onmessage = async () => {
-    try {
-      const status = await self.navigator.permissions.query({ name: 'notifications' });
-      postMessage({ initialState: status.state });
-      status.onchange = () => {
-        postMessage({ changedState: status.state });
-      };
-    } catch (err) {
-      postMessage({ error: String(err) });
+    function messageFrom(worker, message) {
+        const abortController = new AbortController();
+        return new Promise((resolve) => {
+            worker.addEventListener(
+                "message",
+                (event) => {
+                    if (event.data.event == message) {
+                        abortController.abort();
+                        resolve(event.data);
+                    }
+                },
+                { signal: abortController.signal }
+            );
+        });
     }
-  };
-`;
 
-promise_test(async t => {
-  // Start from "prompt"
-  await test_driver.set_permission({ name: 'notifications' }, 'prompt');
+    promise_test(async (t) => {
+        await test_driver.set_permission({ name: "geolocation" }, "prompt");
+        const blobUrl = URL.createObjectURL(
+            new Blob([workerScript], { type: "text/javascript" })
+        );
+        const worker = new Worker(blobUrl);
+        const  { state:initialState }  = await messageFrom(worker, "ready");
+        assert_equals(initialState, "prompt", "Worker sees the initial permission state as 'prompt'");
 
-  // Create a Blob worker
-  const blobUrl = URL.createObjectURL(new Blob([workerScript], { type: 'text/javascript' }));
-  const worker = new Worker(blobUrl);
-
-  const messages = [];
-  worker.onmessage = evt => messages.push(evt.data);
-
-  // Start the worker
-  worker.postMessage({});
-
-  // Wait for the initial message
-  // Typically it should arrive almost immediately
-  await new Promise(resolve => {
-    const observer = setInterval(() => {
-      if (messages.length > 0) {
-        clearInterval(observer);
-        resolve();
-      }
-    }, 10);
-  });
-
-  // Check first message
-  const firstMsg = messages[0];
-  if (firstMsg && firstMsg.error) {
-    assert_unreached(`Worker got error: ${firstMsg.error}`);
-  }
-  assert_true(
-    firstMsg && 'initialState' in firstMsg,
-    'Expected an "initialState" from the Worker'
-  );
-  assert_equals(
-    firstMsg.initialState,
-    'prompt',
-    'Worker sees the initial "prompt" state'
-  );
-
-  // Now we transition to "granted"
-  const changedPromise = new Promise(resolve => {
-    const observer = setInterval(() => {
-      // If we get a second message with changedState, resolve
-      if (messages.length > 1 && 'changedState' in messages[1]) {
-        clearInterval(observer);
-        resolve(messages[1]);
-      }
-    }, 10);
-  });
-
-  await test_driver.set_permission({ name: 'notifications' }, 'granted');
-  const secondMsg = await changedPromise;
-  assert_equals(secondMsg.changedState, 'granted',
-    'Worker sees the permission changed to "granted"');
-
-  // Cleanup
-  await test_driver.set_permission({ name: 'notifications' }, 'prompt');
-}, 'Worker can query the "notifications" permission and detect a transition to "granted"');
+        const setPermissionPromise = test_driver.set_permission({ name: "geolocation" }, "granted");
+        const changePromise = messageFrom(worker, "change");
+        const [{state:changedState}] = await Promise.all([messagePromise, setPermissionPromise]);
+        assert_equals(
+            changedState,
+            "granted",
+            "Worker detects the permission state change to 'granted'"
+        );
+    }, "Worker can query the 'geolocation' permission and detect a transition to 'granted'");
 </script>


### PR DESCRIPTION
Add tests for edge cases, event model, revocation, and worker permissions.

Closes https://github.com/w3c/permissions/issues/460