### PR TITLE
Fix the expectation of the port canonicalization in URLPattern

### DIFF
--- a/urlpattern/resources/urlpatterntestdata.json
+++ b/urlpattern/resources/urlpatterntestdata.json
@@ -1202,10 +1202,7 @@
   {
     "pattern": [{ "protocol": "http", "port": "80 " }],
     "inputs": [{ "protocol": "http", "port": "80" }],
-    "exactly_empty_components": ["port"],
-    "expected_match": {
-      "protocol": { "input": "http", "groups": {} }
-    }
+    "expected_obj": "error"
   },
   {
     "pattern": [{ "protocol": "http", "port": "100000" }],


### PR DESCRIPTION
Fixes https://github.com/whatwg/urlpattern/issues/260.

This test expectation was updated in https://github.com/web-platform-tests/wpt/pull/49782 but it turned out the browser should raise an error.