### PR TITLE
Add fuzzy to avoid Safari failing due to CSS gradient noise

### DIFF
--- a/css/css-images/gradient/conic-gradient-001.html
+++ b/css/css-images/gradient/conic-gradient-001.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta charset="utf-8">
 <link rel="author" title="CGQAQ" href="mailto:m.jason.liu@gmail.com">
 <link rel="author" title="一丝" href="mailto:yiorsi@gmail.com">
 <link rel="help" href="https://www.w3.org/TR/css-color-4/#interpolation">
 <link rel="match" href="conic-gradient-001-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-40000">
 <title>Tests the maximum value of color stops in conic-gradient().</title>
 <style>
     body {

--- a/css/css-images/gradient/gradient-analogous-missing-components-001.html
+++ b/css/css-images/gradient/gradient-analogous-missing-components-001.html
@@ -1,43 +1,43 @@
 <!doctype html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>Gradient analogous missing components carry forward logic tests</title>
-    <link rel="author" title="CGQAQ" href="mailto:m.jason.liu@gmail.com">
-    <link rel="author" title="一丝" href="mailto:yiorsi@gmail.com">
-    <link rel="help" href="https://www.w3.org/TR/css-color-4/#interpolation">
-    <meta name="assert" content="Tests that analogous missing components logic works.">
-    <link rel="match" href="gradient-analogous-missing-components-001-ref.html">
-    <style>
-        .test {
-            margin: 50px;
-            width: 200px;
-            height: 50px;
-            border: 1px solid black;
-        }
+<meta charset="utf-8">
+<title>Gradient analogous missing components carry forward logic tests</title>
+<link rel="author" title="CGQAQ" href="mailto:m.jason.liu@gmail.com">
+<link rel="author" title="一丝" href="mailto:yiorsi@gmail.com">
+<link rel="help" href="https://www.w3.org/TR/css-color-4/#interpolation">
+<meta name="assert" content="Tests that analogous missing components logic works.">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-40000">
+<link rel="match" href="gradient-analogous-missing-components-001-ref.html">
+<style>
+    .test {
+        margin: 50px;
+        width: 200px;
+        height: 50px;
+        border: 1px solid black;
+    }
 
-        .test1 {
-            background: linear-gradient(90deg in srgb, hsl(60deg 0 50%), yellow);
-        }
-        .test2 {
-            background: linear-gradient(90deg in srgb, hsl(20deg 0 50%), yellow);
-        }
-        .test3 {
-            background: linear-gradient(90deg in srgb, hsl(60deg none 50%), yellow);
-        }
-        .test4 {
-            background: linear-gradient(90deg in srgb, hsl(none 0 50%), yellow);
-        }
-        .test5 {
-            background: linear-gradient(90deg in srgb, hsl(none none 50%), yellow);
-        }
-    </style>
-</head>
-<body>
-    <div class="test test1"></div>
-    <div class="test test2"></div>
-    <div class="test test3"></div>
-    <div class="test test4"></div>
-    <div class="test test5"></div>
-</body>
-</html>
+    .test1 {
+        background: linear-gradient(90deg in srgb, hsl(60deg 0 50%), yellow);
+    }
+
+    .test2 {
+        background: linear-gradient(90deg in srgb, hsl(20deg 0 50%), yellow);
+    }
+
+    .test3 {
+        background: linear-gradient(90deg in srgb, hsl(60deg none 50%), yellow);
+    }
+
+    .test4 {
+        background: linear-gradient(90deg in srgb, hsl(none 0 50%), yellow);
+    }
+
+    .test5 {
+        background: linear-gradient(90deg in srgb, hsl(none none 50%), yellow);
+    }
+</style>
+
+<div class="test test1"></div>
+<div class="test test2"></div>
+<div class="test test3"></div>
+<div class="test test4"></div>
+<div class="test test5"></div>

--- a/css/css-images/gradient/gradient-analogous-missing-components-002.html
+++ b/css/css-images/gradient/gradient-analogous-missing-components-002.html
@@ -1,40 +1,39 @@
-<!doctype html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>Gradient analogous missing components carry forward logic tests</title>
-    <link rel="author" title="CGQAQ" href="mailto:m.jason.liu@gmail.com">
-    <link rel="author" title="一丝" href="mailto:yiorsi@gmail.com">
-    <link rel="help" href="https://www.w3.org/TR/css-color-4/#interpolation">
-    <link rel="match" href="gradient-analogous-missing-components-002-ref.html">
-    <meta name="assert" content="Tests that analogous missing components logic works.">
-    <style>
-        .test {
-            margin: 10px 50px;
-            width: 200px;
-            height: 50px;
-            border: 1px solid black;
-            --stop2: rgb(0 255 0); /* lime  */
-        }
-        .test1 {
-            background: linear-gradient(to right, color(srgb none 1 none), var(--stop2));
-        }
-        .test2 {
-            background: linear-gradient(to right in srgb, color(srgb none 1 none), var(--stop2));
-        }
-        .test3 {
-            background: linear-gradient(to right in oklab, color(srgb none 1 none), var(--stop2));
-        }
-        .test4 {
-            background: linear-gradient(to right in display-p3, color(srgb none 1 none), var(--stop2));
-        }
-    </style>
-</head>
-<body>
-    <p>They should be equivalent to `background: color-mix(in srgb, color(srgb none 1 none), lime)`</p>
-    <div class="test test1">This should be a lime background.</div>
-    <div class="test test2">This should be a lime background.</div>
-    <div class="test test3">This should be a lime background.</div>
-    <div class="test test4">This should be a lime background.</div>
-</body>
-</html>
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Gradient analogous missing components carry forward logic tests</title>
+<link rel="author" title="CGQAQ" href="mailto:m.jason.liu@gmail.com">
+<link rel="author" title="一丝" href="mailto:yiorsi@gmail.com">
+<link rel="help" href="https://www.w3.org/TR/css-color-4/#interpolation">
+<link rel="match" href="gradient-analogous-missing-components-002-ref.html">
+<meta name="assert" content="Tests that analogous missing components logic works.">
+<style>
+    .test {
+        margin: 10px 50px;
+        width: 200px;
+        height: 50px;
+        border: 1px solid black;
+        --stop2: rgb(0 255 0);
+        /* lime  */
+    }
+
+    .test1 {
+        background: linear-gradient(to right, color(srgb none 1 none), var(--stop2));
+    }
+
+    .test2 {
+        background: linear-gradient(to right in srgb, color(srgb none 1 none), var(--stop2));
+    }
+
+    .test3 {
+        background: linear-gradient(to right in oklab, color(srgb none 1 none), var(--stop2));
+    }
+
+    .test4 {
+        background: linear-gradient(to right in display-p3, color(srgb none 1 none), var(--stop2));
+    }
+</style>
+<p>They should be equivalent to `background: color-mix(in srgb, color(srgb none 1 none), lime)`</p>
+<div class="test test1">This should be a lime background.</div>
+<div class="test test2">This should be a lime background.</div>
+<div class="test test3">This should be a lime background.</div>
+<div class="test test4">This should be a lime background.</div>

--- a/css/css-images/gradient/gradient-analogous-missing-components-003.html
+++ b/css/css-images/gradient/gradient-analogous-missing-components-003.html
@@ -1,35 +1,33 @@
-<!doctype html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>Gradient analogous missing components carry forward logic tests</title>
-    <link rel="author" title="CGQAQ" href="mailto:m.jason.liu@gmail.com">
-    <link rel="author" title="一丝" href="mailto:yiorsi@gmail.com">
-    <link rel="help" href="https://www.w3.org/TR/css-color-4/#interpolation">
-    <meta name="assert" content="Tests that analogous missing components logic works.">
-    <link rel="match" href="gradient-analogous-missing-components-003-ref.html">
-    <style>
-        .test {
-            margin: 10px 50px;
-            width: 200px;
-            height: 50px;
-            border: 1px solid black;
-            --stop2: rgb(0 255 0); /* lime  */
-        }
-        .test1 {
-            background: linear-gradient(to right in hsl shorter hue, color(srgb none 1 none), var(--stop2));
-        }
-        .test2 {
-            background: linear-gradient(to right in hsl increasing hue, color(srgb none 1 none), var(--stop2));
-        }
-        .test3 {
-            background: linear-gradient(to right in hsl decreasing hue, color(srgb none 1 none), var(--stop2));
-        }
-    </style>
-</head>
-<body>
-    <div class="test test1">This should be a lime background.</div>
-    <div class="test test2">This should be a lime background.</div>
-    <div class="test test3">This should be a lime background.</div>
-</body>
-</html>
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Gradient analogous missing components carry forward logic tests</title>
+<link rel="author" title="CGQAQ" href="mailto:m.jason.liu@gmail.com">
+<link rel="author" title="一丝" href="mailto:yiorsi@gmail.com">
+<link rel="help" href="https://www.w3.org/TR/css-color-4/#interpolation">
+<meta name="assert" content="Tests that analogous missing components logic works.">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-40000">
+<link rel="match" href="gradient-analogous-missing-components-003-ref.html">
+<style>
+    .test {
+        margin: 10px 50px;
+        width: 200px;
+        height: 50px;
+        border: 1px solid black;
+        --stop2: rgb(0 255 0); /* lime  */
+    }
+
+    .test1 {
+        background: linear-gradient(to right in hsl shorter hue, color(srgb none 1 none), var(--stop2));
+    }
+
+    .test2 {
+        background: linear-gradient(to right in hsl increasing hue, color(srgb none 1 none), var(--stop2));
+    }
+
+    .test3 {
+        background: linear-gradient(to right in hsl decreasing hue, color(srgb none 1 none), var(--stop2));
+    }
+</style>
+<div class="test test1">This should be a lime background.</div>
+<div class="test test2">This should be a lime background.</div>
+<div class="test test3">This should be a lime background.</div>

--- a/css/css-images/gradient/gradient-single-stop-none-interpolation.html
+++ b/css/css-images/gradient/gradient-single-stop-none-interpolation.html
@@ -1,40 +1,40 @@
 <!DOCTYPE html>
-<html>
- <head>
-  <title>Gradient interpolation with single stop that has missing components</title>
-  <link rel="author" title="CGQAQ" href="mailto:m.jason.liu@gmail.com">
-  <link rel="help" href="https://www.w3.org/TR/css-color-4/#interpolation">
-  <meta name="assert" content="Gradients with single color stop that having missing components should resolve to zero.">
-  <link rel="match" href="gradient-single-stop-none-interpolation-ref.html">
-  <style>
-    div {
-      height: 100px;
-    }
-    #basic {
-      /* "none" should resolve to zero when we only have one single stop. */
-      background: linear-gradient(to right in srgb, color(srgb none 0.5 0.5));
-    }
-    #multipleNone {
-      /* "none" and "none" gives zero. */
-      background: linear-gradient(to right in srgb, color(srgb none 0 none));
-    }
-    #allNone {
-      /* "none" and "none" gives zero. */
-      background: linear-gradient(to right in srgb, color(srgb none none none));
-    }
-    #noneHue {
-      background: linear-gradient(to right in oklch, oklch(0.8 0.4 none));
-    }
-    #noneHueLonger {
-      background: linear-gradient(to right in oklch longer hue, oklch(0.5 0.3 none));
-    }
- </style>
- </head>
- <body>
-  <div id="basic"></div>
-  <div id="multipleNone"></div>
-  <div id="allNone"></div>
-  <div id="noneHue"></div>
-  <div id="noneHueLonger"></div>
- </body>
-</html>
+<meta charset="utf-8">
+<title>Gradient interpolation with single stop that has missing components</title>
+<link rel="author" title="CGQAQ" href="mailto:m.jason.liu@gmail.com">
+<link rel="help" href="https://www.w3.org/TR/css-color-4/#interpolation">
+<meta name="assert" content="Gradients with single color stop that having missing components should resolve to zero.">
+<link rel="match" href="gradient-single-stop-none-interpolation-ref.html">
+<style>
+  div {
+    height: 100px;
+  }
+
+  #basic {
+    /* "none" should resolve to zero when we only have one single stop. */
+    background: linear-gradient(to right in srgb, color(srgb none 0.5 0.5));
+  }
+
+  #multipleNone {
+    /* "none" and "none" gives zero. */
+    background: linear-gradient(to right in srgb, color(srgb none 0 none));
+  }
+
+  #allNone {
+    /* "none" and "none" gives zero. */
+    background: linear-gradient(to right in srgb, color(srgb none none none));
+  }
+
+  #noneHue {
+    background: linear-gradient(to right in oklch, oklch(0.8 0.4 none));
+  }
+
+  #noneHueLonger {
+    background: linear-gradient(to right in oklch longer hue, oklch(0.5 0.3 none));
+  }
+</style>
+<div id="basic"></div>
+<div id="multipleNone"></div>
+<div id="allNone"></div>
+<div id="noneHue"></div>
+<div id="noneHueLonger"></div>

