### PR TITLE
add disconnected tests for command events

### DIFF
--- a/html/semantics/the-button-element/command-and-commandfor/on-dialog-disconnect.html
+++ b/html/semantics/the-button-element/command-and-commandfor/on-dialog-disconnect.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Keith Cirkel" href="mailto:wpt@keithcirkel.co.uk" />
+<meta name="timeout" content="long">
+<link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<dialog id="invokee"></dialog>
+<button id="invokerbutton" commandfor="invokee" command="show-modal"></button>
+
+<script>
+  const invokee = document.getElementById('invokee');
+  promise_test(
+    async function (t) {
+      assert_false(invokee.open, "invokee.open");
+      assert_false(invokee.matches(":modal"), "invokee :modal");
+      let fired = false;
+      invokee.addEventListener('command', () => {
+        fired = true;
+        invokee.remove();
+      });
+      await clickOn(invokerbutton);
+      assert_true(fired, "command event fired");
+      assert_false(invokee.isConnected, "dialog no longer connected");
+      assert_false(invokee.open, "invokee.open");
+      assert_false(invokee.matches(":modal"), "invokee :modal");
+    },
+    `invoking a dialog and removing during command event does not raise an error`,
+  );
+</script>

--- a/html/semantics/the-button-element/command-and-commandfor/on-popover-disconnect.html
+++ b/html/semantics/the-button-element/command-and-commandfor/on-popover-disconnect.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Keith Cirkel" href="mailto:wpt@keithcirkel.co.uk" />
+<meta name="timeout" content="long">
+<link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<div id="invokee" popover></div>
+<button id="invokerbutton" commandfor="invokee" command="show-popover"></button>
+
+<script>
+  const invokee = document.getElementById('invokee');
+  promise_test(
+    async function (t) {
+      assert_false(invokee.matches(":popover-open"), "invokee :popover-open");
+      let fired = false;
+      invokee.addEventListener('command', () => {
+        fired = true;
+        invokee.remove();
+      });
+      await clickOn(invokerbutton);
+      assert_true(fired, "command event fired");
+      assert_false(invokee.isConnected, "popover no longer connected");
+      assert_false(invokee.matches(":popover-open"), "invokee :popover-open");
+    },
+    `invoking a popover and removing during command event does not raise an error`,
+  );
+</script>


### PR DESCRIPTION
Refs https://github.com/whatwg/html/pull/11049

Adds tests which disconnect the invoking element during the command event, to ensure the result is a no-op.