### PR TITLE
shadow-dom: Fix dict value typo on event construction

### DIFF
--- a/shadow-dom/event-post-dispatch.html
+++ b/shadow-dom/event-post-dispatch.html
@@ -138,7 +138,7 @@ document.body.removeChild(n4.test4);
 let n5 = createTestTree(test5);
 document.body.appendChild(n5.test5);
 test(() => {
-  let log = dispatchEventWithEventLog(n5, n5.target, new MouseEvent('my-event', {bubbles: true, compoesed: true, relatedTarget: n5.relatedTarget}));
+  let log = dispatchEventWithEventLog(n5, n5.target, new MouseEvent('my-event', {bubbles: true, composed: true, relatedTarget: n5.relatedTarget}));
   assert_equals(log.event.target, null);
   assert_equals(log.event.relatedTarget, null);
   assert_equals(log.event.eventPhase, 0);
@@ -147,7 +147,7 @@ test(() => {
 }, 'Event properties post dispatch with relatedTarget in the same shadow tree. (composed: true)');
 
 test(() => {
-  let log = dispatchEventWithEventLog(n5, n5.target, new MouseEvent('my-event', {bubbles: true, compoesed: false, relatedTarget: n5.relatedTarget}));
+  let log = dispatchEventWithEventLog(n5, n5.target, new MouseEvent('my-event', {bubbles: true, composed: false, relatedTarget: n5.relatedTarget}));
   assert_equals(log.event.target, null);
   assert_equals(log.event.relatedTarget, null);
   assert_equals(log.event.eventPhase, 0);


### PR DESCRIPTION
Fix dictionary value typo on event construction (compoesed -> composed)

See https://dom.spec.whatwg.org/#dom-eventinit-composed