### PR TITLE
taskcluster: update wpt docker image to use Ubuntu 22.04 as base

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -57,7 +57,7 @@ tasks:
             owner: ${owner}
             source: ${event.repository.clone_url}
           payload:
-            image: ghcr.io/web-platform-tests/wpt:1
+            image: ghcr.io/web-platform-tests/wpt:2
             maxRunTime: 7200
             artifacts:
               public/results:

--- a/css/css-transforms/group/svg-transform-nested-019.html
+++ b/css/css-transforms/group/svg-transform-nested-019.html
@@ -6,7 +6,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#svg-transform">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <link rel="match" href="reference/svg-green-square-250x250-ref.html">
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-299">
+    <meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-400">
     <meta name="flags" content="svg">
     <meta name="assert" content="Transforms on a parent element should be pre-multiplied to transforms on a child element.  The group of elements should be skewed vertically.  Additionally, the child rect should be translated.">
     <style type="text/css">

--- a/css/css-ui/appearance-auto-001.html
+++ b/css/css-ui/appearance-auto-001.html
@@ -3,6 +3,7 @@
 <title>CSS Basic User Interface Test: appearance: auto</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="auto is supported.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/appearance-button-001.html
+++ b/css/css-ui/appearance-button-001.html
@@ -3,6 +3,7 @@
 <title>CSS Basic User Interface Test: appearance: button</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="button is an alias to auto.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/appearance-checkbox-001.html
+++ b/css/css-ui/appearance-checkbox-001.html
@@ -3,6 +3,7 @@
 <title>CSS Basic User Interface Test: appearance: checkbox</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="checkbox is an alias to auto.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/appearance-listbox-001.html
+++ b/css/css-ui/appearance-listbox-001.html
@@ -3,6 +3,7 @@
 <title>CSS Basic User Interface Test: appearance: listbox</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="listbox is an alias to auto.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/appearance-menulist-001.html
+++ b/css/css-ui/appearance-menulist-001.html
@@ -3,6 +3,7 @@
 <title>CSS Basic User Interface Test: appearance: menulist</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="menulist is an alias to auto.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/appearance-menulist-button-001.html
+++ b/css/css-ui/appearance-menulist-button-001.html
@@ -3,6 +3,7 @@
 <title>CSS Basic User Interface Test: appearance: menulist-button</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="menulist-button is an alias to auto except on drop-down select.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/appearance-meter-001.html
+++ b/css/css-ui/appearance-meter-001.html
@@ -3,6 +3,7 @@
 <title>CSS Basic User Interface Test: appearance: meter</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="meter is an alias to auto.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/appearance-progress-bar-001.html
+++ b/css/css-ui/appearance-progress-bar-001.html
@@ -3,6 +3,7 @@
 <title>CSS Basic User Interface Test: appearance: progress-bar</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="progress-bar is an alias to auto.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/appearance-radio-001.html
+++ b/css/css-ui/appearance-radio-001.html
@@ -3,6 +3,7 @@
 <title>CSS Basic User Interface Test: appearance: radio</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="radio is an alias to auto.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/appearance-searchfield-001.html
+++ b/css/css-ui/appearance-searchfield-001.html
@@ -3,6 +3,7 @@
 <title>CSS Basic User Interface Test: appearance: searchfield</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="searchfield is an alias to auto.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/appearance-textarea-001.html
+++ b/css/css-ui/appearance-textarea-001.html
@@ -3,6 +3,7 @@
 <title>CSS Basic User Interface Test: appearance: textarea</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="textarea is an alias to auto.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/webkit-appearance-auto-001.html
+++ b/css/css-ui/webkit-appearance-auto-001.html
@@ -7,6 +7,7 @@ Edit the appearance-* file instead and then run:
 <title>CSS Basic User Interface Test: -webkit-appearance: auto</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="auto is supported.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/webkit-appearance-button-001.html
+++ b/css/css-ui/webkit-appearance-button-001.html
@@ -7,6 +7,7 @@ Edit the appearance-* file instead and then run:
 <title>CSS Basic User Interface Test: -webkit-appearance: button</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="button is an alias to auto.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/webkit-appearance-checkbox-001.html
