### PR TITLE
Make the wptreport formatter accept screenshot options

### DIFF
--- a/tools/third_party_modified/mozlog/mozlog/commandline.py
+++ b/tools/third_party_modified/mozlog/mozlog/commandline.py
@@ -227,7 +227,7 @@ def setup_handlers(logger, formatters, formatter_options, allow_unused_options=F
             wrapper, wrapper_args = None, ()
             if option == "valgrind":
                 wrapper = valgrind_handler_wrapper
-            elif option == "buffer":
+            elif option in ("buffer", "level"):
                 wrapper, wrapper_args = fmt_options[option][0], (value,)
             else:
                 formatter = fmt_options[option][0](formatter, value)

--- a/tools/third_party_modified/mozlog/tests/test_structured.py
+++ b/tools/third_party_modified/mozlog/tests/test_structured.py
@@ -871,7 +871,8 @@ class TestCommandline(unittest.TestCase):
         args, _ = parser.parse_args(["--log-raw=-"])
         logger = commandline.setup_logging("test_optparse", args, {})
         self.assertEqual(len(logger.handlers), 1)
-        self.assertIsInstance(logger.handlers[0], handlers.StreamHandler)
+        self.assertIsInstance(logger.handlers[0], handlers.base.LogLevelFilter)
+        self.assertIsInstance(logger.handlers[0].inner, handlers.StreamHandler)
 
     def test_limit_formatters(self):
         parser = argparse.ArgumentParser()
@@ -894,8 +895,9 @@ class TestCommandline(unittest.TestCase):
         args, _ = parser.parse_args([u"--log-raw=-"])
         logger = commandline.setup_logging("test_optparse_unicode", args, {})
         self.assertEqual(len(logger.handlers), 1)
-        self.assertEqual(logger.handlers[0].stream, sys.stdout)
-        self.assertIsInstance(logger.handlers[0], handlers.StreamHandler)
+        self.assertIsInstance(logger.handlers[0], handlers.base.LogLevelFilter)
+        self.assertIsInstance(logger.handlers[0].inner, handlers.StreamHandler)
+        self.assertEqual(logger.handlers[0].inner.stream, sys.stdout)
 
     @unittest.skip("Failed on Windows")
     def test_logging_defaultlevel(self):

--- a/tools/wptrunner/wptrunner/formatters/wptreport.py
+++ b/tools/wptrunner/wptrunner/formatters/wptreport.py
@@ -21,7 +21,9 @@ def replace_lone_surrogate(data):
 class WptreportFormatter(BaseFormatter):  # type: ignore
     """Formatter that produces results in the format that wptreport expects."""
 
-    def __init__(self):
+    def __init__(self, enable_screenshot=False):
+        super().__init__()
+        self.enable_screenshot = enable_screenshot
         self.raw_results = {}
         self.results = {}
 
@@ -30,6 +32,8 @@ class WptreportFormatter(BaseFormatter):  # type: ignore
         self.results['time_start'] = data['time']
         self.results["results"] = []
         self.results["subsuites"] = {}
+        if self.enable_screenshot:
+            self.results["screenshots"] = {}
 
     def add_subsuite(self, data):
         self.results["subsuites"][data["name"]] = data.get("run_info", {})
@@ -95,6 +99,13 @@ class WptreportFormatter(BaseFormatter):  # type: ignore
                 for item in data["extra"]["reftest_screenshots"]
                 if isinstance(item, dict)
             }
