### PR TITLE
Add display features-related commands to testdriver (to emulate viewport segments APIs)

### DIFF
--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -186,6 +186,12 @@ the global scope.
 .. js:autofunction:: test_driver.remove_virtual_pressure_source
 ```
 
+### Viewport Segments ###
+```eval_rst
+.. js:autofunction:: test_driver.set_display_features
+.. js:autofunction:: test_driver.clear_display_features
+```
+
 ### Using test_driver in other browsing contexts ###
 
 Testdriver can be used in browsing contexts (i.e. windows or frames)

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -1497,6 +1497,48 @@
          */
         set_protected_audience_k_anonymity: function(owner, name, hashes, context = null) {
             return window.test_driver_internal.set_protected_audience_k_anonymity(owner, name, hashes, context);
+        },
+
+        /**
+         * Overrides the display features provided by the hardware so the viewport segments
+         * can be emulated.
+         *
+         * Matches the `Set display features
+         * <https://drafts.csswg.org/css-viewport/#set-display-features>`_
+         * WebDriver command.
+         *
+         * @param {Array} features - An array of `DisplayFeatureOverride
+         *                           <https://drafts.csswg.org/css-viewport/#display-feature-override>`.
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         *
+         * @returns {Promise} Fulfilled when the display features are set.
+         *                    Rejected in case the WebDriver command errors out
+         *                    (including if the array is malformed).
+         */
+        set_display_features: function(features, context=null) {
+            return window.test_driver_internal.set_display_features(features, context);
+        },
+
+        /**
+         * Removes display features override and returns the control
+         * back to hardware.
+         *
+         * Matches the `Clear display features
+         * <https://drafts.csswg.org/css-viewport/#clear-display-features>`_
+         * WebDriver command.
+         *
+         * @param {WindowProxy} [context=null] - Browsing context in which to
+         *                                       run the call, or null for the
+         *                                       current browsing context.
+         *
+         * @returns {Promise} Fulfilled after the display features override has
+         *                    been removed. Rejected in case the WebDriver
+         *                    command errors out.
+         */
+        clear_display_features: function(context=null) {
+            return window.test_driver_internal.clear_display_features(context);
         }
     };
 
@@ -1758,6 +1800,14 @@
 
         async set_protected_audience_k_anonymity(owner, name, hashes, context=null) {
             throw new Error("set_protected_audience_k_anonymity() is not implemented by testdriver-vendor.js");
+        },
+
+        async set_display_features(features, context=null) {
+            throw new Error("set_display_features() is not implemented by testdriver-vendor.js");
+        },
+
+        async clear_display_features(context=null) {
+            throw new Error("clear_display_features() is not implemented by testdriver-vendor.js");
         }
     };
 })();

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -523,6 +523,27 @@ class SetProtectedAudienceKAnonymityAction:
         owner, name, hashes = payload["owner"], payload["name"], payload["hashes"]
         return self.protocol.protected_audience.set_k_anonymity(owner, name, hashes)
 
+class SetDisplayFeaturesAction:
+    name = "set_display_features"
+
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        features = payload["features"]
+        return self.protocol.display_features.set_display_features(features)
+
+class ClearDisplayFeaturesAction:
+    name = "clear_display_features"
+
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        return self.protocol.display_features.clear_display_features()
+
 actions = [ClickAction,
            DeleteAllCookiesAction,
            GetAllCookiesAction,
@@ -563,4 +584,6 @@ actions = [ClickAction,
            CreateVirtualPressureSourceAction,
            UpdateVirtualPressureSourceAction,
            RemoveVirtualPressureSourceAction,
-           SetProtectedAudienceKAnonymityAction]
+           SetProtectedAudienceKAnonymityAction,
+           SetDisplayFeaturesAction,
+           ClearDisplayFeaturesAction]

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -46,6 +46,7 @@ from .protocol import (AccessibilityProtocolPart,
                        VirtualSensorProtocolPart,
                        DevicePostureProtocolPart,
                        VirtualPressureSourceProtocolPart,
+                       DisplayFeaturesProtocolPart,
                        merge_dicts)
 
 
