### PR TITLE
Add anchor positioning visibility tests.

### DIFF
--- a/css/css-anchor-position/anchor-center-visibility-change-ref.html
+++ b/css/css-anchor-position/anchor-center-visibility-change-ref.html
@@ -17,16 +17,43 @@
   background: lime;
 }
 
-.target {
-  position: fixed;
-  background: cyan;
-  left: 111px;
+.target-inner {
+  width: 30px;
+  height: 20px;
 }
+
+.target {
+  position: absolute;
+}
+
+#target-1 {
+  background: cyan;
+  left: 50px;
+}
+
+#target-2 {
+  top: 20px;
+  left: 0;
+  background: blue;
+}
+
+#target-3 {
+  top: 20px;
+  left: 50px;
+  background: magenta;
+}
+
 </style>
 
 <div class="container">
   <div class="anchor"></div>
-  <div class="target">
-    <div style="width:30px;height:20px;"></div>
+  <div id="target-1" class="target">
+    <div class="target-inner"></div>
+  </div>
+  <div id="target-2" class="target">
+    <div class="target-inner"></div>
+  </div>
+  <div id="target-3" class="target">
+    <div class="target-inner"></div>
   </div>
 </div>

--- a/css/css-anchor-position/anchor-center-visibility-change.html
+++ b/css/css-anchor-position/anchor-center-visibility-change.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
-<title>Tests 'anchor-center' value when target visibility changes</title>
+<title>Tests 'anchor-center' value when target visibility changes (by changing 'display', 'visibility', or popover trigger)</title>
 <link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#valdef-justify-self-anchor-center">
 <link rel="author" href="mailto:plampe@igalia.com">
+<link rel="author" href="mailto:kiet.ho@apple.com">
 <link rel="match" href="anchor-center-visibility-change-ref.html">
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>
@@ -27,27 +28,61 @@
 
 .target {
   position-anchor: --anchor;
-  position: fixed;
-  background: cyan;
+  position: absolute;
+}
+
+.target-inner {
+  width: 30px;
+  height: 20px;
+}
+
+#target-1 {
   justify-self: anchor-center;
+  background: cyan;
   display: none;
+}
+
+#target-2 {
+  align-self: anchor-center;
+  background: blue;
+  visibility: hidden;
+}
+
+#target-3 {
+  align-self: anchor-center;
+  justify-self: anchor-center;
+  background: magenta;
+
+  /* Override default popover style */
+  margin: 0;
+  padding: 0;
+  border: none;
 }
 </style>
 
 <div class="container">
   <div class="anchor"></div>
-  <div id="target" class="target">
-    <div style="width:30px;height:20px;"></div>
+  <div id="target-1" class="target">
+    <div class="target-inner"></div>
+  </div>
+  <div id="target-2" class="target">
+    <div class="target-inner"></div>
+  </div>
+  <div id="target-3" class="target" popover>
+    <div class="target-inner"></div>
   </div>
 </div>
 
 <script>
-  // #target should be invisible initially.
+  // Targets should be invisible initially.
   waitForAtLeastOneFrame().then(() => {
-    // Change #target to be visible.
-    document.getElementById('target').style.display = 'flow';
+    // Change targets to be visible.
+    document.getElementById('target-1').style.display = 'flow';
+    document.getElementById('target-2').style.visibility = 'visible';
+    document.getElementById('target-3').showPopover();
+
     waitForAtLeastOneFrame().then(() => {
-      // #target should be visible and anchor-centered now.
+      // Targets should be visible now.
       takeScreenshot();
     });
   });

