### PR TITLE
Non-HTML endpoints should not have dangling markup protection

### DIFF
--- a/fetch/security/dangling-markup/dangling-markup-mitigation-allowed-apis.https.html
+++ b/fetch/security/dangling-markup/dangling-markup-mitigation-allowed-apis.https.html
@@ -66,7 +66,6 @@
           iframe.contentWindow.eval(call[0]);
           number_api_calls += 1;
           get_requests(registration.active, number_api_calls).then(t.step_func(requests => {
-            console.log(requests);
             resolve(assert_true(requests.has(call[1] + dangling_resource_expected)));
           }));
         }));

--- a/fetch/security/dangling-markup/dangling-markup-mitigation-allowed-apis.https.html
+++ b/fetch/security/dangling-markup/dangling-markup-mitigation-allowed-apis.https.html
@@ -11,13 +11,18 @@
     `location.replace(\`${dangling_url}\`)`,
   ];
 
-  function get_requests(worker, expected) {
-    return new Promise(resolve => {
+  function get_requests(test, worker, expected) {
+    return new Promise((resolve, reject) => {
+      let didTimeout = false;
+      test.step_timeout(() => {
+        didTimeout = true;
+        reject("get_requests timed out");
+      }, 1000);
       navigator.serviceWorker.addEventListener('message', function onMsg(evt) {
         if (evt.data.size >= expected) {
           navigator.serviceWorker.removeEventListener('message', onMsg);
           resolve(evt.data);
-        } else {
+        } else if (!didTimeout) {
           worker.postMessage("");
         }
       });
@@ -45,37 +50,45 @@
     [`const xhr = new XMLHttpRequest();
      xhr.open("GET", \`${"xhr" + dangling_resource}\`);
      xhr.send(null);`, "xhr"],
-    [`new EventSource(\`${"EventSource" + dangling_resource}\`)`, "EventSource"],
+    [`new EventSource(\`${"EventSource" + dangling_resource}\`)`,"EventSource"],
     [`fetch(\`${"fetch" + dangling_resource}\`).catch(()=>{})`, "fetch"],
     [`new Worker(\`${"Worker" + dangling_resource}\`)`, "Worker"],
     [`let text = \`try{importScripts(\\\`${location.href + "/../importScripts" + dangling_resource}\\\`)}catch(e){}\`;
      let blob = new Blob([text], {type : 'text/javascript'});
      let url = URL.createObjectURL(blob);
-     new Worker(url)`, "importScripts"]
+     new Worker(url)`, "importScripts"],
+
   ];
 
-  navigator.serviceWorker.register('service-worker.js');
-  const iframe = document.createElement('iframe');
-  iframe.src = "resources/empty.html";
-  document.body.appendChild(iframe);
+  let iframe, registration;
+  promise_test(async t => {
+    iframe = document.createElement('iframe');
+    iframe.src = "resources/empty.html";
+    document.body.appendChild(iframe);
+    await new Promise(resolve => iframe.onload = resolve);
+    registration = await navigator.serviceWorker.register('service-worker.js');
+    if (!iframe.contentWindow.navigator.serviceWorker.controller)
+      await new Promise(resolve => iframe.contentWindow.navigator.serviceWorker.oncontrollerchange = resolve);
+  }, "Setup controlled frame");
+
   let number_api_calls = 0;
   api_calls.forEach(call => {
-    promise_test(t => {
-      return new Promise(resolve => {
-        navigator.serviceWorker.ready.then(t.step_func(registration => {
-          iframe.contentWindow.eval(call[0]);
-          number_api_calls += 1;
-          get_requests(registration.active, number_api_calls).then(t.step_func(requests => {
-            resolve(assert_true(requests.has(call[1] + dangling_resource_expected)));
-          }));
-        }));
-      });
+    promise_test(async t => {
+      iframe.contentWindow.eval(call[0]);
+      const requests = await get_requests(t, registration.active, number_api_calls + 1);
+      assert_equals(Array.from(requests)[number_api_calls], call[1] + dangling_resource_expected);
+      number_api_calls++;
     }, `Does not block ${call[1]}`);
   });
+  promise_test(async () => {
+    iframe.remove();
+    registration.unregister();
+  }, "Clean up iframe");
 
-  test(t => {
+  async_test(t => {
     let url = new URL(location.origin + "/" + dangling_url);
     // Newlines are removed by the URL parser.
     assert_true(url.href.endsWith(encodeURI(dangling_url.replace("\n",""))));
+    t.done();
   }, `Does not block new URL()`);
 </script>

--- a/fetch/security/dangling-markup/dangling-markup-mitigation-allowed-apis.https.html
+++ b/fetch/security/dangling-markup/dangling-markup-mitigation-allowed-apis.https.html
@@ -40,41 +40,43 @@
   });
 
   const dangling_resource = "404?type=text/javascript&\n<"
+  const dangling_resource_expected = "404?type=text/javascript&%3C"
   const api_calls = [
     [`const xhr = new XMLHttpRequest();
      xhr.open("GET", \`${"xhr" + dangling_resource}\`);
      xhr.send(null);`, "xhr"],
-    [`new EventSource(\`${"EventSource" + dangling_resource}\`)`,"EventSource"],
+    [`new EventSource(\`${"EventSource" + dangling_resource}\`)`, "EventSource"],
     [`fetch(\`${"fetch" + dangling_resource}\`).catch(()=>{})`, "fetch"],
     [`new Worker(\`${"Worker" + dangling_resource}\`)`, "Worker"],
     [`let text = \`try{importScripts(\\\`${location.href + "/../importScripts" + dangling_resource}\\\`)}catch(e){}\`;
      let blob = new Blob([text], {type : 'text/javascript'});
      let url = URL.createObjectURL(blob);
-     new Worker(url)`, "importScripts"],
-
+     new Worker(url)`, "importScripts"]
   ];
 
   navigator.serviceWorker.register('service-worker.js');
   const iframe = document.createElement('iframe');
   iframe.src = "resources/empty.html";
   document.body.appendChild(iframe);
+  let number_api_calls = 0;
   api_calls.forEach(call => {
     promise_test(t => {
       return new Promise(resolve => {
         navigator.serviceWorker.ready.then(t.step_func(registration => {
           iframe.contentWindow.eval(call[0]);
-          get_requests(registration.active, 0).then(t.step_func(requests => {
-            resolve(assert_true(requests.has(call[1] + dangling_resource)));
+          number_api_calls += 1;
+          get_requests(registration.active, number_api_calls).then(t.step_func(requests => {
+            console.log(requests);
+            resolve(assert_true(requests.has(call[1] + dangling_resource_expected)));
           }));
         }));
       });
     }, `Does not block ${call[1]}`);
   });
 
-  async_test(t => {
+  test(t => {
     let url = new URL(location.origin + "/" + dangling_url);
     // Newlines are removed by the URL parser.
     assert_true(url.href.endsWith(encodeURI(dangling_url.replace("\n",""))));
-    t.done();
   }, `Does not block new URL()`);
 </script>


### PR DESCRIPTION
This is already the standard so mark this test as non-tentative and fix it in the process.