### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=293035

### DIFF
--- a/css/css-view-transitions/content-with-transform-ref.html
+++ b/css/css-view-transitions/content-with-transform-ref.html
@@ -7,7 +7,7 @@
   contain: paint;
   width: 100px;
   height: 100px;
-  transform: scale(2.0, 3.0);
+  transform: scale3d(2.0, 3.0, 1.0);
 }
 
 .embedded {

--- a/css/css-view-transitions/inline-with-offset-from-containing-block-ref.html
+++ b/css/css-view-transitions/inline-with-offset-from-containing-block-ref.html
@@ -6,7 +6,7 @@
 
 <style>
   .outer {
-    transform: scale(2);
+    transform: scale3d(2, 2, 1);
     width: 100vw;
     text-align: center;
   }


### PR DESCRIPTION
WebKit export from bug: [css/css-view-transitions/content-with-transform-new-image fails with fuzzy text](https://bugs.webkit.org/show_bug.cgi?id=293035)