### PR TITLE
DONT COMMIT: prerender tests CI testing

### DIFF
--- a/speculation-rules/prerender/cross-origin-isolated.https.html
+++ b/speculation-rules/prerender/cross-origin-isolated.https.html
@@ -11,6 +11,7 @@
 
 <body>
 <script>
+
 setup(() => assertSpeculationRulesIsSupported());
 
 promise_test(async t => {


### PR DESCRIPTION
DON'T MERGE
This is used to investigate prerender tests flakiness.