### PR TITLE
Ensure createImageBitmap resolves in a task

### DIFF
--- a/html/canvas/element/manual/imagebitmap/common.sub.js
+++ b/html/canvas/element/manual/imagebitmap/common.sub.js
@@ -57,7 +57,10 @@ function makeVideo() {
   return makeMakeVideo("/images/pattern")();
 }
 
-var imageBitmapDataUrlVideoPromise = fetch(getVideoURI("/images/pattern"))
+var imageBitmapDataUrlVideoPromise = self.GLOBAL.isWorker()
+    // /common/media.js can't load in a Worker so we don't have getVideoURI
+    ? null
+    : fetch(getVideoURI("/images/pattern"))
     .then(response => Promise.all([response.headers.get("Content-Type"), response.arrayBuffer()]))
     .then(([type, data]) => {
         return new Promise(function(resolve, reject) {

--- a/html/canvas/element/manual/imagebitmap/common.sub.js
+++ b/html/canvas/element/manual/imagebitmap/common.sub.js
@@ -57,7 +57,7 @@ function makeVideo() {
   return makeMakeVideo("/images/pattern")();
 }
 
-var imageBitmapDataUrlVideoPromise = self.GLOBAL.isWorker()
+var imageBitmapDataUrlVideoPromise = self.GLOBAL && self.GLOBAL.isWorker()
     // /common/media.js can't load in a Worker so we don't have getVideoURI
     ? null
     : fetch(getVideoURI("/images/pattern"))

--- a/html/canvas/element/manual/imagebitmap/createImageBitmap-resolves-in-task.any.js
+++ b/html/canvas/element/manual/imagebitmap/createImageBitmap-resolves-in-task.any.js
@@ -1,0 +1,122 @@
+// META: title=createImageBitmap resolves in a task
+// META: script=/common/media.js
+// META: script=./common.sub.js
+function makeWorkerImageBitmap() {
+  return makeOffscreenCanvas().then(canvas => {
+      return createImageBitmap(canvas);
+  });
+}
+var imageSourceTypes = self.GLOBAL.isWorker()
+  ? [
+      { name: 'an OffscreenCanvas',   factory: makeOffscreenCanvas },
+      { name: 'an ImageData',         factory: makeImageData },
+      { name: 'an ImageBitmap',       factory: makeWorkerImageBitmap },
+      { name: 'a Blob',               factory: makeBlob('/images/pattern.png') },
+    ]
+  : imageSourceTypes;
+
+var testFuncs = {
+  reject_sync: (promiseFunc, source, t) => {
+    return new Promise((resolve, reject) => {
+      let rejected = false;
+      requestAnimationFrame(function () {
+        promiseFunc(source).then(function () {
+          reject(new Error('Expected this call to reject'));
+        }, (err) => {
+          rejected = true;
+        })
+      });
+      requestAnimationFrame(() => {
+        try {
+          assert_equals(rejected, true)
+          resolve(t);
+        }
+        catch(err) {
+          reject(err);
+        }
+      });
+    });
+  },
+  resolve_async: (promiseFunc, source, t) => {
+    return new Promise((resolve, reject) => {
+      let taskRan = false;
+      requestAnimationFrame(function () {
+        promiseFunc(source).then(function () {
+          try {
+            assert_equals(taskRan, true)
+            resolve(t);
+          }
+          catch(err) {
+            reject(err)
+          }
+        }, t.unreached_func('Expected this call to resolve'))
+      });
+      requestAnimationFrame(() => {
+        taskRan = true;
+      });
+    });
+  },
+  reject_async: (promiseFunc, source, t) => {
+    return new Promise((resolve, reject) => {
+      let taskRan = false;
+      requestAnimationFrame(function () {
+        promiseFunc(source).then(
+          t.unreached_func('Expected this call to reject'),
+          function () {
+            try {
+              assert_equals(taskRan, true)
+              resolve(t);
+            }
+            catch(err) {
+              reject(err)
+            }
+          },
+        );
+      });
+      requestAnimationFrame(() => {
+        taskRan = true;
+      });
+    });
+  },
+};
+
+var testCases = [
+  {
+    description: 'createImageBitmap with <sourceType> source and ' +
+        'invalid cropHeight',
+    promiseTestFunction: (source) => createImageBitmap(source, 0, 0, 0, 0),
+    resolution: 'reject_sync'
+  },
+  {
+    description: 'createImageBitmap with <sourceType> source and ' +
+        'invalid resizeHeight',
+    promiseTestFunction: (source) => createImageBitmap(source, { resizeWidth: 0,
+      resizeHeight: 0 }),
+    resolution: 'reject_sync'
+  },
+  {
+    description: 'createImageBitmap with <sourceType> source',
+    promiseTestFunction: (source) => createImageBitmap(source),
+    resolution: 'resolve_async'
+  },
+];
+
+imageSourceTypes.forEach(imageSourceType => {
+  testCases.forEach(testCase => {
+    let description = `${testCase.description.replace('<sourceType>',
+        imageSourceType.name)} should ${testCase.resolution.replace('_', ' ')}`;
+
+    promise_test( t => {
+      return imageSourceType.factory().then(source => {
+        const tester = testFuncs[testCase.resolution];
+        return tester(testCase.promiseTestFunction, source, t);
+      }).then(() => t.done())
+    }, description);
+
+  });
+});
+promise_test( t => {
+  return makeBlob('data:,')().then( image => {
+    return testFuncs.reject_async((source) => createImageBitmap(source), image, t);
+  });
+}, 'Invalid Blob source should reject async');

--- a/html/canvas/element/manual/imagebitmap/createImageBitmap-resolves-in-task.any.js
+++ b/html/canvas/element/manual/imagebitmap/createImageBitmap-resolves-in-task.any.js
@@ -19,7 +19,7 @@ var testFuncs = {
     reject_sync: (promiseFunc, source, t) => {
         return new Promise((resolve, reject) => {
             let rejected = false;
-            promiseFunc(source).then(function() {
+            promiseFunc(source).then(() => {
                 reject(new Error('Expected this call to reject'));
             }, (err) => {
                 rejected = true;
@@ -38,7 +38,7 @@ var testFuncs = {
     resolve_async: (promiseFunc, source, t) => {
         return new Promise((resolve, reject) => {
             let taskRan = false;
-            promiseFunc(source).then(function() {
+            promiseFunc(source).then(() => {
                 try {
                     assert_equals(taskRan, true)
                     resolve(t);
@@ -54,10 +54,10 @@ var testFuncs = {
     reject_async: (promiseFunc, source, t) => {
         return new Promise((resolve, reject) => {
             let taskRan = false;
-            Promise.resolve().then(function() {
+            Promise.resolve().then(() => {
                 promiseFunc(source).then(
                     t.unreached_func('Expected this call to reject'),
-                    function() {
+                    () => {
                         try {
                             assert_equals(taskRan, true)
                             resolve(t);

--- a/html/canvas/element/manual/imagebitmap/createImageBitmap-resolves-in-task.any.js
+++ b/html/canvas/element/manual/imagebitmap/createImageBitmap-resolves-in-task.any.js
@@ -26,7 +26,7 @@ var testFuncs = {
             });
             Promise.resolve().then(() => {
                 try {
-                    assert_equals(rejected, true)
+                    assert_equals(rejected, true, 'The promise should be rejected synchronously')
                     resolve(t);
                 } catch (err) {
                     reject(err);
@@ -40,7 +40,7 @@ var testFuncs = {
             let taskRan = false;
             promiseFunc(source).then(() => {
                 try {
-                    assert_equals(taskRan, true)
+                    assert_equals(taskRan, true, 'The promise should be resolved asynchronously')
                     resolve(t);
                 } catch (err) {
                     reject(err)
@@ -59,7 +59,7 @@ var testFuncs = {
                     t.unreached_func('Expected this call to reject'),
                     () => {
                         try {
-                            assert_equals(taskRan, true)
+                            assert_equals(taskRan, tru, 'The promise should be rejected asynchronously')
                             resolve(t);
                         } catch (err) {
                             reject(err)

--- a/html/canvas/element/manual/imagebitmap/createImageBitmap-resolves-in-task.any.js
+++ b/html/canvas/element/manual/imagebitmap/createImageBitmap-resolves-in-task.any.js
@@ -2,121 +2,116 @@
 // META: script=/common/media.js
 // META: script=./common.sub.js
 function makeWorkerImageBitmap() {
-  return makeOffscreenCanvas().then(canvas => {
-      return createImageBitmap(canvas);
-  });
+    return makeOffscreenCanvas().then(canvas => {
+        return createImageBitmap(canvas);
+    });
 }
-var imageSourceTypes = self.GLOBAL.isWorker()
-  ? [
-      { name: 'an OffscreenCanvas',   factory: makeOffscreenCanvas },
-      { name: 'an ImageData',         factory: makeImageData },
-      { name: 'an ImageBitmap',       factory: makeWorkerImageBitmap },
-      { name: 'a Blob',               factory: makeBlob('/images/pattern.png') },
-    ]
-  : imageSourceTypes;
+var imageSourceTypes = self.GLOBAL.isWorker() ?
+    [
+        { name: 'an OffscreenCanvas', factory: makeOffscreenCanvas },
+        { name: 'an ImageData', factory: makeImageData },
+        { name: 'an ImageBitmap', factory: makeWorkerImageBitmap },
+        { name: 'a Blob', factory: makeBlob('/images/pattern.png') },
+    ] :
+    imageSourceTypes;
 
 var testFuncs = {
-  reject_sync: (promiseFunc, source, t) => {
-    return new Promise((resolve, reject) => {
-      let rejected = false;
-      requestAnimationFrame(function () {
-        promiseFunc(source).then(function () {
-          reject(new Error('Expected this call to reject'));
-        }, (err) => {
-          rejected = true;
-        })
-      });
-      requestAnimationFrame(() => {
-        try {
-          assert_equals(rejected, true)
-          resolve(t);
-        }
-        catch(err) {
-          reject(err);
-        }
-      });
-    });
-  },
-  resolve_async: (promiseFunc, source, t) => {
-    return new Promise((resolve, reject) => {
-      let taskRan = false;
-      requestAnimationFrame(function () {
-        promiseFunc(source).then(function () {
-          try {
-            assert_equals(taskRan, true)
-            resolve(t);
-          }
-          catch(err) {
-            reject(err)
-          }
-        }, t.unreached_func('Expected this call to resolve'))
-      });
-      requestAnimationFrame(() => {
-        taskRan = true;
-      });
-    });
-  },
-  reject_async: (promiseFunc, source, t) => {
-    return new Promise((resolve, reject) => {
-      let taskRan = false;
-      requestAnimationFrame(function () {
-        promiseFunc(source).then(
-          t.unreached_func('Expected this call to reject'),
-          function () {
-            try {
-              assert_equals(taskRan, true)
-              resolve(t);
-            }
-            catch(err) {
-              reject(err)
-            }
-          },
-        );
-      });
-      requestAnimationFrame(() => {
-        taskRan = true;
-      });
-    });
-  },
+    reject_sync: (promiseFunc, source, t) => {
+        return new Promise((resolve, reject) => {
+            let rejected = false;
+            promiseFunc(source).then(function() {
+                reject(new Error('Expected this call to reject'));
+            }, (err) => {
+                rejected = true;
+            });
+            Promise.resolve().then(() => {
+                try {
+                    assert_equals(rejected, true)
+                    resolve(t);
+                } catch (err) {
+                    reject(err);
+                }
+            })
+        });
+
+    },
+    resolve_async: (promiseFunc, source, t) => {
+        return new Promise((resolve, reject) => {
+            let taskRan = false;
+            promiseFunc(source).then(function() {
+                try {
+                    assert_equals(taskRan, true)
+                    resolve(t);
+                } catch (err) {
+                    reject(err)
+                }
+            }, t.unreached_func('Expected this call to resolve'))
+            Promise.resolve().then(() => {
+                taskRan = true;
+            });
+        });
+    },
+    reject_async: (promiseFunc, source, t) => {
+        return new Promise((resolve, reject) => {
+            let taskRan = false;
+            Promise.resolve().then(function() {
+                promiseFunc(source).then(
+                    t.unreached_func('Expected this call to reject'),
+                    function() {
+                        try {
+                            assert_equals(taskRan, true)
+                            resolve(t);
+                        } catch (err) {
+                            reject(err)
+                        }
+                    },
+                );
+            });
+            Promise.resolve().then(() => {
+                taskRan = true;
+            });
+        });
+    },
 };
 
-var testCases = [
-  {
-    description: 'createImageBitmap with <sourceType> source and ' +
-        'invalid cropHeight',
-    promiseTestFunction: (source) => createImageBitmap(source, 0, 0, 0, 0),
-    resolution: 'reject_sync'
-  },
-  {
-    description: 'createImageBitmap with <sourceType> source and ' +
-        'invalid resizeHeight',
-    promiseTestFunction: (source) => createImageBitmap(source, { resizeWidth: 0,
-      resizeHeight: 0 }),
-    resolution: 'reject_sync'
-  },
-  {
-    description: 'createImageBitmap with <sourceType> source',
-    promiseTestFunction: (source) => createImageBitmap(source),
-    resolution: 'resolve_async'
-  },
+var testCases = [{
+        description: 'createImageBitmap with <sourceType> source and ' +
+            'invalid cropHeight',
+        promiseTestFunction: (source) => createImageBitmap(source, 0, 0, 0, 0),
+        resolution: 'reject_sync'
+    },
+    {
+        description: 'createImageBitmap with <sourceType> source and ' +
+            'invalid resizeHeight',
+        promiseTestFunction: (source) => createImageBitmap(source, {
+            resizeWidth: 0,
+            resizeHeight: 0
+        }),
+        resolution: 'reject_sync'
+    },
+    {
+        description: 'createImageBitmap with <sourceType> source',
+        promiseTestFunction: (source) => createImageBitmap(source),
+        resolution: 'resolve_async'
+    },
 ];
 
 imageSourceTypes.forEach(imageSourceType => {
-  testCases.forEach(testCase => {
-    let description = `${testCase.description.replace('<sourceType>',
+    testCases.forEach(testCase => {
+        let description = `${testCase.description.replace('<sourceType>',
         imageSourceType.name)} should ${testCase.resolution.replace('_', ' ')}`;
 
-    promise_test( t => {
-      return imageSourceType.factory().then(source => {
-        const tester = testFuncs[testCase.resolution];
-        return tester(testCase.promiseTestFunction, source, t);
-      }).then(() => t.done())
-    }, description);
+        promise_test(t => {
+            return imageSourceType.factory().then(source => {
+                const tester = testFuncs[testCase.resolution];
+                return tester(testCase.promiseTestFunction, source, t);
+            }).then(() => t.done())
+        }, description);
 
-  });
+    });
 });
-promise_test( t => {
-  return makeBlob('data:,')().then( image => {
-    return testFuncs.reject_async((source) => createImageBitmap(source), image, t);
-  });
+promise_test(t => {
+    return makeBlob('data:,')().then(image => {
+        return testFuncs.reject_async((source) => createImageBitmap(source), image, t);
+    });
 }, 'Invalid Blob source should reject async');

--- a/html/canvas/element/manual/imagebitmap/createImageBitmap-resolves-in-task.any.js
+++ b/html/canvas/element/manual/imagebitmap/createImageBitmap-resolves-in-task.any.js
@@ -105,7 +105,7 @@ imageSourceTypes.forEach(imageSourceType => {
             return imageSourceType.factory().then(source => {
                 const tester = testFuncs[testCase.resolution];
                 return tester(testCase.promiseTestFunction, source, t);
-            }).then(() => t.done())
+            })
         }, description);
 
     });


### PR DESCRIPTION
Tests for https://github.com/whatwg/html/pull/11327

See https://github.com/whatwg/html/issues/10611 where it was resolved that Firefox behavior (always resolving the promise in a task) was the better solution.

These tests currently pass in Firefox and fail in Chrome and Safari.

I had to modify the common.sub.js to be able to load it in a worker.