### PR TITLE
Install fonts-noto-cjk for linux-wpt workflow

### DIFF
--- a/css/css-fonts/size-adjust-unicode-range-system-fallback-ref.html
+++ b/css/css-fonts/size-adjust-unicode-range-system-fallback-ref.html
@@ -6,16 +6,17 @@
 @font-face {
   font-family: large-font;
   src: local(Ahem), url(/fonts/Ahem.ttf);
-  size-adjust: 1000%;
-  unicode-range: U+0020;
 }
 
 .space {
   font-family: large-font;
+  font-size: 1000%;
 }
 
 .ref {
   font-family: sans-serif;
+  position: relative;
+  left: -10em;
 }
 </style>
-<span class="space"> </span><span class="ref">あ</span>
+<span class="space">&nbsp;</span><span class="ref">あ</span>


### PR DESCRIPTION
Right now CJK-related tests are not running properly as the characters are rendered as tofu.

This PR installs fonts-noto-cjk to fix it. Also:
- `css/css-fonts/size-adjust-unicode-range-system-fallback.html` is a false pass, as the ref file depends on unsupported `size-adjust`. This PR removes the dependency to make it fail correctly
- It rebaselines the other affected tests
- It fixes #<!-- nolink -->28758 by making the test failures stable.

Reviewed in servo/servo#35567