### PR TITLE
[wdspec] Align webdriver/tests/interop/beforeunload_prompt.py with spec

### DIFF
--- a/webdriver/tests/interop/beforeunload_prompt.py
+++ b/webdriver/tests/interop/beforeunload_prompt.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 import pytest_asyncio
 
@@ -26,7 +27,7 @@ async def check_beforeunload_implicitly_accepted(
     execute_as_async,
     url,
 ):
-    async def check_beforeunload_implicitly_accepted(accepted):
+    async def check_beforeunload_implicitly_accepted():
         current_session.window_handle = new_tab["context"]
 
         page_beforeunload = await setup_beforeunload_page(new_tab)
@@ -37,8 +38,14 @@ async def check_beforeunload_implicitly_accepted(
 
         await subscribe_events([USER_PROMPT_CLOSED_EVENT, USER_PROMPT_OPENED_EVENT])
 
-        # Navigate via classic.
-        current_session.url = page_target
+        # Using WebDriver classic's navigation command to navigate away from
+        # the page can hang if the prompt is not accepted. As such, wrap the
+        # command to fail on timeout gracefully.
+        def sync_navigate():
+            current_session.url = page_target
+
+        await wait_for_future_safe(
+            asyncio.create_task(execute_as_async(sync_navigate)))
 
         # Wait for BiDi events.
         opened_event = await wait_for_future_safe(on_prompt_opened)
@@ -54,7 +61,7 @@ async def check_beforeunload_implicitly_accepted(
         closed_event = await wait_for_future_safe(on_prompt_closed)
         recursive_compare(
             {
-                "accepted": accepted,
+                "accepted": True,
                 "context": new_tab["context"],
                 "type": "beforeunload",
             },
@@ -66,30 +73,31 @@ async def check_beforeunload_implicitly_accepted(
             current_session.alert.text
 
         # Assert the classic url changed.
-        if accepted:
-            assert current_session.url == page_target
-        else:
-            assert current_session.url == page_beforeunload
+        assert current_session.url == page_target
 
     return check_beforeunload_implicitly_accepted
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "accept"})
 async def test_accept(check_beforeunload_implicitly_accepted):
-    await check_beforeunload_implicitly_accepted(True)
+    await check_beforeunload_implicitly_accepted()
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "accept and notify"})
 async def test_accept_and_notify(check_beforeunload_implicitly_accepted):
-    await check_beforeunload_implicitly_accepted(True)
+    await check_beforeunload_implicitly_accepted()
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "dismiss"})
 async def test_dismiss(check_beforeunload_implicitly_accepted):
-    await check_beforeunload_implicitly_accepted(False)
+    await check_beforeunload_implicitly_accepted()
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "dismiss and notify"})
-async def test_dismiss_and_notify(
-        check_beforeunload_implicitly_accepted):
-    await check_beforeunload_implicitly_accepted(False)
+async def test_dismiss_and_notify(check_beforeunload_implicitly_accepted):
+    await check_beforeunload_implicitly_accepted()
+
+
+@pytest.mark.capabilities({"unhandledPromptBehavior": "ignore"})
+async def test_ignore(check_beforeunload_implicitly_accepted):
+    await check_beforeunload_implicitly_accepted()

--- a/webdriver/tests/interop/beforeunload_prompt.py
+++ b/webdriver/tests/interop/beforeunload_prompt.py
@@ -1,15 +1,11 @@
-import asyncio
 import pytest
 import pytest_asyncio
+
 from webdriver.error import NoSuchAlertException
-
-from tests.support.sync import AsyncPoll
-
 from ..bidi import (
     any_string,
     recursive_compare,
 )
-
 
 pytestmark = pytest.mark.asyncio
 
@@ -17,8 +13,9 @@ USER_PROMPT_CLOSED_EVENT = "browsingContext.userPromptClosed"
 USER_PROMPT_OPENED_EVENT = "browsingContext.userPromptOpened"
 
 
+
 @pytest_asyncio.fixture
