### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=280862

### DIFF
--- a/css/css-animations/parsing/animation-range-end-invalid.html
+++ b/css/css-animations/parsing/animation-range-end-invalid.html
@@ -17,4 +17,6 @@ test_invalid_value("animation-range-end", "50% exit");
 test_invalid_value("animation-range-end", "contain contain");
 test_invalid_value("animation-range-end", "none");
 test_invalid_value("animation-range-end", "cover 50% enter 50%");
+test_invalid_value("animation-range-end", "normal 10px");
+test_invalid_value("animation-range-end", "normal foo");
 </script>

--- a/css/css-animations/parsing/animation-range-shorthand.html
+++ b/css/css-animations/parsing/animation-range-shorthand.html
@@ -108,6 +108,8 @@ test_invalid_value("animation-range", "thing 42%");
 test_invalid_value("animation-range", "thing 100%");
 test_invalid_value("animation-range", "thing 100px");
 test_invalid_value("animation-range", "100% thing");
+test_invalid_value("animation-range", "normal foo normal 100%");
+test_invalid_value("animation-range", "normal normal 100%");
 
 test_shorthand_value('animation-range', 'normal', {
   'animation-range-start': 'normal',

--- a/css/css-animations/parsing/animation-range-start-invalid.html
+++ b/css/css-animations/parsing/animation-range-start-invalid.html
@@ -13,4 +13,6 @@ test_invalid_value("animation-range-start", "50% exit");
 test_invalid_value("animation-range-start", "contain contain");
 test_invalid_value("animation-range-start", "none");
 test_invalid_value("animation-range-start", "cover 50% enter 50%");
+test_invalid_value("animation-range-start", "normal 10px");
+test_invalid_value("animation-range-start", "normal foo");
 </script>


### PR DESCRIPTION
WebKit export from bug: [\[scroll-animations\] Implement parsing support for animation-range and its longhand properties](https://bugs.webkit.org/show_bug.cgi?id=280862)