### PR TITLE
script: Clamp table spans according to the HTML specification     

### DIFF
--- a/css/css-tables/colspan-zero-crash.html
+++ b/css/css-tables/colspan-zero-crash.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/36699">
+<link rel="author" href="mailto:fwang@igalia.com" title="Frédéric Wang">
+<span id="span"></span>
+<script>
+  let th = document.createElement("th");
+  span.replaceWith(th);
+  th.colSpan = 0;
+</script>
+

--- a/html/semantics/tabular-data/processing-model-1/col-span-limits.html
+++ b/html/semantics/tabular-data/processing-model-1/col-span-limits.html
@@ -39,11 +39,20 @@ These two must look the same, each having 2 cells in one row:
 </table>
 <br>
 <table id=table3>
-  <col span=1001>
+  <col id="colspan-3" span=1001>
   <tr>
     <td colspan=1000><div class="square"></div></td>
     <td><div class="square"></div></td>
   </tr>
+</table>
+<table>
+    <tr>
+        <td id="colspan-limit-test1" colspan=5></td>
+        <td id="colspan-limit-test2" colspan=0></td>
+        <td id="colspan-limit-test3" colspan=1000></td>
+        <td id="colspan-limit-test4" colspan=1001></td>
+        <td id="colspan-limit-test5" colspan=5555555></td>
+    </tr>
 </table>
 </main>
 
@@ -56,4 +65,48 @@ test(() => {
     assert_equals(table2.offsetWidth, 51, "table2 width");
     assert_equals(table3.offsetWidth, 51, "table3 width");
 }, "col span of 1001 must be treated as 1000");
+
+test(() => {
+    let td = document.createElement("td");
+    td.colSpan = 5;
+    assert_equals(td.colSpan, 5);
+
+    td.colSpan = 0;
+    assert_equals(td.colSpan, 1);
+
+    td.colSpan = 1000;
+    assert_equals(td.colSpan, 1000);
+
+    td.colSpan = 1001;
+    assert_equals(td.colSpan, 1000);
+
+    td.colSpan = 555555;
+    assert_equals(td.colSpan, 1000);
+}, "colspan must be clamped to [1, 1000] when set via script");
+
+test(() => {
+    assert_equals(document.getElementById("colspan-limit-test1").colSpan, 5);
+    assert_equals(document.getElementById("colspan-limit-test2").colSpan, 1);
+    assert_equals(document.getElementById("colspan-limit-test3").colSpan, 1000);
+    assert_equals(document.getElementById("colspan-limit-test4").colSpan, 1000);
+    assert_equals(document.getElementById("colspan-limit-test5").colSpan, 1000);
+}, "colspan must be clamped to [1, 1000] when parsing attributes");
+
+test(() => {
+    let column = document.getElementById("colspan-3");
+    column.span = 5;
+    assert_equals(column.span, 5);
+
+    column.span = 0;
+    assert_equals(column.span, 1);
+
+    column.span = 1000;
+    assert_equals(column.span, 1000);
+
+    column.span = 1001;
+    assert_equals(column.span, 1000);
+
+    column.span = 555555;
+    assert_equals(column.span, 1000);
+}, "column span must be clamped to [1, 1000] when set via script");
 </script>

--- a/html/semantics/tabular-data/processing-model-1/span-limits.html
+++ b/html/semantics/tabular-data/processing-model-1/span-limits.html
@@ -29,6 +29,17 @@
   <!-- We'll add another 65534 rows later -->
 </table>
 
+<table>
+    <tr>
+        <td id="rowspan-limit-test1" rowspan=5></td>
+        <td id="rowspan-limit-test2" rowspan=0></td>
+        <td id="rowspan-limit-test3" rowspan=1000></td>
+        <td id="rowspan-limit-test4" rowspan=65534></td>
+        <td id="rowspan-limit-test5" rowspan=65535></td>
+        <td id="rowspan-limit-test6" rowspan=5555555></td>
+    </tr>
+</table>
+
 <script>
 var $ = document.querySelector.bind(document);
 
@@ -63,4 +74,34 @@ test(() => {
     assert_equals($("#d1").getBoundingClientRect().bottom,
                   $("#d2").getBoundingClientRect().bottom);
 }, "rowspan of 65535 must be treated as 65534");
+
+test(() => {
+    let td = document.createElement("td");
+    td.rowSpan = 5;
+    assert_equals(td.rowSpan, 5);
+
+    td.rowSpan = 0;
+    assert_equals(td.rowSpan, 0);
+
+    td.rowSpan = 1000;
+    assert_equals(td.rowSpan, 1000);
+
+    td.rowSpan = 65534;
+    assert_equals(td.rowSpan, 65534);
+
+    td.rowSpan = 65535;
+    assert_equals(td.rowSpan, 65534);
+
+    td.rowSpan = 555555;
+    assert_equals(td.rowSpan, 65534);
+}, "rowspan must be clamped to [0, 65534] when set via script");
+
+test(() => {
+    assert_equals(document.getElementById("rowspan-limit-test1").rowSpan, 5);
+    assert_equals(document.getElementById("rowspan-limit-test2").rowSpan, 0);
+    assert_equals(document.getElementById("rowspan-limit-test3").rowSpan, 1000);
+    assert_equals(document.getElementById("rowspan-limit-test4").rowSpan, 65534);
+    assert_equals(document.getElementById("rowspan-limit-test5").rowSpan, 65534);
+    assert_equals(document.getElementById("rowspan-limit-test6").rowSpan, 65534);
+}, "rowspan must be clamped to [0, 65534] when parsing attributes");
 </script>


### PR DESCRIPTION
Previously, spans were partially clamped during layout, but this means
that accessing and setting these properties via script wouldn't behave
according to the HTML specification. In addition, the value wasn't
floored in layout, so could lead to panics. This change improves
clamping and moves it to script.
    
Testing: This change includes a new WPT test.
Fixes #<!-- nolink -->36699.

Reviewed in servo/servo#36703