### PR TITLE
Forward `manager_number` to `NullBrowser` constructor

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/servo.py
+++ b/tools/wptrunner/wptrunner/browsers/servo.py
@@ -74,7 +74,7 @@ def update_properties():
 class ServoBrowser(NullBrowser):
     def __init__(self, logger, binary, debug_info=None, binary_args=None,
                  user_stylesheets=None, ca_certificate_path=None, **kwargs):
-        NullBrowser.__init__(self, logger)
+        NullBrowser.__init__(self, logger, **kwargs)
         self.binary = binary
         self.debug_info = debug_info
         self.binary_args = binary_args or []


### PR DESCRIPTION
Testing: No tests, if `test-wpt` broke again then we would notice pretty quickly.
Fixes: https://github.com/servo/servo/issues/37124

Reviewed in servo/servo#37125