### PR TITLE
Fix css-flexbox/percent-height-flex-items-cross-sizez-with-mutations

### DIFF
--- a/css/css-flexbox/percent-height-flex-items-cross-sizes-with-mutations.html
+++ b/css/css-flexbox/percent-height-flex-items-cross-sizes-with-mutations.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
 <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#layout-algorithm">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
-<meta name="assert" content="Tests that the cross size of flexboxes and flex items with % height are computed correctly with various mutations."
+<meta name="assert" content="Tests that the cross size of flexboxes and flex items with % height are computed correctly with various mutations.">
 <style>
 .flexbox {
   display: flex;


### PR DESCRIPTION
When I created this test I ran into some linting errors. When I tried to appease those I accidentally introduced a bug in the markup.