### PR TITLE
[Bluetooth] Align bluetooth tests with the spec

### DIFF
--- a/tools/webdriver/webdriver/bidi/modules/bluetooth.py
+++ b/tools/webdriver/webdriver/bidi/modules/bluetooth.py
@@ -23,14 +23,15 @@ class Bluetooth(BidiModule):
         }
 
     @command
-    def simulate_adapter(self, context: str, state: str) -> Mapping[str, Any]:
+    def simulate_adapter(self, context: str, state: str, type_: str) -> Mapping[str, Any]:
         """
         Represents a command `bluetooth.simulateAdapter` specified in
         https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulateAdapter-command
         """
         return {
             "context": context,
-            "state": state
+            "state": state,
+            "type": type_
         }
 
     @command

--- a/tools/wptrunner/wptrunner/executors/asyncactions.py
+++ b/tools/wptrunner/wptrunner/executors/asyncactions.py
@@ -55,7 +55,9 @@ class BidiBluetoothSimulateAdapterAction:
             raise ValueError("Unexpected context type: %s" % context)
 
         state = payload["state"]
-        return await self.protocol.bidi_bluetooth.simulate_adapter(context, state)
+        return await self.protocol.bidi_bluetooth.simulate_adapter(context,
+                                                                   state,
+                                                                   type_="create")
 
 class BidiBluetoothSimulatePreconnectedPeripheralAction:
     name = "bidi.bluetooth.simulate_preconnected_peripheral"

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -138,9 +138,10 @@ class WebDriverBidiBluetoothProtocolPart(BidiBluetoothProtocolPart):
 
     async def simulate_adapter(self,
           context: str,
-          state: str) -> None:
+          state: str,
+          type_: str) -> None:
         await self.webdriver.bidi_session.bluetooth.simulate_adapter(
-            context=context, state=state)
+            context=context, state=state, type_=type_)
 
     async def simulate_preconnected_peripheral(self,
             context: str,

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -355,7 +355,8 @@ class BidiBluetoothProtocolPart(ProtocolPart):
     @abstractmethod
     async def simulate_adapter(self,
                                context: str,
-                               state: str) -> None:
+                               state: str,
+                               type_: str) -> None:
         """
         Creates a simulated bluetooth adapter.
         :param context: Browsing context to set the simulated adapter to.

--- a/webdriver/tests/bidi/external/bluetooth/simulate_adapter/__init__.py
+++ b/webdriver/tests/bidi/external/bluetooth/simulate_adapter/__init__.py
@@ -15,4 +15,4 @@ async def set_simulate_adapter(bidi_session, context, test_page, state):
                                                  url=test_page, wait="complete")
 
     await bidi_session.bluetooth.simulate_adapter(context=context["context"],
-                                                  state=state)
+                                                  state=state, type_="create")

--- a/webdriver/tests/bidi/external/bluetooth/simulate_adapter/invalid.py
+++ b/webdriver/tests/bidi/external/bluetooth/simulate_adapter/invalid.py
@@ -8,24 +8,24 @@ pytestmark = pytest.mark.asyncio
 async def test_state_invalid_type(bidi_session, top_context, state):
     with pytest.raises(error.InvalidArgumentException):
         await bidi_session.bluetooth.simulate_adapter(
-            context=top_context["context"], state=state)
+            context=top_context["context"], state=state, type_="create")
 
 
 @pytest.mark.parametrize("state", ["", "invalid"])
 async def test_state_invalid_value(bidi_session, top_context, state):
     with pytest.raises(error.InvalidArgumentException):
         await bidi_session.bluetooth.simulate_adapter(
-            context=top_context["context"], state=state)
+            context=top_context["context"], state=state, type_="create")
 
 
 @pytest.mark.parametrize("context", [None, False, 42, {}, []])
 async def test_context_invalid_type(bidi_session, context):
     with pytest.raises(error.InvalidArgumentException):
         await bidi_session.bluetooth.simulate_adapter(
-            context=context, state="powered-on")
+            context=context, state="powered-on", type_="create")
 
 
 async def test_context_unknown_value(bidi_session):
     with pytest.raises(error.NoSuchFrameException):
         await bidi_session.bluetooth.simulate_adapter(
-            context="UNKNOWN_CONTEXT", state="powered-on")
+            context="UNKNOWN_CONTEXT", state="powered-on", type_="create")

--- a/webdriver/tests/bidi/external/bluetooth/simulate_preconnected_peripheral/__init__.py
+++ b/webdriver/tests/bidi/external/bluetooth/simulate_preconnected_peripheral/__init__.py
@@ -6,7 +6,7 @@ async def set_simulate_preconnected_peripheral(bidi_session, context, test_page,
     await bidi_session.browsing_context.navigate(context=context['context'],
                                                  url=test_page, wait="complete")
     await bidi_session.bluetooth.simulate_adapter(context=context["context"],
-                                                  state="powered-on")
+                                                  state="powered-on", type_="create")
     await bidi_session.bluetooth.simulate_preconnected_peripheral(
         context=context["context"],
         address=address, name=name,


### PR DESCRIPTION
Add new required parameter ["create"](https://github.com/WebBluetoothCG/web-bluetooth/commit/63090299716cb458b34ea19e08bee6528d04ed18#diff-5e793325cd2bfc452e268a4aa2f02b4024dd9584bd1db3c2595f61f1ecf7b985R5199) to [`bluetooth.simulateAdapter`](https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulateAdapter-command) command.