### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=288865

### DIFF
--- a/fullscreen/rendering/fullscreen-root-block-size.html
+++ b/fullscreen/rendering/fullscreen-root-block-size.html
@@ -25,8 +25,7 @@ in fullscreen mode.
       }
     });
     await trusted_click();
-    await document.documentElement.requestFullscreen();
-    await fullScreenChange();
+    await Promise.all([document.documentElement.requestFullscreen(), fullScreenChange()]);
     assert_equals(document.fullscreenElement, document.documentElement);
     assert_true(document.documentElement.getBoundingClientRect().width > 0);
   });


### PR DESCRIPTION
WebKit export from bug: [\[ macOS wk1 \] imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-block-size.html is a flaky failure](https://bugs.webkit.org/show_bug.cgi?id=288865)