### PR TITLE
Serialize attribute nodes as the empty string

### DIFF
--- a/domparsing/XMLSerializer-serializeToString.html
+++ b/domparsing/XMLSerializer-serializeToString.html
@@ -256,6 +256,10 @@ test(function () {
   root.setAttributeNS(XMLNS_URI, 'xmlns:foo', '');
   assert_equals(serialize(root), '<root xmlns="" xmlns:foo=""/>');
 }, 'Check if a prefix bound to an empty namespace URI ("no namespace") serialize');
+
+test(function() {
+  assert_equals(serialize(document.createAttribute("foobar")), "")
+}, 'Attribute nodes are serialized as the empty string')
 </script>
  </body>
 </html>


### PR DESCRIPTION
The existing code asserts that attribute nodes are never serialized. This is wrong, because you can pass an attribute node to `XMLSerializer::serializeToString`. Instead, the spec mandates that these are serialized as empty strings (https://w3c.github.io/DOM-Parsing/#dfn-xml-serialization-algorithm).

Testing: Includes a new web platform test
Fixes: https://github.com/servo/servo/issues/36872

Reviewed in servo/servo#36875