### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=290772

### DIFF
--- a/scroll-animations/scroll-timelines/scroll-animation.html
+++ b/scroll-animations/scroll-timelines/scroll-animation.html
@@ -133,6 +133,10 @@ promise_test(async t => {
     scroller.scrollTop =  maxScroll;
     await animation.finished;
 
+    // Wait for the next animation frame for the previous "finish"
+    // event to have dispatched.
+    await waitForNextFrame();
+
     var sent_finish_event = false;
     animation.onfinish = function() {
       sent_finish_event = true;

--- a/web-animations/timing-model/animations/finishing-an-animation.html
+++ b/web-animations/timing-model/animations/finishing-an-animation.html
@@ -326,5 +326,13 @@ promise_test(async t => {
 
 }, 'Finishing a canceled animation sets the current and start times');
 
+promise_test(async t => {
+  const animation = createDiv(t).animate(null, 1);
+  await animation.finished;
+  const eventWatcher = new EventWatcher(t, animation, 'finish', waitForNextFrame);
+  await eventWatcher.wait_for('finish');
+}, 'Finishing an animation fires finish event when a finish event listener is '
+  + 'added as the finished promise resolves');
+
 </script>
 </body>


### PR DESCRIPTION
WebKit export from bug: [\[web-animations\] animation events do not get fired if relevant event listeners are added dynamically after they are enqueued](https://bugs.webkit.org/show_bug.cgi?id=290772)