### PR TITLE
Various fixes for webdriver conformance tests

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -48,11 +48,13 @@ def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
         "server_config": config,
         "user_stylesheets": kwargs.get("user_stylesheets"),
         "headless": kwargs.get("headless"),
+        "capabilities": kwargs.get("capabilities"),
     }
 
 
 def executor_kwargs(logger, test_type, test_environment, run_info_data, **kwargs):
     rv = base_executor_kwargs(test_type, test_environment, run_info_data, **kwargs)
+    rv['capabilities'] = {}
     return rv
 
 

--- a/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -78,7 +78,7 @@ class ServoWebDriverTestharnessExecutor(WebDriverTestharnessExecutor):
     protocol_cls = ServoWebDriverProtocol
 
     def __init__(self, logger, browser, server_config, timeout_multiplier=1,
-                 close_after_done=True, capabilities={}, debug_info=None,
+                 close_after_done=True, capabilities=None, debug_info=None,
                  **kwargs):
         WebDriverTestharnessExecutor.__init__(self, logger, browser, server_config,
                                               timeout_multiplier, capabilities=capabilities,
@@ -96,7 +96,7 @@ class ServoWebDriverRefTestExecutor(WebDriverRefTestExecutor):
     protocol_cls = ServoWebDriverProtocol
 
     def __init__(self, logger, browser, server_config, timeout_multiplier=1,
-                 screenshot_cache=None, capabilities={}, debug_info=None,
+                 screenshot_cache=None, capabilities=None, debug_info=None,
                  **kwargs):
         WebDriverRefTestExecutor.__init__(self, logger, browser, server_config,
                                           timeout_multiplier, screenshot_cache,
@@ -114,7 +114,7 @@ class ServoWebDriverCrashtestExecutor(WebDriverCrashtestExecutor):
     protocol_cls = ServoWebDriverProtocol
 
     def __init__(self, logger, browser, server_config, timeout_multiplier=1,
-                 screenshot_cache=None, capabilities={}, debug_info=None,
+                 screenshot_cache=None, capabilities=None, debug_info=None,
                  **kwargs):
         WebDriverCrashtestExecutor.__init__(self, logger, browser, server_config,
                                             timeout_multiplier, screenshot_cache,


### PR DESCRIPTION
I'm working through test failures under tests/wpt/tests/webdriver/tests/classic/execute_script/execute.py, and these changes allow many of the tests in that file to pass.

Reviewed in servo/servo#35737