### PR TITLE
Add test for parsing and serializing :dir()

### DIFF
--- a/css/selectors/parsing/parse-dir.html
+++ b/css/selectors/parsing/parse-dir.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Selectors: The directionality pseudo-class</title>
+<link rel="author" title="Sam Atkins" href="mailto:sam@ladybird.org">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#dir-pseudo">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script>
+    test_valid_selector(':dir(rtl)');
+    test_valid_selector(':dir(    rtl )', ':dir(rtl)');
+    test_valid_selector(':dir(ltr):dir(rtl)');
+
+    // Firefox converts this to lowercase but Chrome keeps the original casing. Interop issue?
+    test_valid_selector('foo:dir(RTL)', ['foo:dir(rtl)', 'foo:dir(RTL)']);
+
+    // Values other than ltr and rtl are not invalid, but do not match anything.
+    test_valid_selector(':dir(auto)');
+    test_valid_selector(':dir(none)');
+    test_valid_selector(':dir(something-made-up)');
+
+    test_invalid_selector(':dir()');
+    test_invalid_selector(':dir("ltr")');
+    test_invalid_selector(':dir(ltr, rtl)');
+</script>


### PR DESCRIPTION
Hi, Ladybird had some bugs with `:dir()` and as far as I can tell, there are no WPT tests covering it, so here is one based on the others in the `css/selectors/parsing` directory.

There's an apparent interop issue here about whether to lowercase or keep the original case of the ident. I don't know where I would report this so please do let me know what to do about that.

This is my first test submitted here so let me know if I did anything wrong at all. :slightly_smiling_face: 