### PR TITLE
Fix reference for wm-propagation-body-044 to avoid spurious failure.

### DIFF
--- a/css/css-writing-modes/wm-propagation-body-044-ref.html
+++ b/css/css-writing-modes/wm-propagation-body-044-ref.html
@@ -7,7 +7,10 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
 
   <style>
-
+  body
+    {
+      margin-bottom: 0;
+    }
   img#orange-square
     {
       padding-right: 16px;


### PR DESCRIPTION
The presence of a bottom margin of the <body> in the reference means that the overall document will have a slightly larger scrollable height than the testcase. If the window size (vs font size of the vertical text) is such that a scrollbar appears, this results in a fractionally-different size of the scrollbar thumb, and hence a spurious "failure" when comparing the screenshots.

To avoid this, we set the margin-bottom explicitly to zero.

Fixes https://github.com/web-platform-tests/interop/issues/936.