+            if self.enable_screenshot:
+                screenshots = {
+                    f"sha1:{item['hash']}": f"data:image/png;base64,{item['screenshot']}"
+                    for item in data["extra"]["reftest_screenshots"]
+                    if isinstance(item, dict)
+                }
+                self.results["screenshots"].update(screenshots)
         test_name = data["test"]
         subsuite = data.get("subsuite", "")
         result = {"test": test_name,

--- a/tools/wptrunner/wptrunner/formatters/wptscreenshot.py
+++ b/tools/wptrunner/wptrunner/formatters/wptscreenshot.py
@@ -10,6 +10,7 @@ class WptscreenshotFormatter(BaseFormatter):  # type: ignore
     """Formatter that outputs screenshots in the format expected by wpt.fyi."""
 
     def __init__(self, api=None):
+        super().__init__()
         self.api = api or DEFAULT_API
         self.cache = set()
 

--- a/tools/wptrunner/wptrunner/tests/test_wptcommandline.py
+++ b/tools/wptrunner/wptrunner/tests/test_wptcommandline.py
@@ -6,6 +6,7 @@ import pytest
 from mozlog import commandline, structuredlog
 
 from .. import wptcommandline, wptlogging
+from ..formatters.wptreport import WptreportFormatter
 from ..formatters.wptscreenshot import WptscreenshotFormatter
 from .base import active_products
 
@@ -85,3 +86,20 @@ def test_wptscreenshot_api(product, formatter_factory, tmp_path):
 
     assert formatter is not None
     assert formatter.api == api
+
+
+@active_products("product")  # type: ignore[no-untyped-call]
+def test_wptreport_screenshot(product, formatter_factory, tmp_path):
+    api = "http://test.invalid/"
+
+    formatter = formatter_factory(
+        product,
+        [
+            "--log-wptreport",
+            str(tmp_path / "wpt_report.json"),
+            "--log-wptreport-screenshot",
+        ],
+        WptreportFormatter,
+    )
+
+    assert formatter.enable_screenshot == True

--- a/tools/wptrunner/wptrunner/tests/test_wptcommandline.py
+++ b/tools/wptrunner/wptrunner/tests/test_wptcommandline.py
@@ -1,0 +1,87 @@
+# mypy: allow-untyped-defs
+
+import sys
+
+import pytest
+from mozlog import commandline, structuredlog
+
+from .. import wptcommandline, wptlogging
+from ..formatters.wptscreenshot import WptscreenshotFormatter
+from .base import active_products
+
+
+@pytest.fixture
+def formatter_factory(request, monkeypatch, tmp_path):
+    def _formatter_factory(product, args, formatter_cls):
+        # Use a per-test name for the logger we create and setup
+        original_setup_logging = commandline.setup_logging
+        monkeypatch.setattr(
+            commandline,
+            "setup_logging",
+            lambda *args, **kwargs: original_setup_logging(
+                request.node.name, *args[1:], **kwargs
+            ),
+        )
+
+        # Avoid overriding the root logger
+        monkeypatch.setattr(
+            wptlogging,
+            "setup_stdlib_logger",
+            lambda *args, **kwargs: None,
+        )
+
+        # Don't touch the mozlog default logger
+        monkeypatch.setattr(
+            structuredlog,
+            "set_default_logger",
+            lambda *args, **kwargs: None,
+        )
+
+        with monkeypatch.context() as m:
+            m.setattr(
+                "sys.argv",
+                [
+                    "test_wptcommandline#test_logging_options",
+                    "--tests",
+                    str(tmp_path),
+                    "--metadata",
+                    str(tmp_path),
+                    "--product",
+                    product,
+                    *args,
+                ],
+            )
+            kwargs = wptcommandline.parse_args()
+
+        logger = wptlogging.setup(kwargs, {"raw": sys.stdout})
+
+        stack = list(logger.handlers)
+        while stack:
+            item = stack.pop()
+            if isinstance(item, formatter_cls):
+                return item
+            if hasattr(item, "message_handler"):
+                stack.extend(item.message_handler.wrapped)
+
+        raise Exception("Unable to find formatter")
+
+    return _formatter_factory
+
+
+@active_products("product")  # type: ignore[no-untyped-call]
+def test_wptscreenshot_api(product, formatter_factory, tmp_path):
+    api = "http://test.invalid/"
+
+    formatter = formatter_factory(
+        product,
+        [
+            "--log-wptscreenshot",
+            str(tmp_path / "wpt_screenshot.txt"),
+            "--log-wptscreenshot-api",
+            api,
+        ],
+        WptscreenshotFormatter,
+    )
+
+    assert formatter is not None
+    assert formatter.api == api

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -418,6 +418,10 @@ scheme host and port.""")
                                       "Cache API (default: %s)" % wptscreenshot.DEFAULT_API,
                                       {"wptscreenshot"}, "store")
 
+    # mozlog already supports these, so instead we just declare they also apply to wptreport
+    commandline.fmt_options["screenshot"][2].add("wptreport")
+    commandline.fmt_options["no-screenshot"][2].add("wptreport")
+
     commandline.log_formatters["wptreport"] = (wptreport.WptreportFormatter, "wptreport format")
     commandline.log_formatters["wptscreenshot"] = (wptscreenshot.WptscreenshotFormatter, "wpt.fyi screenshots")
 


### PR DESCRIPTION
Builds on top of https://github.com/web-platform-tests/wpt/pull/52426.

This adds a "screenshots" property at the top-level of the report,
whose value is an object where each item is:

    f"sha1:{item['hash']}": f"data:image/png;base64,{item['screenshot']}"