### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=293465

### DIFF
--- a/css/css-view-transitions/pseudo-with-classes-view-transition-group.html
+++ b/css/css-view-transitions/pseudo-with-classes-view-transition-group.html
@@ -17,7 +17,10 @@
   view-transition-class: cls;
 }
 
-:root::view-transition-group(*) {
+:root::view-transition-group(*),
+:root::view-transition-image-pair(*),
+:root::view-transition-new(*),
+:root::view-transition-old(*) {
   animation-play-state: paused;
 }
 


### PR DESCRIPTION
WebKit export from bug: [css/css-view-transitions/pseudo-with-classes-view-transition-group.html is a flaky failure](https://bugs.webkit.org/show_bug.cgi?id=293465)