### PR TITLE
[wptrunner] Add type hints for `wptrunner.browsers.chrome`

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -6,7 +6,7 @@ import socket
 import time
 import traceback
 from abc import ABCMeta, abstractmethod
-from typing import cast, Any, List, Mapping, Optional, Tuple, Type
+from typing import cast, Any, List, Mapping, Optional, Sequence, Tuple, Type
 
 import mozprocess
 from mozdebug import DebuggerInfo
@@ -88,6 +88,12 @@ class BrowserError(Exception):
     pass
 
 
+# TODO: These types can probably be constrained more strictly per-vendor.
+BrowserKwargs = Mapping[str, Any]
+ExecutorKwargs = Mapping[str, Any]
+ExecutorBrowserKwargs = Mapping[str, Any]
+DependentProperties = Mapping[str, Sequence[str]]
+UpdateProperties = Tuple[Sequence[str], DependentProperties]
 BrowserSettings = Mapping[str, Any]
 
 
@@ -151,7 +157,7 @@ class Browser:
         """Browser-specific cleanup that is run after the testrun is finished"""
         pass
 
-    def executor_browser(self) -> Tuple[Type['ExecutorBrowser'], Mapping[str, Any]]:
+    def executor_browser(self) -> Tuple[Type['ExecutorBrowser'], ExecutorBrowserKwargs]:
         """Returns the ExecutorBrowser subclass for this Browser subclass and the keyword arguments
         with which it should be instantiated"""
         return ExecutorBrowser, {}

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -9,11 +9,12 @@ import signal
 import socket
 import sys
 import time
-from typing import Optional
+from typing import Any, Callable, ContextManager, Mapping, Optional
 
 import mozprocess
 from mozlog import get_default_logger, handlers
 from mozlog.structuredlog import StructuredLogger
+from wptserve.config import Config
 
 from . import mpcontext
 from .wptlogging import LogLevelRewriter, QueueHandler, LogQueueThread
@@ -89,6 +90,10 @@ class ProxyLoggingContext:
         self.log_queue.put(None)
         # Wait for thread to shut down but not for too long since it's a daemon
         self.logging_thread.join(1)
+
+
+EnvironmentOptions = Mapping[str, Any]
+EnvironmentExtra = Callable[[EnvironmentOptions, Config], ContextManager[None]]
 
 
 class TestEnvironment:

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -10,19 +10,26 @@ import traceback
 import socket
 import sys
 from abc import ABCMeta, abstractmethod
-from typing import Any, Callable, ClassVar, Tuple, Type
+from typing import Any, Callable, ClassVar, Tuple, Type, TYPE_CHECKING
 from urllib.parse import urljoin, urlsplit, urlunsplit
 
 from . import pytestrunner
 from .actions import actions
 from .asyncactions import async_actions
 from .protocol import Protocol, WdspecProtocol
+if TYPE_CHECKING:
+    from ..browsers.base import ExecutorKwargs
+    from ..environment import TestEnvironment
+    from ..testloader import Subsuite
+    from ..wpttest import TestType, RunInfo
 
 
 here = os.path.dirname(__file__)
 
 
-def executor_kwargs(test_type, test_environment, run_info_data, subsuite, **kwargs):
+def executor_kwargs(test_type: "TestType", test_environment: "TestEnvironment",
+                    run_info_data: "RunInfo", subsuite: "Subsuite",
+                    **kwargs: Any) -> "ExecutorKwargs":
     timeout_multiplier = kwargs["timeout_multiplier"]
     if timeout_multiplier is None:
         timeout_multiplier = 1

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -6,7 +6,7 @@ import sys
 from collections import OrderedDict
 from shutil import which
 from datetime import timedelta
-from typing import Mapping, Optional
+from typing import Any, Callable, Mapping, Optional
 
 from . import config
 from . import products
@@ -28,7 +28,8 @@ def url_or_path(path):
         return abs_path(path)
 
 
-def require_arg(kwargs, name, value_func=None):
+def require_arg(kwargs: Mapping[str, Any], name: str,
+                value_func: Optional[Callable[[Any], bool]] = None) -> None:
     if value_func is None:
         value_func = lambda x: x is not None
 

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -4,13 +4,14 @@ import subprocess
 import sys
 from abc import ABC
 from collections import defaultdict
-from typing import Any, ClassVar, Dict, Optional, Set, Type
+from typing import Any, ClassVar, Dict, Literal, Optional, Set, Type, get_args
 from urllib.parse import urljoin
 
 from .wptmanifest.parser import atoms
 
 atom_reset = atoms["Reset"]
-enabled_tests = {"testharness", "reftest", "wdspec", "crashtest", "print-reftest"}
+TestType = Literal["testharness", "reftest", "wdspec", "crashtest", "print-reftest"]
+enabled_tests = frozenset(get_args(TestType))
 
 
 class Result(ABC):


### PR DESCRIPTION
... in lieu of the Chrome `infrastructure/` coverage the upstream CI doesn't have. Hopefully this will reduce the time wasted fixing trivial breakages only discovered downstream.

Chrome Android type hints to follow.