--- a/css/css-images/infinite-radial-gradient-refcrash.html
+++ b/css/css-images/infinite-radial-gradient-refcrash.html
@@ -2,6 +2,7 @@
 <title>CSS Images Test: repeating-radial-gradient with huge size crashes Chrome</title>
 <link rel="help" href="https://crbug.com/1009307">
 <link rel="match" href="infinite-radial-gradient-crash-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-40000">
 <style>
   #crash {
     background-image: repeating-radial-gradient(closest-corner circle at 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999%, green, green);

--- a/css/css-images/multiple-position-color-stop-radial.html
+++ b/css/css-images/multiple-position-color-stop-radial.html
@@ -2,6 +2,7 @@
 <title>Radial gradient with a two position color stop</title>
 <link rel="help" href="https://drafts.csswg.org/css-images-4/#color-stop-syntax">
 <meta name="assert" content="A color stop with two positions create a hard transition">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-40000">
 <link rel="match" href="reference/100x100-blue-green.html">
 <style>
 #target {

--- a/css/css-images/normalization-linear-2.html
+++ b/css/css-images/normalization-linear-2.html
@@ -3,6 +3,7 @@
 <title>Linear gradient stop normalization</title>
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#linear-gradients">
 <meta name="assert" content="Rendering of linear-gradient with normalized color stops">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-40000">
 <link rel="match" href="reference/100x100-blue.html">
 <style>
   #gradient {

