### PR TITLE
Improve names of Safari WPT matrix jobs

### DIFF
--- a/.github/workflows/safari-wptrunner.yml
+++ b/.github/workflows/safari-wptrunner.yml
@@ -22,7 +22,7 @@ permissions: {}
 
 jobs:
   safari-results:
-    name: ${{ inputs.safari-technology-preview && 'Safari Technology Preview' || 'Safari' }}
+    name: ${{ matrix.current-chunk }} (of ${{ matrix.total-chunks }})
     runs-on:
       - self-hosted
       - webkit-ews


### PR DESCRIPTION
Currently we get: "All Tests: Safari Technology Preview / Safari Technology Preview"

After this, we get: "All Tests: Safari Technology Preview / 1 (of 8)"

This will make things like the usage metrics a lot more useful, as jobs will then have unique names: https://github.com/web-platform-tests/wpt/actions/metrics/usage?tab=jobs