### PR TITLE
fetch: Add missing body mixin to content-encoding tests

### DIFF
--- a/fetch/content-encoding/br/bad-br-body.https.any.js
+++ b/fetch/content-encoding/br/bad-br-body.https.any.js
@@ -2,6 +2,11 @@
 
 [
   "arrayBuffer",
+  "blob",
+  "bytes",
+  "formData",
+  "json",
+  "text"
 ].forEach(method => {
   promise_test(t => {
     return fetch("resources/bad-br-body.py").then(res => {

--- a/fetch/content-encoding/gzip/bad-gzip-body.any.js
+++ b/fetch/content-encoding/gzip/bad-gzip-body.any.js
@@ -9,6 +9,7 @@ promise_test((test) => {
 [
   "arrayBuffer",
   "blob",
+  "bytes",
   "formData",
   "json",
   "text"

--- a/fetch/content-encoding/zstd/bad-zstd-body.https.any.js
+++ b/fetch/content-encoding/zstd/bad-zstd-body.https.any.js
@@ -9,6 +9,7 @@ promise_test((test) => {
 [
   "arrayBuffer",
   "blob",
+  "bytes",
   "formData",
   "json",
   "text"


### PR DESCRIPTION
This enhances test coverage by ensuring content-encoding is validated comprehensively across all relevant mixin types.