### PR TITLE
Treat 'no orphan pointerup' as a pass in the event timing tests

### DIFF
--- a/event-timing/interactionid-orphan-pointerup.html
+++ b/event-timing/interactionid-orphan-pointerup.html
@@ -13,7 +13,8 @@
 <script>
   let observedEntries = [];
   const map = new Map();
-  const events = ['pointerup'];
+  // keydown is being sent right after a pointerup to see if pointerup is present.
+  const events = ['pointerup', 'keydown'];
 
   promise_test(async t => {
     assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
@@ -23,7 +24,11 @@
     const observerPromise = createPerformanceObserverPromise(['event'], callback, readyToResolve);
 
     await interactAndObserve('orphan-pointerup', document.getElementById('testButtonId'), observerPromise);
-    assert_equals(map.get('pointerup'), 0, 'Should have a trivial interactionId for orphan pointerup event.');
+
+    // This test passes when either:
+    // - There is no orphan pointerup triggered by the browser.
+    // - The orphan pointerup doesn't have an interactionId.
+    assert_true(!map.has('pointerup') || map.get('pointerup') === 0, 'Should either have no triggered orphan pointerup event or have a trivial interactionId for orphan pointerup event.');
   }, "Event Timing: Orphan pointerup should not be measured as an interaction.");
 
 </script>

--- a/event-timing/resources/event-timing-test-utils.js
+++ b/event-timing/resources/event-timing-test-utils.js
@@ -357,13 +357,20 @@ async function pointerdown(target) {
     .send();
 }
 
-async function pointerup(target) {
+async function orphanPointerup(target) {
   const actions = new test_driver.Actions();
-  return actions.addPointer("mousePointer", "mouse")
+  await actions.addPointer("mousePointer", "mouse")
     .pointerMove(0, 0, { origin: target })
     .pointerUp()
     .send();
+
+  // Orphan pointerup doesn't get triggered in some browsers. Sending a
+  // non-pointer related event to make sure that at least an event gets handled.
+  // If a browsers sends an orphan pointerup, it will always be before the
+  // keydown, so the test will correctly handle it.
+  await pressKey(target, 'a');
 }
+
 async function auxPointerdown(target) {
   const actions = new test_driver.Actions();
   return actions.addPointer("mousePointer", "mouse")
@@ -525,8 +532,8 @@ async function interactAndObserve(interactionType, target, observerPromise, key 
       break;
     }
     case 'orphan-pointerup': {
-      addListeners(target, ['pointerup']);
-      interactionPromise = pointerup(target);
+      addListeners(target, ['pointerup', 'keydown']);
+      interactionPromise = orphanPointerup(target);
       break;
     }
     case 'space-key-simulated-click': {


### PR DESCRIPTION
This is something we came up while implementing it in Firefox.

We don't fire an orphan pointerup event at all when there is only a pointerup and no pointerdown. So this test was failing. This change adds a timeout mechanism for browsers like Firefox, so we can treat 'no pointerup entry' as a pass.

As a solution, we are sending a non-pointer related event right after the pointerup event, to make sure at least one event is being handled by the test so it doesn't timeout.

It fixes [Bug 1956598](https://bugzilla.mozilla.org/show_bug.cgi?id=1956598).