### PR TITLE
layout: Ignore indefinite `stretch` on min and max sizing properties

### DIFF
--- a/css/css-sizing/keyword-sizes-on-flex-item-001.html
+++ b/css/css-sizing/keyword-sizes-on-flex-item-001.html
@@ -129,20 +129,34 @@
   <div class="test height min-height max-height stretch" data-expected-height="10"></div>
 </div>
 
-
 <!-- Indefinite stretch -->
 <div class="wrapper" style="width: 100px; max-height: 100px">
-  <div class="test height stretch indefinite" data-expected-height="30">X X</div>
-  <div class="test height stretch indefinite" data-expected-height="30">XXX XXX</div>
-  <div class="test height stretch indefinite" data-expected-height="30">XXXXX XXXXX</div>
+  <div class="test height stretch" data-expected-height="30">X X</div>
+  <div class="test height stretch" data-expected-height="30">XXX XXX</div>
+  <div class="test height stretch" data-expected-height="30">XXXXX XXXXX</div>
 
-  <div class="test min-height stretch indefinite" data-expected-height="30">X X</div>
-  <div class="test min-height stretch indefinite" data-expected-height="30">XXX XXX</div>
-  <div class="test min-height stretch indefinite" data-expected-height="30">XXXXX XXXXX</div>
+  <div class="test min-height stretch" data-expected-height="10">X X</div>
+  <div class="test min-height stretch" data-expected-height="10">XXX XXX</div>
+  <div class="test min-height stretch" data-expected-height="10">XXXXX XXXXX</div>
 
-  <div class="test max-height stretch indefinite" data-expected-height="30">X X</div>
-  <div class="test max-height stretch indefinite" data-expected-height="30">XXX XXX</div>
-  <div class="test max-height stretch indefinite" data-expected-height="30">XXXXX XXXXX</div>
+  <div class="test max-height stretch" data-expected-height="510">X X</div>
+  <div class="test max-height stretch" data-expected-height="510">XXX XXX</div>
+  <div class="test max-height stretch" data-expected-height="510">XXXXX XXXXX</div>
+</div>
+
+<!-- Fit-content with indefinite stretch -->
+<div class="wrapper" style="width: 100px; max-height: 100px">
+  <div class="test height" style="height: fit-content" data-expected-height="30">X X</div>
+  <div class="test height" style="height: fit-content" data-expected-height="30">XXX XXX</div>
+  <div class="test height" style="height: fit-content" data-expected-height="30">XXXXX XXXXX</div>
+
+  <div class="test min-height" style="min-height: fit-content" data-expected-height="30">X X</div>
+  <div class="test min-height" style="min-height: fit-content" data-expected-height="30">XXX XXX</div>
+  <div class="test min-height" style="min-height: fit-content" data-expected-height="30">XXXXX XXXXX</div>
+
+  <div class="test max-height" style="max-height: fit-content" data-expected-height="30">X X</div>
+  <div class="test max-height" style="max-height: fit-content" data-expected-height="30">XXX XXX</div>
+  <div class="test max-height" style="max-height: fit-content" data-expected-height="30">XXXXX XXXXX</div>
 </div>
 
 <script src="/resources/testharness.js"></script>

