### PR TITLE
Don't check implementation-defined values in JSON module syntax error test

### DIFF
--- a/html/semantics/scripting-1/the-script-element/json-module/parse-error.html
+++ b/html/semantics/scripting-1/the-script-element/json-module/parse-error.html
@@ -11,8 +11,16 @@ setup({
 async_test(t => {
   window.addEventListener("error", t.step_func_done(e => {
     assert_true(e instanceof ErrorEvent, "ErrorEvent");
-    assert_equals(e.filename, new URL("parse-error.json", location).href);
     assert_true(e.error instanceof SyntaxError, "SyntaxError");
+
+    // The specific values of these properties are implementation-defined
+    // per https://html.spec.whatwg.org/#report-an-exception
+    // and https://html.spec.whatwg.org/#extract-error.
+    // But, we can at least check that they exist.
+    assert_not_equals(e.message, undefined);
+    assert_not_equals(e.filename, undefined);
+    assert_not_equals(e.lineno, undefined);
+    assert_not_equals(e.colno, undefined);
   }));
 });
 </script>


### PR DESCRIPTION
Per discussion in https://github.com/web-platform-tests/interop/issues/933, only check that these values exist, not their specific values which are implementation-defined.