### PR TITLE
Serialization of <position> argument of CSS circle() and ellipse() should match spec

### DIFF
--- a/css/css-masking/parsing/clip-path-valid.html
+++ b/css/css-masking/parsing/clip-path-valid.html
@@ -29,14 +29,14 @@ test_valid_value("clip-path", "circle()");
 test_valid_value("clip-path", "circle(1px)", "circle(1px)");
 test_valid_value("clip-path", "circle(closest-side)", "circle()");
 test_valid_value("clip-path", "circle(at 10% 20%)");
-test_valid_value("clip-path", "circle(farthest-side at center top)", "circle(farthest-side at 50% 0%)");
-test_valid_value("clip-path", "circle(4% at top right)", "circle(4% at 100% 0%)");
+test_valid_value("clip-path", "circle(farthest-side at center top)", "circle(farthest-side at center top)");
+test_valid_value("clip-path", "circle(4% at top right)", "circle(4% at right top)");
 
 test_valid_value("clip-path", "ellipse()");
 test_valid_value("clip-path", "ellipse(1px closest-side)");
 test_valid_value("clip-path", "ellipse(at 10% 20%)");
 test_valid_value("clip-path", "ellipse(closest-side closest-side at 10% 20%)", "ellipse(at 10% 20%)");
-test_valid_value("clip-path", "ellipse(farthest-side 4% at bottom left)", "ellipse(farthest-side 4% at 0% 100%)");
+test_valid_value("clip-path", "ellipse(farthest-side 4% at bottom left)", "ellipse(farthest-side 4% at left bottom)");
 
 test_valid_value("clip-path", "polygon(1% 2%)");
 test_valid_value("clip-path", "polygon(nonzero, 1px 2px, 3em 4em)", "polygon(1px 2px, 3em 4em)");

--- a/css/css-shapes/basic-shape-circle-ellipse-serialization.html
+++ b/css/css-shapes/basic-shape-circle-ellipse-serialization.html
@@ -14,15 +14,15 @@ function checkEquals(input, expected) {
     });
 }
 
-// Keywords get replaced by percentages in 2-value form
-checkEquals("circle(at left bottom)", "circle(at 0% 100%)");
-checkEquals("circle(at bottom left)", "circle(at 0% 100%)");
+// Keywords get serialized as keywords
+checkEquals("circle(at left bottom)", "circle(at left bottom)");
+checkEquals("circle(at bottom left)", "circle(at left bottom)");
 checkEquals("circle(at right calc(10% + 5px))",
-            "circle(at 100% calc(10% + 5px))");
-checkEquals("ellipse(at left bottom)", "ellipse(at 0% 100%)");
-checkEquals("ellipse(at bottom left)", "ellipse(at 0% 100%)");
+            "circle(at right calc(10% + 5px))");
+checkEquals("ellipse(at left bottom)", "ellipse(at left bottom)");
+checkEquals("ellipse(at bottom left)", "ellipse(at left bottom)");
 checkEquals("ellipse(at right calc(10% + 5px))",
-            "ellipse(at 100% calc(10% + 5px))");
+            "ellipse(at right calc(10% + 5px))");
 
 // Only 2 or 4 value form allowed
 checkEquals("circle()", "circle()");
@@ -35,21 +35,21 @@ checkEquals("ellipse(closest-side farthest-side)",
             "ellipse(closest-side farthest-side)");
 
 
-checkEquals("circle(at top 0% right 5px)", "circle(at calc(100% - 5px) 0%)");
-checkEquals("ellipse(at top 0% right 10px)", "ellipse(at calc(100% - 10px) 0%)");
+checkEquals("circle(at top 0% right 5px)", "circle(at right 5px top 0%)");
+checkEquals("ellipse(at top 0% right 10px)", "ellipse(at right 10px top 0%)");
 // Remove defaults like closest-side
 checkEquals("circle(closest-side at center)",
-            "circle(at 50% 50%)");
+            "circle(at center center)");
 checkEquals("ellipse(closest-side closest-side at center)",
-            "ellipse(at 50% 50%)");
+            "ellipse(at center center)");
 
 // don't remove non defaults
 checkEquals("circle(farthest-side at center)",
-            "circle(farthest-side at 50% 50%)");
+            "circle(farthest-side at center center)");
 checkEquals("circle(10px at center)",
-            "circle(10px at 50% 50%)");
+            "circle(10px at center center)");
 checkEquals("ellipse(farthest-side 10px at center)",
-            "ellipse(farthest-side 10px at 50% 50%)");
+            "ellipse(farthest-side 10px at center center)");
 // Ellipse can have 0 radii or two, not one. We cannot
 // eliminate a single closest-side if the other is different
 checkEquals("ellipse(closest-side farthest-side at 50% 50%)",
@@ -57,19 +57,19 @@ checkEquals("ellipse(closest-side farthest-side at 50% 50%)",
 checkEquals("ellipse(closest-side 10% at 50% 50%)",
             "ellipse(closest-side 10% at 50% 50%)");
 
-  // Transform to <length-percentage>.
+// Keywords and offsets are both serialized for 4 component position
 checkEquals("circle(at right 5px bottom 10px)",
-            "circle(at calc(100% - 5px) calc(100% - 10px))");
+            "circle(at right 5px bottom 10px)");
 checkEquals("ellipse(at right 5px bottom 10px)",
-            "ellipse(at calc(100% - 5px) calc(100% - 10px))");
+            "ellipse(at right 5px bottom 10px)");
 
 // Don't convert zero lengths to 0%
