### PR TITLE
css-exclusions: Add assert_implements to avoid false positives.

### DIFF
--- a/css/css-exclusions/wrap-flow-001.html
+++ b/css/css-exclusions/wrap-flow-001.html
@@ -41,8 +41,9 @@
         <div id="log"></div>
 
         <script type="text/javascript">
-            setup({ explicit_done: true });
-
+            setup(() => {
+                assert_implements(CSS.supports('wrap-flow', 'clear'), "'wrap-flow: clear'");
+            }, {explicit_done: true});
             document.fonts.ready.then(() => {
                 test(function() {assert_equals(checkLinePos("linesBelow",150,"top"), true)}, "Verify top of the 'linesBelow' span is positioned correctly");
                 done();

--- a/css/css-exclusions/wrap-flow-002.html
+++ b/css/css-exclusions/wrap-flow-002.html
@@ -44,8 +44,9 @@
         <div id="log"></div>
 
         <script type="text/javascript">
-            setup({ explicit_done: true });
-
+            setup(() => {
+                assert_implements(CSS.supports('wrap-flow', 'start'), "'wrap-flow: start'");
+            }, {explicit_done: true});
             document.fonts.ready.then(() => {
                 test(function() {assert_equals(checkLinePos("lineLeft1",36,"top"), true)}, "Verify top of the 'lineLeft1' span is positioned correctly");
                 test(function() {assert_equals(checkLinePos("lineLeft2",48,"top"), true)}, "Verify top of the 'lineLeft2' span is positioned correctly");

--- a/css/css-exclusions/wrap-flow-003.html
+++ b/css/css-exclusions/wrap-flow-003.html
@@ -44,8 +44,9 @@
         <div id="log"></div>
 
         <script type="text/javascript">
-            setup({ explicit_done: true });
-
+            setup(() => {
+                assert_implements(CSS.supports('wrap-flow', 'auto'), "'wrap-flow: auto'");
+            }, {explicit_done: true});
             document.fonts.ready.then(() => {
                 test(function() {assert_equals(checkLinePos("line1",216,"right"), true)}, "Verify right of the 'line1' span is positioned correctly");
                 test(function() {assert_equals(checkLinePos("line2",192,"right"), true)}, "Verify right of the 'line2' span is positioned correctly");

--- a/css/css-exclusions/wrap-flow-004.html
+++ b/css/css-exclusions/wrap-flow-004.html
@@ -45,8 +45,9 @@
         <div id="log"></div>
 
         <script type="text/javascript">
-            setup({ explicit_done: true });
-
+            setup(() => {
+                assert_implements(CSS.supports('wrap-flow', 'both'), "'wrap-flow: both'");
+            }, {explicit_done: true});
             document.fonts.ready.then(() => {
                 /* Line 1 */
                 test(function() {assert_equals(checkLinePos("line1",0,"top"), true)}, "Verify top of the 'line1' span is positioned correctly");

--- a/css/css-exclusions/wrap-flow-005.html
+++ b/css/css-exclusions/wrap-flow-005.html
@@ -45,8 +45,9 @@
         <div id="log"></div>
 
         <script type="text/javascript">
-            setup({ explicit_done: true });
-
+            setup(() => {
+                assert_implements(CSS.supports('wrap-flow', 'end'), "'wrap-flow: end'");
+            }, {explicit_done: true});
             document.fonts.ready.then(() => {
                 /* Line 1 */
                 test(function() {assert_equals(checkLinePos("line1",0,"top"), true)}, "Verify top of the 'line1' span is positioned correctly");

--- a/css/css-exclusions/wrap-flow-006.html
+++ b/css/css-exclusions/wrap-flow-006.html
@@ -44,8 +44,9 @@
         <div id="log"></div>
 
         <script type="text/javascript">
-            setup({ explicit_done: true });
-
+            setup(() => {
+                assert_implements(CSS.supports('wrap-flow', 'maximum'), "'wrap-flow: maximum'");
+            }, {explicit_done: true});
             document.fonts.ready.then(() => {
                 /*Line 1*/
                 test(function() {assert_equals(checkLinePos("line1",0,"top"), true)}, "Verify top of the 'line1' span is positioned correctly");

--- a/css/css-exclusions/wrap-through-001.html
+++ b/css/css-exclusions/wrap-through-001.html
@@ -51,8 +51,10 @@
         <div id="log"></div>
 
         <script type="text/javascript">
-            setup({ explicit_done: true });
-
+            setup(() => {
+                assert_implements(CSS.supports('wrap-through', 'none'), "'wrap-through: none'");
+                assert_implements(CSS.supports('wrap-flow', 'both'), "'wrap-flow: both'");
+            }, {explicit_done: true});
             document.fonts.ready.then(() => {
                 /* Line 1 */
                 test(function() {assert_equals(checkLinePos("line1",0,"top"), true)}, "Verify top of the first line above the exclusion");


### PR DESCRIPTION
css-exclusions <https://drafts.csswg.org/css-exclusions/> is nowadays deprecated and usupported by all the major browsers.

However, some subtests in this directory still pass because they do not check whether the CSS property is supported before running. As a result, the directory ends up with a misleading score of 30/54.

Fix that by adding the required `assert_implements` checks.