### PR TITLE
Update pyobjc versions

### DIFF
--- a/tools/ci/requirements_macos_color_profile.txt
+++ b/tools/ci/requirements_macos_color_profile.txt
@@ -1,4 +1,14 @@
-pyobjc-core==10.3.1
-pyobjc-framework-Cocoa==9.2
-pyobjc-framework-ColorSync==9.2
-pyobjc-framework-Quartz==9.2
+--only-binary pyobjc-core
+--only-binary pyobjc-framework-cocoa
+--only-binary pyobjc-framework-colorsync
+--only-binary pyobjc-framework-quartz
+
+pyobjc-core==10.3.2 ; python_full_version < '3.9'
+pyobjc-framework-cocoa==10.3.2 ; python_full_version < '3.9'
+pyobjc-framework-colorsync==10.3.2 ; python_full_version < '3.9'
+pyobjc-framework-quartz==10.3.2 ; python_full_version < '3.9'
+
+pyobjc-core==11.0 ; python_full_version >= '3.9'
+pyobjc-framework-cocoa==11.0 ; python_full_version >= '3.9'
+pyobjc-framework-colorsync==11.0 ; python_full_version >= '3.9'
+pyobjc-framework-quartz==11.0 ; python_full_version >= '3.9'


### PR DESCRIPTION
This also limits these to only install binary modules, and only installs these on macOS, as they won't compile on other platforms.

Fixes #43614, fixes #45179, fixes #45180, fixes #45182, fixes #46698, fixes #46700, fixes #46701, fixes #50081, fixes #50082, fixes #50083, and fixes #50084.