### PR TITLE
Add more tests for CSP violations of require-trusted-types-for directive.

### DIFF
--- a/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-001.html
+++ b/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-001.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./support/csp-violations.js"></script>
+<script>
+  promise_test(async t => {
+    let results = await trySendingPlainStringToTrustedTypeSink(
+      ["script"],
+      `\
+header(Content-Security-Policy,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy,require-trusted-types-for 'invalid',True)|\
+header(Content-Security-Policy,require-trusted-types-for 'script',True)`
+    );
+    assert_equals(results.length, 1);
+    assert_true(results[0].exception instanceof TypeError);
+    assert_equals(results[0].violatedPolicies.length, 5);
+  }, `Multiple enforce require-trusted-types-for directives.`);
+
+  promise_test(async t => {
+    let results = await trySendingPlainStringToTrustedTypeSink(
+      ["script"],
+      `\
+header(Content-Security-Policy-Report-Only,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy-Report-Only,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy-Report-Only,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy-Report-Only,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy-Report-Only,require-trusted-types-for 'invalid',True)|\
+header(Content-Security-Policy-Report-Only,require-trusted-types-for 'script',True)`
+    );
+    assert_equals(results.length, 1);
+    assert_equals(results[0].exception, null);
+    assert_equals(results[0].violatedPolicies.length, 5);
+  }, `Multiple report-only require-trusted-types-for directives.`);
+
+  promise_test(async t => {
+    let results = await trySendingPlainStringToTrustedTypeSink(
+      ["script"],
+      `\
+header(Content-Security-Policy-Report-Only,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy,require-trusted-types-for 'unknown',True)|\
+header(Content-Security-Policy,require-trusted-types-for 'script',True)`
+    );
+    assert_equals(results.length, 1);
+    assert_true(results[0].exception instanceof TypeError);
+    assert_equals(results[0].violatedPolicies.length, 5);
+  }, `One violated report-only require-trusted-types-for directive followed by multiple enforce directives`);
+
+  promise_test(async t => {
+    let results = await trySendingPlainStringToTrustedTypeSink(
+      ["script"],
+      `\
+header(Content-Security-Policy,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy-Report-Only,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy-Report-Only,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy-Report-Only,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy-Report-Only,require-trusted-types-for 'unknown',True)|\
+header(Content-Security-Policy-Report-Only,require-trusted-types-for 'script',True)`
+    );
+    assert_equals(results.length, 1);
+    assert_true(results[0].exception instanceof TypeError);
+    assert_equals(results[0].violatedPolicies.length, 5);
+  }, `One violated enforce require-trusted-types-for directive followed by multiple report-only directives`);
+
+
+  promise_test(async t => {
+    let results = await trySendingPlainStringToTrustedTypeSink(
+      ["script"],
+      `\
+header(Content-Security-Policy,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy-Report-Only,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy-Report-Only,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy,require-trusted-types-for 'script',True)|\
+header(Content-Security-Policy-Report-Only,require-trusted-types-for 'script',True)`
+    );
+    assert_equals(results.length, 1);
+    assert_true(results[0].exception instanceof TypeError);
+
+    let violations = results[0].violatedPolicies.sort();
+    assert_equals(violations.length, 6);
+    assert_equals(violations[0].disposition, "enforce");
+    assert_equals(violations[0].policy, "require-trusted-types-for 'script'")
+    assert_equals(violations[1].disposition, "enforce");
+    assert_equals(violations[1].policy, "require-trusted-types-for 'script'")
+    assert_equals(violations[2].disposition, "enforce");
+    assert_equals(violations[2].policy, "require-trusted-types-for 'script'")
+    assert_equals(violations[3].disposition, "report");
+    assert_equals(violations[3].policy, "require-trusted-types-for 'script'")
+    assert_equals(violations[4].disposition, "report");
+    assert_equals(violations[4].policy, "require-trusted-types-for 'script'")
+    assert_equals(violations[5].disposition, "report");
+    assert_equals(violations[5].policy, "require-trusted-types-for 'script'")
+  }, `Mixing enforce and report-only require-trusted-types-for directives.`);
+
+  promise_test(async t => {
+    let results = await trySendingPlainStringToTrustedTypeSink(
+      ["script"],
+      "header(Content-Security-Policy,require-trusted-types-for 'script'%09'script'%0A'script'%0C'script'%0D'script'%20'script',True)",
+    );
+    assert_equals(results.length, 1);
+    assert_true(results[0].exception instanceof TypeError);
+    assert_equals(results[0].violatedPolicies.length, 1);
+  }, `directive "require-trusted-types-for 'script'%09'script'%0A'script'%0C'script'%0D'script'%20'script'" (required-ascii-whitespace)`);
+
+  promise_test(async t => {
+    let results = await trySendingPlainStringToTrustedTypeSink(
+      ["script"],
+      "header(Content-Security-Policy,require-trusted-types-for 'script''script' 'script',True)",
+    );
+    assert_equals(results.length, 1);
+    assert_equals(results[0].exception, null);
+    assert_equals(results[0].violatedPolicies.length, 0);
+  }, `invalid directive "require-trusted-types-for 'script''script'" (no ascii-whitespace)`);
+
+  // https://github.com/w3c/trusted-types/issues/580
+  promise_test(async t => {
+    let results = await trySendingPlainStringToTrustedTypeSink(
+      ["script"],
+      "header(Content-Security-Policy,require-trusted-types-for 'script' 'invalid',True)",
+    );
+    assert_equals(results.length, 1);
+    assert_true(results[0].exception instanceof TypeError);
+    assert_equals(results[0].violatedPolicies.length, 1);
+  }, `directive "require-trusted-types-for 'script' 'invalid'" (unknown sink group)`);
+</script>

