### PR TITLE
Remove AAM labelledby-whitespace, labelledby-empty, and title-whitespace tests

### DIFF
--- a/core-aam/role/roles-contextual.html
+++ b/core-aam/role/roles-contextual.html
@@ -23,8 +23,6 @@
 <div role="region" data-testname="role-map-region-aria-label-whitespace" class="ex-generic" aria-label=" ">x</div>
 <div role="region" data-testname="role-map-region-aria-labelledby" data-expectedrole="region" class="ex" aria-labelledby="labelledby">x</div>
 <div role="region" data-testname="role-map-region-aria-labelledby-non-existing" class="ex-generic" aria-labelledby="non-existing">x</div>
-<div role="region" data-testname="role-map-region-aria-labelledby-empty" class="ex-generic" aria-labelledby="empty">x</div>
-<div role="region" data-testname="role-map-region-aria-labelledby-whitespace" class="ex-generic" aria-labelledby="space">x</div>
 <div role="region" data-testname="role-map-region-title" data-expectedrole="region" title="x" class="ex">x</div>
 <div role="region" data-testname="role-map-region-title-empty" class="ex-generic" title="">x</div>
 <div role="region" data-testname="role-map-region-title-whitespace" class="ex-generic" title=" ">x</div>

--- a/core-aam/role/roles-contextual.html
+++ b/core-aam/role/roles-contextual.html
@@ -25,7 +25,6 @@
 <div role="region" data-testname="role-map-region-aria-labelledby-non-existing" class="ex-generic" aria-labelledby="non-existing">x</div>
 <div role="region" data-testname="role-map-region-title" data-expectedrole="region" title="x" class="ex">x</div>
 <div role="region" data-testname="role-map-region-title-empty" class="ex-generic" title="">x</div>
-<div role="region" data-testname="role-map-region-title-whitespace" class="ex-generic" title=" ">x</div>
 
 <!-- element to reference for aria-labelledby tests -->
 <div id="labelledby">labelledby</div>

--- a/html-aam/roles-contextual.html
+++ b/html-aam/roles-contextual.html
@@ -54,8 +54,6 @@
   <aside data-testname="el-aside-in-section-aria-label-whitespace" class="ex-generic" aria-label=" ">x</aside>
   <aside data-testname="el-aside-in-section-aria-labelledby" data-expectedrole="complementary" class="ex" aria-labelledby="labelledby">x</aside>
   <aside data-testname="el-aside-in-section-aria-labelledby-non-existing" class="ex-generic" aria-labelledby="non-existing">x</aside>
-  <aside data-testname="el-aside-in-section-aria-labelledby-empty" class="ex-generic" aria-labelledby="empty">x</aside>
-  <aside data-testname="el-aside-in-section-aria-labelledby-whitespace" class="ex-generic" aria-labelledby="space">x</aside>
   <aside data-testname="el-aside-in-section-title" data-expectedrole="complementary" title="x" class="ex">x</aside>
   <aside data-testname="el-aside-in-section-title-empty" class="ex-generic" title="">x</aside>
   <aside data-testname="el-aside-in-section-title-whitespace" class="ex-generic" title=" ">x</aside>
@@ -78,13 +76,8 @@
 <img data-testname="el-img-empty-alt-aria-label-empty" class="ex-generic" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" alt aria-label="">
 <img data-testname="el-img-empty-alt-aria-label-whitespace" class="ex-generic" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" alt aria-label=" ">
 <img data-testname="el-img-empty-alt-aria-labelledby" data-expectedrole="image" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" alt aria-labelledby="labelledby">
-<img data-testname="el-img-empty-alt-aria-labelledby-non-existing" class="ex-generic" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" alt aria-labelledby="non-existing">
-<img data-testname="el-img-empty-alt-aria-labelledby-empty" class="ex-generic" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" alt aria-labelledby="empty">
-<img data-testname="el-img-empty-alt-aria-labelledby-whitespace" class="ex-generic" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" alt aria-labelledby="space">
 <img data-testname="el-img-empty-alt-title" class="ex-generic" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" alt title="x">
 <img data-testname="el-img-empty-alt-title-empty" class="ex-generic" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" alt title="">
