### PR TITLE
Implement "Create a Trusted Type" algorithm

### DIFF
--- a/trusted-types/TrustedTypePolicy-createXXX.html
+++ b/trusted-types/TrustedTypePolicy-createXXX.html
@@ -50,11 +50,18 @@
   function anotherGlobalFunction(s) { return s + "#" + this.foo; }
   var foo = "a global var named foo";
 
+  class WrappingClass {
+    callback_to_capture_this(s) {
+      return String(this);
+    }
+  }
+
   const stringTestCases = [
     [ s => s, "whatever" ],
     [ s => null, "" ],
     [ s => "well, " + s, "well, whatever" ],
     [ s => { throw new Error() }, Error ],
+    [ new WrappingClass().callback_to_capture_this, "null"],
     [ s => { aGlobalVarForSideEffectTesting = s; return s }, "whatever" ],
     [ s => aGlobalVarForSideEffectTesting + s, "whateverwhatever" ],
     [ aGlobalFunction.bind(aGlobalObject), "well, whatever" ],
@@ -66,6 +73,7 @@
     [ s => null, "" ],
     [ s => s + "#duck", INPUTS.SCRIPTURL + "#duck" ],
     [ s => { throw new Error() }, Error ],
+    [ new WrappingClass().callback_to_capture_this, "null"],
     [ s => s + "#" + aGlobalVarForSideEffectTesting,
       INPUTS.SCRIPTURL + "#global" ],
     [ anotherGlobalFunction.bind(aGlobalObject), INPUTS.SCRIPTURL + "#well," ],


### PR DESCRIPTION
This algorithm is quite straightforward written in the specification,
but leads to some type awkwardness in Rust. Most notably, the callbacks
have different types and cannot be unified easily. They also return
different string types. Similarly, the returning objects are all unique
types and don't have a common denominator.

Therefore, rather than implementing it in 1-to-1 fashion with the
specification text, it instead uses callbacks to instruct the type
system of what to call when.

This is further complicated by the fact that the callback can exist
or not, as well as return a value or not. This requires multiple
unwrangling, combined with the fact that the algorithm should throw
or not.

All in all, the number of lines is relatively low compared to the
specification algorithm and the Rust compiler does a lot of heavy
lifting figuring out which type is what.

Part of https://github.com/servo/servo/issues/36258
Reviewed in servo/servo#36454