### PR TITLE
Sanitizer API: sanitizing happens after tree constructions

### DIFF
--- a/sanitizer-api/sethtml-tree-construction.sub.dat
+++ b/sanitizer-api/sethtml-tree-construction.sub.dat
@@ -596,6 +596,16 @@ test<div>p</div>tt<p>div</p><test>test</test>
 |   <b>
 
 #data
+<table><div><td>
+#config
+{ "replaceWithChildrenElements": ["table"] }
+#document
+| <div>
+| <tbody>
+|   <tr>
+|     <td>
+
+#data
 <template><div>Hello</div></template>
 #config
 {}


### PR DESCRIPTION
Or at the very least it needs to appear exactly as if it did.

Closes https://github.com/WICG/sanitizer-api/issues/259.