-checkEquals("circle(at right 5% top 0px)", "circle(at calc(95%) 0px)");
-checkEquals("ellipse(at right 5% top 0px)", "ellipse(at calc(95%) 0px)");
+checkEquals("circle(at right 5% top 0px)", "circle(at right 5% top 0px)");
+checkEquals("ellipse(at right 5% top 0px)", "ellipse(at right 5% top 0px)");
 
-// Transform calcs
+// Maintain calcs
 checkEquals("circle(at right calc(10% + 5px) bottom calc(10% + 5px))",
-            "circle(at calc(90% - 5px) calc(90% - 5px))");
+            "circle(at right calc(10% + 5px) bottom calc(10% + 5px))");
 checkEquals("ellipse(at right calc(10% + 5px) bottom calc(10% + 5px))",
-            "ellipse(at calc(90% - 5px) calc(90% - 5px))");
+            "ellipse(at right calc(10% + 5px) bottom calc(10% + 5px))");
 </script>

--- a/css/css-shapes/parsing/shape-outside-computed.html
+++ b/css/css-shapes/parsing/shape-outside-computed.html
@@ -21,16 +21,61 @@
 <script>
 // TODO: Add inset() tests
 
-test_computed_value("shape-outside", "circle(at 10% 20%)");
 test_computed_value("shape-outside", "circle(at calc(75% + 0px) calc(75% + 0px))", "circle(at 75% 75%)");
 test_computed_value("shape-outside", "circle(calc(10px + 0.5em) at -50% 50%) border-box", "circle(30px at -50% 50%) border-box");
 test_computed_value("shape-outside", "circle(calc(10px - 0.5em) at 50% -50%) border-box", "circle(0px at 50% -50%) border-box");
 test_computed_value("shape-outside", "circle(at top 0% right calc(10% * sign(1em - 1px)))", "circle(at 90% 0%)");
 test_computed_value("shape-outside", "circle(at top 0% right calc(10% * sibling-index()))", "circle(at 90% 0%)");
+test_computed_value("shape-outside", "circle(at 10% 20%)");
+test_computed_value("shape-outside", "circle(at 10%)", "circle(at 10% 50%)");
+test_computed_value("shape-outside", "circle(at 20% 30px)");
+test_computed_value("shape-outside", "circle(at 30px center)", "circle(at 30px 50%)");
+test_computed_value("shape-outside", "circle(at 40px top)", "circle(at 40px 0%)");
+test_computed_value("shape-outside", "circle(at bottom 10% right 20%)", "circle(at 80% 90%)");
+test_computed_value("shape-outside", "circle(at bottom calc(10%) right calc(20%))", "circle(at 80% 90%)");
+test_computed_value("shape-outside", "circle(at bottom right)", "circle(at 100% 100%)");
+test_computed_value("shape-outside", "circle(at calc(10%) calc(20%))", "circle(at 10% 20%)");
+test_computed_value("shape-outside", "circle(at center 10em)", "circle(at 50% 400px)");
+test_computed_value("shape-outside", "circle(at center 50px)", "circle(at 50% 50px)");
+test_computed_value("shape-outside", "circle(at center bottom)", "circle(at 50% 100%)");
+test_computed_value("shape-outside", "circle(at center center)", "circle(at 50% 50%)");
+test_computed_value("shape-outside", "circle(at center left)", "circle(at 0% 50%)");
+test_computed_value("shape-outside", "circle(at center)", "circle(at 50% 50%)");
+test_computed_value("shape-outside", "circle(at left bottom)", "circle(at 0% 100%)");
+test_computed_value("shape-outside", "circle(at left center)", "circle(at 0% 50%)");
+test_computed_value("shape-outside", "circle(at left)", "circle(at 0% 50%)");
+test_computed_value("shape-outside", "circle(at right 30% top 60px)", "circle(at 70% 60px)");
+test_computed_value("shape-outside", "circle(at right 40%)", "circle(at 100% 40%)");
+test_computed_value("shape-outside", "circle(at right bottom)", "circle(at 100% 100%)");
+test_computed_value("shape-outside", "circle(at top center)", "circle(at 50% 0%)");
+test_computed_value("shape-outside", "circle(at top)", "circle(at 50% 0%)");
 
 test_computed_value("shape-outside", "ellipse(60% closest-side at 50% 50%)");
 test_computed_value("shape-outside", "ellipse(calc(10px + 0.5em) calc(10px - 0.5em) at -50% 50%) padding-box", "ellipse(30px 0px at -50% 50%) padding-box");
 test_computed_value("shape-outside", "ellipse(calc(10px - 0.5em) calc(10px + 0.5em) at 50% -50%) border-box", "ellipse(0px 30px at 50% -50%) border-box");