-async def check_beforeunload_not_implicitly_accepted(
+async def check_beforeunload_implicitly_accepted(
     bidi_session,
     current_session,
     setup_beforeunload_page,
@@ -29,7 +26,7 @@ async def check_beforeunload_not_implicitly_accepted(
     execute_as_async,
     url,
 ):
-    async def check_beforeunload_not_implicitly_accepted(accept):
+    async def check_beforeunload_implicitly_accepted(accepted):
         current_session.window_handle = new_tab["context"]
 
         page_beforeunload = await setup_beforeunload_page(new_tab)
@@ -40,16 +37,11 @@ async def check_beforeunload_not_implicitly_accepted(
 
         await subscribe_events([USER_PROMPT_CLOSED_EVENT, USER_PROMPT_OPENED_EVENT])
 
-        # Using WebDriver classic's navigation command to navigate away from
-        # the page will hang and wait for the beforeunload dialog to close.
-        # As such start the command immediately as task but await for it later
-        # when BiDi closed the prompt.
-        def sync_navigate():
-            current_session.url = page_target
+        # Navigate via classic.
+        current_session.url = page_target
 
-        task_navigate = asyncio.create_task(execute_as_async(sync_navigate))
+        # Wait for BiDi events.
         opened_event = await wait_for_future_safe(on_prompt_opened)
-
         recursive_compare(
             {
                 "context": new_tab["context"],
@@ -59,59 +51,45 @@ async def check_beforeunload_not_implicitly_accepted(
             opened_event,
         )
 
-        # Close the beforeunload prompt and wait for the navigation to finish.
-        await bidi_session.browsing_context.handle_user_prompt(
-            context=new_tab["context"], accept=accept
-        )
         closed_event = await wait_for_future_safe(on_prompt_closed)
-        await task_navigate
-
-        # Check that the beforeunload prompt is closed and the event was sent.
-        with pytest.raises(NoSuchAlertException):
-            current_session.alert.text
-
         recursive_compare(
             {
-                "accepted": accept,
+                "accepted": accepted,
                 "context": new_tab["context"],
                 "type": "beforeunload",
             },
             closed_event,
         )
 
-        if accept:
+        # Assert the alert cannot be closed via classic.
+        with pytest.raises(NoSuchAlertException):
+            current_session.alert.text
+
+        # Assert the classic url changed.
+        if accepted:
             assert current_session.url == page_target
         else:
             assert current_session.url == page_beforeunload
 
-    return check_beforeunload_not_implicitly_accepted
+    return check_beforeunload_implicitly_accepted
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "accept"})
-@pytest.mark.parametrize("accept", [False, True])
-async def test_accept(check_beforeunload_not_implicitly_accepted, accept):
-    await check_beforeunload_not_implicitly_accepted(accept)
+async def test_accept(check_beforeunload_implicitly_accepted):
+    await check_beforeunload_implicitly_accepted(True)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "accept and notify"})
-@pytest.mark.parametrize("accept", [False, True])
-async def test_accept_and_notify(check_beforeunload_not_implicitly_accepted, accept):
-    await check_beforeunload_not_implicitly_accepted(accept)
+async def test_accept_and_notify(check_beforeunload_implicitly_accepted):
+    await check_beforeunload_implicitly_accepted(True)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "dismiss"})
-@pytest.mark.parametrize("accept", [False, True])
-async def test_dismiss(check_beforeunload_not_implicitly_accepted, accept):
-    await check_beforeunload_not_implicitly_accepted(accept)
+async def test_dismiss(check_beforeunload_implicitly_accepted):
+    await check_beforeunload_implicitly_accepted(False)
 
 
 @pytest.mark.capabilities({"unhandledPromptBehavior": "dismiss and notify"})
-@pytest.mark.parametrize("accept", [False, True])
-async def test_dismiss_and_notify(check_beforeunload_not_implicitly_accepted, accept):
-    await check_beforeunload_not_implicitly_accepted(accept)
-
-
-@pytest.mark.capabilities({"unhandledPromptBehavior": "ignore"})
-@pytest.mark.parametrize("accept", [False, True])
-async def test_ignore(check_beforeunload_not_implicitly_accepted, accept):
-    await check_beforeunload_not_implicitly_accepted(accept)
+async def test_dismiss_and_notify(
+        check_beforeunload_implicitly_accepted):
+    await check_beforeunload_implicitly_accepted(False)

--- a/webdriver/tests/interop/beforeunload_prompt.py
+++ b/webdriver/tests/interop/beforeunload_prompt.py
@@ -1,8 +1,8 @@
 import asyncio
 import pytest
 import pytest_asyncio
-
 from webdriver.error import NoSuchAlertException
+
 from ..bidi import (
     any_string,
     recursive_compare,
@@ -67,7 +67,7 @@ async def check_beforeunload_implicitly_accepted(
             closed_event,
         )
 
-        # Assert the alert cannot be closed via classic.
+        # Assert via classic that the alert is not present.
         with pytest.raises(NoSuchAlertException):
             current_session.alert.text
 

--- a/webdriver/tests/interop/beforeunload_prompt.py
+++ b/webdriver/tests/interop/beforeunload_prompt.py
@@ -14,7 +14,6 @@ USER_PROMPT_CLOSED_EVENT = "browsingContext.userPromptClosed"
 USER_PROMPT_OPENED_EVENT = "browsingContext.userPromptOpened"
 
 
-
 @pytest_asyncio.fixture
 async def check_beforeunload_implicitly_accepted(
     bidi_session,


### PR DESCRIPTION
Align the test with the specification. If capability is set via string, the "beforeUnload" behavior should be "accept" regardless of the capability value.

#### [Html spec](https://html.spec.whatwg.org/#steps-to-fire-beforeunload)
> The steps to fire **beforeunload**
...
6.2. Let userPromptHandler be the result of [WebDriver BiDi user prompt opened](https://w3c.github.io/webdriver-bidi/#webdriver-bidi-user-prompt-opened) with document's [relevant global object](https://html.spec.whatwg.org/#concept-relevant-global), "beforeunload", and "".
...
6.4. If userPromptHandler is "none", then ...
...

#### [WebDriver BiDi user prompt opened](https://www.w3.org/TR/webdriver-bidi/#webdriver-bidi-user-prompt-opened)
> WebDriver BiDi user prompt opened
...
> 3. Let handler configuration be [get the prompt handler](https://w3c.github.io/webdriver/#dfn-get-the-prompt-handler) with type.
...
> 10. Return handler.

#### WebDriver Classic [get the prompt handler](https://w3c.github.io/webdriver/#dfn-get-the-prompt-handler):
> 4. If type is "beforeUnload", return a [prompt handler configuration](https://w3c.github.io/webdriver/#dfn-prompt-handler-configuration) with [handler](https://w3c.github.io/webdriver/#dfn-handler) "accept" and [notify](https://w3c.github.io/webdriver/#dfn-notify) false.
