### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=265734

### DIFF
--- a/css/css-view-transitions/column-span-during-transition-doesnt-skip-ref.html
+++ b/css/css-view-transitions/column-span-during-transition-doesnt-skip-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>View transitions: column-span elements in a fragmented container aren't skipped</title>
+<link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
+<link rel="author" href="mailto:mattwoodrow@apple.com">
+
+<style>
+html {
+  background: pink;
+}
+#container {
+  width: 500px;
+  height: 500px;
+  columns: 2;
+}
+#target {
+  height: 200px;
+  background: green;
+  column-span: all;
+}
+</style>
+<div id=container>
+  <div id=target></div>
+</div>

--- a/css/css-view-transitions/column-span-during-transition-doesnt-skip.html
+++ b/css/css-view-transitions/column-span-during-transition-doesnt-skip.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: column-span elements in a fragmented container aren't skipped</title>
+<link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
+<link rel="author" href="mailto:mattwoodrow@apple.com">
+<link rel="match" href="column-span-during-transition-doesnt-skip-ref.html">
+
+<script src="/common/reftest-wait.js"></script>
+<style>
+#container {
+  width: 500px;
+  height: 500px;
+}
+.fragment {
+  columns: 2;
+}
+#target {
+  height: 200px;
+  background: green;
+  view-transition-name: target;
+  column-span: all;
+}
+
+::view-transition {
+  background: pink;
+}
+::view-transition-group(root) {
+  animation-duration: 500s;
+  visibility: hidden;
+}
+</style>
+<div id=container>
+  <div id=target></div>
+</div>
+
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+function runTransition() {
+  let t = document.startViewTransition();
+  t.ready.then(() => {
+    requestAnimationFrame(() => {
+      container.classList.add("fragment")
+      requestAnimationFrame(takeScreenshot);
+    });
+  });
+}
+
+requestAnimationFrame(() => requestAnimationFrame(runTransition))
+</script>


### PR DESCRIPTION
WebKit export from bug: [\[view-transitions\] Exclude fragmented boxes from capture](https://bugs.webkit.org/show_bug.cgi?id=265734)