### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=279395

### DIFF
--- a/css/css-flexbox/parsing/flex-computed.html
+++ b/css/css-flexbox/parsing/flex-computed.html
@@ -9,13 +9,19 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/computed-testcommon.js"></script>
 <style>
+  #container {
+    container-type: inline-size;
+    width: 10px;
+  }
   #target {
     font-size: 40px;
   }
 </style>
 </head>
 <body>
-<div id="target"></div>
+<div id="container">
+    <div id="target"></div>
+</div>
 <script>
 test_computed_value("flex", "none", "0 0 auto");
 test_computed_value("flex", "1", "1 1 0%");
@@ -25,6 +31,12 @@ test_computed_value("flex", "7% 8", "8 1 7%");
 test_computed_value("flex", "8 auto", "8 1 auto");
 test_computed_value("flex", "calc(10px + 0.5em)", "1 1 30px");
 test_computed_value("flex", "calc(10px - 0.5em)", "1 1 0px");
+test_computed_value("flex", "1 1 calc(10em)", "1 1 400px");
+test_computed_value("flex", "1 1 calc(-10em)", "1 1 0px");
+test_computed_value("flex", "calc(10 + (sign(20cqw - 10px) * 5)) calc(10 + (sign(20cqw - 10px) * 5)) 1px", "5 5 1px");
+test_computed_value("flex", "1 1 calc(10px + (sign(20cqw - 10px) * 5px))", "1 1 5px");
+test_computed_value("flex", "calc(1) calc(2 + 1) calc(3px)", "1 3 3px");
+test_computed_value("flex", "calc(-1) calc(-1) 0", "0 0 0px");
 </script>
 </body>
 </html>

--- a/css/css-flexbox/parsing/flex-invalid.html
+++ b/css/css-flexbox/parsing/flex-invalid.html
@@ -16,6 +16,8 @@ test_invalid_value("flex", "none 1");
 test_invalid_value("flex", "2 3 4");
 test_invalid_value("flex", "5px 7%");
 test_invalid_value("flex", "9 none");
+test_invalid_value("flex", "1 2 calc(0)");
+test_invalid_value("flex", "1 2 calc(3 - 3)");
 </script>
 </body>
 </html>

--- a/css/css-flexbox/parsing/flex-valid.html
+++ b/css/css-flexbox/parsing/flex-valid.html
@@ -9,15 +9,37 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
+<style>
+  #container {
+    container-type: inline-size;
+    width: 10px;
+  }
+  #target {
+    font-size: 40px;
+  }
+</style>
 </head>
 <body>
+<div id="container">
+    <div id="target"></div>
+</div>
 <script>
 test_valid_value("flex", "none", "0 0 auto");
 test_valid_value("flex", "1", "1 1 0%");
 test_valid_value("flex", "2 3", "2 3 0%");
 test_valid_value("flex", "4 5 6px");
+test_valid_value("flex", "6px 4 5", "4 5 6px");
+test_valid_value("flex", "6px 4", "4 1 6px");
+test_valid_value("flex", "6px", "1 1 6px");
 test_valid_value("flex", "7% 8", "8 1 7%");
 test_valid_value("flex", "8 auto", "8 1 auto");
+test_valid_value("flex", "1 1 10em", "1 1 10em");
+test_valid_value("flex", "1 1 calc(10em)", "1 1 calc(10em)");
+test_valid_value("flex", "1 1 calc(-10em)", "1 1 calc(-10em)");
+test_valid_value("flex", "calc(10 + (sign(20cqw - 10px) * 5)) calc(10 + (sign(20cqw - 10px) * 5)) 1px", "calc(10 + (5 * sign(20cqw - 10px))) calc(10 + (5 * sign(20cqw - 10px))) 1px");
+test_valid_value("flex", "1 1 calc(10px + (sign(20cqw - 10px) * 5px))", "1 1 calc(10px + (5px * sign(20cqw - 10px)))");
+test_valid_value("flex", "calc(1) calc(2 + 1) calc(3px)", "calc(1) calc(3) calc(3px)");
+test_valid_value("flex", "calc(-1) calc(-1) 0", "calc(-1) calc(-1) 0px");
 
 // The following is not yet supported by browsers:
 // test_valid_value("flex", "content");


### PR DESCRIPTION
WebKit export from bug: [CSS flex shorthand should not eagerly evaluate calc()](https://bugs.webkit.org/show_bug.cgi?id=279395)