### PR TITLE
URLPattern: correct port and hostname-related test

### DIFF
--- a/urlpattern/resources/urlpatterntestdata.json
+++ b/urlpattern/resources/urlpatterntestdata.json
@@ -1202,10 +1202,11 @@
   {
     "pattern": [{ "protocol": "http", "port": "80 " }],
     "inputs": [{ "protocol": "http", "port": "80" }],
-    "exactly_empty_components": ["port"],
-    "expected_match": {
-      "protocol": { "input": "http", "groups": {} }
-    }
+    "expected_obj": {
+      "protocol": "http",
+      "port": "80"
+    },
+    "expected_match": null
   },
   {
     "pattern": [{ "protocol": "http", "port": "100000" }],
@@ -1874,7 +1875,17 @@
   {
     "pattern": [ "https://{sub.}?example{.com/}foo" ],
     "inputs": [ "https://example.com/foo" ],
-    "expected_obj": "error"
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "{sub.}?example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": { "0": "/foo" } }
+    }
   },
   {
     "pattern": [ "{https://}example.com/foo" ],


### PR DESCRIPTION
For https://github.com/whatwg/urlpattern/issues/260 (port) and https://github.com/whatwg/urlpattern/issues/252 (hostname).

---

This is what I get after I patch WebKit. I don't really understand the outcomes for the `https://{sub.}?example{.com/}foo` test though. Primarily because I have a hard time reading the `URLPattern` parser. I was hoping you could verify with your implementation @anonrig and hopefully @sisidovski can deduce it from the specification.

(This does not depend on https://github.com/whatwg/url/pull/863. That's only for existing tests with a `:` in the hostname.)