### PR TITLE
Map wide gamut canvas tests to web-features

### DIFF
--- a/html/canvas/element/manual/wide-gamut-canvas/WEB_FEATURES.yml
+++ b/html/canvas/element/manual/wide-gamut-canvas/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: canvas-2d-color-management
+  files: "**"

--- a/html/canvas/element/wide-gamut-canvas/WEB_FEATURES.yml
+++ b/html/canvas/element/wide-gamut-canvas/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: canvas-2d-color-management
+  files: "**"

--- a/html/canvas/offscreen/manual/wide-gamut-canvas/WEB_FEATURES.yml
+++ b/html/canvas/offscreen/manual/wide-gamut-canvas/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: canvas-2d-color-management
+  files: "**"

--- a/html/canvas/offscreen/wide-gamut-canvas/WEB_FEATURES.yml
+++ b/html/canvas/offscreen/wide-gamut-canvas/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: canvas-2d-color-management
+  files: "**"


### PR DESCRIPTION
The scope of canvas-2d-color-management in web-features is effectively
`canvas.getContext('2d', { colorSpace: "display-p3" })`. The tests in
these directories were writen for that feature.

One test, imagedata-no-color-settings-crash.html, doesn't actually
contain the string "colorSpace", but it seems OK to include since it's
testing for a bug related to the implementation of the feature.
