### PR TITLE
layout: Fix logic for transforms with non-invertible matrix

### DIFF
--- a/css/css-transforms/individual-transform/individual-transform-3.html
+++ b/css/css-transforms/individual-transform/individual-transform-3.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Individual transform: non-invertible matrix</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#ctm">
+<link rel="help" href="https://drafts.csswg.org/css-transforms-1/#transform-function-lists">
+<link rel="help" href="https://github.com/servo/servo/issues/37146">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="Tests that the element isn't rendered when
+    the current transformation matrix is non-invertible because of `scale`.">
+
+<style>
+.wrapper {
+  width: 200px;
+  height: 200px;
+  background: green;
+}
+.wrapper > div {
+  width: 200px;
+  height: 20px;
+  background: red;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div class="wrapper">
+  <div style="scale: 0"></div>
+  <div style="scale: 0 0"></div>
+  <div style="scale: 0 1"></div>
+  <div style="scale: 1 0"></div>
+  <div style="scale: 0 0 0"></div>
+  <div style="scale: 0 0 1"></div>
+  <div style="scale: 0 1 0"></div>
+  <div style="scale: 0 1 1"></div>
+  <div style="scale: 1 0 0"></div>
+  <div style="scale: 1 0 1"></div>
+  <div style="scale: 1 1 0"></div>
+</div>

--- a/css/css-transforms/transform-matrix-009.html
+++ b/css/css-transforms/transform-matrix-009.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test (Transforms): matrix() with zeros in the diagonal</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/css-transforms-1/#funcdef-transform-matrix">
+<link rel="help" href="https://www.w3.org/TR/css-transforms-1/#transform-function-lists">
+<link rel="help" href="https://github.com/servo/servo/issues/37146">
+<link rel="match" href="../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="Tests that the element is still rendered,
+    even though the current transformation matrix has zeros in the diagonal,
+    as long as the matrix remains invertible.">
+
+<style>
+.wrapper {
+  width: 200px;
+  height: 200px;
+  background: red;
+}
+.test {
+  width: 200px;
+  height: 200px;
+  background: green;
+  transform: matrix(0,1, 1,0, 0,0);
+  /*
+    The resulting matrix is:
+    ┌         ┐
+    │ 0 1 0 0 │
+    │ 1 0 0 0 │
+    │ 0 0 1 0 │
+    │ 0 0 0 1 │
+    └         ┘
+    It could result from e.g. `scaleX(-1) rotate(90deg)`.
+  */
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div class="wrapper">
+  <div class="test"></div>
+</div>


### PR DESCRIPTION
When the the current transformation matrix of a box isn't invertible, the box and its content shouldn't be displayed.

However, the logic was broken:
- It was only checking the `transform` property, but not individual transform properties like `scale`.
- It was treating matrices with m₁₁=0 or m₂₂=0 and non-invertible, even when they can still be invertible and have a visible outcome.
- When m₁₁=0 or m₂₂=0 weren't caused by `transform`, it was replacing the matrix with the identity.

Testing: Adding new WPT
Fixes: #<!-- nolink -->37146

Reviewed in servo/servo#37147