### PR TITLE
add two crash-tests for dialog requestClose

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-2-crash.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-2-crash.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<link rel="author" href="mailto:wpt@keithcirkel.co.uk" />
+<link rel="help" href="https://html.spec.whatwg.org/#dom-dialog-requestclose" />
+
+<!-- This test passes if it does not crash. -->
+
+<script>
+  const dialog = document.createElement("dialog");
+  dialog.setAttribute("open", "");
+  dialog.requestClose();
+</script>

--- a/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-3-crash.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-3-crash.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<link rel="author" href="mailto:wpt@keithcirkel.co.uk" />
+<link rel="help" href="https://html.spec.whatwg.org/#dom-dialog-requestclose" />
+
+<!-- This test passes if it does not crash. -->
+
+<script>
+  const doc = document.implementation.createHTMLDocument("");
+  const dialog = doc.createElement("dialog");
+  doc.body.append(dialog);
+  dialog.setAttribute("open", "");
+  dialog.requestClose();
+</script>


### PR DESCRIPTION
This PR adds two crash tests that can invoke crashes in Chrome; using a disconnected dialog, and a dialog connected to a document with no browsing context.