### PR TITLE
Download Firefox profiles from GitHub

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1,4 +1,6 @@
 # mypy: allow-untyped-defs
+import configparser
+import json
 import os
 import platform
 import re
@@ -9,7 +11,7 @@ import tempfile
 from abc import ABCMeta, abstractmethod
 from datetime import datetime, timedelta, timezone
 from shutil import which
-from typing import Optional
+from typing import Any, Dict, Optional, Tuple
 from urllib.parse import urlsplit, quote
 
 import html5lib
@@ -79,6 +81,11 @@ def get_taskcluster_artifact(index, path):
     resp.raise_for_status()
 
     return resp
+
+
+def get_file_github(repo: str, ref: str, path: str) -> bytes:
+    data: bytes = get(f"https://raw.githubusercontent.com/{repo}/{ref}/{path}").content  # type: ignore
+    return data
 
 
 class Browser:
@@ -359,43 +366,134 @@ class Firefox(Browser):
     def find_webdriver(self, venv_path=None, channel=None):
         return which("geckodriver")
 
-    def get_version_and_channel(self, binary):
-        version_string = call(binary, "--version").strip()
-        m = re.match(r"Mozilla Firefox (\d+\.\d+(?:\.\d+)?)(a|b)?", version_string)
+    def extract_version_number(self, version_string: str) -> Tuple[Optional[str], str]:
+        version_parser = re.compile(r"^(\d+)\.(\d+)(?:\.(\d+))?((a|b)\d+)?")
+        m = version_parser.match(version_string)
         if not m:
             return None, "nightly"
-        version, status = m.groups()
-        channel = {"a": "nightly", "b": "beta"}
-        return version, channel.get(status, "stable")
+        major, minor, patch, pre, channel_id = m.groups()
+        version = f"{major}.{minor}"
+        if patch is not None:
+            version += f".{patch}"
+        if pre is not None:
+            version += pre
+        channel = {"a": "nightly", "b": "beta"}.get(channel_id, "stable")
+        return version, channel
 
-    def get_profile_bundle_url(self, version, channel):
+    def get_version_and_channel(self, binary: str) -> Tuple[Optional[str], str, Optional[str]]:
+        application_ini_path = os.path.join(os.path.dirname(binary), "application.ini")
+        if os.path.exists(application_ini_path):
+            try:
+                return self.get_version_and_channel_application_ini(application_ini_path)
+            except ValueError as e:
+                self.logger.info(f"Reading application ini file failed: {e}")
+                # Fall back to calling the binary
+        version_string: str = call(binary, "--version").strip()  # type: ignore
+        version_re = re.compile(r"Mozilla Firefox (.*)")
+        m = version_re.match(version_string)
+        if not m:
+            return None, "nightly", None
+        version, channel = self.extract_version_number(m.group(1))
+        return version, channel, None
+
+    def get_version_and_channel_application_ini(self, path: str) -> Tuple[Optional[str], str, Optional[str]]:
+        """Try to read application version from an ini file
+
+        This doesn't work in all cases e.g. local builds don't have
+        all the information, or builds where the binary path is a shell
+        script or similar."""
+        config = configparser.ConfigParser()
+        paths = config.read(path)
+        if path not in paths:
+            raise ValueError("Failed to read config file")
+
+        version = config.get("App", "Version", fallback=None)
+        if version is None:
+            raise ValueError("Failed to find Version key")
+        version, channel = self.extract_version_number(version)
+
+        rev = None
+        if channel == "nightly":
+            source_repo = config.get("App", "SourceRepository", fallback=None)
+            commit = config.get("App", "SourceStamp", fallback=None)
+            if source_repo is not None and commit is not None:
+                if source_repo.startswith("https://hg.mozilla.org"):
+                    try:
+                        commit_data: Dict[str, Any] = get(
+                            f"https://hg-edge.mozilla.org/integration/autoland/json-rev/{commit}"
+                        ).json()  # type: ignore
+                        rev = commit_data.get("git_commit")
+                    except Exception:
+                        pass
+                else:
+                    rev = commit
+
+        return version, channel, rev
+
+    def get_git_ref(self, version: str, channel: str, rev: Optional[str]) -> str:
+        if rev is not None:
+            return rev
+
         if channel == "stable":
-            repo = "https://hg.mozilla.org/releases/mozilla-release"
-            tag = "FIREFOX_%s_RELEASE" % version.replace(".", "_")
-        elif channel == "beta":
-            repo = "https://hg.mozilla.org/releases/mozilla-beta"
-            major_version = version.split(".", 1)[0]
-            # For beta we have a different format for betas that are now in stable releases
-            # vs those that are not
-            tags = get("https://hg.mozilla.org/releases/mozilla-beta/json-tags").json()["tags"]
-            tags = {item["tag"] for item in tags}
-            end_tag = "FIREFOX_BETA_%s_END" % major_version
-            if end_tag in tags:
-                tag = end_tag
-            else:
-                tag = "tip"
-        else:
-            repo = "https://hg.mozilla.org/mozilla-central"
-            # Always use tip as the tag for nightly; this isn't quite right
-            # but to do better we need the actual build revision, which we
-            # can get if we have an application.ini file
-            tag = "tip"
+            return "FIREFOX_%s_RELEASE" % version.replace(".", "_")
 
