### PR TITLE
Always load Ahem.ttf as web font and not from local disk

### DIFF
--- a/fonts/ahem.css
+++ b/fonts/ahem.css
@@ -1,6 +1,5 @@
 @font-face {
     font-family: 'Ahem';
-    src: local('Ahem'),
-         url('/fonts/Ahem.ttf');
+    src: url('/fonts/Ahem.ttf');
 }
 


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1965482 for more details. But in short loading the `Ahem.ttf` from the local disk can cause a up to 7s delay during the startup of the web-platform tests.

CC @jfkthame @jgraham @gsnedders @foolip 