### PR TITLE
Fix a typo in fetch/api/body/mime-type.any.js

### DIFF
--- a/fetch/api/body/mime-type.any.js
+++ b/fetch/api/body/mime-type.any.js
@@ -87,7 +87,7 @@
 
 [
   () => new Request("about:blank", { method: "POST", body: new Blob([""], { type: "Text/Plain" }), headers: [["Content-Type", "Text/Html"]] }),
-  () => new Response(new Blob([""], { type: "Text/Plain" }, { headers: [["Content-Type", "Text/Html"]] }))
+  () => new Response(new Blob([""], { type: "Text/Plain" }), { headers: [["Content-Type", "Text/Html"]] })
 ].forEach(bodyContainerCreator => {
   const bodyContainer = bodyContainerCreator();
   const cloned = bodyContainer.clone();


### PR DESCRIPTION
The arguments were wrongly parenthesized, causing the headers to be passed to the Blob constructor, rather than to be passed to the Response constructor, as was intended.