### PR TITLE
Restore check for JSON module parse error filename as a tentative test

### DIFF
--- a/html/semantics/scripting-1/the-script-element/json-module/parse-error-location.tentative.html
+++ b/html/semantics/scripting-1/the-script-element/json-module/parse-error-location.tentative.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>JSON modules: parse error file location</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+setup({
+  allow_uncaught_exception: true,
+});
+async_test(t => {
+  window.addEventListener("error", t.step_func_done(e => {
+    // The specific values of these properties are implementation-defined
+    // per https://html.spec.whatwg.org/#report-an-exception
+    // and https://html.spec.whatwg.org/#extract-error,
+    // but it's preferable if implementations provide the
+    // correct file location.
+    assert_equals(e.filename, new URL("parse-error.json", location).href);
+  }));
+});
+</script>
+<script type="module">
+import v from "./parse-error.json" with { type: "json" };
+</script>


### PR DESCRIPTION
This was removed in https://github.com/web-platform-tests/wpt/pull/51583. 
As requested in https://github.com/web-platform-tests/interop/issues/933, restore the check as a `.tentative` test.