### PR TITLE
Revert "Disable unstable test in CSSTransition-startTime.tentative.html"

### DIFF
--- a/css/css-transitions/CSSTransition-startTime.tentative.html
+++ b/css/css-transitions/CSSTransition-startTime.tentative.html
@@ -52,9 +52,6 @@ promise_test(async t => {
     'A CSS transition added in a later frame has a later start time');
 }, 'The start time of transitions is based on when they are generated');
 
-/*
-// This test has been disabled because it's not stable in Firefox.
-// See https://github.com/web-platform-tests/wpt/issues/51881
 test(t => {
   const div = addDiv(t, {
     style: 'margin-left: 100px; transition: margin-left 100s linear 100s',
@@ -72,7 +69,6 @@ test(t => {
     'Check setting of startTime actually works'
   );
 }, 'The start time of a transition can be set');
-*/
 
 promise_test(async t => {
   const div = addDiv(t, {


### PR DESCRIPTION
Reverts web-platform-tests/wpt#51882. See https://github.com/web-platform-tests/wpt/issues/51881#issuecomment-2798393023:

> We shouldn't be disabling tests for all browsers just because they happen to be flaky in one; unless changes are super-frequent to those tests, relying on admins to merge is typically not-overly-burdensome.