### PR TITLE
Test ::file-selector-button::before renders something

### DIFF
--- a/css/css-pseudo/file-selector-button-002-notref.html
+++ b/css/css-pseudo/file-selector-button-002-notref.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<title>CSS Test Reference</title>
+<input type="file">

--- a/css/css-pseudo/file-selector-button-002.html
+++ b/css/css-pseudo/file-selector-button-002.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<title>::file-selector-button supports ::before</title>
+<link rel="mismatch" href="file-selector-button-002-notref.html">
+<style>
+  input::file-selector-button::before {
+    content: "[before]";
+  }
+</style>
+<input type="file">


### PR DESCRIPTION
file-selector-button is an element-backed pseudo-element so supports ::before.

This test ensures that the ::before renders something, ensuring that an actual button element is used.