### PR TITLE
Implement basics of link preloading

### DIFF
--- a/preload/preload-csp.sub.html
+++ b/preload/preload-csp.sub.html
@@ -24,13 +24,13 @@ promise_test(async (t) => {
   for (const link of links) {
     if (link.rel === 'preload') {
       const r = /\?key=([a-zA-Z0-9\-]+)$/;
-      keys.push(link.href.match(r)[1]);
+      keys.push([link.href, link.as, link.href.match(r)[1]]);
     }
   }
   await new Promise((resolve) => step_timeout(resolve, 3000));
 
-  for (const key of keys) {
-    assert_false(await hasArrivedAtServer(key));
+  for (const [href, type, key] of keys) {
+    assert_false(await hasArrivedAtServer(key), `Preload with href ${href}, type ${type} and key ${key} should not have arrived at the server.`);
   }
 }, 'Preload requests are blocked by CSP.');
 </script>


### PR DESCRIPTION
These changes allow a minimal set of checks for font-src
CSP checks to pass.

Part of #<!-- nolink -->4577
Part of #<!-- nolink -->35035
Reviewed in servo/servo#37036