### PR TITLE
net: Perform CSP checks on fetch responses.

### DIFF
--- a/content-security-policy/default-src/default-src-sri_hash.sub.html
+++ b/content-security-policy/default-src/default-src-sri_hash.sub.html
@@ -7,6 +7,9 @@
     <script src='/resources/testharnessreport.js' nonce='dummy'></script>
 
     <!-- CSP served: default-src {{domains[www]}}:* 'nonce-dummy' 'sha256-wIc3KtqOuTFEu6t17sIBuOswgkV406VJvhSk79Gw6U0=' 'ShA256-L7/UQ9VWpyG7C9RDEC4ctS5hI3Zcw+ta+haPGlByG9c=' 'sha512-rYCVMxWV5nq8IsMo+UZNObWtEiWGok/vDN8BMoEQi41s0znSes6E1Q2aag3Lw3u2J1w2rqH7uF2ws6FpQhfSOA=='; style-src 'unsafe-inline' -->
+    <!-- The domain here is intentionally served with `www`. In the event that the integrity check fails,
+         the request should be disallowed by the source list. If we were to use {{domains[]}},
+         then we would not be able to observe the difference with regards to the integrity check -->
     <!-- ShA256 is intentionally mixed case -->
 </head>
 
@@ -18,6 +21,8 @@
         var port = "{{ports[http][0]}}";
         if (location.protocol === "https:")
           port = "{{ports[https][0]}}";
+        // Since {{domains[www]}} is allowed by the CSP policy, regardless of the integrity check
+        // the request would be allowed.
         var crossorigin_base = location.protocol + "//{{domains[www]}}:" + port;
 
         // Test name, src, integrity, expected to run.

--- a/content-security-policy/script-src/script-src-sri_hash.sub.html
+++ b/content-security-policy/script-src/script-src-sri_hash.sub.html
@@ -7,6 +7,9 @@
     <script src='/resources/testharnessreport.js' nonce='dummy'></script>
 
     <!-- CSP served: script-src {{domains[www]}}:* 'nonce-dummy' 'sha256-wIc3KtqOuTFEu6t17sIBuOswgkV406VJvhSk79Gw6U0=' 'ShA256-L7/UQ9VWpyG7C9RDEC4ctS5hI3Zcw+ta+haPGlByG9c=' 'sha512-rYCVMxWV5nq8IsMo+UZNObWtEiWGok/vDN8BMoEQi41s0znSes6E1Q2aag3Lw3u2J1w2rqH7uF2ws6FpQhfSOA==' -->
+    <!-- The domain here is intentionally served with `www`. In the event that the integrity check fails,
+      the request should be disallowed by the source list. If we were to use {{domains[]}},
+      then we would not be able to observe the difference with regards to the integrity check -->
     <!-- ShA256 is intentionally mixed case -->
 </head>
 
@@ -18,6 +21,8 @@
         var port = "{{ports[http][0]}}";
         if (location.protocol === "https:")
           port = "{{ports[https][0]}}";
+        // Since {{domains[www]}} is allowed by the CSP policy, regardless of the integrity check
+        // the request would be allowed.
         var crossorigin_base = location.protocol + "//{{domains[www]}}:" + port;
 
         // Test name, src, integrity, expected to run.

--- a/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted.html
@@ -2,11 +2,12 @@
 <html>
 
 <head>
-    <title>Parser-inserted scripts without a correct nonce are not allowed with `strict-dynamic` in the script-src directive.</title>
+    <title>Parser-inserted scripts without a correct nonce are not allowed with `Strict-Dynamic` in the script-src directive.</title>
     <script src='/resources/testharness.js' nonce='dummy'></script>
     <script src='/resources/testharnessreport.js' nonce='dummy'></script>
 
-    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' -->
+    <!-- CSP served: script-src 'Strict-Dynamic' 'nonce-dummy' -->
+    <!-- Strict-Dynamic is intentionally mixed case -->
 </head>
 
 <body>

--- a/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted.html.headers
@@ -2,4 +2,4 @@ Expires: Mon, 26 Jul 1997 05:00:00 GMT
 Cache-Control: no-store, no-cache, must-revalidate
 Cache-Control: post-check=0, pre-check=0, false
 Pragma: no-cache
-Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy'
+Content-Security-Policy: script-src 'Strict-Dynamic' 'nonce-dummy'


### PR DESCRIPTION
Also add clarifying comments to the SRI WPT tests with
regards to the `www.` domain and how that interacts with
the integrity checks.

Lastly, adjust the casing for `Strict-Dynamic`, as in
the post-request check that should also be case-insensitive.

Closes servo/servo#37200
Closes servo/servo#36760
Fixes servo/servo#36499
Part of w3c/webappsec-csp#727
Fixes w3c/webappsec-csp#728
Part of servo/servo#4577
Reviewed in servo/servo#37154