### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=293794

### DIFF
--- a/css/css-view-transitions/pseudo-computed-style-stays-in-sync-with-new-element.html
+++ b/css/css-view-transitions/pseudo-computed-style-stays-in-sync-with-new-element.html
@@ -29,12 +29,12 @@ promise_test(async t => {
 
     let viewbox = window.getComputedStyle(
       document.documentElement, "::view-transition-new(target)").objectViewBox;
-    assert_equals(viewbox, "none", "incorrect viewbox " + viewbox);
+    assert_in_array(viewbox, ["none", undefined], "incorrect viewbox " + viewbox);
 
     first.style.filter = "blur(5px)";
     viewbox = window.getComputedStyle(
       document.documentElement, "::view-transition-new(target)").objectViewBox;
-    assert_equals(viewbox, "none", "incorrect viewbox " + viewbox);
+    assert_in_array(viewbox, ["none", undefined], "incorrect viewbox " + viewbox);
 
     transition.finished.then(resolve, reject);
   });


### PR DESCRIPTION
WebKit export from bug: [css/css-view-transitions/pseudo-computed-style-stays-in-sync-with-new-element.html fails due to no object-view-box](https://bugs.webkit.org/show_bug.cgi?id=293794)