### PR TITLE
Print without backgrounds by default.

### DIFF
--- a/docs/writing-tests/assumptions.md
+++ b/docs/writing-tests/assumptions.md
@@ -33,8 +33,9 @@ tests can freely rely on these assumptions being true:
 
 Tests for printing behavior make some further assumptions:
 
- * The UA is set to print background colors and, if it supports
-   graphics, background images.
+ * The UA is in economy mode by default, meaning that background
+   colors and (if it supports graphics) background images will only
+   be visible if `print-color-adjust:exact` is specified in the test.
  * The UA implements reasonable page-breaking behavior; e.g., it is
    assumed that UAs will not break at every opportunity, but only near
    the end of a page unless a page break is forced.

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -631,7 +631,7 @@ class MarionettePrintProtocolPart(PrintProtocolPart):
                 "bottom": margin,
             },
             "shrinkToFit": False,
-            "background": True,
+            "background": False,
         }
         return self.marionette._send_message("WebDriver:Print", body, key="value")
 

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -348,7 +348,7 @@ class WebDriverPrintProtocolPart(PrintProtocolPart):
         pdf_base64 = self.webdriver.print(page={"width": width, "height": height},
                                           margin={"top": margin, "right": margin, "bottom": margin,
                                                   "left": margin},
-                                          background=True,
+                                          background=False,
                                           shrink_to_fit=False)
         return pdf_base64
 


### PR DESCRIPTION
This reflects what actual web browsers do, and is needed in order to be able to test the `economy` value of the `print-color-adjust` CSS property. By forcing backgrounds on, there was no way of disabling them via CSS.

See https://drafts.csswg.org/css-color-adjust-1/#print-color-adjust