### PR TITLE
Adjust Fuzzy Matching for backdrop-filter Test to Reduce Rendering Variability

### DIFF
--- a/css/filter-effects/backdrop-filter-backdrop-root-backdrop-filter.html
+++ b/css/filter-effects/backdrop-filter-backdrop-root-backdrop-filter.html
@@ -5,6 +5,7 @@
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropRoot">
 <link rel=stylesheet  href="resources/backdrop-filter-backdrop-root.css">
 <link rel="match"  href="backdrop-filter-backdrop-root-ref.html">
+<meta name="fuzzy" content="0-1;0-2696">
 
 <!-- A Backdrop Root is formed, anywhere in the document, by:
      - An element with a backdrop-filter value other than "none".

--- a/css/filter-effects/backdrop-filter-backdrop-root-opacity.html
+++ b/css/filter-effects/backdrop-filter-backdrop-root-opacity.html
@@ -5,6 +5,7 @@
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropRoot">
 <link rel=stylesheet  href="resources/backdrop-filter-backdrop-root.css">
 <link rel="match"  href="backdrop-filter-backdrop-root-opacity-ref.html">
+<meta name="fuzzy" content="0-2;0-2696">
 <meta name="fuzzy" content="maxDifference=0-5;totalPixels=0-500">
 
 <!-- A Backdrop Root is formed, anywhere in the document, by:

--- a/css/filter-effects/backdrop-filter-clip-rect-zoom.html
+++ b/css/filter-effects/backdrop-filter-clip-rect-zoom.html
@@ -4,6 +4,7 @@
 <link rel="author" href="mailto:masonf@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
 <link rel="match"  href="backdrop-filter-clip-rect-zoom-ref.html">
+<meta name="fuzzy" content="0-1;0-3">
 
 <div class="box"></div>
 <div class="navbar">

--- a/css/filter-effects/css-filters-animation-brightness.html
+++ b/css/filter-effects/css-filters-animation-brightness.html
@@ -10,6 +10,7 @@
     <link rel="help" href="http://www.w3.org/TR/css3-animations/#animations">
     <link rel="match" href="css-filters-animation-brightness-ref.html">
     <meta name="assert" content="The blue square should be dark blue">
+    <meta name="fuzzy" content="0-1;0-37500">
     <style type="text/css">
         @keyframes animate {
             0% {


### PR DESCRIPTION
#### f6d3b0c1b98a174719f55be1694ee7ab61331c09
<pre>
Adjust Fuzzy Matching for backdrop-filter Test to Reduce Rendering Variability

Adjusts fuzzy matching to prevent false failures caused by minor pixel differences in backdrop-filter rendering.

* css/filter-effects/backdrop-filter-backdrop-root-backdrop-filter.html:
* css/filter-effects/backdrop-filter-backdrop-root-opacity.html:
* css/filter-effects/backdrop-filter-clip-rect-zoom.html:
* css/filter-effects/css-filters-animation-brightness.html:
</pre>