### PR TITLE
Check if `presentationTime` exists before asserting its value since it's an optional attribute

### DIFF
--- a/paint-timing/paint-timing-mixin.html
+++ b/paint-timing/paint-timing-mixin.html
@@ -26,8 +26,12 @@
     });
     const entry = await performance_entry_promise;
     assert_greater_than(entry.paintTime, reference_time);
-    assert_greater_than(entry.presentationTime, entry.paintTime);
-    assert_equals(entry.presentationTime, entry.startTime);
+    if ("presentationTime" in entry) {
+      assert_greater_than(entry.presentationTime, entry.paintTime);
+      assert_equals(entry.presentationTime, entry.startTime);
+    } else {
+      assert_equals(entry.paintTime, entry.startTime);
+    }
 }, "Paint timing entries should expose paintTime and presentationTime");
 </script>
 </body>


### PR DESCRIPTION
Fixes #51535.

In `PaintTimingMixin`, `presentationTime` is an optional attribute:
```
[Exposed=Window]
interface mixin PaintTimingMixin {
    readonly attribute DOMHighResTimeStamp paintTime;
    readonly attribute DOMHighResTimeStamp? presentationTime;
};
```
In other tests we always have this `if ("PresentationTime" in entry)` checks to make sure that they are present. But it seems like we missed this test.