### PR TITLE
Temporary mark infrastructure/browsers/firefox/prefs.html test as expected to fail

### DIFF
--- a/infrastructure/metadata/infrastructure/browsers/firefox/prefs.html.ini
+++ b/infrastructure/metadata/infrastructure/browsers/firefox/prefs.html.ini
@@ -1,2 +1,6 @@
 [prefs.html]
   prefs: ["browser.display.foreground_color:#00FF00"]
+
+  [Ensure that setting gecko prefs works]
+    expected:
+      if product == "firefox": FAIL # https://bugzilla.mozilla.org/show_bug.cgi?id=1954181


### PR DESCRIPTION
Looks like used preference is broken, disable the test until the preference is fixed, or the test is updated to use a different preference.