### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=286767

### DIFF
--- a/css/css-typed-om/the-stylepropertymap/inline/append.tentative.html
+++ b/css/css-typed-om/the-stylepropertymap/inline/append.tentative.html
@@ -19,6 +19,7 @@ const gInvalidTestCases = [
   { property: 'transition-duration', values: [CSS.s(1), '10px', CSS.px(10)], desc: 'a mix of valid and invalid values' },
   { property: 'transition-duration', values: [new CSSUnparsedValue([])], desc: 'a CSSUnparsedValue' },
   { property: 'transition-duration', values: ['var(--A)'], desc: 'a var ref' },
+  { property: 'background-size', values: [document.getElementsByTagName('title')[0].computedStyleMap().get('mask-position')], desc: 'a CSSVariableReferenceValue property' },
 ];
 
 for (const {property, values, desc} of gInvalidTestCases) {


### PR DESCRIPTION
WebKit export from bug: [StylePropertyMap::append is not properly verifying that we don't append CSSVariableReferenceValue style values](https://bugs.webkit.org/show_bug.cgi?id=286767)