--- a/css/css-sizing/keyword-sizes-on-flex-item-002.html
+++ b/css/css-sizing/keyword-sizes-on-flex-item-002.html
@@ -10,8 +10,10 @@
 
 <style>
 .wrapper {
-  display: flex;
+  display: inline-flex;
   flex-direction: column;
+  vertical-align: top;
+  margin-right: 150px;
 }
 .test {
   flex: none;
@@ -129,20 +131,34 @@
   <div class="test height min-height max-height stretch" data-expected-height="10"></div>
 </div>
 
-
 <!-- Indefinite stretch -->
 <div class="wrapper" style="width: 100px; max-height: 100px">
-  <div class="test height stretch indefinite" data-expected-height="30">X X</div>
-  <div class="test height stretch indefinite" data-expected-height="50">XXX XXX</div>
-  <div class="test height stretch indefinite" data-expected-height="50">XXXXX XXXXX</div>
+  <div class="test height stretch" data-expected-height="30">X X</div>
+  <div class="test height stretch" data-expected-height="50">XXX XXX</div>
+  <div class="test height stretch" data-expected-height="50">XXXXX XXXXX</div>
 
-  <div class="test min-height stretch indefinite" data-expected-height="30">X X</div>
-  <div class="test min-height stretch indefinite" data-expected-height="50">XXX XXX</div>
-  <div class="test min-height stretch indefinite" data-expected-height="50">XXXXX XXXXX</div>
+  <div class="test min-height stretch" data-expected-height="10">X X</div>
+  <div class="test min-height stretch" data-expected-height="10">XXX XXX</div>
+  <div class="test min-height stretch" data-expected-height="10">XXXXX XXXXX</div>
 
-  <div class="test max-height stretch indefinite" data-expected-height="30">X X</div>
-  <div class="test max-height stretch indefinite" data-expected-height="50">XXX XXX</div>
-  <div class="test max-height stretch indefinite" data-expected-height="50">XXXXX XXXXX</div>
+  <div class="test max-height stretch" data-expected-height="510">X X</div>
+  <div class="test max-height stretch" data-expected-height="510">XXX XXX</div>
+  <div class="test max-height stretch" data-expected-height="510">XXXXX XXXXX</div>
+</div>
+
+<!-- Fit-content with indefinite stretch -->
+<div class="wrapper" style="width: 100px; max-height: 100px">
+  <div class="test height" style="height: fit-content" data-expected-height="30">X X</div>
+  <div class="test height" style="height: fit-content" data-expected-height="50">XXX XXX</div>
+  <div class="test height" style="height: fit-content" data-expected-height="50">XXXXX XXXXX</div>
+
+  <div class="test min-height" style="min-height: fit-content" data-expected-height="30">X X</div>
+  <div class="test min-height" style="min-height: fit-content" data-expected-height="50">XXX XXX</div>
+  <div class="test min-height" style="min-height: fit-content" data-expected-height="50">XXXXX XXXXX</div>
+
+  <div class="test max-height" style="max-height: fit-content" data-expected-height="30">X X</div>
+  <div class="test max-height" style="max-height: fit-content" data-expected-height="50">XXX XXX</div>
+  <div class="test max-height" style="max-height: fit-content" data-expected-height="50">XXXXX XXXXX</div>
 </div>
 
 <script src="/resources/testharness.js"></script>

--- a/css/css-sizing/keyword-sizes-on-floated-element.html
+++ b/css/css-sizing/keyword-sizes-on-floated-element.html
@@ -9,6 +9,12 @@
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 
 <style>
+.wrapper {
+  display: inline-block;
+  vertical-align: top;
+  margin-right: 150px;
+}
+
 .test {
   float: left;
   margin: 5px;
@@ -36,7 +42,7 @@
 <div id="log"></div>
 
 <!-- Intrinsic keywords -->
-<div style="width: 100px; height: 100px">
+<div class="wrapper" style="width: 100px; height: 100px">
   <div class="test width" style="width: min-content" data-expected-width="30">X X</div>
   <div class="test width" style="width: fit-content" data-expected-width="70">X X</div>
   <div class="test width" style="width: max-content" data-expected-width="70">X X</div>
@@ -93,7 +99,7 @@
 </div>
 
 <!-- Definite stretch -->
-<div style="width: 100px; height: 100px">
+<div class="wrapper" style="width: 100px; height: 100px">
   <div class="test width stretch" data-expected-width="90">X X</div>
   <div class="test width stretch" data-expected-width="90">XXX XXX</div>
   <div class="test width stretch" data-expected-width="90">XXXXX XXXXX</div>
@@ -126,18 +132,33 @@
 </div>
 
 <!-- Indefinite stretch -->
-<div style="width: 100px; max-height: 100px">
-  <div class="test height stretch indefinite" data-expected-height="30">X X</div>
-  <div class="test height stretch indefinite" data-expected-height="50">XXX XXX</div>
-  <div class="test height stretch indefinite" data-expected-height="50">XXXXX XXXXX</div>
+<div class="wrapper" style="width: 100px; max-height: 100px">
+  <div class="test height stretch" data-expected-height="30">X X</div>
+  <div class="test height stretch" data-expected-height="50">XXX XXX</div>
+  <div class="test height stretch" data-expected-height="50">XXXXX XXXXX</div>
 
-  <div class="test min-height stretch indefinite" data-expected-height="30">X X</div>
-  <div class="test min-height stretch indefinite" data-expected-height="50">XXX XXX</div>
-  <div class="test min-height stretch indefinite" data-expected-height="50">XXXXX XXXXX</div>
+  <div class="test min-height stretch" data-expected-height="10">X X</div>
+  <div class="test min-height stretch" data-expected-height="10">XXX XXX</div>
+  <div class="test min-height stretch" data-expected-height="10">XXXXX XXXXX</div>
 
-  <div class="test max-height stretch indefinite" data-expected-height="30">X X</div>
-  <div class="test max-height stretch indefinite" data-expected-height="50">XXX XXX</div>
-  <div class="test max-height stretch indefinite" data-expected-height="50">XXXXX XXXXX</div>
+  <div class="test max-height stretch" data-expected-height="510">X X</div>
+  <div class="test max-height stretch" data-expected-height="510">XXX XXX</div>
+  <div class="test max-height stretch" data-expected-height="510">XXXXX XXXXX</div>
+</div>
+
+<!-- Fit-content with indefinite stretch -->
+<div class="wrapper" style="width: 100px; max-height: 100px">
+  <div class="test height" style="height: fit-content" data-expected-height="30">X X</div>
+  <div class="test height" style="height: fit-content" data-expected-height="50">XXX XXX</div>
+  <div class="test height" style="height: fit-content" data-expected-height="50">XXXXX XXXXX</div>
+
+  <div class="test min-height" style="min-height: fit-content" data-expected-height="30">X X</div>
+  <div class="test min-height" style="min-height: fit-content" data-expected-height="50">XXX XXX</div>
+  <div class="test min-height" style="min-height: fit-content" data-expected-height="50">XXXXX XXXXX</div>
+
+  <div class="test max-height" style="max-height: fit-content" data-expected-height="30">X X</div>
+  <div class="test max-height" style="max-height: fit-content" data-expected-height="50">XXX XXX</div>
+  <div class="test max-height" style="max-height: fit-content" data-expected-height="50">XXXXX XXXXX</div>
 </div>
 
 <script src="/resources/testharness.js"></script>

--- a/css/css-sizing/keyword-sizes-on-inline-block.html
+++ b/css/css-sizing/keyword-sizes-on-inline-block.html
@@ -133,17 +133,32 @@
 
 <!-- Indefinite stretch -->
 <div class="wrapper" style="width: 100px; max-height: 100px">
-  <div class="test height stretch indefinite" data-expected-height="30">X X</div>
-  <div class="test height stretch indefinite" data-expected-height="50">XXX XXX</div>
-  <div class="test height stretch indefinite" data-expected-height="50">XXXXX XXXXX</div>
+  <div class="test height stretch" data-expected-height="30">X X</div>
+  <div class="test height stretch" data-expected-height="50">XXX XXX</div>
+  <div class="test height stretch" data-expected-height="50">XXXXX XXXXX</div>
 
-  <div class="test min-height stretch indefinite" data-expected-height="30">X X</div>
-  <div class="test min-height stretch indefinite" data-expected-height="50">XXX XXX</div>
-  <div class="test min-height stretch indefinite" data-expected-height="50">XXXXX XXXXX</div>
+  <div class="test min-height stretch" data-expected-height="10">X X</div>
+  <div class="test min-height stretch" data-expected-height="10">XXX XXX</div>
+  <div class="test min-height stretch" data-expected-height="10">XXXXX XXXXX</div>
 
-  <div class="test max-height stretch indefinite" data-expected-height="30">X X</div>
-  <div class="test max-height stretch indefinite" data-expected-height="50">XXX XXX</div>
-  <div class="test max-height stretch indefinite" data-expected-height="50">XXXXX XXXXX</div>
+  <div class="test max-height stretch" data-expected-height="510">X X</div>
+  <div class="test max-height stretch" data-expected-height="510">XXX XXX</div>
+  <div class="test max-height stretch" data-expected-height="510">XXXXX XXXXX</div>
+</div>
+
+<!-- Fit-content with indefinite stretch -->
+<div class="wrapper" style="width: 100px; max-height: 100px">
+  <div class="test height" style="height: fit-content" data-expected-height="30">X X</div>
+  <div class="test height" style="height: fit-content" data-expected-height="50">XXX XXX</div>
+  <div class="test height" style="height: fit-content" data-expected-height="50">XXXXX XXXXX</div>
+
+  <div class="test min-height" style="min-height: fit-content" data-expected-height="30">X X</div>
+  <div class="test min-height" style="min-height: fit-content" data-expected-height="50">XXX XXX</div>
+  <div class="test min-height" style="min-height: fit-content" data-expected-height="50">XXXXX XXXXX</div>
+
+  <div class="test max-height" style="max-height: fit-content" data-expected-height="30">X X</div>
+  <div class="test max-height" style="max-height: fit-content" data-expected-height="50">XXX XXX</div>
+  <div class="test max-height" style="max-height: fit-content" data-expected-height="50">XXXXX XXXXX</div>
 </div>
 
 <script src="/resources/testharness.js"></script>

--- a/css/css-sizing/keyword-sizes-on-replaced-element.html
+++ b/css/css-sizing/keyword-sizes-on-replaced-element.html
@@ -8,6 +8,12 @@
 <meta assert="The various keyword sizes work as expected on replaced elements.">
 
 <style>
+.wrapper {
+  display: inline-block;
+  vertical-align: top;
+  margin-right: 150px;
+}
+
 .test {
   margin: 5px;
   border: 3px solid;
@@ -35,7 +41,7 @@
 <div id="log"></div>
 
 <!-- Intrinsic keywords -->
-<div style="width: 200px; height: 100px">
+<div class="wrapper" style="width: 200px; height: 100px">
   <canvas width="100" height="100" class="test width height" style="width: 50px; height: 50px"
           data-expected-width="60" data-expected-height="60"></canvas>
   <canvas width="100" height="100" class="test width height" style="width: 50px; height: min-content"
@@ -141,7 +147,7 @@
 </div>
 
 <!-- Definite stretch -->
-<div style="width: 200px; height: 100px">
+<div class="wrapper" style="width: 200px; height: 100px">
   <canvas width="100" height="100" class="test width stretch"
           data-expected-width="190" data-expected-height="190"></canvas>
   <canvas width="100" height="100" class="test min-width stretch"
@@ -167,26 +173,50 @@
 </div>
 
 <!-- Indefinite stretch -->
-<div style="width: 200px; max-height: 100px">
-  <canvas width="100" height="100" class="test height stretch indefinite"
+<div class="wrapper" style="width: 200px; max-height: 100px">
+  <canvas width="100" height="100" class="test height stretch"
           data-expected-width="110" data-expected-height="110"></canvas>
-  <canvas width="100" height="100" class="test min-height stretch indefinite"
+  <canvas width="100" height="100" class="test min-height stretch"
+          data-expected-width="10" data-expected-height="10"></canvas>
+  <canvas width="100" height="100" class="test max-height stretch"
+          data-expected-width="510" data-expected-height="510"></canvas>
+
+  <canvas width="100" height="100" class="test height stretch" style="max-width: 50px"
+          data-expected-width="60" data-expected-height="60"></canvas>
+  <canvas width="100" height="100" class="test min-height stretch" style="min-width: 50px"
+          data-expected-width="60" data-expected-height="10"></canvas>
+  <canvas width="100" height="100" class="test max-height stretch" style="max-width: 50px"
+          data-expected-width="60" data-expected-height="510"></canvas>
+
+  <canvas width="100" height="100" class="test height stretch" style="min-width: 150px"
+          data-expected-width="160" data-expected-height="160"></canvas>
+  <canvas width="100" height="100" class="test min-height stretch" style="min-width: 150px"
+          data-expected-width="160" data-expected-height="10"></canvas>
+  <canvas width="100" height="100" class="test max-height stretch" style="max-width: 150px"
+          data-expected-width="160" data-expected-height="510"></canvas>
+</div>
+
+<!-- Fit-content with indefinite stretch -->
+<div class="wrapper" style="width: 200px; max-height: 100px">
+  <canvas width="100" height="100" class="test height" style="height: fit-content"
+          data-expected-width="110" data-expected-height="110"></canvas>
+  <canvas width="100" height="100" class="test min-height" style="min-height: fit-content"
           data-expected-width="10" data-expected-height="110"></canvas>
-  <canvas width="100" height="100" class="test max-height stretch indefinite"
+  <canvas width="100" height="100" class="test max-height" style="max-height: fit-content"
           data-expected-width="510" data-expected-height="110"></canvas>
 
-  <canvas width="100" height="100" class="test height stretch indefinite" style="max-width: 50px"
+  <canvas width="100" height="100" class="test height" style="max-width: 50px; height: fit-content"
           data-expected-width="60" data-expected-height="60"></canvas>
-  <canvas width="100" height="100" class="test min-height stretch indefinite" style="min-width: 50px"
+  <canvas width="100" height="100" class="test min-height" style="min-width: 50px; min-height: fit-content"
           data-expected-width="60" data-expected-height="110"></canvas>
-  <canvas width="100" height="100" class="test max-height stretch indefinite" style="max-width: 50px"
+  <canvas width="100" height="100" class="test max-height" style="max-width: 50px; max-height: fit-content"
           data-expected-width="60" data-expected-height="60"></canvas>
 
-  <canvas width="100" height="100" class="test height stretch indefinite" style="min-width: 150px"
+  <canvas width="100" height="100" class="test height" style="min-width: 150px; height: fit-content"
           data-expected-width="160" data-expected-height="160"></canvas>
-  <canvas width="100" height="100" class="test min-height stretch indefinite" style="min-width: 150px"
+  <canvas width="100" height="100" class="test min-height" style="min-width: 150px; min-height: fit-content"
           data-expected-width="160" data-expected-height="160"></canvas>
-  <canvas width="100" height="100" class="test max-height stretch indefinite" style="max-width: 150px"
+  <canvas width="100" height="100" class="test max-height" style="max-width: 150px; max-height: fit-content"
           data-expected-width="160" data-expected-height="110"></canvas>
 </div>
 


### PR DESCRIPTION
We were always treating an indefinite `stretch` as the automatic size. This instead treats it as `0px` on min sizing properties, and as `none` on max sizing properties, aligning with Blink and this recent CSSWG resolution: https://github.com/w3c/csswg-drafts/issues/11006

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#35630