### PR TITLE
Tag URL Standard-only ToASCII tests

### DIFF
--- a/url/resources/toascii.json
+++ b/url/resources/toascii.json
@@ -1,6 +1,9 @@
 [
   "This contains assorted IDNA tests that IdnaTestV2 might not cover.",
   "Feel free to deduplicate with a clear commit message.",
+  "",
+  "If the test only applies to the URL Standard's 'domain to ASCII', ",
+  "and not to TR46's ToASCII, then tag it with `urlStandardOnly`",
   {
     "comment": "Label with hyphens in 3rd and 4th position",
     "input": "aa--",
@@ -239,11 +242,13 @@
   },
   {
     "input": "www.lookout.net\u2A7480",
-    "output": null
+    "output": null,
+    "urlStandardOnly": true
   },
   {
     "input": "www\u00A0.lookout.net",
-    "output": null
+    "output": null,
+    "urlStandardOnly": true
   },
   {
     "input": "\u1680lookout.net",
@@ -251,7 +256,8 @@
   },
   {
     "input": "\u001flookout.net",
-    "output": null
+    "output": null,
+    "urlStandardOnly": true
   },
   {
     "input": "look\u06DDout.net",


### PR DESCRIPTION
This helps with libraries like https://github.com/jsdom/tr46 which separately implement TR46 ToASCII versus the URL Standard's "domain to ASCII".

Part of #51368.

---

Preemptively throwing this up there in case @annevk thinks it's reasonable. Otherwise we'll have to maintain this list in the jsdom/tr46 project, I guess.