### PR TITLE
Implement Trusted types document write sinks

### DIFF
--- a/trusted-types/block-string-assignment-to-Document-write.html
+++ b/trusted-types/block-string-assignment-to-Document-write.html
@@ -124,6 +124,9 @@
                 assert_equals(sink, "Document write");
               } else if (html === "assertSinkEqualsDocumentWriteLn") {
                 assert_equals(sink, "Document writeln");
+              } else if (html === "assertSinkEqualsDocumentWriteLn\n") {
+                // Ensure that new line characters aren't incorrectly added prior to processing
+                assert_unreached(`Should not process any other HTML, but got "${html}"`);
               }
 
               return html.replace("Hi", "Quack")


### PR DESCRIPTION
Implements the Document.write algorithm covering
Trusted HTML.

Part of #<!-- nolink -->36258

Signed-off-by: Tim van der Lippe <tvanderlippe@gmail.com>
Reviewed in servo/servo#36824