### PR TITLE
layout: Restrict stretch alignment to flex items with computed auto size

### DIFF
--- a/css/css-flexbox/stretch-requires-computed-auto-size.html
+++ b/css/css-flexbox/stretch-requires-computed-auto-size.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>Stretch alignment with percentage that behaves as auto</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#valdef-align-items-stretch">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/4525">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  Stretch alignment requires a computed cross size of `auto`.
+  So a cyclic percentage that only behaves as `auto` doesn't stretch.
+">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div style="display: flex">
+  <div style="width: 100px; height: 100px; background: green"></div>
+  <div style="width: 100px; height: 50%; background: red"></div>
+</div>


### PR DESCRIPTION
We were allowing `align-self: stretch` to stretch flex items whose cross size behaves as `auto`, including cyclic percentages.

However, https://github.com/w3c/csswg-drafts/issues/4525 resolved that stretching should only happen when the cross size computes to `auto`.

So this patch exposes this information in `ContentBoxSizesAndPBM`, and refactors the flexbox stretching logic.

Fixes: #<!-- nolink -->36285

Testing:
 - `/css/css-flexbox/quirks-auto-block-size-with-percentage-item.html`
 - `/css/css-flexbox/stretch-requires-computed-auto-size.html`

Reviewed in servo/servo#36288