### PR TITLE
Migrate to modern logger interface

### DIFF
--- a/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tools/webtransport/h3/webtransport_h3_server.py
@@ -411,7 +411,7 @@ class WebTransportSession:
         :param data: The data to send.
         """
         if not self._protocol._allow_datagrams:
-            _logger.warn(
+            _logger.warning(
                 "Sending a datagram while that's not allowed - discarding it")
             return
         stream_id = self.session_id
@@ -453,7 +453,7 @@ class WebTransportEventHandler:
         try:
             self._callbacks[callback_name](*args, **kwargs)
         except Exception as e:
-            _logger.warn(str(e))
+            _logger.warning(str(e))
             traceback.print_exc()
 
     def connect_received(self, response_headers: List[Tuple[bytes,
@@ -538,7 +538,7 @@ class WebTransportH3Server:
             try:
                 secrets_log_file = open(os.environ["SSLKEYLOGFILE"], "a")
             except Exception as e:
-                _logger.warn(str(e))
+                _logger.warning(str(e))
 
         # Workaround https://github.com/aiortc/aioquic/issues/567 with if/else
         if secrets_log_file is not None:


### PR DESCRIPTION
## Description
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
We need it for https://github.com/MozillaSecurity/grizzly/pull/503
