### PR TITLE
[wdspec] `browsingContext.userPrompt` iframe context ID

### DIFF
--- a/webdriver/tests/bidi/browsing_context/user_prompt_closed/user_prompt_closed.py
+++ b/webdriver/tests/bidi/browsing_context/user_prompt_closed/user_prompt_closed.py
@@ -318,7 +318,7 @@ async def test_iframe(
     event = await wait_for_future_safe(on_prompt_closed)
 
     assert event == {
-        "context": new_tab["context"],
+        "context": frame["context"],
         "accepted": True,
         "type": "alert",
     }

--- a/webdriver/tests/bidi/browsing_context/user_prompt_opened/user_prompt_opened.py
+++ b/webdriver/tests/bidi/browsing_context/user_prompt_opened/user_prompt_opened.py
@@ -197,7 +197,7 @@ async def test_iframe(
     event = await wait_for_future_safe(on_entry)
 
     assert event == {
-        "context": new_tab["context"],
+        "context": frame["context"],
         "type": "alert",
         "handler": "dismiss",
         "message": "in iframe",


### PR DESCRIPTION
The `browsingContext.userPromptOpened` and `browsingContext.userPromptClosed` events should point to the proper navigable when prompt is originated from a nested iframe.

[HTML spec](https://html.spec.whatwg.org/#dom-alert-noargs):
> The **alert()** and **alert(message)** method steps are:
> ...
> 5 Let userPromptHandler be [WebDriver BiDi user prompt opened](https://w3c.github.io/webdriver-bidi/#webdriver-bidi-user-prompt-opened) with [this](https://webidl.spec.whatwg.org/#this), "alert", and message.

`this` is an iFrame's window.

[BiDi spec](https://www.w3.org/TR/webdriver-bidi/#webdriver-bidi-user-prompt-opened):
> The [remote end event trigger](https://www.w3.org/TR/webdriver-bidi/#event-remote-end-event-trigger) is the WebDriver BiDi user prompt opened steps given **_window_**, ...
> 1 Let **_navigable_** be **_window’s_** [navigable](https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-navigable).
> 2 Let **_navigable id_** be the [navigable id](https://www.w3.org/TR/webdriver-bidi/#navigable-id) for **_navigable_**.
> ...
> 5 Let params be ...  with the _**context**_ field set to **_navigable id_** ...