### PR TITLE
Fixup dialog-focusability test

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/dialog-focusability.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-focusability.html
@@ -48,11 +48,9 @@
     }
   }
 
-  async_test((t) => {
-    window.onload = async () => {
-      await assert_focus_order([before,within1,after1,dialog2,within2,after2,
-        within3,after3,dialog4,within4,after4]);
-      t.done();
-    };
+  promise_test(async () => {
+    await new Promise(resolve => window.onload = resolve);
+    await assert_focus_order([before,within1,after1,dialog2,within2,after2,
+      within3,after3,dialog4,within4,after4]);
   }, "The dialog element itself should not be keyboard focusable.");
 </script>


### PR DESCRIPTION
This test is Erroring out in both Firefox & Safari, without any immediate feedback. This is because the tests run inside the `window.onload` listener, which means any errors are uncaught in the test harness. Refactoring this to a `promise_test` and merely `await`ing the `onload` event resolves this.

https://wpt.fyi/results/html/semantics/interactive-elements/the-dialog-element/dialog-focusability.html

![a screenshot of the WPT url showing that Firefox & Safari both fail the test with "ERROR"](https://github.com/user-attachments/assets/859dc524-42b6-4fd0-9d55-3c7d3394a3ab)