-        return "%s/archive/%s.zip/testing/profiles/" % (repo, tag)
+        if channel == "beta":
+            ref_prefix = "FIREFOX_%s" % version.replace(".", "_")
+            tags = []
+            build_re = re.compile(fr"{ref_prefix}_BUILD(\d)+")
+            for tag_data in get(
+                    f"https://api.github.com/repos/mozilla-firefox/firefox/git/matching-refs/tags/{ref_prefix}"
+            ).json():  # type: ignore
+                tag = tag_data["ref"].rsplit("/", 1)[1]
+                if tag.endswith("_RELEASE"):
+                    tags = [(0, tag)]
+                    break
+                m = build_re.match(tag)
+                if m:
+                    tags.append((int(m.group(1)), tag))
+            tags.sort()
+            if not tags:
+                raise ValueError(f"No tag found for {version} beta")
+            return f"{tags[-1][1]}"
+
+        return "main"
+
+    def get_profile_github(self, version: str, channel: str, dest: str, rev: Optional[str]) -> None:
+        """Read the testing/profiles data from firefox source on GitHub"""
+
+        # There are several possible approaches here, none of which are great:
+        # 1. Shallow, sparse, clone of the repo with no history and just the testing/profiles
+        #    directory. This is too slow to be usable.
+        # 2. Use the Github repository contents API to read all the files under that directory.
+        #    This requires auth to not run into rate limits.
+        # 3. Gitub tree API has basically the same problems
+        # 4. Download a full archive of the relevant commit from Github and extract only the
+        #    required directory. This is also too slow to be useful.
+        #
+        # In the end we use githubusercontent.com, which has the problem that it doesn't allow
+        # directory listings. So we have to hardcode in all the files we need. In particular
+        # for each profile we are currently just downloading the user.js file and ignoring the
+        # extensions/ directory, which is currently unused.
+        ref = self.get_git_ref(version, channel, rev)
+        file_data = {}
+        profiles_bytes = get_file_github("mozilla-firefox/firefox", ref, "testing/profiles/profiles.json")
+        profiles = json.loads(profiles_bytes)
+        file_data["profiles.json"] = profiles_bytes
+        for subdir in profiles["web-platform-tests"]:
+            rel_path = os.path.join(subdir, "user.js")
+            file_data[rel_path] = get_file_github("mozilla-firefox/firefox",
+                                                  ref,
+                                                  f"testing/profiles/{subdir}/user.js")
+
+        for path, data in file_data.items():
+            dest_path = os.path.join(dest, path)
+            os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+            with open(dest_path, "wb") as f:
+                f.write(data)
 
     def install_prefs(self, binary, dest=None, channel=None):
         if binary and not binary.endswith(".apk"):
-            version, channel_ = self.get_version_and_channel(binary)
+            version, channel_, rev = self.get_version_and_channel(binary)
             if channel is not None and channel != channel_:
                 # Beta doesn't always seem to have the b in the version string, so allow the
                 # manually supplied value to override the one from the binary
@@ -408,7 +506,7 @@ class Firefox(Browser):
         if dest is None:
             dest = os.curdir
 
-        dest = os.path.join(dest, "profiles", channel)
+        dest = os.path.join(dest, "profiles", rev if rev is not None else channel)
         if version:
             dest = os.path.join(dest, version)
         have_cache = False
@@ -426,19 +524,7 @@ class Firefox(Browser):
                 rmtree(dest)
             os.makedirs(dest)
 
-            url = self.get_profile_bundle_url(version, channel)
-
-            self.logger.info(f"Downloading test prefs from {url}")
-            try:
-                extract_dir = tempfile.mkdtemp()
-                unzip(get(url).raw, dest=extract_dir)
-
-                profiles = os.path.join(extract_dir, os.listdir(extract_dir)[0], 'testing', 'profiles')
-                for name in os.listdir(profiles):
-                    path = os.path.join(profiles, name)
-                    shutil.move(path, dest)
-            finally:
-                rmtree(extract_dir)
+            self.get_profile_github(version, channel, dest, rev)
             self.logger.info(f"Test prefs downloaded to {dest}")
         else:
             self.logger.info(f"Using cached test prefs from {dest}")


### PR DESCRIPTION
Firefox development has moved to Github, and although commits are currently being synced back to hg, a bug [1] means that tags are not. This ends up breaking running in stable and beta builds because we can't get the profile data we need.

Given we'll eventually have to move away from hg anyway, start downloaing this data from GH right away.

Unfortunately our combination of wanting to download an entire directory of files and wanting to work without authentication doesn't match well with what GH offers; clones or archive downloads are too slow (even shallow+sparse) and using the rest API runs into rate limits.

In the end we hardcode the fact that we just need the user.js files and use raw.githubusercontent.com for the downloads. This works OK, but is fragile.

At the same time, when we know the specific source revision of the build, use that as the source of the commits rather than a branch like "main" which could have moved in the meantime.

[1]