### PR TITLE
Map :has-slotted tests to web-features

### DIFF
--- a/css/css-scoping/WEB_FEATURES.yml
+++ b/css/css-scoping/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: has-slotted
+  files:
+  - has-slotted-*

--- a/css/css-scoping/has-slotted-001.html
+++ b/css/css-scoping/has-slotted-001.html
@@ -1,6 +1,5 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>:has-slotted</title>
 <link rel="help" href="https://github.com/w3c/csswg-drafts/pull/10586">
 <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
 <p>Test passes if there is a filled green square.</p>

--- a/css/css-scoping/has-slotted-003.html
+++ b/css/css-scoping/has-slotted-003.html
@@ -1,6 +1,5 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>:has-slotted</title>
 <link rel="help" href="https://github.com/w3c/csswg-drafts/pull/10586">
 <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
 <p>Test passes if there is a filled green square.</p>

--- a/css/css-scoping/slotted-has-001.html
+++ b/css/css-scoping/slotted-has-001.html
@@ -1,6 +1,5 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>:has-slotted</title>
 <link rel="help" href="https://github.com/w3c/csswg-drafts/pull/10586">
 <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
 <p>Test passes if there is a filled green square.</p>

--- a/css/css-scoping/slotted-has-002.html
+++ b/css/css-scoping/slotted-has-002.html
@@ -1,6 +1,5 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>:has-slotted</title>
 <link rel="help" href="https://github.com/w3c/csswg-drafts/pull/10586">
 <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
 <p>Test passes if there is a filled green square.</p>

--- a/css/css-scoping/slotted-has-003.html
+++ b/css/css-scoping/slotted-has-003.html
@@ -1,6 +1,5 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>:has-slotted</title>
 <link rel="help" href="https://github.com/w3c/csswg-drafts/pull/10586">
 <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
 <p>Test passes if there is a filled green square.</p>

--- a/css/css-scoping/slotted-has-004.html
+++ b/css/css-scoping/slotted-has-004.html
@@ -1,6 +1,5 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>:has-slotted</title>
 <link rel="help" href="https://github.com/w3c/csswg-drafts/pull/10586">
 <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
 <p>Test passes if there is a filled green square.</p>

--- a/css/selectors/parsing/WEB_FEATURES.yml
+++ b/css/selectors/parsing/WEB_FEATURES.yml
@@ -9,3 +9,6 @@ features:
 - name: state
   files:
   - parse-state.html
+- name: has-slotted
+  files:
+  - parse-has-slotted.tentative.html


### PR DESCRIPTION
Also remove ":has-slotted" titles from some tests that aren't actually
testing :has-slotted, but rather ::slotted(:has(...)).
