### PR TITLE
fix: root element not establishing stacking context (#35390)

### DIFF
--- a/css/CSS2/stacking-context/root-element-creates-stacking-context-ref.html
+++ b/css/CSS2/stacking-context/root-element-creates-stacking-context-ref.html
@@ -1,3 +1,4 @@
 <!DOCTYPE html>
-<html style="width: 0; height: 0; border: 50px solid">
-  <body style="border: 50px solid green; margin: -50px; position: relative">
+<body style="width: 100px; margin: 0">
+  <div style="height: 100px; background: green"></div>
+</body>

--- a/css/CSS2/stacking-context/root-element-creates-stacking-context-ref.html
+++ b/css/CSS2/stacking-context/root-element-creates-stacking-context-ref.html
@@ -1,2 +1,3 @@
+<!DOCTYPE html>
 <html style="width: 0; height: 0; border: 50px solid">
-  <body style="border: 50px solid green; margin: 0; position: relative; inset: -50px">
+  <body style="border: 50px solid green; margin: -50px; position: relative">

--- a/css/CSS2/stacking-context/root-element-creates-stacking-context-ref.html
+++ b/css/CSS2/stacking-context/root-element-creates-stacking-context-ref.html
@@ -1,0 +1,2 @@
+<html style="width: 0; height: 0; border: 50px solid">
+  <body style="border: 50px solid green; margin: 0; position: relative; inset: -50px">

--- a/css/CSS2/stacking-context/root-element-creates-stacking-context.html
+++ b/css/CSS2/stacking-context/root-element-creates-stacking-context.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html style="width: 0; height: 0; border: 50px solid red">
+  <link rel="help" href="https://drafts.csswg.org/css2/#stacking-context">
+  <link rel="match" href="root-element-creates-stacking-context-ref.html">
+  <link rel="author" title="Michael Rees" href="mailto:mrees@noeontheend.com">
+  <meta name="" content="root element forms the root stacking context">
+  <body style="border: 50px solid green; margin: 0; position: relative; inset: -50px; z-index: -1">
+  </body>
+</html>

--- a/css/CSS2/stacking-context/root-element-creates-stacking-context.html
+++ b/css/CSS2/stacking-context/root-element-creates-stacking-context.html
@@ -3,7 +3,7 @@
   <link rel="help" href="https://drafts.csswg.org/css2/#stacking-context">
   <link rel="match" href="root-element-creates-stacking-context-ref.html">
   <link rel="author" title="Michael Rees" href="mailto:mrees@noeontheend.com">
-  <meta name="" content="root element forms the root stacking context">
-  <body style="border: 50px solid green; margin: 0; position: relative; inset: -50px; z-index: -1">
+  <meta name="assert" content="root element forms the root stacking context">
+  <body style="border: 50px solid green; margin: -50px; position: relative; z-index: -1">
   </body>
 </html>


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #<!-- nolink -->35390 
- [X] There are tests for these changes

[Successful WPT run](https://github.com/reesmichael1/servo/actions/runs/14097679625) (which includes the new test files)

(I didn't make the formatting changes intentionally--those came from `mach format` following `mach test-tidy`.)
Reviewed in servo/servo#36174