--- a/css/css-images/normalization-linear-degenerate.html
+++ b/css/css-images/normalization-linear-degenerate.html
@@ -3,6 +3,7 @@
 <title>Linear gradient stop normalization</title>
 <link rel="help" href="https://www.w3.org/TR/css-images-3/#repeating-gradients">
 <meta name="assert" content="Rendering of repeating-linear-gradient w/ stops at the same place">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-40000">
 <link rel="match" href="reference/100x100-blue.html">
 <style>
   #gradient {

--- a/css/css-images/normalization-linear.html
+++ b/css/css-images/normalization-linear.html
@@ -3,6 +3,7 @@
 <title>Linear gradient stop normalization</title>
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#linear-gradients">
 <meta name="assert" content="Rendering of linear-gradient with normalized color stops">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-40000">
 <link rel="match" href="reference/100x100-blue.html">
 <style>
   #gradient {

--- a/css/css-images/normalization-radial-2.html
+++ b/css/css-images/normalization-radial-2.html
@@ -3,6 +3,7 @@
 <title>Radial gradient stop normalization</title>
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#radial-gradients">
 <meta name="assert" content="Rendering of radial-gradient with normalized color stops">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-40000">
 <link rel="match" href="reference/100x100-blue.html">
 <style>
   #gradient {