-<img data-testname="el-img-empty-alt-title-whitespace" class="ex-generic" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" alt title=" ">
-
 
 <!-- el-section -->
 <section data-testname="el-section" aria-label="x" data-expectedrole="region" class="ex">x</section>
@@ -93,8 +86,6 @@
 <section data-testname="el-section-aria-label-whitespace" class="ex-generic" aria-label=" ">x</section>
 <section data-testname="el-section-aria-labelledby" data-expectedrole="region" class="ex" aria-labelledby="labelledby">x</section>
 <section data-testname="el-section-aria-labelledby-non-existing" class="ex-generic" aria-labelledby="non-existing">x</section>
-<section data-testname="el-section-aria-labelledby-empty" class="ex-generic" aria-labelledby="empty">x</section>
-<section data-testname="el-section-aria-labelledby-whitespace" class="ex-generic" aria-labelledby="space">x</section>
 <section data-testname="el-section-title" data-expectedrole="region" title="x" class="ex">x</section>
 <section data-testname="el-section-title-empty" class="ex-generic" title="">x</section>
 <section data-testname="el-section-title-whitespace" class="ex-generic" title=" ">x</section>

--- a/html-aam/roles-contextual.html
+++ b/html-aam/roles-contextual.html
@@ -56,7 +56,6 @@
   <aside data-testname="el-aside-in-section-aria-labelledby-non-existing" class="ex-generic" aria-labelledby="non-existing">x</aside>
   <aside data-testname="el-aside-in-section-title" data-expectedrole="complementary" title="x" class="ex">x</aside>
   <aside data-testname="el-aside-in-section-title-empty" class="ex-generic" title="">x</aside>
-  <aside data-testname="el-aside-in-section-title-whitespace" class="ex-generic" title=" ">x</aside>
 </section>
 
 <!-- el-footer -->
@@ -88,7 +87,6 @@
 <section data-testname="el-section-aria-labelledby-non-existing" class="ex-generic" aria-labelledby="non-existing">x</section>
 <section data-testname="el-section-title" data-expectedrole="region" title="x" class="ex">x</section>
 <section data-testname="el-section-title-empty" class="ex-generic" title="">x</section>
-<section data-testname="el-section-title-whitespace" class="ex-generic" title=" ">x</section>
 
 <!-- element to reference for aria-labelledby tests -->
 <div id="labelledby">labelledby</div>


### PR DESCRIPTION
This PR removes numerous tests that were added in https://github.com/web-platform-tests/wpt/pull/50679; specifically:

1. **Removes all -labelledby-whitespace tests**
2. **Removes all -labelledby-empty roles tests**
3. **Remove all -title-whitespace tests**

There are two big reasons for removing those tests:

The first reason for removing those tests is: If you look at https://wpt.fyi/results/html-aam/roles-contextual.html you’ll see that all of those tests are failing in at least two of the major engines. Some of them are actually failing in _all three_ major engines.

The second reason for removing those tests is: It’s not clear if the test expectations in those test match any existing requirements that are actually defined in any spec.

To put it in other terms: If two (or more) different implementors working from the spec requirements did not produce implementations which pass a particular test, then it seems there might be a high likelihood that the spec doesn’t actually clearly require the behavior the test is testing.

Finally, this PR also removes the el-img-empty-alt-aria-labelledby-non-existing test. And the reason for removing that test is the first reason listed above: That test is failing in multiple engines — and more specifically: That test is failing in _all three_ major engines.

I think the appropriate next step on these tests is that somebody opens one or more issues about them in the ARIA issue tracker. The issue(s) should describe the tests and invite discussion from the spec editors and from implementors about whether or not there are actual requirements in the current specs that match the test expectations.

If the consensus among the implementors is that there are in fact actual requirements in the current specs that match the text expectations, then a WPT PR can be opened at that the time to re-land the tests. And the implementors can update their implementations to match the text expectations — so that their implementations pass the tests rather than failing the tests, as they currently do.

But if the consensus among implementors is instead that there are _not_ actual requirements in the current specs that match those test expectations, then either the specs can either be update to actual specified the desired requirements, or else it can be determined that we don’t in fact want to have requirements in the specs that match the expectations in these tests.
