### PR TITLE
MessagePort: implement disentanglement

### DIFF
--- a/webmessaging/message-channels/close-event/explicitly-closed.tentative.window.js
+++ b/webmessaging/message-channels/close-event/explicitly-closed.tentative.window.js
@@ -33,3 +33,13 @@ promise_test(async t => {
   });
   await closeEventPromise;
 }, 'Close event on port2 is fired when port1, which is in a different window, is explicitly closed.')
+
+promise_test(async t => {
+  const rc = await addWindow();
+  const waitForPort = expectMessagePortFromWindowWithoutStartingIt(window);
+  await createMessageChannelAndSendPortFollowedByClose(rc);
+  const port = await waitForPort;
+  const closeEventPromise = createCloseEventPromise(port);
+  port.start();
+  await closeEventPromise;
+}, 'Close event on port2 is fired when port1, in a different window, is closed during the transfer of port2.')

--- a/webmessaging/message-channels/close-event/resources/helper.js
+++ b/webmessaging/message-channels/close-event/resources/helper.js
@@ -22,6 +22,44 @@ function expectMessagePortFromWindow(window) {
 }
 
 /**
+ * Create a new promise that resolves when the window receives
+ * the MessagePort and does not start it.
+ *
+ * @param {Window} window - The window to wait for the MessagePort.
+ * @returns {Promise<MessagePort>} A promise you should await to ensure the
+ *     window
+ * receives the MessagePort.
+ */
+function expectMessagePortFromWindowWithoutStartingIt(window) {
+  return new Promise(resolve => {
+    window.onmessage = e => {
+      try {
+        assert_true(e.ports[0] instanceof window.MessagePort);
+        resolve(e.ports[0]);
+      } catch (e) {
+        reject(e);
+      }
+    };
+  });
+}
+
+/**
+ * Create a new MessageChannel and transfers one of the ports to
+ * the window which opened the window with a remote context provided
+ * as an argument, and immediately closes the entangled port.
+ *
+ * @param {RemoteContextWrapper} remoteContextWrapper
+ */
+async function createMessageChannelAndSendPortFollowedByClose(remoteContextWrapper) {
+  await remoteContextWrapper.executeScript(() => {
+    const {port1, port2} = new MessageChannel();
+    port1.start();
+    window.opener.postMessage({}, '*', [port2]);
+    port1.close();
+  });
+}
+
+/**
  * Create a new MessageChannel and transfers one of the ports to
  * the window which opened the window with a remote context provided
  * as an argument.


### PR DESCRIPTION
Implement [disentangle](https://html.spec.whatwg.org/multipage/#disentangle)
Remove bespoke gc logic which now becomes unnecessary. 
Adds a wpt test that hits the "disentangle while in transfer" logic.
Updates streams code, fixing an error where disentanglement is conditional on an error.

Test coverage: there are existing tests in `/webmessaging/message-channels/close-event/explicitly-closed.tentative.window.js` for the no transfer case, and the simple completed transfer case, and this PR adds a test for the more complicated transfer in progress case. 

Fix https://github.com/servo/servo/issues/36465

Reviewed in servo/servo#36654