--- a/css/css-images/normalization-radial-3.html
+++ b/css/css-images/normalization-radial-3.html
@@ -3,6 +3,7 @@
 <title>Radial gradient stop normalization</title>
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#radial-gradients">
 <meta name="assert" content="Rendering of radial-gradient with normalized color stops">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-40000">
 <link rel="match" href="reference/100x100-blue.html">
 <style>
   #gradient {

--- a/css/css-images/normalization-radial-4.html
+++ b/css/css-images/normalization-radial-4.html
@@ -3,6 +3,7 @@
 <title>Radial gradient stop normalization</title>
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#repeating-gradients">
 <meta name="assert" content="Rendering of repeating-radial-gradient with normalized color stops">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-40000">
 <link rel="match" href="reference/100x100-blue.html">
 <style>
   #gradient {

--- a/css/css-images/normalization-radial-degenerate.html
+++ b/css/css-images/normalization-radial-degenerate.html
@@ -3,6 +3,7 @@
 <title>Radial gradient stop normalization</title>
 <link rel="help" href="https://www.w3.org/TR/css-images-3/#repeating-gradients">
 <meta name="assert" content="Rendering of repeating-radial-gradient w/ stops at the same place">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-40000">
 <link rel="match" href="reference/100x100-blue.html">
 <style>
   #gradient {

