### PR TITLE
Use embedded stylesheet for `<details>` element

### DIFF
--- a/html/rendering/the-details-element/details-content-security-policy.html
+++ b/html/rendering/the-details-element/details-content-security-policy.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none';">
+  <link rel="author" title="Jo Steven Novaryo" href="mailto:steven.novaryo@gmail.com">
+  <title>Details Element Appearance Should not be Affected By Content Security Policy</title>
+  <link rel="match" href="single-summary.html">
+</head>
+
+<details>
+  <summary>This is the main summary</summary>
+  This is the content
+</details>

--- a/html/rendering/the-details-element/details-multiple-summaries-ref.html
+++ b/html/rendering/the-details-element/details-multiple-summaries-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Details Element Should not Discard the Additional Summary Element</title>
+</head>
+
+<style>
+  #main-summary {
+    display: list-item;
+    list-style: disclosure-open inside;
+  }
+</style>
+
+<div>
+  <summary id="main-summary">This is the main summary</summary>
+  <summary>This is the additional summary</summary>
+  This is the content
+</div>

--- a/html/rendering/the-details-element/details-multiple-summaries.html
+++ b/html/rendering/the-details-element/details-multiple-summaries.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Details Element Should not Discard the Additional Summary Element</title>
+  <link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#the-details-and-summary-elements">
+  <link rel="match" href="details-multiple-summaries-ref.html">
+  <link rel="author" title="Jo Steven Novaryo" href="mailto:steven.novaryo@gmail.com">
+</head>
+
+<details open>
+  <summary>This is the main summary</summary>
+  <summary id="second-summary">This is the additional summary</summary>
+  This is the content
+</details>


### PR DESCRIPTION
Instead of injecting the style in `<details>` shadow tree for each update, we attach an embedded stylesheet `layout/ stylesheet/details.css` for that shadow DOM. The embedded stylesheet is introduced with it's parsing utilities in the shared `components/shared/script_layout/lib.rs` between `layout` and `script`.

All things considered, it is better to implement the styles inside UA stylesheet. But we will need to support shadow-scoped UA style sheet, as detailed [in the discussion](https://github.com/servo/servo/pull/36994#issuecomment-2879757583).

Testing: No WPT Test Regression
Reviewed in servo/servo#36994