### PR TITLE
Fix duplicated test in ParentNode-querySelectors-space-and-dash-attribute-value.html

### DIFF
--- a/dom/nodes/ParentNode-querySelectors-space-and-dash-attribute-value.html
+++ b/dom/nodes/ParentNode-querySelectors-space-and-dash-attribute-value.html
@@ -16,6 +16,6 @@ test(() => {
 }, "querySelector");
 
 test(() => {
-  assert_equals(document.querySelector("a[title='test with - dash and space']"), el);
+  assert_array_equals(document.querySelectorAll("a[title='test with - dash and space']"), [el]);
 }, "querySelectorAll");
 </script>


### PR DESCRIPTION
This test claims to run for both `querySelector` and `querySelectorAll`, but it actually just runs the same test twice for `querySelector`.

It should be fixed now.