--- a/css/css-anchor-position/position-area-visibility-change.html
+++ b/css/css-anchor-position/position-area-visibility-change.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<head>
+  <title>Tests that an element positioned using position-area renders when it's initially hidden, then shown</title>
+
+  <link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-area">
+  <link rel="author" href="mailto:kiet.ho@apple.com">
+  <link rel="match" href="reference/position-area-visibility-change-ref.html">
+
+  <script src="/common/reftest-wait.js"></script>
+  <script src="/common/rendering-utils.js"></script>
+
+  <style>
+    .containing-block {
+      position: relative;
+      width: 150px;
+      height: 150px;
+      outline: 2px black solid;
+    }
+
+    .cell {
+      width: 50px;
+      height: 50px;
+    }
+
+    #anchor-cell {
+      position: absolute;
+      top: 50px;
+      left: 50px;
+
+      anchor-name: --anchor;
+
+      background: green;
+    }
+
+    .anchor-positioned-cell {
+      position: absolute;
+      position-anchor: --anchor;
+    }
+
+    #target-1 {
+      position-area: top right;
+
+      /* Will be changed to 'block' */
+      display: none;
+    }
+
+    #target-2 {
+      position-area: bottom left;
+
+      /* Will be changed to 'visible' */
+      visibility: hidden;
+    }
+
+    #target-3 {
+      position-area: bottom right;
+
+      /* Override default popover style */
+      margin: 0;
+      padding: 0;
+      border: none;
+    }
+
+    .blue-background {
+      background: blue;
+    }
+
+    .magenta-background {
+      background: magenta;
+    }
+
+    .cyan-background {
+      background: cyan;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="containing-block">
+    <div class="cell" id="anchor-cell"></div>
+
+    <div class="cell anchor-positioned-cell" id="target-1">
+      <div class="cell blue-background"></div>
+    </div>
+
+    <div class="cell anchor-positioned-cell" id="target-2">
+      <div class="cell magenta-background"></div>
+    </div>
+
+    <div class="cell anchor-positioned-cell" id="target-3" popover>
+      <div class="cell cyan-background"></div>
+    </div>
+  </div>
+
+  <script>
+    // All targets should initially be hidden.
+    waitForAtLeastOneFrame().then(() => {
+      // Change targets to be visible.
+      document.getElementById('target-1').style.display = 'block';
+      document.getElementById('target-2').style.visibility = 'visible';
+      document.getElementById('target-3').showPopover();
+
+      waitForAtLeastOneFrame().then(() => {
+        // All targets should be visible now.
+        takeScreenshot();
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/css/css-anchor-position/reference/position-area-visibility-change-ref.html
+++ b/css/css-anchor-position/reference/position-area-visibility-change-ref.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+
+<style>
+  .containing-block {
+    position: relative;
+    width: 150px;
+    height: 150px;
+    outline: 2px black solid;
+  }
+
+  .cell {
+    width: 50px;
+    height: 50px;
+  }
+
+  #anchor-cell {
+    position: absolute;
+    top: 50px;
+    left: 50px;
+
+    background: green;
+  }
+
+  .anchor-positioned-cell {
+    position: absolute;
+  }
+
+  #target-1 {
+    top: 0;
+    right: 0;
+  }
+
+  #target-2 {
+    bottom: 0;
+    left: 0;
+  }
+
+  #target-3 {
+    bottom: 0;
+    right: 0;
+  }
+
+  .blue-background {
+    background: blue;
+  }
+
+  .magenta-background {
+    background: magenta;
+  }
+
+  .cyan-background {
+    background: cyan;
+  }
+</style>
+
+<body>
+  <div class="containing-block">
+    <div class="cell" id="anchor-cell"></div>
+
+    <div class="cell anchor-positioned-cell" id="target-1">
+      <div class="cell blue-background"></div>
+    </div>
+
+    <div class="cell anchor-positioned-cell" id="target-2">
+      <div class="cell magenta-background"></div>
+    </div>
+
+    <div class="cell anchor-positioned-cell" id="target-3">
+      <div class="cell cyan-background"></div>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
These tests concern a bug in WebKit where an initially hidden anchor-positioned element (`display: none`, `visibility: hidden` or hidden popover) is not rendered properly when the element is subsequent shown (by changing `display`, `visibility` or shown popover). More specifically, the element itself is rendered but not its descendants. See https://webkit.org/b/291065.

This is an export of https://github.com/WebKit/WebKit/pull/45100