### PR TITLE
Avoid unhandled rejection in view-transition-types-mutable.html

### DIFF
--- a/css/css-view-transitions/view-transition-types-mutable.html
+++ b/css/css-view-transitions/view-transition-types-mutable.html
@@ -4,16 +4,17 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-  promise_test(async () => {
+  test((t) => {
     assert_implements(document.startViewTransition);
     const transition = document.startViewTransition();
+    t.add_cleanup(() => transition.skipTransition());
     assert_true(transition.types instanceof ViewTransitionTypeSet);
-    await transition.finished;
   }, "ViewTransition.types is a ViewTransitionTypeSet");
 
-  promise_test(async () => {
+  test((t) => {
     assert_implements(document.startViewTransition);
     const transition = document.startViewTransition();
+    t.add_cleanup(() => transition.skipTransition());
     const { types } = transition;
     types.add("a");
     types.add("b");
@@ -28,7 +29,6 @@
     types.add("");
     types.add("123");
     assert_array_equals([...types], ["a", ".", "", "123"]);
-    await transition.finished;
   }, "ViewTransitionTypeSet behaves like an ordinary Set of strings");
 
   promise_test(async () => {

--- a/css/css-view-transitions/view-transition-types-mutable.html
+++ b/css/css-view-transitions/view-transition-types-mutable.html
@@ -4,16 +4,17 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-
-    test(() => {
+  promise_test(async () => {
     assert_implements(document.startViewTransition);
-    const { types } = document.startViewTransition();
-    assert_true(types instanceof ViewTransitionTypeSet);
+    const transition = document.startViewTransition();
+    assert_true(transition.types instanceof ViewTransitionTypeSet);
+    await transition.finished;
   }, "ViewTransition.types is a ViewTransitionTypeSet");
 
-  test(() => {
+  promise_test(async () => {
     assert_implements(document.startViewTransition);
-    const { types } = document.startViewTransition();
+    const transition = document.startViewTransition();
+    const { types } = transition;
     types.add("a");
     types.add("b");
     assert_array_equals([...types], ["a", "b"]);
@@ -27,6 +28,7 @@
     types.add("");
     types.add("123");
     assert_array_equals([...types], ["a", ".", "", "123"]);
+    await transition.finished;
   }, "ViewTransitionTypeSet behaves like an ordinary Set of strings");
 
   promise_test(async () => {

--- a/css/css-view-transitions/view-transition-types-mutable.html
+++ b/css/css-view-transitions/view-transition-types-mutable.html
@@ -31,9 +31,10 @@
     assert_array_equals([...types], ["a", ".", "", "123"]);
   }, "ViewTransitionTypeSet behaves like an ordinary Set of strings");
 
-  promise_test(async () => {
+  promise_test(async (t) => {
     assert_implements(document.startViewTransition);
     const transition = document.startViewTransition();
+    t.add_cleanup(() => transition.skipTransition());
     transition.types.add("a");
     await transition.finished;
     assert_array_equals([...transition.types], ["a"]);


### PR DESCRIPTION
Safari gives:

ERROR message: Unhandled rejection: Old view transition aborted by new view transition.

Firefox gives:

ERROR message: Unhandled rejection: Skipped ViewTransition due to another transition starting

Other than that the test passed fine in Safari.