+test_computed_value("shape-outside", "ellipse(at 10% 20%)");
+test_computed_value("shape-outside", "ellipse(at 10%)", "ellipse(at 10% 50%)");
+test_computed_value("shape-outside", "ellipse(at 20% 30px)");
+test_computed_value("shape-outside", "ellipse(at 30px center)", "ellipse(at 30px 50%)");
+test_computed_value("shape-outside", "ellipse(at 40px top)", "ellipse(at 40px 0%)");
+test_computed_value("shape-outside", "ellipse(at bottom 10% right 20%)", "ellipse(at 80% 90%)");
+test_computed_value("shape-outside", "ellipse(at bottom calc(10%) right calc(20%))", "ellipse(at 80% 90%)");
+test_computed_value("shape-outside", "ellipse(at bottom right)", "ellipse(at 100% 100%)");
+test_computed_value("shape-outside", "ellipse(at calc(10%) calc(20%))", "ellipse(at 10% 20%)");
+test_computed_value("shape-outside", "ellipse(at center 10em)", "ellipse(at 50% 400px)");
+test_computed_value("shape-outside", "ellipse(at center 50px)", "ellipse(at 50% 50px)");
+test_computed_value("shape-outside", "ellipse(at center bottom)", "ellipse(at 50% 100%)");
+test_computed_value("shape-outside", "ellipse(at center center)", "ellipse(at 50% 50%)");
+test_computed_value("shape-outside", "ellipse(at center left)", "ellipse(at 0% 50%)");
+test_computed_value("shape-outside", "ellipse(at center)", "ellipse(at 50% 50%)");
+test_computed_value("shape-outside", "ellipse(at left bottom)", "ellipse(at 0% 100%)");
+test_computed_value("shape-outside", "ellipse(at left center)", "ellipse(at 0% 50%)");
+test_computed_value("shape-outside", "ellipse(at left)", "ellipse(at 0% 50%)");
+test_computed_value("shape-outside", "ellipse(at right 30% top 60px)", "ellipse(at 70% 60px)");
+test_computed_value("shape-outside", "ellipse(at right 40%)", "ellipse(at 100% 40%)");
+test_computed_value("shape-outside", "ellipse(at right bottom)", "ellipse(at 100% 100%)");
+test_computed_value("shape-outside", "ellipse(at top center)", "ellipse(at 50% 0%)");
+test_computed_value("shape-outside", "ellipse(at top)", "ellipse(at 50% 0%)");
 
 test_computed_value("shape-outside", "polygon(evenodd, -10px, -20px, -30px, -40px, -50px, -60px) margin-box");
 test_computed_value("shape-outside", "polygon(10%, 20%, 30%, 40%, 50%, 60%) content-box");

--- a/css/css-shapes/parsing/shape-outside-valid-position.html
+++ b/css/css-shapes/parsing/shape-outside-valid-position.html
@@ -13,26 +13,54 @@
 </head>
 <body>
 <script>
-test_valid_value("shape-outside", "circle(at 10%)", "circle(at 10% 50%)");
+test_valid_value("shape-outside", "circle(at 10% 20%)");
+test_valid_value("shape-outside", "circle(at 10%)", "circle(at 10% center)");
 test_valid_value("shape-outside", "circle(at 20% 30px)");
