### PR TITLE
Fix CSP trusted-types/require-trusted-types-for tests for required-ascii-whitespace

### DIFF
--- a/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-001.html
+++ b/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-001.html
@@ -100,15 +100,25 @@ header(Content-Security-Policy-Report-Only,require-trusted-types-for 'script',Tr
     assert_equals(violations[5].policy, "require-trusted-types-for 'script'")
   }, `Mixing enforce and report-only require-trusted-types-for directives.`);
 
-  promise_test(async t => {
-    let results = await trySendingPlainStringToTrustedTypeSink(
-      ["script"],
-      "header(Content-Security-Policy,require-trusted-types-for 'script'%09'script'%0A'script'%0C'script'%0D'script'%20'script',True)",
-    );
-    assert_equals(results.length, 1);
-    assert_true(results[0].exception instanceof TypeError);
-    assert_equals(results[0].violatedPolicies.length, 1);
-  }, `directive "require-trusted-types-for 'script'%09'script'%0A'script'%0C'script'%0D'script'%20'script'" (required-ascii-whitespace)`);
+  // trusted-types-sink-group-keyword can be separated by any ASCII whitespace
+  // per the spec's ABNF:
+  // https://www.w3.org/TR/trusted-types/#require-trusted-types-for-csp-directive
+  // https://w3c.github.io/webappsec-csp/#grammardef-required-ascii-whitespace
+  // U+00A LF breaks the header field value into two lines so make sure that
+  // "the continuation line begins with a space or horizontal tab" in accordance
+  // with https://www.rfc-editor.org/rfc/rfc2616
+  ["%09", "%0A%20", "%0C", "%0D", "%20"].forEach(whitespace => {
+    let directive = `require-trusted-types-for 'invalid'${whitespace}'script'`;
+    promise_test(async t => {
+      let results = await trySendingPlainStringToTrustedTypeSink(
+        ["script"],
+        `header(Content-Security-Policy,${directive},True)`,
+      );
+      assert_equals(results.length, 1);
+      assert_true(results[0].exception instanceof TypeError);
+      assert_equals(results[0].violatedPolicies.length, 1);
+    }, `directive "${directive}" (required-ascii-whitespace)`);
+  });
 
   promise_test(async t => {
     let results = await trySendingPlainStringToTrustedTypeSink(

--- a/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-002.html
+++ b/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-002.html
@@ -66,20 +66,24 @@
     }, `invalid tt-policy-name name "${trustedTypePolicyName}"`);
   });
 
-  // tt-expressions can separated by any ASCII whitespace per the spec's ABNF:
+  // tt-expressions can be separated by any ASCII whitespace per the spec's
+  // ABNF:
   // https://w3c.github.io/trusted-types/dist/spec/#serialized-tt-configuration
   // https://w3c.github.io/webappsec-csp/#grammardef-required-ascii-whitespace
+  // U+00A LF breaks the header field value into two lines so make sure that
+  // "the continuation line begins with a space or horizontal tab" in accordance
+  // with https://www.rfc-editor.org/rfc/rfc2616
   promise_test(async t => {
     let results = await tryCreatingTrustedTypePoliciesWithCSP(
-      ["_TTP1_", "_TTP2_", "_TTP3_", "_TTP4_", "_TTP5_"],
-      "header(Content-Security-Policy,trusted-types _TTP1_%09_TTP2_%0C_TTP3_%0D_TTP4_%20_TTP5_,True)"
+      ["_TTP1_", "_TTP2_", "_TTP3_", "_TTP4_", "_TTP5_", "_TTP6_"],
+      "header(Content-Security-Policy,trusted-types _TTP1_%09_TTP2_%0A%20_TTP3_%0C_TTP4_%0D_TTP5_%20_TTP6_,True)"
     );
-    assert_equals(results.length, 5);
+    assert_equals(results.length, 6);
     results.forEach((result, index) => {
       assert_equals(result.exception, null);
       assert_equals(result.violatedPolicies.length, 0);
     });
-  }, `directive "trusted-type _TTP1_%09_TTP2_%0C_TTP3_%0D_TTP4_%20_TTP5_" (required-ascii-whitespace)`);
+  }, `directive "trusted-type _TTP1_%09_TTP2_%0A%20_TTP3_%0C_TTP4_%0D_TTP5_%20_TTP6_" (required-ascii-whitespace)`);
 
   // tt-expressions must be separated by a required-ascii-whitespace:
   promise_test(async t => {


### PR DESCRIPTION
- U+000A LINE FEED breaks the header field value into two lines so make sure that "the continuation line begins with a space or horizontal tab" in accordance with https://www.rfc-editor.org/rfc/rfc2616
- Adds back corresponding test for trusted-types directive that was removed in https://github.com/web-platform-tests/wpt/pull/51635
- For require-trusted-types-for directive, it was enough for browsers to only successfully parse at least one 'script' token so the problem with U+000A was not observable, and Chromium bug with U+0D either. Split the test into multiple subtests that only use a single 'script' to make it more robust.