### PR TITLE
Implement the `size` presentational hint for `<hr>` elements

### DIFF
--- a/html/rendering/non-replaced-elements/the-hr-element-0/size-ref.html
+++ b/html/rendering/non-replaced-elements/the-hr-element-0/size-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        #foo {
+            height: 50px;
+            box-sizing: border-box;
+        }
+        #bar {
+            border-bottom-width: 0px;
+            box-sizing: border-box;
+        }
+    </style>
+</head>
+<body>
+    <hr id="foo">
+    <hr id="bar">
+</body>
+</html>
+

--- a/html/rendering/non-replaced-elements/the-hr-element-0/size-with-color-or-noshade-ref.html
+++ b/html/rendering/non-replaced-elements/the-hr-element-0/size-with-color-or-noshade-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        hr {
+            border-width: 25px;
+        }
+    </style>
+</head>
+<body>
+    <hr color="black">
+    <hr color="totally-not-a-color">
+    <hr noshade>
+    <hr color="black" noshade>
+</body>
+</html>
+

--- a/html/rendering/non-replaced-elements/the-hr-element-0/size-with-color-or-noshade.html
+++ b/html/rendering/non-replaced-elements/the-hr-element-0/size-with-color-or-noshade.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#the-hr-element-2" />
+<title>hr elements: Tests behaviour of a size attribute with color/noshade attributes present</title>
+<link rel="author" title="Simon Wülker" href="mailto:simon.wuelker@arcor.de">
+<link rel="match" href="/html/rendering/non-replaced-elements/the-hr-element-0/size-with-color-or-noshade-ref.html">
+<meta name="assert" content="This checks that the size attribute of a hr element changes the border widths when color/noshade attributes are present">
+<body>
+    <hr size=50 color="black">
+    <hr size=50 color="totally-not-a-color">
+    <hr size=50 noshade>
+    <hr size=50 color="black" noshade>
+</body>
+</html>
+

--- a/html/rendering/non-replaced-elements/the-hr-element-0/size.html
+++ b/html/rendering/non-replaced-elements/the-hr-element-0/size.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#the-hr-element-2" />
+<title>hr elements: Tests behaviour of a size attribute without color/noshade attributes</title>
+<link rel="author" title="Simon Wülker" href="mailto:simon.wuelker@arcor.de">
+<link rel="match" href="/html/rendering/non-replaced-elements/the-hr-element-0/size-ref.html">
+<meta name="assert" content="This checks that the size attribute of a hr element changes its height.">
+<body>
+    <hr size=50>
+    <hr size=1>
+</body>
+</html>
+


### PR DESCRIPTION
This presentational hint either sets the width values of all borders, removes the bottom border or sets the height of the element, depending on the context. 

This change also implements the corresponding idl attribute (and the `noshade` attribute, which does nothing in html5)

Testing: Adds new web platform tests


Reviewed in servo/servo#37211