### PR TITLE
Move zoom-computed.html 'sign()'-expression parts to separate test.

### DIFF
--- a/css/css-viewport/zoom/parsing/zoom-computed-with-sign-expression.html
+++ b/css/css-viewport/zoom/parsing/zoom-computed-with-sign-expression.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: getComputedStyle().zoom, with a specified value that includes a sign() expression</title>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-property">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<style>
+  #container {
+    container-type: inline-size;
+    width: 100px;
+    font-size: 20px;
+  }
+</style>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+// The sign() expressions below are all expected to resolve to -1.
+
+// Same units:
+test_computed_value("zoom", 'calc(1 + (sign(2cqw - 3cqw) * 0.5))', '0.5');
+test_computed_value("zoom", 'calc(1 + (sign(5px - 10px) * 0.5))', '0.5');
+test_computed_value("zoom", 'calc(1 + (sign(5 - 10) * 0.5))', '0.5');
+test_computed_value("zoom", 'calc(1 + (sign(30deg - 40deg) * 0.5))', '0.5');
+test_computed_value("zoom", 'calc(1 + (sign(3em - 5em) * 0.5))', '0.5');
+
+// Mixed absolute units:
+test_computed_value("zoom", 'calc(1 + (sign(1cm - 1in) * 0.5))', '0.5');
+test_computed_value("zoom", 'calc(1 + (sign(1deg - 1rad) * 0.5))', '0.5');
+
+// Mixed units, one or more of which is context-dependent:
+test_computed_value("zoom", 'calc(1 + (sign(2cqw - 10px) * 0.5))', '0.5');
+test_computed_value("zoom", 'calc(100% + (sign(2cqw - 10px) * 50%))', '0.5');
+test_computed_value("zoom", 'calc(100% + (sign(1em - 30px) * 50%))', '0.5');
+test_computed_value("zoom", 'calc(100% + (sign(2cqw - 1em) * 50%))', '0.5');
+</script>

--- a/css/css-viewport/zoom/parsing/zoom-computed.html
+++ b/css/css-viewport/zoom/parsing/zoom-computed.html
@@ -5,12 +5,6 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/computed-testcommon.js"></script>
-<style>
-  #container {
-    container-type: inline-size;
-    width: 100px;
-  }
-</style>
 <div id="container">
   <div id="target"></div>
 </div>
@@ -20,12 +14,14 @@ test_computed_value("zoom", "normal", "1");
 test_computed_value("zoom", "1", "1");
 test_computed_value("zoom", "1.5", "1.5");
 test_computed_value("zoom", "0.75", "0.75");
-test_computed_value("zoom", 'calc(1 + (sign(2cqw - 10px) * 0.5))', '0.5');
+test_computed_value("zoom", 'calc(1 - 0.5)', '0.5');
+test_computed_value("zoom", 'calc(1 * 0.5)', '0.5');
 
 test_computed_value("zoom", "100%", "1");
 test_computed_value("zoom", "150%", "1.5");
 test_computed_value("zoom", "75%", "0.75");
-test_computed_value("zoom", 'calc(100% + (sign(2cqw - 10px) * 50%))', '0.5');
+test_computed_value("zoom", 'calc(100% - 50%)', '0.5');
+test_computed_value("zoom", 'calc(100% * 0.5)', '0.5');
 
 // Legacy crap, wat
 test_computed_value("zoom", "0", "1");


### PR DESCRIPTION
This patch replaces the moved parts with some simpler calc() expressions; and the new test (zoom-computed-with-sign-expression.html) has a bunch of additional sign(...) tests as well, for completeness.

See the interop test-change-proposal in https://github.com/web-platform-tests/interop/issues/937 for more detail and background on this change.