### PR TITLE
layout: Implement quote depth calculation for CSS `quotes`

### DIFF
--- a/css/css-content/content-quotes-depth-ref.html
+++ b/css/css-content/content-quotes-depth-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: quote-depth behavior</title>
+<body>
+  <div>&#x201c;Test1&#x201d;</div>
+  <div>&#x201c;Test2&#x201d;</div>
+  <div>&#x201c;Test3&#x2018;Test3 Inner&#x2019;&#x201d;</div>
+  <div>Test4</div>
+  <div>&#x201c;Test5</div>
+  <div>Test6&#x201d;</div>
+</body>

--- a/css/css-content/content-quotes-depth.html
+++ b/css/css-content/content-quotes-depth.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Content: quote-depth behavior</title>
+<link rel="author" href="mailto:saku@email.sakupi01.com" title="saku">
+<link rel="help" href="https://www.w3.org/TR/css-content-3/#quotes">
+<meta name="assert" content="content quotes are correctly applied respecting to the depth of the element.">
+<link rel="match" href="content-quotes-depth-ref.html">
+<style>
+  :root {
+    quotes: "\201c" "\201d" "\2018" "\2019";
+  }
+
+  /* quotes made only with before */
+  .test1::before {
+    content: open-quote "Test1" close-quote;
+  }
+
+  /* quotes made only with before and after pseudo-elements */
+  .test2::before {
+    content: open-quote;
+  }
+  
+  .test2::after {
+    content: close-quote;
+  }
+
+  /* Nested quotes */
+  .test3::before {
+    content: open-quote;
+  }
+  
+  .test3::after {
+    content: open-quote "Test3 Inner" close-quote close-quote;
+  }
+
+  /* close-quote will be ignored */
+  .test4::before {
+    content: close-quote;
+  }
+  
+  /* close-quote will be ignored */
+  .test5::before {
+    content: open-quote;
+  }
+  
+  .test5::after { 
+    content: no-close-quote;
+  }
+  
+  /* open-quote will be ignored */
+  .test6::before {
+    content: no-open-quote;
+  }
+  
+  .test6::after { 
+    content: close-quote;
+  }
+</style>
+<body>
+  <div class="test1"></div>
+  <div class="test2">Test2</div>
+  <div class="test3">Test3</div>
+  <div class="test4">Test4</div>
+  <div class="test5">Test5</div>
+  <div class="test6">Test6</div>
+</body>

--- a/css/css-content/content-quotes-depth.html
+++ b/css/css-content/content-quotes-depth.html
@@ -19,7 +19,7 @@
   .test2::before {
     content: open-quote;
   }
-  
+
   .test2::after {
     content: close-quote;
   }
@@ -28,7 +28,7 @@
   .test3::before {
     content: open-quote;
   }
-  
+
   .test3::after {
     content: open-quote "Test3 Inner" close-quote close-quote;
   }
@@ -37,22 +37,22 @@
   .test4::before {
     content: close-quote;
   }
-  
+
   /* close-quote will be ignored */
   .test5::before {
     content: open-quote;
   }
-  
-  .test5::after { 
+
+  .test5::after {
     content: no-close-quote;
   }
-  
+
   /* open-quote will be ignored */
   .test6::before {
     content: no-open-quote;
   }
-  
-  .test6::after { 
+
+  .test6::after {
     content: close-quote;
   }
 </style>


### PR DESCRIPTION
This PR is a supplement to the initial CSS quotes implementation (https://github.com/servo/servo/pull/34770) and implements CSS quotes depth calculation. It also addresses the other issue related to depth calculation. (https://github.com/servo/servo/issues/36686)

- implements CSS quotes depth calculation in layout context level
  - supports nested quotes
  - supports `::before` `::after` content-based quotes (`content: open-quote "Test1" close-quote;` in `::before` was only supported in initial, but now supports `::after` `content: open-quote;` & `::before` `content: close-quote;` way.)
  - ignore `close-quote` if the depth is 0
- implements `no-open-quote` and `no-close-quote` according to the spec

However, this PR has the problem that the calculation sometimes fails and sometimes succeeds. The fail/success timing depends on the layout, and I suspect that the problem is not the calculation logic itself.
I gess the underlying problem would be the parallelization of reflow step.
It'd be great if I could get your opinion on whether the potential problem should be solved in this PR or could be a pending for the future.

Testing: A new reftest is added. (`css/css-content/content-quotes-depth.html`) However, the test is currently marked as FAIL since it's flaky because of the reason previously mentioned. 
Fixes: https://github.com/servo/servo/issues/36686

Reviewed in servo/servo#36998