### PR TITLE
Make more COOP tests robust against partitioned BroadcastChannel

### DIFF
--- a/html/cross-origin-opener-policy/blob-popup.https.html
+++ b/html/cross-origin-opener-policy/blob-popup.https.html
@@ -3,38 +3,44 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script src=/common/get-host-info.sub.js></script>
-<script src="/common/utils.js"></script>
+<script src=/common/utils.js></script>
+<script src=/common/dispatcher/dispatcher.js></script>
 <script>
-async_test(t => {
-  window.test = t; // Make the test available globally so the blob URL can use it
+promise_test(async t => {
   window.furtherPopup = null;
 
-  const bc = new BroadcastChannel(token());
-  bc.onmessage = t.step_func_done(({ data }) => {
-    assert_equals(data.name.length, 0);
-    assert_false(data.opener);
-    assert_true(furtherPopup.closed);
-  });
+  const responseToken = token();
+  const iframeToken = token();
 
   const blobContents = `<script>
-const w = window.open("${get_host_info().HTTPS_REMOTE_ORIGIN}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=x&coep=x&channel=${bc.name}", "${bc.name}");
+const w = window.open("${get_host_info().HTTPS_REMOTE_ORIGIN}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=x&coep=x&responseToken=${responseToken}&iframeToken=${iframeToken}", "${responseToken}");
 window.opener.furtherPopup = w;
 <\/script>`;
   const blob = new Blob([blobContents], { type: "text/html" });
   const blobURL = URL.createObjectURL(blob);
   const popup = window.open(blobURL);
-  t.add_cleanup(() => {
+  t.add_cleanup(async () => {
     // Close the popups once the test is complete.
     // The browsing context of the second popup is closed hence use the
     //  broadcast channel to trigger the closure.
-    bc.postMessage("close");
+    await send(iframeToken, "close");
     popup.close();
   });
+
+  let popupOnloadHappened = false;
   popup.onload = t.step_func(() => {
     assert_equals(popup.opener, window);
     assert_equals(popup.location.href, blobURL);
     assert_equals(popup.document.URL, blobURL);
     assert_equals(popup.origin, window.origin);
+    popupOnloadHappened = true;
   });
+
+  const data = JSON.parse(await receive(responseToken));
+
+  assert_true(popupOnloadHappened);
+  assert_equals(data.name.length, 0);
+  assert_false(data.opener);
+  assert_true(furtherPopup.closed);
 });
 </script>

--- a/html/cross-origin-opener-policy/coep-navigate-popup.https.html
+++ b/html/cross-origin-opener-policy/coep-navigate-popup.https.html
@@ -6,9 +6,11 @@
 <meta name=variant content=?4-last>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/subset-tests.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="resources/common.js"></script>
+<script src=/common/subset-tests.js></script>
+<script src=/common/get-host-info.sub.js></script>
+<script src=/common/utils.js></script>
+<script src=resources/common.js></script>
+<script src=/common/dispatcher/dispatcher.js></script>
 <script>
 [
   {
@@ -55,17 +57,18 @@
 
   ["same-origin", "same-site"].forEach(site => {
     const title = `Popup navigating to ${site} with ${variant.title}`;
-    const channel = title.replace(/ /g,"-");
+    const responseToken = token();
+    const iframeToken = token();
     const navigateHost = site === "same-origin" ? SAME_ORIGIN : SAME_SITE;
-    const navigateURL = `${navigateHost.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=${variant.coop}&coep=${variant.coep}&channel=${channel}`;
+    const navigateURL = `${navigateHost.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=${variant.coop}&coep=${variant.coep}&responseToken=${responseToken}&iframeToken=${iframeToken}`;
     const opener = site === "same-origin" ? variant.opener : false;
 
-    async_test(t => {
+    promise_test(t => {
       // For each test we open a COOP: same-origin/COEP: require-corp document in a popup and then
       // navigate that to either a same-origin (site=="same-origin") or same-site (site=="same-site")
       // document whose COOP and COEP are set as per the top-most array. We then verify that this
       // document has the correct opener for its specific setup.
-      url_test(t, `${SAME_ORIGIN.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=same-origin&coep=require-corp&navigate=${encodeURIComponent(navigateURL)}`, channel, opener);
+      return dispatcher_url_test(t, `${SAME_ORIGIN.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=same-origin&coep=require-corp&navigate=${encodeURIComponent(navigateURL)}`, responseToken, iframeToken, opener, undefined, () => t.done());
     }, title);
   });
 });

--- a/html/cross-origin-opener-policy/historical/coep-navigate-popup-unsafe-inherit.https.html
+++ b/html/cross-origin-opener-policy/historical/coep-navigate-popup-unsafe-inherit.https.html
@@ -3,9 +3,11 @@
 <meta name=timeout content=long>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="../resources/common.js"></script>
-<script src="/common/subset-tests.js"></script>
+<script src=/common/subset-tests.js></script>
+<script src=/common/get-host-info.sub.js></script>
+<script src=/common/utils.js></script>
+<script src=../resources/common.js></script>
+<script src=/common/dispatcher/dispatcher.js></script>
 <script>
 [
   {
@@ -23,17 +25,18 @@
 ].forEach((variant) => {
   ["same-origin", "same-site"].forEach((site) => {
     const title = `Popup navigating to ${site} with ${variant.title}`;
-    const channel = title.replace(/ /g,"-");
+    const responseToken = token();
+    const iframeToken = token();
     const navigateHost = site === "same-origin" ? SAME_ORIGIN : SAME_SITE;
-    const navigateURL = `${navigateHost.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=${variant.coop}&coep=${variant.coep}&channel=${channel}`;
+    const navigateURL = `${navigateHost.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=${variant.coop}&coep=${variant.coep}&responseToken=${responseToken}&iframeToken=${iframeToken}`;
     const opener = site === "same-origin" ? variant.opener : false;
 
-    async_test(t => {
+    promise_test(t => {
       // For each test we open a COOP: same-origin/COEP: require-corp document in a popup and then
       // navigate that to either a document with same origin (site=="same-origin") or
       // not-same-origin (site=="same-site") whose COOP and COEP are set as per the top-most array.
       // We then verify that this document has the correct opener for its specific setup.
-      url_test(t, `${SAME_ORIGIN.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=same-origin&coep=require-corp&navigate=${encodeURIComponent(navigateURL)}`, channel, opener);
+      return dispatcher_url_test(t, `${SAME_ORIGIN.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=same-origin&coep=require-corp&navigate=${encodeURIComponent(navigateURL)}`, responseToken, iframeToken, opener, undefined, () => t.done());
     }, title);
   });
 });


### PR DESCRIPTION
When removing the BroadcastChannelOriginPartitioningEnabled preference from WebKit these three tests showed up as problematic.

So instead of channel, use the responseToken and iframeToken pattern established by other COOP tests.

---

What I'm curious about is why these haven't been problematic for other browsers thus far? Or are they and have they been disabled?