### PR TITLE
Optimize string formatting

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1330,6 +1330,15 @@
         "0xffff": "uffff",
     };
 
+    const formatEscapeMap = {
+        "\\": "\\\\",
+        '"': '\\"'
+    };
+    for (const p in replacements) {
+        formatEscapeMap[String.fromCharCode(p)] = "\\" + replacements[p];
+    }
+    const formatEscapePattern = new RegExp(`[${Object.keys(formatEscapeMap).map(k => k === "\\" ? "\\\\" : k).join("")}]`, "g");
+
     /**
      * Convert a value to a nice, human-readable string
      *
@@ -1380,12 +1389,7 @@
 
         switch (typeof val) {
         case "string":
-            val = val.replace(/\\/g, "\\\\");
-            for (var p in replacements) {
-                var replace = "\\" + replacements[p];
-                val = val.replace(RegExp(String.fromCharCode(p), "g"), replace);
-            }
-            return '"' + val.replace(/"/g, '\\"') + '"';
+            return '"' + val.replace(formatEscapePattern, match => formatEscapeMap[match]) + '"';
         case "boolean":
         case "undefined":
             return String(val);


### PR DESCRIPTION
Instead of doing 36 passes through the string, do a single pass.

This took up around 2% of the time running a large test (Range-mutations-dataChange.html) in jsdom.

Part of https://github.com/jsdom/jsdom/issues/3154.