### PR TITLE
[wptrunner] Trace renderer creation by each executor

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -304,6 +304,10 @@ class ChromeDriverTestharnessExecutor(WebDriverTestharnessExecutor):
                 test_window = self.protocol.testharness.persistent_test_window = None
         if not test_window:
             test_window = super().get_or_create_test_window(protocol)
+            if self.reuse_window:
+                self.logger.info(f"Created new test window {test_window}")
+            # Without `--reuse-window`, each testharness test always creates a
+            # new window, so tracing that event is not interesting.
         if self.reuse_window:
             self.protocol.testharness.persistent_test_window = test_window
         return test_window


### PR DESCRIPTION
When `--reuse-window` is enabled, log when the Chrome executor creates a new window for testharness tests. This will help diagnose bugs like https://crbug.com/417806060 by pinpointing when new renderers are created.