### PR TITLE
compute pressure: Rename estimate to own_contribution_estimate

### DIFF
--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -1437,7 +1437,7 @@
          * @param {String} sample - A `virtual pressure state
          *                          <https://w3c.github.io/compute-pressure/#dom-pressurestate>`_
          *                          such as "critical".
-         * @param {number} estimate - Optional, A `virtual own contribution estimate`
+         * @param {number} own_contribution_estimate - Optional, A `virtual own contribution estimate`
          *                          <https://w3c.github.io/compute-pressure/?experimental=1#the-owncontributionestimate-attribute>`_
          * @param {WindowProxy} [context=null] - Browsing context in which to
          *                                       run the call, or null for the
@@ -1449,8 +1449,8 @@
          *                    virtual pressure source of the given type does not
          *                    exist).
          */
-        update_virtual_pressure_source: function(source_type, sample, estimate, context=null) {
-            return window.test_driver_internal.update_virtual_pressure_source(source_type, sample, estimate, context);
+        update_virtual_pressure_source: function(source_type, sample, own_contribution_estimate, context=null) {
+            return window.test_driver_internal.update_virtual_pressure_source(source_type, sample, own_contribution_estimate, context);
         },
 
         /**
@@ -1748,7 +1748,7 @@
             throw new Error("create_virtual_pressure_source() is not implemented by testdriver-vendor.js");
         },
 
-        async update_virtual_pressure_source(source_type, sample, estimate, context=null) {
+        async update_virtual_pressure_source(source_type, sample, own_contribution_estimate, context=null) {
             throw new Error("update_virtual_pressure_source() is not implemented by testdriver-vendor.js");
         },
 

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -498,8 +498,8 @@ class UpdateVirtualPressureSourceAction:
     def __call__(self, payload):
         source_type = payload["source_type"]
         sample = payload["sample"]
-        estimate = payload["estimate"]
-        return self.protocol.pressure.update_virtual_pressure_source(source_type, sample, estimate)
+        own_contribution_estimate = payload["own_contribution_estimate"]
+        return self.protocol.pressure.update_virtual_pressure_source(source_type, sample, own_contribution_estimate)
 
 class RemoveVirtualPressureSourceAction:
     name = "remove_virtual_pressure_source"

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -721,7 +721,7 @@ class MarionetteVirtualPressureSourceProtocolPart(VirtualPressureSourceProtocolP
     def create_virtual_pressure_source(self, source_type, metadata):
         raise NotImplementedError("create_virtual_pressure_source not yet implemented")
 
-    def update_virtual_pressure_source(self, source_type, sample, estimate):
+    def update_virtual_pressure_source(self, source_type, sample, own_contribution_estimate):
         raise NotImplementedError("update_virtual_pressure_source not yet implemented")
 
     def remove_virtual_pressure_source(self, source_type):

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -685,8 +685,8 @@ class WebDriverVirtualPressureSourceProtocolPart(VirtualPressureSourceProtocolPa
         body.update(metadata)
         return self.webdriver.send_session_command("POST", "pressuresource", body)
 
-    def update_virtual_pressure_source(self, source_type, sample, estimate):
-        body = {"sample": sample, "estimate": estimate}
+    def update_virtual_pressure_source(self, source_type, sample, own_contribution_estimate):
+        body = {"sample": sample, "own_contribution_estimate": own_contribution_estimate}
         return self.webdriver.send_session_command("POST", "pressuresource/%s" % source_type, body)
 
     def remove_virtual_pressure_source(self, source_type):

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -1009,7 +1009,7 @@ class VirtualPressureSourceProtocolPart(ProtocolPart):
         pass
 
     @abstractmethod
-    def update_virtual_pressure_source(self, source_type, sample, estimate):
+    def update_virtual_pressure_source(self, source_type, sample, own_contribution_estimate):
         pass
 
     @abstractmethod

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -468,8 +468,8 @@
         return create_context_action("create_virtual_pressure_source", context, {source_type, metadata});
     };
 
-    window.test_driver_internal.update_virtual_pressure_source = function(source_type, sample, estimate, context=null) {
-        return create_context_action("update_virtual_pressure_source", context, {source_type, sample, estimate});
+    window.test_driver_internal.update_virtual_pressure_source = function(source_type, sample, own_contribution_estimate, context=null) {
+        return create_context_action("update_virtual_pressure_source", context, {source_type, sample, own_contribution_estimate});
     };
 
     window.test_driver_internal.remove_virtual_pressure_source = function(source_type, context=null) {


### PR DESCRIPTION
To match the specification[1], renaming `estimate` parameter to `own_contribution_estimate` in update_virtual_pressure_source test functions.

[1] https://w3c.github.io/compute-pressure/?experimental=1#the-owncontributionestimate-attribute