### PR TITLE
layout: Fix intrinsic contributions of indefinite `stretch` keyword

### DIFF
--- a/css/css-sizing/keyword-sizes-for-intrinsic-contributions.html
+++ b/css/css-sizing/keyword-sizes-for-intrinsic-contributions.html
@@ -47,20 +47,20 @@
 <div class="wrapper" style="width: 0px">
   <div class="test width" data-expected-width="70"><div style="width: min-content">XXX XXX</div></div>
   <div class="test width" data-expected-width="70"><div style="width: fit-content">XXX XXX</div></div>
-  <div class="test width" data-expected-width="70"><div class="stretch">XXX XXX</div></div>
   <div class="test width" data-expected-width="150"><div style="width: max-content">XXX XXX</div></div>
+  <div class="test width" data-expected-width="70"><div class="stretch">XXX XXX</div></div>
 </div>
 <div class="wrapper" style="width: 100px">
   <div class="test width" data-expected-width="70"><div style="width: min-content">XXX XXX</div></div>
   <div class="test width" data-expected-width="90"><div style="width: fit-content">XXX XXX</div></div>
-  <div class="test width" data-expected-width="90"><div class="stretch">XXX XXX</div></div>
   <div class="test width" data-expected-width="150"><div style="width: max-content">XXX XXX</div></div>
+  <div class="test width" data-expected-width="90"><div class="stretch">XXX XXX</div></div>
 </div>
 <div class="wrapper" style="width: 200px">
   <div class="test width" data-expected-width="70"><div style="width: min-content">XXX XXX</div></div>
   <div class="test width" data-expected-width="150"><div style="width: fit-content">XXX XXX</div></div>
-  <div class="test width" data-expected-width="150"><div class="stretch">XXX XXX</div></div>
   <div class="test width" data-expected-width="150"><div style="width: max-content">XXX XXX</div></div>
+  <div class="test width" data-expected-width="150"><div class="stretch">XXX XXX</div></div>
 </div>
 
 <hr>
@@ -69,20 +69,20 @@
 <div class="wrapper" style="width: 0px">
   <div class="test min-width" data-expected-width="70"><div style="min-width: min-content">XXX XXX</div></div>
   <div class="test min-width" data-expected-width="70"><div style="min-width: fit-content">XXX XXX</div></div>
-  <div class="test min-width" data-expected-width="10"><div class="stretch">XXX XXX</div></div>
   <div class="test min-width" data-expected-width="150"><div style="min-width: max-content">XXX XXX</div></div>
+  <div class="test min-width" data-expected-width="10"><div class="stretch">XXX XXX</div></div>
 </div>
 <div class="wrapper" style="width: 100px">
   <div class="test min-width" data-expected-width="70"><div style="min-width: min-content">XXX XXX</div></div>
   <div class="test min-width" data-expected-width="90"><div style="min-width: fit-content">XXX XXX</div></div>
-  <div class="test min-width" data-expected-width="10"><div class="stretch">XXX XXX</div></div>
   <div class="test min-width" data-expected-width="150"><div style="min-width: max-content">XXX XXX</div></div>
+  <div class="test min-width" data-expected-width="10"><div class="stretch">XXX XXX</div></div>
 </div>
 <div class="wrapper" style="width: 200px">
   <div class="test min-width" data-expected-width="70"><div style="min-width: min-content">XXX XXX</div></div>
   <div class="test min-width" data-expected-width="150"><div style="min-width: fit-content">XXX XXX</div></div>
-  <div class="test min-width" data-expected-width="10"><div class="stretch">XXX XXX</div></div>
   <div class="test min-width" data-expected-width="150"><div style="min-width: max-content">XXX XXX</div></div>
+  <div class="test min-width" data-expected-width="10"><div class="stretch">XXX XXX</div></div>
 </div>
 
 <hr>
@@ -91,20 +91,20 @@
 <div class="wrapper" style="width: 0px">
   <div class="test max-width" data-expected-width="70"><div style="max-width: min-content">XXX XXX</div></div>
   <div class="test max-width" data-expected-width="70"><div style="max-width: fit-content">XXX XXX</div></div>
-  <div class="test max-width" data-expected-width="210"><div class="stretch">XXX XXX</div></div>
   <div class="test max-width" data-expected-width="150"><div style="max-width: max-content">XXX XXX</div></div>
+  <div class="test max-width" data-expected-width="210"><div class="stretch">XXX XXX</div></div>
 </div>
 <div class="wrapper" style="width: 100px">
   <div class="test max-width" data-expected-width="70"><div style="max-width: min-content">XXX XXX</div></div>
   <div class="test max-width" data-expected-width="90"><div style="max-width: fit-content">XXX XXX</div></div>
-  <div class="test max-width" data-expected-width="210"><div class="stretch">XXX XXX</div></div>
   <div class="test max-width" data-expected-width="150"><div style="max-width: max-content">XXX XXX</div></div>
+  <div class="test max-width" data-expected-width="210"><div class="stretch">XXX XXX</div></div>
 </div>
 <div class="wrapper" style="width: 200px">
   <div class="test max-width" data-expected-width="70"><div style="max-width: min-content">XXX XXX</div></div>
   <div class="test max-width" data-expected-width="150"><div style="max-width: fit-content">XXX XXX</div></div>
-  <div class="test max-width" data-expected-width="210"><div class="stretch">XXX XXX</div></div>
   <div class="test max-width" data-expected-width="150"><div style="max-width: max-content">XXX XXX</div></div>
+  <div class="test max-width" data-expected-width="210"><div class="stretch">XXX XXX</div></div>
 </div>
 
 <script src="/resources/testharness.js"></script>


### PR DESCRIPTION
In #<!-- nolink -->35630 I treated an indefinite `stretch` as 0px on min sizing properties, and as `none` on max sizing properties. However, this was only for final layout sizes, I forgot about intrinsic contributions.

Blink already modified the relevant test, I'm just reordering it a bit since we are no longer treating `stretch` as `fit-content`, so it seems better to test it at the end.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#36030