### PR TITLE
[media capabilities] Fix webrtc tests.

### DIFF
--- a/media-capabilities/decodingInfo-webrtc.any.js
+++ b/media-capabilities/decodingInfo-webrtc.any.js
@@ -307,7 +307,6 @@ promise_test(t => {
 }, "Test that decodingInfo rejects if the audio configuration contentType has one parameter that isn't codecs");
 
 promise_test(t => {
-  bt709Config.contentType = 'video/webm; codecs="vp09.00.10.08"';
   return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
         type: 'webrtc',
         video: videoConfigurationWithDynamicRange,

--- a/media-capabilities/decodingInfoEncryptedMedia.http.html
+++ b/media-capabilities/decodingInfoEncryptedMedia.http.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>MediaCapabilities.decodingInfo() for encrypted media (non-secure context)</title>
+<title>MediaCapabilities.decodingInfo for encrypted media (non-secure context)</title>
 <script src=/resources/testharness.js></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
@@ -26,6 +26,6 @@ promise_test(t => {
     video: minimalVideoConfiguration,
     keySystemConfiguration: minimalKeySystemConfiguration,
   }));
-}, "Test that decodingInfo() with a keySystemConfiguration fails on a non-secure context.");
+}, "Test that decodingInfo with a keySystemConfiguration fails on a non-secure context.");
 
 </script>


### PR DESCRIPTION
A couple of small fixes:

- A webrtc `decodingInfo` test has an extra line that causes it to fail.
- Fix strings in `decodingInfoEncryptedMedia.http.html` for consistency.