### PR TITLE
Do not enable experimental features if running in stable release mode

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -513,6 +513,9 @@ class Chrome(BrowserSetup):
             if kwargs["enable_webtransport_h3"] is None:
                 # To start the WebTransport over HTTP/3 test server.
                 kwargs["enable_webtransport_h3"] = True
+        else if browser_channel is not None:
+            # browser_channel is not set when running WPT in chromium
+            kwargs["enable_experimental"] = False
         if os.getenv("TASKCLUSTER_ROOT_URL"):
             # We are on Taskcluster, where our Docker container does not have
             # enough capabilities to run Chrome with sandboxing. (gh-20133)

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -513,7 +513,7 @@ class Chrome(BrowserSetup):
             if kwargs["enable_webtransport_h3"] is None:
                 # To start the WebTransport over HTTP/3 test server.
                 kwargs["enable_webtransport_h3"] = True
-        else if browser_channel is not None:
+        elif browser_channel is not None:
             # browser_channel is not set when running WPT in chromium
             kwargs["enable_experimental"] = False
         if os.getenv("TASKCLUSTER_ROOT_URL"):

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -184,9 +184,12 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite
             chrome_options["args"].append(arg)
 
     # do not enable experimental features if running in stable release mode
-    if "--stable-release-mode" not in binary_args:
+    if kwargs["enable_experimental"] is None and "--stable-release-mode" not in binary_args:
         chrome_options["args"].extend(["--enable-experimental-web-platform-features",
                                        "--enable-blink-test-features"])
+
+    if kwargs["enable_experimental"]:
+        chrome_options["args"].extend(["--enable-experimental-web-platform-features"])
 
     # Pass the --headless=new flag to Chrome if WPT's own --headless flag was
     # set. '--headless' should always mean the new headless mode, as the old

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -178,12 +178,15 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite
     # subsuite config.
     binary_args = kwargs.get("binary_args", []) + subsuite.config.get("binary_args", [])
     for arg in binary_args:
+        if arg == "--stable-release-mode":
+            continue
         if arg not in chrome_options["args"]:
             chrome_options["args"].append(arg)
 
     # do not enable experimental features if running in stable release mode
-    if kwargs["enable_experimental"] and "--stable-release-mode" not in binary_args:
-        chrome_options["args"].extend(["--enable-experimental-web-platform-features"])
+    if "--stable-release-mode" not in binary_args:
+        chrome_options["args"].extend(["--enable-experimental-web-platform-features",
+                                       "--enable-blink-test-features"])
 
     # Pass the --headless=new flag to Chrome if WPT's own --headless flag was
     # set. '--headless' should always mean the new headless mode, as the old

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -183,11 +183,15 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite
         if arg not in chrome_options["args"]:
             chrome_options["args"].append(arg)
 
-    # do not enable experimental features if running in stable release mode
+    # Enable experimental features based on stable release mode setting. It is
+    # unfortunately that we need to do this based on a content shell specific
+    # setting, we choose to do this because we can not dynamically set
+    # enable-experimental in run_wpt_tests.py.
     if kwargs["enable_experimental"] is None and "--stable-release-mode" not in binary_args:
         chrome_options["args"].extend(["--enable-experimental-web-platform-features",
                                        "--enable-blink-test-features"])
 
+    # Upstream CI should always explicitly enable/disable experimental features.
     if kwargs["enable_experimental"]:
         chrome_options["args"].extend(["--enable-experimental-web-platform-features"])
 

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -174,9 +174,6 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite
         # https://chromium.googlesource.com/chromium/src/+/HEAD/docs/gpu/swiftshader.md
         chrome_options["args"].extend(["--use-gl=angle", "--use-angle=swiftshader", "--enable-unsafe-swiftshader"])
 
-    if kwargs["enable_experimental"]:
-        chrome_options["args"].extend(["--enable-experimental-web-platform-features"])
-
     # Copy over any other flags that were passed in via `--binary-arg` or the
     # subsuite config.
     binary_args = kwargs.get("binary_args", []) + subsuite.config.get("binary_args", [])
@@ -184,6 +181,9 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite
         if arg not in chrome_options["args"]:
             chrome_options["args"].append(arg)
 
+    # do not enable experimental features if running in stable release mode
+    if kwargs["enable_experimental"] and "--stable-release-mode" not in binary_args:
+        chrome_options["args"].extend(["--enable-experimental-web-platform-features"])
 
     # Pass the --headless=new flag to Chrome if WPT's own --headless flag was
     # set. '--headless' should always mean the new headless mode, as the old


### PR DESCRIPTION
We have a virtual test suite in Chromium to test behavior in this mode. And we should not enable experimental features in this mode.

Bug: crbug.com/418815739