### PR TITLE
[wdspec]Fix /webdriver/tests/bidi/browsing_context/context_destroyed/context_destroyed.py:test_client_window

### DIFF
--- a/webdriver/tests/bidi/browsing_context/context_destroyed/context_destroyed.py
+++ b/webdriver/tests/bidi/browsing_context/context_destroyed/context_destroyed.py
@@ -379,7 +379,7 @@ async def test_client_window(bidi_session, wait_for_event, wait_for_future_safe,
     assert_browsing_context(
         context_info,
         top_level_context["context"],
-        children=None,
+        children=0,
         url="about:blank",
         parent=None,
         user_context="default",


### PR DESCRIPTION
According to the spec, the "get the navigable info"'s "max depth" is null for "browsingContext.contextDestroyed"'s body. Meaning the "children" field should be an empty list instead of "None".

https://www.w3.org/TR/webdriver-bidi/#event-browsingContext-contextDestroyed