### PR TITLE
Update FetchTaskTarget to propagate CSP violations.

### DIFF
--- a/content-security-policy/connect-src/connect-src-websocket-allowed.sub.html
+++ b/content-security-policy/connect-src/connect-src-websocket-allowed.sub.html
@@ -3,7 +3,7 @@
 
 <head>
     <!-- Programmatically converted from a WebKit Reftest, please forgive resulting idiosyncraciws.-->
-    <meta http-equiv="Content-Security-Policy" content="connect-src 'self' ws://{{domains[www1]}}:{{ports[http][0]}}/echo; script-src 'self' 'unsafe-inline';">
+    <meta http-equiv="Content-Security-Policy" content="connect-src 'self' ws://{{domains[www1]}}:{{ports[ws][0]}}/echo; script-src 'self' 'unsafe-inline';">
     <title>connect-src-websocket-blocked</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
@@ -18,9 +18,14 @@
         });
 
         try {
-            var ws = new WebSocket("ws://{{domains[www1]}}:{{ports[http][0]}}/echo");
+            var ws = new WebSocket("ws://{{domains[www1]}}:{{ports[ws][0]}}/echo");
 
-            if (ws.readyState == WebSocket.CLOSING || ws.readyState == WebSocket.CLOSED) {
+            // Not all browsers fail the connection in a synchronous fashion.
+            if (ws.readyState == WebSocket.CONNECTING) {
+                setTimeout( function() {
+                    ws.readyState != WebSocket.CLOSED ? log("allowed") : log("blocked");
+                }, 1000);
+            } else if (ws.readyState == WebSocket.CLOSED) {
                 log("blocked");
             } else {
                 log("allowed");

--- a/content-security-policy/connect-src/connect-src-websocket-blocked.sub.html
+++ b/content-security-policy/connect-src/connect-src-websocket-blocked.sub.html
@@ -18,9 +18,14 @@
         });
 
         try {
-            var ws = new WebSocket("ws://{{domains[www1]}}:{{ports[http][0]}}/echo");
+            var ws = new WebSocket("ws://{{domains[www1]}}:{{ports[ws][0]}}/echo");
 
-            if (ws.readyState == WebSocket.CLOSING || ws.readyState == WebSocket.CLOSED) {
+            // Not all browsers fail the connection in a synchronous fashion.
+            if (ws.readyState == WebSocket.CONNECTING) {
+                setTimeout( function() {
+                    ws.readyState != WebSocket.CLOSED ? log("allowed") : log("blocked");
+                }, 1000);
+            } else if (ws.readyState == WebSocket.CLOSED) {
                 log("blocked");
             } else {
                 log("allowed");


### PR DESCRIPTION
It also updates the FetchResponseListener to process CSP violations to ensure that iframe elements (amongst others) properly generate the CSP events. These iframe elements are used in the Trusted Types tests themselves and weren't propagating the violations before.

However, the tests themselves are still not passing since they also use Websockets, which currently aren't using the fetch machinery itself. That is fixed as part of [1].

[1]: https://github.com/servo/servo/issues/35028

Reviewed in servo/servo#36409