### PR TITLE
Revert "REVERTME: dry-run documentation workflow"

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,7 +2,11 @@ name: documentation
 on:
   push:
     branches:
-      - ubuntu-24.04
+      - master
+    paths:
+      - 'docs/**'
+      - 'resources/**'
+      - 'tools/**'
   pull_request:
     paths:
       - 'docs/**'
@@ -30,4 +34,4 @@ jobs:
       - name: Run website_build.sh
         run: ./tools/ci/website_build.sh
         env:
-          DEPLOY_TOKEN: dummy
+          DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}


### PR DESCRIPTION
This reverts commit 7d7982c38b540a78fcf0824d0d36e27352c15a8f.

Looks like the original commit, which stops building docs on `master`, was only for testing and not meant to be landed.