### PR TITLE
Restore wpt window after each testharness test

### DIFF
--- a/infrastructure/metadata/infrastructure/window/minimize-1.html.ini
+++ b/infrastructure/metadata/infrastructure/window/minimize-1.html.ini
@@ -1,0 +1,4 @@
+[minimize-1.html]
+  [Minimize a window]
+    expected:
+      if os == "android": FAIL

--- a/infrastructure/window/minimize-1.html
+++ b/infrastructure/window/minimize-1.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Use testdriver to minimize the window</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<!-- This is really setup for the actual test which is test2.html which checks the harness restores the window -->
+<script>
+promise_test(async () => {
+  await test_driver.minimize_window()
+  assert_true(document.hidden);
+  // And no cleanup
+}, "Minimize a window");
+</script>

--- a/infrastructure/window/minimize-2.html
+++ b/infrastructure/window/minimize-2.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Use testdriver to check window is not minimized</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<!-- This only checks something meaningful when run after test1.html -->
+<script>
+promise_test(async () => {
+  assert_false(document.hidden);
+}), "Test window is not minimized";
+</script>

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -907,7 +907,8 @@ class FirefoxBrowser(Browser):
             extensions.append(self.specialpowers_path)
         return ExecutorBrowser, {"marionette_port": self.instance.marionette_port,
                                  "extensions": extensions,
-                                 "supports_devtools": True}
+                                 "supports_devtools": True,
+                                 "supports_window_resize": True}
 
     def check_crash(self, process, test):
         return log_gecko_crashes(self.logger,

--- a/tools/wptrunner/wptrunner/browsers/firefox_android.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox_android.py
@@ -356,7 +356,8 @@ class FirefoxAndroidBrowser(Browser):
                                  # We never want marionette to install extensions because
                                  # that doesn't work on Android; instead they are in the profile
                                  "extensions": [],
-                                 "supports_devtools": False}
+                                 "supports_devtools": False,
+                                 "supports_window_resize": False}
 
     def check_crash(self, process, test):
         if not os.environ.get("MINIDUMP_STACKWALK", "") and self.stackwalk_binary:

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -914,6 +914,7 @@ class MarionetteTestharnessExecutor(TestharnessExecutor):
         self.debug_test = debug_test
 
         self.install_extensions = browser.extensions
+        self.initial_window_size = None
 
         self.original_pref_values = {}
 
@@ -928,6 +929,10 @@ class MarionetteTestharnessExecutor(TestharnessExecutor):
             addons.install(extension_path)
 
         self.protocol.testharness.load_runner(self.last_environment["protocol"])
+        try:
+            self.initial_window_size = self.protocol.window.get_rect()
+        except Exception:
+            pass
 
     def is_alive(self):
         return self.protocol.is_alive()
@@ -974,6 +979,9 @@ class MarionetteTestharnessExecutor(TestharnessExecutor):
 
         test_window = protocol.base.create_window()
         self.protocol.base.set_window(test_window)
+        # Restore the window to the initial position
+        if self.browser.supports_window_resize and self.initial_window_size:
+            self.protocol.window.set_rect(self.initial_window_size)
 
         if self.debug_test and self.browser.supports_devtools:
             self.protocol.debug.load_devtools()

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -996,6 +996,14 @@ class WebDriverTestharnessExecutor(TestharnessExecutor, TestDriverExecutorMixin)
 
         self.close_after_done = close_after_done
         self.cleanup_after_test = cleanup_after_test
+        self.initial_window_size = None
+
+    def setup(self, runner, protocol=None):
+        super().setup(runner, protocol)
+        try:
+            self.initial_window_size = self.protocol.window.get_rect()
+        except Exception:
+            pass
 
     def on_environment_change(self, new_environment):
         if new_environment["protocol"] != self.last_environment["protocol"]:
@@ -1025,6 +1033,13 @@ class WebDriverTestharnessExecutor(TestharnessExecutor, TestDriverExecutorMixin)
             # The previous test may not have closed its old windows (if something
             # went wrong or if cleanup_after_test was False), so clean up here.
             protocol.testharness.close_old_windows()
+            # Restore the window to the initial position
+            if self.initial_window_size:
+                try:
+                    self.protocol.window.set_rect(self.initial_window_size)
+                except Exception:
+                    pass
+
             raw_results = self.run_testdriver(protocol, url, timeout)
             extra = {}
             if counters := self._check_for_leaks(protocol):


### PR DESCRIPTION
This is the most straightforward possible approach. The problem is that a test might e.g. minimize the window and if it doesn't correctly cleanup after itself all subsequent tests run in an invalid state. Depending on the OS and WM this could even persist between browser restarts.