### PR TITLE
layout: Floor the max-content size by the min-content size

### DIFF
--- a/css/css-sizing/min-content-le-max-content.tentative.html
+++ b/css/css-sizing/min-content-le-max-content.tentative.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>min-content ≤ max-content</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/12076">
+<meta assert="The max-content size is floored to not be smaller than the min-content.">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+
+<style>
+main {
+  width: 100px;
+  height: 100px;
+  font-size: 0;
+  background: red;
+}
+div {
+  background: green
+}
+span {
+  display: inline-block;
+  vertical-align: top;
+  height: 50px;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<main>
+  <div style="width: min-content">
+    <span style="width: 100px"></span>
+    <span style="margin-right: -50px"></span>
+  </div>
+  <div style="width: max-content">
+    <span style="width: 100px"></span>
+    <span style="margin-right: -50px"></span>
+  </div>
+</main>

--- a/css/css-tables/crashtests/cell-contents-with-negative-outer-size.html
+++ b/css/css-tables/crashtests/cell-contents-with-negative-outer-size.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://github.com/servo/servo/issues/36481">
+<style>span { display: inline-block; margin-right: -1px; }</style>
+<table><td>a<span></span></td></table>


### PR DESCRIPTION
It's typically a given that the min-content size can't exceed the max-content size. However, it was possible to break that assumption when an inline formatting context had contents with a negative outer size (due to margins). This could lead to assert failures.

This patch avoids the problem by flooring the max-content size to not be smaller than the min-content size. Note there is no interoperability: https://github.com/w3c/csswg-drafts/issues/12076

Testing: adding new reftest and crashtest
Fixes: #<!-- nolink -->36481

Reviewed in servo/servo#36518