### PR TITLE
### Update  Thanks to @karlcow for pointing out the existing test coverage in `async-navigator-clipboard-basics.https.html`.  I've updated this PR to add a **negative test case**: it verifies that `navigator.clipboard.readText()` **throws a `NotAllowedError`** when called *without clipboard permission*. This complements the existing test, which only checks successful resolution after permission is granted.  This test helps ensure: - Proper error handling is implemented in the API, - Spec compliance across browsers for rejection behavior.  Let me know if this looks good or if you'd prefer it moved to a different test file.

### DIFF
--- a/clipboard-apis/readText.tentative.html
+++ b/clipboard-apis/readText.tentative.html
@@ -1,21 +1,22 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Clipboard API: navigator.clipboard.readText()</title>
+<title>Clipboard API: navigator.clipboard.readText() - negative test</title>
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
 <body>
-  <h1>Test for navigator.clipboard.readText()</h1>
+  <h1>Negative Test for navigator.clipboard.readText() without permission</h1>
 
   <script>
     promise_test(async t => {
+      await navigator.permissions.revoke({ name: "clipboard-read" }); // ensure permission is not granted
       try {
-        const text = await navigator.clipboard.readText();
-        assert_equals(typeof text, "string", "readText() should resolve to a string");
+        await navigator.clipboard.readText();
+        assert_unreached("readText() should not resolve without permission");
       } catch (e) {
-        assert_unreached("Clipboard readText() threw an error: " + e.message);
+        assert_equals(e.name, "NotAllowedError", "Should throw NotAllowedError without clipboard permission");
       }
-    }, "navigator.clipboard.readText() resolves with a string");
+    }, "navigator.clipboard.readText() throws NotAllowedError without permission");
   </script>
 </body>

--- a/clipboard-apis/readText.tentative.html
+++ b/clipboard-apis/readText.tentative.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Clipboard API: navigator.clipboard.readText()</title>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+  <h1>Test for navigator.clipboard.readText()</h1>
+
+  <script>
+    promise_test(async t => {
+      try {
+        const text = await navigator.clipboard.readText();
+        assert_equals(typeof text, "string", "readText() should resolve to a string");
+      } catch (e) {
+        assert_unreached("Clipboard readText() threw an error: " + e.message);
+      }
+    }, "navigator.clipboard.readText() resolves with a string");
+  </script>
+</body>


### PR DESCRIPTION
Add test for navigator.clipboard.readText()

This test ensures that the Clipboard API's readText() method resolves with a string, in line with the spec.

Fixes #<issue-number-if-any>
