### PR TITLE
Fix web-features ID for text-box tests

### DIFF
--- a/css/css-inline/text-box-trim/WEB_FEATURES.yml
+++ b/css/css-inline/text-box-trim/WEB_FEATURES.yml
@@ -1,3 +1,3 @@
 features:
-- name: text-box-trim
+- name: text-box
   files: "**"


### PR DESCRIPTION
This was added in https://github.com/web-platform-tests/wpt/pull/43390
when text-box-trim was in web-features, but since then it was made a
draft and finally added back as just text-box:
https://github.com/web-platform-dx/web-features/pull/1006
https://github.com/web-platform-dx/web-features/pull/2167
