### PR TITLE
MediaCapture recorder test should not use not-spec-compliant MediaStreamTrackGenerator

### DIFF
--- a/mediacapture-record/MediaRecorder-canvas-media-source.https.html
+++ b/mediacapture-record/MediaRecorder-canvas-media-source.https.html
@@ -37,8 +37,6 @@ async function createWorker(script) {
   const url = URL.createObjectURL(blob);
   const worker = new Worker(url);
   await new Promise(resolve => worker.onmessage = resolve);
-  URL.revokeObjectURL(url);
-  return worker;
 }
 
 async_test(test => {

--- a/mediacapture-record/MediaRecorder-canvas-media-source.https.html
+++ b/mediacapture-record/MediaRecorder-canvas-media-source.https.html
@@ -32,7 +32,7 @@
 <body>
   <script>
 async function createWorker(script) {
-  script = script + "self.postMessage('ready');";
+  script += "self.postMessage('ready');";
   const blob = new Blob([script], { type: 'text/javascript' });
   const url = URL.createObjectURL(blob);
   const worker = new Worker(url);

--- a/mediacapture-record/MediaRecorder-canvas-media-source.https.html
+++ b/mediacapture-record/MediaRecorder-canvas-media-source.https.html
@@ -110,8 +110,8 @@ async_test(test => {
   startCamera().then(async stream => {
     const videoTrack = stream.getVideoTracks()[0];
     const worker = await createWorker(`
-      const CANVAS_WIDTH = ` + CANVAS_WIDTH + `;
-      const CANVAS_HEIGHT = ` + CANVAS_HEIGHT + `;
+      const CANVAS_WIDTH = ${CANVAS_WIDTH};
+      const CANVAS_HEIGHT = ${CANVAS_HEIGHT};
       onmessage = e => {
         const videoTrack = e.data;
         const { readable: readableStream } = new MediaStreamTrackProcessor({

--- a/mediacapture-record/MediaRecorder-canvas-media-source.https.html
+++ b/mediacapture-record/MediaRecorder-canvas-media-source.https.html
@@ -36,9 +36,7 @@ async function createWorker(script) {
   const blob = new Blob([script], { type: 'text/javascript' });
   const url = URL.createObjectURL(blob);
   const worker = new Worker(url);
-  await new Promise(resolve => worker.onmessage = () => {
-      resolve();
-  });
+  await new Promise(resolve => worker.onmessage = resolve);
   URL.revokeObjectURL(url);
   return worker;
 }

--- a/mediacapture-record/legacy/MediaRecorder-canvas-media-source-legacy.https.html
+++ b/mediacapture-record/legacy/MediaRecorder-canvas-media-source-legacy.https.html
@@ -26,22 +26,12 @@
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/testdriver.js"></script>
   <script src="/resources/testdriver-vendor.js"></script>
-  <script src="../mediacapture-streams/permission-helper.js"></script>
+  <script src="../../mediacapture-streams/permission-helper.js"></script>
 </head>
 
 <body>
+  <canvas id="canvas"></canvas>
   <script>
-async function createWorker(script) {
-  script = script + "self.postMessage('ready');";
-  const blob = new Blob([script], { type: 'text/javascript' });
-  const url = URL.createObjectURL(blob);
-  const worker = new Worker(url);
-  await new Promise(resolve => worker.onmessage = () => {
-      resolve();
-  });
-  URL.revokeObjectURL(url);
-  return worker;
-}
 
 async_test(test => {
   const CANVAS_WIDTH = 256;
@@ -110,61 +100,54 @@ async_test(test => {
     return;
   }
 
+  if (!window.MediaStreamTrackProcessor) {
+    test.done();
+    return;
+  }
+
+  const canvas = document.querySelector("canvas");
+  const ctx = canvas.getContext("2d", {
+    alpha: false,
+  });
+
+  canvas.width = CANVAS_WIDTH;
+  canvas.height = CANVAS_HEIGHT;
+
   const {startCamera, stopCamera} = useUserMedia(CAMERA_CONSTRAINTS);
   startCamera().then(async stream => {
     const videoTrack = stream.getVideoTracks()[0];
-    const worker = await createWorker(`
-      const CANVAS_WIDTH = ` + CANVAS_WIDTH + `;
-      const CANVAS_HEIGHT = ` + CANVAS_HEIGHT + `;
-      onmessage = e => {
-        const videoTrack = e.data;
-        const { readable: readableStream } = new MediaStreamTrackProcessor({
-          track: videoTrack
-        });
-
-        const composedTrackGenerator = new VideoTrackGenerator();
-        const sink = composedTrackGenerator.writable;
-
-        const canvas = new OffscreenCanvas(CANVAS_WIDTH, CANVAS_HEIGHT);
-        const ctx = canvas.getContext("2d", {
-          alpha: false,
-        });
-        ctx.fillStyle = "#333";
-        ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
-
-        const transformer = new TransformStream({
-          async transform(cameraFrame, controller) {
-            if (cameraFrame && cameraFrame?.codedWidth > 0) {
-              const leftPos = (CANVAS_WIDTH - cameraFrame.displayWidth) / 2;
-              const topPos = (CANVAS_HEIGHT - cameraFrame.displayHeight) / 2;
-
-              ctx.drawImage(cameraFrame, leftPos, topPos);
-
-              const newFrame = new VideoFrame(canvas, {
-                timestamp: cameraFrame.timestamp
-              });
-              cameraFrame.close();
-              controller.enqueue(newFrame);
-            }
-          }
-        });
-
-        readableStream.pipeThrough(transformer).pipeTo(sink);
-        self.postMessage(composedTrackGenerator.track, [composedTrackGenerator.track]);
-      }
-    `);
-    try {
-      worker.postMessage(videoTrack, [videoTrack]);
-    } catch(e) {
-      test.step_func_done(() => {
-         assert_unreached("MediaStreamTrack transfer not supported");
-      })();
-    }
-    const composedTrack = await new Promise((resolve, reject) => {
-      worker.onmessage = e => resolve(e.data);
-      test.step_timeout(() => reject("unable to get composited track"), 2000);
+    const { readable: readableStream } = new MediaStreamTrackProcessor({
+      track: videoTrack
     });
-    const compositedMediaStream = new MediaStream([composedTrack]);
+
+    const composedTrackGenerator = new MediaStreamTrackGenerator({
+      kind: "video"
+    });
+    const sink = composedTrackGenerator.writable;
+
+    ctx.fillStyle = "#333";
+    ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+    const transformer = new TransformStream({
+      async transform(cameraFrame, controller) {
+        if (cameraFrame && cameraFrame?.codedWidth > 0) {
+          const leftPos = (CANVAS_WIDTH - cameraFrame.displayWidth) / 2;
+          const topPos = (CANVAS_HEIGHT - cameraFrame.displayHeight) / 2;
+
+          ctx.drawImage(cameraFrame, leftPos, topPos);
+
+          const newFrame = new VideoFrame(canvas, {
+            timestamp: cameraFrame.timestamp
+          });
+          cameraFrame.close();
+          controller.enqueue(newFrame);
+        }
+      }
+    });
+
+    readableStream.pipeThrough(transformer).pipeTo(sink);
+
+    const compositedMediaStream = new MediaStream([composedTrackGenerator]);
 
     useMediaRecorder(compositedMediaStream, mimeType, (size => {
       if (size > THRESHOLD_FOR_EMPTY_FRAMES) {
@@ -175,6 +158,7 @@ async_test(test => {
     }));
   });
 }, "MediaRecorder returns frames containing video content");
+
   </script>
 </body>
 


### PR DESCRIPTION
We clone the test as is since it is a chrome specific test to a legacy folder. We update the MediaCapture recorder test to use the spec compliant MediaStreamTrackGenerator API.