### PR TITLE
Fix `/css/css-flexbox/gap-007-*` WPT tests

### DIFF
--- a/css/css-flexbox/gap-007-lr-ref.html
+++ b/css/css-flexbox/gap-007-lr-ref.html
@@ -14,6 +14,7 @@
     display: inline-flex;
     flex-direction: column;
     flex-wrap: wrap;
+    line-height: 18px;
   }
   section > div{
     background-color: grey;

--- a/css/css-flexbox/gap-007-lr.html
+++ b/css/css-flexbox/gap-007-lr.html
@@ -20,6 +20,7 @@
     flex-direction: column;
     flex-wrap: wrap;
     gap: 20px;
+    line-height: 18px;
   }
   section > div{
     background-color: grey;

--- a/css/css-flexbox/gap-007-ltr-ref.html
+++ b/css/css-flexbox/gap-007-ltr-ref.html
@@ -10,6 +10,7 @@
     display: inline-flex;
     flex-direction: column;
     flex-wrap: wrap;
+    line-height: 18px;
   }
   section > div{
     background-color: grey;

--- a/css/css-flexbox/gap-007-ltr.html
+++ b/css/css-flexbox/gap-007-ltr.html
@@ -16,6 +16,7 @@
     flex-direction: column;
     flex-wrap: wrap;
     gap: 20px;
+    line-height: 18px;
   }
   section > div{
     background-color: grey;

--- a/css/css-flexbox/gap-007-rl-ref.html
+++ b/css/css-flexbox/gap-007-rl-ref.html
@@ -14,6 +14,7 @@
     display: inline-flex;
     flex-direction: column;
     flex-wrap: wrap;
+    line-height: 18px;
   }
   section > div{
     background-color: grey;

--- a/css/css-flexbox/gap-007-rl.html
+++ b/css/css-flexbox/gap-007-rl.html
@@ -20,6 +20,7 @@
     flex-direction: column;
     flex-wrap: wrap;
     gap: 20px;
+    line-height: 18px;
   }
   section > div{
     background-color: grey;

--- a/css/css-flexbox/gap-007-rtl-ref.html
+++ b/css/css-flexbox/gap-007-rtl-ref.html
@@ -14,6 +14,7 @@
     display: inline-flex;
     flex-direction: column;
     flex-wrap: wrap;
+    line-height: 18px;
   }
   section > div{
     background-color: grey;

--- a/css/css-flexbox/gap-007-rtl.html
+++ b/css/css-flexbox/gap-007-rtl.html
@@ -20,6 +20,7 @@
     flex-direction: column;
     flex-wrap: wrap;
     gap: 20px;
+    line-height: 18px;
   }
   section > div{
     background-color: grey;


### PR DESCRIPTION
These tests were locally failing for me, both on Servo and Gecko, because these browsers choose a different default font than Blink, making the flex items a bit bigger, and thus only fitting 2 items on the first flex line, instead of 3 items.

Manually setting the `line-height` provides consistent results.

Testing: This doesn't affect CI, but fixes the local problem for me.
Reviewed in servo/servo#36585