### PR TITLE
Correct event_target for CSP violations

### DIFF
--- a/content-security-policy/img-src/icon-blocked.sub.html
+++ b/content-security-policy/img-src/icon-blocked.sub.html
@@ -12,6 +12,7 @@
     var t_spv = async_test("Test that spv event is fired");
     window.addEventListener("securitypolicyviolation", t_spv.step_func_done(function(e) {
       assert_equals(e.violatedDirective, 'img-src');
+      assert_equals(e.target, document);
       assert_true(e.blockedURI.endsWith('/support/fail.png'));
     }));
 

--- a/content-security-policy/img-src/img-src-targeting.html
+++ b/content-security-policy/img-src/img-src-targeting.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="Content-Security-Policy" content="img-src 'none';">
+  <script src='/resources/testharness.js'></script>
+  <script src='/resources/testharnessreport.js'></script>
+</head>
+<body>
+<p>Check that img-src sets correct target</p>
+  <script>
+    var t = async_test("Test that image does not load");
+    var t_spv = async_test("Test that spv event is fired");
+    window.addEventListener("securitypolicyviolation", t_spv.step_func_done(function(e) {
+      assert_equals(e.violatedDirective, 'img-src');
+      assert_equals(e.target, document);
+      assert_true(e.blockedURI.endsWith('/support/fail.png'));
+    }));
+  </script>
+  <img src='/content-security-policy/support/fail.png'
+       onload='t.step(function() { assert_unreached("Image should not have loaded"); t.done(); });'
+       onerror='t.done();'>
+</body>
+
+</html>


### PR DESCRIPTION
All logic is implemented in `report_csp_violations` to avoid
pulling in various element-logic into SecurityManager.

Update the `icon-blocked.sub.html` WPT test to ensure that
the document is the correct target (verified in Firefox and Chrome).

Fixes #<!-- nolink -->36806

Reviewed in servo/servo#36887