### PR TITLE
Propagate destination through load_data

### DIFF
--- a/content-security-policy/frame-src/frame-src-blocked.sub.html
+++ b/content-security-policy/frame-src/frame-src-blocked.sub.html
@@ -18,17 +18,17 @@
         }, false);
 
         function alert_assert(msg) {
-            t_alert.step(function() {
+            t_log.step(function() {
                 if (msg.match(/^FAIL/i)) {
                     assert_unreached(msg);
-                    t_alert.done();
+                    t_log.done();
                 }
                 for (var i = 0; i < expected_alerts.length; i++) {
                     if (expected_alerts[i] == msg) {
                         assert_equals(expected_alerts[i], msg);
                         expected_alerts.splice(i, 1);
                         if (expected_alerts.length == 0) {
-                            t_alert.done();
+                            t_log.done();
                         }
                         return;
                     }


### PR DESCRIPTION
This way, we don't always set the destination to Document (which is as the spec is written today). Instead, we set it it in the load_data, depending on which context we load it from.

Doing so allows us to set the `Destination::IFrame` for navigations in iframes, enabling all frame-related CSP checks.

While we currently block iframes when `frame-src` or `child-src` is set, their respective tests don't pass yet. That's because we don't yet handle the cases
where we fire the correct `load` event.

Also update one WPT test to correctly fail, rather than erroring. That's because it was using the wrong JS test variable.

Part of #<!-- nolink -->4577

Reviewed in servo/servo#37020