### PR TITLE
Update .azure-pipelines.yml to use Ubuntu 24.04

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -71,7 +71,7 @@ jobs:
   displayName: './wpt test-jobs'
   condition: eq(variables['Build.Reason'], 'PullRequest')
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-24.04'
   steps:
   - task: UsePythonVersion@0
     inputs:

--- a/tools/ci/azure/fyi_hook.yml
+++ b/tools/ci/azure/fyi_hook.yml
@@ -10,7 +10,7 @@ jobs:
   displayName: 'wpt.fyi hook: ${{ parameters.artifactName }}'
   dependsOn: ${{ parameters.dependsOn }}
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-24.04'
   steps:
   - checkout: none
   - script: |


### PR DESCRIPTION
See https://dev.azure.com/web-platform-tests/wpt/_build/results?buildId=135189&view=results:

> ##[error]This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101

See also: https://github.com/web-platform-tests/wpt/pull/50649.