### PR TITLE
Trusted Types: Fix mistake in trusted-types-report-only.html when set…

### DIFF
--- a/trusted-types/trusted-types-report-only.html
+++ b/trusted-types/trusted-types-report-only.html
@@ -30,10 +30,10 @@
 
   promise_test(async t => {
     let violation = await trusted_type_violation_without_exception_for(_ =>
-      document.getElementById("script").src = "// #abc"
+      document.getElementById("script").src = "support/namespaces.js#abc"
     );
     assert_true(violation.originalPolicy.includes("trusted-types two"));
-    assert_true(document.getElementById("script").src.endsWith("// #abc"));
+    assert_true(document.getElementById("script").src.endsWith("#abc"));
   }, "Trusted Type violation report-only: assign string to script url");
 
   promise_test(async t => {


### PR DESCRIPTION
…ting script's src

Double slashes were added in https://github.com/web-platform-tests/wpt/pull/50124 to work around testharness errors due to a HTML page being used as a script but the actual fix is to use a JS file instead.