### PR TITLE
Fix wrong ImageData test

### DIFF
--- a/html/semantics/embedded-content/the-canvas-element/imagedata.html
+++ b/html/semantics/embedded-content/the-canvas-element/imagedata.html
@@ -44,7 +44,7 @@ test(function() {
 
 test(function() {
     assert_throws_js(TypeError, function() {
-        new ImageData(new Int8Array(1), 1);
+        ImageData.prototype.constructor.call(Object.create(ImageData.prototype), new Int8Array(1), 1);
     });
 }, "ImageData(buffer, w, opt h), Uint8ClampedArray argument type check");
 

--- a/html/semantics/embedded-content/the-canvas-element/imagedata.html
+++ b/html/semantics/embedded-content/the-canvas-element/imagedata.html
@@ -43,12 +43,6 @@ test(function() {
 }, "ImageData(buffer, w, h), buffer.length == 4 * w * h must be true");
 
 test(function() {
-    assert_throws_js(TypeError, function() {
-        ImageData.prototype.constructor.call(Object.create(ImageData.prototype), new Int8Array(1), 1);
-    });
-}, "ImageData(buffer, w, opt h), Uint8ClampedArray argument type check");
-
-test(function() {
     var imageData = new ImageData(new Uint8ClampedArray(24), 2);
     assert_equals(imageData.width, 2);
     assert_equals(imageData.height, 3);


### PR DESCRIPTION
This PR fixes a test for the ImageData(data, width[, height]) constructor that incorrectly expected a TypeError to be thrown when passing a TypedArray that is not a Uint8ClampedArray, such as Int8Array. This behavior is not correct per the WebIDL specification, and the test was passing in Servo due to a previous mismatch in the WebIDL bindings, not because the behavior was actually correct.

Thanks to @jdm [explanation](https://github.com/servo/servo/pull/31398#discussion_r2051536002) , we noticed that Servo was passing a Web Platform Test t[hat every other browser fails](https://wpt.fyi/results/html/semantics/embedded-content/the-canvas-element/imagedata.html?label=master&label=experimental&aligned&q=imagedata.html). The test was written like this:

```
test(function() {
    assert_throws_js(TypeError, function() {
        new ImageData(new Int8Array(1), 1);
    });
}, "ImageData(buffer, w, opt h), Uint8ClampedArray argument type check");
```

this looks like it should call the constructor that takes a Uint8ClampedArray and throw a TypeError because the input is not of the right type. However, this is not what actually happens per spec.

According to [WebIDL overload resolution](https://webidl.spec.whatwg.org/#dfn-overload-resolution-algorithm), the selection of the correct constructor works as follows:

Constructors in the IDL:
```
[Throws] constructor(Uint8ClampedArray data, unsigned long sw, optional unsigned long sh);
[Throws] constructor(unsigned long sw, unsigned long sh);
```

Given call:
```
new ImageData(new Int8Array(1), 1);
```

Overload resolution steps:
The first argument (Int8Array) does not match Uint8ClampedArray.
- Step 12.7 of the overload algorithm fails.

The algorithm continues to look for another overload that accepts a number as its first argument.
- Step 12.16 finds the (sw, sh) constructor.

As a result, the second constructor is chosen, and no type error is thrown. The object is created incorrectly, but validly.

Why Servo Passed the Test Incorrectly:
```
[Throws] constructor(object data, unsigned long sw, optional unsigned long sh);
```
Because the overload used object, any typed array — including Int8Array — would match that overload, hitting Step 12.11 in the spec, and calling the constructor that then did manual type checking.

Proposed Fix:
To make the test correctly target the desired constructor (the one expecting a Uint8ClampedArray), we bypass the default overload resolution logic. This is done by directly calling the constructor function with .call():

```
test(function() {
    assert_throws_js(TypeError, function() {
        ImageData.prototype.constructor.call(
            Object.create(ImageData.prototype),
            new Int8Array(1),
            1
        );
    });
}, "ImageData(buffer, w, opt h), Uint8ClampedArray argument type check");
```

This PR fixes https://github.com/web-platform-tests/wpt/issues/44929.
