### PR TITLE
[mozlog] Fix message propagation through handlers

### DIFF
--- a/tools/third_party_modified/mozlog/mozlog/handlers/base.py
+++ b/tools/third_party_modified/mozlog/mozlog/handlers/base.py
@@ -18,7 +18,7 @@ class BaseHandler(object):
     def __init__(self, inner):
         self.message_handler = MessageHandler()
         if hasattr(inner, "message_handler"):
-            self.message_handler.wrapped.append(inner)
+            self.message_handler.wrapped.append(inner.message_handler)
 
 
 class LogLevelFilter(BaseHandler):


### PR DESCRIPTION
mozlog users can announce runtime settings to handlers/formatters that can be composed in an arbitrary tree shape. However, doing so crashes:

```
Traceback (most recent call last):
  File "/usr/local/google/home/jonathanjlee/chromium/src/third_party/blink/tools/blinkpy/wpt_tests/wpt_adapter.py", line 230, in _set_up_runner_output_options
    runner_options.log.send_message('show_logs', 'on')
  File "/usr/local/google/home/jonathanjlee/chromium/src/third_party/wpt_tools/wpt/tools/third_party_modified/mozlog/mozlog/structuredlog.py", line 241, in send_message
    rv += handler.message_handler.handle_message(topic, command, *args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/google/home/jonathanjlee/chromium/src/third_party/wpt_tools/wpt/tools/third_party_modified/mozlog/mozlog/handlers/messagehandler.py", line 38, in handle_message
    rv.extend(inner.handle_message(topic, cmd, *args))
              ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'LogLevelFilter' object has no attribute 'handle_message'
```

... because [`MessageHandler`][0] was wrapping a [`BaseHandler`][1] and not the latter's own `MessageHandler`, which has the `handle_message()` method.

This PR is needed to implement https://crbug.com/421262910#comment4.

[0]: https://github.com/web-platform-tests/wpt/blob/master/tools/third_party_modified/mozlog/mozlog/handlers/messagehandler.py
[1]: https://github.com/web-platform-tests/wpt/blob/master/tools/third_party_modified/mozlog/mozlog/handlers/base.py