### PR TITLE
[wptrunner] Plumb `--leak-check` for headless shell

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/headless_shell.py
+++ b/tools/wptrunner/wptrunner/browsers/headless_shell.py
@@ -3,6 +3,7 @@
 from .base import require_arg
 from .base import get_timeout_multiplier   # noqa: F401
 from .chrome import ChromeBrowser  # noqa: F401
+from .chrome import browser_kwargs as browser_kwargs  # noqa: F401
 from .chrome import executor_kwargs as chrome_executor_kwargs
 from ..executors.base import WdspecExecutor  # noqa: F401
 from ..executors.executorchrome import (  # noqa: F401
@@ -33,13 +34,6 @@ __wptrunner__ = {"product": "headless_shell",
 
 def check_args(**kwargs):
     require_arg(kwargs, "webdriver_binary")
-
-
-def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
-    return {"binary": kwargs["binary"],
-            "webdriver_binary": kwargs["webdriver_binary"],
-            "webdriver_args": kwargs.get("webdriver_args"),
-            "debug_info": kwargs["debug_info"]}
 
 
 def executor_kwargs(logger, test_type, test_environment, run_info_data, subsuite,

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -313,7 +313,7 @@ class TestSource:
         if not self.current_group.group or len(self.current_group.group) == 0:
             try:
                 self.current_group = self.test_queue.get()
-                self.logger.debug(f"Got new test group subsuite:{self.current_group[1]} "
+                self.logger.debug(f"Got new test group subsuite:{self.current_group[1]!r} "
                                   f"test_type:{self.current_group[2]}")
             except Empty:
                 return testloader.TestGroup(None, None, None, None)
@@ -473,11 +473,11 @@ class TestRunnerManager(threading.Thread):
 
             if skipped_tests:
                 self.logger.critical(
-                    f"Tests left in the queue: {subsuite}:{skipped_tests[0].id!r} "
+                    f"Tests left in the queue: {subsuite!r}:{skipped_tests[0].id!r} "
                     f"and {len(skipped_tests) - 1} others"
                 )
                 for test in skipped_tests[1:]:
-                    self.logger.debug(f"Test left in the queue: {subsuite}:{test.id!r}")
+                    self.logger.debug(f"Test left in the queue: {subsuite!r}:{test.id!r}")
 
             force_stop = (not isinstance(self.state, RunnerManagerState.stop) or
                           self.state.force_stop)
@@ -900,7 +900,7 @@ class TestRunnerManager(threading.Thread):
             if test is None:
                 return RunnerManagerState.stop(force_stop)
             if subsuite != self.state.subsuite:
-                self.logger.info(f"Restarting browser for new subsuite:{subsuite}")
+                self.logger.info(f"Restarting browser for new subsuite:{subsuite!r}")
                 restart = True
             elif self.restart_on_new_group and test_group is not self.state.test_group:
                 self.logger.info("Restarting browser for new test group")


### PR DESCRIPTION
... by using the `chrome` browser kwargs (the browser implementations happen to be identical at this time). This also fixes an unused `debug_info` kwarg, which after https://github.com/web-platform-tests/wpt/pull/52455, gets logged as:

```
WARNING Browser.__init__ kwargs: {'debug_info': None}
```

Drive-by: The default subsuite is the empty string, which, when logged, looks incomplete, e.g:

```
INFO Restarting browser for new subsuite:
```

Format with `repr()` to add quotation marks.