### PR TITLE
[wdspec] fix test_params_extension_data_path_invalid_webextension

### DIFF
--- a/webdriver/tests/bidi/web_extension/install/invalid.py
+++ b/webdriver/tests/bidi/web_extension/install/invalid.py
@@ -74,7 +74,7 @@ async def test_params_extension_data_archive_path_invalid_webextension(bidi_sess
 async def test_params_extension_data_path_invalid_webextension(bidi_session, extension_data):
     with pytest.raises(error.InvalidWebExtensionException):
         await bidi_session.web_extension.install(
-            extension_data={"type": "path", "path": extension_data["unsigned.xpi"]}
+            extension_data={"type": "path", "path": extension_data["archivePath"]}
         )
 
 


### PR DESCRIPTION
`unsigned.xpi` does not exist in `extension_data`. Instead `archivePath` should be used.