### PR TITLE
Implement inner slot for cryptographic nonce

### DIFF
--- a/html/dom/reflection.js
+++ b/html/dom/reflection.js
@@ -967,6 +967,7 @@ ReflectionTests.reflects = function(data, idlName, idlObj, domName, domObj) {
                                                "previous value", "getAttribute()");
                 ReflectionHarness.assertEquals(idlObj[idlName], previousIdl, "IDL get");
             } else {
+                var previousValue = domObj.getAttribute(domName);
                 idlObj[idlName] = idlTests[i];
                 if (data.type == "boolean") {
                     // Special case yay
@@ -976,6 +977,11 @@ ReflectionTests.reflects = function(data, idlName, idlObj, domName, domObj) {
                     var expected = idlDomExpected[i] + "";
                     if (data.isNullable && idlDomExpected[i] === null) {
                         expected = null;
+                    } else if (idlName == "nonce") {
+                        // nonce doesn't reflect the value, as per /content-security-policy/nonce-hiding/
+                        // tests that confirm that retrieving the nonce value post IDL change does not
+                        // reflect back to the attribute (for security reasons)
+                        expected = previousValue;
                     }
                     ReflectionHarness.assertEquals(domObj.getAttribute(domName), expected,
                                                    "getAttribute()");


### PR DESCRIPTION
Also update the `html/dom/reflection-metadata.html` test
to handle the case where `nonce` does not reflect back
to the attribute after an IDL change.

Part of https://github.com/servo/servo/issues/4577
Fixes https://github.com/web-platform-tests/wpt/issues/43286

Reviewed in servo/servo#36965