### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=290932

### DIFF
--- a/css/css-grid/grid-extrinsically-sized-mutations.html
+++ b/css/css-grid/grid-extrinsically-sized-mutations.html
@@ -15,7 +15,7 @@
   grid-template-rows: 50px;
   height: 50px;
   outline: 1px solid blue;
-  font: 10px Ahem;
+  font: 10px/1 Ahem;
 }
 
 .alignStart {


### PR DESCRIPTION
WebKit export from bug: [Use explicit line-height in recent Flexbox and grid percent height mutation tests](https://bugs.webkit.org/show_bug.cgi?id=290932)