### PR TITLE
refactor dialog requestClose tests to wait for close event

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose.html
@@ -35,14 +35,8 @@ function openDialog(openMethod) {
   assert_true(dialog.matches(':open'));
   assert_equals(dialog.matches(':modal'),openMethod === 'modal');
 }
-function getSignal(t) {
-  const controller = new AbortController();
-  const signal = controller.signal;
-  t.add_cleanup(() => controller.abort());
-  return signal;
-}
 
-async function setup(t,closedby) {
+function setup(t,closedby) {
   t.add_cleanup(() => {
     dialog.close();
     dialog.removeAttribute('closedby');
@@ -52,16 +46,14 @@ async function setup(t,closedby) {
   if (closedby) {
     dialog.setAttribute('closedby',closedby);
   }
-  // Be sure any pending close events (from prior test cleanups) get fired.
-  await waitForRender();
-  return getSignal(t);
+  return t.get_signal();
 }
 
 ['modeless','modal','open'].forEach(openMethod => {
   [null,'any','closedrequest','none'].forEach(closedby => {
     const testDescription = `for ${openMethod} dialog with closedby=${closedby}`;
     promise_test(async (t) => {
-      await setup(t,closedby);
+      setup(t,closedby);
       openDialog(openMethod);
       dialog.requestClose();
       assert_false(dialog.open);
@@ -69,25 +61,35 @@ async function setup(t,closedby) {
     },`requestClose basic behavior ${testDescription}`);
 
     promise_test(async (t) => {
-      const signal = await setup(t,closedby);
+      const signal = setup(t,closedby);
       let events = [];
+      const { promise: untilFullyClosed, resolve: hasClosed } = Promise.withResolvers();
       dialog.addEventListener('cancel',() => events.push('cancel'),{signal});
-      dialog.addEventListener('close',() => events.push('close'),{signal});
+      dialog.addEventListener('close',() => {
+        events.push('close');
+        hasClosed();
+      },{signal});
       openDialog(openMethod);
       assert_array_equals(events,[]);
       dialog.requestClose();
       assert_false(dialog.open);
       assert_false(dialog.matches(':open'));
       assert_array_equals(events,['cancel'],'close is scheduled');
-      await waitForRender();
+      await untilFullyClosed;
       assert_array_equals(events,['cancel','close']);
     },`requestClose fires both cancel and close ${testDescription}`);
 
     promise_test(async (t) => {
-      const signal = await setup(t,'none');
+      const signal = setup(t,'none');
       let events = [];
+      const { promise: untilFullyClosed, resolve: hasClosed } = Promise.withResolvers();
+      const { promise: untilFullyClosedAgain, resolve: hasClosedAgain } = Promise.withResolvers();
+      const closeResolvers = [hasClosed, hasClosedAgain];
       dialog.addEventListener('cancel',() => events.push('cancel'),{signal});
-      dialog.addEventListener('close',() => events.push('close'),{signal});
+      dialog.addEventListener('close',() => {
+        events.push('close');
+        closeResolvers.shift()();
+      },{signal});
       openDialog(openMethod);
       dialog.setAttribute('closedby',closedby);
       assert_array_equals(events,[]);
@@ -95,6 +97,7 @@ async function setup(t,closedby) {
       assert_false(dialog.open,'Adding closedby after dialog is open');
       assert_false(dialog.matches(':open'));
       assert_array_equals(events,['cancel']);
+      await untilFullyClosed;
       events=[];
       openDialog(openMethod);
       dialog.removeAttribute('closedby');
@@ -102,11 +105,13 @@ async function setup(t,closedby) {
       dialog.requestClose();
       assert_false(dialog.open,'Removing closedby after dialog is open');
       assert_array_equals(events,['cancel']);
+      await untilFullyClosedAgain;
+      assert_array_equals(events,['cancel', 'close']);
     },`closedby has no effect on dialog.requestClose() ${testDescription}`);
 
     if (closedby != "none") {
       promise_test(async (t) => {
-        const signal = await setup(t,closedby);
+        const signal = setup(t,closedby);
         let shouldPreventDefault = true;
         dialog.addEventListener('cancel',(e) => {
           if (shouldPreventDefault) {
@@ -124,7 +129,7 @@ async function setup(t,closedby) {
       },`requestClose can be cancelled ${testDescription}`);
 
       promise_test(async (t) => {
-        const signal = await setup(t,closedby);
+        const signal = setup(t,closedby);
         dialog.addEventListener('cancel',(e) => e.preventDefault(),{signal});
         openDialog(openMethod);
         // No user activation here.
@@ -136,7 +141,7 @@ async function setup(t,closedby) {
       },`requestClose avoids abuse prevention logic ${testDescription}`);
 
       promise_test(async (t) => {
-        await setup(t,closedby);
+        setup(t,closedby);
         openDialog(openMethod);
         assert_equals(dialog.returnValue,'','Return value starts out empty');
         const returnValue = 'The return value';
@@ -153,7 +158,7 @@ async function setup(t,closedby) {
       },`requestClose(returnValue) passes along the return value ${testDescription}`);
 
       promise_test(async (t) => {
-        await setup(t,closedby);
+        setup(t,closedby);
         dialog.addEventListener('cancel',(e) => e.preventDefault(),{once:true});
         openDialog(openMethod);
         dialog.returnValue = 'foo';
@@ -168,23 +173,27 @@ async function setup(t,closedby) {
 });
 
 promise_test(async (t) => {
-  await setup(t);
+  setup(t);
   dialog.open = true;
   dialog.requestClose();
   assert_false(dialog.open);
 },`requestClose basic behavior when dialog is open via attribute`);
 
 promise_test(async (t) => {
-  const signal = await setup(t);
+  const signal = setup(t);
   let events = [];
+  const { promise: untilFullyClosed, resolve: hasClosed } = Promise.withResolvers();
   dialog.addEventListener('cancel',() => events.push('cancel'),{signal});
-  dialog.addEventListener('close',() => events.push('close'),{signal});
+  dialog.addEventListener('close',() => {
+    events.push('close')
+    hasClosed();
+  },{signal});
   dialog.open = true;
   assert_array_equals(events,[]);
   dialog.requestClose();
   assert_false(dialog.open);
   assert_array_equals(events,['cancel'],'close is scheduled');
-  await waitForRender();
+  await untilFullyClosed;
   assert_array_equals(events,['cancel','close']);
 },`requestClose fires cancel and close when dialog is open via attribute`);
 


### PR DESCRIPTION
The dialog `requestClose` tests used a `requestAnimationFrame` to check when a `close` event had been dispatched.

While implementing this in Firefox, I noticed that this was a little flakey. So in #52132 I opted for a simple solution of swapping out `requestAnimationFrame` to `step_timeout`. This resolved some flakes in gecko's CI, but _introduced_ flakes in chrome's CI. In #52185 @mfreed7 fixed the flakes by introducing a _double_ `requestAnimationFrame` call. This sadly did not fully resolve flakes.

The flakes come in two flavours: the double rAF sometimes resolves too quickly, meaning the `close` event is never dispatched, or it resolves too slowly, meaning sometimes the _next_ test kicks in and causes code to fire a second `close` event, which the tests then assert on as two `close` events is too many!

Instead of waiting for `requestAnimationFrame` or any other timeout, I've refactored these tests to await on a Promise for the `close` event. This means these tests will wait an indefinite amount of time _until_ the close event has fired.

On the downside, this means the tests will take a lot longer (they will timeout) if they fail to dispatch the event. On the plus side, this means they're way more stable, as they're not relying on side-effectful timing and instead awaiting for the true events.