### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=288819

### DIFF
--- a/css/css-grid/grid-definition/grid-auto-fit-with-calc.html
+++ b/css/css-grid/grid-definition/grid-auto-fit-with-calc.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#auto-repeat">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<style>
+  .grid {
+    display: grid;
+    width: 100px;
+    grid-template-columns: repeat(auto-fit, minmax(calc(100% - 10px), calc(100% - 100px)));
+    background-color: green;
+  }
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="grid">
+  <div style="height: 50px;"></div>
+  <div style="height: 50px;"></div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [\[css-grid\] `ASSERT(!isCalculated())` in `Length::value()` is hit under `RenderGrid::computeAutoRepeatTracksCount()` when loading https://kizu.dev/position-driven-styles/](https://bugs.webkit.org/show_bug.cgi?id=288819)