### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=292963

### DIFF
--- a/css/css-view-transitions/auto-name-get-animations.html
+++ b/css/css-view-transitions/auto-name-get-animations.html
@@ -60,8 +60,8 @@ main.switch .item1 {
     assert_array_equals(pseudos,
       [
         "::view-transition-group(match-element)",
-        "::view-transition-new(match-element)",
-        "::view-transition-old(match-element)"]);
+        "::view-transition-old(match-element)",
+        "::view-transition-new(match-element)"]);
   }, "Generated view-transition-names should not be reflected in script");
 </script>
 


### PR DESCRIPTION
WebKit export from bug: [css/css-view-transitions/auto-name-get-animations.html fails](https://bugs.webkit.org/show_bug.cgi?id=292963)