### PR TITLE
Add command/commandfor buttons to popover-focus-2 test

### DIFF
--- a/html/semantics/popovers/popover-focus-2.html
+++ b/html/semantics/popovers/popover-focus-2.html
@@ -3,6 +3,7 @@
 <title>Popover focus behaviors</title>
 <meta name="timeout" content="long">
 <link rel="author" href="mailto:masonf@chromium.org">
+<link rel="author" title="Luke Warlow" href="mailto:lwarlow@igalia.com">
 <link rel=help href="https://open-ui.org/components/popover.research.explainer">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -10,7 +11,6 @@
 <script src="/resources/testdriver-actions.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="resources/popover-utils.js"></script>
-
 <div id=fixup>
   <button id=button1 tabindex="0">Button1</button>
   <div popover id=popover0  tabindex="0" style="top:300px">
@@ -121,8 +121,28 @@ promise_test(async t => {
     invoker3.removeAttribute('popovertarget');
   });
   await testPopoverFocusNavigation();
-}, "Popover focus navigation with declarative invocation");
-
+}, "Popover focus navigation with popovertarget invocation");
+promise_test(async t => {
+  invoker0.setAttribute('commandfor', 'popover0');
+  invoker1.setAttribute('commandfor', 'popover1');
+  invoker2.setAttribute('commandfor', 'popover2');
+  invoker3.setAttribute('commandfor', 'popover3');
+  invoker0.setAttribute('command', 'toggle-popover');
+  invoker1.setAttribute('command', 'toggle-popover');
+  invoker2.setAttribute('command', 'toggle-popover');
+  invoker3.setAttribute('command', 'toggle-popover');
+  t.add_cleanup(() => {
+    invoker0.removeAttribute('commandfor');
+    invoker1.removeAttribute('commandfor');
+    invoker2.removeAttribute('commandfor');
+    invoker3.removeAttribute('commandfor');
+    invoker0.removeAttribute('command');
+    invoker1.removeAttribute('command');
+    invoker2.removeAttribute('command');
+    invoker3.removeAttribute('command');
+  });
+  await testPopoverFocusNavigation();
+}, "Popover focus navigation with command/commandfor invocation");
 promise_test(async t => {
   const invoker0Click = () => {
     popover0.togglePopover({ source: invoker0 });
@@ -149,11 +169,10 @@ promise_test(async t => {
   await testPopoverFocusNavigation()
 }, "Popover focus navigation with imperative invocation");
 </script>
-
 <button id=circular0 tabindex="0">Invoker</button>
 <div id=popover4 popover>
-  <button id=circular1 autofocus popovertargetaction=hide tabindex="0"></button>
-  <button id=circular2 popovertargetaction=show tabindex="0"></button>
+  <button id=circular1 autofocus tabindex="0"></button>
+  <button id=circular2 tabindex="0"></button>
   <button id=circular3 tabindex="0"></button>
 </div>
 <button id=circular4 tabindex="0">after</button>
@@ -167,16 +186,41 @@ async function testCircularReferenceTabNavigation() {
 promise_test(async t => {
   circular0.setAttribute('popovertarget', 'popover4');
   circular1.setAttribute('popovertarget', 'popover4');
+  circular1.setAttribute('popovertargetaction', 'hide');
   circular2.setAttribute('popovertarget', 'popover4');
+  circular2.setAttribute('popovertargetaction', 'show');
   circular3.setAttribute('popovertarget', 'popover4');
   t.add_cleanup(() => {
     circular0.removeAttribute('popovertarget');
     circular1.removeAttribute('popovertarget');
+    circular1.removeAttribute('popovertargetaction');
     circular2.removeAttribute('popovertarget');
+    circular2.removeAttribute('popovertargetaction');
     circular3.removeAttribute('popovertarget');
   });
   await testCircularReferenceTabNavigation();
-}, "Circular reference tab navigation with declarative invocation");
+}, "Circular reference tab navigation with popovertarget invocation");
+promise_test(async t => {
+  circular0.setAttribute('commandfor', 'popover4');
+  circular1.setAttribute('commandfor', 'popover4');
+  circular2.setAttribute('commandfor', 'popover4');
+  circular3.setAttribute('commandfor', 'popover4');
+  circular0.setAttribute('command', 'toggle-popover');
+  circular1.setAttribute('command', 'hide-popover');
+  circular2.setAttribute('command', 'show-popover');
+  circular3.setAttribute('command', 'toggle-popover');
+  t.add_cleanup(() => {
+    circular0.removeAttribute('commandfor');
+    circular1.removeAttribute('commandfor');
+    circular2.removeAttribute('commandfor');
+    circular3.removeAttribute('commandfor');
+    circular0.removeAttribute('command');
+    circular1.removeAttribute('command');
+    circular2.removeAttribute('command');
+    circular3.removeAttribute('command');
+  });
+  await testCircularReferenceTabNavigation();
+}, "Circular reference tab navigation with command/commandfor invocation");
 promise_test(async t => {
   const circular0Click = () => {
     popover4.togglePopover({ source: circular0 });
@@ -203,18 +247,17 @@ promise_test(async t => {
   await testCircularReferenceTabNavigation();
 }, "Circular reference tab navigation with imperative invocation");
 </script>
-
 <div id=focus-return1>
-  <button popovertargetaction=show tabindex="0">Show popover</button>
+  <button tabindex="0">Show popover</button>
   <div popover id=focus-return1-p>
-    <button popovertargetaction=hide autofocus tabindex="0">Hide popover</button>
+    <button autofocus tabindex="0">Hide popover</button>
   </div>
 </div>
 <script>
 async function testPopoverFocusReturn1() {
   const invoker = document.querySelector('#focus-return1>button');
   const popover = document.querySelector('#focus-return1>[popover]');
-  const hideButton = popover.querySelector('[popovertargetaction=hide]');
+  const hideButton = popover.querySelector('button');
   invoker.focus(); // Make sure button is focused.
   assert_equals(document.activeElement,invoker);
   await sendEnter(); // Activate the invoker
@@ -229,13 +272,33 @@ promise_test(async t => {
   const popover = document.querySelector('#focus-return1>[popover]');
   const hideButton = popover.querySelector('button');
   invoker.setAttribute('popovertarget', 'focus-return1-p');
+  invoker.setAttribute('popovertargetaction', 'show');
   hideButton.setAttribute('popovertarget', 'focus-return1-p');
+  hideButton.setAttribute('popovertargetaction', 'hide');
   t.add_cleanup(() => {
     invoker.removeAttribute('popovertarget');
+    invoker.removeAttribute('popovertargetaction');
     hideButton.removeAttribute('popovertarget');
+    hideButton.removeAttribute('popovertargetaction');
   });
   await testPopoverFocusReturn1();
-}, "Popover focus returns when popover is hidden by invoker with declarative invocation");
+}, "Popover focus returns when popover is hidden by invoker with popovertarget invocation");
+promise_test(async t => {
+  const invoker = document.querySelector('#focus-return1>button');
+  const popover = document.querySelector('#focus-return1>[popover]');
+  const hideButton = popover.querySelector('button');
+  invoker.setAttribute('commandfor', 'focus-return1-p');
+  invoker.setAttribute('command', 'show-popover');
+  hideButton.setAttribute('commandfor', 'focus-return1-p');
+  hideButton.setAttribute('command', 'hide-popover');
+  t.add_cleanup(() => {
+    invoker.removeAttribute('commandfor');
+    invoker.removeAttribute('command');
+    hideButton.removeAttribute('commandfor');
+    hideButton.removeAttribute('command');
+  });
+  await testPopoverFocusReturn1();
+}, "Popover focus returns when popover is hidden by invoker with commandfor invocation");
 promise_test(async t => {
   const invoker = document.querySelector('#focus-return1>button');
   const popover = document.querySelector('#focus-return1>[popover]');
@@ -255,7 +318,6 @@ promise_test(async t => {
   await testPopoverFocusReturn1();
 }, "Popover focus returns when popover is hidden by invoker with imperative invocation");
 </script>
-
 <div id=focus-return2>
   <button tabindex="0">Toggle popover</button>
   <div popover id=focus-return2-p>Popover with <button tabindex="0">focusable element</button></div>
@@ -286,7 +348,17 @@ promise_test(async t => {
     invoker.removeAttribute('popovertarget');
   });
   await testPopoverFocusReturn2();
-}, "Popover focus only returns to invoker when focus is within the popover with declarative invocation");
+}, "Popover focus only returns to invoker when focus is within the popover with popovertarget invocation");
+promise_test(async t => {
+  const invoker = document.querySelector('#focus-return2>button');
+  invoker.setAttribute('command', 'toggle-popover');
+  invoker.setAttribute('commandfor', 'focus-return2-p');
+  t.add_cleanup(() => {
+    invoker.removeAttribute('command');
+    invoker.removeAttribute('commandfor');
+  });
+  await testPopoverFocusReturn2();
+}, "Popover focus only returns to invoker when focus is within the popover with command/commandfor invocation");
 promise_test(async t => {
   const invoker = document.querySelector('#focus-return2>button');
   const popover = document.querySelector('#focus-return2>[popover]');
@@ -300,7 +372,6 @@ promise_test(async t => {
   await testPopoverFocusReturn2();
 }, "Popover focus only returns to invoker when focus is within the popover with imperative invocation");
 </script>
-
 <div id=no-focus-candidate>
   <button tabindex="0">Toggle popover</button>
   <div popover id=no-focus-candidate-p>
@@ -346,7 +417,27 @@ promise_test(async t => {
     nestedPopover.hidePopover();
   });
   await testNoFocusCandidate();
-}, "Cases where the next focus candidate isn't in the direct parent scope with declarative invocation");
+}, "Cases where the next focus candidate isn't in the direct parent scope with popovertarget invocation");
+promise_test(async t => {
+  const invoker = document.querySelector('#no-focus-candidate>button');
+  const popover = document.querySelector('#no-focus-candidate>[popover]');
+  const nestedButton = popover.querySelector('button');
+  const nestedPopover = document.querySelector('#no-focus-candidate>[popover]>[popover]');
+  invoker.setAttribute('commandfor', 'no-focus-candidate-p');
+  invoker.setAttribute('command', 'toggle-popover');
+  nestedButton.setAttribute('commandfor', 'no-focus-candidate-p2');
+  nestedButton.setAttribute('command', 'toggle-popover');
+  t.add_cleanup(() => {
+    invoker.removeAttribute('command');
+    invoker.removeAttribute('commandfor');
+    nestedButton.removeAttribute('command');
+    nestedButton.removeAttribute('commandfor');
+    nestedButton.disabled = false;
+    popover.hidePopover();
+    nestedPopover.hidePopover();
+  });
+  await testNoFocusCandidate();
+}, "Cases where the next focus candidate isn't in the direct parent scope with command/commandfor invocation");
 promise_test(async t => {
   const invoker = document.querySelector('#no-focus-candidate>button');
   const popover = document.querySelector('#no-focus-candidate>[popover]');


### PR DESCRIPTION
This test now covers popovertarget, imperative invokers and commandfor.