### PR TITLE
Fix --log-wptscreenshot-api to actually reach the formatter

### DIFF
--- a/tools/third_party_modified/mozlog/mozlog/commandline.py
+++ b/tools/third_party_modified/mozlog/mozlog/commandline.py
@@ -41,8 +41,8 @@ TEXT_FORMATTERS = ("raw", "mach")
 DOCS_URL = "https://firefox-source-docs.mozilla.org/mozbase/mozlog.html"
 
 
-def level_filter_wrapper(formatter, level):
-    return handlers.LogLevelFilter(formatter, level)
+def level_filter_wrapper(handler, level):
+    return handlers.LogLevelFilter(handler, level)
 
 
 def verbose_wrapper(formatter, verbose):
@@ -227,7 +227,7 @@ def setup_handlers(logger, formatters, formatter_options, allow_unused_options=F
             wrapper, wrapper_args = None, ()
             if option == "valgrind":
                 wrapper = valgrind_handler_wrapper
-            elif option == "buffer":
+            elif option in ("buffer", "level"):
                 wrapper, wrapper_args = fmt_options[option][0], (value,)
             else:
                 formatter = fmt_options[option][0](formatter, value)

--- a/tools/third_party_modified/mozlog/tests/test_commandline.py
+++ b/tools/third_party_modified/mozlog/tests/test_commandline.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+
+import argparse
+import os
+import tempfile
+import unittest
+
+from mozlog import commandline, formatters, handlers
+
+
+class TestCommandline(unittest.TestCase):
+    def test_formatter_option(self):
+        """Test that formatter options work correctly.
+
+        This is a regression test for a bug where --log-level would wrap the formatter
+        instead of the handler, preventing formatter-specific options from reaching
+        the formatter.
+        """
+
+        class CustomFormatter(formatters.base.BaseFormatter):
+            def __init__(self):
+                super().__init__()
+                self.custom_value = None
+
+        def custom_option_wrapper(formatter, value):
+            formatter.custom_value = value
+            return formatter
+
+        original_formatters = commandline.log_formatters.copy()
+        original_fmt_options = commandline.fmt_options.copy()
+
+        self.addCleanup(
+            lambda: setattr(commandline, "log_formatters", original_formatters)
+        )
+        self.addCleanup(
+            lambda: setattr(commandline, "fmt_options", original_fmt_options)
+        )
+
+        commandline.log_formatters["custom"] = (
+            CustomFormatter,
+            "Custom formatter for testing",
+        )
+
+        commandline.fmt_options["customopt"] = (
+            custom_option_wrapper,
+            "Custom option for testing",
+            {"custom"},
+            "store",
+        )
+
+        parser = argparse.ArgumentParser(prog="test_formatter_option")
+        commandline.add_logging_group(parser)
+
+        temp_file = tempfile.NamedTemporaryFile(delete=False)
+        temp_file.close()
+        self.addCleanup(lambda: os.unlink(temp_file.name))
+
+        args = parser.parse_args(
+            [
+                "--log-custom=%s" % temp_file.name,
+                "--log-custom-customopt=test_value",
+            ]
+        )
+
+        logger = commandline.setup_logging("test_formatter_option", args, {})
+
+        self.assertEqual(len(logger.handlers), 1)
+        self.assertIsInstance(logger.handlers[0], handlers.base.LogLevelFilter)
+        log_filter = logger.handlers[0]
+
+        self.assertIsInstance(log_filter.inner, handlers.StreamHandler)
+        handler = log_filter.inner
+        self.addCleanup(lambda: handler.stream.close())
+
+        self.assertIsInstance(handler.formatter, CustomFormatter)
+        formatter = handler.formatter
+
+        self.assertEqual(formatter.custom_value, "test_value")
+
+
+if __name__ == "__main__":
+    import mozunit
+    mozunit.main()

--- a/tools/third_party_modified/mozlog/tests/test_structured.py
+++ b/tools/third_party_modified/mozlog/tests/test_structured.py
@@ -871,7 +871,8 @@ class TestCommandline(unittest.TestCase):
         args, _ = parser.parse_args(["--log-raw=-"])
         logger = commandline.setup_logging("test_optparse", args, {})
         self.assertEqual(len(logger.handlers), 1)
-        self.assertIsInstance(logger.handlers[0], handlers.StreamHandler)
+        self.assertIsInstance(logger.handlers[0], handlers.base.LogLevelFilter)
+        self.assertIsInstance(logger.handlers[0].inner, handlers.StreamHandler)
 
     def test_limit_formatters(self):
         parser = argparse.ArgumentParser()
@@ -894,8 +895,9 @@ class TestCommandline(unittest.TestCase):
         args, _ = parser.parse_args([u"--log-raw=-"])
         logger = commandline.setup_logging("test_optparse_unicode", args, {})
         self.assertEqual(len(logger.handlers), 1)
-        self.assertEqual(logger.handlers[0].stream, sys.stdout)
-        self.assertIsInstance(logger.handlers[0], handlers.StreamHandler)
+        self.assertIsInstance(logger.handlers[0], handlers.base.LogLevelFilter)
+        self.assertIsInstance(logger.handlers[0].inner, handlers.StreamHandler)
+        self.assertEqual(logger.handlers[0].inner.stream, sys.stdout)
 
     @unittest.skip("Failed on Windows")
     def test_logging_defaultlevel(self):

--- a/tools/wptrunner/wptrunner/formatters/wptscreenshot.py
+++ b/tools/wptrunner/wptrunner/formatters/wptscreenshot.py
@@ -10,6 +10,7 @@ class WptscreenshotFormatter(BaseFormatter):  # type: ignore
     """Formatter that outputs screenshots in the format expected by wpt.fyi."""
 
     def __init__(self, api=None):
+        super().__init__()
         self.api = api or DEFAULT_API
         self.cache = set()
 

--- a/tools/wptrunner/wptrunner/tests/test_wptcommandline.py
+++ b/tools/wptrunner/wptrunner/tests/test_wptcommandline.py
@@ -1,0 +1,87 @@
+# mypy: allow-untyped-defs
+
+import sys
+
+import pytest
+from mozlog import commandline, structuredlog
+
+from .. import wptcommandline, wptlogging
+from ..formatters.wptscreenshot import WptscreenshotFormatter
+from .base import active_products
+
+
+@pytest.fixture
+def formatter_factory(request, monkeypatch, tmp_path):
+    def _formatter_factory(product, args, formatter_cls):
+        # Use a per-test name for the logger we create and setup
+        original_setup_logging = commandline.setup_logging
+        monkeypatch.setattr(
+            commandline,
+            "setup_logging",
+            lambda *args, **kwargs: original_setup_logging(
+                request.node.name, *args[1:], **kwargs
+            ),
+        )
+
+        # Avoid overriding the root logger
+        monkeypatch.setattr(
+            wptlogging,
+            "setup_stdlib_logger",
+            lambda *args, **kwargs: None,
+        )
+
+        # Don't touch the mozlog default logger
+        monkeypatch.setattr(
+            structuredlog,
+            "set_default_logger",
+            lambda *args, **kwargs: None,
+        )
+
+        with monkeypatch.context() as m:
+            m.setattr(
+                "sys.argv",
+                [
+                    "test_wptcommandline#test_logging_options",
+                    "--tests",
+                    str(tmp_path),
+                    "--metadata",
+                    str(tmp_path),
+                    "--product",
+                    product,
+                    *args,
+                ],
+            )
+            kwargs = wptcommandline.parse_args()
+
+        logger = wptlogging.setup(kwargs, {"raw": sys.stdout})
+
+        stack = list(logger.handlers)
+        while stack:
+            item = stack.pop()
+            if isinstance(item, formatter_cls):
+                return item
+            if hasattr(item, "message_handler"):
+                stack.extend(item.message_handler.wrapped)
+
+        raise Exception("Unable to find formatter")
+
+    return _formatter_factory
+
+
+@active_products("product")  # type: ignore[no-untyped-call]
+def test_wptscreenshot_api(product, formatter_factory, tmp_path):
+    api = "http://test.invalid/"
+
+    formatter = formatter_factory(
+        product,
+        [
+            "--log-wptscreenshot",
+            str(tmp_path / "wpt_screenshot.txt"),
+            "--log-wptscreenshot-api",
+            api,
+        ],
+        WptscreenshotFormatter,
+    )
+
+    assert formatter is not None
+    assert formatter.api == api


### PR DESCRIPTION
This got overridden by the level wrapper, because it (unlike buffer
and valgrind) wasn't special-cased to be a wrapper and not a
formatter.
