### PR TITLE
Remove invalid tests from should-trusted-type-policy-creation-be-bloc…

### DIFF
--- a/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-002.html
+++ b/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-002.html
@@ -50,7 +50,6 @@
     "policy$name",
     "policy?name",
     "policy!name",
-    "política",
   ];
   invalidTrustedTypePolicyNames.forEach(trustedTypePolicyName => {
     promise_test(async t => {
@@ -72,15 +71,15 @@
   // https://w3c.github.io/webappsec-csp/#grammardef-required-ascii-whitespace
   promise_test(async t => {
     let results = await tryCreatingTrustedTypePoliciesWithCSP(
-      ["_TTP1_", "_TTP2_", "_TTP3_", "_TTP4_", "_TTP5_", "_TTP6_"],
-      "header(Content-Security-Policy,trusted-types _TTP1_%09_TTP2_%0A_TTP3_%0C_TTP4_%0D_TTP5_%20_TTP6_,True)"
+      ["_TTP1_", "_TTP2_", "_TTP3_", "_TTP4_", "_TTP5_"],
+      "header(Content-Security-Policy,trusted-types _TTP1_%09_TTP2_%0C_TTP3_%0D_TTP4_%20_TTP5_,True)"
     );
-    assert_equals(results.length, 6);
+    assert_equals(results.length, 5);
     results.forEach((result, index) => {
       assert_equals(result.exception, null);
       assert_equals(result.violatedPolicies.length, 0);
     });
-  }, `directive "trusted-type _TTP1_%09_TTP2_%0A_TTP3_%0C_TTP4_%0D_TTP5_%20_TTP6_" (required-ascii-whitespace)`);
+  }, `directive "trusted-type _TTP1_%09_TTP2_%0C_TTP3_%0D_TTP4_%20_TTP5_" (required-ascii-whitespace)`);
 
   // tt-expressions must be separated by a required-ascii-whitespace:
   promise_test(async t => {


### PR DESCRIPTION
…ked-by-csp-002.html

- Remove case "policía", the token will be skipped by "If token is an empty string, or if token is not an ASCII string, continue." https://w3c.github.io/webappsec-csp/#parse-serialized-policy

- Remove case U+000A LINE FEED as this is treated as a separator for HTTP header fields and so the Content-Security-Policy header value is what is meant by the test.