### PR TITLE
compositing: Move image output and shutdown management out of the compositor

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -226,6 +226,7 @@ class ServoRefTestExecutor(ServoExecutor):
 
     def screenshot(self, test, viewport_size, dpi, page_ranges):
         with TempFilename(self.tempdir) as output_path:
+            output_path = f"{output_path}.png"
             extra_args = ["--exit",
                           "--output=%s" % output_path,
                           "--window-size", viewport_size or "800x600"]


### PR DESCRIPTION
This is a step toward the renderer-per-WebView goal. It moves various details out of `IOCompositor`.

- Image output: This is moved to servoshell as now applications can access the image contents of a `WebView` via `RenderingContext::read_to_image`. Most options for this are moved to `ServoShellPreferences` apart from `wait_for_stable_image` as this requires a specific kind of coordination in the `ScriptThread` that is also very expensive. Instead, paint is now simply delayed until a stable image is reached and `WebView::paint()` returns a boolean. Maybe this can be revisited in the future.
- Shutdown: Shutdown is now managed by libservo itself. Shutdown state is shared between the compositor and `Servo` instance. In the future, this sharing might be unecessary.
- `CompositeTarget` has been removed entirely. This no longer needs to be passed when creating a Servo instance.

This is an attempt to land #50836 which seems to be wedged.

Reviewed in https://github.com/servo/servo/pull/35538