### PR TITLE
Fail on duplicate YAML keys

### DIFF
--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -1236,6 +1236,34 @@ def test_invalid_web_features_file():
     assert errors == []
 
 
+def test_duplicate_keys_invalid_web_features_file():
+    code = b"""\
+features:
+- name: feature1
+  files:
+  - feature1-*
+features:
+- name: feature2
+  files:
+  - "feature2-*"
+"""
+    # Check when the value is named correctly. It should find the error.
+    errors = check_file_contents("", "css/WEB_FEATURES.yml", io.BytesIO(code))
+    check_errors(errors)
+
+    assert errors == [
+        ('INVALID-WEB-FEATURES-FILE',
+         'The WEB_FEATURES.yml file contains an invalid structure',
+         "css/WEB_FEATURES.yml",
+         None),
+    ]
+
+    # Check when the value is named incorrectly. It should not find the error.
+    errors = check_file_contents("", "css/OTHER_WEB_FEATURES.yml", io.BytesIO(code))
+    check_errors(errors)
+
+    assert errors == []
+
 def test_css_missing_file_manual():
     errors = check_file_contents("", "css/foo/bar-manual.html", io.BytesIO(b""))
     check_errors(errors)

--- a/tools/metadata/yaml/load.py
+++ b/tools/metadata/yaml/load.py
@@ -3,9 +3,25 @@ from ..meta.schema import SchemaValue
 
 import yaml
 
+# PyYaml does not currently handle unique keys.
+# https://github.com/yaml/pyyaml/issues/165#issuecomment-430074049
+# In that issue, there are workarounds to it.
+# https://gist.github.com/pypt/94d747fe5180851196eb?permalink_comment_id=4015118#gistcomment-4015118
+
+class UniqueKeyLoader(yaml.SafeLoader):
+    def construct_mapping(self, node, deep=False):
+        mapping = set()
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            if key in mapping:
+                raise ValueError(f"Duplicate {key!r} key found in YAML.")
+            mapping.add(key)
+        return super().construct_mapping(node, deep)
+
 def load_data_to_dict(f: IO[bytes]) -> Dict[str, Any]:
     try:
-        raw_data = yaml.safe_load(f)
+        loader = UniqueKeyLoader
+        raw_data = yaml.load(f, Loader=loader)
         return SchemaValue.from_dict(raw_data)
     except Exception as e:
         raise e

--- a/tools/metadata/yaml/load.py
+++ b/tools/metadata/yaml/load.py
@@ -9,10 +9,10 @@ import yaml
 # https://gist.github.com/pypt/94d747fe5180851196eb?permalink_comment_id=4015118#gistcomment-4015118
 
 class UniqueKeyLoader(yaml.SafeLoader):
-    def construct_mapping(self, node, deep=False):
+    def construct_mapping(self, node: yaml.MappingNode, deep: bool = False) -> Dict[Any, Any]:
         mapping = set()
         for key_node, value_node in node.value:
-            key = self.construct_object(key_node, deep=deep)
+            key = self.construct_object(key_node, deep=deep)  # type: ignore
             if key in mapping:
                 raise ValueError(f"Duplicate {key!r} key found in YAML.")
             mapping.add(key)

--- a/tools/metadata/yaml/load.py
+++ b/tools/metadata/yaml/load.py
@@ -20,8 +20,7 @@ class UniqueKeyLoader(yaml.SafeLoader):
 
 def load_data_to_dict(f: IO[bytes]) -> Dict[str, Any]:
     try:
-        loader = UniqueKeyLoader
-        raw_data = yaml.load(f, Loader=loader)
+        raw_data = yaml.load(f, Loader=UniqueKeyLoader)
         return SchemaValue.from_dict(raw_data)
     except Exception as e:
         raise e


### PR DESCRIPTION
Fixes: #51638

As mentioned the issue, PyYaml does not handle duplicate keys correctly. This uses a workaround mentioned in their repository. A comment has been added to code about this.