+++ b/css/css-ui/webkit-appearance-checkbox-001.html
@@ -7,6 +7,7 @@ Edit the appearance-* file instead and then run:
 <title>CSS Basic User Interface Test: -webkit-appearance: checkbox</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="checkbox is an alias to auto.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/webkit-appearance-listbox-001.html
+++ b/css/css-ui/webkit-appearance-listbox-001.html
@@ -7,6 +7,7 @@ Edit the appearance-* file instead and then run:
 <title>CSS Basic User Interface Test: -webkit-appearance: listbox</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="listbox is an alias to auto.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/webkit-appearance-menulist-001.html
+++ b/css/css-ui/webkit-appearance-menulist-001.html
@@ -7,6 +7,7 @@ Edit the appearance-* file instead and then run:
 <title>CSS Basic User Interface Test: -webkit-appearance: menulist</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="menulist is an alias to auto.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/webkit-appearance-menulist-button-001.html
+++ b/css/css-ui/webkit-appearance-menulist-button-001.html
@@ -7,6 +7,7 @@ Edit the appearance-* file instead and then run:
 <title>CSS Basic User Interface Test: -webkit-appearance: menulist-button</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="menulist-button is an alias to auto except on drop-down select.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/webkit-appearance-meter-001.html
+++ b/css/css-ui/webkit-appearance-meter-001.html
@@ -7,6 +7,7 @@ Edit the appearance-* file instead and then run:
 <title>CSS Basic User Interface Test: -webkit-appearance: meter</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="meter is an alias to auto.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/webkit-appearance-progress-bar-001.html
+++ b/css/css-ui/webkit-appearance-progress-bar-001.html
@@ -7,6 +7,7 @@ Edit the appearance-* file instead and then run:
 <title>CSS Basic User Interface Test: -webkit-appearance: progress-bar</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="progress-bar is an alias to auto.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/webkit-appearance-radio-001.html
+++ b/css/css-ui/webkit-appearance-radio-001.html
@@ -7,6 +7,7 @@ Edit the appearance-* file instead and then run:
 <title>CSS Basic User Interface Test: -webkit-appearance: radio</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="radio is an alias to auto.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/webkit-appearance-searchfield-001.html
+++ b/css/css-ui/webkit-appearance-searchfield-001.html
@@ -7,6 +7,7 @@ Edit the appearance-* file instead and then run:
 <title>CSS Basic User Interface Test: -webkit-appearance: searchfield</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="searchfield is an alias to auto.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/css/css-ui/webkit-appearance-textarea-001.html
+++ b/css/css-ui/webkit-appearance-textarea-001.html
@@ -7,6 +7,7 @@ Edit the appearance-* file instead and then run:
 <title>CSS Basic User Interface Test: -webkit-appearance: textarea</title>
 <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
 <meta name="assert" content="textarea is an alias to auto.">
+<meta name="fuzzy" content="totalPixels=0-2;maxDifference=0-1">
 <link rel="match" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -4,7 +4,7 @@ components:
     workerType: ci
     schedulerId: taskcluster-github
     deadline: "24 hours"
-    image: ghcr.io/web-platform-tests/wpt:1
+    image: ghcr.io/web-platform-tests/wpt:2
     maxRunTime: 7200
     artifacts:
       public/results:

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -8,14 +8,14 @@ import subprocess
 import sys
 import tempfile
 import time
-
 from urllib.request import urlopen
 from urllib.error import URLError
 
 import pytest
 
-here = os.path.abspath(os.path.dirname(__file__))
 from tools.wpt import utils, wpt
+
+here = os.path.abspath(os.path.dirname(__file__))
 
 
 def is_port_8000_in_use():
@@ -53,6 +53,22 @@ def manifest_dir():
         shutil.copyfile(get_persistent_manifest_path(),
                         os.path.join(path, "MANIFEST.json"))
         yield path
+    finally:
+        utils.rmtree(path)
+
+
+@pytest.fixture(scope="module")
+def download_firefox():
+    print("download_firefox")
+    try:
+        path = tempfile.mkdtemp()
+        with pytest.raises(SystemExit) as excinfo:
+            wpt.main(argv=["install", "-d", path,
+                           "firefox", "browser"])
+            assert excinfo.value.code == 0
+        bin_path = os.path.join(path, "browsers", "nightly")
+        assert os.path.exists(bin_path)
+        yield bin_path
     finally:
         utils.rmtree(path)
 
