### PR TITLE
Do not try to cleanup already ended webdriver session.

### DIFF
--- a/webdriver/tests/support/helpers.py
+++ b/webdriver/tests/support/helpers.py
@@ -80,6 +80,10 @@ def cleanup_session(session):
 
         session.window_handle = current_window
 
+    # Do not try to clean up already ended session.
+    if session.session_id is None:
+        return
+
     _restore_timeouts(session)
     _ensure_valid_window(session)
     _dismiss_user_prompts(session)


### PR DESCRIPTION
The changes introduced in https://github.com/web-platform-tests/wpt/pull/51816 caused failures in the tests which explicitly end session at the end of them (see https://github.com/web-platform-tests/wpt/pull/51816#issuecomment-2815701078), this would lead to failures when trying to perform cleanup steps. This PR suggest to not run these steps if the session was ended.