### PR TITLE
Add overflow default property for replaced element

### DIFF
--- a/css/css-overflow/overflow-replaced-element-002-ref.html
+++ b/css/css-overflow/overflow-replaced-element-002-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#overflow-control">
+<link rel="author" title="Kenzie Raditya Tirtarahardja" href="mailto:kenzieradityatirtarahardja.18@gmail.com">
+<title> Host languages should define UA style sheet rules that apply a default value of clip to replaced elements and set their overflow-clip-margin to content-box.</title>
+<style>
+  img, iframe, video, embed {
+    border: 4px solid red;
+    border-radius: 30px;
+    width: 400px;
+    height: 300px;
+    overflow: clip;
+    overflow-clip-margin: content-box;
+  }
+</style>
+<iframe srcdoc="&lt;style&gt; html { background-color: green; } &lt;style&gt;"></iframe>
+<img src="/media/1x1-green.png" />
+<video controls>
+  <source src="/media/2x2-green.mp4" type=video/mp4">
+</video>
+<embed type="image/png" src="/media/1x1-green.png"/>

--- a/css/css-overflow/overflow-replaced-element-002.html
+++ b/css/css-overflow/overflow-replaced-element-002.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#overflow-control">
+<link rel="author" title="Kenzie Raditya Tirtarahardja" href="mailto:kenzieradityatirtarahardja.18@gmail.com">
+<link rel="match" href="overflow-replaced-element-002-ref.html">
+<title> Host languages should define UA style sheet rules that apply a default value of clip to replaced elements and set their overflow-clip-margin to content-box.</title>
+<style>
+  img, iframe, video, embed {
+    border: 4px solid red;
+    border-radius: 30px;
+    width: 400px;
+    height: 300px;
+  }
+</style>
+<iframe srcdoc="&lt;style&gt; html { background-color: green; } &lt;style&gt;"></iframe>
+<img src="/media/1x1-green.png" />
+<video controls>
+  <source src="/media/2x2-green.mp4" type=video/mp4">
+</video>
+<embed type="image/png" src="/media/1x1-green.png"/>


### PR DESCRIPTION
Set default value for overflow property to replaced element. This is based on https://drafts.csswg.org/css-overflow-4/#overflow-control

We already implement the first half of the above spec [previously](https://github.com/servo/servo/blob/main/components/layout_2020/style_ext.rs#L574-L587).

Note that in chromium, author can change the overflow value of `img`, `video`, and canvas, but not for `iframe`, `embed`, and object. In Firefox, you cannot change the value for all above element.
https://jsfiddle.net/7m98gqsk/ 

There is also a possibility of handling this attribute somewhere in the rust code so that we do not have to change the UA stylesheet for every new replaced element. But for now, I just change the UA stylesheet just like mentioned in the spec.

Testing: This change adds a WPT test.
Fixes: #<!-- nolink -->35950

Try: http://github.com/PotatoCP/servo/actions/runs/14303000315
cc: @xiaochengh @d-desiatkin 

Reviewed in servo/servo#36303