### PR TITLE
layout: consider scroll offset in getClientRect queries

### DIFF
--- a/css/css-position/sticky/position-sticky-transforms.html
+++ b/css/css-position/sticky/position-sticky-transforms.html
@@ -14,7 +14,9 @@
 test(() => {
   const elements = setupStickyTest('top', 50);
   elements.sticky.style.transform = 'scale(2)';
-  elements.scroller.scrollTop = 200;
+  // We will scroll halfway through the sticky element, this will reduce
+  // false positive if an UA is not considering transform yet.
+  elements.scroller.scrollTop = 175;
 
   // Transforms don't affect offsetTop, so use getBoundingClientRect.
   // Scaling the sticky element by 2 means its top-y moves (1/2 * height)

--- a/css/cssom-view/getBoundingClientRect-scroll.html
+++ b/css/cssom-view/getBoundingClientRect-scroll.html
@@ -2,8 +2,8 @@
 <title>getBoundingClientRect for a element inside scroll container</title>
 <link rel="author" title="Jo Steven Novaryo" href="mailto:steven.novaryo@gmail.com">
 <link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-getboundingclientrect">
-<script src="https://wpt.live/resources/testharness.js"></script>
-<script src="https://wpt.live/resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <html>
   <head>
     <style>
@@ -43,7 +43,9 @@
     <div class="scroll_container fixed_containing_block">
       <div class="scroll_container absolute_containing_block">
         <div class="scroll_container">
-          <div class="target_box"></div>
+          <div id="target_static" class="target_box"></div>
+          <div id="target_absolute" class="target_box position_absolute"></div>
+          <div id="target_fixed" class="target_box position_fixed"></div>
           <div class="dummy_overflowing_box"></div>
         </div>
         <div class="dummy_overflowing_box"></div>
@@ -62,8 +64,8 @@
           scroll_container.scrollTo(offset_left, offset_top)
         }
       });
-      var target = document.querySelector('.target_box');
       test(function() {
+        var target = document.querySelector('#target_static');
         let staticRect = target.getBoundingClientRect();
         assert_equals(staticRect.left, -85, 'static positioned target left');
         assert_equals(staticRect.top, -170, 'static positioned target top');
@@ -71,7 +73,7 @@
         assert_equals(staticRect.height, 100, 'static positioned target height');
       }, "getBoundingClientRect for element inside scroll container");
       test(function() {
-        target.style.position = 'absolute';
+        var target = document.querySelector('#target_absolute');
         let absoluteRect = target.getBoundingClientRect();
         assert_equals(absoluteRect.left, -21, 'absolute positioned target left');
         assert_equals(absoluteRect.top, -42, 'absolute positioned target top');
@@ -79,7 +81,7 @@
         assert_equals(absoluteRect.height, 100, 'absolute positioned target height');
       }, "getBoundingClientRect for absolute element inside scroll container");
       test(function() {
-        target.style.position = 'fixed';
+        var target = document.querySelector('#target_fixed');
         let fixedRect = target.getBoundingClientRect();
         assert_equals(fixedRect.left, -5, 'fixed positioned target left');
         assert_equals(fixedRect.top, -10, 'fixed positioned target top');

--- a/css/cssom-view/getBoundingClientRect-scroll.html
+++ b/css/cssom-view/getBoundingClientRect-scroll.html
@@ -40,12 +40,13 @@
     </style>
   </head>
   <body>
+    <div id="target_fixed_uncontained" class="target_box position_fixed"></div>
     <div class="scroll_container fixed_containing_block">
       <div class="scroll_container absolute_containing_block">
         <div class="scroll_container">
-          <div id="target_static" class="target_box"></div>
-          <div id="target_absolute" class="target_box position_absolute"></div>
           <div id="target_fixed" class="target_box position_fixed"></div>
+          <div id="target_absolute" class="target_box position_absolute"></div>
+          <div id="target_static" class="target_box"></div>
           <div class="dummy_overflowing_box"></div>
         </div>
         <div class="dummy_overflowing_box"></div>
@@ -88,6 +89,14 @@
         assert_equals(fixedRect.width, 100, 'fixed positioned target width');
         assert_equals(fixedRect.height, 100, 'fixed positioned target height');
       }, "getBoundingClientRect for fixed element inside scroll container");
