### PR TITLE
Fix #51845: Remove implicit session creation from webdriver

### DIFF
--- a/resources/test/conftest.py
+++ b/resources/test/conftest.py
@@ -55,6 +55,7 @@ def pytest_configure(config):
 
     config.driver = webdriver.Session("localhost", 4444,
                                       capabilities=capabilities)
+    config.driver.start()
     config.add_cleanup(config.driver.end)
 
     # Although the name of the `_create_unverified_context` method suggests

--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -9,24 +9,6 @@ from . import transport
 from .bidi.client import BidiSession
 
 
-def command(func):
-    def inner(self, *args, **kwargs):
-        if hasattr(self, "session"):
-            session = self.session
-        else:
-            session = self
-
-        if session.session_id is None:
-            session.start()
-
-        return func(self, *args, **kwargs)
-
-    inner.__name__ = func.__name__
-    inner.__doc__ = func.__doc__
-
-    return inner
-
-
 class Timeouts:
 
     def __init__(self, session):
@@ -111,7 +93,6 @@ class ActionSequence:
             d["parameters"] = self._pointer_params
         return d
 
-    @command
     def perform(self):
         """Perform all queued actions."""
         self.session.actions.perform([self.dict])
@@ -271,7 +252,6 @@ class Actions:
     def __init__(self, session):
         self.session = session
 
