### PR TITLE
Custom element registries meets initial about:blank

### DIFF
--- a/custom-elements/revamped-scoped-registry/initial-about-blank.tentative.window.js
+++ b/custom-elements/revamped-scoped-registry/initial-about-blank.tentative.window.js
@@ -1,0 +1,23 @@
+async_test(t => {
+  const frame = document.createElement("iframe");
+  document.body.append(frame);
+  frame.contentWindow.eval(`
+    class AA extends HTMLElement { };
+    self.globalAA = AA;
+    customElements.define("a-a", AA);
+    document.body.innerHTML = "<a-a>";
+  `);
+  assert_equals(frame.contentDocument.body.firstChild.localName, "a-a");
+  assert_true(frame.contentDocument.body.firstChild instanceof frame.contentWindow.globalAA);
+
+  const blankDocumentURL = new URL("/common/blank.html", location).href;
+  frame.src = blankDocumentURL;
+  frame.onload = t.step_func_done(t => {
+    assert_equals(frame.contentDocument.URL, blankDocumentURL);
+    assert_equals(frame.contentDocument.body.innerHTML, "");
+    frame.contentDocument.body.innerHTML = "<a-a>";
+    assert_equals(frame.contentDocument.body.firstChild.localName, "a-a");
+    assert_equals(frame.contentWindow.customElements.get("a-a"), undefined);
+    assert_not_equals(frame.contentWindow.globalAA, undefined);
+  });
+}, "Each navigable document has its own registry");


### PR DESCRIPTION
It appears that Chromium and WebKit already conform to the requirement that the non-scoped registry is tied to the lifetime of a Document object. Both of them fail the final assert however as it appears they also reset the Window object for a navigation away from initial about:blank.