+      test(function() {
+        var target = document.querySelector('#target_fixed_uncontained');
+        let fixedUncontainedRect = target.getBoundingClientRect();
+        assert_equals(fixedUncontainedRect.left, 0, 'fixed positioned uncontained target left');
+        assert_equals(fixedUncontainedRect.top, 0, 'fixed positioned uncontained target top');
+        assert_equals(fixedUncontainedRect.width, 100, 'fixed positioned uncontained target width');
+        assert_equals(fixedUncontainedRect.height, 100, 'fixed positioned uncontained target height');
+      }, "getBoundingClientRect for uncontained fixed element");
     </script>
   </body>
 </html>

--- a/css/cssom-view/getBoundingClientRect-scroll.html
+++ b/css/cssom-view/getBoundingClientRect-scroll.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<title>getBoundingClientRect for a element inside scroll container</title>
+<link rel="author" title="Jo Steven Novaryo" href="mailto:steven.novaryo@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-getboundingclientrect">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<html>
+  <head>
+    <style>
+      body {
+        margin: 0;
+      }
+      .scroll_container {
+        width: 300px;
+        height: 300px;
+        overflow: scroll;
+        scrollbar-width: none;
+      }
+      .dummy_overflowing_box {
+        width: 1000px;
+        height: 1000px;
+      }
+      .target_box {
+        width: 100px;
+        height: 100px;
+        background-color: green;
+      }
+      .position_absolute {
+        position: absolute;
+      }
+      .position_fixed {
+        position: fixed;
+      }
+      .absolute_containing_block {
+        position: relative;
+      }
+      .fixed_containing_block {
+        will-change: transform;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="scroll_container fixed_containing_block">
+      <div class="scroll_container absolute_containing_block">
+        <div class="scroll_container">
+          <div class="target_box"></div>
+          <div class="dummy_overflowing_box"></div>
+        </div>
+        <div class="dummy_overflowing_box"></div>
+      </div>
+      <div class="dummy_overflowing_box"></div>
+    </div>
+    <script>
+      setup(() => {
+        var offset_left = 1;
+        var offset_top = 2;
+        for (scroll_container of document.getElementsByClassName('scroll_container')) {
+          offset_left *= 4;
+          offset_top *= 4;
+          scroll_container.scrollBy(offset_left, offset_top)
+        }
+      });
+      var target = document.querySelector('.target_box');
+      test(function() {
+        let staticRect = target.getBoundingClientRect();
+        assert_equals(staticRect.left, -84, 'static positioned target left');
+        assert_equals(staticRect.top, -168, 'static positioned target top');
+        assert_equals(staticRect.width, 100, 'static positioned target width');
+        assert_equals(staticRect.height, 100, 'static positioned target height');
+      }, "getBoundingClientRect for element inside scroll container");
+      test(function() {
+        target.style.position = 'absolute';
+        let absoluteRect = target.getBoundingClientRect();
+        assert_equals(absoluteRect.left, -20, 'absolute positioned target left');
+        assert_equals(absoluteRect.top, -40, 'absolute positioned target top');
+        assert_equals(absoluteRect.width, 100, 'absolute positioned target width');
+        assert_equals(absoluteRect.height, 100, 'absolute positioned target height');
+      }, "getBoundingClientRect for absolute element inside scroll container");
+      test(function() {
+        target.style.position = 'fixed';
+        let fixedRect = target.getBoundingClientRect();
+        assert_equals(fixedRect.left, -4, 'fixed positioned target left');
+        assert_equals(fixedRect.top, -8, 'fixed positioned target top');
+        assert_equals(fixedRect.width, 100, 'fixed positioned target width');
+        assert_equals(fixedRect.height, 100, 'fixed positioned target height');
+      }, "getBoundingClientRect for fixed element inside scroll container");
+    </script>
+  </body>
+</html>

--- a/css/cssom-view/getBoundingClientRect-scroll.html
+++ b/css/cssom-view/getBoundingClientRect-scroll.html
@@ -2,8 +2,8 @@
 <title>getBoundingClientRect for a element inside scroll container</title>
 <link rel="author" title="Jo Steven Novaryo" href="mailto:steven.novaryo@gmail.com">
 <link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-getboundingclientrect">
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
+<script src="https://wpt.live/resources/testharness.js"></script>
+<script src="https://wpt.live/resources/testharnessreport.js"></script>
 <html>
   <head>
     <style>
@@ -17,8 +17,8 @@
         scrollbar-width: none;
       }
       .dummy_overflowing_box {
-        width: 1000px;
-        height: 1000px;
+        width: 5000px;
+        height: 5000px;
       }
       .target_box {
         width: 100px;
@@ -50,37 +50,39 @@
       </div>
       <div class="dummy_overflowing_box"></div>
     </div>
+    <div id="log" class="dummy_overflowing_box"></div>
     <script>
       setup(() => {
         var offset_left = 1;
         var offset_top = 2;
+        window.scrollTo(offset_left, offset_top);
         for (scroll_container of document.getElementsByClassName('scroll_container')) {
           offset_left *= 4;
           offset_top *= 4;
-          scroll_container.scrollBy(offset_left, offset_top)
+          scroll_container.scrollTo(offset_left, offset_top)
         }
       });
       var target = document.querySelector('.target_box');
       test(function() {
         let staticRect = target.getBoundingClientRect();
-        assert_equals(staticRect.left, -84, 'static positioned target left');
-        assert_equals(staticRect.top, -168, 'static positioned target top');
+        assert_equals(staticRect.left, -85, 'static positioned target left');
+        assert_equals(staticRect.top, -170, 'static positioned target top');
         assert_equals(staticRect.width, 100, 'static positioned target width');
         assert_equals(staticRect.height, 100, 'static positioned target height');
       }, "getBoundingClientRect for element inside scroll container");
       test(function() {
         target.style.position = 'absolute';
         let absoluteRect = target.getBoundingClientRect();
-        assert_equals(absoluteRect.left, -20, 'absolute positioned target left');
-        assert_equals(absoluteRect.top, -40, 'absolute positioned target top');
+        assert_equals(absoluteRect.left, -21, 'absolute positioned target left');
+        assert_equals(absoluteRect.top, -42, 'absolute positioned target top');
         assert_equals(absoluteRect.width, 100, 'absolute positioned target width');
         assert_equals(absoluteRect.height, 100, 'absolute positioned target height');
       }, "getBoundingClientRect for absolute element inside scroll container");
       test(function() {
         target.style.position = 'fixed';
         let fixedRect = target.getBoundingClientRect();
-        assert_equals(fixedRect.left, -4, 'fixed positioned target left');
-        assert_equals(fixedRect.top, -8, 'fixed positioned target top');
+        assert_equals(fixedRect.left, -5, 'fixed positioned target left');
+        assert_equals(fixedRect.top, -10, 'fixed positioned target top');
         assert_equals(fixedRect.width, 100, 'fixed positioned target width');
         assert_equals(fixedRect.height, 100, 'fixed positioned target height');
       }, "getBoundingClientRect for fixed element inside scroll container");


### PR DESCRIPTION
Element's getClientRects are supposed to consider scroll offset of its scrollable ancestors. This will allow more of JS API to work properly. For example, we would be able to better handle several common use cases for IntersectionObserver.

This is the updated version of #<!-- nolink -->35798, due to the recent incremental layout changes, we are now able to get the fragment and walk up to the root. These changes serve as the first step of adding proper bounding box related queries that handle transform and/or clipping.

Testing: Existing and new WPT Coverage
Fixes:  #<!-- nolink -->35768
Reviewed in servo/servo#36745