### PR TITLE
Add a test for hit testing to affect elements with 'opacity: 0'

### DIFF
--- a/css/filter-effects/css-filters-opacity-hit-testing.html
+++ b/css/filter-effects/css-filters-opacity-hit-testing.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>Elements with 'opacity: 0' should respond to hit testing.</title>
+<link rel="author" title="Psychpsyo" href="psychpsyo@gmail.com">
+<link rel="help" href="https://drafts.fxtf.org/filter-effects/#FilterProperty">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  div {
+    width: 100px;
+    height: 100px;
+    opacity: 0;
+  }
+</style>
+<div></div>
+<script>
+  test(() => {
+    assert_equals(document.elementFromPoint(50, 50).tagName, "DIV", "element with 'opacity: 0' doesn't respond to hit testing");
+  });
+</script>


### PR DESCRIPTION
Added this over in the Ladybird Browser, which did not handle this correctly: https://github.com/LadybirdBrowser/ladybird/pull/4629
From what I can tell, this case is currently not covered.