-    @command
     def perform(self, actions=None):
         """Performs actions by tick from each action sequence in `actions`.
 
@@ -283,7 +263,6 @@ class Actions:
         actions = self.session.send_session_command("POST", "actions", body)
         return actions
 
-    @command
     def release(self):
         return self.session.send_session_command("DELETE", "actions")
 
@@ -299,7 +278,6 @@ class BrowserWindow:
     def __init__(self, session):
         self.session = session
 
-    @command
     def close(self):
         handles = self.session.send_session_command("DELETE", "window")
         if handles is not None and len(handles) == 0:
@@ -309,24 +287,20 @@ class BrowserWindow:
         return handles
 
     @property
-    @command
     def rect(self):
         return self.session.send_session_command("GET", "window/rect")
 
     @rect.setter
-    @command
     def rect(self, new_rect):
         self.session.send_session_command("POST", "window/rect", new_rect)
 
     @property
-    @command
     def size(self):
         """Gets the window size as a tuple of `(width, height)`."""
         rect = self.rect
         return (rect["width"], rect["height"])
 
     @size.setter
-    @command
     def size(self, new_size):
         """Set window size by passing a tuple of `(width, height)`."""
         try:
@@ -339,14 +313,12 @@ class BrowserWindow:
             pass
 
     @property
-    @command
     def position(self):
         """Gets the window position as a tuple of `(x, y)`."""
         rect = self.rect
         return (rect["x"], rect["y"])
 
     @position.setter
-    @command
     def position(self, new_position):
         """Set window position by passing a tuple of `(x, y)`."""
         try:
@@ -358,15 +330,12 @@ class BrowserWindow:
             # for Android. Revert this once it is implemented.
             pass
 
-    @command
     def maximize(self):
         return self.session.send_session_command("POST", "window/maximize")
 
-    @command
     def minimize(self):
         return self.session.send_session_command("POST", "window/minimize")
 
-    @command
     def fullscreen(self):
         return self.session.send_session_command("POST", "window/fullscreen")
 
@@ -375,7 +344,6 @@ class Find:
     def __init__(self, session):
         self.session = session
 
-    @command
     def css(self, element_selector, all=True):
         elements = self._find_element("css selector", element_selector, all)
         return elements
@@ -409,21 +377,17 @@ class UserPrompt:
     def __init__(self, session):
         self.session = session
 
-    @command
     def dismiss(self):
         self.session.send_session_command("POST", "alert/dismiss")
 
-    @command
     def accept(self):
         self.session.send_session_command("POST", "alert/accept")
 
     @property
-    @command
     def text(self):
         return self.session.send_session_command("GET", "alert/text")
 
     @text.setter
-    @command
     def text(self, value):
         body = {"text": value}
         self.session.send_session_command("POST", "alert/text", body=body)
@@ -603,41 +567,33 @@ class Session:
         return self.send_command(method, url, body, timeout)
 
     @property
-    @command
     def url(self):
         return self.send_session_command("GET", "url")
 
     @url.setter
-    @command
     def url(self, url):
         if urlparse.urlsplit(url).netloc is None:
             return self.url(url)
         body = {"url": url}
         return self.send_session_command("POST", "url", body)
 
-    @command
     def back(self):
         return self.send_session_command("POST", "back")
 
-    @command
     def forward(self):
         return self.send_session_command("POST", "forward")
 
-    @command
     def refresh(self):
         return self.send_session_command("POST", "refresh")
 
     @property
-    @command
     def title(self):
         return self.send_session_command("GET", "title")
 
     @property
-    @command
     def source(self):
         return self.send_session_command("GET", "source")
 
-    @command
     def new_window(self, type_hint="tab"):
         body = {"type": type_hint}
         value = self.send_session_command("POST", "window/new", body)
@@ -645,12 +601,10 @@ class Session:
         return value["handle"]
 
     @property
-    @command
     def window_handle(self):
         return self.send_session_command("GET", "window")
 
     @window_handle.setter
-    @command
     def window_handle(self, handle):
         body = {"handle": handle}
         return self.send_session_command("POST", "window", body=body)
@@ -666,16 +620,13 @@ class Session:
         return self.send_session_command("POST", url, body)
 
     @property
-    @command
     def handles(self):
         return self.send_session_command("GET", "window/handles")
 
     @property
-    @command
     def active_element(self):
         return self.send_session_command("GET", "element/active")
 
-    @command
     def cookies(self, name=None):
         if name is None:
             url = "cookie"
@@ -683,7 +634,6 @@ class Session:
             url = "cookie/%s" % name
         return self.send_session_command("GET", url, {})
 
-    @command
     def set_cookie(self, name, value, path=None, domain=None,
             secure=None, expiry=None, http_only=None):
         body = {
@@ -712,7 +662,6 @@ class Session:
 
     #[...]
 
-    @command
     def execute_script(self, script, args=None):
         if args is None:
             args = []
@@ -723,7 +672,6 @@ class Session:
         }
         return self.send_session_command("POST", "execute/sync", body)
 
-    @command
     def execute_async_script(self, script, args=None):
         if args is None:
             args = []
@@ -736,11 +684,9 @@ class Session:
 
     #[...]
 
-    @command
     def screenshot(self):
         return self.send_session_command("GET", "screenshot")
 
-    @command
     def print(self,
               background=None,
               margin=None,
@@ -787,13 +733,11 @@ class ShadowRoot:
         url = f"shadow/{self.id}/{uri}"
         return self.session.send_session_command(method, url, body)
 
-    @command
     def find_element(self, strategy, selector):
         body = {"using": strategy,
                 "value": selector}
         return self.send_shadow_command("POST", "element", body)
 
-    @command
     def find_elements(self, strategy, selector):
         body = {"using": strategy,
                 "value": selector}
@@ -835,76 +779,60 @@ class WebElement:
         url = "element/%s/%s" % (self.id, uri)
         return self.session.send_session_command(method, url, body)
 
-    @command
     def find_element(self, strategy, selector):
         body = {"using": strategy,
                 "value": selector}
         return self.send_element_command("POST", "element", body)
 
-    @command
     def click(self):
         self.send_element_command("POST", "click", {})
 
-    @command
     def tap(self):
         self.send_element_command("POST", "tap", {})
 
-    @command
     def clear(self):
         self.send_element_command("POST", "clear", {})
 
-    @command
     def send_keys(self, text):
         return self.send_element_command("POST", "value", {"text": text})
 
     @property
-    @command
     def text(self):
         return self.send_element_command("GET", "text")
 
     @property
-    @command
     def name(self):
         return self.send_element_command("GET", "name")
 
-    @command
     def style(self, property_name):
         return self.send_element_command("GET", "css/%s" % property_name)
 
     @property
-    @command
     def rect(self):
         return self.send_element_command("GET", "rect")
 
     @property
-    @command
     def selected(self):
         return self.send_element_command("GET", "selected")
 
-    @command
     def screenshot(self):
         return self.send_element_command("GET", "screenshot")
 
     @property
-    @command
     def shadow_root(self):
         return self.send_element_command("GET", "shadow")
 
-    @command
     def attribute(self, name):
         return self.send_element_command("GET", "attribute/%s" % name)
 
-    @command
     def get_computed_label(self):
         return self.send_element_command("GET", "computedlabel")
 
-    @command
     def get_computed_role(self):
         return self.send_element_command("GET", "computedrole")
 
     # This MUST come last because otherwise @property decorators above
     # will be overridden by this.
-    @command
     def property(self, name):
         return self.send_element_command("GET", "property/%s" % name)
 


### PR DESCRIPTION
Nowhere do we actually intend on relying on the implicit session creation behaviour, and it actively causes problems when the browser crashes during wdspec tests (because we'll create a new session to run the cleanup commands).

Therefore, let us simply just remove the implicit session creation altogether, thereby obliging people to deliberately and explicitly start their session.

Fixes #51845. See there for more background.