### PR TITLE
Map to navigator.pdfViewerEnabled test to web-features

### DIFF
--- a/html/webappapis/system-state-and-capabilities/the-navigator-object/WEB_FEATURES.yml
+++ b/html/webappapis/system-state-and-capabilities/the-navigator-object/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: pdf-viewer
+  files:
+  - plugins-and-mimetypes.html


### PR DESCRIPTION
This tests both the property and the other changes to mimeTypes and
plugins that went along with its introduction. This technically tests
more than the feature, but it should all go together and all browsers
pass the test, so this seems fine.
