### PR TITLE
Create another dialog requestClose crashtest

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-4-crash.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose-4-crash.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<link rel="author" href="mailto:wpt@keithcirkel.co.uk" />
+<link rel="help" href="https://html.spec.whatwg.org/#dom-dialog-requestclose" />
+
+<!-- This test passes if it does not crash. -->
+
+<script>
+  const doc = document.implementation.createHTMLDocument("");
+  const dialog = doc.createElement("dialog");
+  dialog.setAttribute("open", "");
+  doc.body.append(dialog);
+  dialog.requestClose();
+</script>


### PR DESCRIPTION
Following from https://github.com/web-platform-tests/wpt/pull/52020 this creates another crashtest, subtly different from the previous ones; this sets the open attribute while disconnected, only to connect and call requestClose. crashtest-3 sets the open attribute _after_ connect. This is different enough that different code paths get hit!