-test_valid_value("shape-outside", "circle(at 30px center)", "circle(at 30px 50%)");
-test_valid_value("shape-outside", "circle(at 40px top)", "circle(at 40px 0%)");
-test_valid_value("shape-outside", "circle(at bottom 10% right 20%)", "circle(at calc(80%) calc(90%))");
-test_valid_value("shape-outside", "circle(at bottom right)", "circle(at 100% 100%)");
-test_valid_value("shape-outside", "circle(at center)", "circle(at 50% 50%)");
-test_valid_value("shape-outside", "circle(at center 50px)", "circle(at 50% 50px)");
-test_valid_value("shape-outside", "circle(at center bottom)", "circle(at 50% 100%)");
-test_valid_value("shape-outside", "circle(at center center)", "circle(at 50% 50%)");
-test_valid_value("shape-outside", "circle(at center left)", "circle(at 0% 50%)");
-test_valid_value("shape-outside", "circle(at left)", "circle(at 0% 50%)");
-test_valid_value("shape-outside", "circle(at left bottom)", "circle(at 0% 100%)");
-test_valid_value("shape-outside", "circle(at left center)", "circle(at 0% 50%)");
-test_valid_value("shape-outside", "circle(at right 40%)", "circle(at 100% 40%)");
-test_valid_value("shape-outside", "circle(at right 30% top 60px)", "circle(at calc(70%) 60px)");
-test_valid_value("shape-outside", "circle(at top)", "circle(at 50% 0%)");
-test_valid_value("shape-outside", "circle(at top center)","circle(at 50% 0%)");
+test_valid_value("shape-outside", "circle(at 30px center)", "circle(at 30px center)");
+test_valid_value("shape-outside", "circle(at 40px top)", "circle(at 40px top)");
+test_valid_value("shape-outside", "circle(at bottom 10% right 20%)", "circle(at right 20% bottom 10%)");
+test_valid_value("shape-outside", "circle(at bottom calc(10%) right calc(20%))", "circle(at right calc(20%) bottom calc(10%))");
+test_valid_value("shape-outside", "circle(at bottom right)", "circle(at right bottom)");
+test_valid_value("shape-outside", "circle(at center 10em)");
+test_valid_value("shape-outside", "circle(at center 50px)", "circle(at center 50px)");
+test_valid_value("shape-outside", "circle(at center bottom)", "circle(at center bottom)");
+test_valid_value("shape-outside", "circle(at center center)", "circle(at center center)");
+test_valid_value("shape-outside", "circle(at center left)", "circle(at left center)");
+test_valid_value("shape-outside", "circle(at center)", "circle(at center center)");
+test_valid_value("shape-outside", "circle(at left bottom)", "circle(at left bottom)");
+test_valid_value("shape-outside", "circle(at left center)", "circle(at left center)");
+test_valid_value("shape-outside", "circle(at left)", "circle(at left center)");
+test_valid_value("shape-outside", "circle(at right 30% top 60px)", "circle(at right 30% top 60px)");
+test_valid_value("shape-outside", "circle(at right 40%)", "circle(at right 40%)");
+test_valid_value("shape-outside", "circle(at right)", "circle(at right center)");
+test_valid_value("shape-outside", "circle(at top center)", "circle(at center top)");
+test_valid_value("shape-outside", "circle(at top)", "circle(at center top)");
 test_valid_value("shape-outside", "circle(at top 0% right calc(10% * sign(1em - 1px)))", "circle(at calc(100% - (10% * sign(1em - 1px))) 0%)");
 test_valid_value("shape-outside", "circle(at top 0% right calc(10% * sibling-index()))", "circle(at calc(100% - (10% * sibling-index())) 0%)");
+
+test_valid_value("shape-outside", "ellipse(at 10% 20%)");
+test_valid_value("shape-outside", "ellipse(at 10%)", "ellipse(at 10% center)");
+test_valid_value("shape-outside", "ellipse(at 20% 30px)");
+test_valid_value("shape-outside", "ellipse(at 30px center)", "ellipse(at 30px center)");
+test_valid_value("shape-outside", "ellipse(at 40px top)", "ellipse(at 40px top)");
+test_valid_value("shape-outside", "ellipse(at bottom 10% right 20%)", "ellipse(at right 20% bottom 10%)");
+test_valid_value("shape-outside", "ellipse(at bottom calc(10%) right calc(20%))", "ellipse(at right calc(20%) bottom calc(10%))");
+test_valid_value("shape-outside", "ellipse(at bottom right)", "ellipse(at right bottom)");
+test_valid_value("shape-outside", "ellipse(at center 10em)");
+test_valid_value("shape-outside", "ellipse(at center 50px)", "ellipse(at center 50px)");
+test_valid_value("shape-outside", "ellipse(at center bottom)", "ellipse(at center bottom)");
+test_valid_value("shape-outside", "ellipse(at center center)", "ellipse(at center center)");
+test_valid_value("shape-outside", "ellipse(at center left)", "ellipse(at left center)");
+test_valid_value("shape-outside", "ellipse(at center)", "ellipse(at center center)");
+test_valid_value("shape-outside", "ellipse(at left bottom)", "ellipse(at left bottom)");
+test_valid_value("shape-outside", "ellipse(at left center)", "ellipse(at left center)");
+test_valid_value("shape-outside", "ellipse(at left)", "ellipse(at left center)");
+test_valid_value("shape-outside", "ellipse(at right 30% top 60px)", "ellipse(at right 30% top 60px)");
+test_valid_value("shape-outside", "ellipse(at right 40%)", "ellipse(at right 40%)");
+test_valid_value("shape-outside", "ellipse(at right)", "ellipse(at right center)");
+test_valid_value("shape-outside", "ellipse(at top center)", "ellipse(at center top)");
+test_valid_value("shape-outside", "ellipse(at top)", "ellipse(at center top)");
+
 </script>
 </body>
 </html>

