### PR TITLE
layout: Ensure compatible positioning context during flexbox block content sizing calculation

### DIFF
--- a/css/css-flexbox/mixed-containing-blocks-crash.html
+++ b/css/css-flexbox/mixed-containing-blocks-crash.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Flexbox: Mixed containing blocks</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-flexbox">
+<link rel="help" href="https://github.com/servo/servo/issues/36121">
+<meta name="assert" content="This test ensures that flex boxes that establish a containing block for fixed position descendants do not cause a crash when combined with flex items that establish a containing block for absolutely positioned descendants.">
+
+<html>
+    <div class="box" style="display: flex; flex-direction: column; transform: translateX(1px)">
+      <div style="position: relative;"><div>Three</div><div style="position: absolute">fixed</div></div>
+    </div>
+</div>
+


### PR DESCRIPTION
Sometimes column Flexbox needs to do an early layout pass to determine
the preferred block content size of flex items. Previously the
absolutely positioned children created during this pass were discarded,
but now they are cached to be possibly used during the final layout
phase of the flex item. Since they are not thrown away, it is necessary
that the `PositioningContext` used to collect them is compatible with
their final `PositioningContext`.

Fixes #<!-- nolink -->36121.

<!-- Please describe your changes on the following line: -->


Reviewed in servo/servo#36123