### PR TITLE
Move Lato fonts to /fonts

### DIFF
--- a/css/css-fonts/font-face-sign-function.html
+++ b/css/css-fonts/font-face-sign-function.html
@@ -9,7 +9,7 @@
   }
   @font-face {
     font-family: "Lato";
-    src: url('support/fonts/Lato-Medium.ttf') format('truetype');
+    src: url('/fonts/Lato-Medium.ttf') format('truetype');
     font-display: swap;
     font-weight: calc(sign(1rem - 1px) * 400);
     font-width: calc(sign(1rem - 1px) * 100%);

--- a/css/css-fonts/font-face-stretch-auto-static-ref.html
+++ b/css/css-fonts/font-face-stretch-auto-static-ref.html
@@ -5,7 +5,7 @@
 <style>
     @font-face {
         font-family: "Lato";
-        src: url('support/fonts/Lato-Medium.ttf') format('truetype');
+        src: url('/fonts/Lato-Medium.ttf') format('truetype');
         font-display: swap;
         font-stretch: normal;
     }

--- a/css/css-fonts/font-face-stretch-auto-static.html
+++ b/css/css-fonts/font-face-stretch-auto-static.html
@@ -8,7 +8,7 @@
 <style>
     @font-face {
         font-family: "Lato";
-        src: url('support/fonts/Lato-Medium.ttf') format('truetype');
+        src: url('/fonts/Lato-Medium.ttf') format('truetype');
         font-display: swap;
         font-stretch: auto;
     }

--- a/css/css-fonts/font-face-style-auto-static-ref.html
+++ b/css/css-fonts/font-face-style-auto-static-ref.html
@@ -5,7 +5,7 @@
 <style>
     @font-face {
         font-family: "Lato";
-        src: url('support/fonts/Lato-Medium.ttf') format('truetype');
+        src: url('/fonts/Lato-Medium.ttf') format('truetype');
         font-display: swap;
         font-style: normal;
     }

--- a/css/css-fonts/font-face-style-auto-static.html
+++ b/css/css-fonts/font-face-style-auto-static.html
@@ -8,7 +8,7 @@
 <style>
     @font-face {
         font-family: "Lato";
-        src: url('support/fonts/Lato-Medium.ttf') format('truetype');
+        src: url('/fonts/Lato-Medium.ttf') format('truetype');
         font-display: swap;
         font-style: auto;
     }

--- a/css/css-fonts/font-face-weight-auto-static-ref.html
+++ b/css/css-fonts/font-face-weight-auto-static-ref.html
@@ -5,7 +5,7 @@
 <style>
     @font-face {
         font-family: "Lato";
-        src: url('support/fonts/Lato-Medium.ttf') format('truetype');
+        src: url('/fonts/Lato-Medium.ttf') format('truetype');
         font-display: swap;
         font-weight: normal;
     }

--- a/css/css-fonts/font-face-weight-auto-static.html
+++ b/css/css-fonts/font-face-weight-auto-static.html
@@ -8,7 +8,7 @@
 <style>
     @font-face {
         font-family: "Lato";
-        src: url('support/fonts/Lato-Medium.ttf') format('truetype');
+        src: url('/fonts/Lato-Medium.ttf') format('truetype');
         font-display: swap;
         font-weight: auto;
     }

--- a/css/css-fonts/font-feature-resolution-001-ref.html
+++ b/css/css-fonts/font-feature-resolution-001-ref.html
@@ -8,7 +8,7 @@
 <style>
   @font-face {
     font-family: lato-ffs-;
-    src: url(support/fonts/Lato-Medium-Liga.ttf);
+    src: url(/fonts/Lato-Medium-Liga.ttf);
   }
   .test, .ref {
     font-family: lato-ffs-;

--- a/css/css-fonts/font-feature-resolution-001.html
+++ b/css/css-fonts/font-feature-resolution-001.html
@@ -10,16 +10,16 @@
 <style>
   @font-face {
     font-family: lato-ffs-;
-    src: url(support/fonts/Lato-Medium-Liga.ttf);
+    src: url(/fonts/Lato-Medium-Liga.ttf);
   }
   @font-face {
     font-family: lato-ffs-0;
-    src: url(support/fonts/Lato-Medium-Liga.ttf);
+    src: url(/fonts/Lato-Medium-Liga.ttf);
     font-feature-settings: 'liga' off;
   }
   @font-face {
     font-family: lato-ffs-1;
-    src: url(support/fonts/Lato-Medium-Liga.ttf);
+    src: url(/fonts/Lato-Medium-Liga.ttf);
     font-feature-settings: 'liga' on;
   }
   .test, .ref {

--- a/css/css-fonts/font-feature-resolution-002-ref.html
+++ b/css/css-fonts/font-feature-resolution-002-ref.html
@@ -8,7 +8,7 @@
 <style>
   @font-face {
     font-family: lato-ffs-;
-    src: url(support/fonts/Lato-Medium-Liga.ttf);
+    src: url(/fonts/Lato-Medium-Liga.ttf);
   }
  .test, .ref {
     font-family: lato-ffs-;

--- a/css/css-fonts/font-feature-resolution-002.html
+++ b/css/css-fonts/font-feature-resolution-002.html
@@ -10,16 +10,16 @@
 <style>
   @font-face {
     font-family: lato-ffs-;
-    src: url(support/fonts/Lato-Medium-Liga.ttf);
+    src: url(/fonts/Lato-Medium-Liga.ttf);
   }
   @font-face {
     font-family: lato-ffs-0;
-    src: url(support/fonts/Lato-Medium-Liga.ttf);
+    src: url(/fonts/Lato-Medium-Liga.ttf);
     font-feature-settings: 'dlig' off;
   }
   @font-face {
     font-family: lato-ffs-1;
-    src: url(support/fonts/Lato-Medium-Liga.ttf);
+    src: url(/fonts/Lato-Medium-Liga.ttf);
     font-feature-settings: 'dlig' on;
   }
   .test, .ref {

--- a/css/css-fonts/font-synthesis-01-ref.html
+++ b/css/css-fonts/font-synthesis-01-ref.html
@@ -6,7 +6,7 @@
 <style>
     @font-face {
 				font-family: "test";
-				src: url(support/fonts/Lato-Medium.ttf);
+				src: url(/fonts/Lato-Medium.ttf);
 			}
     .test {
 				font-family: "test";

--- a/css/css-fonts/font-synthesis-01.html
+++ b/css/css-fonts/font-synthesis-01.html
@@ -9,7 +9,7 @@
 <style>
     @font-face {
 				font-family: "test";
-				src: url(support/fonts/Lato-Medium.ttf);
+				src: url(/fonts/Lato-Medium.ttf);
 			}
     @supports not (font-synthesis: none) {
         .test {color: red;}

--- a/css/css-fonts/font-synthesis-02-ref.html
+++ b/css/css-fonts/font-synthesis-02-ref.html
@@ -6,7 +6,7 @@
 <style>
     @font-face {
 				font-family: "test";
-				src: url(support/fonts/Lato-Medium.ttf);
+				src: url(/fonts/Lato-Medium.ttf);
 			}
     .test {
 				font-family: "test";

--- a/css/css-fonts/font-synthesis-02.html
+++ b/css/css-fonts/font-synthesis-02.html
@@ -9,7 +9,7 @@
 <style>
     @font-face {
 				font-family: "test";
-				src: url(support/fonts/Lato-Medium.ttf);
+				src: url(/fonts/Lato-Medium.ttf);
 			}
     @supports not (font-synthesis: style) {
         .test {color: red;}

--- a/css/css-fonts/font-synthesis-03-ref.html
+++ b/css/css-fonts/font-synthesis-03-ref.html
@@ -6,7 +6,7 @@
 <style>
     @font-face {
 				font-family: "test";
-				src: url(support/fonts/Lato-Medium.ttf);
+				src: url(/fonts/Lato-Medium.ttf);
 			}
     .test {
 				font-family: "test";

--- a/css/css-fonts/font-synthesis-03.html
+++ b/css/css-fonts/font-synthesis-03.html
@@ -9,7 +9,7 @@
 <style>
     @font-face {
 				font-family: "test";
-				src: url(support/fonts/Lato-Medium.ttf);
+				src: url(/fonts/Lato-Medium.ttf);
 			}
     @supports not (font-synthesis: none) {
         .test {color: red;}

--- a/css/css-fonts/font-synthesis-04-ref.html
+++ b/css/css-fonts/font-synthesis-04-ref.html
@@ -6,7 +6,7 @@
 <style>
     @font-face {
 				font-family: "test";
-				src: url(support/fonts/Lato-Medium.ttf);
+				src: url(/fonts/Lato-Medium.ttf);
 			}
     .test {
 				font-family: "test";

--- a/css/css-fonts/font-synthesis-04.html
+++ b/css/css-fonts/font-synthesis-04.html
@@ -9,7 +9,7 @@
 <style>
     @font-face {
 				font-family: "test";
-				src: url(support/fonts/Lato-Medium.ttf);
+				src: url(/fonts/Lato-Medium.ttf);
 			}
     @supports not (font-synthesis: weight) {
         .test {color: red;}

--- a/css/css-fonts/font-synthesis-05-ref.html
+++ b/css/css-fonts/font-synthesis-05-ref.html
@@ -6,7 +6,7 @@
 <style>
     @font-face {
 				font-family: "test";
-				src: url(support/fonts/Lato-Medium.ttf);
+				src: url(/fonts/Lato-Medium.ttf);
 			}
     .test {
 				font-family: "test";

--- a/css/css-fonts/font-synthesis-05.html
+++ b/css/css-fonts/font-synthesis-05.html
@@ -9,7 +9,7 @@
 <style>
     @font-face {
 				font-family: "test";
-				src: url(support/fonts/Lato-Medium.ttf);
+				src: url(/fonts/Lato-Medium.ttf);
 			}
     @supports not (font-synthesis: weight style) {
         .test p {color: red;}

--- a/css/css-fonts/font-synthesis-07-ref.html
+++ b/css/css-fonts/font-synthesis-07-ref.html
@@ -5,7 +5,7 @@
 <style>
   @font-face {
     font-family: Lato;
-    src: url(support/fonts/Lato-Medium.ttf);
+    src: url(/fonts/Lato-Medium.ttf);
   }
   .test {
      font: 2em/1 Lato;

--- a/css/css-fonts/font-synthesis-07.html
+++ b/css/css-fonts/font-synthesis-07.html
@@ -8,7 +8,7 @@
 <style>
   @font-face {
     font-family: Lato;
-    src: url(support/fonts/Lato-Medium.ttf);
+    src: url(/fonts/Lato-Medium.ttf);
   }
   .test {
      font: 2em/1 Lato;

--- a/css/css-fonts/font-synthesis-08-ref.html
+++ b/css/css-fonts/font-synthesis-08-ref.html
@@ -5,7 +5,7 @@
 <style>
     @font-face {
         font-family: "lato";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     .test {
         font-family: "lato";

--- a/css/css-fonts/font-synthesis-08.html
+++ b/css/css-fonts/font-synthesis-08.html
@@ -9,7 +9,7 @@
 <style>
     @font-face {
         font-family: "lato";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     .test {
         font-family: "lato";

--- a/css/css-fonts/font-synthesis-position-001-ref.html
+++ b/css/css-fonts/font-synthesis-position-001-ref.html
@@ -8,7 +8,7 @@
      */
     @font-face {
         font-family: "lato";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     .test {
         font-family: "lato";

--- a/css/css-fonts/font-synthesis-position-001.html
+++ b/css/css-fonts/font-synthesis-position-001.html
@@ -13,7 +13,7 @@
      */
     @font-face {
         font-family: "lato";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     @supports not (font-synthesis-position: none) {
         .test::before {

--- a/css/css-fonts/font-synthesis-small-caps-first-letter-ref.html
+++ b/css/css-fonts/font-synthesis-small-caps-first-letter-ref.html
@@ -6,7 +6,7 @@
 <style>
     @font-face {
         font-family: "Lato-Medium";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     .test {
         font-family: "Lato-Medium";

--- a/css/css-fonts/font-synthesis-small-caps-first-letter.html
+++ b/css/css-fonts/font-synthesis-small-caps-first-letter.html
@@ -9,7 +9,7 @@
 <style>
     @font-face {
         font-family: "Lato-Medium";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     @supports not (font-synthesis-small-caps: none) {
         .test {color: red;}

--- a/css/css-fonts/font-synthesis-small-caps-first-line-ref.html
+++ b/css/css-fonts/font-synthesis-small-caps-first-line-ref.html
@@ -6,7 +6,7 @@
 <style>
     @font-face {
         font-family: "Lato-Medium";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     .test {
         font-family: "Lato-Medium";

--- a/css/css-fonts/font-synthesis-small-caps-first-line.html
+++ b/css/css-fonts/font-synthesis-small-caps-first-line.html
@@ -9,7 +9,7 @@
 <style>
     @font-face {
         font-family: "Lato-Medium";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     @supports not (font-synthesis-small-caps: none) {
         .test {color: red;}

--- a/css/css-fonts/font-synthesis-small-caps-ref.html
+++ b/css/css-fonts/font-synthesis-small-caps-ref.html
@@ -6,7 +6,7 @@
 <style>
     @font-face {
         font-family: "lato";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     .test {
         font-family: "lato";

--- a/css/css-fonts/font-synthesis-small-caps.html
+++ b/css/css-fonts/font-synthesis-small-caps.html
@@ -9,7 +9,7 @@
 <style>
     @font-face {
         font-family: "lato";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     @supports not (font-synthesis-small-caps: none) {
         .test {color: red;}

--- a/css/css-fonts/font-synthesis-style-first-letter-ref.html
+++ b/css/css-fonts/font-synthesis-style-first-letter-ref.html
@@ -5,7 +5,7 @@
 <style>
     @font-face {
         font-family: "Lato-Medium";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     .test {
         font-family: "Lato-Medium";

--- a/css/css-fonts/font-synthesis-style-first-letter.html
+++ b/css/css-fonts/font-synthesis-style-first-letter.html
@@ -8,7 +8,7 @@
 <style>
     @font-face {
         font-family: "Lato-Medium";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     @supports not (font-synthesis-style: none) {
         .test {color: red;}

--- a/css/css-fonts/font-synthesis-style-first-line-ref.html
+++ b/css/css-fonts/font-synthesis-style-first-line-ref.html
@@ -5,7 +5,7 @@
 <style>
     @font-face {
         font-family: "Lato-Medium";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     .test {
         font-family: "Lato-Medium";

--- a/css/css-fonts/font-synthesis-style-first-line.html
+++ b/css/css-fonts/font-synthesis-style-first-line.html
@@ -8,7 +8,7 @@
 <style>
     @font-face {
         font-family: "Lato-Medium";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     @supports not (font-synthesis-style: none) {
         .test {color: red;}

--- a/css/css-fonts/font-synthesis-style-ref.html
+++ b/css/css-fonts/font-synthesis-style-ref.html
@@ -5,7 +5,7 @@
 <style>
     @font-face {
         font-family: "lato";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     .test {
         font-family: "lato";

--- a/css/css-fonts/font-synthesis-style.html
+++ b/css/css-fonts/font-synthesis-style.html
@@ -8,7 +8,7 @@
 <style>
     @font-face {
         font-family: "lato";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     @supports not (font-synthesis-style: none) {
         .test {color: red;}

--- a/css/css-fonts/font-synthesis-weight-first-letter-ref.html
+++ b/css/css-fonts/font-synthesis-weight-first-letter-ref.html
@@ -5,7 +5,7 @@
 <style>
     @font-face {
         font-family: "Lato-Medium";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     .test {
         font-family: "Lato-Medium";

--- a/css/css-fonts/font-synthesis-weight-first-letter.html
+++ b/css/css-fonts/font-synthesis-weight-first-letter.html
@@ -8,7 +8,7 @@
 <style>
     @font-face {
         font-family: "Lato-Medium";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     @supports not (font-synthesis-weight: none) {
         .test {color: red;}

--- a/css/css-fonts/font-synthesis-weight-first-line-ref.html
+++ b/css/css-fonts/font-synthesis-weight-first-line-ref.html
@@ -5,7 +5,7 @@
 <style>
     @font-face {
         font-family: "Lato-Medium";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     .test {
         font-family: "Lato-Medium";

--- a/css/css-fonts/font-synthesis-weight-first-line.html
+++ b/css/css-fonts/font-synthesis-weight-first-line.html
@@ -8,7 +8,7 @@
 <style>
     @font-face {
         font-family: "Lato-Medium";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     @supports not (font-synthesis-weight: none) {
         .test {color: red;}

--- a/css/css-fonts/font-synthesis-weight-ref.html
+++ b/css/css-fonts/font-synthesis-weight-ref.html
@@ -5,7 +5,7 @@
 <style>
     @font-face {
         font-family: "lato";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     .test {
         font-family: "lato";

--- a/css/css-fonts/font-synthesis-weight.html
+++ b/css/css-fonts/font-synthesis-weight.html
@@ -8,7 +8,7 @@
 <style>
     @font-face {
         font-family: "lato";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     @supports not (font-synthesis-weight: none) {
         .test {color: red;}

--- a/css/css-fonts/font-variant-position-04-notref.html
+++ b/css/css-fonts/font-variant-position-04-notref.html
@@ -9,7 +9,7 @@
      */
     @font-face {
         font-family: "lato";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     .test {
         font-family: "lato";

--- a/css/css-fonts/font-variant-position-04.html
+++ b/css/css-fonts/font-variant-position-04.html
@@ -12,7 +12,7 @@
      */
     @font-face {
         font-family: "lato";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     .test {
         font-family: "lato";

--- a/css/css-fonts/font-variant-position-05-notref.html
+++ b/css/css-fonts/font-variant-position-05-notref.html
@@ -9,7 +9,7 @@
      */
     @font-face {
         font-family: "lato";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     .test {
         font-family: "lato";

--- a/css/css-fonts/font-variant-position-05.html
+++ b/css/css-fonts/font-variant-position-05.html
@@ -12,7 +12,7 @@
      */
     @font-face {
         font-family: "lato";
-        src: url(support/fonts/Lato-Medium.ttf);
+        src: url(/fonts/Lato-Medium.ttf);
     }
     .test {
         font-family: "lato";

--- a/css/css-fonts/lang-attribute-affects-rendering-of-second-text-run-ref.html
+++ b/css/css-fonts/lang-attribute-affects-rendering-of-second-text-run-ref.html
@@ -9,7 +9,7 @@
       font-family: test-font-family;
       /* <Lato-Medium.ttf> provides different ligatures for English and
          Turkish. */
-      src: url(support/fonts/Lato-Medium.ttf);
+      src: url(/fonts/Lato-Medium.ttf);
     }
 
     div { font-family: test-font-family; }

--- a/css/css-fonts/lang-attribute-affects-rendering-of-second-text-run.html
+++ b/css/css-fonts/lang-attribute-affects-rendering-of-second-text-run.html
@@ -11,7 +11,7 @@
       font-family: test-font-family;
       /* <Lato-Medium.ttf> provides different ligatures for English and
          Turkish. */
-      src: url(support/fonts/Lato-Medium.ttf);
+      src: url(/fonts/Lato-Medium.ttf);
     }
 
     div { font-family: test-font-family; }

--- a/css/css-fonts/lang-attribute-affects-rendering-ref.html
+++ b/css/css-fonts/lang-attribute-affects-rendering-ref.html
@@ -7,7 +7,7 @@
 
     @font-face {
       font-family: test-font-family;
-      src: url(support/fonts/Lato-Medium.ttf);
+      src: url(/fonts/Lato-Medium.ttf);
     }
 
     div { font-family: test-font-family; }

--- a/css/css-fonts/lang-attribute-affects-rendering.html
+++ b/css/css-fonts/lang-attribute-affects-rendering.html
@@ -11,7 +11,7 @@
       font-family: test-font-family;
       /* <Lato-Medium.ttf> provides different ligatures for English and
          Turkish. */
-      src: url(support/fonts/Lato-Medium.ttf);
+      src: url(/fonts/Lato-Medium.ttf);
     }
 
     div { font-family: test-font-family; }

--- a/css/css-text/text-autospace/text-autospace-ligature-001-ref.html
+++ b/css/css-text/text-autospace/text-autospace-ligature-001-ref.html
@@ -4,7 +4,7 @@
 <style>
 @font-face {
   font-family: ligature-font;
-  src: url('../../css-fonts/support/fonts/Lato-Medium-Liga.ttf');
+  src: url('/fonts/Lato-Medium-Liga.ttf');
 }
 #test-container {
   font-family: ligature-font;

--- a/css/css-text/text-autospace/text-autospace-ligature-001.html
+++ b/css/css-text/text-autospace/text-autospace-ligature-001.html
@@ -5,7 +5,7 @@
 <style>
 @font-face {
   font-family: ligature-font;
-  src: url('../../css-fonts/support/fonts/Lato-Medium-Liga.ttf');
+  src: url('/fonts/Lato-Medium-Liga.ttf');
 }
 #test-container {
   font-family: ligature-font;

--- a/html/canvas/element/manual/text/canvas.2d.lang-ref.html
+++ b/html/canvas/element/manual/text/canvas.2d.lang-ref.html
@@ -26,7 +26,7 @@
     let test_font = new FontFace(
       // Lato-Medium is a font with language specific ligatures.
       "Lato-Medium",
-      "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+      "url(/fonts/Lato-Medium.ttf)"
     );
 
     test_font.load().then((font) => {

--- a/html/canvas/element/manual/text/canvas.2d.lang.dynamic-ref.html
+++ b/html/canvas/element/manual/text/canvas.2d.lang.dynamic-ref.html
@@ -29,7 +29,7 @@
     let test_font = new FontFace(
       // Lato-Medium is a font with language specific ligatures.
       "Lato-Medium",
-      "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+      "url(/fonts/Lato-Medium.ttf)"
     );
 
     test_font.load().then((font) => {

--- a/html/canvas/element/manual/text/canvas.2d.lang.dynamic.html
+++ b/html/canvas/element/manual/text/canvas.2d.lang.dynamic.html
@@ -18,7 +18,7 @@
     let test_font = new FontFace(
       // Lato-Medium is a font with language specific ligatures.
       "Lato-Medium",
-      "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+      "url(/fonts/Lato-Medium.ttf)"
     );
 
     test_font.load().then((font) => {

--- a/html/canvas/element/manual/text/canvas.2d.lang.empty-ref.html
+++ b/html/canvas/element/manual/text/canvas.2d.lang.empty-ref.html
@@ -7,7 +7,7 @@
     let test_font = new FontFace(
       // Lato-Medium is a font with language specific ligatures.
       "Lato-Medium",
-      "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+      "url(/fonts/Lato-Medium.ttf)"
     );
 
     test_font.load().then((font) => {

--- a/html/canvas/element/manual/text/canvas.2d.lang.empty.canvas.html
+++ b/html/canvas/element/manual/text/canvas.2d.lang.empty.canvas.html
@@ -11,7 +11,7 @@
       let test_font = new FontFace(
         // Lato-Medium is a font with language specific ligatures.
         "Lato-Medium",
-        "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+        "url(/fonts/Lato-Medium.ttf)"
       );
 
       test_font.load().then((font) => {

--- a/html/canvas/element/manual/text/canvas.2d.lang.html
+++ b/html/canvas/element/manual/text/canvas.2d.lang.html
@@ -31,7 +31,7 @@
       let test_font = new FontFace(
         // Lato-Medium is a font with language specific ligatures.
         "Lato-Medium",
-        "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+        "url(/fonts/Lato-Medium.ttf)"
       );
 
       test_font.load().then((font) => {

--- a/html/canvas/element/manual/text/canvas.2d.lang.inherit.disconnected.canvas.html
+++ b/html/canvas/element/manual/text/canvas.2d.lang.inherit.disconnected.canvas.html
@@ -39,7 +39,7 @@
       let test_font = new FontFace(
         // Lato-Medium is a font with language specific ligatures.
         "Lato-Medium",
-        "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+        "url(/fonts/Lato-Medium.ttf)"
       );
 
       test_font.load().then((font) => {

--- a/html/canvas/element/manual/text/canvas.2d.lang.inherit.disconnected.canvas.no.lang.html
+++ b/html/canvas/element/manual/text/canvas.2d.lang.inherit.disconnected.canvas.no.lang.html
@@ -38,7 +38,7 @@
       let test_font = new FontFace(
         // Lato-Medium is a font with language specific ligatures.
         "Lato-Medium",
-        "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+        "url(/fonts/Lato-Medium.ttf)"
       );
 
       test_font.load().then((font) => {

--- a/html/canvas/element/manual/text/canvas.2d.lang.inherit.html
+++ b/html/canvas/element/manual/text/canvas.2d.lang.inherit.html
@@ -23,7 +23,7 @@
       let test_font = new FontFace(
         // Lato-Medium is a font with language specific ligatures.
         "Lato-Medium",
-        "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+        "url(/fonts/Lato-Medium.ttf)"
       );
 
       test_font.load().then((font) => {

--- a/html/canvas/element/manual/text/canvas.2d.unknown.lang-ref.html
+++ b/html/canvas/element/manual/text/canvas.2d.unknown.lang-ref.html
@@ -27,7 +27,7 @@
     let test_font = new FontFace(
       // Lato-Medium is a font with language specific ligatures.
       "Lato-Medium",
-      "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+      "url(/fonts/Lato-Medium.ttf)"
     );
 
     test_font.load().then((font) => {

--- a/html/canvas/offscreen/manual/text/canvas.2d.offscreen.lang-ref.html
+++ b/html/canvas/offscreen/manual/text/canvas.2d.offscreen.lang-ref.html
@@ -26,7 +26,7 @@
     let test_font = new FontFace(
       // Lato-Medium is a font with language specific ligatures.
       "Lato-Medium",
-      "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+      "url(/fonts/Lato-Medium.ttf)"
     );
 
     test_font.load().then((font) => {

--- a/html/canvas/offscreen/manual/text/canvas.2d.offscreen.lang.html
+++ b/html/canvas/offscreen/manual/text/canvas.2d.offscreen.lang.html
@@ -38,7 +38,7 @@
       let test_font = new FontFace(
         // Lato-Medium is a font with language specific ligatures.
         "Lato-Medium",
-        "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+        "url(/fonts/Lato-Medium.ttf)"
       );
 
       test_font.load().then((font) => {

--- a/html/canvas/offscreen/manual/text/canvas.2d.offscreen.lang.inherit.html
+++ b/html/canvas/offscreen/manual/text/canvas.2d.offscreen.lang.inherit.html
@@ -37,7 +37,7 @@
       let test_font = new FontFace(
         // Lato-Medium is a font with language specific ligatures.
         "Lato-Medium",
-        "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+        "url(/fonts/Lato-Medium.ttf)"
       );
 
       test_font.load().then((font) => {

--- a/html/canvas/offscreen/manual/text/canvas.2d.offscreen.transferred.lang.html
+++ b/html/canvas/offscreen/manual/text/canvas.2d.offscreen.transferred.lang.html
@@ -32,7 +32,7 @@
       let test_font = new FontFace(
         // Lato-Medium is a font with language specific ligatures.
         "Lato-Medium",
-        "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+        "url(/fonts/Lato-Medium.ttf)"
       );
 
       test_font.load().then((font) => {

--- a/html/canvas/offscreen/manual/text/canvas.2d.offscreen.transferred.lang.inherit.document.html
+++ b/html/canvas/offscreen/manual/text/canvas.2d.offscreen.transferred.lang.inherit.document.html
@@ -32,7 +32,7 @@
       let test_font = new FontFace(
         // Lato-Medium is a font with language specific ligatures.
         "Lato-Medium",
-        "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+        "url(/fonts/Lato-Medium.ttf)"
       );
 
       test_font.load().then((font) => {

--- a/html/canvas/offscreen/manual/text/canvas.2d.offscreen.transferred.lang.inherit.html
+++ b/html/canvas/offscreen/manual/text/canvas.2d.offscreen.transferred.lang.inherit.html
@@ -31,7 +31,7 @@
       let test_font = new FontFace(
         // Lato-Medium is a font with language specific ligatures.
         "Lato-Medium",
-        "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+        "url(/fonts/Lato-Medium.ttf)"
       );
 
       test_font.load().then((font) => {

--- a/html/canvas/offscreen/manual/text/canvas.2d.offscreen.worker.lang-ref.html
+++ b/html/canvas/offscreen/manual/text/canvas.2d.offscreen.worker.lang-ref.html
@@ -29,7 +29,7 @@
     let test_font = new FontFace(
       // Lato-Medium is a font with language specific ligatures.
       "Lato-Medium",
-      "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+      "url(/fonts/Lato-Medium.ttf)"
     );
 
     test_font.load().then((font) => {

--- a/html/canvas/offscreen/manual/text/text-lang-worker-en.js
+++ b/html/canvas/offscreen/manual/text/text-lang-worker-en.js
@@ -5,7 +5,7 @@ self.onmessage = function(e) {
   let test_font = new FontFace(
     // Lato-Medium is a font with language specific ligatures.
     "Lato-Medium",
-    "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+    "url(/fonts/Lato-Medium.ttf)"
   );
 
   test_font.load().then((font) => {

--- a/html/canvas/offscreen/manual/text/text-lang-worker-inherit.js
+++ b/html/canvas/offscreen/manual/text/text-lang-worker-inherit.js
@@ -5,7 +5,7 @@ self.onmessage = function(e) {
   let test_font = new FontFace(
     // Lato-Medium is a font with language specific ligatures.
     "Lato-Medium",
-    "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+    "url(/fonts/Lato-Medium.ttf)"
   );
 
   test_font.load().then((font) => {

--- a/html/canvas/offscreen/manual/text/text-lang-worker-tr.js
+++ b/html/canvas/offscreen/manual/text/text-lang-worker-tr.js
@@ -5,7 +5,7 @@ self.onmessage = function(e) {
   let test_font = new FontFace(
     // Lato-Medium is a font with language specific ligatures.
     "Lato-Medium",
-    "url(/css/css-fonts/support/fonts/Lato-Medium.ttf)"
+    "url(/fonts/Lato-Medium.ttf)"
   );
 
   test_font.load().then((font) => {


### PR DESCRIPTION
The Lato fonts are needed for language tests in html/canvas. Those  tests are generated and the generation script looks for fonts in /fonts. So move the Lato font files there.