### PR TITLE
Object.__init__ takes 0 arguments

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -106,7 +106,7 @@ class Browser:
     def __init__(self, logger: StructuredLogger, *, manager_number: int, **kwargs: Any):
         if kwargs:
             logger.warning(f"Browser.__init__ kwargs: {kwargs!r}")
-        super().__init__(**kwargs)
+        super().__init__()
         self.logger = logger
         self.manager_number = manager_number
 


### PR DESCRIPTION
When roll wpt tooling to chromium, we met the following error: TypeError: object.__init__() takes exactly one argument (the instance to initialize)

Seems kwargs is not empty when running WPT with headless shell.

This is a follow up change on top of PR 52455