--- a/trusted-types/support/csp-violations.js
+++ b/trusted-types/support/csp-violations.js
@@ -99,3 +99,18 @@ function tryCreatingTrustedTypePoliciesWithCSP(policyNames, cspHeaders) {
     document.head.appendChild(iframe);
   });
 }
+
+function trySendingPlainStringToTrustedTypeSink(sinkGroups, cspHeaders) {
+  return new Promise(resolve => {
+    window.addEventListener("message", event => {
+      resolve(event.data);
+    }, {once: true});
+    let iframe = document.createElement("iframe");
+    let url = `/trusted-types/support/send-plain-string-to-trusted-type-sink.html?sinkGroups=${sinkGroups.map(name => encodeURIComponent(name)).toString()}`;
+    url += "&pipe=header(Content-Security-Policy,connect-src 'none')"
+    if (cspHeaders)
+      url += `|${cspHeaders}`;
+    iframe.src = url;
+    document.head.appendChild(iframe);
+  });
+}

--- a/trusted-types/support/send-plain-string-to-trusted-type-sink.html
+++ b/trusted-types/support/send-plain-string-to-trusted-type-sink.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="./csp-violations.js"></script>
+<script>
+const params = new URLSearchParams(window.location.search);
+const maxSinkGroupCount = 10;
+let results = [];
+async function trySendPlainStringToTrustedTypeSink(sinkGroup) {
+  let {violations, exception} = await trusted_type_violations_and_exception_for(_ => {
+    switch (sinkGroup) {
+    case "script":
+      document.createElement("div").innerHTML = "unsafe";
+      break;
+    default:
+      throw "unknown sink group";
+      break;
+    }
+  });
+  return {
+    sinkGroup: sinkGroup,
+    exception: exception,
+    violatedPolicies: violations.map(v => {
+      return { policy: v.originalPolicy, disposition: v.disposition};
+    }),
+  };
+}
+(async function (sinkGroup) {
+  for (let sinkGroup of params.get("sinkGroups").split(",", maxSinkGroupCount)) {
+    results.push(await trySendPlainStringToTrustedTypeSink(sinkGroup));
+  }
+  parent.postMessage(results);
+})();
+</script>


### PR DESCRIPTION
This applies on top of https://github.com/web-platform-tests/wpt/pull/50872