### PR TITLE
Update scrollend tests to avoid using a frame based timeout

### DIFF
--- a/dom/events/scrolling/scroll_support.js
+++ b/dom/events/scrolling/scroll_support.js
@@ -105,10 +105,15 @@ async function waitForScrollReset(test, scroller, x = 0, y = 0) {
 
 async function createScrollendPromiseForTarget(test,
                                                target_div,
-                                               timeoutMs = 500) {
+                                               timeoutMs = 500,
+                                               targetIsRoot = false) {
   return waitForScrollendEvent(test, target_div, timeoutMs).then(evt => {
     assert_false(evt.cancelable, 'Event is not cancelable');
-    assert_false(evt.bubbles, 'Event targeting element does not bubble');
+    if (targetIsRoot) {
+      assert_true(evt.bubbles, 'Event targeting element does not bubble');
+    } else {
+      assert_false(evt.bubbles, 'Event targeting element does not bubble');
+    }
   });
 }
 

--- a/dom/events/scrolling/scrollend-event-fired-for-programmatic-scroll.html
+++ b/dom/events/scrolling/scrollend-event-fired-for-programmatic-scroll.html
@@ -39,20 +39,10 @@ html {
 </div>
 </body>
 <script>
-let element_scrollend_arrived = false;
-let document_scrollend_arrived = false;
+let invalid_scrollend_arrived = false;
 
-function onElementScrollEnd(event) {
-  assert_false(event.cancelable);
-  assert_false(event.bubbles);
-  element_scrollend_arrived = true;
-}
-
-function onDocumentScrollEnd(event) {
-  assert_false(event.cancelable);
-  // scrollend events are bubbled when the target node is document.
-  assert_true(event.bubbles);
-  document_scrollend_arrived = true;
+function onInvalidScrollEnd(event) {
+  invalid_scrollend_arrived = true;
 }
 
 let scroll_fn_variants = [
@@ -119,20 +109,20 @@ function runTest() {
   async function testScrollFn(testInfo, t) {
     await waitForCompositorCommit();
 
-    targetDiv.addEventListener("scrollend", onElementScrollEnd);
-    document.addEventListener("scrollend", onDocumentScrollEnd);
+    let scrollendPromise = null;
+    if (testInfo.target == document.scrollingElement) {
+      targetDiv.addEventListener("scrollend", onInvalidScrollEnd);
+      scrollendPromise = createScrollendPromiseForTarget(t, document, 700, true);
+    } else {
+      document.addEventListener("scrollend", onInvalidScrollEnd);
+      scrollendPromise = createScrollendPromiseForTarget(t, targetDiv, 700, false);
+    }
 
     testInfo.target[testInfo.fn]({ top: 200, left: 200,
                                    behavior: testInfo.behavior });
 
-    await waitFor(() => {
-      return element_scrollend_arrived || document_scrollend_arrived;
-    }, testInfo.target.tagName + "." + testInfo.fn + " did not receive scrollend event.");
-    if (testInfo.target == document.scrollingElement) {
-      assert_false(element_scrollend_arrived);
-    } else {
-      assert_false(document_scrollend_arrived);
-    }
+    await scrollendPromise;
+    assert_false(invalid_scrollend_arrived, "Scrollend should not fire to target that has not scrolled");
 
     assert_equals(testInfo.target.scrollLeft, 200,
                   testInfo.target.tagName + "." + testInfo.fn + " scrollLeft");

--- a/dom/events/scrolling/scrollend-event-fired-for-scroll-attr-change.html
+++ b/dom/events/scrolling/scrollend-event-fired-for-scroll-attr-change.html
@@ -39,20 +39,10 @@ html {
 </div>
 </body>
 <script>
-var element_scrollend_arrived = false;
-var document_scrollend_arrived = false;
+let invalid_scrollend_arrived = false;
 
-function onElementScrollEnd(event) {
-  assert_false(event.cancelable);
-  assert_false(event.bubbles);
-  element_scrollend_arrived = true;
-}
-
-function onDocumentScrollEnd(event) {
-  assert_false(event.cancelable);
-  // scrollend events are bubbled when the target node is document.
-  assert_true(event.bubbles);
-  document_scrollend_arrived = true;
+function onInvalidScrollEnd(event) {
+  invalid_scrollend_arrived = true;
 }
 
 let scroll_attr_change_variants = [
@@ -117,24 +107,24 @@ let scroll_attr_change_variants = [
 function runTest() {
 
   async function testScrollAttrChange(testInfo, t) {
-    targetDiv.addEventListener("scrollend", onElementScrollEnd);
-    document.addEventListener("scrollend", onDocumentScrollEnd);
-
     testInfo.target.style.scrollBehavior = testInfo.behavior;
 
     await waitForCompositorCommit();
 
+    let scrollendPromise = null;
+    if (testInfo.target == document.scrollingElement) {
+      targetDiv.addEventListener("scrollend", onInvalidScrollEnd);
+      scrollendPromise = createScrollendPromiseForTarget(t, document, 700, true);
+    } else {
+      document.addEventListener("scrollend", onInvalidScrollEnd);
+      scrollendPromise = createScrollendPromiseForTarget(t, targetDiv, 700, false);
+    }
+
     testInfo.target[testInfo.attribute] = 200;
 
-    await waitFor(() => {
-      return element_scrollend_arrived || document_scrollend_arrived;
-    }, testInfo.target.tagName + "." + testInfo.attribute + " did not receive scrollend event.");
+    await scrollendPromise;
+    assert_false(invalid_scrollend_arrived, "Scrollend should not fire to target that has not scrolled");
 
-    if (testInfo.target == document.scrollingElement) {
-      assert_false(element_scrollend_arrived);
-    } else {
-      assert_false(document_scrollend_arrived);
-    }
     assert_equals(testInfo.target[testInfo.attribute], 200,
                   testInfo.target.tagName + "." + testInfo.attribute + " " + testInfo.behavior);
   }


### PR DESCRIPTION
Update scrollend tests to avoid using waitFor(), which makes use of a frame based timeout.

Fixes: https://github.com/web-platform-tests/interop/issues/921