### PR TITLE
Map getVideoPlaybackQuality() tests to web-features

### DIFF
--- a/media-playback-quality/WEB_FEATURES.yml
+++ b/media-playback-quality/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: media-playback-quality
+  files: "**"


### PR DESCRIPTION
There's only a single idlharness.js test in this directory, so this is
only tested at superficial level, but any additional tests would go in
this directory, so it's the right mapping.
