### PR TITLE
add missing inputs to urlpatterntestdata.json

### DIFF
--- a/urlpattern/resources/urlpatterntestdata.json
+++ b/urlpattern/resources/urlpatterntestdata.json
@@ -2432,6 +2432,7 @@
   },
   {
     "pattern": [{ "hostname": "bad#hostname" }],
+    "inputs": [{ "hostname": "bad" }],
     "exactly_empty_components": ["port"],
     "expected_match": {
       "hostname": { "input": "bad", "groups": {} }
@@ -2439,14 +2440,11 @@
   },
   {
     "pattern": [{ "hostname": "bad%hostname" }],
-    "exactly_empty_components": ["port"],
-    "expected_match": {
-      "hostname": { "input": "bad%hostname", "groups": {} }
-    }
+    "expected_obj": "error"
   },
   {
     "pattern": [{ "hostname": "bad/hostname" }],
-    "exactly_empty_components": ["port"],
+    "inputs": [{ "hostname": "bad" }],
     "expected_match": {
       "hostname": { "input": "bad", "groups": {} }
     }
@@ -2481,7 +2479,8 @@
   },
   {
     "pattern": [{ "hostname": "bad\\\\hostname" }],
-    "expected_obj": "error"
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_match": null
   },
   {
     "pattern": [{ "hostname": "bad^hostname" }],
@@ -2493,21 +2492,21 @@
   },
   {
     "pattern": [{ "hostname": "bad\nhostname" }],
-    "exactly_empty_components": ["port"],
+    "inputs": [{ "hostname": "badhostname" }],
     "expected_match": {
       "hostname": { "input": "badhostname", "groups": {} }
     }
   },
   {
     "pattern": [{ "hostname": "bad\rhostname" }],
-    "exactly_empty_components": ["port"],
+    "inputs": [{ "hostname": "badhostname" }],
     "expected_match": {
       "hostname": { "input": "badhostname", "groups": {} }
     }
   },
   {
     "pattern": [{ "hostname": "bad\thostname" }],
-    "exactly_empty_components": ["port"],
+    "inputs": [{ "hostname": "badhostname" }],
     "expected_match": {
       "hostname": { "input": "badhostname", "groups": {} }
     }


### PR DESCRIPTION
Some tests lacked input field, and some should just fail. This is another patch to fix and improve urlpattern test suite.

Ref: https://github.com/web-platform-tests/wpt/pull/49782

cc @annevk @sisidovski @lemire

Downstream PR testing these changes: https://github.com/ada-url/ada/pull/909