### PR TITLE
Revert "Add null check to aria-utils checking for expected values are provided"

### DIFF
--- a/wai-aria/scripts/aria-utils.js
+++ b/wai-aria/scripts/aria-utils.js
@@ -45,9 +45,6 @@ const AriaUtils = {
     }
     for (const el of els) {
       let role = el.getAttribute("data-expectedrole");
-      if (!role) {
-        throw `Element should have attribute \'data-expectedrole\'. Element: ${el.outerHTML}`;
-      }
       let testName = el.getAttribute("data-testname") || role; // data-testname optional if role is unique per test file
       if (typeof roleTestNamePrefix !== "undefined") {
         testName = roleTestNamePrefix + testName;
@@ -140,9 +137,6 @@ const AriaUtils = {
     }
     for (const el of els) {
       let label = el.getAttribute("data-expectedlabel");
-      if (!label) {
-        throw `Element should have attribute \'data-expectedlabel\'. Element: ${el.outerHTML}`;
-      }
       let testName = el.getAttribute("data-testname") || label; // data-testname optional if label is unique per test file
       if (typeof labelTestNamePrefix !== "undefined") {
         testName = labelTestNamePrefix + testName;


### PR DESCRIPTION
Reverts web-platform-tests/wpt#49485 as it inadvertently disabled ~150+ tests and caused a few real regressions too.

Discussion:
https://github.com/web-platform-tests/wpt/pull/49485#issuecomment-2725840533