### PR TITLE
Remove COOP noopener-allow-popups null check, as it is not standard

### DIFF
--- a/html/cross-origin-opener-policy/resources/noopener-helper.js
+++ b/html/cross-origin-opener-policy/resources/noopener-helper.js
@@ -121,8 +121,9 @@ const test_noopener_navigating_away = (popup_coop) => {
     assert_equals(await receive(reply_token), 'Popup loaded');
     t.add_cleanup(() => send(popup_token, 'window.close()'));
 
-    // Assert that we can script the popup.
-    assert_not_equals(popup.window, null, 'can script the popup');
+    // There's an open question if we should check that popup.window is null here.
+    // See https://github.com/whatwg/html/issues/10457
+    // Assert that we cannot script the popup.
     assert_false(popup.closed, 'popup closed');
 
     // Ensure that the popup has no access to its opener.


### PR DESCRIPTION
A non-standard null check has made it into the Cross-Origin-Opener-Policy noopener-allow-popups tests.

The behavior is being discussed at https://github.com/whatwg/html/issues/10457

This PR removes that check from the relevant tests.