### PR TITLE
canvas: Add vello backend

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/servo.py
+++ b/tools/wptrunner/wptrunner/browsers/servo.py
@@ -37,7 +37,8 @@ def check_args(**kwargs):
     require_arg(kwargs, "binary")
 
 
-def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
+def browser_kwargs(logger, test_type, run_info_data, config, subsuite, **kwargs):
+    kwargs["binary_args"].extend(subsuite.config.get("binary_args", []))
     return {
         "binary": kwargs["binary"],
         "debug_info": kwargs["debug_info"],
@@ -68,7 +69,7 @@ def env_options():
 
 
 def update_properties():
-    return ["debug", "os", "processor"], {"os": ["version"], "processor": ["bits"]}
+    return ["debug", "os", "processor", "subsuite"], {"os": ["version"], "processor": ["bits"]}
 
 
 class ServoBrowser(NullBrowser):


### PR DESCRIPTION
using existing abstractions in canvas_paint_thread (so it lives in embedded process). Current implementation uses normal wgpu, so we block on GPU work.

examples that are rendered correctly:
- https://curran.github.io/HTML5Examples/canvas/helloCanvas.html
- https://curran.github.io/HTML5Examples/canvas/sierpinskiTriangle/index.html
- https://curran.github.io/HTML5Examples/canvas/smileyFace.html (raqote backend doesn't render this correctly but vello does):
![raqote](https://github.com/user-attachments/assets/ca4be9b2-b40d-4816-a86f-a73b405af009)
![vello](https://github.com/user-attachments/assets/349639af-b292-440b-a11d-dcc642f908c6)


Vello backend is gated behind `vello` feature and `dom_canvas_vello_enabled` pref.

Testing: Currently untested via WPT but there are manual examples that run.
Relevant issue: #<!-- nolink -->35230

Reviewed in servo/servo#36821