### PR TITLE
Make sure that event timing tests first check if the Event Timing is supported

### DIFF
--- a/event-timing/interactionid-keyboard-event-simulated-click-button-space.html
+++ b/event-timing/interactionid-keyboard-event-simulated-click-button-space.html
@@ -13,7 +13,7 @@
 
 <script>
   promise_test(async t => {
-
+    assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
     let map = new Map();
 
     const button = document.getElementById('button');

--- a/event-timing/interactionid-keyboard-event-simulated-click-checkbox-space.html
+++ b/event-timing/interactionid-keyboard-event-simulated-click-checkbox-space.html
@@ -13,7 +13,7 @@
 
 <script>
   promise_test(async t => {
-
+    assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
     let map = new Map();
 
     const checkbox = document.querySelector('input[type="checkbox"]');

--- a/event-timing/interactionid-keyboard-event-simulated-click-link-enter.html
+++ b/event-timing/interactionid-keyboard-event-simulated-click-link-enter.html
@@ -13,7 +13,7 @@
 
 <script>
   promise_test(async t => {
-
+    assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
     let map = new Map();
 
     const link = document.getElementById('lnk');


### PR DESCRIPTION
Even though these tests exercise the `PerformanceEventTiming`, they don't have this initial check that asserts the implementation of `window.PerformanceEventTiming`. Due to this, these tests were timing out instead of failing directly on browsers that don't implement it (e.g. Safari).

[We have this check in many other tests.](https://github.com/search?q=repo%3Aweb-platform-tests%2Fwpt%20assert_implements(window.PerformanceEventTiming%2C%20%27Event%20Timing%20is%20not%20supported.%27)%3B&type=code)

[If you look at this wpt.fyi results](https://wpt.fyi/results/event-timing?label=master&label=experimental&aligned&q=event-timing%2Finteractionid-keyboard-event-), these three tests are timing out on Safari, which doesn't implement this API yet, after 10 seconds. Adding this check would save us 30 seconds of testing runtime on Safari and would give more accurate results.