### PR TITLE
[webcodecs] Test non zero timestamps

### DIFF
--- a/webcodecs/audioDecoder-codec-specific.https.any.js
+++ b/webcodecs/audioDecoder-codec-specific.https.any.js
@@ -371,7 +371,7 @@ promise_test(async t => {
 
   await decoder.flush();
   assert_equals(outputs, CONFIG.codec === 'vorbis' ? 1 : 2, 'outputs');
-}, 'Test decoding a with negative timestamp');
+}, 'Test decoding a with a negative timestamp');
 
 promise_test(async t => {
   const callbacks = {};
@@ -394,7 +394,7 @@ promise_test(async t => {
 
   await decoder.flush();
   assert_equals(outputs, CONFIG.codec === 'vorbis' ? 1 : 2, 'outputs');
-}, 'Test decoding a with positive timestamp');
+}, 'Test decoding a with a positive timestamp');
 
 promise_test(async t => {
   const callbacks = {};

--- a/webcodecs/audioDecoder-codec-specific.https.any.js
+++ b/webcodecs/audioDecoder-codec-specific.https.any.js
@@ -356,6 +356,9 @@ promise_test(async t => {
 
   let outputs = 0;
   callbacks.output = frame => {
+    if (outputs === 0) {
+      assert_equals(frame.timestamp, -42);
+    }
     outputs++;
     frame.close();
   };
@@ -376,6 +379,9 @@ promise_test(async t => {
 
   let outputs = 0;
   callbacks.output = frame => {
+    if (outputs === 0) {
+      assert_equals(frame.timestamp, 42);
+    }
     outputs++;
     frame.close();
   };

--- a/webcodecs/audioDecoder-codec-specific.https.any.js
+++ b/webcodecs/audioDecoder-codec-specific.https.any.js
@@ -381,6 +381,26 @@ promise_test(async t => {
   };
 
   decoder.configure(CONFIG);
+  decoder.decode(new EncodedAudioChunk(
+      {type: 'key', timestamp: 42, data: CHUNK_DATA[0]}));
+  decoder.decode(new EncodedAudioChunk(
+      {type: 'key', timestamp: CHUNKS[0].duration + 42, data: CHUNK_DATA[1]}));
+
+  await decoder.flush();
+  assert_equals(outputs, CONFIG.codec === 'vorbis' ? 1 : 2, 'outputs');
+}, 'Test decoding a with positive timestamp');
+
+promise_test(async t => {
+  const callbacks = {};
+  const decoder = createAudioDecoder(t, callbacks);
+
+  let outputs = 0;
+  callbacks.output = frame => {
+    outputs++;
+    frame.close();
+  };
+
+  decoder.configure(CONFIG);
   decoder.decode(CHUNKS[0]);
   decoder.decode(CHUNKS[1]);
 


### PR DESCRIPTION
This PR adds a new test to verify the `AudioDecoder` can handle an initial timetamp above zero. It also checks that this timestamp gets used when outputting the first `AudioData`. Additionally it adds the same check for the existing test for negative timestamps.

Please let me know if there is anything that needs to be changed.