### PR TITLE
Remove most disabled expectations from infrastructure/

### DIFF
--- a/infrastructure/metadata/infrastructure/assumptions/allowed-to-play.html.ini
+++ b/infrastructure/metadata/infrastructure/assumptions/allowed-to-play.html.ini
@@ -1,6 +1,4 @@
 [allowed-to-play.html]
-  disabled:
-    if product == "firefox": https://bugzilla.mozilla.org/show_bug.cgi?id=1607802
   expected:
     if product == "safari": ERROR # https://bugs.webkit.org/show_bug.cgi?id=190775
 

--- a/infrastructure/metadata/infrastructure/reftest/testdriver-in-ref.html.ini
+++ b/infrastructure/metadata/infrastructure/reftest/testdriver-in-ref.html.ini
@@ -1,5 +1,5 @@
 [testdriver-in-ref.html]
-  disabled:
+  expected:
     # https://github.com/web-platform-tests/wpt/issues/13183
-    if product == "firefox" or product == "firefox_android":
-      "marionette executor doesn't currently implement testdriver for reftests"
+    # marionette executor doesn't currently implement testdriver for reftests
+    if product == "firefox" or product == "firefox_android": TIMEOUT

--- a/infrastructure/metadata/infrastructure/testdriver/bidi/bluetooth/handle_request_device_prompt.https.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/bidi/bluetooth/handle_request_device_prompt.https.html.ini
@@ -1,2 +1,3 @@
-disabled:
-  if product != "chrome": @True
+[handle_request_device_prompt.https.html]
+  expected:
+    if product != "chrome": ERROR

--- a/infrastructure/metadata/infrastructure/testdriver/bidi/bluetooth/simulate_adapter.https.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/bidi/bluetooth/simulate_adapter.https.html.ini
@@ -1,2 +1,3 @@
-disabled:
-  if product != "chrome": @True
+[simulate_adapter.https.html]
+  expected:
+    if product != "chrome": ERROR

--- a/infrastructure/metadata/infrastructure/testdriver/bidi/bluetooth/simulate_preconnected_peripheral.https.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/bidi/bluetooth/simulate_preconnected_peripheral.https.html.ini
@@ -1,2 +1,3 @@
-disabled:
-  if product != "chrome": @True
+[simulate_preconnected_peripheral.https.html]
+  expected:
+    if product != "chrome": ERROR

--- a/infrastructure/metadata/infrastructure/testdriver/bidi/permissions/set_permission.https.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/bidi/permissions/set_permission.https.html.ini
@@ -1,2 +1,3 @@
-disabled:
-  if product != "chrome": @True
+[set_permission.https.html]
+  expected:
+    if product != "chrome": ERROR

--- a/infrastructure/metadata/infrastructure/webdriver/bidi/subscription.html.ini
+++ b/infrastructure/metadata/infrastructure/webdriver/bidi/subscription.html.ini
@@ -1,2 +1,3 @@
-disabled:
-  if product != "chrome": @True
+[subscription.html]
+  expected:
+    if product != "chrome": ERROR

--- a/infrastructure/metadata/infrastructure/webdriver/bidi/subscription.window.js.ini
+++ b/infrastructure/metadata/infrastructure/webdriver/bidi/subscription.window.js.ini
@@ -1,2 +1,3 @@
-disabled:
-  if product != "chrome": @True
+[subscription.window.html]
+  expected:
+    if product != "chrome": ERROR

--- a/infrastructure/metadata/infrastructure/webdriver/tests/test_load_file.py.ini
+++ b/infrastructure/metadata/infrastructure/webdriver/tests/test_load_file.py.ini
@@ -1,2 +1,0 @@
-disabled:
-  if product == "firefox": @True


### PR DESCRIPTION
This is very much an anti-pattern, as it risks hiding genuine new
breakage (which has happened at least once, albeit caught during
review; c.f. https://github.com/web-platform-tests/wpt/pull/50626#pullrequestreview-2770009019); disabling tests should very much be an option of absolute
last resort.

For allowed-to-play.html.ini, the referenced Firefox bug was fixed
five years ago, which means we haven't had coverage for five years
because the test was disabled and thus we never noticed it starting to
pass once again. (Fixes #52014.)

For testdriver-in-ref.html.ini, we have no reason to disable this
test; it is merely one of many that are expected to timeout in
Firefox, and that's a perfectly reasonable assertion.

For test_load_file.py.ini, it's unclear why it got disabled in Firefox
in first place; earlier in the PR it had been marked as flaky, and
then got disabled without any further discussion or comment. (https://github.com/web-platform-tests/wpt/pull/42729/commits/e47c42d79552a92ae7d0c8b15a4b0036ad982b58 on https://github.com/web-platform-tests/wpt/pull/42729)

For testdriver/bidi/ and webdriver/bidi/, we should definitely be
running these tests on all browsers. Sure, currently only the Chrome
testharness executor supports bidi, but bidi tests cannot be allowed
to cause critical errors on other browsers (e.g., via enabling the
capability when it is unsupported, and thus causing the executor to
never successfully setup).

This leaves two disabled annotations in infrastructure:

```
infrastructure/metadata/infrastructure/testdriver/minimize_restore_popup.html.ini
2:  disabled: https://github.com/web-platform-tests/wpt/issues/45137

infrastructure/metadata/infrastructure/browsers/firefox/__dir__.ini
1:disabled:
2-  if product != "firefox": true
```

Both of these seem much more defensible than any of the others.
