### PR TITLE
Fix whatwg/html#11182: Add tests to ensure "locked for focus" is not implemented

### DIFF
--- a/focus/focus-double-sync-calls.html
+++ b/focus/focus-double-sync-calls.html
@@ -11,32 +11,32 @@
   <input id="input2" placeholder="input2"/>
 </body>
 <script>
-// Tentative due to https://github.com/whatwg/html/issues/11177
-
 // This test tests calling focus() in the "focus" event
 // listener on the element again when the focus has
 // moved away.
-promise_test((t) => {
+
+// This is for https://github.com/whatwg/html/pull/11182
+async_test((t) => {
   let previouslyCalled = false;
   let counter = 0;
-  let p = new Promise(r=>{
-    input1.addEventListener("focus", function(e) {
-      counter++;
-      if (!previouslyCalled) {
-        input2.focus();
-        previouslyCalled = true;
-      }
-      input1.focus();
 
-      // In a success run, counter can only be 2 here
-      // because focus() synchronously fire the event listener.
-      if (counter == 2) {
-        r();
-      }
-    });
+  input1.addEventListener("focus", function(e) {
+    counter++;
+    if (!previouslyCalled) {
+      input2.focus();
+      previouslyCalled = true;
+    }
+
+    input1.focus();
+
+    if (counter !== 2) {
+      // If `lock-for-focus` is implemented, the above input1.focus()
+      // shouldn't work, so the counter should never be 2.
+      assert_unreached();
+    }
+    t.done();
   });
 
   input1.focus();
-  return p;
 }, "Element.focus() in focus listener when focus has moved away");
 </script>

--- a/focus/nested-focus-within-iframe-focus-event.html
+++ b/focus/nested-focus-within-iframe-focus-event.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<head>
+  <meta charset=utf-8>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Test calling dialog focusing steps in navigable's focus handler</title>
+  <script src=/resources/testharness.js></script>
+  <script src=/resources/testharnessreport.js></script>
+</head>
+<body>
+  <iframe id="iframe" srcdoc="<dialog>Hello</dialog>"></iframe>
+</body>
+<script>
+// https://github.com/whatwg/html/pull/11182
+window.onload = function() {
+  async_test((t) => {
+    iframe.addEventListener("focus", function() {
+      const dialog = iframe.contentDocument.body.querySelector("dialog");
+      dialog.showModal();
+      // If `lock-for-focus` is implemented, showModal() can't
+      // trigger the dialog-focusing-steps, hence the activeElement
+      // shouldn't be the dialog.
+      assert_equals(iframe.contentDocument.activeElement, dialog);
+      t.done();
+    })
+
+    iframe.focus();
+  }, "dialog.focus() in navigable's focus handler");
+}
+</script>


### PR DESCRIPTION
`focus-double-sync-calls.html` ensures that when `element.focus()` is called, `locked for focus` isn't implemented.

`nested-focus-within-iframe-focus-event.html` ensures that `allow focus steps` doesn't use `locked for focus`.


