### PR TITLE
Update connect-src blocked tests to match spec

### DIFF
--- a/content-security-policy/connect-src/connect-src-eventsource-blocked.sub.html
+++ b/content-security-policy/connect-src/connect-src-eventsource-blocked.sub.html
@@ -17,20 +17,15 @@
             log("violated-directive=" + e.violatedDirective);
         });
 
-        try {
-            var es = new EventSource("http://{{domains[www1]}}:{{ports[http][0]}}/content-security-policy/connect-src/resources/simple-event-stream");
-            // Firefox and Chrome don't throw an exception and takes some time to close async
-            if (es.readyState == EventSource.CONNECTING) {
-                setTimeout( function() {
-                    es.readyState != EventSource.CLOSED ? log("allowed") : log("blocked");
-                }, 1000);
-            } else if (es.readyState == EventSource.CLOSED) {
-                log("blocked");
-            } else {
-                log("allowed");
-            }
-        } catch (e) {
+        var es = new EventSource("http://{{domains[www1]}}:{{ports[http][0]}}/content-security-policy/connect-src/resources/simple-event-stream");
+        if (es.readyState == EventSource.CONNECTING) {
+            setTimeout( function() {
+                es.readyState != EventSource.CLOSED ? log("allowed") : log("blocked");
+            }, 1000);
+        } else if (es.readyState == EventSource.CLOSED) {
             log("blocked");
+        } else {
+            log("allowed");
         }
     </script>
     <div id="log"></div>

--- a/content-security-policy/connect-src/connect-src-eventsource-blocked.sub.html
+++ b/content-security-policy/connect-src/connect-src-eventsource-blocked.sub.html
@@ -19,6 +19,7 @@
 
         var es = new EventSource("http://{{domains[www1]}}:{{ports[http][0]}}/content-security-policy/connect-src/resources/simple-event-stream");
         es.onerror = () => {
+            assert_equals(es.readyState, EventSource.CLOSED, "EventSource should be closed");
             log("blocked");
         }
     </script>

--- a/content-security-policy/connect-src/connect-src-eventsource-blocked.sub.html
+++ b/content-security-policy/connect-src/connect-src-eventsource-blocked.sub.html
@@ -18,14 +18,8 @@
         });
 
         var es = new EventSource("http://{{domains[www1]}}:{{ports[http][0]}}/content-security-policy/connect-src/resources/simple-event-stream");
-        if (es.readyState == EventSource.CONNECTING) {
-            setTimeout( function() {
-                es.readyState != EventSource.CLOSED ? log("allowed") : log("blocked");
-            }, 1000);
-        } else if (es.readyState == EventSource.CLOSED) {
+        es.onerror = () => {
             log("blocked");
-        } else {
-            log("allowed");
         }
     </script>
     <div id="log"></div>

--- a/content-security-policy/connect-src/connect-src-syncxmlhttprequest-blocked.sub.html
+++ b/content-security-policy/connect-src/connect-src-syncxmlhttprequest-blocked.sub.html
@@ -24,6 +24,8 @@
             log("Fail");
         } catch (e) {
             log("Pass");
+            assert_true(e instanceof DOMException, "Exception should be a DOMException");
+            assert_equals(e.code, DOMException.NETWORK_ERR, "Exception should be a 'NetworkError'");
         }
 
     </script>

--- a/content-security-policy/connect-src/connect-src-syncxmlhttprequest-blocked.sub.html
+++ b/content-security-policy/connect-src/connect-src-syncxmlhttprequest-blocked.sub.html
@@ -25,7 +25,7 @@
                 log("Fail");
             }
             xhr.onerror = function() {
-                log("Pass");
+                log("Fail");
             }
         } catch (e) {
             log("Pass");

--- a/content-security-policy/connect-src/connect-src-syncxmlhttprequest-blocked.sub.html
+++ b/content-security-policy/connect-src/connect-src-syncxmlhttprequest-blocked.sub.html
@@ -21,12 +21,7 @@
             var xhr = new XMLHttpRequest;
             xhr.open("GET", "http://www1.{{host}}:{{ports[http][0]}}/content-security-policy/support/fail.png", false);
             xhr.send();
-            xhr.onload = function() {
-                log("Fail");
-            }
-            xhr.onerror = function() {
-                log("Fail");
-            }
+            log("Fail");
         } catch (e) {
             log("Pass");
         }

--- a/content-security-policy/connect-src/connect-src-websocket-blocked.sub.html
+++ b/content-security-policy/connect-src/connect-src-websocket-blocked.sub.html
@@ -18,13 +18,9 @@
         });
 
         var ws = new WebSocket("ws://{{domains[www1]}}:{{ports[http][0]}}/echo");
-
-        if (ws.readyState == WebSocket.CLOSING || ws.readyState == WebSocket.CLOSED) {
+        ws.onerror = () => {
             log("blocked");
-        } else {
-            log("allowed");
         }
-
     </script>
     <div id="log"></div>
 </body>

--- a/content-security-policy/connect-src/connect-src-websocket-blocked.sub.html
+++ b/content-security-policy/connect-src/connect-src-websocket-blocked.sub.html
@@ -17,16 +17,12 @@
             log("violated-directive=" + e.violatedDirective);
         });
 
-        try {
-            var ws = new WebSocket("ws://{{domains[www1]}}:{{ports[http][0]}}/echo");
+        var ws = new WebSocket("ws://{{domains[www1]}}:{{ports[http][0]}}/echo");
 
-            if (ws.readyState == WebSocket.CLOSING || ws.readyState == WebSocket.CLOSED) {
-                log("blocked");
-            } else {
-                log("allowed");
-            }
-        } catch (e) {
+        if (ws.readyState == WebSocket.CLOSING || ws.readyState == WebSocket.CLOSED) {
             log("blocked");
+        } else {
+            log("allowed");
         }
 
     </script>

--- a/content-security-policy/connect-src/connect-src-websocket-blocked.sub.html
+++ b/content-security-policy/connect-src/connect-src-websocket-blocked.sub.html
@@ -19,6 +19,7 @@
 
         var ws = new WebSocket("ws://{{domains[www1]}}:{{ports[http][0]}}/echo");
         ws.onerror = () => {
+            assert_equals(ws.readyState, WebSocket.CLOSED, "WebSocket should be closed");
             log("blocked");
         }
     </script>

--- a/content-security-policy/connect-src/connect-src-xmlhttprequest-blocked.sub.html
+++ b/content-security-policy/connect-src/connect-src-xmlhttprequest-blocked.sub.html
@@ -17,17 +17,13 @@
             log("violated-directive=" + e.violatedDirective);
         });
 
-        try {
-            var xhr = new XMLHttpRequest;
-            xhr.open("GET", "http://www1.{{host}}:{{ports[http][0]}}/content-security-policy/support/fail.png", true);
-            xhr.send();
-            xhr.onload = function() {
-                log("Fail");
-            }
-            xhr.onerror = function() {
-                log("Pass");
-            }
-        } catch (e) {
+        var xhr = new XMLHttpRequest;
+        xhr.open("GET", "http://www1.{{host}}:{{ports[http][0]}}/content-security-policy/support/fail.png", true);
+        xhr.send();
+        xhr.onload = function() {
+            log("Fail");
+        }
+        xhr.onerror = function() {
             log("Pass");
         }
 


### PR DESCRIPTION
These tests previously allowed multiple conflicting implementations.

connect-src-websocket-blocked.sub.html - Now fails in Firefox and WebKit.

connect-src-eventsource-blocked.sub.html - Now fails in WebKit.

Fixes #50387 