### PR TITLE
Start to migrate PR jobs away from Azure Pipelines

### DIFF
--- a/.github/workflows/pull_request_test_jobs.yml
+++ b/.github/workflows/pull_request_test_jobs.yml
@@ -1,0 +1,59 @@
+name: "test-jobs"
+on:
+  pull_request:
+
+jobs:
+  decision:
+    name: ./wpt test-jobs
+    runs-on: ubuntu-24.04
+    outputs:
+      test_jobs: ${{ steps.test_jobs.outputs.test_jobs }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4.1.0
+        with:
+          fetch-depth: 2
+      - name: ./wpt test-jobs
+        id: test_jobs
+        run: |
+          set -eux
+          echo "test_jobs=$( ./wpt test-jobs --json HEAD^1..HEAD )" >> $GITHUB_OUTPUT
+
+  affected_safari_preview:
+    name: "affected tests: Safari Technology Preview"
+    needs: decision
+    if: contains(fromJSON(needs.decision.outputs.test_jobs), 'affected_tests')
+    uses: ./.github/workflows/safari-wptrunner.yml
+    with:
+      artifact-name: "safari-preview-affected-tests"
+      safari-technology-preview: true
+      safaridriver-diagnose: false
+      fetch-depth: 2
+      extra-options: "--affected ${{ github.sha }}^1"
+
+  affected_without_changes_safari_preview:
+    name: "affected tests without changes: Safari Technology Preview"
+    needs: decision
+    if: contains(fromJSON(needs.decision.outputs.test_jobs), 'affected_tests')
+    uses: ./.github/workflows/safari-wptrunner.yml
+    with:
+      artifact-name: safari-preview-affected-tests-without-changes
+      safari-technology-preview: true
+      safaridriver-diagnose: false
+      fetch-depth: 2
+      test-rev: "HEAD^1"
+      extra-options: "--affected ${{ github.sha }}"
+
+  infrastructure_mac:
+    name: "infrastructure/ tests: macOS"
+    needs: decision
+    if: contains(fromJSON(needs.decision.outputs.test_jobs), 'wptrunner_infrastructure')
+    uses: ./.github/workflows/safari-wptrunner.yml
+    with:
+      artifact-name: safari-infrastructure-results
+      safari-technology-preview: true
+      safaridriver-diagnose: false
+      extra-options: >-
+        --manifest MANIFEST.json
+        --metadata infrastructure/metadata/
+        --include infrastructure/

--- a/.github/workflows/safari-wptrunner.yml
+++ b/.github/workflows/safari-wptrunner.yml
@@ -15,6 +15,26 @@ on:
         description: "Run safaridriver capturing diagnostics"
         required: true
         type: boolean
+      fetch-ref:
+        description: "The ref to fetch and initially checkout"
+        required: false
+        type: string
+      fetch-depth:
+        description: "The fetch-depth to checkout"
+        required: false
+        type: number
+      test-rev:
+        description: "The rev to checkout before running the tests"
+        required: false
+        type: string
+      matrix-include:
+        description: "Extra items to include in the matrix, to override test-type/current-chunk/total-chunks"
+        required: false
+        type: string
+      extra-options:
+        description: "Extra options to pass to wpt run"
+        required: false
+        type: string
 
 # We never interact with the GitHub API, thus we can simply disable all
 # permissions the GitHub token would have.
@@ -29,13 +49,23 @@ jobs:
     timeout-minutes: 180
     strategy:
       matrix:
-        current-chunk: [1, 2, 3, 4, 5, 6, 7, 8]
-        total-chunks: [8]
+        current-chunk:
+          - 1
+        total-chunks:
+          - 1
+        include: ${{ fromJSON(inputs.matrix-include || '[]') }}
     steps:
       - name: checkout
         uses: actions/checkout@v4.1.0
         with:
-          fetch-depth: 1
+          fetch-depth: ${{ inputs.fetch-depth || 1 }}
+          ref: ${{ inputs.fetch-ref }}
+      - name: test-checkout
+        if: inputs.test-rev
+        env:
+          REV: ${{ inputs.test-rev }}
+        run: |-
+          git switch --force --progress -d "$REV"
       - name: Set display color profile
         run: |-
           ./wpt macos-color-profile
@@ -71,8 +101,9 @@ jobs:
             --no-manifest-update \
             --no-restart-on-unexpected \
             --no-fail-on-unexpected \
-            --this-chunk=${{ matrix.current-chunk }} \
-            --total-chunks=${{ matrix.total-chunks }} \
+            --no-pause \
+            --this-chunk ${{ matrix.current-chunk }} \
+            --total-chunks ${{ matrix.total-chunks }} \
             --chunk-type hash \
             --log-wptreport ${{ runner.temp }}/wpt_report_${{ matrix.current-chunk }}.json \
             --log-wptscreenshot ${{ runner.temp }}/wpt_screenshot_${{ matrix.current-chunk }}.txt \
@@ -81,6 +112,8 @@ jobs:
             --channel ${{ inputs.safari-technology-preview && 'preview' || 'stable' }} \
             --kill-safari \
             --max-restarts 100 \
+            ${{ inputs.extra-options }} \
+            -- \
             safari
       - name: Publish results
         uses: actions/upload-artifact@v4.1.0
@@ -105,8 +138,8 @@ jobs:
       - name: Cleanup
         if: always()
         run: |-
-            set -ux
-            sudo sed -i '' '/^# Start web-platform-tests hosts$/,/^# End web-platform-tests hosts$/d' /etc/hosts
+          set -ux
+          sudo sed -i '' '/^# Start web-platform-tests hosts$/,/^# End web-platform-tests hosts$/d' /etc/hosts
 
   safari-notify:
     needs: safari-results

--- a/.github/workflows/safari_stable.yml
+++ b/.github/workflows/safari_stable.yml
@@ -7,7 +7,8 @@ permissions: {}
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [epochs]
+    workflows:
+      - epochs
     types:
       - completed
   push:
@@ -34,3 +35,12 @@ jobs:
       artifact-name: "safari-results"
       safari-technology-preview: false
       safaridriver-diagnose: false
+      matrix-include: >-
+        [{"current-chunk": 1, "total-chunks": 8},
+         {"current-chunk": 2, "total-chunks": 8},
+         {"current-chunk": 3, "total-chunks": 8},
+         {"current-chunk": 4, "total-chunks": 8},
+         {"current-chunk": 5, "total-chunks": 8},
+         {"current-chunk": 6, "total-chunks": 8},
+         {"current-chunk": 7, "total-chunks": 8},
+         {"current-chunk": 8, "total-chunks": 8}]

--- a/.github/workflows/safari_technology_preview.yml
+++ b/.github/workflows/safari_technology_preview.yml
@@ -7,7 +7,8 @@ permissions: {}
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [epochs]
+    workflows:
+      - epochs
     types:
       - completed
   push:
@@ -34,3 +35,12 @@ jobs:
       artifact-name: "safari-technology-preview-results"
       safari-technology-preview: true
       safaridriver-diagnose: false
+      matrix-include: >-
+        [{"current-chunk": 1, "total-chunks": 8},
+         {"current-chunk": 2, "total-chunks": 8},
+         {"current-chunk": 3, "total-chunks": 8},
+         {"current-chunk": 4, "total-chunks": 8},
+         {"current-chunk": 5, "total-chunks": 8},
+         {"current-chunk": 6, "total-chunks": 8},
+         {"current-chunk": 7, "total-chunks": 8},
+         {"current-chunk": 8, "total-chunks": 8}]

--- a/tools/ci/jobs.py
+++ b/tools/ci/jobs.py
@@ -145,6 +145,8 @@ def create_parser():
                         help="Jobs to check for. Return code is 0 if all jobs are found, otherwise 1")
     parser.add_argument("--json", action="store_true",
                         help="Output jobs as JSON, instead of one per line")
+    parser.add_argument("--json-indent", type=int,
+                        help="Indent the JSON with this many spaces (default: no indentation, single line output)")
     return parser
 
 
@@ -153,7 +155,7 @@ def run(**kwargs):
     jobs = get_jobs(paths, **kwargs)
     if not kwargs["includes"]:
         if kwargs["json"]:
-            json.dump(sorted(jobs), sys.stdout, indent=2)
+            json.dump(sorted(jobs), sys.stdout, indent=kwargs["json_indent"])
             sys.stdout.write("\n")
         else:
             for item in sorted(jobs):


### PR DESCRIPTION
This moves the Safari test jobs away from Azure Pipelines, onto GitHub Actions, running on the same infrastructure as the full test runs.

(Sorry this took me so long to do, but notably this actually follows through on the promise of a single entry-point to run the tests!)