### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=277908

### DIFF
--- a/mediacapture-insertable-streams/VideoTrackGenerator-with-window-tracks.https.html
+++ b/mediacapture-insertable-streams/VideoTrackGenerator-with-window-tracks.https.html
@@ -248,7 +248,8 @@
       // The first frame may not have had scaleResolutionDownBy applied
       const numTries = 5;
       for (let i = 1; i <= numTries; i++) {
-        worker.postMessage({type:"getVideoFrame", track: e.track}, [e.track]);
+        const clone = e.track.clone();
+        worker.postMessage({type:"getVideoFrame", track: clone}, [clone]);
         const {frame: outputFrame} = await new Promise(resolve => worker.onmessage = e => resolve(e.data));
         if (outputFrame.displayWidth !== width / 2) {
           assert_less_than(i, numTries, `First ${numTries} frames were the wrong size.`);


### PR DESCRIPTION
WebKit export from bug: [\[ iOS macOS Debug wk2 \] imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator-with-window-tracks.https.html is a flaky text failure](https://bugs.webkit.org/show_bug.cgi?id=277908)