### PR TITLE
taskcluster: use Firefox from Mozilla PPA in docker image

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -48,6 +48,12 @@ RUN apt-add-repository -y ppa:deadsnakes/ppa
 RUN apt-get -qqy update \
     && apt-get install -qqy python-is-python3
 
+# Add Mozilla's PPA and set it as the preferred package over the default apt
+# version of FireFox in Ubuntu 22.04 which is simply a reference to the snap
+# version and snaps can't be installed inside docker.
+RUN add-apt-repository ppa:mozillateam/ppa
+COPY firefox-ppa-override.txt /etc/apt/preferences.d/mozilla-firefox
+
 # Installing just the deps of firefox and chrome is moderately tricky, so
 # just install the default versions of them, and some extra deps we happen
 # to know that chrome requires

--- a/tools/docker/firefox-ppa-override.txt
+++ b/tools/docker/firefox-ppa-override.txt
@@ -1,0 +1,7 @@
+Package: firefox
+Pin: release o=LP-PPA-mozillateam
+Pin-Priority: 1001
+
+Package: firefox
+Pin: version 1:1snap
+Pin-Priority: -1


### PR DESCRIPTION
The default apt package for Firefox in Ubuntu 22.04 is just a reference to a snap package and requires explicitly installing firefox using `snap install firefox`. However, snap doesn't work inside docker containers as it requires other services like systemd and snapd to be enabled and running.

After moving to 22.04 in #51161, the missing firefox package causes failure in CI integration tests, specifically 'tests/test_wpt.py':

```
/usr/lib/python3.8/subprocess.py: CalledProcessError
----------------------------- Captured stderr call -----------------------------

Command '/usr/bin/firefox' requires the firefox snap to be installed.
Please install it with:

snap install firefox
```

As a workaround, this patch adds Mozilla's PPA as an apt source and gives it higher priority than the default package. This has been tested locally and the integration test now passes with this patch.