### PR TITLE
layout: Simplify `PositioningContext` by having it hold a single `Vec`

### DIFF
--- a/css/css-grid/abspos/abspos-in-flexbox-in-grid-crash.html
+++ b/css/css-grid/abspos/abspos-in-flexbox-in-grid-crash.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/36696">
+
+<div style="display: flex; position: relative">
+  <div style="display:grid">
+    <div>
+      <div style="display: flex">
+        <div style="position: absolute"></div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
`PositioningContext` held two vectors, one inside an `Option`, to
differentiate between the version used for a containing block for all
descendants (including `position: absolute` and `position: fixed`) or
only for `position: absolute` descendants. This distinction was really
hard to reason about and required a lot of bookkeeping about what kind
of `PositioningContext` a layout box's parent expected. In addition, it
led to a lot of mistakes.

This change simplifies things so that `PositioningContext` only holds a
single vector. When it comes time to lay out hoisted absolutely positioned
fragments, the code then:
 - lays out all of them (in the case of a `PositioningContext` for all
   descendants), or
 - only lays out the `position: absolute` descendants and preserves the
   `position: fixed` descendants (in the case the `PositioningContext`
   is only for `position: absolute`.), or
- lays out none of them if the `PositioningContext` was created for
  box that did not establish a containing block for absolutes.

It's possible that this way of dealing with hoisted absolutes is a bit
less efficient, but, the number of these descendants is typically quite
small, so it should not be significant. In addition, this decreases the
size in memory of all `PositioningContexts` which are created in more
situations as time goes on.

Testing: There is a new WPT test with this change.
Fixes: #<!-- nolink -->36696.

Reviewed in servo/servo#36795