### PR TITLE
Use local time and provide subtest name for sv-SE locale test

### DIFF
--- a/ecmascript/locale-compat.html
+++ b/ecmascript/locale-compat.html
@@ -44,7 +44,10 @@ test(t => { // https://bugs.chromium.org/p/chromium/issues/detail?id=1418727
 }, '`Date.prototype.toLocaleString` produces `yyyy-mm-dd` instead of `m/d/yyyy` for `en-CA` locale');
 
 test(t => { // https://bugzilla.mozilla.org/show_bug.cgi?id=1864612
-  assert_true(new Intl.DateTimeFormat('sv-SE', {}).format(0).endsWith('-01-01'));
-});
+  const date = new Date('1970-01-01T00:00:00');
+  const formatter = new Intl.DateTimeFormat('sv-SE')
+
+  assert_equals(formatter.format(date), '1970-01-01');
+}, '`Intl.DateTimeFormat.prototype.format` produces `yyyy-mm-dd` instead of `yyyy-m-d` for `sv-SE` locale');
 
 </script>


### PR DESCRIPTION
Using `format(0)` is the same as `format(Date(0))`, which creates a Date object which is at the epoch. However, because we output it with no regard from the time zone, this will fail if you're in a time zone behind UTC.

To avoid this, we move to just using local time, matching the other tests in this file, thus guaranteeing this test passes everywhere.

Also, we may as well check the exact string, because "1970" is the least interesting part of this test.