### PR TITLE
Avoid potential false-positive in empty translate attribute test

### DIFF
--- a/html/dom/elements/global-attributes/the-translate-attribute-012.html
+++ b/html/dom/elements/global-attributes/the-translate-attribute-012.html
@@ -14,7 +14,7 @@
 
 
 
-<div class="test"><div id="box" translate="">&nbsp;</div></div>
+<div class="test" translate="no"><div id="box" translate="">&nbsp;</div></div>
 
 
 <script>


### PR DESCRIPTION
Previously div#box would have a translation mode of translate-enabled even if the value set for it's translate attribute was invalid by virtue of having no ancestors with translate mode set to no-translate.

This patch fixes that and avoids the potential false positive that comes along with it.