### PR TITLE
Misc cleanup to WPT getBoundingClientRect-newline.html

### DIFF
--- a/css/cssom-view/getBoundingClientRect-newline.html
+++ b/css/cssom-view/getBoundingClientRect-newline.html
@@ -5,17 +5,14 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>
-div {
+div[contenteditable] {
   white-space: pre;
-  font-family: Ahem;
-  font-size: 10px;
-  line-height: 1;
+  font: 10px/1 Ahem;
   width: 10ch;
 }
 </style>
 <body>
 <div contenteditable></div>
-</body>
 <script>
 function getBoundingClientRect(node, offset) {
   const range = document.createRange();
@@ -37,3 +34,4 @@ test(function() {
   assert_less_than(rect6.y, rect7.y);
 }, 'Range.getBoundingClientRect() should return the first position of the next line when the collapsed range is a newline character');
 </script>
+</body>


### PR DESCRIPTION
This fixes several issues with getBoundingClientRect-newline.html (which was recently added in https://github.com/web-platform-tests/wpt/pull/51929 )

The main issue was that the test's `div {...}` style was inadvertently targeting the dynamically appended test results, which made the results impossible to read.  This patch makes that selector targeted to the single div that it's meant to affect.

While we're at it, this patch also:
* combines the `Ahem` styles to use the 'font' shorthand, per recommendation "the font shorthand should normally be used" at
https://web-platform-tests.org/writing-tests/ahem.html
* moves the trailing <script> tag to be inside the <body> rather than after it, which is necessary for the test to validate (show up properly in view-source without red-squiggly-underlines).