### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=285026

### DIFF
--- a/css/css-grid/masonry/tentative/baseline/masonry-grid-item-self-baseline-002a.html
+++ b/css/css-grid/masonry/tentative/baseline/masonry-grid-item-self-baseline-002a.html
@@ -23,7 +23,6 @@ body { width:600px; height:600px; border:1px solid; box-sizing:border-box; }
   padding-block-start: 1px;
   margin-left: 1px;
   border:1px solid;
-  masonry-auto-flow: next;
   height: 100px;
   width: 100px;
 }

--- a/css/css-grid/masonry/tentative/baseline/masonry-grid-item-self-baseline-002b.html
+++ b/css/css-grid/masonry/tentative/baseline/masonry-grid-item-self-baseline-002b.html
@@ -23,7 +23,6 @@ body { width:600px; height:600px; border:1px solid; box-sizing:border-box; }
   padding-block-start: 1px;
   margin-left: 1px;
   border:1px solid;
-  masonry-auto-flow: next;
   height: 100px;
   width: 100px;
 }


### PR DESCRIPTION
WebKit export from bug: [\[css-masonry\] Remove masonry-auto-flow property from baseline tests](https://bugs.webkit.org/show_bug.cgi?id=285026)