--- a/css/css-shapes/shape-functions/circle-function-valid.html
+++ b/css/css-shapes/shape-functions/circle-function-valid.html
@@ -14,19 +14,19 @@
 <script>
 test_valid_value("shape-outside", "circle()");
 test_valid_value("shape-outside", "circle(1px)");
-test_valid_value("shape-outside", "circle(20px at center)", "circle(20px at 50% 50%)");
+test_valid_value("shape-outside", "circle(20px at center)", "circle(20px at center center)");
 test_valid_value("shape-outside", "circle(at 10% 20%)");
-test_valid_value("shape-outside", "circle(4% at top right)", "circle(4% at 100% 0%)");
+test_valid_value("shape-outside", "circle(4% at top right)", "circle(4% at right top)");
 test_valid_value("shape-outside", "circle(calc(100% - 20px) at calc(100% - 20px) calc(100% / 4))", "circle(calc(100% - 20px) at calc(100% - 20px) calc(25%))");
 
-test_valid_value("shape-outside", "circle(closest-corner at center)", "circle(closest-corner at 50% 50%)");
-test_valid_value("shape-outside", "circle(closest-corner at 20px 50px)", "circle(closest-corner at 20px 50px)");
-test_valid_value("shape-outside", "circle(closest-side at center)", "circle(at 50% 50%)");
+test_valid_value("shape-outside", "circle(closest-corner at center)", "circle(closest-corner at center center)");
+test_valid_value("shape-outside", "circle(closest-corner at 20px 50px)");
+test_valid_value("shape-outside", "circle(closest-side at center)", "circle(at center center)");
 test_valid_value("shape-outside", "circle(closest-side at 20px 30%)", "circle(at 20px 30%)");
-test_valid_value("shape-outside", "circle(farthest-corner at center top)", "circle(farthest-corner at 50% 0%)");
-test_valid_value("shape-outside", "circle(farthest-corner at center)", "circle(farthest-corner at 50% 50%)");
-test_valid_value("shape-outside", "circle(farthest-side at center top)", "circle(farthest-side at 50% 0%)");
-test_valid_value("shape-outside", "circle(farthest-side at center)", "circle(farthest-side at 50% 50%)");
+test_valid_value("shape-outside", "circle(farthest-corner at center top)");
+test_valid_value("shape-outside", "circle(farthest-corner at center)", "circle(farthest-corner at center center)");
+test_valid_value("shape-outside", "circle(farthest-side at center top)", "circle(farthest-side at center top)");
+test_valid_value("shape-outside", "circle(farthest-side at center)", "circle(farthest-side at center center)");
 </script>
 </body>
 </html>

--- a/css/css-shapes/shape-functions/ellipse-function-valid.html
+++ b/css/css-shapes/shape-functions/ellipse-function-valid.html
@@ -13,19 +13,19 @@
 <script>
 test_valid_value("shape-outside", "ellipse()");
 test_valid_value("shape-outside", "ellipse(1px 2px)");
-test_valid_value("shape-outside", "ellipse(20px 40px at center)", "ellipse(20px 40px at 50% 50%)");
+test_valid_value("shape-outside", "ellipse(20px 40px at center)", "ellipse(20px 40px at center center)");
 test_valid_value("shape-outside", "ellipse(closest-side 20%)");
 test_valid_value("shape-outside", "ellipse(farthest-side 20%)");
 test_valid_value("shape-outside", "ellipse(closest-corner 20%)");
 test_valid_value("shape-outside", "ellipse(farthest-corner 20%)");
 test_valid_value("shape-outside", "ellipse(at 10% 20%)");
 test_valid_value("shape-outside", "ellipse(at -10px -20%)");
-test_valid_value("shape-outside", "ellipse(4% 20% at top right)", "ellipse(4% 20% at 100% 0%)");
+test_valid_value("shape-outside", "ellipse(4% 20% at top right)", "ellipse(4% 20% at right top)");
 test_valid_value("shape-outside", "ellipse(calc(100% - 20px) calc(80% - 10px) at calc(100% - 20px) calc(100% / 4))", "ellipse(calc(100% - 20px) calc(80% - 10px) at calc(100% - 20px) calc(25%))");
 
