### PR TITLE
Clean up DisableAhemAntialias

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -162,10 +162,8 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite
     chrome_options["args"].append("--disable-features=ScrollbarAnimations")
 
     if kwargs["enable_mojojs"]:
-        blink_features.append('MojoJS')
-        blink_features.append('MojoJSTest')
-
-    chrome_options["args"].append("--enable-blink-features=" + ','.join(blink_features))
+        blink_features = ['MojoJS', 'MojoJSTest']
+        chrome_options["args"].append("--enable-blink-features=" + ','.join(blink_features))
 
     if kwargs["enable_swiftshader"]:
         # https://chromium.googlesource.com/chromium/src/+/HEAD/docs/gpu/swiftshader.md

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -161,9 +161,6 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite
     # Disable overlay scrollbar animations to prevent flaky wpt screenshots based on timing.
     chrome_options["args"].append("--disable-features=ScrollbarAnimations")
 
-    # Always disable antialiasing on the Ahem font.
-    blink_features = ['DisableAhemAntialias']
-
     if kwargs["enable_mojojs"]:
         blink_features.append('MojoJS')
         blink_features.append('MojoJSTest')


### PR DESCRIPTION
This feature was removed (in [1]) because it was no longer needed since font antialiasing is disabled on all test platforms.

[1]
https://crrev.com/c/chromium/src/+/6370105