### PR TITLE
Replace command invoker clickOn with .click call on button

### DIFF
--- a/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch-content-attribute.html
+++ b/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch-content-attribute.html
@@ -5,9 +5,6 @@
 <link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-actions.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
 <script src="resources/invoker-utils.js"></script>
 
 <button
@@ -24,17 +21,17 @@
 <div popover id="popover" oncommand="return false"></div>
 
 <script>
-  promise_test(async function (t) {
+  test(function (t) {
     assert_true(
       typeof invokee.oncommand == "function",
       "invokee has an oncommand function",
     );
     assert_equals(invokee.valueAsNumber, 0, "input is equal to 0");
-    await clickOn(invokerbutton);
+    invokerbutton.click();
     assert_equals(invokee.valueAsNumber, 1, "input is equal to 1");
   }, "oncommand content attribute works");
 
-  promise_test(async function (t) {
+  test(function (t) {
     t.add_cleanup(() => {
       invokerbutton.command = "--custom-command";
     });
@@ -44,7 +41,7 @@
       "invokee has an oncommand function",
     );
     assert_false(popover.matches(":popover-open"), "popover is not open");
-    await clickOn(invokerbutton);
+    invokerbutton.click();
     assert_false(popover.matches(":popover-open"), "popover is still not open");
   }, "oncommand content with a value of false prevents default");
 </script>

--- a/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.html
+++ b/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.html
@@ -5,9 +5,6 @@
 <link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-actions.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
 <script src="resources/invoker-utils.js"></script>
 
 <div id="invokee"></div>
@@ -26,10 +23,10 @@
     invokerbutton.removeAttribute("type");
   }
 
-  promise_test(async function (t) {
+  test(function (t) {
     let event = null;
     invokee.addEventListener("command", (e) => (event = e), { once: true });
-    await clickOn(invokerbutton);
+    invokerbutton.click();
     assert_true(event instanceof CommandEvent, "event is CommandEvent");
     assert_equals(event.type, "command", "type");
     assert_equals(event.bubbles, false, "bubbles");
@@ -40,13 +37,13 @@
     assert_equals(event.source, invokerbutton, "source");
   }, "event dispatches on click with addEventListener");
 
-  promise_test(async function (t) {
+  test(function (t) {
     let event = null;
     t.add_cleanup(() => {
         invokee.oncommand = null;
     });
     invokee.oncommand = (e) => (event = e);
-    await clickOn(invokerbutton);
+    invokerbutton.click();
     assert_true(event instanceof CommandEvent, "event is CommandEvent");
     assert_equals(event.type, "command", "type");
     assert_equals(event.bubbles, false, "bubbles");
@@ -60,12 +57,12 @@
   // valid custom invokeactions
   ["--foo", "--foo-", "--cAsE-cArRiEs", "--", "--a-", "--a-b", "---", "--show-picker"].forEach(
     (command) => {
-      promise_test(async function (t) {
+      test(function (t) {
         t.add_cleanup(resetState);
         let event = null;
         invokee.addEventListener("command", (e) => (event = e), { once: true });
         invokerbutton.command = command;
-        await clickOn(invokerbutton);
+        invokerbutton.click();
         assert_true(event instanceof CommandEvent, "event is CommandEvent");
         assert_equals(event.type, "command", "type");
         assert_equals(event.bubbles, false, "bubbles");
@@ -76,12 +73,12 @@
         assert_equals(event.source, invokerbutton, "source");
       }, `setting custom command property to ${command} (must include dash) sets event command`);
 
-      promise_test(async function (t) {
+      test(function (t) {
         t.add_cleanup(resetState);
         let event = null;
         invokee.addEventListener("command", (e) => (event = e), { once: true });
         invokerbutton.setAttribute("command", command);
-        await clickOn(invokerbutton);
+        invokerbutton.click();
         assert_true(event instanceof CommandEvent, "event is CommandEvent");
         assert_equals(event.type, "command", "type");
         assert_equals(event.bubbles, false, "bubbles");
@@ -96,26 +93,26 @@
 
   // invalid custom invokeactions
   ["-foo", "-foo-", "foo-bar", "-foo bar", "—-emdash", "hidedocument"].forEach((command) => {
-    promise_test(async function (t) {
+    test(function (t) {
       t.add_cleanup(resetState);
       let event = null;
       invokee.addEventListener("command", (e) => (event = e), { once: true });
       invokerbutton.command = command;
-      await clickOn(invokerbutton);
+      invokerbutton.click();
       assert_equals(event, null, "event should not have fired");
     }, `setting custom command property to ${command} (no dash) did not dispatch an event`);
 
-    promise_test(async function (t) {
+    test(function (t) {
       t.add_cleanup(resetState);
       let event = null;
       invokee.addEventListener("command", (e) => (event = e), { once: true });
       invokerbutton.setAttribute("command", command);
-      await clickOn(invokerbutton);
+      invokerbutton.click();
       assert_equals(event, null, "event should not have fired");
     }, `setting custom command attribute to ${command} (no dash) did not dispatch an event`);
   });
 
-  promise_test(async function (t) {
+  test(function (t) {
     let called = false;
     invokerbutton.addEventListener(
       "click",
@@ -131,53 +128,53 @@
       },
       { once: true },
     );
-    await clickOn(invokerbutton);
+    invokerbutton.click();
     assert_false(called, "event was not called");
   }, "event does not dispatch if click:preventDefault is called");
 
-  promise_test(async function (t) {
+  test(function (t) {
     let event = null;
     invokee.addEventListener("command", (e) => (event = e), { once: true });
-    await clickOn(invalidbutton);
+    invalidbutton.click();
     assert_equals(event, null, "command should not have fired");
   }, "event does not dispatch on input[type=button]");
 
-  promise_test(async function (t) {
+  test(function (t) {
     t.add_cleanup(resetState);
     let called = false;
     invokee.addEventListener("command", (e) => (called = true), { once: true });
     invokerbutton.setAttribute("disabled", "");
-    await clickOn(invokerbutton);
+    invokerbutton.click();
     assert_false(called, "event was not called");
   }, "event does not dispatch if invoker is disabled");
 
-  promise_test(async function (t) {
+  test(function (t) {
     t.add_cleanup(resetState);
     let called = false;
     invokee.addEventListener("command", (e) => (called = true), { once: true });
     invokerbutton.setAttribute("form", "aform");
     invokerbutton.removeAttribute("type");
-    await clickOn(invokerbutton);
+    invokerbutton.click();
     assert_false(called, "event was not called");
   }, "event does NOT dispatch if button is form associated, with implicit type");
 
-  promise_test(async function (t) {
+  test(function (t) {
     t.add_cleanup(resetState);
     let called = false;
     invokee.addEventListener("command", (e) => (called = true), { once: true });
     invokerbutton.setAttribute("form", "aform");
     invokerbutton.setAttribute("type", "invalid");
-    await clickOn(invokerbutton);
+    invokerbutton.click();
     assert_false(called, "event was not called");
   }, "event does NOT dispatch if button is form associated, with explicit type=invalid");
 
-  promise_test(async function (t) {
+  test(function (t) {
     t.add_cleanup(resetState);
     let event;
     invokee.addEventListener("command", (e) => (event = e), { once: true });
     invokerbutton.setAttribute("form", "aform");
     invokerbutton.setAttribute("type", "button");
-    await clickOn(invokerbutton);
+    invokerbutton.click();
     assert_true(event instanceof CommandEvent, "event is CommandEvent");
     assert_equals(event.type, "command", "type");
     assert_equals(event.bubbles, false, "bubbles");
@@ -188,27 +185,27 @@
     assert_equals(event.source, invokerbutton, "source");
   }, "event dispatches if button is form associated, with explicit type=button");
 
-  promise_test(async function (t) {
+  test(function (t) {
     t.add_cleanup(resetState);
     let called = false;
     invokee.addEventListener("command", (e) => (called = true), { once: true });
     invokerbutton.setAttribute("form", "aform");
     invokerbutton.setAttribute("type", "submit");
-    await clickOn(invokerbutton);
+    invokerbutton.click();
     assert_false(called, "event was not called");
   }, "event does NOT dispatch if button is form associated, with explicit type=submit");
 
-  promise_test(async function (t) {
+  test(function (t) {
     t.add_cleanup(resetState);
     let called = false;
     invokee.addEventListener("command", (e) => (called = true), { once: true });
     invokerbutton.setAttribute("form", "aform");
     invokerbutton.setAttribute("type", "reset");
-    await clickOn(invokerbutton);
+    invokerbutton.click();
     assert_false(called, "event was called");
   }, "event does NOT dispatch if button is form associated, with explicit type=reset");
 
-  promise_test(async function (t) {
+  test(function (t) {
     svgInvokee = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     svgInvokee.setAttribute("id", "svg-invokee");
     t.add_cleanup(resetState);
@@ -220,7 +217,7 @@
     invokerbutton.setAttribute("commandfor", "svg-invokee");
     invokerbutton.setAttribute("command", "--custom-command");
     assert_equals(invokerbutton.commandForElement, svgInvokee);
-    await clickOn(invokerbutton);
+    invokerbutton.click();
     assert_not_equals(event, null, "event was called");
     assert_true(event instanceof CommandEvent, "event is CommandEvent");
     assert_equals(event.source, invokerbutton, "event.invoker is set to right element");

--- a/html/semantics/the-button-element/command-and-commandfor/event-dispatch-shadow.html
+++ b/html/semantics/the-button-element/command-and-commandfor/event-dispatch-shadow.html
@@ -4,9 +4,6 @@
 <link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-actions.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
 <script src="resources/invoker-utils.js"></script>
 
 <div id="div"></div>

--- a/html/semantics/the-button-element/command-and-commandfor/event-interface.html
+++ b/html/semantics/the-button-element/command-and-commandfor/event-interface.html
@@ -4,9 +4,6 @@
 <link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-actions.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
 <script src="resources/invoker-utils.js"></script>
 
 <div id="div"></div>

--- a/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior-request-close.tentative.html
+++ b/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior-request-close.tentative.html
@@ -6,9 +6,6 @@
 <link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-actions.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
 <script src="resources/invoker-utils.js"></script>
 <!-- Merge the following tests into the main test file when the feature is stable -->
 
@@ -32,8 +29,8 @@
 
   ["request-close", /* test case sensitivity */ "reQuEst-Close"].forEach((command) => {
     ["property", "attribute"].forEach((setType) => {
-      promise_test(
-        async function (t) {
+      test(
+        function (t) {
           t.add_cleanup(resetState);
           invokee.show();
           assert_true(invokee.open, "invokee.open");
@@ -43,7 +40,7 @@
           } else {
             containedinvoker.setAttribute("command", command);
           }
-          await clickOn(containedinvoker);
+          containedinvoker.click();
           assert_equals(invokee.returnValue, "");
           assert_false(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
@@ -51,8 +48,8 @@
         `invoking to request-close (with command ${setType} as ${command}) open dialog closes`,
       );
 
-      promise_test(
-        async function (t) {
+      test(
+        function (t) {
           t.add_cleanup(resetState);
           invokee.show();
           assert_true(invokee.open, "invokee.open");
@@ -63,7 +60,7 @@
             containedinvoker.setAttribute("command", command);
           }
           containedinvoker.setAttribute("value", "foo");
-          await clickOn(containedinvoker);
+          containedinvoker.click();
           assert_equals(invokee.returnValue, "foo");
           assert_false(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
@@ -71,8 +68,8 @@
         `invoking to request-close with value (with command ${setType} as ${command}) open dialog closes and sets returnValue`,
       );
 
-      promise_test(
-        async function (t) {
+      test(
+        function (t) {
           t.add_cleanup(resetState);
           invokee.show();
           assert_true(invokee.open, "invokee.open");
@@ -87,15 +84,15 @@
           invokee.addEventListener("command", (e) => e.preventDefault(), {
             once: true,
           });
-          await clickOn(containedinvoker);
+          containedinvoker.click();
           assert_true(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
         },
         `invoking to request-close (with command ${setType} as ${command}) open dialog with preventDefault is no-op`,
       );
 
-      promise_test(
-        async function (t) {
+      test(
+        function (t) {
           t.add_cleanup(resetState);
           invokee.showModal();
           assert_true(invokee.open, "invokee.open");
@@ -108,15 +105,15 @@
           invokee.addEventListener("command", (e) => e.preventDefault(), {
             once: true,
           });
-          await clickOn(containedinvoker);
+          containedinvoker.click();
           assert_true(invokee.open, "invokee.open");
           assert_true(invokee.matches(":modal"), "invokee :modal");
         },
         `invoking to request-close (with command ${setType} as ${command}) open modal dialog with preventDefault is no-op`,
       );
 
-      promise_test(
-        async function (t) {
+      test(
+        function (t) {
           t.add_cleanup(resetState);
           invokee.show();
           assert_true(invokee.open, "invokee.open");
@@ -133,15 +130,15 @@
             },
             { once: true },
           );
-          await clickOn(containedinvoker);
+          containedinvoker.click();
           assert_false(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
         },
         `invoking to request-close (with command ${setType} as ${command}) open dialog while changing command still closes`,
       );
 
-      promise_test(
-        async function (t) {
+      test(
+        function (t) {
           t.add_cleanup(resetState);
           invokee.showModal();
           assert_true(invokee.open, "invokee.open");
@@ -158,7 +155,7 @@
             },
             { once: true },
           );
-          await clickOn(containedinvoker);
+          containedinvoker.click();
           assert_false(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
         },
@@ -174,7 +171,7 @@
     invokerbutton.setAttribute("command", "request-close");
     assert_false(invokee.open, "invokee.open");
     assert_false(invokee.matches(":modal"), "invokee :modal");
-    await clickOn(containedinvoker);
+    containedinvoker.click();
     assert_false(invokee.open, "invokee.open");
     assert_false(invokee.matches(":modal"), "invokee :modal");
   }, "invoking (as request-close) already closed dialog is noop");
@@ -182,8 +179,8 @@
   // Open Popovers using Dialog actions
   ["request-close"].forEach((command) => {
     ["manual", "auto"].forEach((popoverState) => {
-      promise_test(
-        async function (t) {
+      test(
+        function (t) {
           t.add_cleanup(resetState);
           invokee.setAttribute("popover", popoverState);
           invokee.showPopover();
@@ -197,7 +194,7 @@
           invokee.addEventListener("command", (e) => e.preventDefault(), {
             once: true,
           });
-          await clickOn(containedinvoker);
+          containedinvoker.click();
           assert_true(
             invokee.matches(":popover-open"),
             "invokee :popover-open",
@@ -212,8 +209,8 @@
 
   // Elements being disconnected during invoke steps
   ["request-close"].forEach((command) => {
-    promise_test(
-      async function (t) {
+    test(
+      function (t) {
         t.add_cleanup(() => {
           document.body.prepend(invokee);
           resetState();
@@ -231,36 +228,36 @@
             once: true,
           },
         );
-        await clickOn(invokerbutton);
+        invokerbutton.click();
         assert_false(invokee.open, "invokee.open");
         assert_false(invokee.matches(":modal"), "invokee :modal");
       },
       `invoking (as ${command}) dialog that is removed is noop`,
     );
 
-    promise_test(
-      async function (t) {
+    test(
+      function (t) {
         const invokerbutton = document.createElement("button");
         invokerbutton.commandForElement = invokee;
         invokerbutton.setAttribute("command", command);
         assert_false(invokee.open, "invokee.open");
         assert_false(invokee.matches(":modal"), "invokee :modal");
-        await clickOn(invokerbutton);
+        invokerbutton.click();
         assert_false(invokee.open, "invokee.open");
         assert_false(invokee.matches(":modal"), "invokee :modal");
       },
       `invoking (as ${command}) dialog from a detached invoker`,
     );
 
-    promise_test(
-      async function (t) {
+    test(
+      function (t) {
         const invokerbutton = document.createElement("button");
         const invokee = document.createElement("dialog");
         invokerbutton.commandForElementt = invokee;
         invokerbutton.setAttribute("command", command);
         assert_false(invokee.open, "invokee.open");
         assert_false(invokee.matches(":modal"), "invokee :modal");
-        await clickOn(invokerbutton);
+        invokerbutton.click();
         assert_false(invokee.open, "invokee.open");
         assert_false(invokee.matches(":modal"), "invokee :modal");
       },

--- a/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior.html
+++ b/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior.html
@@ -5,9 +5,6 @@
 <link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-actions.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
 <script src="resources/invoker-utils.js"></script>
 
 <dialog id="invokee">
@@ -31,8 +28,8 @@
   ["show-modal", /* test case sensitivity */ "sHoW-mOdAl"].forEach(
     (command) => {
       ["property", "attribute"].forEach((setType) => {
-        promise_test(
-          async function (t) {
+        test(
+          function (t) {
             t.add_cleanup(resetState);
             assert_false(invokee.open, "invokee.open");
             assert_false(invokee.matches(":modal"), "invokee :modal");
@@ -41,15 +38,15 @@
             } else {
               invokerbutton.setAttribute("command", command);
             }
-            await clickOn(invokerbutton);
+            invokerbutton.click();
             assert_true(invokee.open, "invokee.open");
             assert_true(invokee.matches(":modal"), "invokee :modal");
           },
           `invoking (with command ${setType} as ${command}) closed dialog opens as modal`,
         );
 
-        promise_test(
-          async function (t) {
+        test(
+          function (t) {
             t.add_cleanup(resetState);
             assert_false(invokee.open, "invokee.open");
             assert_false(invokee.matches(":modal"), "invokee :modal");
@@ -61,15 +58,15 @@
             } else {
               invokerbutton.setAttribute("command", command);
             }
-            await clickOn(invokerbutton);
+            invokerbutton.click();
             assert_false(invokee.open, "invokee.open");
             assert_false(invokee.matches(":modal"), "invokee :modal");
           },
           `invoking (with command ${setType} as ${command}) closed dialog with preventDefault is noop`,
         );
 
-        promise_test(
-          async function (t) {
+        test(
+          function (t) {
             t.add_cleanup(resetState);
             assert_false(invokee.open, "invokee.open");
             assert_false(invokee.matches(":modal"), "invokee :modal");
@@ -85,7 +82,7 @@
             } else {
               invokerbutton.setAttribute("command", command);
             }
-            await clickOn(invokerbutton);
+            invokerbutton.click();
             assert_true(invokee.open, "invokee.open");
             assert_true(invokee.matches(":modal"), "invokee :modal");
           },
@@ -99,8 +96,8 @@
 
   ["close", /* test case sensitivity */ "cLoSe"].forEach((command) => {
     ["property", "attribute"].forEach((setType) => {
-      promise_test(
-        async function (t) {
+      test(
+        function (t) {
           t.add_cleanup(resetState);
           invokee.show();
           assert_true(invokee.open, "invokee.open");
@@ -110,7 +107,7 @@
           } else {
             containedinvoker.setAttribute("command", command);
           }
-          await clickOn(containedinvoker);
+          containedinvoker.click();
           assert_equals(invokee.returnValue, "");
           assert_false(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
@@ -118,8 +115,8 @@
         `invoking to close (with command ${setType} as ${command}) open dialog closes`,
       );
 
-      promise_test(
-        async function (t) {
+      test(
+        function (t) {
           t.add_cleanup(resetState);
           invokee.show();
           assert_true(invokee.open, "invokee.open");
@@ -130,7 +127,7 @@
             containedinvoker.setAttribute("command", command);
           }
           containedinvoker.setAttribute("value", "foo");
-          await clickOn(containedinvoker);
+          containedinvoker.click();
           assert_equals(invokee.returnValue, "foo");
           assert_false(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
@@ -138,8 +135,8 @@
         `invoking to close (with command ${setType} as ${command}) open dialog closes and sets returnValue`,
       );
 
-      promise_test(
-        async function (t) {
+      test(
+        function (t) {
           t.add_cleanup(resetState);
           invokee.show();
           assert_true(invokee.open, "invokee.open");
@@ -154,15 +151,15 @@
           invokee.addEventListener("command", (e) => e.preventDefault(), {
             once: true,
           });
-          await clickOn(containedinvoker);
+          containedinvoker.click();
           assert_true(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
         },
         `invoking to close (with command ${setType} as ${command}) open dialog with preventDefault is no-op`,
       );
 
-      promise_test(
-        async function (t) {
+      test(
+        function (t) {
           t.add_cleanup(resetState);
           invokee.showModal();
           assert_true(invokee.open, "invokee.open");
@@ -175,15 +172,15 @@
           invokee.addEventListener("command", (e) => e.preventDefault(), {
             once: true,
           });
-          await clickOn(containedinvoker);
+          containedinvoker.click();
           assert_true(invokee.open, "invokee.open");
           assert_true(invokee.matches(":modal"), "invokee :modal");
         },
         `invoking to close (with command ${setType} as ${command}) open modal dialog with preventDefault is no-op`,
       );
 
-      promise_test(
-        async function (t) {
+      test(
+        function (t) {
           t.add_cleanup(resetState);
           invokee.show();
           assert_true(invokee.open, "invokee.open");
@@ -200,15 +197,15 @@
             },
             { once: true },
           );
-          await clickOn(containedinvoker);
+          containedinvoker.click();
           assert_false(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
         },
         `invoking to close (with command ${setType} as ${command}) open dialog while changing command still closes`,
       );
 
-      promise_test(
-        async function (t) {
+      test(
+        function (t) {
           t.add_cleanup(resetState);
           invokee.showModal();
           assert_true(invokee.open, "invokee.open");
@@ -225,7 +222,7 @@
             },
             { once: true },
           );
-          await clickOn(containedinvoker);
+          containedinvoker.click();
           assert_false(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
         },
@@ -242,7 +239,7 @@
     invokee.show();
     assert_true(invokee.open, "invokee.open");
     assert_false(invokee.matches(":modal"), "invokee :modal");
-    await clickOn(containedinvoker);
+    containedinvoker.click();
     assert_true(invokee.open, "invokee.open");
     assert_false(invokee.matches(":modal"), "invokee :modal");
   }, "invoking (as show-modal) open dialog is noop");
@@ -260,7 +257,7 @@
       },
       { once: true },
     );
-    await clickOn(invokerbutton);
+    invokerbutton.click();
     assert_true(invokee.open, "invokee.open");
     assert_true(invokee.matches(":modal"), "invokee :modal");
   }, "invoking (as show-modal) open modal, while changing command still a no-op");
@@ -271,7 +268,7 @@
     assert_false(invokee.open, "invokee.open");
     assert_false(invokee.matches(":modal"), "invokee :modal");
     invokee.setAttribute("popover", "auto");
-    await clickOn(invokerbutton);
+    invokerbutton.click();
     assert_true(invokee.open, "invokee.open");
     assert_true(invokee.matches(":modal"), "invokee :modal");
   }, "invoking (as show-modal) closed popover dialog opens as modal");
@@ -283,7 +280,7 @@
     invokerbutton.setAttribute("command", "close");
     assert_false(invokee.open, "invokee.open");
     assert_false(invokee.matches(":modal"), "invokee :modal");
-    await clickOn(containedinvoker);
+    containedinvoker.click();
     assert_false(invokee.open, "invokee.open");
     assert_false(invokee.matches(":modal"), "invokee :modal");
   }, "invoking (as close) already closed dialog is noop");
@@ -291,8 +288,8 @@
   // Open Popovers using Dialog actions
   ["show-modal", "close"].forEach((command) => {
     ["manual", "auto"].forEach((popoverState) => {
-      promise_test(
-        async function (t) {
+      test(
+        function (t) {
           t.add_cleanup(resetState);
           invokee.setAttribute("popover", popoverState);
           invokee.showPopover();
@@ -306,7 +303,7 @@
           invokee.addEventListener("command", (e) => e.preventDefault(), {
             once: true,
           });
-          await clickOn(containedinvoker);
+          containedinvoker.click();
           assert_true(
             invokee.matches(":popover-open"),
             "invokee :popover-open",
@@ -340,7 +337,7 @@
             once: true,
           },
         );
-        await clickOn(invokerbutton);
+        invokerbutton.click();
         assert_false(invokee.open, "invokee.open");
         assert_false(invokee.matches(":modal"), "invokee :modal");
       },
@@ -354,7 +351,7 @@
         invokerbutton.setAttribute("command", command);
         assert_false(invokee.open, "invokee.open");
         assert_false(invokee.matches(":modal"), "invokee :modal");
-        await clickOn(invokerbutton);
+        invokerbutton.click();
         assert_false(invokee.open, "invokee.open");
         assert_false(invokee.matches(":modal"), "invokee :modal");
       },
@@ -369,7 +366,7 @@
         invokerbutton.setAttribute("command", command);
         assert_false(invokee.open, "invokee.open");
         assert_false(invokee.matches(":modal"), "invokee :modal");
-        await clickOn(invokerbutton);
+        invokerbutton.click();
         assert_false(invokee.open, "invokee.open");
         assert_false(invokee.matches(":modal"), "invokee :modal");
       },

--- a/html/semantics/the-button-element/command-and-commandfor/on-dialog-disconnect.html
+++ b/html/semantics/the-button-element/command-and-commandfor/on-dialog-disconnect.html
@@ -5,9 +5,6 @@
 <link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-actions.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
 <script src="resources/invoker-utils.js"></script>
 
 <dialog id="invokee"></dialog>
@@ -15,8 +12,8 @@
 
 <script>
   const invokee = document.getElementById('invokee');
-  promise_test(
-    async function (t) {
+  test(
+    function (t) {
       assert_false(invokee.open, "invokee.open");
       assert_false(invokee.matches(":modal"), "invokee :modal");
       let fired = false;
@@ -24,7 +21,7 @@
         fired = true;
         invokee.remove();
       });
-      await clickOn(invokerbutton);
+      invokerbutton.click();
       assert_true(fired, "command event fired");
       assert_false(invokee.isConnected, "dialog no longer connected");
       assert_false(invokee.open, "invokee.open");

--- a/html/semantics/the-button-element/command-and-commandfor/on-dialog-invalid-behavior.html
+++ b/html/semantics/the-button-element/command-and-commandfor/on-dialog-invalid-behavior.html
@@ -5,9 +5,6 @@
 <link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-actions.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
 <script src="resources/invoker-utils.js"></script>
 
 <dialog id="invokee">
@@ -36,39 +33,39 @@
     "toggle-popover",
     "show-picker",
   ].forEach((action) => {
-    promise_test(async function (t) {
+    test(function (t) {
       t.add_cleanup(resetState);
       invokerbutton.setAttribute("command", action);
       assert_false(invokee.open, "invokee.open");
       assert_false(invokee.matches(":modal"), "invokee :modal");
-      await clickOn(invokerbutton);
+      invokerbutton.click();
       assert_false(invokee.open, "invokee.open");
       assert_false(invokee.matches(":modal"), "invokee :modal");
     }, `invoking (as ${action}) on dialog does nothing`);
 
-    promise_test(async function (t) {
+    test(function (t) {
       t.add_cleanup(resetState);
       containedinvoker.setAttribute("command", action);
       invokee.show();
       assert_true(invokee.open, "invokee.open");
       assert_false(invokee.matches(":modal"), "invokee :modal");
-      await clickOn(containedinvoker);
+      containedinvoker.click();
       assert_true(invokee.open, "invokee.open");
       assert_false(invokee.matches(":modal"), "invokee :modal");
     }, `invoking (as ${action}) on open dialog does nothing`);
 
-    promise_test(async function (t) {
+    test(function (t) {
       t.add_cleanup(resetState);
       containedinvoker.setAttribute("command", action);
       invokee.showModal();
       assert_true(invokee.open, "invokee.open");
       assert_true(invokee.matches(":modal"), "invokee :modal");
-      await clickOn(containedinvoker);
+      containedinvoker.click();
       assert_true(invokee.open, "invokee.open");
       assert_true(invokee.matches(":modal"), "invokee :modal");
     }, `invoking (as ${action}) on open modal dialog does nothing`);
 
-    promise_test(async function (t) {
+    test(function (t) {
       t.add_cleanup(resetState);
       containedinvoker.setAttribute("command", action);
       invokee.showModal();
@@ -81,7 +78,7 @@
         },
         { once: true },
       );
-      await clickOn(containedinvoker);
+      containedinvoker.click();
       assert_true(invokee.open, "invokee.open");
       assert_true(invokee.matches(":modal"), "invokee :modal");
     }, `invoking (as ${action}) on open modal while changing the attributer does nothing`);
@@ -90,8 +87,8 @@
   // Open Popovers using Dialog actions
   ["show-modal", "close"].forEach((action) => {
     ["manual", "auto"].forEach((popoverState) => {
-      promise_test(
-        async function (t) {
+      test(
+        function (t) {
           t.add_cleanup(resetState);
           invokee.setAttribute("popover", popoverState);
           invokee.showPopover();
@@ -105,7 +102,7 @@
           invokee.addEventListener("command", (e) => e.preventDefault(), {
             once: true,
           });
-          await clickOn(containedinvoker);
+          containedinvoker.click();
           assert_true(
             invokee.matches(":popover-open"),
             "invokee :popover-open",

--- a/html/semantics/the-button-element/command-and-commandfor/on-popover-behavior.html
+++ b/html/semantics/the-button-element/command-and-commandfor/on-popover-behavior.html
@@ -5,9 +5,6 @@
 <link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-actions.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
 <script src="resources/invoker-utils.js"></script>
 
 <div id="invokee" popover>
@@ -32,7 +29,7 @@
     invokee.addEventListener("command", (e) => { invokerbutton.setAttribute('command', 'hide-popover'); }, {
       once: true,
     });
-    await clickOn(invokerbutton);
+    invokerbutton.click();
     t.add_cleanup(resetState);
     assert_true(invokee.matches(":popover-open"));
   }, "changing command attribute inside invokeevent doesn't impact the invocation");
@@ -45,26 +42,26 @@
     "tOgGlE-pOpOvEr",
     "sHoW-pOpOvEr",
   ].forEach((command) => {
-    promise_test(
-      async function (t) {
+    test(
+      function (t) {
         t.add_cleanup(resetState);
         invokerbutton.command = command;
         assert_false(invokee.matches(":popover-open"));
-        await clickOn(invokerbutton);
+        invokerbutton.click();
         assert_true(invokee.matches(":popover-open"));
       },
       `invoking (as ${command}) closed popover opens`,
     );
 
-    promise_test(
-      async function (t) {
+    test(
+      function (t) {
         t.add_cleanup(resetState);
         invokerbutton.command = command;
         assert_false(invokee.matches(":popover-open"));
         invokee.addEventListener("command", (e) => e.preventDefault(), {
           once: true,
         });
-        await clickOn(invokerbutton);
+        invokerbutton.click();
         assert_false(invokee.matches(":popover-open"));
       },
       `invoking (as ${command}) closed popover with preventDefault does not open`,
@@ -79,20 +76,20 @@
     "tOgGlE-pOpOvEr",
     "hIdE-pOpOvEr",
   ].forEach((command) => {
-    promise_test(
-      async function (t) {
+    test(
+      function (t) {
         t.add_cleanup(resetState);
         invokerbutton.command = command;
         invokee.showPopover();
         assert_true(invokee.matches(":popover-open"));
-        await clickOn(invokerbutton);
+        invokerbutton.click();
         assert_false(invokee.matches(":popover-open"));
       },
       `invoking (as ${command}) open popover closes`,
     );
 
-    promise_test(
-      async function (t) {
+    test(
+      function (t) {
         t.add_cleanup(resetState);
         invokerbutton.command = command;
         invokee.showPopover();
@@ -100,26 +97,26 @@
         invokee.addEventListener("command", (e) => e.preventDefault(), {
           once: true,
         });
-        await clickOn(invokerbutton);
+        invokerbutton.click();
         assert_true(invokee.matches(":popover-open"));
       },
       `invoking (as ${command}) open popover with preventDefault does not close`,
     );
 
-    promise_test(
-      async function (t) {
+    test(
+      function (t) {
         t.add_cleanup(resetState);
         containedinvoker.command = command;
         invokee.showPopover();
         assert_true(invokee.matches(":popover-open"));
-        await clickOn(containedinvoker);
+        containedinvoker.click();
         assert_false(invokee.matches(":popover-open"));
       },
       `invoking (as ${command}) from within open popover closes`,
     );
 
-    promise_test(
-      async function (t) {
+    test(
+      function (t) {
         t.add_cleanup(resetState);
         containedinvoker.command = command;
         invokee.showPopover();
@@ -127,7 +124,7 @@
           once: true,
         });
         assert_true(invokee.matches(":popover-open"));
-        await clickOn(containedinvoker);
+        containedinvoker.click();
         assert_true(invokee.matches(":popover-open"));
       },
       `invoking (as ${command}) from within open popover with preventDefault does not close`,
@@ -135,21 +132,21 @@
   });
 
   // show-popover specific
-  promise_test(async function (t) {
+  test(function (t) {
     t.add_cleanup(resetState);
     invokerbutton.setAttribute("command", "show-popover");
     invokee.showPopover();
     assert_true(invokee.matches(":popover-open"));
-    await clickOn(invokerbutton);
+    invokerbutton.click();
     assert_true(invokee.matches(":popover-open"));
   }, "invoking (as show-popover) open popover is noop");
 
   // hide-popover specific
-  promise_test(async function (t) {
+  test(function (t) {
     t.add_cleanup(resetState);
     invokerbutton.setAttribute("command", "hide-popover");
     assert_false(invokee.matches(":popover-open"));
-    await clickOn(invokerbutton);
+    invokerbutton.click();
     assert_false(invokee.matches(":popover-open"));
   }, "invoking (as hide-popover) closed popover is noop");
 </script>

--- a/html/semantics/the-button-element/command-and-commandfor/on-popover-disconnect.html
+++ b/html/semantics/the-button-element/command-and-commandfor/on-popover-disconnect.html
@@ -5,7 +5,6 @@
 <link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
 <script src="resources/invoker-utils.js"></script>
 
 <div id="invokee" popover></div>
@@ -13,8 +12,8 @@
 
 <script>
   const invokee = document.getElementById('invokee');
-  promise_test(
-    async function (t) {
+  test(
+    function (t) {
       assert_false(invokee.matches(":popover-open"), "invokee :popover-open");
       let fired = false;
       invokee.addEventListener('command', () => {

--- a/html/semantics/the-button-element/command-and-commandfor/on-popover-disconnect.html
+++ b/html/semantics/the-button-element/command-and-commandfor/on-popover-disconnect.html
@@ -6,8 +6,6 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-actions.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
 <script src="resources/invoker-utils.js"></script>
 
 <div id="invokee" popover></div>
@@ -23,7 +21,7 @@
         fired = true;
         invokee.remove();
       });
-      await clickOn(invokerbutton);
+      invokerbutton.click();
       assert_true(fired, "command event fired");
       assert_false(invokee.isConnected, "popover no longer connected");
       assert_false(invokee.matches(":popover-open"), "invokee :popover-open");

--- a/html/semantics/the-button-element/command-and-commandfor/on-popover-invalid-behavior.html
+++ b/html/semantics/the-button-element/command-and-commandfor/on-popover-invalid-behavior.html
@@ -5,9 +5,6 @@
 <link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-actions.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
 <script src="resources/invoker-utils.js"></script>
 
 <div id="invokee" popover>
@@ -27,20 +24,20 @@
 
   // invalid actions on show-popover
   [null, "", "foo-bar", "showpopover", "show-modal", "show-picker", "open", "close"].forEach((command) => {
-    promise_test(async function (t) {
+    test(function (t) {
       t.add_cleanup(resetState);
       invokerbutton.command = command;
       assert_false(invokee.matches(":popover-open"));
-      await clickOn(invokerbutton);
+      invokerbutton.click();
       assert_false(invokee.matches(":popover-open"));
     }, `invoking (as ${command}) on popover does nothing`);
 
-    promise_test(async function (t) {
+    test(function (t) {
       t.add_cleanup(resetState);
       invokerbutton.command = command;
       invokee.showPopover();
       assert_true(invokee.matches(":popover-open"));
-      await clickOn(invokerbutton);
+      invokerbutton.click();
       assert_true(invokee.matches(":popover-open"));
     }, `invoking (as ${command}) on open popover does nothing`);
   });


### PR DESCRIPTION
This allows the tests to be run in the browser, there's no need for a trusted click so this is equivalent.