### PR TITLE
Avoid "OSError: [Errno 39] Directory not empty" when running tests

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -3,6 +3,7 @@
 import base64
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 import threading
@@ -221,7 +222,7 @@ class ServoRefTestExecutor(ServoExecutor):
         self.implementation.reset()
 
     def teardown(self):
-        os.rmdir(self.tempdir)
+        shutil.rmtree(self.tempdir)
         ServoExecutor.teardown(self)
 
     def screenshot(self, test, viewport_size, dpi, page_ranges):


### PR DESCRIPTION
Since #<!-- nolink -->35538, when executorservo.py tries to remove the temporary directories after running tests, an error is produced because these directories aren't empty.

Therefore, this changes `os.rmdir` into `shutil.rmtree`, in order to remove the directories and their contents.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#35641