### PR TITLE
Add CSP check for inline style attribute

### DIFF
--- a/content-security-policy/style-src/style-src-inline-style-with-csstext.html
+++ b/content-security-policy/style-src/style-src-inline-style-with-csstext.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<head>
+    <meta http-equiv="Content-Security-Policy" content="style-src 'self';">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+
+    <script>
+      var t = async_test("Manipulating cssText should be allowed with 'self'");
+      document.addEventListener("securitypolicyviolation", t.unreached_func("Should not trigger a security policy violation"));
+    </script>
+</head>
+<body>
+    <div id='log'></div>
+
+    <div id="content">Lorem ipsum</div>
+
+    <script>
+      t.step(function() {
+        var contentEl = document.getElementById("content");
+        contentEl.style.cssText = 'margin-left: 2px;';
+        var marginLeftVal = getComputedStyle(contentEl).getPropertyValue('margin-left');
+        assert_equals(marginLeftVal, "2px");
+        t.done();
+      });
+    </script>
+
+</body>
+</html>


### PR DESCRIPTION
To be able to abort the update, extract the functionality into a separate method. Otherwise, we don't run the `node.rev_version` at the end, which according to the comment is probably important.

Not all `style-src` tests pass and I don't fully understand why yet, but I presume it has to do with some special quirks of stylesheets that other CSP checks don't have. All `style-src-attr-elem` tests pass though.

Part of #<!-- nolink -->4577

Reviewed in servo/servo#36923