### PR TITLE
Treat null fragment the same as an empty string in location hash setter

### DIFF
--- a/html/browsers/history/the-location-interface/location_hash_set_empty_string.html
+++ b/html/browsers/history/the-location-interface/location_hash_set_empty_string.html
@@ -12,6 +12,6 @@ window.location.hash = '';
 
 test(() => {
     assert_true(window.location.hash === '');
-    assert_true(window.location.href === orig_location + '#');
+    assert_true(window.location.href === orig_location);
 }, 'window.location.hash is an empty string');
 </script>


### PR DESCRIPTION
See: https://github.com/whatwg/html/issues/11243

Aligns the test with chrome and webkit behaviour.