-test_valid_value("shape-outside", "ellipse(10px closest-side at top right)", "ellipse(10px closest-side at 100% 0%)");
-test_valid_value("shape-outside", "ellipse(farthest-side 20px at center top)", "ellipse(farthest-side 20px at 50% 0%)");
-test_valid_value("shape-outside", "ellipse(farthest-side farthest-side at top right)", "ellipse(farthest-side farthest-side at 100% 0%)");
+test_valid_value("shape-outside", "ellipse(10px closest-side at top right)", "ellipse(10px closest-side at right top)");
+test_valid_value("shape-outside", "ellipse(farthest-side 20px at center top)", "ellipse(farthest-side 20px at center top)");
+test_valid_value("shape-outside", "ellipse(farthest-side farthest-side at top right)", "ellipse(farthest-side farthest-side at right top)");
 </script>
 </body>
 </html>

--- a/css/css-shapes/shape-outside/values/shape-outside-circle-009.html
+++ b/css/css-shapes/shape-outside/values/shape-outside-circle-009.html
@@ -21,62 +21,62 @@
             var valid_circle_radii_tests = [
                 {
                   "actual": "circle(at +50px)",
-                  "expected_inline": "circle(at 50px 50%)",
+                  "expected_inline": "circle(at 50px center)",
                   "expected_computed": "circle(at 50px 50%)"
                 },
                 {
                   "actual": "circle(at -50px)",
-                  "expected_inline": "circle(at -50px 50%)",
+                  "expected_inline": "circle(at -50px center)",
                   "expected_computed": "circle(at -50px 50%)"
                 },
                 {
                   "actual": "circle(at +50%)",
-                  "expected_inline": "circle(at 50% 50%)",
+                  "expected_inline": "circle(at 50% center)",
                   "expected_computed": "circle(at 50% 50%)"
                 },
                 {
                   "actual": "circle(at -50%)",
-                  "expected_inline": "circle(at -50% 50%)",
+                  "expected_inline": "circle(at -50% center)",
                   "expected_computed": "circle(at -50% 50%)"
                 },
                 {
                   "actual": "circle(at left +50px)",
-                  "expected_inline": "circle(at 0% 50px)",
+                  "expected_inline": "circle(at left 50px)",
                   "expected_computed": "circle(at 0% 50px)"
                 },
                 {
                   "actual": "circle(at left +50%)",
-                  "expected_inline": "circle(at 0% 50%)",
+                  "expected_inline": "circle(at left 50%)",
                   "expected_computed": "circle(at 0% 50%)"
                 },
                 {
                   "actual": "circle(at right -50px)",
-                  "expected_inline": "circle(at 100% -50px)",
+                  "expected_inline": "circle(at right -50px)",
                   "expected_computed": "circle(at 100% -50px)"
                 },
                 {
                   "actual": "circle(at right -50%)",
-                  "expected_inline": "circle(at 100% -50%)",
+                  "expected_inline": "circle(at right -50%)",
                   "expected_computed": "circle(at 100% -50%)"
                 },
                 {
                   "actual": "circle(at +50px top)",
-                  "expected_inline": "circle(at 50px 0%)",
+                  "expected_inline": "circle(at 50px top)",
                   "expected_computed": "circle(at 50px 0%)"
                 },
                 {
                   "actual": "circle(at +50% top)",
-                  "expected_inline": "circle(at 50% 0%)",
+                  "expected_inline": "circle(at 50% top)",
                   "expected_computed": "circle(at 50% 0%)"
                 },
                 {
                   "actual": "circle(at -50px bottom)",
-                  "expected_inline": "circle(at -50px 100%)",
+                  "expected_inline": "circle(at -50px bottom)",
                   "expected_computed": "circle(at -50px 100%)"
                 },
                 {
                   "actual": "circle(at -50% bottom)",
-                  "expected_inline": "circle(at -50% 100%)",
+                  "expected_inline": "circle(at -50% bottom)",
                   "expected_computed": "circle(at -50% 100%)"
                 },
                 {

--- a/css/css-shapes/shape-outside/values/shape-outside-circle-011.html
+++ b/css/css-shapes/shape-outside/values/shape-outside-circle-011.html
@@ -21,7 +21,7 @@
             var circle_position_calc_tests = [];
             ParsingUtils.calcTestValues.forEach(function(value) {
                 testCase = ['circle(at '+ value[0] +')',
-                            'circle(at '+ value[1] +' 50%)'];
+                            'circle(at '+ value[1] +' center)'];
                 if(Object.prototype.toString.call( value[2] ) === '[object Array]' && value[2].length == 2) {
                     testCase.push([ 'circle(at '+ value[2][0] +' 50%)',
                                     'circle(at '+ value[2][1] +' 50%)'

--- a/css/css-shapes/shape-outside/values/shape-outside-ellipse-009.html
+++ b/css/css-shapes/shape-outside/values/shape-outside-ellipse-009.html
@@ -21,62 +21,62 @@
             var valid_ellipse_radii_tests = [
                 {
                   "actual": "ellipse(at +50px)",
-                  "expected_inline": "ellipse(at 50px 50%)",
+                  "expected_inline": "ellipse(at 50px center)",
                   "expected_computed": "ellipse(at 50px 50%)"
                 },
                 {
                   "actual": "ellipse(at -50px)",
-                  "expected_inline": "ellipse(at -50px 50%)",
+                  "expected_inline": "ellipse(at -50px center)",
                   "expected_computed": "ellipse(at -50px 50%)"
                 },
                 {
                   "actual": "ellipse(at +50%)",
-                  "expected_inline": "ellipse(at 50% 50%)",
+                  "expected_inline": "ellipse(at 50% center)",
                   "expected_computed": "ellipse(at 50% 50%)"
                 },
                 {
                   "actual": "ellipse(at -50%)",
-                  "expected_inline": "ellipse(at -50% 50%)",
+                  "expected_inline": "ellipse(at -50% center)",
                   "expected_computed": "ellipse(at -50% 50%)"
                 },
                 {
                   "actual": "ellipse(at left +50px)",
-                  "expected_inline": "ellipse(at 0% 50px)",
+                  "expected_inline": "ellipse(at left 50px)",
                   "expected_computed": "ellipse(at 0% 50px)"
                 },
                 {
                   "actual": "ellipse(at left +50%)",
-                  "expected_inline": "ellipse(at 0% 50%)",
+                  "expected_inline": "ellipse(at left 50%)",
                   "expected_computed": "ellipse(at 0% 50%)"
                 },
                 {
                   "actual": "ellipse(at right -50px)",
-                  "expected_inline": "ellipse(at 100% -50px)",
+                  "expected_inline": "ellipse(at right -50px)",
                   "expected_computed": "ellipse(at 100% -50px)"
                 },
                 {
                   "actual": "ellipse(at right -50%)",
-                  "expected_inline": "ellipse(at 100% -50%)",
+                  "expected_inline": "ellipse(at right -50%)",
                   "expected_computed": "ellipse(at 100% -50%)"
                 },
                 {
                   "actual": "ellipse(at +50px top)",
-                  "expected_inline": "ellipse(at 50px 0%)",
+                  "expected_inline": "ellipse(at 50px top)",
                   "expected_computed": "ellipse(at 50px 0%)"
                 },
                 {
                   "actual": "ellipse(at +50% top)",
-                  "expected_inline": "ellipse(at 50% 0%)",
+                  "expected_inline": "ellipse(at 50% top)",
                   "expected_computed": "ellipse(at 50% 0%)"
                 },
                 {
                   "actual": "ellipse(at -50px bottom)",
-                  "expected_inline": "ellipse(at -50px 100%)",
+                  "expected_inline": "ellipse(at -50px bottom)",
                   "expected_computed": "ellipse(at -50px 100%)"
                 },
                 {
                   "actual": "ellipse(at -50% bottom)",
-                  "expected_inline": "ellipse(at -50% 100%)",
+                  "expected_inline": "ellipse(at -50% bottom)",
                   "expected_computed": "ellipse(at -50% 100%)"
                 },
                 {

--- a/css/css-shapes/shape-outside/values/support/parsing-utils.js
+++ b/css/css-shapes/shape-outside/values/support/parsing-utils.js
@@ -145,7 +145,8 @@ function buildPositionTests(shape, valid, type, units) {
         });
     } else {
         if (valid) {
-            validPositions.forEach(function(test) {
+            var positions = is_computed ? validComputedPositions : validSpecifiedPositions;
+            positions.forEach(function(test) {
                 var testCase = [], testName, actual, expected;
                 // skip if this isn't explicitly testing length units
                 if (!(type.indexOf('lengthUnit') != -1 && test[0].indexOf("u1") == -1)) {
@@ -516,7 +517,100 @@ var validUnits = [
                  ]
 
 /// [actual, expected]
-var validPositions = [
+var validSpecifiedPositions = [
+
+/// [ percent ], [ length ], [ percent | percent ], [ percent | length ], [ length | percent ], [ length | length ]
+    ["50%", "50% center"],
+    ["50u1", "50u1 center"],
+    ["50% 50%", "50% 50%"],
+    ["50% 50u1", "50% 50u1"],
+    ["50u1 50%", "50u1 50%"],
+    ["50u1 50u1", "50u1 50u1"],
+
+///// [ keyword ], [ keyword keyword ] x 5 keywords
+    ["left", "left center"],
+    ["top", "center top"],
+    ["right", "right center"],
+    ["bottom", "center bottom"],
+    ["center", "center center"],
+
+    ["left top", "left top"],
+    ["left bottom", "left bottom"],
+    ["left center", "left center"],
+
+    ["top left", "left top"],
+    ["top right", "right top"],
+    ["top center", "center top"],
+
+    ["right top", "right top"],
+    ["right bottom", "right bottom"],
+    ["right center", "right center"],
+
+    ["bottom left", "left bottom"],
+    ["bottom right", "right bottom"],
+    ["bottom center", "center bottom"],
+
+    ["center top", "center top"],
+    ["center left", "left center"],
+    ["center right", "right center"],
+    ["center bottom", "center bottom"],
+    ["center center", "center center"],
+
+////// [ keyword | percent ], [ keyword | length ], [ percent | keyword ], [ length | keyword ] x 5 keywords
+    ["left 50%", "left 50%"],
+    ["left 50u1", "left 50u1"],
+
+    ["50% top", "50% top"],
+    ["50u1 top", "50u1 top"],
+
+    ["right 80%", "right 80%"],
+    ["right 80u1", "right 80u1"],
+
+    ["70% bottom", "70% bottom"],
+    ["70u1 bottom", "70u1 bottom"],
+
+    ["center 60%", "center 60%"],
+    ["center 60u1", "center 60u1"],
+    ["60% center", "60% center"],
+    ["60u1 center", "60u1 center"],
+
+////// [ keyword percent |  keyword percent], [ keyword percent |  keyword length],
+////// [ keyword length | keyword length],  [ keyword length | keyword percent] x 5 keywords
+    ["left 50% top 50%", "left 50% top 50%"],
+    ["left 50% top 50u1", "left 50% top 50u1"],
+    ["left 50% bottom 70%", "left 50% bottom 70%"],
+    ["left 50% bottom 70u1", "left 50% bottom 70u1"],
+    ["left 50u1 top 50%", "left 50u1 top 50%"],
+    ["left 50u1 top 50u1", "left 50u1 top 50u1"],
+    ["left 50u1 bottom 70%", "left 50u1 bottom 70%"],
+
+    ["top 50% left 50%", "left 50% top 50%"],
+    ["top 50% left 50u1", "left 50u1 top 50%"],
+    ["top 50% right 80%", "right 80% top 50%"],
+    ["top 50% right 80u1", "right 80u1 top 50%"],
+    ["top 50u1 left 50%", "left 50% top 50u1"],
+    ["top 50u1 left 50u1", "left 50u1 top 50u1"],
+    ["top 50u1 right 80%", "right 80% top 50u1"],
+
+    ["bottom 70%  left 50%",    "left 50% bottom 70%"],
+    ["bottom 70%  left 50u1",   "left 50u1 bottom 70%"],
+    ["bottom 70%  right 80%",   "right 80% bottom 70%"],
+    ["bottom 70%  right 80u1",  "right 80u1 bottom 70%"],
+    ["bottom 70u1 left 50%",    "left 50% bottom 70u1"],
+    ["bottom 70u1 right 50%",   "right 50% bottom 70u1"],
+    ["bottom 70u1 right 80u1",  "right 80u1 bottom 70u1"],
+
+    ["right 80% top 50%",      "right 80% top 50%"],
+    ["right 80% top 50u1",     "right 80% top 50u1"],
+    ["right 80% bottom 70%",   "right 80% bottom 70%"],
+    ["right 80% bottom 70u1",  "right 80% bottom 70u1"],
+    ["right 80u1 top 50%",     "right 80u1 top 50%"],
+    ["right 80u1 bottom 70%",  "right 80u1 bottom 70%"],
+    ["right 80u1 bottom 70u1", "right 80u1 bottom 70u1"],
+];
+
+/// [actual, expected]
+var validComputedPositions = [
 
 /// [ percent ], [ length ], [ percent | percent ], [ percent | length ], [ length | percent ], [ length | length ]
     ["50%", "50% 50%"],


### PR DESCRIPTION
The current serialization of the <position> argument to CSS circle() and ellipse()
was not following the spec, which outlines exactly how specified and computed
serialization should behave.

This updates the implementation and quite a few tests to align.

WebKit-commit: https://commits.webkit.org/283287@main
Bug: https://bugs.webkit.org/show_bug.cgi?id=279200
Reviewed-on: https://github.com/WebKit/WebKit/pull/33195

cc @weinig — can you check my merge resolution of `css/css-shapes/parsing/shape-outside-computed.html` and `css/css-shapes/parsing/shape-outside-valid-position.html` looks right to you? I'm mostly sus about some of the new tests that were added after your commit (especially around `sign` and `sibling-index`).