### PR TITLE
layout: Support `stretch` cross size for automatic min size in flexbox

### DIFF
--- a/css/css-sizing/stretch/flexbox-auto-minimum-001.html
+++ b/css/css-sizing/stretch/flexbox-auto-minimum-001.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Automatic minimum size of flex item with stretch cross size</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#stretch-fit-sizing">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#min-size-auto">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta assert="A definite `stretch` cross size can be transferred through the
+  aspect ratio when computing the automatic minimum size of a flex item.">
+
+<style>
+div {
+  display: flex;
+  flex-direction: column;
+  height: 200px;
+  width: 200px;
+  background: red;
+}
+canvas {
+  width: stretch;
+  align-self: start;
+  flex-basis: 0;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class="flex">
+  <canvas width="100" height="100"></canvas>
+</div>

--- a/css/css-sizing/stretch/flexbox-auto-minimum-002.html
+++ b/css/css-sizing/stretch/flexbox-auto-minimum-002.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Automatic minimum size of flex item with stretch cross size</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#stretch-fit-sizing">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#min-size-auto">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta assert="A definite `stretch` cross size can be transferred through the
+  aspect ratio when computing the automatic minimum size of a flex item.">
+
+<style>
+div {
+  display: flex;
+  flex-direction: row;
+  height: 200px;
+  width: 200px;
+  background: red;
+}
+canvas {
+  height: stretch;
+  align-self: start;
+  flex-basis: 0;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class="flex">
+  <canvas width="100" height="100"></canvas>
+</div>


### PR DESCRIPTION
The computation of the automatic minimum size may involve transferring a definite cross size into the main axis through the aspect ratio. We were only considering numeric sizes as definite, but `stretch` can also be definite.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#35652