### PR TITLE
Add test coverage for bad base URLs to URL.canParse()

### DIFF
--- a/url/url-statics-canparse.any.js
+++ b/url/url-statics-canparse.any.js
@@ -16,6 +16,11 @@
     "expected": false
   },
   {
+    "url": undefined,
+    "base": "https://test:test/",
+    "expected": false
+  },
+  {
     "url": "aaa:/b",
     "base": undefined,
     "expected": true


### PR DESCRIPTION
Part of https://github.com/jsdom/whatwg-url/issues/268.