### PR TITLE
Add estimate with NULL to update_virtual_pressure_source

### DIFF
--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -1428,7 +1428,7 @@
          * Causes a virtual pressure source to report a new reading.
          *
          * Matches the `Update virtual pressure source
-         * <https://w3c.github.io/compute-pressure/#update-virtual-pressure-source>`_
+         * <https://w3c.github.io/compute-pressure/?experimental=1#update-virtual-pressure-source>`_
          * WebDriver command.
          *
          * @param {String} source_type - A `virtual pressure source type
@@ -1437,6 +1437,9 @@
          * @param {String} sample - A `virtual pressure state
          *                          <https://w3c.github.io/compute-pressure/#dom-pressurestate>`_
          *                          such as "critical".
+         * @param {number} estimate - Optional, A `virtual own contribution estimate`
+         *                          <https://w3c.github.io/compute-pressure/?experimental=1#the-owncontributionestimate-attribute>`_
+
          * @param {WindowProxy} [context=null] - Browsing context in which to
          *                                       run the call, or null for the
          *                                       current browsing context.
@@ -1447,8 +1450,8 @@
          *                    virtual pressure source of the given type does not
          *                    exist).
          */
-        update_virtual_pressure_source: function(source_type, sample, context=null) {
-            return window.test_driver_internal.update_virtual_pressure_source(source_type, sample, context);
+        update_virtual_pressure_source: function(source_type, sample, estimate, context=null) {
+            return window.test_driver_internal.update_virtual_pressure_source(source_type, sample, estimate, context);
         },
 
         /**
@@ -1723,7 +1726,7 @@
             throw new Error("create_virtual_pressure_source() is not implemented by testdriver-vendor.js");
         },
 
-        async update_virtual_pressure_source(source_type, sample, context=null) {
+        async update_virtual_pressure_source(source_type, sample, estimate, context=null) {
             throw new Error("update_virtual_pressure_source() is not implemented by testdriver-vendor.js");
         },
 

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -498,7 +498,8 @@ class UpdateVirtualPressureSourceAction:
     def __call__(self, payload):
         source_type = payload["source_type"]
         sample = payload["sample"]
-        return self.protocol.pressure.update_virtual_pressure_source(source_type, sample)
+        estimate = payload["estimate"]
+        return self.protocol.pressure.update_virtual_pressure_source(source_type, sample, estimate)
 
 class RemoveVirtualPressureSourceAction:
     name = "remove_virtual_pressure_source"

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -721,7 +721,7 @@ class MarionetteVirtualPressureSourceProtocolPart(VirtualPressureSourceProtocolP
     def create_virtual_pressure_source(self, source_type, metadata):
         raise NotImplementedError("create_virtual_pressure_source not yet implemented")
 
-    def update_virtual_pressure_source(self, source_type, sample):
+    def update_virtual_pressure_source(self, source_type, sample, estimate):
         raise NotImplementedError("update_virtual_pressure_source not yet implemented")
 
     def remove_virtual_pressure_source(self, source_type):

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -684,8 +684,8 @@ class WebDriverVirtualPressureSourceProtocolPart(VirtualPressureSourceProtocolPa
         body.update(metadata)
         return self.webdriver.send_session_command("POST", "pressuresource", body)
 
-    def update_virtual_pressure_source(self, source_type, sample):
-        body = {"sample": sample}
+    def update_virtual_pressure_source(self, source_type, sample, estimate):
+        body = {"sample": sample, "estimate": estimate}
         return self.webdriver.send_session_command("POST", "pressuresource/%s" % source_type, body)
 
     def remove_virtual_pressure_source(self, source_type):

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -1009,7 +1009,7 @@ class VirtualPressureSourceProtocolPart(ProtocolPart):
         pass
 
     @abstractmethod
-    def update_virtual_pressure_source(self, source_type, sample):
+    def update_virtual_pressure_source(self, source_type, sample, estimate):
         pass
 
     @abstractmethod

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -468,9 +468,8 @@
         return create_context_action("create_virtual_pressure_source", context, {source_type, metadata});
     };
 
-    window.test_driver_internal.update_virtual_pressure_source = function(source_type, sample, context=null) {
-        return create_context_action("update_virtual_pressure_source", context, {source_type, sample});
-    };
+    window.test_driver_internal.update_virtual_pressure_source = function(source_type, sample, estimate=null, context=null) {
+       return create_context_action("update_virtual_pressure_source", context, {source_type, sample, estimate});
 
     window.test_driver_internal.remove_virtual_pressure_source = function(source_type, context=null) {
         return create_context_action("remove_virtual_pressure_source", context, {source_type});


### PR DESCRIPTION
spec PR: https://github.com/w3c/compute-pressure/pull/305

This PR add own pressure estimate parameter to the update_virtual_pressure_source command as specified in https://w3c.github.io/compute-pressure/?experimental=1#update-virtual-pressure-source