### PR TITLE
Nesting selectors that refer to pseudo elements must not match the originating element

### DIFF
--- a/css/css-nesting/contextually-invalid-selectors-001.html
+++ b/css/css-nesting/contextually-invalid-selectors-001.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>
+    Contextually invalid selectors due to implicit :is() in nesting should not match and have no
+    specificity
+</title>
+<link rel="help" href="https://drafts.csswg.org/css-nesting/#nest-selector" />
+<link
+    rel="match"
+    href="/css/reference/ref-filled-green-100px-square-only.html"
+/>
+<style>
+    div {
+        color: green;
+        background-color: currentColor;
+        width: 100px;
+        height: 100px;
+    }
+
+    p {
+        color: initial;
+    }
+
+    *,
+    ::before {
+        & * {
+            color: red;
+        }
+    }
+</style>
+
+<p>Test passes if there is a filled green square.</p>
+<div></div>

--- a/css/css-nesting/contextually-invalid-selectors-002.html
+++ b/css/css-nesting/contextually-invalid-selectors-002.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>
+    Contextually invalid selectors due to :is() should not match and have no
+    specificity
+</title>
+<link rel="help" href="https://drafts.csswg.org/css-nesting/#nest-selector" />
+<link
+    rel="match"
+    href="/css/reference/ref-filled-green-100px-square-only.html"
+/>
+<style>
+    div {
+        color: green;
+        background-color: currentColor;
+        width: 100px;
+        height: 100px;
+    }
+
+    p {
+        color: initial;
+    }
+
+    :is(*, ::before) * {
+        color: purple;
+    }
+</style>
+
+<p>Test passes if there is a filled green square.</p>
+<div></div>

--- a/css/css-nesting/contextually-invalid-selectors-003.html
+++ b/css/css-nesting/contextually-invalid-selectors-003.html
@@ -5,6 +5,7 @@
     specificity
 </title>
 <link rel="help" href="https://drafts.csswg.org/css-nesting/#nest-selector" />
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=293230">
 <link
     rel="match"
     href="/css/reference/ref-filled-green-100px-square-only.html"
@@ -21,15 +22,10 @@
         color: initial;
     }
 
-    *,
-    ::before {
-        & * {
+    div::before {
+        & { /* `&` must not match the originating element */
             color: red;
         }
-    }
-
-    :is(*, ::before) * {
-        color: purple;
     }
 </style>
 


### PR DESCRIPTION
See: https://bugs.webkit.org/show_bug.cgi?id=293230
https://codepen.io/romainmenke/pen/ZYYNOgv

It seems that WebKit has a specific quirk where nested selectors with pseudo's in the parent do work, while they shouldn't. But instead of matching the pseudo, they match the originating element.

This change adds a specific test to catch this mishap.