### PR TITLE
Append to existing CSP list in Document::set_csp_list

### DIFF
--- a/content-security-policy/meta/meta-append-header.html
+++ b/content-security-policy/meta/meta-append-header.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta http-equiv="Content-Security-Policy" content="img-src 'none'">
+<script nonce="abc" src="/resources/testharness.js"></script>
+<script nonce="abc" src="/resources/testharnessreport.js"></script>
+
+<body>
+  <script nonce="abc">
+    promise_test(t => {
+      return new Promise((resolve, reject) => {
+        const img = document.createElement("img");
+        img.src = "/content-security-policy/support/fail.png";
+
+        img.onload = () => reject("Image loaded unexpectedly");
+        img.onerror = (e) => resolve()
+
+        document.body.appendChild(img);
+      });
+    }, "dynamic img-src is blocked by meta CSP");
+
+    promise_test(t => {
+      return new Promise((resolve, reject) => {
+        const script = document.createElement("script");
+        script.src = "../resources/ran.js";
+
+        script.onload = () => reject("Script executed unexpectedly");
+        script.onerror = () => resolve();
+
+        document.body.appendChild(script);
+      });
+    }, "script without `abc` nonce is blocked by header CSP");
+  </script>
+</body>

--- a/content-security-policy/meta/meta-append-header.html.headers
+++ b/content-security-policy/meta/meta-append-header.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: script-src 'nonce-abc'

--- a/content-security-policy/meta/meta-multiple-csp.html
+++ b/content-security-policy/meta/meta-multiple-csp.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta http-equiv="Content-Security-Policy" content="script-src 'nonce-abc'">
+<meta http-equiv="Content-Security-Policy" content="img-src 'none'">
+<script nonce="abc" src="/resources/testharness.js"></script>
+<script nonce="abc" src="/resources/testharnessreport.js"></script>
+
+<body>
+  <script nonce="abc">
+    promise_test(t => {
+      return new Promise((resolve, reject) => {
+        const img = document.createElement("img");
+        img.src = "/content-security-policy/support/fail.png";
+
+        img.onload = () => reject("Image loaded unexpectedly");
+        img.onerror = (e) => resolve()
+
+        document.body.appendChild(img);
+      });
+    }, "dynamic img-src is blocked by meta CSP");
+
+    promise_test(t => {
+      return new Promise((resolve, reject) => {
+        const script = document.createElement("script");
+        script.src = "../resources/ran.js";
+
+        script.onload = () => reject("Script executed unexpectedly");
+        script.onerror = () => resolve();
+
+        document.body.appendChild(script);
+      });
+    }, "script without `abc` nonce is blocked by meta CSP");
+  </script>
+</body>


### PR DESCRIPTION
The `Document::set_csp_list` method now appends new policies to any
existing `CspList` rather than replacing it. This ensures that CSPs
from multiple sources (e.g., HTTP headers and `<meta>` tags) are
merged as expected, following the spec.

This change avoids silently discarding header-defined policies when
a `<meta http-equiv="Content-Security-Policy">` is present in the
document.

Reviewed in servo/servo#36828