### PR TITLE
Adjust `fill-fallback-currentcolor-1.svg` by adding fuzziness to account for gradient noise

### DIFF
--- a/svg/pservers/reftests/fill-fallback-currentcolor-1.svg
+++ b/svg/pservers/reftests/fill-fallback-currentcolor-1.svg
@@ -1,5 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <h:link rel="match" href="reference/green-100x100.svg"/>
+  <h:meta name="fuzzy" content="0-1;0-3939" />
   <linearGradient id="lg">
     <stop stop-color="#008000"/>
   </linearGradient>


### PR DESCRIPTION
This test currently fails in WebKit due to gradient noise, this patch is to just add `fuziness` to account for it.