### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=293599

### DIFF
--- a/css/css-view-transitions/inline-with-offset-from-containing-block.html
+++ b/css/css-view-transitions/inline-with-offset-from-containing-block.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 <link rel="match" href="inline-with-offset-from-containing-block-ref.html">
-<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-1500">
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-1633">
 
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>

--- a/css/css-view-transitions/new-content-captures-different-size.html
+++ b/css/css-view-transitions/new-content-captures-different-size.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="new-content-captures-different-size-ref.html">
-<meta name=fuzzy content="maxDifference=0-100; totalPixels=0-15000">
+<meta name=fuzzy content="maxDifference=0-100; totalPixels=0-15393">
 <script src="/common/reftest-wait.js"></script>
 <style>
   html {


### PR DESCRIPTION
WebKit export from bug: [Cleanup some view transitions expectations](https://bugs.webkit.org/show_bug.cgi?id=293599)