@@ -120,7 +136,8 @@ def test_list_tests(manifest_dir):
 
 
 @pytest.mark.slow
-def test_list_tests_missing_manifest(manifest_dir):
+@pytest.mark.remote_network
+def test_list_tests_missing_manifest(manifest_dir, download_firefox):
     """The `--list-tests` option should not produce an error in the absence of
     a test manifest file."""
 
@@ -135,17 +152,20 @@ def test_list_tests_missing_manifest(manifest_dir):
                        # drastically reduces the time to execute the test.
                        "--tests", here,
                        "--metadata", manifest_dir,
+                       "--log-mach", "-",
                        "--list-tests",
                        "--yes",
                        # WebTransport server is not needed (web-platform-tests/wpt#41675).
                        "--no-enable-webtransport-h3",
+                       "--binary", download_firefox,
                        "firefox", "/dom/nodes/Element-tagName.html"])
 
     assert excinfo.value.code == 0
 
 
 @pytest.mark.slow
-def test_list_tests_invalid_manifest(manifest_dir):
+@pytest.mark.remote_network
+def test_list_tests_invalid_manifest(manifest_dir, download_firefox):
     """The `--list-tests` option should not produce an error in the presence of
     a malformed test manifest file."""
 
@@ -165,10 +185,12 @@ def test_list_tests_invalid_manifest(manifest_dir):
                        # drastically reduces the time to execute the test.
                        "--tests", here,
                        "--metadata", manifest_dir,
+                       "--log-mach", "-",
                        "--list-tests",
                        "--yes",
                        # WebTransport server is not needed (web-platform-tests/wpt#41675).
                        "--no-enable-webtransport-h3",
+                       "--binary", download_firefox,
                        "firefox", "/dom/nodes/Element-tagName.html"])
 
     assert excinfo.value.code == 0

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 
 import errno
+import logging
 import os
 import shutil
 import socket
@@ -13,7 +14,7 @@ from urllib.error import URLError
 
 import pytest
 
-from tools.wpt import utils, wpt
+from tools.wpt import browser, utils, wpt
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -59,15 +60,12 @@ def manifest_dir():
 
 @pytest.fixture(scope="module")
 def download_firefox():
-    print("download_firefox")
     try:
+        logger = logging.getLogger("download_firefox")
         path = tempfile.mkdtemp()
-        with pytest.raises(SystemExit) as excinfo:
-            wpt.main(argv=["install", "-d", path,
-                           "firefox", "browser"])
-            assert excinfo.value.code == 0
-        bin_path = os.path.join(path, "browsers", "nightly")
-        assert os.path.exists(bin_path)
+        firefox = browser.Firefox(logger)
+        bin_path = firefox.install(dest=path)
+        assert os.path.exists(bin_path) and os.path.isfile(bin_path)
         yield bin_path
     finally:
         utils.rmtree(path)


### PR DESCRIPTION
The wpt taskcluster docker image currently uses ubuntu 20.04 as the base. This means any binary that we run using this image must be compatible with the glibc version in Ubuntu 20.04.

As reported in #43361, this blocks Servo from upgrading our own CI runners (Github Actions based) to the latest Ubuntu images, since the browser binary produced will link against newer GlibC. We had worked around this in Servo by using 20.04 runners only for the job that built servo binary used by WPT.fyi.

Due to actions/runner-images#11101, it is now urgent for Servo to move away from 20.04.

This patch simply attempts to switch the base of the taskcluster image to Ubuntu 22.04. Some prelimarily santiy checks were done locally:
 - The new image builds successfully
 - A subset of Servo reftests were run using the new local image and validated to contain the same number of PASSES

I have not attempted to move to 24.04 directly as there were issues raised in #43361 related to wayland-as-default in 24.04. I don't have any insight into such issues, so I'm updating the image to only 22.04 for now, as a quick fix.

**Before merging this patch, more thorough testing is required**. This requires:

 - [ ] Publishing the updated docker image to Github Container registry
 - [ ] Triggering a test run in the staging version of WPT.fyi with the updated docker image and ensuring the image works with all supported browsers.

I don't have the permissions needed to publish the image and also lack have full knowledge of the WPT infra to perform such testing. I hope someone with such acess can help me with this.