### PR TITLE
Avoid timeout in iframe loading=lazy navigation.reload test

### DIFF
--- a/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-nav-navigation-navigate.html
+++ b/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-nav-navigation-navigate.html
@@ -14,8 +14,8 @@ iframe.hidden = false;
 <script src="/resources/testharnessreport.js"></script>
 <script>
 setup({single_test: true});
+assert_true("navigation" in window, "Navigation API is supported");
 iframeLoaded.then(() => {
-  assert_true("navigation" in window, "Navigation API is supported");
   // Need a timeout to detect failure when there are two navigations.
   step_timeout(() => {
     assert_equals(iframe.contentWindow.location.href, new URL("support/blank.htm?nav", location.href).href);

--- a/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-reload-navigation-reload.html
+++ b/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-reload-navigation-reload.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reloading iframe loading='lazy' before it is loaded: location.reload</title>
+<title>Reloading iframe loading='lazy' before it is loaded: navigation.reload</title>
 <iframe src="support/blank.htm?src" loading="lazy" hidden></iframe>
 <script>
 const iframe = document.querySelector('iframe');
@@ -7,7 +7,9 @@ const iframeLoaded = new Promise(resolve => {
   iframe.onload = resolve;
 });
 // Should have no effect on lazy-loading
-iframe.contentWindow.navigation.reload();
+if ("navigation" in iframe.contentWindow) {
+  iframe.contentWindow.navigation.reload();
+}
 iframe.hidden = false;
 </script>
 <!-- Loading testharness.js here is intentional to reproduce a bug in WebKit. -->

--- a/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-reload-navigation-reload.html
+++ b/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-reload-navigation-reload.html
@@ -7,9 +7,7 @@ const iframeLoaded = new Promise(resolve => {
   iframe.onload = resolve;
 });
 // Should have no effect on lazy-loading
-if ("navigation" in iframe.contentWindow) {
-  iframe.contentWindow.navigation.reload();
-}
+iframe.contentWindow.navigation.reload();
 iframe.hidden = false;
 </script>
 <!-- Loading testharness.js here is intentional to reproduce a bug in WebKit. -->
@@ -17,10 +15,10 @@ iframe.hidden = false;
 <script src="/resources/testharnessreport.js"></script>
 <script>
 setup({single_test: true});
+assert_true("navigation" in window, "Navigation API is supported");
 iframeLoaded.then(() => {
   // Need a timeout to detect failure when there are two navigations.
   step_timeout(() => {
-    assert_true("navigation" in window, "Navigation API is supported");
     assert_equals(iframe.contentWindow.location.href, new URL("support/blank.htm?src", location.href).href);
     done();
   }, 1000);


### PR DESCRIPTION
If `navigation.reload` is not supported, the `iframe.hidden = false;` line was not reached, so `iframeLoaded` would never resolve.