### PR TITLE
layout: Share styles to inline box children via `SharedInlineStyles`

### DIFF
--- a/css/css-display/display-contents-inline-002.html
+++ b/css/css-display/display-contents-inline-002.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Display: display:contents in inline layout should affect style of descendants</title>
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-pass-no-red-ref.html">
+<style>
+    #contents {
+        display: contents;
+        color: black;
+    }
+    .red { color: red; }
+</style>
+<p>You should see the word PASS and no red below.</p>
+<span>
+    P<span class="red"><div id="contents">AS</div></span>S
+</span>


### PR DESCRIPTION
`TextRun`s use their parent style to render. Previously, these styles
were cloned and stored directly in the box tree `TextRun` and resulting
`TextFragment`s. This presents a problem for incremental layout.
Wrapping the style in another layer of shared ownership and mutability
will allow updating all `TextFragment`s during repaint-only incremental
layout by simply updating the box tree styles of the original text
parents.

This adds a new set of borrows when accessing text styles, but also
makes it so that during box tree block construction
`InlineFormattingContext`s are created lazily and now
`InlineFormattingContextBuilder::finish` consumes the builder, making
the API make a bit more sense. This should also improve performance of
box tree block construction slightly.

Testing: This should not change observable behavior and thus is covered
by existing WPT tests.

Reviewed in servo/servo#36896