### PR TITLE
Fix the issue #51441 by waiting for the actual scrolling to happen in test_move_focus_dont_scroll_viewport.

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/focus-after-close.html
+++ b/html/semantics/interactive-elements/the-dialog-element/focus-after-close.html
@@ -167,7 +167,12 @@ async function test_move_focus_dont_scroll_viewport(showModal) {
   document.body.appendChild(outViewPortButton);
 
   await new Promise(resolve => {
-    document.addEventListener("scroll", resolve, { once: true });
+    document.addEventListener("scroll", () => {
+      if (resolve && document.documentElement.scrollTop) {
+        resolve();
+        resolve = null;
+      }
+    });
     outViewPortButton.focus();
   });
 


### PR DESCRIPTION
Because scrolling to the button may happen over a period of time, we can't assume that scrollTop has moved when we receive the first scroll event.