### PR TITLE
Fix a test to declare line-height with Ahem.

### DIFF
--- a/css/css-align/abspos/align-self-static-position-005-ref.html
+++ b/css/css-align/abspos/align-self-static-position-005-ref.html
@@ -14,7 +14,7 @@
 }
 </style>
 <div class="container">
-  <span style="font: 20px Ahem;">hello
+  <span style="font: 20px/1 Ahem;">hello
     <span class="abs">hello</span>
     <span style="vertical-align: top; font-size: 50px;">world</span>
   </span>

--- a/css/css-align/abspos/align-self-static-position-005.html
+++ b/css/css-align/abspos/align-self-static-position-005.html
@@ -22,7 +22,7 @@
 }
 </style>
 <div class="container">
-  <span style="font: 20px Ahem;">hello
+  <span style="font: 20px/1 Ahem;">hello
     <span class="abs">hello</span>
     <span style="vertical-align: top; font-size: 50px;">world</span>
   </span>


### PR DESCRIPTION
This fixes the test align-self-static-position-005.html and its reference from recent PR https://github.com/web-platform-tests/wpt/pull/52260 to declare a line-height of `1` when specifying the Ahem font, per best practices at https://web-platform-tests.org/writing-tests/ahem.html

Per that documentation: when using Ahem in a WPT, "An explicit (i.e., not normal) line-height should also always be used")

This is needed in order for the test to pass in Firefox, since Gecko uses a larger-than-1 value as the "normal" line-height for Ahem.)