### PR TITLE
[wdspec] add `proxy` to `create_user_context`

### DIFF
--- a/tools/webdriver/webdriver/bidi/modules/browser.py
+++ b/tools/webdriver/webdriver/bidi/modules/browser.py
@@ -28,12 +28,16 @@ class Browser(BidiModule):
 
     @command
     def create_user_context(
-        self, accept_insecure_certs: Optional[bool] = None
+        self, accept_insecure_certs: Optional[bool] = None,
+        proxy: Optional[Mapping[str, Any]] = None
     ) -> Mapping[str, Any]:
         params: MutableMapping[str, Any] = {}
 
         if accept_insecure_certs is not None:
             params["acceptInsecureCerts"] = accept_insecure_certs
+
+        if proxy is not None:
+            params["proxy"] = proxy
 
         return params
 

--- a/webdriver/tests/support/fixtures_bidi.py
+++ b/webdriver/tests/support/fixtures_bidi.py
@@ -499,10 +499,10 @@ async def create_user_context(bidi_session):
 
     user_contexts = []
 
-    async def create_user_context(accept_insecure_certs=None):
+    async def create_user_context(accept_insecure_certs=None, proxy=None):
         nonlocal user_contexts
         user_context = await bidi_session.browser.create_user_context(
-            accept_insecure_certs=accept_insecure_certs
+            accept_insecure_certs=accept_insecure_certs, proxy=proxy
         )
         user_contexts.append(user_context)
 


### PR DESCRIPTION
It looks like CI check in https://github.com/web-platform-tests/wpt/pull/52691 times out due to huge amount of affected tests. So split the PR into 2.

Part 1: expose `proxy` to `create_user_context` without any tests.