### PR TITLE
Support single-value `<select>` elements

### DIFF
--- a/html/rendering/widgets/the-select-element/option-add-label-quirks.html
+++ b/html/rendering/widgets/the-select-element/option-add-label-quirks.html
@@ -2,7 +2,7 @@
 <title>OPTION's label attribute in SELECT -- Adding a label (quirks)</title>
 <link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#the-select-element-2">
 <link rel="match" href="option-label-ref.html">
-<meta name="assert" content="An option element is expected to be rendered by displaying the element's label.">
+<meta name="assert" content="An option element is expected to be rendered by displaying the element's label when the document is in quirks mode">
 
 <select>
   <option>Element Text</option>


### PR DESCRIPTION
https://github.com/user-attachments/assets/9aba75ff-4190-4a85-89ed-d3f3aa53d3b0



Among other things this adds a new `EmbedderMsg::ShowSelectElementMenu` to tell the embedder to display a select popup at the given location.

This is a draft because some small style adjustments need to be made:
* the select element should always have the width of the largest option
* the border should be part of the shadow tree

Apart from that, it's mostly ready for review.

<details><summary>HTML for demo video</summary>

```html
<html>

<body>
<select id="c" name="choice">
  <option value="first">First Value</option>
  <option value="second">Second Value</option>
  <option value="third">Third Value</option>
</select>
</body>
</html>
```
</details>

Reviewed in servo/servo#35684