### PR TITLE
Check CSP for `javascript:` URLs

### DIFF
--- a/content-security-policy/unsafe-eval/eval-blocked-in-about-blank-iframe.html
+++ b/content-security-policy/unsafe-eval/eval-blocked-in-about-blank-iframe.html
@@ -19,18 +19,27 @@
     const document_loaded = new Promise(resolve => window.onload = resolve);
     await document_loaded;
 
-    const eval_error = new Promise(resolve => {
-      window.addEventListener('message', function(e) {
-        assert_not_equals(e.data, 'FAIL', 'eval was executed in the frame');
-        if (e.data === 'PASS')
-          resolve();
+    const eval_error = new Promise((resolve, reject) => {
+      window.addEventListener('message', function(event) {
+        try {
+          assert_not_equals(event.data, 'FAIL', 'eval was executed in the frame');
+          if (event.data === 'PASS') {
+            resolve();
+          }
+        } catch (e) {
+          reject(e);
+        }
       });
     });
-    const csp_violation_report = new Promise(resolve => {
-      window.addEventListener('message', function(e) {
-        if (e.data["violated-directive"]) {
-          assert_equals(e.data["violated-directive"], "script-src");
-          resolve();
+    const csp_violation_report = new Promise((resolve, reject) => {
+      window.addEventListener('message', function(event) {
+        try {
+          if (event.data["violated-directive"]) {
+            assert_equals(event.data["violated-directive"], "script-src");
+            resolve();
+          }
+        } catch (e) {
+          reject(e);
         }
       });
     });


### PR DESCRIPTION
Also update a WPT test to fail-fast if the iframe incorrectly
evaluates the `eval`. Before, it would run into a timeout if
the implementation is correct. Now we reject the promise
when an exception is thrown.

Requires servo/rust-content-security-policy#6

Reviewed in servo/servo#36709