### PR TITLE
Trusted Types reporting: Tweak comments about assumptions on .headers files

### DIFF
--- a/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html
+++ b/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html
@@ -3,24 +3,12 @@
   <script nonce="123" src="/resources/testharness.js"></script>
   <script nonce="123"src="/resources/testharnessreport.js"></script>
   <script src="./support/csp-violations.js"></script>
+  <meta http-equiv="Content-Security-Policy" content="script-src http: https: 'nonce-123' 'report-sample'">
+  <meta http-equiv="Content-Security-Policy" content="connect-src 'none'">
+  <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">
 </head>
 <body>
   <script nonce="123">
-  // CSP insists the "trusted-types: ..." directives are deliverd as headers
-  // (rather than as "<meta http-equiv" tags). This test assumes the following
-  // headers are set in the .headers file:
-  //
-  //   Content-Security-Policy: script-src 'unsafe-inline'; report-uri ...
-  //   Content-Security-Policy: connect-src 'none'
-  //   Content-Security-Policy: require-trusted-types-for 'script'
-  //
-  // The second rule is there so we can provoke a CSP violation report at will.
-  // The intent is that in order to test that a violation has *not* been thrown
-  // (and without resorting to abominations like timeouts), we force a *another*
-  // CSP violation (by violating the connect-src rule) and when that event is
-  // processed we can we sure that an earlier event - if it indeed occurred -
-  // must have already been processed.
-
   // A sample policy we use to test trustedTypes.createPolicy behaviour.
   const id = x => x;
   const a_policy = {

--- a/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html.headers
+++ b/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html.headers
@@ -1,3 +1,0 @@
-Content-Security-Policy: script-src http: https: 'nonce-123' 'report-sample'
-Content-Security-Policy: connect-src 'none'
-Content-Security-Policy: require-trusted-types-for 'script'

--- a/trusted-types/trusted-types-eval-reporting-report-only.html
+++ b/trusted-types/trusted-types-eval-reporting-report-only.html
@@ -3,23 +3,13 @@
   <script nonce="123" src="/resources/testharness.js"></script>
   <script nonce="123" src="/resources/testharnessreport.js"></script>
   <script nonce="123" src="./support/csp-violations.js"></script>
+  <!-- Content-Security-Policy-Report-Only directives are not supported on meta
+       tags per https://www.w3.org/TR/CSP3/#cspro-header. This test sets at
+       least one such directive in a .headers file. Please refer to that file
+       for the complete set of CSP rules that apply to this test. -->
 </head>
 <body>
   <script nonce="123">
-  // CSP insists the "trusted-types: ..." directives are delivered as headers
-  // (rather than as "<meta http-equiv" tags). This test assumes the following
-  // headers are set in the .headers file:
-  //
-  //   Content-Security-Policy: script-src 'unsafe-inline' 'unsafe-eval'; report-uri ...
-  //   Content-Security-Policy: connect-src 'none'
-  //   Content-Security-Policy-Report-Only: require-trusted-types-for 'script'
-  //
-  // The last rule is there so we can provoke a CSP violation report at will.
-  // The intent is that in order to test that a violation has *not* been thrown
-  // (and without resorting to abominations like timeouts), we force a *another*
-  // CSP violation (by violating the img-src rule) and when that event is
-  // processed we can we sure that an earlier event - if it indeed occurred -
-  // must have already been processed.
 
   // A sample policy we use to test trustedTypes.createPolicy behaviour.
   const id = x => x;

--- a/trusted-types/trusted-types-report-only.html
+++ b/trusted-types/trusted-types-report-only.html
@@ -3,7 +3,11 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="/content-security-policy/support/testharness-helper.js"></script>
-<script src="./support/csp-violations.js"></script>
+  <script src="./support/csp-violations.js"></script>
+  <!-- Content-Security-Policy-Report-Only directives are not supported on meta
+       tags per https://www.w3.org/TR/CSP3/#cspro-header. This test sets at
+       least one such directive in a .headers file. Please refer to that file
+       for the complete set of CSP rules that apply to this test. -->
 </head>
 <body>
 
@@ -14,12 +18,6 @@
   <script id="script2"></script>
 
   <script>
-  // CSP insists the "trusted-types: ..." directives are delivered as headers
-  // (rather than as "meta http-equiv" tags). This test assumes the following
-  // headers are set in the .headers file:
-  //
-  //   Content-Security-Policy-Report-Only: trusted-types ...; report-uri ...
-
   // A sample policy we use to test trustedTypes.createPolicy behaviour.
   const id = x => x;
   const policy = trustedTypes.createPolicy("two", {

--- a/trusted-types/trusted-types-reporting.html
+++ b/trusted-types/trusted-types-reporting.html
@@ -4,30 +4,18 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="./support/csp-violations.js"></script>
+  <!-- Content-Security-Policy-Report-Only directives are not supported on meta
+       tags per https://www.w3.org/TR/CSP3/#cspro-header. This test sets at
+       least one such directive in a .headers file. It also sets a default-src
+       rule to allow all scripting except 'unsafe-eval', so we can also test
+       reporting of this case. Please refer to that file for the complete set of
+       CSP rules that apply to this test. -->
 </head>
 <body>
   <!-- Some elements for the tests to act on. -->
   <script id="customscript" is="custom-script" src="a"></script>
   <svg><script id="svgscript"></script></svg>
   <script>
-  // CSP insists the "trusted-types: ..." directives are delivered as headers
-  // (rather than as "<meta http-equiv" tags). This test assumes the following
-  // headers are set in the .headers file:
-  //
-  //   Content-Security-Policy: trusted-types one
-  //   Content-Security-Policy-Report-Only: trusted-types two; report-uri ...
-  //   Content-Security-Policy: connect-src 'none'
-  //   Content-Security-Policy: default-src * 'unsafe-inline'
-  //
-  // The third rule is there so we can provoke a CSP violation report at will.
-  // The intent is that in order to test that a violation has *not* been thrown
-  // (and without resorting to abominations like timeouts), we force a *another*
-  // CSP violation (by violating the connect-src rule) and when that event is
-  // processed we can we sure that an earlier event - if it indeed occurred -
-  // must have already been processed.
-  //
-  // The last rule allows all scripting except 'unsafe-eval', so we can also
-  // test reporting of this case.
 
   const url = "" + document.location;
 


### PR DESCRIPTION
…ders files with the actual content of .header files.

Also replace the comment about "provoking a CSP violation report at will" with just that connect-src is required by csp-violations.js.