### PR TITLE
[wdspec] fix geolocation tests

### DIFF
--- a/webdriver/tests/bidi/emulation/set_geolocation_override/__init__.py
+++ b/webdriver/tests/bidi/emulation/set_geolocation_override/__init__.py
@@ -16,9 +16,10 @@ async def get_current_geolocation(bidi_session, context):
         function_declaration="""() =>
             new Promise(
                 resolve => window.navigator.geolocation.getCurrentPosition(
-                    position => resolve(position.coords.toJSON())
-                )
-            )
+                    position => resolve(position.coords.toJSON()),
+                    error => resolve({code: error.code, message: error.message}),
+                    {timeout: 500}
+            ))
         """,
         target=ContextTarget(context["context"]),
         await_promise=True,

--- a/webdriver/tests/bidi/emulation/set_geolocation_override/conftest.py
+++ b/webdriver/tests/bidi/emulation/set_geolocation_override/conftest.py
@@ -7,7 +7,7 @@ from ... import get_context_origin
 async def set_geolocation_permission(bidi_session):
     data_to_cleanup = {}
 
-    async def set_geolocation_permission(context, user_context=None):
+    async def set_geolocation_permission(context, user_context="default"):
         nonlocal data_to_cleanup
 
         origin = await get_context_origin(bidi_session, context)

--- a/webdriver/tests/bidi/emulation/set_geolocation_override/contexts.py
+++ b/webdriver/tests/bidi/emulation/set_geolocation_override/contexts.py
@@ -99,7 +99,9 @@ async def test_multiple_contexts(
         contexts=[new_tab["context"], new_context["context"]], coordinates=None
     )
 
-    assert await get_current_geolocation(bidi_session, new_tab) == default_coordinates
+    # The new coordinates can be different from the initial ones if the position
+    # was not available at the beginning.
+    assert await get_current_geolocation(bidi_session, new_tab) != TEST_COORDINATES
     assert (
-        await get_current_geolocation(bidi_session, new_context) == default_coordinates
+        await get_current_geolocation(bidi_session, new_context) != TEST_COORDINATES
     )


### PR DESCRIPTION
1. Tolerate not available real geolocation.
2. Fix `userContext` default value.
3. Test `null` user context.