### PR TITLE
Fix: Add support for stylesheet MIME type quirk in quirks mode

### DIFF
--- a/html/links/stylesheet/quirk-origin-check-positive.html
+++ b/html/links/stylesheet/quirk-origin-check-positive.html
@@ -1,0 +1,18 @@
+<!-- quirks -->
+<title>Same-origin stylesheet with non-CSS MIME type quirk</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#link-type-stylesheet">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="stylesheet" href="resources/quirk-stylesheet.css.txt">
+<p class="test">This text should be green.</p>
+<script>
+setup({ single_test: true });
+onload = () => {
+  assert_equals(
+    getComputedStyle(document.querySelector('.test')).color, 
+    'rgb(0, 128, 0)',
+    "Same-origin stylesheet with non-CSS MIME type should be applied in quirks mode"
+  );
+  done();
+};
+</script>

--- a/html/links/stylesheet/quirk-origin-check-positive.html
+++ b/html/links/stylesheet/quirk-origin-check-positive.html
@@ -9,7 +9,7 @@
 setup({ single_test: true });
 onload = () => {
   assert_equals(
-    getComputedStyle(document.querySelector('.test')).color, 
+    getComputedStyle(document.querySelector('.test')).color,
     'rgb(0, 128, 0)',
     "Same-origin stylesheet with non-CSS MIME type should be applied in quirks mode"
   );

--- a/html/links/stylesheet/resources/quirk-stylesheet.css.txt
+++ b/html/links/stylesheet/resources/quirk-stylesheet.css.txt
@@ -1,0 +1,1 @@
+.test { color: green; }


### PR DESCRIPTION
This PR implements the HTML spec quirk for stylesheets: https://html.spec.whatwg.org/multipage/#link-type-stylesheet

The implementation adds a check in `stylesheet_loader.rs` to handle this quirk condition correctly, and adds a new WPT test to verify that same-origin non-CSS MIME type resources are properly treated as CSS in quirks mode.

Testing: Added a new WPT test (`quirk-origin-check-positive.html`) that verifies the positive case for this quirk. 
Fixes: https://github.com/servo/servo/issues/36324
Reviewed in servo/servo#36338