### PR TITLE
Make input element display-inside always flow-root

### DIFF
--- a/html/rendering/widgets/text-control-client-width.html
+++ b/html/rendering/widgets/text-control-client-width.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>text control with `display: inline` must not have 0 client width</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#form-controls">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<input id="input" style="display: inline;">
+<textarea id="textarea" style="display: inline;"></textarea>
+
+<script>
+test(() => {
+  assert_greater_than(document.querySelector("#input").clientWidth, 0);
+}, "Input with `display: inline` should have positive client width");
+
+test(() => {
+  assert_greater_than(document.querySelector("#textarea").clientWidth, 0);
+}, "Textarea with `display: inline` should have positive client width");
+</script>

--- a/html/rendering/widgets/text-control-flow-root-ref.html
+++ b/html/rendering/widgets/text-control-flow-root-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+
+<input id="input1">
+<br>
+<input style="transform: scale(0.5);">
+<br>
+aaa<input>aaa
+<br>
+<textarea></textarea>
+<br>
+<textarea style="transform: scale(0.5);"></textarea>
+<br>
+aa<textarea style="transform: scale(0.5);">aa</textarea>aa

--- a/html/rendering/widgets/text-control-flow-root.html
+++ b/html/rendering/widgets/text-control-flow-root.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>display inside of text control should always be flow-root</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#form-controls">
+<link rel=match href="text-control-flow-root-ref.html">
+
+<input id="input1" style="display: inline;">
+<br>
+<input style="display: inline; transform: scale(0.5);">
+<br>
+aaa<input style="display: inline;">aaa
+<br>
+<textarea style="display: inline;"></textarea>
+<br>
+<textarea style="display: inline; transform: scale(0.5);"></textarea>
+<br>
+aa<textarea style="display: inline; transform: scale(0.5);">aa</textarea>aa


### PR DESCRIPTION
<https://html.spec.whatwg.org/multipage/rendering.html#form-controls>

Make so that inner display type of an input element always `flow-root`

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #<!-- nolink -->33669
- [X] There are [tests](https://github.com/servo/servo/pull/35908/files#diff-a5c4b30fe962daa68bf1b6213a8bb864a545e49818202da0da29b62dbb7d3f49) for these changes OR 

Try: https://github.com/PotatoCP/servo/actions/runs/13891284110

cc @xiaochengh 


Reviewed in servo/servo#35908