### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=293644

### DIFF
--- a/css/css-sizing/image-max-width-and-height-behaves-as-auto.html
+++ b/css/css-sizing/image-max-width-and-height-behaves-as-auto.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#min-max-widths">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers">
+<meta name="assert" content="When computed logical width is auto, computed logical height behaves as auto,
+the used logical height should be determined with respect to any max logical width constraint.">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<style>
+.container {
+  width: 100px;
+}
+img {
+  max-width: 100%;
+  height: 100%;
+}
+</style>
+</head>
+<body>
+  <p>Test passes if there is a filled green square.</p>
+  <div class="container">
+    <img src="aspect-ratio/support/200x200-green.png"/>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [ptv.com.pk: The image size is stretched vertically leading to gap on second column in Safari compared to Firefox & Chrome](https://bugs.webkit.org/show_bug.cgi?id=293644)