### PR TITLE
Remove most usage of target_platform

### DIFF
--- a/webdriver/tests/classic/new_session/merge.py
+++ b/webdriver/tests/classic/new_session/merge.py
@@ -40,13 +40,16 @@ def test_merge_invalid(new_session, add_browser_capabilities, key, value):
     assert_error(response, "invalid argument")
 
 
-def test_merge_platform_name(new_session, add_browser_capabilities, target_platform):
+def test_merge_platform_name(new_session, add_browser_capabilities):
     always_match = add_browser_capabilities({})
 
     if "platformName" in always_match:
         platform_name = always_match.pop("platformName")
     else:
-        platform_name = target_platform
+        response, _ = new_session(
+            {"capabilities": {"alwaysMatch": always_match}})
+        value = assert_success(response)
+        platform_name = value["capabilities"]["platformName"]
 
     # Remove pageLoadStrategy so we can use it to validate the merging of the firstMatch
     # capabilities, and guarantee platformName isn't simply ignored.
@@ -61,7 +64,7 @@ def test_merge_platform_name(new_session, add_browser_capabilities, target_platf
         }, {
             "platformName": platform_name,
             "pageLoadStrategy": "eager",
-        }]}})
+        }]}}, delete_existing_session=True)
 
     value = assert_success(response)
 

--- a/webdriver/tests/classic/new_session/merge.py
+++ b/webdriver/tests/classic/new_session/merge.py
@@ -5,23 +5,6 @@ import pytest
 from tests.support.asserts import assert_error, assert_success
 
 
-@pytest.mark.parametrize("body", [
-    lambda key, value: {"alwaysMatch": {key: value}},
-    lambda key, value: {"firstMatch": [{key: value}]}
-], ids=["alwaysMatch", "firstMatch"])
-def test_platform_name(new_session, add_browser_capabilities, body, target_platform):
-    capabilities = body("platformName", target_platform)
-    if "alwaysMatch" in capabilities:
-        capabilities["alwaysMatch"] = add_browser_capabilities(capabilities["alwaysMatch"])
-    else:
-        capabilities["firstMatch"][0] = add_browser_capabilities(capabilities["firstMatch"][0])
-
-    response, _ = new_session({"capabilities": capabilities})
-    value = assert_success(response)
-
-    assert value["capabilities"]["platformName"] == target_platform
-
-
 invalid_merge = [
     ("acceptInsecureCerts", (True, True)),
     ("unhandledPromptBehavior", ("accept", "accept")),

--- a/webdriver/tests/classic/new_session/platform_name.py
+++ b/webdriver/tests/classic/new_session/platform_name.py
@@ -1,7 +1,0 @@
-from tests.support.asserts import assert_success
-
-
-def test_corresponds_to_local_system(new_session, add_browser_capabilities, target_platform):
-    response, _ = new_session({"capabilities": {"alwaysMatch": add_browser_capabilities({})}})
-    value = assert_success(response)
-    assert value["capabilities"]["platformName"] == target_platform


### PR DESCRIPTION
Currently we set `target_platform` based on what `mozinfo` returns for the given platform; [the spec for `platformName`](https://w3c.github.io/webdriver/#:~:text=%22platformName%22,-If%20value%20is) in an (informative) note suggests certain values, but it doesn't place any normative requirements on `platformName`, and thus these tests aren't justified by the spec.

Some of these can be rewritten to first create a session, and then use the value from that as the reference value; others seem impossible to write any test for.

See the individual tests. See also https://github.com/web-platform-tests/wpt/pull/52709 which does add some further coverage based on what the spec does require.