### PR TITLE
Add mock server for geolocation coordinates for Firefox.

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -752,6 +752,9 @@ class ProfileCreator:
 
         if self.test_type == "wdspec":
             profile.set_preferences({"remote.prefs.recommended": True})
+            profile.set_preferences({
+                "geo.provider.network.url": "https://web-platform.test:8444/webdriver/tests/support/http_handlers/geolocation_override.py"
+            })
 
         if self.debug_test:
             profile.set_preferences({"devtools.console.stdout.content": True})

--- a/webdriver/tests/support/http_handlers/geolocation_override.py
+++ b/webdriver/tests/support/http_handlers/geolocation_override.py
@@ -1,0 +1,16 @@
+import json
+
+
+def main(request, response):
+    response.headers.set(b"Content-Type", b"application/json")
+    response.headers.set(b"Cache-Control", b"no-cache")
+    response.content = json.dumps(
+        {
+            "status": "OK",
+            "location": {
+                "lat": 37.41857,
+                "lng": -122.08769,
+            },
+            "accuracy": 42,
+        }
+    ).encode("utf-8")


### PR DESCRIPTION
The mock server set in mozilla-central is set in https://searchfox.org/mozilla-central/source/testing/profiles/web-platform/user.js#96 and the code of the server is located in `mozilla` folder, that works in mozilla CI but not here. So we need to set mock server here.

Tests time out without these changes: https://github.com/web-platform-tests/wpt/pull/51956/checks?check_run_id=40406302430.
And pass with them: https://github.com/web-platform-tests/wpt/pull/51956/checks?check_run_id=40406302189.