### PR TITLE
Add tests for integrity="sha256-..."

### DIFF
--- a/subresource-integrity/subresource-integrity.html
+++ b/subresource-integrity/subresource-integrity.html
@@ -53,6 +53,13 @@
     ).execute();
 
     new SRIScriptTest(
+        true,
+        "Same-origin with non-Base64 hash.",
+        `${same_origin_prefix}script.js?${token()}`,
+        "sha256-..."
+    ).execute();
+
+    new SRIScriptTest(
         false,
         "Same-origin with incorrect hash.",
         `${same_origin_prefix}script.js?${token()}`,
@@ -241,6 +248,16 @@
         {
             href: "style.css?4",
             integrity: ""
+        }
+    );
+
+    new SRIStyleTest(
+        style_tests,
+        true,
+        "Same-origin with non-Base64 integrity",
+        {
+            href: "style.css?4.5",
+            integrity: "sha256-..."
         }
     );
 


### PR DESCRIPTION
This was reported by @vogtm:
https://github.com/web-platform-tests/interop/issues/666

The attribute value doesn't follow the ABNF grammar in
https://w3c.github.io/webappsec-subresource-integrity/#the-integrity-attribute
and thus should behave the same as an unknown algorithm, like the foo666
tests in this file.

The added tests pass in Chrome+Safari but fail in Firefox.
