### PR TITLE
Add test case for ElementInternals validation customError

### DIFF
--- a/custom-elements/form-associated/ElementInternals-validation.html
+++ b/custom-elements/form-associated/ElementInternals-validation.html
@@ -170,6 +170,12 @@ test(() => {
   assert_false(validity.valid);
   assert_equals(control.i.validationMessage, 'customError message');
 
+  // customError should be false if not explicitly set
+  control.i.setValidity({badInput: true}, 'error message');
+  assert_false(validity.customError);
+  assert_false(validity.valid);
+  assert_equals(control.i.validationMessage, 'error message');
+
   // Set multiple flags
   control.i.setValidity({badInput: true, customError: true}, 'multiple errors');
   assert_true(validity.badInput);

--- a/custom-elements/form-associated/ElementInternals-validation.html
+++ b/custom-elements/form-associated/ElementInternals-validation.html
@@ -170,12 +170,6 @@ test(() => {
   assert_false(validity.valid);
   assert_equals(control.i.validationMessage, 'customError message');
 
-  // customError should be false if not explicitly set
-  control.i.setValidity({badInput: true}, 'error message');
-  assert_false(validity.customError);
-  assert_false(validity.valid);
-  assert_equals(control.i.validationMessage, 'error message');
-
   // Set multiple flags
   control.i.setValidity({badInput: true, customError: true}, 'multiple errors');
   assert_true(validity.badInput);
@@ -193,6 +187,14 @@ test(() => {
   assert_throws_js(TypeError, () => { control.i.setValidity({valueMissing: true}); },
       'setValidity() requires the second argument if the first argument contains true');
 }, 'validity and setValidity()');
+
+test(() => {
+  const control = document.createElement('my-control');  
+  control.i.setValidity({badInput: true}, 'error message');
+  assert_false(validity.customError);
+  assert_false(validity.valid);
+  assert_equals(control.i.validationMessage, 'error message');
+}, "validity.customError should be false if not explicitly set via setValidity()");
 
 test(() => {
   document.body.insertAdjacentHTML('afterbegin', '<my-control><light-child></my-control>');

--- a/custom-elements/form-associated/ElementInternals-validation.html
+++ b/custom-elements/form-associated/ElementInternals-validation.html
@@ -189,7 +189,7 @@ test(() => {
 }, 'validity and setValidity()');
 
 test(() => {
-  const control = document.createElement('my-control');  
+  const control = document.createElement('my-control');
   control.i.setValidity({badInput: true}, 'error message');
   assert_false(validity.customError);
   assert_false(validity.valid);


### PR DESCRIPTION
`customError` in ValidityState should only be true, if explicitly set. This is currently correct in Chromium and Firefox, but not WebKit.