--- a/css/css-images/normalization-radial.html
+++ b/css/css-images/normalization-radial.html
@@ -3,6 +3,7 @@
 <title>Radial gradient stop normalization</title>
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#radial-gradients">
 <meta name="assert" content="Rendering of radial-gradient with normalized color stops">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-40000">
 <link rel="match" href="reference/100x100-blue.html">
 <style>
   #gradient {

--- a/css/css-images/tiled-gradients.html
+++ b/css/css-images/tiled-gradients.html
@@ -1,23 +1,17 @@
 <!doctype html>
-<html>
-    <head>
-        <meta charset="utf-8">
-        <title>Eight Red Triangles on White Ground (with gradients)</title>
-        <link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size">
-        <meta name="assert" content="Gradients are correctly repeated.">
-        <meta name="fuzzy" content="0-255; 0-564">
-        <link rel="match" href="tiled-gradients-ref.html">
-        <style>
-            #gradient {
-                width: 400px;
-                height: 200px;
-                background-size: 25% 50%;
-                background-image: linear-gradient(to bottom left, red 50%, transparent 50%);
-            }
-        </style>
-    </head>
-    <body>
-        <div id="gradient"></div>
-    </body>
-</html>
+<meta charset="utf-8">
+<title>Eight Red Triangles on White Ground (with gradients)</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size">
+<meta name="assert" content="Gradients are correctly repeated.">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-40000">
+<link rel="match" href="tiled-gradients-ref.html">
+<style>
+    #gradient {
+        width: 400px;
+        height: 200px;
+        background-size: 25% 50%;
+        background-image: linear-gradient(to bottom left, red 50%, transparent 50%);
+    }
+</style>
 
+<div id="gradient"></div>


### PR DESCRIPTION
**I and @CGQAQ are working on improving the interoperability of CSS gradients and colors**. This PR is part of that work.

---

A lot of gradient cases Safari actually supports, but fails due to gradient noise.

This  #PR mainly adds `<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-40000">`
I'm not sure that `totalPixels=0-40000` is an appropriate value, borrowed mostly from other WPT cases.

----

There are also some minor tweaks: 

- formatting 
- removing `head, html, body` tags, which is consistent with Chromium's code style.

Closes: https://bugs.webkit.org/show_bug.cgi?id=200209