@@ -727,6 +728,15 @@ class MarionetteVirtualPressureSourceProtocolPart(VirtualPressureSourceProtocolP
     def remove_virtual_pressure_source(self, source_type):
         raise NotImplementedError("remove_virtual_pressure_source not yet implemented")
 
+class MarionetteDisplayFeaturesProtocolPart(DisplayFeaturesProtocolPart):
+    def setup(self):
+        self.marionette = self.parent.marionette
+
+    def set_display_features(self, features):
+        raise NotImplementedError("set_display_features not yet implemented")
+
+    def clear_display_features(self):
+        raise NotImplementedError("clear_display_features not yet implemented")
 
 class MarionetteProtocol(Protocol):
     implements = [MarionetteBaseProtocolPart,
@@ -750,7 +760,8 @@ class MarionetteProtocol(Protocol):
                   MarionetteAccessibilityProtocolPart,
                   MarionetteVirtualSensorProtocolPart,
                   MarionetteDevicePostureProtocolPart,
-                  MarionetteVirtualPressureSourceProtocolPart]
+                  MarionetteVirtualPressureSourceProtocolPart,
+                  MarionetteDisplayFeaturesProtocolPart]
 
     def __init__(self, executor, browser, capabilities=None, timeout_multiplier=1, e10s=True, ccov=False):
         do_delayed_imports()

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -46,6 +46,7 @@ from .protocol import (BaseProtocolPart,
                        StorageProtocolPart,
                        VirtualPressureSourceProtocolPart,
                        ProtectedAudienceProtocolPart,
+                       DisplayFeaturesProtocolPart,
                        merge_dicts)
 
 from typing import Any, List, Optional, Tuple
@@ -700,6 +701,17 @@ class WebDriverProtectedAudienceProtocolPart(ProtectedAudienceProtocolPart):
         body = {"owner": owner, "name": name, "hashes": hashes}
         return self.webdriver.send_session_command("POST", "protected_audience/set_k_anonymity", body)
 
+class WebDriverDisplayFeaturesProtocolPart(DisplayFeaturesProtocolPart):
+    def setup(self):
+        self.webdriver = self.parent.webdriver
+
+    def set_display_features(self, features):
+        body = {"features": features}
+        return self.webdriver.send_session_command("POST", "displayfeatures", body)
+
+    def clear_display_features(self):
+        return self.webdriver.send_session_command("DELETE", "displayfeatures")
+
 class WebDriverProtocol(Protocol):
     enable_bidi = False
     implements = [WebDriverBaseProtocolPart,
@@ -724,7 +736,8 @@ class WebDriverProtocol(Protocol):
                   WebDriverDevicePostureProtocolPart,
                   WebDriverStorageProtocolPart,
                   WebDriverVirtualPressureSourceProtocolPart,
-                  WebDriverProtectedAudienceProtocolPart]
+                  WebDriverProtectedAudienceProtocolPart,
+                  WebDriverDisplayFeaturesProtocolPart]
 
     def __init__(self, executor, browser, capabilities, **kwargs):
         super().__init__(executor, browser)

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -1025,3 +1025,17 @@ class ProtectedAudienceProtocolPart(ProtocolPart):
     @abstractmethod
     def set_k_anonymity(self, owner, name, hashes):
         pass
+
+class DisplayFeaturesProtocolPart(ProtocolPart):
+    """Protocol part for Display Features/Viewport Segments"""
+    __metaclass__ = ABCMeta
+
+    name = "display_features"
+
+    @abstractmethod
+    def set_display_features(self, features):
+        pass
+
+    @abstractmethod
+    def clear_display_features(self):
+        pass

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -480,5 +480,13 @@
         owner, name, hashes, context=null) {
       return create_context_action(
           'set_protected_audience_k_anonymity', context, {owner, name, hashes});
+    };
+
+    window.test_driver_internal.set_display_features = function(features, context=null) {
+        return create_context_action("set_display_features", context, {features});
+    };
+
+    window.test_driver_internal.clear_display_features = function(context=null) {
+        return create_context_action("clear_display_features", context, {});
     }
 })();


### PR DESCRIPTION
Spec PR: w3c/csswg-drafts#11137

This PR adds the required infrastructure to manipulate display features from testdriver in order to emulate the CSS and JS Viewport Segments APIs. The two new commands correspond to the two WebDriver extension commands added by the spec PR above.

JS Viewport Segments API: https://drafts.csswg.org/css-viewport/#segments
CSS Viewport Segments API: https://www.w3.org/TR/mediaqueries-5/#mf-horizontal-viewport-segments